### PR TITLE
fix: seperate different model flashinfer params

### DIFF
--- a/rtp_llm/cpp/devices/OpData.h
+++ b/rtp_llm/cpp/devices/OpData.h
@@ -1080,6 +1080,8 @@ struct DevicePrepParams {
     size_t   decoder_batch_size = 0;
     bool     diff_qkv_len       = false;
     bool     has_alibi_slopes   = false;
+
+    int model_id = 0;  // use to identify the model, for different model, the flash infer params are different
 };
 
 struct DevicePrepOutput {

--- a/rtp_llm/cpp/devices/cuda_impl/CudaDevice.cc
+++ b/rtp_llm/cpp/devices/cuda_impl/CudaDevice.cc
@@ -524,7 +524,8 @@ DevicePrepOutput CudaDevice::prepareModelRunCommon(const DevicePrepParams& param
         params.input_lengths->slice(0, params.decoder_batch_size),
         params.kv_cache_block_id ? params.kv_cache_block_id->slice(0, params.decoder_batch_size) : nullptr,
         decode_kv_cache_block_id_d,
-        params.attn_dtype);
+        params.attn_dtype,
+        params.model_id);
     output.prefill_flash_infer_attn = FlashInferAttnParams::prepare(
         this,
         params.configs,
@@ -535,11 +536,13 @@ DevicePrepOutput CudaDevice::prepareModelRunCommon(const DevicePrepParams& param
             params.kv_cache_block_id->slice(params.decoder_batch_size, params.context_batch_size) :
             nullptr,
         prefill_kv_cache_block_id_d,
-        params.attn_dtype);
+        params.attn_dtype,
+        params.model_id);
     output.decode_trt_attn =
         prepareTrtAttn(params.configs, params.kv_cache, decode_kv_cache_block_id_d, params.decoder_batch_size);
     output.prefill_trt_attn =
         prepareTrtAttn(params.configs, params.kv_cache, prefill_kv_cache_block_id_d, params.context_batch_size);
+
     return output;
 }
 

--- a/rtp_llm/cpp/models/GptModel.cc
+++ b/rtp_llm/cpp/models/GptModel.cc
@@ -228,7 +228,8 @@ rtp_llm::AttentionCommonInputs GptModel::prepareAttentionInputs(const GptModelIn
                                   context_batch_size,
                                   decoder_batch_size,
                                   attention_inputs.max_prefix_length > 0,
-                                  (bool)weights_.linear_bias_slopes});
+                                  (bool)weights_.linear_bias_slopes,
+                                  (int)model_id_});
     device_->checkError();
 
     attention_inputs.decode_flash_infer_attn.swap(prep_output.decode_flash_infer_attn);


### PR DESCRIPTION
Draft Model and Target Model should hold different flashinfer params cache.
If not, since params has host(CPU) buffers and there is no sync after Draft Model forward, it will cause CUDA illegal memory access at `PersistentVariableLengthMergeStatesKernel` when target model rewrite params.