### PR TITLE
fix: qwen35 dense model weight loading

### DIFF
--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -79,6 +79,7 @@ class Qwen3NextBase(BaseModel):
         config.hidden_size = config_json["hidden_size"]
         config.vocab_size = config_json["vocab_size"]
         config.max_seq_len = config_json["max_position_embeddings"]
+        config.tie_word_embeddings = config_json.get("tie_word_embeddings", False)
 
     @classmethod
     def _parse_rope_config(cls, config_json: dict, config: ModelConfig):


### PR DESCRIPTION
According to https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/config.json, Qwen35 dense model use tie_word_embeddings to reuse embedding weight in lm_head, which is not leveraged in Qwen3 model's config, leads to following errors.

Traceback (most recent call last):
  File "/opt/conda310/envs/rtpllm/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/opt/conda310/envs/rtpllm/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/start_backend_server.py", line 450, in start_backend_server
    return local_rank_start(global_controller, py_env_configs, 0, pipe_writer)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/start_backend_server.py", line 115, in local_rank_start
    raise e
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/start_backend_server.py", line 81, in local_rank_start
    backend_manager.start()
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/server/backend_manager.py", line 121, in start
    self.engine = ModelFactory.from_model_configs(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_factory.py", line 200, in from_model_configs
    model = ModelFactory._create_model(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_factory.py", line 80, in _create_model
    model = model_cls.from_config(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/models/base_model.py", line 263, in from_config
    model.load()
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/utils/time_util.py", line 45, in wrapped
    result = func(*args, **kwargs)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/models/base_model.py", line 149, in load
    self._load(device_str)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/models/base_model.py", line 177, in _load
    self.weight: ModelWeights = self.model_weights_loader.load_weights(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/utils/time_util.py", line 45, in wrapped
    result = func(*args, **kwargs)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/loader.py", line 88, in load_weights
    weights = self._load_weight(device)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/loader.py", line 251, in _load_weight
    return self._load_from_scratch(device)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/loader.py", line 502, in _load_from_scratch
    for layer_id, name, tensor in self.prepare_weights(convert_device):
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/loader.py", line 337, in prepare_weights
    weights = weight.load(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/weight_module.py", line 161, in load
    raw_tensors = self._load_raw_tensor(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/weight_module.py", line 370, in _load_raw_tensor
    raise e
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/model_loader/weight_module.py", line 355, in _load_raw_tensor
    ckpt_weight.merge_fun(
  File "/opt/conda310/envs/rtpllm/lib/python3.10/site-packages/rtp_llm/utils/model_weight.py", line 155, in identity
    raise Exception("ts is empty")
Exception: ts is empty

After fixing, the model can be setup successfully.