### PR TITLE
chore: black only format .py (skip .pyi)

### DIFF
--- a/open_source/.pre-commit-config.yaml
+++ b/open_source/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
+        types_or: [python]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2


### PR DESCRIPTION
auto-generated `.pyi` may cause `black format tool` AST build failed, so skip it.