### PR TITLE
fix: fix enable_device_cache is false by default

### DIFF
--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -83,11 +83,15 @@ std::shared_ptr<GenerateConfig> QueryConverter::transGenerateConfig(const Genera
             RoleType(role_addr.role()), role_addr.ip(), role_addr.http_port(), role_addr.grpc_port());
     }
 
-    generate_config->inter_request_id    = config_proto->inter_request_id();
-    generate_config->reuse_cache         = config_proto->reuse_cache();
-    generate_config->enable_3fs          = config_proto->enable_3fs();
-    generate_config->enable_device_cache = config_proto->enable_device_cache();
-    generate_config->enable_memory_cache = config_proto->enable_memory_cache();
+    generate_config->inter_request_id = config_proto->inter_request_id();
+    generate_config->reuse_cache      = config_proto->reuse_cache();
+    generate_config->enable_3fs       = config_proto->enable_3fs();
+    if (config_proto->has_enable_device_cache()) {
+        generate_config->enable_device_cache = config_proto->enable_device_cache().value();
+    }
+    if (config_proto->has_enable_memory_cache()) {
+        generate_config->enable_memory_cache = config_proto->enable_memory_cache().value();
+    }
     TRANS_OPTIONAL(trace_id);
 
     return generate_config;

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -138,10 +138,10 @@ def trans_input(input_py: GenerateInput):
     generate_config_pb.ignore_eos = input_py.generate_config.ignore_eos
     generate_config_pb.reuse_cache = input_py.generate_config.reuse_cache
     generate_config_pb.enable_3fs = input_py.generate_config.enable_3fs
-    generate_config_pb.enable_memory_cache = (
+    generate_config_pb.enable_memory_cache.value = (
         input_py.generate_config.enable_memory_cache
     )
-    generate_config_pb.enable_device_cache = (
+    generate_config_pb.enable_device_cache.value = (
         input_py.generate_config.enable_device_cache
     )
 

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -93,8 +93,8 @@ message GenerateConfigPB {
     repeated int32 variable_num_beams = 49;
     google.protobuf.StringValue trace_id = 50;
     bool return_all_hidden_states = 51;
-    bool enable_memory_cache = 52;
-    bool enable_device_cache = 53;
+    google.protobuf.BoolValue enable_memory_cache = 52;
+    google.protobuf.BoolValue enable_device_cache = 53;
 }
 
 message MMPreprocessConfigPB {


### PR DESCRIPTION
* 问题
proto enable_device_cache 中默认为false，导致显存reuse cache未生效。

* 修复方案
如果query未配置该选项则使用generate_config中的默认值，默认为true。
proto3不支持optional，故使用`google.protobuf.BoolValue`。
