### PR TITLE
fix: deepep port reservation & process manager exit on rank failure

### DIFF
--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_low_latency_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_low_latency_router_test.py
@@ -31,7 +31,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.deepep_low_la
 )
 from rtp_llm.ops import MoeConfig, NcclCommConfig, ParallelismConfig, RuntimeConfig
 from rtp_llm.test.utils.numeric_util import per_token_cast_back
-from rtp_llm.test.utils.port_util import PortManager, PortsContext
+from rtp_llm.test.utils.port_util import PortManager, PortsContext, get_random_start_port
 
 NUM_TOKEN_PER_RANK = 64
 HIDDEN_SIZE = 7168
@@ -298,8 +298,9 @@ def _spawn_wrapper(
 
 
 def test_deepep_low_latency_router():
-    port_manager = PortManager()
-    ports, locks = port_manager.get_consecutive_ports(1)
+    # Need 12 consecutive ports: nccl_port+0 through nccl_port+11 used by _init_router
+    port_manager = PortManager(start_port=get_random_start_port())
+    ports, locks = port_manager.get_consecutive_ports(12)
     nccl_port = ports[0]
 
     world_size = 2

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_test.py
@@ -30,7 +30,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.deepep_normal
 )
 from rtp_llm.ops import MoeConfig, NcclCommConfig, ParallelismConfig
 from rtp_llm.test.utils.numeric_util import per_token_cast_back
-from rtp_llm.test.utils.port_util import PortManager
+from rtp_llm.test.utils.port_util import PortManager, get_random_start_port
 
 from rtp_llm.ops.compute_ops import trt_fp8_quantize_128  # isort:skip
 
