### PR TITLE
hotfix: support multi merge copy for rocm mtp

### DIFF
--- a/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.cc
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.cc
@@ -10,6 +10,7 @@
 
 #include "rtp_llm/cpp/kernels/rmsnormKernels.h"
 #include "rtp_llm/cpp/kernels/activation_kernels.h"
+#include "rtp_llm/cpp/kernels/copy_utils.h"
 #include "rtp_llm/cpp/kernels/tensor_ops_kernels.h"
 #include "rtp_llm/cpp/kernels/embedding_kernels.h"
 #include "rtp_llm/cpp/kernels/mask_logits.h"
@@ -287,6 +288,16 @@ void ROCmDevice::copy(const CopyParams& params) {
     if (copyType == hipMemcpyDeviceToHost) {
         ROCM_CHECK(hipStreamSynchronize(stream_));
     }
+}
+
+void ROCmDevice::multiMergeCopy(const MultiMergeCopyParams& params) {
+    std::vector<void*>  multi_src_ptrs(params.src_ptrs.size());
+    std::vector<size_t> multi_src_copy_sizes(params.src_ptrs.size());
+    for (size_t i = 0; i < params.src_ptrs.size(); i++) {
+        multi_src_ptrs[i]       = params.src_ptrs[i];
+        multi_src_copy_sizes[i] = params.copy_size[i];
+    }
+    InvokeMultiMergeCopyKernel(params.dst_ptr, multi_src_ptrs, multi_src_copy_sizes, params.dst_offsets, stream_);
 }
 
 void ROCmDevice::noBlockCopy(const CopyParams& params) {

--- a/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
@@ -180,6 +180,7 @@ public:
         return hostAllocator_.get();
     }
     void                   copy(const CopyParams& params) override;
+    void                   multiMergeCopy(const MultiMergeCopyParams& params) override;
     void                   noBlockCopy(const CopyParams& params) override;
     void                   bufMemset(Buffer& buf, int val, DeviceStream stream = DeviceStream::DEFAULT) override;
     TransposeOutput        transpose(const TransposeParams& params) override;


### PR DESCRIPTION
Support the multiMergeCopy capability when the size of all_streams is greater than or equal to 8 during gatherModelInput.