### PR TITLE
Implement true EP (Expert Parallelism) mode for Qwen3 ROCm MoE

### DIFF
--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -53,14 +53,17 @@ def auto_configure_deepep(
     - PD separation + Decode node + Multi-node multi-GPU (>=9 GPUs): 1, 1, 1
     """
 
-    # in cp mode, do not use all gather, tp_size set to 1
+    # Use all_gather only in pure TP mode (ep_size == 1).
+    # When ep_size > 1, use DeepEP for expert parallel dispatch regardless
+    # of whether ep_size equals tp_size (e.g. 4tp4ep, 8tp8ep).
+    # In CP mode, do not use all gather, tp_size set to 1
     tp_size = parallelism_config.get_attn_tp_size()
     ep_size = parallelism_config.ep_size
     moe_config.ll_num_max_token = ll_num_max_token
     moe_config.use_all_gather = (
         moe_config.use_all_gather
         and not deep_ep_config.use_deepep_low_latency
-        and (ep_size == tp_size or ep_size == 1)
+        and ep_size == 1
     )
     if moe_config.use_all_gather:
         moe_config.use_deepep_moe = False

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -53,14 +53,17 @@ def auto_configure_deepep(
     - PD separation + Decode node + Multi-node multi-GPU (>=9 GPUs): 1, 1, 1
     """
 
-    # in cp mode, do not use all gather, tp_size set to 1
+    # Use all_gather only in pure TP mode (ep_size == 1).
+    # When ep_size > 1, use DeepEP for expert parallel dispatch regardless
+    # of whether ep_size equals tp_size (e.g. 4tp4ep, 8tp8ep).
+    # In CP mode, do not use all gather, tp_size set to 1
     tp_size = parallelism_config.get_attn_tp_size()
     ep_size = parallelism_config.ep_size
     moe_config.ll_num_max_token = ll_num_max_token
     moe_config.use_all_gather = (
         moe_config.use_all_gather
         and not deep_ep_config.use_deepep_low_latency
-        and (ep_size == tp_size or ep_size == 1)
+        and ep_size == 1
     )
     if moe_config.use_all_gather:
         moe_config.use_deepep_moe = False
@@ -336,12 +339,18 @@ def setup_default_args(py_env_configs):
             "[MI308X] enable FT_DISABLE_CUSTOM_AR by default, as amd has own implementation."
         )
 
-    if os.path.exists("/dev/kfd") and py_env_configs.kv_cache_config.seq_size_per_block == 0:
+    if (
+        os.path.exists("/dev/kfd")
+        and py_env_configs.kv_cache_config.seq_size_per_block == 0
+    ):
         py_env_configs.kv_cache_config.seq_size_per_block = 16
         logging.info(
             "[MI308X] set SEQ_SIZE_PER_BLOCK 16 by default, as it just support 16 now."
         )
-    if os.path.exists("/dev/alixpu") and py_env_configs.kv_cache_config.seq_size_per_block == 0:
+    if (
+        os.path.exists("/dev/alixpu")
+        and py_env_configs.kv_cache_config.seq_size_per_block == 0
+    ):
         py_env_configs.kv_cache_config.seq_size_per_block = 256
         logging.info("set SEQ_SIZE_PER_BLOCK 256 by default")
     if py_env_configs.kv_cache_config.seq_size_per_block == 0:

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -14,9 +14,14 @@ from enum import IntEnum, auto
 from typing import Optional, Tuple
 
 import torch
-from deep_ep import Buffer as DeepEPBuffer
-from deep_ep import Config as DeepEPConfig
 from torch.distributed import ProcessGroup
+
+try:
+    from deep_ep import Buffer as DeepEPBuffer
+    from deep_ep import Config as DeepEPConfig
+except ImportError:
+    DeepEPBuffer = None  # type: ignore[misc,assignment]
+    DeepEPConfig = None  # type: ignore[misc,assignment]
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig

--- a/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
@@ -47,10 +47,13 @@ if device_type == DeviceType.ROCm:
         RocmEpLowLatencyStrategy,
         RocmEpNormalStrategy,
         RocmFp8PerChannelPureTPStrategy,
+        TorchDistEpNormalStrategy,
     )
+
     registry = StrategyRegistry()
     registry.register(RocmEpLowLatencyStrategy())
     registry.register(RocmEpNormalStrategy())
+    registry.register(TorchDistEpNormalStrategy())
     registry.register(RocmFp8PerChannelPureTPStrategy())
     registry.register(RocmBf16PureTPStrategy())
     registry.register(BatchedTritonStrategy())

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deepep_normal_fused_moe_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deepep_normal_fused_moe_executor.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional
 
 import aiter
-import numpy as np
 import torch
 import torch.nn.functional as F
 
@@ -33,6 +32,10 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         # ROCm executor doesn't have specific conditions beyond router checks
         pass
 
