### PR TITLE
fix(flexlb): add secondary sorting strategy for low flow case

### DIFF
--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/ShortestTTFTStrategy.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/balance/strategy/ShortestTTFTStrategy.java
@@ -300,7 +300,13 @@ public class ShortestTTFTStrategy implements LoadBalancer {
      * @return 排序后的Worker列表 从小到大
      */
     private List<ScoredWorker> sortByTTFT(List<ScoredWorker> workers) {
-        return workers.stream().sorted(Comparator.comparingLong(ScoredWorker::ttft)).toList();
+        // 二级排序
+        // 1. 第一级排序：按 ttft（首Token时间）从小到大排序
+        // 2. 第二级排序：当 ttft 相等时，按 lastSelectedTime（最后选择时间）从小到大排序
+        return workers.stream()
+                .sorted(Comparator.comparingLong(ScoredWorker::ttft)
+                        .thenComparingLong(worker -> worker.worker().getLastSelectedTime().get()))
+                .toList();
     }
 
     /**


### PR DESCRIPTION
To address the issue of unbalanced traffic distribution under low traffic conditions, add a secondary sort based on the farthest machine that has not been selected yet, to solve the problem of always selecting the first machine