### PR TITLE
feat: Support DeepEP dual mode for dynamic Normal/LowLatency switching in PDFusion

### DIFF
--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -383,12 +383,14 @@ class DeepEPConfig:
         self.use_deepep_moe: Optional[bool] = None
         self.use_deepep_internode: Optional[bool] = None
         self.use_deepep_low_latency: Optional[bool] = None
+        self.support_dual_mode: Optional[bool] = None
 
     def to_string(self):
         return (
             f"use_deepep_moe: {self.use_deepep_moe}\n"
             f"use_deepep_internode: {self.use_deepep_internode}\n"
-            f"use_deepep_low_latency: {self.use_deepep_low_latency}"
+            f"use_deepep_low_latency: {self.use_deepep_low_latency}\n"
+            f"support_dual_mode: {self.support_dual_mode}"
         )
 
 

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -92,11 +92,14 @@ def auto_configure_deepep(
             moe_config.use_deepep_internode = deep_ep_config.use_deepep_internode
         if deep_ep_config.use_deepep_low_latency is not None:
             moe_config.use_deepep_low_latency = deep_ep_config.use_deepep_low_latency
+        if deep_ep_config.support_dual_mode is not None:
+            moe_config.support_dual_mode = deep_ep_config.support_dual_mode
         logging.info(
             f"Using user-specified DeepEP configuration:\n"
             f"  USE_DEEPEP_MOE: {moe_config.use_deepep_moe}\n"
             f"  USE_DEEPEP_INTERNODE: {moe_config.use_deepep_internode}\n"
-            f"  USE_DEEPEP_LOW_LATENCY: {moe_config.use_deepep_low_latency}"
+            f"  USE_DEEPEP_LOW_LATENCY: {moe_config.use_deepep_low_latency}\n"
+            f"  SUPPORT_DUAL_MODE: {moe_config.support_dual_mode}\n"
             f"  ll_num_max_token: {moe_config.ll_num_max_token}"
         )
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -188,6 +188,7 @@ struct MoeConfig {
     int         max_moe_normal_masked_token_num = 1024;
     bool        use_all_gather                  = false;
     int         ll_num_max_token                = 0;
+    int         ll_num_max_token_per_rank       = 0;
     std::string to_string() const;
 };
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -180,6 +180,7 @@ struct MoeConfig {
     bool        use_deepep_moe                  = false;
     bool        use_deepep_internode            = false;
     bool        use_deepep_low_latency          = true;
+    bool        support_dual_mode               = false;
     bool        use_deepep_p2p_low_latency      = false;
     bool        fake_balance_expert             = false;
     bool        hack_moe_expert                 = false;

--- a/rtp_llm/cpp/devices/GraphBase.h
+++ b/rtp_llm/cpp/devices/GraphBase.h
@@ -13,6 +13,7 @@ public:
     virtual void           setPositionEncoding(torch::Tensor position_encoding)      = 0;
     virtual void           setTokenTypeEmbedding(torch::Tensor token_type_embedding) = 0;
     virtual void           setInputEmbeddingScalar(float input_embedding_scalar)     = 0;
+    virtual void           setDualModeParams(bool support_dual_mode)                 = 0;
     virtual bool           canRun(PyModelInputs& inputs)                             = 0;
     py::object             py_instance_;
 };

--- a/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.cc
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.cc
@@ -222,6 +222,14 @@ void CudaGraphRunner::tryGetRealGraphDecodeBatchSize(PyModelInputs& inputs) {
 }
 
 bool CudaGraphRunner::canRun(PyModelInputs& inputs) {
+    // Dual mode: check basic conditions first, then continue to common checks
+    if (inputs.support_dual_mode) {
+        if (!inputs.all_short_global || !inputs.all_decode_or_score_global) {
+            return false;
+        }
+        // Continue to common checks below
+    }
+
     // Check if this is speculative sampling:
     // 1. prefix_lengths is not empty
     // 2. all values in input_lengths are the same
@@ -349,6 +357,10 @@ void CudaGraphRunner::setMaxPrefillCudaGraphLen(int max_prefill_cuda_graph_len) 
     RTP_LLM_LOG_INFO("Set max_perfill_cuda_graph_len_ to %d", max_perfill_cuda_graph_len_);
 }
 
+void CudaGraphRunner::setDualModeParams(bool support_dual_mode) {
+    support_dual_mode_ = support_dual_mode;
+}
+
 void CudaGraphRunner::initCaptureBertEmbeddingInputs(PyModelInputs& inputs, int max_bs, int max_num_token) {
     auto options_cuda_int32 = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA).requires_grad(false);
     // Initialize BertEmbeddingInputs for capture
@@ -400,6 +412,11 @@ void CudaGraphRunner::initCapture() {
 
         // Setup BertEmbedding inputs using the extracted function
         initCaptureBertEmbeddingInputs(inputs, max_bs_, max_num_token_);
+
+        // Setup dual mode parameters for capture
+        inputs.support_dual_mode = support_dual_mode_;
+        inputs.all_short_global  = true;
+        RTP_LLM_LOG_INFO("initCapture: dual mode params set (support=%d, all_short=true)", support_dual_mode_);
 
         torch::Tensor output;
         capture_mem_hold_ = CaptureMemoryHold(output, inputs, is_prefill_cuda_graph_mode_);
@@ -525,6 +542,10 @@ void CudaGraphRunner::prepareCaptureInputs(PyModelInputs& inputs, int batch_size
     inputs.attention_inputs.dtype       = capture_mem_hold_.py_model_inputs_.attention_inputs.dtype;
     inputs.bert_embedding_inputs        = capture_mem_hold_.py_model_inputs_.bert_embedding_inputs;
     inputs.attention_inputs.is_s_padded = true;
+
+    // Dual mode flags for capture
+    inputs.support_dual_mode = capture_mem_hold_.py_model_inputs_.support_dual_mode;
+    inputs.all_short_global  = capture_mem_hold_.py_model_inputs_.all_short_global;
 }
 
 CaptureMemoryHold CudaGraphRunner::createCaptureMemoryHold(PyModelInputs& inputs, int tokens_count) {

--- a/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.h
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.h
@@ -74,11 +74,15 @@ public:
     void           replayDecode(int bs);
     void           replayPrefill(int seq_len);
     void           setMaxPrefillCudaGraphLen(int max_prefill_cuda_graph_len);
+    void           setDualModeParams(bool support_dual_mode) override;
+    py::object     normalForward(PyModelInputs& inputs);
     int            getCurrentRealGraphBs();
     PyModelOutputs forward(PyModelInputs& inputs) override;
     void           initCapture() override;
 
 private:
+    bool support_dual_mode_{false};
+
     // Common capture logic for both prefill and decode
     void captureOneGraphInstance(int key, const char* key_type);
     // Common replay and sync check logic

--- a/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.h
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaGraphRunner.h
@@ -75,7 +75,6 @@ public:
     void           replayPrefill(int seq_len);
     void           setMaxPrefillCudaGraphLen(int max_prefill_cuda_graph_len);
     void           setDualModeParams(bool support_dual_mode) override;
-    py::object     normalForward(PyModelInputs& inputs);
     int            getCurrentRealGraphBs();
     PyModelOutputs forward(PyModelInputs& inputs) override;
     void           initCapture() override;

--- a/rtp_llm/cpp/devices/cuda_impl/CudaGraphUtils.h
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaGraphUtils.h
@@ -50,6 +50,10 @@ public:
         py_model_inputs_.attention_inputs.is_s_padded               = inputs.attention_inputs.is_s_padded;
         py_model_inputs_.attention_inputs.decode_cu_seqlens_d       = inputs.attention_inputs.decode_cu_seqlens_d;
         py_model_inputs_.attention_inputs.sequence_lengths_plus_1_d = inputs.attention_inputs.sequence_lengths_plus_1_d;
+
+        // Dual mode parameters
+        py_model_inputs_.support_dual_mode = inputs.support_dual_mode;
+        py_model_inputs_.all_short_global  = inputs.all_short_global;
     }
 
 public:

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -101,35 +101,95 @@ torch_ext::PyAttentionInputs PyWrappedModel::buildPyAttentionInputs(const GptMod
 }
 
 #if USING_CUDA
-bool PyWrappedModel::epAllGatherAllTrue(bool local_value) {
+std::pair<bool, bool> PyWrappedModel::epAllGatherBothTrue(bool local_first, bool local_second) {
     if (ep_size_ <= 1) {
-        return local_value;
+        return {local_first, local_second};
     }
 
     // Multiple ranks in EP group: use all-gather on DP_AND_TP (EP group)
     try {
         py::gil_scoped_acquire gil;
 
-        auto local_tensor =
-            torch::tensor({local_value ? 1 : 0}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
+        auto local_tensor = torch::tensor({local_first ? 1 : 0, local_second ? 1 : 0},
+                                          torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
 
         py::module_ collective_torch = py::module_::import("rtp_llm.models_py.distributed.collective_torch");
         py::object  all_gather_func  = collective_torch.attr("all_gather");
-        py::object  group_ep         = collective_torch.attr("Group").attr("DP_AND_TP");  // EP group = DP_AND_TP
+        py::object  group_ep         = collective_torch.attr("Group").attr("DP_AND_TP");
 
         auto gathered_obj = all_gather_func(local_tensor, group_ep);
         auto gathered     = gathered_obj.cast<torch::Tensor>();
 
-        int num_true = gathered.sum().item<int>();
-        return (num_true == ep_size_);
+        // gathered shape: [ep_size, 2]
+        auto gathered_reshaped = gathered.view({ep_size_, 2});
+        bool all_true_first    = (gathered_reshaped.select(1, 0).sum().item<int>() == ep_size_);
+        bool all_true_second   = (gathered_reshaped.select(1, 1).sum().item<int>() == ep_size_);
+
+        return {all_true_first, all_true_second};
 
     } catch (const std::exception& e) {
-        RTP_LLM_LOG_ERROR("PyWrappedModel::epAllGatherAllTrue failed: %s, using conservative default (false)",
+        RTP_LLM_LOG_ERROR("PyWrappedModel::epAllGatherBothTrue failed: %s, using conservative default (false, false)",
                           e.what());
-        return false;
+        return {false, false};
     }
 }
 #endif  // USING_CUDA
+
+std::pair<bool, bool> PyWrappedModel::calculateDualModeFlags(const GptModelInputs&               inputs,
+                                                             const torch_ext::PyAttentionInputs& attention_inputs) {
+
+    // Dual mode logic: use TWO independent parameters
+    // 1. all_short_global: for MoE mode selection (based on token length from inputs)
+    // 2. all_decode_or_score_global: for CUDA Graph usage (based on decode/score detection)
+
+    // === Part 1: Calculate all_short_global (for MoE mode) ===
+    int  local_total_tokens = inputs.combo_tokens->shape()[0];
+    bool local_is_short     = (local_total_tokens <= ll_num_max_token_per_rank_);
+
+    // === Part 2: Calculate local_is_decode_or_score (for CUDA Graph) ===
+    bool has_prefill_local        = hasContextBatch(attention_inputs);
+    bool local_is_decode_or_score = false;
+
+    // Score phase detection (for speculative sampling)
+    bool is_score_phase_local = false;
+    if (gen_num_per_cycle_ > 1 && has_prefill_local) {
+        auto attn_input_lengths = attention_inputs.input_lengths;
+        if (attn_input_lengths.defined() && attn_input_lengths.numel() > 0) {
+            int  expected_score_length = gen_num_per_cycle_ + 1;
+            bool all_match_expected    = true;
+            for (int i = 0; i < attn_input_lengths.size(0); i++) {
+                if (attn_input_lengths[i].item<int>() != expected_score_length) {
+                    all_match_expected = false;
+                    break;
+                }
+            }
+            if (all_match_expected) {
+                is_score_phase_local = true;
+            }
+        }
+    }
+
+    if (is_score_phase_local) {
+        local_is_decode_or_score = true;  // Score phase: fixed length (gen_num+1)
+    } else {
+        local_is_decode_or_score = !has_prefill_local;  // No prefill → decode
+    }
+
+    // === Global synchronization or fallback ===
+#if USING_CUDA
+    // CUDA: EP all-gather synchronization (optimized to one communication)
+    return epAllGatherBothTrue(local_is_short, local_is_decode_or_score);
+#else
+    if (ep_size_ > 1) {
+        RTP_LLM_LOG_WARNING("Dual mode on multi-card non-CUDA environment detected (ep_size=%d). "
+                            "Falling back to conservative mode: NORMAL MoE, no CUDA Graph",
+                            ep_size_);
+        return {false, false};  // NORMAL MoE, no CUDA Graph
+    } else {
+        return {local_is_short, local_is_decode_or_score};
+    }
+#endif
+}
 
 // Helper function to setup KV cache for attention inputs
 void PyWrappedModel::setupKVCacheForAttentionInputs(torch_ext::PyAttentionInputs& py_attn_inputs,
@@ -325,69 +385,9 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
         bool all_short_global           = false;
 
         if (support_dual_mode_) {
-            // Dual mode logic: use TWO independent parameters
-            // 1. all_short_global: for MoE mode selection (based on token length from inputs)
-            // 2. all_decode_or_score_global: for CUDA Graph usage (based on decode/score detection)
-
-            // === Part 1: Calculate all_short_global (for MoE mode) ===
-            int local_total_tokens = 0;
-
-            if (inputs.input_lengths && inputs.input_lengths->size() > 0) {
-                int  batch_size         = inputs.input_lengths->shape()[0];
-                auto input_lengths_data = inputs.input_lengths->data<int32_t>();
-                for (int i = 0; i < batch_size; i++) {
-                    local_total_tokens += input_lengths_data[i];
-                }
-            }
-
-            bool local_is_short = (local_total_tokens <= ll_num_max_token_per_rank_);
-
-            // === Part 2: Calculate local_is_decode_or_score (for CUDA Graph) ===
-            bool has_prefill_local        = hasContextBatch(attention_inputs);
-            bool local_is_decode_or_score = false;
-
-            // Score phase detection (for speculative sampling)
-            bool is_score_phase_local = false;
-            if (gen_num_per_cycle_ > 1 && has_prefill_local) {
-                auto attn_input_lengths = attention_inputs.input_lengths;
-                if (attn_input_lengths.defined() && attn_input_lengths.numel() > 0) {
-                    int  expected_score_length = gen_num_per_cycle_ + 1;
-                    bool all_match_expected    = true;
-                    for (int i = 0; i < attn_input_lengths.size(0); i++) {
-                        if (attn_input_lengths[i].item<int>() != expected_score_length) {
-                            all_match_expected = false;
-                            break;
-                        }
-                    }
-                    if (all_match_expected) {
-                        is_score_phase_local = true;
-                    }
-                }
-            }
-
-            if (is_score_phase_local) {
-                local_is_decode_or_score = true;  // Score phase: fixed length (gen_num+1)
-            } else {
-                local_is_decode_or_score = !has_prefill_local;  // No prefill → decode
-            }
-
-            // === Global synchronization or fallback ===
-#if USING_CUDA
-            // CUDA: EP all-gather synchronization
-            all_short_global           = epAllGatherAllTrue(local_is_short);
-            all_decode_or_score_global = epAllGatherAllTrue(local_is_decode_or_score);
-#else
-            if (ep_size_ > 1) {
-                RTP_LLM_LOG_WARNING("Dual mode on multi-card non-CUDA environment detected (ep_size=%d). "
-                                    "Falling back to conservative mode: NORMAL MoE, no CUDA Graph",
-                                    ep_size_);
-                all_short_global           = false;  // NORMAL MoE
-                all_decode_or_score_global = false;  // no CUDA Graph
-            } else {
-                all_short_global           = local_is_short;
-                all_decode_or_score_global = local_is_decode_or_score;
-            }
-#endif
+            auto [all_short, all_decode_or_score] = calculateDualModeFlags(inputs, attention_inputs);
+            all_short_global                      = all_short;
+            all_decode_or_score_global            = all_decode_or_score;
         }
 
         auto py_model_inputs = PyModelInputs({token_ids, input_hiddens, attention_inputs, bert_embedding_inputs});

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -30,6 +30,8 @@ public:
 
 private:
     std::optional<PyCacheStoreInputs> prepareWriteCacheParams(const GptModelInputs& inputs);
+    std::pair<bool, bool>             calculateDualModeFlags(const GptModelInputs&               inputs,
+                                                             const torch_ext::PyAttentionInputs& attention_inputs);
 
 private:
     // Helper functions to reduce code duplication
@@ -49,8 +51,8 @@ private:
     }
 
 #if USING_CUDA
-    // EP group all-gather: returns true if all ranks have true value
-    bool epAllGatherAllTrue(bool local_value);
+    // EP group all-gather: gather two bool values in one communication
+    std::pair<bool, bool> epAllGatherBothTrue(bool local_first, bool local_second);
 #endif
 
     GraphBase*    graph_runner_{nullptr};

--- a/rtp_llm/cpp/normal_engine/NormalBatchStreamProcessor.cc
+++ b/rtp_llm/cpp/normal_engine/NormalBatchStreamProcessor.cc
@@ -113,7 +113,7 @@ absl::StatusOr<GptModelInputs> NormalBatchStreamProcessor::gatherModelInput(cons
                 return absl::InvalidArgumentError(error_msg.str());
             }
             merged_tokens[batch_idx]    = currentTokens[0];
-            input_lengths[batch_idx]    = stream->inputLength();
+            input_lengths[batch_idx]    = 1;                        // decode always has 1 token
             sequence_lengths[batch_idx] = stream->seqLength() - 1;  // need remove
             if (need_cal_position_id) {
                 stream->generateNextPositionId(combo_position_ids + batch_idx * position_id_len_factor_, device_);
@@ -383,7 +383,7 @@ void NormalBatchStreamProcessor::setCommonSamplerInputs(SamplerInputs&          
     int32_t*  no_repeat_ngram_size = sampler_inputs.no_repeat_ngram_size->data<int32_t>();
     bool*     do_sample            = sampler_inputs.do_sample->data<bool>();
 
-    int  batch_idx       = 0;
+    int batch_idx = 0;
     for (auto& stream : all_streams) {
         int sampler_batch_size;
         if (score_batch) {
@@ -416,7 +416,7 @@ void NormalBatchStreamProcessor::setCommonSamplerInputs(SamplerInputs&          
                 top_p[batch_idx]       = 1;
                 temperature[batch_idx] = 1;
             }
-            no_repeat_ngram_size[batch_idx] = stream->generateConfig()->no_repeat_ngram_size.value_or(0);
+            no_repeat_ngram_size[batch_idx]     = stream->generateConfig()->no_repeat_ngram_size.value_or(0);
             sampler_inputs.generator[batch_idx] = stream->getGenerator();
             batch_idx += 1;
         }

--- a/rtp_llm/cpp/normal_engine/NormalBatchStreamProcessor.cc
+++ b/rtp_llm/cpp/normal_engine/NormalBatchStreamProcessor.cc
@@ -113,7 +113,7 @@ absl::StatusOr<GptModelInputs> NormalBatchStreamProcessor::gatherModelInput(cons
                 return absl::InvalidArgumentError(error_msg.str());
             }
             merged_tokens[batch_idx]    = currentTokens[0];
-            input_lengths[batch_idx]    = 1;                        // decode always has 1 token
+            input_lengths[batch_idx]    = stream->inputLength();
             sequence_lengths[batch_idx] = stream->seqLength() - 1;  // need remove
             if (need_cal_position_id) {
                 stream->generateNextPositionId(combo_position_ids + batch_idx * position_id_len_factor_, device_);

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -521,6 +521,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("use_deepep_internode", &MoeConfig::use_deepep_internode)
         .def_readwrite("use_deepep_low_latency", &MoeConfig::use_deepep_low_latency)
         .def_readwrite("use_deepep_p2p_low_latency", &MoeConfig::use_deepep_p2p_low_latency)
+        .def_readwrite("support_dual_mode", &MoeConfig::support_dual_mode)
         .def_readwrite("fake_balance_expert", &MoeConfig::fake_balance_expert)
         .def_readwrite("hack_moe_expert", &MoeConfig::hack_moe_expert)
         .def_readwrite("deep_ep_num_sm", &MoeConfig::deep_ep_num_sm)
@@ -534,6 +535,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.use_deepep_internode,
                                       self.use_deepep_low_latency,
                                       self.use_deepep_p2p_low_latency,
+                                      self.support_dual_mode,
                                       self.fake_balance_expert,
                                       self.hack_moe_expert,
                                       self.deep_ep_num_sm,
@@ -542,7 +544,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.ll_num_max_token);
             },
             [](py::tuple t) {
-                if (t.size() != 10)
+                if (t.size() != 11)
                     throw std::runtime_error("Invalid state!");
                 MoeConfig c;
                 try {
@@ -550,12 +552,13 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.use_deepep_internode            = t[1].cast<bool>();
                     c.use_deepep_low_latency          = t[2].cast<bool>();
                     c.use_deepep_p2p_low_latency      = t[3].cast<bool>();
-                    c.fake_balance_expert             = t[4].cast<bool>();
-                    c.hack_moe_expert                 = t[5].cast<bool>();
-                    c.deep_ep_num_sm                  = t[6].cast<int>();
-                    c.max_moe_normal_masked_token_num = t[7].cast<int>();
-                    c.use_all_gather                  = t[8].cast<bool>();
-                    c.ll_num_max_token                = t[9].cast<int>();
+                    c.support_dual_mode               = t[4].cast<bool>();
+                    c.fake_balance_expert             = t[5].cast<bool>();
+                    c.hack_moe_expert                 = t[6].cast<bool>();
+                    c.deep_ep_num_sm                  = t[7].cast<int>();
+                    c.max_moe_normal_masked_token_num = t[8].cast<int>();
+                    c.use_all_gather                  = t[9].cast<bool>();
+                    c.ll_num_max_token                = t[10].cast<int>();
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("MoeConfig unpickle error: ") + e.what());
                 }

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -528,6 +528,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("max_moe_normal_masked_token_num", &MoeConfig::max_moe_normal_masked_token_num)
         .def_readwrite("use_all_gather", &MoeConfig::use_all_gather)
         .def_readwrite("ll_num_max_token", &MoeConfig::ll_num_max_token)
+        .def_readwrite("ll_num_max_token_per_rank", &MoeConfig::ll_num_max_token_per_rank)
         .def("to_string", &MoeConfig::to_string)
         .def(py::pickle(
             [](const MoeConfig& self) {
@@ -541,10 +542,11 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.deep_ep_num_sm,
                                       self.max_moe_normal_masked_token_num,
                                       self.use_all_gather,
-                                      self.ll_num_max_token);
+                                      self.ll_num_max_token,
+                                      self.ll_num_max_token_per_rank);
             },
             [](py::tuple t) {
-                if (t.size() != 11)
+                if (t.size() != 12)
                     throw std::runtime_error("Invalid state!");
                 MoeConfig c;
                 try {
@@ -559,6 +561,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.max_moe_normal_masked_token_num = t[8].cast<int>();
                     c.use_all_gather                  = t[9].cast<bool>();
                     c.ll_num_max_token                = t[10].cast<int>();
+                    c.ll_num_max_token_per_rank       = t[11].cast<int>();
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("MoeConfig unpickle error: ") + e.what());
                 }

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -111,9 +111,10 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_readwrite("attention_inputs", &PyModelInputs::attention_inputs, "Attention inputs structure")
         .def_readwrite(
             "bert_embedding_inputs", &PyModelInputs::bert_embedding_inputs, "BERT embedding inputs structure")
-        .def_readwrite("has_prefill_global",
-                       &PyModelInputs::has_prefill_global,
-                       "Global prefill indicator across DP ranks (for DeepEP dual mode)");
+        .def_readwrite("all_short_global",
+                       &PyModelInputs::all_short_global,
+                       "Global short request indicator for MoE mode selection (for DeepEP dual mode)")
+        .def_readwrite("support_dual_mode", &PyModelInputs::support_dual_mode, "Dual mode flag");
 
     pybind11::class_<PyModelOutputs>(m, "PyModelOutputs")
         .def(pybind11::init<>(), "Default constructor")

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -110,7 +110,10 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_readwrite("input_hiddens", &PyModelInputs::input_hiddens, "Input hidden states tensor")
         .def_readwrite("attention_inputs", &PyModelInputs::attention_inputs, "Attention inputs structure")
         .def_readwrite(
-            "bert_embedding_inputs", &PyModelInputs::bert_embedding_inputs, "BERT embedding inputs structure");
+            "bert_embedding_inputs", &PyModelInputs::bert_embedding_inputs, "BERT embedding inputs structure")
+        .def_readwrite("has_prefill_global",
+                       &PyModelInputs::has_prefill_global,
+                       "Global prefill indicator across DP ranks (for DeepEP dual mode)");
 
     pybind11::class_<PyModelOutputs>(m, "PyModelOutputs")
         .def(pybind11::init<>(), "Default constructor")

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -104,7 +104,9 @@ struct PyModelInputs {
     torch::Tensor       input_hiddens;
     PyAttentionInputs   attention_inputs;
     BertEmbeddingInputs bert_embedding_inputs;
-    bool                has_prefill_global{false};
+    bool                all_decode_or_score_global{false};
+    bool                all_short_global{false};
+    bool                support_dual_mode{false};
 };
 
 struct PyModelOutputs {

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -104,6 +104,7 @@ struct PyModelInputs {
     torch::Tensor       input_hiddens;
     PyAttentionInputs   attention_inputs;
     BertEmbeddingInputs bert_embedding_inputs;
+    bool                has_prefill_global{false};
 };
 
 struct PyModelOutputs {

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -356,26 +356,6 @@ class DeepEPWrapper:
                 cls._instance = None
             cls._initialized = False
 
-    @property
-    def buffer(self) -> DeepEPBuffer:
-        """Get the DeepEP buffer.
-
-        Returns:
-            The initialized DeepEP buffer
-        """
-        if self._mode == DeepEPMode.DUAL:
-            raise RuntimeError(
-                "Dual mode should use get_buffer() to specify which buffer"
-            )
-        elif self._mode == DeepEPMode.NORMAL:
-            if self._normal_buffer is None:
-                raise RuntimeError("Normal buffer is not initialized")
-            return self._normal_buffer
-        else:
-            if self._lowlatency_buffer is None:
-                raise RuntimeError("LowLatency buffer is not initialized")
-            return self._lowlatency_buffer
-
     def get_buffer(self, use_low_latency: bool) -> DeepEPBuffer:
         """Get buffer based on mode.
 
@@ -388,16 +368,6 @@ class DeepEPWrapper:
         Raises:
             RuntimeError: If buffer not initialized
         """
-        if self._mode == DeepEPMode.DUAL:
-            if use_low_latency:
-                if self._lowlatency_buffer is None:
-                    raise RuntimeError("LowLatency buffer not initialized in DUAL mode")
-                return self._lowlatency_buffer
-            else:
-                if self._normal_buffer is None:
-                    raise RuntimeError("Normal buffer not initialized in DUAL mode")
-                return self._normal_buffer
-
         if use_low_latency:
             if self._lowlatency_buffer is None:
                 raise RuntimeError(
@@ -698,6 +668,8 @@ def init_deepep_wrapper(engine_config: EngineConfig, model_config: ModelConfig) 
                     model_config.quant_config,
                 )
             )
+
+        engine_config.moe_config.ll_num_max_token_per_rank = ll_num_max_token_per_rank
 
         deepep_config = DeepepWrapperConfig.from_config_adapter(
             deepep_config_adapter, ll_num_max_token_per_rank

--- a/rtp_llm/models_py/distributed/test/deepep_test.py
+++ b/rtp_llm/models_py/distributed/test/deepep_test.py
@@ -1934,7 +1934,7 @@ class DeepEPTest(TestCase):
         deep_ep_wrapper = DeepEPWrapper.get_instance(
             deepep_config, group=dist.group.WORLD
         )
-        buffer = deep_ep_wrapper.buffer
+        buffer = deep_ep_wrapper.get_buffer(use_low_latency=False)
         # run test
         DeepEPTest._test_intranode_main(
             args["max_seq_len"],
@@ -1992,7 +1992,7 @@ class DeepEPTest(TestCase):
         deep_ep_wrapper = DeepEPWrapper.get_instance(
             deepep_config, group=dist.group.WORLD
         )
-        buffer = deep_ep_wrapper.buffer
+        buffer = deep_ep_wrapper.get_buffer(use_low_latency=True)
         # run test
         DeepEPTest._test_low_latency_main(
             (args["max_generate_batch_size"] + config_adapter.tp_size - 1)
@@ -2053,7 +2053,7 @@ class DeepEPTest(TestCase):
         deep_ep_wrapper = DeepEPWrapper.get_instance(
             deepep_config, group=dist.group.WORLD
         )
-        buffer = deep_ep_wrapper.buffer
+        buffer = deep_ep_wrapper.get_buffer(use_low_latency=True)
         # run test
         ffn_disaggregate_config = (
             config_adapter.parallelism_config.ffn_disaggregate_config
@@ -2115,7 +2115,7 @@ class DeepEPTest(TestCase):
         deep_ep_wrapper = DeepEPWrapper.get_instance(
             deepep_config, group=dist.group.WORLD
         )
-        buffer = deep_ep_wrapper.buffer
+        buffer = deep_ep_wrapper.get_buffer(use_low_latency=False)
         # run test
         DeepEPTest._test_intranode_expert_alignment_main(
             deep_ep_wrapper.ep_rank,
@@ -2173,7 +2173,7 @@ class DeepEPTest(TestCase):
         deep_ep_wrapper = DeepEPWrapper.get_instance(
             deepep_config, group=dist.group.WORLD
         )
-        buffer = deep_ep_wrapper.buffer
+        buffer = deep_ep_wrapper.get_buffer(use_low_latency=True)
         # run test
         DeepEPTest._test_low_latency_per_token_quant_main(
             (args["max_generate_batch_size"] + config_adapter.tp_size - 1)

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -59,14 +59,60 @@ class GenericMoeLayer(nn.Module):
         self.select_topk = SelectTopk(
             config, moe_config.fake_balance_expert, parallelism_config.dp_rank
         )
-        config_adapter = MoEConfigAdapter(
-            model_config=config,
-            parallelism_config=parallelism_config,
-            moe_config=moe_config,
-            quant_config=quant_config,
-            enable_cuda_graph=enable_cuda_graph,
-        )
-        self.fused_moe = FusedMoeFactory().create_fused_moe(config_adapter, weights)
+
+        # Dual mode requires ep_size > 1 (DeepEP enabled)
+        support_dual_mode_config = getattr(moe_config, "support_dual_mode", False)
+        ep_size = parallelism_config.ep_size
+        self.support_dual_mode = support_dual_mode_config and ep_size > 1
+
+        if self.support_dual_mode:
+            # Dual mode: create two separate FusedMoe instances
+            import copy
+
+            # Normal mode (for prefill/long sequences)
+            moe_config_normal = copy.deepcopy(moe_config)
+            moe_config_normal.use_deepep_low_latency = False
+            moe_config_normal.support_dual_mode = True
+
+            config_adapter_normal = MoEConfigAdapter(
+                model_config=config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config_normal,
+                quant_config=quant_config,
+                enable_cuda_graph=False,
+            )
+            self.fused_moe_normal = FusedMoeFactory().create_fused_moe(
+                config_adapter_normal, weights
+            )
+
+            # LowLatency mode (for decode/short sequences)
+            moe_config_lowlatency = copy.deepcopy(moe_config)
+            moe_config_lowlatency.use_deepep_low_latency = True
+            moe_config_lowlatency.support_dual_mode = True
+
+            config_adapter_lowlatency = MoEConfigAdapter(
+                model_config=config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config_lowlatency,
+                quant_config=quant_config,
+                enable_cuda_graph=enable_cuda_graph,
+            )
+            self.fused_moe_lowlatency = FusedMoeFactory().create_fused_moe(
+                config_adapter_lowlatency, weights
+            )
+
+            self.fused_moe = None
+        else:
+            config_adapter = MoEConfigAdapter(
+                model_config=config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config,
+                quant_config=quant_config,
+                enable_cuda_graph=enable_cuda_graph,
+            )
+            self.fused_moe = FusedMoeFactory().create_fused_moe(config_adapter, weights)
+            self.fused_moe_normal = None
+            self.fused_moe_lowlatency = None
 
         self.w1 = weights.get(W.moe_w1, None)
         self.w2 = weights.get(W.moe_w2, None)
@@ -91,18 +137,23 @@ class GenericMoeLayer(nn.Module):
         # for group topk
         self.correction_bias = weights.get(W.e_score_correction_b, None)
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, has_prefill_global: Optional[bool] = None
+    ) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
         router_logits = self.gate(hidden_states)
         router_logits_fp32 = router_logits.float()
+
+        if self.support_dual_mode:
+            topk_ids_dtype = self.fused_moe_lowlatency.topk_ids_dtype
+        else:
+            topk_ids_dtype = self.fused_moe.topk_ids_dtype
 
         topk_weights = torch.empty(
             (num_tokens, self.top_k),
             dtype=torch.float32,
             device=hidden_states.device,
         )
-        # different executor may need different topk_ids dtype
-        topk_ids_dtype = self.fused_moe.topk_ids_dtype
         topk_ids = torch.empty(
             (num_tokens, self.top_k),
             dtype=topk_ids_dtype,
@@ -132,12 +183,35 @@ class GenericMoeLayer(nn.Module):
             # Top-K selection using C++ SelectTopkOp
             self.select_topk(router_logits_fp32, topk_ids, topk_weights)
 
-        experts_output = self.fused_moe(
-            hidden_states=hidden_states,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            activation="SiGLU",
-        )
+        # Select FusedMoe based on dual mode
+        if self.support_dual_mode:
+            if has_prefill_global is None:
+                has_prefill_global = num_tokens > 1
+                logging.warning(
+                    "has_prefill_global is None in dual mode, using fallback: num_tokens=%d -> %s",
+                    num_tokens,
+                    has_prefill_global,
+                )
+
+            current_fused_moe = (
+                self.fused_moe_normal
+                if has_prefill_global
+                else self.fused_moe_lowlatency
+            )
+            experts_output = current_fused_moe(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation="SiGLU",
+            )
+        else:
+            experts_output = self.fused_moe(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation="SiGLU",
+            )
+
         if self.shared_expert is not None:
             shared_expert_output = self.shared_expert(hidden_states)
             if self.shared_expert_gate is not None:
@@ -224,6 +298,7 @@ class GenericMoeDecoderLayer(nn.Module):
         residual: torch.Tensor,
         fmha_impl: FMHAImplBase,
         kv_cache: Optional[KVCache] = None,
+        has_prefill_global: Optional[bool] = None,
     ) -> DecodeLayerOutput:
         # equivalent to:
         # residual = residual + hidden_states
@@ -238,7 +313,12 @@ class GenericMoeDecoderLayer(nn.Module):
         hidden_states = self.post_attention_layernorm(hidden_states, residual)
 
         # MLP (Dense or MoE，shared expert 逻辑已经在 GenericMoeLayer 内部处理)
-        hidden_states = self.mlp(hidden_states)
+        if hasattr(self.mlp, "support_dual_mode") and self.mlp.support_dual_mode:
+            hidden_states = self.mlp(
+                hidden_states, has_prefill_global=has_prefill_global
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
 
         # 返回 mlp_output 和 residual，让下一层的 input_layernorm 来 fuse 最后的 add
         return DecodeLayerOutput(hidden_states, residual)
@@ -296,6 +376,9 @@ class GenericMoeModel(GptModelBase):
             weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
         )
 
+        self.support_dual_mode = getattr(moe_config, "support_dual_mode", False)
+        self.dp_size = parallelism_config.dp_size
+
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         input_ids: torch.Tensor = inputs.input_ids
         hidden_states = self.embed_tokens(input_ids)
@@ -304,6 +387,20 @@ class GenericMoeModel(GptModelBase):
                 inputs
             )  # pyright: ignore[reportUnreachable]
 
+        has_prefill_global = False
+        if self.support_dual_mode:
+            if hasattr(inputs, "has_prefill_global"):
+                has_prefill_global = inputs.has_prefill_global
+            else:
+                # Fallback: use heuristic based on input length
+                num_tokens = hidden_states.size(0)
+                has_prefill_global = num_tokens > 1
+                logging.warning(
+                    "has_prefill_global missing in dual mode, using fallback: num_tokens=%d -> %s",
+                    num_tokens,
+                    has_prefill_global,
+                )
+
         residual = torch.zeros_like(hidden_states)
         for i, decoder_layer in enumerate(self.layers[: self.layer_num]):
             output = decoder_layer(
@@ -311,6 +408,7 @@ class GenericMoeModel(GptModelBase):
                 residual,
                 fmha_impl,
                 kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+                has_prefill_global=has_prefill_global,
             )
             hidden_states = output.hidden_states
             residual = output.residual

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
@@ -52,7 +52,11 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
         resolver = MoeConfigResolver()
         checker.check(get_sm()[0] >= 9)
         checker.check(resolver.is_ep_enabled(config))
-        checker.check(resolver.use_low_latency(config))
+
+        support_dual_mode = getattr(config.moe_config, "support_dual_mode", False)
+        use_low_latency = resolver.use_low_latency(config)
+        checker.check(support_dual_mode or use_low_latency)
+
         checker.check(DeepEPWrapper.supported())
 
     def __init__(
@@ -79,12 +83,18 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
             self.config, self._ll_num_max_token_per_rank
         )
         wrapper = DeepEPWrapper.get_instance(deepep_config)
-        assert (
-            wrapper.mode == DeepEPMode.LOW_LATENCY
-        ), "DeepEP mode should be LOW_LATENCY"
-        self._buffer = wrapper.buffer
+
+        if wrapper.mode == DeepEPMode.DUAL:
+            self._buffer = wrapper.get_buffer(use_low_latency=True)
+            self._num_max_dispatch_tokens_per_rank = self._ll_num_max_token_per_rank
+        else:
+            assert (
+                wrapper.mode == DeepEPMode.LOW_LATENCY
+            ), f"DeepEP mode should be LOW_LATENCY, got {wrapper.mode}"
+            self._buffer = wrapper.buffer
+            self._num_max_dispatch_tokens_per_rank = wrapper.ll_num_max_token_per_rank
+
         self._num_topk = wrapper.num_topk
-        self._num_max_dispatch_tokens_per_rank = wrapper.ll_num_max_token_per_rank
         self._use_fp8_dispatch = use_fp8_dispatch
         self._zero_copy = False
         self._async_finish = False

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
@@ -53,7 +53,7 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
         checker.check(get_sm()[0] >= 9)
         checker.check(resolver.is_ep_enabled(config))
 
-        support_dual_mode = getattr(config.moe_config, "support_dual_mode", False)
+        support_dual_mode = config.moe_config.support_dual_mode
         use_low_latency = resolver.use_low_latency(config)
         checker.check(support_dual_mode or use_low_latency)
 
@@ -84,17 +84,10 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
         )
         wrapper = DeepEPWrapper.get_instance(deepep_config)
 
-        if wrapper.mode == DeepEPMode.DUAL:
-            self._buffer = wrapper.get_buffer(use_low_latency=True)
-            self._num_max_dispatch_tokens_per_rank = self._ll_num_max_token_per_rank
-        else:
-            assert (
-                wrapper.mode == DeepEPMode.LOW_LATENCY
-            ), f"DeepEP mode should be LOW_LATENCY, got {wrapper.mode}"
-            self._buffer = wrapper.buffer
-            self._num_max_dispatch_tokens_per_rank = wrapper.ll_num_max_token_per_rank
+        self._buffer = wrapper.get_buffer(use_low_latency=True)
 
         self._num_topk = wrapper.num_topk
+        self._num_max_dispatch_tokens_per_rank = wrapper.ll_num_max_token_per_rank
         self._use_fp8_dispatch = use_fp8_dispatch
         self._zero_copy = False
         self._async_finish = False

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
@@ -47,7 +47,7 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         checker.check(get_sm()[0] >= 9)
         checker.check(resolver.is_ep_enabled(config))
 
-        support_dual_mode = getattr(config.moe_config, "support_dual_mode", False)
+        support_dual_mode = config.moe_config.support_dual_mode
         use_low_latency = resolver.use_low_latency(config)
         checker.check(support_dual_mode or not use_low_latency)
 
@@ -75,13 +75,12 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         deepep_config = DeepepWrapperConfig.from_config_adapter(self.config)
         self.deepep_buffer_wrapper = DeepEPWrapper.get_instance(deepep_config)
 
-        if self.deepep_buffer_wrapper.mode == DeepEPMode.DUAL:
-            self._buffer = self.deepep_buffer_wrapper.get_buffer(use_low_latency=False)
-        else:
-            assert (
-                self.deepep_buffer_wrapper.mode == DeepEPMode.NORMAL
-            ), f"DeepEP mode should be NORMAL, got {self.deepep_buffer_wrapper.mode}"
-            self._buffer = self.deepep_buffer_wrapper.buffer
+        # Always use get_buffer() for consistency across all modes
+        assert (
+            self.deepep_buffer_wrapper.mode == DeepEPMode.NORMAL
+            or self.deepep_buffer_wrapper.mode == DeepEPMode.DUAL
+        ), f"DeepEP mode should be NORMAL or DUAL, got {self.deepep_buffer_wrapper.mode}"
+        self._buffer = self.deepep_buffer_wrapper.get_buffer(use_low_latency=False)
 
         self.async_mode = False
         self.expert_alignment = expert_alignment

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
@@ -46,7 +46,11 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         resolver = MoeConfigResolver()
         checker.check(get_sm()[0] >= 9)
         checker.check(resolver.is_ep_enabled(config))
-        checker.check(not resolver.use_low_latency(config))
+
+        support_dual_mode = getattr(config.moe_config, "support_dual_mode", False)
+        use_low_latency = resolver.use_low_latency(config)
+        checker.check(support_dual_mode or not use_low_latency)
+
         checker.check(DeepEPWrapper.supported())
 
     def __init__(
@@ -70,9 +74,15 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         self.top_k = config.moe_topk_group
         deepep_config = DeepepWrapperConfig.from_config_adapter(self.config)
         self.deepep_buffer_wrapper = DeepEPWrapper.get_instance(deepep_config)
-        assert (
-            self.deepep_buffer_wrapper.mode == DeepEPMode.NORMAL
-        ), "DeepEP mode should be NORMAL"
+
+        if self.deepep_buffer_wrapper.mode == DeepEPMode.DUAL:
+            self._buffer = self.deepep_buffer_wrapper.get_buffer(use_low_latency=False)
+        else:
+            assert (
+                self.deepep_buffer_wrapper.mode == DeepEPMode.NORMAL
+            ), f"DeepEP mode should be NORMAL, got {self.deepep_buffer_wrapper.mode}"
+            self._buffer = self.deepep_buffer_wrapper.buffer
+
         self.async_mode = False
         self.expert_alignment = expert_alignment
         self.handle: Any = None
@@ -127,9 +137,7 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
             num_tokens_per_expert,
             is_token_in_rank,
             _,
-        ) = self.deepep_buffer_wrapper.buffer.get_dispatch_layout(
-            tp_expert_ids, self.expert_num
-        )
+        ) = self._buffer.get_dispatch_layout(tp_expert_ids, self.expert_num)
 
         # dispatch
         (
@@ -139,7 +147,7 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
             num_recv_tokens_per_expert_list,
             self.handle,
             _,
-        ) = self.deepep_buffer_wrapper.buffer.dispatch(
+        ) = self._buffer.dispatch(
             tp_expert_input,
             None,
             num_tokens_per_rank,
@@ -198,9 +206,7 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
     ) -> torch.Tensor:
         assert self.handle is not None, "handler is None"
         assert payload.fused_expert_output is not None, "fused_expert_output is None"
-        out_token, _, _ = self.deepep_buffer_wrapper.buffer.combine(
-            payload.fused_expert_output, self.handle
-        )
+        out_token, _, _ = self._buffer.combine(payload.fused_expert_output, self.handle)
         self.handle = None
 
         # gather

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
@@ -49,6 +49,7 @@ class CudaFp8PerBlockEpLowLatencyStrategy(MoeStrategy):
         resolver = MoeConfigResolver()
         quant_method = resolver.get_quant_method(config)
         checker.check(quant_method == "FP8_PER_BLOCK")
+        checker.check(config.moe_config.use_deepep_low_latency)
 
     def get_attributes(self) -> StrategyAttributes:
         from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_masked_executor import (
@@ -71,6 +72,13 @@ class CudaFp8PerBlockEpLowLatencyStrategy(MoeStrategy):
 
 class CudaFp8PerBlockEpNormalStrategy(MoeStrategy):
     """CUDA FP8 PerBlock EP normal mode strategy"""
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method == "FP8_PER_BLOCK")
+        checker.check(not config.moe_config.use_deepep_low_latency)
 
     def get_attributes(self) -> StrategyAttributes:
         from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_continous_executor import (

--- a/rtp_llm/server/server_args/moe_group_args.py
+++ b/rtp_llm/server/server_args/moe_group_args.py
@@ -9,7 +9,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--use_deepep_moe",
         env_name="USE_DEEPEP_MOE",
-        bind_to=(deep_ep_config, 'use_deepep_moe'),
+        bind_to=(deep_ep_config, "use_deepep_moe"),
         type=str2bool,
         help="设置为 `True` 以启用 DeepEP 来处理 MoE 模型的 expert 部分。默认值为 None，允许自动配置。",
     )
@@ -17,7 +17,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--use_deepep_internode",
         env_name="USE_DEEPEP_INTERNODE",
-        bind_to=(deep_ep_config, 'use_deepep_internode'),
+        bind_to=(deep_ep_config, "use_deepep_internode"),
         type=str2bool,
         help="设置为 `True` 以启用 DeepEP 来优化跨节点 (inter-node) 通信。默认值为 None，允许自动配置。",
     )
@@ -25,15 +25,24 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--use_deepep_low_latency",
         env_name="USE_DEEPEP_LOW_LATENCY",
-        bind_to=(deep_ep_config, 'use_deepep_low_latency'),
+        bind_to=(deep_ep_config, "use_deepep_low_latency"),
         type=str2bool,
         help="设置为 `True` 以启用 DeepEP 的低延迟模式。默认值为 None，允许自动配置。",
     )
 
     moe_group.add_argument(
+        "--support_dual_mode",
+        env_name="SUPPORT_DUAL_MODE",
+        bind_to=(deep_ep_config, "support_dual_mode"),
+        type=str2bool,
+        default=False,
+        help="设置为 `True` 以同时支持 Normal 和 LowLatency 模式，在 Prefill 时使用 Normal，Decode 时使用 LowLatency + CUDA Graph。",
+    )
+
+    moe_group.add_argument(
         "--use_deepep_p2p_low_latency",
         env_name="USE_DEEPEP_P2P_LOW_LATENCY",
-        bind_to=(moe_config, 'use_deepep_p2p_low_latency'),
+        bind_to=(moe_config, "use_deepep_p2p_low_latency"),
         type=str2bool,
         default=False,
         help="设置为 `True` 以启用 DeepEP 的点对点 (P2P) 低延迟模式。",
@@ -42,7 +51,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--deep_ep_num_sm",
         env_name="DEEP_EP_NUM_SM",
-        bind_to=(moe_config, 'deep_ep_num_sm'),
+        bind_to=(moe_config, "deep_ep_num_sm"),
         type=int,
         default=0,
         help="为 DeepEPBuffer 设置 SM (Streaming Multiprocessor) 数量。设置为 `0` 将使用系统默认配置。",
@@ -51,7 +60,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--fake_balance_expert",
         env_name="FAKE_BALANCE_EXPERT",
-        bind_to=(moe_config, 'fake_balance_expert'),
+        bind_to=(moe_config, "fake_balance_expert"),
         type=str2bool,
         default=False,
         help="设置为 `True` 时，为 MoE 模型中的 expert 启用伪均衡 (fake balancing) 机制。用于测试或模拟特定均衡行为。",
@@ -60,7 +69,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_control_step",
         env_name="EPLB_CONTROL_STEP",
-        bind_to=(eplb_config, 'eplb_control_step'),
+        bind_to=(eplb_config, "eplb_control_step"),
         type=int,
         default=100,
         help="为 EPLB (Expert Placement Load Balancing) 控制器指定控制周期或步骤参数。这可能影响专家的负载均衡调整的频率或粒度。",
@@ -69,7 +78,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_test_mode",
         env_name="EPLB_TEST_MODE",
-        bind_to=(eplb_config, 'eplb_test_mode'),
+        bind_to=(eplb_config, "eplb_test_mode"),
         type=str2bool,
         default=False,
         help="设置为 `True` 时，为 ExpertBalancer 组件启用测试模式。用于调试或特定的测试场景。",
@@ -78,7 +87,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_balance_layer_per_step",
         env_name="EPLB_BALANCE_LAYER_PER_STEP",
-        bind_to=(eplb_config, 'eplb_balance_layer_per_step'),
+        bind_to=(eplb_config, "eplb_balance_layer_per_step"),
         type=int,
         default=1,
         help="设置 eplb 每次更新的层数。",
@@ -87,7 +96,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_mode",
         env_name="EPLB_MODE",
-        bind_to=(eplb_config, 'eplb_mode'),
+        bind_to=(eplb_config, "eplb_mode"),
         type=str,
         default="NONE",
         help="专家并行的负载均衡模式",
@@ -95,7 +104,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_update_time",
         env_name="EPLB_UPDATE_TIME",
-        bind_to=(eplb_config, 'eplb_update_time'),
+        bind_to=(eplb_config, "eplb_update_time"),
         type=int,
         default=5000,
         help="专家并行复杂均衡的更新时间",
@@ -103,7 +112,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--redundant_expert",
         env_name="REDUNDANT_EXPERT",
-        bind_to=(eplb_config, 'redundant_expert'),
+        bind_to=(eplb_config, "redundant_expert"),
         type=int,
         default=0,
         help="冗余专家个数",
@@ -111,7 +120,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--balance_method",
         env_name="BALANCE_METHOD",
-        bind_to=(eplb_config, 'balance_method'),
+        bind_to=(eplb_config, "balance_method"),
         type=str,
         default="mix",
         help="负载均衡的方法",
@@ -119,7 +128,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_force_repack",
         env_name="EPLB_FORCE_REPACK",
-        bind_to=(eplb_config, 'eplb_force_repack'),
+        bind_to=(eplb_config, "eplb_force_repack"),
         type=int,
         default=0,
         help="EPLB_FORCE_REPACK",
@@ -127,7 +136,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--eplb_stats_window_size",
         env_name="EPLB_STATS_WINDOW_SIZE",
-        bind_to=(eplb_config, 'eplb_stats_window_size'),
+        bind_to=(eplb_config, "eplb_stats_window_size"),
         type=int,
         default=10,
         help="负载均衡的统计窗口大小",
@@ -135,7 +144,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--max_moe_normal_masked_token_num",
         env_name="RTP_LLM_MAX_MOE_NORMAL_MASKED_TOKEN_NUM",
-        bind_to=(moe_config, 'max_moe_normal_masked_token_num'),
+        bind_to=(moe_config, "max_moe_normal_masked_token_num"),
         type=int,
         default=1024,
         help="moe normal使用masked的最大token数目",
@@ -143,7 +152,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
     moe_group.add_argument(
         "--use_all_gather",
         env_name="USE_ALL_GATHER",
-        bind_to=(moe_config, 'use_all_gather'),
+        bind_to=(moe_config, "use_all_gather"),
         type=str2bool,
         default=True,
         help="是否使用 all_gather 进行通信。",


### PR DESCRIPTION
This PR implements DeepEP Dual Mode and fixes critical issues in mixed TP/DP scenarios.

1. DeepEP Dual Mode
This PR implements dynamic mode switching for DeepEP (Deep Expert Parallelism) to enable **PDFusion deployments** (non-PD-separated scenarios) to use:
- **DeepEP Normal mode** for prefill (high throughput, supports long context)
- **DeepEP LowLatency mode** for decode (low latency, CUDA Graph compatible)
Using by test configuration SUPPORT_DUAL_MODE=1  or --support_dual_mode
Supported Scenarios:
- NVIDIA GPUs (CUDA environment required)
- Multiple DP (Data Parallelism)\Multiple TP (Tensor Parallelism) \ Mixed TP and DP configurations (e.g., 2TP + 2DP)
Limitations: Not compatible with Speculative Sampling (will throw error if gen_num_per_cycle > 1)

2. Port Mapping Fix
doc: https://alidocs.dingtalk.com/i/nodes/YQBnd5ExVEjea40qC0rGlaOEJyeZqMmz
Fixed critical port mapping issue in mixed TP/DP test scenarios:
Problem: Test infrastructure incorrectly calculated port offsets, targeting ranks without active frontends
Solution: Corrected port_offset calculation to always target tp_rank=0 of each DP replica (where frontend servers run)
Impact: Fixes test failures in maga_server_manager.py for all mixed parallelism configurations

