### PR TITLE
fix: plan before replay

### DIFF
--- a/rtp_llm/cpp/devices/cuda_impl/CudaFlashInfer.h
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaFlashInfer.h
@@ -53,9 +53,12 @@ public:
     std::vector<torch::Tensor> flash_mla_plan;
     MlaOpsType                 mla_ops_type = MlaOpsType::AUTO;
 
-    bool          decode_plan = true;
-    torch::Tensor plan;
-    DataType      dtype = DataType::TYPE_INVALID;
+    bool                      decode_plan = true;
+    torch::Tensor             plan;
+    DataType                  dtype = DataType::TYPE_INVALID;
+    rtp_llm::AttentionConfigs attn_configs;
+    bool                      is_prefill;
+    bool                      enable_cuda_graph = false;
 
     static bool
     check(rtp_llm::DeviceBase* device, const rtp_llm::AttentionConfigs& attn_configs, DataType dtype, bool is_prefill);


### PR DESCRIPTION
Before replay cuda graph containing flashinfer, we should call flashinfer's plan interface to generate 'kv_chunk_size_ptr', 'kv_tile_indices' tensor which is owned in flashinfer's workspace tensor.

This PR is to supplement the logic.

How sglang use cuda graph + flashinfer is an example:
[call update when prepare replay input](https://github.com/sgl-project/sglang/blob/9a1a9a42099368f4bfe13c3a3be778276aff1ed3/python/sglang/srt/layers/attention/flashinfer_backend.py#L651)
[call plan in update](https://github.com/sgl-project/sglang/blob/9a1a9a42099368f4bfe13c3a3be778276aff1ed3/python/sglang/srt/layers/attention/flashinfer_backend.py#L1064)