+    @property
+    def topk_ids_dtype(self) -> torch.dtype:
+        return torch.int32
+
     def __init__(
         self,
         config: MoEConfigAdapter,
@@ -47,27 +50,8 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         self.w13_weight = weights[W.moe_w1]
         self.w2_weight = weights[W.moe_w2]
 
-        self.num_experts = config.expert_num
-
-    def parse_sorted_ids(self, sorted_ids: torch.Tensor):
-        arr_uint32 = sorted_ids.cpu().numpy().view(np.uint32)
-        results = []
-        for i, val in enumerate(arr_uint32):
-            topk_id = (val >> 24) & 0xFF
-            token_id = val & 0xFFFFFF
-            results.append(
-                {
-                    "index": i,
-                    "signed": sorted_ids[i].item(),
-                    "unsigned": val,
-                    "topk_id": topk_id,
-                    "token_id": token_id,
-                }
-            )
-            print(
-                f"[{i:3d}] {sorted_ids[i].item():12d} -> topk_id={topk_id}, token_id={token_id}"
-            )
-        return results
+        # Use actual local expert count from weight shape, not global config
+        self.num_experts = self.w13_weight.shape[0]
 
     def get_block_size(self, num_tokens: int, topk: int, num_experts: int) -> int:
         """
@@ -164,14 +148,8 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         block_size = self.get_block_size(M, topk, self.num_experts)
 
         # === 构建 local_expert_mask（用于 EP）===
-        expert_mask = torch.zeros(self.num_experts, dtype=torch.int32, device=device)
-        num_experts_per_partition = self.num_experts // self.ep_size
-        if self.ep_size > 1:
-            expert_mask[0:num_experts_per_partition] = 1
-        else:
-            start = self.ep_rank * num_experts_per_partition
-            end = start + num_experts_per_partition
-            expert_mask[start:end] = 1
+        # Dispatch 已经将全局专家 ID 映射为本地 ID，所有本地专家都是活跃的
+        expert_mask = torch.ones(self.num_experts, dtype=torch.int32, device=device)
 
         # === MoE Sorting ===
         (
@@ -190,11 +168,17 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
             expert_mask=expert_mask,
         )
 
+        # In EP mode (ep_size > 1), the router handles weighting in _combine,
+        # so skip kernel-side weighting. In non-EP mode, the kernel must
+        # apply router weights since there's no external combiner.
+        # Per aiter convention, ck_moe_stage1 never applies weighting —
+        # only ck_moe_stage2 does.
+        routed_weights = sorted_weights if self.ep_size <= 1 else None
+
         # === Stage 1: Up/Gate Projection + Activation ===
         a2 = torch.empty((M, topk, inter_dim // 2), dtype=dtype, device=device)
         fc1_scale = None
         a1_scale = None
-        # act_op = 1 if activation == "silu" else 0  # 1 = silu_and_mul
 
         aiter.ck_moe_stage1(
             hidden_states=a1,
@@ -209,11 +193,10 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
             w1_scale=fc1_scale,
             a1_scale=a1_scale,
             block_m=block_size,
-            sorted_weights=sorted_weights if apply_router_weight_on_input else None,
         )
 
-        # Reshape for stage2
-        a2 = a2.view(M, topk, -1)
+        # Reshape for stage2: [M, topk, inter_dim//2] -> [M*topk, inter_dim//2]
+        a2 = a2.view(-1, a2.shape[-1])
 
         # === Stage 2: Down Projection + Weighted Combine ===
         fc2_scale = None
@@ -232,7 +215,7 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
             w2_scale=fc2_scale,
             a2_scale=a2_scale,
             block_m=block_size,
-            sorted_weights=sorted_weights if not apply_router_weight_on_input else None,
+            sorted_weights=routed_weights,
         )
 
         return CombineForwardPayload(fused_expert_output=moe_buf)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/torch_dist_ep_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/torch_dist_ep_router.py
@@ -1,0 +1,352 @@
+"""Torch distributed-based EP router.
+
+Uses torch.distributed.all_to_all for expert parallel
+dispatch and combine, without depending on DeepEP.
+
+Suitable for single-node EP (e.g. 4tp4ep, 8tp8ep) where NCCL/RCCL
+all_to_all provides sufficient performance.
+
+Protocol:
+  Dispatch:
+    1. Flatten [tokens, topk] → [flat_total] pairs of (hidden, global_expert_id, weight)
+    2. Classify each pair by destination rank (rank = global_expert_id // experts_per_rank)
+    3. Build per-dst-rank send buffers, pad to max across all ranks
+    4. all_to_all hidden/weights/ids/orig_idx → each rank gets its expert's tokens
+       along with the original flattened index for combine
+    5. Remap global expert IDs to local IDs for executor
+
+  Combine:
+    1. Weight expert outputs by router weights
+    2. All-gather weighted outputs + orig_flat_idx from all ranks
+    3. Scatter into [flat_total, H] using index_add, then sum over topk
+"""
+
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    ExpertTokensMetadata,
+    FusedMoeDataRouter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
+
+
+def _pad_and_cat(
+    chunks: list[torch.Tensor],
+    counts: list[int],
+    max_c: int,
+    extra_dim: int,
+) -> torch.Tensor:
+    """Pad each chunk to max_c along dim 0 and concatenate.
+
+    For 2D tensors (e.g. hidden states), extra_dim is the hidden dimension.
+    For 1D tensors (e.g. weights/indices), extra_dim is ignored.
+    """
+    padded = []
+    for i, chunk in enumerate(chunks):
+        deficit = max_c - counts[i]
+        if deficit > 0 and max_c > 0:
+            pad_shape = (deficit, extra_dim) if chunk.dim() == 2 else (deficit,)
+            pad = torch.zeros(pad_shape, dtype=chunk.dtype, device=chunk.device)
+            padded.append(torch.cat([chunk, pad], dim=0))
+        else:
+            padded.append(chunk)
+    return torch.cat(padded, dim=0).contiguous()
+
+
+class TorchDistEpRouter(FusedMoeDataRouter):
+    """EP router using torch.distributed all_to_all for dispatch/combine."""
+
+    @classmethod
+    def router_type(cls):
+        return RouterType.DEEPEP_NORMAL
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        """Check if TorchDistEpRouter can handle the configuration."""
+        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+            MoeConfigResolver,
+        )
+
+        resolver = MoeConfigResolver()
+        checker.check(resolver.is_ep_enabled(config))
+        checker.check(not resolver.is_single_gpu(config))
+        checker.check(not resolver.use_all_gather(config))
+        checker.check(not resolver.use_low_latency(config))
+        # DeepEP must NOT be available (otherwise prefer DeepEP version)
+        try:
+            import deep_ep  # noqa: F401
+
+            checker.check(False)
+        except ImportError:
+            pass
+
+    def __init__(
+        self,
+        config: MoEConfigAdapter,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(config, quant_config)
+
+        self.ep_size = config.ep_size
+        self.ep_rank = config.ep_rank
+        self.expert_num = config.expert_num
+        self.expert_num_per_rank = self.expert_num // self.ep_size
+
+        assert (
+            dist.is_initialized()
+        ), "torch.distributed must be initialized before using TorchDistEpRouter"
+        self._ep_group = dist.group.WORLD
+
+        # Metadata cached between prepare() and finalize()
+        self._dispatch_meta: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------ #
+    #  Dispatch
+    # ------------------------------------------------------------------ #
+
+    def _dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
+        """Route tokens to expert-owning ranks.
+
+        Args:
+            hidden_states: [num_tokens, hidden_size]
+            topk_ids:      [num_tokens, topk] — global expert IDs
+            topk_weights:  [num_tokens, topk]
+
+        Returns:
+            recv_hidden:  [recv_count, hidden_size] — tokens for our experts
+            recv_weights: [recv_count] — router weights
+            recv_lids:    [recv_count] — local expert IDs
+            recv_oids:    [recv_count] — original flat indices
+            send_counts:  per-dst-rank token counts
+        """
+        num_tokens, hidden_dim = hidden_states.shape
+        topk = topk_ids.shape[1]
+        flat_total = num_tokens * topk
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+
+        # Flatten: [num_tokens, topk] → [flat_total]
+        flat_h = (
+            hidden_states.unsqueeze(1)
+            .expand(-1, topk, -1)
+            .reshape(flat_total, hidden_dim)
+        )
+        flat_ids = topk_ids.reshape(flat_total)
+        flat_w = topk_weights.reshape(flat_total)
+        flat_oi = torch.arange(flat_total, device=device, dtype=torch.int64)
+
+        # Classify each (token, expert) pair by destination rank
+        send_h_chunks: list[torch.Tensor] = []
+        send_w_chunks: list[torch.Tensor] = []
+        send_i_chunks: list[torch.Tensor] = []
+        send_o_chunks: list[torch.Tensor] = []
+        send_counts: list[int] = []
+
+        for dst in range(self.ep_size):
+            e_start = dst * self.expert_num_per_rank
+            e_end = e_start + self.expert_num_per_rank
+            mask = (flat_ids >= e_start) & (flat_ids < e_end)
+
+            if mask.any():
+                idx = mask.nonzero(as_tuple=False).squeeze(-1)
+                local_ids = flat_ids[idx] - e_start
+                send_h_chunks.append(flat_h[idx].contiguous())
+                send_w_chunks.append(flat_w[idx].contiguous())
+                send_i_chunks.append(local_ids.contiguous())
+                send_o_chunks.append(flat_oi[idx].contiguous())
+                send_counts.append(int(idx.numel()))
+            else:
+                send_h_chunks.append(
+                    torch.empty((0, hidden_dim), dtype=dtype, device=device)
+                )
+                send_w_chunks.append(torch.empty(0, dtype=torch.float32, device=device))
+                send_i_chunks.append(torch.empty(0, dtype=torch.int64, device=device))
+                send_o_chunks.append(torch.empty(0, dtype=torch.int64, device=device))
+                send_counts.append(0)
+
+        # Gather max chunk size across ranks for padding alignment
+        all_max_list: list[int] = [0] * self.ep_size
+        dist.all_gather_object(all_max_list, max(send_counts), group=self._ep_group)
+        max_count = max(all_max_list)
+
+        # Pad and concatenate each buffer type
+        cat_h = _pad_and_cat(send_h_chunks, send_counts, max_count, hidden_dim)
+        cat_w = _pad_and_cat(send_w_chunks, send_counts, max_count, 0)
+        cat_i = _pad_and_cat(send_i_chunks, send_counts, max_count, 0)
+        cat_o = _pad_and_cat(send_o_chunks, send_counts, max_count, 0)
+
+        # All-to-all: exchange padded chunks across all ranks
+        r_h = torch.empty_like(cat_h)
+        r_w = torch.empty_like(cat_w)
+        r_i = torch.empty_like(cat_i)
+        r_o = torch.empty_like(cat_o)
+
+        for recv, send in [(r_h, cat_h), (r_w, cat_w), (r_i, cat_i), (r_o, cat_o)]:
+            dist.all_to_all(
+                list(recv.chunk(self.ep_size, dim=0)),
+                list(send.chunk(self.ep_size, dim=0)),
+                group=self._ep_group,
+            )
+
+        # Extract our rank's received tokens
+        recv_total = sum(send_counts)
+
+        def our_slice(t: torch.Tensor) -> torch.Tensor:
+            chunk = t.chunk(self.ep_size, dim=0)[self.ep_rank]
+            return chunk[:recv_total] if recv_total > 0 else chunk
+
+        if recv_total > 0:
+            return (
+                our_slice(r_h),
+                our_slice(r_w),
+                our_slice(r_i),
+                our_slice(r_o),
+                send_counts,
+            )
+        else:
+            return (
+                torch.empty((0, hidden_dim), dtype=dtype, device=device),
+                torch.empty(0, dtype=torch.float32, device=device),
+                torch.empty(0, dtype=torch.int64, device=device),
+                torch.empty(0, dtype=torch.int64, device=device),
+                send_counts,
+            )
+
+    # ------------------------------------------------------------------ #
+    #  Combine
+    # ------------------------------------------------------------------ #
+
+    def _combine(
+        self,
+        expert_output: torch.Tensor,
+        recv_weights: torch.Tensor,
+        recv_orig_flat_idx: torch.Tensor,
+        num_tokens: int,
+        topk: int,
+        hidden_dim: int,
+    ) -> torch.Tensor:
+        """Scatter expert results back to original token positions.
+
+        Args:
+            expert_output:      [recv_count, hidden_size]
+            recv_weights:       [recv_count]
+            recv_orig_flat_idx: [recv_count] — original flat indices
+            num_tokens:         original num_tokens
+            topk:               original topk
+            hidden_dim:         hidden dimension
+
+        Returns:
+            output: [num_tokens, hidden_size]
+        """
+        device = expert_output.device
+        dtype = expert_output.dtype
+        flat_total = num_tokens * topk
+        recv_count = expert_output.shape[0]
+
+        if recv_count == 0:
+            return torch.zeros((num_tokens, hidden_dim), dtype=dtype, device=device)
+
+        # Weight outputs by router scores
+        weighted = expert_output * recv_weights.to(expert_output.dtype).unsqueeze(-1)
+
+        # All-gather weighted outputs + original flat indices from all ranks
+        all_gathered_h = [
+            torch.empty((recv_count, hidden_dim), dtype=dtype, device=device)
+            for _ in range(self.ep_size)
+        ]
+        all_gathered_o = [
+            torch.empty(recv_count, dtype=torch.int64, device=device)
+            for _ in range(self.ep_size)
+        ]
+        dist.all_gather(all_gathered_h, weighted, group=self._ep_group)
+        dist.all_gather(all_gathered_o, recv_orig_flat_idx, group=self._ep_group)
+
+        # Scatter into [flat_total, H] using index_add, then sum over topk
+        output = torch.zeros((flat_total, hidden_dim), dtype=dtype, device=device)
+        for src_h, src_o in zip(all_gathered_h, all_gathered_o):
+            if src_h.numel() > 0:
+                output.index_add_(0, src_o, src_h)
+
+        return output.reshape(num_tokens, topk, hidden_dim).sum(dim=1)
+
+    # ------------------------------------------------------------------ #
+    #  FusedMoeDataRouter interface
+    # ------------------------------------------------------------------ #
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        a1_scale: Optional[torch.Tensor],
+        a2_scale: Optional[torch.Tensor],
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> ExpertForwardPayload:
+        assert a1_scale is None and a2_scale is None, "quant not supported"
+
+        recv_h, recv_w, recv_lids, recv_oids, send_counts = self._dispatch(
+            a1, topk_ids, topk_weights
+        )
+        num_tokens, topk = topk_ids.shape
+
+        self._dispatch_meta = {
+            "num_tokens": num_tokens,
+            "topk": topk,
+            "recv_weights": recv_w,
+            "recv_orig_flat_idx": recv_oids,
+            "hidden_dim": a1.shape[-1],
+        }
+
+        # Compute per-expert token counts from received local expert IDs
+        expert_num_tokens_cpu = [0] * self.expert_num_per_rank
+        if recv_h.shape[0] > 0:
+            lids_cpu = recv_lids.cpu().tolist()
+            for lid in lids_cpu:
+                expert_num_tokens_cpu[lid] += 1
+
+        return ExpertForwardPayload(
+            expert_x=recv_h,
+            expert_x_origin_dtype=a1.dtype,
+            expert_x_scale=None,
+            expert_tokens_meta=ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=expert_num_tokens_cpu,
+            ),
+            expert_topk_ids=recv_lids.reshape(-1, 1),
+            expert_topk_weights=recv_w.reshape(-1, 1),
+        )
+
+    def finalize(
+        self,
+        payload: CombineForwardPayload,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        extra_finalize_args: Optional[dict[str, Any]],
+        skip_allreduce: bool = False,
+    ) -> torch.Tensor:
+        meta = self._dispatch_meta
+
+        return self._combine(
+            expert_output=payload.fused_expert_output,
+            recv_weights=meta["recv_weights"],
+            recv_orig_flat_idx=meta["recv_orig_flat_idx"],
+            num_tokens=meta["num_tokens"],
+            topk=meta["topk"],
+            hidden_dim=meta["hidden_dim"],
+        )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/__init__.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/__init__.py
@@ -3,10 +3,12 @@
 from .bf16_no_quant import RocmBf16PureTPStrategy
 from .ep import RocmEpLowLatencyStrategy, RocmEpNormalStrategy
 from .fp8_per_channel import RocmFp8PerChannelPureTPStrategy
+from .torch_dist_ep import TorchDistEpNormalStrategy
 
 __all__ = [
     "RocmEpNormalStrategy",
     "RocmEpLowLatencyStrategy",
     "RocmFp8PerChannelPureTPStrategy",
     "RocmBf16PureTPStrategy",
+    "TorchDistEpNormalStrategy",
 ]

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/torch_dist_ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/torch_dist_ep.py
@@ -1,0 +1,44 @@
+"""Torch distributed-based EP strategy (no DeepEP dependency)."""
+
+from typing import Any
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.priority_attributes import (
+    StrategyAttributes,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.strategy_base import MoeStrategy
+
+
+class TorchDistEpNormalStrategy(MoeStrategy):
+    """ROCm EP normal mode using torch.distributed all_to_all (no DeepEP)."""
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        """Only applicable when DeepEP is NOT available."""
+        try:
+            import deep_ep  # noqa: F401
+
+            # DeepEP available, prefer DeepepNormalRouter
+            checker.check(False)
+        except ImportError:
+            pass
+
+    def get_attributes(self) -> StrategyAttributes:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
+            FusedMoeExecutor,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.torch_dist_ep_router import (
+            TorchDistEpRouter,
+        )
+
+        quant_config = FusedMoEQuantConfig(quant_dtype=None)
+        return StrategyAttributes(
+            router_class=TorchDistEpRouter,
+            executor_class=FusedMoeExecutor,
+            quant_config=quant_config,
+        )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_moe_kernels.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_moe_kernels.py
@@ -1,0 +1,222 @@
+"""Unit tests for aiter MoE kernels: moe_sorting_fwd, ck_moe_stage1, ck_moe_stage2."""
+
+import itertools
+from unittest import SkipTest, TestCase, main
+
+import torch
+from aiter.ops.shuffle import shuffle_weight
+from torch import dtype as _dtype
+
+from rtp_llm.ops import MoeConfig, ParallelismConfig
+
+
+class MoEKernelsTest(TestCase):
+    """Test aiter MoE kernels against torch reference."""
+
+    DTYPES = [torch.bfloat16]
+    TOKEN_NUM = [32, 64]
+    HIDDEN_DIM = [256, 512]
+    EXPERT_NUM = [8, 32]
+    INTER_DIM = [512, 1024]
+    TOP_K = [1, 4]
+    BLOCK_SIZE_M = 32
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            raise SkipTest("CUDA is not available")
+        torch.set_default_device("cuda")
+
+    def _torch_moe_ref(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        apply_router_weight: bool = True,
+    ) -> torch.Tensor:
+        """Reference MoE forward: w1(gate)*w1(up) -> silu -> w2 -> sum(topk)."""
+        import torch.nn.functional as F
+
+        M, D = hidden_states.shape
+        top_k = topk_ids.shape[1]
+
+        if M == 0:
+            return torch.empty(
+                (0, D), dtype=hidden_states.dtype, device=hidden_states.device
+            )
+
+        compute_dtype = hidden_states.dtype
+        w1 = w1.to(compute_dtype)
+        w2 = w2.to(compute_dtype)
+
+        hidden_expanded = hidden_states.unsqueeze(1).expand(-1, top_k, -1)
+        ffn_out = torch.zeros(
+            (M, top_k, D), dtype=compute_dtype, device=hidden_states.device
+        )
+
+        for expert_id in range(w1.size(0)):
+            mask = topk_ids == expert_id
+            if not mask.any():
+                continue
+            tokens = hidden_expanded[mask]
+            upgate = torch.matmul(tokens, w1[expert_id].t())
+            gate, up = upgate.chunk(2, dim=-1)
+            activated = F.silu(gate) * up
+            out = torch.matmul(activated, w2[expert_id].t())
+            ffn_out[mask] = out
+
+        if apply_router_weight:
+            ffn_out = ffn_out * topk_weights.unsqueeze(-1)
+
+        return ffn_out.sum(dim=1).to(hidden_states.dtype)
+
+    def _run_kernel_test(
+        self,
+        dtype: _dtype,
+        token_num: int,
+        hidden_dim: int,
+        expert_num: int,
+        inter_dim: int,
+        top_k: int,
+    ):
+        import aiter
+
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
+            BLOCK_SIZE_M,
+        )
+
+        torch.manual_seed(42)
+        hidden_states = (
+            torch.randn(token_num, hidden_dim, device="cuda").to(dtype) * 0.03
+        )
+        topk_ids = torch.topk(
+            torch.rand(token_num, expert_num, device="cuda"), top_k, dim=1
+        ).indices.to(torch.int32)
+        topk_weights = torch.softmax(
+            torch.randn(token_num, top_k, device="cuda"), dim=-1
+        ).to(torch.float32)
+
+        w1 = (
+            torch.randn(expert_num, inter_dim, hidden_dim, device="cuda").to(dtype)
+            * 0.02
+        )
+        w2 = (
+            torch.randn(expert_num, hidden_dim, inter_dim // 2, device="cuda").to(dtype)
+            * 0.02
+        )
+
+        w1_shuffled = shuffle_weight(w1, layout=(16, 16))
+        w2_shuffled = shuffle_weight(w2, layout=(16, 16))
+
+        # === Step 1: Test moe_sorting_fwd ===
+        device = "cuda"
+        M = token_num
+        block_size = BLOCK_SIZE_M
+        max_num_tokens_padded = topk_ids.numel() + expert_num * block_size - top_k
+        max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+
+        sorted_ids = torch.empty(
+            (max_num_tokens_padded,), dtype=torch.int32, device=device
+        )
+        sorted_weights = torch.empty(
+            (max_num_tokens_padded,), dtype=torch.float32, device=device
+        )
+        sorted_expert_ids = torch.empty(
+            (max_num_m_blocks,), dtype=torch.int32, device=device
+        )
+        num_valid_ids = torch.empty((2,), dtype=torch.int32, device=device)
+        moe_buf = torch.empty((M, hidden_dim), dtype=dtype, device=device)
+
+        aiter.moe_sorting_fwd(
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            sorted_token_ids=sorted_ids,
+            sorted_weights=sorted_weights,
+            sorted_expert_ids=sorted_expert_ids,
+            num_valid_ids=num_valid_ids,
+            moe_buf=moe_buf,
+            num_experts=expert_num,
+            unit_size=block_size,
+            local_expert_mask=None,
+        )
+
+        # Verify sorting produces valid outputs
+        self.assertEqual(sorted_ids.dtype, torch.int32)
+        self.assertEqual(sorted_weights.dtype, torch.float32)
+        self.assertEqual(sorted_expert_ids.dtype, torch.int32)
+        self.assertGreater(num_valid_ids[0].item(), 0)
+        self.assertEqual(moe_buf.shape, (M, hidden_dim))
+
+        # === Step 2: Test ck_moe_stage1 + ck_moe_stage2 with kernel-side weighting ===
+        a2 = torch.empty((M, top_k, inter_dim // 2), dtype=dtype, device=device)
+
+        aiter.ck_moe_stage1(
+            hidden_states=hidden_states,
+            w1=w1_shuffled,
+            w2=w2_shuffled,
+            sorted_token_ids=sorted_ids,
+            sorted_expert_ids=sorted_expert_ids,
+            num_valid_ids=num_valid_ids,
+            out=a2,
+            topk=top_k,
+            kernelName="",
+            w1_scale=None,
+            a1_scale=None,
+            block_m=block_size,
+            sorted_weights=sorted_weights,  # Enable kernel-side weighting
+        )
+
+        a2 = a2.view(-1, a2.shape[-1])
+
+        aiter.ck_moe_stage2(
+            inter_states=a2,
+            w1=w1_shuffled,
+            w2=w2_shuffled,
+            sorted_token_ids=sorted_ids,
+            sorted_expert_ids=sorted_expert_ids,
+            num_valid_ids=num_valid_ids,
+            out=moe_buf,
+            topk=top_k,
+            kernelName="",
+            w2_scale=None,
+            a2_scale=None,
+            block_m=block_size,
+            sorted_weights=sorted_weights,  # Enable kernel-side weighting
+        )
+
+        # === Step 3: Compare against torch reference ===
+        ref_out = self._torch_moe_ref(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            w1=w1,
+            w2=w2,
+            apply_router_weight=True,
+        )
+
+        torch.testing.assert_close(moe_buf, ref_out, atol=1e-2, rtol=1e-2)
+
+    def test_moe_kernels(self):
+        """Test moe_sorting_fwd + ck_moe_stage1/2 against torch reference."""
+        for params in itertools.product(
+            self.DTYPES,
+            self.TOKEN_NUM,
+            self.HIDDEN_DIM,
+            self.EXPERT_NUM,
+            self.INTER_DIM,
+            self.TOP_K,
+        ):
+            with self.subTest(
+                dtype=params[0],
+                token_num=params[1],
+                hidden_dim=params[2],
+                expert_num=params[3],
+                inter_dim=params[4],
+                top_k=params[5],
+            ):
+                self._run_kernel_test(*params)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/torch_dist_ep_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/torch_dist_ep_router_test.py
@@ -1,0 +1,291 @@
+"""Unit tests for TorchDistEpRouter dispatch/combine logic.
+
+Tests the pure-Python routing logic (classification, padding, indexing)
+without requiring a multi-GPU distributed environment. The _dispatch and
+_combine methods are tested by re-implementing them with local
+all_to_all simulation using tensor chunking.
+"""
+
+from unittest import SkipTest, TestCase, main
+
+import torch
+
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.torch_dist_ep_router import (
+    _pad_and_cat,
+)
+
+
+class PadAndCatTest(TestCase):
+    """Test _pad_and_cat utility function."""
+
+    def test_pad_2d_tensors(self):
+        """Test padding and concatenation of 2D tensors (hidden states)."""
+        chunks = [
+            torch.randn(3, 64),
+            torch.randn(5, 64),
+            torch.randn(2, 64),
+        ]
+        counts = [3, 5, 2]
+        max_c = 5
+        extra_dim = 64
+
+        result = _pad_and_cat(chunks, counts, max_c, extra_dim)
+
+        # 3 chunks, each padded to max_c=5 => total 15 rows
+        self.assertEqual(result.shape, (15, 64))
+
+        # Check first chunk (3 rows of data + 2 rows of zeros)
+        first_chunk = result[:5]
+        torch.testing.assert_close(first_chunk[:3], chunks[0])
+        self.assertTrue((first_chunk[3:] == 0).all())
+
+        # Check second chunk (no padding needed)
+        second_chunk = result[5:10]
+        torch.testing.assert_close(second_chunk, chunks[1])
+
+    def test_pad_1d_tensors(self):
+        """Test padding and concatenation of 1D tensors (weights/indices)."""
+        chunks = [
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.tensor([4.0, 5.0, 6.0, 7.0]),
+        ]
+        counts = [3, 4]
+        max_c = 4
+        extra_dim = 0  # ignored for 1D
+
+        result = _pad_and_cat(chunks, counts, max_c, extra_dim)
+
+        self.assertEqual(result.shape, (8,))
+        torch.testing.assert_close(result[:3], chunks[0])
+        self.assertEqual(result[3].item(), 0.0)  # padding
+
+    def test_empty_chunks(self):
+        """Test handling of empty chunks."""
+        chunks = [
+            torch.empty(0, 32),
+            torch.randn(3, 32),
+        ]
+        counts = [0, 3]
+        max_c = 3
+        extra_dim = 32
+
+        result = _pad_and_cat(chunks, counts, max_c, extra_dim)
+        self.assertEqual(result.shape, (6, 32))
+
+    def test_max_c_zero(self):
+        """Test when max_c is 0 (no tokens at all)."""
+        chunks = [torch.empty(0, 32), torch.empty(0, 32)]
+        counts = [0, 0]
+        max_c = 0
+        extra_dim = 32
+
+        result = _pad_and_cat(chunks, counts, max_c, extra_dim)
+        self.assertEqual(result.shape, (0, 32))
+
+
+class SimulatedDispatchCombineTest(TestCase):
+    """Test dispatch/combine roundtrip using local simulation.
+
+    With ep_size=1, all experts are local, so dispatch keeps all data
+    and combine reconstructs the original weighted sum.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            raise SkipTest("CUDA is not available")
+        torch.set_default_device("cuda")
+
+    def _simulate_dispatch_ep1(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        expert_num: int,
+    ):
+        """Simulate _dispatch for ep_size=1 (all experts local)."""
+        num_tokens, hidden_dim = hidden_states.shape
+        topk = topk_ids.shape[1]
+        flat_total = num_tokens * topk
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+
+        # Flatten
+        flat_h = (
+            hidden_states.unsqueeze(1)
+            .expand(-1, topk, -1)
+            .reshape(flat_total, hidden_dim)
+        )
+        flat_ids = topk_ids.reshape(flat_total)
+        flat_w = topk_weights.reshape(flat_total)
+        flat_oi = torch.arange(flat_total, device=device, dtype=torch.int64)
+
+        # ep_size=1: all experts belong to rank 0
+        e_start = 0
+        e_end = expert_num
+        mask = (flat_ids >= e_start) & (flat_ids < e_end)
+        assert mask.all(), "All expert IDs should be local for ep_size=1"
+
+        local_ids = flat_ids  # local expert IDs = global for ep_size=1
+
+        return flat_h, flat_w, local_ids, flat_oi
+
+    def _simulate_combine_ep1(
+        self,
+        expert_output: torch.Tensor,
+        recv_weights: torch.Tensor,
+        recv_orig_flat_idx: torch.Tensor,
+        num_tokens: int,
+        topk: int,
+        hidden_dim: int,
+    ):
+        """Simulate _combine for ep_size=1 (single rank, no all_gather needed)."""
+        device = expert_output.device
+        dtype = expert_output.dtype
+        flat_total = num_tokens * topk
+        recv_count = expert_output.shape[0]
+
+        if recv_count == 0:
+            return torch.zeros((num_tokens, hidden_dim), dtype=dtype, device=device)
+
+        # Weight by router scores
+        weighted = expert_output * recv_weights.to(expert_output.dtype).unsqueeze(-1)
+
+        # Scatter into [flat_total, H] using index_add
+        output = torch.zeros((flat_total, hidden_dim), dtype=dtype, device=device)
+        output.index_add_(0, recv_orig_flat_idx, weighted)
+
+        return output.reshape(num_tokens, topk, hidden_dim).sum(dim=1)
+
+    def _run_roundtrip_test(
+        self,
+        token_num: int,
+        hidden_dim: int,
+        expert_num: int,
+        top_k: int,
+    ):
+        """Test dispatch -> identity expert -> combine roundtrip with ep_size=1."""
+        torch.manual_seed(42)
+
+        hidden_states = (
+            torch.randn(token_num, hidden_dim, device="cuda").to(torch.bfloat16) * 0.03
+        )
+        topk_ids = torch.topk(
+            torch.rand(token_num, expert_num, device="cuda"), top_k, dim=1
+        ).indices.to(torch.int32)
+        topk_weights = torch.softmax(
+            torch.randn(token_num, top_k, device="cuda"), dim=-1
+        ).to(torch.float32)
+
+        # Dispatch (ep_size=1, all local)
+        recv_h, recv_w, recv_lids, recv_oids = self._simulate_dispatch_ep1(
+            hidden_states, topk_ids, topk_weights, expert_num
+        )
+
+        # Verify: all tokens dispatched, expert IDs preserved
+        self.assertEqual(recv_h.shape, (token_num * top_k, hidden_dim))
+        self.assertTrue((recv_lids.flatten() >= 0).all())
+        self.assertTrue((recv_lids.flatten() < expert_num).all())
+
+        # Identity expert: output = input
+        expert_output = recv_h.clone()
+
+        # Combine
+        result = self._simulate_combine_ep1(
+            expert_output, recv_w, recv_oids, token_num, top_k, hidden_dim
+        )
+
+        # Expected: identity expert with weighting = hidden_states expanded * topk_weights
+        flat_h = recv_h.float()
+        flat_w = recv_w.float()
+        expected_flat = flat_h * flat_w.unsqueeze(-1)
+        expected = expected_flat.reshape(token_num, top_k, hidden_dim).sum(dim=1)
+        expected = expected.to(torch.bfloat16)
+
+        torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-1)
+
+    def test_dispatch_combine_ep1_small(self):
+        """Test dispatch/combine with ep_size=1, small config."""
+        self._run_roundtrip_test(
+            token_num=16,
+            hidden_dim=128,
+            expert_num=4,
+            top_k=2,
+        )
+
+    def test_dispatch_combine_ep1_medium(self):
+        """Test dispatch/combine with ep_size=1, medium config."""
+        self._run_roundtrip_test(
+            token_num=32,
+            hidden_dim=256,
+            expert_num=8,
+            top_k=4,
+        )
+
+    def test_dispatch_combine_ep1_large(self):
+        """Test dispatch/combine with ep_size=1, larger config."""
+        self._run_roundtrip_test(
+            token_num=64,
+            hidden_dim=512,
+            expert_num=32,
+            top_k=8,
+        )
+
+    def test_dispatch_invariants_ep2(self):
+        """Test dispatch classification invariants for ep_size=2."""
+        torch.manual_seed(42)
+        ep_size = 2
+        token_num = 32
+        hidden_dim = 256
+        expert_num = 8  # 4 per rank
+        top_k = 2
+
+        hidden_states = torch.randn(token_num, hidden_dim, device="cuda").to(
+            torch.bfloat16
+        )
+        topk_ids = torch.topk(
+            torch.rand(token_num, expert_num, device="cuda"), top_k, dim=1
+        ).indices.to(torch.int32)
+        topk_weights = torch.softmax(
+            torch.randn(token_num, top_k, device="cuda"), dim=-1
+        ).to(torch.float32)
+
+        # Simulate dispatch for each rank and verify invariants
+        flat_total = token_num * top_k
+        flat_ids = topk_ids.flatten()
+        expert_num_per_rank = expert_num // ep_size
+
+        # Track which flat indices go to each rank
+        rank_counts = []
+        for rank in range(ep_size):
+            e_start = rank * expert_num_per_rank
+            e_end = e_start + expert_num_per_rank
+            mask = (flat_ids >= e_start) & (flat_ids < e_end)
+            count = int(mask.sum())
+            rank_counts.append(count)
+
+            # Verify local expert IDs are in [0, expert_num_per_rank)
+            if count > 0:
+                local_ids = flat_ids[mask] - e_start
+                self.assertTrue((local_ids >= 0).all())
+                self.assertTrue((local_ids < expert_num_per_rank).all())
+
+        # Total must match flat_total
+        self.assertEqual(sum(rank_counts), flat_total)
+
+    def test_zero_tokens(self):
+        """Test dispatch with zero tokens (edge case)."""
+        hidden_states = torch.empty(0, 256, device="cuda", dtype=torch.bfloat16)
+        topk_ids = torch.empty(0, 2, device="cuda", dtype=torch.int32)
+        topk_weights = torch.empty(0, 2, device="cuda", dtype=torch.float32)
+
+        # ep_size=1, expert_num=4
+        flat_h, flat_w, flat_lids, flat_oids = self._simulate_dispatch_ep1(
+            hidden_states, topk_ids, topk_weights, expert_num=4
+        )
+
+        self.assertEqual(flat_h.shape, (0, 256))
+        self.assertEqual(flat_lids.numel(), 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/test/auto_configure_deepep_test.py
+++ b/rtp_llm/test/auto_configure_deepep_test.py
@@ -36,12 +36,14 @@ class AutoConfigureDeepepTest(TestCase):
 
     def test_use_all_gather_disables_all_deepep(self):
         """Test: USE_ALL_GATHER enabled should disable all DeepEP settings"""
-        # Setup: ep_size == tp_size and USE_ALL_GATHER is True
+        # use_all_gather only works when ep_size == 1 (pure TP mode).
+        # When ep_size > 1, use_all_gather is silently disabled and DeepEP
+        # auto-configuration kicks in.
 
+        # Part 1: use_all_gather=True with ep_size > 1 is overridden to False
         self._setup_parallel_info(
             world_size=8, tp_size=8, ep_size=8, local_world_size=8
         )
-
         self.moe_config.use_all_gather = True
         role_type = RoleType.PDFUSION
 
@@ -52,9 +54,27 @@ class AutoConfigureDeepepTest(TestCase):
             role_type=role_type,
         )
 
+        # use_all_gather is forced False because ep_size != 1,
+        # so auto-configure runs (single-node multi-GPU => moe=True)
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
+
+        # Part 2: use_all_gather=True with ep_size == 1 disables all DeepEP
+        self._setup_parallel_info(
+            world_size=8, tp_size=8, ep_size=1, local_world_size=8
+        )
+        self.moe_config.use_all_gather = True
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
         # Verify: All DeepEP settings should be 0
         self._assert_deepep_config(moe=False, low_latency=False, internode=False)
-        # test set use_all_gather = False cause use_deepep_moe = True
+
+        # Part 3: use_all_gather=False with ep_size == 1 triggers auto-configure
         self.moe_config.use_all_gather = False
         self.moe_config.use_deepep_moe = False
         self.moe_config.use_deepep_low_latency = False


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                          
                                              
  Introduce native Expert Parallelism (EP) support for ROCm MoE models, enabling distribution of experts across multiple ranks without relying on DeepEP.                                                                                                             
                                                                                                                                                         
  - Add `TorchDistEpRouter` — a torch.distributed all_to_all-based dispatch/combine router that routes tokens to expert-owning ranks and reconstructs outputs without DeepEP dependency                                                                               
  - Add `TorchDistEpNormalStrategy` — a new fused MoE strategy selected when `ep_size > 1`, DeepEP is unavailable, and all-gather/low-latency modes are disabled                                                                                                      
  - Add `FusedMoeExecutor` (ROCm) — a two-stage CK kernel executor (`ck_moe_stage1` + `ck_moe_stage2`) that processes tokens dispatched to local experts, replacing the single fused kernel path used in TP-only mode                                                 
  - Extend `MoeConfigResolver` with EP-related config helpers (`is_ep_enabled`, `use_all_gather`, `use_low_latency`)                                                                                                                                                  
  - Update `StrategyRegistry` to route EP configurations to the new `TorchDistEpNormalStrategy`                                                                                                                                                                       
  - Fix double router weighting bug: remove `sorted_weights` from kernel calls since weighting is handled by the router's `_combine()` step                                                                                                                           
                                                                                                                                                                                                                                                                      
  ## Key Changes                                                                                                                                                                                                                                                      
                                                                                   
  | File | Change |                                                                                                                                                                                                                                                   
  |------|--------|                                                                                                                                                                                                                                                   
  | `torch_dist_ep_router.py` | New: EP router using `all_to_all` dispatch and `all_gather` combine |                                                                                                                                                                 
  | `torch_dist_ep.py` | New: `TorchDistEpNormalStrategy` implementation |                                                                                                                                                                                            
  | `deepep_normal_fused_moe_executor.py` | Modified: CK two-stage executor for ROCm |                                                                                                                                                                                
  | `config_resolver.py` | Extended: EP config resolution helpers |                                                                                                                                                                                                   
  | `__init__.py` | Extended: register new strategy |                                                                                                                                                                                                                 
  | `deepep_wrapper.py` | Updated: DeepEP fallback logic |       