### PR TITLE
fix: fix truncate token type err

### DIFF
--- a/rtp_llm/pipeline/pipeline.py
+++ b/rtp_llm/pipeline/pipeline.py
@@ -301,7 +301,7 @@ class Pipeline(object):
                     )
                 else:
                     tokens = tokens.reshape(-1)
-                tokens_lists_for_decode_input.append(tokens)
+                tokens_lists_for_decode_input.append(tokens.tolist())
         for i, generate_output in enumerate(generate_outputs.generate_outputs):
             tokens_list = tokens_lists_for_decode_input[i]
             output_lens.append(len(tokens_list))

--- a/rtp_llm/utils/word_util.py
+++ b/rtp_llm/utils/word_util.py
@@ -166,7 +166,13 @@ def truncate_response_with_stop_words(
     return response
 
 
-def truncate_token_with_stop_word_id(tokens: List[int], stop_word_ids: List[List[int]]):
+def truncate_token_with_stop_word_id(
+    tokens: List[int], stop_word_ids: List[List[int]]
+) -> List[int]:
+    assert isinstance(tokens, list), (
+        f"tokens must be List[int], got {type(tokens).__name__}. "
+        "Convert ndarray/tensor with .tolist() before calling."
+    )
     for stop_word_id in stop_word_ids:
         if stop_word_id and tokens[-len(stop_word_id) :] == stop_word_id:
             tokens = tokens[: (-len(stop_word_id))]


### PR DESCRIPTION
tokens = generate_output.output_ids.cpu().numpy().flatten() 将 tokens 转为 numpy array
tokens_lists_for_decode_input.append(tokens) 将 numpy array 直接添加到列表
在 word_util.py 中：
truncate_token_with_stop_word_id 未处理 numpy array 的情况

修复：加入列表时转为list

未添加stop_words_str，或stop words str 未命中，没有走这部分逻辑
