### PR TITLE
feat: return raw output in streaming mode

### DIFF
--- a/rtp_llm/cpp/model_rpc/RPCPool.h
+++ b/rtp_llm/cpp/model_rpc/RPCPool.h
@@ -41,6 +41,7 @@ public:
             args.SetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, -1);
             args.SetInt(GRPC_ARG_MAX_CONCURRENT_STREAMS, 100000);
             args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 10000);
+            // 需配合 GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS 使用，例如 500
             args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5000);
             args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
             auto grpc_channel = grpc::CreateCustomChannel(peer, grpc::InsecureChannelCredentials(), args);

--- a/rtp_llm/openai/api_datatype.py
+++ b/rtp_llm/openai/api_datatype.py
@@ -232,16 +232,16 @@ class RendererInfo(BaseModel):
 
 
 class DebugInfo(BaseModel):
-    input_prompt: str
-    input_ids: List[int]
-    input_urls: List[str]
-    tokenizer_info: str
-    max_seq_len: int
-    eos_token_id: Optional[int]
-    stop_word_ids_list: List[List[int]]
-    stop_words_list: List[str]
-    renderer_info: RendererInfo
-    generate_config: GenerateConfig
+    input_prompt: Optional[str] = None
+    input_ids: Optional[List[int]] = None
+    input_urls: Optional[List[str]] = None
+    tokenizer_info: Optional[str] = None
+    max_seq_len: Optional[int] = None
+    eos_token_id: Optional[int] = None
+    stop_word_ids_list: Optional[List[List[int]]] = None
+    stop_words_list: Optional[List[str]] = None
+    renderer_info: Optional[RendererInfo] = None
+    generate_config: Optional[GenerateConfig] = None
     output_ids: Optional[List[List[int]]] = None
     raw_output: Optional[List[str]] = None
 

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -401,12 +401,26 @@ class OpenaiEndpoint(object):
     ) -> CompleteResponseAsyncGenerator:
         async def response_generator():
             debug_info_responded = False
+
             async for response in choice_generator:
+                output = None
+                if (
+                    debug_info is not None
+                    and response.extra_outputs is not None
+                    and response.extra_outputs.output_ids is not None
+                ):
+                    output = DebugInfo()
+                    output.output_ids = response.extra_outputs.output_ids
+                    output.raw_output = [
+                        tokenizer.decode(output_ids)
+                        for output_ids in response.extra_outputs.output_ids
+                    ]
+
                 yield ChatCompletionStreamResponse(
                     choices=response.choices,
                     usage=response.usage,
                     aux_info=response.aux_info,
-                    debug_info=debug_info if not debug_info_responded else None,
+                    debug_info=debug_info if not debug_info_responded else output,
                     extra_outputs=response.extra_outputs,
                 )
                 debug_info_responded = True

--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/deepseekv31_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/deepseekv31_detector.py
@@ -97,6 +97,23 @@ class DeepSeekV31Detector(BaseFormatDetector):
 
         MTP-safe: First checks for complete <｜tool▁call▁begin｜>...<｜tool▁call▁end｜> blocks.
         Falls back to regex-based incremental parsing for partial data.
