### PR TITLE
feat: frontend support ssl

### DIFF
--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -16,8 +16,10 @@ from rtp_llm.utils.fuser import MountRwMode, fetch_remote_file_to_local
 from rtp_llm.utils.weight_type import WEIGHT_TYPE
 
 DEFAULT_START_PORT = 8088
+DEFAULT_SSL_CERTFILE = ""
+DEFAULT_SSL_KEYFILE = ""
 MASTER_INFO_PORT_NUM = 11
-MIN_WORKER_INFO_PORT_NUM = 7
+MIN_WORKER_INFO_PORT_NUM = 8
 WORKER_INFO_PORT_NUM = MIN_WORKER_INFO_PORT_NUM
 
 
@@ -43,6 +45,8 @@ class ServerConfig:
     def __init__(self):
         self.frontend_server_count = 4
         self.start_port = DEFAULT_START_PORT
+        self.ssl_certfile = DEFAULT_SSL_CERTFILE
+        self.ssl_keyfile = DEFAULT_SSL_KEYFILE
         self.timeout_keep_alive = 5
         self.frontend_server_id = 0
         self.rank_id = 0
@@ -52,6 +56,8 @@ class ServerConfig:
             os.environ.get("FRONTEND_SERVER_COUNT", self.frontend_server_count)
         )
         self.start_port = int(os.environ.get("START_PORT", self.start_port))
+        self.ssl_certfile = os.environ.get("SSL_CERTFILE", self.ssl_certfile)
+        self.ssl_keyfile = os.environ.get("SSL_KEYFILE", self.ssl_keyfile)
         self.timeout_keep_alive = int(
             os.environ.get("TIMEOUT_KEEP_ALIVE", self.timeout_keep_alive)
         )

--- a/rtp_llm/distribute/worker_info.py
+++ b/rtp_llm/distribute/worker_info.py
@@ -308,6 +308,10 @@ class WorkerInfo(object):
     def backend_server_port_offset(local_rank: int, server_port: int = -1) -> int:
         return WorkerInfo.server_port_offset(local_rank, server_port) + 6
 
+    @staticmethod
+    def ssl_server_port_offset(local_rank: int, server_port: int = -1) -> int:
+        return WorkerInfo.server_port_offset(local_rank, server_port) + 7
+
     # used for ut
     def reload(self):
         new_info = self.from_env()

--- a/rtp_llm/server/server_args/worker_group_args.py
+++ b/rtp_llm/server/server_args/worker_group_args.py
@@ -7,6 +7,6 @@ def init_worker_group_args(parser):
         "--worker_info_port_num",
         env_name="WORKER_INFO_PORT_NUM",
         type=int,
-        default=7,
+        default=8,
         help="worker的总的端口的数量",
     )

--- a/rtp_llm/start_frontend_server.py
+++ b/rtp_llm/start_frontend_server.py
@@ -19,22 +19,22 @@ from rtp_llm.utils.concurrency_controller import (
 )
 
 
-def start_frontend_server(rank_id: int, server_id: int, global_controller: ConcurrencyController):
+def start_frontend_server(rank_id: int, server_id: int, global_controller: ConcurrencyController, ssl: bool = False):
     ## collect all args and envs.
     py_env_configs = PyEnvConfigs()
     py_env_configs.update_from_env()
     py_env_configs.server_config.frontend_server_id = server_id
     py_env_configs.server_config.rank_id = rank_id
-    setproctitle(f"rtp_llm_frontend_server_rank_{rank_id}_server_{server_id}")
+    setproctitle(f"rtp_llm_frontend_server_rank_{rank_id}_server_{server_id}_ssl_{ssl}")
     app = None
     g_frontend_server_info = FrontendServerInfo(
         py_env_configs.server_config.frontend_server_id
     )
     try:
-        logging.info(f"g_frontend_server_info = {g_frontend_server_info}")
+        logging.info(f"g_frontend_server_info = {g_frontend_server_info} {ssl}")
         set_global_controller(global_controller)
         separated_frontend = os.environ.get("ROLE_TYPE", "") == "FRONTEND"
-        app = FrontendApp(py_env_configs, separated_frontend)
+        app = FrontendApp(py_env_configs, separated_frontend, ssl)
         app.start()
     except BaseException as e:
         logging.error(


### PR DESCRIPTION
This PR adds optional SSL/TLS support to the service by introducing an additional SSL-enabled port at server_port + 7. The original server port remains unchanged and continues to serve traffic as before.

When both SSL_CERTFILE and SSL_KEYFILE environment variables are set, the application automatically starts listening on the SSL port (server_port + 7) using the provided certificate and key files. If these environment variables are not configured, the SSL port is not opened, maintaining backward compatibility and default behavior.