### PR TITLE
fix: fix model size and reset default dist timeout to 10 minutes

### DIFF
--- a/rtp_llm/config/gpt_init_model_parameters.py
+++ b/rtp_llm/config/gpt_init_model_parameters.py
@@ -1422,6 +1422,16 @@ class GptInitModelParameters:
         return res
 
     def eval_model_size(self):
+        model_size = self.eval_model_weight_size()
+        kv_cache_mem_size = self._eval_kv_cache_mem_size()
+        runtime_buffer = self._eval_runtime_buffer_mem_size()
+        total_size = model_size + kv_cache_mem_size + runtime_buffer
+        logging.info(
+            f"total_size(Bytes): {total_size}, model_size:{model_size}, kv_cache_mem_size:{kv_cache_mem_size}, runtime_buffer:{runtime_buffer}"
+        )
+        return total_size
+
+    def eval_model_weight_size(self):
         layer_param_bytes = 2
         if self.quant_algo.getWeightBits() == 8:
             layer_param_bytes = 1
@@ -1434,14 +1444,7 @@ class GptInitModelParameters:
             + self.gpt_init_params.hidden_size * layer_param_bytes
             + self.word_emb_param_count * 2
         )  # maybe some model donot have lm_head
-
-        kv_cache_mem_size = self._eval_kv_cache_mem_size()
-        runtime_buffer = self._eval_runtime_buffer_mem_size()
-        total_size = model_size + kv_cache_mem_size + runtime_buffer
-        logging.info(
-            f"total_size(Bytes): {total_size}, model_size:{model_size}, kv_cache_mem_size:{kv_cache_mem_size}, runtime_buffer:{runtime_buffer}"
-        )
-        return total_size
+        return model_size
 
     def _eval_kv_cache_mem_size(self):
         if self.task_type != TaskType.LANGUAGE_MODEL:

--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -276,7 +276,7 @@ class GangConfig:
         self.gang_config_string: Optional[str] = None
         self.zone_name: str = ""
         self.distribute_config_file: str = ""
-        self.dist_barrier_timeout: int = 45
+        self.dist_barrier_timeout: Optional[int] = None
         self.gang_sleep_time: int = 10
         self.gang_timeout_min: int = 30
         self.json_gang_parts: Optional[str] = None
@@ -294,8 +294,9 @@ class GangConfig:
         self.distribute_config_file = os.environ.get(
             "DISTRIBUTE_CONFIG_FILE", self.distribute_config_file
         )
-        self.dist_barrier_timeout = int(
-            os.environ.get("DIST_BARRIER_TIMEOUT", self.dist_barrier_timeout)
+        dist_barrier_timeout_env = os.environ.get("DIST_BARRIER_TIMEOUT")
+        self.dist_barrier_timeout = (
+            int(dist_barrier_timeout_env) if dist_barrier_timeout_env else None
         )
         self.gang_sleep_time = int(
             os.environ.get("GANG_SLEEP_TIME", self.gang_sleep_time)

--- a/rtp_llm/distribute/gang_server.py
+++ b/rtp_llm/distribute/gang_server.py
@@ -11,9 +11,9 @@ from threading import Thread
 from typing import Any, Dict, List, Union
 
 import requests
+import torch.distributed
 import uvicorn
 from fastapi import FastAPI
-import torch.distributed
 
 from rtp_llm.config.py_config_modules import PyEnvConfigs, StaticConfig
 from rtp_llm.config.uvicorn_config import UVICORN_LOGGING_CONFIG
@@ -426,13 +426,16 @@ class GangServer:
         )
         logging.info(f"gang worker {g_parallel_info} init_process_group {master_url}")
         init_process_timeout = self.py_env_configs.gang_config.dist_barrier_timeout
+        # Default value is 10 minutes for NCCL
+        if init_process_timeout is not None:
+            init_process_timeout = timedelta(seconds=init_process_timeout)
         os.environ["TORCH_DIST_INIT_BARRIER"] = "1"
         torch.distributed.init_process_group(
             backend=torch.distributed.Backend.NCCL,
             init_method=master_url,
             rank=g_parallel_info.world_rank,
             world_size=g_parallel_info.world_size,
-            timeout=timedelta(seconds=init_process_timeout),
+            timeout=init_process_timeout,
         )
 
         logging.info(f"gang worker {g_parallel_info} start_health_check")

--- a/rtp_llm/model_loader/loader.py
+++ b/rtp_llm/model_loader/loader.py
@@ -248,7 +248,7 @@ class ModelLoader:
             raise ValueError(f"Unknown load method: {load_method}")
 
     def _is_memory_enough_for_fastsafetensor(self):
-        model_size = self._weights_info.config.eval_model_size()
+        model_size = self._weights_info.config.eval_model_weight_size()
         device_mem_info = self._load_config.exported_device.get_mem_info()
         max_file_size = self._load_config.database.get_max_file_size()
         if device_mem_info is None:
@@ -403,7 +403,7 @@ class ModelLoader:
     def _choose_weight_convert_device(self, current_device):
         if "FORCE_CPU_LOAD_WEIGHTS" in os.environ:
             return "cpu"
-        model_size = self._weights_info.config.eval_model_size()
+        model_size = self._weights_info.config.eval_model_weight_size()
         device_mem_info = self._load_config.exported_device.get_mem_info()
         if device_mem_info is None:
             return "cpu"


### PR DESCRIPTION
1. 之前的eval_model_size函数包含了不只模型参数的大小，还包含kv cache、runtime buffer大小；在模型加载阶段时会根据模型参数大小来选择加载时的device是否切到cpu，这里并不需要考虑kv cache、runtime buffer大小，因此新增eval_model_weight_size用以返回模型参数大小。
2. init_process_group 的timeout会影响其他集合操作（boardcast）的超时时间，修改默认值为None，使用torch.distributed默认值10分钟。