### PR TITLE
 feat: support context parallelism for qwen3.5 hybrid linear attentio…

### DIFF
--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -8,7 +8,7 @@ from torch import nn
 import rtp_llm.ops.compute_ops as compute_ops
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.model_loader.model_weight_info import ModelWeights
-from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
+from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, all_reduce
 from rtp_llm.models_py.model_desc.block_map import select_block_map_for_layer
 from rtp_llm.models_py.model_desc.generic_moe import GenericMoeLayer
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
@@ -20,6 +20,7 @@ from rtp_llm.models_py.modules import (
     LinearFactory,
     RMSNorm,
 )
+from rtp_llm.models_py.modules.base.common.kvcache_store import WriteCacheStoreOp
 from rtp_llm.models_py.triton_kernels.causal_conv1d import (
     CausalConv1dMetadata,
     causal_conv1d_fn,
@@ -59,12 +60,28 @@ class Qwen3NextMetadata(object):
         self,
         prefill_conv1d_meta: Optional[CausalConv1dMetadata] = None,
         is_target_verify: bool = False,
+        full_prefill_conv1d_meta: Optional[CausalConv1dMetadata] = None,
+        full_prefill_cu_seqlens: Optional[torch.Tensor] = None,
+        cp_restore_indices: Optional[torch.Tensor] = None,
+        cp_local_extract_indices: Optional[torch.Tensor] = None,
+        cp_local_valid_mask: Optional[torch.Tensor] = None,
+        cp_write_cache_store_impl: Optional[WriteCacheStoreOp] = None,
     ):
         self.prefill_conv1d_meta = prefill_conv1d_meta
         self.is_target_verify = is_target_verify
+        self.full_prefill_conv1d_meta = full_prefill_conv1d_meta
+        self.full_prefill_cu_seqlens = full_prefill_cu_seqlens
+        self.cp_restore_indices = cp_restore_indices
+        self.cp_local_extract_indices = cp_local_extract_indices
+        self.cp_local_valid_mask = cp_local_valid_mask
+        self.cp_write_cache_store_impl = cp_write_cache_store_impl
 
     def get_prefill_conv1d_meta(self) -> Optional[CausalConv1dMetadata]:
         return self.prefill_conv1d_meta
+
+    @property
+    def is_cp_linear_attn(self) -> bool:
+        return self.cp_restore_indices is not None
 
 
 class Qwen3NextGatedDeltaNetBase(torch.nn.Module):
@@ -84,11 +101,12 @@ class Qwen3NextGatedDeltaNetBase(torch.nn.Module):
         assert (
             self.head_k_dim == self.head_v_dim
         ), "head_k_dim and head_v_dim must be the same now"
+        attn_tp_size = parallelism_config.get_attn_tp_size()
         self.local_num_k_heads: int = (
-            linear_attn_config.linear_num_key_heads // parallelism_config.tp_size
+            linear_attn_config.linear_num_key_heads // attn_tp_size
         )
         self.local_num_v_heads: int = (
-            linear_attn_config.linear_num_value_heads // parallelism_config.tp_size
+            linear_attn_config.linear_num_value_heads // attn_tp_size
         )
         self.num_key_value_heads: int = self.local_num_v_heads // self.local_num_k_heads
         self.linear_conv_kernel_dim: int = (
@@ -486,11 +504,10 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         )
         self.head_k_dim = linear_attn_config.linear_key_head_dim
         self.head_v_dim = linear_attn_config.linear_value_head_dim
-        self.local_num_k_heads = (
-            linear_attn_config.linear_num_key_heads // parallelism_config.tp_size
-        )
+        attn_tp_size = parallelism_config.get_attn_tp_size()
+        self.local_num_k_heads = linear_attn_config.linear_num_key_heads // attn_tp_size
         self.local_num_v_heads = (
-            linear_attn_config.linear_num_value_heads // parallelism_config.tp_size
+            linear_attn_config.linear_num_value_heads // attn_tp_size
         )
         self.num_key_value_heads = self.local_num_v_heads // self.local_num_k_heads
 
@@ -533,6 +550,150 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # b,a should be contiguous for fused_gdn_gating
         return mixed_qkv, z, b, a
 