+
+        NOTE: This MTP-safe path is a workaround, not a true incremental parser.
+        The root cause is that the base class assumes bot_token at buffer start (for not MTP, yes).
+        When prefix content exists (e.g., "</think>\n\n<tool_call>..."), the base
+        class fails with MalformedJSON because it tries to parse from index 0.
+
+        Current behavior: Buffer accumulates failed chunks until both bot_token
+        and eot_token are present, then parses everything at once (batch parsing).
+
+        A cleaner fix would be to modify base class to:
+        1. Find bot_token anywhere in buffer (not just at start)
+        2. Emit text before bot_token as normal_text immediately
+        3. Continue true incremental parsing from bot_token onward
+
+        This workaround was added to avoid modifying base class behavior that
+        affects all detectors. Future refactoring should consider the base class fix.
+        Currently, this workaround only applies to Qwen25Detector, DeepSeekV31Detector and KimiK2Detector.
         """
         self._buffer += new_text
         current_text = self._buffer

--- a/rtp_llm/openai/renderers/sglang_helpers/function_call/qwen25_detector.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/function_call/qwen25_detector.py
@@ -86,6 +86,23 @@ class Qwen25Detector(BaseFormatDetector):
 
         MTP-safe: First checks for complete <tool_call>...</tool_call> blocks in buffer.
         Falls back to base class incremental parsing for partial data.
+
+        NOTE: This MTP-safe path is a workaround, not a true incremental parser.
+        The root cause is that the base class assumes bot_token at buffer start (for not MTP, yes).
+        When prefix content exists (e.g., "</think>\n\n<tool_call>..."), the base
+        class fails with MalformedJSON because it tries to parse from index 0.
+
+        Current behavior: Buffer accumulates failed chunks until both bot_token
+        and eot_token are present, then parses everything at once (batch parsing).
+
+        A cleaner fix would be to modify base class to:
+        1. Find bot_token anywhere in buffer (not just at start)
+        2. Emit text before bot_token as normal_text immediately
+        3. Continue true incremental parsing from bot_token onward
+
+        This workaround was added to avoid modifying base class behavior that
+        affects all detectors. Future refactoring should consider the base class fix.
+        Currently, this workaround only applies to Qwen25Detector, DeepSeekV31Detector and KimiK2Detector.
         """
         self._buffer += new_text
 

--- a/rtp_llm/test/openai_response_test.py
+++ b/rtp_llm/test/openai_response_test.py
@@ -31,6 +31,7 @@ from rtp_llm.openai.api_datatype import (
     ChatCompletionRequest,
     ChatCompletionStreamResponse,
     ChatMessage,
+    DebugInfo,
     FinisheReason,
     GPTFunctionDefinition,
     GPTToolDefinition,
@@ -2403,11 +2404,11 @@ class OpenaiResponseTest(IsolatedAsyncioTestCase):
         await return_output_ids_test_suite.test_no_stream()
 
     async def test_debug_info_with_output_ids_and_raw_output(self):
-        """Test that debug_info includes output_ids and raw_output when debug_info=True"""
+        """Test that debug_info includes output_ids and raw_output when debug_info=True (non-streaming)"""
         tokenizer = QwenTestTokenizer(
             f"{self.test_data_path}/qwen_7b/tokenizer/qwen.tiktoken"
         )
-        test_ids = [198, 84169, 25, 49434, 239, 73670, 37029]
+        test_ids = [198, 84169, 25, 73670, 37029]
 
         generate_env_config = GenerateEnvConfig()
         render_config = RenderConfig()
@@ -2437,7 +2438,18 @@ class OpenaiResponseTest(IsolatedAsyncioTestCase):
             id_generator, request, generate_config
         )
 
-        debug_info = None
+        debug_info = DebugInfo(
+            input_prompt="test prompt",
+            input_ids=[1, 2, 3],
+            input_urls=[],
+            tokenizer_info="test tokenizer",
+            max_seq_len=MAX_SEQ_LEN,
+            eos_token_id=tokenizer.eos_token_id or 0,
+            stop_word_ids_list=[],
+            stop_words_list=[],
+            renderer_info=chat_renderer.get_renderer_info(),
+            generate_config=generate_config,
+        )
         generate = OpenaiEndpoint._complete_stream_response(
             stream_generator, debug_info, tokenizer
         )
@@ -2449,6 +2461,98 @@ class OpenaiResponseTest(IsolatedAsyncioTestCase):
         self.assertIsNotNone(response.extra_outputs.output_ids)
         self.assertEqual(len(response.extra_outputs.output_ids), 1)
         self.assertEqual(response.extra_outputs.output_ids[0], test_ids)
