### PR TITLE
fix: hold flashinfer host buffer

### DIFF
--- a/rtp_llm/cpp/devices/OpData.h
+++ b/rtp_llm/cpp/devices/OpData.h
@@ -1091,6 +1091,8 @@ struct DevicePrepOutput {
 
     // rocm
     ParamsPtr decode_aiter_attn;
+
+    std::vector<BufferPtr> flash_infer_host_buffers;
 };
 
 struct LoraLinearOutput {

--- a/rtp_llm/cpp/devices/cuda_impl/CudaDevice.cc
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaDevice.cc
@@ -540,6 +540,18 @@ DevicePrepOutput CudaDevice::prepareModelRunCommon(const DevicePrepParams& param
         prepareTrtAttn(params.configs, params.kv_cache, decode_kv_cache_block_id_d, params.decoder_batch_size);
     output.prefill_trt_attn =
         prepareTrtAttn(params.configs, params.kv_cache, prefill_kv_cache_block_id_d, params.context_batch_size);
+
+    FlashInferAttnParams* prefill_flash_infer_attn = (FlashInferAttnParams*)output.prefill_flash_infer_attn.get();
+    if (prefill_flash_infer_attn) {
+        output.flash_infer_host_buffers.push_back(prefill_flash_infer_attn->int_host_workspace);
+        output.flash_infer_host_buffers.push_back(prefill_flash_infer_attn->buf_h);
+    }
+    FlashInferAttnParams* decode_flash_infer_attn = (FlashInferAttnParams*)output.decode_flash_infer_attn.get();
+    if (decode_flash_infer_attn) {
+        output.flash_infer_host_buffers.push_back(decode_flash_infer_attn->int_host_workspace);
+        output.flash_infer_host_buffers.push_back(decode_flash_infer_attn->buf_h);
+    }
+
     return output;
 }
 

--- a/rtp_llm/cpp/devices/cuda_impl/CudaFlashInfer.h
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaFlashInfer.h
@@ -9,7 +9,7 @@ namespace rtp_llm {
 class AttentionConfigs;
 
 struct FlashInferAttnParams: ParamsBase {
-private:
+public:
     BufferPtr float_workspace;
     BufferPtr int_workspace;
     BufferPtr int_host_workspace;

--- a/rtp_llm/cpp/models/GptModel.cc
+++ b/rtp_llm/cpp/models/GptModel.cc
@@ -231,6 +231,10 @@ rtp_llm::AttentionCommonInputs GptModel::prepareAttentionInputs(const GptModelIn
                                   (bool)weights_.linear_bias_slopes});
     device_->checkError();
 
+    for (const auto& buffer : prep_output.flash_infer_host_buffers) {
+        buffer_holder_.hold_host(buffer);
+    }
+
     attention_inputs.decode_flash_infer_attn.swap(prep_output.decode_flash_infer_attn);
     attention_inputs.prefill_flash_infer_attn.swap(prep_output.prefill_flash_infer_attn);
     attention_inputs.decode_trt_attn.swap(prep_output.decode_trt_attn);


### PR DESCRIPTION
Extend the host buffer lifespan to avoid illegal memory access in `PersistentVariableLengthMergeStatesKernel`