### PR TITLE
fix: init system prompt only on tp_rank 0

### DIFF
--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -327,9 +327,11 @@ KVCacheInfo NormalEngine::getCacheStatusInfo(int64_t latest_version, bool need_c
 }
 
 absl::Status NormalEngine::startLoop() {
-    RTP_LLM_LOG_INFO("start init system prompt");
-    THROW_IF_STATUS_ERROR(initSystemPrompt());
-    RTP_LLM_LOG_INFO("init system prompt done");
+    if (device_->getDeviceProperties().tp_rank == 0) {
+        RTP_LLM_LOG_INFO("start init system prompt");
+        THROW_IF_STATUS_ERROR(initSystemPrompt());
+        RTP_LLM_LOG_INFO("init system prompt done");
+    }
     RTP_LLM_LOG_INFO("start normal engine loop");
     running_     = true;
     loop_thread_ = autil::Thread::createThread(std::bind(&NormalEngine::loop, this), "normal_engine_loop");


### PR DESCRIPTION
## PR 标题
`fix: init system prompt only on tp_rank 0`

## 背景 / 问题
在 TP>1 的场景下，system prompt 构建阶段会走：

- `SystemPromptConstructor::construct()`
  - `engine->preRun(..., build_system_prompt)`
    - `stream->initKVBlock()`
      - `StreamCacheResource::loadCacheSync()`
        - `cache_manager->asyncLoadCache(...)`

由于此前 `NormalEngine::startLoop()` 会在**所有 tp_rank** 上调用 `initSystemPrompt()`，导致 **system prompt 的 cache load（connector 的 asyncLoadCache）会被每个 rank 都触发**，带来：
- 在 remote connector 仅 tp_rank==0 初始化线程池/广播器的实现约束下，**非 rank0 触发 load 逻辑存在不合理性/潜在风险**
- 与预期不一致：**应由 rank0 统一发起 load**，其他 rank 参与 TP collective / forward 即可

## 解决方案
在 `NormalEngine::startLoop()` 中增加 `tp_rank==0` 判断，使 `initSystemPrompt()` **仅在 rank0 执行**：

- rank0：构建 system prompt，并触发 `initKVBlock -> loadCacheSync -> asyncLoadCache`
- 其他 rank：不再进入 system prompt 构建链路，从而避免重复 load

## 代码改动
- `rtp_llm/cpp/normal_engine/NormalEngine.cc`
  - `NormalEngine::startLoop()`：`initSystemPrompt()` 增加 `if (device_->getDeviceProperties().tp_rank == 0)` 保护

## 影响评估
- **行为变化**：system prompt 阶段的 connector load 从 “所有 rank” 收敛为 “仅 rank0”
- **对正常请求路径**：不影响（正常请求本就以 rank0 为主驱动调度/同步）
- **风险点（已通过 smoke 覆盖）**：TP 模式下启动阶段同步/collective 时序是否正常

## 测试
已验证 smoke（CUDA12.9）：
- `//internal_source/rtp_llm/test/smoke:multi_task`
- `//internal_source/rtp_llm/test/smoke:multi_task_tp2`
- `//internal_source/rtp_llm/test/smoke:pd_seperation_multi_task`
- `//internal_source/rtp_llm/test/smoke:pd_seperation_multi_task_tp`