### PR TITLE
opt startup speed: reduce too long health check interval & move import in func 

### DIFF
--- a/rtp_llm/__init__.py
+++ b/rtp_llm/__init__.py
@@ -1,3 +1,5 @@
+import time
+st = time.time()
 # load th_transformer.so
 # Import internal models to register them
 from rtp_llm.utils.import_util import has_internal_source
@@ -7,3 +9,6 @@ from .ops import *
 
 if has_internal_source():
     import internal_source.rtp_llm.models_py
+
+consume_s = time.time() - st
+print(f"import in __init__ took {consume_s:.2f}s")

--- a/rtp_llm/async_decoder_engine/engine_creator.py
+++ b/rtp_llm/async_decoder_engine/engine_creator.py
@@ -11,8 +11,10 @@ from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.models.base_model import BaseModel
 from rtp_llm.models.propose_model.propose_model import ProposeModel
 from rtp_llm.ops import TaskType
+from rtp_llm.utils.time_util import timer_wrapper
 
 
+@timer_wrapper(description="create async engine")
 def create_engine(
     model: BaseModel,
     engine_config: EngineConfig,

--- a/rtp_llm/async_decoder_engine/rpc_engine.py
+++ b/rtp_llm/async_decoder_engine/rpc_engine.py
@@ -1,4 +1,6 @@
 from typing import Dict, Optional
+import logging
+import time
 
 from typing_extensions import override
 
@@ -10,6 +12,7 @@ from rtp_llm.models.propose_model.propose_model import ProposeModel
 from rtp_llm.ops import TaskType
 from rtp_llm.ops.rtp_llm.rtp_llm_op import RtpLLMOp
 from rtp_llm.utils.mm_process_engine import MMProcessEngine
+from rtp_llm.utils.time_util import timer_wrapper
 
 
 class LanguageCppEngine(BaseEngine):
@@ -45,9 +48,13 @@ class LanguageCppEngine(BaseEngine):
             engine_config, model, self.mm_engine, propose_model, self.token_processor
         )
 
+    @timer_wrapper(description="start async engine")
     @override
     def _start(self) -> None:
+        start_time = time.time()
         self.rtp_llm_op_.start()
