### PR TITLE
fix: fix reuse cache smoke may failed

### DIFF
--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -99,7 +99,8 @@ std::string KVCacheConfig::to_string() const {
         << "test_block_num: " << test_block_num << "\n"
         << "use_block_cache: " << use_block_cache << "\n"
         << "enable_device_cache: " << enable_device_cache << "\n"
-        << "enable_memory_cache: " << enable_memory_cache << "\n";
+        << "enable_memory_cache: " << enable_memory_cache << "\n"
+        << "write_cache_sync: " << write_cache_sync << "\n";
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -115,6 +115,7 @@ struct KVCacheConfig {
     int         use_block_cache     = -1;  // -1 means not set, use Optional<int> equivalent
     bool        enable_device_cache = true;
     bool        enable_memory_cache = false;
+    bool        write_cache_sync    = false;
     void        insertMultiTaskPromptTokens(std::string task_id, std::vector<int64_t> tokens_id);
     std::string to_string() const;
 };

--- a/rtp_llm/cpp/engine_base/stream/ResourceContext.h
+++ b/rtp_llm/cpp/engine_base/stream/ResourceContext.h
@@ -18,6 +18,7 @@ struct ResourceContext {
     bool enable_3fs{false};
     bool enable_device_cache{true};
     bool enable_memory_cache{false};
+    bool write_cache_sync{false};
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -243,7 +243,20 @@ void StreamCacheResource::waitLoadCacheDone(const std::shared_ptr<AsyncContext>&
 void StreamCacheResource::storeCacheAsync() {
     auto meta              = std::make_shared<MetaImpl>(reuseCache() && enableMemoryCache());
     auto connector_context = std::make_shared<KVCacheConnectorReadWriteContextImpl>(batch_kv_cache_resource_, meta);
-    resource_context_.cache_manager->asyncStoreCache(connector_context);
+    auto store_context     = resource_context_.cache_manager->asyncStoreCache(connector_context);
+    // wait done is for smoke test only
+    if (resource_context_.write_cache_sync) {
+        waitStoreCacheDone(store_context);
+    }
+}
+
+void StreamCacheResource::waitStoreCacheDone(const std::shared_ptr<AsyncContext>& store_context) {
+    if (!store_context) {
+        return;
+    }
+    while (!store_context->done()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
@@ -111,6 +111,7 @@ private:
     void loadCacheSync();
     void waitLoadCacheDone(const std::shared_ptr<AsyncContext>& load_context);
     void storeCacheAsync();
+    void waitStoreCacheDone(const std::shared_ptr<AsyncContext>& store_context);
 
 private:
     GenerateStream*          stream_;

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -261,6 +261,7 @@ absl::Status NormalEngine::initSystemPrompt() {
     resource_context_.enable_3fs          = kv_cache_config.enable_3fs;
     resource_context_.enable_device_cache = kv_cache_config.enable_device_cache;
     resource_context_.enable_memory_cache = kv_cache_config.enable_memory_cache;
+    resource_context_.write_cache_sync    = kv_cache_config.write_cache_sync;
 
     if (!kv_cache_config.multi_task_prompt_tokens.empty()) {
         resource_context_.reuse_cache = true;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -282,6 +282,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("use_block_cache", &KVCacheConfig::use_block_cache)
         .def_readwrite("enable_device_cache", &KVCacheConfig::enable_device_cache)
         .def_readwrite("enable_memory_cache", &KVCacheConfig::enable_memory_cache)
+        .def_readwrite("write_cache_sync", &KVCacheConfig::write_cache_sync)
         .def("insertMultiTaskPromptTokens", &KVCacheConfig::insertMultiTaskPromptTokens)
         .def("to_string", &KVCacheConfig::to_string)
         .def(py::pickle(
@@ -309,10 +310,11 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.test_block_num,
                                       self.use_block_cache,
                                       self.enable_device_cache,
-                                      self.enable_memory_cache);
+                                      self.enable_memory_cache,
+                                      self.write_cache_sync);
             },
             [](py::tuple t) {
-                if (t.size() != 24)
+                if (t.size() != 25)
                     throw std::runtime_error("Invalid state!");
                 KVCacheConfig c;
                 try {
@@ -340,6 +342,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.use_block_cache              = t[21].cast<int>();
                     c.enable_device_cache          = t[22].cast<bool>();
                     c.enable_memory_cache          = t[23].cast<bool>();
+                    c.write_cache_sync             = t[24].cast<bool>();
 
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("KVCacheConfig unpickle error: ") + e.what());

--- a/rtp_llm/cpp/speculative_engine/SpeculativeEngine.cc
+++ b/rtp_llm/cpp/speculative_engine/SpeculativeEngine.cc
@@ -121,11 +121,8 @@ absl::Status SpeculativeEngine::init() {
     }
     RETURN_IF_STATUS_ERROR(initCacheManager(warm_up_result));
     RTP_LLM_LOG_INFO("create cache manager done");
-    propose_executor_ = createProposeExecutor(score_model_params_,
-                                              propose_model_params_,
-                                              device_,
-                                              resource_context_.cache_manager,
-                                              getLoraManager());
+    propose_executor_ = createProposeExecutor(
+        score_model_params_, propose_model_params_, device_, resource_context_.cache_manager, getLoraManager());
     RTP_LLM_LOG_INFO("create speculative executor done");
     score_executor_.reset(
         new ScoreExecutor(score_model_params_, device_, resource_context_.cache_manager, getLoraManager()));
@@ -286,6 +283,7 @@ absl::Status SpeculativeEngine::initSystemPrompt() {
     resource_context_.enable_3fs          = score_model_params_.kv_cache_config.enable_3fs;
     resource_context_.enable_device_cache = score_model_params_.kv_cache_config.enable_device_cache;
     resource_context_.enable_memory_cache = score_model_params_.kv_cache_config.enable_memory_cache;
+    resource_context_.write_cache_sync    = score_model_params_.kv_cache_config.write_cache_sync;
 
     if (!score_model_params_.kv_cache_config.multi_task_prompt_tokens.empty()) {
         resource_context_.reuse_cache = true;

--- a/rtp_llm/server/server_args/kv_cache_group_args.py
+++ b/rtp_llm/server/server_args/kv_cache_group_args.py
@@ -117,3 +117,11 @@ def init_kv_cache_group_args(parser, kv_cache_config):
         default=10000,
         help="Memory Cache 多TP同步的超时时间, 单位为毫秒",
     )
+    kv_cache_group.add_argument(
+        "--write_cache_sync",
+        env_name="WRITE_CACHE_SYNC",
+        bind_to=(kv_cache_config, "write_cache_sync"),
+        type=str2bool,
+        default=False,
+        help="KVCache 同步写入开关. 当开启时, 在写入 Cache 时会等待写入完成. 默认关闭(即异步写入), Smoke 测试时需开启",
+    )


### PR DESCRIPTION
* 问题
reuse cache smoke不稳定，可能会出现失败的情况。

* 原因
cache写入到内存时，由于是异步写，所以在smoke中可能存在前一个query的kvcache尚未写入结束时，后一个query就已经来了，此时就会出现cache miss，reuse_len为0，导致smoke失败

* 解决方案
加一个同步写的环境变量WRITE_CACHE_SYNC，在smoke时置为True，同步写Cache到内存