### PR TITLE
support to run example/test.py on Arm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -115,7 +115,7 @@ build:arm --crosstool_top=@bazel_tools//tools/cpp:toolchain
 build:arm --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 build:arm --linkopt -ldl
 build:arm --copt="-DUSING_CUDA=0"
-build:arm --copt="-fopenmp"
+build:arm --define=xft_use_icx=false
 
 build:debug --copt -g --copt -O0 --copt -U_FORTIFY_SOURCE
 build:trace --copt="-DCUTLASS_DEBUG_TRACE_LEVEL=1"

--- a/example/test.py
+++ b/example/test.py
@@ -12,7 +12,7 @@ import os
 async def main():
     update_master_info('127.0.0.1', 42345)
     os.environ["MODEL_TYPE"] = os.environ.get("MODEL_TYPE", "qwen2")
-    os.environ["CHECKPOINT_PATH"] = os.environ.get("CHECKPOINT_PATH", "Qwen/Qwen-1_8B-Chat")
+    os.environ["CHECKPOINT_PATH"] = os.environ.get("CHECKPOINT_PATH", "Qwen/Qwen1.5-1.8B-Chat")
     os.environ["RESERVER_RUNTIME_MEM_MB"] = "0"
     os.environ["DEVICE_RESERVE_MEMORY_BYTES"] = f"{128 * 1024 ** 2}"
     model_config = ModelFactory.create_normal_model_config()

