### PR TITLE
fix: change default device from cuda:0 to cuda

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -53,7 +53,7 @@ class FlashInferTRTLLMParams(object):
         self.cu_kv_seqlens = cu_kv_seqlens
 
 
-def create_g_workspace_buffer(device: str = "cuda:0"):
+def create_g_workspace_buffer(device: str = "cuda"):
     global g_zero_workspace_buffer, g_empty_workspace_buffer
     if g_zero_workspace_buffer is None:
         g_zero_workspace_buffer = torch.zeros(

--- a/rtp_llm/models_py/standalone/auto_model.py
+++ b/rtp_llm/models_py/standalone/auto_model.py
@@ -98,7 +98,7 @@ class AutoModel:
             runtime_config=engine_config.runtime_config,
             model_specific_config=engine_config.model_specific_config,
         )
-        self.device = "cuda:0"
+        self.device = "cuda"
 
         # init kv cache and bind it to py model
         self.tokens_per_block = self.model_config.attn_config.tokens_per_block

--- a/rtp_llm/utils/ckpt_file_info.py
+++ b/rtp_llm/utils/ckpt_file_info.py
@@ -177,7 +177,7 @@ class CkptFileInfo:
 
                     return tensor
 
-    def load_tensors(self, device: str = "cuda:0", direct_io=True):
+    def load_tensors(self, device: str = "cuda", direct_io=True):
         file_path = os.path.abspath(self.file_name)
         if file_path.startswith(("/dev/shm", "/run/shm", "/sys/fs/cgroup")):
             logging.info(f"abs path : {file_path} cannot use direct_io")


### PR DESCRIPTION
Use current device instead of `cuda:0` to avoid unexpected CUDA mem malloc.