### PR TITLE
fix: multiple request with top_k = 0 out of vocab

### DIFF
--- a/src/fastertransformer/devices/arm_impl/ArmDevice.cc
+++ b/src/fastertransformer/devices/arm_impl/ArmDevice.cc
@@ -113,7 +113,7 @@ DeviceStatus ArmCpuDevice::getDeviceStatus() {
     status.host_memory_status.allocated_bytes = buffer_status.host_allocated_bytes;
     status.device_memory_status.available_bytes = status.device_memory_status.free_bytes + status.device_memory_status.preserved_bytes;
 
-    status.device_memory_status.min_preserved_bytes = 128 * 1024 * 1024; // 128M for warm up
+    status.device_memory_status.min_preserved_bytes = status.device_memory_status.free_bytes / 2; // warm up and init kv cache
     return status;
 }
 

--- a/src/fastertransformer/devices/arm_impl/ArmSampleOp.cc
+++ b/src/fastertransformer/devices/arm_impl/ArmSampleOp.cc
@@ -46,11 +46,11 @@ void setup_topk_runtime_args(int    batch_size,
     for (int i = 0; i < batch_size; i++) {
         uint  k = top_ks_size > 1 ? top_ks[i] : top_k;
         float p = top_ps_size > 1 ? top_ps[i] : top_p;
-        if (k == 0 && p == 0.0f) {
-            k = 1;
-        }
         if (k > 0 && p == 0.0f) {
             p = 1.0f;
+        }
+        if (k == 0) {
+            k = 1;
         }
         // Clip k value. A topk sampling kernel supports up to TOP_K_MAX=64.
         top_ks[i] = k > TOP_K_MAX ? TOP_K_MAX : k;


### PR DESCRIPTION
Fix multiple request with top_k = 0 out of vocab
Increase kv cache memory to avoid RESOURCE_EXHAUSTED: LACK MEM