### PR TITLE
feat: Enhance GLM-4 function call detector to support GLM-4.7 format with added unit tests.

### DIFF
--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/glm4_moe_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/glm4_moe_detector.py
@@ -16,54 +16,98 @@ from rtp_llm.openai.renderers.sglang_helpers.function_call.ebnf_composer import 
     EBNFComposer,
 )
 
-logger = logging.getLogger(__name__)
-
 
 def get_argument_type(func_name: str, arg_key: str, defined_tools: list):
     name2tool = {tool.function.name: tool for tool in defined_tools}
     if func_name not in name2tool:
         return None
     tool = name2tool[func_name]
-    if arg_key not in tool.function.parameters["properties"]:
+    properties = (tool.function.parameters or {}).get("properties", {})
+    if not isinstance(properties, dict) or arg_key not in properties:
         return None
-    return tool.function.parameters["properties"][arg_key].get("type", None)
+    return properties[arg_key].get("type", None)
 
 
-def parse_arguments(json_value):
+def _convert_to_number(value: str):
+    """Convert string to int or float."""
     try:
-        parsed_value = json.loads(json_value)
+        if "." in value or "e" in value.lower():
+            return float(value)
+        else:
+            return int(value)
+    except (ValueError, AttributeError):
+        return value
+
+
+def parse_arguments(value, arg_type=None):
+    """Parse argument value with multiple fallback strategies. Always try to parse as JSON first.
+
+    Args:
+        value: Raw string value to parse
+        arg_type: Expected type hint ('string', 'number', 'object', etc.)
+
+    Returns:
+        Tuple of (parsed_value, is_valid_json)
+    """
+    # Strategy 1: Direct JSON parsing
+    try:
+        parsed_value = json.loads(value)
+        # Type coercion for number type
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
         return parsed_value, True
-    except:
-        # If that fails, try wrapping it to unescape JSON characters
-        try:
-            # Wrap the value as a JSON string field
-            wrapped = json.loads('{"tmp": "' + json_value + '"}')
-            # parse the unescaped value
-            parsed_value = json.loads(wrapped["tmp"])
-            return parsed_value, True
-        except:
-            # Final fallback to ast.literal_eval
-            try:
-                parsed_value = ast.literal_eval(json_value)
-                return parsed_value, True
-            except:
-                return json_value, False
+    except Exception:
+        logging.warn("parse_arguments strategy 1 failed for: %s", value)
+
+    # Strategy 2: Unescape and parse
+    try:
+        wrapped = json.loads('{"tmp": "' + value + '"}')
+        parsed_value = json.loads(wrapped["tmp"])
+        if arg_type == "number" and isinstance(parsed_value, str):
+            parsed_value = _convert_to_number(parsed_value)
+        return parsed_value, True
+    except Exception:
+        logging.warn("parse_arguments strategy 2 failed for: %s", value)
+
+    # Strategy 3: ast.literal_eval
+    try:
+        parsed_value = ast.literal_eval(value)
+        return parsed_value, True
+    except Exception:
+        logging.warn("parse_arguments strategy 3 failed for: %s", value)
+
+    return value, False
 
 
 class Glm4MoeDetector(BaseFormatDetector):
     """
-    Detector for GLM-4.5 and GLM-4.6 models.
-    Assumes function call format:
-      <tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>北京</arg_value>\n<arg_key>date</arg_key>\n<arg_value>2024-06-27</arg_value>\n</tool_call>\n<tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>上海</arg_value>\n<arg_key>date</arg_key>\n<arg_value>2024-06-27</arg_value>\n</tool_call>
+    Detector for GLM-4.5, GLM-4.6, and GLM-4.7 models.
+
+    Supported formats:
+
+    1. GLM-4.5/4.6 with newline separator:
+       <tool_call>get_weather
+       <arg_key>city</arg_key>
+       <arg_value>北京</arg_value>
+       </tool_call>
+
+    2. GLM-4.5/4.6 with literal \\n separator:
+       <tool_call>get_weather\\n<arg_key>city</arg_key>\\n<arg_value>北京</arg_value>\\n</tool_call>
+
+    3. GLM-4.7 with no separator:
+       <tool_call>get_weather<arg_key>city</arg_key><arg_value>北京</arg_value></tool_call>
+
+    4. GLM-4.7 no-argument call:
+       <tool_call>get_time</tool_call>
     """
 
     def __init__(self):
         super().__init__()
         self.bot_token = "<tool_call>"
         self.eot_token = "</tool_call>"
