### PR TITLE
feat: memory support hybrid kv cache

### DIFF
--- a/rtp_llm/cpp/cache/CacheConfig.h
+++ b/rtp_llm/cpp/cache/CacheConfig.h
@@ -21,6 +21,7 @@ struct CacheConfig {
     std::vector<std::vector<int>> full_groups;    // for hybrid attention
     std::vector<CacheGroupType>   group_types;    // for hybrid attention
     std::vector<int>              layer_to_group_id;
+    std::vector<int>              layer_to_block_stride_bytes;
 
     // Model configuration
     rtp_llm::DataType dtype;

--- a/rtp_llm/cpp/cache/HybridConfigCreator.cc
+++ b/rtp_llm/cpp/cache/HybridConfigCreator.cc
@@ -201,6 +201,12 @@ CacheConfig HybridConfigCreator::createHybridConfig(const ModelConfig&       mod
     // Setup layer to group mapping
     HybridConfigCreator::setupLayerToGroupMapping(config);
 
+    // Per-layer block stride (kv + scale).
+    // For hybrid attention, the physical per-layer stride follows the selected physical layout stride.
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
+
     return config;
 }
 

--- a/rtp_llm/cpp/cache/SingleConfigCreator.cc
+++ b/rtp_llm/cpp/cache/SingleConfigCreator.cc
@@ -50,6 +50,11 @@ CacheConfig SingleConfigCreator::createSingleConfig(const ModelConfig&       mod
     config.block_size_bytes = config.kv_block_size_bytes + config.kv_scale_size_bytes;
     config.group_layer_num  = layer_num;  // only 1 group for SingleConfig
 
+    // Per-layer block stride (kv + scale).
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
+
     // Global layer ids are the indices used by BlockPool::convertIndexToAddr (0..N-1 in a single-model case).
     config.global_layer_ids.push_back(all_layer_ids);
     config.layer_ids.push_back(all_layer_ids);

--- a/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.cc
@@ -15,7 +15,7 @@ int SingleTypeKVCacheAllocator::getNeedBlocks(const MallocInfo& malloc_info) con
     if (!malloc_info.batch_kv_cache_resource || !malloc_info.complete_token_ids) {
         return 0;
     }
-    const bool reuse_enabled    = malloc_info.enable_device_cache;
+    const bool reuse_enabled    = malloc_info.reuse_cache;
     const int  reuse_blocks_len = reuse_enabled ? malloc_info.batch_kv_cache_resource->curBlocksNum() : 0;
     const int  batch_size       = malloc_info.batch_kv_cache_resource->batchSize();
     const int  seq_len          = malloc_info.complete_token_ids->seqLength();

--- a/rtp_llm/cpp/cache/Types.h
+++ b/rtp_llm/cpp/cache/Types.h
@@ -76,6 +76,7 @@ struct MallocInfo {
     CompleteTokenIdsPtr     complete_token_ids;
     int64_t                 request_id          = 0;
     bool                    verbose             = true;  // for failed log
+    bool                    reuse_cache         = true;
     bool                    enable_device_cache = true;
 };
 

--- a/rtp_llm/cpp/cache/connector/memory/KVCacheMemoryConnector.cc
+++ b/rtp_llm/cpp/cache/connector/memory/KVCacheMemoryConnector.cc
@@ -45,6 +45,8 @@ bool KVCacheMemoryConnector::init() {
                             "init failed, sync timeout is invalid, sync timeout: %ld ms",
                             memory_cache_sync_timeout_ms);
 
+    checkLayerBlockStrideBytes();
+
     initBlockPool();
     block_cache_ = std::make_shared<MemoryBlockCache>();
 
@@ -60,15 +62,31 @@ bool KVCacheMemoryConnector::init() {
     return true;
 }
 
+void KVCacheMemoryConnector::checkLayerBlockStrideBytes() const {
+    const size_t layer_num          = cache_config_.layer_all_num;
+    const auto&  layer_block_stride = cache_config_.layer_to_block_stride_bytes;
+    RTP_LLM_CHECK_WITH_INFO(layer_block_stride.size() == layer_num,
+                            "layer block stride size must equal to layer num, got=%zu need=%zu",
+                            layer_block_stride.size(),
+                            layer_num);
+    for (size_t i = 0; i < layer_num; ++i) {
+        RTP_LLM_CHECK_WITH_INFO(
+            layer_block_stride[i] > 0, "invalid block stride bytes at layer=%zu: %d", i, layer_block_stride[i]);
+    }
+}
+
 void KVCacheMemoryConnector::initBlockPool() {
     const auto memory_cache_size_mb = kv_cache_config_.memory_cache_size_mb;
     RTP_LLM_CHECK_WITH_INFO(memory_cache_size_mb > 0,
                             "init block pool failed, memory size is invalid, memory size: %ld MB",
                             memory_cache_size_mb);
 
+    const auto& layer_block_stride = cache_config_.layer_to_block_stride_bytes;
+
     // block_size here means "one cache-key across all layers" total bytes (kv + scale).
-    const size_t block_size = cache_config_.block_size_bytes;
-    RTP_LLM_CHECK_WITH_INFO(block_size > 0, "init block pool failed, block size is invalid: %zu", block_size);
+    // Use per-layer block strides so NULL_BLOCK_IDX layers still occupy space in merged layout.
+    size_t block_size = std::accumulate(layer_block_stride.begin(), layer_block_stride.end(), 0);
+    RTP_LLM_CHECK_WITH_INFO(block_size > 0, "block size is invalid: %zu", block_size);
 
     block_pool_ = createBlockPool(block_size, memory_cache_size_mb);
     RTP_LLM_CHECK_WITH_INFO(block_pool_ != nullptr, "init block pool failed, create block pool failed");
@@ -76,23 +94,23 @@ void KVCacheMemoryConnector::initBlockPool() {
 
 std::shared_ptr<AsyncMatchContext> KVCacheMemoryConnector::asyncMatch(const std::shared_ptr<KVCacheResource>& resource,
                                                                       const std::shared_ptr<Meta>&            meta) {
-    if (!meta) {
-        RTP_LLM_LOG_WARNING("async match failed, meta is null");
-        return nullptr;
-    }
+    RTP_LLM_CHECK_WITH_INFO(meta != nullptr, "async match failed, meta is null");
+    RTP_LLM_CHECK_WITH_INFO(resource != nullptr, "async match failed, resource is null");
     if (!meta->enableMemoryCache()) {
-        return nullptr;
-    }
-    if (!resource) {
-        RTP_LLM_LOG_WARNING("async match failed, resource is null");
         return nullptr;
     }
 
     const auto& cache_keys = resource->cacheKeys();
-    // do not match last block, whether it is aligned or not, or may cause core dump in computing ops.
+    // do not match last block, whether it is aligned or not, otherwise may cause core dump in computing ops.
     const auto cache_keys_size = cache_keys.empty() ? 0 : cache_keys.size() - 1;
     if (cache_keys_size == 0) {
         RTP_LLM_LOG_DEBUG("async match skip, cache keys is empty");
+        return nullptr;
+    }
+
+    const auto& layer_block_ids = resource->layerBlocks();
+    if (!checkLayerBlocks(layer_block_ids, cache_keys_size)) {
+        RTP_LLM_LOG_WARNING("async match failed, invalid layer_block_ids, cache_keys_size=%zu", cache_keys_size);
         return nullptr;
     }
 
@@ -108,12 +126,22 @@ std::shared_ptr<AsyncMatchContext> KVCacheMemoryConnector::asyncMatch(const std:
 
     autil::ScopedTime2 timer;
 
+    // matched_num must end at a key that satisfies BOTH:
+    // - memory cache key is complete
+    // - all gpu blocks for this key are valid (non-null)
+    //
+    // Notes:
+    // - If a key is complete, we allow gpu blocks to be partially invalid and keep matching further.
+    // - If all gpu blocks are valid, the final matched key must be complete.
     size_t matched_num = 0;
-    for (; matched_num < cache_keys_size; ++matched_num) {
-        const auto cache_key    = cache_keys.at(matched_num);
+    for (size_t i = 0; i < cache_keys_size; ++i) {
+        const auto cache_key    = cache_keys.at(i);
         const auto match_result = block_cache_->match(static_cast<CacheKeyType>(cache_key));
         if (isNullBlockIdx(match_result.matched_index)) {
-            break;  // 只处理连续前缀
+            break;  // only continuous prefix
+        }
+        if (match_result.is_complete && gpuBlocksAllValid(layer_block_ids, i)) {
+            matched_num = i + 1;
         }
     }
 
@@ -126,15 +154,22 @@ std::shared_ptr<AsyncMatchContext> KVCacheMemoryConnector::asyncMatch(const std:
     return std::make_shared<MemoryAsyncMatchContext>(matched_num);
 }
 
+bool KVCacheMemoryConnector::gpuBlocksAllValid(const LayerBlockIds& layer_block_ids, size_t key_index) const {
+    for (size_t layer = 0; layer < cache_config_.layer_all_num; ++layer) {
+        const auto& blocks = layer_block_ids.at(layer)->blocks();
+        if (isNullBlockIdx(blocks.at(key_index))) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncRead(const std::shared_ptr<KVCacheResource>&   resource,
                                                                 const std::shared_ptr<Meta>&              meta,
                                                                 const std::shared_ptr<AsyncMatchContext>& match_context,
                                                                 int start_read_block_index,
                                                                 int read_block_num) {
-    if (!resource) {
-        RTP_LLM_LOG_WARNING("async read failed, resource is null");
-        return nullptr;
-    }
+    RTP_LLM_CHECK_WITH_INFO(resource != nullptr, "async read failed, resource is null");
     const auto& cache_keys      = resource->cacheKeys();
     const auto  cache_keys_size = cache_keys.empty() ? 0 : cache_keys.size() - 1;
     if (cache_keys_size == 0) {
@@ -163,11 +198,6 @@ std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncRead(const std::share
 
     auto copy_plan = buildCopyPlanForRead(cache_keys, layer_block_ids, start_read_block_index, read_block_num);
     if (!copy_plan || copy_plan->copy_infos.empty()) {
-        RTP_LLM_LOG_WARNING(
-            "async read failed, build copy plan for read failed, cache keys size: %zu, start_read_block_index: %d, read_block_num: %d",
-            cache_keys_size,
-            start_read_block_index,
-            read_block_num);
         reportReadMetrics(false, timer.done_us(), cache_keys_size, 0);
         return nullptr;
     }
@@ -202,59 +232,46 @@ std::shared_ptr<KVCacheMemoryConnector::CopyPlan> KVCacheMemoryConnector::buildC
         const auto cache_key    = cache_keys.at(i);
         const auto match_result = block_cache_->match(static_cast<CacheKeyType>(cache_key));
         if (isNullBlockIdx(match_result.matched_index)) {
+            RTP_LLM_LOG_WARNING("build copy plan for read failed, cache key not found, cache key: %ld", cache_key);
             success = false;
             break;
         }
+        // 每次都加引用的原因是为了确保match到的block不会被释放(避免在写时malloc如果cache满弹出该block)
         referenceBlocks({match_result.matched_index}, /*cache_ref=*/false);
 
         CopyInfoPerKey copy_info;
-        copy_info.cache_key       = cache_key;
-        copy_info.mem_block_index = match_result.matched_index;
-        copy_info.mem_block_size  = match_result.block_size;
-        copy_info.gpu_layer_blocks.reserve(layer_num);
+        copy_info.cache_key = cache_key;
+        copy_info.mem_block = match_result.matched_index;
+        copy_info.gpu_blocks.reserve(layer_num);
         for (size_t layer = 0; layer < layer_num; ++layer) {
-            const int gpu_block_idx = layer_block_ids.at(layer)->blocks().at(i);
-            if (isNullBlockIdx(gpu_block_idx)) {
-                RTP_LLM_LOG_DEBUG("build copy plan for read, found null gpu block index, cache key: %zu, layer: %zu",
-                                  cache_key,
-                                  layer);
-                continue;
-            }
-            LayerBlock lb{static_cast<int>(layer), static_cast<BlockIdxType>(gpu_block_idx)};
-            copy_info.gpu_layer_blocks.push_back(lb);
+            // Do NOT skip NULL_BLOCK_IDX here. The merged memory block layout requires reserving
+            // per-layer stride even when this layer has no gpu block (-1).
+            copy_info.gpu_blocks.push_back(layer_block_ids.at(layer)->blocks().at(i));
         }
+        copy_info.is_complete = match_result.is_complete;
         copy_infos.emplace_back(std::move(copy_info));
     }
 
-    auto plan        = new CopyPlan();
-    plan->copy_infos = std::move(copy_infos);
-    plan->direction  = CopyDirection::H2D;
-    auto deleter     = [this](CopyPlan* plan) {
-        std::vector<BlockIdxType> blocks;
-        blocks.reserve(plan->copy_infos.size());
-        for (const auto& copy_info : plan->copy_infos) {
-            blocks.push_back(copy_info.mem_block_index);
-        }
-        freeBlocks(blocks, /*cache_free=*/false);
-        delete plan;
-    };
-    std::shared_ptr<CopyPlan> plan_ptr(plan, deleter);
-    return success ? plan_ptr : nullptr;
+    // 在match时已经保证了最后一个key是complete, 这里再校验下
+    if (success && !copy_infos.empty() && !copy_infos.back().is_complete) {
+        RTP_LLM_LOG_WARNING("build copy plan for read failed, last key is not complete, cache key: %ld",
+                            copy_infos.back().cache_key);
+        success = false;
+    }
+
+    // free blocks in destructor
+    auto plan = createCopyPlan(copy_infos, CopyDirection::H2D);
+    return success ? plan : nullptr;
 }
 
 std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncWrite(const std::shared_ptr<KVCacheResource>& resource,
                                                                  const std::shared_ptr<Meta>&            meta) {
-    if (!meta) {
-        RTP_LLM_LOG_WARNING("async write failed, meta is null");
-        return nullptr;
-    }
+    RTP_LLM_CHECK_WITH_INFO(meta != nullptr, "async write failed, meta is null");
+    RTP_LLM_CHECK_WITH_INFO(resource != nullptr, "async write failed, resource is null");
     if (!meta->enableMemoryCache()) {
         return nullptr;
     }
-    if (!resource) {
-        RTP_LLM_LOG_WARNING("async write failed, resource is null");
-        return nullptr;
-    }
+
     const auto& cache_keys = resource->cacheKeys();
     const auto  cache_keys_size =
         cache_keys.empty() ? 0 : (resource->lastBlockAligned() ? cache_keys.size() : cache_keys.size() - 1);
@@ -272,26 +289,26 @@ std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncWrite(const std::shar
     }
 
     // 计算内存中已存在的前缀长度
-    size_t cpu_matched_num = 0;
-    for (; cpu_matched_num < cache_keys_size; ++cpu_matched_num) {
-        if (!block_cache_->contains(static_cast<CacheKeyType>(cache_keys[cpu_matched_num]))) {
+    size_t mem_matched_num = 0;
+    for (; mem_matched_num < cache_keys_size; ++mem_matched_num) {
+        if (!block_cache_->contains(static_cast<CacheKeyType>(cache_keys[mem_matched_num]))) {
             break;
         }
     }
-    if (cpu_matched_num == cache_keys_size) {
+    if (mem_matched_num == cache_keys_size) {
         RTP_LLM_LOG_DEBUG(
             "async write skip, all cache keys already in memory cache, matched num: %zu, cache keys size: %zu",
-            cpu_matched_num,
+            mem_matched_num,
             cache_keys_size);
         reportWriteMetrics(true, timer.done_us(), static_cast<int64_t>(cache_keys_size), 0);
         return nullptr;
     }
 
-    auto copy_plan =
-        buildCopyPlanForWrite(cache_keys, layer_block_ids, cpu_matched_num, cache_keys_size - cpu_matched_num);
+    bool no_need_write = false;
+    auto copy_plan     = buildCopyPlanForWrite(
+        cache_keys, layer_block_ids, mem_matched_num, cache_keys_size - mem_matched_num, no_need_write);
     if (!copy_plan || copy_plan->copy_infos.empty()) {
-        RTP_LLM_LOG_WARNING("async write failed, build copy plan for write failed");
-        reportWriteMetrics(false, timer.done_us(), static_cast<int64_t>(cache_keys_size), 0);
+        reportWriteMetrics(no_need_write, timer.done_us(), static_cast<int64_t>(cache_keys_size), 0);
         return nullptr;
     }
 
@@ -303,9 +320,9 @@ std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncWrite(const std::shar
                 for (const auto& copy_info : copy_plan->copy_infos) {
                     MemoryBlockCache::CacheItem item;
                     item.cache_key   = copy_info.cache_key;
-                    item.block_index = static_cast<BlockIdxType>(copy_info.mem_block_index);
-                    item.block_size  = copy_info.mem_block_size;
+                    item.block_index = copy_info.mem_block;
                     item.is_resident = false;
+                    item.is_complete = copy_info.is_complete;
                     putToCache(item);
                 }
                 // reset resource to decrease block ref count in destructor
@@ -326,78 +343,89 @@ std::shared_ptr<AsyncContext> KVCacheMemoryConnector::asyncWrite(const std::shar
     return context;
 }
 
-std::shared_ptr<KVCacheMemoryConnector::CopyPlan> KVCacheMemoryConnector::buildCopyPlanForWrite(
-    const CacheKeysType& cache_keys, const LayerBlockIds& layer_block_ids, int start_index, int write_num) {
+std::shared_ptr<KVCacheMemoryConnector::CopyPlan>
+KVCacheMemoryConnector::buildCopyPlanForWrite(const CacheKeysType& cache_keys,
+                                              const LayerBlockIds& layer_block_ids,
+                                              int                  start_index,
+                                              int                  write_num,
+                                              bool&                no_need_write) {
     const auto                  layer_num = cache_config_.layer_all_num;
     std::vector<CopyInfoPerKey> copy_infos;
     copy_infos.reserve(write_num);
-    std::map<size_t, std::vector<size_t>> indices_by_block_size;  // mem block size -> index in copy info vector
-    bool                                  success = true;
+
+    // Hybrid-attn support:
+    // We allow writing "partial" keys (incomplete KV) to keep prefix continuity,
+    // BUT the final written key MUST be "complete" (complete KV on all layers),
+    // otherwise the written tail cannot be reused by asyncMatch.
+    int last_complete_index = -1;  // cache_key index in [start_index, start_index + write_num)
 
     for (int i = start_index; i < start_index + write_num; ++i) {
-        const auto              cache_key   = cache_keys.at(i);
-        size_t                  total_bytes = 0;
-        std::vector<LayerBlock> gpu_layer_blocks;
-        gpu_layer_blocks.reserve(layer_num);
+        const auto                cache_key = cache_keys.at(i);
+        std::vector<BlockIdxType> gpu_blocks;
+        gpu_blocks.reserve(layer_num);
+        size_t null_block_num = 0;
         for (size_t layer = 0; layer < layer_num; ++layer) {
             const int gpu_block_idx = layer_block_ids.at(layer)->blocks().at(i);
+            // Do NOT skip NULL_BLOCK_IDX here. We must keep per-layer stride slots in the merged big block.
             if (isNullBlockIdx(gpu_block_idx)) {
-                continue;
+                ++null_block_num;
             }
-            gpu_layer_blocks.push_back(LayerBlock{static_cast<int>(layer), static_cast<BlockIdxType>(gpu_block_idx)});
-            const auto buffers = allocator_->convertIndexToBuffer(static_cast<int>(layer), gpu_block_idx);
-            for (const auto& buffer : buffers) {
-                if (buffer.addr && buffer.size_bytes > 0) {
-                    total_bytes += buffer.size_bytes;
-                }
-            }
+            gpu_blocks.push_back(gpu_block_idx);
         }
-        if (gpu_layer_blocks.empty() || total_bytes == 0) {
-            RTP_LLM_LOG_WARNING(
-                "build copy plan for write failed, invalid gpu_layer_blocks or total_bytes, cache key: %zu, gpu blocks: %zu, total bytes: %zu",
-                cache_key,
-                gpu_layer_blocks.size(),
-                total_bytes);
-            success = false;
-            break;
+
+        const bool is_complete = null_block_num == 0;
+        if (is_complete) {
+            last_complete_index = i;
         }
 
         CopyInfoPerKey copy_info;
-        copy_info.cache_key        = cache_key;
-        copy_info.mem_block_index  = NULL_BLOCK_IDX;
-        copy_info.mem_block_size   = total_bytes;
-        copy_info.gpu_layer_blocks = std::move(gpu_layer_blocks);
+        copy_info.cache_key   = cache_key;
+        copy_info.mem_block   = NULL_BLOCK_IDX;
+        copy_info.gpu_blocks  = std::move(gpu_blocks);
+        copy_info.is_complete = is_complete;
         copy_infos.emplace_back(std::move(copy_info));
-        indices_by_block_size[total_bytes].push_back(copy_infos.size() - 1);
     }
 
-    if (success) {
-        for (const auto& [block_size, indices] : indices_by_block_size) {
-            std::vector<BlockIdxType> mem_blocks;
-            if (!mallocBlocks(indices.size(), mem_blocks)) {
-                success = false;
-                break;
-            }
-            for (size_t j = 0; j < indices.size(); ++j) {
-                copy_infos[indices[j]].mem_block_index = mem_blocks[j];
-            }
-        }
+    // ensure the final written key is complete
+    no_need_write = last_complete_index < start_index;
+    if (no_need_write) {
+        return nullptr;
     }
 
+    // drop keys behind the last complete key
+    const size_t keep_cnt = static_cast<size_t>(last_complete_index - start_index + 1);
+    copy_infos.resize(keep_cnt);
+
+    std::vector<BlockIdxType> mem_blocks;
+    if (!mallocBlocks(copy_infos.size(), mem_blocks)) {
+        RTP_LLM_LOG_WARNING("build copy plan for write failed, malloc blocks failed, need blocks: %zu",
+                            copy_infos.size());
+        return nullptr;
+    }
+    for (size_t i = 0; i < copy_infos.size(); ++i) {
+        copy_infos[i].mem_block = mem_blocks[i];
+    }
+
+    // free blocks in destructor
+    auto plan = createCopyPlan(copy_infos, CopyDirection::D2H);
+    return plan;
+}
+
+std::shared_ptr<KVCacheMemoryConnector::CopyPlan>
+KVCacheMemoryConnector::createCopyPlan(const std::vector<CopyInfoPerKey>& copy_infos, const CopyDirection& direction) {
     auto plan        = new CopyPlan();
-    plan->direction  = CopyDirection::D2H;
-    plan->copy_infos = std::move(copy_infos);
+    plan->copy_infos = copy_infos;
+    plan->direction  = direction;
     auto deleter     = [this](CopyPlan* plan) {
         std::vector<BlockIdxType> blocks;
         blocks.reserve(plan->copy_infos.size());
         for (const auto& copy_info : plan->copy_infos) {
-            blocks.push_back(copy_info.mem_block_index);
+            blocks.push_back(copy_info.mem_block);
         }
         freeBlocks(blocks, /*cache_free=*/false);
         delete plan;
     };
-    std::shared_ptr<CopyPlan> plan_ptr(plan, deleter);
-    return success ? plan_ptr : nullptr;
+    return std::shared_ptr<CopyPlan>(plan, deleter);
 }
 
 bool KVCacheMemoryConnector::startCopyAsync(const std::shared_ptr<MemoryAsyncContext>& context,
@@ -423,14 +451,11 @@ KVCacheMemoryConnector::sendCopyPlan(const std::shared_ptr<CopyPlan>& copy_plan)
     mem_req.set_copy_direction(copy_plan->direction == CopyDirection::H2D ? MemoryOperationRequestPB::H2D :
                                                                             MemoryOperationRequestPB::D2H);
     for (const auto& copy_info : copy_plan->copy_infos) {
-        auto* gpu_block = mem_req.add_gpu_blocks();
-        for (const auto& lb : copy_info.gpu_layer_blocks) {
-            auto* layer_block = gpu_block->add_layer_blocks();
-            layer_block->set_layer_id(lb.layer_id);
-            layer_block->set_block_id(lb.block_id);
+        auto* item = mem_req.add_copy_items();
+        item->set_mem_block(copy_info.mem_block);
+        for (const auto& block : copy_info.gpu_blocks) {
+            item->add_gpu_blocks(block);
         }
-        mem_req.add_mem_block_ids(copy_info.mem_block_index);
-        mem_req.add_mem_block_sizes(copy_info.mem_block_size);
     }
 
     std::vector<FunctionRequestPB> requests;
@@ -452,51 +477,37 @@ KVCacheMemoryConnector::sendCopyPlan(const std::shared_ptr<CopyPlan>& copy_plan)
 }
 
 void KVCacheMemoryConnector::printCopyPlan(const std::shared_ptr<CopyPlan>& copy_plan) const {
-    RTP_LLM_LOG_INFO("print copy plan, direction: %d, copy infos size: %zu",
-                     static_cast<int>(copy_plan->direction),
-                     copy_plan->copy_infos.size());
+    std::ostringstream oss;
+    oss << "copy plan direction: " << (copy_plan->direction == CopyDirection::H2D ? "H2D" : "D2H")
+        << ", copy infos size: " << copy_plan->copy_infos.size() << "\n";
     for (int i = 0; i < copy_plan->copy_infos.size(); ++i) {
-        const auto&        copy_info = copy_plan->copy_infos.at(i);
-        std::ostringstream oss;
-        oss << "copy info " << i << ": cache key: " << copy_info.cache_key
-            << ", mem block size: " << copy_info.mem_block_size << ", mem block index: " << copy_info.mem_block_index
+        const auto& copy_info = copy_plan->copy_infos.at(i);
+        oss << "copy info " << i << ": cache key: " << copy_info.cache_key << ", mem block: " << copy_info.mem_block
             << ", gpu layer blocks: [";
-        for (const auto& gpu_layer_block : copy_info.gpu_layer_blocks) {
-            oss << "(layer " << gpu_layer_block.layer_id << ", block " << gpu_layer_block.block_id << "), ";
+        for (const auto& gpu_block : copy_info.gpu_blocks) {
+            oss << gpu_block << ", ";
         }
-        oss << "]";
-        RTP_LLM_LOG_INFO(oss.str().c_str());
+        oss << "]\n";
     }
+    RTP_LLM_LOG_INFO("%s", oss.str().c_str());
 }
 
 bool KVCacheMemoryConnector::copyCache(const MemoryOperationRequestPB& request, MemoryOperationResponsePB& response) {
-    RTP_LLM_CHECK(request.gpu_blocks_size() == request.mem_block_ids_size());
-    RTP_LLM_CHECK(request.gpu_blocks_size() == request.mem_block_sizes_size());
-
     autil::ScopedTime2 timer;
     const auto         copy_direction =
         (request.copy_direction() == MemoryOperationRequestPB::H2D) ? CopyDirection::H2D : CopyDirection::D2H;
 
     std::vector<BufferPtr> dst_buffers;
     std::vector<BufferPtr> src_buffers;
-    for (int i = 0; i < request.gpu_blocks_size(); ++i) {
-        const auto& gpu_block      = request.gpu_blocks(i);
-        const auto  mem_block_id   = static_cast<BlockIdxType>(request.mem_block_ids(i));
-        const auto  mem_block_size = request.mem_block_sizes(i);
+    for (int i = 0; i < request.copy_items_size(); ++i) {
+        const auto&                     item      = request.copy_items(i);
+        const auto                      mem_block = static_cast<BlockIdxType>(item.mem_block());
+        const std::vector<BlockIdxType> gpu_blocks(item.gpu_blocks().begin(), item.gpu_blocks().end());
 
-        std::vector<LayerBlock> gpu_layer_blocks;
-        gpu_layer_blocks.reserve(gpu_block.layer_blocks_size());
-        for (const auto& lb : gpu_block.layer_blocks()) {
-            gpu_layer_blocks.push_back(LayerBlock{lb.layer_id(), static_cast<BlockIdxType>(lb.block_id())});
-        }
-
-        if (!prepareCopyBuffers(
-                gpu_layer_blocks, mem_block_id, mem_block_size, copy_direction, dst_buffers, src_buffers)) {
-            RTP_LLM_LOG_WARNING(
-                "copy cache failed, prepare copy buffers failed, mem_block_id=%d, mem_block_size=%ld, direction=%s",
-                mem_block_id,
-                mem_block_size,
-                copy_direction == CopyDirection::H2D ? "H2D" : "D2H");
+        if (!prepareCopyBuffers(mem_block, gpu_blocks, copy_direction, dst_buffers, src_buffers)) {
+            RTP_LLM_LOG_WARNING("copy cache failed, prepare copy buffers failed, mem_block=%d, direction=%s",
+                                mem_block,
+                                copy_direction == CopyDirection::H2D ? "H2D" : "D2H");
             response.set_success(false);
             reportCopyMetrics(false, timer.done_us(), copy_direction);
             return false;
@@ -506,53 +517,71 @@ bool KVCacheMemoryConnector::copyCache(const MemoryOperationRequestPB& request, 
     if (!dst_buffers.empty()) {
         device_->noBlockCopy(MultiCopyParams{dst_buffers, src_buffers});
     }
-    response.set_success(true);
 
+    response.set_success(true);
     reportCopyMetrics(true, timer.done_us(), copy_direction);
     return true;
 }
 
-bool KVCacheMemoryConnector::prepareCopyBuffers(const std::vector<LayerBlock>& gpu_layer_blocks,
-                                                BlockIdxType                   mem_block_index,
-                                                size_t                         mem_block_size,
-                                                CopyDirection                  direction,
-                                                std::vector<BufferPtr>&        dst,
-                                                std::vector<BufferPtr>&        src) {
-    RTP_LLM_CHECK_WITH_INFO(mem_block_index != NULL_BLOCK_IDX, "mem block index is null");
-    RTP_LLM_CHECK_WITH_INFO(block_pool_ != nullptr, "block pool is null, mem_block_size=%zu", mem_block_size);
-    auto mem_buffers = block_pool_->convertIndexToBuffer(/*layer_id=*/0, mem_block_index);
+bool KVCacheMemoryConnector::prepareCopyBuffers(BlockIdxType                     mem_block,
+                                                const std::vector<BlockIdxType>& gpu_blocks,
+                                                CopyDirection                    direction,
+                                                std::vector<BufferPtr>&          dst,
+                                                std::vector<BufferPtr>&          src) {
+    RTP_LLM_CHECK_WITH_INFO(mem_block != NULL_BLOCK_IDX, "mem block is null");
+    RTP_LLM_CHECK_WITH_INFO(block_pool_ != nullptr, "block pool is null");
+    auto mem_buffers = block_pool_->convertIndexToBuffer(/*layer_id=*/0, mem_block);
     if (mem_buffers.empty()) {
-        RTP_LLM_LOG_WARNING("prepare copy buffers failed, mem buffers are empty, block_idx=%d, direction=%s",
-                            mem_block_index,
+        RTP_LLM_LOG_WARNING("prepare copy buffers failed, mem buffers are empty, block=%d, direction=%s",
+                            mem_block,
                             direction == CopyDirection::H2D ? "H2D" : "D2H");
         return false;
     }
 
     // memory has only one buffer
     const auto& mem_buffer = mem_buffers[0];
-    RTP_LLM_CHECK_WITH_INFO(mem_buffer.addr != nullptr, "mem buffer address is null");
-    RTP_LLM_CHECK_WITH_INFO(mem_buffer.size_bytes >= mem_block_size,
-                            "mem buffer size is less than mem block size, mem_buffer_size=%zu, mem_block_size=%zu",
+    RTP_LLM_CHECK_WITH_INFO(mem_buffer.addr != nullptr && mem_buffer.size_bytes > 0,
+                            "mem buffer address is null or size is 0, addr=%p, size=%zu, block=%d, direction=%s",
+                            mem_buffer.addr,
                             mem_buffer.size_bytes,
-                            mem_block_size);
+                            mem_block,
+                            direction == CopyDirection::H2D ? "H2D" : "D2H");
+
+    const size_t layer_num = cache_config_.layer_all_num;
+    RTP_LLM_CHECK_WITH_INFO(gpu_blocks.size() == layer_num,
+                            "gpu_blocks must contain all layers, got=%zu need=%zu",
+                            gpu_blocks.size(),
+                            layer_num);
 
     size_t byte_off = 0;
-    for (const auto& lb : gpu_layer_blocks) {
-        const int  layer_id      = lb.layer_id;
-        const auto gpu_block_idx = lb.block_id;
-        const auto gpu_buffers   = allocator_->convertIndexToBuffer(layer_id, gpu_block_idx);
+    for (int layer = 0; layer < layer_num; ++layer) {
+        const auto gpu_block    = gpu_blocks.at(layer);
+        const auto layer_stride = cache_config_.layer_to_block_stride_bytes[layer];
+
+        if (isNullBlockIdx(gpu_block)) {
+            byte_off += layer_stride;
+            continue;
+        }
+
+        const auto gpu_buffers      = allocator_->convertIndexToBuffer(layer, gpu_block);
+        size_t     within_layer_off = 0;
         for (const auto& gpu_buffer : gpu_buffers) {
-            RTP_LLM_CHECK_WITH_INFO(
-                byte_off + gpu_buffer.size_bytes <= mem_block_size,
-                "append copy bytes to buffers failed, mem block overflow: offset=%zu bytes=%zu mem_size=%zu",
-                byte_off,
-                gpu_buffer.size_bytes,
-                mem_block_size);
-            if (!appendCopyBytesToBuffers(mem_buffer, gpu_buffer, byte_off, direction, dst, src)) {
+            if (within_layer_off + gpu_buffer.size_bytes > layer_stride) {
+                RTP_LLM_LOG_WARNING("prepare copy buffers failed, gpu buffer overflow: "
+                                    "layer=%zu byte_off=%zu within_layer_off=%zu gpu_buffer_size=%zu",
+                                    layer,
+                                    byte_off,
+                                    within_layer_off,
+                                    gpu_buffer.size_bytes);
                 return false;
             }
-            byte_off += gpu_buffer.size_bytes;
+            const size_t off = byte_off + within_layer_off;
+            if (!appendCopyBytesToBuffers(mem_buffer, gpu_buffer, off, direction, dst, src)) {
+                return false;
+            }
+            within_layer_off += gpu_buffer.size_bytes;
         }
+        byte_off += layer_stride;
     }
     return true;
 }

--- a/rtp_llm/cpp/cache/connector/memory/KVCacheMemoryConnector.h
+++ b/rtp_llm/cpp/cache/connector/memory/KVCacheMemoryConnector.h
@@ -57,15 +57,11 @@ public:
     std::vector<CacheKeyType> cacheKeys() const;
 
 private:
-    struct LayerBlock {
-        int          layer_id;
-        BlockIdxType block_id;
-    };
     struct CopyInfoPerKey {
-        CacheKeyType            cache_key;
-        std::vector<LayerBlock> gpu_layer_blocks;
-        BlockIdxType            mem_block_index;
-        size_t                  mem_block_size;
+        CacheKeyType              cache_key{0};
+        BlockIdxType              mem_block{NULL_BLOCK_IDX};
+        std::vector<BlockIdxType> gpu_blocks;
+        bool                      is_complete{true};
     };
     enum class CopyDirection {
         H2D = 0,
@@ -83,18 +79,20 @@ private:
     std::shared_ptr<CopyPlan> buildCopyPlanForWrite(const CacheKeysType& cache_keys,
                                                     const LayerBlockIds& layer_block_ids,
                                                     int                  start_index,
-                                                    int                  write_num);
+                                                    int                  write_num,
+                                                    bool&                no_need_write);
+    std::shared_ptr<CopyPlan> createCopyPlan(const std::vector<CopyInfoPerKey>& copy_infos,
+                                             const CopyDirection&               direction);
     bool startCopyAsync(const std::shared_ptr<MemoryAsyncContext>& context, const std::shared_ptr<CopyPlan>& copy_plan);
     std::shared_ptr<BroadcastResult<FunctionRequestPB, FunctionResponsePB>>
          sendCopyPlan(const std::shared_ptr<CopyPlan>& copy_plan) const;
     void printCopyPlan(const std::shared_ptr<CopyPlan>& copy_plan) const;
 
-    bool prepareCopyBuffers(const std::vector<LayerBlock>& gpu_layer_blocks,
-                            BlockIdxType                   mem_block_index,
-                            size_t                         mem_block_size,
-                            CopyDirection                  direction,
-                            std::vector<BufferPtr>&        dst,
-                            std::vector<BufferPtr>&        src);
+    bool prepareCopyBuffers(BlockIdxType                     mem_block,
+                            const std::vector<BlockIdxType>& gpu_blocks,
+                            CopyDirection                    direction,
+                            std::vector<BufferPtr>&          dst,
+                            std::vector<BufferPtr>&          src);
     bool appendCopyBytesToBuffers(const BlockInfo&        mem_block,
                                   const BlockInfo&        gpu_block,
                                   size_t                  byte_off,
@@ -102,7 +100,10 @@ private:
                                   std::vector<BufferPtr>& dst,
                                   std::vector<BufferPtr>& src);
 
+    void checkLayerBlockStrideBytes() const;
     bool checkLayerBlocks(const LayerBlockIds& layer_block_ids, size_t required_len) const;
+    bool gpuBlocksAllValid(const LayerBlockIds& layer_block_ids, size_t key_index) const;
+
     bool mallocBlocks(size_t need_blocks, std::vector<BlockIdxType>& malloced_blocks);
     bool freeBlocks(const std::vector<BlockIdxType>& blocks, bool cache_free = true);
     void referenceBlocks(const std::vector<BlockIdxType>& blocks, bool cache_ref = true);

--- a/rtp_llm/cpp/cache/connector/memory/MemoryBlockCache.cc
+++ b/rtp_llm/cpp/cache/connector/memory/MemoryBlockCache.cc
@@ -17,9 +17,9 @@ MemoryBlockCache::MatchResult MemoryBlockCache::match(CacheKeyType cache_key) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
     const auto& [success, item] = lru_cache_.get(cache_key);
     if (success) {
-        return {item.block_index, item.block_size};
+        return {item.block_index, item.block_size, item.is_complete};
     } else {
-        return {NULL_BLOCK_IDX, 0};
+        return {NULL_BLOCK_IDX, 0, false};
     }
 }
 
@@ -33,8 +33,15 @@ std::pair<bool, std::optional<MemoryBlockCache::CacheItem>> MemoryBlockCache::pu
 
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (lru_cache_.contains(item.cache_key)) {
-        // Increase old matched item's popularity
-        lru_cache_.get(item.cache_key);
+        // Key exists:
+        // - Always increase old matched item's popularity
+        // - Allow "partial -> complete" upgrade (same cache_key) by replacing the stored item.
+        //   Return the old item as "popped" so the caller can free the old block.
+        const auto& [success, old_item] = lru_cache_.get(item.cache_key);
+        if (success && !old_item.is_complete && item.is_complete) {
+            lru_cache_.put(item.cache_key, item);
+            return {true, old_item};
+        }
         return {false, std::nullopt};
     }
 

--- a/rtp_llm/cpp/cache/connector/memory/MemoryBlockCache.h
+++ b/rtp_llm/cpp/cache/connector/memory/MemoryBlockCache.h
@@ -19,11 +19,15 @@ public:
         BlockIdxType block_index{NULL_BLOCK_IDX};
         size_t       block_size{0};
         bool         is_resident{false};
+        // 表示是否是完整的 KVCache, 只有当所有层都有 cache 时才为 true
+        // 对于全注意力模型: 这个值始终为 true ; 对于混合注意力模型: 所有层都有 cache 时才为 true
+        bool is_complete{true};
     };
 
     struct MatchResult {
         BlockIdxType matched_index{NULL_BLOCK_IDX};
         size_t       block_size{0};
+        bool         is_complete{false};
     };
 
 public:

--- a/rtp_llm/cpp/cache/connector/memory/test/KVCacheMemoryConnectorTest.cc
+++ b/rtp_llm/cpp/cache/connector/memory/test/KVCacheMemoryConnectorTest.cc
@@ -59,6 +59,12 @@ static CrashHandlerInstaller g_crash_handler_installer;
 
 }  // namespace
 
+// Test-local helper struct. Business code no longer exposes a LayerBlock type.
+struct LayerBlock {
+    int          layer_id{0};
+    BlockIdxType block_id{NULL_BLOCK_IDX};
+};
+
 class TestReadMeta: public rtp_llm::Meta {
 public:
     explicit TestReadMeta(bool enable_memory_cache = true): enable_memory_cache_(enable_memory_cache) {}
@@ -115,11 +121,8 @@ private:
         RuntimeConfig               runtime_config;
         ModelSpecificConfig         model_specific_config;
 
-        // Keep tests stable on shared GPUs with low free memory:
-        // - device_reserve_memory_bytes=0 => use DeviceFactory default (-512MB), i.e. reserve (free - 512MB)
-        // - host_reserve_memory_bytes=0  => don't reserve pinned host memory
-        device_resource_config.device_reserve_memory_bytes = 2048000000;
-        device_resource_config.host_reserve_memory_bytes   = 2048000000;
+        device_resource_config.device_reserve_memory_bytes = 2ULL * 1024 * 1024 * 1024;  // 2 GiB
+        device_resource_config.host_reserve_memory_bytes   = 0;
 
         DeviceFactory::initDevices(parallelism_config,
                                    model_config,
@@ -159,14 +162,20 @@ private:
         mha_spec->dtype              = rtp_llm::DataType::TYPE_FP16;
         mha_spec->type               = KVCacheSpecType::MultiHeadAttention;
         config.cache_specs.push_back(mha_spec);
-        // Keep CacheConfig sizes consistent with the business definition:
-        // block_size_bytes = "one cacheKey across all layers" total bytes (kv + scale).
+        // Keep CacheConfig sizes consistent with current business definition (see CacheConfig.h):
+        // - kv_block_stride_bytes / kv_scale_stride_bytes are "per-layer" strides for one logical block
+        // - kv_block_size_bytes / kv_scale_size_bytes are "all layers" totals for one logical block
+        // - block_size_bytes = kv + scales together for one logical block (all layers)
         config.dtype                 = mha_spec->dtype;
-        config.kv_block_stride_bytes = mha_spec->block_size_bytes();  // one-layer KV bytes for one logical block
-        config.kv_scale_stride_bytes = 0;
+        config.kv_block_stride_bytes = mha_spec->block_size_bytes();
+        config.kv_scale_stride_bytes = mha_spec->scale_block_size_bytes();
         config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
-        config.kv_scale_size_bytes   = 0;
-        config.block_size_bytes      = config.kv_block_size_bytes;  // (kv + scale)
+        config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
+        config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
+        // Per-layer stride used by MemoryConnector merged layout.
+        const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+        config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                                  static_cast<int>(per_layer_stride_bytes));
 
         std::vector<int> layer_ids(layer_num);
         for (int i = 0; i < layer_num; ++i) {
@@ -270,6 +279,18 @@ private:
         }
         return total;
     }
+    size_t memoryCacheBlockBytes(const CacheConfig& cfg) const {
+        size_t total = 0;
+        for (const auto& stride : cfg.layer_to_block_stride_bytes) {
+            if (stride > 0) {
+                total += static_cast<size_t>(stride);
+            }
+        }
+        return total;
+    }
+    size_t memoryCacheBlockBytes() const {
+        return memoryCacheBlockBytes(cache_config_);
+    }
 
     void setBlockBytes(const BlockInfo& b, size_t byte_offset, size_t byte_len, char c) const {
         ASSERT_NE(b.addr, nullptr);
@@ -321,16 +342,19 @@ private:
         }
     }
 
-    void verifyGpuBufferContent(const std::vector<KVCacheMemoryConnector::LayerBlock>& gpu_layer_blocks) const {
+    void verifyGpuBufferContent(const std::vector<LayerBlock>& gpu_layer_blocks) const {
         for (const auto& layer_block : gpu_layer_blocks) {
+            if (isNullBlockIdx(layer_block.block_id)) {
+                continue;
+            }
             const auto gpu_bufs = allocator_->convertIndexToBuffer(layer_block.layer_id, layer_block.block_id);
             ASSERT_GT(sumBlockInfosBytes(gpu_bufs), 0u);
             verifyBlockInfosContent(gpu_bufs, static_cast<char>('k' + layer_block.layer_id));
         }
     }
-    void verifyCpuBufferContent(const std::vector<KVCacheMemoryConnector::LayerBlock>& gpu_layer_blocks,
-                                BlockIdxType                                           mem_block_index,
-                                size_t                                                 mem_block_size) const {
+    void verifyCpuBufferContent(const std::vector<LayerBlock>& gpu_layer_blocks,
+                                BlockIdxType                   mem_block_index,
+                                size_t                         mem_block_size) const {
         auto pool = requireExistingBlockPool(mem_block_size);
         ASSERT_NE(pool, nullptr);
         const auto mem_bufs = pool->convertIndexToBuffer(0, mem_block_index);
@@ -339,36 +363,67 @@ private:
         ASSERT_NE(mem_buffer.addr, nullptr);
         ASSERT_GE(mem_buffer.size_bytes, mem_block_size);
 
-        size_t offset = 0;
-        for (const auto& layer_block : gpu_layer_blocks) {
-            const auto gpu_bufs = allocator_->convertIndexToBuffer(layer_block.layer_id, layer_block.block_id);
+        const size_t              layer_num = static_cast<size_t>(cache_config_.layer_all_num);
+        std::vector<BlockIdxType> layer_to_block(layer_num, NULL_BLOCK_IDX);
+        for (const auto& lb : gpu_layer_blocks) {
+            ASSERT_GE(lb.layer_id, 0);
+            ASSERT_LT(static_cast<size_t>(lb.layer_id), layer_num);
+            layer_to_block[static_cast<size_t>(lb.layer_id)] = lb.block_id;
+        }
+
+        size_t byte_off = 0;
+        for (size_t layer = 0; layer < layer_num; ++layer) {
+            const size_t layer_stride = static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[layer]);
+            const auto   block_id     = layer_to_block[layer];
+            if (isNullBlockIdx(block_id)) {
+                byte_off += layer_stride;
+                continue;
+            }
+            const auto gpu_bufs = allocator_->convertIndexToBuffer(static_cast<int>(layer), block_id);
             const auto bytes    = sumBlockInfosBytes(gpu_bufs);
             ASSERT_GT(bytes, 0u);
+            ASSERT_LE(bytes, layer_stride);
 
-            const char expected_k = static_cast<char>('k' + layer_block.layer_id);
-            verifyBlockBytesEq(mem_buffer, offset, bytes, expected_k);
-            offset += bytes;
+            const char expected_k = static_cast<char>('k' + static_cast<int>(layer));
+            verifyBlockBytesEq(mem_buffer, byte_off, bytes, expected_k);
+            byte_off += layer_stride;
         }
     }
-    void prepareBufferContent(const std::vector<KVCacheMemoryConnector::LayerBlock>& gpu_layer_blocks,
-                              BlockIdxType&                                          mem_block_index,
-                              size_t&                                                mem_block_size,
-                              bool                                                   fill_gpu,
-                              bool                                                   fill_cpu) const {
+    void prepareBufferContent(const std::vector<LayerBlock>& gpu_layer_blocks,
+                              BlockIdxType&                  mem_block_index,
+                              size_t&                        mem_block_size,
+                              bool                           fill_gpu,
+                              bool                           fill_cpu) const {
         // std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks{
         //     {/*layer_id*/0, /*block_id*/1},
         //     {/*layer_id*/1, /*block_id*/2},
         //     {/*layer_id*/2, /*block_id*/2},
         // };
+        const size_t              layer_num = static_cast<size_t>(cache_config_.layer_all_num);
+        std::vector<BlockIdxType> layer_to_block(layer_num, NULL_BLOCK_IDX);
+        for (const auto& lb : gpu_layer_blocks) {
+            ASSERT_GE(lb.layer_id, 0);
+            ASSERT_LT(static_cast<size_t>(lb.layer_id), layer_num);
+            layer_to_block[static_cast<size_t>(lb.layer_id)] = lb.block_id;
+        }
+
         size_t total = 0;
-        for (const auto& layer_block : gpu_layer_blocks) {
-            const auto gpu_bufs = allocator_->convertIndexToBuffer(layer_block.layer_id, layer_block.block_id);
+        for (size_t layer = 0; layer < layer_num; ++layer) {
+            total += static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[layer]);
+        }
+
+        for (size_t layer = 0; layer < layer_num; ++layer) {
+            const auto block_id = layer_to_block[layer];
+            if (isNullBlockIdx(block_id)) {
+                continue;
+            }
+            const auto gpu_bufs = allocator_->convertIndexToBuffer(static_cast<int>(layer), block_id);
             const auto bytes    = sumBlockInfosBytes(gpu_bufs);
             ASSERT_GT(bytes, 0u);
+            ASSERT_LE(bytes, static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[layer]));
             if (fill_gpu) {
-                setBlockInfosContent(gpu_bufs, static_cast<char>('k' + layer_block.layer_id));
+                setBlockInfosContent(gpu_bufs, static_cast<char>('k' + static_cast<int>(layer)));
             }
-            total += bytes;
         }
 
         // 申请memory block
@@ -383,33 +438,44 @@ private:
         ASSERT_NE(mem_buffer.addr, nullptr);
         EXPECT_GE(mem_buffer.size_bytes, total);
 
-        // 给mem_buffer填充数据
+        // Fill memory buffer (merged layout: reserve per-layer stride even if block is null).
         if (fill_cpu) {
-            size_t offset = 0;
-            for (const auto& layer_block : gpu_layer_blocks) {
-                const auto gpu_bufs = allocator_->convertIndexToBuffer(layer_block.layer_id, layer_block.block_id);
+            size_t byte_off = 0;
+            for (size_t layer = 0; layer < layer_num; ++layer) {
+                const size_t layer_stride = static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[layer]);
+                const auto   block_id     = layer_to_block[layer];
+                if (isNullBlockIdx(block_id)) {
+                    byte_off += layer_stride;
+                    continue;
+                }
+                const auto gpu_bufs = allocator_->convertIndexToBuffer(static_cast<int>(layer), block_id);
                 const auto bytes    = sumBlockInfosBytes(gpu_bufs);
                 ASSERT_GT(bytes, 0u);
-                setBlockBytes(mem_buffer, offset, bytes, static_cast<char>('k' + layer_block.layer_id));
-                offset += bytes;
+                ASSERT_LE(bytes, layer_stride);
+                setBlockBytes(mem_buffer, byte_off, bytes, static_cast<char>('k' + static_cast<int>(layer)));
+                byte_off += layer_stride;
             }
         }
 
         mem_block_index = malloced_mem_block_index;
-        mem_block_size  = total;
+        // Use the actual pool block size as the mem-block-size key.
+        mem_block_size = mem_buffer.size_bytes;
     }
-    void addOneCopyInfoToPb(MemoryOperationRequestPB&                              req,
-                            const std::vector<KVCacheMemoryConnector::LayerBlock>& gpu_layer_blocks,
-                            BlockIdxType                                           mem_block_index,
-                            size_t                                                 mem_block_size) const {
-        auto* gb = req.add_gpu_blocks();
+    void addOneCopyItemToPb(MemoryOperationRequestPB&      req,
+                            const std::vector<LayerBlock>& gpu_layer_blocks,
+                            BlockIdxType                   mem_block_index) const {
+        auto*            item      = req.add_copy_items();
+        const size_t     layer_num = static_cast<size_t>(cache_config_.layer_all_num);
+        std::vector<int> blocks(layer_num, static_cast<int>(NULL_BLOCK_IDX));
         for (const auto& layer_block : gpu_layer_blocks) {
-            auto* lb = gb->add_layer_blocks();
-            lb->set_layer_id(layer_block.layer_id);
-            lb->set_block_id(layer_block.block_id);
+            ASSERT_GE(layer_block.layer_id, 0);
+            ASSERT_LT(static_cast<size_t>(layer_block.layer_id), layer_num);
+            blocks[static_cast<size_t>(layer_block.layer_id)] = static_cast<int>(layer_block.block_id);
         }
-        req.add_mem_block_ids(static_cast<int32_t>(mem_block_index));
-        req.add_mem_block_sizes(mem_block_size);
+        for (size_t layer = 0; layer < layer_num; ++layer) {
+            item->add_gpu_blocks(blocks[layer]);
+        }
+        item->set_mem_block(static_cast<int>(mem_block_index));
     }
     LayerBlockIds makeLayerBlockIds(const std::vector<std::vector<BlockIdxType>>& per_layer_block_indices,
                                     size_t                                        cache_keys_num) const {
@@ -445,7 +511,18 @@ private:
         res->setLastBlockAligned(true);
         return res;
     }
-    std::vector<BlockIdxType> putItemsToCache(const CacheKeysType& keys, size_t mem_block_size) const {
+
+    // Put items into memory block cache.
+    // If `is_complete_flags` is empty, all items are treated as "complete" by default.
+    std::vector<BlockIdxType> putItemsToCache(const CacheKeysType&        keys,
+                                              size_t                      mem_block_size,
+                                              std::initializer_list<bool> is_complete_flags = {}) const {
+        RTP_LLM_CHECK_WITH_INFO(
+            is_complete_flags.size() == 0 || keys.size() == is_complete_flags.size(),
+            "keys size must equal is_complete_flags size when flags are provided, keys=%zu flags=%zu",
+            keys.size(),
+            is_complete_flags.size());
+
         std::vector<BlockIdxType> block_indices;
         if (keys.empty()) {
             return block_indices;
@@ -470,6 +547,7 @@ private:
             item.block_index = block_idx;
             item.block_size  = mem_block_size;
             item.is_resident = false;
+            item.is_complete = (is_complete_flags.size() == 0) ? true : *(is_complete_flags.begin() + i);
             connector_->block_cache_->put(item);
 
             pool->blockCacheReference({block_idx});
@@ -496,7 +574,7 @@ private:
         }
         if (block_size > 0) {
             // Pool block size should be >= requested mem_block_size.
-            EXPECT_GE(cache_config_.block_size_bytes, block_size);
+            EXPECT_GE(memoryCacheBlockBytes(), block_size);
         }
         return pool;
     }
@@ -506,7 +584,7 @@ private:
             ADD_FAILURE() << "expected block pool exists, block_size=" << block_size;
         }
         if (pool && block_size > 0) {
-            EXPECT_GE(cache_config_.block_size_bytes, block_size);
+            EXPECT_GE(memoryCacheBlockBytes(), block_size);
         }
         return pool;
     }
@@ -561,22 +639,23 @@ TEST_F(KVCacheMemoryConnectorTest, init_ReturnFalse_WhenMemoryCacheSyncTimeoutMs
 }
 
 TEST_F(KVCacheMemoryConnectorTest, init_ReturnFalse_WhenBlockSizeBytesZero) {
-    auto cfg             = cache_config_;
-    cfg.block_size_bytes = 0;
+    // NOTE: business code no longer validates `block_size_bytes` for memory cache block size.
+    // `init()` validates `layer_to_block_stride_bytes` instead.
+    auto cfg = cache_config_;
+    cfg.layer_to_block_stride_bytes.clear();
 
     auto kv_cfg                         = kv_cache_config_;
     kv_cfg.memory_cache_size_mb         = 64;
     kv_cfg.memory_cache_sync_timeout_ms = 1000;
 
-    // initBlockPool() checks block_size_bytes > 0
     auto conn = std::make_shared<KVCacheMemoryConnector>(cfg, kv_cfg, allocator_, device_, server_addrs_);
     EXPECT_THROW(conn->init(), std::runtime_error);
 }
 
 TEST_F(KVCacheMemoryConnectorTest, init_ReturnFalse_WhenPoolTooSmallForBlockSize) {
     auto cfg = cache_config_;
-    // Make sure pool_size_mb * 1MB / block_size_bytes == 0 -> createBlockPool() should fail with CHECK.
-    cfg.block_size_bytes = 2 * 1024 * 1024;  // 2MB
+    // Make sure pool_size_mb * 1MB / total_stride_bytes == 0 -> createBlockPool() should fail with CHECK.
+    cfg.layer_to_block_stride_bytes.assign(static_cast<size_t>(cfg.layer_num), 1024 * 1024);  // 1MB per layer
 
     auto kv_cfg                         = kv_cache_config_;
     kv_cfg.memory_cache_size_mb         = 1;     // 1MB
@@ -607,8 +686,10 @@ TEST_F(KVCacheMemoryConnectorTest, initBlockPool_Throw_WhenMemoryCacheSizeMbZero
 }
 
 TEST_F(KVCacheMemoryConnectorTest, initBlockPool_Throw_WhenBlockSizeBytesZero) {
-    auto cfg             = cache_config_;
-    cfg.block_size_bytes = 0;
+    // NOTE: business code no longer validates `block_size_bytes` for memory cache block size.
+    // `initBlockPool()` validates `layer_to_block_stride_bytes` instead.
+    auto cfg = cache_config_;
+    cfg.layer_to_block_stride_bytes.clear();
 
     auto kv_cfg                         = kv_cache_config_;
     kv_cfg.memory_cache_size_mb         = 64;
@@ -621,8 +702,8 @@ TEST_F(KVCacheMemoryConnectorTest, initBlockPool_Throw_WhenBlockSizeBytesZero) {
 TEST_F(KVCacheMemoryConnectorTest, initBlockPool_Throw_WhenCreateBlockPoolFails) {
     auto cfg = cache_config_;
     // Force createBlockPool() to compute block_num=0:
-    // block_num = pool_size_mb * 1MB / block_size_bytes.
-    cfg.block_size_bytes = 2 * 1024 * 1024;  // 2MB
+    // block_num = pool_size_mb * 1MB / total_stride_bytes.
+    cfg.layer_to_block_stride_bytes.assign(static_cast<size_t>(cfg.layer_num), 1024 * 1024);  // 1MB per layer
 
     auto kv_cfg                         = kv_cache_config_;
     kv_cfg.memory_cache_size_mb         = 1;     // 1MB
@@ -646,12 +727,11 @@ TEST_F(KVCacheMemoryConnectorTest, initBlockPool_ReturnTrue_AndRegistersPool) {
 TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnNull_WhenGpuReuseLenGEKeysSize) {
     const size_t                           N = 3;
     CacheKeysType                          cache_keys{70001, 70002, 70003};
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1, 1}, {2, 2, 2}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/N);
 
     // Even if memory has matches, asyncMatch should skip when gpu reuse covers all keys.
-    const auto   bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t mem_size = sumBlockInfosBytes(bufs);
+    const size_t mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
     putItemsToCache(cache_keys, mem_size);
 
@@ -662,7 +742,7 @@ TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnNull_WhenGpuReuseLenGEKeysSi
 
 TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnNull_WhenNoPrefixMatched) {
     CacheKeysType                          cache_keys{71001, 71002};
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1}, {2, 2}, {3, 3}, {4, 4}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/0);
 
     // No cache prefill => matched_num == 0
@@ -673,15 +753,14 @@ TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnNull_WhenNoPrefixMatched) {
 
 TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnMatchedNum_WhenPrefixMatchedAndStopAtFirstMiss) {
     CacheKeysType                          cache_keys{72001, 72002, 72003};
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1, 1}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/0);
 
-    const auto   bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t mem_size = sumBlockInfosBytes(bufs);
+    const size_t mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
 
     // Only prefill first 2 keys in cache; 3rd miss => matched_num should be 2.
-    putItemsToCache({cache_keys[0], cache_keys[1]}, mem_size);
+    putItemsToCache({cache_keys[0], cache_keys[1]}, mem_size, /*is_complete_flags=*/{false, true});
 
     auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
     auto match_ctx = connector_->asyncMatch(res, meta);
@@ -691,11 +770,90 @@ TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnMatchedNum_WhenPrefixMatched
     EXPECT_EQ(match_ctx->matchedBlockCount(), 2u);
 }
 
-TEST_F(KVCacheMemoryConnectorTest, asyncRead_ReturnNull_OnInvalidInputs) {
-    // resource is nullptr
-    auto ctx_null =
-        connector_->asyncRead(nullptr, nullptr, nullptr, /*start_read_block_index=*/0, /*read_block_num=*/0);
-    EXPECT_EQ(ctx_null, nullptr);
+TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnMatchedNum_MustEndAtBigKey_WhenSmallKeysAlsoHit) {
+    // NOTE: asyncMatch always skips the last cache_key (see implementation comment),
+    // so add a dummy tail key to keep the tested prefix length explicit.
+    CacheKeysType                          cache_keys{73001, 73002, 73003, 73004, 73999};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{
+        {1, 1, 1, 1, 1},
+        {2, 2, 2, 2, 2},
+        {3, 3, 3, 3, 3},
+        {4, 4, 4, 4, 4},
+    };
+    auto res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/0);
+
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+
+    // Continuous prefix hits in cache:
+    // - 73001: small
+    // - 73002: small
+    // - 73003: big   (last big => matched_num should end here)
+    // - 73004: small (still hit, but must NOT extend matched_num beyond last big)
+    putItemsToCache({cache_keys[0], cache_keys[1], cache_keys[2], cache_keys[3]},
+                    mem_size,
+                    /*is_complete_flags=*/{false, false, true, false});
+
+    auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+    auto match_ctx = connector_->asyncMatch(res, meta);
+    ASSERT_NE(match_ctx, nullptr);
+    EXPECT_TRUE(match_ctx->done());
+    EXPECT_TRUE(match_ctx->success());
+    EXPECT_EQ(match_ctx->matchedBlockCount(), 3u);
+}
+
+TEST_F(KVCacheMemoryConnectorTest, asyncMatch_AllowsContinuingWhenBigKeyHasInvalidGpuBlocks_UntilBigAndAllValid) {
+    // Hybrid-attn case: memory may have a "big" key, but the GPU blocks can still be partially invalid.
+    // asyncMatch should keep scanning prefix hits, but ONLY count keys that are both:
+    // - is_complete == true in memory cache
+    // - all GPU blocks are valid (non-null) for that key
+    //
+    // NOTE: asyncMatch skips the last cache_key, so add a dummy tail key.
+    CacheKeysType cache_keys{75001, 75002, 75999};
+
+    // 4 layers, 3 keys:
+    // - key 75001: big in memory, but GPU blocks are NOT all valid (layer1 is NULL)
+    // - key 75002: big in memory, GPU blocks are all valid => matched_num should become 2
+    std::vector<std::vector<BlockIdxType>> lbs_vec{
+        /*layer0*/ {1, 1, 1},
+        /*layer1*/ {NULL_BLOCK_IDX, 1, 1},
+        /*layer2*/ {1, 1, 1},
+        /*layer3*/ {1, 1, 1},
+    };
+    auto res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/0);
+
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+    putItemsToCache({cache_keys[0], cache_keys[1]}, mem_size, /*is_complete_flags=*/{true, true});
+
+    auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+    auto match_ctx = connector_->asyncMatch(res, meta);
+    ASSERT_NE(match_ctx, nullptr);
+    EXPECT_TRUE(match_ctx->done());
+    EXPECT_TRUE(match_ctx->success());
+    EXPECT_EQ(match_ctx->matchedBlockCount(), 2u);
+}
+
+TEST_F(KVCacheMemoryConnectorTest, asyncMatch_ReturnNull_WhenPrefixHitsButAllKeysAreSmall) {
+    // Prefix keys hit (continuous), but none are big => matched_num stays 0 => asyncMatch returns nullptr.
+    CacheKeysType                          cache_keys{74001, 74002, 74999};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}, {4, 4, 4}};
+    auto                                   res = makeCacheResource(cache_keys, lbs_vec, /*reuse_len=*/0);
+
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+
+    putItemsToCache({cache_keys[0], cache_keys[1]}, mem_size, /*is_complete_flags=*/{false, false});
+
+    auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+    auto match_ctx = connector_->asyncMatch(res, meta);
+    EXPECT_EQ(match_ctx, nullptr);
+}
+
+TEST_F(KVCacheMemoryConnectorTest, asyncRead_InvalidInputs_ReturnNullOrThrow) {
+    // resource is nullptr => RTP_LLM_CHECK triggers exception
+    EXPECT_ANY_THROW(
+        (void)connector_->asyncRead(nullptr, nullptr, nullptr, /*start_read_block_index=*/0, /*read_block_num=*/0));
 
     // empty cache_keys
     auto res_empty_keys = makeCacheResource({}, {{1}});
@@ -704,11 +862,11 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_ReturnNull_OnInvalidInputs) {
     EXPECT_EQ(ctx1, nullptr);
 
     // empty layer_block_ids
-    auto res_empty_lbs        = std::make_shared<KVCacheResource>();
-    res_empty_lbs->cache_keys = CacheKeysType{1};
+    // NOTE: asyncRead always skips the last cache_key (cache_keys.size() - 1), so keep size >= 2 here.
+    auto res_empty_lbs = makeCacheResource(/*cache_keys=*/{1, 2}, /*per_layer_block_indices=*/{{1, 2}});
     res_empty_lbs->layer_block_ids.clear();
     auto ctx2 =
-        connector_->asyncRead(res_empty_lbs, nullptr, nullptr, /*start_read_block_index=*/0, /*read_block_num=*/0);
+        connector_->asyncRead(res_empty_lbs, nullptr, nullptr, /*start_read_block_index=*/0, /*read_block_num=*/1);
     EXPECT_EQ(ctx2, nullptr);
 }
 
@@ -763,8 +921,7 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_Success_IncrementsReuseLen_ByMatche
     // 初始 reuse_len=1, 内存全部命中 => mem_match_len=3，最终 reuse_len=3
     CacheKeysType cache_keys{40001, 40002, 40003};
 
-    const auto   bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t mem_size = sumBlockInfosBytes(bufs);
+    const size_t mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
 
     auto block_indices = putItemsToCache(cache_keys, mem_size);
@@ -773,6 +930,8 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_Success_IncrementsReuseLen_ByMatche
     std::vector<std::vector<BlockIdxType>> lbs_vec{
         {101, 102, 103},  // layer0
         {201, 202, 203},  // layer1
+        {301, 302, 303},  // layer2
+        {401, 402, 403},  // layer3
     };
     auto res = makeCacheResource(cache_keys, lbs_vec, 1);
 
@@ -809,14 +968,13 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_FailureOnMemResponse_NoReuseLenIncr
 
     CacheKeysType cache_keys{50001, 50002};
 
-    const auto   bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t mem_size = sumBlockInfosBytes(bufs);
+    const size_t mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
 
     auto block_indices = putItemsToCache(cache_keys, mem_size);
     ASSERT_EQ(block_indices.size(), cache_keys.size());
 
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{11, 12}, {21, 22}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{11, 12}, {21, 22}, {31, 32}, {41, 42}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec);
 
     auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
@@ -860,14 +1018,13 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_FailureOnRpcStatus_NoReuseLenIncrem
 
     CacheKeysType cache_keys{60001, 60002};
 
-    const auto   bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t mem_size = sumBlockInfosBytes(bufs);
+    const size_t mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
 
     auto block_indices = putItemsToCache(cache_keys, mem_size);
     ASSERT_EQ(block_indices.size(), cache_keys.size());
 
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{31, 32}, {41, 42}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{31, 32}, {41, 42}, {51, 52}, {61, 62}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec);
 
     auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
@@ -904,11 +1061,10 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_ReturnNull_WhenThreadPoolFull) {
     EXPECT_NE(connector_->wait_done_thread_pool_->pushTask([]() {}), autil::ThreadPoolBase::ERROR_NONE);
 
     CacheKeysType cache_keys{70001, 70002};
-    const auto    bufs     = allocator_->convertIndexToBuffer(0, 0);
-    const size_t  mem_size = sumBlockInfosBytes(bufs);
+    const size_t  mem_size = memoryCacheBlockBytes();
     ASSERT_GT(mem_size, 0u);
     putItemsToCache(cache_keys, mem_size);
-    auto res       = makeCacheResource(cache_keys, {{1, 2}, {3, 4}});
+    auto res       = makeCacheResource(cache_keys, {{1, 2}, {3, 4}, {5, 6}, {7, 8}});
     auto meta      = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
     auto match_ctx = connector_->asyncMatch(res, meta);
     ASSERT_NE(match_ctx, nullptr);
@@ -922,39 +1078,44 @@ TEST_F(KVCacheMemoryConnectorTest, asyncRead_ReturnNull_WhenThreadPoolFull) {
     connector_->wait_done_thread_pool_ = old_pool;
 }
 
-TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnNull_OnInvalidInputs) {
-    // resource is nullptr
-    auto ctx_null = connector_->asyncWrite(nullptr, nullptr);
-    EXPECT_EQ(ctx_null, nullptr);
+TEST_F(KVCacheMemoryConnectorTest, asyncWrite_InvalidInputs_ReturnNullOrThrow) {
+    auto meta = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+
+    // meta is nullptr => RTP_LLM_CHECK triggers exception
+    EXPECT_ANY_THROW((void)connector_->asyncWrite(makeCacheResource(/*cache_keys=*/{1}, /*lbs=*/{{1}}), nullptr));
+
+    // resource is nullptr => RTP_LLM_CHECK triggers exception
+    EXPECT_ANY_THROW((void)connector_->asyncWrite(nullptr, meta));
 
     // empty cache_keys
     auto res_empty_keys = makeCacheResource({}, {{1}});
-    auto ctx1           = connector_->asyncWrite(res_empty_keys, nullptr);
+    auto ctx1           = connector_->asyncWrite(res_empty_keys, meta);
     EXPECT_EQ(ctx1, nullptr);
 
     // empty layer_block_ids
-    auto res_empty_lbs        = std::make_shared<KVCacheResource>();
-    res_empty_lbs->cache_keys = CacheKeysType{1};
+    auto res_empty_lbs = makeCacheResource(/*cache_keys=*/{1}, /*lbs=*/{{1}});
     res_empty_lbs->layer_block_ids.clear();
-    auto ctx2 = connector_->asyncWrite(res_empty_lbs, nullptr);
+    auto ctx2 = connector_->asyncWrite(res_empty_lbs, meta);
     EXPECT_EQ(ctx2, nullptr);
 }
 
 TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnNull_WhenAllKeysInCache) {
     // 两个 key 均已在内存缓存中
-    const int                              layer0        = 0;
     const int                              gpu_block_idx = 1;
     CacheKeysType                          cache_keys{10, 11};
     std::vector<std::vector<BlockIdxType>> lbs_vec{
-        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)}};
+        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)},
+        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)},
+        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)},
+        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)},
+    };
     auto res = makeCacheResource(cache_keys, lbs_vec);
 
-    const auto   bufs  = allocator_->convertIndexToBuffer(layer0, gpu_block_idx);
-    const size_t total = sumBlockInfosBytes(bufs);
-    ASSERT_GT(total, 0u);
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
 
     // 预置到 cache
-    auto block_indices = putItemsToCache(cache_keys, total);
+    auto block_indices = putItemsToCache(cache_keys, mem_size);
     ASSERT_EQ(block_indices.size(), cache_keys.size());
 
     const size_t cache_size_before = connector_->block_cache_->size();
@@ -966,17 +1127,15 @@ TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnNull_WhenAllKeysInCache) {
 }
 
 TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnSuccess_WhenPrefixInCacheOnlyWriteSuffix) {
-    const int                              layer0 = 0;
     CacheKeysType                          cache_keys{60001, 60002, 60003};
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 2, 3}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec);
 
-    const auto   bufs  = allocator_->convertIndexToBuffer(layer0, /*block_id=*/1);
-    const size_t total = sumBlockInfosBytes(bufs);
-    ASSERT_GT(total, 0u);
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
 
     // Pre-insert only the first key, so cpu_matched_num should be 1 and only suffix gets written.
-    auto pre_blocks = putItemsToCache({cache_keys[0]}, total);
+    auto pre_blocks = putItemsToCache({cache_keys[0]}, mem_size);
     ASSERT_EQ(pre_blocks.size(), 1u);
     ASSERT_TRUE(connector_->block_cache_->contains(cache_keys[0]));
     const size_t cache_before = connector_->block_cache_->size();
@@ -1013,37 +1172,19 @@ TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnSuccess_WhenKeyInsertedDurin
     connector_->broadcast_manager_ = broadcast_manager;
 
     CacheKeysType                          cache_keys{61001, 61002};
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 2}};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{{1, 2}, {3, 4}, {5, 6}, {7, 8}};
     auto                                   res = makeCacheResource(cache_keys, lbs_vec);
 
-    // Ensure block pools exist for the exact total_bytes computed by buildCopyPlanForWrite():
-    // it sums kv + scale only for layers whose gpu block id is NOT NULL for that key.
-    auto totalBytesForKeyIndex = [&](size_t key_index) -> size_t {
-        size_t      total           = 0;
-        const auto& layer_block_ids = res->layerBlocks();
-        for (size_t layer = 0; layer < layer_block_ids.size(); ++layer) {
-            const int gpu_block_idx = layer_block_ids.at(layer)->blocks().at(key_index);
-            if (gpu_block_idx == NULL_BLOCK_IDX) {
-                continue;
-            }
-            const auto buffers = allocator_->convertIndexToBuffer(static_cast<int>(layer), gpu_block_idx);
-            total += sumBlockInfosBytes(buffers);
-        }
-        return total;
-    };
-    const size_t total_key0 = totalBytesForKeyIndex(/*key_index=*/0);
-    const size_t total_key1 = totalBytesForKeyIndex(/*key_index=*/1);
-    ASSERT_GT(total_key0, 0u);
-    ASSERT_GT(total_key1, 0u);
-    ASSERT_NE(ensureBlockPool(total_key0), nullptr);
-    ASSERT_NE(ensureBlockPool(total_key1), nullptr);
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+    ASSERT_NE(ensureBlockPool(mem_size), nullptr);
 
     auto meta = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
     auto ctx  = connector_->asyncWrite(res, meta);
     ASSERT_NE(ctx, nullptr);
 
     // While in flight, insert the first key so write_done should skip inserting it.
-    auto pre_blocks = putItemsToCache({cache_keys[0]}, total_key0);
+    auto pre_blocks = putItemsToCache({cache_keys[0]}, mem_size);
     ASSERT_EQ(pre_blocks.size(), 1u);
     ASSERT_TRUE(connector_->block_cache_->contains(cache_keys[0]));
 
@@ -1066,29 +1207,110 @@ TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnSuccess_WhenKeyInsertedDurin
 TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnNull_WhenBuildPlanEmpty) {
     // 所有 layer 对于第一个未命中 key 的 blockIdx 都为 NULL，导致 plan 为空
     CacheKeysType cache_keys{100, 101};
-    // 2 层，全部 NULL
-    std::vector<std::vector<BlockIdxType>> lbs_vec{{NULL_BLOCK_IDX, NULL_BLOCK_IDX}, {NULL_BLOCK_IDX, NULL_BLOCK_IDX}};
-    auto                                   res = makeCacheResource(cache_keys, lbs_vec);
+    // 4 层，全部 NULL
+    std::vector<std::vector<BlockIdxType>> lbs_vec{
+        {NULL_BLOCK_IDX, NULL_BLOCK_IDX},
+        {NULL_BLOCK_IDX, NULL_BLOCK_IDX},
+        {NULL_BLOCK_IDX, NULL_BLOCK_IDX},
+        {NULL_BLOCK_IDX, NULL_BLOCK_IDX},
+    };
+    auto res = makeCacheResource(cache_keys, lbs_vec);
 
     auto meta = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
     auto ctx  = connector_->asyncWrite(res, meta);
     EXPECT_EQ(ctx, nullptr);
 }
 
-TEST_F(KVCacheMemoryConnectorTest, asyncWrite_Success_AddsToBlockCache_AndKeepsMemBlocks) {
-    // 默认 RPC 服务均返回 OK + mem success
-    const int                              layer0        = 0;
-    const int                              gpu_block_idx = 2;
-    const size_t                           N             = 2;
-    CacheKeysType                          cache_keys{200, 201};
+TEST_F(KVCacheMemoryConnectorTest, asyncWrite_ReturnNull_WhenAllKeysAreSmall_NoNeedWrite) {
+    // Hybrid-attn: allow writing small keys for continuity, BUT if there is NO "big" key in the tail,
+    // buildCopyPlanForWrite() should return nullptr and asyncWrite should be a no-op (return nullptr).
+    CacheKeysType                          cache_keys{81001, 81002, 81003};
     std::vector<std::vector<BlockIdxType>> lbs_vec{
-        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx + 1)}};
+        /*layer0*/ {1, 1, 1},
+        /*layer1*/ {NULL_BLOCK_IDX, 1, 1},  // key0 small
+        /*layer2*/ {1, NULL_BLOCK_IDX, 1},  // key1 small
+        /*layer3*/ {1, 1, NULL_BLOCK_IDX},  // key2 small
+    };
     auto res = makeCacheResource(cache_keys, lbs_vec);
 
-    const auto   bufs  = allocator_->convertIndexToBuffer(layer0, gpu_block_idx);
-    const size_t total = sumBlockInfosBytes(bufs);
-    ASSERT_GT(total, 0u);
-    auto pool = ensureBlockPool(total);
+    auto pool = connector_->block_pool_;
+    ASSERT_NE(pool, nullptr);
+    const size_t free_before = pool->freeBlocksNum();
+
+    auto meta = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+    auto ctx  = connector_->asyncWrite(res, meta);
+    EXPECT_EQ(ctx, nullptr);
+    EXPECT_EQ(pool->freeBlocksNum(), free_before);
+}
+
+TEST_F(KVCacheMemoryConnectorTest, asyncWrite_DropsTailAfterLastBigKey_InHybridAttn) {
+    // Hybrid-attn: write small keys for continuity, but ensure the final written key is big.
+    // Keys after the last big key must be dropped.
+    std::vector<std::unique_ptr<TestRpcServer>> servers;
+    std::vector<std::string>                    addrs;
+    for (int i = 0; i < 2; ++i) {
+        auto service = std::make_unique<TestRpcService>();
+        auto server  = std::make_unique<TestRpcServer>(std::move(service));
+        ASSERT_TRUE(server->start());
+        addrs.push_back("127.0.0.1:" + std::to_string(server->listenPort()));
+        servers.push_back(std::move(server));
+    }
+    auto broadcast_manager = std::make_shared<BroadcastManager>(addrs);
+    ASSERT_TRUE(broadcast_manager->init());
+    connector_->broadcast_manager_ = broadcast_manager;
+
+    CacheKeysType cache_keys{82001, 82002, 82003, 82004};
+    // 4 layers, 4 keys:
+    // - key0 big (all valid)
+    // - key1 small (layer1 NULL)
+    // - key2 big (all valid)  => last big
+    // - key3 small (layer3 NULL) => should be DROPPED (not written, not inserted)
+    std::vector<std::vector<BlockIdxType>> lbs_vec{
+        /*layer0*/ {1, 1, 1, 1},
+        /*layer1*/ {1, NULL_BLOCK_IDX, 1, 1},
+        /*layer2*/ {1, 1, 1, 1},
+        /*layer3*/ {1, 1, 1, NULL_BLOCK_IDX},
+    };
+    auto res = makeCacheResource(cache_keys, lbs_vec);
+
+    const size_t cache_before = connector_->block_cache_->size();
+    auto         meta         = std::make_shared<TestReadMeta>(/*enable_memory_cache=*/true);
+    auto         ctx          = connector_->asyncWrite(res, meta);
+    ASSERT_NE(ctx, nullptr);
+    ASSERT_TRUE(waitUntilDone(ctx));
+    EXPECT_TRUE(ctx->success());
+
+    EXPECT_TRUE(connector_->block_cache_->contains(cache_keys[0]));
+    EXPECT_TRUE(connector_->block_cache_->contains(cache_keys[1]));
+    EXPECT_TRUE(connector_->block_cache_->contains(cache_keys[2]));
+    EXPECT_FALSE(connector_->block_cache_->contains(cache_keys[3]));
+
+    // Written count should be >= 3 (exact +3 if cache was empty and no evictions)
+    EXPECT_GE(connector_->block_cache_->size(), cache_before + 3);
+
+    connector_->broadcast_manager_.reset();
+    for (auto& s : servers) {
+        s->shutdown();
+    }
+    servers.clear();
+    addrs.clear();
+}
+
+TEST_F(KVCacheMemoryConnectorTest, asyncWrite_Success_AddsToBlockCache_AndKeepsMemBlocks) {
+    // 默认 RPC 服务均返回 OK + mem success
+    const size_t                           N = 2;
+    CacheKeysType                          cache_keys{200, 201};
+    std::vector<std::vector<BlockIdxType>> lbs_vec{
+        {2, 3},
+        {4, 5},
+        {6, 7},
+        {8, 9},
+    };
+    auto res = makeCacheResource(cache_keys, lbs_vec);
+
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+    auto pool = ensureBlockPool(mem_size);
     ASSERT_NE(pool, nullptr);
     const size_t free_before  = pool->freeBlocksNum();
     const size_t cache_before = connector_->block_cache_->size();
@@ -1126,17 +1348,18 @@ TEST_F(KVCacheMemoryConnectorTest, asyncWrite_FailureOnMemResponse_FreesAllocate
     ASSERT_TRUE(broadcast_manager->init());
     connector_->broadcast_manager_ = broadcast_manager;
 
-    const int                              layer0        = 0;
-    const int                              gpu_block_idx = 1;
     CacheKeysType                          cache_keys{301, 302};
     std::vector<std::vector<BlockIdxType>> lbs_vec{
-        {static_cast<BlockIdxType>(gpu_block_idx), static_cast<BlockIdxType>(gpu_block_idx)}};
+        {1, 2},
+        {3, 4},
+        {5, 6},
+        {7, 8},
+    };
     auto res = makeCacheResource(cache_keys, lbs_vec);
 
-    const auto   bufs  = allocator_->convertIndexToBuffer(layer0, gpu_block_idx);
-    const size_t total = sumBlockInfosBytes(bufs);
-    ASSERT_GT(total, 0u);
-    auto pool = ensureBlockPool(total);
+    const size_t mem_size = memoryCacheBlockBytes();
+    ASSERT_GT(mem_size, 0u);
+    auto pool = ensureBlockPool(mem_size);
     ASSERT_NE(pool, nullptr);
     const size_t free_before  = pool->freeBlocksNum();
     const size_t cache_before = connector_->block_cache_->size();
@@ -1216,10 +1439,10 @@ TEST_F(KVCacheMemoryConnectorTest, sendCopyPlan_ReturnContext_AllRanksSuccess) {
     ASSERT_GT(total, 0u);
 
     KVCacheMemoryConnector::CopyInfoPerKey info;
-    info.cache_key        = 1;
-    info.mem_block_index  = static_cast<BlockIdxType>(1);
-    info.mem_block_size   = total;
-    info.gpu_layer_blocks = {KVCacheMemoryConnector::LayerBlock{layer_id, static_cast<BlockIdxType>(gpu_block_idx)}};
+    info.cache_key = 1;
+    info.mem_block = static_cast<BlockIdxType>(1);
+    info.gpu_blocks.assign(static_cast<size_t>(cache_config_.layer_all_num), NULL_BLOCK_IDX);
+    info.gpu_blocks[static_cast<size_t>(layer_id)] = static_cast<BlockIdxType>(gpu_block_idx);
     std::vector<KVCacheMemoryConnector::CopyInfoPerKey> infos{info};
 
     auto plan        = std::make_shared<KVCacheMemoryConnector::CopyPlan>();
@@ -1260,10 +1483,10 @@ TEST_F(KVCacheMemoryConnectorTest, sendCopyPlan_ReturnContext_PartialRanksFail) 
     ASSERT_GT(total, 0u);
 
     KVCacheMemoryConnector::CopyInfoPerKey info;
-    info.cache_key        = 2;
-    info.mem_block_index  = static_cast<BlockIdxType>(1);
-    info.mem_block_size   = total;
-    info.gpu_layer_blocks = {KVCacheMemoryConnector::LayerBlock{layer_id, static_cast<BlockIdxType>(gpu_block_idx)}};
+    info.cache_key = 2;
+    info.mem_block = static_cast<BlockIdxType>(1);
+    info.gpu_blocks.assign(static_cast<size_t>(cache_config_.layer_all_num), NULL_BLOCK_IDX);
+    info.gpu_blocks[static_cast<size_t>(layer_id)] = static_cast<BlockIdxType>(gpu_block_idx);
     std::vector<KVCacheMemoryConnector::CopyInfoPerKey> infos{info};
 
     auto plan        = std::make_shared<KVCacheMemoryConnector::CopyPlan>();
@@ -1317,10 +1540,10 @@ TEST_F(KVCacheMemoryConnectorTest, sendCopyPlan_ReturnContext_RpcStatusError) {
     ASSERT_GT(total, 0u);
 
     KVCacheMemoryConnector::CopyInfoPerKey info;
-    info.cache_key        = 3;
-    info.mem_block_index  = static_cast<BlockIdxType>(1);
-    info.mem_block_size   = total;
-    info.gpu_layer_blocks = {KVCacheMemoryConnector::LayerBlock{layer_id, static_cast<BlockIdxType>(gpu_block_idx)}};
+    info.cache_key = 3;
+    info.mem_block = static_cast<BlockIdxType>(1);
+    info.gpu_blocks.assign(static_cast<size_t>(cache_config_.layer_all_num), NULL_BLOCK_IDX);
+    info.gpu_blocks[static_cast<size_t>(layer_id)] = static_cast<BlockIdxType>(gpu_block_idx);
     std::vector<KVCacheMemoryConnector::CopyInfoPerKey> infos{info};
 
     auto plan        = std::make_shared<KVCacheMemoryConnector::CopyPlan>();
@@ -1334,18 +1557,16 @@ TEST_F(KVCacheMemoryConnectorTest, sendCopyPlan_ReturnContext_RpcStatusError) {
 
 TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnFalse_CountMismatch) {
     MemoryOperationRequestPB req;
-    auto*                    gb = req.add_gpu_blocks();
-    auto*                    lb = gb->add_layer_blocks();
-    lb->set_layer_id(0);
-    lb->set_block_id(1);
-    // Intentionally do not add mem_block_ids or mem_block_sizes to trigger mismatch
+    auto*                    item = req.add_copy_items();
+    item->add_gpu_blocks(1);
+    // Intentionally do not set mem_block to trigger mismatch
     req.set_copy_direction(MemoryOperationRequestPB::H2D);
 
     MemoryOperationResponsePB resp;
     EXPECT_THROW((void)connector_->copyCache(req, resp), rtp_llm::RTPException);
 }
 
-TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnFalse_InvalidMemBlockSize) {
+TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnFalse_InvalidMemBlock) {
     const int    layer_id      = 0;
     const int    gpu_block_idx = 1;
     const auto   gpu_bufs      = allocator_->convertIndexToBuffer(layer_id, gpu_block_idx);
@@ -1353,12 +1574,10 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnFalse_InvalidMemBlockSize) {
     ASSERT_GT(total, 0u);
 
     MemoryOperationRequestPB req;
-    auto*                    gb = req.add_gpu_blocks();
-    auto*                    lb = gb->add_layer_blocks();
-    lb->set_layer_id(layer_id);
-    lb->set_block_id(gpu_block_idx);
-    req.add_mem_block_ids(1);
-    req.add_mem_block_sizes(0);  // invalid mem block size
+    auto*                    item = req.add_copy_items();
+    item->add_gpu_blocks(gpu_block_idx);
+    // invalid mem_block index for block_pool_
+    item->set_mem_block(NULL_BLOCK_IDX);
     req.set_copy_direction(MemoryOperationRequestPB::H2D);
 
     MemoryOperationResponsePB resp;
@@ -1379,17 +1598,16 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnFalse_InvalidLayerId_BuildCop
     const BlockIdxType mem_block_index = static_cast<BlockIdxType>(mem_blocks[0]);
 
     MemoryOperationRequestPB req;
-    auto*                    gb = req.add_gpu_blocks();
-    auto*                    lb = gb->add_layer_blocks();
-    lb->set_layer_id(cache_config_.layer_num);  // out of range
-    lb->set_block_id(gpu_block_idx);
-    req.add_mem_block_ids(mem_block_index);
-    req.add_mem_block_sizes(static_cast<int64_t>(total));
+    auto*                    item = req.add_copy_items();
+    // gpu_blocks size > layer_num => invalid "layer index"
+    for (int l = 0; l < cache_config_.layer_num + 1; ++l) {
+        item->add_gpu_blocks(gpu_block_idx);
+    }
+    item->set_mem_block(mem_block_index);
     req.set_copy_direction(MemoryOperationRequestPB::H2D);
 
     MemoryOperationResponsePB resp;
-    // 这里会在 allocator_->convertIndexToBuffer(...) 内部触发 RTP_LLM_CHECK 抛异常，而不是返回 false。
-    EXPECT_THROW(connector_->copyCache(req, resp), rtp_llm::RTPException);
+    EXPECT_ANY_THROW((void)connector_->copyCache(req, resp));
 }
 
 TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_SingleLayer) {
@@ -1415,12 +1633,11 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_SingleLayer) {
     setBlockBytes(mem_buffer, /*byte_offset=*/0, total, 'a');
 
     MemoryOperationRequestPB req;
-    auto*                    gb = req.add_gpu_blocks();
-    auto*                    lb = gb->add_layer_blocks();
-    lb->set_layer_id(layer_id);
-    lb->set_block_id(gpu_block_idx);
-    req.add_mem_block_ids(mem_block_index);
-    req.add_mem_block_sizes(static_cast<int64_t>(total));
+    auto*                    item = req.add_copy_items();
+    for (int l = 0; l < cache_config_.layer_num; ++l) {
+        item->add_gpu_blocks(l == layer_id ? gpu_block_idx : NULL_BLOCK_IDX);
+    }
+    item->set_mem_block(mem_block_index);
     req.set_copy_direction(MemoryOperationRequestPB::H2D);
 
     MemoryOperationResponsePB resp;
@@ -1434,7 +1651,7 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_SingleLayer) {
 
 TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_MultiLayer) {
     // 创建两个block_size不同的memory buffer
-    std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks1{
+    std::vector<LayerBlock> gpu_layer_blocks1{
         {/*layer_id*/ 0, /*block_id*/ 1},
         {/*layer_id*/ 1, /*block_id*/ 2},
     };
@@ -1444,7 +1661,7 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_MultiLayer) {
     ASSERT_FALSE(isNullBlockIdx(mem_block_index1));
     ASSERT_NE(mem_block_size1, 0);
 
-    std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks2{
+    std::vector<LayerBlock> gpu_layer_blocks2{
         {/*layer_id*/ 0, /*block_id*/ 1},
         {/*layer_id*/ 1, /*block_id*/ 2},
         {/*layer_id*/ 2, /*block_id*/ 2},
@@ -1457,8 +1674,8 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_H2D_MultiLayer) {
 
     MemoryOperationRequestPB req;
     req.set_copy_direction(MemoryOperationRequestPB::H2D);
-    addOneCopyInfoToPb(req, gpu_layer_blocks1, mem_block_index1, mem_block_size1);
-    addOneCopyInfoToPb(req, gpu_layer_blocks2, mem_block_index2, mem_block_size2);
+    addOneCopyItemToPb(req, gpu_layer_blocks1, mem_block_index1);
+    addOneCopyItemToPb(req, gpu_layer_blocks2, mem_block_index2);
 
     MemoryOperationResponsePB resp;
     auto                      ok = connector_->copyCache(req, resp);
@@ -1493,12 +1710,11 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_SingleLayer) {
     EXPECT_GE(mem_buffer.size_bytes, total);
 
     MemoryOperationRequestPB req;
-    auto*                    gb = req.add_gpu_blocks();
-    auto*                    lb = gb->add_layer_blocks();
-    lb->set_layer_id(layer_id);
-    lb->set_block_id(gpu_block_idx);
-    req.add_mem_block_ids(mem_block_index);
-    req.add_mem_block_sizes(static_cast<int64_t>(total));
+    auto*                    item = req.add_copy_items();
+    for (int l = 0; l < cache_config_.layer_num; ++l) {
+        item->add_gpu_blocks(l == layer_id ? gpu_block_idx : NULL_BLOCK_IDX);
+    }
+    item->set_mem_block(mem_block_index);
     req.set_copy_direction(MemoryOperationRequestPB::D2H);
 
     MemoryOperationResponsePB resp;
@@ -1511,7 +1727,7 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_SingleLayer) {
 }
 
 TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_MultiLayer) {
-    std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks1{
+    std::vector<LayerBlock> gpu_layer_blocks1{
         {/*layer_id*/ 0, /*block_id*/ 1},
         {/*layer_id*/ 1, /*block_id*/ 2},
     };
@@ -1521,7 +1737,7 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_MultiLayer) {
     ASSERT_FALSE(isNullBlockIdx(mem_block_index1));
     ASSERT_NE(mem_block_size1, 0);
 
-    std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks2{
+    std::vector<LayerBlock> gpu_layer_blocks2{
         {/*layer_id*/ 0, /*block_id*/ 1},
         {/*layer_id*/ 1, /*block_id*/ 2},
         {/*layer_id*/ 2, /*block_id*/ 2},
@@ -1534,8 +1750,8 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_MultiLayer) {
 
     MemoryOperationRequestPB req;
     req.set_copy_direction(MemoryOperationRequestPB::D2H);
-    addOneCopyInfoToPb(req, gpu_layer_blocks1, mem_block_index1, mem_block_size1);
-    addOneCopyInfoToPb(req, gpu_layer_blocks2, mem_block_index2, mem_block_size2);
+    addOneCopyItemToPb(req, gpu_layer_blocks1, mem_block_index1);
+    addOneCopyItemToPb(req, gpu_layer_blocks2, mem_block_index2);
 
     MemoryOperationResponsePB resp;
     auto                      ok = connector_->copyCache(req, resp);
@@ -1550,7 +1766,7 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_ReturnTrue_D2H_MultiLayer) {
 // Regression test: verifies multi-layer D2H copy uses correct byte offsets even when memory buffer dtype size != 1.
 // This would fail if prepareCopyBuffers mistakenly treats bytes as elements in Buffer::slice().
 TEST_F(KVCacheMemoryConnectorTest, copyCache_D2H_MultiLayer_ValidatesByteOffsets) {
-    std::vector<KVCacheMemoryConnector::LayerBlock> gpu_layer_blocks{
+    std::vector<LayerBlock> gpu_layer_blocks{
         {/*layer_id*/ 0, /*block_id*/ 1},
         {/*layer_id*/ 1, /*block_id*/ 2},
     };
@@ -1562,11 +1778,10 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_D2H_MultiLayer_ValidatesByteOffsets
         setBlockInfosContent(gpu_bufs, static_cast<char>('k' + lb.layer_id));
     }
 
-    // Allocate one memory block sized to hold both layers' kv bytes contiguously.
+    // Allocate one memory block for the merged layout (one cache-key across all layers).
     size_t total_bytes = 0;
-    for (const auto& lb : gpu_layer_blocks) {
-        const auto gpu_bufs = allocator_->convertIndexToBuffer(lb.layer_id, lb.block_id);
-        total_bytes += sumBlockInfosBytes(gpu_bufs);
+    for (int layer = 0; layer < cache_config_.layer_all_num; ++layer) {
+        total_bytes += static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[static_cast<size_t>(layer)]);
     }
     ASSERT_GT(total_bytes, 0u);
 
@@ -1585,21 +1800,33 @@ TEST_F(KVCacheMemoryConnectorTest, copyCache_D2H_MultiLayer_ValidatesByteOffsets
 
     MemoryOperationRequestPB req;
     req.set_copy_direction(MemoryOperationRequestPB::D2H);
-    addOneCopyInfoToPb(req, gpu_layer_blocks, mem_block_index, total_bytes);
+    addOneCopyItemToPb(req, gpu_layer_blocks, mem_block_index);
 
     MemoryOperationResponsePB resp;
     const auto                ok = connector_->copyCache(req, resp);
     ASSERT_TRUE(ok);
     ASSERT_TRUE(resp.success());
 
-    // Validate two segments land at correct byte offsets.
-    size_t byte_off = 0;
+    // Validate segments land at correct per-layer stride offsets.
+    const size_t              layer_num = static_cast<size_t>(cache_config_.layer_all_num);
+    std::vector<BlockIdxType> layer_to_block(layer_num, NULL_BLOCK_IDX);
     for (const auto& lb : gpu_layer_blocks) {
-        const auto gpu_bufs = allocator_->convertIndexToBuffer(lb.layer_id, lb.block_id);
+        layer_to_block[static_cast<size_t>(lb.layer_id)] = lb.block_id;
+    }
+    size_t byte_off = 0;
+    for (size_t layer = 0; layer < layer_num; ++layer) {
+        const size_t layer_stride = static_cast<size_t>(cache_config_.layer_to_block_stride_bytes[layer]);
+        const auto   block_id     = layer_to_block[layer];
+        if (isNullBlockIdx(block_id)) {
+            byte_off += layer_stride;
+            continue;
+        }
+        const auto gpu_bufs = allocator_->convertIndexToBuffer(static_cast<int>(layer), block_id);
         const auto bytes    = sumBlockInfosBytes(gpu_bufs);
         ASSERT_GT(bytes, 0u);
-        verifyBlockBytesEq(mem_buffer, byte_off, bytes, static_cast<char>('k' + lb.layer_id));
-        byte_off += bytes;
+        ASSERT_LE(bytes, layer_stride);
+        verifyBlockBytesEq(mem_buffer, byte_off, bytes, static_cast<char>('k' + static_cast<int>(layer)));
+        byte_off += layer_stride;
     }
 }
 

--- a/rtp_llm/cpp/cache/connector/memory/test/MemoryBlockCacheTest.cc
+++ b/rtp_llm/cpp/cache/connector/memory/test/MemoryBlockCacheTest.cc
@@ -20,11 +20,13 @@ TEST(MemoryBlockCacheTest, match_ReturnNull_WhenKeyNotFoundAndCacheNonEmpty) {
     item.block_index = 70;
     item.block_size  = 7000;
     item.is_resident = false;
+    item.is_complete = true;
     ASSERT_TRUE(cache.put(item).first);
 
     auto mr = cache.match(999);  // not exist
     EXPECT_TRUE(isNullBlockIdx(mr.matched_index));
     EXPECT_EQ(mr.block_size, 0u);
+    EXPECT_FALSE(mr.is_complete);
 }
 
 TEST(MemoryBlockCacheTest, match_ReturnHit_WhenKeyExistsAndUpdatesRecency) {
@@ -36,6 +38,7 @@ TEST(MemoryBlockCacheTest, match_ReturnHit_WhenKeyExistsAndUpdatesRecency) {
         item.block_index                = 40 + i;
         item.block_size                 = 3000 + i;
         item.is_resident                = false;
+        item.is_complete                = true;
         auto [success, popped_item_opt] = cache.put(item);
         EXPECT_TRUE(success);
         EXPECT_FALSE(popped_item_opt.has_value());
@@ -59,6 +62,7 @@ TEST(MemoryBlockCacheTest, contains_ReturnTrue_WhenKeyExists) {
     item.block_index = 90;
     item.block_size  = 9000;
     item.is_resident = false;
+    item.is_complete = true;
     ASSERT_TRUE(cache.put(item).first);
 
     EXPECT_TRUE(cache.contains(900));
@@ -72,6 +76,7 @@ TEST(MemoryBlockCacheTest, contains_ReturnFalse_WhenKeyNotFoundAndCacheNonEmpty)
     item.block_index = 91;
     item.block_size  = 9001;
     item.is_resident = false;
+    item.is_complete = true;
     ASSERT_TRUE(cache.put(item).first);
 
     EXPECT_FALSE(cache.contains(999));
@@ -91,6 +96,7 @@ TEST(MemoryBlockCacheTest, contains_ReturnFalse_WhenContainsDoesNotUpdateRecency
         item.block_index = 10 + i;
         item.block_size  = 1;
         item.is_resident = false;
+        item.is_complete = true;
         ASSERT_TRUE(cache.put(item).first);
     }
 
@@ -109,6 +115,7 @@ TEST(MemoryBlockCacheTest, put_ReturnTrue_WhenInsertNewItem) {
     item.block_index = 7;
     item.block_size  = 1234;
     item.is_resident = false;
+    item.is_complete = true;
 
     auto [success, popped_item_opt] = cache.put(item);
     EXPECT_TRUE(success);
@@ -143,6 +150,7 @@ TEST(MemoryBlockCacheTest, put_ReturnFalse_WhenCacheKeyDuplicate) {
     item1.block_index               = 10;
     item1.block_size                = 4096;
     item1.is_resident               = false;
+    item1.is_complete               = true;
     auto [success, popped_item_opt] = cache.put(item1);
     EXPECT_TRUE(success);
     EXPECT_FALSE(popped_item_opt.has_value());
@@ -154,6 +162,7 @@ TEST(MemoryBlockCacheTest, put_ReturnFalse_WhenCacheKeyDuplicate) {
     item2.block_index                 = 11;
     item2.block_size                  = 8192;
     item2.is_resident                 = true;
+    item2.is_complete                 = true;
     auto [success2, popped_item_opt2] = cache.put(item2);
     EXPECT_FALSE(success2);
     EXPECT_FALSE(popped_item_opt2.has_value());
@@ -162,6 +171,61 @@ TEST(MemoryBlockCacheTest, put_ReturnFalse_WhenCacheKeyDuplicate) {
     auto mr = cache.match(200);
     EXPECT_EQ(mr.matched_index, 10);
     EXPECT_EQ(mr.block_size, 4096u);
+}
+
+TEST(MemoryBlockCacheTest, match_ReturnHit_WhenKeyExistsButIsSmall) {
+    MemoryBlockCache cache;
+
+    MemoryBlockCache::CacheItem item;
+    item.cache_key   = 777;
+    item.block_index = 77;
+    item.block_size  = 7777;
+    item.is_resident = false;
+    item.is_complete = false;  // partial KV
+    ASSERT_TRUE(cache.put(item).first);
+
+    auto mr = cache.match(777);
+    EXPECT_FALSE(isNullBlockIdx(mr.matched_index));
+    EXPECT_EQ(mr.matched_index, 77);
+    EXPECT_EQ(mr.block_size, 7777u);
+    EXPECT_FALSE(mr.is_complete);
+}
+
+TEST(MemoryBlockCacheTest, put_UpgradePartialToComplete_ReplacesAndReturnsOldItem) {
+    MemoryBlockCache cache;
+
+    MemoryBlockCache::CacheItem small;
+    small.cache_key   = 888;
+    small.block_index = 80;
+    small.block_size  = 1000;
+    small.is_resident = false;
+    small.is_complete = false;
+    {
+        auto [ok, popped] = cache.put(small);
+        EXPECT_TRUE(ok);
+        EXPECT_FALSE(popped.has_value());
+    }
+
+    MemoryBlockCache::CacheItem big;
+    big.cache_key   = 888;
+    big.block_index = 81;
+    big.block_size  = 2000;
+    big.is_resident = false;
+    big.is_complete = true;
+    {
+        auto [ok, popped] = cache.put(big);
+        EXPECT_TRUE(ok);
+        ASSERT_TRUE(popped.has_value());
+        EXPECT_EQ(popped->cache_key, 888);
+        EXPECT_EQ(popped->block_index, 80);
+        EXPECT_EQ(popped->block_size, 1000u);
+        EXPECT_FALSE(popped->is_complete);
+    }
+
+    auto mr = cache.match(888);
+    EXPECT_EQ(mr.matched_index, 81);
+    EXPECT_EQ(mr.block_size, 2000u);
+    EXPECT_TRUE(mr.is_complete);
 }
 
 TEST(MemoryBlockCacheTest, put_ReturnPoppedItem_WhenCacheFull) {
@@ -175,6 +239,7 @@ TEST(MemoryBlockCacheTest, put_ReturnPoppedItem_WhenCacheFull) {
     item1.block_index = 1;
     item1.block_size  = 111;
     item1.is_resident = false;
+    item1.is_complete = true;
     {
         auto [success, popped_item_opt] = cache.put(item1);
         EXPECT_TRUE(success);
@@ -187,6 +252,7 @@ TEST(MemoryBlockCacheTest, put_ReturnPoppedItem_WhenCacheFull) {
     item2.block_index = 2;
     item2.block_size  = 222;
     item2.is_resident = false;
+    item2.is_complete = true;
     {
         auto [success, popped_item_opt] = cache.put(item2);
         EXPECT_TRUE(success);
@@ -217,6 +283,7 @@ TEST(MemoryBlockCacheTest, put_ReturnFalse_WhenCacheFullButPopFailed) {
     item.block_index = 1;
     item.block_size  = 1;
     item.is_resident = false;
+    item.is_complete = true;
 
     auto [success, popped_item_opt] = cache.put(item);
     EXPECT_FALSE(success);
@@ -234,6 +301,7 @@ TEST(MemoryBlockCacheTest, pop_ReturnNonResidentBlocks_WhenSkipResident) {
         item.block_index                = 20 + i;
         item.block_size                 = 1000 + i;
         item.is_resident                = (i == 1);  // key=301 is resident
+        item.is_complete                = true;
         auto [success, popped_item_opt] = cache.put(item);
         EXPECT_TRUE(success);
         EXPECT_FALSE(popped_item_opt.has_value());
@@ -279,6 +347,7 @@ TEST(MemoryBlockCacheTest, pop_ReturnLimitedBlocks_WhenNumsLessThanSize) {
         item.block_index                = 30 + i;
         item.block_size                 = 2000 + i;
         item.is_resident                = false;
+        item.is_complete                = true;
         auto [success, popped_item_opt] = cache.put(item);
         EXPECT_TRUE(success);
         EXPECT_FALSE(popped_item_opt.has_value());
@@ -310,6 +379,7 @@ TEST(MemoryBlockCacheTest, pop_ReturnEmpty_WhenAllResident) {
         item.block_index                = 50 + i;
         item.block_size                 = 4000 + i;
         item.is_resident                = true;
+        item.is_complete                = true;
         auto [success, popped_item_opt] = cache.put(item);
         EXPECT_TRUE(success);
         EXPECT_FALSE(popped_item_opt.has_value());
@@ -329,6 +399,7 @@ TEST(MemoryBlockCacheTest, empty_ReturnTrue_WhenCacheEmpty) {
     auto mr = cache.match(42);
     EXPECT_TRUE(isNullBlockIdx(mr.matched_index));
     EXPECT_EQ(mr.block_size, 0u);
+    EXPECT_FALSE(mr.is_complete);
 }
 
 TEST(MemoryBlockCacheTest, cacheKeys_ReturnsKeysInMRUOrder) {

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -57,6 +57,11 @@ inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
 
     config.block_size_bytes = config.kv_block_size_bytes + config.kv_scale_size_bytes;
 
+    // Per-layer block stride (kv + scale).
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
+
     return config;
 }
 
@@ -158,6 +163,11 @@ inline CacheConfig makeSimpleHybridMhaCacheConfig(int               layer_num,
     config.kv_scale_stride_bytes = full_spec->scale_block_size_bytes();
     config.kv_scale_size_bytes   = static_cast<size_t>(config.group_layer_num) * config.kv_scale_stride_bytes;
     config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
+
+    // Per-layer block stride (kv + scale).
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
     return config;
 }
 

--- a/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
@@ -201,6 +201,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, GetNeedBlocksUsesGroupGetNeedBlocksAndReu
                                            CacheKeysType{100, 101, 102, 103});
         MallocInfo info{batch_res, token_ids};
         info.enable_device_cache = false;
+        info.reuse_cache         = false;
         // common_total = full(3) + linear(1) = 4
         // extra_total  = full(1) + linear(reserve_step=2) = 3
         // total = 4 + 2*3 = 10
@@ -216,6 +217,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, GetNeedBlocksUsesGroupGetNeedBlocksAndReu
                                            CacheKeysType{100, 101, 102, 103});
         MallocInfo info{batch_res, token_ids};
         info.enable_device_cache = true;
+        info.reuse_cache         = true;
         // full: common=3 extra=1
         // linear: common=count(0,3]=2, extra=reserve_step(=2)
         // common_total = 3 + 2 = 5
@@ -295,6 +297,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, DisableReuseKeepsOnlyLinearTailOnInitMall
 
     MallocInfo info{batch_res, token_ids};
     info.enable_device_cache = false;
+    info.reuse_cache         = false;
     auto result              = allocator->malloc(info);
     ASSERT_TRUE(result.success);
 
@@ -338,6 +341,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, DisableDeviceCacheSkipsReuseMatchAndAlloc
 
     MallocInfo info{batch_res, token_ids};
     info.enable_device_cache = false;
+    info.reuse_cache         = false;
     auto result              = allocator->malloc(info);
     ASSERT_TRUE(result.success);
 
@@ -425,6 +429,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, InsertIntoCacheInsertsOnlyFullBlocks) {
 
     MallocInfo malloc_info{batch_res, token_ids};
     malloc_info.enable_device_cache = false;
+    malloc_info.reuse_cache         = false;
     auto malloc_result              = allocator->malloc(malloc_info);
     ASSERT_TRUE(malloc_result.success);
     ASSERT_EQ(batch_res->blocksNum(0, gid_full), 3);

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -403,21 +403,16 @@ service EmbeddingRpcService {
 }
 
 message MemoryOperationRequestPB {
-    message GpuBlock {
-        message LayerBlock {
-            int32 layer_id = 1;
-            int32 block_id = 2;
-        }
-        repeated LayerBlock layer_blocks = 1;
+    message CopyItem {
+        int32 mem_block = 1;
+        repeated int32 gpu_blocks = 2;
     }
     enum CopyDirection {
         H2D = 0;
         D2H = 1;
     }
-    repeated GpuBlock gpu_blocks = 1;
-    repeated int32 mem_block_ids = 2;
-    repeated int64 mem_block_sizes = 3;
-    CopyDirection copy_direction = 4;
+    repeated CopyItem copy_items = 1;
+    CopyDirection copy_direction = 2;
 }
 
 message MemoryOperationResponsePB {


### PR DESCRIPTION
## PR 摘要：Memory KVCache 复用支持混合注意力（Hybrid Attention）

本 PR 让 **内存侧 KVCache 复用**具备混合注意力场景下的正确性保障。核心思路是引入 **KV 完整/不完整（`is_complete`）** 的语义，并在 **match / read / write** 三个阶段统一采用“**以 KV 完整（`is_complete=true`）作为稳定边界**”的策略，避免复用不完整 KV 或将不完整 KV 写入缓存导致后续误命中。

### `is_complete` 的定义（原 big/small）
- **`is_complete=true`（完整）**：该 cache key 对应的 KV **完整可复用**（混合注意力下可理解为 full + linear 都齐，所有必要分量都存在）。
- **`is_complete=false`（不完整）**：该 cache key 对应的 KV **不完整**（仅包含部分分量，例如只有 full，没有 linear），不适合作为复用边界。

### Match：确定“可安全复用”的命中边界
- 在匹配过程中允许出现“完整/不完整”混合的连续前缀，但**最终命中点**只会选择满足“**KV 完整**”条件的 key（即 `is_complete=true`）。
- 如果某个 key 虽然在缓存中存在，但对应 KV 不完整（`is_complete=false`）或完整性校验不通过，则不会将其作为复用终点，而是继续向后寻找可用的“完整边界”。

### Read：只读取到“可复用边界”且边界必须是完整
- 读取阶段以 match 决定的复用边界为准，确保读取的数据范围对应“可安全复用”的部分。
- 额外约束：读取范围的末尾必须落在 **`is_complete=true`** 的 key 上，避免把不完整 KV（`is_complete=false`）作为复用尾部带入后续计算。

### Write：允许写入连续前缀，但写入结果必须以完整收口
- 写入阶段允许在构建连续前缀时包含 `is_complete=false` 的 key（为了保持前缀连续性），但会**强制保证最终写入到缓存中的尾部是 `is_complete=true`** 的 key。
- 若待写入范围内不存在任何 `is_complete=true` 的 key，则直接跳过写入（避免将不可复用的尾部写入缓存）。
- 若存在 `is_complete=true` 的 key，则只写入到“最后一个 `is_complete=true` 的 key”为止，丢弃其后的 `is_complete=false` 尾部，因为即使写入也不会被读。
- 支持 **不完整 → 完整** 演进：同一 key 在后续变完整时可升级为 `is_complete=true`，提升混合注意力场景下的命中稳定性。