### PR TITLE
feat: use decode fake req rather than prefill fake req

### DIFF
--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -166,6 +166,7 @@ std::shared_ptr<GenerateStream> NormalEngine::createMinFakeStream(int32_t max_ne
     fake_input->fake_query                      = true;
     auto stream                                 = makeStream(fake_input);
     stream->setIsDummyStream(true);
+    stream->setIsContextStream(false);
     stream->setMetricsReporter(nullptr);
     stream->fakeInitKVBlock();
     return stream;


### PR DESCRIPTION
when ep_size > 1, each ep node need sync when ep dispatch and combine. Now the fake request is prefill request, which lead the ep node cannot run in cuda graph.

Image this situation: one ep node is running in cuda graph and another is not, the second one is slower due to bubble between kernels. It makes the first one waste time on waiting ep dispatch and combine.

Other LLM Inference engine like sglang, it names the fake request 'idle request', which is allow cuda graph.

To solve this problem, we just change fake request from prefill to decode