### PR TITLE
fix:fix python moe gate expert balance test

### DIFF
--- a/rtp_llm/models_py/bindings/cuda/SelectTopkOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/SelectTopkOp.cc
@@ -53,8 +53,27 @@ void SelectTopkOp::forward(torch::Tensor router_logits, torch::Tensor expert_ids
                                                      0,
                                                      normalization_mode,
                                                      current_stream);
+
     } else {
         throw std::runtime_error("Unimplemented dtype for SelectTopkOp: " + std::string(topk_t.name()));
+    }
+
+    if (configs_.moe_config.fake_balance_expert) {
+        if (expert_ids.dtype() == torch::kInt64) {
+            fake_balance_expert(expert_ids.data_ptr<int64_t>(),
+                                expert_scales.data_ptr<float>(),
+                                configs_.dp_rank_,
+                                num_expert,
+                                token_num * top_k,
+                                current_stream);
+        } else if (expert_ids.dtype() == torch::kInt32) {
+            fake_balance_expert(expert_ids.data_ptr<int32_t>(),
+                                expert_scales.data_ptr<float>(),
+                                configs_.dp_rank_,
+                                num_expert,
+                                token_num * top_k,
+                                current_stream);
+        }
     }
 }
 

--- a/rtp_llm/models_py/bindings/cuda/SelectTopkOp.h
+++ b/rtp_llm/models_py/bindings/cuda/SelectTopkOp.h
@@ -5,6 +5,7 @@
 #include "trt_plugins/mixtureOfExperts/mixtureOfExpertsPlugin.h"
 #include "rtp_llm/cpp/devices/cuda_impl/CudaDevice.h"
 #include "rtp_llm/cpp/devices/DeviceFactory.h"
+#include "rtp_llm/cpp/kernels/moe_kernels.h"
 
 namespace trt_plugins = tensorrt_llm::plugins;
 


### PR DESCRIPTION
- 修python moe test expert balance的测试
- internal 修load quant ci结果不稳定的问题，猜测是weight有时候使用cuda kernel做quant, 有时候使用cpu torch的实现做quant导致的