### PR TITLE
fix: dynamically determine libpython path based on version

### DIFF
--- a/rtp_llm/ops/__init__.py
+++ b/rtp_llm/ops/__init__.py
@@ -101,11 +101,16 @@ try:
 except BaseException as e:
     logging.info(f"Exception: {e}, traceback: {traceback.format_exc()}")
 
-# frontend cannot load libpython3.10.so, so we need to load it manually
+# frontend cannot load libpython*.so, so we need to load it manually
 import sysconfig
 from ctypes import cdll
 
-cdll.LoadLibrary(sysconfig.get_config_var("LIBDIR") + "/libpython3.10.so")
+_pylib = f"libpython{sys.version_info.major}.{sys.version_info.minor}.so"
+_pylib_path = os.path.join(sysconfig.get_config_var("LIBDIR"), _pylib)
+if os.path.exists(_pylib_path):
+    cdll.LoadLibrary(_pylib_path)
+else:
+    logging.warning(f"Could not find {_pylib_path}, shared lib loading may fail")
 
 try:
     from libth_transformer_config import (

--- a/rtp_llm/ops/__init__.py
+++ b/rtp_llm/ops/__init__.py
@@ -105,12 +105,16 @@ except BaseException as e:
 import sysconfig
 from ctypes import cdll
 
-_pylib = f"libpython{sys.version_info.major}.{sys.version_info.minor}.so"
-_pylib_path = os.path.join(sysconfig.get_config_var("LIBDIR"), _pylib)
-if os.path.exists(_pylib_path):
-    cdll.LoadLibrary(_pylib_path)
+_libdir = sysconfig.get_config_var("LIBDIR")
+if _libdir:
+    _pylib = f"libpython{sys.version_info.major}.{sys.version_info.minor}.so"
+    _pylib_path = os.path.join(_libdir, _pylib)
+    if os.path.exists(_pylib_path):
+        cdll.LoadLibrary(_pylib_path)
+    else:
+        logging.warning(f"Could not find {_pylib_path}, shared lib loading may fail")
 else:
-    logging.warning(f"Could not find {_pylib_path}, shared lib loading may fail")
+    logging.warning("sysconfig LIBDIR is not set, skipping libpython preload")
 
 try:
     from libth_transformer_config import (


### PR DESCRIPTION
The shared library path for libpython was previously hardcoded to 3.10. This change uses sys.version_info to dynamically construct the filename (e.g., libpython3.12.so) and verifies the file exists before attempting to load it. This ensures compatibility across different Python versions and prevents potential crashes if the library is missing.