### PR TITLE
fix: remove HOME of rocm test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -192,7 +192,6 @@ build:asan --copt -fdebug-types-section # for "fix relocation truncated to fit: 
 build:asan --linkopt -fsanitize=address
 
 test:rocm --test_env PATH="/opt/rocm/bin:/opt/rh/gcc-toolset-12/root/usr/bin:/opt/conda310/bin:/opt/conda310/condabin:/usr/share/Modules/bin:/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/X11R6/bin:/opt/cmake/cmake-3.26.4/bin:$PATH"
-test:rocm --test_env HOME=/home/admin
 test:rocm --test_env LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:/opt/rocm/lib:/opt/conda310/lib/:/usr/lib64:/opt/amdgpu/lib64:$LD_LIBRARY_PATH"
 test --test_env LD_LIBRARY_PATH="/opt/rocm/lib:/opt/conda310/lib/:/usr/local/nvidia/lib64:/usr/lib64:/usr/local/cuda/lib64:/opt/amdgpu/lib64:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
 test --test_env OMP_NUM_THREADS=8


### PR DESCRIPTION
Remove HOME setup for ROCm test.
The aiter package is now available as a wheel replace of source code, so HOME-based path configuration are no longer needed.