### PR TITLE
fix: fix pure tp c10dBroadcast() timeout

### DIFF
--- a/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
@@ -25,7 +25,8 @@ FIFOScheduler::FIFOScheduler(const RuntimeConfig&                   runtime_conf
     max_seq_len_(model_config.max_seq_len),
     max_batch_tokens_size_(runtime_config.fifo_scheduler_config.max_batch_tokens_size),
     max_generate_batch_size_(runtime_config.max_generate_batch_size),
-    need_fill_fake_stream_(parallelism_config.dp_size > 1 && parallelism_config.tp_rank == 0),
+    need_fill_fake_stream_((parallelism_config.dp_size > 1 || parallelism_config.tp_size > 1)
+                           && parallelism_config.tp_rank == 0),
     metrics_reporter_(metrics_reporter) {
     RTP_LLM_LOG_INFO("max_generate_batch_size is [%d], max_batch_tokens_size is [%d]",
                      max_generate_batch_size_,


### PR DESCRIPTION
## 现象
PD 分离 prefill 节点`dp_size=1, tp_size>1`时，引擎启动后长时间无请求会 core dump 在 `NCCL broadcast（tpSyncModelInputs）`。 
## 根因：
  1. Rank 0 在` FIFOScheduler::schedule() `中` cond_.wait() `无限阻塞(need_fill_fake_stream_ 只考虑了 dp>1，没考虑 tp>1）
  2. Rank 1-7 在 step() 中跳过 scheduler 直接进入 `process() → tpSyncModelInputs() → c10dBroadcast() `等待 rank 0
  3. Rank 0 永远不进 process()，rank 1-7 等待超时（c10d ProcessGroupNCCL 默认 DIST_COMM_TIMEOUT）→ core dump
  4. 之前用的是 raw ncclBroadcast(无超时），rank 1-7 只是静默阻塞直到请求到来，不会 core dump。但实际上也是有死锁状态的，只是不表现为crash。
## 修复：
  tp>1 时 scheduler 使用 wait_for(10ms) 代替 wait()，rank 0 每 10ms 返回空 streams → step() 中已有的 streams.empty() && tp_size <= 1 判断确保 rank 0 进入 process() → broadcast skip_run=true → 所有rank 同步返回。