### PR TITLE
fix(src): fix bazel build special type cast and template match for cuda118

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,8 +28,8 @@ build --define=using_cuda=true --define=using_cuda_nvcc=true
 build --crosstool_top=@local_config_cuda//crosstool:toolchain
 build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda/"
 build --host_action_env CUDA_TOOLKIT_PATH="/usr/local/cuda/"
-build --action_env TF_CUDA_VERSION="11.8"
-build --host_action_env TF_CUDA_VERSION="11.8"
+build --action_env TF_CUDA_VERSION="11.4" # 11.8 12.1
+build --host_action_env TF_CUDA_VERSION="11.4" # 11.8 12.1
 build --action_env TF_CUDA_PATHS="/usr/local/cuda/"
 build --host_action_env TF_CUDA_PATHS="/usr/local/cuda/"
 build --action_env TF_CUDA_CLANG="0"

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,8 +28,8 @@ build --define=using_cuda=true --define=using_cuda_nvcc=true
 build --crosstool_top=@local_config_cuda//crosstool:toolchain
 build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda/"
 build --host_action_env CUDA_TOOLKIT_PATH="/usr/local/cuda/"
-build --action_env TF_CUDA_VERSION="11.4"
-build --host_action_env TF_CUDA_VERSION="11.4"
+build --action_env TF_CUDA_VERSION="11.8"
+build --host_action_env TF_CUDA_VERSION="11.8"
 build --action_env TF_CUDA_PATHS="/usr/local/cuda/"
 build --host_action_env TF_CUDA_PATHS="/usr/local/cuda/"
 build --action_env TF_CUDA_CLANG="0"

--- a/maga_transformer/cpp/deprecated/ParallelWordEmbeddingWrapper.cc
+++ b/maga_transformer/cpp/deprecated/ParallelWordEmbeddingWrapper.cc
@@ -86,7 +86,10 @@ void ParallelWordEmbeddingWrapper<T>::forward(ft::Tensor&      embeddings,
         auto embedding_buf = std::make_shared<ft::Buffer>(
             ft::MemoryType::MEMORY_GPU, ft::getTensorType<T>(),
             nccl_embeddings.shape(), nccl_embeddings.getPtr<T>());
-        device_->allGather({{embedding_buf}});
+        // explicit types cast for params
+        std::vector<ft::BufferPtr> buffer_vector = {embedding_buf};
+        ft::AllGatherParams params = {buffer_vector};
+        device_->allGather(params);
         ft::invokeTransposeAxis012(embeddings.getPtr<T>(),
                                   nccl_embeddings.getPtr<T>(),
                                   tensor_para_.world_size_,

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -212,14 +212,12 @@ inline __device__ __nv_bfloat16 operator*(const __nv_bfloat16 x, const __nv_bflo
 inline __device__ __nv_bfloat16 operator*=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hmul(x, y); };
 inline __device__ __nv_bfloat16 operator/(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
 inline __device__ __nv_bfloat16 operator/=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
-
+#endif
 
 inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
 {
     __nv_bfloat162 t; t.x = x; t.y = y; return t;
 }
-
-#endif
 
 inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -194,7 +194,7 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 #endif
 }
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) 
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) && !defined(USE_CUDA12)
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator+=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator-(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hsub2(x, y); };

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -198,7 +198,6 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
-inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
 
 inline __device__ __nv_bfloat16 operator+(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };
 inline __device__ __nv_bfloat16 operator+=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -197,6 +197,7 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) && !defined(USE_CUDA12)
 inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
+inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
 
 inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
 {

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -195,9 +195,14 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) && !defined(USE_CUDA12)
-inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
+inline __device__ __nv_bfloat162 operator+=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
+inline __device__ __nv_bfloat162 operator-(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hsub2(x, y); };
+inline __device__ __nv_bfloat162 operator-=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hsub2(x, y); };
+inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
+inline __device__ __nv_bfloat162 operator*=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
 inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
+inline __device__ __nv_bfloat162 operator/=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
 
 inline __device__ __nv_bfloat16 operator+(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };
 inline __device__ __nv_bfloat16 operator+=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };
