### PR TITLE
feat: support kserve

### DIFF
--- a/maga_transformer/BUILD
+++ b/maga_transformer/BUILD
@@ -138,14 +138,30 @@ py_library(
 
 py_library(
     name = "sdk",
-    srcs = glob([
-        "*.py",
-    ]),
+    srcs = [
+        '__init__.py',
+        'inference.py',
+        'model_factory.py',
+        'start_server.py',
+        '_ft_pickler.py',
+        'model_factory_register.py',
+    ],
     deps = [
         ":models",
         ":uvicorn",
         ":fastapi",
         ":psutil",
+    ],
+    imports = ["."],
+)
+
+py_library(
+    name = "kserve_server",
+    srcs = [
+        'kserve_server.py',
+    ],
+    deps = [
+        ":sdk",
     ],
     imports = ["."],
 )
@@ -242,7 +258,48 @@ py_wheel(
     ] + whl_deps(),
 )
 
-
+py_wheel(
+    name = "maga_transformer_kserve_whl",
+    distribution = "maga_transformer",
+    python_tag = "py3",
+    tags = ["manual", "local"],
+    version = "0.0.1",
+    deps = [
+        ":maga_transformer_package",
+        "//deps:extension_package",
+    ],
+    requires=[
+        "filelock",
+        "jinja2",
+        "sympy",
+        "typing-extensions",
+        "importlib_metadata",
+        "transformers==4.33.1",
+        "sentencepiece==0.1.99",
+        "fastapi==0.108.0",
+        "uvicorn==0.21.1",
+        "dacite",
+        "pynvml",
+        "thrift",
+        "numpy==1.24.1",
+        "psutil",
+        "tiktoken==0.4.0",
+        "lru-dict",
+        "py-spy",
+        "safetensors",
+        "cpm_kernels",
+        "pyodps",
+        "Pillow",
+        "protobuf==3.20.0",
+        "torchvision==0.16.0",
+        "einops",
+        "prettytable",
+        "pydantic==2.5.3",
+        "timm==0.9.12",
+        "kserve",
+    ] + whl_deps(),
+)
+ 
 pyc_wheel(
     name = "maga_transformer",
     package_name = "maga_transformer-0.1.4",

--- a/maga_transformer/__init__.py
+++ b/maga_transformer/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-import logging
 import logging.config
 
 if os.environ.get('FT_SERVER_TEST') is not None:

--- a/maga_transformer/kserve_server.py
+++ b/maga_transformer/kserve_server.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# @Author: zibai.gj
+# @Time  : 2024-02-26
+
+import kserve
+from kserve.model import PredictorConfig
+from kserve.protocol.rest.v2_datamodels import GenerateRequest, GenerateResponse
+from kserve.errors import InferenceError
+from typing import Dict, Any, AsyncIterator, Optional
+import argparse
+import asyncio
+
+from maga_transformer.inference import InferenceWorker
+
+
+class LLMModel(kserve.Model):
+    def __init__(self, predictor_config: Optional[PredictorConfig] = None):
+        super().__init__('rtp-llm', predictor_config)
+        self._inference_worker = InferenceWorker()
+        self.ready = True
+
+    def preprocess(self, payload, context=None):
+        raise InferenceError("USE_GENERATE_ENDPOINT_ERROR")
+
+    async def generate(self, generate_request: GenerateRequest, headers: Dict[str, str] = None) \
+            -> AsyncIterator[Any]:
+        if headers.get("streaming", "false") == "true":
+            return self.stream_wrap(generate_request)
+        else:
+            return await self.nonstream_wrap(generate_request)
+
+    async def nonstream_wrap(self, generate_request: GenerateRequest):
+        rep_gen = self._inference_worker.inference(text=generate_request.text_input,
+                                                   generate_config=generate_request.parameters)
+        async for rep in rep_gen:
+            pass
+        return GenerateResponse(text_output=rep['response'], model_name=self.name)
+
+    async def stream_wrap(self, generate_request: GenerateRequest):
+        rep_gen = self._inference_worker.inference(text=generate_request.text_input,
+                                                   generate_config=generate_request.parameters)
+        async for rep in rep_gen:
+            yield rep['response']
+            await asyncio.sleep(0)
+
+    async def predict(self, input_batch, context=None):
+        raise InferenceError("USE_GENERATE_ENDPOINT_ERROR")
+
+    def postprocess(self, outputs, context=None):
+        raise InferenceError("USE_GENERATE_ENDPOINT_ERROR")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(parents=[kserve.model_server.parser])
+    args, _ = parser.parse_known_args()
+    predictor_config = PredictorConfig(args.predictor_host, args.predictor_protocol,
+                                       args.predictor_use_ssl,
+                                       args.predictor_request_timeout_seconds)
+    kserve.ModelServer().start(models=[LLMModel(predictor_config)])
+
+# curl http://0.0.0.0:8080/v2/models/rtp-llm/generate_stream -d '{"text_input":"hi","parameters":{"max_new_tokens":10}}'  -H "content-type:application/json"
+# curl http://0.0.0.0:8080/v2/models/rtp-llm/generate -d '{"text_input":"hi","parameters":{"max_new_tokens":10}}'  -H "content-type:application/json"


### PR DESCRIPTION
feat: support kserve

kserve yaml demo:
```
kind: InferenceService
metadata:
  name: rtp-llm
spec:
  predictor:
    containers:
    - command:
        - "/opt/conda310/bin/python"
        - "-m"
        - "maga_transformer.kserve_server"
      env:
        - name: MODEL_TYPE
          value: phi
        - name: TOKENIZER_PATH
          value: /model/path/
        - name: CHECKPOINT_PATH
          value: /model/path/
      image: <test image url>
      name: kserve-container
      resources:
        limits:
          cpu: "2"
          memory: 8Gi
          nvidia.com/gpu: "1"
        requests:
          cpu: "2"
          memory: 8Gi
          nvidia.com/gpu: "1"
```
test:
```
curl http://<ingress_host>:<ingress_port>/v2/models/rtp-llm/generate_stream -d '{"text_input":"hi","parameters":{"max_new_tokens":10}}'  -H "content-type:application/json"
```