### PR TITLE
fix: TokenNormalizer MTP streaming preserves spaces between Chinese

### DIFF
--- a/rtp_llm/openai/renderers/reasoning_tool_base_renderer.py
+++ b/rtp_llm/openai/renderers/reasoning_tool_base_renderer.py
@@ -394,7 +394,7 @@ class ReasoningToolBaseRenderer(CustomChatRenderer, ABC):
         new_token_ids = status.output_ids[len(status.last_output_ids) :]
         normalizer = TokenNormalizer(self.tokenizer)
 
-        collected_deltas = await self._process_normalized_tokens(
+        collected_deltas, normalizer_yielded = await self._process_normalized_tokens(
             normalizer,
             status,
             new_token_ids,
@@ -404,9 +404,12 @@ class ReasoningToolBaseRenderer(CustomChatRenderer, ABC):
             is_streaming,
         )
 
-        # We track per-token buffering via status.delta_output_string and detector internal
-        # buffers. The token IDs are always safe to mark as consumed for next iteration.
-        if new_token_ids:
+        # Update last_output_ids based on what the NORMALIZER yielded, not what we emitted.
+        # If normalizer yielded content but detector buffered it (collected_deltas empty),
+        # we still consumed the tokens and should update.
+        # If normalizer didn't yield anything (buffered for \uFFFD resolution),
+        # don't update so next iteration has full context for sliding window.
+        if normalizer_yielded and new_token_ids:
             status.last_token_length = len(new_token_ids)
             status.last_output_ids = status.output_ids
 
@@ -425,68 +428,39 @@ class ReasoningToolBaseRenderer(CustomChatRenderer, ABC):
         stop_words_str: List[str],
         stop_word_slice_list: List[str],
         is_streaming: bool,
-    ) -> List[OutputDelta]:
-        """Process tokens through normalization and detector."""
+    ) -> Tuple[List[OutputDelta], bool]:
+        """Normalize tokens and feed them through the detector pipeline.
+
+        Returns:
+            (collected_deltas, normalizer_yielded): the output deltas and whether
+            the normalizer emitted any text (used to decide state advancement).
+        """
+        normalizer_yielded = False
+
         if is_streaming:
-            return await self._process_streaming_tokens(
-                normalizer,
-                status,
-                new_token_ids,
-                output,
-                stop_words_str,
-                stop_word_slice_list,
-            )
-        else:
-            return await self._process_non_streaming_tokens(
-                normalizer,
-                status,
-                new_token_ids,
-                output,
-                stop_words_str,
-                stop_word_slice_list,
-            )
+            collected_deltas = []
+            for delta_text in normalizer.normalize_tokens(
+                status.prev_token_id, new_token_ids
+            ):
+                normalizer_yielded = True
+                token_delta = await self._process_single_token_delta(
+                    status,
+                    delta_text,
+                    output,
+                    stop_words_str,
+                    stop_word_slice_list,
+                    is_streaming=True,
+                )
+                if token_delta is not None:
+                    collected_deltas.append(token_delta)
+            return collected_deltas, normalizer_yielded
 
-    async def _process_streaming_tokens(
-        self,
-        normalizer: TokenNormalizer,
-        status: StreamStatus,
-        new_token_ids: List[int],
-        output: GenerateOutput,
-        stop_words_str: List[str],
-        stop_word_slice_list: List[str],
-    ) -> List[OutputDelta]:
-        """Process tokens one by one through detector."""
-        collected_deltas = []
-        for delta_text in normalizer.normalize_tokens(
-            status.prev_token_id, new_token_ids
-        ):
-            token_delta = await self._process_single_token_delta(
-                status,
-                delta_text,
-                output,
-                stop_words_str,
-                stop_word_slice_list,
-                is_streaming=True,
-            )
-            if token_delta is not None:
-                collected_deltas.append(token_delta)
-        return collected_deltas
-
-    async def _process_non_streaming_tokens(
-        self,
-        normalizer: TokenNormalizer,
-        status: StreamStatus,
-        new_token_ids: List[int],
-        output: GenerateOutput,
-        stop_words_str: List[str],
-        stop_word_slice_list: List[str],
-    ) -> List[OutputDelta]:
-        """Accumulate all text first, then process once."""
+        # Non-streaming: accumulate all text first, then process once
         all_text = "".join(
             normalizer.normalize_tokens(status.prev_token_id, new_token_ids)
         )
         if not all_text:
