### PR TITLE
fix pymodel sp before moe mlp

### DIFF
--- a/rtp_llm/models_py/modules/moe/fused_moe.py
+++ b/rtp_llm/models_py/modules/moe/fused_moe.py
@@ -172,6 +172,8 @@ class FusedMoe(torch.nn.Module):
         else:
             extra_finalize_args.update({"a1_shape": a1.shape})
 
+        extra_finalize_args.update({"original_num_tokens": hidden_states.size(0)})
+
         output = self.router.finalize(
             fused_out,
             payload.expert_topk_weights,

--- a/rtp_llm/models_py/modules/moe/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/moe/routers/deepep_normal_router.py
@@ -4,6 +4,7 @@ import torch
 from librtp_compute_ops.rtp_llm_ops import trt_fp8_quantize_128
 
 from rtp_llm.config.gpt_init_model_parameters import GptInitModelParameters
+from rtp_llm.distribute.collective import Group, all_gather
 from rtp_llm.models_py.distributed.deepep_wrapper import get_deepep_wrapper
 from rtp_llm.models_py.modules.fp8_kernel import scaled_fp8_per_token_quant
 from rtp_llm.models_py.modules.moe import (
@@ -57,6 +58,16 @@ class DeepepNormalRouter(FusedMoeDataRouter):
         if a1_scale is not None or a2_scale is not None:
             raise ValueError("DeepEPNormal a1_scale or a2_scale should be None")
         act_dtype = a1.dtype
+
+        # scatter
+        tp_size = self.config.tp_size
+        tp_rank = self.config.tp_rank
+        token_num = a1.size(0)
+        tp_token_size = (token_num + tp_size - 1) // tp_size
+
+        slice_begin = min(tp_token_size * tp_rank, token_num)
+        slice_size = min(token_num - slice_begin, tp_token_size)
+
         if self.use_fp8:
             if quant_config.is_per_act_token:
                 a1, a1_scale = scaled_fp8_per_token_quant(a1, None)
@@ -65,18 +76,27 @@ class DeepepNormalRouter(FusedMoeDataRouter):
             else:
                 a1, a1_scale = trt_fp8_quantize_128(a1, False)
 
-            input = (a1, a1_scale)
+            tp_expert_a1 = torch.narrow(a1, 0, slice_begin, slice_size)
+            tp_expert_a1_scale = torch.narrow(a1_scale, 0, slice_begin, slice_size)
+            tp_expert_input = (tp_expert_a1, tp_expert_a1_scale)
         else:
-            input = a1
+            tp_expert_a1 = torch.narrow(a1, 0, slice_begin, slice_size)
+            tp_expert_input = tp_expert_a1
         # pre dispatch
         # topk_ids = topk_ids.long()
+
+        tp_expert_ids = torch.narrow(topk_ids, 0, slice_begin, slice_size)
+        tp_expert_scales = torch.narrow(topk_weights, 0, slice_begin, slice_size)
+
         (
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
             num_tokens_per_expert,
             is_token_in_rank,
             event1,
-        ) = self.deepep_buffer_wrapper.buffer.get_dispatch_layout(topk_ids, num_experts)
+        ) = self.deepep_buffer_wrapper.buffer.get_dispatch_layout(
+            tp_expert_ids, num_experts
+        )
         # dispatch
         (
             output,
@@ -86,14 +106,14 @@ class DeepepNormalRouter(FusedMoeDataRouter):
             self.handle,
             event2,
         ) = self.deepep_buffer_wrapper.buffer.dispatch(
-            input,
+            tp_expert_input,
             None,
             num_tokens_per_rank,
             num_tokens_per_rdma_rank,
             is_token_in_rank,
             num_tokens_per_expert,
-            topk_ids,
-            topk_weights,
+            tp_expert_ids,
+            tp_expert_scales,
             expert_alignment=self.expert_alignment,
         )
         if self.use_fp8:
@@ -155,5 +175,27 @@ class DeepepNormalRouter(FusedMoeDataRouter):
             fused_expert_output, self.handle
         )
         self.handle = None
+
+        # gather
+        tp_size = self.config.tp_size
+        original_num_tokens = extra_finalize_args["original_num_tokens"]
+        tp_token_size = (original_num_tokens + tp_size - 1) // tp_size
+
+        if tp_size > 1:
+            # combine_x.size(0) might be 0
+            if out_token.size(0) < tp_token_size:
+                padding_out_token = torch.empty(
+                    size=(tp_token_size - out_token.size(0), out_token.size(1)),
+                    device=out_token.device,
+                    dtype=out_token.dtype,
+                )
+                out_token = torch.cat([out_token, padding_out_token], dim=0)
+
+            gatherd_output = all_gather(out_token, group=Group.TP).reshape(
+                tp_size * tp_token_size, -1
+            )
+            gatherd_output = gatherd_output[:original_num_tokens, :]
+            return gatherd_output
+
         # out_token should be a tensor with shape and dtype like a1
         return out_token

--- a/rtp_llm/models_py/modules/moe/routers/test/deepep_normal_router_test.py
+++ b/rtp_llm/models_py/modules/moe/routers/test/deepep_normal_router_test.py
@@ -4,9 +4,14 @@ import random
 from typing import List
 
 import torch
+from librtp_compute_ops import init_device
 
 from rtp_llm.config.gpt_init_model_parameters import GptInitModelParameters
