### PR TITLE
feat: handle cuda oom error for py model

### DIFF
--- a/rtp_llm/cpp/core/BUILD
+++ b/rtp_llm/cpp/core/BUILD
@@ -162,7 +162,18 @@ cc_library(
     deps = [
         "//rtp_llm/cpp/core:allocator",
         "//rtp_llm/cpp/devices:devices_base",
+        "//rtp_llm/cpp/core:allocator_util",
     ] + torch_deps(),
     include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "allocator_util",
+    hdrs = [
+        "torch_utils/allocator_util.h"
+    ],
+    copts = copts(),
+    deps = torch_deps(),
     visibility = ["//visibility:public"],
 )

--- a/rtp_llm/cpp/core/Buffer.h
+++ b/rtp_llm/cpp/core/Buffer.h
@@ -7,16 +7,20 @@
 #include <string>
 #include <functional>
 #include <sstream>
+#include <cstring>
 
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 namespace rtp_llm {
+
+constexpr const char* TORCH_ALLOCATED_TAG = "torch_allocated";
 
 class QBuffer;
 
 struct BufferHints {
     BufferHints(const std::string& tag = ""): tag(tag) {}
-
-    std::string tag = "";
+    BufferHints(const std::string& tag, const std::string& stk): tag(tag), stack(stk) {}
+    std::string tag   = "";
+    std::string stack = "";
 };
 
 // Buffer is similar to Tensor, but with more limited functionality.

--- a/rtp_llm/cpp/core/torch_utils/allocator_util.h
+++ b/rtp_llm/cpp/core/torch_utils/allocator_util.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+namespace rtp_llm {
+
+namespace py = pybind11;
+
+const std::string capturePythonStackTrace(bool trace_memory) {
+    if (trace_memory) {
+        py::gil_scoped_acquire gil;
+        try {
+            py::object traceback_module = py::module::import("traceback");
+            py::object format_stack     = traceback_module.attr("format_stack");
+            py::list   stack_list       = format_stack(py::none(), py::int_(10));
+
+            std::string result;
+            result.reserve(1024);
+
+            for (auto item : stack_list) {
+                result += py::str(item).cast<std::string>();
+            }
+            return result;
+        } catch (...) {
+            return "torch_allocated";
+        }
+    } else {
+        return "torch_allocated";
+    }
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/devices/BufferManager.h
+++ b/rtp_llm/cpp/devices/BufferManager.h
@@ -66,6 +66,7 @@ public:
     void                 setTraceMemory(bool trace_memory);
     virtual BufferStatus queryStatus();
     std::string          printAllocationRecords(IAllocator* allocator);
+    std::string          printAllocationRecordsStack(IAllocator* allocator);
 
     void holdRecycle();
     void releaseRecycleHold();


### PR DESCRIPTION
功能：在py model中追踪torch分配tensor的python堆栈。
使用方式：设置环境变量：`RTP_LLM_TRACE_MEMORY=1`

在runtime oom发生时记录日志：
<img width="1026" height="870" alt="截屏2025-12-02 14 11 29" src="https://github.com/user-attachments/assets/ab926b47-b34c-4502-8efd-57fde7195f37" />



