### PR TITLE
feat: Support the eplb feature on ROCm devices and fix some bug

### DIFF
--- a/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
@@ -250,6 +250,15 @@ protected:
     void InvokeROCmDeepGemmWi8Ai8(const GemmParams& params, BufferPtr output);
     // void prepareCommBuffer(const PrepareCommBufferParams& params) override;
 
+    void updateExpertGpuLoads(const MoeConfigs&          moe_conf,
+                              const OptionalExpertStats& expert_stats,
+                              BufferPtr                  expert_ids) override;
+
+    void balanceExperts(BufferPtr                  expert_ids,
+                        const OptionalExpertStats& expert_stats,
+                        const MoeConfigs&          moe_conf,
+                        const FfnLayerWeights&     weights);
+
 public:
     void setStream(hipStream_t stream) {
         current_stream_ = stream;

--- a/rtp_llm/cpp/devices/rocm_impl/ROCmDistributedOp.cc
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmDistributedOp.cc
@@ -62,7 +62,8 @@ NcclParam ROCmDevice::getNcclParam(ParallelMode mode) {
 }
 
 void ROCmDevice::broadcast(const BroadcastParams& params) {
-    RTP_LLM_CHECK_WITH_INFO(params.mode == ParallelMode::TP, "broadcast not support mode [%d]", params.mode);
+    RTP_LLM_CHECK_WITH_INFO(params.mode == ParallelMode::TP || params.mode == ParallelMode::DP_AND_TP,
+        "broadcast not support mode [%d]", params.mode);
     if (tp_nccl_param_.world_size_ < 2) {
         return;
     }

--- a/rtp_llm/cpp/rocm/cuda_shims.h
+++ b/rtp_llm/cpp/rocm/cuda_shims.h
@@ -115,6 +115,7 @@ __host__ __device__ inline float special_cast<float, amd_bfloat16>(amd_bfloat16 
 #define cudaStreamCreate hipStreamCreate
 #define cudaStreamDestroy hipStreamDestroy
 #define cudaStreamWaitEvent hipStreamWaitEvent
+#define cudaStreamDefault hipStreamDefault
 
 #define CUDA_IPC_HANDLE_SIZE HIP_IPC_HANDLE_SIZE
 #define cudaIpcGetMemHandle hipIpcGetMemHandle

--- a/rtp_llm/eplb/ep_balancer.py
+++ b/rtp_llm/eplb/ep_balancer.py
@@ -140,7 +140,7 @@ class ExpertBalancer:
         for idx in self.moe_layer_index:
             if (
                 most_unbalanced_idx == -1
-                or max_per_layer[idx] > max_per_layer[most_unbalanced_idx]
+                or (idx < max_per_layer.shape[0] and max_per_layer[idx] > max_per_layer[most_unbalanced_idx])
             ):
                 most_unbalanced_idx = idx
 


### PR DESCRIPTION
1.Support the eplb feature on ROCm devices.
2.Fix bug：Repeatedly executing “x = ReduceSum(x)” with tp8 will cause an overflow and set the value of x to 0.
3.Fix bug：When “HACK_LAYER_NUM” is used, the size of “max_per_layer” may be smaller than “moe_layer_index”, which can cause a core dump.