@@ -207,6 +212,7 @@ inline __device__ __nv_bfloat16 operator*(const __nv_bfloat16 x, const __nv_bflo
 inline __device__ __nv_bfloat16 operator*=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hmul(x, y); };
 inline __device__ __nv_bfloat16 operator/(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
 inline __device__ __nv_bfloat16 operator/=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
+
 
 inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
 {

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -198,6 +198,16 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hmul2(x, y); };
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
+inline __device__ __nv_bfloat162 operator/(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16h2div2(x, y); };
+
+inline __device__ __nv_bfloat16 operator+(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };
+inline __device__ __nv_bfloat16 operator+=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hadd(x, y); };
+inline __device__ __nv_bfloat16 operator-(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hsub(x, y); };
+inline __device__ __nv_bfloat16 operator-=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hsub(x, y); };
+inline __device__ __nv_bfloat16 operator*(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hmul(x, y); };
+inline __device__ __nv_bfloat16 operator*=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hmul(x, y); };
+inline __device__ __nv_bfloat16 operator/(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
+inline __device__ __nv_bfloat16 operator/=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
 
 inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
 {

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -134,6 +134,32 @@ inline __device__ __nv_bfloat16 bf16hmul(const __nv_bfloat16 x, const __nv_bfloa
 #endif
 }
 
+// fix 
+inline __device__ __nv_bfloat162 bf16h2div2(const __nv_bfloat162 x, const __nv_bfloat162 y) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+    float fxl, fxh, fyl, fyh;
+    fxl = __low2float(x);
+    fxh = __high2float(x);
+    fyl = __low2float(y);
+    fyh = __high2float(y);
+    assert(fyl != 0.0f && fyh != 0.0f && "Division by zero!");
+    return __floats2bfloat162_rn(fxl / fyl, fxh / fyh);
+#else
+    return __h2div(x, y);
+#endif
+}
+
+inline __device__ __nv_bfloat16 bf16hdiv(const __nv_bfloat16 x, const __nv_bfloat16 y) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+    float fx = __bfloat162float(x);
+    float fy = __bfloat162float(y);
+    assert(fy != 0.0f && "bf16hdiv Division by zero!");
+    return __float2bfloat16(fx / fy);
+#else 
+    return __hdiv(x, y);
+#endif
+}
+
 inline __device__ __nv_bfloat162 bf16hfma2(const __nv_bfloat162 x, const __nv_bfloat162 y, const __nv_bfloat162 z) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
     float fxl, fxh, fyl, fyh, fzl, fzh;

--- a/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
+++ b/src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh
@@ -194,7 +194,7 @@ inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
 #endif
 }
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) && !defined(USE_CUDA12)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800) 
 inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator+=(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hadd2(x, y); };
 inline __device__ __nv_bfloat162 operator-(const __nv_bfloat162 x, const __nv_bfloat162 y) { return bf16hsub2(x, y); };