-            return []
+            return [], False
 
         complete_delta = await self._process_single_token_delta(
             status,
@@ -496,7 +470,7 @@ class ReasoningToolBaseRenderer(CustomChatRenderer, ABC):
             stop_word_slice_list,
             is_streaming=False,
         )
-        return [complete_delta] if complete_delta is not None else []
+        return ([complete_delta] if complete_delta is not None else []), True
 
     async def _process_reasoning_and_tool_calls(
         self,

--- a/rtp_llm/openai/renderers/sglang_helpers/token_normalizer.py
+++ b/rtp_llm/openai/renderers/sglang_helpers/token_normalizer.py
@@ -4,6 +4,13 @@ Token-level input normalization for MTP (Multi-Token-Per-step) streaming.
 This module implements token-level decomposition to make detectors MTP-safe by ensuring
 they receive text decoded from individual tokens rather than multi-token chunks.
 
+Design Note:
+    This normalizer is designed to be stateless and created fresh each iteration.
+    The caller (reasoning_tool_base_renderer.py) handles state by:
+    1. Tracking last_output_ids and last_token_length
+    2. Computing prev_token_ids = last_output_ids[-last_token_length:]
+    3. This gives the normalizer the context it needs to resolve incomplete UTF-8
+
 Theoretical Foundation:
     Extended Transition Function Decomposition (from Compiler Theory):
     δ*(q₀, w) = δ(δ*(...δ(q₀, t₁), t₂), ...), tₙ)
@@ -14,6 +21,7 @@ Key Insight:
     This moves complexity from FSM logic (detector code) to data pipeline (token iteration).
 
 Usage:
+    # Created fresh each iteration (stateless)
     normalizer = TokenNormalizer(tokenizer)
     for delta_text in normalizer.normalize_tokens(prev_tokens, new_tokens):
         result = detector.parse_streaming_increment(delta_text, tools)
@@ -25,13 +33,24 @@ from typing import Generator, List
 
 logger = logging.getLogger(__name__)
 
+# Max number of tokens to include in the sliding window when resolving incomplete
+# UTF-8 sequences.  UTF-8 uses at most 4 bytes per code-point; with byte-level BPE
+# each byte can be its own token, so a single character may span up to 4 tokens.
+# Qwen-style tokenizers sometimes merge a preceding space into the same token as the
+# first byte (e.g. " 薯" → 3 tokens), giving 5 tokens for space + 4-byte char.
+# 6 provides a small safety margin.
+_MAX_UTF8_WINDOW = 6
+
 
 class TokenNormalizer:
     """
     Normalizes multi-token input into single-token text deltas for detectors.
 
-    Handles edge cases like incomplete UTF-8 sequences (\\uFFFD) by maintaining
-    minimal context from previous tokens.
+    This is a stateless normalizer - it does not maintain state across calls.
+    The caller is responsible for tracking context via prev_token_ids.
+
+    Handles edge cases like incomplete UTF-8 sequences (\\uFFFD) by using
+    a sliding window to combine tokens when necessary.
     """
 
     def __init__(self, tokenizer):
@@ -50,7 +69,7 @@ class TokenNormalizer:
         Decompose multi-token input into single-token text deltas.
 
         Uses an adaptive sliding window to handle multi-byte UTF-8 characters split
-        across tokens (common in ChatGLM tokenizers).
+        across tokens (common in ChatGLM and Qwen tokenizers).
 
         Args:
             prev_token_ids: Previously decoded token IDs (for context)
@@ -62,13 +81,7 @@ class TokenNormalizer:
         if not new_token_ids:
             return
 
-        # NOTE: Some tokenizers (e.g. ChatGLM style) may decode trailing incomplete UTF-8
-        # sequences as the replacement character (\uFFFD). We intentionally avoid emitting
-        # \uFFFD and instead wait for enough context to decode a valid character. Because
-        # of this, we must not treat trailing \uFFFD from prev_token_ids as "already
-        # emitted" when slicing deltas for the current step.
-        prev_decoded = self.tokenizer.decode(prev_token_ids)
-        yielded_length = len(prev_decoded.rstrip("\uFFFD"))
+        yielded_length = self._calculate_yielded_length(prev_token_ids)
 
         for i in range(len(new_token_ids)):
             cumulative_tokens = prev_token_ids + new_token_ids[: i + 1]