-        self.func_call_regex = r"<tool_call>.*?</tool_call>"
+        self.func_call_regex = re.compile(r"<tool_call>.*?</tool_call>", re.DOTALL)
         self.func_detail_regex = re.compile(
-            r"<tool_call>(.*?)(?:\\n|\n)(.*)</tool_call>", re.DOTALL
+            r"<tool_call>(.*?)(<arg_key>.*?)?</tool_call>", re.DOTALL
         )
         self.func_arg_regex = re.compile(
             r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
@@ -86,23 +130,44 @@ class Glm4MoeDetector(BaseFormatDetector):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             return StreamingParseResult(normal_text=normal_text, calls=[])
-        match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
+        match_result_list = self.func_call_regex.findall(text)
         calls = []
         try:
             for match_result in match_result_list:
                 # Get function name
                 func_detail = self.func_detail_regex.search(match_result)
-                func_name = func_detail.group(1)
-                func_args = func_detail.group(2)
+                if func_detail is None:
+                    continue
+                func_name = (
+                    func_detail.group(1).strip().rstrip("\\n")
+                    if func_detail.group(1)
+                    else ""
+                )
+                func_args = func_detail.group(2) if func_detail.group(2) else ""
                 pairs = self.func_arg_regex.findall(func_args)
                 arguments = {}
                 for arg_key, arg_value in pairs:
                     arg_key = arg_key.strip()
                     arg_value = arg_value.strip()
                     arg_type = get_argument_type(func_name, arg_key, tools)
-                    if arg_type != "string":
-                        arg_value, is_good_json = parse_arguments(arg_value)
-                    arguments[arg_key] = arg_value
+                    parsed_value, is_good_json = parse_arguments(arg_value, arg_type)
+
+                    if arg_type == "string":
+                        # Ensure string type even if parsed as dict/list
+                        if isinstance(parsed_value, str):
+                            arguments[arg_key] = parsed_value
+                        elif isinstance(parsed_value, (dict, list)):
+                            arguments[arg_key] = json.dumps(
+                                parsed_value, ensure_ascii=False
+                            )
+                        else:
+                            arguments[arg_key] = str(parsed_value)
+                    elif arg_type is None:
+                        # If type is not defined, keep parsed value as-is
+                        arguments[arg_key] = parsed_value if is_good_json else arg_value
+                    else:
+                        # For other types (number, object, array, etc.)
+                        arguments[arg_key] = parsed_value if is_good_json else arg_value
                 # construct match_result for parse_base_json
                 match_result = {"name": func_name, "parameters": arguments}
                 calls.extend(self.parse_base_json(match_result, tools))

--- a/rtp_llm/test/BUILD
+++ b/rtp_llm/test/BUILD
@@ -167,3 +167,16 @@ py_test(
     ],
     exec_properties = {'gpu':'A10'},
 )
+
+py_test(
+    name = "glm4_moe_detector_test",
+    srcs = [
+        "glm4_moe_detector_test.py",
+    ],
+    data = [],
+    deps = [
+        "//rtp_llm:testlib"
+    ],
+    imports = [],
+    exec_properties = {'gpu':'A10'},
+)

