### PR TITLE
fix: fix kvcache may not save in pd sep

### DIFF
--- a/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
@@ -265,6 +265,7 @@ void PrefillRpcServer::remoteLoadCacheEnd(PrefillGenerateContext& prefill_contex
     auto error_code = transRPCErrorCode(load_response.error_info().error_code());
     CLIENT_GRPC_RET_IF_ERROR(prefill_context, error_code == ErrorCode::NONE_ERROR, error_code);
     RTP_LLM_LOG_DEBUG("request [%ld] remote load cache done", prefill_context.request_id);
+    prefill_context.getStream()->setRemoteGenerate();
     prefill_context.getStream()->releaseResource();
 }
 

--- a/rtp_llm/cpp/model_rpc/PrefillRpcServerNew.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillRpcServerNew.cc
@@ -348,6 +348,7 @@ ErrorInfo PrefillRpcServerNew::waitStoreCacheForAllRankDone(PrefillGenerateConte
     }
 
     // release kv resource
+    prefill_context.getStream()->setRemoteGenerate();
     prefill_context.getStream()->releaseResource();
     return ErrorInfo::OkStatus();
 }
@@ -366,11 +367,11 @@ grpc::Status PrefillRpcServerNew::RemoteStore(grpc::ServerContext*        server
         return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "deadline exceed");
     }
 
-    auto        cache_manager    = engine_->resourceContext().cache_manager;
-    const auto& cache_config     = cache_manager->cacheConfig();
-    auto        k_block_size     = cache_config.kv_block_stride_bytes;
-    auto        v_block_size     = cache_config.kv_block_stride_bytes;
-    auto        layer_num        = maga_init_params_.model_config_.num_layers;
+    auto        cache_manager = engine_->resourceContext().cache_manager;
+    const auto& cache_config  = cache_manager->cacheConfig();
+    auto        k_block_size  = cache_config.kv_block_stride_bytes;
+    auto        v_block_size  = cache_config.kv_block_stride_bytes;
+    auto        layer_num     = maga_init_params_.model_config_.num_layers;
 
     auto remote_addr_size = request->partition_infos_size();
     if (remote_addr_size == 0) {


### PR DESCRIPTION
* 问题
pd分离场景下，prefill（rpc线程）在remote load结束之后立即release resource，此行为在rpc线程中触发，但是reuse cache只有stream是finished或remote running状态下才写cache到显存，但是scheduler可能尚未调度到该stream并将其设置为remote running状态，导致rpc release resource时kvcache可能并未写入显存。ci的reuse cache smoke不稳定也与此有关。

* 解决方法
在prefill调用release resource之前，主动将stream置为remote running。

此改动为临时修复，考虑到以下几点：
1. 之后p2p connector接入之后，不会再有PrefillRpcServer。
2. 改动简单。