### PR TITLE
fix: fix model size and reset default dist timeout to 10 minutes

### DIFF
--- a/rtp_llm/config/gpt_init_model_parameters.py
+++ b/rtp_llm/config/gpt_init_model_parameters.py
@@ -1433,6 +1433,16 @@ class GptInitModelParameters:
         return res
 
     def eval_model_size(self):
+        model_size = self.eval_model_weight_size()
+        kv_cache_mem_size = self._eval_kv_cache_mem_size()
+        runtime_buffer = self._eval_runtime_buffer_mem_size()
+        total_size = model_size + kv_cache_mem_size + runtime_buffer
+        logging.info(
+            f"total_size(Bytes): {total_size}, model_size:{model_size}, kv_cache_mem_size:{kv_cache_mem_size}, runtime_buffer:{runtime_buffer}"
+        )
+        return total_size
+
+    def eval_model_weight_size(self):
         layer_param_bytes = 2
         if self.quant_algo.getWeightBits() == 8:
             layer_param_bytes = 1
@@ -1445,14 +1455,7 @@ class GptInitModelParameters:
             + self.gpt_init_params.hidden_size * layer_param_bytes
             + self.word_emb_param_count * 2
         )  # maybe some model donot have lm_head
-
-        kv_cache_mem_size = self._eval_kv_cache_mem_size()
-        runtime_buffer = self._eval_runtime_buffer_mem_size()
-        total_size = model_size + kv_cache_mem_size + runtime_buffer
-        logging.info(
-            f"total_size(Bytes): {total_size}, model_size:{model_size}, kv_cache_mem_size:{kv_cache_mem_size}, runtime_buffer:{runtime_buffer}"
-        )
-        return total_size
+        return model_size
 
     def _eval_kv_cache_mem_size(self):
         if self.task_type != TaskType.LANGUAGE_MODEL:

--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -290,7 +290,7 @@ class GangConfig:
         self.gang_config_string: Optional[str] = None
         self.zone_name: str = ""
         self.distribute_config_file: str = ""
-        self.dist_barrier_timeout: int = 45
+        self.dist_barrier_timeout: Optional[int] = None
         self.gang_sleep_time: int = 10
         self.gang_startup_interval: float = 0.1
         self.gang_timeout_min: int = 30
@@ -309,8 +309,9 @@ class GangConfig:
         self.distribute_config_file = os.environ.get(
             "DISTRIBUTE_CONFIG_FILE", self.distribute_config_file
         )
-        self.dist_barrier_timeout = int(
-            os.environ.get("DIST_BARRIER_TIMEOUT", self.dist_barrier_timeout)
+        dist_barrier_timeout_env = os.environ.get("DIST_BARRIER_TIMEOUT")
+        self.dist_barrier_timeout = (
+            int(dist_barrier_timeout_env) if dist_barrier_timeout_env else None
         )
         self.gang_sleep_time = int(
             os.environ.get("GANG_SLEEP_TIME", self.gang_sleep_time)

--- a/rtp_llm/distribute/gang_server.py
+++ b/rtp_llm/distribute/gang_server.py
@@ -428,13 +428,16 @@ class GangServer:
         )
         logging.info(f"gang worker {g_parallel_info} init_process_group {master_url}")
         init_process_timeout = self.py_env_configs.gang_config.dist_barrier_timeout
+        # Default value is 10 minutes for NCCL
+        if init_process_timeout is not None:
+            init_process_timeout = timedelta(seconds=init_process_timeout)
         os.environ["TORCH_DIST_INIT_BARRIER"] = "1"
         torch.distributed.init_process_group(
             backend=torch.distributed.Backend.NCCL,
             init_method=master_url,
             rank=g_parallel_info.world_rank,
             world_size=g_parallel_info.world_size,
-            timeout=timedelta(seconds=init_process_timeout),
+            timeout=init_process_timeout,
         )
 
         logging.info(f"gang worker {g_parallel_info} start_health_check")

--- a/rtp_llm/model_loader/loader.py
+++ b/rtp_llm/model_loader/loader.py
@@ -226,7 +226,7 @@ class ModelLoader:
         return self._load_from_scratch(device)
     
     def _is_memory_enough_for_fastsafetensor(self):
-        model_size = self._weights_info.config.eval_model_size()
+        model_size = self._weights_info.config.eval_model_weight_size()
         device_mem_info = self._load_config.exported_device.get_mem_info()
         max_file_size = self._load_config.database.get_max_file_size()
         if device_mem_info is None:
@@ -375,7 +375,7 @@ class ModelLoader:
     def _choose_weight_convert_device(self, current_device):
         if "FORCE_CPU_LOAD_WEIGHTS" in os.environ:
             return "cpu"
-        model_size = self._weights_info.config.eval_model_size()
+        model_size = self._weights_info.config.eval_model_weight_size()
         device_mem_info = self._load_config.exported_device.get_mem_info()
         if device_mem_info is None:
             return "cpu"


### PR DESCRIPTION
cherry-pick a commit to fix model size and reset default dist timeout to 10 minutes (deepseek v3.2 load weight costs 900s)
