### PR TITLE
fix: Add cudagraph support with comprehensive testing and JIT cache path for internal model

### DIFF
--- a/rtp_llm/test/utils/maga_server_manager.py
+++ b/rtp_llm/test/utils/maga_server_manager.py
@@ -142,6 +142,14 @@ class MagaServerManager(object):
             current_env["CUDA_VISIBLE_DEVICES"] = ",".join(
                 [str(_) for _ in self._device_ids]
             )
+
+        # Set DeepGEMM JIT cache directory to use a persistent global cache
+        # instead of the temporary test.outputs directory. This allows kernel
+        # cache reuse across test runs, avoiding expensive JIT compilation overhead.
+        if "DG_JIT_CACHE_DIR" not in current_env:
+            home_dir = os.environ.get("HOME", os.path.expanduser("~"))
+            current_env["DG_JIT_CACHE_DIR"] = os.path.join(home_dir, ".deep_gemm")
+
         bazel_outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
         if "MULTI_TASK_PROMPT" in current_env:
             current_env["MULTI_TASK_PROMPT"] = os.path.join(


### PR DESCRIPTION
This PR enhances internal model with cudagraph support, extensive smoke test coverage, PD (prefill-decode) separation testing, and added persistent JIT cache directory for bazel/local test.

1. Smoke Test Infrastructure Enhancement. For internal model, test  CUDA Graph + PD separation + deepep. Prefill is deepep normal, ep = 2. Decode is deepep low-latency and CUDA Graph, ep = 2.
2. internal model support CUDA Graph, return true.
3. Added persistent JIT cache directory for bazel/local test. Previously, JIT-compiled kernels were stored in temporary test output directories.
