### PR TITLE
fix: missing tool calls when incremental parsing is combined with MTP

### DIFF
--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/deepseekv31_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/deepseekv31_detector.py
@@ -94,9 +94,81 @@ class DeepSeekV31Detector(BaseFormatDetector):
     ) -> StreamingParseResult:
         """
         Streaming incremental parsing tool calls for DeepSeekV3 format.
+
+        MTP-safe: First checks for complete <｜tool▁call▁begin｜>...<｜tool▁call▁end｜> blocks.
+        Falls back to regex-based incremental parsing for partial data.
         """
         self._buffer += new_text
         current_text = self._buffer
+
+        # MTP-safe path: Parse any complete tool call blocks first
+        # This handles MTP scenarios where multiple tokens arrive in single chunk
+        tool_call_start = "<｜tool▁call▁begin｜>"
+        tool_call_end = "<｜tool▁call▁end｜>"
+        collected_calls: list[ToolCallItem] = []
+
+        while tool_call_start in current_text and tool_call_end in current_text:
+            start_idx = current_text.find(tool_call_start)
+            end_idx = current_text.find(tool_call_end)
+
+            # Only process if we have a complete block (end comes after start)
+            if end_idx <= start_idx:
+                break
+
+            # Extract the complete tool call block
+            block_end = end_idx + len(tool_call_end)
+            complete_block = current_text[start_idx:block_end]
+
+            # Try to parse with the full regex
+            match = re.search(self.func_detail_regex, complete_block, re.DOTALL)
+            if match:
+                func_name = match.group(1).strip()
+                func_args_raw = match.group(2).strip()
+
+                # Initialize state if this is the first tool call
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = [""]
+
+                # Ensure we have enough entries in our tracking arrays
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+
+                # Create complete tool call item
+                collected_calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=func_name,
+                        parameters=func_args_raw,
+                    )
+                )
+
+                # Store tool call info for serving layer
+                try:
+                    parsed_args = json.loads(func_args_raw) if func_args_raw else {}
+                except json.JSONDecodeError:
+                    parsed_args = {}
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": func_name,
+                    "arguments": parsed_args,
+                }
+                self.streamed_args_for_tool[self.current_tool_id] = func_args_raw or ""
+                self.current_tool_id += 1
+
+                # Extend arrays for next potential tool call
+                self.prev_tool_call_arr.append({})
+                self.streamed_args_for_tool.append("")
+
+            # Remove processed block from buffer
+            current_text = current_text[block_end:]
+            self._buffer = current_text
+
+        # If we parsed any complete blocks, return those results
+        if collected_calls:
+            return StreamingParseResult(normal_text="", calls=collected_calls)
 
         # Check if we have a tool call (either the start token or individual tool call)
         has_tool_call = (

--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/kimik2_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/kimik2_detector.py
@@ -108,9 +108,83 @@ class KimiK2Detector(BaseFormatDetector):
     ) -> StreamingParseResult:
         """
         Streaming incremental parsing tool calls for KimiK2 format.
+
+        MTP-safe: First checks for complete <|tool_call_begin|>...<|tool_call_end|> blocks.
+        Falls back to regex-based incremental parsing for partial data.
         """
         self._buffer += new_text
         current_text = self._buffer
+
+        # MTP-safe path: Parse any complete tool call blocks first
+        # This handles MTP scenarios where multiple tokens arrive in single chunk
+        collected_calls: list[ToolCallItem] = []
+        while (
+            self.tool_call_start_token in current_text
+            and self.tool_call_end_token in current_text
+        ):
+            start_idx = current_text.find(self.tool_call_start_token)
+            end_idx = current_text.find(self.tool_call_end_token)
+
+            # Only process if we have a complete block (end comes after start)
+            if end_idx <= start_idx:
+                break
+
+            # Extract the complete tool call block
+            block_end = end_idx + len(self.tool_call_end_token)
+            complete_block = current_text[start_idx:block_end]
+
+            # Try to parse with the full regex
+            match = self.tool_call_regex.search(complete_block)
+            if match:
+                function_id = match.group("tool_call_id")
+                function_args = match.group("function_arguments")
+                function_name = function_id.split(".")[1].split(":")[0]
+                function_idx = int(function_id.split(".")[1].split(":")[1])
+
+                # Initialize state if this is the first tool call
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                    self.prev_tool_call_arr = []
+                    self.streamed_args_for_tool = [""]
+
+                # Ensure we have enough entries in our tracking arrays
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+
+                # Create complete tool call item
+                collected_calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=function_name,
+                        parameters=function_args,
+                    )
+                )
+
+                # Store tool call info for serving layer
+                try:
+                    parsed_args = json.loads(function_args) if function_args else {}
+                except json.JSONDecodeError:
+                    parsed_args = {}
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": function_name,
+                    "arguments": parsed_args,
+                }
+                self.streamed_args_for_tool[self.current_tool_id] = function_args or ""
+                self.current_tool_id += 1
+
+                # Extend arrays for next potential tool call
+                self.prev_tool_call_arr.append({})
+                self.streamed_args_for_tool.append("")
+
+            # Remove processed block from buffer
+            current_text = current_text[block_end:]
+            self._buffer = current_text
+
+        # If we parsed any complete blocks, return those results
+        if collected_calls:
+            return StreamingParseResult(normal_text="", calls=collected_calls)
 
         # Check if we have a tool call (either the start token or individual tool call)
         has_tool_call = (

--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/qwen25_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/qwen25_detector.py
@@ -83,9 +83,86 @@ class Qwen25Detector(BaseFormatDetector):
     ) -> StreamingParseResult:
         """
         Streaming incremental parsing for Qwen 2.5 tool calls.
-        Uses base class implementation with buffering to handle partial end tokens.
+
+        MTP-safe: First checks for complete <tool_call>...</tool_call> blocks in buffer.
+        Falls back to base class incremental parsing for partial data.
         """
