### PR TITLE
[ROCm] refine quantization related code

### DIFF
--- a/src/fastertransformer/devices/OpData.h
+++ b/src/fastertransformer/devices/OpData.h
@@ -551,6 +551,9 @@ struct QuantizeParams {
     OptionalConstBufferRef  static_scale;
     OptionalConstBufferRef  static_scale_reciprocal;
 
+    // for groupwise quantize
+    int64_t    groupSize;
+
     QuantizeParams(const Buffer&          input,
                    DataType               qtype,
                    size_t                 axis,
@@ -566,9 +569,20 @@ struct QuantizeParams {
         smoother(smoother),
         shift(shift),
         static_scale(static_scale),
-        static_scale_reciprocal(static_scale_reciprocal) {}
-
-    QuantizeParams(const Buffer& input, DataType qtype, size_t axis): input(input), qtype(qtype), axis(axis), qscheme(QScheme::Qint8PerChannelLastAxis) {}
+        static_scale_reciprocal(static_scale_reciprocal),
+        groupSize(64) {}
+    QuantizeParams(const Buffer& input, DataType qtype, size_t axis):
+        input(input),
+        qtype(qtype),
+        axis(axis),
+        qscheme(QScheme::Qint8PerChannelLastAxis),
+        groupSize(64) {}
+    QuantizeParams(const Buffer& input, DataType qtype, size_t axis, int64_t groupSize):
+        input(input),
+        qtype(qtype),
+        axis(axis),
+        qscheme(QScheme::Qint8PerChannelLastAxis),
+        groupSize(groupSize) {}
 };
 
 }  // namespace fastertransformer

--- a/src/fastertransformer/devices/rocm_impl/ROCmDevice.h
+++ b/src/fastertransformer/devices/rocm_impl/ROCmDevice.h
@@ -50,6 +50,8 @@ public:
     void allGather(const AllGatherParams& params);
 
     BufferPtr quantize(const QuantizeParams& params) override;
+    BufferPtr dequantize(const QuantizeParams& params);
+    void      printBuffer(const BufferPtr buffer);
 
 public:
     BufferPtr        testVecAdd(const BufferPtr a, const BufferPtr b);

--- a/src/fastertransformer/devices/rocm_impl/ROCmGemmOp.cc
+++ b/src/fastertransformer/devices/rocm_impl/ROCmGemmOp.cc
@@ -8,7 +8,7 @@
 #include "src/fastertransformer/core/BufferHelper.h"
 #include "src/fastertransformer/cuda/Dispatch.h"
 #include "src/fastertransformer/rocm/quantizePreprocessors.h"
-#include "src/fastertransformer/kernels/quantization_tensor.h"
+#include "src/fastertransformer/kernels/rocm/quantization_rocm.h"
 
 #include <numeric>
 #include <utility>
@@ -201,12 +201,12 @@ BufferPtr ROCmDevice::gemm(const GemmParams& params) {
             DISPATCH_CUDA_FUNCTION_DATA_TYPE(params.A.type(),
                                              invokePerColDequantizationInt4x2,
                                              fpB.get()->data(),
-                                             (int8_t*)(QB.kernel().data()),
                                              arguments.k,
                                              arguments.n,
+                                             group_size,
+                                             (int8_t*)(QB.kernel().data()),
                                              QB.scales().data<half>(),
                                              QB.zeros().data<half>(),
-                                             group_size,
                                              stream_);
             sync_check_cuda_error();
 

--- a/src/fastertransformer/devices/rocm_impl/ROCmQuantizeOp.cc
+++ b/src/fastertransformer/devices/rocm_impl/ROCmQuantizeOp.cc
@@ -1,7 +1,7 @@
 #include "src/fastertransformer/devices/rocm_impl/ROCmDevice.h"
 #include "src/fastertransformer/cuda/Dispatch.h"
 #include "src/fastertransformer/rocm/quantizePreprocessors.h"
-#include "src/fastertransformer/kernels/quantization_tensor.h"
+#include "src/fastertransformer/kernels/rocm/quantization_rocm.h"
 
 using namespace std;
 namespace fastertransformer {
@@ -17,14 +17,7 @@ inline rocm::QuantType quantTypeConvert(DataType dtype) {
         }
     }
 }
-/**
- *  Symmetric Per Channle
- *  Inputs: kernel、 scales（optional）、quantType
- *  Limits：kernel（2D、3D）scales（1D）、quantType（int8、int4x2）
- *  Outputs: QBuffer(kernel, scales, zeros(empty))
- *  note：if scales is null, compute scales
- *
- * **/
+
 BufferPtr ROCmDevice::quantize(const QuantizeParams& params) {
     FT_CHECK_WITH_INFO((params.input.type() == DataType::TYPE_FP16 || params.input.type() == DataType::TYPE_FP32
                         || params.input.type() == DataType::TYPE_BF16),
@@ -39,84 +32,75 @@ BufferPtr ROCmDevice::quantize(const QuantizeParams& params) {
 
     FT_CHECK_WITH_INFO((params.axis == (params.input.dim() - 1)), "quantize only support last axis.");
 
-    if (params.input.where() == MemoryType::MEMORY_CPU) {
-        FT_LOG_INFO("cpu quantize");
-        size_t axis   = params.input.dim() - 1;
-        auto   scales = allocateBuffer(
-            {DataType::TYPE_FP16, {params.input.shape()[axis]}, getMemAllocationType(params.input.where())},
-            {"scales"});
-
-        auto kernel = allocateBuffer(
-            {DataType::TYPE_INT8, params.input.shape(), getMemAllocationType(params.input.where())}, {"kernel"});
-        // TODO(lidongjin) The dispatch maro only support multi template type but without data cast,
-        // or one template type with data cast, here need multi template type with data cast.
-        if (params.input.type() == DataType::TYPE_FP16) {
-            rocm::symmetric_quantize(kernel->data<int8_t>(),
-                                     nullptr,
-                                     scales->data<half>(),
-                                     params.input.data<half>(),
-                                     params.input.shape(),
-                                     quantTypeConvert(params.qtype));
-        } else if (params.input.type() == DataType::TYPE_FP32) {
-            rocm::symmetric_quantize(kernel->data<int8_t>(),
-                                     nullptr,
-                                     scales->data<half>(),
-                                     params.input.data<float>(),
-                                     params.input.shape(),
-                                     quantTypeConvert(params.qtype));
-        } else {
-            FT_CHECK_WITH_INFO(false, "ERROR data type [%d] for  quantize input.", params.input.type());
-        }
-
-        return BufferPtr(new QBuffer(
-            std::move(kernel),
-            std::move(scales),
-            std::move(BufferPtr(new Buffer(MemoryType::MEMORY_CPU_PINNED, DataType::TYPE_INVALID, {0}, nullptr)))));
-    } else if (params.input.where() == MemoryType::MEMORY_GPU) {
+    if (params.input.where() == MemoryType::MEMORY_GPU) {
         FT_CHECK_WITH_INFO((params.input.dim() == 2), "quantize only support 2D input.");
-        auto scales = allocateBuffer(
-            {DataType::TYPE_FP16, {params.input.shape()[1]}, getMemAllocationType(params.input.where())}, {"scales"});
+        size_t groupSize   = params.groupSize;
+        size_t scales_dim0 = params.input.shape()[0] / groupSize;
 
         auto kernel =
             allocateBuffer({params.qtype == DataType::TYPE_QINT8 ? DataType::TYPE_INT8 : DataType::TYPE_INT4X2,
                             params.input.shape(),
                             getMemAllocationType(params.input.where())},
                            {"kernel"});
+        auto scales = allocateBuffer(
+            {DataType::TYPE_FP16, {scales_dim0, params.input.shape()[1]}, getMemAllocationType(params.input.where())},
+            {"scales"});
+        auto zeros = allocateBuffer(
+            {DataType::TYPE_FP16, {scales_dim0, params.input.shape()[1]}, getMemAllocationType(params.input.where())},
+            {"zeros"});
 
-        if (params.qtype == DataType::TYPE_QINT8) {
-            DISPATCH_CUDA_FUNCTION_DATA_TYPE(
-                params.input.type(),
-                invokePerColQuantizationInt8,
-                kernel->data<int8_t>(),
-                params.input.data(),
-                params.input.shape()[0],
-                params.input.shape()[1],
-                scales->data<half>(),
-                params.smoother.has_value() ? params.smoother.value().get().data<float>() : nullptr,
-                params.shift.has_value() ? params.shift.value().get().data<float>() : nullptr,
-                stream_);
-        } else if (params.qtype == DataType::TYPE_QINT4X2) {
-            DISPATCH_CUDA_FUNCTION_DATA_TYPE(
-                params.input.type(),
-                invokePerColQuantizationInt4x2,
-                (int8_t*)(kernel->data()),
-                params.input.data(),
-                params.input.shape()[0],
-                params.input.shape()[1],
-                scales->data<half>(),
-                params.smoother.has_value() ? params.smoother.value().get().data<float>() : nullptr,
-                params.shift.has_value() ? params.shift.value().get().data<float>() : nullptr,
-                stream_);
+        if (params.qtype == DataType::TYPE_QINT4X2) {
+            DISPATCH_CUDA_FUNCTION_DATA_TYPE(params.input.type(),
+                                             invokePerColQuantizationInt4x2,
+                                             params.input.data(),
+                                             params.input.shape()[0],
+                                             params.input.shape()[1],
+                                             groupSize,
+                                             (uint8_t*)(kernel->data()),
+                                             scales->data<half>(),
+                                             zeros->data<half>(),
+                                             stream_);
+        } else {
+            FT_FAIL("other quantize not implemented");
         }
 
         sync_check_cuda_error();
-        return BufferPtr(new QBuffer(
-            std::move(kernel),
-            std::move(scales),
-            std::move(BufferPtr(new Buffer(MemoryType::MEMORY_GPU, DataType::TYPE_INVALID, {0}, nullptr)))));
+        return BufferPtr(new QBuffer(std::move(kernel), std::move(scales), std::move(zeros)));
 
     } else {
-        FT_FAIL("other device not implemented");
+        FT_FAIL("cpu quantize not implemented");
+    }
+}
+
+BufferPtr ROCmDevice::dequantize(const QuantizeParams& params) {
+    if (params.input.where() == MemoryType::MEMORY_GPU) {
+        if (params.qtype == DataType::TYPE_QINT4X2) {
+            const QBuffer& QB          = reinterpret_cast<const QBuffer&>(params.input);
+            size_t         kernel_dim0 = QB.kernel().shape()[0];
+            size_t         scales_dim0 = QB.scales().shape()[0];
+            size_t         group_size  = (kernel_dim0 / scales_dim0);
+
+            BufferPtr fpB =
+                allocateBuffer({QB.scales().type(), {QB.kernel().shape()}, AllocationType::DEVICE}, {"fpB"});
+
+            DISPATCH_CUDA_FUNCTION_DATA_TYPE(fpB.get()->type(),
+                                             invokePerColDequantizationInt4x2,
+                                             fpB.get()->data(),
+                                             (size_t)(QB.kernel().shape()[0]),
+                                             (size_t)(QB.kernel().shape()[1]),
+                                             group_size,
+                                             (int8_t*)(QB.kernel().data()),
+                                             QB.scales().data<half>(),
+                                             QB.zeros().data<half>(),
+                                             stream_);
+
+            sync_check_cuda_error();
+            return fpB;
+        } else {
+            FT_FAIL("other dequantize not implemented");
+        }
+    } else {
+        FT_FAIL("cpu dequantize not implemented");
     }
 }
 

--- a/src/fastertransformer/devices/rocm_impl/test/BUILD
+++ b/src/fastertransformer/devices/rocm_impl/test/BUILD
@@ -51,7 +51,7 @@ cc_test(
 cc_test(
     name = "gemm_op_test",
     srcs = [
-        "ROCmGemmOpTest.cc",
+        "ops/ROCmGemmOpTest.cc",
     ],
     data = [],
     env = device_test_envs(),

--- a/src/fastertransformer/kernels/BUILD
+++ b/src/fastertransformer/kernels/BUILD
@@ -11,6 +11,7 @@ cc_library(
         "activation_fp8_kernels.cu",
         "unfused_attention_fp8_kernels.cu",
         "moe_kernels.cu",
+        "rocm/*.cu",
     ]),
     hdrs = glob([
         "*.h",
@@ -21,6 +22,7 @@ cc_library(
     ], exclude=[
         "AttentionFP8Weight.h",
         "moe_kernels.h",
+        "rocm/*.h",
     ]),
     deps = [
         "//src/fastertransformer/cuda:memory_utils",
@@ -85,7 +87,7 @@ cc_library(
         "sampling_penalty_kernels.cu",
         "custom_ar_kernels.cu",
         "decoder_masked_multihead_attention.cu",
-        "quantization_tensor.cu",
+        "rocm/quantization_rocm.cu",
     ]+glob([
         "decoder_masked_multihead_attention/*.cu",
     ]),
@@ -119,7 +121,7 @@ cc_library(
         "penalty_types.h",
         "decoder_masked_multihead_attention.h",
         "custom_ar_kernels.h",
-        "quantization_tensor.h",
+        "rocm/quantization_rocm.h",
     ] + glob([
         "decoder_masked_multihead_attention/*.h",
     ]),

--- a/src/fastertransformer/kernels/quantization_tensor.cu
+++ b/src/fastertransformer/kernels/quantization_tensor.cu
@@ -15,56 +15,54 @@
  */
 
 #include "src/fastertransformer/utils/assert_utils.h"
-#include "src/fastertransformer/kernels/quantization_tensor.h"
-#include "src/fastertransformer/kernels/reduce_kernel_utils.cuh"
-#if USING_CUDA
 #include "src/fastertransformer/cuda/cuda_type_utils.cuh"
 #include "src/fastertransformer/cuda/cuda_utils.h"
-#endif
-#if USING_ROCM
-#include "src/fastertransformer/rocm/hip_utils.h"
-#endif
+#include "src/fastertransformer/kernels/reduce_kernel_utils.cuh"
+#include "src/fastertransformer/kernels/quantization_tensor.h"
 
-namespace fastertransformer {
-#if USING_ROCM
-using namespace rocm;
-#endif
+namespace fastertransformer
+{
 
-__global__ void quantizedKernel(char4* dst, const float4* src, const int64_t sizeDiv4, const float* scalePtr) {
-    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x) {
-        const float  scale = __ldg(scalePtr);
-        char4        tmp;
-        const float4 floatTmp = __ldg(src + idx);
-        tmp.x                 = cuda_cast<int8_t>(floatTmp.x * scale);
-        tmp.y                 = cuda_cast<int8_t>(floatTmp.y * scale);
-        tmp.z                 = cuda_cast<int8_t>(floatTmp.z * scale);
-        tmp.w                 = cuda_cast<int8_t>(floatTmp.w * scale);
-        dst[idx]              = tmp;
-    }
-}
-
-__global__ void quantizedKernel(char4* dst, const half2* src, const int64_t sizeDiv4, const float* scalePtr) {
-    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x) {
+__global__ void quantizedKernel(char4* dst, const float4* src, const int64_t sizeDiv4, const float* scalePtr)
+{
+    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x)
+    {
         const float scale = __ldg(scalePtr);
-        char4       tmp;
-        int         srcId = idx << 1;
-
-        const uint2 h2 = __ldg(reinterpret_cast<const uint2*>(src + srcId));
-
-        const half2 half2Tmp  = reinterpret_cast<const half2&>(h2.x);
-        const half2 half2Tmp2 = reinterpret_cast<const half2&>(h2.y);
-
-        tmp.x    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.x) * scale);
-        tmp.y    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.y) * scale);
-        tmp.z    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.x) * scale);
-        tmp.w    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.y) * scale);
+        char4 tmp;
+        const float4 floatTmp = __ldg(src + idx);
+        tmp.x = cuda_cast<int8_t>(floatTmp.x * scale);
+        tmp.y = cuda_cast<int8_t>(floatTmp.y * scale);
+        tmp.z = cuda_cast<int8_t>(floatTmp.z * scale);
+        tmp.w = cuda_cast<int8_t>(floatTmp.w * scale);
         dst[idx] = tmp;
     }
 }
 
-template<typename T>
+__global__ void quantizedKernel(char4* dst, const half2* src, const int64_t sizeDiv4, const float* scalePtr)
+{
+    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x)
+    {
+        const float scale = __ldg(scalePtr);
+        char4 tmp;
+        int srcId = idx << 1;
+
+        const uint2 h2 = __ldg(reinterpret_cast<const uint2*>(src + srcId));
+
+        const half2 half2Tmp = reinterpret_cast<const half2&>(h2.x);
+        const half2 half2Tmp2 = reinterpret_cast<const half2&>(h2.y);
+
+        tmp.x = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.x) * scale);
+        tmp.y = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.y) * scale);
+        tmp.z = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.x) * scale);
+        tmp.w = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.y) * scale);
+        dst[idx] = tmp;
+    }
+}
+
+template <typename T>
 void invokeQuantization(
-    int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize) {
+    int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize)
+{
     FT_CHECK_WITH_INFO(size % 4 == 0, "[ERROR][invokeQuantization] size should be a multiple of 4.\n");
 
     int numBlocks{static_cast<int>((size + 255) / 256)};
@@ -74,16 +72,19 @@ void invokeQuantization(
     dim3 grid(std::min(numBlocks, maxGridSize));
     FT_CHECK_WITH_INFO(grid.x <= maxGridSize, "[ERROR][invokeQuantization] grid max size is exceeded\n");
     dim3 block(64);
-    if (std::is_same_v<T, float>) {
-        quantizedKernel<<<grid, block, 0, stream>>>((char4*)dst, (const float4*)src, size / 4, scalePtr);
-    } else if (std::is_same_v<T, half>) {
-        quantizedKernel<<<grid, block, 0, stream>>>((char4*)dst, (const half2*)src, size / 4, scalePtr);
+    if (std::is_same_v<T, float>)
+    {
+        quantizedKernel<<<grid, block, 0, stream>>>((char4*) dst, (const float4*) src, size / 4, scalePtr);
+    }
+    else if (std::is_same_v<T, half>)
+    {
+        quantizedKernel<<<grid, block, 0, stream>>>((char4*) dst, (const half2*) src, size / 4, scalePtr);
     }
 }
 
-#define INSTANTIATE_INVOKE_QUANTIZATION(T)                                                                             \
-    template void invokeQuantization(                                                                                  \
-        int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize);
+#define INSTANTIATE_INVOKE_QUANTIZATION(T)                                                                        \
+template void invokeQuantization(                                                                                 \
+    int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize);
 
 INSTANTIATE_INVOKE_QUANTIZATION(float);
 INSTANTIATE_INVOKE_QUANTIZATION(half);
@@ -91,94 +92,78 @@ INSTANTIATE_INVOKE_QUANTIZATION(half);
 INSTANTIATE_INVOKE_QUANTIZATION(__nv_bfloat16);
 #endif
 
-template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
-__global__ void perTokenQuantization(int8_t*       dst,
-                                     const T*      src,
-                                     const int64_t numRows,
-                                     const int64_t numCols,
-                                     float*        scalePtr,
-                                     const float*  smoother,
-                                     const float*  shift) {
+template <typename T, bool IS_SMOOTHER, bool IS_SHIFT>
+__global__ void perTokenQuantization(
+    int8_t* dst, const T* src, const int64_t numRows, const int64_t numCols, float* scalePtr, const float* smoother, const float* shift)
+{
     const T* srcRow = src + blockIdx.x * numCols;
-    int8_t*  dstRow = dst + blockIdx.x * numCols;
+    int8_t* dstRow = dst + blockIdx.x * numCols;
 
     T localMax = 1e-6f;
-    for (int i = threadIdx.x; i < numCols; i += blockDim.x) {
+    for (int i = threadIdx.x; i < numCols; i += blockDim.x)
+    {
         T val = srcRow[i];
-        if (IS_SMOOTHER) {
+        if(IS_SMOOTHER){
             val = cuda_cast<T>(val / cuda_cast<T>(smoother[i]));
         }
-        if (IS_SHIFT) {
+        if(IS_SHIFT){
             val = cuda_cast<T>(val + cuda_cast<T>(shift[i]));
         }
         localMax = cuda_max(localMax, cuda_abs(val));
     }
     const float rowMax = blockAllReduceMax(cuda_cast<float>(localMax));
 
-    if (threadIdx.x == 0) {
+    if (threadIdx.x == 0)
+    {
         scalePtr[blockIdx.x] = rowMax / 127.f;
     }
 
     const float scaleOrigQuant = 127.f / rowMax;
-    for (int i = threadIdx.x; i < numCols; i += blockDim.x) {
+    for (int i = threadIdx.x; i < numCols; i += blockDim.x)
+    {
         T val = srcRow[i];
-        if (IS_SMOOTHER) {
+        if(IS_SMOOTHER){
             val = val / cuda_cast<T>(smoother[i]);
         }
-        if (IS_SHIFT) {
+        if(IS_SHIFT){
             val = cuda_cast<T>(val + cuda_cast<T>(shift[i]));
         }
         dstRow[i] = cuda_cast<int8_t>(cuda_cast<float>(val) * scaleOrigQuant);
     }
 }
 
-template<typename T, bool IS_SMOOTHER>
-void dispatch_per_token_quantization_shift(int8_t*       dst,
-                                           const T*      src,
-                                           const int64_t numRows,
-                                           const int64_t numCols,
-                                           float*        scalePtr,
-                                           const float*  smoother,
-                                           const float*  shift,
-                                           cudaStream_t  stream) {
+template <typename T, bool IS_SMOOTHER>
+void dispatch_per_token_quantization_shift(
+    int8_t* dst, const T* src, const int64_t numRows, const int64_t numCols, float* scalePtr, const float* smoother, const float* shift, cudaStream_t stream)
+{
     // each block is responsible for a single row
     const dim3 block(512);
     const dim3 grid(numRows);
 
-    if (shift != nullptr) {
-        perTokenQuantization<T, IS_SMOOTHER, true>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
-    } else {
-        perTokenQuantization<T, IS_SMOOTHER, false>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
+    if(shift != nullptr){
+        perTokenQuantization<T, IS_SMOOTHER, true><<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
+    }
+    else{
+        perTokenQuantization<T, IS_SMOOTHER, false><<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
     }
 }
 
 template<typename T>
-void invokePerTokenQuantization(int8_t*       dst,
-                                const T*      src,
-                                const int64_t numRows,
-                                const int64_t numCols,
-                                float*        scalePtr,
-                                const float*  smoother,
-                                const float*  shift,
-                                cudaStream_t  stream) {
-    if (smoother != nullptr) {
+void invokePerTokenQuantization(
+    int8_t* dst, const T* src, const int64_t numRows, const int64_t numCols, float* scalePtr, const float* smoother, const float* shift, cudaStream_t stream)
+{
+    if(smoother != nullptr){
         dispatch_per_token_quantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
-    } else {
+    }
+    else{
         dispatch_per_token_quantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
     }
+
 }
 
 #define INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(T)                                                                   \
-    template void invokePerTokenQuantization(int8_t*       dst,                                                        \
-                                             const T*      src,                                                        \
-                                             const int64_t numRows,                                                    \
-                                             const int64_t numCols,                                                    \
-                                             float*        scalePtr,                                                   \
-                                             const float*  smoother,                                                   \
-                                             const float*  shift,                                                      \
-                                             cudaStream_t  stream)
+    template void invokePerTokenQuantization(                                                                          \
+        int8_t* dst, const T* src, const int64_t numRows, const int64_t numCols, float* scalePtr, const float* smoother, const float* shift, cudaStream_t stream)
 
 INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(float);
 INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(half);
@@ -186,434 +171,4 @@ INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(half);
 INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(__nv_bfloat16);
 #endif
 
-/////////////////////////////////////////////////////////////////////////////////////////////////
-// int8 col quant ///////////////////////////////////////////////////////////////////////////////
-template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
-__global__ void perColQuantization(int8_t*       dst,
-                                   const T*      src,
-                                   const int64_t numRows,
-                                   const int64_t numCols,
-                                   half*         scalePtr,
-                                   const float*  smoother,
-                                   const float*  shift,
-                                   float*        dbgfp  = nullptr,
-                                   int*          dbgint = nullptr) {
-    uint32_t colIdx = blockIdx.x;
-    const T* srcCol = src + colIdx;
-    int8_t*  dstCol = dst + colIdx;
-
-    T localMax = 1e-6f;
-    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
-        T val = srcCol[rowIdx * numCols];
-        if (IS_SMOOTHER) {
-            val = cuda_cast<T>(val / cuda_cast<T>(smoother[rowIdx]));
-        }
-        if (IS_SHIFT) {
-            val = cuda_cast<T>(val + cuda_cast<T>(shift[rowIdx]));
-        }
-        localMax = cuda_max(localMax, cuda_abs(val));
-    }
-    const float colMax = blockAllReduceMax(cuda_cast<float>(localMax));
-
-    if (threadIdx.x == 0) {
-        scalePtr[colIdx] = cuda_cast<half>(colMax / 128.f);
-    }
-
-    const float scaleOrigQuant = 128.f / colMax;
-    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
-        T val = srcCol[rowIdx * numCols];
-        if (IS_SMOOTHER) {
-            val = val / cuda_cast<T>(smoother[rowIdx]);
-        }
-        if (IS_SHIFT) {
-            val = cuda_cast<T>(val + cuda_cast<T>(shift[rowIdx]));
-        }
-        dstCol[rowIdx * numCols] = cuda_cast<int8_t>(cuda_cast<float>(val) * scaleOrigQuant);
-    }
-}
-
-template<typename T, bool IS_SMOOTHER>
-void dispatch_per_col_quantization_shift(int8_t*       dst,
-                                         const T*      src,
-                                         const int64_t numRows,
-                                         const int64_t numCols,
-                                         half*         scalePtr,
-                                         const float*  smoother,
-                                         const float*  shift,
-                                         cudaStream_t  stream) {
-    // each block is responsible for a single row
-    const dim3 block(512);
-    const dim3 grid(numCols);
-
-    if (shift != nullptr) {
-        perColQuantization<T, IS_SMOOTHER, true>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
-    } else {
-        perColQuantization<T, IS_SMOOTHER, false>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
-    }
-}
-
-template<typename T>
-void invokePerColQuantizationInt8(int8_t*       dst,
-                                  const T*      src,
-                                  const int64_t numRows,
-                                  const int64_t numCols,
-                                  half*         scalePtr,
-                                  const float*  smoother,
-                                  const float*  shift,
-                                  cudaStream_t  stream) {
-    if (smoother != nullptr) {
-        dispatch_per_col_quantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
-    } else {
-        dispatch_per_col_quantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
-    }
-}
-
-#define INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(T)                                                                \
-    template void invokePerColQuantizationInt8(int8_t*       dst,                                                      \
-                                               const T*      src,                                                      \
-                                               const int64_t numRows,                                                  \
-                                               const int64_t numCols,                                                  \
-                                               half*         scalePtr,                                                 \
-                                               const float*  smoother,                                                 \
-                                               const float*  shift,                                                    \
-                                               cudaStream_t  stream)
-
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(float);
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(__nv_bfloat16);
-#endif
-
-/////////////////////////////////////////////////////////////////////////////////////////////////
-// int8 col dequant /////////////////////////////////////////////////////////////////////////////
-template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
-__global__ void perColDequantization(T*            dst,
-                                     const int8_t* src,
-                                     const int64_t numRows,
-                                     const int64_t numCols,
-                                     const half*   scalePtr,
-                                     const float*  smoother,
-                                     const float*  shift,
-                                     float*        dbgfp  = nullptr,
-                                     int*          dbgint = nullptr) {
-    uint32_t      colIdx = blockIdx.x;
-    const int8_t* srcRow = src + colIdx;
-    T*            dstRow = dst + colIdx;
-
-    float scaleOrigQuant = cuda_cast<float>(scalePtr[colIdx]);
-    if (IS_SMOOTHER) {
-        scaleOrigQuant = scaleOrigQuant * smoother[colIdx];
-    }
-    if (IS_SHIFT) {
-        scaleOrigQuant = scaleOrigQuant - shift[colIdx];
-    }
-
-    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
-        uint8_t tmpi8 = srcRow[rowIdx * numCols];
-
-        T val = cuda_cast<T>(cuda_cast<float>(tmpi8) * scaleOrigQuant);
-
-        if (IS_SMOOTHER) {
-            val = val * cuda_cast<T>(smoother[rowIdx]);
-        }
-        if (IS_SHIFT) {
-            val = cuda_cast<T>(val - cuda_cast<T>(shift[rowIdx]));
-        }
-
-        dstRow[rowIdx * numCols] = val;
-    }
-}
-
-template<typename T, bool IS_SMOOTHER>
-void dispatch_per_col_dequantization_shift(T*            dst,
-                                           const int8_t* src,
-                                           const int64_t numRows,
-                                           const int64_t numCols,
-                                           half*         scalePtr,
-                                           const float*  smoother,
-                                           const float*  shift,
-                                           cudaStream_t  stream) {
-    // each block is responsible for a single col
-    const dim3 block(512);
-    const dim3 grid(numCols);
-
-    if (shift != nullptr) {
-        perColDequantization<T, IS_SMOOTHER, true>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
-    } else {
-        perColDequantization<T, IS_SMOOTHER, false>
-            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
-    }
-}
-
-template<typename T>
-void invokePerColDequantizationInt8(T*            dst,
-                                    const int8_t* src,
-                                    const int64_t numRows,
-                                    const int64_t numCols,
-                                    half*         scalePtr,
-                                    const float*  smoother,
-                                    const float*  shift,
-                                    cudaStream_t  stream) {
-    if (smoother != nullptr) {
-        dispatch_per_col_dequantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
-    } else {
-        dispatch_per_col_dequantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
-    }
-}
-
-#define INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(T)                                                              \
-    template void invokePerColDequantizationInt8(T*            dst,                                                    \
-                                                 const int8_t* src,                                                    \
-                                                 const int64_t numRows,                                                \
-                                                 const int64_t numCols,                                                \
-                                                 half*         scalePtr,                                               \
-                                                 const float*  smoother,                                               \
-                                                 const float*  shift,                                                  \
-                                                 cudaStream_t  stream)
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(float);
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(__nv_bfloat16);
-#endif
-
-/////////////////////////////////////////////////////////////////////////////////////////////////
-// int4 col quant ///////////////////////////////////////////////////////////////////////////////
-template<typename T>
-__global__ void perColQuantization(char4*        dst,
-                                   const T*      src,
-                                   const int64_t numRows,
-                                   const int64_t numCols,
-                                   const int64_t numColsBlk,
-                                   half*         scalePtr,
-                                   const float*  smoother,
-                                   const float*  shift,
-                                   float*        dbgfp  = nullptr,
-                                   int*          dbgint = nullptr) {
-    uint8_t* pDst      = (uint8_t*)dst;
-    uint32_t colBlkIdx = blockIdx.x;
-    const T* srcCol    = src + colBlkIdx * numColsBlk;
-    uint8_t* dstCol    = pDst + colBlkIdx * numColsBlk / 2;
-
-    T localMax = 1e-6f;
-    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
-        for (int colInBlkIdx = 0; colInBlkIdx < numColsBlk; colInBlkIdx++) {
-            T val = srcCol[rowIdx * numCols + colInBlkIdx];
-
-            localMax = cuda_max(localMax, cuda_abs(val));
-        }
-    }
-    const float colBlkMax = blockAllReduceMax(cuda_cast<float>(localMax));
-
-    if (threadIdx.x == 0) {
-        scalePtr[colBlkIdx] = colBlkMax / 8.0f;
-    }
-
-    const float scaleOrigQuant = 8.f / colBlkMax;
-    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
-        // one loop process 2 cols of intput, and 1 col of uint8_t output
-        for (int colInBlkIdx = 0; colInBlkIdx < numColsBlk / 2; colInBlkIdx++) {
-            T vall = srcCol[rowIdx * numCols + colInBlkIdx * 2];
-            T valh = srcCol[rowIdx * numCols + colInBlkIdx * 2 + 1];
-
-            int8_t tmpi8l = cuda_cast<int8_t>(cuda_cast<float>(vall) * scaleOrigQuant);
-            int8_t tmpi8h = cuda_cast<int8_t>(cuda_cast<float>(valh) * scaleOrigQuant);
-            int8_t tmpi4l = tmpi8l & 0x0F;
-            int8_t tmpi4h = tmpi8h & 0x0F;
-
-            uint8_t tmpuint = tmpi4l;
-            tmpuint         = tmpuint << 4;
-            tmpuint         = tmpuint | tmpi4h;
-
-            dstCol[rowIdx * numCols / 2 + colInBlkIdx] = tmpuint;
-        }
-    }
-}
-
-template<typename T>
-void invokePerColQuantizationInt4x2(int8_t*       dst,
-                                    const T*      src,
-                                    const int64_t numRows,
-                                    const int64_t numCols,
-                                    half*         scalePtr,
-                                    const float*  smoother,
-                                    const float*  shift,
-                                    cudaStream_t  stream) {
-
-    const int colBlk = 2;
-    assert(colBlk % 2 == 0);
-    assert(numCols % colBlk == 0);
-
-    const dim3 block(512);
-    const dim3 grid(numCols / colBlk);
-
-    // perColQuantization<T>
-    //     <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, colBlk, scalePtr, smoother, nullptr);
-}
-
-#define INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(T)                                                              \
-    template void invokePerColQuantizationInt4x2(int8_t*       dst,                                                    \
-                                                 const T*      src,                                                    \
-                                                 const int64_t numRows,                                                \
-                                                 const int64_t numCols,                                                \
-                                                 half*         scalePtr,                                               \
-                                                 const float*  smoother,                                               \
-                                                 const float*  shift,                                                  \
-                                                 cudaStream_t  stream)
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(float);
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(__nv_bfloat16);
-#endif
-
-/////////////////////////////////////////////////////////////////////////////////////////////////
-// int4 col dequant /////////////////////////////////////////////////////////////////////////////
-template<typename T>
-__global__ void perColDequantization(T*            dst,
-                                     const char4*  src,
-                                     const int64_t numRows,
-                                     const int64_t numCols,
-                                     const half*   scalePtr,
-                                     const half*   zerosPtr,
-                                     const int64_t groupSize,
-                                     float*        dbgfp  = nullptr,
-                                     int*          dbgint = nullptr) {
-    const uint8_t* pSrc      = (const uint8_t*)src;
-    uint32_t       colPckIdx = blockIdx.y;
-    uint32_t       rowBlkIdx = blockIdx.x;
-
-    float scalel = cuda_cast<float>(scalePtr[rowBlkIdx * numCols + colPckIdx * 2 + 0]);
-    float scaleh = cuda_cast<float>(scalePtr[rowBlkIdx * numCols + colPckIdx * 2 + 1]);
-    float zerosl = cuda_cast<float>(zerosPtr[rowBlkIdx * numCols + colPckIdx * 2 + 0]);
-    float zerosh = cuda_cast<float>(zerosPtr[rowBlkIdx * numCols + colPckIdx * 2 + 1]);
-
-    uint8_t tmpu8 = pSrc[(groupSize * rowBlkIdx + threadIdx.x) * numCols / 2 + colPckIdx];
-
-    uint8_t tmpu4l = tmpu8 & 0x0F;
-    uint8_t tmpu4h = (tmpu8 >> 4) & 0x0F;
-
-    if (tmpu4l & 0x08)
-        tmpu4l |= 0xF0;
-    if (tmpu4h & 0x08)
-        tmpu4h |= 0xF0;
-    int8_t tmpi4l = tmpu4l;
-    int8_t tmpi4h = tmpu4h;
-
-    float tmpfpl = cuda_cast<float>(tmpi4l);
-    float tmpfph = cuda_cast<float>(tmpi4h);
-
-    T vall = cuda_cast<T>(tmpfpl * scalel + zerosl);
-    T valh = cuda_cast<T>(tmpfph * scaleh + zerosh);
-
-    dst[(groupSize * rowBlkIdx + threadIdx.x) * numCols + colPckIdx * 2 + 0] = vall;
-    dst[(groupSize * rowBlkIdx + threadIdx.x) * numCols + colPckIdx * 2 + 1] = valh;
-}
-
-template<typename T>
-void invokePerColDequantizationInt4x2(T*            dst,
-                                      const int8_t* src,
-                                      const int64_t numRows,
-                                      const int64_t numCols,
-                                      half*         scalePtr,
-                                      half*         zerosPtr,
-                                      const int64_t groupSize,
-                                      cudaStream_t  stream) {
-    const dim3 block(groupSize);
-    const dim3 grid(numRows / groupSize, numCols / 2, 1);
-
-    perColDequantization<T>
-        <<<grid, block, 0, stream>>>(dst, (char4*)src, numRows, numCols, scalePtr, zerosPtr, groupSize);
-}
-
-#define INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(T)                                                            \
-    template void invokePerColDequantizationInt4x2(T*            dst,                                                  \
-                                                   const int8_t* src,                                                  \
-                                                   const int64_t numRows,                                              \
-                                                   const int64_t numCols,                                              \
-                                                   half*         scalePtr,                                             \
-                                                   half*         zerosPtr,                                             \
-                                                   const int64_t groupSize,                                            \
-                                                   cudaStream_t  stream)
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(float);
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(__nv_bfloat16);
-#endif
-
-/////////////////////////////////////////////////////////////////////////////////////////////////
-// int4 row dequant /////////////////////////////////////////////////////////////////////////////
-template<typename T>
-__global__ void perRowDequantization(T*            dst,
-                                     const char4*  src,
-                                     const int64_t numRows,
-                                     const int64_t numCols,
-                                     const half*   scalePtr,
-                                     const half*   zerosPtr,
-                                     const int64_t groupSize,
-                                     float*        dbgfp  = nullptr,
-                                     int*          dbgint = nullptr) {
-    const uint8_t* pSrc      = (const uint8_t*)src;
-    uint32_t       rowIdx    = blockIdx.y;
-    uint32_t       colGrpIdx = blockIdx.x;
-    uint32_t       colGrpNum = numCols / groupSize;
-
-    float scale = cuda_cast<float>(scalePtr[rowIdx * colGrpNum + colGrpIdx]);
-    float zeros = cuda_cast<float>(zerosPtr[rowIdx * colGrpNum + colGrpIdx]);
-    // scale = 1.0f;
-    // zeros = 0;
-
-    uint8_t tmpu8 = pSrc[rowIdx * numCols / 2 + colGrpIdx * groupSize / 2 + threadIdx.x];
-
-    uint8_t tmpu4l = tmpu8 & 0x0F;
-    uint8_t tmpu4h = (tmpu8 >> 4) & 0x0F;
-
-    if (tmpu4l & 0x08)
-        tmpu4l |= 0xF0;
-    if (tmpu4h & 0x08)
-        tmpu4h |= 0xF0;
-    int8_t tmpi4l = tmpu4l;
-    int8_t tmpi4h = tmpu4h;
-
-    float tmpfpl = cuda_cast<float>(tmpi4l);
-    float tmpfph = cuda_cast<float>(tmpi4h);
-
-    T vall = cuda_cast<T>(tmpfpl * scale);
-    T valh = cuda_cast<T>(tmpfph * scale);
-
-    dst[rowIdx * numCols + colGrpIdx * groupSize + threadIdx.x * 2 + 0] = vall;
-    dst[rowIdx * numCols + colGrpIdx * groupSize + threadIdx.x * 2 + 1] = valh;
-}
-
-template<typename T>
-void invokePerRowDequantizationInt4x2(T*            dst,
-                                      const int8_t* src,
-                                      const int64_t numRows,
-                                      const int64_t numCols,
-                                      half*         scalePtr,
-                                      half*         zerosPtr,
-                                      const int64_t groupSize,
-                                      cudaStream_t  stream) {
-    const dim3 block(groupSize / 2);
-    const dim3 grid(numCols / groupSize, numRows, 1);
-
-    perRowDequantization<T>
-        <<<grid, block, 0, stream>>>(dst, (char4*)src, numRows, numCols, scalePtr, zerosPtr, groupSize);
-}
-
-#define INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(T)                                                            \
-    template void invokePerRowDequantizationInt4x2(T*            dst,                                                  \
-                                                   const int8_t* src,                                                  \
-                                                   const int64_t numRows,                                              \
-                                                   const int64_t numCols,                                              \
-                                                   half*         scalePtr,                                             \
-                                                   half*         zerosPtr,                                             \
-                                                   const int64_t groupSize,                                            \
-                                                   cudaStream_t  stream)
-INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(float);
-INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(half);
-#ifdef ENABLE_BF16
-INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(__nv_bfloat16);
-#endif
-}  // namespace fastertransformer
+} 

--- a/src/fastertransformer/kernels/quantization_tensor.h
+++ b/src/fastertransformer/kernels/quantization_tensor.h
@@ -15,74 +15,18 @@
  */
 #pragma once
 
-#if USING_CUDA
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
-#endif
-
-#if USING_ROCM
-#include "src/fastertransformer/rocm/cuda_shims.h"
-#include "src/fastertransformer/cuda/cuda_type_utils.cuh"
-#endif
 
 namespace fastertransformer
 {
-#if USING_CUDA
+
 template <typename T>
 void invokeQuantization(
     int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream = 0, int maxGirdSize = 0);
-#endif
+
 template <typename T>
 void invokePerTokenQuantization(
     int8_t* dst, const T* src, const int64_t numRows, const int64_t numCols, float* scalePtr, const float* smoother,  const float* shift, cudaStream_t stream = 0);
 
-template<typename T>
-void invokePerColQuantizationInt8(int8_t*       dst,
-                                  const T*      src,
-                                  const int64_t numRows,
-                                  const int64_t numCols,
-                                  half*         scalePtr,
-                                  const float*  smoother,
-                                  const float*  shift,
-                                  cudaStream_t  stream = 0);
-
-template<typename T>
-void invokePerColDequantizationInt8(T*            dst,
-                                    const int8_t* src,
-                                    const int64_t numRows,
-                                    const int64_t numCols,
-                                    half*         scalePtr,
-                                    const float*  smoother,
-                                    const float*  shift,
-                                    cudaStream_t  stream = 0);
-
-template<typename T>
-void invokePerColQuantizationInt4x2(int8_t*       dst,
-                                    const T*      src,
-                                    const int64_t numRows,
-                                    const int64_t numCols,
-                                    half*         scalePtr,
-                                    const float*  smoother,
-                                    const float*  shift,
-                                    cudaStream_t  stream = 0);
-
-template<typename T>
-void invokePerColDequantizationInt4x2(T*            dst,
-                                      const int8_t* src,
-                                      const int64_t numRows,
-                                      const int64_t numCols,
-                                      half*         scalePtr,
-                                      half*         zerosPtr,
-                                      const int64_t groupSize,
-                                      cudaStream_t  stream = 0);
-
-template<typename T>
-void invokePerRowDequantizationInt4x2(T*            dst,
-                                      const int8_t* src,
-                                      const int64_t numRows,
-                                      const int64_t numCols,
-                                      half*         scalePtr,
-                                      half*         zerosPtr,
-                                      const int64_t groupSize,
-                                      cudaStream_t  stream = 0);                                      
 }

--- a/src/fastertransformer/kernels/rocm/quantization_rocm.cu
+++ b/src/fastertransformer/kernels/rocm/quantization_rocm.cu
@@ -1,0 +1,583 @@
+#include "src/fastertransformer/utils/assert_utils.h"
+#include "src/fastertransformer/kernels/rocm/quantization_rocm.h"
+#include "src/fastertransformer/kernels/reduce_kernel_utils.cuh"
+#include "src/fastertransformer/rocm/hip_utils.h"
+
+namespace fastertransformer {
+using namespace rocm;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// int4 col quant ///////////////////////////////////////////////////////////////////////////////
+template<typename T>
+__global__ void perColQuantization(const T*      src,
+                                   const int64_t numRows,
+                                   const int64_t numCols,
+                                   const int64_t groupSize,
+                                   uint8_t*      weightPtr,
+                                   half*         scalePtr,
+                                   half*         zerosPtr,
+                                   float*        dbgfp  = nullptr,
+                                   int*          dbgint = nullptr) {
+    uint32_t colPckIdx = blockIdx.y;
+    uint32_t rowGrpIdx = blockIdx.x;
+
+    float       vall      = cuda_cast<float>(src[(rowGrpIdx * groupSize + threadIdx.x) * numCols + colPckIdx * 2 + 0]);
+    float       valh      = cuda_cast<float>(src[(rowGrpIdx * groupSize + threadIdx.x) * numCols + colPckIdx * 2 + 1]);
+    const float groupMaxl = blockAllReduceMax(vall);
+    const float groupMaxh = blockAllReduceMax(valh);
+
+    if (threadIdx.x == 0) {
+        scalePtr[rowGrpIdx * numCols + colPckIdx * 2 + 0]  = groupMaxl / 7.0f;
+        scalePtr[rowGrpIdx * numCols + colPckIdx * 2 + 1]  = groupMaxh / 7.0f;
+        zerosPtr[rowGrpIdx * numCols + colPckIdx * 2 + 0] = 0;
+        zerosPtr[rowGrpIdx * numCols + colPckIdx * 2 + 1] = 0;
+    }
+
+    const float scaleOrigQuantl = 7.f / groupMaxl;
+    const float scaleOrigQuanth = 7.f / groupMaxh;
+
+    int8_t tmpi8l = cuda_cast<int8_t>(cuda_cast<float>(vall) * scaleOrigQuantl);
+    int8_t tmpi8h = cuda_cast<int8_t>(cuda_cast<float>(valh) * scaleOrigQuanth);
+
+    uint8_t tmpu4l = tmpi8l & 0x0F;
+    uint8_t tmpu4h = tmpi8h & 0x0F;
+
+    uint8_t tmpu8 = tmpu4h;
+    tmpu8         = tmpu8 << 4;
+    tmpu8         = tmpu8 | tmpu4l;
+
+    weightPtr[(rowGrpIdx * groupSize + threadIdx.x) * numCols / 2 + colPckIdx] = tmpu8;
+}
+
+template<typename T>
+void invokePerColQuantizationInt4x2(const T*      src,
+                                    const int64_t numRows,
+                                    const int64_t numCols,
+                                    const int64_t groupSize,
+                                    uint8_t*      weightPtr,
+                                    half*         scalePtr,
+                                    half*         zerosPtr,
+                                    cudaStream_t  stream) {
+    assert(numRows % groupSize == 0);
+    const dim3 block(groupSize);
+    const dim3 grid(numRows / groupSize, numCols / 2, 1);
+    perColQuantization<T><<<grid, block, 0, stream>>>(src, numRows, numCols, groupSize, weightPtr, scalePtr, zerosPtr);
+}
+
+#define INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(T)                                                              \
+    template void invokePerColQuantizationInt4x2(const T*      src,                                                    \
+                                                 const int64_t numRows,                                                \
+                                                 const int64_t numCols,                                                \
+                                                 const int64_t groupSize,                                              \
+                                                 uint8_t*      weightPtr,                                              \
+                                                 half*         scalePtr,                                               \
+                                                 half*         zerosPtr,                                               \
+                                                 cudaStream_t  stream)
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(float);
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT4X2(__nv_bfloat16);
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// int4 col dequant /////////////////////////////////////////////////////////////////////////////
+template<typename T>
+__global__ void perColDequantization(T*            dst,
+                                     const int64_t numRows,
+                                     const int64_t numCols,
+                                     const int64_t groupSize,
+                                     const char4*  weightPtr,
+                                     const half*   scalePtr,
+                                     const half*   zerosPtr,
+                                     float*        dbgfp  = nullptr,
+                                     int*          dbgint = nullptr) {
+    const uint8_t* pWeight   = (const uint8_t*)weightPtr;
+    uint32_t       colPckIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    uint32_t       rowIdx    = blockIdx.y;
+    uint32_t       rowGrpIdx = rowIdx / groupSize;
+    if (colPckIdx >= numCols / 2)
+        return;
+
+    float scalel = cuda_cast<float>(scalePtr[rowGrpIdx * numCols + colPckIdx * 2 + 0]);
+    float scaleh = cuda_cast<float>(scalePtr[rowGrpIdx * numCols + colPckIdx * 2 + 1]);
+    float zerosl = cuda_cast<float>(zerosPtr[rowGrpIdx * numCols + colPckIdx * 2 + 0]);
+    float zerosh = cuda_cast<float>(zerosPtr[rowGrpIdx * numCols + colPckIdx * 2 + 0]);
+
+    uint8_t tmpu8 = pWeight[rowIdx * numCols / 2 + colPckIdx];
+
+    uint8_t tmpu4l = tmpu8 & 0x0F;
+    uint8_t tmpu4h = (tmpu8 >> 4) & 0x0F;
+
+    if (tmpu4l & 0x08)
+        tmpu4l |= 0xF0;
+    if (tmpu4h & 0x08)
+        tmpu4h |= 0xF0;
+    int8_t tmpi4l = tmpu4l;
+    int8_t tmpi4h = tmpu4h;
+
+    float tmpfpl = cuda_cast<float>(tmpi4l);
+    float tmpfph = cuda_cast<float>(tmpi4h);
+
+    T vall = cuda_cast<T>(tmpfpl * scalel + zerosl);
+    T valh = cuda_cast<T>(tmpfph * scaleh + zerosh);
+
+    dst[rowIdx * numCols + colPckIdx * 2 + 0] = vall;
+    dst[rowIdx * numCols + colPckIdx * 2 + 1] = valh;
+}
+
+template<typename T>
+void invokePerColDequantizationInt4x2(T*            dst,
+                                      const int64_t numRows,
+                                      const int64_t numCols,
+                                      const int64_t groupSize,
+                                      const int8_t* weightPtr,
+                                      half*         scalePtr,
+                                      half*         zerosPtr,
+                                      cudaStream_t  stream) {
+    assert(numRows % groupSize == 0);
+    const dim3 block(numCols / 2 < 512 ? numCols / 2 : 512);
+    const dim3 grid((numCols / 2 + block.x - 1) / block.x, numRows, 1);
+    perColDequantization<T>
+        <<<grid, block, 0, stream>>>(dst, numRows, numCols, groupSize, (char4*)weightPtr, scalePtr, zerosPtr);
+}
+
+#define INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(T)                                                            \
+    template void invokePerColDequantizationInt4x2(T*            dst,                                                  \
+                                                   const int64_t numRows,                                              \
+                                                   const int64_t numCols,                                              \
+                                                   const int64_t groupSize,                                            \
+                                                   const int8_t* weightPtr,                                            \
+                                                   half*         scalePtr,                                             \
+                                                   half*         zerosPtr,                                             \
+                                                   cudaStream_t  stream)
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(float);
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT4X2(__nv_bfloat16);
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+__global__ void quantizedKernel(char4* dst, const float4* src, const int64_t sizeDiv4, const float* scalePtr) {
+    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x) {
+        const float  scale = __ldg(scalePtr);
+        char4        tmp;
+        const float4 floatTmp = __ldg(src + idx);
+        tmp.x                 = cuda_cast<int8_t>(floatTmp.x * scale);
+        tmp.y                 = cuda_cast<int8_t>(floatTmp.y * scale);
+        tmp.z                 = cuda_cast<int8_t>(floatTmp.z * scale);
+        tmp.w                 = cuda_cast<int8_t>(floatTmp.w * scale);
+        dst[idx]              = tmp;
+    }
+}
+
+__global__ void quantizedKernel(char4* dst, const half2* src, const int64_t sizeDiv4, const float* scalePtr) {
+    for (int64_t idx = blockIdx.x * blockDim.x + threadIdx.x; idx < sizeDiv4; idx += blockDim.x * gridDim.x) {
+        const float scale = __ldg(scalePtr);
+        char4       tmp;
+        int         srcId = idx << 1;
+
+        const uint2 h2 = __ldg(reinterpret_cast<const uint2*>(src + srcId));
+
+        const half2 half2Tmp  = reinterpret_cast<const half2&>(h2.x);
+        const half2 half2Tmp2 = reinterpret_cast<const half2&>(h2.y);
+
+        tmp.x    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.x) * scale);
+        tmp.y    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp.y) * scale);
+        tmp.z    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.x) * scale);
+        tmp.w    = cuda_cast<int8_t>(cuda_cast<float>(half2Tmp2.y) * scale);
+        dst[idx] = tmp;
+    }
+}
+
+template<typename T>
+void invokeQuantization(
+    int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize) {
+    FT_CHECK_WITH_INFO(size % 4 == 0, "[ERROR][invokeQuantization] size should be a multiple of 4.\n");
+
+    int numBlocks{static_cast<int>((size + 255) / 256)};
+    if (maxGridSize == -1) {
+        maxGridSize = numBlocks;
+    }
+    dim3 grid(std::min(numBlocks, maxGridSize));
+    FT_CHECK_WITH_INFO(grid.x <= maxGridSize, "[ERROR][invokeQuantization] grid max size is exceeded\n");
+    dim3 block(64);
+    if (std::is_same_v<T, float>) {
+        quantizedKernel<<<grid, block, 0, stream>>>((char4*)dst, (const float4*)src, size / 4, scalePtr);
+    } else if (std::is_same_v<T, half>) {
+        quantizedKernel<<<grid, block, 0, stream>>>((char4*)dst, (const half2*)src, size / 4, scalePtr);
+    }
+}
+
+#define INSTANTIATE_INVOKE_QUANTIZATION(T)                                                                             \
+    template void invokeQuantization(                                                                                  \
+        int8_t* dst, const T* src, const int64_t size, const float* scalePtr, cudaStream_t stream, int maxGridSize);
+
+INSTANTIATE_INVOKE_QUANTIZATION(float);
+INSTANTIATE_INVOKE_QUANTIZATION(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_QUANTIZATION(__nv_bfloat16);
+#endif
+
+template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
+__global__ void perTokenQuantization(int8_t*       dst,
+                                     const T*      src,
+                                     const int64_t numRows,
+                                     const int64_t numCols,
+                                     float*        scalePtr,
+                                     const float*  smoother,
+                                     const float*  shift) {
+    const T* srcRow = src + blockIdx.x * numCols;
+    int8_t*  dstRow = dst + blockIdx.x * numCols;
+
+    T localMax = 1e-6f;
+    for (int i = threadIdx.x; i < numCols; i += blockDim.x) {
+        T val = srcRow[i];
+        if (IS_SMOOTHER) {
+            val = cuda_cast<T>(val / cuda_cast<T>(smoother[i]));
+        }
+        if (IS_SHIFT) {
+            val = cuda_cast<T>(val + cuda_cast<T>(shift[i]));
+        }
+        localMax = cuda_max(localMax, cuda_abs(val));
+    }
+    const float rowMax = blockAllReduceMax(cuda_cast<float>(localMax));
+
+    if (threadIdx.x == 0) {
+        scalePtr[blockIdx.x] = rowMax / 127.f;
+    }
+
+    const float scaleOrigQuant = 127.f / rowMax;
+    for (int i = threadIdx.x; i < numCols; i += blockDim.x) {
+        T val = srcRow[i];
+        if (IS_SMOOTHER) {
+            val = val / cuda_cast<T>(smoother[i]);
+        }
+        if (IS_SHIFT) {
+            val = cuda_cast<T>(val + cuda_cast<T>(shift[i]));
+        }
+        dstRow[i] = cuda_cast<int8_t>(cuda_cast<float>(val) * scaleOrigQuant);
+    }
+}
+
+template<typename T, bool IS_SMOOTHER>
+void dispatch_per_token_quantization_shift(int8_t*       dst,
+                                           const T*      src,
+                                           const int64_t numRows,
+                                           const int64_t numCols,
+                                           float*        scalePtr,
+                                           const float*  smoother,
+                                           const float*  shift,
+                                           cudaStream_t  stream) {
+    // each block is responsible for a single row
+    const dim3 block(512);
+    const dim3 grid(numRows);
+
+    if (shift != nullptr) {
+        perTokenQuantization<T, IS_SMOOTHER, true>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
+    } else {
+        perTokenQuantization<T, IS_SMOOTHER, false>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
+    }
+}
+
+template<typename T>
+void invokePerTokenQuantization(int8_t*       dst,
+                                const T*      src,
+                                const int64_t numRows,
+                                const int64_t numCols,
+                                float*        scalePtr,
+                                const float*  smoother,
+                                const float*  shift,
+                                cudaStream_t  stream) {
+    if (smoother != nullptr) {
+        dispatch_per_token_quantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
+    } else {
+        dispatch_per_token_quantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
+    }
+}
+
+#define INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(T)                                                                   \
+    template void invokePerTokenQuantization(int8_t*       dst,                                                        \
+                                             const T*      src,                                                        \
+                                             const int64_t numRows,                                                    \
+                                             const int64_t numCols,                                                    \
+                                             float*        scalePtr,                                                   \
+                                             const float*  smoother,                                                   \
+                                             const float*  shift,                                                      \
+                                             cudaStream_t  stream)
+
+INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(float);
+INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_TOKEN_QUANTIZATION(__nv_bfloat16);
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// int8 col quant ///////////////////////////////////////////////////////////////////////////////
+template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
+__global__ void perColQuantization(int8_t*       dst,
+                                   const T*      src,
+                                   const int64_t numRows,
+                                   const int64_t numCols,
+                                   half*         scalePtr,
+                                   const float*  smoother,
+                                   const float*  shift,
+                                   float*        dbgfp  = nullptr,
+                                   int*          dbgint = nullptr) {
+    uint32_t colIdx = blockIdx.x;
+    const T* srcCol = src + colIdx;
+    int8_t*  dstCol = dst + colIdx;
+
+    T localMax = 1e-6f;
+    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
+        T val = srcCol[rowIdx * numCols];
+        if (IS_SMOOTHER) {
+            val = cuda_cast<T>(val / cuda_cast<T>(smoother[rowIdx]));
+        }
+        if (IS_SHIFT) {
+            val = cuda_cast<T>(val + cuda_cast<T>(shift[rowIdx]));
+        }
+        localMax = cuda_max(localMax, cuda_abs(val));
+    }
+    const float colMax = blockAllReduceMax(cuda_cast<float>(localMax));
+
+    if (threadIdx.x == 0) {
+        scalePtr[colIdx] = cuda_cast<half>(colMax / 128.f);
+    }
+
+    const float scaleOrigQuant = 128.f / colMax;
+    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
+        T val = srcCol[rowIdx * numCols];
+        if (IS_SMOOTHER) {
+            val = val / cuda_cast<T>(smoother[rowIdx]);
+        }
+        if (IS_SHIFT) {
+            val = cuda_cast<T>(val + cuda_cast<T>(shift[rowIdx]));
+        }
+        dstCol[rowIdx * numCols] = cuda_cast<int8_t>(cuda_cast<float>(val) * scaleOrigQuant);
+    }
+}
+
+template<typename T, bool IS_SMOOTHER>
+void dispatch_per_col_quantization_shift(int8_t*       dst,
+                                         const T*      src,
+                                         const int64_t numRows,
+                                         const int64_t numCols,
+                                         half*         scalePtr,
+                                         const float*  smoother,
+                                         const float*  shift,
+                                         cudaStream_t  stream) {
+    // each block is responsible for a single row
+    const dim3 block(512);
+    const dim3 grid(numCols);
+
+    if (shift != nullptr) {
+        perColQuantization<T, IS_SMOOTHER, true>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
+    } else {
+        perColQuantization<T, IS_SMOOTHER, false>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
+    }
+}
+
+template<typename T>
+void invokePerColQuantizationInt8(int8_t*       dst,
+                                  const T*      src,
+                                  const int64_t numRows,
+                                  const int64_t numCols,
+                                  half*         scalePtr,
+                                  const float*  smoother,
+                                  const float*  shift,
+                                  cudaStream_t  stream) {
+    if (smoother != nullptr) {
+        dispatch_per_col_quantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
+    } else {
+        dispatch_per_col_quantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
+    }
+}
+
+#define INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(T)                                                                \
+    template void invokePerColQuantizationInt8(int8_t*       dst,                                                      \
+                                               const T*      src,                                                      \
+                                               const int64_t numRows,                                                  \
+                                               const int64_t numCols,                                                  \
+                                               half*         scalePtr,                                                 \
+                                               const float*  smoother,                                                 \
+                                               const float*  shift,                                                    \
+                                               cudaStream_t  stream)
+
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(float);
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_COL_QUANTIZATION_INT8(__nv_bfloat16);
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// int8 col dequant /////////////////////////////////////////////////////////////////////////////
+template<typename T, bool IS_SMOOTHER, bool IS_SHIFT>
+__global__ void perColDequantization(T*            dst,
+                                     const int8_t* src,
+                                     const int64_t numRows,
+                                     const int64_t numCols,
+                                     const half*   scalePtr,
+                                     const float*  smoother,
+                                     const float*  shift,
+                                     float*        dbgfp  = nullptr,
+                                     int*          dbgint = nullptr) {
+    uint32_t      colIdx = blockIdx.x;
+    const int8_t* srcRow = src + colIdx;
+    T*            dstRow = dst + colIdx;
+
+    float scaleOrigQuant = cuda_cast<float>(scalePtr[colIdx]);
+    if (IS_SMOOTHER) {
+        scaleOrigQuant = scaleOrigQuant * smoother[colIdx];
+    }
+    if (IS_SHIFT) {
+        scaleOrigQuant = scaleOrigQuant - shift[colIdx];
+    }
+
+    for (int rowIdx = threadIdx.x; rowIdx < numRows; rowIdx += blockDim.x) {
+        uint8_t tmpi8 = srcRow[rowIdx * numCols];
+
+        T val = cuda_cast<T>(cuda_cast<float>(tmpi8) * scaleOrigQuant);
+
+        if (IS_SMOOTHER) {
+            val = val * cuda_cast<T>(smoother[rowIdx]);
+        }
+        if (IS_SHIFT) {
+            val = cuda_cast<T>(val - cuda_cast<T>(shift[rowIdx]));
+        }
+
+        dstRow[rowIdx * numCols] = val;
+    }
+}
+
+template<typename T, bool IS_SMOOTHER>
+void dispatch_per_col_dequantization_shift(T*            dst,
+                                           const int8_t* src,
+                                           const int64_t numRows,
+                                           const int64_t numCols,
+                                           half*         scalePtr,
+                                           const float*  smoother,
+                                           const float*  shift,
+                                           cudaStream_t  stream) {
+    // each block is responsible for a single col
+    const dim3 block(512);
+    const dim3 grid(numCols);
+
+    if (shift != nullptr) {
+        perColDequantization<T, IS_SMOOTHER, true>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, shift);
+    } else {
+        perColDequantization<T, IS_SMOOTHER, false>
+            <<<grid, block, 0, stream>>>(dst, src, numRows, numCols, scalePtr, smoother, nullptr);
+    }
+}
+
+template<typename T>
+void invokePerColDequantizationInt8(T*            dst,
+                                    const int8_t* src,
+                                    const int64_t numRows,
+                                    const int64_t numCols,
+                                    half*         scalePtr,
+                                    const float*  smoother,
+                                    const float*  shift,
+                                    cudaStream_t  stream) {
+    if (smoother != nullptr) {
+        dispatch_per_col_dequantization_shift<T, true>(dst, src, numRows, numCols, scalePtr, smoother, shift, stream);
+    } else {
+        dispatch_per_col_dequantization_shift<T, false>(dst, src, numRows, numCols, scalePtr, nullptr, shift, stream);
+    }
+}
+
+#define INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(T)                                                              \
+    template void invokePerColDequantizationInt8(T*            dst,                                                    \
+                                                 const int8_t* src,                                                    \
+                                                 const int64_t numRows,                                                \
+                                                 const int64_t numCols,                                                \
+                                                 half*         scalePtr,                                               \
+                                                 const float*  smoother,                                               \
+                                                 const float*  shift,                                                  \
+                                                 cudaStream_t  stream)
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(float);
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_COL_DEQUANTIZATION_INT8(__nv_bfloat16);
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+// int4 row dequant /////////////////////////////////////////////////////////////////////////////
+template<typename T>
+__global__ void perRowDequantization(T*            dst,
+                                     const char4*  src,
+                                     const int64_t numRows,
+                                     const int64_t numCols,
+                                     const half*   scalePtr,
+                                     const half*   zerosPtr,
+                                     const int64_t groupSize,
+                                     float*        dbgfp  = nullptr,
+                                     int*          dbgint = nullptr) {
+    const uint8_t* pSrc      = (const uint8_t*)src;
+    uint32_t       rowIdx    = blockIdx.y;
+    uint32_t       colGrpIdx = blockIdx.x;
+    uint32_t       colGrpNum = numCols / groupSize;
+
+    float scale = cuda_cast<float>(scalePtr[rowIdx * colGrpNum + colGrpIdx]);
+    float zeros = cuda_cast<float>(zerosPtr[rowIdx * colGrpNum + colGrpIdx]);
+    // scale = 1.0f;
+    // zeros = 0;
+
+    uint8_t tmpu8 = pSrc[rowIdx * numCols / 2 + colGrpIdx * groupSize / 2 + threadIdx.x];
+
+    uint8_t tmpu4l = tmpu8 & 0x0F;
+    uint8_t tmpu4h = (tmpu8 >> 4) & 0x0F;
+
+    if (tmpu4l & 0x08)
+        tmpu4l |= 0xF0;
+    if (tmpu4h & 0x08)
+        tmpu4h |= 0xF0;
+    int8_t tmpi4l = tmpu4l;
+    int8_t tmpi4h = tmpu4h;
+
+    float tmpfpl = cuda_cast<float>(tmpi4l);
+    float tmpfph = cuda_cast<float>(tmpi4h);
+
+    T vall = cuda_cast<T>(tmpfpl * scale);
+    T valh = cuda_cast<T>(tmpfph * scale);
+
+    dst[rowIdx * numCols + colGrpIdx * groupSize + threadIdx.x * 2 + 0] = vall;
+    dst[rowIdx * numCols + colGrpIdx * groupSize + threadIdx.x * 2 + 1] = valh;
+}
+
+template<typename T>
+void invokePerRowDequantizationInt4x2(T*            dst,
+                                      const int8_t* src,
+                                      const int64_t numRows,
+                                      const int64_t numCols,
+                                      half*         scalePtr,
+                                      half*         zerosPtr,
+                                      const int64_t groupSize,
+                                      cudaStream_t  stream) {
+    const dim3 block(groupSize / 2);
+    const dim3 grid(numCols / groupSize, numRows, 1);
+
+    perRowDequantization<T>
+        <<<grid, block, 0, stream>>>(dst, (char4*)src, numRows, numCols, scalePtr, zerosPtr, groupSize);
+}
+
+#define INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(T)                                                            \
+    template void invokePerRowDequantizationInt4x2(T*            dst,                                                  \
+                                                   const int8_t* src,                                                  \
+                                                   const int64_t numRows,                                              \
+                                                   const int64_t numCols,                                              \
+                                                   half*         scalePtr,                                             \
+                                                   half*         zerosPtr,                                             \
+                                                   const int64_t groupSize,                                            \
+                                                   cudaStream_t  stream)
+INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(float);
+INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(half);
+#ifdef ENABLE_BF16
+INSTANTIATE_INVOKE_PER_ROW_DEQUANTIZATION_INT4X2(__nv_bfloat16);
+#endif
+}  // namespace fastertransformer

