### PR TITLE
fix: use MoEConfigAdapter attributes to init strategy  directly

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 
+from rtp_llm.models_py.modules.base.common.kvcache_store import WriteCacheStoreOp
 from rtp_llm.models_py.modules.factory.attention import common
 
 # Select implementation based on CP method
@@ -145,7 +146,15 @@ class CPFlashInferImpl(FMHAImplBase):
         # Create params
         self.fmha_params = self.fmha_impl.prepare(attn_inputs)
         self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
-        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+        if attn_inputs.is_prefill and attn_inputs.cache_store_inputs:
+            self.write_cache_store_impl = WriteCacheStoreOp(
+                attn_inputs.context_parallel_info.prefill_actual_input_lengths_cpu,
+                attn_inputs.prefix_lengths,
+                attn_inputs.kv_cache_block_id_host,
+                attn_inputs.cache_store_inputs,
+            )
+        else:
+            self.write_cache_store_impl = None
 
         self.attn_inputs = attn_inputs
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_cp_impl.py
@@ -186,7 +186,7 @@ class PCPAllGatherAttnOp:
             positions=params.positions_d,
             paged_kv_cache=kv_cache_tensor,
             kv_indices=params.page_indice_d,
-            kv_indptr=params.prefill_ragged_kv_len_indptr_d,
+            kv_indptr=params.decode_page_indptr_d,
             kv_last_page_len=params.paged_kv_last_page_len_d,
             kv_layout="HND",
         )
@@ -198,8 +198,8 @@ class PCPAllGatherAttnOp:
         v0 = torch.index_select(all_values, 0, self.kv0_idx).contiguous()
         v1 = torch.index_select(all_values, 0, self.kv1_idx).contiguous()
 
-        attn_output_part0 = self.prefill_wrappers["part0"].run(q0, k0, v0)
-        attn_output_part1 = self.prefill_wrappers["part1"].run(q1, k1, v1)
+        output = torch.empty_like(q_reshaped)
+        output[self.q0_idx] = self.prefill_wrappers["part0"].run(q0, k0, v0)
+        output[self.q1_idx] = self.prefill_wrappers["part1"].run(q1, k1, v1)
 
-        out = torch.cat([attn_output_part0, attn_output_part1], dim=0)
-        return out
+        return output

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_overlap_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/allgather_overlap_impl.py
@@ -219,7 +219,7 @@ class PCPAllGatherOverlapAttnOp:
             positions=params.positions_d,
             paged_kv_cache=kv_cache_tensor,
             kv_indices=params.page_indice_d,
-            kv_indptr=params.prefill_ragged_kv_len_indptr_d,
+            kv_indptr=params.decode_page_indptr_d,
             kv_last_page_len=params.paged_kv_last_page_len_d,
             kv_layout="HND",
         )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
@@ -222,7 +222,7 @@ class PCPAll2AllAttnOp:
                     positions=self.all_shuffle_indices[self.prefill_cp_rank],
                     paged_kv_cache=kv_cache_tensor,
                     kv_indices=params.page_indice_d,
-                    kv_indptr=params.prefill_ragged_kv_len_indptr_d,
+                    kv_indptr=params.decode_page_indptr_d,
                     kv_last_page_len=params.paged_kv_last_page_len_d,
                     kv_layout="HND",
                 )
@@ -253,7 +253,7 @@ class PCPAll2AllAttnOp:
                     positions=self.all_shuffle_indices[src_rank],
                     paged_kv_cache=kv_cache_tensor,
                     kv_indices=params.page_indice_d,
-                    kv_indptr=params.prefill_ragged_kv_len_indptr_d,
+                    kv_indptr=params.decode_page_indptr_d,
                     kv_last_page_len=params.paged_kv_last_page_len_d,
                     kv_layout="HND",
                 )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
@@ -53,8 +53,8 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
 
         # Calculate parameters from config
         max_num_tokens = (
-            config.ll_num_max_token + config.parallelism_config.tp_size - 1
-        ) // config.parallelism_config.tp_size
+            config.ll_num_max_token + config.tp_size - 1
+        ) // config.tp_size
         self.max_num_tokens = max_num_tokens
         self.num_dispatchers = 1
         self.w1 = weights[W.moe_w1]

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
@@ -97,8 +97,8 @@ class BatchedDataRouter(FusedMoeDataRouter):
 
         # Calculate parameters from config
         max_num_tokens = (
-            config.ll_num_max_token + config.parallelism_config.tp_size - 1
-        ) // config.parallelism_config.tp_size
+            config.ll_num_max_token + config.tp_size - 1
+        ) // config.tp_size
         self.max_num_tokens = max_num_tokens
         self.ep_rank = config.ep_rank
         self.tp_size = config.tp_size

--- a/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
@@ -6,7 +6,9 @@ Manages registration and selection of all MOE strategies.
 import logging
 from typing import List
 
-from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import MoEConfigAdapter
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
 
 from .defs.strategy_base import MoeStrategy
 
@@ -72,9 +74,9 @@ class StrategyRegistry:
             logger.error(
                 f"No suitable MOE strategy found. Config details: "
                 f"quant_config={config.model_config.quant_config}, "
-                f"ep_size={config.parallelism_config.ep_size}, "
-                f"world_size={config.parallelism_config.world_size}, "
-                f"tp_size={config.parallelism_config.tp_size}, "
+                f"ep_size={config.ep_size}, "
+                f"world_size={config.world_size}, "
+                f"tp_size={config.tp_size}, "
                 f"use_deepep_low_latency={config.moe_config.use_deepep_low_latency if config.moe_config else False}"
             )
             raise ValueError(

--- a/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
@@ -73,7 +73,7 @@ class MoeConfigResolver:
         Returns:
             Whether EP is enabled
         """
-        return config.parallelism_config.ep_size > 1
+        return config.ep_size > 1
 
     @staticmethod
     def use_low_latency(config: MoEConfigAdapter) -> bool:
@@ -97,7 +97,7 @@ class MoeConfigResolver:
         Returns:
             Whether single GPU
         """
-        return config.parallelism_config.ep_size == 1
+        return config.ep_size == 1
 
     @staticmethod
     def is_tp_equal_ep(config: MoEConfigAdapter) -> bool:
@@ -109,7 +109,7 @@ class MoeConfigResolver:
         Returns:
             Whether TP size equals EP size
         """
-        return config.parallelism_config.tp_size == config.parallelism_config.ep_size
+        return config.tp_size == config.ep_size
 
     @staticmethod
     def use_all_gather(config: MoEConfigAdapter) -> bool:


### PR DESCRIPTION
当前虽然有MoEConfigAdapter，然而仍然会从parallism_config中获取moe的config（如tp_size/ep_size等），在prefill cp时cp_size=tp_size,直接获取parallism_config的tp_size会导致moe的router strategy错误地初始化为PureTpRouter。修改为直接使用MoEConfigAdapter中的属性。