### PR TITLE
optimize AMD layernorm

### DIFF
--- a/rtp_llm/cpp/core/Buffer.cc
+++ b/rtp_llm/cpp/core/Buffer.cc
@@ -173,4 +173,15 @@ bool Buffer::operator==(const Buffer& other) {
     return (other.data_ == data_) && (other.shape_ == shape_) && (other.type_ == type_) && (other.where_ == where_);
 }
 
+void Buffer::resetData(void* data, DeleterFuncType deleter) {
+    RTP_LLM_CHECK_WITH_INFO(view_count_ == 0, 
+        "Buffer::resetData: cannot reset buffer with active views, view_count_ = " + std::to_string(view_count_));
+    
+    if (deleter_) {
+        deleter_(this);
+    }
+    data_ = data;
+    deleter_ = deleter;
+}
+
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/core/Buffer.h
+++ b/rtp_llm/cpp/core/Buffer.h
@@ -150,6 +150,8 @@ public:
 
     std::string debugStringMeta() const;
 
+    void resetData(void* data, DeleterFuncType deleter = nullptr);
+
 private:
     DeleterFuncType getSubBufferDeleter() const;
 

--- a/rtp_llm/cpp/core/torch_utils/BufferTorchUtils.h
+++ b/rtp_llm/cpp/core/torch_utils/BufferTorchUtils.h
@@ -246,4 +246,13 @@ inline std::array<torch::Tensor, 3> QBuffer2torchTensor(const ConstQBufferPtr& b
                 buf->zeros().where(), buf->zeros().type(), buf->zeros().shape(), buf->zeros().data(), nullptr))))};
 }
 
+inline void resetBufferFromTensor(BufferPtr buffer, const torch::Tensor tensor) {
+    void* data = tensor.data_ptr();
+    
+    auto tensor_holder = std::make_shared<torch::Tensor>(tensor);
+    auto deleter = [tensor_holder](Buffer* buf) -> void {
+    };
+    
+    buffer->resetData(data, deleter);
+}
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/devices/rocm_impl/ROCmLayernorm.cc
+++ b/rtp_llm/cpp/devices/rocm_impl/ROCmLayernorm.cc
@@ -241,9 +241,9 @@ LayernormOutput ROCmDevice::layernorm(const LayernormParams& params) {
             else
             {
                 auto res_tensor = layernorm2d(input_tensor, weight_tensor, beta_tensor, static_cast<double>(eps), bias_tensor);
-                copy({*norm_output, *torchTensor2Buffer(res_tensor)});
+                resetBufferFromTensor(norm_output, res_tensor);
                 if (params.return_normed_output) {
-                    copy({*params.before_norm_output, *torchTensor2Buffer(res_tensor)});
+                    resetBufferFromTensor(params.before_norm_output, res_tensor);
                 }
             }
         }
@@ -287,7 +287,7 @@ LayernormOutput ROCmDevice::layernorm(const LayernormParams& params) {
                 else
                 {
                     auto res_tensor = rmsnorm2d(input_tensor, weight_tensor, static_cast<double>(eps), 0);
-                    copy({*norm_output, *torchTensor2Buffer(res_tensor)});
+                    resetBufferFromTensor(norm_output, res_tensor);
                 }
             }
         }


### PR DESCRIPTION
remove device-to-device copies in rocm layernorm implementation, and replaced by carefully designed host pointer manipulations