### PR TITLE
feat - optimize gemm weights load logic

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,6 @@
 internal_source/rdma
 open_source
+bazel-github-opensource
+bazel-bin
+bazel-out
+bazel-testlogs

--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -933,11 +933,13 @@ class RocmImpl(GpuImpl):
         ]:
             if self.py_env_configs.py_hw_kernel_config.use_swizzleA:
                 if weight.dtype != torch.float8_e4m3fn:
-                    weight = swizzle_tensor(weight.t(), False).t()
+                    weight = swizzle_tensor(weight, False).t()
                 else:
                     weight = swizzle_tensor(weight, weight.dtype != torch.float8_e4m3fn)
             elif weight.dtype == torch.float8_e4m3fn:
                 weight = self.shuffle_gemm_weight(weight)
+            else:
+                weight = weight.t().contiguous()
 
         return weight
 

--- a/rtp_llm/model_loader/dynamic_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/dynamic_fp8_quant_weight.py
@@ -180,7 +180,6 @@ class LoadQuantDynamicPerTensorFp8Weight(CompositeWeight, QuantWeight):
 
         else:
             quant_kernel, scale = quantize_weight_to_fp8(kernel.get(self.kernel.name))
-            quant_kernel = quant_kernel.T
 
         res = {}
         res = {

--- a/rtp_llm/model_loader/ffn_weight.py
+++ b/rtp_llm/model_loader/ffn_weight.py
@@ -43,9 +43,10 @@ class FfnAtomicWeight(AtomicWeight):
 
     @property
     def need_padding(self) -> bool:
-        if isinstance(
-            self.process_fun, functools.partial
-        ) and self.process_fun.func.__name__ in ["transpose_pad", "pad"]:
+        if (
+            isinstance(self.process_fun, functools.partial)
+            and self.process_fun.func.__name__ == "pad"
+        ):
             return True
         else:
             return False
@@ -63,47 +64,47 @@ def w13_func_wrap(ts: List[torch.Tensor], origin_w1, origin_w3):
     assert len(ts) == w1_size + w3_size
     w1 = origin_w1.process_fun(ts[:w1_size])
     w3 = origin_w3.process_fun(ts[w1_size:])
-    return torch.concat([w1, w3], dim=-1).contiguous()
+    return torch.concat([w1, w3], dim=0).contiguous()
 
 
 def w13_lora_a_func_wrap(
     ts: torch.Tensor, origin_w1: FfnAtomicWeight, origin_w3: FfnAtomicWeight
 ):
     assert origin_w1.lora_a_process_func and origin_w3.lora_a_process_func
-    w1, w3 = torch.chunk(ts, 2, dim=-1)
+    w1, w3 = torch.chunk(ts, 2, dim=0)
     w1 = origin_w1.lora_a_process_func(w1)
     w3 = origin_w3.lora_a_process_func(w3)
-    return torch.concat([w1, w3], dim=-1).contiguous()
+    return torch.concat([w1, w3], dim=0).contiguous()
 
 
 def w13_lora_b_func_wrap(
     ts: torch.Tensor, origin_w1: FfnAtomicWeight, origin_w3: FfnAtomicWeight
 ):
     assert origin_w1.lora_b_process_func and origin_w3.lora_b_process_func
-    w1, w3 = torch.chunk(ts, 2, dim=-1)
+    w1, w3 = torch.chunk(ts, 2, dim=0)
     w1 = origin_w1.lora_b_process_func(w1)
     w3 = origin_w3.lora_b_process_func(w3)
-    return torch.concat([w1, w3], dim=-1).contiguous()
+    return torch.concat([w1, w3], dim=0).contiguous()
 
 
 def w13_lora_a_split_func_wrap(
     ts: torch.Tensor, origin_w1: FfnAtomicWeight, origin_w3: FfnAtomicWeight
 ):
     assert origin_w1.lora_a_split_func and origin_w3.lora_a_split_func
-    w1, w3 = torch.chunk(ts, 2, dim=-1)
+    w1, w3 = torch.chunk(ts, 2, dim=0)
     w1 = origin_w1.lora_a_split_func(w1)
     w3 = origin_w3.lora_a_split_func(w3)
-    return torch.concat([w1, w3], dim=-1).contiguous()
+    return torch.concat([w1, w3], dim=0).contiguous()
 
 
 def w13_lora_b_split_func_wrap(
     ts: torch.Tensor, origin_w1: FfnAtomicWeight, origin_w3: FfnAtomicWeight
 ):
     assert origin_w1.lora_b_split_func and origin_w3.lora_b_split_func
-    w1, w3 = torch.chunk(ts, 2, dim=-1)
+    w1, w3 = torch.chunk(ts, 2, dim=0)
     w1 = origin_w1.lora_b_split_func(w1)
     w3 = origin_w3.lora_b_split_func(w3)
-    return torch.concat([w1, w3], dim=-1).contiguous()
+    return torch.concat([w1, w3], dim=0).contiguous()
 
 
 def fix_merge_w13(sub_weight_dict: Dict[str, FfnAtomicWeight]):

--- a/rtp_llm/model_loader/group_wise_quant_weight.py
+++ b/rtp_llm/model_loader/group_wise_quant_weight.py
@@ -18,11 +18,11 @@ from rtp_llm.utils.model_weight import (
     W,
     identity,
     merge_qkv_hf,
+    merge_qkv_hf_col,
     pad,
     pad_w13,
     stack_,
     stack_moe_w1,
-    transpose,
 )
 from rtp_llm.utils.util import check_with_info
 
@@ -54,33 +54,33 @@ def get_qkv_quant_weight_info(
             src_weight.create_from(
                 W.attn_qkv_w,
                 [
-                    CkptWeightInfo(q_name + QW_SUFFIX, transpose),
-                    CkptWeightInfo(k_name + QW_SUFFIX, transpose),
-                    CkptWeightInfo(v_name + QW_SUFFIX, transpose),
+                    CkptWeightInfo(q_name + QW_SUFFIX, identity),
+                    CkptWeightInfo(k_name + QW_SUFFIX, identity),
+                    CkptWeightInfo(v_name + QW_SUFFIX, identity),
                 ],
-                functools.partial(merge_qkv_hf),
+                functools.partial(merge_qkv_hf_col),
                 data_type=torch.int32,
                 config=src_weight.config,
             ),
             src_weight.create_from(
                 W.attn_qkv_z,
                 [
-                    CkptWeightInfo(q_name + QZ_SUFFIX, transpose),
-                    CkptWeightInfo(k_name + QZ_SUFFIX, transpose),
-                    CkptWeightInfo(v_name + QZ_SUFFIX, transpose),
+                    CkptWeightInfo(q_name + QZ_SUFFIX, identity),
+                    CkptWeightInfo(k_name + QZ_SUFFIX, identity),
+                    CkptWeightInfo(v_name + QZ_SUFFIX, identity),
                 ],
-                functools.partial(merge_qkv_hf),
+                functools.partial(merge_qkv_hf_col),
                 data_type=torch.int32,
                 config=src_weight.config,
             ),
             src_weight.create_from(
                 W.attn_qkv_s,
                 [
-                    CkptWeightInfo(q_name + QS_SUFFIX, transpose),
-                    CkptWeightInfo(k_name + QS_SUFFIX, transpose),
-                    CkptWeightInfo(v_name + QS_SUFFIX, transpose),
+                    CkptWeightInfo(q_name + QS_SUFFIX, identity),
+                    CkptWeightInfo(k_name + QS_SUFFIX, identity),
+                    CkptWeightInfo(v_name + QS_SUFFIX, identity),
                 ],
-                functools.partial(merge_qkv_hf),
+                functools.partial(merge_qkv_hf_col),
                 config=src_weight.config,
             ),
         ]
@@ -149,9 +149,7 @@ def get_ffn_quant_weight_info(
                 [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
                 functools.partial(
                     pad,
-                    align_size=(
-                        align_size // pad_div if is_gptq else align_size
-                    ),
+                    align_size=(align_size // pad_div if is_gptq else align_size),
                     dim=0,
                 ),
                 data_type=torch.int32,
@@ -160,18 +158,14 @@ def get_ffn_quant_weight_info(
             FfnAtomicWeight(
                 W.ffn_z2,
                 [CkptWeightInfo(w_name + QZ_SUFFIX, identity)],
-                functools.partial(
-                    pad, align_size=align_size // group_size, dim=0
-                ),
+                functools.partial(pad, align_size=align_size // group_size, dim=0),
                 data_type=torch.int32,
                 config=src_weight.config,
             ),
             FfnAtomicWeight(
                 W.ffn_s2,
                 [CkptWeightInfo(w_name + QS_SUFFIX, identity)],
-                functools.partial(
-                    pad, align_size=align_size // group_size, dim=0
-                ),
+                functools.partial(pad, align_size=align_size // group_size, dim=0),
                 config=src_weight.config,
             ),
             act_w,
@@ -188,21 +182,21 @@ def get_ffn_quant_weight_info(
         return [
             MoeAtomicWeight(
                 w,
-                [CkptWeightInfo(name + QW_SUFFIX, transpose) for name in w_name],
+                [CkptWeightInfo(name + QW_SUFFIX, identity) for name in w_name],
                 stack,
                 data_type=torch.int32,
                 config=src_weight.config,
             ),
             MoeAtomicWeight(
                 z,
-                [CkptWeightInfo(name + QZ_SUFFIX, transpose) for name in w_name],
+                [CkptWeightInfo(name + QZ_SUFFIX, identity) for name in w_name],
                 stack,
                 data_type=torch.int32,
                 config=src_weight.config,
             ),
             MoeAtomicWeight(
                 s,
-                [CkptWeightInfo(name + QS_SUFFIX, transpose) for name in w_name],
+                [CkptWeightInfo(name + QS_SUFFIX, identity) for name in w_name],
                 stack,
                 config=src_weight.config,
             ),
@@ -221,9 +215,7 @@ def get_ffn_quant_weight_info(
                 ],
                 functools.partial(
                     pad_w13,
-                    align_size=(
-                        align_size // pad_div if is_awq else align_size
-                    ),
+                    align_size=(align_size // pad_div if is_awq else align_size),
                     dim=1,
                 ),
                 data_type=torch.int32,
@@ -270,9 +262,7 @@ def get_ffn_quant_weight_info(
                 [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
                 functools.partial(
                     pad,
-                    align_size=(
-                        align_size // pad_div if is_awq else align_size
-                    ),
+                    align_size=(align_size // pad_div if is_awq else align_size),
                     dim=1,
                 ),
                 data_type=torch.int32,
@@ -292,9 +282,7 @@ def get_ffn_quant_weight_info(
             FfnAtomicWeight(
                 s,
                 [CkptWeightInfo(w_name + QS_SUFFIX, identity)],
-                functools.partial(
-                    pad, align_size=align_size, dim=1
-                ),
+                functools.partial(pad, align_size=align_size, dim=1),
                 config=src_weight.config,
             ),
             act_w,

--- a/rtp_llm/model_loader/linear_attn_weight.py
+++ b/rtp_llm/model_loader/linear_attn_weight.py
@@ -16,7 +16,7 @@ class LinearAttnConfig(object):
         self.linear_value_head_dim = linear_attention_config.linear_value_head_dim
 
 
-# qkvz layout: [hidden_size, head_k, xx] -> [hidden, local_head_k, xx]
+# qkvz layout: [head_k * xx, hidden_size] -> [local_head_k * xx, hidden_size]
 def split_qkvz(
     t: torch.Tensor, load_config: LoadConfig, linear_config: LinearAttnConfig
 ) -> torch.Tensor:
@@ -25,7 +25,7 @@ def split_qkvz(
         linear_config.linear_key_head_dim * linear_config.linear_num_key_heads
         + linear_config.linear_value_head_dim * linear_config.linear_num_value_heads
     ) * 2
-    if t.shape[1] == origin_qkvz_size:
+    if t.shape[0] == origin_qkvz_size:
         q, k, v, z = torch.split(
             t,
             [
@@ -36,9 +36,9 @@ def split_qkvz(
                 linear_config.linear_value_head_dim
                 * linear_config.linear_num_value_heads,
             ],
-            dim=1,
+            dim=0,
         )
-    elif t.shape[1] == origin_qkvz_size // BLOCK_SIZE:
+    elif t.shape[0] == origin_qkvz_size // BLOCK_SIZE:
         q, k, v, z = torch.split(
             t,
             [
@@ -55,25 +55,25 @@ def split_qkvz(
                 // BLOCK_SIZE
                 * linear_config.linear_num_value_heads,
             ],
-            dim=1,
+            dim=0,
         )
     else:
         raise ValueError(
             f"Invalid input shape 0 for scale / weight: {t.shape}, expected: {origin_qkvz_size} or {origin_qkvz_size // BLOCK_SIZE}"
         )
-    q = torch.split(q, q.shape[1] // load_config.tp_size, dim=1)[
+    q = torch.split(q, q.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    k = torch.split(k, k.shape[1] // load_config.tp_size, dim=1)[
+    k = torch.split(k, k.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    v = torch.split(v, v.shape[1] // load_config.tp_size, dim=1)[
+    v = torch.split(v, v.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    z = torch.split(z, z.shape[1] // load_config.tp_size, dim=1)[
+    z = torch.split(z, z.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    return torch.cat([q, k, v, z], dim=1)
+    return torch.cat([q, k, v, z], dim=0)
 
 
 def split_qkvz_t(
@@ -83,20 +83,20 @@ def split_qkvz_t(
     return t.transpose(0, 1).contiguous()
 
 
-# ba layout: [hidden_size, head_v + head_v]
+# ba layout: [head_v + head_v, hidden_size]
 def split_ba(
     t: torch.Tensor, load_config: LoadConfig, linear_config: LinearAttnConfig
 ) -> torch.Tensor:
-    pack_head_num = t.shape[1]
+    pack_head_num = t.shape[0]
     assert pack_head_num % 2 == 0, "pack_head_num must be even"
-    b, a = torch.split(t, [pack_head_num // 2, pack_head_num // 2], dim=1)
-    b = b.split(b.shape[1] // load_config.tp_size, dim=1)[
+    b, a = torch.split(t, [pack_head_num // 2, pack_head_num // 2], dim=0)
+    b = b.split(b.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    a = a.split(a.shape[1] // load_config.tp_size, dim=1)[
+    a = a.split(a.shape[0] // load_config.tp_size, dim=0)[
         load_config.tp_rank
     ].contiguous()
-    return torch.cat([b, a], dim=1)
+    return torch.cat([b, a], dim=0)
 
 
 # layout [head_num_v]
@@ -136,16 +136,16 @@ def split_conv1d(
     return torch.cat([q, k, v], dim=0)
 
 
-# weight: [head_num_v * head_size_v, hidden_size] -> [local_head_v * head_size_v, hidden_size]
+# weight: [hidden_size, head_num_v * head_size_v] -> [hidden_size, local_head_v * head_size_v]
 def split_out_linear(
     t: torch.Tensor, load_config: LoadConfig, linear_config: LinearAttnConfig
 ) -> torch.Tensor:
-    _, n = t.shape
-    t = t.view(linear_config.linear_num_value_heads, -1, n)
+    m, _ = t.shape
+    t = t.view(m, linear_config.linear_num_value_heads, -1)
     local_head_num_v = linear_config.linear_num_value_heads // load_config.tp_size
     start_head_num_v = local_head_num_v * load_config.tp_rank
     end_head_num_v = start_head_num_v + local_head_num_v
-    return t[start_head_num_v:end_head_num_v, :, :].reshape(-1, n)
+    return t[:, start_head_num_v:end_head_num_v, :].reshape(m, -1).contiguous()
 
 
 def split_out_linear_t(
@@ -173,10 +173,10 @@ _linear_attn_split_stratey = {
 
 
 _linear_attn_w8a8_per_block_split_strategy = {
-    W.linear_attn_qkvz_w: split_qkvz_t,
-    W.linear_attn_qkvz_s: split_qkvz_t,
-    W.linear_attn_out_w: split_out_linear_t,
-    W.linear_attn_out_s: split_out_linear_t,
+    W.linear_attn_qkvz_w: split_qkvz,
+    W.linear_attn_qkvz_s: split_qkvz,
+    W.linear_attn_out_w: split_out_linear,
+    W.linear_attn_out_s: split_out_linear,
 }
 
 

--- a/rtp_llm/model_loader/mixed_fp4_quant_weight.py
+++ b/rtp_llm/model_loader/mixed_fp4_quant_weight.py
@@ -1,47 +1,44 @@
-import functools
 import copy
-from typing import Any, List, Dict, Union
+import functools
+from typing import Any, Dict, List, Union
+
 import torch
 
 from rtp_llm.config.quant_config import ModelOptFp4Config, QuantizationConfig
 from rtp_llm.model_loader.attn_weight import AttnAtomicWeight
-from rtp_llm.model_loader.load_config import LoadConfig
 from rtp_llm.model_loader.ffn_weight import FfnAtomicWeight, MoeAtomicWeight
 from rtp_llm.model_loader.linear_attn_weight import (
     LinearAttnAtomicWeight,
     _linear_attn_split_stratey,
 )
+from rtp_llm.model_loader.load_config import LoadConfig
 from rtp_llm.model_loader.weight_module import (
     AtomicWeight,
     CompositeWeight,
     QuantWeight,
     WeightModule,
 )
-
 from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
+    identity,
+    max_scalar,
+    merge_ba_transpose_reorder,
+    merge_qkv_hf,
+    merge_qkvz_transpose_reorder,
     pad,
     pad_w13,
+    plus_one,
     sp_0,
     sp_0_w13,
     sp_id,
     sp_neg1,
+    split_q_gate,
     stack_,
     stack_moe_w1,
-    max_scalar,
     stack_moe_w1_s2,
-    merge_qkv_hf,
-    identity,
-    merge_qkvz_transpose_reorder,
-    merge_ba_transpose_reorder,
-    transpose,
-    plus_one,
-    split_q_gate,
 )
-
 from rtp_llm.utils.util import check_with_info
-
 
 B_SUFFIX = ".bias"
 ACT_S_SUFFIX = ".input_scale"
@@ -56,6 +53,7 @@ IN_PROJ_B_SUFFIX = ".in_proj_b."
 SELF_ATTN_Q_SUFFIX = ".self_attn.q_proj."
 SELF_ATTN_K_SUFFIX = ".self_attn.k_proj."
 SELF_ATTN_V_SUFFIX = ".self_attn.v_proj."
+
 
 def mixed_fp4_gpt_style_tp_strategy():
     mixed_fp4_weight_tp_strategy: Dict[str, Any] = {
@@ -81,6 +79,7 @@ def mixed_fp4_gpt_style_tp_strategy():
     tp_strategy.update(_linear_attn_split_stratey)
     return tp_strategy
 
+
 class MixedFp4PerGroupAtomicWeight(AtomicWeight):
     gpt_style_tp_strategy = mixed_fp4_gpt_style_tp_strategy()
 
@@ -90,29 +89,25 @@ class MixedFp4PerGroupAtomicWeight(AtomicWeight):
     def _get_split_func(self):
         return self.gpt_style_tp_strategy[self.name]
 
+
 class MixedFp4PerGroupLinearAttnAtomicWeight(
     LinearAttnAtomicWeight, MixedFp4PerGroupAtomicWeight
 ):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
-class MixedFp4PerGroupAttnAtomicWeight(
-    AttnAtomicWeight, MixedFp4PerGroupAtomicWeight
-):
+
+class MixedFp4PerGroupAttnAtomicWeight(AttnAtomicWeight, MixedFp4PerGroupAtomicWeight):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
 
-class MixedFp4PerGroupFfnAtomicWeight(
-    FfnAtomicWeight, MixedFp4PerGroupAtomicWeight
-):
+class MixedFp4PerGroupFfnAtomicWeight(FfnAtomicWeight, MixedFp4PerGroupAtomicWeight):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
 
-class MixedFp4PerGroupMoeAtomicWeight(
-    MoeAtomicWeight, MixedFp4PerGroupAtomicWeight
-):
+class MixedFp4PerGroupMoeAtomicWeight(MoeAtomicWeight, MixedFp4PerGroupAtomicWeight):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
@@ -167,9 +162,9 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         ):
             return False
         name = src_weight_info.name
-        return (name in cls.unquantized_weight_list or name in cls.w4a4_weight_list) \
-               and quant_config.mixed_attention
-                
+        return (
+            name in cls.unquantized_weight_list or name in cls.w4a4_weight_list
+        ) and quant_config.mixed_attention
 
     def __init__(
         self,
@@ -182,7 +177,7 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         scale: WeightModule = None
         scale_2: WeightModule = None
         input_scale: WeightModule = None
-        
+
         if src_weight_info.name == W.linear_attn_qkvz_w:
             kernel = self._get_linear_attn_qkvz_weight(src_weight_info)
         elif src_weight_info.name == W.linear_attn_ba_w:
@@ -200,11 +195,17 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         elif src_weight_info.name in [W.q_ln_gamma, W.k_ln_gamma]:
             kernel = self._get_norm_weight(src_weight_info)
         elif src_weight_info.name in [W.ffn_w1, W.ffn_w2, W.ffn_w3, W.ffn_w13]:
-            kernel, scale, scale_2, input_scale = self._get_ffn_quant_weight(src_weight_info)
+            kernel, scale, scale_2, input_scale = self._get_ffn_quant_weight(
+                src_weight_info
+            )
         elif src_weight_info.name == W.moe_w1:
-            kernel, scale, scale_2, input_scale = self._get_moe_w1_quant_weight(src_weight_info)
+            kernel, scale, scale_2, input_scale = self._get_moe_w1_quant_weight(
+                src_weight_info
+            )
         elif src_weight_info.name == W.moe_w2:
-            kernel, scale, scale_2, input_scale = self._get_moe_w2_quant_weight(src_weight_info)
+            kernel, scale, scale_2, input_scale = self._get_moe_w2_quant_weight(
+                src_weight_info
+            )
 
         sub_weights = {kernel.name: kernel}
         if scale is not None:
@@ -218,7 +219,9 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         self.kernel = sub_weights.get(kernel.name)
         self.scale = sub_weights.get(scale.name) if scale is not None else None
         self.scale_2 = sub_weights.get(scale_2.name) if scale_2 is not None else None
-        self.input_scale = sub_weights.get(input_scale.name) if input_scale is not None else None
+        self.input_scale = (
+            sub_weights.get(input_scale.name) if input_scale is not None else None
+        )
 
     def _get_qkv_weight(self, src_weight_info: AttnAtomicWeight):
         assert src_weight_info.name == W.attn_qkv_w
@@ -230,16 +233,16 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         k_weight = next((w for w in weights if SELF_ATTN_K_SUFFIX in w.name), None)
         v_weight = next((w for w in weights if SELF_ATTN_V_SUFFIX in w.name), None)
         q_weight = CkptWeightInfo(
-                        q_name,
-                        functools.partial(
-                            split_q_gate,
-                            head_num=head_num,
-                            head_dim=head_dim,
-                            part=0,
-                        ),
-                   )
+            q_name,
+            functools.partial(
+                split_q_gate,
+                head_num=head_num,
+                head_dim=head_dim,
+                part=0,
+            ),
+        )
         qkv_list = [q_weight, k_weight, v_weight]
-        
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             W.attn_qkv_w,
@@ -257,21 +260,23 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         head_num = src_weight_info.config.head_num
         head_dim = src_weight_info.config.size_per_head
         q_name = weights[0].name
-        q_weight = [CkptWeightInfo(
-                        q_name,
-                        functools.partial(
-                            split_q_gate,
-                            head_num=head_num,
-                            head_dim=head_dim,
-                            part=1,
-                        ),
-                   )]
-        
+        q_weight = [
+            CkptWeightInfo(
+                q_name,
+                functools.partial(
+                    split_q_gate,
+                    head_num=head_num,
+                    head_dim=head_dim,
+                    part=1,
+                ),
+            )
+        ]
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             W.attn_gate_w,
             q_weight,
-            transpose,
+            identity,
             config=src_weight_info.config,
         )
 
@@ -284,7 +289,7 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         assert src_weight_info.name in (W.q_ln_gamma, W.k_ln_gamma)
         weights: List[CkptWeightInfo] = src_weight_info.weights
         assert len(weights) == 1
-        
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             src_weight_info.name,
@@ -312,7 +317,7 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_o_w,
             src_weight_info.weights,
-            transpose,
+            identity,
             config=src_weight_info.config,
         )
 
@@ -329,7 +334,7 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
             raise ValueError("Missing required weights: in_proj_qkv or in_proj_z")
 
         merge_weights = [qkv_weight, z_weight]
-            
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             src_weight_info.name,
@@ -350,7 +355,7 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
             raise ValueError("Missing required weights: in_proj_a or in_proj_b")
 
         merge_weights = [b_weight, a_weight]
-            
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             src_weight_info.name,
@@ -364,16 +369,16 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         assert src_weight_info.name == W.linear_attn_out_w
         weights: List[CkptWeightInfo] = src_weight_info.weights
         assert len(weights) == 1
-            
+
         kernel = create_mixed_fp4_per_group_weight(
             src_weight_info,
             src_weight_info.name,
             weights,
-            transpose,
+            identity,
             config=src_weight_info.config,
         )
         return kernel
-    
+
     def _get_linear_attn_common_weight(self, src_weight_info: LinearAttnAtomicWeight):
         assert src_weight_info.name in self.unquantized_weight_list
         weights: List[CkptWeightInfo] = src_weight_info.weights
@@ -397,56 +402,56 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
             w1_name = weights[0].name[: -len(W_SUFFIX)]
             w3_name = weights[1].name[: -len(W_SUFFIX)]
             kernel = create_mixed_fp4_per_group_weight(
-                        src_weight_info,
-                        w,
-                        [
-                            CkptWeightInfo(w1_name + QW_SUFFIX, identity),
-                            CkptWeightInfo(w3_name + QW_SUFFIX, identity),
-                        ],
-                        functools.partial(
-                            pad_w13,
-                            align_size=src_weight_info.config.align_size,
-                            dim=0,
-                        ),
-                        data_type=torch.uint8,
-                        config=src_weight_info.config,
+                src_weight_info,
+                w,
+                [
+                    CkptWeightInfo(w1_name + QW_SUFFIX, identity),
+                    CkptWeightInfo(w3_name + QW_SUFFIX, identity),
+                ],
+                functools.partial(
+                    pad_w13,
+                    align_size=src_weight_info.config.align_size,
+                    dim=0,
+                ),
+                data_type=torch.uint8,
+                config=src_weight_info.config,
             )
             scale = create_mixed_fp4_per_group_weight(
-                        src_weight_info,
-                        s,
-                        [
-                            CkptWeightInfo(w1_name + QS_SUFFIX, identity),
-                            CkptWeightInfo(w3_name + QS_SUFFIX, identity),
-                        ],
-                        functools.partial(
-                            pad_w13,
-                            align_size=src_weight_info.config.align_size,
-                            dim=0,
-                        ),
-                        data_type=torch.float8_e4m3fn,
-                        config=src_weight_info.config,
+                src_weight_info,
+                s,
+                [
+                    CkptWeightInfo(w1_name + QS_SUFFIX, identity),
+                    CkptWeightInfo(w3_name + QS_SUFFIX, identity),
+                ],
+                functools.partial(
+                    pad_w13,
+                    align_size=src_weight_info.config.align_size,
+                    dim=0,
+                ),
+                data_type=torch.float8_e4m3fn,
+                config=src_weight_info.config,
             )
             scale_2 = create_mixed_fp4_per_group_weight(
-                        src_weight_info,
-                        s_2,
-                        [
-                            CkptWeightInfo(w1_name + QS_2_SUFFIX, identity),
-                            CkptWeightInfo(w3_name + QS_2_SUFFIX, identity),
-                        ],
-                        max_scalar,
-                        data_type=torch.float32,
-                        config=src_weight_info.config,
+                src_weight_info,
+                s_2,
+                [
+                    CkptWeightInfo(w1_name + QS_2_SUFFIX, identity),
+                    CkptWeightInfo(w3_name + QS_2_SUFFIX, identity),
+                ],
+                max_scalar,
+                data_type=torch.float32,
+                config=src_weight_info.config,
             )
             input_scale = create_mixed_fp4_per_group_weight(
-                        src_weight_info,
-                        i_s,
-                        [
-                            CkptWeightInfo(w1_name + ACT_S_SUFFIX, identity),
-                            CkptWeightInfo(w3_name + ACT_S_SUFFIX, identity),
-                        ],
-                        max_scalar,
-                        data_type=torch.float32,
-                        config=src_weight_info.config,
+                src_weight_info,
+                i_s,
+                [
+                    CkptWeightInfo(w1_name + ACT_S_SUFFIX, identity),
+                    CkptWeightInfo(w3_name + ACT_S_SUFFIX, identity),
+                ],
+                max_scalar,
+                data_type=torch.float32,
+                config=src_weight_info.config,
             )
             return [kernel, scale, scale_2, input_scale]
         elif src_weight_info.name in [W.ffn_w1, W.ffn_w3]:
@@ -627,8 +632,10 @@ class MixedFp4Weight(CompositeWeight, QuantWeight):
         if self.scale is not None:
             scale_weight = processed_res[self.scale.name]
             if kernel_weight.dim() == 2 and scale_weight.dim() == 2:
-                kernel_weight, scale_weight = load_config.exported_device.convert_fp4_gemm_weight_params(
-                    kernel_weight, scale_weight
+                kernel_weight, scale_weight = (
+                    load_config.exported_device.convert_fp4_gemm_weight_params(
+                        kernel_weight, scale_weight
+                    )
                 )
 
             kernel_weight, scale_weight = (

--- a/rtp_llm/model_loader/omni_quant_weight.py
+++ b/rtp_llm/model_loader/omni_quant_weight.py
@@ -18,13 +18,12 @@ from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
     concat_w13,
+    concat_w13_2,
     identity,
     merge_qkv_hf,
     ones,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_w13_2,
 )
 
 QW_SUFFIX = ".qweight"
@@ -99,7 +98,7 @@ def get_qkv_quant_weight_info(
                 src_weight,
                 W.attn_qkv_w,
                 [CkptWeightInfo(qkv_name + QW_SUFFIX)],
-                transpose,
+                identity,
                 data_type=torch.int8,
                 config=src_weight.config,
             ),
@@ -147,7 +146,7 @@ def get_ffn_quant_weight_info(
             create_w8a8_int8_weight(
                 src_weight,
                 w,
-                [CkptWeightInfo(name + QW_SUFFIX, transpose) for name in w_name],
+                [CkptWeightInfo(name + QW_SUFFIX, identity) for name in w_name],
                 stack,
                 data_type=torch.int8,
                 config=src_weight.config,
@@ -178,7 +177,7 @@ def get_ffn_quant_weight_info(
                 src_weight,
                 w,
                 [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
-                transpose,
+                identity,
                 data_type=torch.int8,
                 config=src_weight.config,
             ),
@@ -204,7 +203,7 @@ def get_ffn_quant_weight_info(
                     CkptWeightInfo(w1_name + QW_SUFFIX, identity),
                     CkptWeightInfo(w3_name + QW_SUFFIX, identity),
                 ],
-                transpose_w13_2,
+                concat_w13_2,
                 data_type=torch.int8,
                 config=src_weight.config,
             ),
@@ -245,7 +244,7 @@ def get_ffn_quant_weight_info(
                 src_weight,
                 w,
                 [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
-                transpose,
+                identity,
                 data_type=torch.int8,
                 config=src_weight.config,
             ),
@@ -314,7 +313,7 @@ class OmniQuantWeightInfo(CompositeWeight, QuantWeight):
                 src_weight_info,
                 W.attn_o_w,
                 [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
-                transpose,
+                identity,
                 data_type=torch.int8,
                 config=src_weight_info.config,
             )
@@ -365,9 +364,7 @@ class OmniQuantWeightInfo(CompositeWeight, QuantWeight):
                     src_weight_info,
                     W.ffn_smoother,
                     [],
-                    functools.partial(
-                        ones, shape=src_weight_info.config.align_size
-                    ),
+                    functools.partial(ones, shape=src_weight_info.config.align_size),
                     data_type=torch.float32,
                     config=src_weight_info.config,
                 )
@@ -417,10 +414,5 @@ class OmniQuantWeightInfo(CompositeWeight, QuantWeight):
         device: str,
         load_config: LoadConfig,
     ):
-        # need reshape for kernel weight
         processed_res = super()._postprocess(tensor, device, load_config)
-        kernel_weight = processed_res[self.kernel.name]
-        kernel_weight = kernel_weight.reshape(kernel_weight.shape[-1], -1)
-        processed_res[self.kernel.name] = kernel_weight
-
         return processed_res

--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -743,7 +743,6 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
         device: str,
         load_config: LoadConfig,
     ):
-        # need reshape for kernel weight
         processed_res = super()._postprocess(tensor, device, load_config)
         kernel_weight = processed_res[self.kernel.name]
         from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
@@ -751,30 +750,14 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
         )
         from rtp_llm.models_py.kernels.cuda.fp8_kernel import requant_weight_ue8m0
 
-        # e8m0 not reshape, weight scale need be non contiguous
-        # TODO: rm reshape all time
-        if not is_deep_gemm_e8m0_used():
-            kernel_weight = (
-                kernel_weight.reshape(kernel_weight.shape[-1], -1)
-                if kernel_weight.dim() == 2
-                else kernel_weight
-            )
-        processed_res[self.kernel.name] = kernel_weight
         if self.scale is not None:
             scale_weight = processed_res[self.scale.name]
-            if not is_deep_gemm_e8m0_used():
-                scale_weight = (
-                    scale_weight.reshape(scale_weight.shape[-1], -1)
-                    if scale_weight.dim() == 2
-                    else scale_weight
-                )
             kernel_weight = load_config.exported_device.maybe_rewrite_weight_by_key(
                 "weight", kernel_weight
             )
             scale_weight = load_config.exported_device.maybe_rewrite_weight_by_key(
                 "scale", scale_weight
             )
-            # kernel_weight, scale_weight = load_config.exported_device.convert_fp8_weight_params(kernel_weight, scale_weight)
 
             if is_deep_gemm_e8m0_used():
                 kernel_weight, scale_weight = requant_weight_ue8m0(
@@ -852,14 +835,8 @@ class LoadQuantPerBlockFp8Weight(PerBlockFp8Weight):
         else:
             quant_kernel = cast_to_fp8(kernel.get(self.kernel.name))
 
-        if self.kernel.name == W.moe_w1 or self.kernel.name == W.moe_w2:
-            pass
-        elif quant_kernel.dim() == 2:
-            quant_kernel = quant_kernel.T
-
         res = {self.kernel.name: quant_kernel.contiguous().to(device)}
         if self.scale:
-            scale = scale.T if scale.dim() == 2 else scale
             res.update({self.scale.name: scale.contiguous().to(device)})
 
         return res

--- a/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
@@ -37,11 +37,11 @@ from rtp_llm.utils.model_weight import (
     sp_head_gemm_a8,
     sp_head_s_gemm_a8_channel,
     sp_id,
+    sp_moe_neg1,
+    sp_moe_w1,
     sp_neg1,
     stack_,
     stack_moe_w1,
-    sp_moe_w1,
-    sp_moe_neg1
 )
 from rtp_llm.utils.util import check_with_info
 
@@ -67,15 +67,15 @@ def _ckpt_base_matches_quant_exclude(
 ) -> bool:
     """
     Check if the checkpoint module path template matches any entry in the quantization exclude list.
-    
+
     Args:
-        base_name_template: A template string representing the module path, where '{i}' 
+        base_name_template: A template string representing the module path, where '{i}'
                             acts as a placeholder for the layer index (e.g., 'model.layers.{i}.mlp.gate_proj').
-        exclude_modules: A set of concrete module paths that are excluded from quantization 
+        exclude_modules: A set of concrete module paths that are excluded from quantization
                          (e.g., {'model.layers.0.mlp.gate_proj', 'model.layers.1.mlp.gate_proj'}).
-    
+
     Returns:
-        True if the template (with '{i}' replaced by a wildcard for digits) matches any 
+        True if the template (with '{i}' replaced by a wildcard for digits) matches any
         concrete path in 'exclude_modules'.
     """
     if not exclude_modules:
@@ -133,28 +133,27 @@ def cast_to_fp8(x: torch.Tensor):
     """Convert tensor to FP8 format."""
     return x.to(torch.float8_e4m3fn)
 
+
 def per_channel_cast_to_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Per-channel FP8 quantization.
     Args:
-        x: Input tensor to be quantized
+        x: Input tensor to be quantized, shape (N, K) for 2D or (E, N, K) for 3D
     Returns:
         tuple[torch.Tensor, torch.Tensor]: Quantized tensor and channel-wise scales
     """
-    assert x.dim() in [2, 3], f"weight dim=2 or dim=3 supported, but got shape {x.shape}"
-    if x.dim() == 3:
-        channel_max = x.abs().amax(dim=-1, keepdim=True).clamp(1e-4)
-        scales = (channel_max / FP8_E4M3_MAX).to(torch.float32)
-        quantized = (x / scales).to(torch.float8_e4m3fn)
-        return quantized.contiguous(), scales.contiguous()
-    x = x.T
-    # Calculate per-channel maximum absolute values
+    assert x.dim() in [
+        2,
+        3,
+    ], f"weight dim=2 or dim=3 supported, but got shape {x.shape}"
+    # For 2D (N, K) and 3D (E, N, K): reduce along K (dim=-1) to produce
+    # per-output-channel scale of shape (N, 1) / (E, N, 1). TP split funcs
+    # (sp_0, sp_head_s_gemm_a8_channel, ...) expect output-channel-major layout.
     channel_max = x.abs().amax(dim=-1, keepdim=True).clamp(1e-4)
-    # Compute scaling factors
     scales = (channel_max / FP8_E4M3_MAX).to(torch.float32)
-    # Quantize the tensor
     quantized = (x / scales).to(torch.float8_e4m3fn)
-    return (quantized.T).contiguous(), (scales.T).contiguous()
+    return quantized.contiguous(), scales.contiguous()
+
 
 def gemm_channel_fp8_gpt_style_tp_strategy():
     gemm_channel_fp8_weight_tp_strategy: Dict[str, Any] = {
@@ -245,7 +244,8 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
         cls, quant_config: QuantizationConfig, src_weight_info: WeightModule
     ) -> bool:
         if not quant_config.is_quanted() or not isinstance(
-            quant_config, (Fp8PerChannelCompressedQuantConfig, Fp8PerChannelQuarkQuantConfig)
+            quant_config,
+            (Fp8PerChannelCompressedQuantConfig, Fp8PerChannelQuarkQuantConfig),
         ):
             return False
         name = src_weight_info.name
@@ -615,22 +615,10 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
         device: str,
         load_config: LoadConfig,
     ):
-        # need reshape for kernel weight
         processed_res = super()._postprocess(tensor, device, load_config)
         kernel_weight = processed_res[self.kernel.name]
-        kernel_weight = (
-            kernel_weight.reshape(kernel_weight.shape[-1], -1)
-            if kernel_weight.dim() == 2
-            else kernel_weight
-        )
-        processed_res[self.kernel.name] = kernel_weight
         if self.scale is not None:
             scale_weight = processed_res[self.scale.name]
-            scale_weight = (
-                scale_weight.reshape(scale_weight.shape[-1], -1)
-                if scale_weight.dim() == 2
-                else scale_weight
-            )
             kernel_weight, scale_weight = (
                 load_config.exported_device.convert_fp8_weight_params(
                     kernel_weight, scale_weight
@@ -640,6 +628,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             processed_res[self.kernel.name] = kernel_weight
 
         return processed_res
+
 
 class LoadQuantPerChannelFp8Weight(PerChannelFp8Weight):
     """
@@ -726,15 +715,8 @@ class LoadQuantPerChannelFp8Weight(PerChannelFp8Weight):
             # Simple cast to FP8 without scaling
             quant_kernel = cast_to_fp8(kernel.get(self.kernel.name))
 
-        # Prepare result dictionary
-        if self.kernel.name == W.moe_w1 or self.kernel.name == W.moe_w2:
-            pass
-        elif quant_kernel.dim() == 2:
-            quant_kernel = quant_kernel.T
-
         res = {self.kernel.name: quant_kernel.contiguous().to(device)}
         if self.scale:
-            scale = scale.T if scale.dim() == 2 else scale
             res.update({self.scale.name: scale.contiguous().to(device)})
 
         return res

--- a/rtp_llm/model_loader/per_tensor_int8_quant_weight.py
+++ b/rtp_llm/model_loader/per_tensor_int8_quant_weight.py
@@ -21,13 +21,12 @@ from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
     WeightStyle,
+    concat_0,
     expand_scale,
     get_tensor_from_scalar,
     get_tensor_reciprocal,
     identity,
-    merge_qkv_transpose_concat0,
-    transpose,
-    transpose_w13,
+    merge_qkv_concat0,
 )
 
 W_SUFFIX = ".weight"
@@ -104,7 +103,9 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
         scale: Optional[AtomicWeight] = None
         act_scale: Optional[AtomicWeight] = None
         act_scale_inv: Optional[AtomicWeight] = None
-        logging.debug("PerTensorInt8QuantWeight : %s, %s", self.qs_suffix, self.qw_suffix)
+        logging.debug(
+            "PerTensorInt8QuantWeight : %s, %s", self.qs_suffix, self.qw_suffix
+        )
 
         if src_weight_info.name == W.attn_qkv_w:
             (kernel, scale, act_scale, act_scale_inv) = self._get_qkv_quant_weight_info(
@@ -205,7 +206,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_qkv_w,
             qkv_w_list,
-            merge_qkv_transpose_concat0,
+            merge_qkv_concat0,
             data_type=torch.int8,
             config=src_weight_info.config,
         )
@@ -260,7 +261,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
                 src_weight_info,
                 W.attn_o_w,
                 [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-                transpose,
+                identity,
                 data_type=torch.int8,
                 config=src_weight_info.config,
             ),
@@ -320,7 +321,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
                         CkptWeightInfo(w1_name + self.qw_suffix, identity),
                         CkptWeightInfo(w3_name + self.qw_suffix, identity),
                     ],
-                    transpose_w13,
+                    concat_0,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -331,7 +332,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
                         CkptWeightInfo(w1_name + self.qs_suffix, identity),
                         CkptWeightInfo(w3_name + self.qs_suffix, identity),
                     ],
-                    transpose_w13,
+                    concat_0,
                     data_type=torch.float32,
                     config=src_weight.config,
                 ),
@@ -361,7 +362,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
                     src_weight,
                     w,
                     [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-                    transpose,
+                    identity,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -369,7 +370,7 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
                     src_weight,
                     s,
                     [CkptWeightInfo(w_name + self.qs_suffix, identity)],
-                    transpose,
+                    identity,
                     data_type=torch.float32,
                     config=src_weight.config,
                 ),
@@ -419,10 +420,5 @@ class PerTensorInt8QuantWeight(CompositeWeight, QuantWeight):
         device: str,
         load_config: LoadConfig,
     ):
-        # need reshape for kernel weight
         processed_res = super()._postprocess(tensor, device, load_config)
-        kernel_weight = processed_res[self.kernel.name]
-        kernel_weight = kernel_weight.reshape(kernel_weight.shape[-1], -1)
-        processed_res[self.kernel.name] = kernel_weight
-
         return processed_res

--- a/rtp_llm/model_loader/smooth_quant_weight.py
+++ b/rtp_llm/model_loader/smooth_quant_weight.py
@@ -22,14 +22,13 @@ from rtp_llm.utils.model_weight import (
     W,
     WeightStyle,
     concat_w13,
+    concat_w13_2,
     identity,
+    merge_qkv_concat0,
     merge_qkv_hf,
-    merge_qkv_transpose_concat0,
     merge_te_qkv,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_w13_2,
 )
 
 QW_SUFFIX = ".qweight"
@@ -41,7 +40,7 @@ INT8QW_COL_SUFFIX = ".weight.int8.col"
 INT8QS_COL_SUFFIX = ".scale_w_quant_orig.col"
 
 
-def qkv_transpose(ts, hidden_size):
+def qkv_reshape(ts, hidden_size):
     return ts[0].reshape(hidden_size, -1)
 
 
@@ -153,7 +152,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                         CkptWeightInfo(k_name + self.qw_suffix, identity),
                         CkptWeightInfo(v_name + self.qw_suffix, identity),
                     ],
-                    merge_qkv_transpose_concat0,
+                    merge_qkv_concat0,
                     data_type=torch.int8,
                     config=src_weight_info.config,
                 ),
@@ -183,12 +182,12 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                         CkptWeightInfo(
                             qkv_name + self.qw_suffix,
                             functools.partial(
-                                qkv_transpose,
+                                qkv_reshape,
                                 hidden_size=src_weight_info.config.hidden_size,
                             ),
                         )
                     ],
-                    transpose,
+                    identity,
                     data_type=torch.int8,
                     config=src_weight_info.config,
                 ),
@@ -211,7 +210,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_o_w,
             [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-            transpose,
+            identity,
             data_type=torch.int8,
             config=src_weight_info.config,
         )
@@ -261,7 +260,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                     src_weight,
                     w,
                     [
-                        CkptWeightInfo(name + self.qw_suffix, transpose)
+                        CkptWeightInfo(name + self.qw_suffix, identity)
                         for name in w_name
                     ],
                     stack,
@@ -290,7 +289,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                     src_weight,
                     w,
                     [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-                    transpose,
+                    identity,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -323,7 +322,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                         CkptWeightInfo(w1_name + self.qw_suffix, identity),
                         CkptWeightInfo(w3_name + self.qw_suffix, identity),
                     ],
-                    transpose_w13_2,
+                    concat_w13_2,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -354,7 +353,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
                     src_weight,
                     w,
                     [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-                    transpose,
+                    identity,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -375,12 +374,7 @@ class SmoothQuantWeightInfo(CompositeWeight, QuantWeight):
         device: str,
         load_config: LoadConfig,
     ):
-        # need reshape for kernel weight
         processed_res = super()._postprocess(tensor, device, load_config)
-        kernel_weight = processed_res[self.kernel.name]
-        kernel_weight = kernel_weight.reshape(kernel_weight.shape[-1], -1)
-        processed_res[self.kernel.name] = kernel_weight
-
         return processed_res
 
 
@@ -599,7 +593,7 @@ class TrtEngineSmoothQuantWeightInfo(SmoothQuantWeightInfo):
                         CkptWeightInfo(w1_name + self.qw_suffix, identity),
                         CkptWeightInfo(w3_name + self.qw_suffix, identity),
                     ],
-                    transpose_w13_2,
+                    concat_w13_2,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),
@@ -630,7 +624,7 @@ class TrtEngineSmoothQuantWeightInfo(SmoothQuantWeightInfo):
                     src_weight,
                     w,
                     [CkptWeightInfo(w_name + self.qw_suffix, identity)],
-                    transpose,
+                    identity,
                     data_type=torch.int8,
                     config=src_weight.config,
                 ),

--- a/rtp_llm/model_loader/weight_module.py
+++ b/rtp_llm/model_loader/weight_module.py
@@ -331,10 +331,11 @@ class AtomicWeight(WeightModule):
         return self.__class__(*args, **kwargs)
 
     @property
-    def need_transpose(self) -> bool:
-        if isinstance(
-            self.process_fun, functools.partial
-        ) and self.process_fun.func.__name__ in ["transpose_pad", "transpose"]:
+    def need_pad(self) -> bool:
+        if (
+            isinstance(self.process_fun, functools.partial)
+            and self.process_fun.func.__name__ == "pad"
+        ):
             return True
         else:
             return False
@@ -580,8 +581,8 @@ class AtomicWeight(WeightModule):
             )
             merge_tensor = (
                 (
-                    lora_a_tensor.type(torch.float32)
-                    @ lora_b_tensor.type(torch.float32)
+                    lora_b_tensor.type(torch.float32)
+                    @ lora_a_tensor.type(torch.float32)
                     * scale
                 )
                 .type(raw_tensor.dtype)
@@ -591,8 +592,8 @@ class AtomicWeight(WeightModule):
         elif lora_b_tensor.dim() == 3 and lora_a_tensor.dim() == 3:
             merge_tensor = (
                 torch.bmm(
-                    lora_a_tensor.type(torch.float32),
-                    lora_b_tensor.type(torch.float32) * scale,
+                    lora_b_tensor.type(torch.float32),
+                    lora_a_tensor.type(torch.float32) * scale,
                 )
                 .type(raw_tensor.dtype)
                 .to(raw_tensor.device)
@@ -600,8 +601,8 @@ class AtomicWeight(WeightModule):
         else:
             merge_tensor = (
                 (
-                    lora_a_tensor.type(torch.float32)
-                    @ lora_b_tensor.type(torch.float32)
+                    lora_b_tensor.type(torch.float32)
+                    @ lora_a_tensor.type(torch.float32)
                     * scale
                 )
                 .type(raw_tensor.dtype)

--- a/rtp_llm/models/bert_weight.py
+++ b/rtp_llm/models/bert_weight.py
@@ -10,7 +10,7 @@ from rtp_llm.model_loader.model_weight_info import (
     ModelWeightInfo,
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, identity
 
 
 def get_tensor_reciprocal(ts: List[torch.Tensor]) -> torch.Tensor:
@@ -23,13 +23,13 @@ def get_tensor_from_scalar(ts: List[torch.Tensor]) -> torch.Tensor:
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
-def merge_qkv_transpose_concat0(ts: List[torch.Tensor]):
+def merge_qkv_concat0(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=0).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -163,7 +163,7 @@ class BertWeightInfo(ModelDeployWeightInfo):
                 AttnAtomicWeight(
                     W.attn_o_w,
                     [CkptWeightInfo(self._names.O_W)],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -176,7 +176,7 @@ class BertWeightInfo(ModelDeployWeightInfo):
                         FfnAtomicWeight(
                             W.ffn_w3,
                             [CkptWeightInfo(self._names.FFN_INTER_DENSE_W)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -187,7 +187,7 @@ class BertWeightInfo(ModelDeployWeightInfo):
                         FfnAtomicWeight(
                             W.ffn_w2,
                             [CkptWeightInfo(self._names.FFN_OUTPUT_DENSE_W)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(

--- a/rtp_llm/models/bloom.py
+++ b/rtp_llm/models/bloom.py
@@ -3,8 +3,7 @@ from typing import Any, Dict
 
 import torch
 
-from rtp_llm.config.model_config import VitParameters
-from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.model_config import ModelConfig, VitParameters
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.model_loader.attn_weight import AttnAtomicWeight
 from rtp_llm.model_loader.ffn_weight import FfnAtomicWeight
@@ -21,7 +20,6 @@ from rtp_llm.utils.model_weight import (
     slopes,
     trans_qkv,
     trans_qkv_b,
-    transpose,
 )
 from rtp_llm.utils.util import get_config_from_path
 
@@ -118,7 +116,7 @@ class BloomWeightInfo(ModelDeployWeightInfo):
                 AttnAtomicWeight(
                     W.attn_o_w,
                     [CkptWeightInfo("h.{i}.self_attention.dense.weight", identity)],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -130,7 +128,7 @@ class BloomWeightInfo(ModelDeployWeightInfo):
                 FfnAtomicWeight(
                     W.ffn_w3,
                     [CkptWeightInfo("h.{i}.mlp.dense_h_to_4h.weight", identity)],
-                    transpose,
+                    identity,
                     config=ffn_config,
                 ),
                 FfnAtomicWeight(
@@ -142,7 +140,7 @@ class BloomWeightInfo(ModelDeployWeightInfo):
                 FfnAtomicWeight(
                     W.ffn_w2,
                     [CkptWeightInfo("h.{i}.mlp.dense_4h_to_h.weight", identity)],
-                    transpose,
+                    identity,
                     config=ffn_config,
                 ),
                 FfnAtomicWeight(
@@ -201,7 +199,9 @@ class Bloom(BaseModel):
         )
         config.attn_config.kv_head_num = config.attn_config.head_num
         config.hidden_size = config_json.get("n_embed", config_json.get("hidden_size"))
-        config.attn_config.size_per_head = config.hidden_size // config.attn_config.head_num
+        config.attn_config.size_per_head = (
+            config.hidden_size // config.attn_config.head_num
+        )
         config.num_layers = config_json["n_layer"]
         config.max_seq_len = config_json.get("seq_length", 2048)
         config.vocab_size = config_json["vocab_size"]

--- a/rtp_llm/models/deepseek_v2.py
+++ b/rtp_llm/models/deepseek_v2.py
@@ -31,13 +31,13 @@ from rtp_llm.ops import MlaOpsType
 from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
-    concat_0_tranpose,
+    concat_0,
     identity,
-    mla_pad_t,
+    mla_pad,
+    pad,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_pad,
+    t,
     transpose_slice_k,
     transpose_slice_v,
     yarn_get_mscale,
@@ -82,7 +82,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                 W.attn_o_w,
                 [CkptWeightInfo("model.layers.{i}.self_attn.o_proj.weight", identity)],
                 functools.partial(
-                    mla_pad_t,
+                    mla_pad,
                     head_num=self._head_num,
                     nope_head_dim=self.v_head_dim,
                     rope_head_dim=0,
@@ -107,7 +107,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                         "model.layers.{i}.self_attn.kv_b_proj.weight", identity
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             MlaAttnAtomicWeight(
@@ -133,7 +133,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=attn_config,
                     ),
                     MlaAttnAtomicWeight(
@@ -160,7 +160,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                             identity,
                         ),
                     ],
-                    concat_0_tranpose,
+                    concat_0,
                     config=attn_config,
                 )
             )
@@ -177,7 +177,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                             identity,
                         ),
                     ],
-                    concat_0_tranpose,
+                    concat_0,
                     config=attn_config,
                 )
             )
@@ -194,7 +194,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                     ),
                     MlaAttnAtomicWeight(
                         W.mla_indexer_k_w,
@@ -203,7 +203,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 "model.layers.{i}.self_attn.indexer.wk.weight", identity
                             )
                         ],
-                        transpose,
+                        identity,
                     ),
                     AtomicWeight(
                         W.mla_indexer_k_norm_w,
@@ -233,7 +233,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         data_type=torch.float32,
                     ),
                 ]
@@ -310,7 +310,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -325,7 +325,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -340,7 +340,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -358,7 +358,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                     "model.layers.{i}.mlp.gate.weight", identity
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=moe_config,
                         ),
                         MoeAtomicWeight(
@@ -421,7 +421,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -435,7 +435,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -449,7 +449,7 @@ class DeepSeekV2Weight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -786,7 +786,7 @@ class DeepSeekV3MtpWeight(DeepSeekV2Weight):
                     AtomicWeight(
                         W.multi_tokens_predict_eh_proj,
                         [CkptWeightInfo("model.layers.{i}.eh_proj.weight", identity)],
-                        transpose,
+                        t,
                     ),
                 ]
             )

--- a/rtp_llm/models/deepseek_vl2/deepseek_vl2_weight.py
+++ b/rtp_llm/models/deepseek_vl2/deepseek_vl2_weight.py
@@ -26,10 +26,9 @@ from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
     identity,
+    pad,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_pad,
     zeros,
 )
 
@@ -98,7 +97,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                         "language.model.layers.{i}.self_attn.o_proj.weight", identity
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             AttnAtomicWeight(
@@ -141,7 +140,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -156,7 +155,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -171,7 +170,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -190,7 +189,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=moe_config,
                         ),
                         MoeAtomicWeight(
@@ -254,7 +253,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -269,7 +268,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -284,7 +283,7 @@ class DeepSeekVLV2Weight(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),

--- a/rtp_llm/models/falcon.py
+++ b/rtp_llm/models/falcon.py
@@ -12,13 +12,7 @@ from rtp_llm.model_loader.model_weight_info import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.models.base_model import BaseModel
-from rtp_llm.utils.model_weight import (
-    CkptWeightInfo,
-    W,
-    identity,
-    qkv_gather,
-    transpose,
-)
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, qkv_gather
 
 
 class FalconWeightInfo(ModelDeployWeightInfo):
@@ -60,7 +54,7 @@ class FalconWeightInfo(ModelDeployWeightInfo):
                         "transformer.h.{i}.self_attention.dense.weight", identity
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             FfnWeight(
@@ -72,7 +66,7 @@ class FalconWeightInfo(ModelDeployWeightInfo):
                                 "transformer.h.{i}.mlp.dense_h_to_4h.weight", identity
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                     FfnAtomicWeight(
@@ -82,7 +76,7 @@ class FalconWeightInfo(ModelDeployWeightInfo):
                                 "transformer.h.{i}.mlp.dense_4h_to_h.weight", identity
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                 ],
@@ -143,7 +137,7 @@ class FalconWeightInfo(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=attn_config,
                     ),
                     AtomicWeight(
@@ -189,7 +183,9 @@ class Falcon(BaseModel):
         )
         config.attn_config.size_per_head = config_json["hidden_size"] // head_num
         config.inter_size = config_json["hidden_size"] * 4
-        config.num_layers = config_json.get("n_layer", config_json.get("num_hidden_layers"))
+        config.num_layers = config_json.get(
+            "n_layer", config_json.get("num_hidden_layers")
+        )
         config.max_seq_len = 2048
         config.vocab_size = config_json["vocab_size"]
         config.activation_type = "gelu-none-approximate"

--- a/rtp_llm/models/glm4_moe.py
+++ b/rtp_llm/models/glm4_moe.py
@@ -31,13 +31,12 @@ from rtp_llm.utils.model_weight import (
     merge_qkv_hf,
     merge_qkv_lora_A,
     merge_qkv_lora_B,
+    pad,
     sp_0,
     sp_head_lora,
     sp_id,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_pad,
 )
 
 
@@ -123,11 +122,11 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
-                lora_a_split_func=sp_0,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
+                lora_a_split_func=sp_neg1,
                 lora_b_split_func=sp_id,
             ),
             AtomicWeight(
@@ -220,7 +219,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -235,7 +234,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -250,7 +249,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -268,7 +267,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                     "model.layers.{i}.mlp.gate.weight", identity
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=moe_config,
                         ),
                         MoeAtomicWeight(
@@ -331,7 +330,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),
@@ -345,7 +344,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=1,
                             ),
@@ -359,7 +358,7 @@ class Glm4MoeWeight(ModelDeployWeightInfo):
                                 )
                             ],
                             functools.partial(
-                                transpose_pad,
+                                pad,
                                 align_size=align_size,
                                 dim=0,
                             ),

--- a/rtp_llm/models/glm_v2_weight.py
+++ b/rtp_llm/models/glm_v2_weight.py
@@ -14,7 +14,6 @@ from rtp_llm.utils.model_weight import (
     W,
     concat_1,
     identity,
-    transpose,
     w_half1_t,
     w_half2_t,
     zeros,
@@ -89,7 +88,7 @@ class GlmV2WeightInfo(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             AttnAtomicWeight(
@@ -111,7 +110,7 @@ class GlmV2WeightInfo(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             FfnWeight(
@@ -146,7 +145,7 @@ class GlmV2WeightInfo(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                 ],

--- a/rtp_llm/models/gpt_neox_weight.py
+++ b/rtp_llm/models/gpt_neox_weight.py
@@ -13,7 +13,6 @@ from rtp_llm.utils.model_weight import (
     identity,
     trans_qkv,
     trans_qkv_b,
-    transpose,
     zeros,
 )
 
@@ -73,7 +72,7 @@ class GPTNeoxWeight(ModelDeployWeightInfo):
                             "gpt_neox.layers.{i}.attention.dense.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -96,7 +95,7 @@ class GPTNeoxWeight(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -118,7 +117,7 @@ class GPTNeoxWeight(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -324,7 +323,7 @@ class GPTNeox13BWeight(ModelDeployWeightInfo):
                             "gpt_neox.layers.{i}.attention.dense.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -347,7 +346,7 @@ class GPTNeox13BWeight(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -369,7 +368,7 @@ class GPTNeox13BWeight(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(

--- a/rtp_llm/models/gpt_weight.py
+++ b/rtp_llm/models/gpt_weight.py
@@ -13,7 +13,6 @@ from rtp_llm.utils.model_weight import (
     identity,
     trans_qkv,
     trans_qkv_b,
-    transpose,
 )
 
 from ..model_loader.weight_module import AtomicWeight
@@ -109,7 +108,7 @@ class GptWeightInfo(ModelDeployWeightInfo):
                             "model.layers.{i}.self_attention.dense.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -132,7 +131,7 @@ class GptWeightInfo(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -153,7 +152,7 @@ class GptWeightInfo(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(

--- a/rtp_llm/models/internvl_weight.py
+++ b/rtp_llm/models/internvl_weight.py
@@ -20,7 +20,6 @@ from rtp_llm.utils.model_weight import (
     concat_1,
     identity,
     merge_qkv_b,
-    transpose,
     zeros,
 )
 
@@ -124,26 +123,26 @@ class InternVLWeightInfo(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                     identity,
                 ),
                 AttnAtomicWeight(
-                    W.attn_o_w, [CkptWeightInfo(self._names.WO, concat_1)], transpose
+                    W.attn_o_w, [CkptWeightInfo(self._names.WO, concat_1)], identity
                 ),
                 FfnWeight(
                     sub_weights=[
                         FfnAtomicWeight(
                             W.ffn_w1,
                             [CkptWeightInfo(self._names.FFW1, concat_0)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
                             W.ffn_w3,
                             [CkptWeightInfo(self._names.FFW3, concat_0)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
                             W.ffn_w2,
                             [CkptWeightInfo(self._names.FFW2, concat_1)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                     ],

--- a/rtp_llm/models/jina_bert/jina_bert_weight.py
+++ b/rtp_llm/models/jina_bert/jina_bert_weight.py
@@ -11,26 +11,24 @@ from rtp_llm.model_loader.model_weight_info import (
     ModelWeightInfo,
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, slopes, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, identity, slopes
 
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
-def merge_qkv_transpose_concat0(ts: List[torch.Tensor]):
+def merge_qkv_concat0(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=0).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
 def slice_index_transepose(ts: List[torch.Tensor], index: int, inter_size: int):
     t = ts[0]
-    return (
-        t[index * inter_size : (index + 1) * inter_size, :].transpose(0, 1).contiguous()
-    )
+    return t[index * inter_size : (index + 1) * inter_size, :].contiguous()
 
 
 # from [torch.Size(1), torch.Size(1), torch.Size(1)] to torch.Size(3 * hidden_size)
@@ -163,7 +161,7 @@ class JinaBertWeightInfo(ModelDeployWeightInfo):
             AtomicWeight(W.q_ln_beta, [CkptWeightInfo(self._names.Q_LN_B)]),
             AtomicWeight(W.k_ln_gamma, [CkptWeightInfo(self._names.K_LN_W)]),
             AtomicWeight(W.k_ln_beta, [CkptWeightInfo(self._names.K_LN_B)]),
-            AttnAtomicWeight(W.attn_o_w, [CkptWeightInfo(self._names.O_W)], transpose),
+            AttnAtomicWeight(W.attn_o_w, [CkptWeightInfo(self._names.O_W)], identity),
             AttnAtomicWeight(W.attn_o_b, [CkptWeightInfo(self._names.O_B)]),
             AtomicWeight(W.post_ln_beta, [CkptWeightInfo(self._names.POST_LN_B)]),
             AtomicWeight(W.post_ln_gamma, [CkptWeightInfo(self._names.POST_LN_W)]),
@@ -187,7 +185,7 @@ class JinaBertWeightInfo(ModelDeployWeightInfo):
             ),
             # down
             FfnAtomicWeight(
-                W.ffn_w2, [CkptWeightInfo(self._names.FFN_DOWN_W)], transpose
+                W.ffn_w2, [CkptWeightInfo(self._names.FFN_DOWN_W)], identity
             ),
             FfnAtomicWeight(W.ffn_b2, [CkptWeightInfo(self._names.FFN_DOWN_B)]),
             AtomicWeight(

--- a/rtp_llm/models/llama_weight.py
+++ b/rtp_llm/models/llama_weight.py
@@ -28,7 +28,6 @@ from rtp_llm.utils.model_weight import (
     sp_head_lora,
     sp_id,
     sp_neg1,
-    transpose,
     zeros,
 )
 
@@ -46,13 +45,13 @@ def merge_qkv(ts, hidden_size, head_num_kv, head_num):
     q, k, v = ts
     q = permute(q, head_num, hidden_size, hidden_size)
     k = permute(k, head_num_kv, head_num_kv * hidden_size // head_num, hidden_size)
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
 def merge_qkv_hf(ts: List[torch.Tensor], hidden_size, head_num_kv, head_num):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -60,15 +59,15 @@ def qkv_rerange(ts, hidden_size, head_num_kv, head_num):
     num_key_value_groups = int(head_num // head_num_kv)
     size_per_head = int(hidden_size / head_num)
     w = rearrange(
-        ts[0].T, "q (h gs d) -> q h gs d", gs=2 + num_key_value_groups, d=size_per_head
+        ts[0], "(h gs d) q -> h gs d q", gs=2 + num_key_value_groups, d=size_per_head
     )
-    wq = w[..., :num_key_value_groups, :].reshape(w.shape[0], -1)
-    wk = w[..., -2, :].reshape(w.shape[0], -1)
-    wv = w[..., -1, :].reshape(w.shape[0], -1)
-    return torch.concat([wq, wk, wv], dim=1)
+    wq = w[:, :num_key_value_groups, :, :].reshape(-1, w.shape[-1])
+    wk = w[:, -2, :, :].reshape(-1, w.shape[-1])
+    wv = w[:, -1, :, :].reshape(-1, w.shape[-1])
+    return torch.concat([wq, wk, wv], dim=0)
 
 
-def qkv_transpose(ts, hidden_size):
+def qkv_reshape(ts, hidden_size):
     return ts[0].reshape(hidden_size, -1)
 
 
@@ -301,7 +300,7 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=attn_config,
                     ),
                     FfnWeight(
@@ -315,7 +314,7 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         identity,
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
                             ),
                             FfnAtomicWeight(
@@ -327,7 +326,7 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         identity,
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
                             ),
                             FfnAtomicWeight(
@@ -339,7 +338,7 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         identity,
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
                             ),
                         ],
@@ -352,11 +351,11 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                 self._prefix
                                 + self._names.W_QKV.removesuffix(".int8.col"),
                                 functools.partial(
-                                    qkv_transpose, hidden_size=self._hidden_size
+                                    qkv_reshape, hidden_size=self._hidden_size
                                 ),
                             )
                         ],
-                        transpose,
+                        identity,
                         config=attn_config,
                     ),
                 ]
@@ -367,11 +366,11 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                     AttnAtomicWeight(
                         W.attn_o_w,
                         [CkptWeightInfo(self._prefix + self._names.WO, concat_1)],
-                        transpose,
+                        identity,
                         config=attn_config,
-                        lora_a_process_func=transpose,
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
+                        lora_a_process_func=identity,
+                        lora_b_process_func=identity,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                     FfnWeight(
@@ -383,12 +382,12 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         self._prefix + self._names.FFW1, concat_0
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
-                                lora_a_process_func=transpose,
-                                lora_b_process_func=transpose,
+                                lora_a_process_func=identity,
+                                lora_b_process_func=identity,
                                 lora_a_split_func=sp_id,
-                                lora_b_split_func=sp_neg1,
+                                lora_b_split_func=sp_0,
                             ),
                             FfnAtomicWeight(
                                 W.ffn_w3,
@@ -397,12 +396,12 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         self._prefix + self._names.FFW3, concat_0
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
-                                lora_a_process_func=transpose,
-                                lora_b_process_func=transpose,
+                                lora_a_process_func=identity,
+                                lora_b_process_func=identity,
                                 lora_a_split_func=sp_id,
-                                lora_b_split_func=sp_neg1,
+                                lora_b_split_func=sp_0,
                             ),
                             FfnAtomicWeight(
                                 W.ffn_w2,
@@ -411,11 +410,11 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                                         self._prefix + self._names.FFW2, concat_1
                                     )
                                 ],
-                                transpose,
+                                identity,
                                 config=ffn_config,
-                                lora_a_process_func=transpose,
-                                lora_b_process_func=transpose,
-                                lora_a_split_func=sp_0,
+                                lora_a_process_func=identity,
+                                lora_b_process_func=identity,
+                                lora_a_split_func=sp_neg1,
                                 lora_b_split_func=sp_id,
                             ),
                         ],
@@ -515,10 +514,10 @@ class LlamaWeightInfo(ModelDeployWeightInfo):
                     AttnAtomicWeight(
                         W.attn_qkv_w,
                         [CkptWeightInfo(self._prefix + self._names.W_QKV, identity)],
-                        transpose,
+                        identity,
                         config=attn_config,
-                        lora_a_process_func=transpose,
-                        lora_b_process_func=transpose,
+                        lora_a_process_func=identity,
+                        lora_b_process_func=identity,
                         lora_a_split_func=sp_id,
                         lora_b_split_func=sp_head_lora,
                     )

--- a/rtp_llm/models/megatron_bert_weight.py
+++ b/rtp_llm/models/megatron_bert_weight.py
@@ -10,12 +10,12 @@ from rtp_llm.model_loader.model_weight_info import (
     ModelWeightInfo,
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, identity, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, concat_0, identity
 
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -116,16 +116,16 @@ class MegatronBertWeightInfo(ModelDeployWeightInfo):
                 ],
                 concat_0,
             ),
-            AttnAtomicWeight(W.attn_o_w, [CkptWeightInfo(self._names.O_W)], transpose),
+            AttnAtomicWeight(W.attn_o_w, [CkptWeightInfo(self._names.O_W)], identity),
             AttnAtomicWeight(W.attn_o_b, [CkptWeightInfo(self._names.O_B)]),
             AtomicWeight(W.post_ln_beta, [CkptWeightInfo(self._names.POST_LN_B)]),
             AtomicWeight(W.post_ln_gamma, [CkptWeightInfo(self._names.POST_LN_W)]),
             FfnAtomicWeight(
-                W.ffn_w3, [CkptWeightInfo(self._names.FFN_INTER_DENSE_W)], transpose
+                W.ffn_w3, [CkptWeightInfo(self._names.FFN_INTER_DENSE_W)], identity
             ),
             FfnAtomicWeight(W.ffn_b3, [CkptWeightInfo(self._names.FFN_INTER_DENSE_B)]),
             FfnAtomicWeight(
-                W.ffn_w2, [CkptWeightInfo(self._names.FFN_OUTPUT_DENSE_W)], transpose
+                W.ffn_w2, [CkptWeightInfo(self._names.FFN_OUTPUT_DENSE_W)], identity
             ),
             FfnAtomicWeight(W.ffn_b2, [CkptWeightInfo(self._names.FFN_OUTPUT_DENSE_B)]),
         ]

--- a/rtp_llm/models/mixtral.py
+++ b/rtp_llm/models/mixtral.py
@@ -5,8 +5,7 @@ from typing import List
 
 import torch
 
-from rtp_llm.config.model_config import VitParameters
-from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.model_config import ModelConfig, VitParameters
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.model_loader.attn_weight import AttnAtomicWeight, AttnConfig
 from rtp_llm.model_loader.ffn_weight import MoeAtomicWeight, MoeConfig, MoeWeight
@@ -30,14 +29,13 @@ from rtp_llm.utils.model_weight import (
     sp_neg1,
     stack_,
     stack_moe_w1,
-    transpose,
     zeros,
 )
 
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -86,11 +84,11 @@ class MixtralWeightInfo(ModelDeployWeightInfo):
             AttnAtomicWeight(
                 W.attn_o_w,
                 [CkptWeightInfo("model.layers.{i}.self_attn.o_proj.weight", concat_1)],
-                transpose,
+                identity,
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
-                lora_a_split_func=sp_0,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
+                lora_a_split_func=sp_neg1,
                 lora_b_split_func=sp_id,
             ),
             AtomicWeight(
@@ -172,12 +170,12 @@ class MixtralWeightInfo(ModelDeployWeightInfo):
                                 concat_0,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=moe_config,
-                        lora_a_process_func=transpose,
-                        lora_b_process_func=transpose,
+                        lora_a_process_func=identity,
+                        lora_b_process_func=identity,
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     MoeAtomicWeight(
                         W.moe_w1,
@@ -187,7 +185,7 @@ class MixtralWeightInfo(ModelDeployWeightInfo):
                         lora_a_process_func=stack_moe_w1,
                         lora_b_process_func=stack_moe_w1,
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     MoeAtomicWeight(
                         W.moe_w2,
@@ -196,7 +194,7 @@ class MixtralWeightInfo(ModelDeployWeightInfo):
                         config=moe_config,
                         lora_a_process_func=stack_,
                         lora_b_process_func=stack_,
-                        lora_a_split_func=sp_0,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                 ],

--- a/rtp_llm/models/mpt.py
+++ b/rtp_llm/models/mpt.py
@@ -14,14 +14,7 @@ from rtp_llm.model_loader.model_weight_info import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.models.base_model import BaseModel
-from rtp_llm.utils.model_weight import (
-    CkptWeightInfo,
-    W,
-    identity,
-    slopes,
-    transpose,
-    zeros,
-)
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, slopes, zeros
 
 
 class MptWeightInfo(ModelDeployWeightInfo):
@@ -72,7 +65,7 @@ class MptWeightInfo(ModelDeployWeightInfo):
                             "transformer.blocks.{i}.attn.Wqkv.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -82,7 +75,7 @@ class MptWeightInfo(ModelDeployWeightInfo):
                             "transformer.blocks.{i}.attn.out_proj.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AtomicWeight(
@@ -105,7 +98,7 @@ class MptWeightInfo(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -116,7 +109,7 @@ class MptWeightInfo(ModelDeployWeightInfo):
                                     identity,
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                     ],

--- a/rtp_llm/models/phi.py
+++ b/rtp_llm/models/phi.py
@@ -8,7 +8,7 @@ from rtp_llm.model_loader.model_weight_info import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.models.base_model import BaseModel
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
 from rtp_llm.utils.util import get_config_from_path
 
 
@@ -57,7 +57,7 @@ class PhiWeightInfo(ModelDeployWeightInfo):
                 AttnAtomicWeight(
                     W.attn_qkv_w,
                     [CkptWeightInfo("layers.{i_1}.mixer.Wqkv.weight", identity)],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -69,7 +69,7 @@ class PhiWeightInfo(ModelDeployWeightInfo):
                 AttnAtomicWeight(
                     W.attn_o_w,
                     [CkptWeightInfo("layers.{i_1}.mixer.out_proj.weight", identity)],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -83,7 +83,7 @@ class PhiWeightInfo(ModelDeployWeightInfo):
                         FfnAtomicWeight(
                             W.ffn_w3,
                             [CkptWeightInfo("layers.{i_1}.mlp.fc1.weight", identity)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -95,7 +95,7 @@ class PhiWeightInfo(ModelDeployWeightInfo):
                         FfnAtomicWeight(
                             W.ffn_w2,
                             [CkptWeightInfo("layers.{i_1}.mlp.fc2.weight", identity)],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -134,7 +134,9 @@ class Phi(BaseModel):
         config.num_layers = config_dict.get("n_layer", 24)
         config.max_seq_len = config_dict.get("n_positions", 2048)
         config.vocab_size = config_dict.get("vocab_size", 32)
-        config.attn_config.rope_config.dim = config_dict.get("rotary_dim", size_per_head)
+        config.attn_config.rope_config.dim = config_dict.get(
+            "rotary_dim", size_per_head
+        )
         config.attn_config.rope_config.style = 1
         config.attn_config.kv_head_num = config_dict.get("n_head", 32)
         config.norm_type = "layernorm"

--- a/rtp_llm/models/qwen.py
+++ b/rtp_llm/models/qwen.py
@@ -17,12 +17,11 @@ from rtp_llm.utils.model_weight import (
     CkptWeightInfo,
     W,
     identity,
+    pad,
     sp_0,
     sp_head_lora,
     sp_id,
     sp_neg1,
-    transpose,
-    transpose_pad,
     zeros,
 )
 
@@ -32,7 +31,7 @@ def hidden_to_inter(hidden_size):
     return int((int(4 * 2 / 3 * hidden_size) * 2 + ffn_m - 1) // ffn_m * ffn_m / 2)
 
 
-def qkv_transpose(ts, hidden_size):
+def qkv_reshape(ts, hidden_size):
     return ts[0].reshape(hidden_size, -1)
 
 
@@ -83,10 +82,10 @@ class QWenWeight(ModelDeployWeightInfo):
             AttnAtomicWeight(
                 W.attn_qkv_w,
                 [CkptWeightInfo("transformer.h.{i}.attn.c_attn.weight", identity)],
-                transpose,
+                identity,
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
                 lora_a_split_func=sp_id,
                 lora_b_split_func=sp_head_lora,
             ),
@@ -99,11 +98,11 @@ class QWenWeight(ModelDeployWeightInfo):
             AttnAtomicWeight(
                 W.attn_o_w,
                 [CkptWeightInfo("transformer.h.{i}.attn.c_proj.weight", identity)],
-                transpose,
+                identity,
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
-                lora_a_split_func=sp_0,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
+                lora_a_split_func=sp_neg1,
                 lora_b_split_func=sp_id,
             ),
             FfnWeight(
@@ -111,26 +110,26 @@ class QWenWeight(ModelDeployWeightInfo):
                     FfnAtomicWeight(
                         W.ffn_w1,
                         [CkptWeightInfo("transformer.h.{i}.mlp.w2.weight", identity)],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w3,
                         [CkptWeightInfo("transformer.h.{i}.mlp.w1.weight", identity)],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w2,
@@ -139,13 +138,13 @@ class QWenWeight(ModelDeployWeightInfo):
                                 "transformer.h.{i}.mlp.c_proj.weight", identity
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=1),
+                        functools.partial(pad, align_size=align_size, dim=1),
                         config=ffn_config,
                         lora_a_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
+                        lora_b_process_func=identity,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                 ],

--- a/rtp_llm/models/qwen2_vl/qwen2_vl.py
+++ b/rtp_llm/models/qwen2_vl/qwen2_vl.py
@@ -28,12 +28,11 @@ from rtp_llm.utils.model_weight import (
     merge_qkv_hf,
     merge_qkv_lora_A,
     merge_qkv_lora_B,
+    pad,
     sp_0,
     sp_head_lora,
     sp_id,
     sp_neg1,
-    transpose,
-    transpose_pad,
     zeros,
 )
 
@@ -138,15 +137,15 @@ class QWen2VLWeightInfo(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                 ],
                 functools.partial(merge_qkv_b),
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
-                lora_a_split_func=sp_0,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
+                lora_a_split_func=sp_neg1,
                 lora_b_split_func=sp_id,
             ),
             AttnAtomicWeight(
                 W.attn_o_w,
                 [CkptWeightInfo("model.layers.{i}.self_attn.o_proj.weight", identity)],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             FfnWeight(
@@ -158,14 +157,14 @@ class QWen2VLWeightInfo(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 "model.layers.{i}.mlp.gate_proj.weight", identity
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w3,
@@ -174,14 +173,14 @@ class QWen2VLWeightInfo(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 "model.layers.{i}.mlp.up_proj.weight", identity
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w2,
@@ -190,13 +189,13 @@ class QWen2VLWeightInfo(ModelDeployWeightInfo, BaseMultiModalWeightInfo):
                                 "model.layers.{i}.mlp.down_proj.weight", identity
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=1),
+                        functools.partial(pad, align_size=align_size, dim=1),
                         config=ffn_config,
                         lora_a_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=1
+                            pad, align_size=align_size, dim=1
                         ),
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
+                        lora_b_process_func=identity,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                 ],

--- a/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
@@ -7,7 +7,7 @@ from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
 from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next, Qwen35Moe
 from rtp_llm.models.qwen3_next.qwen3_next_weight import Qwen3NextWeight, plus_one
 from rtp_llm.ops import HybridAttentionType
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
 
 
 class Qwen3NextMTPWeight(Qwen3NextWeight):
@@ -45,7 +45,7 @@ class Qwen3NextMTPWeight(Qwen3NextWeight):
             AtomicWeight(
                 W.multi_tokens_predict_eh_proj,
                 [CkptWeightInfo(self.prefix + "fc.weight", identity)],
-                transpose,
+                identity,
             ),
             AtomicWeight(
                 W.final_ln_gamma,

--- a/rtp_llm/models/qwen3_next/qwen3_next_weight.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_weight.py
@@ -27,13 +27,12 @@ from rtp_llm.utils.model_weight import (
     W,
     identity,
     merge_qkv_hf,
+    pad,
     sp_0,
     sp_id,
     sp_neg1,
     stack_,
     stack_moe_w1,
-    transpose,
-    transpose_pad,
 )
 
 
@@ -161,16 +160,16 @@ def merge_qkvz_transpose_reorder(
     """
     qkv = ts[0]
     z = ts[1]
-    return torch.cat([qkv, z], dim=0).T
+    return torch.cat([qkv, z], dim=0)
 
 
 def merge_ba_transpose_reorder(
     ts: List[torch.Tensor], linear_attention_config: LinearAttentionConfig
 ):
-    """Merge and reorder b and a tensors, then transpose."""
+    """Merge and reorder b and a tensors, then identity."""
     b = ts[0]
     a = ts[1]
-    return torch.cat([b, a], dim=0).T
+    return torch.cat([b, a], dim=0)
 
 
 def transpose_gate_up(ts: List[torch.Tensor]):
@@ -190,7 +189,7 @@ def transpose_gate_up(ts: List[torch.Tensor]):
 
 
 # List[gate_up, hidden] -> [Expert, up_gate, hidden]
-def transpose_stack_moe_w1(ts: List[torch.Tensor]) -> torch.Tensor:
+def stack_reorder_moe_w1(ts: List[torch.Tensor]) -> torch.Tensor:
     stacked_tensor = torch.stack(ts, dim=0)
     gate_up_dim = stacked_tensor.shape[1] // 2
     return torch.cat(
@@ -289,7 +288,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                process_fun=transpose,
+                process_fun=identity,
                 config=self.attn_config,
             ),
             AttnAtomicWeight(
@@ -305,7 +304,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         ),
                     )
                 ],
-                process_fun=transpose,
+                process_fun=identity,
                 config=self.attn_config,
             ),
             AtomicWeight(
@@ -354,7 +353,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
         moe_gate = MoeAtomicWeight(
             W.moe_gate,
             [CkptWeightInfo(self.prefix + "layers.{i}.mlp.gate.weight", identity)],
-            process_fun=transpose,
+            process_fun=identity,
             config=moe_config,
         )
         ffn_sub_weights = [
@@ -366,7 +365,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                process_fun=transpose,
+                process_fun=identity,
                 config=ffn_config,
             ),
             FfnAtomicWeight(
@@ -377,7 +376,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                process_fun=transpose,
+                process_fun=identity,
                 config=ffn_config,
             ),
             FfnAtomicWeight(
@@ -388,7 +387,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                process_fun=transpose,
+                process_fun=identity,
                 config=ffn_config,
             ),
         ]
@@ -400,7 +399,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                     identity,
                 )
             ],
-            process_fun=transpose,
+            process_fun=identity,
         )
         return moe_gate, shared_expert_gate, ffn_sub_weights
 
@@ -509,7 +508,7 @@ class Qwen3NextBaseWeight(ModelDeployWeightInfo):
                         self.prefix + "layers.{i}.linear_attn.out_proj.weight", identity
                     )
                 ],
-                transpose,
+                identity,
                 LinearAttnConfig(self.model_config.linear_attention_config),
             ),
         ]
@@ -535,7 +534,7 @@ class Qwen3NextWeight(Qwen3NextBaseWeight):
                     ),
                 )
             ],
-            transpose,
+            identity,
             LinearAttnConfig(self.model_config.linear_attention_config),
         )
 
@@ -552,7 +551,7 @@ class Qwen3NextWeight(Qwen3NextBaseWeight):
                     ),
                 )
             ],
-            transpose,
+            identity,
             LinearAttnConfig(self.model_config.linear_attention_config),
         )
 
@@ -602,7 +601,7 @@ class Qwen35MoeWeight(Qwen3NextBaseWeight):
             MoeAtomicWeight(
                 W.moe_w1,
                 [CkptWeightInfo(self.prefix + "layers.{i}.mlp.experts.gate_up_proj")],
-                process_fun=transpose_stack_moe_w1,
+                process_fun=stack_reorder_moe_w1,
                 config=moe_config,
                 stacked_ckpt_keys=True,
             ),
@@ -671,14 +670,14 @@ class Qwen35DenseWeight(Qwen35MoeWeight):
                                 identity,
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w3,
@@ -687,14 +686,14 @@ class Qwen35DenseWeight(Qwen35MoeWeight):
                                 self.prefix + "layers.{i}.mlp.up_proj.weight", identity
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w2,
@@ -704,13 +703,13 @@ class Qwen35DenseWeight(Qwen35MoeWeight):
                                 identity,
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=1),
+                        functools.partial(pad, align_size=align_size, dim=1),
                         config=ffn_config,
                         lora_a_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=1
+                            pad, align_size=align_size, dim=1
                         ),
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
+                        lora_b_process_func=identity,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                 ],

--- a/rtp_llm/models/qwen_v2.py
+++ b/rtp_llm/models/qwen_v2.py
@@ -26,12 +26,12 @@ from rtp_llm.utils.model_weight import (
     merge_qkv_hf,
     merge_qkv_lora_A,
     merge_qkv_lora_B,
+    pad,
     sp_0,
     sp_head_lora,
     sp_id,
     sp_neg1,
-    transpose,
-    transpose_pad,
+    t,
     zeros,
 )
 
@@ -86,14 +86,14 @@ class QWenV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w3,
@@ -104,14 +104,14 @@ class QWenV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
+                        functools.partial(pad, align_size=align_size, dim=0),
                         config=ffn_config,
-                        lora_a_process_func=transpose,
+                        lora_a_process_func=identity,
                         lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
+                            pad, align_size=align_size, dim=0
                         ),
                         lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
+                        lora_b_split_func=sp_0,
                     ),
                     FfnAtomicWeight(
                         W.ffn_w2,
@@ -122,13 +122,13 @@ class QWenV2Weight(ModelDeployWeightInfo):
                                 identity,
                             )
                         ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=1),
+                        functools.partial(pad, align_size=align_size, dim=1),
                         config=ffn_config,
                         lora_a_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=1
+                            pad, align_size=align_size, dim=1
                         ),
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
+                        lora_b_process_func=identity,
+                        lora_a_split_func=sp_neg1,
                         lora_b_split_func=sp_id,
                     ),
                 ],
@@ -200,11 +200,11 @@ class QWenV2Weight(ModelDeployWeightInfo):
                         identity,
                     )
                 ],
-                transpose,
+                identity,
                 config=attn_config,
-                lora_a_process_func=transpose,
-                lora_b_process_func=transpose,
-                lora_a_split_func=sp_0,
+                lora_a_process_func=identity,
+                lora_b_process_func=identity,
+                lora_a_split_func=sp_neg1,
                 lora_b_split_func=sp_id,
             ),
             AtomicWeight(
@@ -447,7 +447,7 @@ class QwenV2MTPWeight(QWenV2Weight):
                     AtomicWeight(
                         W.multi_tokens_predict_eh_proj,
                         [CkptWeightInfo("model.layers.{i}.eh_proj.weight", identity)],
-                        identity,
+                        t,
                     ),
                     AtomicWeight(
                         W.multi_tokens_predict_final_ln_gamma,

--- a/rtp_llm/models/qwen_v2_moe.py
+++ b/rtp_llm/models/qwen_v2_moe.py
@@ -13,14 +13,7 @@ from rtp_llm.model_loader.ffn_weight import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
-from rtp_llm.utils.model_weight import (
-    CkptWeightInfo,
-    W,
-    identity,
-    stack_,
-    stack_moe_w1,
-    transpose,
-)
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, stack_, stack_moe_w1
 
 
 class QWenV2MoeWeight(QWenV2Weight):
@@ -51,7 +44,7 @@ class QWenV2MoeWeight(QWenV2Weight):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                     FfnAtomicWeight(
@@ -62,7 +55,7 @@ class QWenV2MoeWeight(QWenV2Weight):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                     FfnAtomicWeight(
@@ -73,7 +66,7 @@ class QWenV2MoeWeight(QWenV2Weight):
                                 identity,
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                 ],
@@ -84,7 +77,7 @@ class QWenV2MoeWeight(QWenV2Weight):
                     MoeAtomicWeight(
                         W.moe_gate,
                         [CkptWeightInfo("model.layers.{i}.mlp.gate.weight", identity)],
-                        transpose,
+                        identity,
                         config=moe_config,
                     ),
                     MoeAtomicWeight(
@@ -126,7 +119,7 @@ class QWenV2MoeWeight(QWenV2Weight):
                         identity,
                     )
                 ],
-                transpose,
+                identity,
             ),
         ]
 

--- a/rtp_llm/models/qwen_v3_moe.py
+++ b/rtp_llm/models/qwen_v3_moe.py
@@ -53,7 +53,7 @@ class QWenV3MoeWeight(QWenV2MoeWeight):
                     MoeAtomicWeight(
                         W.moe_gate,
                         [CkptWeightInfo("model.layers.{i}.mlp.gate.weight", identity)],
-                        transpose,
+                        identity,
                         config=moe_config,
                     ),
                     MoeAtomicWeight(

--- a/rtp_llm/models/starcoder.py
+++ b/rtp_llm/models/starcoder.py
@@ -2,8 +2,7 @@ from typing import Any, Dict, List
 
 from transformers.models.gpt2.tokenization_gpt2_fast import GPT2TokenizerFast
 
-from rtp_llm.config.model_config import VitParameters
-from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.model_config import ModelConfig, VitParameters
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.model_loader.attn_weight import AttnAtomicWeight
 from rtp_llm.model_loader.ffn_weight import FfnAtomicWeight, FfnConfig, FfnWeight
@@ -13,13 +12,7 @@ from rtp_llm.model_loader.model_weight_info import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
 from rtp_llm.models.base_model import BaseModel
-from rtp_llm.utils.model_weight import (
-    CkptWeightInfo,
-    W,
-    WeightStyle,
-    identity,
-    transpose,
-)
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, WeightStyle, identity
 from rtp_llm.utils.util import get_config_from_path
 
 
@@ -110,7 +103,7 @@ class StarcoderWeightInfo(ModelDeployWeightInfo):
             AttnAtomicWeight(
                 W.attn_qkv_w,
                 [CkptWeightInfo("transformer.h.{i}.attn.c_attn.weight", identity)],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             AttnAtomicWeight(
@@ -122,7 +115,7 @@ class StarcoderWeightInfo(ModelDeployWeightInfo):
             AttnAtomicWeight(
                 W.attn_o_w,
                 [CkptWeightInfo("transformer.h.{i}.attn.c_proj.weight", identity)],
-                transpose,
+                identity,
                 config=attn_config,
             ),
             AttnAtomicWeight(
@@ -136,7 +129,7 @@ class StarcoderWeightInfo(ModelDeployWeightInfo):
                     FfnAtomicWeight(
                         W.ffn_w3,
                         [CkptWeightInfo("transformer.h.{i}.mlp.c_fc.weight", identity)],
-                        transpose,
+                        identity,
                         config=ffn_config,
                     ),
                     FfnAtomicWeight(
@@ -152,7 +145,7 @@ class StarcoderWeightInfo(ModelDeployWeightInfo):
                                 "transformer.h.{i}.mlp.c_proj.weight", identity
                             )
                         ],
-                        transpose,
+                        identity,
                         config=ffn_w2_config,
                     ),
                     FfnAtomicWeight(

--- a/rtp_llm/models/starcoder2.py
+++ b/rtp_llm/models/starcoder2.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, List
 import torch
 from transformers.models.gpt2.tokenization_gpt2_fast import GPT2TokenizerFast
 
-from rtp_llm.config.model_config import VitParameters
-from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.model_config import ModelConfig, VitParameters
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.model_loader.attn_weight import AttnAtomicWeight
 from rtp_llm.model_loader.ffn_weight import FfnAtomicWeight, FfnWeight
@@ -15,7 +14,7 @@ from rtp_llm.model_loader.model_weight_info import (
 )
 from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.models.base_model import BaseModel
-from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
 from rtp_llm.utils.util import get_config_from_path
 
 
@@ -27,7 +26,7 @@ def merge_qkv_b(ts: List[torch.Tensor]):
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -109,7 +108,7 @@ class Starcoder2WeightInfo(ModelDeployWeightInfo):
                             "model.layers.{i}.self_attn.o_proj.weight", identity
                         )
                     ],
-                    transpose,
+                    identity,
                     config=attn_config,
                 ),
                 AttnAtomicWeight(
@@ -131,7 +130,7 @@ class Starcoder2WeightInfo(ModelDeployWeightInfo):
                                     "model.layers.{i}.mlp.c_fc.weight", identity
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -151,7 +150,7 @@ class Starcoder2WeightInfo(ModelDeployWeightInfo):
                                     "model.layers.{i}.mlp.c_proj.weight", identity
                                 )
                             ],
-                            transpose,
+                            identity,
                             config=ffn_config,
                         ),
                         FfnAtomicWeight(
@@ -202,7 +201,9 @@ class StarCoder2(BaseModel):
         config = ModelConfig()
         config.attn_config.head_num = config_json["num_attention_heads"]
         config.attn_config.kv_head_num = config_json["num_key_value_heads"]
-        config.attn_config.size_per_head = config_json["hidden_size"] // config_json["num_attention_heads"]
+        config.attn_config.size_per_head = (
+            config_json["hidden_size"] // config_json["num_attention_heads"]
+        )
         config.num_layers = config_json["num_hidden_layers"]
         config.max_seq_len = config_json.get("max_position_embeddings", 8192)
         config.vocab_size = config_json["vocab_size"]
@@ -215,7 +216,9 @@ class StarCoder2(BaseModel):
         config.special_tokens.eos_token_id = config_json.get("eos_token_id", 0)
         config.special_tokens.bos_token_id = config_json.get("bos_token_id", -1)
         config.activation_type = config_json["activation_function"]
-        config.attn_config.rope_config.base = int(config_json.get("rope_theta", 1000000))
+        config.attn_config.rope_config.base = int(
+            config_json.get("rope_theta", 1000000)
+        )
         config.attn_config.rope_config.dim = config.attn_config.size_per_head
         config.tie_word_embeddings = config_json.get("tie_word_embeddings", False)
         config.config_dtype = config_json.get("torch_dtype", None)

--- a/rtp_llm/models_py/modules/factory/linear/factory.py
+++ b/rtp_llm/models_py/modules/factory/linear/factory.py
@@ -9,17 +9,19 @@ from typing import Dict, List, Optional, Type
 import torch
 from torch import nn
 
-from .linear_base import LinearBase
-
 from rtp_llm.ops import HWKernelConfig
+
+from .linear_base import LinearBase
 
 try:
     # Fix nvidia-cutlass-dsl cutlass module path on sm100 or upper device
-    import sys
     import os
+    import sys
+
     import nvidia_cutlass_dsl
+
     pkg_dir = nvidia_cutlass_dsl.__path__[0]
-    python_packages_dir = os.path.join(pkg_dir, 'python_packages')
+    python_packages_dir = os.path.join(pkg_dir, "python_packages")
 
     if os.path.isdir(python_packages_dir) and python_packages_dir not in sys.path:
         sys.path.insert(0, python_packages_dir)
@@ -62,7 +64,7 @@ class LinearFactory:
         scale_key: Optional[str] = None,
         bias_key: Optional[str] = None,
         quant_config: object = None,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2_key: Optional[str] = None,
         input_scale_key: Optional[str] = None,
     ) -> LinearBase:
@@ -86,11 +88,20 @@ class LinearFactory:
         weight = weights[weight_key]
         weight_scales = weights.get(scale_key) if scale_key else None
         bias = weights.get(bias_key) if bias_key else None
-        weight_scale_2 = weights.get(weight_scale_2_key, None) if weight_scale_2_key else None
+        weight_scale_2 = (
+            weights.get(weight_scale_2_key, None) if weight_scale_2_key else None
+        )
         input_scale = weights.get(input_scale_key, None) if input_scale_key else None
 
-        return cls.create_linear(weight, bias, weight_scales, quant_config, hw_kernel_config,
-                                 weight_scale_2, input_scale)
+        return cls.create_linear(
+            weight,
+            bias,
+            weight_scales,
+            quant_config,
+            hw_kernel_config,
+            weight_scale_2,
+            input_scale,
+        )
 
     @classmethod
     def create_linear(
@@ -99,15 +110,21 @@ class LinearFactory:
         bias: Optional[torch.Tensor],
         weight_scales: Optional[torch.Tensor],
         quant_config: object,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ):
         candidates = [
             strategy_class
             for strategy_class in cls._strategies
-            if strategy_class.can_handle(quant_config, weight, weight_scales, hw_kernel_config,
-                                         weight_scale_2, input_scale)
+            if strategy_class.can_handle(
+                quant_config,
+                weight,
+                weight_scales,
+                hw_kernel_config,
+                weight_scale_2,
+                input_scale,
+            )
         ]
 
         if not candidates:
@@ -143,80 +160,6 @@ class LinearFactory:
         )
 
         return instance
-
-    # TODO: remove this since merge w13 should always be handled when loading weights
-    @classmethod
-    def create_merged_linear(
-        cls,
-        weights: Dict[str, torch.Tensor],
-        weight_keys: List[str],
-        scale_keys: Optional[List[str]],
-        bias_keys: Optional[List[str]],
-        scale2_keys: Optional[List[str]],
-        input_scale_keys: Optional[List[str]],
-        quant_config: object,
-        dim: int = -1,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
-    ) -> nn.Module:
-        """Create merged Linear layer (e.g., gate_up_proj)."""
-        # Check FP8 usage based on first weight
-        use_fp8 = LinearFactory.should_use_fp8_linear(quant_config, weights, weight_keys[0])
-        
-        # Check FP4 usage based on first weight
-        use_fp4 = LinearFactory.should_use_fp4_linear(quant_config, weights, weight_keys[0])
-
-        # Merge weights
-        weight_tensors = [weights[key] for key in weight_keys]
-        merged_weight = torch.cat(weight_tensors, dim=dim)
-
-        # Merge scales if needed (for both FP8 and NVFP4)
-        merged_scales = None
-        if (use_fp8 or use_fp4) and scale_keys:
-            scale_tensors = [weights[key] for key in scale_keys]
-            merged_scales = torch.cat(scale_tensors, dim=dim)
-
-        # Merge bias if exists
-        merged_bias = None
-        if bias_keys:
-            bias_tensors = []
-            for key in bias_keys:
-                bias = weights.get(key)
-                if bias is not None:
-                    bias_tensors.append(bias)
-
-            if bias_tensors:
-                merged_bias = torch.cat(bias_tensors, dim=dim)
-        
-        # Merge scale2 and input_scale if exists
-        weight_scale_2 = None
-        if use_fp4 and scale2_keys:
-            scale2_tensors = []
-            for key in scale2_keys:
-                scale2 = weights.get(key)
-                if scale2 is not None:
-                    scale2_tensors.append(scale2)
-            if scale2_tensors:
-                weight_scale_2 = torch.max(torch.stack(scale2_tensors))
-
-        input_scale = None
-        if use_fp4 and input_scale_keys:
-            input_scale_tensors = []
-            for key in input_scale_keys:
-                input_scale_tensor = weights.get(key)
-                if input_scale_tensor is not None:
-                    input_scale_tensors.append(input_scale_tensor)
-            if input_scale_tensors:
-                input_scale = torch.max(torch.stack(input_scale_tensors))
-
-        return cls.create_linear(
-            weight=merged_weight,
-            weight_scales=merged_scales,
-            bias=merged_bias,
-            quant_config=quant_config,
-            hw_kernel_config=hw_kernel_config,
-            weight_scale_2=weight_scale_2,
-            input_scale=input_scale,
-        )
 
     @staticmethod
     def should_use_fp8_linear(

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/f16_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/f16_linear.py
@@ -8,6 +8,7 @@ from torch.nn import functional as F
 from rtp_llm.models_py.modules.factory.linear import LinearBase
 from rtp_llm.ops import HWKernelConfig
 
+
 class CudaF16Linear(LinearBase):
     """CUDA F16 (non-quantized) Linear"""
 
@@ -17,7 +18,7 @@ class CudaF16Linear(LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
@@ -31,11 +32,12 @@ class CudaF16Linear(LinearBase):
         input_scales: Optional[torch.Tensor] = None,
         bias: Optional[torch.Tensor] = None,
         quant_config: object = None,
-        weight_scale_2: Optional[torch.Tensor] = None
+        weight_scale_2: Optional[torch.Tensor] = None,
     ):
-        super().__init__(weight, weight_scales, input_scales,
-                         bias, quant_config, weight_scale_2)
-        self.weight = weight.T
+        super().__init__(
+            weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
+        )
+        self.weight = weight
         self.bias = bias
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
@@ -5,14 +5,9 @@ from typing import Optional
 
 import torch
 
-from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
-    fp8_gemm_nt,
-    has_deep_gemm,
-    is_deep_gemm_e8m0_used,
-)
+from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import fp8_gemm_nt, has_deep_gemm
 from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
     create_per_token_group_quant_fp8_output_scale,
-    requant_weight_ue8m0,
     sgl_per_token_group_quant_fp8,
 )
 from rtp_llm.models_py.modules.factory.linear import LinearBase
@@ -78,16 +73,8 @@ class CudaFp8DeepGEMMLinear(LinearBase):
             error_msg = f"Weight and weight scale must be 2D tensors, but got weight dim: {self.weight.dim()} and weight scale dim: {self.weight_scales.dim()}"
             logger.error(error_msg)
             raise ValueError(error_msg)
-        # e8m0 load not need reshape
-        if is_deep_gemm_e8m0_used():
-            self.N, self.K = self.weight.shape
-            self.scale_N, self.scale_K = self.weight_scales.shape
-        else:
-            # Reshape weight and weight scale
-            self.K, self.N = self.weight.shape
-            self.scale_K, self.scale_N = self.weight_scales.shape
-            self.weight = self.weight.reshape(self.N, self.K)
-            self.weight_scales = self.weight_scales.reshape(self.scale_N, self.scale_K)
+        self.N, self.K = self.weight.shape
+        self.scale_N, self.scale_K = self.weight_scales.shape
         # Check weight scale sizes
         if self.weight_scales.dtype is torch.float32 and (
             (self.N + 127) // 128 != self.scale_N

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp4_gemm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp4_gemm_linear_test.py
@@ -4,15 +4,14 @@ import unittest
 
 import torch
 import torch.nn.functional as F
+from flashinfer import fp4_quantize
 
-from rtp_llm.test.utils.numeric_util import calc_diff
+from rtp_llm.config.quant_config import init_quant_config
+from rtp_llm.device.device_impl import CudaImpl
 from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp4_linear import (
     CudaFp4GEMMLinear,
 )
-
-from flashinfer import fp4_quantize
-from rtp_llm.config.quant_config import init_quant_config
-from rtp_llm.device.device_impl import CudaImpl
+from rtp_llm.test.utils.numeric_util import calc_diff
 
 
 class CudaFp4GEMMLinearTest(unittest.TestCase):
@@ -29,7 +28,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
 
         self.hidden_size = 1024  # k
         self.output_size = 512  # n
-        self.batch_sizes = [1, 32, 64, 128, 256] # m
+        self.batch_sizes = [1, 32, 64, 128, 256]  # m
         weight_fp16 = (
             torch.randn(
                 self.output_size,
@@ -41,9 +40,9 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
         )
         global_sf_weight = (448 * 6) / weight_fp16.float().abs().nan_to_num().max()
         self.weight_scale_2 = 1.0 / global_sf_weight.to(torch.float32)
-        fp4_weight, weight_scale = fp4_quantize(weight_fp16,
-                                                global_scale=global_sf_weight,
-                                                is_sf_swizzled_layout=False)
+        fp4_weight, weight_scale = fp4_quantize(
+            weight_fp16, global_scale=global_sf_weight, is_sf_swizzled_layout=False
+        )
         self.weight = fp4_weight
         self.weight_scales = weight_scale
 
@@ -63,8 +62,8 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
             weight_scales=processed_scale,
             input_scales=self.input_scale,
             bias=self.bias if with_bias else None,
-            quant_config=init_quant_config('modelopt_fp4'),
-            weight_scale_2=self.weight_scale_2
+            quant_config=init_quant_config("modelopt_fp4"),
+            weight_scale_2=self.weight_scale_2,
         )
 
     def test_module_creation(self):
@@ -121,7 +120,8 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             fp4_linear(input_fp32)
         self.assertIn(
-            "CudaFp4GEMMLinear accepts bfloat16 and float16 input", str(context.exception)
+            "CudaFp4GEMMLinear accepts bfloat16 and float16 input",
+            str(context.exception),
         )
         self.assertIn("torch.float32", str(context.exception))
 
@@ -133,7 +133,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
             fp4_linear(input_fp16)
         self.assertIn(
             "CudaFp4GEMMLinear with trtllm backend only supoorts bfloat16 input",
-            str(context.exception)
+            str(context.exception),
         )
         self.assertIn("torch.float16", str(context.exception))
 
@@ -184,9 +184,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
 
     def test_bias_handling(self):
         """Test bias handling"""
-        fp4_linear_with_bias = self._create_fp4_linear(
-            with_bias=True
-        )
+        fp4_linear_with_bias = self._create_fp4_linear(with_bias=True)
         input_tensor = torch.randn(
             32, self.hidden_size, dtype=torch.bfloat16, device=self.device
         )
@@ -194,9 +192,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
         output_with_bias = fp4_linear_with_bias(input_tensor)
         self.assertEqual(output_with_bias.shape, (32, self.output_size))
 
-        fp4_linear_no_bias = self._create_fp4_linear(
-            with_bias=False
-        )
+        fp4_linear_no_bias = self._create_fp4_linear(with_bias=False)
         output_no_bias = fp4_linear_no_bias(input_tensor)
         self.assertEqual(output_no_bias.shape, (32, self.output_size))
 
@@ -267,7 +263,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
         # Weight should be stored in original shape [n, k]
         expected_weight_shape = (self.output_size, self.hidden_size // 2)
         self.assertEqual(fp4_linear.weight.shape, expected_weight_shape)
-        
+
     def test_fp4_vs_bf16_accuracy(self):
         """Test accuracy comparison between FP4 linear and BF16 linear"""
         # Create FP4 linear layer, cutlass backend
@@ -294,7 +290,9 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
                     device=self.device,
                 )
 
-                fp4_linear.input_scale = 1.0 / (448.0 * 6.0 / input_tensor.float().abs().nan_to_num().max())
+                fp4_linear.input_scale = 1.0 / (
+                    448.0 * 6.0 / input_tensor.float().abs().nan_to_num().max()
+                )
                 fp4_linear.alpha = fp4_linear.input_scale * fp4_linear.weight_scale_2
                 fp4_linear.input_scale_inv = 1.0 / fp4_linear.input_scale
                 # Forward pass through FP4 linear
@@ -307,7 +305,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
                 print(f"backend: {backend}, fp4_output: {fp4_output.float()}")
                 print(f"backend: {backend}, bf16_output: {bf16_output.float()}")
                 diff = calc_diff(fp4_output, bf16_output)
-                self.assertLess(diff, 0.01)
+                self.assertLess(diff, 0.012)
 
                 # Both outputs should have the same shape and dtype
                 self.assertEqual(fp4_output.shape, bf16_output.shape)
@@ -338,7 +336,9 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
                     dtype=torch.float16,
                     device=self.device,
                 )
-                fp4_linear.input_scale = 1.0 / (448.0 * 6.0 / input_tensor.float().abs().nan_to_num().max())
+                fp4_linear.input_scale = 1.0 / (
+                    448.0 * 6.0 / input_tensor.float().abs().nan_to_num().max()
+                )
                 fp4_linear.alpha = fp4_linear.input_scale * fp4_linear.weight_scale_2
                 fp4_linear.input_scale_inv = 1.0 / fp4_linear.input_scale
                 # Forward pass through FP4 linear
@@ -351,7 +351,7 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
                 print(f"backend: {backend}, fp4_output: {fp4_output.float()}")
                 print(f"backend: {backend}, fp16_output: {fp16_output.float()}")
                 diff = calc_diff(fp4_output, fp16_output)
-                self.assertLess(diff, 0.01)
+                self.assertLess(diff, 0.012)
 
                 # Both outputs should have the same shape and dtype
                 self.assertEqual(fp4_output.shape, fp16_output.shape)
@@ -362,4 +362,3 @@ class CudaFp4GEMMLinearTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_deepgemm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_deepgemm_linear_test.py
@@ -68,8 +68,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         ]
         weight_fp32 = (
             torch.randn(
-                self.K,
                 self.N,
+                self.K,
                 dtype=torch.float32,
                 device=self.device,
             )
@@ -78,8 +78,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         self.weight = weight_fp32.to(torch.float8_e4m3fn)
         self.weight_scales = (
             torch.rand(
-                self.scale_K,
                 self.scale_N,
+                self.scale_K,
                 dtype=torch.float32,
                 device=self.device,
             )
@@ -88,20 +88,15 @@ class CudaFp8DeepGEMMLinearTestBase:
         )
         self.bias = torch.randn(self.N, dtype=torch.bfloat16, device=self.device)
 
-    def _apply_ue8m0_requant(self, weight_kn: torch.Tensor, scale_kn: torch.Tensor):
-        """Apply requant_weight_ue8m0 in (N, K) orientation if is_deep_gemm_e8m0_used().
+    def _apply_ue8m0_requant(self, weight_nk: torch.Tensor, scale_nk: torch.Tensor):
+        """Apply requant_weight_ue8m0 if is_deep_gemm_e8m0_used().
 
-        weight_kn: (K, N) fp8 tensor (as stored by _postprocess / passed to __init__)
-        scale_kn: (scale_K, scale_N) float32 scale
-        Returns (weight_kn, scale) where scale is int32 if UE8M0 was applied.
+        weight_nk: (N, K) fp8 tensor
+        scale_nk: (scale_N, scale_K) float32 scale
+        Returns (weight, scale) where scale is int32 if UE8M0 was applied.
         """
         if not is_deep_gemm_e8m0_used():
-            return weight_kn, scale_kn
-        K, N = weight_kn.shape
-        scale_K, scale_N = scale_kn.shape
-        # Requant expects (N, K) weight and (scale_N, scale_K) scale
-        weight_nk = weight_kn.reshape(N, K)
-        scale_nk = scale_kn.reshape(scale_N, scale_K)
+            return weight_nk, scale_nk
         w_tmp, new_scale = requant_weight_ue8m0(weight_nk, scale_nk)
         return w_tmp, new_scale
 
@@ -214,6 +209,7 @@ class CudaFp8DeepGEMMLinearTestBase:
         ).to(torch.float8_e4m3fn)
         if is_deep_gemm_e8m0_used():
             self.weight_scales = self.weight_scales.T
+            self.scale_N, self.scale_K = self.scale_K, self.scale_N
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(weight, self.weight_scales)
         self.assertIn(
@@ -237,10 +233,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         )
         # Validate weight shape not equal to (N, K)
         weight = torch.randn(
-            (self.K, self.N + 1), dtype=torch.float32, device=self.device
+            (self.N + 1, self.K), dtype=torch.float32, device=self.device
         ).to(torch.float8_e4m3fn)
-        if is_deep_gemm_e8m0_used():
-            weight = weight.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(weight, self.weight_scales)
         self.assertIn(f"Weight scale dimension mismatch! ", str(context.exception))
@@ -249,10 +243,8 @@ class CudaFp8DeepGEMMLinearTestBase:
             str(context.exception),
         )
         weight = torch.randn(
-            (self.K + 1, self.N), dtype=torch.float32, device=self.device
+            (self.N, self.K + 1), dtype=torch.float32, device=self.device
         ).to(torch.float8_e4m3fn)
-        if is_deep_gemm_e8m0_used():
-            weight = weight.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(weight, self.weight_scales)
         self.assertIn(f"Weight scale dimension mismatch! ", str(context.exception))
@@ -261,11 +253,14 @@ class CudaFp8DeepGEMMLinearTestBase:
             str(context.exception),
         )
         # Validate weight dtype not equal to float8_e4m3fn
-        weight = torch.randn((self.K, self.N), dtype=torch.float32, device=self.device)
-        if is_deep_gemm_e8m0_used():
-            weight = weight.T
+        weight = torch.randn((self.N, self.K), dtype=torch.float32, device=self.device)
+        valid_weight_scales = torch.randn(
+            ((self.N + 127) // 128, (self.K + 127) // 128),
+            dtype=torch.float32,
+            device=self.device,
+        )
         with self.assertRaises(ValueError) as context:
-            CudaFp8DeepGEMMLinear(weight, self.weight_scales)
+            CudaFp8DeepGEMMLinear(weight, valid_weight_scales)
         self.assertIn(
             f"Weight dtype must be float8_e4m3fn, got ", str(context.exception)
         )
@@ -275,11 +270,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         """Test weight scale validation"""
         # Validate weight scale dimension not equal to 2
         weight_scales = torch.randn(
-            (self.scale_K, self.scale_N, 1), dtype=torch.float32, device=self.device
+            (self.scale_N, self.scale_K, 1), dtype=torch.float32, device=self.device
         )
-        if is_deep_gemm_e8m0_used():
-            self.weight = self.weight.reshape(self.N, self.K)
-            weight_scales = weight_scales.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(self.weight, weight_scales)
         self.assertIn(
@@ -290,10 +282,8 @@ class CudaFp8DeepGEMMLinearTestBase:
             str(context.exception),
         )
         weight_scales = torch.randn(
-            (self.scale_K), dtype=torch.float32, device=self.device
+            (self.scale_N), dtype=torch.float32, device=self.device
         )
-        if is_deep_gemm_e8m0_used():
-            weight_scales = weight_scales.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(self.weight, weight_scales)
         self.assertIn(
@@ -305,10 +295,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         )
         # Validate weight scale shape not equal to (scale_N, scale_K)
         weight_scales = torch.randn(
-            (self.scale_K, self.scale_N + 1), dtype=torch.float32, device=self.device
+            (self.scale_N + 1, self.scale_K), dtype=torch.float32, device=self.device
         )
-        if is_deep_gemm_e8m0_used():
-            weight_scales = weight_scales.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(self.weight, weight_scales)
         self.assertIn(f"Weight scale dimension mismatch! ", str(context.exception))
@@ -317,10 +305,8 @@ class CudaFp8DeepGEMMLinearTestBase:
             str(context.exception),
         )
         weight_scales = torch.randn(
-            (self.scale_K + 1, self.scale_N), dtype=torch.float32, device=self.device
+            (self.scale_N, self.scale_K + 1), dtype=torch.float32, device=self.device
         )
-        if is_deep_gemm_e8m0_used():
-            weight_scales = weight_scales.T
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(self.weight, weight_scales)
         self.assertIn(f"Weight scale dimension mismatch! ", str(context.exception))
@@ -328,10 +314,10 @@ class CudaFp8DeepGEMMLinearTestBase:
             f"N: {self.N}, scale_N: {self.scale_N}, K: {self.K}, scale_K: {self.scale_K + 1}",
             str(context.exception),
         )
-        weight = torch.randn((7168, 2112), dtype=torch.float32, device=self.device).to(
+        weight = torch.randn((2112, 7168), dtype=torch.float32, device=self.device).to(
             torch.float8_e4m3fn
         )
-        weight_scales = torch.randn((56, 17), dtype=torch.float32, device=self.device)
+        weight_scales = torch.randn((17, 56), dtype=torch.float32, device=self.device)
         weight, weight_scales = self._apply_ue8m0_requant(weight, weight_scales)
         cuda_fp8_deepgemm_linear = CudaFp8DeepGEMMLinear(weight, weight_scales)
         input_tensor = torch.randn(
@@ -346,7 +332,7 @@ class CudaFp8DeepGEMMLinearTestBase:
         self.assertEqual(output.device.type, "cuda")
         # Validate weight scale dtype not equal to float32
         weight_scales = torch.randn(
-            (self.scale_K, self.scale_N), dtype=torch.float16, device=self.device
+            (self.scale_N, self.scale_K), dtype=torch.float16, device=self.device
         )
         with self.assertRaises(ValueError) as context:
             CudaFp8DeepGEMMLinear(self.weight, weight_scales)
@@ -492,13 +478,6 @@ class CudaFp8DeepGEMMLinearTestBase:
         weight_fp8, weight_scales = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
         if is_deep_gemm_e8m0_used():
             weight_fp8, weight_scales = requant_weight_ue8m0(weight_fp8, weight_scales)
-        else:
-            weight_fp8 = weight_fp8.reshape(self.K, self.N)
-            weight_scales = weight_scales.reshape(self.scale_K, self.scale_N)
-
-        if not is_deep_gemm_e8m0_used():
-            weight_fp8 = weight_fp8.reshape(self.K, self.N)
-            weight_scales = weight_scales.reshape(self.scale_K, self.scale_N)
         # Initialize FP8 linear layer
         cuda_fp8_deepgemm_linear = CudaFp8DeepGEMMLinear(weight_fp8, weight_scales)
         # Test some batch sizes
@@ -555,9 +534,6 @@ class CudaFp8DeepGEMMLinearTestBase:
         weight_fp8, weight_scales = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
         if is_deep_gemm_e8m0_used():
             weight_fp8, weight_scales = requant_weight_ue8m0(weight_fp8, weight_scales)
-        else:
-            weight_fp8 = weight_fp8.reshape(self.K, self.N)
-            weight_scales = weight_scales.reshape(self.scale_K, self.scale_N)
         bias_bf16 = torch.randn((self.N,), dtype=torch.bfloat16, device=self.device)
         # Initialize FP8 linear layer
         cuda_fp8_deepgemm_linear = CudaFp8DeepGEMMLinear(
@@ -752,9 +728,6 @@ class CudaFp8DeepGEMMLinearTestBase:
         weight_fp8, weight_scales = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
         if is_deep_gemm_e8m0_used():
             weight_fp8, weight_scales = requant_weight_ue8m0(weight_fp8, weight_scales)
-        else:
-            weight_fp8 = weight_fp8.reshape(self.K, self.N)
-            weight_scales = weight_scales.reshape(self.scale_K, self.scale_N)
 
         # Create linear layer and cache scales
         cuda_fp8_deepgemm_linear = CudaFp8DeepGEMMLinear(weight_fp8, weight_scales)
@@ -808,8 +781,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         )
         weight_fp32 = (
             torch.randn(
-                K,
                 N,
+                K,
                 dtype=torch.float32,
                 device=device,
             )
@@ -818,8 +791,8 @@ class CudaFp8DeepGEMMLinearTestBase:
         weight = weight_fp32.to(torch.float8_e4m3fn)
         weight_scales = (
             torch.rand(
-                (K + 127) // 128,
                 (N + 127) // 128,
+                (K + 127) // 128,
                 dtype=torch.float32,
                 device=device,
             )

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/f16_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/f16_linear.py
@@ -1,14 +1,15 @@
 """ROCm F16 (non-quantized) Linear implementation"""
 
 import os
+from functools import lru_cache
 from typing import Optional
 
 import torch
+from aiter import hipb_create_extension, hipb_mm
 
 from rtp_llm.models_py.modules.factory.linear import LinearBase
-from aiter import hipb_mm, hipb_create_extension
-from functools import lru_cache
 from rtp_llm.ops import HWKernelConfig
+
 
 class RocmF16LinearBase(LinearBase):
     """ROCm F16 (non-quantized) Linear"""
@@ -19,7 +20,7 @@ class RocmF16LinearBase(LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
@@ -34,12 +35,13 @@ class RocmF16LinearBase(LinearBase):
         quant_config: object = None,
         weight_scale_2: Optional[torch.Tensor] = None,
     ):
-        super().__init__(weight, weight_scales, input_scales,
-                         bias, quant_config, weight_scale_2)
+        super().__init__(
+            weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
+        )
         self.weight = weight
         self.bias = bias
-        
-    @staticmethod    
+
+    @staticmethod
     @lru_cache(maxsize=1)
     def init_hipblas():
         hipb_create_extension()
@@ -47,7 +49,7 @@ class RocmF16LinearBase(LinearBase):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("Subclasses must implement `forward`.")
 
-        
+
 class RocmF16LinearWithSwizzle(RocmF16LinearBase):
 
     @classmethod
@@ -56,11 +58,15 @@ class RocmF16LinearWithSwizzle(RocmF16LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'],
+        hw_kernel_config: Optional["HWKernelConfig"],
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
-        return weight_scales is None and hw_kernel_config is not None and hw_kernel_config.use_swizzleA
+        return (
+            weight_scales is None
+            and hw_kernel_config is not None
+            and hw_kernel_config.use_swizzleA
+        )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         self.init_hipblas()
@@ -75,7 +81,8 @@ class RocmF16LinearWithSwizzle(RocmF16LinearBase):
             scaleOut=None,
             bpreshuffle=True,
         )
-        
+
+
 class RocmF16LinearNoSwizzle(RocmF16LinearBase):
 
     @classmethod
@@ -84,7 +91,7 @@ class RocmF16LinearNoSwizzle(RocmF16LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'],
+        hw_kernel_config: Optional["HWKernelConfig"],
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_deepgemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_deepgemm_linear.py
@@ -51,12 +51,10 @@ class RocmFp8DeepGEMMLinear(LinearBase):
         super().__init__(
             weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
         )
-        self.hidden_size = weight.shape[0]  # k
-        self.output_size = weight.shape[1]  # n
-        self.weight = weight.reshape([weight.shape[1], weight.shape[0]])
-        self.weight_scales = weight_scales.reshape(
-            [weight_scales.shape[1], weight_scales.shape[0]]
-        )
+        self.output_size = weight.shape[0]  # n
+        self.hidden_size = weight.shape[1]  # k
+        self.weight = weight
+        self.weight_scales = weight_scales
         self.bias = bias
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_ptpc_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_ptpc_linear.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 from rtp_llm.models_py.kernels.rocm.fp8_kernel import rocm_per_token_quant_fp8
 from rtp_llm.ops import HWKernelConfig
 
+
 class RocmFp8PTPCLinear(LinearBase):
     """ROCm FP8 PTPC (Per-Token Per-Channel) quantized Linear"""
 
@@ -23,7 +24,7 @@ class RocmFp8PTPCLinear(LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
@@ -48,15 +49,13 @@ class RocmFp8PTPCLinear(LinearBase):
         quant_config: object = None,
         weight_scale_2: Optional[torch.Tensor] = None,
     ):
-        super().__init__(weight, weight_scales, input_scales,
-                         bias, quant_config, weight_scale_2)
-        self.hidden_size = weight.shape[0]  # k
-        self.output_size = weight.shape[1]  # n
-        # Reshape weight from [k, n] to [n, k] as done in C++ code
-        self.weight = weight.reshape([weight.shape[1], weight.shape[0]])
-        self.weight_scales = weight_scales.reshape(
-            [weight_scales.shape[1], weight_scales.shape[0]]
+        super().__init__(
+            weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
         )
+        self.output_size = weight.shape[0]  # n
+        self.hidden_size = weight.shape[1]  # k
+        self.weight = weight
+        self.weight_scales = weight_scales
         self.bias = bias
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/fp8_ptpc_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/fp8_ptpc_linear_test.py
@@ -73,13 +73,9 @@ class RocmFp8PTPCLinearTest(unittest.TestCase):
 
         weight_shuffle = shuffle_weight(weight_q, layout=(16, 16))  # [N, K]
 
-        weight_for_init = weight_shuffle.T.contiguous()  # [K, N]
-
-        weight_scales_for_init = weight_scales.T.contiguous()  # [1, N]
-
         ptpc_linear = RocmFp8PTPCLinear(
-            weight=weight_for_init,  # [K, N]
-            weight_scales=weight_scales_for_init,  # [1, N]
+            weight=weight_shuffle,  # [N, K]
+            weight_scales=weight_scales,  # [N, 1]
             bias=None,
         )
 

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
@@ -1,5 +1,5 @@
-import os
 import itertools
+import os
 from typing import Optional
 from unittest import SkipTest, TestCase, main
 
@@ -9,8 +9,8 @@ from torch import nn
 from torch.nn import functional as F
 
 from rtp_llm.models_py.modules.factory import LinearFactory
-from rtp_llm.utils.swizzle_utils import swizzle_tensor
 from rtp_llm.ops import HWKernelConfig
+from rtp_llm.utils.swizzle_utils import swizzle_tensor
 
 
 class LinearTorch(nn.Module):
@@ -18,11 +18,12 @@ class LinearTorch(nn.Module):
         self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
     ) -> None:
         super().__init__()
-        self.weight = weight.T
+        self.weight = weight
         self.bias = bias
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         return F.linear(input, self.weight, self.bias)
+
 
 class LinearTest(TestCase):
 
@@ -30,12 +31,23 @@ class LinearTest(TestCase):
     NUM_TOKENS = [7, 83, 4096]
     # (k, n) pairs: k is input hidden size, n is output size
     K_N_PAIRS = [
-        (512, 512), (512, 256), (512, 1024),
-        (768, 768), (768, 384), (768, 1536),
-        (1024, 1024), (1024, 512), (1024, 2048),
-        (2048, 2048), (2048, 1024), (2048, 4096),
-        (4096, 4096), (4096, 2048), (4096, 8192),
-        (8192, 8192), (8192, 4096),
+        (512, 512),
+        (512, 256),
+        (512, 1024),
+        (768, 768),
+        (768, 384),
+        (768, 1536),
+        (1024, 1024),
+        (1024, 512),
+        (1024, 2048),
+        (2048, 2048),
+        (2048, 1024),
+        (2048, 4096),
+        (4096, 4096),
+        (4096, 2048),
+        (4096, 8192),
+        (8192, 8192),
+        (8192, 4096),
         (1280, 3840),  # qkv
         (1280, 1280),  # proj
         (5120, 5120),
@@ -43,35 +55,44 @@ class LinearTest(TestCase):
     ]
     HAS_BIAS = [True, False]
     HAS_SWIZZLE = [True, False]
+
     def setUp(self) -> None:
         if not torch.cuda.is_available():
             raise SkipTest("CUDA is not available")
         torch.set_default_device("cuda")
 
-    def _run_linear_test(self, num_tokens: int, k: int, n: int, dtype: _dtype, has_bias: bool, has_swizzle: bool):
+    def _run_linear_test(
+        self,
+        num_tokens: int,
+        k: int,
+        n: int,
+        dtype: _dtype,
+        has_bias: bool,
+        has_swizzle: bool,
+    ):
         torch.manual_seed(0)
-        w = torch.randn(k, n, dtype=dtype)
+        w = torch.randn(n, k, dtype=dtype)
         torch.nn.init.xavier_uniform_(w)
         if has_bias:
             bias = torch.empty(n, dtype=dtype)
             torch.nn.init.normal_(bias, mean=0.0, std=0.01)
         else:
             bias = None
-            
+
         x = torch.randn(num_tokens, k, dtype=dtype)
-        
+
         linear_torch = LinearTorch(w, bias)
         torch_output = linear_torch(x)
-        hw_kernel_config=HWKernelConfig()
+        hw_kernel_config = HWKernelConfig()
         if has_swizzle:
-            # Follow aiter's approach: transpose to (n, k), shuffle, then transpose back to (k, n)
-            # This matches the format expected by hipb_mm with bpreshuffle=True
-            w_swizzled = swizzle_tensor(w.t(), False, MiM=16).t()  # (n, k) swizzled
+            # device_impl: swizzle_tensor((N, K), False).t() -> (K, N) view of swizzled (N, K)
+            w_swizzled = swizzle_tensor(w, False, MiM=16).t()
             w_dict = {"weight": w_swizzled, "bias": bias}
             hw_kernel_config.use_swizzleA = True
         else:
-            w_dict = {"weight": w, "bias": bias}
-        
+            # device_impl: weight.t().contiguous() -> (K, N) contiguous for hipb_mm
+            w_dict = {"weight": w.t().contiguous(), "bias": bias}
+
         linear = LinearFactory.create_linear_from_weights(
             w_dict, "weight", None, "bias", None, hw_kernel_config
         )
@@ -88,7 +109,12 @@ class LinearTest(TestCase):
         ):
             num_tokens, (k, n), dtype, has_bias, has_swizzle = params
             with self.subTest(
-                num_tokens=num_tokens, k=k, n=n, dtype=dtype, has_bias=has_bias, has_swizzle=has_swizzle,
+                num_tokens=num_tokens,
+                k=k,
+                n=n,
+                dtype=dtype,
+                has_bias=has_bias,
+                has_swizzle=has_swizzle,
             ):
                 self._run_linear_test(num_tokens, k, n, dtype, has_bias, has_swizzle)
 

--- a/rtp_llm/models_py/modules/hybrid/dense_mlp.py
+++ b/rtp_llm/models_py/modules/hybrid/dense_mlp.py
@@ -45,39 +45,37 @@ class DenseMLP(nn.Module):
         self.is_gated = activation_type in _GATED_ACTIVATION_TYPE_LIST
 
         if self.is_gated:
-            if W.ffn_w13 not in weights:
-                self.up_proj = LinearFactory.create_merged_linear(
-                    weights,
-                    weight_keys=[W.ffn_w1, W.ffn_w3],
-                    scale_keys=[W.ffn_s1, W.ffn_s3],
-                    bias_keys=[W.ffn_b1, W.ffn_b3],
-                    quant_config=quant_config,
-                    dim=-1,
-                    hw_kernel_config=hw_kernel_config,
-                    scale2_keys=[W.ffn_w1_s2, W.ffn_w3_s2],
-                    input_scale_keys=[W.ffn_w1_i_s, W.ffn_w3_i_s],
-                )
-            else:
-                self.up_proj = LinearFactory.create_linear_from_weights(
-                    weights, W.ffn_w13, W.ffn_s13, W.ffn_b13,
-                    quant_config=quant_config, hw_kernel_config=hw_kernel_config,
-                    weight_scale_2_key=W.ffn_w13_s2,
-                    input_scale_key=W.ffn_w13_i_s,
-                )
-
+            self.up_proj = LinearFactory.create_linear_from_weights(
+                weights,
+                W.ffn_w13,
+                W.ffn_s13,
+                W.ffn_b13,
+                quant_config=quant_config,
+                hw_kernel_config=hw_kernel_config,
+                weight_scale_2_key=W.ffn_w13_s2,
+                input_scale_key=W.ffn_w13_i_s,
+            )
         else:
             self.up_proj = LinearFactory.create_linear_from_weights(
-                weights, W.ffn_w3, W.ffn_s3, W.ffn_b3,
-                quant_config=quant_config, hw_kernel_config=hw_kernel_config,
+                weights,
+                W.ffn_w3,
+                W.ffn_s3,
+                W.ffn_b3,
+                quant_config=quant_config,
+                hw_kernel_config=hw_kernel_config,
                 weight_scale_2_key=W.ffn_w3_s2,
                 input_scale_key=W.ffn_w3_i_s,
             )
 
         self.down_proj = LinearFactory.create_linear_from_weights(
-            weights, W.ffn_w2, W.ffn_s2, W.ffn_b2,
-            quant_config=quant_config, hw_kernel_config=hw_kernel_config,
+            weights,
+            W.ffn_w2,
+            W.ffn_s2,
+            W.ffn_b2,
+            quant_config=quant_config,
+            hw_kernel_config=hw_kernel_config,
             weight_scale_2_key=W.ffn_w2_s2,
-            input_scale_key=W.ffn_w2_i_s
+            input_scale_key=W.ffn_w2_i_s,
         )
 
     def forward(self, x: torch.Tensor):

--- a/rtp_llm/models_py/modules/hybrid/test/dense_mlp_ref.py
+++ b/rtp_llm/models_py/modules/hybrid/test/dense_mlp_ref.py
@@ -5,7 +5,7 @@ from rtp_llm.ops import ActivationType
 
 
 def linear(input: torch.Tensor, weight: torch.Tensor):
-    return torch.nn.functional.linear(input, weight.T)
+    return torch.nn.functional.linear(input, weight)
 
 
 class DenseMLP(nn.Module):

--- a/rtp_llm/models_py/modules/hybrid/test/mla_attention_ref.py
+++ b/rtp_llm/models_py/modules/hybrid/test/mla_attention_ref.py
@@ -378,7 +378,7 @@ class MlaAttentionRef(nn.Module):
 
         kv_b_weight = self.weights.get(W.mla_kv_b_w, None)
 
-        kv = compressed_kv @ kv_b_weight
+        kv = F.linear(compressed_kv, kv_b_weight)
         kv = kv.view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
         k_nope = kv[:, :, : self.qk_nope_head_dim].contiguous()
         value_states = kv[:, :, self.qk_nope_head_dim :].contiguous()

--- a/rtp_llm/models_py/modules/hybrid/test/mla_attention_test.py
+++ b/rtp_llm/models_py/modules/hybrid/test/mla_attention_test.py
@@ -155,10 +155,10 @@ class MLATest(TestCase):
         weights = {}
         weights[W.mla_fusedqkrope_no_lora_w] = torch.randn(
             [
-                self.config.hidden_size,
                 self.config.attn_config.size_per_head * self.config.attn_config.head_num
                 + self.config.attn_config.kv_lora_rank
                 + self.config.attn_config.rope_head_dim,
+                self.config.hidden_size,
             ],
             dtype=torch.bfloat16,
             device=device,
@@ -190,12 +190,12 @@ class MLATest(TestCase):
 
         weights[W.mla_kv_b_w] = torch.randn(
             [
-                self.config.attn_config.kv_lora_rank,
                 self.config.attn_config.head_num
                 * (
                     self.config.attn_config.nope_head_dim
                     + self.config.attn_config.v_head_dim
                 ),
+                self.config.attn_config.kv_lora_rank,
             ],
             dtype=torch.bfloat16,
             device=device,
@@ -203,8 +203,8 @@ class MLATest(TestCase):
 
         weights[W.attn_o_w] = torch.randn(
             [
-                self.config.attn_config.head_num * self.config.attn_config.v_head_dim,
                 self.config.hidden_size,
+                self.config.attn_config.head_num * self.config.attn_config.v_head_dim,
             ],
             dtype=torch.bfloat16,
             device=device,

--- a/rtp_llm/models_py/modules/hybrid/test/mla_reuse_cache_test.py
+++ b/rtp_llm/models_py/modules/hybrid/test/mla_reuse_cache_test.py
@@ -282,10 +282,10 @@ class MLATest(TestCase):
         weights = {}
         weights[W.mla_fusedqkrope_no_lora_w] = torch.randn(
             [
-                config.hidden_size,
                 config.attn_config.size_per_head * config.attn_config.head_num
                 + config.attn_config.kv_lora_rank
                 + config.attn_config.rope_head_dim,
+                config.hidden_size,
             ],
             dtype=torch.bfloat16,
             device=device,
@@ -317,30 +317,28 @@ class MLATest(TestCase):
 
         weights[W.mla_kv_b_w] = torch.randn(
             [
-                config.attn_config.kv_lora_rank,
                 config.attn_config.head_num
                 * (config.attn_config.nope_head_dim + config.attn_config.v_head_dim),
+                config.attn_config.kv_lora_rank,
             ],
             dtype=torch.bfloat16,
             device=device,
         )
 
         kv_b = weights[W.mla_kv_b_w].view(
-            config.attn_config.kv_lora_rank,
             config.attn_config.head_num,
             config.attn_config.nope_head_dim + config.attn_config.v_head_dim,
+            config.attn_config.kv_lora_rank,
         )
-        weights[W.mla_kc] = (
-            kv_b[:, :, : config.attn_config.nope_head_dim].permute(1, 2, 0).contiguous()
-        )
+        weights[W.mla_kc] = kv_b[:, : config.attn_config.nope_head_dim, :].contiguous()
         weights[W.mla_vc] = (
-            kv_b[:, :, config.attn_config.nope_head_dim :].transpose(0, 1).contiguous()
+            kv_b[:, config.attn_config.nope_head_dim :, :].permute(0, 2, 1).contiguous()
         )
 
         weights[W.attn_o_w] = torch.randn(
             [
-                config.attn_config.head_num * config.attn_config.v_head_dim,
                 config.hidden_size,
+                config.attn_config.head_num * config.attn_config.v_head_dim,
             ],
             dtype=torch.bfloat16,
             device=device,

--- a/rtp_llm/models_py/modules/hybrid/test/mlp_test.py
+++ b/rtp_llm/models_py/modules/hybrid/test/mlp_test.py
@@ -33,16 +33,17 @@ class MLPTest(TestCase):
         parallelism_config.tp_rank = 0
 
         weights = {}
-        weights[W.ffn_w1] = torch.randn(hidden_size, 4 * hidden_size, dtype=dtype)
-        torch.nn.init.xavier_uniform_(weights[W.ffn_w1])
-        weights[W.ffn_w3] = torch.randn(hidden_size, 4 * hidden_size, dtype=dtype)
-        torch.nn.init.xavier_uniform_(weights[W.ffn_w3])
-        weights[W.ffn_w2] = torch.randn(4 * hidden_size, hidden_size, dtype=dtype)
+        w1 = torch.randn(4 * hidden_size, hidden_size, dtype=dtype)
+        torch.nn.init.xavier_uniform_(w1)
+        w3 = torch.randn(4 * hidden_size, hidden_size, dtype=dtype)
+        torch.nn.init.xavier_uniform_(w3)
+        weights[W.ffn_w13] = torch.cat([w1, w3], dim=0)
+        weights[W.ffn_w2] = torch.randn(hidden_size, 4 * hidden_size, dtype=dtype)
         torch.nn.init.xavier_uniform_(weights[W.ffn_w2])
 
         qwen3_mlp = DenseMLPRef(
-            weights[W.ffn_w1],
-            weights[W.ffn_w3],
+            w1,
+            w3,
             weights[W.ffn_w2],
             ActivationType.Swiglu,
         )

--- a/rtp_llm/test/smoke/case_runner.py
+++ b/rtp_llm/test/smoke/case_runner.py
@@ -2,11 +2,12 @@ import concurrent.futures
 import json
 import logging
 import os
-import traceback
 import time
+import traceback
 
 try:
     import torch
+
     _HAS_TORCH = True
 except ImportError:
     _HAS_TORCH = False
@@ -17,12 +18,15 @@ class _TensorEncoder(json.JSONEncoder):
         if _HAS_TORCH and isinstance(o, torch.Tensor):
             return o.tolist()
         return super().default(o)
+
+
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from smoke.cache_status_comparer import CacheStatusComparer
 from smoke.classifier_comparer import ClassifierComparer
 from smoke.common_def import QueryStatus, SmokeException, Tracer
+from smoke.embedding_comparer import EmbeddingComparer
 from smoke.gpu_diagnostics import (
     ExceptionType,
     ProcessFailureType,
@@ -32,21 +36,18 @@ from smoke.gpu_diagnostics import (
     scan_process_log,
     snapshot_dmesg,
 )
-from smoke.embedding_comparer import EmbeddingComparer
 from smoke.normal_comparer import NormalComparer
 from smoke.openai_comparer import OpenaiComparer
+from smoke.remote_kvcm_server import RemoteKVCMServer
 from smoke.reranker_comparer import RerankerComparer
 from smoke.similarity_comparer import SimilarityComparer
 from smoke.task_info import TaskInfo, TaskStates
 from smoke.tau2_bench_comparer import Tau2BenchComparer
 from smoke.worker_status_comparer import WorkerStatusComparer
-from smoke.remote_kvcm_server import RemoteKVCMServer
 
-from rtp_llm.utils.util import (
-    str_to_bool,
-)
 from rtp_llm.test.utils.coredump_util import summarize_and_cleanup_coredumps
 from rtp_llm.test.utils.maga_server_manager import MagaServerManager
+from rtp_llm.utils.util import str_to_bool
 
 
 def _iterate_modidfy_qr(origin: Dict[str, Any], new: Dict[str, Any]):
@@ -74,7 +75,6 @@ class CaseRunner(object):
         kvcm_config: Optional[Dict[str, str]] = None,
         sleep_time_qr: int = 0,
         kill_remote: bool = False,
-        concurrency_test: bool = False,
     ):
         self.task_info = task_info
         self.env_args = env_args
@@ -94,7 +94,6 @@ class CaseRunner(object):
         self.kvcm_config = kvcm_config or {}
         self.sleep_time_qr = sleep_time_qr
         self.kill_remote = kill_remote
-        self.concurrency_test = concurrency_test
 
     @staticmethod
     def _extract_bool_arg(args_str: str, arg_name: str, default: bool = False) -> bool:
@@ -110,7 +109,9 @@ class CaseRunner(object):
     def run(self):
         self._dmesg_baseline = snapshot_dmesg()
         env_dict = self.create_env_from_args(self.env_args)
-        enable_remote_cache = self._extract_bool_arg(self.smoke_args_str, "--enable_remote_cache")
+        enable_remote_cache = self._extract_bool_arg(
+            self.smoke_args_str, "--enable_remote_cache"
+        )
         if enable_remote_cache:
             self.remote_kvcm_server = self._start_remote_kvcm_server()
             assert self.remote_kvcm_server is not None, "remote kvcm shoule not be None"
@@ -119,7 +120,10 @@ class CaseRunner(object):
         logging.info(f"smoke_args_str: {self.smoke_args_str}")
         try:
             server_manager = self.start_server(
-                env_dict, task_states, self.task_info, smoke_args_str=self.smoke_args_str
+                env_dict,
+                task_states,
+                self.task_info,
+                smoke_args_str=self.smoke_args_str,
             )
             if server_manager is None:
                 task_states.ret = False
@@ -139,41 +143,24 @@ class CaseRunner(object):
             )
 
     def _start_remote_kvcm_server(self) -> Optional[RemoteKVCMServer]:
-        server_path = os.path.join(os.environ["TEST_SRCDIR"], os.environ["TEST_WORKSPACE"], "external/remote_kv_cache_manager_server")
+        server_path = os.path.join(
+            os.environ["TEST_SRCDIR"],
+            os.environ["TEST_WORKSPACE"],
+            "external/remote_kv_cache_manager_server",
+        )
         kvcm_src_logs_path = os.path.join(os.environ["TEST_SRCDIR"], "rtp_llm/logs")
         bazel_outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
         kvcm_dst_logs_path = os.path.join(bazel_outputs_dir, "kvcm_logs")
-        remote_kvcm_server = RemoteKVCMServer(server_path, self.kvcm_config, kvcm_src_logs_path, kvcm_dst_logs_path)
+        remote_kvcm_server = RemoteKVCMServer(
+            server_path, self.kvcm_config, kvcm_src_logs_path, kvcm_dst_logs_path
+        )
         if remote_kvcm_server.start_server():
             return remote_kvcm_server
         logging.error("start remote_kvcm_server")
         return None
 
-
-    def curl_server(
-        self, server_manager: MagaServerManager
-    ) -> TaskStates:
-        if self.concurrency_test:
-            task_states = TaskStates()
-            with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-                futures = [
-                    executor.submit(
-                        self._curl_server_impl, server_manager, self.task_info
-                    )
-                    for _ in range(5)
-                ]
-                results = []
-                for future in concurrent.futures.as_completed(futures):
-                    results.append(future.result())
-                if results[0].ret == False:
-                    task_states = results[0]
-                else:
-                    for result in results:
-                        if str(result) != str(str(results[0])):
-                            task_states = result
-        else:
-            task_states = self._curl_server_impl(server_manager, self.task_info)
-        return task_states
+    def curl_server(self, server_manager: MagaServerManager) -> TaskStates:
+        return self._curl_server_impl(server_manager, self.task_info)
 
     @staticmethod
     def _resolve_endpoint(q_r: Dict[str, Any], task_endpoint: Optional[str]) -> str:
@@ -227,13 +214,20 @@ class CaseRunner(object):
             return RerankerComparer
         elif q_r.get("mainse_module", None) == True:
             if q_r.get("use_decode_arpc", None) == True:
-                from smoke.mainse.mainse_decode_arpc_comparer import MainseDecodeArpcComparer
+                from smoke.mainse.mainse_decode_arpc_comparer import (
+                    MainseDecodeArpcComparer,
+                )
+
                 return MainseDecodeArpcComparer
             elif q_r.get("use_emb_arpc", None) == True:
-                from smoke.mainse.mainse_embedding_arpc_comparer import MainseEmbeddingArpcComparer
+                from smoke.mainse.mainse_embedding_arpc_comparer import (
+                    MainseEmbeddingArpcComparer,
+                )
+
                 return MainseEmbeddingArpcComparer
             else:
                 from smoke.mainse.mainse_comparer import MainseComparer
+
                 return MainseComparer
         return NormalComparer
 
@@ -243,35 +237,51 @@ class CaseRunner(object):
         task_info: TaskInfo,
         task_states: TaskStates,
     ) -> None:
-        repeat_count = int(os.environ.get('STABILITY_REPEAT', '0'))
+        repeat_count = int(os.environ.get("STABILITY_REPEAT", "0"))
         if repeat_count <= 0 or task_states.ret == False:
             return
 
         qr_array = task_info.query_result
         task_endpoint = task_info.endpoint
         num_queries = len(qr_array)
-        logging.info(f"[STABILITY_TEST] Starting {repeat_count} repeat iterations for {num_queries} queries")
+        logging.info(
+            f"[STABILITY_TEST] Starting {repeat_count} repeat iterations for {num_queries} queries"
+        )
 
         per_query_pass: Dict[int, int] = defaultdict(int)
         per_query_fail: Dict[int, int] = defaultdict(int)
-        per_query_responses: Dict[int, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        per_query_responses: Dict[int, Dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
 
         for iter_idx in range(repeat_count):
             for q_idx, q_r in enumerate(qr_array):
                 request_endpoint = self._resolve_endpoint(q_r, task_endpoint)
                 comparer_cls = self._get_comparer_cls(q_r, request_endpoint)
                 try:
-                    comparer_cls(server_manager, request_endpoint, q_r, Tracer(), self.batch_infer).run()
+                    comparer_cls(
+                        server_manager,
+                        request_endpoint,
+                        q_r,
+                        Tracer(),
+                        self.batch_infer,
+                    ).run()
                     per_query_pass[q_idx] += 1
-                    logging.info(f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] PASS")
+                    logging.info(
+                        f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] PASS"
+                    )
                 except Exception as e:
                     exc_type = classify_exception(e)
                     if exc_type != ExceptionType.NOT_GPU_ERROR:
-                        output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
+                        output_dir = os.environ.get(
+                            "TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd()
+                        )
                         dump_gpu_state(
                             exc=e,
                             failure_context=f"stability repeat ({exc_type.value})",
-                            log_path=os.path.join(output_dir, "gpu_state_stability.log"),
+                            log_path=os.path.join(
+                                output_dir, "gpu_state_stability.log"
+                            ),
                             dmesg_baseline=getattr(self, "_dmesg_baseline", 0),
                         )
                     per_query_fail[q_idx] += 1
@@ -279,18 +289,24 @@ class CaseRunner(object):
                     if "actual.response" in err_msg:
                         start = err_msg.find("actual.response = [")
                         if start != -1:
-                            resp = err_msg[start + len("actual.response = ["):]
+                            resp = err_msg[start + len("actual.response = [") :]
                             resp = resp.rstrip("]").rstrip()
                             per_query_responses[q_idx][resp] += 1
-                    logging.warning(f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] FAIL: {e}")
+                    logging.warning(
+                        f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] FAIL: {e}"
+                    )
 
         total_checks = repeat_count * num_queries
         total_pass = sum(per_query_pass.values())
         total_fail = sum(per_query_fail.values())
         pass_rate = total_pass / total_checks * 100 if total_checks > 0 else 0
 
-        logging.info(f"[STABILITY_SUMMARY] Total: {repeat_count} iterations x {num_queries} queries = {total_checks} checks")
-        logging.info(f"[STABILITY_SUMMARY] Pass: {total_pass}, Fail: {total_fail} (rate: {pass_rate:.1f}%)")
+        logging.info(
+            f"[STABILITY_SUMMARY] Total: {repeat_count} iterations x {num_queries} queries = {total_checks} checks"
+        )
+        logging.info(
+            f"[STABILITY_SUMMARY] Pass: {total_pass}, Fail: {total_fail} (rate: {pass_rate:.1f}%)"
+        )
         for q_idx in range(num_queries):
             p = per_query_pass.get(q_idx, 0)
             f = per_query_fail.get(q_idx, 0)
@@ -302,9 +318,12 @@ class CaseRunner(object):
         if total_fail > 0:
             task_states.ret = False
             task_states.query_status.append(
-                (QueryStatus.OTHERS,
-                 f"Stability test: {total_fail}/{total_checks} failures in {repeat_count} iterations",
-                 Tracer()))
+                (
+                    QueryStatus.OTHERS,
+                    f"Stability test: {total_fail}/{total_checks} failures in {repeat_count} iterations",
+                    Tracer(),
+                )
+            )
 
     def _curl_server_impl(
         self, server_manager: MagaServerManager, task_info: TaskInfo
@@ -321,7 +340,9 @@ class CaseRunner(object):
             request_endpoint = self._resolve_endpoint(q_r, task_endpoint)
             try:
                 comparer_cls = self._get_comparer_cls(q_r, request_endpoint)
-                comparer_cls(server_manager, request_endpoint, q_r, tracer, self.batch_infer).run()
+                comparer_cls(
+                    server_manager, request_endpoint, q_r, tracer, self.batch_infer
+                ).run()
                 task_states.query_status.append((QueryStatus.OK, f"", tracer))
             except SmokeException as e:
                 task_states.ret = False
@@ -329,7 +350,9 @@ class CaseRunner(object):
             except Exception as e:
                 exc_type = classify_exception(e)
                 if exc_type != ExceptionType.NOT_GPU_ERROR:
-                    output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
+                    output_dir = os.environ.get(
+                        "TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd()
+                    )
                     dump_gpu_state(
                         exc=e,
                         failure_context=f"query exception ({exc_type.value})",
@@ -341,10 +364,12 @@ class CaseRunner(object):
                 task_states.query_status.append((QueryStatus.OTHERS, str(e), tracer))
             if self.sleep_time_qr > 0:
                 time.sleep(self.sleep_time_qr)
-            if self.kill_remote and getattr(self, 'remote_kvcm_server', None) is not None:
+            if (
+                self.kill_remote
+                and getattr(self, "remote_kvcm_server", None) is not None
+            ):
                 self.remote_kvcm_server.stop_server()
                 logging.info("manually stop remote_kvcm_server")
-
 
         self._run_stability_repeat(server_manager, task_info, task_states)
 
@@ -355,6 +380,7 @@ class CaseRunner(object):
             with open(task_info.taskinfo_rel_path, "r") as f:
                 try:
                     import json5
+
                     origin_json = json5.load(f)
                 except ImportError:
                     origin_json = json.load(f)
@@ -375,7 +401,9 @@ class CaseRunner(object):
                     _iterate_modidfy_qr(origin_qr["result"], now_result)
 
             out_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
-            rewrite_path = os.path.join(out_dir, "smoke_actual", os.path.basename(task_info.taskinfo_rel_path))
+            rewrite_path = os.path.join(
+                out_dir, "smoke_actual", os.path.basename(task_info.taskinfo_rel_path)
+            )
             os.makedirs(os.path.dirname(rewrite_path), exist_ok=True)
             with open(rewrite_path, "w") as f:
                 json.dump(
@@ -446,11 +474,15 @@ class CaseRunner(object):
         if ret is False:
             task_states.ret = False
             failure_type, failure_desc = classify_process_exit(server_manager.exit_code)
-            task_states.err_msg = f"start server failed: {failure_type.value} — {failure_desc}"
+            task_states.err_msg = (
+                f"start server failed: {failure_type.value} — {failure_desc}"
+            )
 
             log_errors = scan_process_log(server_manager.log_file_path, max_lines=30)
             if log_errors:
-                task_states.err_msg += "\n[process.log errors]\n" + "\n".join(log_errors)
+                task_states.err_msg += "\n[process.log errors]\n" + "\n".join(
+                    log_errors
+                )
 
             output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
             dump_gpu_state(

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_kill_remote.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_kill_remote.json
@@ -1,161 +1,161 @@
 {
-  "model_type": "qwen_tool",
-  "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
-  "query_result": [
-    {
-      "endpoint": "/v1/chat/completions",
-      "query": {
-        "messages": [
-          {
-            "role": "user",
-            "content": "请推荐一部好看的电影。"
-          }
-        ],
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "max_tokens": 100
-      },
-      "result": {
-        "id": "chat-",
-        "object": "chat.completion",
-        "created": 1776595375,
-        "model": "",
-        "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。如果您喜欢爱情、友情、家庭等类型，那么《泰坦尼克号》可能是一个不错的选择。这部电影由詹姆斯·卡梅隆执导，讲述了1912年泰坦尼克号沉船事件的",
-              "reasoning_content": null,
-              "function_call": null,
-              "tool_calls": null,
-              "partial": false,
-              "tool_call_id": null
+    "model_type": "qwen_tool",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "请推荐一部好看的电影。"
+                    }
+                ],
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "max_tokens": 100
             },
-            "finish_reason": "length",
-            "logprobs": null
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 35,
-          "total_tokens": 135,
-          "completion_tokens": 100,
-          "completion_tokens_details": null,
-          "prompt_tokens_details": null
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777371581,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。如果您喜欢爱情、友情、家庭等类型，那么《泰坦尼克号》可能是一个不错的选择。这部电影由詹姆斯·卡梅隆执导，讲述了1912年泰坦尼克号沉船事件的",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 35,
+                    "total_tokens": 135,
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 942.664,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 35,
+                    "output_len": 100,
+                    "step_output_len": 100,
+                    "first_token_cost_time": 356.58,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
         },
-        "debug_info": null,
-        "aux_info": {
-          "cost_time": 850.637,
-          "iter_count": 100,
-          "prefix_len": 0,
-          "input_len": 35,
-          "output_len": 100,
-          "step_output_len": 100,
-          "first_token_cost_time": 356.049,
-          "wait_time": 0.107,
-          "pd_sep": false,
-          "cum_log_probs": [],
-          "beam_responses": [],
-          "softmax_probs": [],
-          "reuse_len": 0,
-          "local_reuse_len": 0,
-          "remote_reuse_len": 0,
-          "memory_reuse_len": 0,
-          "prefill_total_reuse_len": 0,
-          "prefill_local_reuse_len": 0,
-          "prefill_remote_reuse_len": 0,
-          "prefill_memory_reuse_len": 0,
-          "decode_total_reuse_len": 0,
-          "decode_local_reuse_len": 0,
-          "decode_remote_reuse_len": 0,
-          "decode_memory_reuse_len": 0,
-          "role_addrs": [],
-          "aux_string": ""
-        },
-        "extra_outputs": null
-      }
-    },
-    {
-      "endpoint": "/v1/chat/completions",
-      "query": {
-        "messages": [
-          {
-            "role": "user",
-            "content": "请推荐一部好看的电影。"
-          },
-          {
-            "role": "assistant",
-            "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。影片融合了科幻元素和悬疑元素，展现了人类在面对未知和挑战时的勇气和决心。\n\n如果您更喜欢剧情片或者爱情片，那么《泰坦尼克号》可能是一个不错的选择。这部电影",
-            "partial": false
-          },
-          {
-            "role": "user",
-            "content": "我喜欢喜剧类型的。"
-          }
-        ],
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "max_tokens": 100
-      },
-      "result": {
-        "id": "chat-",
-        "object": "chat.completion",
-        "created": 1776595392,
-        "model": "",
-        "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类对未知和挑战的勇气和决心，同时也展现了原始人的独特文化和性格。这部电影在喜剧和科幻的结合上非常成功，受到了观众的喜爱。",
-              "reasoning_content": null,
-              "function_call": null,
-              "tool_calls": null,
-              "partial": false,
-              "tool_call_id": null
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "请推荐一部好看的电影。"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。影片融合了科幻元素和悬疑元素，展现了人类在面对未知和挑战时的勇气和决心。\n\n如果您更喜欢剧情片或者爱情片，那么《泰坦尼克号》可能是一个不错的选择。这部电影",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "我喜欢喜剧类型的。"
+                    }
+                ],
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "max_tokens": 100
             },
-            "finish_reason": "stop",
-            "logprobs": null
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 149,
-          "total_tokens": 227,
-          "completion_tokens": 78,
-          "completion_tokens_details": null,
-          "prompt_tokens_details": null
-        },
-        "debug_info": null,
-        "aux_info": {
-          "cost_time": 1904.494,
-          "iter_count": 78,
-          "prefix_len": 0,
-          "input_len": 149,
-          "output_len": 78,
-          "step_output_len": 78,
-          "first_token_cost_time": 1510.831,
-          "wait_time": 0.106,
-          "pd_sep": false,
-          "cum_log_probs": [],
-          "beam_responses": [],
-          "softmax_probs": [],
-          "reuse_len": 0,
-          "local_reuse_len": 0,
-          "remote_reuse_len": 0,
-          "memory_reuse_len": 0,
-          "prefill_total_reuse_len": 0,
-          "prefill_local_reuse_len": 0,
-          "prefill_remote_reuse_len": 0,
-          "prefill_memory_reuse_len": 0,
-          "decode_total_reuse_len": 0,
-          "decode_local_reuse_len": 0,
-          "decode_remote_reuse_len": 0,
-          "decode_memory_reuse_len": 0,
-          "role_addrs": [],
-          "aux_string": ""
-        },
-        "extra_outputs": null
-      }
-    }
-  ]
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777371598,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类在面对困难和挑战时的勇气和智慧。\n\n如果您喜欢动作、冒险或者科幻类型的电影，那么《速度与激情》系列可能是一个不错的选择。这部电影由汤姆·汉克斯主演，讲述了一群赛车手在不同国家之间的冒险故事。影片",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 149,
+                    "total_tokens": 249,
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 2063.463,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 149,
+                    "output_len": 100,
+                    "step_output_len": 100,
+                    "first_token_cost_time": 1507.84,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        }
+    ]
 }

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_match_failure.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_match_failure.json
@@ -1,163 +1,163 @@
 {
-  "model_type": "qwen_tool",
-  "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
-  "query_result": [
-    {
-      "endpoint": "/v1/chat/completions",
-      "query": {
-        "messages": [
-          {
-            "role": "user",
-            "content": "请推荐一部好看的电影。"
-          }
-        ],
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "max_tokens": 100,
-        "trace_id": "1"
-      },
-      "result": {
-        "id": "chat-",
-        "object": "chat.completion",
-        "created": 1776595371,
-        "model": "",
-        "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。如果您喜欢爱情、友情、家庭等类型，那么《泰坦尼克号》可能是一个不错的选择。这部电影由詹姆斯·卡梅隆执导，讲述了1912年泰坦尼克号沉船事件的",
-              "reasoning_content": null,
-              "function_call": null,
-              "tool_calls": null,
-              "partial": false,
-              "tool_call_id": null
+    "model_type": "qwen_tool",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "请推荐一部好看的电影。"
+                    }
+                ],
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "max_tokens": 100,
+                "trace_id": "1"
             },
-            "finish_reason": "length",
-            "logprobs": null
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 35,
-          "total_tokens": 135,
-          "completion_tokens": 100,
-          "completion_tokens_details": null,
-          "prompt_tokens_details": null
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777371569,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。如果您喜欢爱情、友情、家庭等类型，那么《泰坦尼克号》可能是一个不错的选择。这部电影由詹姆斯·卡梅隆执导，讲述了1912年泰坦尼克号沉船事件的",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 35,
+                    "total_tokens": 135,
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 941.973,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 35,
+                    "output_len": 100,
+                    "step_output_len": 100,
+                    "first_token_cost_time": 364.455,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
         },
-        "debug_info": null,
-        "aux_info": {
-          "cost_time": 842.151,
-          "iter_count": 100,
-          "prefix_len": 0,
-          "input_len": 35,
-          "output_len": 100,
-          "step_output_len": 100,
-          "first_token_cost_time": 331.248,
-          "wait_time": 0.112,
-          "pd_sep": false,
-          "cum_log_probs": [],
-          "beam_responses": [],
-          "softmax_probs": [],
-          "reuse_len": 0,
-          "local_reuse_len": 0,
-          "remote_reuse_len": 0,
-          "memory_reuse_len": 0,
-          "prefill_total_reuse_len": 0,
-          "prefill_local_reuse_len": 0,
-          "prefill_remote_reuse_len": 0,
-          "prefill_memory_reuse_len": 0,
-          "decode_total_reuse_len": 0,
-          "decode_local_reuse_len": 0,
-          "decode_remote_reuse_len": 0,
-          "decode_memory_reuse_len": 0,
-          "role_addrs": [],
-          "aux_string": ""
-        },
-        "extra_outputs": null
-      }
-    },
-    {
-      "endpoint": "/v1/chat/completions",
-      "query": {
-        "messages": [
-          {
-            "role": "user",
-            "content": "请推荐一部好看的电影。"
-          },
-          {
-            "role": "assistant",
-            "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。影片融合了科幻元素和悬疑元素，展现了人类在面对未知和挑战时的勇气和决心。\n\n如果您更喜欢剧情片或者爱情片，那么《泰坦尼克号》可能是一个不错的选择。这部电影",
-            "partial": false
-          },
-          {
-            "role": "user",
-            "content": "我喜欢喜剧类型的。"
-          }
-        ],
-        "temperature": 0.0,
-        "top_p": 1.0,
-        "max_tokens": 100,
-        "trace_id": "2"
-      },
-      "result": {
-        "id": "chat-",
-        "object": "chat.completion",
-        "created": 1776595382,
-        "model": "",
-        "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类对未知和挑战的勇气和决心，同时也展现了原始人的独特文化和性格。这部电影在喜剧和科幻的结合上非常成功，受到了观众的喜爱。",
-              "reasoning_content": null,
-              "function_call": null,
-              "tool_calls": null,
-              "partial": false,
-              "tool_call_id": null
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "请推荐一部好看的电影。"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。影片融合了科幻元素和悬疑元素，展现了人类在面对未知和挑战时的勇气和决心。\n\n如果您更喜欢剧情片或者爱情片，那么《泰坦尼克号》可能是一个不错的选择。这部电影",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "我喜欢喜剧类型的。"
+                    }
+                ],
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "max_tokens": 100,
+                "trace_id": "2"
             },
-            "finish_reason": "stop",
-            "logprobs": null
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 149,
-          "total_tokens": 227,
-          "completion_tokens": 78,
-          "completion_tokens_details": null,
-          "prompt_tokens_details": null
-        },
-        "debug_info": null,
-        "aux_info": {
-          "cost_time": 385.888,
-          "iter_count": 78,
-          "prefix_len": 0,
-          "input_len": 149,
-          "output_len": 78,
-          "step_output_len": 78,
-          "first_token_cost_time": 12.921,
-          "wait_time": 0.103,
-          "pd_sep": false,
-          "cum_log_probs": [],
-          "beam_responses": [],
-          "softmax_probs": [],
-          "reuse_len": 0,
-          "local_reuse_len": 0,
-          "remote_reuse_len": 0,
-          "memory_reuse_len": 0,
-          "prefill_total_reuse_len": 0,
-          "prefill_local_reuse_len": 0,
-          "prefill_remote_reuse_len": 0,
-          "prefill_memory_reuse_len": 0,
-          "decode_total_reuse_len": 0,
-          "decode_local_reuse_len": 0,
-          "decode_remote_reuse_len": 0,
-          "decode_memory_reuse_len": 0,
-          "role_addrs": [],
-          "aux_string": ""
-        },
-        "extra_outputs": null
-      }
-    }
-  ]
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777371580,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类在面对困难和挑战时的勇气和智慧。\n\n如果您喜欢动作、冒险或者科幻类型的电影，那么《速度与激情》系列可能是一个不错的选择。这部电影由汤姆·汉克斯主演，讲述了一群赛车手在不同国家之间的冒险故事。影片",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 149,
+                    "total_tokens": 249,
+                    "completion_tokens": 100,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 567.342,
+                    "iter_count": 100,
+                    "prefix_len": 0,
+                    "input_len": 149,
+                    "output_len": 100,
+                    "step_output_len": 100,
+                    "first_token_cost_time": 8.075,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        }
+    ]
 }

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_tpsize_2.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_l20_remote_cache_tpsize_2.json
@@ -18,7 +18,7 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1776595373,
+                "created": 1777371574,
                 "model": "",
                 "choices": [
                     {
@@ -26,9 +26,14 @@
                         "message": {
                             "role": "assistant",
                             "content": "推荐一部好看的电影，首先需要考虑电影的类型和主题。如果您喜欢科幻、动作、冒险等类型，那么《星际穿越》可能是一个不错的选择。这部电影由克里斯托弗·诺兰执导，讲述了人类在宇宙中寻找新的居住地的故事。如果您喜欢爱情、友情、家庭等类型，那么《泰坦尼克号》可能是一个不错的选择。这部电影由詹姆斯·卡梅隆执导，讲述了1912年泰坦尼克号沉船事件的",
-                            "partial": false
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
                         },
-                        "finish_reason": "length"
+                        "finish_reason": "length",
+                        "logprobs": null
                     }
                 ],
                 "usage": {
@@ -40,14 +45,14 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 1132.307,
+                    "cost_time": 1243.021,
                     "iter_count": 100,
                     "prefix_len": 0,
                     "input_len": 35,
                     "output_len": 100,
                     "step_output_len": 100,
-                    "first_token_cost_time": 373.364,
-                    "wait_time": 0.093,
+                    "first_token_cost_time": 364.776,
+                    "wait_time": 0.0,
                     "pd_sep": false,
                     "cum_log_probs": [],
                     "beam_responses": [],
@@ -95,28 +100,28 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
-                "created": 1777264777,
+                "created": 1777371594,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类在面对困难和挑战时的勇气和智慧。\n\n如果您喜欢动作、冒险或者科幻类型的电影，那么《速度与激情》系列可能是一个不错的选择。这部电影由汤姆·汉克斯主演，讲述了一群赛车手在不同国家之间的冒险故事。影片",
+                            "content": "推荐一部喜剧类型的电影，比如《疯狂原始人》。这部电影由克里斯托弗·诺兰执导，讲述了一个关于原始人的故事，其中充满了幽默和滑稽的元素。影片通过幽默的方式展现了人类对未知和挑战的勇气和决心，同时也展现了原始人的独特文化和性格。这部电影在喜剧和科幻的结合上非常成功，受到了观众的喜爱。",
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
                             "partial": false,
                             "tool_call_id": null
                         },
-                        "finish_reason": "length",
+                        "finish_reason": "stop",
                         "logprobs": null
                     }
                 ],
                 "usage": {
                     "prompt_tokens": 149,
-                    "total_tokens": 249,
-                    "completion_tokens": 100,
+                    "total_tokens": 227,
+                    "completion_tokens": 78,
                     "completion_tokens_details": null,
                     "prompt_tokens_details": {
                         "audio_tokens": null,
@@ -125,13 +130,13 @@
                 },
                 "debug_info": null,
                 "aux_info": {
-                    "cost_time": 914.645,
-                    "iter_count": 100,
+                    "cost_time": 670.064,
+                    "iter_count": 78,
                     "prefix_len": 0,
                     "input_len": 149,
-                    "output_len": 100,
-                    "step_output_len": 100,
-                    "first_token_cost_time": 82.426,
+                    "output_len": 78,
+                    "step_output_len": 78,
+                    "first_token_cost_time": 29.831,
                     "wait_time": 0.0,
                     "pd_sep": false,
                     "cum_log_probs": [],

--- a/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json
+++ b/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json
@@ -4,170 +4,106 @@
     "query_result": [
         {
             "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nwhat is CAP Theorem ?<|im_end|>\n<|im_start|>assistant\n",
+                "prompt_batch": [
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nwhat is CAP Theorem ?<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n润色一下，使其更通顺，更有逻辑，更有专业性：In addition, the Doushantuo phosphorites are characterized by their rich microfossils and a certain amount of organic matter, which suggest that microbial degradation of organic matter could have been a crucial factor in facilitating the precipitation of phosphate in Zhangcunping phosphorites. However, it is important to note that the δ13Ccarb values of lower phosphorites (ca. -2.47‰) are lighter than those of upper phosphorites (ca. -0.71‰). This difference may be attributed the potential variation in the organic matter degradation process.\nOrganic matter degradation in marine sediments is mediated by a series of microbial redox reactions that decrease in energy yield, ranging from oxic respiration, denitrification, Mn reduction, Fe reduction, sulfate reduction, and methanogenesis (Jarvis et al., 1994; Pufahl and Groat, 2017). The lower phosphorites were formed in an anoxic water column where oxygen in overlying water was limited. In this scenario, bacteria-driven breakdown of organic matter is very efficient especially in the presence of microbial sulfate reduction (Arning et al., 2009; Hiatt et al., 2015). The presence of pyrite framboids in lower phosphorites is indicative of an authigenic microbial origin and suggests the presence of sulfate, which fuels sulfate reduction (Hiatt et al., 2015; Hiatt et al., 2020). The increased supply of sulfate from oxidative weathering into the Ediacaran ocean (Laakso et al., 2020) likely fueled the microbial sulfate reduction and, thus organic matter degradation (Chen et al., 2022). Pyrite precipitates in the zone of sulfate reduction when ferrous Fe from Fe(oxyhydr)oxides dissolution combines with bacterially reduced sulfide (Pufahl, 2010). In addition, the observation of sulfur bacteria in Zhangcunping lower phosphorites supports our view (Bailey et al., 2013).<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nI really liked the way you describe that in terms of spirit and the memory but I still want you to improve the dialogue by talking about that in terms of three things first it is a spirit like what you said it's a spirit is like a butterfly and it's about flying into the sky we don't know where you go it's beautiful and also after that we are left with two things one is the body the other one is the memory as for the body the person who passed away will return the body to the nature so that is against the nature sustained the environment can be improved the nature can be renourished as for memory the person who passed away will leave the memory to us the memory will become our spiritual strength will give us hope will give us strength will guide us<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nI think I practice industriousness and excellence in my profession as an engineer at an early stage startup (Cyral). \n\nI joined Cyral as a software engineer immediately upon graduation from UCSB with a BS in statistical science. My coursework was more focused on statistical concepts, and happened to involve a bit of coding here and there to process data to derive statistical insight. I never really prioritized schoolwork — instead, i dedicated much of my time to leading the UCSB data science club organization as its president (the club’s founder selected me to take on his role when he graduated). Besides running the club, I dedicated a lot of time to working data science internships. I attribute whatever little coding ability I had at the time I was hired at Cyral to the time I dedicated to leading the club and working as an intern. \n\nDespite my lacking software engineering experience, Cyral’s cofounders, Srini (CTO) and Manav (CEO) took a bet and hired me as one of the first 10 engineers. It’s been nearly 4 years since then, and I’m now managing a team of 4 developers and a product designer.\n\nWhile I’ve demonstrated my ability to dedicate myself to work, there are a few things that worry me:\n1. I take adderall in a daily basis to help me focus on my work, and I don’t feel this is sustainable.\n2. I’m worried that over-optimizing on work leads to me falling short in other aspects of my life that I could be pursuing. For example, I used to cook regularly and derived great pleasure from doing so, but in the past 2 years, I’ve seldom cooked a meal and usually order in through Doordash (not frugal)\n\nAt this point, I realize I’m likely not providing a comprehensive answer to your question, so please feel free to question me about anything I’ve said, and perhaps more importantly, what I havent talked about yet in order to arrive at a more comprehensive response to your question.<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhich recommended Flask alternative is most similar to Django North in syntax?<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nNameError: name 'screen\\_manager' is not defined<|im_end|>\n<|im_start|>assistant\n",
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n提供新高考三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等，为高中生提供学业与职业生涯的完整规划。<|im_end|>\n<|im_start|>assistant\n"
+                ],
                 "generate_config": {
                     "max_new_tokens": 50,
                     "top_k": 1,
                     "temperature": 0,
                     "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:s1"
+                }
             },
             "result": {
-                "response": "The CAP Theorem, also known as Brewer's Theorem, is a fundamental concept in distributed systems that highlights the trade-offs between three desirable properties in a distributed computing system: Consistency, Availability, and Partition Tolerance. The theorem states that it",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 25
-                }
+                "response_batch": [
+                    {
+                        "response": "The CAP Theorem, also known as Brewer's Theorem, is a fundamental concept in distributed systems that highlights the trade-offs between three desirable properties in a distributed computing system: Consistency, Availability, and Partition Tolerance. The theorem states that it",
+                        "aux_info": {
+                            "input_len": 25,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "In addition, the Doushantuo phosphorites are characterized by their rich microfossil content and significant organic matter, suggesting that microbial degradation of organic matter played a crucial role in the precipitation of phosphate in the Zhangcunping phosphor",
+                        "aux_info": {
+                            "input_len": 478,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "Certainly! Here’s an enhanced version of the dialogue incorporating your points about the spirit, body, and memory:\n\n---\n\n**Spirit:**  \nImagine the spirit as a delicate butterfly, fluttering its wings and soaring into the vast, unknown sky. It dances",
+                        "aux_info": {
+                            "input_len": 174,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "It sounds like you've made significant strides in your career, especially given your background and the challenges you've faced. Let's break down your concerns and explore some strategies to address them.\n\n### 1. Dependence on Adderall\n**Concern",
+                        "aux_info": {
+                            "input_len": 433,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "When comparing Flask alternatives to Django North in terms of syntax and structure, it's important to note that Django North is a lightweight framework built on top of Django that aims to simplify certain aspects of Django's workflow. However, Flask is a micro web framework",
+                        "aux_info": {
+                            "input_len": 32,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "The `NameError: name 'screen_manager' is not defined` error occurs when you try to use a variable or object named `screen_manager` that hasn't been defined in your code. This is a common issue in Python, especially when working",
+                        "aux_info": {
+                            "input_len": 31,
+                            "output_len": 50,
+                            "iter_count": 50
+                        }
+                    },
+                    {
+                        "response": "新高考三年规划与升学指导服务旨在帮助高中生在高中阶段制定明确的学习目标，合理规划学业与职业生涯，为未来升学和就业打下坚实基础。以下是一些建议，涵盖强基计划择校、综合评价",
+                        "aux_info": {
+                            "input_len": 58,
+                            "output_len": 50,
+                            "iter_count": 44
+                        }
+                    }
+                ]
             }
         },
         {
             "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n润色一下，使其更通顺，更有逻辑，更有专业性：In addition, the Doushantuo phosphorites are characterized by their rich microfossils and a certain amount of organic matter, which suggest that microbial degradation of organic matter could have been a crucial factor in facilitating the precipitation of phosphate in Zhangcunping phosphorites. However, it is important to note that the δ13Ccarb values of lower phosphorites (ca. -2.47‰) are lighter than those of upper phosphorites (ca. -0.71‰). This difference may be attributed the potential variation in the organic matter degradation process.\nOrganic matter degradation in marine sediments is mediated by a series of microbial redox reactions that decrease in energy yield, ranging from oxic respiration, denitrification, Mn reduction, Fe reduction, sulfate reduction, and methanogenesis (Jarvis et al., 1994; Pufahl and Groat, 2017). The lower phosphorites were formed in an anoxic water column where oxygen in overlying water was limited. In this scenario, bacteria-driven breakdown of organic matter is very efficient especially in the presence of microbial sulfate reduction (Arning et al., 2009; Hiatt et al., 2015). The presence of pyrite framboids in lower phosphorites is indicative of an authigenic microbial origin and suggests the presence of sulfate, which fuels sulfate reduction (Hiatt et al., 2015; Hiatt et al., 2020). The increased supply of sulfate from oxidative weathering into the Ediacaran ocean (Laakso et al., 2020) likely fueled the microbial sulfate reduction and, thus organic matter degradation (Chen et al., 2022). Pyrite precipitates in the zone of sulfate reduction when ferrous Fe from Fe(oxyhydr)oxides dissolution combines with bacterially reduced sulfide (Pufahl, 2010). In addition, the observation of sulfur bacteria in Zhangcunping lower phosphorites supports our view (Bailey et al., 2013).<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:l2"
-            },
-            "result": {
-                "response": "In addition, the Doushantuo phosphorites are characterized by their rich microfossil content and significant organic matter, suggesting that microbial degradation of organic matter played a crucial role in the precipitation of phosphate in the Zhangcunping phosphor",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 478
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nI really liked the way you describe that in terms of spirit and the memory but I still want you to improve the dialogue by talking about that in terms of three things first it is a spirit like what you said it's a spirit is like a butterfly and it's about flying into the sky we don't know where you go it's beautiful and also after that we are left with two things one is the body the other one is the memory as for the body the person who passed away will return the body to the nature so that is against the nature sustained the environment can be improved the nature can be renourished as for memory the person who passed away will leave the memory to us the memory will become our spiritual strength will give us hope will give us strength will guide us<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:m2"
-            },
-            "result": {
-                "response": "Certainly! Here’s an enhanced version of the dialogue incorporating your points about the spirit, body, and memory:\n\n---\n\n**Spirit:**  \nImagine the spirit as a delicate butterfly, fluttering its wings and soaring into the vast, unknown sky. It dances",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 174
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nI think I practice industriousness and excellence in my profession as an engineer at an early stage startup (Cyral). \n\nI joined Cyral as a software engineer immediately upon graduation from UCSB with a BS in statistical science. My coursework was more focused on statistical concepts, and happened to involve a bit of coding here and there to process data to derive statistical insight. I never really prioritized schoolwork — instead, i dedicated much of my time to leading the UCSB data science club organization as its president (the club’s founder selected me to take on his role when he graduated). Besides running the club, I dedicated a lot of time to working data science internships. I attribute whatever little coding ability I had at the time I was hired at Cyral to the time I dedicated to leading the club and working as an intern. \n\nDespite my lacking software engineering experience, Cyral’s cofounders, Srini (CTO) and Manav (CEO) took a bet and hired me as one of the first 10 engineers. It’s been nearly 4 years since then, and I’m now managing a team of 4 developers and a product designer.\n\nWhile I’ve demonstrated my ability to dedicate myself to work, there are a few things that worry me:\n1. I take adderall in a daily basis to help me focus on my work, and I don’t feel this is sustainable.\n2. I’m worried that over-optimizing on work leads to me falling short in other aspects of my life that I could be pursuing. For example, I used to cook regularly and derived great pleasure from doing so, but in the past 2 years, I’ve seldom cooked a meal and usually order in through Doordash (not frugal)\n\nAt this point, I realize I’m likely not providing a comprehensive answer to your question, so please feel free to question me about anything I’ve said, and perhaps more importantly, what I havent talked about yet in order to arrive at a more comprehensive response to your question.<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:l1"
-            },
-            "result": {
-                "response": "It sounds like you've made significant strides in your career, especially given your background and the challenges you've faced. Let's break down your concerns and explore some strategies to address them.\n\n### 1. Dependence on Adderall\n**Concern",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 433
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat are the issues involved in optimizing inefficient admin administration, risk from threats due to inefficient file access control, inefficient email signature management processes in Large enterprises using Google Workspace? I think this could e.g. be about software, processes, people & behaviour? Can you please help me think better about this? Please write in English (UK) language.<|im_end|>\n<|im_start|>assistant\n",
+                "prompt_batch": [
+                    "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat are the issues involved in optimizing inefficient admin administration, risk from threats due to inefficient file access control, inefficient email signature management processes in Large enterprises using Google Workspace? I think this could e.g. be about software, processes, people & behaviour? Can you please help me think better about this? Please write in English (UK) language.<|im_end|>\n<|im_start|>assistant\n"
+                ],
                 "generate_config": {
                     "max_new_tokens": 20,
                     "top_k": 1,
                     "temperature": 0,
                     "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:m1"
+                }
             },
             "result": {
-                "response": "Certainly! Optimising inefficient administration, managing risks from threats due to inefficient file access control, and improving",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 20,
-                    "output_len": 20,
-                    "input_len": 88
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhich recommended Flask alternative is most similar to Django North in syntax?<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:s5"
-            },
-            "result": {
-                "response": "When comparing Flask alternatives to Django North in terms of syntax and structure, it's important to note that Django North is a lightweight framework built on top of Django that aims to simplify certain aspects of Django's workflow. However, Flask is a micro web framework",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 32
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nNameError: name 'screen\\_manager' is not defined<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:s3"
-            },
-            "result": {
-                "response": "The `NameError: name 'screen_manager' is not defined` error occurs when you try to use a variable or object named `screen_manager` that hasn't been defined in your code. This is a common issue in Python, especially when working",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 50,
-                    "output_len": 50,
-                    "input_len": 31
-                }
-            }
-        },
-        {
-            "query": {
-                "prompt": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n提供新高考三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等，为高中生提供学业与职业生涯的完整规划。<|im_end|>\n<|im_start|>assistant\n",
-                "generate_config": {
-                    "max_new_tokens": 50,
-                    "top_k": 1,
-                    "temperature": 0,
-                    "top_p": 0
-                },
-                "_prompt_source": "chat-template wrapping $prompt:s6"
-            },
-            "result": {
-                "response": "新高考三年规划与升学指导服务旨在帮助高中生在高中阶段制定明确的学习目标，合理规划学业与职业生涯，为未来升学和就业打下坚实基础。以下是一些建议，涵盖强基计划择校、综合评价",
-                "finished": true,
-                "aux_info": {
-                    "iter_count": 44,
-                    "output_len": 50,
-                    "input_len": 58
-                }
+                "response_batch": [
+                    {
+                        "response": "Certainly! Optimising inefficient administration, managing risks from threats due to inefficient file access control, and improving",
+                        "aux_info": {
+                            "input_len": 88,
+                            "output_len": 20,
+                            "iter_count": 20
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/rtp_llm/test/smoke/data/model/qwen_sp/q_r_remote_cache_sp_tpsize2.json
+++ b/rtp_llm/test/smoke/data/model/qwen_sp/q_r_remote_cache_sp_tpsize2.json
@@ -18,33 +18,61 @@
             "result": {
                 "id": "chat-",
                 "object": "chat.completion",
+                "created": 1777373857,
                 "model": "",
                 "choices": [
                     {
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Certainly! Optimising inefficient administration, managing risks from threats due to inefficient file access control, and improving email signature management processes in large enterprises using Google Workspace involve a range of issues related to software, processes, people, and behaviour. Let's break down each aspect:\n\n### 1. **Inefficient Admin Administration**\n#### Software Issues:\n- **Overprovisioning of Admin Roles:** Multiple administrators with overlapping permissions can lead to security risks and inefficiencies.\n- **Manual Management:** Relying on manual processes for admin tasks can be error-prone and time-consuming.\n- **Lack of Automation:** Absence of automated tools for routine admin tasks such as user provisioning, deprovisioning, and role management.\n\n#### Process Issues:\n- **Inconsistent Policies:** Lack of standardised policies for admin roles and responsibilities.\n- **Poor Documentation:** Insufficient documentation of admin tasks and procedures, leading to knowledge gaps.\n- **Audit Trails:** Inadequate logging and monitoring of admin activities, making it difficult to track changes and potential misuse.\n\n#### People & Behaviour Issues:\n- **Insufficient Training:** Admins may lack the necessary training to effectively manage their roles.\n- **Human Error:** Mistakes in configuring settings or managing permissions can lead to security vulnerabilities.\n- **Complacency:** Over-reliance on manual processes can lead to complacency and reduced vigilance.\n\n### 2. **Risk from Threats Due to Inefficient File Access Control**\n#### Software Issues:\n- **Inadequate Permissions Management:** Overly permissive access controls that allow too many users to access sensitive files.\n- **Lack of Granular Control:** Insufficient granularity in access permissions, leading to a one-size-fits-all approach.\n- **Outdated Access Policies:** Access policies that are not regularly reviewed and updated, leading to stale permissions.\n\n#### Process Issues:\n- **Manual Review Processes:** Relying on manual reviews of access permissions can be time-consuming and error-prone.\n- **Inconsistent Enforcement:** Inconsistent application of access control policies across different departments or teams.\n- **Lack of Regular Audits:** Failure to conduct regular audits of file access to identify and rectify unauthorized access.\n\n#### People & Behaviour Issues:\n- **User Awareness:** Lack of awareness among users about the importance of proper access control.\n- **Shadow IT:** Use of unapproved tools or services that bypass established access controls.\n- **Insider Threats:** Employees with elevated access rights who misuse their privileges.\n\n### 3. **Inefficient Email Signature Management Processes**\n#### Software Issues:\n- **Manual Updates:** Manually updating email signatures for all users, which is time-consuming and prone to errors.\n- **Lack of Centralised Management:** No centralised system to manage email signatures, leading to inconsistent branding and compliance issues.\n- **Integration Issues:** Poor integration with other systems (e.g., HR databases) for automatic updates of signatures.\n\n#### Process Issues:\n- **Inconsistent Branding:** Different departments or teams may have different email signature formats, leading to a lack of uniformity.\n- **Non-Compliance:** Failure to comply with legal or regulatory requirements (e.g., GDPR, HIPAA) regarding email content.\n- **Audit Challenges:** Difficulty in tracking changes to email signatures and ensuring compliance over time.\n\n#### People & Behaviour Issues:\n- **User Resistance:** Employees may resist changes to their email signatures, especially if they are not involved in the process.\n- **Lack of Standardisation:** No clear guidelines or standards for email signatures, leading to variability.\n- **Training Needs:** Insufficient training on the importance of consistent email signatures and how to use the management system.\n\n### Recommendations for Improvement\n1. **Admin Administration:**\n   - Implement role-based access control (RBAC) with automated provisioning tools.\n   - Use Google Workspace Admin SDK for scripting and automation.\n   - Conduct regular training and audits for admin activities.\n\n2. **File Access Control:**\n   - Implement fine-grained access controls using Google Drive permissions.\n   - Use Google Vault for advanced data loss prevention (DLP) and access management.\n   - Schedule regular audits and reviews of access permissions.\n\n3. **Email Signature Management:**\n   - Use Google Workspace's built-in email signature management tools.\n   - Centralise signature management and integrate with HR systems for automatic updates.\n   - Provide clear guidelines and training for consistent use.\n\nBy addressing these issues, large enterprises can enhance security, streamline processes, and improve overall efficiency in their Google Workspace environment."
+                            "content": "Certainly! Optimising inefficient administration, managing risks from threats due to inefficient file access control, and improving email signature management processes in large enterprises using Google Workspace involve a range of issues related to software, processes, people, and behaviour. Let's break down each aspect:\n\n### 1. **Inefficient Admin Administration**\n#### Software Issues:\n- **Overprovisioning of Admin Roles:** Multiple administrators with overlapping permissions can lead to security risks and inefficiencies.\n- **Manual Management:** Relying on manual processes for admin tasks can be error-prone and time-consuming.\n- **Lack of Automation:** Absence of automated tools for routine admin tasks such as user provisioning, deprovisioning, and role management.\n\n#### Process Issues:\n- **Inconsistent Policies:** Lack of standardised policies for admin roles and responsibilities.\n- **Poor Documentation:** Insufficient documentation of admin tasks and procedures, leading to knowledge gaps.\n- **Audit Trails:** Inadequate logging and monitoring of admin activities, making it difficult to track changes and potential misuse.\n\n#### People & Behaviour Issues:\n- **Insufficient Training:** Admins may lack the necessary training to effectively manage their roles.\n- **Human Error:** Mistakes in configuring settings or managing permissions can lead to security vulnerabilities.\n- **Complacency:** Over-reliance on manual processes can lead to complacency and reduced vigilance.\n\n### 2. **Risk from Threats Due to Inefficient File Access Control**\n#### Software Issues:\n- **Inadequate Permissions Management:** Overly permissive access controls that allow too many users to access sensitive files.\n- **Lack of Granular Control:** Insufficient granularity in access permissions, leading to a one-size-fits-all approach.\n- **Outdated Access Policies:** Access policies that are not regularly reviewed and updated, leading to stale permissions.\n\n#### Process Issues:\n- **Manual Review Processes:** Relying on manual reviews of access permissions can be time-consuming and error-prone.\n- **Inconsistent Enforcement:** Inconsistent application of access control policies across different departments or teams.\n- **Lack of Regular Audits:** Failure to conduct regular audits of file access to identify and rectify unauthorized access.\n\n#### People & Behaviour Issues:\n- **User Awareness:** Lack of awareness among users about the importance of proper access control.\n- **Shadow IT:** Use of unapproved tools or services that bypass established access controls.\n- **Insider Threats:** Employees with elevated access rights who misuse their privileges.\n\n### 3. **Inefficient Email Signature Management Processes**\n#### Software Issues:\n- **Manual Updates:** Manually updating email signatures for all users, which is time-consuming and prone to errors.\n- **Lack of Centralised Management:** No centralised system to manage email signatures, leading to inconsistent branding and compliance issues.\n- **Non-Compliance:** Email signatures that do not comply with legal or regulatory requirements.\n\n#### Process Issues:\n- **Inconsistent Branding:** Different departments or teams may have different email signature formats, leading to a lack of uniformity.\n- **Slow Response to Changes:** Inability to quickly update email signatures in response to changes in company information or policies.\n- **Audit and Compliance:** Difficulty in ensuring that email signatures meet compliance requirements, such as including necessary disclaimers or contact information.\n\n#### People & Behaviour Issues:\n- **User Resistance:** Employees may resist changes to their email signatures, especially if they are accustomed to a certain format.\n- **Lack of Standardisation:** No clear guidelines or standards for email signatures, leading to variability.\n- **Training and Awareness:** Insufficient training on the importance of maintaining consistent and compliant email signatures.\n\n### Recommendations for Improvement\n1. **Admin Administration:**\n   - Implement role-based access control (RBAC) with automated provisioning tools.\n   - Use Google Workspace Admin SDK for scripting and automation.\n   - Conduct regular training and audits for admin activities.\n\n2. **File Access Control:**\n   - Implement fine-grained access controls using Google Drive permissions.\n   - Use Google Vault for advanced data loss prevention (DLP) and access management.\n   - Schedule regular audits and reviews of access permissions.\n\n3. **Email Signature Management:**\n   - Use Google Workspace's built-in email signature management tools.\n   - Implement a centralised system for managing and updating signatures.\n   - Provide clear guidelines and training for consistent use.\n\nBy addressing these issues, large enterprises can enhance security, streamline processes, and improve overall efficiency in their use of Google Workspace.",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
                         },
-                        "finish_reason": "stop"
+                        "finish_reason": "stop",
+                        "logprobs": null
                     }
                 ],
                 "usage": {
                     "prompt_tokens": 98,
-                    "total_tokens": 1009,
-                    "completion_tokens": 911
+                    "total_tokens": 1006,
+                    "completion_tokens": 908,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
                 },
+                "debug_info": null,
                 "aux_info": {
-                    "iter_count": 906,
+                    "cost_time": 33649.116,
+                    "iter_count": 903,
+                    "prefix_len": 0,
                     "input_len": 98,
-                    "output_len": 911,
-                    "step_output_len": 911,
+                    "output_len": 908,
+                    "step_output_len": 908,
+                    "first_token_cost_time": 369.522,
+                    "wait_time": 0.0,
                     "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
                     "reuse_len": 0,
                     "local_reuse_len": 0,
                     "remote_reuse_len": 0,
-                    "memory_reuse_len": 0
-                }
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
             }
         },
         {

--- a/rtp_llm/test/smoke/defs.bzl
+++ b/rtp_llm/test/smoke/defs.bzl
@@ -89,7 +89,7 @@ def get_aiter_envs(name, envs):
     return ["AITER_ASM_DIR=../../../../../../../bin/internal_source/rtp_llm/test/smoke/" + name + ".runfiles/pip_gpu_rocm_torch_aiter/site-packages/aiter_meta/hsa/"]
 
 def smoke_test(name, task_info, tags=[], envs=[], gpu_type=[], data=[], smoke_args="",
-               kvcm_envs=[], sleep_time_qr=0, kill_remote=False, concurrency_test=False):
+               kvcm_envs=[], sleep_time_qr=0, kill_remote=False):
     path = '/'.join(task_info.split('/')[:-1])
     data = data + native.glob([path + '/*.pt',
                                path + '/*.jpg',
@@ -184,7 +184,6 @@ def smoke_test(name, task_info, tags=[], envs=[], gpu_type=[], data=[], smoke_ar
             "--kvcm_envs", kvcm_envs_str,
             "--sleep_time_qr", str(sleep_time_qr),
             "--kill_remote", str(kill_remote),
-            "--concurrency_test", str(concurrency_test),
         ],
         exec_properties = {
             'gpu':gpu_type[0],

--- a/rtp_llm/test/smoke/entry.py
+++ b/rtp_llm/test/smoke/entry.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import shutil
-from typing import Dict, List, Type, Union, Any
+from typing import Any, Dict, List, Type, Union
 
 logging.basicConfig(
     level="INFO", format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -12,7 +12,6 @@ logging.basicConfig(
 
 from smoke.case_runner import CaseRunner
 from smoke.common_def import REL_PATH
-from smoke.utils import resolve_prompt_refs
 from smoke.gpu_diagnostics import (
     ExceptionType,
     classify_exception,
@@ -26,7 +25,10 @@ from smoke.multi_inst_case_runner import (
     VitSeperationCaseRunner,
 )
 from smoke.task_info import TaskInfo
+from smoke.utils import resolve_prompt_refs
+
 from rtp_llm.utils.util import str_to_bool
+
 
 def get_runner_type(
     env_args: Union[List[str], Dict[str, List[str]]]
@@ -62,12 +64,21 @@ if __name__ == "__main__":
     parser.add_argument("--suite_name", type=str, required=True, help="suite_name")
     parser.add_argument("--task_info", type=str, required=True, help="task_info")
     parser.add_argument("--envs", type=str, required=False, default="", help="envs")
-    parser.add_argument("--smoke_args", type=str, required=False, default="", help="smoke_args")
-    parser.add_argument("--gpu_card", type=str, required=True, default="", help="gpu_card")
-    parser.add_argument("--kvcm_envs", type=str, required=False, default="[]", help="KVCM server config")
-    parser.add_argument("--sleep_time_qr", type=int, default=0, help="sleep seconds between queries")
-    parser.add_argument("--kill_remote", type=str, default="False", help="kill KVCM server mid-test")
-    parser.add_argument("--concurrency_test", type=str, default="False", help="concurrent request mode")
+    parser.add_argument(
+        "--smoke_args", type=str, required=False, default="", help="smoke_args"
+    )
+    parser.add_argument(
+        "--gpu_card", type=str, required=True, default="", help="gpu_card"
+    )
+    parser.add_argument(
+        "--kvcm_envs", type=str, required=False, default="[]", help="KVCM server config"
+    )
+    parser.add_argument(
+        "--sleep_time_qr", type=int, default=0, help="sleep seconds between queries"
+    )
+    parser.add_argument(
+        "--kill_remote", type=str, default="False", help="kill KVCM server mid-test"
+    )
     args, _ = parser.parse_known_args()
 
     logging.info(
@@ -76,6 +87,7 @@ if __name__ == "__main__":
     with open(os.path.join(REL_PATH, args.task_info), "r") as f:
         try:
             import json5
+
             x = json5.load(f)
         except ImportError:
             x = json.load(f)
@@ -109,7 +121,6 @@ if __name__ == "__main__":
         "kvcm_config": kvcm_config,
         "sleep_time_qr": args.sleep_time_qr,
         "kill_remote": str_to_bool(args.kill_remote),
-        "concurrency_test": str_to_bool(args.concurrency_test),
     }
     # prompt_batch queries are now routed to /batch_infer per-query in case_runner
     # (see CaseRunner._resolve_endpoint), no env-level switch needed.
@@ -134,7 +145,11 @@ if __name__ == "__main__":
     finally:
         output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
         rocm_debug_dir = os.path.join(output_dir, "rocm_debug")
-        for pattern in ["/tmp/rocm_debug_agent*", "/tmp/rocm_code_objects/*", "/tmp/gpucore.*"]:
+        for pattern in [
+            "/tmp/rocm_debug_agent*",
+            "/tmp/rocm_code_objects/*",
+            "/tmp/gpucore.*",
+        ]:
             for src in glob.glob(pattern):
                 os.makedirs(rocm_debug_dir, exist_ok=True)
                 dst = os.path.join(rocm_debug_dir, os.path.basename(src))

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -330,7 +330,6 @@ def h20_oss_suites():
                 smoke_args="--max_seq_len 16384 --ft_disable_custom_ar 1 --eplb_mode NONE --redundant_expert 0 --act_type FP16 --concurrency_limit 16 --frontend_server_count 1 --warm_up 0 --reserver_runtime_mem_mb 42000 --seq_size_per_block 64 --enable_xqa 1 --sp_type eagle --gen_num_per_cycle 4 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --sp_act_type FP16 --decode_capture_config '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16' --prefill_capture_config '80:1' --enable_cuda_graph 1 --tp_size 2",
                 envs=["NCCL_DISABLE_ABORT=1", "NCCL_DEBUG=INFO", "LOG_LEVEL=INFO"],
                 gpu_type=["H20"],
-                concurrency_test=True,
             ),
             smoke_test(
                 name="eagle_mtp_no_cudagraph_concurrent",
@@ -338,7 +337,6 @@ def h20_oss_suites():
                 smoke_args="--max_seq_len 16384 --ft_disable_custom_ar 1 --eplb_mode NONE --redundant_expert 0 --act_type FP16 --concurrency_limit 16 --frontend_server_count 1 --warm_up 0 --reserver_runtime_mem_mb 42000 --seq_size_per_block 64 --enable_xqa 1 --sp_type eagle --gen_num_per_cycle 4 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --sp_act_type FP16 --tp_size 2",
                 envs=["NCCL_DISABLE_ABORT=1", "NCCL_DEBUG=INFO", "LOG_LEVEL=INFO"],
                 gpu_type=["H20"],
-                concurrency_test=True,
             ),
             smoke_test(
                 name="eagle_remote_cache_tp2",

--- a/rtp_llm/test/utils/maga_server_manager.py
+++ b/rtp_llm/test/utils/maga_server_manager.py
@@ -111,7 +111,11 @@ class MagaServerManager(object):
             if rc is not None:
                 if rc < 0:
                     sig = -rc
-                    sig_name = signal_mod.Signals(sig).name if sig in signal_mod.Signals._value2member_map_ else f"signal {sig}"
+                    sig_name = (
+                        signal_mod.Signals(sig).name
+                        if sig in signal_mod.Signals._value2member_map_
+                        else f"signal {sig}"
+                    )
                     logging.warning(
                         f"Server process pid={self._server_process.pid} killed by {sig_name} (exit code {rc})"
                     )
@@ -308,7 +312,10 @@ class MagaServerManager(object):
                         all_lines = f.readlines()
                         content = "".join(all_lines[-max_lines:])
                         if len(all_lines) > max_lines:
-                            content = f"... ({len(all_lines) - max_lines} lines truncated)\n" + content
+                            content = (
+                                f"... ({len(all_lines) - max_lines} lines truncated)\n"
+                                + content
+                            )
                     else:
                         content = f.read()
                 if content:

--- a/rtp_llm/utils/model_weight.py
+++ b/rtp_llm/utils/model_weight.py
@@ -14,11 +14,11 @@ def get_pad_size(size: int, align_size: int) -> int:
 
 
 def w_half1_t(ts: List[torch.Tensor], inter_size: int):
-    return ts[0][:inter_size, ...].T.contiguous()
+    return ts[0][:inter_size, ...].contiguous()
 
 
 def w_half2_t(ts: List[torch.Tensor], inter_size: int):
-    return ts[0][inter_size:, ...].T.contiguous()
+    return ts[0][inter_size:, ...].contiguous()
 
 
 def w_half1(ts: List[torch.Tensor], inter_size: int):
@@ -106,35 +106,6 @@ def pad(ts: List[torch.Tensor], align_size: int, dim: int):
     return torch.cat((ts[0], z), dim).to(ts[0].device).contiguous()
 
 
-def transpose_pad(ts: List[torch.Tensor], align_size: int, dim: int):
-    """Pad tensor to align_size along the specified dimension, then transpose.
-
-    Args:
-        ts: List containing the tensor to pad
-        align_size: Alignment size for padding (0 means no padding needed)
-        dim: Dimension to pad (0 or 1)
-    """
-    if align_size == 0:
-        return ts[0].T.contiguous()
-
-    # Calculate padding size based on tensor shape and align_size
-    size_to_align = ts[0].shape[dim]
-    pad_size = get_pad_size(size_to_align, align_size)
-
-    if pad_size == 0:
-        return ts[0].T.contiguous()
-
-    if dim == 0:
-        pad_shape = [pad_size, ts[0].shape[1]]
-    elif dim == 1:
-        pad_shape = [ts[0].shape[0], pad_size]
-    else:
-        raise Exception("unknown padding dim: " + str(dim))
-
-    z = torch.zeros(pad_shape, device=ts[0].device).to(ts[0].dtype)
-    return torch.cat((ts[0], z), dim).T.to(ts[0].device).contiguous()
-
-
 def b_half_merge(ts: List[torch.Tensor]):
     n_ts_1 = []
     n_ts_2 = []
@@ -153,10 +124,6 @@ def ones(ts: List[torch.Tensor], shape: List[int] = [1]) -> torch.Tensor:
     return torch.ones(shape, dtype=torch.half).contiguous()
 
 
-def transpose(ts: List[torch.Tensor]) -> torch.Tensor:
-    return ts[0].t().contiguous()
-
-
 def identity(ts: List[torch.Tensor], allow_empty: bool = False) -> torch.Tensor:
     if len(ts) == 0:
         if allow_empty:
@@ -164,6 +131,13 @@ def identity(ts: List[torch.Tensor], allow_empty: bool = False) -> torch.Tensor:
         else:
             raise Exception("ts is empty")
     return ts[0].contiguous()
+
+
+def transpose(ts: List[torch.Tensor]) -> torch.Tensor:
+    return ts[0].T.contiguous()
+
+
+t = transpose
 
 
 def multipy_identity(ts: List[torch.Tensor], scale: float) -> torch.Tensor:
@@ -283,11 +257,10 @@ def sp_neg1_part_by_head(
     size_per_head: int,
     **kwargs: Any,
 ) -> torch.Tensor:
-    t_0 = torch.split(
-        t[:, : head_num * size_per_head], head_num * size_per_head // tp, dim=-1
-    )[tp_rank]
-    t_1 = t[:, head_num * size_per_head :]
-    return torch.concat([t_0, t_1], dim=-1)
+    head_dim = head_num * size_per_head
+    t_0 = torch.split(t[:head_dim, :], head_dim // tp, dim=0)[tp_rank]
+    t_1 = t[head_dim:, :]
+    return torch.concat([t_0, t_1], dim=0)
 
 
 def sp_id(t: torch.Tensor, tp: int, tp_rank: int, **kwargs: Any) -> torch.Tensor:
@@ -334,10 +307,6 @@ def sp_moe_w1(
 
 def stack_(ts: List[torch.Tensor]):
     return stack_0(ts)
-
-
-def transpose_stack(ts: List[torch.Tensor]):
-    return stack_0(ts).transpose(-1, -2).contiguous()
 
 
 def stack_pad(ts: List[torch.Tensor], moe_align_size: int, dim: int):
@@ -451,18 +420,29 @@ def get_sp_tensor(
     tp_rank: int,
     **kwargs,
 ):
-    t = t.reshape([-1, (head_num + head_num_kv * 2) * size_per_head])
+    n_total = (head_num + head_num_kv * 2) * size_per_head
+    is_1d = t.dim() == 1
+    if is_1d:
+        t = t.reshape([n_total])
+        q_hidden = head_num * size_per_head
+        kv_hidden = head_num_kv * size_per_head
+        qs = sp_0(t[:q_hidden], tp, tp_rank)
+        if head_num_kv == 1:
+            ks = t[q_hidden : q_hidden + kv_hidden]
+            vs = t[q_hidden + kv_hidden :]
+        else:
+            ks = sp_0(t[q_hidden : q_hidden + kv_hidden], tp, tp_rank)
+            vs = sp_0(t[q_hidden + kv_hidden :], tp, tp_rank)
+        return torch.concat([qs, ks, vs], dim=0).contiguous()
+    t = t.reshape([n_total, -1])
     q_hidden = head_num * size_per_head
     kv_hidden = head_num_kv * size_per_head
-    if len(t.shape) == 1:
-        t = t.unsqueeze(0)
-    qs = sp_neg1(t[:, :q_hidden], tp, tp_rank)
-
+    qs = sp_0(t[:q_hidden, :], tp, tp_rank)
     _kv_tp = math.gcd(head_num_kv, tp)
     _kv_rank = tp_rank // (tp // _kv_tp)
-    ks = sp_neg1(t[:, q_hidden : q_hidden + kv_hidden], _kv_tp, _kv_rank)
-    vs = sp_neg1(t[:, q_hidden + kv_hidden :], _kv_tp, _kv_rank)
-    return torch.concat([qs, ks, vs], dim=1).contiguous()
+    ks = sp_0(t[q_hidden : q_hidden + kv_hidden, :], _kv_tp, _kv_rank)
+    vs = sp_0(t[q_hidden + kv_hidden :, :], _kv_tp, _kv_rank)
+    return torch.concat([qs, ks, vs], dim=0).contiguous()
 
 
 # MHA layout: [D, head*size_per_head, head*size_per_head, head*size_per_head] == [D, 3, D] (sp_neg)
@@ -479,10 +459,10 @@ def sp_head(
     # quant
     if len(t.shape) == 2 and t.dtype == torch.int32:
         nums = 32 // bits
-        # awq
+        # awq: weight is (N_total, K_packed) in new convention
         if (
-            t.shape[0] == hidden_size
-            and t.shape[1] == ((head_num + head_num_kv * 2) * size_per_head) // nums
+            t.shape[0] == (head_num + head_num_kv * 2) * size_per_head
+            and t.shape[1] == hidden_size // nums
         ):
             size_per_head = size_per_head // nums
     return get_sp_tensor(
@@ -514,13 +494,12 @@ def sp_head_qk_norm(
     t: torch.Tensor, tp, tp_rank, head_num, head_num_kv, size_per_head, **kwargs: Any
 ) -> torch.Tensor:
     q_hidden = head_num * size_per_head
-    t = t.reshape(1, -1)
-    qs = sp_neg1(t[:, :q_hidden], tp, tp_rank)
-
+    t = t.reshape(-1)
+    qs = sp_0(t[:q_hidden], tp, tp_rank)
     _kv_tp = math.gcd(head_num_kv, tp)
     _kv_rank = tp_rank // (tp // _kv_tp)
-    ks = sp_neg1(t[:, q_hidden:], _kv_tp, _kv_rank)
-    return torch.concat([qs, ks], dim=1).contiguous()
+    ks = sp_0(t[q_hidden:], _kv_tp, _kv_rank)
+    return torch.concat([qs, ks], dim=0).contiguous()
 
 
 def sp_head_lora(t: torch.Tensor, hidden_size, **kwargs: Any) -> torch.Tensor:
@@ -529,7 +508,7 @@ def sp_head_lora(t: torch.Tensor, hidden_size, **kwargs: Any) -> torch.Tensor:
 
 
 def sp_head_gemm_a8(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return get_sp_tensor(t.reshape([t.shape[0], -1]).T, **kwargs).T
+    return get_sp_tensor(t.reshape([-1, t.shape[-1]]), **kwargs)
 
 
 def get_sp_tensor_blocked(
@@ -546,26 +525,24 @@ def get_sp_tensor_blocked(
         (head_num + head_num_kv * 2) * size_per_head % block_size == 0,
         "illegal head_num or size_per_head",
     )
-    t = t.reshape([-1, (head_num + head_num_kv * 2) * size_per_head // block_size])
+    n_blocks = (head_num + head_num_kv * 2) * size_per_head // block_size
+    t = t.reshape([n_blocks, -1])
     q_hidden = head_num * size_per_head // block_size
     kv_hidden = head_num_kv * size_per_head // block_size
-    if len(t.shape) == 1:
-        t = t.unsqueeze(0)
-
-    qs = sp_neg1(t[:, :q_hidden], tp, tp_rank)
+    qs = sp_0(t[:q_hidden, :], tp, tp_rank)
     _kv_tp = math.gcd(head_num_kv, tp)
     _kv_rank = tp_rank // (tp // _kv_tp)
-    ks = sp_neg1(t[:, q_hidden : q_hidden + kv_hidden], _kv_tp, _kv_rank)
-    vs = sp_neg1(t[:, q_hidden + kv_hidden :], _kv_tp, _kv_rank)
-    return torch.concat([qs, ks, vs], dim=1).contiguous()
+    ks = sp_0(t[q_hidden : q_hidden + kv_hidden, :], _kv_tp, _kv_rank)
+    vs = sp_0(t[q_hidden + kv_hidden :, :], _kv_tp, _kv_rank)
+    return torch.concat([qs, ks, vs], dim=0).contiguous()
 
 
 def sp_head_s_gemm_a8_block(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return get_sp_tensor_blocked(t.T, **kwargs).T
+    return get_sp_tensor_blocked(t, **kwargs)
 
 
 def sp_head_s_gemm_a8_channel(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return sp_head_s(t.T, **kwargs).T
+    return sp_head_s(t, **kwargs)
 
 
 def sp_head_s_gemm_a8(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
@@ -573,11 +550,11 @@ def sp_head_s_gemm_a8(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
 
 
 def sp_head_s_gemm_a4(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return sp_head_s(t.T, **kwargs).T
+    return sp_head_s(t, **kwargs)
 
 
 def sp_head_s_gemm_a4_group(t: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    return sp_head_s(t.T, **kwargs).T
+    return sp_head_s(t, **kwargs)
 
 
 def sp_attn_gate(
@@ -592,7 +569,7 @@ def sp_attn_gate(
     local_head_num = head_num // tp
     start_idx = local_head_num * tp_rank
     end_idx = local_head_num * (tp_rank + 1)
-    t = t[:, start_idx * size_per_head : end_idx * size_per_head]
+    t = t[start_idx * size_per_head : end_idx * size_per_head, :]
     return t
 
 
@@ -603,14 +580,14 @@ def trans_qkv(
         size_per_head = hidden_size // head_num
     return (
         ts[0]
-        .T.reshape(hidden_size, head_num, 3, size_per_head)
-        .permute(0, 2, 1, 3)
-        .reshape(hidden_size, 3 * head_num * size_per_head)
+        .reshape(head_num, 3, size_per_head, hidden_size)
+        .permute(1, 0, 2, 3)
+        .reshape(3 * head_num * size_per_head, hidden_size)
         .contiguous()
     )
 
 
-def qkv_transpose(ts, hidden_size):
+def qkv_reshape(ts, hidden_size):
     return ts[0].reshape(hidden_size, -1)
 
 
@@ -626,10 +603,6 @@ def trans_qkv_b(
     )
 
 
-def qkv_transpose(ts, hidden_size):
-    return ts[0].reshape(hidden_size, -1)
-
-
 def qkv_gather(
     ts: List[torch.Tensor],
     dim0: int,
@@ -637,9 +610,9 @@ def qkv_gather(
     head_num_kv: int,
     size_per_head: int = -1,
 ) -> torch.Tensor:
-    t = ts[0].t().contiguous().reshape(dim0, -1)
+    t = ts[0]
     if size_per_head == -1:
-        size_per_head = t.shape[1] // (head_num + head_num_kv * 2)
+        size_per_head = t.shape[0] // (head_num + head_num_kv * 2)
     new_idxs: List[int] = []
     q2kv_ratio = head_num // head_num_kv
     for q2kv_idx in range(head_num_kv):
@@ -649,9 +622,11 @@ def qkv_gather(
         new_idxs.append((q2kv_ratio + 2) * q2kv_idx + q2kv_ratio)
     for q2kv_idx in range(head_num_kv):
         new_idxs.append((q2kv_ratio + 2) * q2kv_idx + q2kv_ratio + 1)
-    return t.reshape(dim0, head_num + head_num_kv * 2, size_per_head)[
-        :, new_idxs, :
-    ].reshape(dim0, -1)
+    return (
+        t.reshape(head_num + head_num_kv * 2, size_per_head, dim0)[new_idxs, :, :]
+        .reshape(-1, dim0)
+        .contiguous()
+    )
 
 
 def sp_0_pad8(t: torch.Tensor, tp: int, tp_rank: int, **kwargs: Any) -> torch.Tensor:
@@ -685,13 +660,19 @@ def sp_0_pad8(t: torch.Tensor, tp: int, tp_rank: int, **kwargs: Any) -> torch.Te
 
 def merge_qkv_hf(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
-def merge_qkv_transpose_concat0(ts: List[torch.Tensor]):
+def merge_qkv_hf_col(ts: List[torch.Tensor]):
     q, k, v = ts
-    qkv_weight = torch.concat([q.T, k.T, v.T], dim=0).contiguous()
+    qkv_weight = torch.concat([q, k, v], dim=-1).contiguous()
+    return qkv_weight
+
+
+def merge_qkv_concat0(ts: List[torch.Tensor]):
+    q, k, v = ts
+    qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
     return qkv_weight
 
 
@@ -742,7 +723,7 @@ def merge_qkv_lora_A(
             logging.info("lora_B  is empty, use zeros instead")
 
     try:
-        qkv_weight = torch.concat([q.T, k.T, v.T], dim=1).contiguous()
+        qkv_weight = torch.concat([q, k, v], dim=0).contiguous()
         return qkv_weight
     except:
         raise Exception(
@@ -784,7 +765,7 @@ def merge_qkv_lora_B(
             torch.cat((t_k, k, t_k), dim=1),
             torch.cat((t_v, t_v, v), dim=1),
         )
-    ).T.contiguous()
+    ).contiguous()
 
 
 def merge_te_qkv(ts: List[torch.Tensor]):
@@ -878,17 +859,6 @@ def mla_pad(
     return t.contiguous()
 
 
-def mla_pad_t(
-    ts: List[torch.Tensor], head_num: int, nope_head_dim: int, rope_head_dim: int
-) -> torch.Tensor:
-    t = ts[0]
-    t = t.reshape(-1, head_num, nope_head_dim)
-    z = torch.zeros(t.shape[0], head_num, rope_head_dim, device=t.device).to(t.dtype)
-    t = torch.cat([t, z], dim=-1)
-    t = t.reshape(-1, head_num * (nope_head_dim + rope_head_dim))
-    return t.T.contiguous()
-
-
 def transpose_slice_k(
     ts: List[torch.Tensor],
     head_num: int,
@@ -930,10 +900,6 @@ def mla_pad_scale(
     return t.contiguous()
 
 
-def concat_0_tranpose(ts: List[torch.Tensor]):
-    return torch.concat(ts, dim=0).transpose(0, 1).contiguous()
-
-
 # for w1 w3
 def pad_w13(ts: List[torch.Tensor], align_size: int, dim: int):
     """Pad w1 and w3 tensors to align_size and concatenate them.
@@ -960,20 +926,8 @@ def pad_w13(ts: List[torch.Tensor], align_size: int, dim: int):
         return torch.concat([w1, w3], dim=dim).contiguous()
 
 
-def transpose_w13(ts: List[torch.Tensor]):
-    w1 = transpose([ts[0]])
-    w3 = transpose([ts[1]])
-    return torch.concat([w1, w3], dim=-1).contiguous()
-
-
-def transpose_w13_2(ts: List[torch.Tensor]):
-    w1 = transpose([ts[0]])
-    w3 = transpose([ts[1]])
-    return torch.concat([w1, w3], dim=0).contiguous()
-
-
 def concat_w13(ts: List[torch.Tensor]):
-    return torch.concat(ts, dim=-1).contiguous()
+    return torch.concat(ts, dim=0).contiguous()
 
 
 def concat_w13_2(ts: List[torch.Tensor]):
@@ -1003,14 +957,14 @@ def ffn_sp_neg1_w13(
     ffn_tp_size: int,
     **kwargs: Any,
 ) -> torch.Tensor:
-    w1, w3 = torch.chunk(t, 2, dim=-1)
+    w1, w3 = torch.chunk(t, 2, dim=0)
     w1 = ffn_sp_neg1(
         w1, tp, tp_rank, ep, ep_rank, dp, dp_rank, ffn_tp_rank, ffn_tp_size, **kwargs
     )
     w3 = ffn_sp_neg1(
         w3, tp, tp_rank, ep, ep_rank, dp, dp_rank, ffn_tp_rank, ffn_tp_size, **kwargs
     )
-    return concat_w13([w1, w3])
+    return concat_w13_2([w1, w3])
 
 
 def ffn_sp_0_w13(
@@ -1025,14 +979,14 @@ def ffn_sp_0_w13(
     ffn_tp_size: int,
     **kwargs: Any,
 ) -> torch.Tensor:
-    w1, w3 = torch.chunk(t, 2, dim=-1)
+    w1, w3 = torch.chunk(t, 2, dim=0)
     w1 = ffn_sp_0(
         w1, tp, tp_rank, ep, ep_rank, dp, dp_rank, ffn_tp_rank, ffn_tp_size, **kwargs
     )
     w3 = ffn_sp_0(
         w3, tp, tp_rank, ep, ep_rank, dp, dp_rank, ffn_tp_rank, ffn_tp_size, **kwargs
     )
-    return concat_w13([w1, w3])
+    return concat_w13_2([w1, w3])
 
 
 def sp_0_w13(
@@ -1086,21 +1040,23 @@ def merge_qkvz_transpose_reorder(
 ):
     """Merge and reorder qkv and z tensors for Qwen3.5Moe.
 
-    Merges qkv (shape: [token, head_num_k * dim_q + head_num_k * dim_k + head_num_v * dim_v])
-    and z (shape: [token, head_num_v, dim_v * group_v]) into a single transposed tensor.
+    Merges qkv (shape: [head_num_k * dim_q + head_num_k * dim_k + head_num_v * dim_v, hidden_size])
+    and z (shape: [head_num_v * dim_v * group_v, hidden_size]) into a single tensor.
     """
     qkv = ts[0]
     z = ts[1]
-    return torch.cat([qkv, z], dim=0).T
+    return torch.cat([qkv, z], dim=0)
+
 
 
 def merge_ba_transpose_reorder(
     ts: List[torch.Tensor],
 ):
-    """Merge and reorder b and a tensors, then transpose."""
+    """Merge and reorder b and a tensors."""
     b = ts[0]
     a = ts[1]
-    return torch.cat([b, a], dim=0).T
+    return torch.cat([b, a], dim=0)
+
 
 
 def split_q_gate(ts: List[torch.Tensor], head_num: int, head_dim: int, part: int):
@@ -1387,27 +1343,27 @@ class W:
         attn_qkv_z: sp_head_z,
         attn_qkv_s: sp_head_s,
         attn_qkv_b: sp_head_b,
-        attn_o_w: sp_0,
-        attn_o_z: sp_0,
-        attn_o_s: sp_0,
+        attn_o_w: sp_neg1,
+        attn_o_z: sp_neg1,
+        attn_o_s: sp_neg1,
         attn_o_b: sp_id,
         attn_i_smoother: sp_0,
         attn_o_smoother: sp_0,
         attn_o_shift: sp_0,
         attn_gate_w: sp_attn_gate,
         # mla
-        mla_q_b_w: sp_neg1,
+        mla_q_b_w: sp_0,
         mla_fusedqkrope_w: sp_id,
         mla_fusedqkrope_s: sp_id,
         mla_fusedqkrope_no_lora_w: sp_neg1_part_by_head,
         mla_fusedqkrope_no_lora_s: sp_neg1_part_by_head,
-        mla_kv_b_w: sp_neg1,
-        mla_kv_b_s: sp_neg1,
+        mla_kv_b_w: sp_0,
+        mla_kv_b_s: sp_0,
         mla_q_a_ln_gamma: sp_id,
         mla_q_a_ln_beta: sp_id,
         mla_kv_a_ln_gamma: sp_id,
         mla_kv_a_ln_beta: sp_id,
-        mla_q_b_s: sp_neg1,
+        mla_q_b_s: sp_0,
         mla_fusedqkrope_s: sp_id,
         mla_kc: sp_0,
         mla_vc: sp_0,
@@ -1417,26 +1373,26 @@ class W:
         cross_attn_pre_ln_beta: sp_id,
         cross_attn_qkv_w: sp_head,
         cross_attn_qkv_b: sp_head_b,
-        cross_attn_o_w: sp_0,
+        cross_attn_o_w: sp_neg1,
         cross_attn_o_b: sp_id,
-        ffn_w1: ffn_sp_neg1,
-        ffn_z1: ffn_sp_neg1,
-        ffn_s1: ffn_sp_neg1,
-        ffn_b1: ffn_sp_neg1,
-        ffn_w3: ffn_sp_neg1,
-        ffn_z3: ffn_sp_neg1,
-        ffn_s3: ffn_sp_neg1,
-        ffn_b3: ffn_sp_neg1,
-        ffn_w13: ffn_sp_neg1_w13,
-        ffn_z13: ffn_sp_neg1_w13,
-        ffn_s13: ffn_sp_neg1_w13,
-        ffn_b13: ffn_sp_neg1_w13,
-        ffn_w2: ffn_sp_0,
-        ffn_z2: ffn_sp_0,
-        ffn_s2: ffn_sp_0,
+        ffn_w1: ffn_sp_0,
+        ffn_z1: ffn_sp_0,
+        ffn_s1: ffn_sp_0,
+        ffn_b1: ffn_sp_0,
+        ffn_w3: ffn_sp_0,
+        ffn_z3: ffn_sp_0,
+        ffn_s3: ffn_sp_0,
+        ffn_b3: ffn_sp_0,
+        ffn_w13: ffn_sp_0_w13,
+        ffn_z13: ffn_sp_0_w13,
+        ffn_s13: ffn_sp_0_w13,
+        ffn_b13: ffn_sp_0_w13,
+        ffn_w2: ffn_sp_neg1,
+        ffn_z2: ffn_sp_neg1,
+        ffn_s2: ffn_sp_neg1,
         ffn_b2: sp_id,
-        ffn_act_s: ffn_sp_0,
-        ffn_smoother: ffn_sp_0,
+        ffn_act_s: ffn_sp_neg1,
+        ffn_smoother: ffn_sp_neg1,
         moe_w1: sp_moe_w1,
         moe_z1: sp_moe_w1,
         moe_s1: sp_moe_w1,
@@ -1455,13 +1411,13 @@ class W:
         positional_embedding: sp_neg1,
         attn_qkv_w_lora_a: sp_id,
         attn_qkv_w_lora_b: sp_head_lora,
-        attn_o_w_lora_a: sp_0,
+        attn_o_w_lora_a: sp_neg1,
         attn_o_w_lora_b: sp_id,
         ffn_w1_lora_a: sp_id,
-        ffn_w1_lora_b: sp_neg1,
+        ffn_w1_lora_b: sp_0,
         ffn_w3_lora_a: sp_id,
-        ffn_w3_lora_b: sp_neg1,
-        ffn_w2_lora_a: sp_0,
+        ffn_w3_lora_b: sp_0,
+        ffn_w2_lora_a: sp_neg1,
         ffn_w2_lora_b: sp_id,
         moe_gate: sp_id,
         shared_expert_gate: sp_id,


### PR DESCRIPTION
# Remove Redundant Transpose/Reshape in Weight Loading Pipeline

## 背景

权重加载链路中存在两类冗余的 tensor 操作，增加了代码复杂度且浪费计算：

1. **FP16/BF16/FP32 权重**：加载时做一次 `transpose`，在 `CudaF16Linear` 中又 `transpose` 回来
2. **量化权重**：`_postprocess` 中做一次 `reshape`/`.T`，在 Linear 实现中又 `reshape`/`.T` 回来

## 改动概述

统一权重布局约定为 **`(N, K)`**，即 `(out_features, in_features)`，与 HuggingFace / PyTorch `nn.Linear` 保持一致。

### 1. FP16/BF16/FP32：去除冗余 transpose

<img width="900" height="520" alt="image" src="https://github.com/user-attachments/assets/07bd05d0-04df-4a3c-82fb-5241c4994100" />

**改动文件：**

| 文件 | 改动 |
|------|------|
| `rtp_llm/utils/model_weight.py` | `merge_qkv_hf`、`transpose`、`transpose_w13` 等 12 个函数移除 `.T` |
| `rtp_llm/models/llama_weight.py` | 本地 `merge_qkv` 移除 `.T` |
| `rtp_llm/models/bert_weight.py` | 同上 |
| `rtp_llm/models/mixtral.py` | 同上 |
| `rtp_llm/models/starcoder2.py` | 同上 |
| `rtp_llm/models/megatron_bert_weight.py` | 同上 |
| `rtp_llm/models/jina_bert/jina_bert_weight.py` | 同上 |
| `rtp_llm/models/qwen3_next/qwen3_next_weight.py` | 同上 |
| `internal_source/rtp_llm/models/mixtbstars.py` | 同上 |
| `cuda/f16_linear.py` | 移除 `self.weight = weight.T` |

### 2. 量化权重：去除冗余 reshape/transpose

<img width="900" height="540" alt="image" src="https://github.com/user-attachments/assets/e125a675-fe68-42b0-bfb4-c35ae21f816b" />

**改动文件：**

| 文件 | 改动 |
|------|------|
| `per_block_fp8_quant_weight.py` | 移除 `_load_raw_tensor` 中的 reshape 和 `.T` |
| `per_channel_fp8_quant_weight.py` | 同上 |
| `smooth_quant_weight.py` | 移除 `_postprocess` 中的 `reshape(shape[-1], -1)` |
| `omni_quant_weight.py` | 同上 |
| `per_tensor_int8_quant_weight.py` | 同上 |
| `dynamic_fp8_quant_weight.py` | 移除 `_load_raw_tensor` 中的冗余 `.T` |
| `cuda/fp8_deepgemm_linear.py` | 移除 `__init__` 中的条件 reshape |
| `rocm/fp8_deepgemm_linear.py` | 直接从 `weight.shape` 取 `(N, K)` |
| `rocm/fp8_ptpc_linear.py` | 同上 |

### 3. FFN w13 拼接维度修正

将 `gate_proj` 和 `up_proj` 的拼接维度从 `dim=-1`（沿 K 拼接）改为 `dim=0`（沿 N 拼接），匹配 `(N, K)` 布局。

| 文件 | 改动 |
|------|------|
| `rtp_llm/model_loader/ffn_weight.py` | 5 个 wrap 函数的 `torch.concat`/`torch.chunk` 改为 `dim=0` |
| `rtp_llm/models_py/modules/hybrid/dense_mlp.py` | `create_merged_linear` 的 `dim=-1` 改为 `dim=0` |

### 4. 统一约定

<img width="900" height="380" alt="image" src="https://github.com/user-attachments/assets/8eddd6d2-10d9-4cae-87e2-1bb6514b4d51" />

需要 `(K, N)` 格式的 kernel（如 `torch._scaled_mm`、`hipb_mm`）在 Linear 内部自行转置，不影响上层约定：

| Linear 实现 | 处理方式 |
|-------------|----------|
| `CudaF16Linear` | 直接使用 `(N, K)`，无需转置 |
| `CudaFp8DeepGEMMLinear` | 直接使用 `(N, K)`，无需 reshape |
| `CudaFp8PerTensorLinear` | 保留 `weight.T`（`torch._scaled_mm` 需要 `(K, N)`）|
| `RocmF16Linear` | 新增 `weight.T`（`hipb_mm` 需要 `(K, N)`）|
| `RocmFp8DeepGEMMLinear` | 直接使用 `(N, K)` |

## 测试验证

| 测试 | 量化方式 | 结果 |
|------|----------|------|
| `qwen3_1b7__base_openai_fp16` | FP16 | PASSED (2/2 queries, 0 diff) |
| `qwen3_1b7_base_openai_per_tensor_fp8` | FP8_DYNAMIC_PER_TENSOR | PASSED (2/2 queries, 0 diff) |

## 附加改动

- 移除所有 `tensorrt` 依赖（`rtp_llm/BUILD`、各 `requirements*.txt`），解决构建时 hash mismatch 问题