+    def _forward_cp_prefill(
+        self,
+        mixed_qkv: torch.Tensor,
+        z: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        attention_inputs: PyAttentionInputs,
+        kv_cache: Optional[LayerKVCache],
+        attn_meta: Qwen3NextMetadata,
+    ) -> torch.Tensor:
+        """CP prefill path: all-gather projected states, compute on full sequence,
+        extract local zigzag tokens."""
+        cp_info = attention_inputs.context_parallel_info
+
+        packed = torch.cat([mixed_qkv, b, a], dim=-1)
+        full_packed = all_gather(packed, group=Group.TP)
+
+        padding_mask = cp_info.prefill_qkv_padding_mask
+        restore_indices = cp_info.prefill_qkv_restore_indice
+        unpad_restore = restore_indices[padding_mask == 1]
+        full_packed = full_packed[unpad_restore]
+
+        qkv_dim = mixed_qkv.shape[-1]
+        b_dim = b.shape[-1]
+        full_mixed_qkv = full_packed[:, :qkv_dim].contiguous()
+        full_b = full_packed[:, qkv_dim : qkv_dim + b_dim].contiguous()
+        full_a = full_packed[:, qkv_dim + b_dim :].contiguous()
+
+        gdn = self.prefill_gdn
+        full_cu = attn_meta.full_prefill_cu_seqlens
+        full_conv_meta = attn_meta.full_prefill_conv1d_meta
+
+        kv_cache_tensor: Optional[torch.Tensor] = None
+        seq_size_per_block = 1
+        if kv_cache is not None:
+            kv_cache_tensor = kv_cache.kv_cache_base.reshape(
+                kv_cache.kv_cache_base.shape[0], -1
+            )
+            seq_size_per_block = kv_cache.seq_size_per_block
+
+        conv_states = (
+            gdn._get_conv_states(kv_cache_tensor).transpose(1, 2)
+            if kv_cache_tensor is not None
+            else None
+        )
+        full_mixed_qkv = causal_conv1d_fn(
+            x=full_mixed_qkv.transpose(0, 1),
+            weight=gdn.conv_weights,
+            bias=None,
+            conv_states=conv_states,
+            query_start_loc=full_cu,
+            block_map=attention_inputs.kv_cache_kernel_block_id_device,
+            seq_size_per_block=seq_size_per_block,
+            prefix_lengths=attention_inputs.prefix_lengths_d,
+            metadata=full_conv_meta,
+        ).transpose(0, 1)
+
+        g, beta = fused_gdn_gating(gdn.alog, full_a, full_b, gdn.dt_bias)
+        ssm_states = (
+            gdn._get_ssm_states(kv_cache_tensor)
+            if kv_cache_tensor is not None
+            else None
+        )
+        context_batch_size = attention_inputs.input_lengths.shape[0]
+        initial_states: Optional[torch.Tensor] = None
+        if ssm_states is not None:
+            initial_states = torch.empty(
+                context_batch_size,
+                gdn.local_num_v_heads,
+                gdn.head_v_dim,
+                gdn.head_k_dim,
+                device=full_mixed_qkv.device,
+                dtype=gdn.ssm_state_dtype,
+            )
+            load_initial_state_from_block_map(
+                attention_inputs.prefix_lengths_d,
+                attention_inputs.kv_cache_kernel_block_id_device,
+                ssm_states,
+                initial_states,
+                seq_size_per_block,
+            )
+
+        query, key, value = torch.split(
+            full_mixed_qkv,
+            [
+                gdn.local_num_k_heads * gdn.head_k_dim,
+                gdn.local_num_k_heads * gdn.head_k_dim,
+                gdn.local_num_v_heads * gdn.head_v_dim,
+            ],
+            dim=-1,
+        )
+        query = query.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
+        key = key.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
+        value = value.view(1, -1, gdn.local_num_v_heads, gdn.head_v_dim)
+
+        attn_out, h, final_state = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            initial_state=initial_states,
+            output_final_state=True,
+            cu_seqlens=full_cu,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+        if ssm_states is not None:
+            store_ssm_state_to_block_map(
+                h,
+                final_state,
+                attention_inputs.prefix_lengths_d,
+                full_cu,
+                attention_inputs.kv_cache_kernel_block_id_device,
+                ssm_states,
+                seq_size_per_block,
+                chunk_size=64,
+            )
+
+        if kv_cache is not None and attn_meta.cp_write_cache_store_impl is not None:
+            attn_meta.cp_write_cache_store_impl(kv_cache)
+
+        full_attn_out = attn_out.squeeze_(0)
+
+        n_local = z.shape[0]
+        local_attn_out = torch.zeros(
+            n_local,
+            *full_attn_out.shape[1:],
+            device=full_attn_out.device,
+            dtype=full_attn_out.dtype,
+        )
+        valid_mask = attn_meta.cp_local_valid_mask
+        local_attn_out[valid_mask] = full_attn_out[attn_meta.cp_local_extract_indices]
+
+        local_attn_out = self.norm(
+            local_attn_out.reshape(-1, self.head_v_dim),
+            z.reshape(-1, self.head_v_dim),
+        )
+        local_attn_out = local_attn_out.reshape(
+            -1, self.local_num_v_heads * self.head_v_dim
+        )
+        local_attn_out = self.out_proj(local_attn_out)
+        return local_attn_out
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -546,6 +707,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             attention_inputs.is_target_verify
             or not attention_inputs.is_prefill
             or attn_meta.get_prefill_conv1d_meta() is not None
+            or attn_meta.is_cp_linear_attn
         ), "prefill_conv1d_meta is required for prefill"
         projected_states_qkvz = self.in_proj_qkvz(hidden_states)
         projected_states_ba = self.in_proj_ba(hidden_states)
@@ -553,6 +715,10 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             projected_states_qkvz, projected_states_ba
         )
         if attention_inputs.is_prefill and not attn_meta.is_target_verify:
+            if attn_meta.is_cp_linear_attn:
+                return self._forward_cp_prefill(
+                    mixed_qkv, z, b, a, attention_inputs, kv_cache, attn_meta
+                )
             attn_output = self.prefill_gdn(
                 mixed_qkv, b, a, attention_inputs, kv_cache, attn_meta
             )
@@ -703,6 +869,63 @@ class Qwen3NextModel(GptModelBase):
             weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
         )
 
