### PR TITLE
feat: add Bazel genrule for FlexLB jar build

### DIFF
--- a/rtp_llm/flexlb/BUILD
+++ b/rtp_llm/flexlb/BUILD
@@ -1,0 +1,16 @@
+genrule(
+    name = "flexlb_jar",
+    srcs = glob(["**"]),
+    outs = ["flexlb-api.jar"],
+    cmd = """
+        set -e
+        OUT=$$(realpath $@)
+        FLEXLB_DIR=$$(dirname $(location mvnw))
+        cd $$FLEXLB_DIR
+        ./mvnw package -DskipTests -q >&2
+        JAR=$$(ls flexlb-api/target/flexlb-api-*.jar | grep -v sources | head -1)
+        cp $$JAR $$OUT
+    """,
+    local = True,
+    visibility = ["//visibility:public"],
+)

--- a/rtp_llm/flexlb/BUILD
+++ b/rtp_llm/flexlb/BUILD
@@ -5,6 +5,16 @@ genrule(
     cmd = """
         set -e
         OUT=$$(realpath $@)
+        # Find Java in known locations if not in PATH
+        if ! command -v java >/dev/null 2>&1; then
+            for d in /opt/taobao/install/ajdk21_*/bin /opt/jdk21/bin /usr/lib/jvm/java-21/bin; do
+                if [ -x "$$d/java" ]; then
+                    export JAVA_HOME=$$(dirname $$d)
+                    export PATH="$$d:$$PATH"
+                    break
+                fi
+            done
+        fi
         FLEXLB_DIR=$$(dirname $(location mvnw))
         cd $$FLEXLB_DIR
         ./mvnw package -DskipTests -q >&2

--- a/rtp_llm/flexlb/BUILD
+++ b/rtp_llm/flexlb/BUILD
@@ -17,7 +17,7 @@ genrule(
         fi
         FLEXLB_DIR=$$(dirname $(location mvnw))
         cd $$FLEXLB_DIR
-        ./mvnw package -DskipTests -q -P opensource >&2
+        ./mvnw package -DskipTests -q -P '!internal' >&2
         JAR=$$(ls flexlb-api/target/flexlb-api-*.jar | grep -v sources | head -1)
         cp $$JAR $$OUT
     """,

--- a/rtp_llm/flexlb/BUILD
+++ b/rtp_llm/flexlb/BUILD
@@ -17,7 +17,7 @@ genrule(
         fi
         FLEXLB_DIR=$$(dirname $(location mvnw))
         cd $$FLEXLB_DIR
-        ./mvnw package -DskipTests -q >&2
+        ./mvnw package -DskipTests -q -P opensource >&2
         JAR=$$(ls flexlb-api/target/flexlb-api-*.jar | grep -v sources | head -1)
         cp $$JAR $$OUT
     """,


### PR DESCRIPTION
## Summary
- Add `rtp_llm/flexlb/BUILD` with a genrule to build FlexLB API jar via Maven
- The genrule searches for Java 21 in known CI paths (`/opt/taobao/install/ajdk21_*/bin`)
- Produces `flexlb-api.jar` for use as a Bazel data dependency in smoke tests

## Changes
- `rtp_llm/flexlb/BUILD`: New genrule `flexlb_jar` that runs `mvnw package` and outputs the jar

## Context
This is needed for the FlexLB integration smoke test (`flexlb_frontend_app_case`) in the internal repo, which depends on `//rtp_llm/flexlb:flexlb_jar`.