### PR TITLE
optimize kv_block_array

### DIFF
--- a/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmDevice.h
@@ -296,7 +296,8 @@ public:
     ParamsPtr PrepareCKAttn(const AttentionConfigs& configs,
                             const BufferPtr&        kv_cache_block_id,
                             int                     batch_size,
-                            bool                    use_fp8_fmha_);
+                            bool                    use_fp8_fmha_,
+                            bool                    use_offset_array = false);
     void      maskLogits(Buffer& logits, const Buffer& mask) override;
 
 private:

--- a/rtp_llm/cpp/kernels/kv_cache/kv_cache_utils.h
+++ b/rtp_llm/cpp/kernels/kv_cache/kv_cache_utils.h
@@ -307,6 +307,21 @@ struct OffsetIndexedKVBlockArray: public KVBlockArray {
     __host__ __device__ inline void* getVBlockPtr(int32_t seqIdx, int32_t tokenIdx) const {
         return getBlockPtr(seqIdx, tokenIdx, KVIdxType::V_IDX);
     }
+    __host__ __device__ inline void* getScaleBlockPtr(DataType const* offsets, int32_t tokenIdx, KVIdxType kvIdx) const {
+        auto const offset = offsets[tokenIdx >> mTokensPerBlockLog2];
+        return reinterpret_cast<void*>(reinterpret_cast<char*>(scale)
+                                       + (offset.get() * 2 + static_cast<int32_t>(kvIdx))
+                                        * static_cast<uint64_t>(mScaleBytesPerBlock));
+    }
+    __host__ __device__ inline void* getScalePtr(int32_t seqIdx, int32_t tokenIdx, KVIdxType kvIdx) {
+        return getScaleBlockPtr(getRowPtr(kvIdx, seqIdx), tokenIdx, kvIdx);
+    }
+    __host__ __device__ inline void* getKScalePtr(int32_t seqIdx, int32_t tokenIdx) {
+        return getScalePtr(seqIdx, tokenIdx, KVIdxType::K_IDX);
+    }
+    __host__ __device__ inline void* getVScalePtr(int32_t seqIdx, int32_t tokenIdx) {
+        return getScalePtr(seqIdx, tokenIdx, KVIdxType::V_IDX);
+    }
 };
 #endif
 

--- a/rtp_llm/cpp/kernels/kv_cache/kv_cache_utils.h
+++ b/rtp_llm/cpp/kernels/kv_cache/kv_cache_utils.h
@@ -224,30 +224,23 @@ struct KVBlockArray: public KVBlockArrayForContextFMHA {
                + getLocalIdx(globalTokenIdx) * vectorize_size + channelIdx % vectorize_size;
     }
 