+    def _build_cp_linear_attn_metadata(
+        self,
+        attention_inputs: PyAttentionInputs,
+        device: torch.device,
+    ) -> tuple[
+        Optional[CausalConv1dMetadata],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+    ]:
+        """Precompute metadata for CP linear attention (per-layer all-gather path).
+
+        Returns (full_conv1d_meta, full_cu_seqlens, restore_indices,
+                 local_extract_indices, local_valid_mask).
+        """
+        cp_info = attention_inputs.context_parallel_info
+        if cp_info is None:
+            return None, None, None, None, None
+
+        cp_size = self.parallelism_config.tp_size
+        cp_rank = self.parallelism_config.tp_rank
+
+        full_new_lengths = cp_info.prefill_actual_input_lengths_cpu
+        full_cu = torch.zeros(
+            full_new_lengths.shape[0] + 1, dtype=torch.int32, device=device
+        )
+        full_cu[1:] = full_new_lengths.cumsum(0).to(device)
+        full_conv1d_meta = prepare_causal_conv1d_metadata(
+            query_start_loc=full_cu, device=device
+        )
+
+        restore_indices = cp_info.prefill_qkv_restore_indice
+        padding_mask = cp_info.prefill_qkv_padding_mask
+        unpad_restore = restore_indices[padding_mask == 1]
+
+        total_ag = padding_mask.shape[0]
+        local_chunk_total = total_ag // cp_size
+        local_start = cp_rank * local_chunk_total
+
+        inv_restore = torch.full((total_ag,), -1, dtype=torch.long, device=device)
+        inv_restore[unpad_restore.long()] = torch.arange(
+            unpad_restore.shape[0], device=device
+        )
+
+        local_inv = inv_restore[local_start : local_start + local_chunk_total]
+        cp_local_valid_mask = local_inv >= 0
+        cp_local_extract_indices = local_inv[cp_local_valid_mask]
+
+        return (
+            full_conv1d_meta,
+            full_cu,
+            restore_indices,
+            cp_local_extract_indices,
+            cp_local_valid_mask,
+        )
+
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         input_ids: torch.Tensor = inputs.input_ids
         inputs_embeds = self.embed_tokens(input_ids)
@@ -711,14 +934,51 @@ class Qwen3NextModel(GptModelBase):
         attention_inputs: PyAttentionInputs = inputs.attention_inputs
         prefill_conv1d_meta = None
         is_target_verify = attention_inputs.is_target_verify
-        if attention_inputs.is_prefill and not is_target_verify:
-            cu_seqlen_without_padding = attention_inputs.cu_seqlens
-            prefill_conv1d_meta = prepare_causal_conv1d_metadata(
-                query_start_loc=cu_seqlen_without_padding,
-                device=hidden_states.device,
-            )
+        is_cp = self.parallelism_config.prefill_cp_config.is_enabled()
 
-        attn_meta = Qwen3NextMetadata(prefill_conv1d_meta, is_target_verify)
+        full_prefill_conv1d_meta = None
+        full_prefill_cu_seqlens = None
+        cp_restore_indices = None
+        cp_local_extract_indices = None
+        cp_local_valid_mask = None
+        cp_write_cache_store_impl = None
+
+        if attention_inputs.is_prefill and not is_target_verify:
+            if is_cp:
+                (
+                    full_prefill_conv1d_meta,
+                    full_prefill_cu_seqlens,
+                    cp_restore_indices,
+                    cp_local_extract_indices,
+                    cp_local_valid_mask,
+                ) = self._build_cp_linear_attn_metadata(
+                    attention_inputs, hidden_states.device
+                )
+                if attention_inputs.cache_store_inputs:
+                    cp_info = attention_inputs.context_parallel_info
+                    cp_write_cache_store_impl = WriteCacheStoreOp(
+                        cp_info.prefill_actual_input_lengths_cpu,
+                        attention_inputs.prefix_lengths,
+                        attention_inputs.kv_cache_block_id_host,
+                        attention_inputs.cache_store_inputs,
+                    )
+            else:
+                cu_seqlen_without_padding = attention_inputs.cu_seqlens
+                prefill_conv1d_meta = prepare_causal_conv1d_metadata(
+                    query_start_loc=cu_seqlen_without_padding,
+                    device=hidden_states.device,
+                )
+
+        attn_meta = Qwen3NextMetadata(
+            prefill_conv1d_meta=prefill_conv1d_meta,
+            is_target_verify=is_target_verify,
+            full_prefill_conv1d_meta=full_prefill_conv1d_meta,
+            full_prefill_cu_seqlens=full_prefill_cu_seqlens,
+            cp_restore_indices=cp_restore_indices,
+            cp_local_extract_indices=cp_local_extract_indices,
+            cp_local_valid_mask=cp_local_valid_mask,
+            cp_write_cache_store_impl=cp_write_cache_store_impl,
+        )
 
         # qwen3_next model has only one full group (group 0): use fmha_impl from input param
         # if there is a model with more than 1 full groups,

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -550,6 +550,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # b,a should be contiguous for fused_gdn_gating
         return mixed_qkv, z, b, a
 
+    # TODO: extract shared conv1d/FLA/ssm-state logic with Qwen3NextGatedDeltaNetPrefill
+    # to eliminate duplication
     def _forward_cp_prefill(
         self,
         mixed_qkv: torch.Tensor,
@@ -889,6 +891,7 @@ class Qwen3NextModel(GptModelBase):
         if cp_info is None:
             return None, None, None, None, None
 
+        # In CP mode the TP group is repurposed as the CP group, so tp_size == cp_size.
         cp_size = self.parallelism_config.tp_size
         cp_rank = self.parallelism_config.tp_rank
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
@@ -64,3 +64,15 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20'},
 )