--- a/maga_transformer/BUILD
+++ b/maga_transformer/BUILD
@@ -20,12 +20,23 @@ tensorrt = [
 ]
 
 xft_dep = select({
+    "//:using_arm": [],
     "//:xft_use_icx": [
         "xfastertransformer_devel_icx",
     ],
     "//conditions:default": [
         "xfastertransformer_devel",
     ],
+})
+
+arch_dep = select({
+    "//:using_arm": [],
+    "//conditions:default": [":decord"],
+})
+
+arch_with_version_dep = select({
+    "//:using_arm": [],
+    "//conditions:default": ["decord==0.6.0"],
 })
 
 requirement([
@@ -83,11 +94,10 @@ py_library(
     deps = [
         ":torch",
         ":safetensors",
-        ":decord",
         ":lru-dict",
         ":cpm_kernels",
         ":prettytable",
-    ]
+    ] + arch_dep
 )
 
 py_library(
@@ -150,12 +160,12 @@ py_library(
         ":ops",
         ":timm",
         ":onnx",
-        ":decord",
         ":nest_asyncio"
-    ] + select({
+    ] + arch_dep + select({
         "//:using_cuda12": tensorrt,
         "//conditions:default": []
     }) + select({
+        "//:using_arm": [],
         "//:xft_use_icx": [
             "xfastertransformer_devel_icx",
         ],
@@ -366,14 +376,13 @@ py_wheel(
         "timm==0.9.12",
         "sentence-transformers==2.7.0",
         "grpcio==1.62.0",
-        "decord==0.6.0",
         "oss2",
         "json5",
         "dashscope>=1.11.0",
         "jieba",
         "openai",
         "nest_asyncio",
-    ] + whl_deps() + xft_dep,
+    ] + whl_deps() + xft_dep + arch_with_version_dep,
 )
 
 py_wheel(
@@ -415,11 +424,10 @@ py_wheel(
         "pydantic==2.5.3",
         "sentence-transformers==2.7.0",
         "grpcio==1.62.0",
-        "decord==0.6.0",
         "timm==0.9.12",
         "kserve",
         "nest_asyncio",
-    ] + whl_deps() + xft_dep,
+    ] + whl_deps() + xft_dep + arch_with_version_dep,
 )
 
 rename_wheel(

--- a/maga_transformer/cpp/BUILD
+++ b/maga_transformer/cpp/BUILD
@@ -254,6 +254,9 @@ cc_library(
         "//:using_cuda": [
             "//src/fastertransformer/devices/cuda_impl:cuda_impl",
         ],
+        "//:using_arm": [
+            "//src/fastertransformer/devices/arm_impl:arm_cpu_impl",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"]

--- a/maga_transformer/cpp/test/GptModelTest.cc
+++ b/maga_transformer/cpp/test/GptModelTest.cc
@@ -59,6 +59,7 @@ TEST_F(GptModelTest, testSimple) {
     GptModelInputs inputs = {
         std::move(combo_tokens), std::move(input_lengths), std::move(sequence_lengths)
     };
+    inputs.prefix_lengths = createBuffer<int32_t>({1}, {0}, AllocationType::HOST);
     inputs.lm_output_indexes = createBuffer<int32_t>({1}, {2}, AllocationType::HOST);
     inputs.attention_mask = mask_buf;
     inputs.kv_cache_offset = kv_cache_offset;
@@ -101,6 +102,7 @@ TEST_F(GptModelTest, testSimple) {
     inputs.combo_tokens = createBuffer<int32_t>({1}, {151645}, AllocationType::HOST);
     inputs.input_lengths = createBuffer<int32_t>({1}, {3}, AllocationType::HOST);
     inputs.sequence_lengths = createBuffer<int32_t>({1}, {3}, AllocationType::HOST);
+    inputs.prefix_lengths = createBuffer<int32_t>({0}, {}, AllocationType::HOST);
     inputs.lm_output_indexes = createBuffer<int32_t>({1}, {0}, AllocationType::HOST);
     device_->syncAndCheck();
     outputs = model->forward(inputs);
@@ -120,6 +122,7 @@ TEST_F(GptModelTest, testSimple) {
     inputs.combo_tokens = createBuffer<int32_t>({4}, {151645, 13048, 11, 220}, AllocationType::HOST);
     inputs.input_lengths = createBuffer<int32_t>({2}, {3, 3}, AllocationType::HOST);
     inputs.sequence_lengths = createBuffer<int32_t>({1}, {3}, AllocationType::HOST);
+    inputs.prefix_lengths = createBuffer<int32_t>({1}, {0}, AllocationType::HOST);
     inputs.lm_output_indexes = createBuffer<int32_t>({2}, {0, 3}, AllocationType::HOST);
 
     inputs.kv_cache_offset = allocateKVBlocks(cache_config, {3, 3}, kv_cache);

--- a/maga_transformer/distribute/worker_info.py
+++ b/maga_transformer/distribute/worker_info.py
@@ -20,11 +20,14 @@ class ParallelInfo(object):
         self.world_size = world_size
         self.world_rank = world_rank
         self.local_world_size = local_world_size
-        if bool(os.environ.get("SP_CHECKPOINT_PATH", "") != ""):
-            self.device = 'cuda:0'
-        else:
-            self.device = self.world_rank % self.local_world_size
 
+        if torch.cuda.is_available():
+            if bool(os.environ.get("SP_CHECKPOINT_PATH", "") != ""):
+                self.device = 'cuda:0'
+            else:
+                self.device = self.world_rank % self.local_world_size
+        else:
+            self.device = 'cpu'
 
     @property
     def is_pp_first(self) -> bool:

--- a/maga_transformer/models/__init__.py
+++ b/maga_transformer/models/__init__.py
@@ -9,20 +9,22 @@ from .bloom import Bloom
 from .chat_glm_v2 import ChatGlmV2
 from .chat_glm_v3 import ChatGlmV3
 from .chat_glm_v4 import ChatGlmV4
-from .chat_glm_v4_vision import ChatGlmV4Vision
 from .qwen import QWen_7B, QWen_13B, QWen_1B8
 from .qwen_v2 import QWenV2
 from .falcon import Falcon
 from .mpt import Mpt
 from .phi import Phi
-from .llava import Llava
-from .qwen_vl import QWen_VL
 from .mixtral import Mixtral
 from .bert import Bert
 from .jina_bert.jina_bert import JinaBert
 from .megatron_bert import MegatronBert
 from .qwen_v2_moe import Qwen2Moe
-from .cogvlm2 import CogVLM2
+import platform
+if platform.processor() != 'aarch64':
+    from .chat_glm_v4_vision import ChatGlmV4Vision
+    from .llava import Llava
+    from .qwen_vl import QWen_VL
+    from .cogvlm2 import CogVLM2
 
 import logging
 try:

--- a/maga_transformer/pipeline/pipeline.py
+++ b/maga_transformer/pipeline/pipeline.py
@@ -3,6 +3,7 @@ import logging
 import torch
 import asyncio
 import threading
+import platform
 import queue
 import json
 from typing import Any, List, Union, Iterator, Tuple, Callable, Optional, Dict, Generator, AsyncGenerator
@@ -254,7 +255,10 @@ class Pipeline(object):
     async def generate_stream(self, request_id: int, token_ids: List[int], urls: List[Future[torch.Tensor]],
                             generate_config: GenerateConfig, **kwargs: Any) -> AsyncGenerator[GenerateResponse, None]:
         token_type_ids = []
-        token_ids = torch.tensor(token_ids, dtype=torch.int, pin_memory=True)
+        if platform.processor() == 'aarch64':
+            token_ids = torch.tensor(token_ids, dtype=torch.int)
+        else:
+            token_ids = torch.tensor(token_ids, dtype=torch.int, pin_memory=True)
 
         input = GenerateInput(request_id=request_id,
                               token_ids=token_ids,

--- a/maga_transformer/server/inference_server.py
+++ b/maga_transformer/server/inference_server.py
@@ -42,7 +42,10 @@ class InferenceServer(object):
     def __init__(self):
         if 'LOAD_CKPT_NUM_PROCESS' not in os.environ:
             os.environ['LOAD_CKPT_NUM_PROCESS'] = '0'
-        if 'NCCL_P2P_DISABLE' not in os.environ and 'RTX' in torch.cuda.get_device_name(0):
+        if torch.cuda.is_available():
+            if 'NCCL_P2P_DISABLE' not in os.environ and 'RTX' in torch.cuda.get_device_name(0):
+                os.environ['NCCL_P2P_DISABLE'] = '1'
+        else:
             os.environ['NCCL_P2P_DISABLE'] = '1'
         self._access_logger = AccessLogger()
         self._gang_server = GangServer()

--- a/maga_transformer/server/inference_worker.py
+++ b/maga_transformer/server/inference_worker.py
@@ -50,7 +50,7 @@ class InferenceWorker():
         copy_gemm_config()
         logging.info("starting InferenceWorker")
         if not torch.cuda.is_available():
-            raise Exception("GPU not found")
+            logging.info("GPU not found: using CPU")
 
         self.model: AsyncModel = ModelFactory.create_from_env()
         self.pipeline = Pipeline(self.model, self.model.tokenizer)

--- a/maga_transformer/start_server.py
+++ b/maga_transformer/start_server.py
@@ -69,6 +69,8 @@ def multi_rank_start():
 
 def main():
     os.makedirs('logs', exist_ok=True)
+    if not torch.cuda.is_available():
+        return local_rank_start()
 
     if g_parallel_info.world_size % torch.cuda.device_count() != 0 and g_parallel_info.world_size > torch.cuda.device_count():
         raise Exception(f'result: {g_parallel_info.world_size % torch.cuda.device_count()} \

--- a/open_source/bazel/arch_select.bzl
+++ b/open_source/bazel/arch_select.bzl
@@ -3,6 +3,7 @@ load("@pip_cpu_torch//:requirements.bzl", requirement_cpu="requirement")
 load("@pip_gpu_torch//:requirements.bzl", requirement_gpu="requirement")
 load("@pip_gpu_cuda12_torch//:requirements.bzl", requirement_gpu_cuda12="requirement")
 load("@pip_gpu_rocm_torch//:requirements.bzl", requirement_gpu_rocm="requirement")
+load("@pip_cpu_arm_torch//:requirements.bzl", requirement_cpu_arm="requirement")
 
 def requirement(names):
     for name in names:
@@ -12,6 +13,7 @@ def requirement(names):
                 "//:using_cuda12": [requirement_gpu_cuda12(name)],
                 "//:using_cuda11": [requirement_gpu(name)],
                 "//:using_rocm": [requirement_gpu_rocm(name)],
+                "//:using_arm": [requirement_cpu_arm(name)],
                 "//conditions:default": [requirement_cpu(name)],
             }),
             visibility = ["//visibility:public"],

--- a/open_source/deps/pip.bzl
+++ b/open_source/deps/pip.bzl
@@ -37,3 +37,10 @@ def pip_deps():
         python_interpreter = "/opt/conda310/bin/python3",
         timeout=12000,
     )
+
+    pip_install(
+        name = "pip_cpu_arm_torch",
+        requirements = ["//open_source/deps:requirements_cpu_arm.txt", "//open_source/deps:requirements_base.txt"],
+        python_interpreter = "/opt/conda310/bin/python3",
+        timeout=12000,
+    )

--- a/open_source/deps/requirements_base.txt
+++ b/open_source/deps/requirements_base.txt
@@ -30,8 +30,8 @@ aiohttp
 sentence-transformers==2.7.0
 orjson
 grpcio==1.62.0
-xfastertransformer_devel==1.8.1.1
-xfastertransformer_devel_icx==1.8.1.1
+xfastertransformer_devel==1.8.1.1 ; platform_machine == "x86_64"
+xfastertransformer_devel_icx==1.8.1.1 ; platform_machine == "x86_64"
 decord==0.6.0 ; platform_machine == "x86_64"
 accelerate==0.25.0
 # add qwen agent package

--- a/open_source/deps/requirements_cpu_arm.txt
+++ b/open_source/deps/requirements_cpu_arm.txt
@@ -1,0 +1,1 @@
+https://github.com/TianyuLi0/rtp-llm/raw/pytorch_2.3.0_aarch64_acl_24.04/3rdparty/acl/torch-2.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl

--- a/src/fastertransformer/devices/arm_impl/ArmAttentionOp.cc
+++ b/src/fastertransformer/devices/arm_impl/ArmAttentionOp.cc
@@ -233,7 +233,7 @@ void ArmCpuDevice::logTime(std::chrono::microseconds diff, size_t index) {
     a_cnt_[index] += 1;
 }
 
-#define USING_THREADED_MHA 1
+#define USING_THREADED_MHA 0
 void ArmCpuDevice::contextAttentionFallback(const AttentionModuleParams& params) {
     auto datatype      = params.input.type();
     auto batch_size    = params.common.context_batch_size;
@@ -341,7 +341,7 @@ void ArmCpuDevice::contextAttentionFallback(const AttentionModuleParams& params)
                 throw OpException(OpErrorType::ERROR_UNIMPLEMENTED);
             }
         } else {
-            throw std::runtime_error("SelfAttention RoPE type is not supported");
+            throw std::runtime_error(fmtstr("SelfAttention RoPE type is not supported %d", params.configs.rope_config.style));
         }
     }
     tEnd = std::chrono::steady_clock::now();

--- a/src/fastertransformer/devices/arm_impl/ArmDevice.h
+++ b/src/fastertransformer/devices/arm_impl/ArmDevice.h
@@ -40,6 +40,7 @@ public:
     void broadcast(const BroadcastParams& params) override;
     void allReduceSum(const AllReduceParams& params);
     void printStat();
+    DeviceStatus getDeviceStatus();
 
 private:
     std::unique_ptr<IAllocator> allocator_;

--- a/src/fastertransformer/devices/arm_impl/ArmSampleOp.cc
+++ b/src/fastertransformer/devices/arm_impl/ArmSampleOp.cc
@@ -1,0 +1,359 @@
+#include "src/fastertransformer/devices/arm_impl/ArmDevice.h"
+#include "src/fastertransformer/devices/DeviceFactory.h"
+#include "src/fastertransformer/core/allocator.h"
+#include "src/fastertransformer/core/cpu_allocator.h"
+#include "src/fastertransformer/devices/utils/DebugUtils.h"
+
+#include <cstring>
+#include <random>
+#include <vector>
+#include <set>
+#include <cfloat>
+#include <omp.h>
+#include <functional>
+
+#define TOP_K_MAX 1024
+
+namespace fastertransformer {
+
+float random_one_data(std::mt19937& generator) {
+    static std::uniform_real_distribution<float> dist(0.0, 1.0);
+    float rand = dist(generator);
+    return rand;
+}
+
+void temperaturePenalty(float *           logits,
+                        const float* temperatures,
+                        const int    batch_size,
+                        const int    vocab_size) {
+    for (int i = 0; i < batch_size; i++) {
+        float inv_temperatures = 1.0f / (temperatures[i] + 1e-6f);
+        for (int j = 0; j < vocab_size; j++) {
+            logits[i * vocab_size + j] *= inv_temperatures;
+        }
+    }
+}
+
+void setup_topk_runtime_args(int    batch_size,
+                             uint   top_k,
+                             uint*  top_ks,
+                             int    top_ks_size,
+                             float  top_p,
+                             float* top_ps,
+                             int    top_ps_size,
+                             bool*  skip_decode)
+{
+    for (int i = 0; i < batch_size; i++) {
+        uint  k = top_ks_size > 1 ? top_ks[i] : top_k;
+        float p = top_ps_size > 1 ? top_ps[i] : top_p;
+        if (k == 0 && p == 0.0f) {
+            k = 1;
+        }
+        if (k > 0 && p == 0.0f) {
+            p = 1.0f;
+        }
+        // Clip k value. A topk sampling kernel supports up to TOP_K_MAX=64.
+        top_ks[i] = k > TOP_K_MAX ? TOP_K_MAX : k;
+        if (k > TOP_K_MAX) {
+            printf("[WARNING] topk (%d) is larger than max supported number (%d) for token %d"
+                   " clip to max supported number %d. \n",
+                   k,
+                   TOP_K_MAX,
+                   i,
+                   top_ks[i]);
+        }
+        // Clip p value if it is out of range. range = [0.0, 1.0].
+        top_ps[i] = p < 0.0f ? 0.0f : (p > 1.0f ? 1.0f : p);
+        if (p < 0.0f || p > 1.0f) {
+            printf("[WARNING] topp (%f) is out of range ([0.0, 1.0f]) for token %d"
+                   " clip to closest number %f.\n",
+                   p,
+                   i,
+                   top_ps[i]);
+        }
+        skip_decode[i] = k == 0;
+    }
+}
+
+void repetitionPenalty(float *           logits,
+                       const float* penalties,
+                       const int*   output_ids,
+                       const int    batch_size,
+                       const int    vocab_size,
+                       const int*   input_lengths,
+                       const int    max_input_length,
+                       const int    step) {
+    for (int i = 0; i < batch_size; i++) {
+        const int input_length = input_lengths != nullptr ? input_lengths[i] : max_input_length;
+        std::set<int> preIdSet;
+        for (int j = 0; j < step && j < input_length; j++) {
+            if (j >= input_lengths[i]) {
+                continue;
+            }
+            preIdSet.insert(output_ids[i * (step + 1) + j]);
+        }
+        for (auto id : preIdSet) {
+            float logit = logits[i * vocab_size + id];
+            logits[i * vocab_size + id] = logit < 0.0f ? logit * penalties[i] : logit / penalties[i];
+        }
+    }
+}
+
+void minLengthPenaltyNew(float*         logits,
+                         const int* min_lengths,
+                         const int* end_ids,
+                         const int* sequence_lengths,
+                         const int* input_lengths,
+                         const int batch_size,
+                         const int vocab_size) {
+    for (int i = 0; i < batch_size; i++) {
+        if (sequence_lengths[i] - input_lengths[i] < min_lengths[i]) {
+            logits[i * vocab_size + end_ids[i]] = -FLT_MAX;;
+        }
+    }
+}
+
+void topKKernel(float* output,
+                int* output_indices,
+                const float* logits,
+                int batch_size,
+                int vocab_size,
+                int max_top_k,
+                const uint32_t* topk) {
+    parallel_for(batch_size, [&](int b) {
+        std::vector<std::pair<float, int> > data_vec(vocab_size);
+        parallel_for(vocab_size, [&](int i) {
+            data_vec[i] = std::make_pair(logits[b * vocab_size + i], i);
+        });
+        std::partial_sort(data_vec.begin(), data_vec.begin() + topk[b], data_vec.end(),
+                          [](std::pair<float, int> lhs, std::pair<float, int> rhs) {
+                              if (lhs.first > rhs.first) return true;
+                              if (lhs.first < rhs.first) return false;
+                              return lhs.second < rhs.second;
+                          });
+        parallel_for(topk[b], [&](int i) {
+            output[b * max_top_k + i] = data_vec[i].first;
+            output_indices[b * max_top_k + i] = data_vec[i].second;
+        });
+    });
+}
+
+void topk_sampling(int    batch_size,
+                   const int*  topk_tmp_id_buf,
+                   float*         topk_tmp_val_buf,
+                   std::vector<std::mt19937>& generator_lists,
+                   int*           ids,
+                   int*           sequence_length,
+                   bool*          finished,
+                   float*         cum_log_probs,
+                   float*         output_log_probs,
+                   float*         index_log_probs,
+                   int*           token_id_for_index_prob,
+                   const int      max_top_k,
+                   const uint32_t*     top_ks,
+                   const float    top_p,
+                   const float*   top_ps,
+                   const int*     end_ids,
+                   const int      vocab_size,
+                   const bool*    skip_decode,
+                   int step)
+{
+    parallel_for(batch_size, [&](int batch_id) {
+        if (skip_decode != nullptr && skip_decode[batch_id]) {
+            return;
+        }
+
+        if (finished != nullptr && finished[batch_id] == true) {
+            ids[batch_id * step + step - 1] = end_ids[batch_id];
+            return;
+        }
+
+        const int k = (top_ks != nullptr) ? top_ks[batch_id] : max_top_k;
+        const float prob_threshold = (top_ps != nullptr) ? top_ps[batch_id] : top_p;
+
+        float s_sum = 0.0f;
+        float s_max = topk_tmp_val_buf[batch_id * max_top_k];
+        for (int i = 0; i < k; i++) {
+            topk_tmp_val_buf[batch_id * max_top_k + i] = std::exp(topk_tmp_val_buf[batch_id * max_top_k + i] - s_max);
+            s_sum += topk_tmp_val_buf[batch_id * max_top_k + i];
+        }
+
+        float rand_num = random_one_data(generator_lists[batch_id]) * prob_threshold * s_sum;
+        for (int i = 0; i < k; i++) {
+            float exp_logit = topk_tmp_val_buf[batch_id * max_top_k + i];
+            rand_num = rand_num - exp_logit;
+            if (rand_num <= 0.0f || i == k - 1) {
+                ids[batch_id * step + step - 1] = topk_tmp_id_buf[batch_id * max_top_k + i];
+                if (cum_log_probs != nullptr || output_log_probs != nullptr) {
+                    float log_prob = logf(exp_logit) - logf(s_sum);
+                    if (cum_log_probs != nullptr) {
+                        cum_log_probs[batch_id] += log_prob;
+                    }
+                    if (output_log_probs != nullptr) {
+                        output_log_probs[batch_id] = log_prob;
+                    }
+                }
+                break;
+            }
+        }
+        if (sequence_length != nullptr && finished != nullptr) {
+            sequence_length[batch_id] = finished[batch_id] ? sequence_length[batch_id] : sequence_length[batch_id] +
+                                                                                         1;
+            finished[batch_id] = ids[batch_id] == end_ids[batch_id] ? true : false;
+        }
+    });
+}
+
+void ArmCpuDevice::sampleGreedy(const GreedyParams& params) {
+    const auto& logits = params.logits;
+    const auto batch_size = logits.shape()[0];
+    RUNTIME_ASSERT_OP_ARG(batch_size < init_params_.max_batch_size,
+                          "batch_size exceeded device limit %ld: %ld",
+                          init_params_.max_batch_size, batch_size);
+    const auto vocab_size_padded = logits.shape()[1];
+    const auto step = params.step;
+    RUNTIME_ASSERT_OP_ARG(batch_size == params.token_ids.shape()[0],
+                          "logits.shape[0] should equal to token_ids.shape[0], but %ld vs %ld",
+                          batch_size, params.token_ids.shape()[0]);
+    RUNTIME_ASSERT_OP_ARG((step == params.token_ids.shape()[1] - 1),
+                          "step should equal to token_ids.shape[1] - 1, but %ld vs %ld",
+                          step, params.token_ids.shape()[1] - 1);
+    auto& tokens = params.token_ids;
+    // auto transposed_tokens = transpose({*device_tokens});
+
+    // 1. prepare buffers
+    auto& top_k = params.top_k;
+    auto& top_p = params.top_p;
+    auto& temperature = params.temperature;
+    auto& random_seed = params.random_seed;
+    FT_CHECK(top_k.size() == batch_size);
+    FT_CHECK(top_p.size() == batch_size);
+    FT_CHECK(temperature.size() == batch_size);
+
+    auto default_top_k = top_k.data<uint32_t>()[0];
+    auto default_top_p = top_p.data<float>()[0];
+    auto max_top_k = *std::max_element(top_k.data<uint32_t>(), top_k.dataWithOffset<uint32_t>(top_k.size()));
+    if (max_top_k == 0) {
+        // for safety. TopKSamplingLayer handles a case of top_k=0 and top_p=0 as
+        // a greedy decode, i.e. top_k=1, although such case has max_top_k=0.
+        max_top_k = 1;
+    }
+    auto max_top_p = *std::max_element(top_p.data<float>(), top_p.dataWithOffset<float>(top_p.size()));
+    FT_LOG_DEBUG("max_top_k: %d, max_top_p: %f", max_top_k, max_top_p);
+
+    auto skip_top_k_decode_buf = allocateBuffer({DataType::TYPE_BOOL, {batch_size}});
+    auto topk_tmp_val_buf = allocateBuffer({DataType::TYPE_FP32, {batch_size * max_top_k}});
+    auto topk_tmp_id_buf = allocateBuffer({DataType::TYPE_INT32, {batch_size * max_top_k}});
+
+    // std::mt19937 generator(seed);
+    std::vector<std::mt19937> generator_lists(batch_size);
+    unsigned one_seed = std::random_device{}();
+    for (size_t i = 0; i < batch_size; i++) {
+        generator_lists[i] = std::mt19937(one_seed + i);
+    }
+    if (random_seed) {
+        auto& seeds = random_seed.value().get();
+        uint64_t* seedsPtr = seeds.data<uint64_t>();
+        if (seeds.size() == 1) {
+            for (int i = 0; i < batch_size; i++) {
+                generator_lists[i] = std::mt19937(seedsPtr[0]);
+            }
+        } else {
+            RUNTIME_ASSERT_OP_ARG((seeds.size() == batch_size),
+                                  "random_seed.size() should equal to batch_size, but %ld vs %ld",
+                                  seeds.size(), batch_size);
+            for (int i = 0; i < batch_size; i++) {
+                generator_lists[i] = std::mt19937(seedsPtr[i]);
+            }
+        }
+    }
+
+    // 3.2. compute logits penalty
+    if (std::any_of(temperature.data<float>(),
+                    temperature.data<float>() + batch_size,
+                    [&](auto t) { return t != 1.0f; }))
+    {
+        temperaturePenalty(
+                logits.data<float>(),
+                temperature.data<float>(),
+                batch_size,
+                vocab_size_padded
+        );
+    }
+
+    const auto decoder_batch_size = params.sequence_lengths.shape()[0];
+    if (decoder_batch_size) {
+        if (step > 1 && params.repetition_penalty && decoder_batch_size) {
+            auto& repetition_penalty = params.repetition_penalty->get();
+            if (std::any_of(repetition_penalty.data<float>(),
+                            repetition_penalty.data<float>() + batch_size,
+                            [&](auto t) { return t != 1.0f; }))
+            {
+//                const auto repetition_penalty_type = RepetitionPenaltyType::Multiplicative;
+                repetitionPenalty(logits.data<float>(),
+                                  repetition_penalty.data<float>(),
+                                  tokens.data<int32_t>(),
+                                  batch_size,
+                                  vocab_size_padded,
+                                  params.sequence_lengths.data<int32_t>(),
+                                  step + 1,
+                                  step);
+            }
+        }
+        if (params.min_lengths.has_value())
+            if (params.min_lengths && params.eos_ids) {
+                minLengthPenaltyNew(logits.data<float>(),
+                                    params.min_lengths.value().get().data<int32_t>(),
+                                    params.eos_ids.value().get().data<int32_t>(),
+                                    params.sequence_lengths.data<int32_t>(),
+                                    params.input_lengths.data<int32_t>(),
+                                    batch_size,
+                                    vocab_size_padded);
+            }
+    }
+
+    // 4. run sampling
+    // 4.1 run top_k
+    setup_topk_runtime_args(batch_size,
+                            default_top_k,
+                            top_k.data<uint32_t>(),
+                            batch_size,
+                            default_top_p,
+                            top_p.data<float>(),
+                            batch_size,
+                            skip_top_k_decode_buf->data<bool>());
+
+    float* topk_logs = topk_tmp_val_buf->data<float>();
+    int* topk_logs_indices = topk_tmp_id_buf->data<int>();
+
+    topKKernel(topk_logs,
+               topk_logs_indices,
+               logits.data<float>(), batch_size,
+               vocab_size_padded,
+               max_top_k,
+               top_k.data<uint32_t>());
+
+    printBufferData(tokens, "before topk_sampling", nullptr, true);
+
+    topk_sampling(batch_size, topk_logs_indices, topk_logs, generator_lists,
+                  tokens.data<int32_t>(),
+                  nullptr, // sequence_length
+                  nullptr, // finished
+                  nullptr, //          cum_log_probs,
+                  nullptr, //         output_log_probs,
+                  nullptr, //         index_log_probs,
+                  nullptr, //            token_id_for_index_prob,
+                  max_top_k,
+                  top_k.data<uint32_t>(),
+                  1.0f,
+                  top_p.data<float>(),
+                  params.eos_ids.value().get().data<int32_t>(),
+                  vocab_size_padded,
+                  skip_top_k_decode_buf->data<bool>(),
+                  step + 1);
+
+    // printBufferData(tokens, "output_token_ids", nullptr, true);
+
+    return;
+}
+}; // namespace fastertransformer

--- a/src/fastertransformer/devices/arm_impl/ArmSoftmaxOp.cc
+++ b/src/fastertransformer/devices/arm_impl/ArmSoftmaxOp.cc
@@ -43,7 +43,7 @@ void context_mask(BufferPtr input, const Buffer& mask) {
         for (int i = 0; i < dim2 * dim3; i++) {
             auto v = input->dataWithOffset(tid * dim2 * dim3 + i);
             auto m = mask.dataWithOffset(b * dim2 * dim3 + i);
-            *(float*)v += (1.0f - *(float*)m) * -10000.0f;
+            *(T*)v += (1.0f - *(T*)m) * -10000.0f;
         }
     });
 #endif

--- a/src/fastertransformer/devices/arm_impl/BUILD
+++ b/src/fastertransformer/devices/arm_impl/BUILD
@@ -17,5 +17,6 @@ cc_library(
         "@arm_compute//support",
     ],
     visibility = ["//visibility:public"],
-    copts = copts(),
+    copts = copts() + ["-fopenmp"],
+    alwayslink = 1,
 )


### PR DESCRIPTION
- Add pytorch requirement for Arm CPU, link to th_transformer
- Integrate sampleGreedy from Haijiang
- Add tracker allocator for Arm device
- Add cpu support for start server function
- Using the commom parallel_for for Arm sample operation
- Fix integration issues

To run the example:
bazel test //example:test  --config=arm --test_output=all