### PR TITLE
fix: Skip cudagraph capture at prefillWarmup stage

### DIFF
--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -370,7 +370,7 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
 
         // Cast the Python object to PyModelOutputs and extract hidden states
         CudaGraphState graph_state;
-        if (enable_cuda_graph_ && graph_runner_->canRun(py_model_inputs, graph_state)) {
+        if (cuda_graph_ready_ && graph_runner_->canRun(py_model_inputs, graph_state)) {
             DevicePerfWrapper wrapper(device_, "cuda graph python forward");
             py_model_inputs.attention_inputs.is_s_padded = true;
             py_model_outputs                             = graph_runner_->forward(py_model_inputs, graph_state);

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -56,6 +56,7 @@ private:
     py::object py_model_;
     py::object held_attn_pyobj_;
     bool       enable_cuda_graph_{false};
+    bool       cuda_graph_ready_{false};  // true only after graph_runner_ is successfully created and captured
     bool       is_prefill_cuda_graph_mode_{false};
     bool       use_spec_decoding_{false};
 
@@ -110,7 +111,8 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
     py_model_                 = py_instance;
     auto py_initialize_method = py_model_.attr("initialize");
     py_init_result            = py_initialize_method(init_resources);
-    if (enable_cuda_graph_) {
+    // Skip CUDA graph capture when kv_cache_layer_layout is unavailable (e.g. warmup phase with cache_manager=nullptr)
+    if (enable_cuda_graph_ && (is_prefill_cuda_graph_mode || params.kv_cache_layer_layout.has_value())) {
 #if USING_CUDA
         c10::ScalarType dtype = dataTypeToTorchType(description_.data_type);
 
@@ -172,10 +174,16 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         RTP_LLM_LOG_INFO("allocation records before capture:");
         params.device->traceMemoryUsage();
         graph_runner_->initCapture();
+        cuda_graph_ready_ = true;
         RTP_LLM_LOG_INFO("allocation records after capture:");
         params.device->traceMemoryUsage();
+    } else if (enable_cuda_graph_) {
+        RTP_LLM_LOG_WARNING(
+            "CUDA graph capture skipped: kv_cache_layer_layout is not available (warmup phase). "
+            "cuda_graph_ready_ remains false. Note: warmup VRAM measurement may be lower than actual "
+            "peak usage because CUDA graph memory is not accounted for, which could lead to over-allocation "
+            "of KV cache blocks and potential OOM when CUDA graph is captured later.");
     }
-
     auto py_init_success = py_init_result.cast<bool>();
     if (!py_init_success) {
         throw std::runtime_error("PyWrappedModel constructor: Python model initialization failed.");


### PR DESCRIPTION
## Problems:

NormalEngine initialization goes through warmup -> initCacheManager -> initExecutor procedure, presented below. 

https://github.com/alibaba/rtp-llm/blob/1ae04a310711ea49d4da3b15ff6f628509c8d54d/rtp_llm/cpp/normal_engine/NormalEngine.cc#L69-L82 

At warmup stage, KVCacheManager is set nullptr during NormalExecutor initialization,  which results in PyModelWrapper created with no KVCache enabled.  If we launched rtp_llm with cudagraph enabled, then  it will will try to capture decode graph in prefill warmup. 

https://github.com/alibaba/rtp-llm/blob/1ae04a310711ea49d4da3b15ff6f628509c8d54d/rtp_llm/cpp/normal_engine/NormalEngine.cc#L208

https://github.com/alibaba/rtp-llm/blob/1ae04a310711ea49d4da3b15ff6f628509c8d54d/rtp_llm/cpp/normal_engine/NormalExecutor.cc#L66-L69

Besides if we are using hybrid attention models like Qwen35, kv cache is now required strictly by default. 

https://github.com/alibaba/rtp-llm/blob/1ae04a310711ea49d4da3b15ff6f628509c8d54d/rtp_llm/models_py/model_desc/qwen3_next.py#L399


launch command: 
```
python3 -m rtp_llm.start_server --checkpoint_path=/home/admin/qwen35_2b --model_type=qwen35_dense --max_seq_len=10240  --enable_cuda_graph=1
```
Results in stack trace below : 
  what():  AssertionError: kv_cache is required for decode

At:
  /home/admin/rtp-llm/rtp_llm/models_py/model_desc/qwen3_next.py(399): forward
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1750): _call_impl
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1739): _wrapped_call_impl
  /home/admin/rtp-llm/rtp_llm/models_py/model_desc/qwen3_next.py(572): forward
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1750): _call_impl
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1739): _wrapped_call_impl
  /home/admin/rtp-llm/rtp_llm/models_py/model_desc/qwen3_next.py(654): forward
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1750): _call_impl
  /opt/conda310/lib/python3.10/site-packages/torch/nn/modules/module.py(1739): _wrapped_call_impl
  /home/admin/rtp-llm/rtp_llm/models_py/model_desc/qwen3_next.py(749): forward

## Modifications: 
This skips cudagraph capture by examining kv_cache_layer nullptr which is default in warmup. And it may need consideration that potential inaccuracies exists in VRAM measurement, which are within acceptable tolerance and problems can be reported in engine setup if KVCacheManager requires a larger space. 
