### PR TITLE
feat: dynamicly select blockM of deepgemm

### DIFF
--- a/rtp_llm/cpp/cuda/deep_gemm/ConfigUtils.h
+++ b/rtp_llm/cpp/cuda/deep_gemm/ConfigUtils.h
@@ -161,8 +161,14 @@ public:
         swap_ab(swap_ab) {}
 };
 
-DeepGemmConfig
-getBestConfig(int m, int n, int k, int num_groups, int num_sms, DeepGemmType gemm_type, int expected_m = -1) {
+DeepGemmConfig getBestConfig(int          m,
+                             int          n,
+                             int          k,
+                             int          num_groups,
+                             int          num_sms,
+                             DeepGemmType gemm_type,
+                             int          expected_m     = -1,
+                             bool         use_64_padding = false) {
     static std::unordered_map<DeepGemmConfigKey, DeepGemmConfig, DeepGemmConfigKeyHasher> best_configs;
 
     DeepGemmConfigKey key{m, n, k, num_groups, num_sms, gemm_type, expected_m};
@@ -214,6 +220,10 @@ getBestConfig(int m, int n, int k, int num_groups, int num_sms, DeepGemmType gem
             block_m = 64;
         } else {
             block_m = 128;
+        }
+
+        if (gemm_type == DeepGemmType::GroupedContiguous && use_64_padding) {
+            block_m = 64;
         }
 
         // For some reason, m64n8k32 is not used in deep gemm.

--- a/rtp_llm/cpp/cuda/deep_gemm/DeepGemmPlugin.cpp
+++ b/rtp_llm/cpp/cuda/deep_gemm/DeepGemmPlugin.cpp
@@ -164,6 +164,7 @@ void DeepGemmPlugin::groupedGemmFp8Contiguous(const Buffer& lhs,
                                               Buffer&       output,
                                               const Buffer& m_indices,
                                               int           user_deep_gemm_num_sm,
+                                              bool          use_64_padding,
                                               cudaStream_t  stream) {
 #ifdef ENABLE_FP8
     // lhs.fp8 e4m3, [m_sum, k]; scales -> fp32, [m_sum, k / 128]
@@ -180,7 +181,7 @@ void DeepGemmPlugin::groupedGemmFp8Contiguous(const Buffer& lhs,
     auto lhs_scales = getColMajorTmaAlignedTensor(reinterpret_cast<const QBuffer&>(lhs).scales());
     int  num_sms    = getNumSms(user_deep_gemm_num_sm);
 
-    auto best_config = getBestConfig(m, n, k, 1, num_sms, DeepGemmType::GroupedContiguous);
+    auto best_config = getBestConfig(m, n, k, 1, num_sms, DeepGemmType::GroupedContiguous, -1, use_64_padding);
 
     runDeepGemm(output.data<__nv_bfloat16>(),
                 reinterpret_cast<const QBuffer&>(lhs).kernel().data<__nv_fp8_e4m3>(),

--- a/rtp_llm/cpp/cuda/deep_gemm/DeepGemmPlugin.h
+++ b/rtp_llm/cpp/cuda/deep_gemm/DeepGemmPlugin.h
@@ -18,6 +18,7 @@ public:
                                          Buffer&       output,
                                          const Buffer& m_indices,
                                          int           user_deep_gemm_num_sm,
+                                         bool          use_64_padding,
                                          cudaStream_t  stream);
     static void groupedGemmFp8Masked(const Buffer& lhs,
                                      const Buffer& rhs,

--- a/rtp_llm/cpp/cuda/deep_gemm/test/deep_gemm_plugin_test.cpp
+++ b/rtp_llm/cpp/cuda/deep_gemm/test/deep_gemm_plugin_test.cpp
@@ -105,7 +105,7 @@ public:
         BufferPtr output = device_->allocateBuffer(
             {DataType::TYPE_BF16, {(unsigned long)m * num_groups, (unsigned long)n}, AllocationType::DEVICE});
 
-        DeepGemmPlugin::groupedGemmFp8Contiguous(*lhs, *rhs, *output, *(torchTensor2Buffer(m_indices)), -1, 0);
+        DeepGemmPlugin::groupedGemmFp8Contiguous(*lhs, *rhs, *output, *(torchTensor2Buffer(m_indices)), -1, 0, 0);
         auto gemm_output = torch::from_blob(output->data(),
                                             {(int64_t)m * num_groups, (int64_t)n},
                                             torch::TensorOptions().dtype(torch::kBFloat16).device(torch::kCUDA));

--- a/rtp_llm/cpp/utils/math_utils.h
+++ b/rtp_llm/cpp/utils/math_utils.h
@@ -46,6 +46,10 @@ inline size_t pad_to_multiple_of_16(const size_t& input) {
     return pad(input, 16);
 }
 
+inline size_t pad_to_multiple_of_64(const size_t& input) {
+    return pad(input, 64);
+}
+
 inline size_t pad_to_multiple_of_128(const size_t& input) {
     return pad(input, 128);
 }


### PR DESCRIPTION
Enable blockM=64 deep_gemm by dynamicly selecting blockM. Profits can be obtained on small models and small batchs. 

e2e time (ms) | batch = 16 | batch = 8 | batch = 4 | batch = 2 | batch = 1
-- | -- | -- | -- | -- | --
blockM128 e2e | 286.60 | 191.39 | 122.92 | 80.78 | 45.24
blockM64 e2e | 284.00 | 188.62 | 115.05 | 71.20 | 44.69

