### PR TITLE
fix: lock py version of deps

### DIFF
--- a/open_source/bazel/arch_select.bzl
+++ b/open_source/bazel/arch_select.bzl
@@ -65,7 +65,7 @@ def subscribe_deps():
 def whl_deps():
     return select({
         "@//:using_cuda12": ["torch==2.6.0+cu126"],
-        "@//:using_rocm": ["pyrsmi", "amdsmi@https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis%2FAMD%2Famd_smi%2Fali%2Famd_smi.tar", "aiter@https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis/AMD/RTP/aiter-0.1.6%2Bgit.329d07ba.date.202511061023-py3-none-any.whl"],
+        "@//:using_rocm": ["pyrsmi==0.2.0", "amdsmi@https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis%2FAMD%2Famd_smi%2Fali%2Famd_smi.tar", "aiter@https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis/AMD/RTP/aiter-0.1.6%2Bgit.329d07ba.date.202511061023-py3-none-any.whl"],
         "//conditions:default": ["torch==2.1.2"],
     })
 
@@ -73,7 +73,7 @@ def platform_deps():
     return select({
         "@//:using_arm": [],
         "@//:using_cuda12_arm": [],
-        "@//:using_rocm": ["pyyaml","decord==0.6.0"],
+        "@//:using_rocm": ["pyyaml==6.0.2","decord==0.6.0"],
         "//conditions:default": ["decord==0.6.0"],
     })
 

--- a/open_source/deps/requirements_rocm.txt
+++ b/open_source/deps/requirements_rocm.txt
@@ -2,7 +2,7 @@
 https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/pytorch_triton_rocm-3.0.0%2Brocm6.4.1.git75cc27c2-cp310-cp310-linux_x86_64.whl
 https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/torch-2.4.1%2Brocm6.4.1.git4e7ae583-cp310-cp310-linux_x86_64.whl
 https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/torchvision-0.19.0%2Brocm6.4.1.git4d41ad71-cp310-cp310-linux_x86_64.whl
-pyrsmi
-pyyaml
+pyrsmi==0.2.0
+pyyaml==6.0.2
 https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis/AMD/RTP/aiter-0.1.6%2Bgit.329d07ba.date.202511061023-py3-none-any.whl
 https://sinian-metrics-platform.oss-cn-hangzhou.aliyuncs.com/kis%2FAMD%2Famd_smi%2Fali%2Famd_smi.tar


### PR DESCRIPTION
Fix core error of rocm as pyrsmi 1.0.0 version is not supported now;
Lock version of 0.2.0;