### PR TITLE
fix: code 8214 grpc keepalive watchdog timeout

### DIFF
--- a/rtp_llm/cpp/model_rpc/RPCPool.h
+++ b/rtp_llm/cpp/model_rpc/RPCPool.h
@@ -40,8 +40,8 @@ public:
             args.SetInt(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, -1);
             args.SetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, -1);
             args.SetInt(GRPC_ARG_MAX_CONCURRENT_STREAMS, 100000);
-            args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 10000);
-            args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5000);
+            args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 40000);
+            args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 20000);
             args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
             auto grpc_channel = grpc::CreateCustomChannel(peer, grpc::InsecureChannelCredentials(), args);
             if (!grpc_channel) {


### PR DESCRIPTION
目前grpc接口使用同步API，且keepalive过期时间为 5s，与后台线程唤醒间隔相同，容易导致网络帧缺乏空闲线程处理，而被误判为连接异常，出现 keepalive watchdog timeout 错误。
彻底解决线程阻塞问题需要重构RpcService为callback或者异步API。快速止血可以先调整keepalive的配置。

此PR只调整keepalive配置。


详细讨论见：
https://project.aone.alibaba-inc.com/v2/project/2057243/bug#viewIdentifier=5dfb195e2e2b84f6b2f24718&openWorkitemIdentifier=78252351

UPDATE: 可以只修改 GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS。影响较小，先不做处理