-        result = super().parse_streaming_increment(new_text, tools)
+        self._buffer += new_text
+
+        collected_calls: list = []
+        collected_normal_text = ""
+
+        # MTP-safe path: Parse any complete tool call blocks first
+        # This handles MTP scenarios where multiple tokens arrive in single chunk
+        while self.bot_token in self._buffer and self.eot_token in self._buffer:
+            bot_idx = self._buffer.find(self.bot_token)
+            eot_idx = self._buffer.find(self.eot_token)
+
+            # Only process if we have a complete block (eot comes after bot)
+            if eot_idx <= bot_idx:
+                break
+
+            # Extract text before tool call as normal text
+            if bot_idx > 0:
+                collected_normal_text += self._buffer[:bot_idx]
+
+            # Extract and parse the complete tool call block
+            block_end = eot_idx + len(self.eot_token)
+            complete_block = self._buffer[bot_idx:block_end]
+
+            # Initialize state if this is the first tool call
+            if self.current_tool_id == -1:
+                self.current_tool_id = 0
+                self.prev_tool_call_arr = []
+                self.streamed_args_for_tool = [""]
+
+            # Ensure we have enough entries in our tracking arrays
+            while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                self.prev_tool_call_arr.append({})
+            while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                self.streamed_args_for_tool.append("")
+
+            # Parse the complete block using detect_and_parse
+            result = self.detect_and_parse(complete_block, tools)
+            if result.calls:
+                for call in result.calls:
+                    call.tool_index = self.current_tool_id
+                    # Store tool call info for serving layer
+                    self.prev_tool_call_arr[self.current_tool_id] = {
+                        "name": call.name,
+                        "arguments": (
+                            json.loads(call.parameters) if call.parameters else {}
+                        ),
+                    }
+                    self.streamed_args_for_tool[self.current_tool_id] = (
+                        call.parameters or ""
+                    )
+                    collected_calls.append(call)
+                    self.current_tool_id += 1
+                    # Extend arrays for next potential tool call
+                    self.prev_tool_call_arr.append({})
+                    self.streamed_args_for_tool.append("")
+
+            # Remove processed block from buffer
+            self._buffer = self._buffer[block_end:]
+
+        # If we parsed any complete blocks, return those results
+        if collected_calls or collected_normal_text:
+            # Reset buffer for base class if we're switching to incremental mode
+            remaining = self._buffer
+            self._buffer = ""
+            # If there's remaining content that might be partial, handle with base class
+            if remaining:
+                self._buffer = remaining
+            return StreamingParseResult(
+                normal_text=collected_normal_text, calls=collected_calls
+            )
+
+        # Fall back to base class incremental parsing for partial data
+        # Reset buffer since we're passing to base class which will re-accumulate
+        remaining = self._buffer
+        self._buffer = ""
+        result = super().parse_streaming_increment(remaining, tools)
 
         # Handle partial end tokens that are streamed character by character
         if result.normal_text:

--- a/rtp_llm/test/BUILD
+++ b/rtp_llm/test/BUILD
@@ -206,3 +206,16 @@ py_test(
     imports = [],
     exec_properties = {'gpu':'A10'},
 )
+
+py_test(
+    name = "mtp_streaming_tool_parsing_test",
+    srcs = [
+        "mtp_streaming_tool_parsing_test.py",
+    ],
+    data = [],
+    deps = [
+        "//rtp_llm:testlib"
+    ],
+    imports = [],
+    exec_properties = {'gpu':'A10'},
+)


### PR DESCRIPTION
之前 qwen3、deepseek、kimi 参照 sglang 实现了增量 tool call 返回。其中基于假设：每个chunk只会有一个token。但开启MTP后一个chunk大部分时候都会有多个token，此时会导致 tool call 解析失败。此PR为修复该问题。
主要变更就是在之前增量解析的基础上加了一个兜底处理