@@ -76,78 +89,129 @@ class TokenNormalizer:
             delta_text = decoded_cumulative[yielded_length:]
 
             if delta_text and "\uFFFD" in delta_text:
-                valid_delta = self._resolve_incomplete_utf8(new_token_ids, i)
+                # Try to resolve with a sliding window that includes future tokens
+                valid_delta = self._try_resolve_with_future_tokens(
+                    prev_token_ids, new_token_ids, i, yielded_length
+                )
                 if valid_delta and valid_delta != "\uFFFD":
                     yield valid_delta
                     yielded_length += len(valid_delta)
+                # If can't resolve, skip this token - caller's prev_token_ids will
+                # include it next iteration, allowing resolution then
                 continue
 
             if delta_text:
                 yield delta_text
                 yielded_length += len(delta_text)
 
-    def _resolve_incomplete_utf8(
-        self, new_token_ids: List[int], current_index: int
+    def _calculate_yielded_length(self, prev_token_ids: List[int]) -> int:
+        """
+        Calculate the length of text that has already been yielded.
+
+        Key insight: If prev_decoded ends with \uFFFD, it means the last token(s)
+        produced incomplete output that was NOT yielded. In that case, we need to
+        find where the incomplete portion starts and only count the complete part.
+
+        We do this by iteratively decoding shorter prefixes of prev_token_ids
+        until we find one that produces complete UTF-8 (no replacement characters).
+
+        IMPORTANT: We must check token boundaries, not just strip \uFFFD from the
+        end, because the character(s) before \uFFFD may also be part of the
+        incomplete sequence (e.g., a space that's part of a multi-token encoding).
+
+        Args:
+            prev_token_ids: Previously decoded token IDs
+
+        Returns:
+            int: Length of the already-yielded portion
+        """
+        if not prev_token_ids:
+            return 0
+
+        prev_decoded = self.tokenizer.decode(prev_token_ids)
+
+        # If no replacement character, everything was yielded
+        if "\uFFFD" not in prev_decoded:
+            return len(prev_decoded)
+
+        # There's an incomplete sequence. We need to find the last COMPLETE token.
+        # Iterate backwards through the tokens to find the longest prefix
+        # that decodes without any replacement characters.
+        for split_point in range(len(prev_token_ids) - 1, -1, -1):
+            prefix_tokens = prev_token_ids[:split_point]
+            if not prefix_tokens:
+                return 0
+            prefix_decoded = self.tokenizer.decode(prefix_tokens)
+            if "\uFFFD" not in prefix_decoded:
+                return len(prefix_decoded)
+
+        # All tokens produce incomplete output
+        return 0
+
+    def _try_resolve_with_future_tokens(
+        self,
+        prev_token_ids: List[int],
+        new_token_ids: List[int],
+        current_index: int,
+        yielded_length: int,
     ) -> str:
         """
-        Resolve incomplete UTF-8 using adaptive sliding window.
+        Try to resolve incomplete UTF-8 by looking ahead in the token sequence.
 
-        Tries increasing context windows (2, 3, 4 tokens) until finding valid UTF-8.
+        This method looks at multiple tokens together to find valid UTF-8.
+        It's designed for MTP (Multi-Token-Per-step) where multiple tokens arrive together.
+
+        Args:
+            prev_token_ids: Previously decoded token IDs (for context)
+            new_token_ids: New token IDs including the current and future tokens
+            current_index: Index of the current token within new_token_ids
+            yielded_length: Length of already-yielded text
+
+        Returns:
+            str: Valid UTF-8 text if resolved, empty string otherwise
         """
-        # Cap window size to avoid O(n^2) behavior for long MTP chunks.
-        max_window_size = 4
-        upper_bound = min(current_index + 1, max_window_size)
-        for window_size in range(2, upper_bound + 1):
-            window_start = max(0, current_index + 1 - window_size)
-            window_tokens = new_token_ids[window_start : current_index + 1]
-            window_decoded = self.tokenizer.decode(window_tokens)
+        max_window_size = _MAX_UTF8_WINDOW
 
-            if "\uFFFD" not in window_decoded:
-                if window_size > 1:
-                    prev_window_decoded = self.tokenizer.decode(window_tokens[:-1])
-                    return window_decoded[len(prev_window_decoded) :]
-                return window_decoded
+        # Combine prev and new tokens for sliding window context
+        combined_tokens = prev_token_ids + new_token_ids
+        current_absolute_index = len(prev_token_ids) + current_index
+
+        # How many future tokens we can see (for MTP)
+        max_lookahead = len(new_token_ids) - current_index - 1
+
+        # First, check if new tokens alone decode cleanly (no prev context needed)
+        # This handles cases where prev has incomplete UTF-8 but new tokens are complete
+        # Example: prev=[107] -> '\uFFFD', new=[34718] -> '片' (complete alone)
+        for lookahead in range(max_lookahead + 1):
+            new_only_tokens = new_token_ids[
+                current_index : current_index + 1 + lookahead
+            ]
+            if new_only_tokens:
+                new_only_decoded = self.tokenizer.decode(new_only_tokens)
+                if "\uFFFD" not in new_only_decoded:
+                    # New tokens alone are valid! Return them directly
+                    return new_only_decoded
+
+        # Try different combinations of window size and lookahead with prev context
+        for lookahead in range(max_lookahead + 1):
+            window_end = current_absolute_index + 1 + lookahead
+
+            for window_size in range(2, max_window_size + 1):
+                window_start = max(0, window_end - window_size)
+
+                if window_end > len(combined_tokens):
+                    continue
+
+                window_tokens = combined_tokens[window_start:window_end]
+                window_decoded = self.tokenizer.decode(window_tokens)
+
+                if "\uFFFD" not in window_decoded:
+                    # Found valid UTF-8! Calculate what to emit
+                    # Get the part that's from the current position onwards
+                    full_decoded = self.tokenizer.decode(combined_tokens[:window_end])
+                    new_text = full_decoded[yielded_length:]
+
+                    if new_text and "\uFFFD" not in new_text:
+                        return new_text
 
         return ""
-
-
-def normalize_and_process(
-    tokenizer,
-    detector,
-    prev_token_ids: List[int],
-    new_token_ids: List[int],
-    tools,
-    is_streaming: bool,
-):
-    """
-    Convenience function to normalize tokens and feed them to a detector.
-
-    This function wraps the normalization logic and detector invocation,
-    accumulating results across all token deltas.
-
-    Args:
-        tokenizer: Tokenizer instance
-        detector: Format detector instance
-        prev_token_ids: Previously decoded token IDs
-        new_token_ids: New token IDs from current iteration
-        tools: Tool definitions for detector
-        is_streaming: Whether in streaming mode
-
-    Returns:
-        List of StreamingParseResult objects produced by feeding each normalized
-        delta_text into the detector.
-
-    Example:
-        results, remaining = normalize_and_process(
-            tokenizer, detector, [1,2,3], [4,5,6], tools, True
-        )
-        # Process results...
-    """
-    normalizer = TokenNormalizer(tokenizer)
-    results = []
-
-    for delta_text in normalizer.normalize_tokens(prev_token_ids, new_token_ids):
-        result = detector.parse_streaming_increment(delta_text, tools)
-        results.append(result)
-
-    return results

--- a/rtp_llm/test/incremental_streaming_test.py
+++ b/rtp_llm/test/incremental_streaming_test.py
@@ -622,3 +622,156 @@ class TestQwen25DetectAndParse(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStreamingStringWithSpaces(unittest.TestCase):
+    """Test that string values containing spaces are not truncated during streaming.
+
+    This guards against a bug where partial_json_parser auto-adds closing quotes
+    to incomplete strings, and the streaming logic failed to handle the first
+    argument streaming after tool name was sent (prev_arguments was None).
+
+    Bug: When streaming "可乐 薯片 饼干", the content after the first space was lost.
+    """
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="search_item",
+                    description="Search for items",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "intent": {"type": "string"},
+                            "isDeduplicate": {"type": "integer"},
+                        },
+                    },
+                ),
+            )
+        ]
+
+    def test_string_with_spaces_not_truncated(self):
+        """
+        Test that string values containing spaces are NOT truncated during streaming.
+
+        This is the exact bug scenario:
+        - Chunk 1: tool name + partial string "可乐"
+        - Chunk 2: more string content " 薯片" (space + content)
+        - Chunk 3: remaining string " 饼干..." (space + content)
+
+        Previously, chunks 2 and 3 were lost because:
+        1. After chunk 1, prev_tool_call_arr was not updated
+        2. When chunk 2 arrived, prev_arguments was None
+        3. The elif branch was skipped, argument_diff stayed None
+        """
+        detector = Qwen25Detector()
+
+        chunks = [
+            detector.bot_token,
+            '{"name": "search_item", "arguments": {"intent": "可乐',
+            " ",
+            "薯片",  # This was being lost
+            " ",
+            "饼干",
+            '"',
+            ",",
+            " ",
+            '"',
+            "isDeduplicate",
+            '"',
+            ":",
+            "0}}",
+            detector.eot_token,
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+
+        # Collect all parameters
+        final_params = "".join([c.parameters for c in all_calls if c.parameters])
+        expected = json.dumps(
+            {"intent": "可乐 薯片 饼干", "isDeduplicate": 0}, ensure_ascii=False
+        )
+
+        self.assertEqual(
+            final_params,
+            expected,
+            f"Expected '{expected}' but got '{final_params}'. "
+            f"String with spaces was truncated!",
+        )
+
+    def test_string_with_spaces_character_by_character(self):
+        """
+        Test string with spaces streamed character by character.
+
+        This is an even more extreme case where each character arrives separately.
+        """
+        detector = Qwen25Detector()
+
+        # Character-by-character streaming after the tool name is sent
+        chunks = [
+            detector.bot_token,
+            '{"name": "search_item", "arguments": {"intent": "',
+            "a",  # First char
+            " ",  # Space - critical test
+            "b",  # Char after space
+            " ",
+            "c",
+            '"}',
+            "}",
+            detector.eot_token,
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+
+        final_params = "".join([c.parameters for c in all_calls if c.parameters])
+        expected = json.dumps({"intent": "a b c"}, ensure_ascii=False)
+
+        self.assertEqual(final_params, expected)
+
+    def test_multiple_string_parameters_with_spaces(self):
+        """Test multiple string parameters, each with spaces."""
+        detector = Qwen25Detector()
+
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "filter": {"type": "string"},
+                        },
+                    },
+                ),
+            )
+        ]
+
+        chunks = [
+            detector.bot_token,
+            '{"name": "search", "arguments": {"query": "hello',
+            " world",
+            '", "filter": "foo',
+            " bar",
+            '"}}',
+            detector.eot_token,
+        ]
+
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, tools)
+            all_calls.extend(result.calls)
+
+        final_params = "".join([c.parameters for c in all_calls if c.parameters])
+        expected = json.dumps({"query": "hello world", "filter": "foo bar"})
+
+        self.assertEqual(final_params, expected)