-from rtp_llm.distribute.worker_info import g_parallel_info, update_master_info
+from rtp_llm.distribute.worker_info import (
+    g_master_info,
+    g_parallel_info,
+    update_master_info,
+)
 from rtp_llm.models_py.distributed.deepep_wrapper import init_deepep_wrapper
 from rtp_llm.models_py.distributed.process_group_state import (
     destroy_distributed_environment,
@@ -43,6 +48,11 @@ def init_router(rank: int, use_fp8: bool):
     init_distributed_environment(config, backend="nccl", timeout=60)
     init_deepep_wrapper(group=get_ep_group().device_group, params=config)
     router = DeepepNormalRouter(config, use_fp8, expert_alignment=1)
+    config.dp_tp_nccl_port = g_master_info.dp_tp_nccl_port
+    config.th_nccl_port = g_master_info.th_nccl_port
+    config.tp_nccl_port = g_master_info.tp_nccl_port
+    config.ffn_tp_nccl_port = g_master_info.ffn_tp_nccl_port
+    init_device(config)
     return config, router
 
 
@@ -66,16 +76,28 @@ def worker_function(rank: int, use_fp8: bool, token_num_per_rank: List[int]):
     random.seed(rank)
     config, router = init_router(rank, use_fp8)
     try:
+        dp_rank = config.dp_rank
+        dp_size = config.dp_size
         top_k = config.expert_num
         # test dispatch
         current_device = torch.device(f"cuda:{rank}")
         for i in range(5):
-            token_num = token_num_per_rank[rank]
+            token_num = token_num_per_rank[dp_rank]
+            # 相同dp_rank的a1相同
+            torch.manual_seed(rank * dp_size + dp_rank)
             a1 = (
                 torch.randn([token_num, config.hidden_size])
                 .to(current_device)
                 .to(torch.bfloat16)
             )
+
+            a1[:, :128] = (
+                torch.arange(token_num, dtype=torch.bfloat16)
+                .view(token_num, 1)
+                .repeat(1, 128)
+                .cuda()
+            )
+
             topk_weights = torch.ones([token_num, top_k]).to(current_device)
             topk_ids = torch.arange(config.expert_num, device=current_device).repeat(
                 token_num, 1
@@ -102,27 +124,34 @@ def worker_function(rank: int, use_fp8: bool, token_num_per_rank: List[int]):
                 combine_x = dequant_to_bf16(payload.expert_x, payload.expert_x_scale)
             else:
                 combine_x = payload.expert_x
-            a2 = router.finalize(combine_x, topk_weights, topk_ids, False, None, None)
+            # pass token_num to finalize for gather
+            extra_finalize_args = {"original_num_tokens": token_num}
+            a2 = router.finalize(
+                combine_x, topk_weights, topk_ids, False, None, extra_finalize_args
+            )
             if router.use_fp8:
                 x, scale = trt_fp8_quantize_128(a1, False)
                 ref_a2 = dequant_to_bf16(x, scale) * config.world_size
             else:
                 ref_a2 = a1 * config.world_size
-            torch.testing.assert_close(ref_a2, a2)
+            torch.testing.assert_close(ref_a2[:, :128], a2[:, :128])
     finally:
         destroy_distributed_environment()
 
 
-def test_single(world_size: int, use_fp8: bool):
+def test_single(world_size: int, test_tp_size: int, use_fp8: bool):
     with PortsContext(None, 1) as ports:
         start_port = ports[0]
         os.environ["START_PORT"] = str(start_port)
         os.environ["WORLD_SIZE"] = str(world_size)
-        os.environ["TP_SIZE"] = str(world_size)
+        os.environ["TP_SIZE"] = str(test_tp_size)
+        os.environ["DP_SIZE"] = str(world_size // test_tp_size)
 
         # 启动world_size个进程
         processes = []
-        token_num_per_rank = [random.randint(4, 12) // 4 * 4 for _ in range(world_size)]
+        token_num_per_rank = [
+            random.randint(4, 12) // 4 * 4 for _ in range(world_size // test_tp_size)
+        ]
         for rank in range(world_size):
             # 为每个进程设置环境变量
             os.environ["WORLD_RANK"] = str(rank)
@@ -136,11 +165,11 @@ def test_single(world_size: int, use_fp8: bool):
             p.start()
 
         for p in processes:
-            p.join(timeout=30)
+            p.join(timeout=300)
             # KILL Process
             if p.is_alive():
                 p.terminate()
-                p.join(timeout=5)
+                p.join(timeout=60)
                 if p.is_alive():
                     p.kill()
                     p.join()
@@ -152,15 +181,11 @@ def test_single(world_size: int, use_fp8: bool):
 
 if __name__ == "__main__":
     mp.set_start_method("spawn")
-    # 获取当前可用的GPU数量
-    max_gpu_count = torch.cuda.device_count()
-    print(f"当前可用GPU数量: {max_gpu_count}")
 
-    # 根据最大GPU数量裁剪world_size列表
-    available_world_sizes = [ws for ws in [2, 4] if ws <= max_gpu_count]
-    print(f"可用的world_size: {available_world_sizes}")
+    world_size = 2
+    test_tp_sizes = [1, 2]
 
     # 为每个world_size运行test_single函数
     for use_fp8 in [True, False]:
-        for world_size in available_world_sizes:
-            test_single(world_size, use_fp8)
+        for test_tp_size in test_tp_sizes:
+            test_single(world_size, test_tp_size, use_fp8)


### PR DESCRIPTION
在 MoE 块内的 MLP 之前，需要按TP切分数据。然后 all-to-all 发送给目标专家。专家计算完成后，all-to-all获取结果，然后allgather合并各个TP的结果。目前c++ model支持该功能，但python model不支持。
本次PR实现：
1.  python model 支持在 moe mlp 之前按 TP 切分数据，在专家计算完成后 allgather 合并计算结果
2. 增加对应单测，包括多TP和单TP测试
