### PR TITLE
chore: rm check for fake_stream

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/StreamGroups.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamGroups.h
@@ -47,8 +47,6 @@ public:
             adapter_names.push_back(stream->adapterName());
             gen_timeline_ |= stream->genTimeline();
         }
-        RTP_LLM_CHECK_WITH_INFO(
-            !(streams.size() > 1 && is_fake_stream_), "streams.size()[%d] > 1 && is_fake_stream_", streams.size());
     }
 
     size_t totalDecodeBatchSize() const {


### PR DESCRIPTION
This check may raise error when `gen_timeline: true` or use old speculative decoding framework, so I remove it.