--- a/src/fastertransformer/kernels/rocm/quantization_rocm.h
+++ b/src/fastertransformer/kernels/rocm/quantization_rocm.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "src/fastertransformer/rocm/cuda_shims.h"
+#include "src/fastertransformer/cuda/cuda_type_utils.cuh"
+
+namespace fastertransformer {
+template<typename T>
+void invokePerColQuantizationInt4x2(const T*      src,
+                                    const int64_t numRows,
+                                    const int64_t numCols,
+                                    const int64_t groupSize,
+                                    uint8_t*      weightPtr,
+                                    half*         scalePtr,
+                                    half*         zerosPtr,
+                                    cudaStream_t  stream = 0);
+
+template<typename T>
+void invokePerColDequantizationInt4x2(T*            dst,
+                                      const int64_t numRows,
+                                      const int64_t numCols,
+                                      const int64_t groupSize,
+                                      const int8_t* weightPtr,
+                                      half*         scalePtr,
+                                      half*         zerosPtr,
+                                      cudaStream_t  stream = 0);
+
+template<typename T>
+void invokePerTokenQuantization(int8_t*       dst,
+                                const T*      src,
+                                const int64_t numRows,
+                                const int64_t numCols,
+                                float*        scalePtr,
+                                const float*  smoother,
+                                const float*  shift,
+                                cudaStream_t  stream = 0);
+
+template<typename T>
+void invokePerColQuantizationInt8(int8_t*       dst,
+                                  const T*      src,
+                                  const int64_t numRows,
+                                  const int64_t numCols,
+                                  half*         scalePtr,
+                                  const float*  smoother,
+                                  const float*  shift,
+                                  cudaStream_t  stream = 0);
+
+template<typename T>
+void invokePerColDequantizationInt8(T*            dst,
+                                    const int8_t* src,
+                                    const int64_t numRows,
+                                    const int64_t numCols,
+                                    half*         scalePtr,
+                                    const float*  smoother,
+                                    const float*  shift,
+                                    cudaStream_t  stream = 0);
+
+template<typename T>
+void invokePerRowDequantizationInt4x2(T*            dst,
+                                      const int8_t* src,
+                                      const int64_t numRows,
+                                      const int64_t numCols,
+                                      half*         scalePtr,
+                                      half*         zerosPtr,
+                                      const int64_t groupSize,
+                                      cudaStream_t  stream = 0);
+}  // namespace fastertransformer


### PR DESCRIPTION
 - add `groupSize` member in `struct QuantizeParams` for group wise quantization
 - revert `src/fastertransfomer/kernels/quantization_tensor.h/cu` to commit 8c993e73b6b8d3aa29d0d548ca92e5e76e60394e
 - move rocm quant related kernels into `src/fastertransfomer/kenrels/rocm` folder
 - add int4x2 quant/dequant unit test
 - fix rocm gpu mem allocate bug