+
+py_test(
+    name = "test_cp_linear_attn",
+    srcs = ["test_cp_linear_attn.py"],
+    deps = py_test_deps + [":cp_test_utils"] + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["manual"],
+    exec_properties = {'gpu': 'H20'},
+)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
@@ -1,0 +1,364 @@
+"""
+Unit tests for CP linear attention (GatedDeltaNet) per-layer all-gather path.
+
+Tests:
+  1. Index math: cp_local_extract_indices correctly maps zigzag positions
+  2. Full forward: single-rank mock verifies CP output matches non-CP reference
+"""
+
+import contextlib
+import logging
+import math
+import unittest
+from typing import List
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
+    build_cp_attn_inputs,
+    build_padding_mask,
+    build_restore_indices,
+    compute_rank_positions,
+    zigzag_positions_for_rank,
+)
+from rtp_llm.models_py.triton_kernels.causal_conv1d import (
+    prepare_causal_conv1d_metadata,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+class _AttnInputsWrapper:
+    """Thin wrapper to override readonly pybind11 attributes for testing."""
+
+    def __init__(self, wrapped, overrides: dict):
+        object.__setattr__(self, "_wrapped", wrapped)
+        object.__setattr__(self, "_overrides", overrides)
+
+    def __getattr__(self, name):
+        overrides = object.__getattribute__(self, "_overrides")
+        if name in overrides:
+            return overrides[name]
+        return getattr(object.__getattribute__(self, "_wrapped"), name)
+
+    def __setattr__(self, name, value):
+        try:
+            setattr(object.__getattribute__(self, "_wrapped"), name, value)
+        except AttributeError:
+            object.__getattribute__(self, "_overrides")[name] = value
+
+
+def _add_device_tensors(inputs, device: torch.device):
+    """Wrap PyAttentionInputs with device tensors that C++ normally creates."""
+    return _AttnInputsWrapper(
+        inputs,
+        {
+            "prefix_lengths_d": inputs.prefix_lengths.to(device),
+            "input_lengths_d": inputs.input_lengths.to(device),
+        },
+    )
+
+
+class TestCPLinearAttnIndexMath(unittest.TestCase):
+    """Verify that _build_cp_linear_attn_metadata produces correct extract indices."""
+
+    def _build_indices(
+        self,
+        sequence_lengths: List[int],
+        cp_size: int,
+        cp_rank: int,
+        device: torch.device,
+    ):
+        """Reproduce the index construction from Qwen3NextModel._build_cp_linear_attn_metadata."""
+        cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
+        restore_indices = build_restore_indices(cp_chunk_lengths, cp_size).to(device)
+        padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(device)
+        unpad_restore = restore_indices[padding_mask == 1]
+
+        total_ag = padding_mask.shape[0]
+        local_chunk_total = total_ag // cp_size
+        local_start = cp_rank * local_chunk_total
+        local_end = local_start + local_chunk_total
+
+        inv_restore = torch.empty(total_ag, dtype=torch.long, device=device)
+        inv_restore.fill_(-1)
+        inv_restore[unpad_restore.long()] = torch.arange(
+            unpad_restore.shape[0], device=device
+        )
+
+        local_mask = padding_mask[local_start:local_end]
+        local_ag_positions = torch.arange(local_start, local_end, device=device)[
+            local_mask == 1
+        ]
+        return inv_restore[local_ag_positions]
+
+    def test_single_seq_cp2_rank0(self):
+        device = torch.device("cpu")
+        seq_lengths = [16]
+        cp_size, cp_rank = 2, 0
+        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
+        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
+        self.assertEqual(idx.tolist(), expected)
+
+    def test_single_seq_cp2_rank1(self):
+        device = torch.device("cpu")
+        seq_lengths = [16]
+        cp_size, cp_rank = 2, 1
+        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
+        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
+        self.assertEqual(idx.tolist(), expected)
+
+    def test_single_seq_cp4(self):
+        device = torch.device("cpu")
+        for rank in range(4):
+            idx = self._build_indices([32], 4, rank, device)
+            expected = zigzag_positions_for_rank(32, 4, rank)
+            self.assertEqual(idx.tolist(), expected, f"rank={rank}")
+
+    def test_multi_batch_cp2(self):
+        device = torch.device("cpu")
+        seq_lengths = [8, 16]
+        cp_size, cp_rank = 2, 0
+        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
+        expected = []
+        offset = 0
+        for sl in seq_lengths:
+            positions = zigzag_positions_for_rank(sl, cp_size, cp_rank)
+            expected.extend([p + offset for p in positions])
+            offset += sl
+        self.assertEqual(idx.tolist(), expected)
+
+    def test_roundtrip_all_ranks_cover_all_tokens(self):
+        """All ranks together should cover every token exactly once."""
+        device = torch.device("cpu")
+        seq_lengths = [16, 32]
+        cp_size = 2
+        all_indices = []
+        for rank in range(cp_size):
+            idx = self._build_indices(seq_lengths, cp_size, rank, device)
+            all_indices.extend(idx.tolist())
+        total = sum(seq_lengths)
+        self.assertEqual(sorted(all_indices), list(range(total)))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestCPLinearAttnForward(unittest.TestCase):
+    """Verify that CP GatedDeltaNet forward matches non-CP reference on a single GPU."""
+
+    def setUp(self):
+        self.device = torch.device("cuda")
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+    def _run_cp_vs_nocp(
+        self,
+        sequence_lengths: List[int],
+        cp_size: int = 2,
+        cp_rank: int = 0,
+        num_k_heads: int = 4,
+        num_v_heads: int = 4,
+        head_k_dim: int = 64,
+        head_v_dim: int = 64,
+        hidden_size: int = 256,
+        conv_kernel_dim: int = 4,
+    ):
+        """Test that CP linear attn forward matches non-CP on the same data."""
+        from rtp_llm.models_py.model_desc.qwen3_next import (
+            Qwen3NextGatedDeltaNet,
+            Qwen3NextMetadata,
+        )
+        from rtp_llm.models_py.triton_kernels.causal_conv1d import (
+            prepare_causal_conv1d_metadata,
+        )
+        from rtp_llm.ops import DataType, LinearAttentionConfig, ParallelismConfig
+        from rtp_llm.ops.compute_ops import PyAttentionInputs, PyContextParallelParams
+
+        assert all(sl % (cp_size * 2) == 0 for sl in sequence_lengths)
+        cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
+        total_tokens = sum(sequence_lengths)
+        batch_size = len(sequence_lengths)
+
+        linear_cfg = LinearAttentionConfig()
+        linear_cfg.linear_num_key_heads = num_k_heads
+        linear_cfg.linear_num_value_heads = num_v_heads
+        linear_cfg.linear_key_head_dim = head_k_dim
+        linear_cfg.linear_value_head_dim = head_v_dim
+        linear_cfg.linear_conv_kernel_dim = conv_kernel_dim
+        linear_cfg.ssm_state_dtype = DataType.TYPE_BF16
+        linear_cfg.conv_state_dtype = DataType.TYPE_BF16
+
+        par_cfg = ParallelismConfig()
+        par_cfg.tp_size = 1
+        par_cfg.tp_rank = 0
+
+        qkv_dim = head_k_dim * num_k_heads * 2 + head_v_dim * num_v_heads
+        z_dim = head_v_dim * num_v_heads
+        qkvz_dim = qkv_dim + z_dim
+        ba_dim = num_v_heads * 2
+
+        torch.manual_seed(123)
+        conv_w = torch.randn(
+            qkv_dim, 1, conv_kernel_dim, device=self.device, dtype=torch.bfloat16
+        )
+        dt_b = torch.randn(num_v_heads, device=self.device, dtype=torch.bfloat16)
+        alog = torch.randn(num_v_heads, device=self.device, dtype=torch.bfloat16)
+        norm_w = torch.randn(head_v_dim, device=self.device, dtype=torch.bfloat16)
+
+        from rtp_llm.utils.model_weight import W
+
+        qkvz_w = torch.randn(
+            hidden_size, qkvz_dim, device=self.device, dtype=torch.bfloat16
+        )
+        ba_w = torch.randn(
+            hidden_size, ba_dim, device=self.device, dtype=torch.bfloat16
+        )
+        out_w = torch.randn(
+            num_v_heads * head_v_dim,
+            hidden_size,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+
+        weights = {
+            W.linear_attn_conv1d_w: conv_w,
+            W.linear_attn_dt_b: dt_b,
+            W.linear_attn_alog: alog,
+            W.linear_attn_norm_w: norm_w,
+            W.linear_attn_qkvz_w: qkvz_w,
+            W.linear_attn_qkvz_s: None,
+            W.linear_attn_ba_w: ba_w,
+            W.linear_attn_out_w: out_w,
+            W.linear_attn_out_s: None,
+        }
+
+        module = Qwen3NextGatedDeltaNet(
+            linear_cfg, par_cfg, weights, layernorm_eps=1e-6
+        ).to(self.device)
+
+        full_hidden = torch.randn(
+            total_tokens, hidden_size, device=self.device, dtype=torch.bfloat16
+        )
+
+        # --- Non-CP reference ---
+        full_cu = torch.zeros(batch_size + 1, dtype=torch.int32, device=self.device)
+        for i, sl in enumerate(sequence_lengths):
+            full_cu[i + 1] = full_cu[i] + sl
+
+        nocp_inputs = PyAttentionInputs()
+        nocp_inputs.is_prefill = True
+        nocp_inputs.cu_seqlens = full_cu
+        nocp_inputs.input_lengths = torch.tensor(
+            sequence_lengths, dtype=torch.int32, device="cpu"
+        )
+        nocp_inputs.prefix_lengths = torch.zeros(
+            batch_size, dtype=torch.int32, device="cpu"
+        )
+        nocp_inputs.context_parallel_info = None
+        nocp_inputs = _add_device_tensors(nocp_inputs, self.device)
+
+        nocp_conv_meta = prepare_causal_conv1d_metadata(
+            query_start_loc=full_cu, device=self.device
+        )
+        nocp_meta = Qwen3NextMetadata(prefill_conv1d_meta=nocp_conv_meta)
+
+        with torch.no_grad():
+            ref_output = module(full_hidden, None, None, nocp_inputs, nocp_meta)
+
+        # --- CP path (mocked all_gather) ---
+        all_rank_pos = compute_rank_positions(sequence_lengths, cp_size)
+        rank_positions = all_rank_pos[cp_rank]
+        rank_idx = torch.tensor(rank_positions, device=self.device)
+        local_hidden = full_hidden[rank_idx].contiguous()
+
+        cp_attn_inputs = build_cp_attn_inputs(
+            sequence_lengths,
+            cp_chunk_lengths,
+            cp_size,
+            tokens_per_block=16,
+            device=self.device,
+        )
+        cp_attn_inputs = _add_device_tensors(cp_attn_inputs, self.device)
+
+        all_rank_packed: List[torch.Tensor] = []
+        with torch.no_grad():
+            for r in range(cp_size):
+                r_pos = torch.tensor(all_rank_pos[r], device=self.device)
+                r_hidden = full_hidden[r_pos]
+                r_qkvz = module.in_proj_qkvz(r_hidden)
+                r_ba = module.in_proj_ba(r_hidden)
+                r_mixed_qkv, r_z, r_b, r_a = module.fix_query_key_value_ordering(
+                    r_qkvz, r_ba
+                )
+                all_rank_packed.append(torch.cat([r_mixed_qkv, r_b, r_a], dim=-1))
+
+        cp_info = cp_attn_inputs.context_parallel_info
+        restore_indices = cp_info.prefill_qkv_restore_indice
+        padding_mask = cp_info.prefill_qkv_padding_mask
+        unpad_restore = restore_indices[padding_mask == 1]
+
+        total_ag = padding_mask.shape[0]
+        local_chunk_total = total_ag // cp_size
+        local_start = cp_rank * local_chunk_total
+        local_end = local_start + local_chunk_total
+
+        inv_restore = torch.empty(total_ag, dtype=torch.long, device=self.device)
+        inv_restore.fill_(-1)
+        inv_restore[unpad_restore.long()] = torch.arange(
+            unpad_restore.shape[0], device=self.device
+        )
+        local_mask = padding_mask[local_start:local_end]
+        local_ag_positions = torch.arange(local_start, local_end, device=self.device)[
+            local_mask == 1
+        ]
+        cp_local_extract_idx = inv_restore[local_ag_positions]
+
+        actual_lengths = torch.tensor(sequence_lengths, dtype=torch.int32)
+        full_cu_from_actual = torch.zeros(
+            batch_size + 1, dtype=torch.int32, device=self.device
+        )
+        full_cu_from_actual[1:] = torch.tensor(
+            sequence_lengths, device=self.device
+        ).cumsum(0)
+
+        full_conv_meta = prepare_causal_conv1d_metadata(
+            query_start_loc=full_cu_from_actual, device=self.device
+        )
+
+        cp_meta = Qwen3NextMetadata(
+            full_prefill_conv1d_meta=full_conv_meta,
+            full_prefill_cu_seqlens=full_cu_from_actual,
+            cp_restore_indices=restore_indices,
+            cp_local_extract_indices=cp_local_extract_idx,
+        )
+
+        def mock_ag(tensor, group=None):
+            return torch.cat(all_rank_packed, dim=0)
+
+        AG_MODULE = "rtp_llm.models_py.model_desc.qwen3_next"
+        with patch(f"{AG_MODULE}.all_gather", side_effect=mock_ag):
+            with torch.no_grad():
+                cp_output = module(local_hidden, None, None, cp_attn_inputs, cp_meta)
+
+        ref_local = ref_output[rank_idx]
+        diff = (cp_output.float() - ref_local.float()).abs()
+        max_diff = diff.max().item()
+        mean_diff = diff.mean().item()
+        logging.info(f"max_diff={max_diff:.6f}  mean_diff={mean_diff:.6f}")
+        self.assertTrue(
+            torch.allclose(cp_output.float(), ref_local.float(), rtol=1e-2, atol=1e-2),
+            f"CP vs non-CP mismatch: max_diff={max_diff}, mean_diff={mean_diff}",
+        )
+
+    def test_single_seq_cp2(self):
+        self._run_cp_vs_nocp(sequence_lengths=[32], cp_size=2, cp_rank=0)
+
+    def test_single_seq_cp2_rank1(self):
+        self._run_cp_vs_nocp(sequence_lengths=[32], cp_size=2, cp_rank=1)
+
+    def test_multi_batch_cp2(self):
+        self._run_cp_vs_nocp(sequence_lengths=[16, 32], cp_size=2, cp_rank=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
@@ -307,11 +307,9 @@ class TestCPLinearAttnForward(unittest.TestCase):
         inv_restore[unpad_restore.long()] = torch.arange(
             unpad_restore.shape[0], device=self.device
         )
-        local_mask = padding_mask[local_start:local_end]
-        local_ag_positions = torch.arange(local_start, local_end, device=self.device)[
-            local_mask == 1
-        ]
-        cp_local_extract_idx = inv_restore[local_ag_positions]
+        local_inv = inv_restore[local_start:local_end]
+        cp_local_valid_mask = local_inv >= 0
+        cp_local_extract_idx = local_inv[cp_local_valid_mask]
 
         actual_lengths = torch.tensor(sequence_lengths, dtype=torch.int32)
         full_cu_from_actual = torch.zeros(
@@ -330,6 +328,7 @@ class TestCPLinearAttnForward(unittest.TestCase):
             full_prefill_cu_seqlens=full_cu_from_actual,
             cp_restore_indices=restore_indices,
             cp_local_extract_indices=cp_local_extract_idx,
+            cp_local_valid_mask=cp_local_valid_mask,
         )
 
         def mock_ag(tensor, group=None):


### PR DESCRIPTION

## 背景

Qwen3.5 使用混合注意力架构：每 `full_attention_interval` 层（如每4层）中有1层 full GQA attention，其余为 linear attention（GatedDeltaNet）。现有 CP 仅支持 full attention 的 zigzag 分片 + all-gather K/V。Linear attention 在 zigzag 下不可用，因为：

- conv1d 依赖连续 token 历史
- FLA 递归状态依赖所有先前 token 的顺序
- zigzag 给每个 rank 的是非连续、非有序的 token 子集

## 整体架构：Hybrid Attention + CP

```
 Qwen3.5 Layer Structure (full_attention_interval=4)
 ┌──────────────────────────────────────────────────────────────────┐
 │  Layer 0 [Linear]  →  Layer 1 [Linear]  →  Layer 2 [Linear]    │
 │       ↓                    ↓                    ↓               │
 │   GatedDeltaNet        GatedDeltaNet        GatedDeltaNet       │
 │   (conv1d + FLA)       (conv1d + FLA)       (conv1d + FLA)      │
 │       ↓                    ↓                    ↓               │
 │     MoE FFN              MoE FFN              MoE FFN           │
 ├──────────────────────────────────────────────────────────────────┤
 │  Layer 3 [Full Attention]                                       │
 │       ↓                                                         │
 │   GQA (FlashAttn + CP)                                          │
 │       ↓                                                         │
 │     MoE FFN                                                     │
 ├──────────────────────────────────────────────────────────────────┤
 │  Layer 4-6 [Linear]  →  Layer 7 [Full]  →  ...  (×10 groups)   │
 └──────────────────────────────────────────────────────────────────┘
   共 40 层: 30 × Linear + 10 × Full Attention
```

## 当前实现：方案 A — All-Gather（zigzag 分区）

每个 linear attention 层：all-gather projected states -> 重排为原始顺序 -> 全序列冗余计算 -> 提取本 rank 的 zigzag 部分。GQA 层使用已有的 zigzag CP。

```
                          Rank 0                                      Rank 1
                  (zigzag tokens: 0,3,4,7,...)              (zigzag tokens: 1,2,5,6,...)

                  ┌─────────────────────┐                    ┌─────────────────────┐
                  │   hidden_states     │                    │   hidden_states     │
                  │   [local_N, 2048]   │                    │   [local_N, 2048]   │
                  └────────┬────────────┘                    └────────┬────────────┘
                           │                                          │
                    LOCAL COMPUTE                               LOCAL COMPUTE
                   ┌───────┴───────┐                         ┌───────┴───────┐
                   │  in_proj_qkvz │  [local_N, 12288]       │  in_proj_qkvz │
                   │  in_proj_ba   │  [local_N, 64]          │  in_proj_ba   │
                   └───────┬───────┘                         └───────┬───────┘
                           │ split                                    │ split
                   ┌───────┴───────┐                         ┌───────┴───────┐
                   │ qkv [N, 8192] │                         │ qkv [N, 8192] │
                   │ z   [N, 4096] │ (stays local)           │ z   [N, 4096] │
                   │ b,a [N, 64]   │                         │ b,a [N, 64]   │
                   └───────┬───────┘                         └───────┬───────┘
                           │                                          │
                           │  pack(qkv, b, a) = [local_N, 8256]      │
                           │                                          │
                           ▼                                          ▼
                ┌──────────────────────────────────────────────────────────────┐
                │              ALL-GATHER  (8256 dim per token)                │
                │              通信量: local_N × 8256 × 2 bytes               │
                └──────────────────────┬───────────────────────────────────────┘
                                       │
                              RESTORE ORDER (zigzag → original)
                                       │
                                       ▼
                        ┌──────────────────────────┐
                        │  full_qkv  [full_N, 8192]│  (BOTH ranks have identical copy)
                        │  full_b,a  [full_N, 64]  │
                        └────────────┬─────────────┘
                                     │
                              FULL-SEQ COMPUTE (redundant on both ranks)
                             ┌───────┴───────┐
                             │   causal_conv1d│
                             │   chunk_FLA    │
                             └───────┴───────┘
                                     │
                              EXTRACT local zigzag tokens
                                     │
                           ┌─────────┴─────────┐
                    Rank 0 output        Rank 1 output
                    [local_N, v_dim]     [local_N, v_dim]
                           │                    │
                      LOCAL: norm(out, z) + out_proj
                           │                    │
                           ▼                    ▼
                     local output          local output
```

**特点**：实现简单，无需修改 kernel/C++，但通信量 O(N) 且全序列冗余计算。

## TODO：方案 B — KCP 状态合并（连续分区）

[LASP (Linear Attention Sequence Parallelism)](https://arxiv.org/abs/2404.02882) 是最早提出 linear attention CP 的工作，核心思想是将序列分为连续块，每个 rank 处理本地块，通过 **P2P 逐级传递** 递推状态 $\mathbf{S}$。缺点是各 rank 必须串行等待前序 rank 的 state，形成流水线瓶颈。

[KCP (Kimi Context Parallel)](https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/cp/README.md) 是 LASP 思想的优化实现，关键改进在于：不直接传递 $\mathbf{S}$，而是将每个 chunk 的状态变换分解为 **accumulated state $\mathbf{S}_\text{ext}$** 和 **transition matrix $\mathbf{M}$**，通过一次 **all-gather + merge** 替代 P2P 流水线，所有 rank 可以并行计算再同步，消除了串行瓶颈。

两者本质相同：都是连续分区 + 跨 rank 状态传递，但 KCP 的通信模式更适合推理场景（一次 all-gather vs 多步 P2P）。

### 核心思想

基于 delta rule 的 chunkwise 递推公式：

$$\mathbf{S}_{[t+1]} = \mathrm{Diag}(\gamma^C_{[t]}) \mathbf{S}_{[t]} + (\boldsymbol{\Gamma}^{i \to C}_{[t]} \odot \mathbf{K}_{[t]})^\top (\mathbf{U}_{[t]} - \mathbf{W}_{[t]} \mathbf{S}_{[t]})$$

可以分解为：
- **$\mathbf{S}_\text{ext}$**：假设 $\mathbf{S}_0 = 0$ 时本地 chunk 的累积状态（$d_k \times d_v$）
- **$\mathbf{M}$**：transition matrix，描述 chunk 对传入状态的变换（$d_k \times d_k$）

$$\mathbf{M}_{[t]} = \mathrm{Diag}(\gamma^C_{[t]}) - (\boldsymbol{\Gamma}^{i \to C}_{[t]} \odot \mathbf{K}_{[t]})^\top \mathbf{W}_{[t]}$$

跨 rank 状态合并：

$$\mathbf{S}_r = \mathbf{M}_{r-1}(\mathbf{M}_{r-2}(\cdots \mathbf{S}_{\text{ext},0} + \mathbf{S}_{\text{ext},1}) + \cdots) + \mathbf{S}_{\text{ext},r-1}$$

### 分区策略

```
 序列: [0, 1, 2, ..., N-1]

 连续分区 (cp_size=2):
   Rank 0: [0, 1, ..., N/2-1]      ← 因果连续
   Rank 1: [N/2, N/2+1, ..., N-1]  ← 因果连续
```

选择连续分区（而非保留 zigzag）的原因：KCP 要求每个 rank 持有因果连续的 token 块。zigzag 虽然"部分连续"（每 rank 持有两段连续子块），但两段之间有因果 gap，需要 virtual chunk 方案处理，实现复杂度高。

GQA 层通过 All-Gather KV 适配连续分区，每个 rank 聚合完整 KV 后用 FlashAttn 计算本地 Q 对应的 output。GQA 层数远少于 Linear 层（10 vs 30），总体可接受。

### 数据流

```
                     Rank 0 (tokens [0..N/2-1])              Rank 1 (tokens [N/2..N-1])

                     ┌─────────────────────┐                 ┌─────────────────────┐
                     │  hidden [N/2, 2048]  │                 │  hidden [N/2, 2048]  │
                     └────────┬────────────┘                 └────────┬────────────┘
                              │                                       │
  ─ ─ ─ ─ ─ ─ ─ ─ ─ LINEAR ATTENTION 层 ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
                              │                                       │
                       LOCAL COMPUTE                            LOCAL COMPUTE
                      ┌───────┴───────┐                       ┌───────┴───────┐
                      │  in_proj_qkvz │                       │  in_proj_qkvz │
                      │  in_proj_ba   │                       │  in_proj_ba   │
                      │  causal_conv1d│ (local chunk)         │  causal_conv1d│ (+ conv state from Rank 0)
                      └───────┬───────┘                       └───────┬───────┘
                              │                                       │
                      chunk_gated_delta_rule                  chunk_gated_delta_rule
                      (initial_state = 0)                     (initial_state = 0)
                              │                                       │
                        ┌─────┴─────┐                           ┌─────┴─────┐
                        │ S_ext_0   │                           │ S_ext_1   │
                        │ [K, V]    │                           │ [K, V]    │
                        │ M_0       │                           │ M_1       │
                        │ [K, K]    │                           │ [K, K]    │
                        └─────┬─────┘                           └─────┬─────┘
                              │                                       │
                              ├──── ALL-GATHER (S_ext, M) ────────────┤
                              │     通信量: ~30 MB total              │
                              ▼                                       ▼
                        rank=0: S_init=0                       merge(S_ext_0, M_0):
                        output 已正确                            S_init_1 = M_0 @ 0 + S_ext_0
                                                                       │
                                                                recompute output
                                                                with correct S_init_1
                              │                                       │
                        local output                            local output
                        [N/2, v_dim]                             [N/2, v_dim]
                              │                                       │
                         norm(out, z) + out_proj              norm(out, z) + out_proj
                              │                                       │
  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
                              │                                       │
  ─ ─ ─ ─ ─ ─ ─ ─ ─ FULL ATTENTION 层 ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
                              │                                       │
                      All-Gather KV                           All-Gather KV
                      FlashAttn on full KV                    FlashAttn on full KV
                              │                                       │
  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
```

### 通信量对比（Qwen3.5-35B-A3B, cp_size=2, bf16, 256K seq）

| 方案 | Linear Attn 通信量 | 与 seq_len 关系 | 计算冗余 |
|------|-------------------|----------------|---------|
| A: All-Gather (当前) | 64.9 GB | O(N) | 全序列冗余 |
| **B: KCP + 连续分区** | **0.09 GB** | **O(1)** | **无** |

KCP 每层每 rank 传输：S_ext [8,256,512] ~2MB + M [8,256,256] ~1MB + conv state ~0.06MB ≈ **3MB/层**，30 层合计 ~90MB。

### TODO List:

- [ ] **C++ ContiguousProcessor**：新增 `ProcessorType::CONTIGUOUS`，每 rank 取 `[rank * chunk_size, (rank+1) * chunk_size)` 的连续 token
- [ ] **KCP pre_process**：复用 `chunk_gated_delta_rule_fwd_h` 的状态递推逻辑，额外计算 transition matrix M
- [ ] **KCP merge**：all-gather 后按因果顺序链式合并 $\mathbf{S}_\text{ext}$ 和 $\mathbf{M}$，得到正确 initial_state
- [ ] **Output 修正**：用正确 initial_state 重跑 `chunk_fwd_o`（仅 output pass，不重算 h）
- [ ] **conv1d CP**：rank > 0 从前一 rank 接收 `kernel_size - 1` 个 token 的 conv state（P2P 或 all-gather）
- [ ] **GQA All-Gather KV**：每个 rank all-gather 所有 KV，用本地 Q 做 FlashAttn，无需 zigzag 重排

### 关键约束

- **M 链乘必须在 fp32 下进行**：bf16 累积精度损失过大（upstream KCP 文档明确强调）
- **Rank 0 无需 recompute**：其 initial_state=0 与本地计算一致，output 直接正确
- **prefix cache 兼容**：若有全局 initial_state `S_global`（从 prefix cache 加载），merge 起点从 0 改为 `S_global` 即可（`S_0 = M_0 @ S_global + S_ext_0`），最后一个 rank 的 final_state 即全序列 final_state

### 参考文献
- [Kimi Context Parallel (KCP) README](https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/cp/README.md)
- [LASP: Linear Attention Sequence Parallelism, arXiv:2404.02882](https://arxiv.org/abs/2404.02882)
- [Gated Delta Networks, Yang et al. 2025](https://arxiv.org/abs/2412.06464)