+
+        # Verify debug_info has output_ids and raw_output
+        self.assertIsNotNone(response.debug_info)
+        self.assertIsNotNone(response.debug_info.output_ids)
+        self.assertIsNotNone(response.debug_info.raw_output)
+        self.assertEqual(response.debug_info.output_ids, [test_ids])
+        expected_raw_output = tokenizer.decode(test_ids)
+        self.assertEqual(response.debug_info.raw_output, [expected_raw_output])
+
+    async def test_debug_info_with_output_ids_and_raw_output_streaming(self):
+        """Test that debug_info includes output_ids and raw_output when debug_info=True (streaming mode)"""
+        tokenizer = QwenTestTokenizer(
+            f"{self.test_data_path}/qwen_7b/tokenizer/qwen.tiktoken"
+        )
+        test_ids = [198, 84169, 25, 73670, 37029]
+        generate_env_config = GenerateEnvConfig()
+        render_config = RenderConfig()
+        render_params = RendererParams(
+            model_type="qwen",
+            max_seq_len=MAX_SEQ_LEN,
+            eos_token_id=tokenizer.eos_token_id or 0,
+            stop_word_ids_list=[],
+        )
+        chat_renderer = ChatRendererFactory.get_renderer(
+            tokenizer,
+            render_params,
+            generate_env_config=generate_env_config,
+            render_config=render_config,
+        )
+        request = ChatCompletionRequest(
+            messages=[ChatMessage(role=RoleEnum.user, content="hello")],
+            stream=True,
+        )
+        input_length = 314
+        id_generator = fake_output_generator(
+            test_ids, MAX_SEQ_LEN, tokenizer.eos_token_id or 0, input_length
+        )
+
+        generate_config = GenerateConfig(is_streaming=True, return_output_ids=True)
+        stream_generator = chat_renderer.render_response_stream(
+            id_generator, request, generate_config
+        )
+
+        debug_info = DebugInfo(
+            input_prompt="test prompt",
+            input_ids=[1, 2, 3],
+            input_urls=[],
+            tokenizer_info="test tokenizer",
+            max_seq_len=MAX_SEQ_LEN,
+            eos_token_id=tokenizer.eos_token_id or 0,
+            stop_word_ids_list=[],
+            stop_words_list=[],
+            renderer_info=chat_renderer.get_renderer_info(),
+            generate_config=generate_config,
+        )
+        generate = OpenaiEndpoint._complete_stream_response(
+            stream_generator, debug_info, tokenizer
+        )
+        # Collect all streaming chunks
+        chunks = []
+        async for chunk in generate:
+            chunks.append(chunk)
+
+        # Verify that at least 5 chunks exist
+        debug_info_chunks = [c for c in chunks if c.debug_info is not None]
+        self.assertGreater(
+            len(debug_info_chunks),
+            5,
+            f"recevied chunks' length: {len(debug_info_chunks)}",
+        )
+
+        # collect output_ids and raw_output from all debug_info chunks
+        # the output may many choices, make sure the return is apended to correct index
+        output_ids_collected = []
+        raw_output_collected = []
+        for chunk in debug_info_chunks:
+            if chunk.debug_info.output_ids:
+                for i, ids in enumerate(chunk.debug_info.output_ids):
+                    if len(output_ids_collected) <= i:
+                        output_ids_collected.append(ids)
+                    else:
+                        output_ids_collected[i].extend(ids)
+            if chunk.debug_info.raw_output:
+                for i, raw in enumerate(chunk.debug_info.raw_output):
+                    if len(raw_output_collected) <= i:
+                        raw_output_collected.append(raw)
+                    else:
+                        raw_output_collected[i] += raw
+
+        self.assertEqual(output_ids_collected, [test_ids])
+        expected_raw_output = tokenizer.decode(test_ids)
+        self.assertEqual(raw_output_collected, [expected_raw_output])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
之前在 #421 支持了debug_info返回raw output。但是由于流式调用时第一个chunk就会返回debug_info，因此流式调用实际上没有返回raw output。该PR补充
同时增加之前PR里的重要注释