-    template <KvCacheDataType CType>
-    __host__ __device__ inline int32_t getVLocalIdx(int32_t globalTokenIdx,
-                                                    int32_t headIdx,
-                                                    int32_t dimsPerHead,
-                                                    int32_t channelIdx) const {
+    template<KvCacheDataType CType>
+    __host__ __device__ inline int32_t
+    getVLocalIdx(int32_t globalTokenIdx, int32_t headIdx, int32_t dimsPerHead, int32_t channelIdx) const {
         constexpr int element_size = ElementSizeInBytes<CType>::value;
-        static_assert(16 % element_size == 0,
-                        "kv cache element size must divide 16");
+        static_assert(16 % element_size == 0, "kv cache element size must divide 16");
         constexpr int vectorize_size = 16 / element_size;
 
         assert(mTokensPerBlock % vectorize_size == 0);
         int32_t localTokenIdx = getLocalIdx(globalTokenIdx);
         // shape:  [numHeads,                    mTokensPerBlock/vs, dimsPerHead, vs]
         // stride: [mTokensPerBlock*dimsPerHead, dimsPerHead*vs,     vs,          1]
-        return headIdx * dimsPerHead * mTokensPerBlock +
-               localTokenIdx / vectorize_size * dimsPerHead * vectorize_size +
-               channelIdx * vectorize_size +
-               localTokenIdx % vectorize_size;
+        return headIdx * dimsPerHead * mTokensPerBlock + localTokenIdx / vectorize_size * dimsPerHead * vectorize_size
+               + channelIdx * vectorize_size + localTokenIdx % vectorize_size;
     }
 
-    __host__ __device__ inline int32_t getVLocalIdx(int32_t globalTokenIdx,
-                                                    int32_t headIdx,
-                                                    int32_t dimsPerHead,
-                                                    int32_t channelIdx) const {
+    __host__ __device__ inline int32_t
+    getVLocalIdx(int32_t globalTokenIdx, int32_t headIdx, int32_t dimsPerHead, int32_t channelIdx) const {
         // shape: [numHeads, dimsPerHead, mTokensPerBlock]
         // stride: [dimsPerHead*mTokensPerBlock, mTokensPerBlock, 1]
         return headIdx * dimsPerHead * mTokensPerBlock + channelIdx * mTokensPerBlock + getLocalIdx(globalTokenIdx);
@@ -291,12 +284,10 @@ private:
 // Use raw offset (kv_block_offset) to index KV blocks (skip
 // invokeConvertOffsetToBlockArrayData)
 struct OffsetIndexedKVBlockArray: public KVBlockArray {
-    int32_t kv_block_offset_;
     OffsetIndexedKVBlockArray() = default;
-    OffsetIndexedKVBlockArray(KVBlockArray& base, DataType* raw_block_table, int32_t kv_block_offset):
-        KVBlockArray(base), kv_block_offset_(kv_block_offset) {
+    OffsetIndexedKVBlockArray(KVBlockArray& base, DataType* raw_block_table): KVBlockArray(base) {
         cache_type = base.cache_type;
-        data = raw_block_table;
+        data       = raw_block_table;
     }
     __host__ __device__ inline DataType const* getRowPtr(KVIdxType kvIdx, int32_t seqIdx) const {
         return data + seqIdx * mMaxBlocksPerSeq;
@@ -304,7 +295,7 @@ struct OffsetIndexedKVBlockArray: public KVBlockArray {
     __host__ __device__ inline void* getBlockPtr(DataType const* offsets, int32_t tokenIdx, KVIdxType kvIdx) const {
         auto const offset = offsets[tokenIdx >> mTokensPerBlockLog2];
         return reinterpret_cast<void*>(reinterpret_cast<char*>(getPoolPtr(offset))
-                                       + (offset.get() + static_cast<int32_t>(kvIdx) * kv_block_offset_)
+                                       + (offset.get() * 2 + static_cast<int32_t>(kvIdx))
                                              * static_cast<uint64_t>(mBytesPerBlock));
     }
     __host__ __device__ inline void* getBlockPtr(int32_t seqIdx, int32_t tokenIdx, KVIdxType kvIdx) const {

--- a/rtp_llm/cpp/kernels/unfused_attention_kernels.cu
+++ b/rtp_llm/cpp/kernels/unfused_attention_kernels.cu
@@ -4247,25 +4247,27 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
 
     if (store_cache) {
         if (head_idx < head_num_kv) {
-            KVBlockArray kv_block_array = param.kv_block_array;
-            Tcache*      k_cache = reinterpret_cast<Tcache*>(kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
-            Tcache*      v_cache = reinterpret_cast<Tcache*>(kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
+            KVBlockArray              kv_block_array        = param.kv_block_array;
+            OffsetIndexedKVBlockArray offset_kv_block_array = param.offset_kv_block_array;
+            Tcache* k_cache = reinterpret_cast<Tcache*>(offset_kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
+            Tcache* v_cache = reinterpret_cast<Tcache*>(offset_kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
             if constexpr (std::is_same<Tcache, __nv_fp8_e4m3>::value) {
-                float* k_scale_ptr   = reinterpret_cast<float*>(kv_block_array.getKScalePtr(batch_idx, dst_kv_seq_idx));
-                float* v_scale_ptr   = reinterpret_cast<float*>(kv_block_array.getVScalePtr(batch_idx, dst_kv_seq_idx));
-                const int inScaleIdx = kv_block_array.getKVScaleLocalIdx(dst_kv_seq_idx, head_idx);
+                float* k_scale_ptr =
+                    reinterpret_cast<float*>(offset_kv_block_array.getKScalePtr(batch_idx, dst_kv_seq_idx));
+                float* v_scale_ptr =
+                    reinterpret_cast<float*>(offset_kv_block_array.getVScalePtr(batch_idx, dst_kv_seq_idx));
+                const int inScaleIdx = offset_kv_block_array.getKVScaleLocalIdx(dst_kv_seq_idx, head_idx);
 
                 __shared__ float s_max[2];
                 s_max[0] = float(1 << (8 - 1));
                 s_max[1] = float(1 << (8 - 1));
 #pragma unroll
                 for (int vec_i = 0; vec_i < vec_size; vec_i++) {
-                    const int inKBlockIdx = kv_block_array.getKLocalIdx<KvCacheDataType::FP8>(
+                    const int inKBlockIdx = offset_kv_block_array.getKLocalIdx<KvCacheDataType::FP8>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
 
-                    const int inVBlockIdx =
-                        kv_block_array.getVLocalIdx(dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
-
+                    const int inVBlockIdx = offset_kv_block_array.getVLocalIdx(
+                        dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
                     k_cache[inKBlockIdx] =
                         Tcache(float(reinterpret_cast<T*>(&k)[vec_i]) * (float(1 << (8 - 1)) / s_max[0]));
                     v_cache[inVBlockIdx] =
@@ -4278,12 +4280,12 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
             } else {
 #pragma unroll
                 for (int vec_i = 0; vec_i < vec_size; vec_i++) {
-                    const int inKBlockIdx = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
+                    const int inKBlockIdx = offset_kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
                     k_cache[inKBlockIdx] = reinterpret_cast<T*>(&k)[vec_i];
 
-                    const int inVBlockIdx =
-                        kv_block_array.getVLocalIdx(dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
+                    const int inVBlockIdx = offset_kv_block_array.getVLocalIdx(
+                        dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
                     v_cache[inVBlockIdx] = reinterpret_cast<T*>(&v)[vec_i];
                 }
             }
@@ -4415,23 +4417,26 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
     }
     if (store_cache) {
         if (head_idx < head_num_kv) {
-            KVBlockArray kv_block_array = param.kv_block_array;
-            Tcache*      k_cache = reinterpret_cast<Tcache*>(kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
-            Tcache*      v_cache = reinterpret_cast<Tcache*>(kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
+            KVBlockArray              kv_block_array        = param.kv_block_array;
+            OffsetIndexedKVBlockArray offset_kv_block_array = param.offset_kv_block_array;
+            Tcache* k_cache = reinterpret_cast<Tcache*>(offset_kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
+            Tcache* v_cache = reinterpret_cast<Tcache*>(offset_kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
             if constexpr (std::is_same<Tcache, __nv_fp8_e4m3>::value) {
-                float* k_scale_ptr   = reinterpret_cast<float*>(kv_block_array.getKScalePtr(batch_idx, dst_kv_seq_idx));
-                float* v_scale_ptr   = reinterpret_cast<float*>(kv_block_array.getVScalePtr(batch_idx, dst_kv_seq_idx));
-                const int inScaleIdx = kv_block_array.getKVScaleLocalIdx(dst_kv_seq_idx, head_idx);
+                float* k_scale_ptr =
+                    reinterpret_cast<float*>(offset_kv_block_array.getKScalePtr(batch_idx, dst_kv_seq_idx));
+                float* v_scale_ptr =
+                    reinterpret_cast<float*>(offset_kv_block_array.getVScalePtr(batch_idx, dst_kv_seq_idx));
+                const int inScaleIdx = offset_kv_block_array.getKVScaleLocalIdx(dst_kv_seq_idx, head_idx);
 
                 __shared__ float s_max[2];
                 s_max[0] = float(1 << (8 - 1));
                 s_max[1] = float(1 << (8 - 1));
 #pragma unroll
                 for (int vec_i = 0; vec_i < vec_size; vec_i++) {
-                    const int inKBlockIdx = kv_block_array.getKLocalIdx<KvCacheDataType::FP8>(
+                    const int inKBlockIdx = offset_kv_block_array.getKLocalIdx<KvCacheDataType::FP8>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
 
-                    const int inVBlockIdx = kv_block_array.getVLocalIdx<KvCacheDataType::FP8>(
+                    const int inVBlockIdx = offset_kv_block_array.getVLocalIdx<KvCacheDataType::FP8>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
 
                     k_cache[inKBlockIdx] =
@@ -4447,11 +4452,11 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
             } else {
 #pragma unroll
                 for (int vec_i = 0; vec_i < vec_size; vec_i++) {
-                    const int inKBlockIdx = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
+                    const int inKBlockIdx = offset_kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
                     k_cache[inKBlockIdx] = reinterpret_cast<T*>(&k)[vec_i];
 
-                    const int inVBlockIdx = kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(
+                    const int inVBlockIdx = offset_kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(
                         dst_kv_seq_idx, head_idx, size_per_head, tidx * vec_size + vec_i);
 
                     v_cache[inVBlockIdx] = reinterpret_cast<T*>(&v)[vec_i];

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -296,7 +296,7 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     use_fmha_fp8 = attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
 
     auto params = device_->PrepareCKAttn(
-        attn_configs_, kv_cache_block_id_device, attn_inputs.sequence_lengths.size(0), use_fmha_fp8);
+        attn_configs_, kv_cache_block_id_device, attn_inputs.sequence_lengths.size(0), use_fmha_fp8, true);
     if (!params) {
         throw std::runtime_error("FusedRopeKVCacheDecodeOp::prepare: PrepareCKAttn failed. "
                                  "kv_cache_block_id_size="
@@ -345,6 +345,11 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
 
     PrefixPromptBatchWeightsParam prefix_prompt_param;
     prefix_prompt_param.kv_block_array = kv_block_array;
+    auto kv_cache_block_id_device = torchTensor2Buffer(params->kv_cache_block_id_device);
+    auto offset_kv_block_array         = OffsetIndexedKVBlockArray(
+            kv_block_array,
+            reinterpret_cast<rtp_llm::KVBlockArrayForContextFMHA::DataType*>(kv_cache_block_id_device->data()));
+    prefix_prompt_param.offset_kv_block_array = offset_kv_block_array;
 
     // 设置 prefix_lengths 参数
     int max_prefix_length = 0;


### PR DESCRIPTION
optimize KV-Offset computation by using 1-d offset instead of 2-d offset, in order to optimize Qwen models' decode efficiency when handling low-concurrency requests.