--- a/rtp_llm/test/glm4_moe_detector_test.py
+++ b/rtp_llm/test/glm4_moe_detector_test.py
@@ -1,0 +1,260 @@
+import unittest
+
+from rtp_llm.openai.renderers.sglang_helpers.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+)
+from rtp_llm.openai.renderers.sglang_helpers.function_call.glm4_moe_detector import (
+    Glm4MoeDetector,
+)
+
+
+def create_tools():
+    """Create test tool definitions."""
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="Get the weather",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "The city name"},
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["city"],
+                },
+            ),
+        ),
+        Tool(
+            type="function",
+            function=Function(
+                name="get_time",
+                description="Get current time",
+                parameters={"type": "object", "properties": {}},
+            ),
+        ),
+    ]
+
+
+class TestGlm4MoeDetector(unittest.TestCase):
+    """Test Glm4MoeDetector with various GLM-4 and GLM-4.7 formats."""
+
+    def setUp(self):
+        self.detector = Glm4MoeDetector()
+        self.tools = create_tools()
+
+    # ========== With Args Tests ==========
+
+    def test_with_args_newline_separator(self):
+        """GLM-4 style: function name and args separated by actual newline."""
+        text = "<tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>杭州</arg_value>\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        expected_name = "get_weather"
+        expected_params = '"city": "杭州"'
+        self.assertEqual(
+            len(result.calls), 1, f"expected 1 call, actual {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            expected_name,
+            f"expected {expected_name}, actual {result.calls[0].name}",
+        )
+        self.assertIn(
+            expected_params,
+            result.calls[0].parameters,
+            f"expected {expected_params} in actual {result.calls[0].parameters}",
+        )
+
+    def test_with_args_literal_newline_separator(self):
+        """GLM-4 style: function name and args separated by literal \\n."""
+        text = "<tool_call>get_weather\\n<arg_key>city</arg_key>\\n<arg_value>杭州</arg_value>\\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        expected_name = "get_weather"
+        expected_params = '"city": "杭州"'
+        self.assertEqual(
+            len(result.calls), 1, f"expected 1 call, actual {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            expected_name,
+            f"expected {expected_name}, actual {result.calls[0].name}",
+        )
+        self.assertIn(
+            expected_params,
+            result.calls[0].parameters,
+            f"expected {expected_params} in actual {result.calls[0].parameters}",
+        )
+
+    def test_with_args_no_separator(self):
+        """GLM-4.7 style: no separator between function name and args."""
+        text = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>杭州</arg_value></tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        expected_name = "get_weather"
+        expected_params = '"city": "杭州"'
+        self.assertEqual(
+            len(result.calls), 1, f"expected 1 call, actual {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            expected_name,
+            f"expected {expected_name}, actual {result.calls[0].name}",
+        )
+        self.assertIn(
+            expected_params,
+            result.calls[0].parameters,
+            f"expected {expected_params} in actual {result.calls[0].parameters}",
+        )
+
+    # ========== Without Args Tests ==========
+
+    def test_no_args_newline_separator(self):
+        """GLM-4 style: no args, with trailing newline."""
+        text = "<tool_call>get_time\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            len(result.calls), 1, f"Expected 1 call, got {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            "get_time",
+            f"Expected get_time, got {result.calls[0].name}",
+        )
+        self.assertEqual(
+            result.calls[0].parameters,
+            "{}",
+            f"Expected {{}}, got {result.calls[0].parameters}",
+        )
+
+    def test_no_args_literal_newline_separator(self):
+        """GLM-4 style: no args, with literal \\n."""
+        text = "<tool_call>get_time\\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            len(result.calls), 1, f"Expected 1 call, got {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            "get_time",
+            f"Expected get_time, got {result.calls[0].name}",
+        )
+        self.assertEqual(
+            result.calls[0].parameters,
+            "{}",
+            f"Expected {{}}, got {result.calls[0].parameters}",
+        )
+
+    def test_no_args_no_separator(self):
+        """GLM-4.7 style: no args, no separator."""
+        text = "<tool_call>get_time</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            len(result.calls), 1, f"Expected 1 call, got {len(result.calls)}"
+        )
+        self.assertEqual(
+            result.calls[0].name,
+            "get_time",
+            f"Expected get_time, got {result.calls[0].name}",
+        )
+        self.assertEqual(
+            result.calls[0].parameters,
+            "{}",
+            f"Expected {{}}, got {result.calls[0].parameters}",
+        )
+
+    # ========== Multiple Args Tests ==========
+
+    def test_multiple_args_newline_separator(self):
+        """GLM-4 style: multiple args with newlines."""
+        text = (
+            "<tool_call>get_weather\n"
+            "<arg_key>city</arg_key>\n<arg_value>杭州</arg_value>\n"
+            "<arg_key>unit</arg_key>\n<arg_value>celsius</arg_value>\n"
+            "</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        params = result.calls[0].parameters
+        self.assertIn('"city": "杭州"', params, f"Expected city in {params}")
+        self.assertIn('"unit": "celsius"', params, f"Expected unit in {params}")
+
+    def test_multiple_args_no_separator(self):
+        """GLM-4.7 style: multiple args without separators."""
+        text = (
+            "<tool_call>get_weather"
+            "<arg_key>city</arg_key><arg_value>杭州</arg_value>"
+            "<arg_key>unit</arg_key><arg_value>celsius</arg_value>"
+            "</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        params = result.calls[0].parameters
+        self.assertIn('"city": "杭州"', params, f"Expected city in {params}")
+        self.assertIn('"unit": "celsius"', params, f"Expected unit in {params}")
+
+    # ========== Multiple Tool Calls Tests ==========
+
+    def test_multiple_tool_calls(self):
+        """Test multiple tool calls in one text."""
+        text = (
+            "<tool_call>get_weather<arg_key>city</arg_key><arg_value>杭州</arg_value></tool_call>"
+            "<tool_call>get_weather<arg_key>city</arg_key><arg_value>北京</arg_value></tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            len(result.calls), 2, f"Expected 2 calls, got {len(result.calls)}"
+        )
+        self.assertIn('"city": "杭州"', result.calls[0].parameters)
+        self.assertIn('"city": "北京"', result.calls[1].parameters)
+
+    # ========== Normal Text Tests ==========
+
+    def test_normal_text_before_tool_call(self):
+        """Test that normal text before tool call is preserved."""
+        text = "让我查询天气<tool_call>get_weather<arg_key>city</arg_key><arg_value>杭州</arg_value></tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            result.normal_text,
+            "让我查询天气",
+            f"Expected '让我查询天气', got '{result.normal_text}'",
+        )
+        self.assertEqual(len(result.calls), 1)
+
+    def test_no_tool_call(self):
+        """Test text without any tool call."""
+        text = "这是普通文本，没有工具调用"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(
+            result.normal_text, text, f"Expected '{text}', got '{result.normal_text}'"
+        )
+        self.assertEqual(
+            len(result.calls), 0, f"Expected 0 calls, got {len(result.calls)}"
+        )
+
+    # ========== has_tool_call Tests ==========
+
+    def test_has_tool_call_true(self):
+        """Test has_tool_call returns True when tool call exists."""
+        text = "<tool_call>get_weather</tool_call>"
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        """Test has_tool_call returns False when no tool call."""
+        text = "这是普通文本"
+        self.assertFalse(self.detector.has_tool_call(text))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
GLM-4.7 可能输出不带 arg 的tool call，例如 `<tool_call>get_all_func</tool_call>`. 
因此会导致解析失败，需要兼容处理。
过去GLM4.6所使用的tool call解析器默认必有arg：
```
<tool_call>get_current_weather
<arg_key>location</arg_key>
<arg_value>杭州</arg_value>
</tool_call>
```
sglang 和 智谱 官方已兼容。