+        consume_s = time.time() - start_time
+        logging.info(f"start rtp_llm_op_ took {consume_s:.2f}s")
 
         # Start HTTP server for language model tasks
         if (

--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -1,9 +1,12 @@
 import logging
 import os
+import time
 from typing import Optional
 
 from rtp_llm.config.kv_cache_config import KVCacheConfig
 from rtp_llm.config.model_args import ModelArgs
+
+st = time.time()
 from rtp_llm.ops import (
     ArpcConfig,
     CacheStoreConfig,
@@ -25,6 +28,10 @@ from rtp_llm.ops import (
     SpeculativeExecutionConfig,
     VitSeparation,
 )
+
+consume_s = time.time() - st
+print(f"import rtp_llm.ops took {consume_s:.2f}s")
+
 
 DEFAULT_START_PORT = 8088
 MASTER_INFO_PORT_NUM = 11

--- a/rtp_llm/server/server_args/generate_args_from_env_clean.py
+++ b/rtp_llm/server/server_args/generate_args_from_env_clean.py
@@ -5,6 +5,7 @@
 """
 
 import argparse
+import datetime
 import os
 from ast import arg
 from typing import Any, List, Tuple
@@ -249,4 +250,7 @@ def main():
 
 
 if __name__ == "__main__":
+    # measure the initialization time
+    current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    print(f"[PROCESS_START]{current_time} Start generate args")
     main()

--- a/rtp_llm/start_backend_server.py
+++ b/rtp_llm/start_backend_server.py
@@ -14,9 +14,6 @@ from typing import List
 import torch
 from setproctitle import setproctitle
 
-from rtp_llm.config.py_config_modules import DistributeConfig, PyEnvConfigs, VitConfig
-from rtp_llm.server.backend_manager import BackendManager
-
 CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(str(CUR_PATH), ".."))
 
@@ -28,13 +25,12 @@ from rtp_llm.distribute.worker_info import (
     update_worker_info,
 )
 from rtp_llm.ops import VitSeparation
-from rtp_llm.server.vit_rpc_server import vit_start_server
 from rtp_llm.utils.concurrency_controller import (
     ConcurrencyController,
     set_global_controller,
 )
 from rtp_llm.utils.process_manager import ProcessManager
-from rtp_llm.utils.util import copy_gemm_config
+
 
 setup_logging()
 
@@ -46,6 +42,11 @@ def local_rank_start(
 ):
     """Start local rank with proper signal handling for graceful shutdown"""
     backend_manager = None
+    logging.info(f"[PROCESS_START]Start local rank process")
+    start_time = time.time()
+    from rtp_llm.server.backend_manager import BackendManager
+    from rtp_llm.utils.util import copy_gemm_config
+    logging.info(f"import BackendManager took {time.time()- start_time:.2f}s")
 
     def signal_handler(signum, frame):
         logging.info(
@@ -163,6 +164,7 @@ def _create_rank_processes(
         reader, writer = multiprocessing.Pipe(duplex=False)
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(cuda_device_list)
         os.environ["WORLD_RANK"] = str(world_rank)
+        logging.info(f"[PROCESS_SPAWN]Start local rank outer {world_rank}")
         proc = Process(
             target=local_rank_start,
             args=(global_controller, py_env_configs, writer),
@@ -330,6 +332,7 @@ def start_backend_server(
     py_env_configs: PyEnvConfigs,
     pipe_writer=None,
 ):
+    logging.info(f"[PROCESS_START]Start backend server process")
     setproctitle("rtp_llm_backend_server")
     os.makedirs("logs", exist_ok=True)
     load_gpu_nic_affinity()
@@ -344,6 +347,7 @@ def start_backend_server(
 
     # TODO(xinfei.sxf) fix this
     if py_env_configs.vit_config.vit_separation == VitSeparation.VIT_SEPARATION_ROLE:
+        from rtp_llm.server.vit_rpc_server import vit_start_server
         return vit_start_server()
 
     if not torch.cuda.is_available():

--- a/rtp_llm/start_frontend_server.py
+++ b/rtp_llm/start_frontend_server.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import time
 import traceback
 
 from setproctitle import setproctitle
@@ -11,8 +12,6 @@ CUR_PATH = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(str(CUR_PATH), ".."))
 
 from rtp_llm.config.log_config import setup_logging
-from rtp_llm.distribute.worker_info import FrontendServerInfo, update_worker_info
-from rtp_llm.frontend.frontend_app import FrontendApp
 from rtp_llm.ops import RoleType
 from rtp_llm.utils.concurrency_controller import (
     ConcurrencyController,
@@ -29,6 +28,16 @@ def start_frontend_server(
     py_env_configs: PyEnvConfigs,
 ):
     # Set rank_id and server_id on the passed config
+    logging.info(
+        f"[PROCESS_START]Start frontend server process rank_{rank_id}_server_{server_id}"
+    )
+    start_time = time.time()
+    from rtp_llm.distribute.worker_info import FrontendServerInfo, update_worker_info
+    from rtp_llm.frontend.frontend_app import FrontendApp
+
+    if rank_id == 0 and server_id == 0:
+        logging.info(f"import FrontendApp took {time.time() - start_time:.2f}s")
+
     py_env_configs.server_config.frontend_server_id = server_id
     py_env_configs.server_config.rank_id = rank_id
     setproctitle(f"rtp_llm_frontend_server_rank_{rank_id}_server_{server_id}")

--- a/rtp_llm/test/utils/maga_server_manager.py
+++ b/rtp_llm/test/utils/maga_server_manager.py
@@ -62,45 +62,18 @@ class MagaServerManager(object):
         return int(self._port)
 
     def wait_sever_done(self, timeout: int = 1600):
-        host = "localhost"
-        retry_interval = 1  # 重试间隔（秒）
-        start_time = time.time()
+        # currently we can not check vit server health, assume it is ready, xieshui will fix it
+        if int(self._env_args.get("VIT_SEPARATION", "0")) == 1:
+            return True
+
+        from rtp_llm.utils.util import wait_sever_done
 
         port = (
             WorkerInfo.rpc_server_port_offset(0, int(self._port))
             if (int(self._env_args.get("VIT_SEPARATION", "0")) == 1)
             else self._port
         )
-        port = str(port)
-
-        logging.info(f"等待pid[{self._server_process.pid}]启动中...\n端口 {port}")
-        while True:
-            try:
-                # 尝试连接到指定的主机和端口
-                sock = socket.create_connection((host, port), timeout=timeout)
-                sock.close()
-                logging.info(f"端口 {port} 已启动成功")
-                return True
-            except (socket.error, ConnectionRefusedError):
-                # 如果连接失败，等待一段时间后重试
-                time.sleep(retry_interval)
-
-                if (
-                    not psutil.pid_exists(self._server_process.pid)
-                    or self._server_process.poll()
-                ):
-                    logging.warning(
-                        f"进程:[{self._server_process.pid}] 状态异常, 服务启动失败,请查看日志文件:{self._log_file}"
-                    )
-                    self.print_process_log()
-                    return False
-                # 如果等待时间超过预设的超时时间，则放弃等待
-                if time.time() - start_time > timeout:
-                    logging.warning(
-                        f"等待端口 {port} 启动超时,请查看日志文件:{self._log_file}"
-                    )
-                    self.print_process_log()
-                    return False
+        return wait_sever_done(self._server_process, port, timeout)
 
     def start_server(
         self,

--- a/rtp_llm/utils/test/BUILD
+++ b/rtp_llm/utils/test/BUILD
@@ -45,6 +45,7 @@ py_test(
         "//rtp_llm:_ft_pickler",
         "//rtp_llm:pynvml",
         "//rtp_llm:psutil",
+        "//rtp_llm:fastapi",
     ],
 )
 

--- a/rtp_llm/utils/test/process_manager_test.py
+++ b/rtp_llm/utils/test/process_manager_test.py
@@ -394,5 +394,394 @@ class TestProcessManager(unittest.TestCase):
         self.assertTrue(self.manager.terminated)
 
 
+class TestProcessManagerHealthCheck(unittest.TestCase):
+    """Test cases for health check functionality"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.manager = ProcessManager(shutdown_timeout=50, monitor_interval=1)
+        logging.basicConfig(level=logging.INFO)
+
+    def tearDown(self):
+        """Clean up after tests"""
+        for proc in self.manager.processes:
+            if hasattr(proc, "_mock_name"):
+                continue
+            if proc.is_alive():
+                proc.terminate()
+                try:
+                    proc.join(timeout=1)
+                except Exception:
+                    pass
+                if proc.is_alive():
+                    try:
+                        os.kill(proc.pid, signal.SIGKILL)
+                    except (OSError, ProcessLookupError):
+                        pass
+
+    def test_register_health_check(self):
+        """Test registering health check for processes"""
+        # Create mock processes
+        mock_procs = [Mock() for _ in range(2)]
+        for mock_proc in mock_procs:
+            mock_proc.is_alive.return_value = True
+            mock_proc._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="test_service",
+            check_ready_fn=mock_check_fn,
+            retry_interval_seconds=0.1,
+        )
+
+        # Verify registration
+        self.assertIn("test_service", self.manager.health_check_configs)
+        config = self.manager.health_check_configs["test_service"]
+        self.assertEqual(config["processes"], mock_procs)
+        self.assertEqual(config["retry_interval_seconds"], 0.1)
+        self.assertEqual(config["check_ready_fn"], mock_check_fn)
+
+        # Verify status initialization
+        self.assertIn("test_service", self.manager.health_check_status)
+        status = self.manager.health_check_status["test_service"]
+        self.assertFalse(status["ready"])
+        self.assertFalse(status["checked"])
+
+    def test_health_check_worker_success(self):
+        """Test health check worker with successful check"""
+        # Mock processes
+        mock_procs = [Mock() for _ in range(2)]
+        for mock_proc in mock_procs:
+            mock_proc.is_alive.return_value = True
+            mock_proc._mock_name = "mock_proc"
+
+        # Create a mock check function that returns True
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="backend_server",
+            check_ready_fn=mock_check_fn,
+        )
+
+        # Run worker
+        self.manager._health_check_worker("backend_server")
+
+        # Verify status updated
+        status = self.manager.health_check_status["backend_server"]
+        self.assertTrue(status["ready"])
+        self.assertTrue(status["checked"])
+
+        # Verify check function was called
+        mock_check_fn.assert_called()
+
+    def test_health_check_worker_process_dead(self):
+        """Test health check worker when process is dead"""
+        # Mock dead processes
+        mock_procs = [Mock() for _ in range(2)]
+        for mock_proc in mock_procs:
+            mock_proc.is_alive.return_value = False
+            mock_proc._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="backend_server",
+            check_ready_fn=mock_check_fn,
+        )
+
+        # Run worker
+        self.manager._health_check_worker("backend_server")
+
+        # Verify status - should be checked but not ready
+        status = self.manager.health_check_status["backend_server"]
+        self.assertFalse(status["ready"])
+        self.assertTrue(status["checked"])
+
+        # Health check should not be called since process is dead
+        mock_check_fn.assert_not_called()
+
+    def test_start_parallel_health_checks_no_registration(self):
+        """Test starting parallel health checks with no registered checks"""
+        with patch("logging.info") as mock_info:
+            self.manager.start_parallel_health_checks()
+            mock_info.assert_any_call("No health checks registered")
+
+    def test_start_parallel_health_checks(self):
+        """Test starting parallel health checks"""
+        # Mock processes for multiple services
+        backend_procs = [Mock()]
+        backend_procs[0].is_alive.return_value = True
+        backend_procs[0]._mock_name = "backend_mock"
+
+        frontend_procs = [Mock()]
+        frontend_procs[0].is_alive.return_value = True
+        frontend_procs[0]._mock_name = "frontend_mock"
+
+        # Create mock check functions
+        backend_check_fn = Mock(return_value=False)
+        frontend_check_fn = Mock(return_value=False)
+
+        # Register multiple health checks
+        self.manager.register_health_check(
+            processes=backend_procs,
+            process_name="backend_server",
+            check_ready_fn=backend_check_fn,
+        )
+        self.manager.register_health_check(
+            processes=frontend_procs,
+            process_name="frontend_server",
+            check_ready_fn=frontend_check_fn,
+        )
+
+        # Start parallel checks
+        self.manager.start_parallel_health_checks()
+
+        backend_check_fn.return_value = True
+        frontend_check_fn.return_value = True
+
+        # Verify threads created
+        self.assertEqual(len(self.manager.health_check_threads), 2)
+        self.assertTrue(all(t.is_alive() for t in self.manager.health_check_threads))
+
+        # Wait for checks to complete
+        for thread in self.manager.health_check_threads:
+            thread.join(timeout=2)
+
+        # Verify both services are ready
+        self.assertTrue(self.manager.health_check_status["backend_server"]["ready"])
+        self.assertTrue(self.manager.health_check_status["frontend_server"]["ready"])
+
+    def test_wait_for_health_checks_success(self):
+        """Test waiting for health checks to complete successfully"""
+        # Mock processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register and start health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="test_service",
+            check_ready_fn=mock_check_fn,
+        )
+
+        self.manager.start_parallel_health_checks()
+
+        # Wait for completion
+        result = self.manager.wait_for_health_checks(timeout=5)
+
+        self.assertTrue(result)
+        self.assertTrue(self.manager.health_check_status["test_service"]["ready"])
+        self.assertTrue(self.manager.health_check_status["test_service"]["checked"])
+
+    def test_wait_for_health_checks_failure(self):
+        """Test waiting for health checks when they fail"""
+        # Mock dead processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = False
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register and start health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="test_service",
+            check_ready_fn=mock_check_fn,
+        )
+
+        self.manager.start_parallel_health_checks()
+
+        # Wait for completion
+        result = self.manager.wait_for_health_checks(timeout=5)
+
+        self.assertFalse(result)
+        self.assertFalse(self.manager.health_check_status["test_service"]["ready"])
+
+    def test_wait_for_health_checks_no_threads(self):
+        """Test waiting when no health check threads exist"""
+        result = self.manager.wait_for_health_checks()
+        self.assertTrue(result)
+
+    def test_wait_for_health_checks_timeout(self):
+        """Test waiting for health checks with timeout"""
+        # Mock processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a mock check function that never succeeds
+        mock_check_fn = Mock(return_value=False)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="slow_service",
+            check_ready_fn=mock_check_fn,
+            retry_interval_seconds=10,  # Long interval to simulate slow check
+        )
+
+        self.manager.start_parallel_health_checks()
+
+        # Wait with short timeout
+        result = self.manager.wait_for_health_checks(timeout=0.5)
+
+        # Should fail because check didn't complete
+        self.assertFalse(result)
+
+    def test_parallel_health_checks_multiple_processes(self):
+        """Test health checks work correctly with multiple processes per service"""
+        # Mock multiple processes for a service (e.g., frontend with multiple workers)
+        mock_procs = [Mock() for _ in range(3)]
+        for mock_proc in mock_procs:
+            mock_proc.is_alive.return_value = True
+            mock_proc._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="frontend_workers",
+            check_ready_fn=mock_check_fn,
+        )
+
+        self.manager.start_parallel_health_checks()
+
+        # Wait for completion
+        result = self.manager.wait_for_health_checks(timeout=5)
+
+        self.assertTrue(result)
+        self.assertTrue(self.manager.health_check_status["frontend_workers"]["ready"])
+
+    def test_health_check_worker_one_process_dies(self):
+        """Test health check when one of multiple processes dies"""
+        # Mock processes where one dies
+        mock_procs = [Mock() for _ in range(2)]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[1].is_alive.return_value = False  # One is dead
+        for mock_proc in mock_procs:
+            mock_proc._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="service_with_dead_proc",
+            check_ready_fn=mock_check_fn,
+        )
+
+        # Run worker
+        self.manager._health_check_worker("service_with_dead_proc")
+
+        # Should detect that not all processes are alive
+        status = self.manager.health_check_status["service_with_dead_proc"]
+        self.assertFalse(status["ready"])
+        self.assertTrue(status["checked"])
+
+    def test_run_health_checks(self):
+        """Test the convenience method run_health_checks"""
+        # Mock processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a mock check function
+        mock_check_fn = Mock(return_value=True)
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="test_service",
+            check_ready_fn=mock_check_fn,
+        )
+
+        # Run health checks (should start and wait)
+        result = self.manager.run_health_checks(timeout=5)
+
+        # Verify success
+        self.assertTrue(result)
+        self.assertTrue(self.manager.health_check_status["test_service"]["ready"])
+        self.assertTrue(self.manager.health_check_status["test_service"]["checked"])
+
+    def test_health_check_with_exception(self):
+        """Test health check when check_ready_fn raises exception"""
+        # Mock processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a check function that raises exception first, then succeeds
+        call_count = [0]
+
+        def check_fn_with_exception():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("First call fails")
+            return True
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="flaky_service",
+            check_ready_fn=check_fn_with_exception,
+            retry_interval_seconds=0.1,
+        )
+
+        # Run health checks - should eventually succeed after retry
+        result = self.manager.run_health_checks(timeout=5)
+
+        # Verify success after retry
+        self.assertTrue(result)
+        self.assertTrue(self.manager.health_check_status["flaky_service"]["ready"])
+        self.assertGreater(call_count[0], 1)  # Should have been called more than once
+
+    def test_custom_check_ready_function(self):
+        """Test health check with custom check_ready_fn"""
+        # Mock processes
+        mock_procs = [Mock()]
+        mock_procs[0].is_alive.return_value = True
+        mock_procs[0]._mock_name = "mock_proc"
+
+        # Create a custom check function that tracks state
+        check_state = {"counter": 0}
+
+        def custom_check():
+            check_state["counter"] += 1
+            return check_state["counter"] >= 3  # Succeed on third call
+
+        # Register health check
+        self.manager.register_health_check(
+            processes=mock_procs,
+            process_name="custom_service",
+            check_ready_fn=custom_check,
+            retry_interval_seconds=0.05,
+        )
+
+        # Run health checks
+        result = self.manager.run_health_checks(timeout=5)
+
+        # Verify custom function was called multiple times
+        self.assertTrue(result)
+        self.assertEqual(check_state["counter"], 3)
+        self.assertTrue(self.manager.health_check_status["custom_service"]["ready"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/utils/time_util.py
+++ b/rtp_llm/utils/time_util.py
@@ -44,7 +44,7 @@ def timer_wrapper(description=""):
             with Timer() as t:
                 result = func(*args, **kwargs)
             desc = description if description else func.__name__
-            logging.info(f"{desc} took: {t.cost_ms()/1000:.0f}s")
+            logging.info(f"{desc} took: {t.cost_ms()/1000:.2f}s")
             return result
 
         return wrapped


### PR DESCRIPTION
**Current RTP startup process involves the following (spawn) steps:**

1. Generate environment  
2. Start main process  
3. Start backend server subprocess  
4. If tp > 1, start multi-local-rank subprocesses  
5. Once all backends are ready, start frontend process  

During spawn-based subprocess/independent process startup, top-level unnecessary imports are triggered, introducing overhead that is not needed in parent processes.  
For example, placing `from rtp_llm.server.backend_app import BackendApp` outside of functions causes both steps 2 and 3 to import dependencies they don’t actually use. A single such import takes ~8–10 s.

Some imports are harder to remove due to tight coupling; examples include several imports in `rtp-llm/__init__.py`.

Additionally, some health-check intervals are unreasonably long, leading to unnecessary idle time. For instance, the 5-second interval while waiting for the backend to become ready can waste up to 5 s.

In this PR I also fully decouple the frontend from the backend, allowing them to start independently. This eliminates the frontend latency previously caused by spawning new processes.