@@ -212,12 +212,12 @@ inline __device__ __nv_bfloat16 operator*(const __nv_bfloat16 x, const __nv_bflo
 inline __device__ __nv_bfloat16 operator*=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hmul(x, y); };
 inline __device__ __nv_bfloat16 operator/(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
 inline __device__ __nv_bfloat16 operator/=(const __nv_bfloat16 x, const __nv_bfloat16 y) { return bf16hdiv(x, y); };
-#endif
 
 inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
 {
     __nv_bfloat162 t; t.x = x; t.y = y; return t;
 }
+#endif
 
 inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800

--- a/src/fastertransformer/devices/cuda_impl/CudaOps.cc
+++ b/src/fastertransformer/devices/cuda_impl/CudaOps.cc
@@ -121,6 +121,10 @@ SPECIALIZE_CAST_TO(__nv_bfloat16, int64_t);
 SPECIALIZE_CAST_TO(__nv_bfloat16, uint64_t);
 SPECIALIZE_CAST_TO(__nv_bfloat16, __half);
 SPECIALIZE_CAST_TO(__half, __nv_bfloat16);
+SPECIALIZE_CAST_TO(__nv_bfloat16, int8_t)
+SPECIALIZE_CAST_TO(__nv_bfloat16, uint8_t)
+SPECIALIZE_CAST_TO(__nv_bfloat16, int32_t)
+SPECIALIZE_CAST_TO(__nv_bfloat16, uint32_t)
 
 // TODO: change this to use efficient cuda kernel
 template<typename DstT, typename SrcT>

--- a/src/fastertransformer/kernels/gpt_kernels.cu
+++ b/src/fastertransformer/kernels/gpt_kernels.cu
@@ -15,6 +15,7 @@
  */
 
 #include <assert.h>
+#include "src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh"
 #include "src/fastertransformer/cuda/cuda_fp8_utils.h"
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!
@@ -49,7 +50,14 @@ __global__ void embedding_lookup_kernel(T*                    from_tensor,
         T         pos_embed       = (T)0.0f;
         T         type_embed      = (T)0.0f;
         embedding = embedding_table[input_id * hidden_units + col_index];
-        embedding *= input_embedding_scalar;
+        // embedding *= input_embedding_scalar;
+        if constexpr (std::is_same<T, __nv_bfloat16>::value) {
+            embedding *= __double2bfloat16(input_embedding_scalar);
+        } else if constexpr (std::is_same<T, __half>::value){
+            embedding *= static_cast<T>(input_embedding_scalar);
+        } else {
+            embedding *= input_embedding_scalar;
+        }
 
         if constexpr(USE_POS_EMB) {
             assert(pos_table != nullptr);

--- a/src/fastertransformer/kernels/gpt_kernels.cu
+++ b/src/fastertransformer/kernels/gpt_kernels.cu
@@ -15,7 +15,7 @@
  */
 
 #include <assert.h>
-#include "src/fastertransformer/cuda/cuda_bf16_fallbacks.cuh"
+#include "src/fastertransformer/cuda/cuda_type_utils.cuh"
 #include "src/fastertransformer/cuda/cuda_fp8_utils.h"
 #ifndef CUDART_VERSION
 #error CUDART_VERSION Undefined!

--- a/src/fastertransformer/kernels/sampling_topp_kernels.cu
+++ b/src/fastertransformer/kernels/sampling_topp_kernels.cu
@@ -1309,15 +1309,15 @@ addBiasSoftMax(T* logits, const T* bias, const int* end_ids, const bool* finishe
     for (int tid = threadIdx.x; tid < n_padded; tid += blockDim.x) {
         if (tid < n) {
             if (finish) {
-                logits[offset + tid] = (tid == end_ids[bid]) ? MAX_T_VAL : -MAX_T_VAL;
+                logits[offset + tid] = (tid == end_ids[bid]) ? static_cast<T>(MAX_T_VAL) : static_cast<T>(-MAX_T_VAL);
             }
             else {
-                T bias_val = (bias != nullptr) ? bias[tid] : (T)0.0f;
+                T bias_val = (bias != nullptr) ? bias[tid] : static_cast<T>(0.0f);
                 logits[offset + tid] += bias_val;
             }
         }
         else {
-            logits[offset + tid] = -MAX_T_VAL;
+            logits[offset + tid] = static_cast<T>(-MAX_T_VAL);
         }
         max_val = max(max_val, (float)logits[offset + tid]);
     }


### PR DESCRIPTION
## fix(src): fix bazel build special type cast and template match for cuda118

### Local Environment
- download the `tar.gc` in [releasev0.2.0](https://github.com/alibaba/rtp-llm/releases/tag/v0.2.0)
- GPU A100
- Python 3.10.13
- gcc (GCC) 10.2.1 20200825 (Alibaba 10.2.1-3 2.17)
- nvcc -V
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2022 NVIDIA Corporation
Built on Wed_Sep_21_10:33:58_PDT_2022
Cuda compilation tools, release 11.8, V11.8.89
Build cuda_11.8.r11.8/compiler.31833905_0
```

### Build Result
#### bazel build
![image](https://github.com/alibaba/rtp-llm/assets/50772219/123d66ed-a3a1-435c-af55-efbb1a267ca4)

#### bazel build test
![image](https://github.com/alibaba/rtp-llm/assets/50772219/c12e8c40-a465-4647-b676-70ddbb201557)
![image](https://github.com/alibaba/rtp-llm/assets/50772219/170470fd-c972-443e-a293-a18e4cfc5268)
![image](https://github.com/alibaba/rtp-llm/assets/50772219/3108397f-9231-4dca-84ed-6e3eec71eea2)


#### whl
![image](https://github.com/alibaba/rtp-llm/assets/50772219/a28606a4-f888-4d81-a3eb-369af3deefe2)