--- a/rtp_llm/test/token_normalizer_test.py
+++ b/rtp_llm/test/token_normalizer_test.py
@@ -4,9 +4,11 @@ Tests for TokenNormalizer with adaptive sliding window.
 These tests verify that the normalizer correctly handles:
 1. Normal single-byte tokens
 2. Multi-byte Unicode characters split across tokens (ChatGLM-style)
-3. Adaptive sliding window when \\uFFFD is detected
+3. Adaptive sliding window when \uFFFD is detected
+4. Real Qwen tokenizer behavior with Chinese text containing spaces (MTP-safe streaming)
 """
 
+import os
 import unittest
 from unittest.mock import Mock
 
@@ -192,6 +194,244 @@ class TestSimpleTokenizer(unittest.TestCase):
         self.assertEqual(len(deltas), 2)
         self.assertEqual(deltas[0], "C")
         self.assertEqual(deltas[1], "D")
+
+
+def _get_qwen_tokenizer():
+    """
+    Get Qwen tokenizer with fallback chain for CI compatibility.
+
+    Priority:
+    1. Local Qwen3-8B (most accurate for testing)
+    2. Repo testdata qwen3_30b/tokenizer
+    3. Repo testdata qwen2_tokenizer (similar behavior for space handling)
+    4. HuggingFace remote (Qwen/Qwen2.5-7B-Instruct)
+
+    Returns:
+        tokenizer or None if not available
+    """
+    try:
+        from transformers import AutoTokenizer
+    except ImportError:
+        return None
+
+    tokenizer_paths = [
+        # Repo testdata paths
+        "rtp_llm/test/model_test/fake_test/testdata/qwen3_30b/tokenizer",
+        "rtp_llm/test/tokenizer_test/testdata/qwen2_tokenizer",
+    ]
+
+    for path in tokenizer_paths:
+        if os.path.exists(path):
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    path, trust_remote_code=True, verbose=False
+                )
+                return tokenizer
+            except Exception:
+                continue
+
+    # Fallback to HuggingFace remote
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            "Qwen/Qwen2.5-7B-Instruct", trust_remote_code=True, verbose=False
+        )
+        return tokenizer
+    except Exception:
+        return None
+
+
+class TestTokenNormalizerWithQwen(unittest.TestCase):
+    """
+    Test TokenNormalizer with real Qwen tokenizer behavior.
+
+    This tests the critical bug fix: spaces between Chinese characters must be
+    preserved during streaming token normalization.
+
+    Bug scenario:
+    - Model outputs: {"intent": "可乐 薯片 饼干"}
+    - Before fix: {"intent": "可乐"}  <- Lost " 薯片 饼干"
+    - After fix: {"intent": "可乐 薯片 饼干"} (correct)
+
+    Root cause: Qwen tokenizer encodes " 薯" (space + Chinese char) as 3 tokens
+    where individual tokens produce \\uFFFD (replacement character) when decoded
+    alone. TokenNormalizer must use sliding window to resolve these.
+    """
+
+    def setUp(self):
+        """Load Qwen tokenizer with fallbacks."""
+        self.tokenizer = _get_qwen_tokenizer()
+        self.tokenizer_available = self.tokenizer is not None
+
+    def test_single_token_streaming_preserves_spaces(self):
+        """
+        Test single-token streaming (one token per call).
+
+        Simulates traditional streaming where each token arrives separately.
+        """
+        if not self.tokenizer_available:
+            self.skipTest("Qwen tokenizer not available")
+
+        text = "可乐 薯片 饼干"
+        tokens = self.tokenizer.encode(text, add_special_tokens=False)
+
+        normalizer = TokenNormalizer(self.tokenizer)
+        prev_tokens = []
+        all_deltas = []
+
+        for token in tokens:
+            deltas = list(normalizer.normalize_tokens(prev_tokens, [token]))
+            all_deltas.extend(deltas)
+            prev_tokens = prev_tokens + [token]
+
+        reconstructed = "".join(all_deltas)
+        self.assertEqual(
+            reconstructed,
+            text,
+            f"Single-token streaming should preserve spaces: "
+            f"expected {repr(text)}, got {repr(reconstructed)}",
+        )
+
+    def test_mtp_streaming_preserves_spaces(self):
+        """
+        Test MTP (Multi-Token-Per-step) streaming.
+
+        Simulates speculative decoding where multiple tokens arrive per call.
+        This is the exact scenario where the bug occurred in production.
+        """
+        if not self.tokenizer_available:
+            self.skipTest("Qwen tokenizer not available")
+
+        text = "可乐 薯片 饼干"
+        tokens = self.tokenizer.encode(text, add_special_tokens=False)
+
+        # Test various chunk sizes (MTP scenarios, chunk_size=1 covered by single-token test)
+        chunk_sizes = [2, 3, 4]
+
+        for chunk_size in chunk_sizes:
+            normalizer = TokenNormalizer(self.tokenizer)
+            prev_tokens = []
+            all_deltas = []
+
+            for i in range(0, len(tokens), chunk_size):
+                chunk = tokens[i : i + chunk_size]
+                deltas = list(normalizer.normalize_tokens(prev_tokens, chunk))
+                all_deltas.extend(deltas)
+                prev_tokens = prev_tokens + chunk
+
+            reconstructed = "".join(all_deltas)
+            self.assertEqual(
+                reconstructed,
+                text,
+                f"MTP streaming with chunk_size={chunk_size} should preserve spaces: "
+                f"expected {repr(text)}, got {repr(reconstructed)}",
+            )
+
+    def test_no_replacement_characters_in_final_result(self):
+        """
+        Verify final result has no replacement characters.
+
+        This is a critical invariant: the normalizer should resolve all
+        incomplete UTF-8 sequences and never emit \\uFFFD.
+        """
+        if not self.tokenizer_available:
+            self.skipTest("Qwen tokenizer not available")
+
+        text = "可乐 薯片 饼干"
+        tokens = self.tokenizer.encode(text, add_special_tokens=False)
+
+        normalizer = TokenNormalizer(self.tokenizer)
+        prev_tokens = []
+        all_deltas = []
+
+        for token in tokens:
+            deltas = list(normalizer.normalize_tokens(prev_tokens, [token]))
+            all_deltas.extend(deltas)
+            prev_tokens = prev_tokens + [token]
+
+        result = "".join(all_deltas)
+        self.assertNotIn(
+            "\uFFFD", result, "Final result should not contain replacement characters"
+        )
+
+
+class TestTokenNormalizerMockEdgeCases(unittest.TestCase):
+    """
+    Test edge cases with mock tokenizer to simulate problematic scenarios.
+
+    These tests ensure the normalizer handles the specific case where:
+    - Space token produces \\uFFFD when decoded alone
+    - Space is correctly decoded with context from adjacent tokens
+    """
+
+    def test_space_preserved_with_replacement_char_handling(self):
+        """
+        Simulate exact scenario: space token produces \\uFFFD alone.
+
+        Token sequence:
+        - Token 100: "可乐" (complete)
+        - Token 101: space -> \\uFFFD alone, but works with context
+        - Token 102: "薯片" (complete)
+
+        Expected: "可乐 薯片" (space preserved)
+        """
+        mock_tokenizer = Mock()
+
+        def mock_decode(token_ids):
+            if not token_ids:
+                return ""
+
+            # Simulate Qwen-style encoding where space is part of multi-token sequence
+            token_map = {
+                (100,): "可乐",
+                (101,): "\uFFFD",  # Space alone produces replacement
+                (100, 101): "可乐 ",  # Space works with preceding context
+                (102,): "薯片",
+                (101, 102): " 薯片",  # Space works with following context
+                (100, 101, 102): "可乐 薯片",
+            }
+
+            key = tuple(token_ids)
+            if key in token_map:
+                return token_map[key]
+
+            # Fallback concatenation
+            result = ""
+            for tid in token_ids:
+                if tid == 100:
+                    result += "可乐"
+                elif tid == 101:
+                    result += "\uFFFD"
+                elif tid == 102:
+                    result += "薯片"
+            return result
+
+        mock_tokenizer.decode = mock_decode
+
+        normalizer = TokenNormalizer(mock_tokenizer)
+        prev_tokens = []
+        all_deltas = []
+
+        # Process token 100 ("可乐")
+        deltas = list(normalizer.normalize_tokens(prev_tokens, [100]))
+        all_deltas.extend(deltas)
+        prev_tokens = [100]
+
+        # Process token 101 (space that produces \\uFFFD alone)
+        deltas = list(normalizer.normalize_tokens(prev_tokens, [101]))
+        all_deltas.extend(deltas)
+        prev_tokens = [100, 101]
+
+        # Process token 102 ("薯片")
+        deltas = list(normalizer.normalize_tokens(prev_tokens, [102]))
+        all_deltas.extend(deltas)
+
+        result = "".join(all_deltas)
+        expected = "可乐 薯片"
+        self.assertEqual(
+            result,
+            expected,
+            f"Space should be preserved: expected {repr(expected)}, got {repr(result)}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix bug where streaming tool call parsing loses spaces between Chinese characters (e.g., "可乐 薯片 饼干" → "可乐").

Root cause: Qwen tokenizer encodes " 薯" (space + Chinese) as 3 tokens that produce \uFFFD when decoded individually. The normalizer now uses a sliding window to resolve incomplete UTF-8 sequences.

Key changes:
- Make TokenNormalizer stateless (created fresh each iteration)
- Add _calculate_yielded_length to handle incomplete UTF-8 in prev tokens
- Add _try_resolve_with_future_tokens for MTP sliding window resolution
- Add comprehensive tests with real Qwen tokenizer