### PR TITLE
fix: enable earlier embedding tensor release

### DIFF
--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -298,8 +298,7 @@ class GenericMoeModel(GptModelBase):
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         input_ids: torch.Tensor = inputs.input_ids
-        inputs_embeds = self.embed_tokens(input_ids)
-        hidden_states = inputs_embeds
+        hidden_states = self.embed_tokens(input_ids)
         if fmha_impl is None:
             fmha_impl = self.prepare_fmha_impl(
                 inputs


### PR DESCRIPTION
Remove the intermediate `inputs_embeds` variable in `GenericMoeModel.forward()`. This eliminates an unnecessary reference, allowing PyTorch to potentially release the embedding tensor earlier, especially beneficial under long sequence scenarios.