@@ -205,8 +205,9 @@ def worker_function(
 
 
 def test_single(world_size: int, test_tp_size: int, use_fp8: bool):
-    port_manager = PortManager()
-    ports, locks = port_manager.get_consecutive_ports(1)
+    # Need 10 consecutive ports: nccl_port+0 (init), +1 (dp_tp), +6 (ffn_tp), +9 (tp)
+    port_manager = PortManager(start_port=get_random_start_port())
+    ports, locks = port_manager.get_consecutive_ports(10)
     nccl_port = ports[0]
 
     dp_size = world_size // test_tp_size

--- a/rtp_llm/start_backend_server.py
+++ b/rtp_llm/start_backend_server.py
@@ -356,7 +356,11 @@ def multi_rank_start(
     manager.set_processes(processes)
     manager.monitor_and_release_processes()
 
-    return processes
+    # If we get here, at least one rank died. Use os._exit() instead of
+    # sys.exit() to skip atexit handlers / __del__ / finally blocks, which
+    # can deadlock when CUDA/NCCL state is partially torn down.
+    logging.error("Backend rank monitoring ended, force exiting backend process")
+    os._exit(1)
 
 
 def load_gpu_nic_affinity():

--- a/rtp_llm/start_server.py
+++ b/rtp_llm/start_server.py
@@ -19,7 +19,7 @@ from rtp_llm.config.server_config_setup import setup_and_configure_server
 from rtp_llm.ops import RoleType
 from rtp_llm.server.server_args.server_args import setup_args
 from rtp_llm.utils.concurrency_controller import init_controller
-from rtp_llm.utils.process_manager import ProcessManager
+from rtp_llm.utils.process_manager import HealthCheckFatalError, ProcessManager
 
 setup_logging()
 
@@ -73,7 +73,7 @@ def start_backend_server_impl(
             return True
 
         if startup_status["error"]:
-            raise Exception(startup_status["error"])
+            raise HealthCheckFatalError(startup_status["error"])
 
         # Non-blocking check if data is available
         if pipe_reader.poll(timeout=0):
@@ -96,12 +96,12 @@ def start_backend_server_impl(
                     error = f"Backend server start failed: {error_msg}"
                     startup_status["error"] = error
                     pipe_reader.close()
-                    raise Exception(error)
+                    raise HealthCheckFatalError(error)
             except EOFError:
                 error = "Backend server pipe closed unexpectedly"
                 startup_status["error"] = error
                 pipe_reader.close()
-                raise Exception(error)
+                raise HealthCheckFatalError(error)
 
         return False
 

--- a/rtp_llm/utils/process_manager.py
+++ b/rtp_llm/utils/process_manager.py
@@ -7,6 +7,12 @@ from multiprocessing import Process
 from typing import Callable, Dict, List, Optional
 
 
+class HealthCheckFatalError(Exception):
+    """Raised by check_ready_fn to indicate a permanent startup failure
+    that should not be retried (e.g. backend explicitly reported failure)."""
+    pass
+
+
 class ProcessManager:
     """Process manager for managing and monitoring processes"""
 
@@ -231,6 +237,12 @@ class ProcessManager:
                         self.health_check_status[process_name]["checked"] = True
                     logging.info(f"{process_name} is ready")
                     return
+            except HealthCheckFatalError as e:
+                logging.error(f"{process_name} startup failed permanently: {str(e)}")
+                with self.health_check_lock:
+                    self.health_check_status[process_name]["ready"] = False
+                    self.health_check_status[process_name]["checked"] = True
+                return
             except Exception as e:
                 logging.debug(f"{process_name} health check exception: {str(e)}")
             time.sleep(retry_interval)


### PR DESCRIPTION
## Commit 1: fix: reserve enough consecutive ports in deepep router tests

### Root Cause

`deepep_normal_router_test` 和 `deepep_low_latency_router_test` 在 CI 中偶发 `EADDRINUSE` 错误。原因是测试只锁定了 1 个端口，但 `_init_router` 内部实际使用了 `nccl_port` 的多个偏移（normal: +0, +1, +6, +9；low_latency: +0 到 +11），这些偏移端口未被锁定，可能与并行测试冲突。

### Fix

- `deepep_normal_router_test`: `get_consecutive_ports(1)` → `get_consecutive_ports(10)`，覆盖最大偏移 +9
- `deepep_low_latency_router_test`: `get_consecutive_ports(1)` → `get_consecutive_ports(12)`，覆盖最大偏移 +11
- 使用 `get_random_start_port()` 随机化起始端口，进一步避免并行测试冲突

---

## Commit 2: fix: ensure service exits when a rank process dies during startup

### Root Cause

TP=4 场景下，某个 rank 进程启动失败（如 NCCL init 超时）时：

1. `multi_rank_start()` 中的 `ProcessManager.monitor_and_release_processes()` 检测到 rank 进程死亡，终止所有 rank
2. `monitor_and_release_processes()` 返回后，原代码执行 `return processes`，导致 backend 进程**继续运行**但不做任何事
3. 外层 `start_server.py` 的 `ProcessManager` 看到 backend 进程还活着，不会触发退出
4. **整个服务永远挂住**，无法被 k8s 等外部管理器检测到失败

同时，`_health_check_worker` 中所有异常都被 `except Exception` 捕获后仅打印 debug 日志并继续重试，无法区分"启动永久失败"和"暂时连不上"。

### Fix

1. **`HealthCheckFatalError`** — 新增异常类，用于标识不可恢复的启动失败
2. **`_health_check_worker`** — 新增 `except HealthCheckFatalError` 分支，捕获后标记检查失败并立即返回；普通 `Exception` 继续重试（保留长时间启动的兼容性）
3. **`check_backend_ready()`** — pipe 报告失败、pipe 意外关闭时抛出 `HealthCheckFatalError`
4. **`multi_rank_start()`** — `monitor_and_release_processes()` 返回后调用 `os._exit(1)` 强制退出 backend 进程，让外层 ProcessManager 立即感知。使用 `os._exit()` 而非 `sys.exit()` 以避免 CUDA/NCCL 状态部分释放时的 atexit 死锁

---

## 关于 shutdown SIGSEGV (已移除)

经分析，shutdown 时的 SIGSEGV 根因是 `AcclMetricReporter` 自有的 `autil::LoopThread`（非 kmonitor 线程）在 `XServerTransport` 析构过程中访问了已被释放的 `XStatsManagerImpl` hash map。这是 ACCL 库内部的析构顺序 bug（先释放数据，再 join 线程），需要在 ACCL 库层面修复，reorder `stopKmonitorFactory()` 无法解决此问题。