### PR TITLE
chore: rm unexpected accept token num metrics count

### DIFF
--- a/rtp_llm/cpp/speculative_engine/speculative_sampler/SpeculativeSampler.cc
+++ b/rtp_llm/cpp/speculative_engine/speculative_sampler/SpeculativeSampler.cc
@@ -174,10 +174,6 @@ void SpeculativeSampler::batchSample(SpeculativeSamplerOutput&           sample_
         if (propose_stream_output->propose_step == 0) {
             size_t accept_len = 1;
 
-            if (!stream->isDummyStream()) {
-                sample_output.accept_token_num += accept_len;
-            }
-
             rtp_llm::BufferPtr accept_tokens = device_->allocateBuffer(
                 {rtp_llm::DataType::TYPE_INT32, {1, accept_len}, rtp_llm::AllocationType::HOST}, {"accept_tokens"});
 


### PR DESCRIPTION
Prefill accept tokens should not be counted.