### PR TITLE
fix: always load weights using CPU due to incorrect ROCm mem info

### DIFF
--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -331,7 +331,7 @@ class RocmImpl(GpuImpl):
         id = self.get_device_id()
         used = rocml.smi_get_device_memory_used(id)
         total = rocml.smi_get_device_memory_total(id)
-        return MemInfo(total - used, used)
+        return MemInfo(free=total - used, used=used)
 
     @property
     def arch(self) -> str:


### PR DESCRIPTION
fix: always load weights using CPU due to incorrect ROCm mem info

The previous value order caused the free memory to reflect the system's used memory, leading to always use cpu to load weights