### PR TITLE
feat: Qwen3.5 Blackwell GDN prefill optimization

### DIFF
--- a/rtp_llm/models_py/bindings/cuda/FlashInferOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/FlashInferOp.cc
@@ -55,23 +55,44 @@ ParamsBasePtr FlashInferPrefillOp::prepare(torch_ext::PyAttentionInputs attn_inp
     return ParamsBasePtr(attn_params);
 }
 
-torch::Tensor FlashInferPrefillOp::forward(const torch::Tensor&                   q,
+torch::Tensor FlashInferPrefillOp::forward(const torch::Tensor&                   q_in,
                                            std::optional<torch_ext::LayerKVCache> kv_cache,
                                            const FlashInferAttnParamsPtr&         params) {
     RTP_LLM_CHECK_WITH_INFO(params != nullptr, "flash infer op should have params");
 
-    const int     local_head_num = attn_configs_.head_num;
-    const int     size_per_head  = attn_configs_.size_per_head;
-    const int     bs             = q.size(0);
+    const int local_head_num = attn_configs_.head_num;
+    const int size_per_head  = attn_configs_.size_per_head;
+
+    // FlashInfer expects 3D query: [nnz, num_heads, head_dim]
+    torch::Tensor q;
+    if (q_in.dim() == 2) {
+        q = q_in.view({q_in.size(0), local_head_num, size_per_head});
+    } else if (q_in.dim() == 3) {
+        q = q_in;
+    } else {
+        q = q_in.view({-1, local_head_num, size_per_head});
+    }
+
+    const int bs = q.size(0);
+
+    if (!kv_cache.has_value()) {
+        return torch::zeros({bs, local_head_num * size_per_head}, torch::TensorOptions(q.dtype()).device(q.device()));
+    }
+
     torch::Tensor output =
-        torch::empty({bs, local_head_num * size_per_head}, torch::TensorOptions(q.dtype()).device(q.device()));
+        torch::empty({bs, local_head_num, size_per_head}, torch::TensorOptions(q.dtype()).device(q.device()));
     auto softmax_scale = (1.0f / sqrtf(size_per_head * 1.0f)) * attn_configs_.softmax_extra_scale;
     RTP_LLM_LOG_DEBUG("prefill flashinfer");
-    torch::Tensor k_cache, v_cache;
-    if (kv_cache.has_value()) {
-        k_cache = kv_cache.value().kv_cache_base.select(1, 0);
-        v_cache = kv_cache.value().kv_cache_base.select(1, 1);
+
+    auto kv_base = kv_cache.value().kv_cache_base;
+    if (kv_base.dim() == 2) {
+        const int64_t page_size   = attn_configs_.tokens_per_block;
+        const int64_t kv_head_num = attn_configs_.kv_head_num;
+        kv_base                   = kv_base.view({-1, 2, page_size, kv_head_num, (int64_t)size_per_head});
     }
+    torch::Tensor k_cache = kv_base.select(1, 0);
+    torch::Tensor v_cache = kv_base.select(1, 1);
+
     StreamType stream = GET_CURRENT_STREAM();
     BatchPrefillWithPagedKVCacheRun(params->float_workspace_d,         // float_workspace_buffer
                                     params->int_workspace_d,           // int_workspace_buffer
@@ -96,7 +117,7 @@ torch::Tensor FlashInferPrefillOp::forward(const torch::Tensor&                 
                                     attn_configs_.rope_config.scale,
                                     attn_configs_.rope_config.base,
                                     (int64_t)stream);
-    return output;
+    return output.view({bs, local_head_num * size_per_head});
 }
 
 FlashInferDecodeOp::FlashInferDecodeOp(const AttentionConfigs& attn_configs,

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
@@ -55,8 +55,66 @@ void GroupTopKOp::forward(torch::Tensor&       topk_values,
                                           stream);
             break;
         default:
-            // Handle other data types
             throw std::invalid_argument("Invalid dtype, only supports float16, float32, and bfloat16");
+            break;
+    }
+    return;
+}
+
+void GroupTopKOp::forward_fused(torch::Tensor&       topk_values,
+                                torch::Tensor&       topk_indices,
+                                torch::Tensor&       raw_logits,
+                                torch::Tensor const& bias,
+                                torch::Tensor&       scores_out,
+                                int64_t              n_group,
+                                int64_t              topk_group,
+                                int64_t              topk,
+                                bool                 renormalize,
+                                double               routed_scaling_factor) {
+    auto    input_size  = raw_logits.sizes();
+    int64_t num_tokens  = input_size[0];
+    int64_t num_experts = input_size[1];
+
+    torch::Tensor group_scores =
+        torch::empty({num_tokens, n_group}, torch::dtype(torch::kFloat32).device(torch::kCUDA));
+
+    auto stream = c10::cuda::getCurrentCUDAStream(raw_logits.get_device());
+
+    switch (topk_indices.scalar_type()) {
+        case torch::kInt64:
+            invokeNoAuxTcFused<float, int64_t>(reinterpret_cast<float*>(raw_logits.mutable_data_ptr()),
+                                               reinterpret_cast<float const*>(bias.data_ptr()),
+                                               reinterpret_cast<float*>(scores_out.mutable_data_ptr()),
+                                               reinterpret_cast<float*>(group_scores.mutable_data_ptr()),
+                                               reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+                                               reinterpret_cast<int64_t*>(topk_indices.mutable_data_ptr()),
+                                               num_tokens,
+                                               num_experts,
+                                               n_group,
+                                               topk_group,
+                                               topk,
+                                               renormalize,
+                                               routed_scaling_factor,
+                                               stream);
+            break;
+        case torch::kInt32:
+            invokeNoAuxTcFused<float, int32_t>(reinterpret_cast<float*>(raw_logits.mutable_data_ptr()),
+                                               reinterpret_cast<float const*>(bias.data_ptr()),
+                                               reinterpret_cast<float*>(scores_out.mutable_data_ptr()),
+                                               reinterpret_cast<float*>(group_scores.mutable_data_ptr()),
+                                               reinterpret_cast<float*>(topk_values.mutable_data_ptr()),
+                                               reinterpret_cast<int32_t*>(topk_indices.mutable_data_ptr()),
+                                               num_tokens,
+                                               num_experts,
+                                               n_group,
+                                               topk_group,
+                                               topk,
+                                               renormalize,
+                                               routed_scaling_factor,
+                                               stream);
+            break;
+        default:
+            throw std::invalid_argument("Invalid dtype, only supports int32 and int64");
             break;
     }
     return;
@@ -71,6 +129,18 @@ void registerGroupTopKOp(const pybind11::module& m) {
              pybind11::arg("topk_indices"),
              pybind11::arg("scores"),
              pybind11::arg("scores_with_bias"),
+             pybind11::arg("n_group"),
+             pybind11::arg("topk_group"),
+             pybind11::arg("topk"),
+             pybind11::arg("renormalize"),
+             pybind11::arg("routed_scaling_factor"))
+        .def("forward_fused",
+             &GroupTopKOp::forward_fused,
+             pybind11::arg("topk_values"),
+             pybind11::arg("topk_indices"),
+             pybind11::arg("raw_logits"),
+             pybind11::arg("bias"),
+             pybind11::arg("scores_out"),
              pybind11::arg("n_group"),
              pybind11::arg("topk_group"),
              pybind11::arg("topk"),

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
@@ -19,6 +19,18 @@ public:
                  int64_t              topk,
                  bool                 renormalize,
                  double               routed_scaling_factor);
+
+    // Fused version: computes sigmoid + bias_add internally, saving 2 kernel launches.
+    void forward_fused(torch::Tensor&       topk_values,
+                       torch::Tensor&       topk_indices,
+                       torch::Tensor&       raw_logits,
+                       torch::Tensor const& bias,
+                       torch::Tensor&       scores_out,
+                       int64_t              n_group,
+                       int64_t              topk_group,
+                       int64_t              topk,
+                       bool                 renormalize,
+                       double               routed_scaling_factor);
 };
 
 void registerGroupTopKOp(const pybind11::module& m);

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
@@ -442,6 +442,85 @@ __global__ void topk_with_k2_kernel(T*            output,
 #endif
 }
 
+// Fused kernel: sigmoid + bias_add + topk_with_k2 in a single kernel launch.
+// Reads raw_logits, computes sigmoid, adds bias for group score computation,
+// writes sigmoid values back to scores (for weight extraction in kernel 2).
+template<typename T>
+__global__ void topk_with_k2_fused_kernel(T*            group_scores_output,
+                                          T*            raw_logits,
+                                          T const*      bias,
+                                          T*            scores_output,
+                                          int64_t const num_tokens,
+                                          int64_t const num_cases,
+                                          int64_t const n_group,
+                                          int64_t const num_experts,
+                                          int64_t const num_experts_per_group) {
+    int32_t warp_id = threadIdx.x / WARP_SIZE;
+    int32_t lane_id = threadIdx.x % WARP_SIZE;
+
+    int32_t case_id = blockIdx.x * NUM_WARPS_PER_BLOCK + warp_id;
+    if (case_id < num_cases) {
+        int32_t token_id      = case_id / n_group;
+        int32_t group_id      = case_id % n_group;
+        int64_t expert_offset = token_id * num_experts + group_id * num_experts_per_group;
+
+        // Compute sigmoid + bias for all experts in this group, write sigmoid to scores.
+        // Also find top-2 values for group score.
+        T largest        = -INFINITY;
+        T second_largest = -INFINITY;
+
+        cg::thread_block          block = cg::this_thread_block();
+        cg::thread_block_tile<32> tile  = cg::tiled_partition<32>(block);
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        asm volatile("griddepcontrol.wait;");
+#endif
+
+        if (num_experts_per_group > WARP_SIZE) {
+            for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
+                T logit       = raw_logits[expert_offset + i];
+                T sigmoid_val = T(1.0f) / (T(1.0f) + expf(-float(logit)));
+                // Write sigmoid value back for weight extraction in kernel 2
+                scores_output[expert_offset + i] = sigmoid_val;
+                T value                          = sigmoid_val + bias[group_id * num_experts_per_group + i];
+                // Also write scores_with_bias back to raw_logits (reuse as scores_with_bias buffer)
+                raw_logits[expert_offset + i] = value;
+                if (value > largest) {
+                    second_largest = largest;
+                    largest        = value;
+                } else if (value > second_largest) {
+                    second_largest = value;
+                }
+            }
+        } else {
+            for (int i = lane_id; i < num_experts_per_group; i += WARP_SIZE) {
+                T logit                          = raw_logits[expert_offset + i];
+                T sigmoid_val                    = T(1.0f) / (T(1.0f) + expf(-float(logit)));
+                scores_output[expert_offset + i] = sigmoid_val;
+                T value                          = sigmoid_val + bias[group_id * num_experts_per_group + i];
+                raw_logits[expert_offset + i]    = value;
+                largest                          = value;
+            }
+        }
+
+        __syncwarp();
+        T    max1          = cg::reduce(tile, largest, cg::greater<T>());
+        T    max2          = max1;
+        bool equal_to_max1 = (max1 == largest);
+        int  count_max1    = __popc(__ballot_sync(FULL_WARP_MASK, equal_to_max1));
+        if (count_max1 == 1) {
+            largest = (largest == max1) ? second_largest : largest;
+            max2    = cg::reduce(tile, largest, cg::greater<T>());
+        }
+        if (lane_id == 0) {
+            group_scores_output[case_id] = max1 + max2;
+        }
+    }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
 template<typename T, typename IdxT>
 __global__ void group_idx_and_topk_idx_kernel(T*            scores,
                                               T const*      group_scores,
@@ -648,8 +727,88 @@ void invokeNoAuxTc(T*                 scores,
                                          double const       routed_scaling_factor,                                     \
                                          cudaStream_t const stream);
 
+template<typename T, typename IdxT>
+void invokeNoAuxTcFused(T*                 raw_logits,
+                        T const*           bias,
+                        T*                 scores,
+                        T*                 group_scores,
+                        T*                 topk_values,
+                        IdxT*              topk_indices,
+                        int64_t const      num_tokens,
+                        int64_t const      num_experts,
+                        int64_t const      n_group,
+                        int64_t const      topk_group,
+                        int64_t const      topk,
+                        int                norm_node,
+                        double const       routed_scaling_factor,
+                        cudaStream_t const stream) {
+    int64_t num_experts_per_group   = num_experts / n_group;
+    int64_t num_cases               = num_tokens * n_group;
+    int64_t topk_with_k2_num_blocks = (num_cases - 1) / NUM_WARPS_PER_BLOCK + 1;
+    // Fused kernel: sigmoid + bias_add + topk_with_k2 in one launch.
+    // After this kernel, raw_logits contains scores_with_bias, scores contains sigmoid values.
+    LAUNCH_KERNEL_WITH_PDL((topk_with_k2_fused_kernel<T>),
+                           topk_with_k2_num_blocks,
+                           BLOCK_SIZE,
+                           0,
+                           stream,
+                           group_scores,
+                           raw_logits,
+                           bias,
+                           scores,
+                           num_tokens,
+                           num_cases,
+                           n_group,
+                           num_experts,
+                           num_experts_per_group);
+    check_cuda_error();
+
+    int64_t topk_with_k_group_num_blocks = (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
+    size_t  dynamic_smem_in_bytes = warp_topk::calc_smem_size_for_block_wide<T, int32_t>(NUM_WARPS_PER_BLOCK, topk);
+    // raw_logits now contains scores_with_bias (written by fused kernel above)
+    LAUNCH_KERNEL_WITH_PDL((group_idx_and_topk_idx_kernel<T, IdxT>),
+                           topk_with_k_group_num_blocks,
+                           BLOCK_SIZE,
+                           dynamic_smem_in_bytes,
+                           stream,
+                           scores,
+                           group_scores,
+                           topk_values,
+                           topk_indices,
+                           raw_logits,
+                           num_tokens,
+                           n_group,
+                           topk_group,
+                           topk,
+                           num_experts,
+                           num_experts_per_group,
+                           norm_node,
+                           routed_scaling_factor);
+    check_cuda_error();
+
+#undef LAUNCH_KERNEL
+}
+
+#define INSTANTIATE_NOAUX_TC_FUSED(T, IdxT)                                                                            \
+    template void invokeNoAuxTcFused<T, IdxT>(T * raw_logits,                                                          \
+                                              T const*           bias,                                                 \
+                                              T*                 scores,                                               \
+                                              T*                 group_scores,                                         \
+                                              T*                 topk_values,                                          \
+                                              IdxT*              topk_indices,                                         \
+                                              int64_t const      num_tokens,                                           \
+                                              int64_t const      num_experts,                                          \
+                                              int64_t const      n_group,                                              \
+                                              int64_t const      topk_group,                                           \
+                                              int64_t const      topk,                                                 \
+                                              int                norm_node,                                            \
+                                              double const       routed_scaling_factor,                                \
+                                              cudaStream_t const stream);
+
 INSTANTIATE_NOAUX_TC(float, int32_t);
 INSTANTIATE_NOAUX_TC(float, int64_t);
+INSTANTIATE_NOAUX_TC_FUSED(float, int32_t);
+INSTANTIATE_NOAUX_TC_FUSED(float, int64_t);
 // INSTANTIATE_NOAUX_TC(half, int32_t);
 // #ifdef ENABLE_BF16
 // INSTANTIATE_NOAUX_TC(__nv_bfloat16, int32_t);

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
@@ -34,4 +34,24 @@ void invokeNoAuxTc(T*                 scores,
                    double const       routed_scaling_factor,
                    cudaStream_t const stream = 0);
 
+// Fused version: computes sigmoid + bias_add internally, avoiding 2 extra kernel launches.
+// raw_logits: [num_tokens, num_experts] pre-sigmoid logits
+// bias: [num_experts] correction bias per expert
+// scores: [num_tokens, num_experts] output for post-sigmoid values (written by kernel)
+template<typename T, typename IdxT>
+void invokeNoAuxTcFused(T*                 raw_logits,
+                        T const*           bias,
+                        T*                 scores,
+                        T*                 group_scores,
+                        T*                 topk_values,
+                        IdxT*              topk_indices,
+                        int64_t const      num_tokens,
+                        int64_t const      num_experts,
+                        int64_t const      n_group,
+                        int64_t const      topk_group,
+                        int64_t const      topk,
+                        int                norm_node,
+                        double const       routed_scaling_factor,
+                        cudaStream_t const stream = 0);
+
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/kernels/cuda/fp8_kernel/fp8_kernel.py
+++ b/rtp_llm/models_py/kernels/cuda/fp8_kernel/fp8_kernel.py
@@ -56,9 +56,9 @@ def ceil_to_ue8m0(x: torch.Tensor):
 def _transform_scale_ue8m0(sf, mn):
     import deep_gemm.utils.layout
 
+    sf = sf.index_select(-2, torch.arange(mn, device=sf.device) // 128)
     if not sf.is_cuda:
         sf = sf.cuda()
-    sf = sf.index_select(-2, torch.arange(mn, device=sf.device) // 128)
     sf = deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(sf)
     return sf
 

--- a/rtp_llm/models_py/kernels/cuda/fp8_kernel/fp8_kernel.py
+++ b/rtp_llm/models_py/kernels/cuda/fp8_kernel/fp8_kernel.py
@@ -133,23 +133,22 @@ def sgl_per_token_group_quant_fp8(
         scale_ue8m0=scale_ue8m0,
     )
     if x.shape[0] > 0:
-        if masked_m is not None:
-            per_token_group_quant_fp8_v2(
-                x,
-                x_q,
-                x_s,
-                group_size,
-                eps,
-                fp8_min,
-                fp8_max,
-                scale_ue8m0,
-                fuse_silu_and_mul,
-                masked_m,
-            )
-        else:
-            per_token_group_quant_fp8(
-                x, x_q, x_s, group_size, eps, fp8_min, fp8_max, scale_ue8m0
-            )
+        # Always use v2: single-pass reads (vs v1's two-pass), vectorized 128-bit stores.
+        # v2 requires eps == 1e-10 (hardcoded as LOCAL_ABSMAX_ABS in the kernel).
+        # This is safe because eps is only used to prevent division by zero in absmax
+        # computation, and 1e-10 serves this purpose for all practical inputs.
+        per_token_group_quant_fp8_v2(
+            x,
+            x_q,
+            x_s,
+            group_size,
+            1e-10,  # v2 requires eps == LOCAL_ABSMAX_ABS == 1e-10
+            fp8_min,
+            fp8_max,
+            scale_ue8m0,
+            fuse_silu_and_mul,
+            masked_m,
+        )
 
     return x_q, x_s
 

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -36,6 +36,7 @@ from rtp_llm.models_py.triton_kernels.fla.blackwell_prefill import (
 )
 from rtp_llm.models_py.triton_kernels.fla.block import (
     load_initial_state_from_block_map,
+    store_final_state_only_to_block_map,
     store_ssm_state_to_block_map,
 )
 from rtp_llm.models_py.triton_kernels.fla.chunk import chunk_gated_delta_rule
@@ -43,7 +44,6 @@ from rtp_llm.models_py.triton_kernels.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule,
 )
 from rtp_llm.models_py.triton_kernels.fla.gdn_gating import fused_gdn_gating
-from rtp_llm.models_py.triton_kernels.fla.l2norm import l2norm_fwd
 from rtp_llm.models_py.utils.debug import cudagraph_debug_kernel
 from rtp_llm.models_py.utils.typed_storage_view import LinearCacheConverter
 from rtp_llm.ops import (
@@ -445,19 +445,10 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         attn_inputs: PyAttentionInputs,
         seq_size_per_block: int,
     ) -> torch.Tensor:
-        # l2norm_fwd handles non-contiguous input directly (strided kernel),
-        # producing contiguous output in a single kernel per tensor.
-        # q and k must be separate calls: downstream chunk pipeline kernels
-        # require each to be independently contiguous with stride H_qk*D.
-        query = l2norm_fwd(query)
-        key = l2norm_fwd(key)
         value = value.contiguous()
         beta = beta.float()
-        # g from fused_gdn_gating is already contiguous
 
         output_final_state = ssm_states is not None
-        # Pre-allocate output tensors so blackwell_chunk_gated_delta_rule
-        # doesn't allocate device memory internally.
         output = torch.empty_like(value)
         output_state = None
         if output_final_state:
@@ -481,6 +472,7 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 initial_state=initial_states,
                 output_final_state=output_final_state,
                 cu_seqlens=cu_seqlens,
+                use_qk_l2norm_in_kernel=True,
                 output=output,
                 output_state=output_state,
             )
@@ -490,7 +482,6 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 exc_info=True,
             )
             Qwen3NextGatedDeltaNetPrefill._blackwell_available = False
-            # Re-do with Triton (q/k already l2norm-ed, so pass use_qk_l2norm_in_kernel=False)
             attn_out, h, final_state = chunk_gated_delta_rule(
                 query,
                 key,
@@ -500,7 +491,7 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 initial_state=initial_states,
                 output_final_state=True,
                 cu_seqlens=cu_seqlens,
-                use_qk_l2norm_in_kernel=False,
+                use_qk_l2norm_in_kernel=True,
             )
             if ssm_states is not None:
                 store_ssm_state_to_block_map(
@@ -518,15 +509,13 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         if output_final_state:
             attn_out, final_state = result
             final_state = final_state.transpose(-1, -2).contiguous()
-            store_ssm_state_to_block_map(
-                final_state,
+            store_final_state_only_to_block_map(
                 final_state,
                 attn_inputs.prefix_lengths_d,
                 cu_seqlens,
                 attn_inputs.kv_cache_kernel_block_id_device,
                 ssm_states,
                 seq_size_per_block,
-                chunk_size=128,
             )
         else:
             attn_out = result if not isinstance(result, tuple) else result[0]

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -748,7 +748,15 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         qkvz_w = weights[W.linear_attn_qkvz_w]
         ba_w = weights[W.linear_attn_ba_w]
         has_qkvz_scale = weights.get(W.linear_attn_qkvz_s) is not None
-        self._use_merged_proj = not has_qkvz_scale and qkvz_w.dtype == ba_w.dtype
+        # Merge qkvz and ba projections if shapes are compatible and no FP8 scales
+        can_merge = (
+            not has_qkvz_scale
+            and qkvz_w.dtype == ba_w.dtype
+            and qkvz_w.ndim == 2
+            and ba_w.ndim == 2
+            and qkvz_w.shape[1] == ba_w.shape[1]
+        )
+        self._use_merged_proj = can_merge
         if self._use_merged_proj:
             self._qkvz_dim = qkvz_w.shape[0]
             merged_w = torch.cat([qkvz_w, ba_w], dim=0)

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -992,7 +992,56 @@ class Qwen3NextModel(GptModelBase):
             weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
         )
 
+    _profile_dir = os.environ.get("SAVE_TORCH_PROFILE", "")
+    _profile_call_count = 0
+    _profile_done = False
+
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids: torch.Tensor = inputs.input_ids
+        num_tokens = input_ids.shape[0]
+        should_profile = (
+            self._profile_dir
+            and not Qwen3NextModel._profile_done
+            and num_tokens > 60000
+        )
+        if should_profile:
+            Qwen3NextModel._profile_call_count += 1
+        if should_profile and Qwen3NextModel._profile_call_count >= 2:
+            import torch.profiler
+
+            trace_path = os.path.join(
+                self._profile_dir, f"profile_{num_tokens}tok.json"
+            )
+            logger.info(f"Profiling {num_tokens} tokens, saving to {trace_path}")
+            # Use schedule with warmup to avoid CUPTI lazy kernel loading overhead.
+            # warmup=1: first forward instruments all Triton/CUDA kernels (70ms+ overhead).
+            # active=1: second forward records clean timings without instrumentation gaps.
+            schedule = torch.profiler.schedule(wait=0, warmup=1, active=1, repeat=1)
+            prof = torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
+                schedule=schedule,
+            )
+            prof.start()
+            prof.step()  # step 0: warmup starts
+            self._forward_impl(inputs, fmha_impl)
+            torch.cuda.synchronize()
+            prof.step()  # step 1: active recording starts
+            result = self._forward_impl(inputs, fmha_impl)
+            torch.cuda.synchronize()
+            prof.step()  # step 2: recording ends
+            prof.stop()
+            prof.export_chrome_trace(trace_path)
+            Qwen3NextModel._profile_done = True
+            logger.info(f"Profile saved: {trace_path}")
+            return result
+        return self._forward_impl(inputs, fmha_impl)
+
+    def _forward_impl(
+        self, inputs: PyModelInputs, fmha_impl: Any = None
+    ) -> PyModelOutputs:
         input_ids: torch.Tensor = inputs.input_ids
         inputs_embeds = self.embed_tokens(input_ids)
         hidden_states = inputs_embeds

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -1,4 +1,7 @@
 import logging
+
+logger = logging.getLogger(__name__)
+import os
 import sys
 from typing import Any, Dict, Optional
 
@@ -19,6 +22,7 @@ from rtp_llm.models_py.modules import (
     FMHAImplBase,
     LinearFactory,
     RMSNorm,
+    RMSResNorm,
 )
 from rtp_llm.models_py.triton_kernels.causal_conv1d import (
     CausalConv1dMetadata,
@@ -27,6 +31,9 @@ from rtp_llm.models_py.triton_kernels.causal_conv1d import (
     prepare_causal_conv1d_metadata,
 )
 from rtp_llm.models_py.triton_kernels.common.layernorm_gated import RmsNormGated
+from rtp_llm.models_py.triton_kernels.fla.blackwell_prefill import (
+    chunk_gated_delta_rule as blackwell_chunk_gated_delta_rule,
+)
 from rtp_llm.models_py.triton_kernels.fla.block import (
     load_initial_state_from_block_map,
     store_ssm_state_to_block_map,
@@ -36,6 +43,7 @@ from rtp_llm.models_py.triton_kernels.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule,
 )
 from rtp_llm.models_py.triton_kernels.fla.gdn_gating import fused_gdn_gating
+from rtp_llm.models_py.triton_kernels.fla.l2norm import l2norm_fwd
 from rtp_llm.models_py.utils.debug import cudagraph_debug_kernel
 from rtp_llm.models_py.utils.typed_storage_view import LinearCacheConverter
 from rtp_llm.ops import (
@@ -181,6 +189,149 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         ).transpose(0, 1)
         return out
 
+    _BLACKWELL_SEQ_THRESHOLD = 6144
+    _blackwell_available: Optional[bool] = None
+    _blackwell_warmed_up: bool = False
+
+    @classmethod
+    def _is_blackwell_gpu(cls) -> bool:
+        if cls._blackwell_available is None:
+            if not torch.cuda.is_available():
+                cls._blackwell_available = False
+            else:
+                major, _ = torch.cuda.get_device_capability()
+                cls._blackwell_available = major >= 10
+        return cls._blackwell_available
+
+    def _use_blackwell_kernel(self, total_seq_len: int, batch_size: int = 1) -> bool:
+        if os.environ.get("ENABLE_BLACKWELL_GDN", "0") != "1":
+            return False
+        if blackwell_chunk_gated_delta_rule is None:
+            return False
+        if self.head_k_dim != 128:
+            return False
+        if not self._is_blackwell_gpu():
+            return False
+        # Blackwell kernel's varlen support has correctness issues with
+        # multi-sequence batches; restrict to single-sequence requests.
+        if batch_size > 1:
+            return False
+        return True
+
+    @classmethod
+    def warmup_blackwell_kernel(
+        cls,
+        head_k_dim: int,
+        local_num_k_heads: int,
+        local_num_v_heads: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        """Pre-compile Blackwell GDN kernel while GPU memory is available.
+
+        Must be called during model init, before KV cache fills GPU memory.
+        Triggers JIT compilation (~15s) and cudaLibraryLoad so that subsequent
+        calls only need the cached compiled kernel.
+        """
+        if cls._blackwell_warmed_up:
+            return
+        if os.environ.get("ENABLE_BLACKWELL_GDN", "0") != "1":
+            return
+        if blackwell_chunk_gated_delta_rule is None:
+            return
+        if head_k_dim != 128:
+            return
+        if not cls._is_blackwell_gpu():
+            return
+
+        logger.info("Blackwell GDN kernel: starting warmup JIT compilation (~15s)...")
+        # Use a small seq_len to minimize memory and compute during warmup.
+        # The compiled kernel is cached by (D, dtype, is_varlen, is_initial_state,
+        # output_final_state, scale, device_idx) — seq_len doesn't affect the cache key.
+        warmup_seq = 128  # one chunk
+        warmup_batch = 1
+        try:
+            q = torch.randn(
+                warmup_batch,
+                warmup_seq,
+                local_num_k_heads,
+                head_k_dim,
+                dtype=dtype,
+                device=device,
+            )
+            k = torch.randn_like(q)
+            v = torch.randn(
+                warmup_batch,
+                warmup_seq,
+                local_num_v_heads,
+                head_k_dim,
+                dtype=dtype,
+                device=device,
+            )
+            g = torch.randn(
+                1, warmup_seq, local_num_v_heads, dtype=torch.float32, device=device
+            )
+            beta = torch.rand(
+                1, warmup_seq, local_num_v_heads, dtype=torch.float32, device=device
+            )
+            initial_state = torch.zeros(
+                warmup_batch,
+                local_num_v_heads,
+                head_k_dim,
+                head_k_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+            output = torch.empty_like(v)
+            output_state = torch.empty(
+                warmup_batch,
+                local_num_v_heads,
+                head_k_dim,
+                head_k_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+            cu_seqlens = torch.tensor([0, warmup_seq], dtype=torch.int32, device=device)
+
+            # Warmup WITH initial_state + output_final_state (the common prefill config)
+            blackwell_chunk_gated_delta_rule(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                output=output,
+                output_state=output_state,
+            )
+            torch.cuda.synchronize(device)
+
+            # Also warmup WITHOUT initial_state (first prefill, no KV cache)
+            blackwell_chunk_gated_delta_rule(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                initial_state=None,
+                output_final_state=False,
+                cu_seqlens=cu_seqlens,
+                output=output,
+            )
+            torch.cuda.synchronize(device)
+
+            del q, k, v, g, beta, initial_state, output, output_state, cu_seqlens
+            cls._blackwell_warmed_up = True
+            logger.info("Blackwell GDN kernel: warmup complete, kernel cached.")
+        except Exception:
+            logger.warning(
+                "Blackwell GDN kernel warmup failed, disabling Blackwell path",
+                exc_info=True,
+            )
+            cls._blackwell_available = False
+
     def _fla(
         self,
         mixed_qkv: torch.Tensor,
@@ -190,6 +341,18 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         seq_size_per_block: int,
         attn_inputs: PyAttentionInputs,
     ) -> torch.Tensor:
+        # Lazy warmup: trigger Blackwell JIT compilation on the first forward call.
+        # This runs after KVCache allocation, so CUDA driver memory from JIT
+        # doesn't interfere with memory accounting.
+        if not Qwen3NextGatedDeltaNetPrefill._blackwell_warmed_up:
+            Qwen3NextGatedDeltaNetPrefill.warmup_blackwell_kernel(
+                self.head_k_dim,
+                self.local_num_k_heads,
+                self.local_num_v_heads,
+                mixed_qkv.dtype,
+                mixed_qkv.device,
+            )
+
         g, beta = fused_gdn_gating(self.alog, a, b, self.dt_bias)
         ssm_states = (
             self._get_ssm_states(kv_cache_tensor)
@@ -229,6 +392,22 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         query = query.view(1, query.shape[0], self.local_num_k_heads, self.head_k_dim)
         key = key.view(1, key.shape[0], self.local_num_k_heads, self.head_k_dim)
         value = value.view(1, value.shape[0], self.local_num_v_heads, self.head_v_dim)
+
+        total_seq_len = mixed_qkv.shape[0]
+        if self._use_blackwell_kernel(total_seq_len, context_batch_size):
+            return self._fla_blackwell(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                initial_states,
+                ssm_states,
+                cu_seqlens_without_padding,
+                attn_inputs,
+                seq_size_per_block,
+            )
+
         attn_out, h, final_state = chunk_gated_delta_rule(
             query,
             key,
@@ -251,6 +430,106 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 seq_size_per_block,
                 chunk_size=64,
             )
+        return attn_out.squeeze_(0)
+
+    def _fla_blackwell(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_states: Optional[torch.Tensor],
+        ssm_states: Optional[torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        attn_inputs: PyAttentionInputs,
+        seq_size_per_block: int,
+    ) -> torch.Tensor:
+        # l2norm_fwd handles non-contiguous input directly (strided kernel),
+        # producing contiguous output in a single kernel per tensor.
+        # q and k must be separate calls: downstream chunk pipeline kernels
+        # require each to be independently contiguous with stride H_qk*D.
+        query = l2norm_fwd(query)
+        key = l2norm_fwd(key)
+        value = value.contiguous()
+        beta = beta.float()
+        # g from fused_gdn_gating is already contiguous
+
+        output_final_state = ssm_states is not None
+        # Pre-allocate output tensors so blackwell_chunk_gated_delta_rule
+        # doesn't allocate device memory internally.
+        output = torch.empty_like(value)
+        output_state = None
+        if output_final_state:
+            batch_size = initial_states.shape[0] if initial_states is not None else 1
+            output_state = torch.empty(
+                batch_size,
+                self.local_num_v_heads,
+                self.head_v_dim,
+                self.head_v_dim,
+                dtype=torch.float32,
+                device=query.device,
+            )
+
+        try:
+            result = blackwell_chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                initial_state=initial_states,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+                output=output,
+                output_state=output_state,
+            )
+        except Exception:
+            logger.warning(
+                "Blackwell GDN kernel failed, falling back to Triton",
+                exc_info=True,
+            )
+            Qwen3NextGatedDeltaNetPrefill._blackwell_available = False
+            # Re-do with Triton (q/k already l2norm-ed, so pass use_qk_l2norm_in_kernel=False)
+            attn_out, h, final_state = chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g,
+                beta.to(query.dtype),
+                initial_state=initial_states,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                use_qk_l2norm_in_kernel=False,
+            )
+            if ssm_states is not None:
+                store_ssm_state_to_block_map(
+                    h,
+                    final_state,
+                    attn_inputs.prefix_lengths_d,
+                    cu_seqlens,
+                    attn_inputs.kv_cache_kernel_block_id_device,
+                    ssm_states,
+                    seq_size_per_block,
+                    chunk_size=64,
+                )
+            return attn_out.squeeze_(0)
+
+        if output_final_state:
+            attn_out, final_state = result
+            final_state = final_state.transpose(-1, -2).contiguous()
+            store_ssm_state_to_block_map(
+                final_state,
+                final_state,
+                attn_inputs.prefix_lengths_d,
+                cu_seqlens,
+                attn_inputs.kv_cache_kernel_block_id_device,
+                ssm_states,
+                seq_size_per_block,
+                chunk_size=128,
+            )
+        else:
+            attn_out = result if not isinstance(result, tuple) else result[0]
         return attn_out.squeeze_(0)
 
     def forward(
@@ -476,14 +755,28 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         self.parallelism_config = parallelism_config
         self.weights = weights
         self.quant_config = quant_config
-        # in_proj_qkvz is bf16 / fp8
-        self.in_proj_qkvz = LinearFactory.create_linear_from_weights(
-            weights, W.linear_attn_qkvz_w, W.linear_attn_qkvz_s, None, quant_config
-        )
-        # in_proj_ba is bf16
-        self.in_proj_ba = LinearFactory.create_linear_from_weights(
-            weights, W.linear_attn_ba_w, None, None, quant_config
-        )
+
+        qkvz_w = weights[W.linear_attn_qkvz_w]
+        ba_w = weights[W.linear_attn_ba_w]
+        has_qkvz_scale = weights.get(W.linear_attn_qkvz_s) is not None
+        self._use_merged_proj = not has_qkvz_scale and qkvz_w.dtype == ba_w.dtype
+        if self._use_merged_proj:
+            self._qkvz_dim = qkvz_w.shape[0]
+            merged_w = torch.cat([qkvz_w, ba_w], dim=0)
+            self.in_proj_merged = LinearFactory.create_linear(
+                weight=merged_w,
+                bias=None,
+                weight_scales=None,
+                quant_config=quant_config,
+            )
+        else:
+            self._qkvz_dim = 0
+            self.in_proj_qkvz = LinearFactory.create_linear_from_weights(
+                weights, W.linear_attn_qkvz_w, W.linear_attn_qkvz_s, None, quant_config
+            )
+            self.in_proj_ba = LinearFactory.create_linear_from_weights(
+                weights, W.linear_attn_ba_w, None, None, quant_config
+            )
         self.head_k_dim = linear_attn_config.linear_key_head_dim
         self.head_v_dim = linear_attn_config.linear_value_head_dim
         self.local_num_k_heads = (
@@ -500,6 +793,9 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         self.decode_gdn = Qwen3NextGatedDeltaNetDecode(
             linear_attn_config, parallelism_config, weights
         )
+        # Blackwell GDN kernel uses lazy JIT compilation on first inference call.
+        # Warmup during init is disabled to avoid CUDA memory interference with
+        # KV cache allocation.
         self.norm = RmsNormGated(
             weights[W.linear_attn_norm_w],
             eps=layernorm_eps,
@@ -547,8 +843,13 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             or not attention_inputs.is_prefill
             or attn_meta.get_prefill_conv1d_meta() is not None
         ), "prefill_conv1d_meta is required for prefill"
-        projected_states_qkvz = self.in_proj_qkvz(hidden_states)
-        projected_states_ba = self.in_proj_ba(hidden_states)
+        if self._use_merged_proj:
+            merged_out = self.in_proj_merged(hidden_states)
+            projected_states_qkvz = merged_out[:, : self._qkvz_dim]
+            projected_states_ba = merged_out[:, self._qkvz_dim :].contiguous()
+        else:
+            projected_states_qkvz = self.in_proj_qkvz(hidden_states)
+            projected_states_ba = self.in_proj_ba(hidden_states)
         mixed_qkv, z, b, a = self.fix_query_key_value_ordering(
             projected_states_qkvz, projected_states_ba
         )
@@ -621,23 +922,24 @@ class Qwen3NextDecoderLayer(nn.Module):
                 config.activation_type, parallelism_config, weights, config.quant_config
             )
 
-        self.input_layernorm = RMSNorm(
+        self.input_layernorm = RMSResNorm(
             weights[W.pre_ln_gamma], eps=config.layernorm_eps
         )
-        self.post_attention_layernorm = RMSNorm(
+        self.post_attention_layernorm = RMSResNorm(
             weights[W.post_ln_gamma], eps=config.layernorm_eps
         )
 
     def forward(
         self,
         hidden_states: torch.Tensor,
+        residual: torch.Tensor,
         fmha_impl: FMHAImplBase,
         kv_cache: Optional[LayerKVCache] = None,
         attention_inputs: Optional[PyAttentionInputs] = None,
         attn_meta: Qwen3NextMetadata = Qwen3NextMetadata(),
-    ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Fused: residual = residual + hidden_states; hidden_states = rmsnorm(residual)
+        hidden_states = self.input_layernorm(hidden_states, residual)
         # Self Attention
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
@@ -646,13 +948,11 @@ class Qwen3NextDecoderLayer(nn.Module):
             attention_inputs=attention_inputs,
             attn_meta=attn_meta,
         )
-        hidden_states = residual + hidden_states
+        # Fused: residual = residual + hidden_states; hidden_states = rmsnorm(residual)
+        hidden_states = self.post_attention_layernorm(hidden_states, residual)
         # Fully Connected
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states
+        return hidden_states, residual
 
 
 class Qwen3NextModel(GptModelBase):
@@ -699,7 +999,7 @@ class Qwen3NextModel(GptModelBase):
                 for idx in range(self.layer_num)
             ]
         )
-        self.norm = RMSNorm(
+        self.norm = RMSResNorm(
             weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
         )
 
@@ -707,6 +1007,7 @@ class Qwen3NextModel(GptModelBase):
         input_ids: torch.Tensor = inputs.input_ids
         inputs_embeds = self.embed_tokens(input_ids)
         hidden_states = inputs_embeds
+        residual = torch.zeros_like(hidden_states)
 
         attention_inputs: PyAttentionInputs = inputs.attention_inputs
         prefill_conv1d_meta = None
@@ -720,23 +1021,19 @@ class Qwen3NextModel(GptModelBase):
 
         attn_meta = Qwen3NextMetadata(prefill_conv1d_meta, is_target_verify)
 
-        # qwen3_next model has only one full group (group 0): use fmha_impl from input param
-        # if there is a model with more than 1 full groups,
-        # we should prepare fmha_impl for each full group/ fix later
-
         if fmha_impl is None:
             fmha_impl = self.prepare_fmha_impl(inputs)
 
         for i, decoder_layer in enumerate(self.layers):
-            # Switch to correct block_map for this layer in hybrid attention mode
             select_block_map_for_layer(attention_inputs, i)
-            hidden_states = decoder_layer(
+            hidden_states, residual = decoder_layer(
                 hidden_states,
+                residual,
                 fmha_impl,
                 kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
                 attention_inputs=attention_inputs,
                 attn_meta=attn_meta,
             )
 
-        hidden_states = self.norm(hidden_states)
+        hidden_states = self.norm(hidden_states, residual)
         return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/model_desc/qwen3_next_mtp.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next_mtp.py
@@ -11,7 +11,7 @@ from rtp_llm.models_py.model_desc.qwen3_next import (
     Qwen3NextDecoderLayer,
     Qwen3NextMetadata,
 )
-from rtp_llm.models_py.modules import AttnImplFactory, Embedding, LinearFactory, RMSNorm
+from rtp_llm.models_py.modules import AttnImplFactory, Embedding, LinearFactory, RMSNorm, RMSResNorm
 from rtp_llm.ops import HybridAttentionType, ParallelismConfig
 from rtp_llm.ops.compute_ops import PyAttentionInputs, PyModelInputs, PyModelOutputs
 from rtp_llm.utils.model_weight import W
@@ -75,7 +75,7 @@ class Qwen3NextMTPModel(GptModelBase):
                 for idx in range(self.layer_num)
             ]
         )
-        self.norm = RMSNorm(
+        self.norm = RMSResNorm(
             weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
         )
 
@@ -87,6 +87,7 @@ class Qwen3NextMTPModel(GptModelBase):
         h_norm = self.pre_fc_norm_hidden(last_hidden_states)
         cat_hidden_states = torch.cat([e_norm, h_norm], -1)
         hidden_states = self.fc(cat_hidden_states)
+        residual = torch.zeros_like(hidden_states)
 
         attention_inputs: PyAttentionInputs = inputs.attention_inputs
         if fmha_impl is None:
@@ -96,12 +97,13 @@ class Qwen3NextMTPModel(GptModelBase):
         for i, decoder_layer in enumerate(self.layers):
             select_block_map_for_layer(attention_inputs, i)
 
-            hidden_states = decoder_layer(
+            hidden_states, residual = decoder_layer(
                 hidden_states,
+                residual,
                 fmha_impl,
                 kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
                 attention_inputs=inputs.attention_inputs,
                 attn_meta=Qwen3NextMetadata(),
             )
-        hidden_states = self.norm(hidden_states)
+        hidden_states = self.norm(hidden_states, residual)
         return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/modules/base/cuda/select_topk.py
+++ b/rtp_llm/models_py/modules/base/cuda/select_topk.py
@@ -37,19 +37,37 @@ class GroupTopK(nn.Module):
         renormalize: bool,
         routed_scaling_factor: float,
     ):
-        scores = scores.sigmoid()
-        scores_with_bias = scores + correction_bias.unsqueeze(0)
-        self.group_topk_op.forward(
-            topk_weights,
-            topk_ids,
-            scores,
-            scores_with_bias,
-            n_group,
-            topk_group,
-            topk,
-            renormalize,
-            routed_scaling_factor,
-        )
+        # Use fused kernel: sigmoid + bias_add + topk in one CUDA launch,
+        # avoiding 2 separate PyTorch kernel launches for sigmoid and add.
+        scores_out = torch.empty_like(scores)
+        try:
+            self.group_topk_op.forward_fused(
+                topk_weights,
+                topk_ids,
+                scores,
+                correction_bias,
+                scores_out,
+                n_group,
+                topk_group,
+                topk,
+                renormalize,
+                routed_scaling_factor,
+            )
+        except (AttributeError, TypeError):
+            # Fallback for older builds without forward_fused
+            scores = scores.sigmoid()
+            scores_with_bias = scores + correction_bias.unsqueeze(0)
+            self.group_topk_op.forward(
+                topk_weights,
+                topk_ids,
+                scores,
+                scores_with_bias,
+                n_group,
+                topk_group,
+                topk,
+                renormalize,
+                routed_scaling_factor,
+            )
 
 
 class FakeBalanceExpert(nn.Module):

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/flash_infer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/flash_infer.py
@@ -10,7 +10,7 @@ from rtp_llm.ops.compute_ops import (
     FlashInferDecodeOp,
     FlashInferPrefillOp,
     FusedRopeKVCacheDecodeOp,
-    FusedRopeKVCachePrefillOpQKVOut,
+    FusedRopeKVCachePrefillOpQOut,
     LayerKVCache,
     PyAttentionInputs,
 )
@@ -27,7 +27,7 @@ class FlashInferPrefillImpl(FMHAImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
         self.fmha_impl = FlashInferPrefillOp(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpQKVOut(attn_configs)
+        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpQOut(attn_configs)
         self.attn_configs = attn_configs
 
         # Store input info

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -328,11 +328,14 @@ class FlashInferTRTLLMPrefillOp(object):
     def __del__(self):
         release_trt_workspace_buffer(self.workspace_buffer)
 
+    _SUPPORTED_PAGE_SIZES = {32, 64}
+
     def support(self, attention_inputs: PyAttentionInputs):
         return (
             is_sm_100()
             and attention_inputs.is_prefill
             and attention_inputs.kv_cache_kernel_block_id_device is not None
+            and self.seq_size_per_block in self._SUPPORTED_PAGE_SIZES
         )
 
     def prepare(self, attention_inputs: PyAttentionInputs) -> FlashInferTRTLLMParams:
@@ -435,8 +438,12 @@ class FlashInferTRTLLMDecodeOp(object):
     def __del__(self):
         release_trt_workspace_buffer(self.workspace_buffer)
 
+    _SUPPORTED_PAGE_SIZES = {32, 64}
+
     def support(self, attention_inputs: PyAttentionInputs):
         if not is_sm_100():
+            return False
+        if self.seq_size_per_block not in self._SUPPORTED_PAGE_SIZES:
             return False
         # Note: this max q length is used for mtp decode verification.
         decode_kernel_max_q_len = 11

--- a/rtp_llm/models_py/triton_kernels/BUILD
+++ b/rtp_llm/models_py/triton_kernels/BUILD
@@ -1,6 +1,6 @@
 py_library(
     name = "fla",
-    srcs = glob(["fla/*.py"]),
+    srcs = glob(["fla/*.py"]) + glob(["fla/blackwell_prefill/*.py"]),
     deps = [":common"],
     visibility = ["//visibility:public"]
 )

--- a/rtp_llm/models_py/triton_kernels/common/layernorm_gated.py
+++ b/rtp_llm/models_py/triton_kernels/common/layernorm_gated.py
@@ -30,52 +30,51 @@ def _layer_norm_fwd_1pass_kernel(
     N,  # number of columns in X
     eps,  # epsilon to avoid division by zero
     BLOCK_N: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_Z: tl.constexpr,
     NORM_BEFORE_GATE: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
 ):
-    # Map the program id to the row of X and Y it should compute.
-    row = tl.program_id(0)
+    # Map the program id to a batch of rows
+    row_start = tl.program_id(0) * ROWS_PER_BLOCK
     group = tl.program_id(1)
-    X += row * stride_x_row + group * N
-    Y += row * stride_y_row + group * N
-    if HAS_Z:
-        Z += row * stride_z_row + group * N
-    if not IS_RMS_NORM:
-        Mean += group * M
-    Rstd += group * M
-    W += group * N
-    if HAS_BIAS:
-        B += group * N
-    # Compute mean and variance
     cols = tl.arange(0, BLOCK_N)
-    x = tl.load(X + cols, mask=cols < N, other=0.0).to(tl.float32)
-    if HAS_Z and not NORM_BEFORE_GATE:
-        z = tl.load(Z + cols, mask=cols < N).to(tl.float32)
-        x *= z * tl.sigmoid(z)
-    if not IS_RMS_NORM:
-        mean = tl.sum(x, axis=0) / N
-        tl.store(Mean + row, mean)
-        xbar = tl.where(cols < N, x - mean, 0.0)
-        var = tl.sum(xbar * xbar, axis=0) / N
-    else:
-        xbar = tl.where(cols < N, x, 0.0)
-        var = tl.sum(xbar * xbar, axis=0) / N
-    rstd = 1 / tl.sqrt(var + eps)
-    tl.store(Rstd + row, rstd)
-    # Normalize and apply linear transformation
-    mask = cols < N
-    w = tl.load(W + cols, mask=mask).to(tl.float32)
+    col_mask = cols < N
+    # Load weight/bias once (shared across rows)
+    w = tl.load(W + group * N + cols, mask=col_mask).to(tl.float32)
     if HAS_BIAS:
-        b = tl.load(B + cols, mask=mask).to(tl.float32)
-    x_hat = (x - mean) * rstd if not IS_RMS_NORM else x * rstd
-    y = x_hat * w + b if HAS_BIAS else x_hat * w
-    if HAS_Z and NORM_BEFORE_GATE:
-        z = tl.load(Z + cols, mask=mask).to(tl.float32)
-        y *= z * tl.sigmoid(z)
-    # Write output
-    tl.store(Y + cols, y, mask=mask)
+        b = tl.load(B + group * N + cols, mask=col_mask).to(tl.float32)
+    for r in range(ROWS_PER_BLOCK):
+        row = row_start + r
+        row_mask = row < M
+        x_ptr = X + row * stride_x_row + group * N
+        y_ptr = Y + row * stride_y_row + group * N
+        load_mask = col_mask & row_mask
+        x = tl.load(x_ptr + cols, mask=load_mask, other=0.0).to(tl.float32)
+        if HAS_Z and not NORM_BEFORE_GATE:
+            z = tl.load(Z + row * stride_z_row + group * N + cols, mask=load_mask).to(
+                tl.float32
+            )
+            x *= z * tl.sigmoid(z)
+        if not IS_RMS_NORM:
+            mean = tl.sum(x, axis=0) / N
+            tl.store(Mean + group * M + row, mean, mask=row_mask)
+            xbar = tl.where(load_mask, x - mean, 0.0)
+            var = tl.sum(xbar * xbar, axis=0) / N
+        else:
+            xbar = tl.where(load_mask, x, 0.0)
+            var = tl.sum(xbar * xbar, axis=0) / N
+        rstd = 1 / tl.sqrt(var + eps)
+        tl.store(Rstd + group * M + row, rstd, mask=row_mask)
+        x_hat = (x - mean) * rstd if not IS_RMS_NORM else x * rstd
+        y = x_hat * w + b if HAS_BIAS else x_hat * w
+        if HAS_Z and NORM_BEFORE_GATE:
+            z = tl.load(Z + row * stride_z_row + group * N + cols, mask=load_mask).to(
+                tl.float32
+            )
+            y *= z * tl.sigmoid(z)
+        tl.store(y_ptr + cols, y, mask=load_mask)
 
 
 def layer_norm_fwd(
@@ -120,9 +119,16 @@ def layer_norm_fwd(
     BLOCK_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(group_size))
     if group_size > BLOCK_N:
         raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
-    # heuristics for number of warps
+    # heuristics for number of warps and rows per block
     num_warps = min(max(BLOCK_N // 256, 1), 8)
-    grid = (M, ngroups)
+    # Process multiple rows per block to reduce launch count for large M.
+    # For M=4M rows with N=128, this reduces blocks from 4M to ~64K.
+    ROWS_PER_BLOCK = 1
+    if M > 8192:
+        ROWS_PER_BLOCK = min(64, max(1, 8192 // BLOCK_N))
+    elif M > 1024:
+        ROWS_PER_BLOCK = min(16, max(1, 2048 // BLOCK_N))
+    grid = (triton.cdiv(M, ROWS_PER_BLOCK), ngroups)
     with torch.cuda.device(x.device.index):
         _layer_norm_fwd_1pass_kernel[grid](
             x,
@@ -139,6 +145,7 @@ def layer_norm_fwd(
             group_size,
             eps,
             BLOCK_N=BLOCK_N,
+            ROWS_PER_BLOCK=ROWS_PER_BLOCK,
             NORM_BEFORE_GATE=norm_before_gate,
             IS_RMS_NORM=is_rms_norm,
             num_warps=num_warps,

--- a/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/__init__.py
+++ b/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/__init__.py
@@ -1,0 +1,51 @@
+def _ensure_cutlass_importable():
+    """Ensure cutlass package is importable.
+
+    nvidia-cutlass-dsl installs its Python packages under
+    nvidia_cutlass_dsl/python_packages/ and relies on a .pth file to add that
+    directory to sys.path. In sandboxed environments (like Bazel) .pth files
+    are not processed, so we need to add the path manually.
+    """
+    try:
+        import cutlass  # noqa: F401
+
+        return  # already importable
+    except ImportError:
+        pass
+
+    import importlib
+    import sys
+
+    try:
+        spec = importlib.util.find_spec("nvidia_cutlass_dsl")
+        if spec is None or not spec.submodule_search_locations:
+            return
+        for base in spec.submodule_search_locations:
+            import os
+
+            pp = os.path.join(base, "python_packages")
+            if os.path.isdir(pp) and pp not in sys.path:
+                sys.path.insert(0, pp)
+    except Exception:
+        pass
+
+
+_ensure_cutlass_importable()
+
+try:
+    import cutlass
+
+    _ver = getattr(cutlass, "__version__", "0.0.0")
+    if tuple(int(x) for x in _ver.split(".")[:3]) < (4, 4, 2):
+        import logging as _log
+
+        _log.getLogger(__name__).info(
+            "nvidia-cutlass-dsl %s < 4.4.2, Blackwell GDN kernel disabled", _ver
+        )
+        chunk_gated_delta_rule = None  # type: ignore
+    else:
+        from .gdn import chunk_gated_delta_rule
+except Exception:
+    chunk_gated_delta_rule = None  # type: ignore
+
+__all__ = ["chunk_gated_delta_rule"]

--- a/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn.py
+++ b/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn.py
@@ -1,0 +1,4630 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Gated Delta Networks (GDN) chunked linear attention kernel for NVIDIA Blackwell (SM100).
+#
+# Implements the Chunk-wise Gated Delta Rule linear attention using CuTe-DSL,
+# for Blackwell Architecture.
+#
+# Key Features:
+#   - Supports Persistent & Non-persistent modes
+#   - Supports fixed-length and variable-length sequences (cu_seqlens)
+#   - Supports grouped value attention (GVA) where h_v is a multiple of h_q
+#   - Supports head dimension (128)
+#   - Supports input data types (f16/bf16)
+#   - Supports output data types (f16/bf16)
+#   - Supports initial_state to provide the initial state
+#   - Supports output_final_state flag to return the final state
+#   - State input and output are in f32 (fp16/bf16 not supported yet)
+
+import functools
+import warnings
+from typing import Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import torch
+from cutlass import Int32, Int64
+from cutlass._mlir.dialects import nvvm
+from cutlass.cute import EnableTVMFFI
+from cutlass.cute.runtime import from_dlpack
+
+from .gdn_helpers import (
+    make_smem_layout_a_kind,
+    make_smem_layout_b_kind,
+    make_smem_layout_epi_kind,
+)
+from .gdn_tile_scheduler import (
+    GdnStaticTileScheduler,
+    GdnStaticTileSchedulerParams,
+    create_gdn_static_tile_scheduler,
+    create_gdn_static_tile_scheduler_params,
+)
+
+
+def make_thread_cooperative_group(size: Int32):
+    # return pipeline.CooperativeGroup(pipeline.Agent.Thread, size, size) # old version
+    return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
+
+
+class GDN:
+    """Blackwell (SM100) kernel for Chunk-wise Gated Delta Rule linear attention."""
+
+    def __init__(
+        self,
+        is_persistent: bool = False,
+        chunk_size: Int32 = 128,  # Only 128 is supported in current version
+        head_dim: Int32 = 128,  # Only 128 is supported in current version
+    ):
+        self.chunk_size = chunk_size
+        self.is_persistent = is_persistent
+
+        self.head_dim = head_dim
+        self.cta_tiler = (chunk_size, chunk_size, head_dim)
+        self.gate_tiler = (chunk_size, 1)
+        self.beta_tiler = (chunk_size, 1)
+        self.state_output_tiler = (head_dim, head_dim)
+        self.o_output_tiler = (chunk_size, head_dim)
+
+        self.g_beta_dtype = cutlass.Float32
+        self.acc_dtype = cutlass.Float32
+        self.state_dtype = cutlass.Float32
+
+        self.mma_tiler = (chunk_size, chunk_size, head_dim)
+        self.qk_mma_tiler = self.mma_tiler
+        self.kkt_mma_tiler = self.mma_tiler
+        self.kst_mma_tiler = self.mma_tiler
+        self.tuw_mma_tiler = self.mma_tiler
+        self.o_intra_mma_tiler = (chunk_size, head_dim, chunk_size)
+        self.qs_mma_tiler = (chunk_size, head_dim, head_dim)
+        self.update_s_mma_tiler = (head_dim, head_dim, chunk_size)
+
+        self.epi_tile = (128, 128)
+
+        self.cluster_shape_mnk = (1, 1, 1)
+
+        self.buffer_align_bytes = 1024
+
+        self.q_stage = 1
+        self.one_stage = 1
+        self.kv_stage = 1
+        self.qk_stage = 2
+        self.gate_stage = 1
+        self.beta_stage = 1
+        self.mma_cudacore_stage = 1
+        self.mma_qk_stage = 2
+        self.epi_stage = 1
+
+        self.cudacore_warp_ids = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.load_warp_id = 5
+        self.epilogue_warp_id = 6
+        self.gb_warp_id = 7
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.cudacore_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                self.epilogue_warp_id,
+                self.gb_warp_id,
+            )
+        )
+
+        # TMEM configuration
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+        self.tmem_kkt_output = 0
+        self.tmem_qkt_output = 384
+        self.tmem_gate_qk = 384
+        self.tmem_gate_q = 448  # 448
+        self.tmem_k_input = 64
+        self.tmem_kst_output = 256
+        self.tmem_ivt_ss_l0_output = 448
+        self.tmem_ivt_ts_l0_input = 320
+        self.tmem_ivt_ts_l0_output = 448
+        self.tmem_ivt_ss_l1_output = 320
+        self.tmem_ivt_ts_l1_input = 320
+        self.tmem_ivt_ts_l1_output = 256
+        self.tmem_tuw_output = 256
+        self.tmem_o_intra_output = 256
+        self.tmem_o_inter_output = 256
+        self.tmem_update_s_output = 128
+        self.tmem_gamma = 256
+
+        self.tmem_state = 128
+
+        # Registers configuration
+        self.num_regs_cudacore = 240
+        self.num_regs_mma = 64
+        self.num_regs_other = 64
+        self.num_regs_gb = 64
+
+        # Named barrier IDs
+        self.cta_sync_bar_id = 0
+        self.tmem_alloc_sync_bar_id = 1
+        self.cudacore_mma_sync_bar_id = 2
+        self.wg_sync_bar_id = 3
+        self.epi_load_sync_bar_id = 4
+
+        # Matrix inversion using TFloat32
+        self.invert_type_ab = cutlass.TFloat32
+        self.invert_acc_type = cutlass.Float32
+        self.invert_mma_sub_l0_tiler = (64, 64, 32)
+        self.invert_mma_sub_l1_tiler = (64, 64, 64)
+        self.invert_mma_tiler = (128, 128, 64)
+        self.invert_sub_stage = 1
+        self.sub_stage = 9
+
+    @staticmethod
+    def can_implement(
+        q_shape: Tuple[int, int, int, int] | Tuple[int, Tuple[int, ...], int, int],
+        v_shape: Tuple[int, int, int, int] | Tuple[int, Tuple[int, ...], int, int],
+        in_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        g_beta_dtype: Type[cutlass.Numeric],
+        use_qk_l2norm_in_kernel: bool = False,
+    ) -> bool:
+        """
+        Check if the gdn can be implemented
+        """
+
+        can_implement = True
+
+        # Unpack parameters
+        b, s_q, h_q, d = q_shape
+        b_, _, h_v, d_ = v_shape
+
+        if use_qk_l2norm_in_kernel:
+            warnings.warn("use_qk_l2norm_in_kernel is not supported yet", stacklevel=2)
+            can_implement = False
+
+        if b != b_:
+            warnings.warn("q & k must have the same batch size", stacklevel=2)
+            can_implement = False
+
+        if d != d_:
+            warnings.warn("q & k must have the same head dimension", stacklevel=2)
+            can_implement = False
+
+        # todo: maybe support more later.
+        if d not in {128}:
+            warnings.warn("head dimension must be 128", stacklevel=2)
+            can_implement = False
+
+        if h_v % h_q != 0:
+            warnings.warn("h_v must be divisible by h_q", stacklevel=2)
+
+            can_implement = False
+
+        if isinstance(s_q, tuple) and len(s_q) != b:
+            warnings.warn(
+                "variable_seqlen s_q must have the length of batch size", stacklevel=2
+            )
+            can_implement = False
+
+        if in_dtype not in {
+            cutlass.BFloat16,
+            cutlass.Float16,
+            torch.float16,
+            torch.bfloat16,
+        }:
+            warnings.warn(
+                "in_dtype must be BFloat16 or Float16 or torch.float16 or torch.bfloat16",
+                stacklevel=2,
+            )
+            can_implement = False
+
+        if out_dtype not in {
+            cutlass.BFloat16,
+            cutlass.Float16,
+            torch.float16,
+            torch.bfloat16,
+        }:
+            warnings.warn(
+                "out_dtype must be BFloat16 or Float16 or torch.float16 or torch.bfloat16",
+                stacklevel=2,
+            )
+            can_implement = False
+
+        if g_beta_dtype not in {cutlass.Float32, torch.float32}:
+            warnings.warn(
+                "g_beta_dtype must be Float32 or torch.float32, but got {}".format(
+                    g_beta_dtype
+                ),
+                stacklevel=2,
+            )
+            can_implement = False
+
+        return can_implement
+
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        o_intra_tiled_mma: cute.TiledMma,
+        o_intra_tiled_ts_mma_new: cute.TiledMma,
+        qs_tiled_mma: cute.TiledMma,
+        update_s_tiled_mma: cute.TiledMma,
+        kkt_tiled_mma: cute.TiledMma,
+        kst_tiled_mma: cute.TiledMma,
+        fake_state_tiled_mma: cute.TiledMma,
+        invert_sub_tiled_mma_ss_l0: cute.TiledMma,
+        invert_sub_tiled_mma_ts_l0: cute.TiledMma,
+        invert_sub_tiled_mma_ss_l1: cute.TiledMma,
+        invert_sub_tiled_mma_ts_l1: cute.TiledMma,
+        tuw_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        tma_atom_state_f32: Optional[cute.CopyAtom],
+        mState_f32: Optional[cute.Tensor],
+        gate: cute.Tensor,
+        beta: cute.Tensor,
+        O: cute.Tensor,
+        tma_atom_state_output: Optional[cute.CopyAtom],
+        mStateOutput: Optional[cute.Tensor],
+        tma_atom_o_output: cute.CopyAtom,
+        mO_qdl: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        qk_smem_layout_staged: cute.ComposedLayout,
+        o_intra_smem_layout_staged_a: cute.ComposedLayout,
+        o_intra_smem_layout_staged_b: cute.ComposedLayout,
+        o_intra_smem_layout_staged_a_new: cute.ComposedLayout,
+        qs_smem_layout_staged_a: cute.ComposedLayout,
+        qs_smem_layout_staged_b: cute.ComposedLayout,
+        update_s_smem_layout_staged_a: cute.ComposedLayout,
+        update_s_smem_layout_staged_b: cute.ComposedLayout,
+        state_smem_layout_staged: cute.ComposedLayout,
+        state_smem_layout_f32_staged: cute.ComposedLayout,
+        state_output_smem_layout_staged: cute.ComposedLayout,
+        o_output_smem_layout_staged: cute.ComposedLayout,
+        gate_smem_layout_staged: cute.Layout,
+        beta_smem_layout_staged: cute.Layout,
+        ivt_smem_layout: cute.Layout,
+        sub_inner_smem_layout_staged: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l0_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l0_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l0_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l0_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l1_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ss_l1_b: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l1_a: cute.ComposedLayout,
+        invert_sub_smem_layout_staged_ts_l1_b: cute.ComposedLayout,
+        tuw_smem_layout_staged_a: cute.ComposedLayout,
+        tuw_smem_layout_staged_b: cute.ComposedLayout,
+        v_smem_layout_staged_b: cute.ComposedLayout,
+        scale: cutlass.Float32,
+        tile_sched_params: GdnStaticTileSchedulerParams,
+    ):
+        """Warp-specialized GDN kernel entry point."""
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        # Prefetch TMA descriptors
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o_output)
+            if cutlass.const_expr(tma_atom_state_f32 is not None):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_state_f32)
+            if cutlass.const_expr(tma_atom_state_output is not None):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_state_output)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_qk_producer, load_qk_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.qk_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_kv_bytes,
+            barrier_storage=storage.load_qk_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        load_v_producer, load_v_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.one_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                len(self.cudacore_warp_ids),
+            ),
+            tx_count=self.tma_copy_v_bytes,
+            barrier_storage=storage.load_v_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        load_state_producer, load_state_consumer = pipeline.PipelineTmaAsync.create(
+            num_stages=self.one_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len(self.cudacore_warp_ids)),
+            tx_count=self.tma_copy_state_f32_bytes,
+            barrier_storage=storage.load_state_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        mma_qk_producer0, mma_qk_consumer0 = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_qk_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.mma_qk_mbar_ptr0.data_ptr(),
+        ).make_participants()
+
+        mma_cudacore_producer0, mma_cudacore_consumer0 = (
+            pipeline.PipelineUmmaAsync.create(
+                num_stages=self.mma_cudacore_stage,
+                producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+                consumer_group=make_thread_cooperative_group(
+                    self.threads_per_warp * len(self.cudacore_warp_ids)
+                ),
+                barrier_storage=storage.mma_cudacore_mbar_ptr0.data_ptr(),
+            ).make_participants()
+        )
+
+        gb_w0_producer, gb_w0_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.gate_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.gb_w0_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        epi_w0_producer, epi_w0_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(self.threads_per_warp),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            barrier_storage=storage.epi_w0_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        w0_epi_producer, w0_epi_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.cudacore_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(self.threads_per_warp),
+            barrier_storage=storage.w0_epi_mbar_ptr.data_ptr(),
+        ).make_participants()
+
+        tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
+
+        #  tmem barrier init
+        if warp_idx == self.gb_warp_id:
+            cute.arch.mbarrier_init(
+                tmem_dealloc_mbar_ptr,
+                self.threads_per_warp * len((*self.cudacore_warp_ids,)),
+            )
+        cute.arch.mbarrier_init_fence()
+
+        sQK = storage.sQK.get_tensor(
+            qk_smem_layout_staged.outer, swizzle=qk_smem_layout_staged.inner
+        )
+        sQ = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 1].iterator,
+                swizzle_=q_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            q_smem_layout_staged.outer,
+        )
+        sK = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 0].iterator,
+                swizzle_=k_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            k_smem_layout_staged.outer,
+        )
+        sStateInput = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=state_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            state_smem_layout_staged.outer,
+        )
+        sV = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sV.data_ptr(),
+                swizzle_=v_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            v_smem_layout_staged_b.outer,
+        )
+
+        sGate = storage.sGate.get_tensor(gate_smem_layout_staged)
+        sBeta = storage.sBeta.get_tensor(beta_smem_layout_staged)
+        sGateCumsum = storage.sGateCumsum.get_tensor(
+            cute.select(gate_smem_layout_staged, mode=[0, 1])
+        )
+        sSubInner = storage.sSubInner.get_tensor(sub_inner_smem_layout_staged)
+        sInvertSubSSL0A = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 6].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l0_a.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l0_a.outer,
+        )
+
+        sInvertSubSSL0B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 7].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l0_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l0_b.outer,
+        )
+        sInvertSubTSL0B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 8].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ts_l0_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ts_l0_b.outer,
+        )
+        sInvertSubSSL1A = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l1_a.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l1_a.outer,
+        )
+        sInvertSubSSL1B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 2].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ss_l1_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ss_l1_b.outer,
+        )
+        sInvertSubTSL1B = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 6].iterator,
+                swizzle_=invert_sub_smem_layout_staged_ts_l1_b.inner,
+                dtype=self.invert_type_ab,
+            ),
+            invert_sub_smem_layout_staged_ts_l1_b.outer,
+        )
+
+        sInvertSubReg = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator, dtype=self.invert_type_ab
+            ),
+            cute.make_layout(((4, 128), 8)),
+        )
+
+        sStateInputF32 = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=state_smem_layout_f32_staged.inner,
+                dtype=self.state_dtype,
+            ),
+            state_smem_layout_f32_staged.outer,
+        )
+        sStateOutput = cute.make_tensor(
+            cute.recast_ptr(
+                sQK[None, None, None, 0].iterator,
+                swizzle_=state_output_smem_layout_staged.inner,
+                dtype=self.state_dtype,
+            ),
+            state_output_smem_layout_staged.outer,
+        )
+
+        sOIntraB = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator,
+                swizzle_=o_intra_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            o_intra_smem_layout_staged_b.outer,
+        )
+        sQSB = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=qs_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            qs_smem_layout_staged_b.outer,
+        )
+
+        sUpdateA = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 4].iterator,
+                swizzle_=update_s_smem_layout_staged_a.inner,
+                dtype=self.i_dtype,
+            ),
+            update_s_smem_layout_staged_a.outer,
+        )
+        sUpdateB = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=update_s_smem_layout_staged_b.inner,
+                dtype=self.i_dtype,
+            ),
+            update_s_smem_layout_staged_b.outer,
+        )
+
+        sO = cute.make_tensor(
+            cute.recast_ptr(
+                storage.sState.data_ptr(),
+                swizzle_=o_output_smem_layout_staged.inner,
+                dtype=self.i_dtype,
+            ),
+            o_output_smem_layout_staged.outer,
+        )
+        sIvt = storage.sIvt.get_tensor(ivt_smem_layout)
+
+        sTuwA = cute.make_tensor(
+            cute.recast_ptr(
+                sSubInner[None, None, None, 0].iterator,
+                swizzle_=tuw_smem_layout_staged_a.inner,
+                dtype=self.i_dtype,
+            ),
+            tuw_smem_layout_staged_a.outer,
+        )
+        sTuwB = cute.make_tensor(
+            cute.recast_ptr(storage.sV.data_ptr(), dtype=self.k_dtype),
+            tuw_smem_layout_staged_b,
+        )
+        sTuwAStore_layout = cute.make_layout(
+            ((128, (4, 2)), 8), stride=((4, (1, 512)), 1024)
+        )
+        sTuwAStore = cute.make_tensor(
+            cute.recast_ptr(sTuwA.iterator, dtype=cutlass.Float32), sTuwAStore_layout
+        )
+
+        if warp_idx == self.epilogue_warp_id:
+            # Alloc tmem buffer
+            tmem_alloc_cols = cutlass.Int32(self.tmem_alloc_cols)
+            cute.arch.alloc_tmem(tmem_alloc_cols, storage.tmem_holding_buf)
+
+        # Ensure visibility of local mbarrier inits and tmem alloc
+        cute.arch.sync_threads()
+
+        tmem_ptr = cute.arch.retrieve_tmem_ptr(
+            self.acc_dtype,
+            alignment=16,
+            ptr_to_buffer_holding_addr=storage.tmem_holding_buf,
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(0)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQK)
+        tSrK = qk_thr_mma.make_fragment_B(sQK)
+        qk_acc_shape = qk_thr_mma.partition_shape_C(
+            (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+        )
+        tQKtQK_fake = qk_thr_mma.make_fragment_C(qk_acc_shape)
+        tQKtQK = cute.make_tensor(tmem_ptr + self.tmem_qkt_output, tQKtQK_fake.layout)
+
+        kkt_thr_mma = kkt_tiled_mma.get_slice(0)  # default 1sm
+        tArK = kkt_thr_mma.make_fragment_A(sQK)
+        tArKT = kkt_thr_mma.make_fragment_B(sQK)
+        kkt_acc_shape = kkt_thr_mma.partition_shape_C(
+            (self.kkt_mma_tiler[0], self.kkt_mma_tiler[1])
+        )
+
+        fake_state_thr_mma = fake_state_tiled_mma.get_slice(0)
+
+        kst_thr_mma = kst_tiled_mma.get_slice(0)
+        tKSrK_0 = kst_thr_mma.make_fragment_A(sQK)
+        tKSrST = kst_thr_mma.make_fragment_B(sStateInput)
+        kst_acc_shape = kst_thr_mma.partition_shape_C(
+            (self.kst_mma_tiler[0], self.kst_mma_tiler[1])
+        )
+        tKStKS_fake = kst_thr_mma.make_fragment_C(kst_acc_shape)
+        tKStKS = cute.make_tensor(tmem_ptr + self.tmem_kst_output, tKStKS_fake.layout)
+        # input smem A
+        tKStK_layout = cute.composition(tKStKS.layout, cute.make_layout((128, 64)))
+        tKtK = cute.make_tensor(tmem_ptr + self.tmem_k_input, tKStK_layout)
+
+        invert_sub_thr_mma_ss_l0 = invert_sub_tiled_mma_ss_l0.get_slice(0)
+        tSrD = invert_sub_thr_mma_ss_l0.make_fragment_A(sInvertSubSSL0A)
+        tSrC = invert_sub_thr_mma_ss_l0.make_fragment_B(sInvertSubSSL0B)
+        invert_sub_acc_shape = invert_sub_thr_mma_ss_l0.partition_shape_C(
+            (self.invert_mma_sub_l0_tiler[0], self.invert_mma_sub_l0_tiler[1])
+        )
+
+        tKKTtKKT_fake = kkt_thr_mma.make_fragment_C(kkt_acc_shape)
+        tKKTtKKT = cute.make_tensor(
+            tmem_ptr + self.tmem_kkt_output, tKKTtKKT_fake.layout
+        )
+
+        tItSSL0_fake = invert_sub_thr_mma_ss_l0.make_fragment_C(invert_sub_acc_shape)
+        tItSSL0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ss_l0_output, tItSSL0_fake.layout
+        )
+
+        # : ((128,128),1,1):((65536,1),0,0)
+        tQgate_layout = cute.make_layout(((128, 64), 1, 1), stride=((65536, 1), 0, 0))
+        tQgate = cute.make_tensor(tmem_ptr + self.tmem_gate_q, tQgate_layout)
+
+        tGamma_layout = cute.make_layout(((128, 128), 1, 1), stride=((65536, 1), 0, 0))
+        tGamma = cute.make_tensor(tmem_ptr + self.tmem_gamma, tGamma_layout)
+
+        # tStage
+        tStateF32_layout = cute.make_layout(
+            ((128, 128), 1, 1), stride=((65536, 1), 0, 0)
+        )
+        tStateF32 = cute.make_tensor(tmem_ptr + self.tmem_state, tStateF32_layout)
+
+        invert_sub_thr_mma_ts_l0 = invert_sub_tiled_mma_ts_l0.get_slice(0)
+        tInrDCL0A_fake = invert_sub_thr_mma_ts_l0.make_fragment_A(
+            invert_sub_smem_layout_staged_ts_l0_a.outer.shape
+        )
+        tInrDCL0A = cute.make_tensor(
+            cute.recast_ptr(
+                tmem_ptr,
+                dtype=tInrDCL0A_fake.element_type,
+            )
+            + self.tmem_ivt_ts_l0_input,
+            tInrDCL0A_fake.layout,
+        )
+
+        # input smem B
+        tSrDCL0B = invert_sub_thr_mma_ts_l0.make_fragment_B(sInvertSubTSL0B)
+
+        # output tmem C
+        tItTSL0_fake = invert_sub_thr_mma_ts_l0.make_fragment_C(invert_sub_acc_shape)
+        tItTSL0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ts_l0_output, tItTSL0_fake.layout
+        )
+
+        invert_sub_thr_mma_ss_l1 = invert_sub_tiled_mma_ss_l1.get_slice(0)
+        tSrD_ivt_l1 = invert_sub_thr_mma_ss_l1.make_fragment_A(sInvertSubSSL1A)
+        tSrC_ivt_l1 = invert_sub_thr_mma_ss_l1.make_fragment_B(sInvertSubSSL1B)
+        invert_sub_acc_l1_shape = invert_sub_thr_mma_ss_l1.partition_shape_C(
+            (self.invert_mma_sub_l1_tiler[0], self.invert_mma_sub_l1_tiler[1])
+        )
+        tCtAcc_ivt_l1_ss_fake = invert_sub_thr_mma_ss_l1.make_fragment_C(
+            invert_sub_acc_l1_shape
+        )
+        tStO_ivt_l1_ss0 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ss_l1_output, tCtAcc_ivt_l1_ss_fake.layout
+        )
+
+        invert_sub_thr_mma_ts_l1 = invert_sub_tiled_mma_ts_l1.get_slice(0)
+        invert_acc_ts_l1_shape = invert_sub_thr_mma_ts_l1.partition_shape_C(
+            (self.invert_mma_sub_l1_tiler[0], self.invert_mma_sub_l1_tiler[1])
+        )
+        # output tmem C
+        tOtTSL1_fake = invert_sub_thr_mma_ts_l1.make_fragment_C(invert_acc_ts_l1_shape)
+        tOtTSL1 = cute.make_tensor(
+            tmem_ptr + self.tmem_ivt_ts_l1_output, tOtTSL1_fake.layout
+        )
+
+        tuw_thr_mma = tuw_tiled_mma.get_slice(0)
+        # input smem A
+        tTUWrA = tuw_thr_mma.make_fragment_A(sTuwA)
+        # input smem B
+        tTUWrB = tuw_thr_mma.make_fragment_B(sTuwB)
+        # output tmem C
+        tuw_acc_shape = tuw_thr_mma.partition_shape_C(
+            (self.tuw_mma_tiler[0], self.tuw_mma_tiler[1])
+        )
+        tVtTUW_fake = tuw_thr_mma.make_fragment_C(tuw_acc_shape)
+        tVtTUW = cute.make_tensor(tmem_ptr + self.tmem_tuw_output, tVtTUW_fake.layout)
+
+        o_intra_thr_mma = o_intra_tiled_mma.get_slice(0)
+        # input smem B
+        tOIntrarB = o_intra_thr_mma.make_fragment_B(sOIntraB)
+        # output tmem C
+        o_intra_acc_shape = o_intra_thr_mma.partition_shape_C(
+            (self.o_intra_mma_tiler[0], self.o_intra_mma_tiler[1])
+        )
+
+        o_intra_thr_mma_new = o_intra_tiled_ts_mma_new.get_slice(0)
+        # input smem A
+        tQKMtQKM_layout = cute.composition(tQKtQK.layout, cute.make_layout((128, 64)))
+        tQKMtQKM = cute.make_tensor(tmem_ptr + self.tmem_gate_qk, tQKMtQKM_layout)
+
+        update_s_thr_mma = update_s_tiled_mma.get_slice(0)
+        tUpdateA = update_s_thr_mma.make_fragment_A(sUpdateA)
+        tUpdateB = update_s_thr_mma.make_fragment_B(sUpdateB)
+        update_s_acc_shape = update_s_thr_mma.partition_shape_C(
+            (self.update_s_mma_tiler[0], self.update_s_mma_tiler[1])
+        )
+        tStUpdate_fake = update_s_thr_mma.make_fragment_C(update_s_acc_shape)
+        tStUpdate = cute.make_tensor(
+            tmem_ptr + self.tmem_update_s_output, tStUpdate_fake.layout
+        )
+
+        qs_thr_mma = qs_tiled_mma.get_slice(0)
+        tQSB = qs_thr_mma.make_fragment_B(sQSB)
+        qs_acc_shape = qs_thr_mma.partition_shape_C(
+            (self.qs_mma_tiler[0], self.qs_mma_tiler[1])
+        )
+        tOintertQS_fake = qs_thr_mma.make_fragment_C(qs_acc_shape)
+        tOintertQS = cute.make_tensor(
+            tmem_ptr + self.tmem_o_inter_output, tOintertQS_fake.layout
+        )
+
+        loop_count = cute.ceil_div(mO_qdl.shape[0], self.cta_tiler[0])
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Load Gate Beta
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.gb_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_gb)
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            lane_id = tidx % 32
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                head_coord = curr_block_coord[2][0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    batch_base = cuseqlen_q
+                    gate_vals = cute.make_rmem_tensor((4), cutlass.Float32)
+                    beta_vals = cute.make_rmem_tensor((4), cutlass.Float32)
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        # step1: read gate beta
+                        for it in cutlass.range_constexpr(4):
+                            curr_idx = i * 128 + it * 32 + lane_id
+                            if curr_idx < seqlen_q:
+                                if cutlass.const_expr(cum_seqlen_q is not None):
+                                    gate_vals[it] = gate[
+                                        batch_base + curr_idx, 0, (head_coord, 0)
+                                    ]
+                                    beta_vals[it] = beta[
+                                        batch_base + curr_idx, 0, (head_coord, 0)
+                                    ]
+                                else:
+                                    gate_vals[it] = gate[
+                                        curr_idx, 0, (head_coord, batch_coord)
+                                    ]
+                                    beta_vals[it] = beta[
+                                        curr_idx, 0, (head_coord, batch_coord)
+                                    ]
+                            else:
+                                gate_vals[it] = cutlass.Float32(0)
+                                beta_vals[it] = cutlass.Float32(0)
+                        # step2: write to smem
+                        sGate0 = sGate[None, None, 0]  # assume only one stage
+                        sBeta0 = sBeta[None, None, 0]
+
+                        gb_handle = gb_w0_producer.acquire_and_advance()
+
+                        for it in cutlass.range_constexpr(4):
+                            sGate0[it * 32 + lane_id] = gate_vals[it]
+                            sBeta0[it * 32 + lane_id] = beta_vals[it]
+
+                        # step3: notify cuda core wg
+                        gb_handle.commit()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue: Store Output
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.epilogue_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    curr_block_coord_o = curr_block_coord
+                    mO_qdl_ = mO_qdl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        logical_offset_mO = (
+                            mO_qdl_.shape[0] - seqlen_q,
+                            0,
+                            (0, cuseqlen_q + seqlen_q),
+                        )
+                        mO_qdl_ = cute.domain_offset(logical_offset_mO, mO_qdl_)
+                        curr_block_coord_o = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], 0),
+                        )
+
+                    gO_mnl = cute.flat_divide(
+                        mO_qdl_, cute.select(self.mma_tiler, mode=[0, 1])
+                    )
+                    tOsO, tOgO_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_o_output,
+                        0,
+                        cute.make_layout(1),
+                        cute.group_modes(sO, 0, 2),
+                        cute.group_modes(gO_mnl, 0, 2),
+                    )
+                    tQgO = tOgO_qdl[None, None, 0, curr_block_coord_o[2]]
+                    w0_handle = epi_w0_producer.acquire_and_advance()
+                    w0_handle.commit()
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        w0_handle = epi_w0_producer.acquire_and_advance()
+                        cute.copy(tma_atom_o_output, tOsO[None, 0], tQgO[None, i])
+
+                        cute.arch.cp_async_bulk_commit_group()
+
+                        # Ensure O0 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+                        w0_handle.commit()
+
+                    if cutlass.const_expr(tma_atom_state_output is not None):
+                        gStateOutput = cute.flat_divide(
+                            mStateOutput,
+                            cute.select(self.update_s_mma_tiler, mode=[0, 1]),
+                        )
+                        tSsS, tSgS_vkl = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_state_output,
+                            0,  # no multicast
+                            cute.make_layout(1),
+                            cute.group_modes(sStateOutput, 0, 2),
+                            cute.group_modes(gStateOutput, 0, 4),
+                        )
+                        tSgS = tSgS_vkl[None, curr_block_coord[2]]
+                        w0_epi_handle = w0_epi_consumer.wait_and_advance()
+                        cute.copy(
+                            tma_atom_state_output,
+                            tSsS[None, 0],  # only 1 stage
+                            tSgS[None],
+                        )
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                        w0_epi_handle.release()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                # The smem is reused, ensuring the State Output store is complete
+                if cutlass.const_expr(
+                    tma_atom_state_output is not None and self.is_persistent
+                ):
+                    cute.arch.barrier_arrive(
+                        barrier_id=self.epi_load_sync_bar_id,
+                        number_of_threads=self.threads_per_warp * 2,
+                    )
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD: tma load QKVS
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_other)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+                batch_coord = curr_block_coord[2][1]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not GdnStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+
+                if not continue_cond:
+                    mQ_qdl_ = mQ_qdl
+                    mK_kdl_ = mK_kdl
+                    mV_dkl_ = mV_dkl
+                    curr_block_coord_q = curr_block_coord
+                    curr_block_coord_kv = curr_block_coord
+                    curr_block_coord_state = curr_block_coord
+
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        logical_offset_mQ = (
+                            cuseqlen_q,
+                            0,
+                            (0, 0),
+                        )
+                        mQ_qdl_ = cute.domain_offset(logical_offset_mQ, mQ_qdl)
+                        curr_block_coord_q = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], Int32(0)),
+                        )
+                        logical_offset_mK = (
+                            cuseqlen_q,
+                            0,
+                            (0, 0),
+                        )
+                        logical_offset_mV = (
+                            0,
+                            cuseqlen_q,
+                            (0, 0),
+                        )
+                        mK_kdl_ = cute.domain_offset(logical_offset_mK, mK_kdl)
+                        mV_dkl_ = cute.domain_offset(logical_offset_mV, mV_dkl)
+                        curr_block_coord_kv = (
+                            curr_block_coord[0],
+                            curr_block_coord[1],
+                            (curr_block_coord[2][0], Int32(0)),
+                        )
+
+                    gQ_qdl = cute.flat_divide(
+                        mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2])
+                    )
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQK, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord_q[2]]
+
+                    gK_kdl = cute.flat_divide(
+                        mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2])
+                    )
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord_kv[2]]
+
+                    gV_kdl = cute.flat_divide(
+                        mV_dkl_, cute.select(self.tuw_mma_tiler, mode=[1, 2])
+                    )
+                    tSgV_kdl = tuw_thr_mma.partition_B(gV_kdl)
+                    tVsV, tVgV_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_kdl, 0, 3),
+                    )
+                    tVgV = tVgV_kdl[None, 0, None, curr_block_coord_kv[2]]
+
+                    if cutlass.const_expr(tma_atom_state_f32 is not None):
+                        gStateF32 = cute.flat_divide(
+                            mState_f32, cute.select(self.kst_mma_tiler, mode=[1, 2])
+                        )
+                        tKSgStateF32 = fake_state_thr_mma.partition_B(gStateF32)
+                        tSsSF32, tSgSF32_kdl = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_state_f32,
+                            0,  # no multicast
+                            cute.make_layout(1),
+                            cute.group_modes(sStateInputF32, 0, 3),
+                            cute.group_modes(tKSgStateF32, 0, 3),
+                        )
+                        tSgSF32 = tSgSF32_kdl[None, None, 0, curr_block_coord_state[2]]
+                        state_f32_handle0 = load_state_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_state_f32,
+                            tSgSF32[None, 0],
+                            tSsSF32[None, state_f32_handle0.index],
+                            tma_bar_ptr=state_f32_handle0.barrier,
+                        )
+
+                    for i in cutlass.range(loop_count, unroll=1):
+                        w0_coord = i
+                        k0_handle = load_qk_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, w0_coord],
+                            tKsK[None, k0_handle.index],
+                            tma_bar_ptr=k0_handle.barrier,
+                        )
+
+                        q_handle = load_qk_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_q,
+                            tQgQ[None, w0_coord],
+                            tQsQ[None, q_handle.index],
+                            tma_bar_ptr=q_handle.barrier,
+                        )
+
+                        v_handle0 = load_v_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, w0_coord],
+                            tVsV[None, v_handle0.index],
+                            tma_bar_ptr=v_handle0.barrier,
+                        )
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                if cutlass.const_expr(
+                    tma_atom_state_output is not None and self.is_persistent
+                ):
+                    cute.arch.barrier(
+                        barrier_id=self.epi_load_sync_bar_id,
+                        number_of_threads=self.threads_per_warp * 2,
+                    )
+            # dealloc tmem buffer
+            cute.arch.relinquish_tmem_alloc_permit()
+            cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
+            tmem_alloc_cols = Int32(self.tmem_alloc_cols)
+            #  Retrieving tmem ptr and make acc
+            tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                cutlass.Float32,
+                alignment=16,
+                ptr_to_buffer_holding_addr=storage.tmem_holding_buf,
+            )
+            cute.arch.dealloc_tmem(tmem_ptr, tmem_alloc_cols)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA: mma warp
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_mma)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            tSrDC_ivt_l1_fake = invert_sub_thr_mma_ts_l1.make_fragment_A(
+                invert_sub_smem_layout_staged_ts_l1_a.outer.shape
+            )
+            tSrDC_ivt_l1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tSrDC_ivt_l1_fake.element_type,
+                )
+                + self.tmem_ivt_ts_l1_input,
+                tSrDC_ivt_l1_fake.layout,
+            )
+            tSrA_ivt_l1 = invert_sub_thr_mma_ts_l1.make_fragment_B(sInvertSubTSL1B)
+
+            tOrP = o_intra_thr_mma_new.make_fragment_A(
+                o_intra_smem_layout_staged_a_new.outer
+            )
+            tOrP0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tOrP.element_type,
+                )
+                + self.tmem_gate_qk * 2,
+                tOrP.layout,
+            )
+
+            tQSA = o_intra_thr_mma_new.make_fragment_A(qs_smem_layout_staged_a.outer)
+            tQSA0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr,
+                    dtype=tQSA.element_type,
+                )
+                + self.tmem_gate_q * 2,
+                tQSA.layout,
+            )
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                continue_cond = False
+
+                if not continue_cond:
+                    for _i in cutlass.range(loop_count, unroll=1):
+                        k_handle0 = load_qk_consumer.wait_and_advance()
+                        qk_handle0 = mma_qk_producer0.acquire_and_advance()
+
+                        kkt_tiled_mma = self.exec_mma(
+                            kkt_tiled_mma,
+                            tKKTtKKT,
+                            tArK,
+                            tArKT,
+                            k_handle0.index,
+                            k_handle0.index,
+                        )
+
+                        qk_handle0.commit()
+
+                        q_handle = load_qk_consumer.wait_and_advance()
+
+                        qk_handle1 = mma_qk_producer0.acquire_and_advance()
+
+                        qk_tiled_mma = self.exec_mma(
+                            qk_tiled_mma,
+                            tQKtQK,
+                            tSrQ,
+                            tSrK,
+                            q_handle.index,
+                            k_handle0.index,
+                        )
+
+                        qk_handle1.commit()
+
+                        cs_handle = mma_cudacore_producer0.acquire_and_advance()
+                        cute.arch.barrier(
+                            barrier_id=self.cudacore_mma_sync_bar_id,
+                            number_of_threads=self.threads_per_warp * 5,
+                        )
+
+                        kst_tiled_mma = self.exec_mma(
+                            kst_tiled_mma,
+                            tKStKS,
+                            tKSrK_0,
+                            tKSrST,
+                            0,
+                            0,
+                        )
+
+                        cs_handle.commit()
+
+                        cs_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ss_l0 = self.exec_mma(
+                            invert_sub_tiled_mma_ss_l0,
+                            tItSSL0,
+                            tSrD,
+                            tSrC,
+                            0,
+                            0,
+                        )
+
+                        cs_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ts_l0 = self.exec_mma(
+                            invert_sub_tiled_mma_ts_l0,
+                            tItTSL0,
+                            tInrDCL0A,
+                            tSrDCL0B,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        invert_sub_tiled_mma_ss_l1 = self.exec_mma(
+                            invert_sub_tiled_mma_ss_l1,
+                            tStO_ivt_l1_ss0,
+                            tSrD_ivt_l1,
+                            tSrC_ivt_l1,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        k_handle0.release()
+
+                        invert_sub_tiled_mma_ts_l1 = self.exec_mma(
+                            invert_sub_tiled_mma_ts_l1,
+                            tOtTSL1,
+                            tSrDC_ivt_l1,
+                            tSrA_ivt_l1,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        tuw_tiled_mma = self.exec_mma(
+                            tuw_tiled_mma,
+                            tVtTUW,
+                            tTUWrA,
+                            tTUWrB,
+                            0,
+                            0,
+                        )
+
+                        c0_handle.commit()
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        q_handle.release()
+
+                        tCtAcc_o_intra_acc_shape_fake = o_intra_thr_mma.make_fragment_C(
+                            o_intra_acc_shape
+                        )
+                        tStO_o_intra0 = cute.make_tensor(
+                            tmem_ptr + self.tmem_o_intra_output,
+                            tCtAcc_o_intra_acc_shape_fake.layout,
+                        )
+
+                        o_intra_tiled_ts_mma_new = self.exec_mma(
+                            o_intra_tiled_ts_mma_new,
+                            tStO_o_intra0,
+                            tOrP0,
+                            tOIntrarB,
+                            0,
+                            0,
+                        )
+
+                        qs_tiled_mma = self.exec_mma(
+                            qs_tiled_mma,
+                            tOintertQS,
+                            tQSA0,
+                            tQSB,
+                            0,
+                            0,
+                            True,
+                        )
+
+                        c0_handle.commit()
+                        c0_handle = mma_cudacore_producer0.acquire_and_advance()
+
+                        update_s_tiled_mma = self.exec_mma(
+                            update_s_tiled_mma,
+                            tStUpdate,
+                            tUpdateA,
+                            tUpdateB,
+                            0,
+                            0,
+                            True,
+                        )
+
+                        c0_handle.commit()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Mainloop: mainloop warp group
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < 4:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_cudacore)
+
+            tile_sched = create_gdn_static_tile_scheduler(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                if not continue_cond:
+                    gO_mnl = cute.flat_divide(
+                        O, cute.select(self.mma_tiler, mode=[0, 1])
+                    )
+                    # Use input state
+                    if cutlass.const_expr(tma_atom_state_f32 is not None):
+                        load_state_consumer.wait_and_advance()
+                        self.init_state_from_smem(
+                            kst_thr_mma,
+                            tStateF32,
+                            sStateInputF32,
+                        )
+                        load_state_consumer.release()
+                    else:
+                        self.init_state_zeros(
+                            kst_thr_mma,
+                            tStateF32,
+                        )
+
+                    # Arguments
+                    atom_args = (
+                        kkt_thr_mma,
+                        kst_thr_mma,
+                        qk_thr_mma,
+                        qs_thr_mma,
+                    )
+                    tensor_args = (
+                        sGate,
+                        sBeta,
+                        sGateCumsum,
+                        sStateInput,
+                        sIvt,
+                        sQ,
+                        sK,
+                        sV,
+                        sO,
+                        sInvertSubReg,
+                        sInvertSubSSL0A,
+                        sInvertSubSSL0B,
+                        sInvertSubSSL1B,
+                        sInvertSubTSL0B,
+                        sInvertSubSSL1A,
+                        sInvertSubTSL1B,
+                        sTuwAStore,
+                        sTuwA,
+                        sOIntraB,
+                        sUpdateB,
+                        tGamma,
+                        tKKTtKKT,
+                        tQKtQK,
+                        tQKMtQKM,
+                        tKtK,
+                        tKStKS,
+                        tItTSL0,
+                        tInrDCL0A,
+                        tOtTSL1,
+                        tVtTUW,
+                        tOintertQS,
+                        tItSSL0,
+                        tStateF32,
+                        tQgate,
+                    )
+                    pipeline_args = (
+                        gb_w0_consumer,
+                        epi_w0_consumer,
+                        mma_qk_consumer0,
+                        mma_cudacore_consumer0,
+                        load_v_consumer,
+                    )
+
+                    # Corner case
+                    tail_count = mO_qdl.shape[0] % self.cta_tiler[0]
+
+                    if tail_count == 0:
+                        value_args = (
+                            scale,
+                            loop_count,
+                            0,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                        )
+                    else:
+                        value_args = (
+                            scale,
+                            loop_count - 1,
+                            0,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                        )
+                        pipeline_args = (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        )
+                        value_args = (
+                            scale,
+                            1,
+                            loop_count - 1,
+                        )
+                        (
+                            gb_w0_consumer,
+                            epi_w0_consumer,
+                            mma_qk_consumer0,
+                            mma_cudacore_consumer0,
+                            load_v_consumer,
+                        ) = self.main_loop(
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                            pipeline_args,
+                            True,
+                            tail_count=tail_count,
+                        )
+
+                    # Output state
+                    if cutlass.const_expr(tma_atom_state_output is not None):
+                        w0_epi_handle = w0_epi_producer.acquire_and_advance()
+                        self.store_state_to_smem(
+                            tStUpdate, sStateOutput, update_s_thr_mma
+                        )
+                        w0_epi_handle.commit()
+
+                    w0_handle = epi_w0_consumer.wait_and_advance()
+                    w0_handle.release()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
+
+    @cute.jit
+    def main_loop(
+        self,
+        value_args: tuple,
+        atom_args: tuple,
+        tensor_args: tuple,
+        pipeline_args: tuple,
+        need_mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ) -> Tuple[
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Per-chunk mainloop executed by cudacore warps (0-3)."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        (
+            scale,
+            loop_count,
+            loop_base,
+        ) = value_args
+
+        (
+            kkt_thr_mma,
+            kst_thr_mma,
+            qk_thr_mma,
+            qs_thr_mma,
+        ) = atom_args
+
+        (
+            sGate,
+            sBeta,
+            sGateCumsum,
+            sStateInput,
+            sIvt,
+            sQ,
+            sK,
+            sV,
+            sO,
+            sInvertSubReg,
+            sInvertSubSSL0A,
+            sInvertSubSSL0B,
+            sInvertSubSSL1B,
+            sInvertSubTSL0B,
+            sInvertSubSSL1A,
+            sInvertSubTSL1B,
+            sTuwAStore,
+            sTuwA,
+            sOIntraB,
+            sUpdateB,
+            tGamma,
+            tKKTtKKT,
+            tQKtQK,
+            tQKMtQKM,
+            tKtK,
+            tKStKS,
+            tItTSL0,
+            tInrDCL0A,
+            tOtTSL1,
+            tVtTUW,
+            tOintertQS,
+            tItSSL0,
+            tStateF32,
+            tQgate,
+        ) = tensor_args
+
+        (
+            gb_w0_consumer,
+            epi_w0_consumer,
+            mma_qk_consumer0,
+            mma_cudacore_consumer0,
+            load_v_consumer,
+        ) = pipeline_args
+
+        for _i in cutlass.range(loop_base, loop_base + loop_count, unroll=1):
+            gb_handle = gb_w0_consumer.wait_and_advance()
+            sGate0 = sGate[None, None, gb_handle.index]
+            sBeta0 = sBeta[None, None, gb_handle.index]
+            tval = self.chunk_local_cumsum(sGate0, sGateCumsum, self.wg_sync_bar_id)
+            beta_val = sBeta0[tidx]
+            gb_handle.release()
+
+            self.compute_gamma_tmem(
+                tval,
+                sGateCumsum,
+                kkt_thr_mma,
+                tGamma,
+                self.wg_sync_bar_id,
+                need_mask,
+                tail_count,
+            )
+            qk_handle0 = mma_qk_consumer0.wait_and_advance()
+
+            self.apply_gamma_beta(
+                kkt_thr_mma,
+                sIvt,
+                tKKTtKKT,
+                beta_val,
+                tGamma,
+            )
+
+            gate_tail = (
+                sGateCumsum[tail_count - 1]
+                if cutlass.const_expr(need_mask)
+                else sGateCumsum[127]
+            )
+            w0_handle = epi_w0_consumer.wait_and_advance()
+            self.load_state_apply_gate(
+                kst_thr_mma,
+                tStateF32,
+                sStateInput,
+                gate_tail,
+            )
+            cute.arch.fence_view_async_shared()
+
+            qk_handle1 = mma_qk_consumer0.wait_and_advance()
+            self.load_qk_epi(
+                qk_thr_mma, tQKtQK, tQKMtQKM, tGamma, need_mask, tail_count
+            )
+
+            cute.arch.barrier_arrive(
+                barrier_id=self.cudacore_mma_sync_bar_id,
+                number_of_threads=self.threads_per_warp * 5,
+            )
+
+            reverse_result = cute.make_rmem_tensor((32, 1), self.acc_dtype)
+
+            self.reverse_smem_sub(reverse_result, sIvt)
+
+            self.store_ivt_smem_l0_ss_a(
+                reverse_result,
+                sInvertSubReg,
+                sInvertSubSSL0A,
+            )
+
+            self.store_ivt_smem_l0_ss_b(
+                kkt_thr_mma,
+                tKKTtKKT,
+                sInvertSubSSL0B,
+            )
+
+            self.store_ivt_p1(
+                sInvertSubReg,
+                sInvertSubTSL0B,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+            v_handle0 = load_v_consumer.wait_and_advance()
+
+            tval_exp = cute.math.exp(tval, fastmath=True)
+            self.get_uw_b(
+                kst_thr_mma, tKStKS, tval_exp, beta_val, sV, need_mask, tail_count
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            self.load_ivt_ss_l0(tItSSL0, tInrDCL0A)
+            c0_handle.release()
+            self.store_ivt_smem_l1_ss_b(
+                kkt_thr_mma,
+                tKKTtKKT,
+                sInvertSubSSL1B,
+            )
+
+            self.store_ivt_p2(
+                sInvertSubReg,
+                sInvertSubSSL1A,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+
+            self.load_ivt_ts_l0(
+                tItTSL0,
+                sInvertSubSSL1A,
+                sInvertSubTSL1B,
+            )
+
+            c0_handle.release()
+
+            self.store_k_epi(kkt_thr_mma, sK, tKtK, need_mask, tail_count)
+            self.store_ivt_p3(
+                sInvertSubReg,
+                sInvertSubTSL1B,
+            )
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+            self.save_tmem(tItTSL0, sTuwAStore)
+            self.store_ivt_ad(sInvertSubReg, sTuwA)
+            self.store_ivt_c(sTuwAStore)
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            self.load_ivt_result(tOtTSL1, sTuwAStore)
+            c0_handle.release()
+
+            self.load_q_epi(qk_thr_mma, sQ, tQgate, tval_exp, need_mask, tail_count)
+
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            v_handle0.release()
+            self.load_v(tVtTUW, sOIntraB)
+            c0_handle.release()
+            self.load_k(tKtK, sUpdateB, gate_tail, tval)
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            qk_handle0.release()
+            c0_handle.release()
+            self.store_o_smem(tOintertQS, sO, qs_thr_mma, scale)
+
+            w0_handle.release()
+            qk_handle1.release()
+            c0_handle = mma_cudacore_consumer0.wait_and_advance()
+            c0_handle.release()
+
+        return (
+            gb_w0_consumer,
+            epi_w0_consumer,
+            mma_qk_consumer0,
+            mma_cudacore_consumer0,
+            load_v_consumer,
+        )
+
+    @cute.jit
+    def exec_mma(
+        self,
+        tiled_mma,
+        tCtAcc,
+        tCrA,
+        tCrB,
+        a_consumer_index,
+        b_consumer_index,
+        setAcc: bool = False,
+    ):
+        """Issue a tcgen05 GEMM."""
+        for kphase_idx in cutlass.range(cute.size(tCrB, mode=[2]), unroll_all=True):
+            # set accu = 1
+            tiled_mma.set(
+                tcgen05.Field.ACCUMULATE,
+                cutlass.Boolean(kphase_idx != 0 or setAcc),
+            )
+            cute.gemm(
+                tiled_mma,
+                tCtAcc,
+                tCrA[None, None, kphase_idx, a_consumer_index],
+                tCrB[None, None, kphase_idx, b_consumer_index],
+                tCtAcc,
+            )
+        return tiled_mma
+
+    @cute.jit
+    def get_uw_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        gate_val: cutlass.Float32,
+        beta_val: cutlass.Float32,
+        sV: cute.Tensor,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Compute V_new = beta*V - beta*gamma*(K@S^T) in-place in smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        frg_tile = 8
+        sV_frg = cute.logical_divide(sV, cute.make_layout(frg_tile))
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+        tTMEM_LOADrS_frag = cute.logical_divide(
+            tTMEM_LOADrS, cute.make_layout(frg_tile)
+        )
+
+        if cutlass.const_expr(mask):
+            if thread_idx >= tail_count:
+                beta_val = self.g_beta_dtype(0)
+
+        combined_factor = gate_val * beta_val
+
+        each_iter = corr_tile_size // frg_tile
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+
+            # Load V from smem
+            for it in cutlass.range_constexpr(each_iter):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    # mul2
+                    (
+                        tTMEM_LOADrS_frag[inner_idx + 0, it],
+                        tTMEM_LOADrS_frag[inner_idx + 1, it],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frag[inner_idx + 0, it],
+                            tTMEM_LOADrS_frag[inner_idx + 1, it],
+                        ),
+                        (-combined_factor, -combined_factor),
+                    )
+
+                    # fma2
+                    (
+                        tTMEM_LOADrS_frag[inner_idx + 0, it],
+                        tTMEM_LOADrS_frag[inner_idx + 1, it],
+                    ) = cute.arch.fma_packed_f32x2(
+                        (
+                            beta_val,
+                            beta_val,
+                        ),
+                        (
+                            cutlass.Float32(
+                                sV_frg[inner_idx + 0, (i * each_iter + it, thread_idx)]
+                            ),
+                            cutlass.Float32(
+                                sV_frg[inner_idx + 1, (i * each_iter + it, thread_idx)]
+                            ),
+                        ),
+                        (
+                            tTMEM_LOADrS_frag[inner_idx + 0, it],
+                            tTMEM_LOADrS_frag[inner_idx + 1, it],
+                        ),
+                    )
+                sV_frg[None, (i * each_iter + it, thread_idx)].store(
+                    tTMEM_LOADrS_frag[None, it].load().to(self.i_dtype)
+                )
+
+    @cute.jit
+    def store_state_to_smem(
+        self,
+        tO: cute.Tensor,
+        sO: cute.Tensor,
+        thr_mma: cute.ThrMma,
+    ):
+        """Copy final state from TMEM to smem for TMA store to global."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tOcO = thr_mma.partition_C(tO)
+        tOsO = thr_mma.partition_C(sO)
+
+        corr_tile_size = 32  # must >= 8
+        tOsO_sub = cute.make_tensor(
+            cute.recast_ptr(tOsO.iterator, dtype=self.state_dtype),
+            cute.shape(tOsO)[0],
+        )
+        tOsO_tile = cute.logical_divide(
+            tOsO_sub, (None, (None, 32 // (128 // corr_tile_size)))
+        )
+
+        tIn_i_layout = cute.composition(
+            tO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        sOut_i_layout = cute.composition(
+            tOsO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tO.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        smem_copy_atom = sm100_utils.get_smem_store_op(
+            self.s_output, self.state_dtype, self.acc_dtype, tiled_tmem_load
+        )
+        tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            sOut_i_sub = cute.make_tensor(
+                tOsO_tile[None, (None, (None, i))].iterator, sOut_i_layout
+            )
+            tTMEM_STOREsO_i = thr_tmem_load.partition_D(sOut_i_sub)
+            cute.copy(tiled_smem_store, tTMEM_LOADrS, tTMEM_STOREsO_i)
+
+        # fence view async shared
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def store_o_smem(
+        self,
+        tO: cute.Tensor,
+        sO: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        scale: cutlass.Float32,
+    ):
+        """Scale and convert O from TMEM (f32) to smem (f16/bf16) for TMA store."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tOcO = thr_mma.partition_C(tO)
+        tOsO = thr_mma.partition_C(sO)
+
+        corr_tile_size = 128  # must >= 8
+
+        # ((128,(8,16)),1,1,(1,1))
+        tOsO_sub = cute.make_tensor(
+            cute.recast_ptr(tOsO.iterator, dtype=self.i_dtype),
+            cute.shape(tOsO)[0],
+        )
+        tOsO_tile = cute.logical_divide(
+            tOsO_sub, (None, (None, 16 // (128 // corr_tile_size)))
+        )
+
+        tIn_i_layout = cute.composition(
+            tO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        sOut_i_layout = cute.composition(
+            tOsO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tO.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_LOADrS.iterator, dtype=self.i_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        smem_copy_atom = sm100_utils.get_smem_store_op(
+            self.o_layout, self.i_dtype, self.acc_dtype, tiled_tmem_load
+        )
+        tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+
+            frg_cnt = 4  # must 4
+            frg_tile = cute.size(tTMEM_LOADrS) // frg_cnt
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, cute.make_layout(frg_tile)
+            )
+            tTMEM_STORErS_x4_e_frg = cute.logical_divide(
+                tTMEM_STORErS_x4_e, cute.make_layout(frg_tile)
+            )
+
+            for j in cutlass.range_constexpr(frg_cnt):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    # mul2
+                    (
+                        tTMEM_LOADrS_frg[inner_idx + 0, j],
+                        tTMEM_LOADrS_frg[inner_idx + 1, j],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frg[inner_idx + 0, j],
+                            tTMEM_LOADrS_frg[inner_idx + 1, j],
+                        ),
+                        (scale, scale),
+                    )
+                tTMEM_STORErS_x4_e_frg[None, j].store(
+                    tTMEM_LOADrS_frg[None, j].load().to(self.i_dtype)
+                )
+
+            # store
+            sOut_i_sub = cute.make_tensor(
+                tOsO_tile[None, (None, (None, i))].iterator, sOut_i_layout
+            )
+            tTMEM_STOREsO_i = thr_tmem_load.partition_D(sOut_i_sub)
+            cute.copy(tiled_smem_store, tTMEM_STORErS_x4_e, tTMEM_STOREsO_i)
+
+        # fence view async shared
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def load_k(
+        self,
+        tIn: cute.Tensor,
+        sUpdateB: cute.Tensor,
+        gate: cutlass.Float32,
+        val: cutlass.Float32,
+    ):
+        """Load K from TMEM, apply per-token gate decay."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        gate_val = cute.math.exp((gate - val), fastmath=True)
+
+        k = self.read_tmem_128(tIn)
+
+        k_f16 = cute.make_tensor(
+            cute.recast_ptr(k.iterator, dtype=self.i_dtype),
+            cute.make_layout(128),
+        )
+        k_f16_frag = cute.logical_divide(k_f16, cute.make_layout(8))
+
+        for bid in cutlass.range_constexpr(0, 2):
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+
+                store_row = load_row
+                store_col = bid * 8 + col
+
+                store_row_bid = store_row // 16
+                store_row_offset = store_row % 16
+                sUpdateB[
+                    ((None, store_col), store_row_offset), 0, store_row_bid, 0
+                ].store(
+                    (k_f16_frag[None, store_col].load() * gate_val).to(self.i_dtype)
+                )
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def init_state_zeros(
+        self,
+        thr_mma: cute.ThrMma,
+        tOutF32: cute.Tensor,
+    ):
+        """Zero-initialize the recurrent state in TMEM (no initial_state provided)."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+        corr_tile_size = 128
+
+        # Apply gate State
+        cInOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tInOut_i_layout = cute.composition(
+            tOutF32.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tInOut_i = cute.make_tensor(tOutF32.iterator, tInOut_i_layout)
+        cInOut_i = cute.make_tensor(tOcO.iterator, cInOut_i_layout)
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STOREcInOut = thr_tmem_store_f32.partition_S(cInOut_i)
+        tTMEM_STORErInOut = cute.make_rmem_tensor(
+            tTMEM_STOREcInOut.shape, self.acc_dtype
+        )
+
+        frg_tile = 4
+        zeros = cute.zeros_like(cute.make_layout(frg_tile), self.acc_dtype)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            tTMEM_STORErInOut_frg = cute.logical_divide(
+                tTMEM_STORErInOut, ((frg_tile, None), None)
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            for j in cutlass.range_constexpr(each_iter):
+                tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(zeros)
+
+            # store
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def init_state_from_smem(
+        self,
+        thr_mma: cute.ThrMma,
+        tOutF32: cute.Tensor,
+        sStateInputF32: cute.Tensor,
+    ):
+        """Load initial_state from smem (f32) into TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 128
+        cInOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tInOut_i_layout = cute.composition(
+            tOutF32.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tInOut_i = cute.make_tensor(tOutF32.iterator, tInOut_i_layout)
+        cInOut_i = cute.make_tensor(tOcO.iterator, cInOut_i_layout)
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STOREcInOut = thr_tmem_store_f32.partition_S(cInOut_i)
+        tTMEM_STORErInOut = cute.make_rmem_tensor(
+            tTMEM_STOREcInOut.shape, self.acc_dtype
+        )
+
+        frg_tile = 4  # must 4
+        sStateInputF32_frag = cute.logical_divide(
+            sStateInputF32, (((None, frg_tile), None))
+        )
+        tTMEM_STORErInOut_frg = cute.logical_divide(
+            tTMEM_STORErInOut, ((frg_tile, None), None)
+        )
+        each_iter = corr_tile_size // frg_tile
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            # Load from smem
+            idx_offset = i * corr_tile_size
+            for j in cutlass.range_constexpr(each_iter):
+                idx = idx_offset + j * frg_tile
+                bid = idx // 32
+                bid_inner = idx % 32 // 8
+                inner_idx = idx % 8 // 4
+                s_vec = sStateInputF32_frag[
+                    (thread_idx, (None, inner_idx)), 0, (bid_inner, bid), 0
+                ].load()
+                tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(s_vec)
+
+            # store
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_state_apply_gate(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sStateInput: cute.Tensor,
+        gate: cutlass.Float32,
+    ):
+        """Apply chunk-level gate decay to state in TMEM, and copy state to smem (f16) for KST GEMM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        # Apply gate State
+        # cInOut_i_layout = cute.composition(tOcO.layout, cute.make_layout((128, corr_tile_size)))
+        tInOut_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        # fp16 state
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tInOut_i = cute.make_tensor(tIn.iterator, tInOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tmem_store_atom_f32 = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store_f32 = tcgen05.make_tmem_copy(tmem_store_atom_f32, tInOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store_f32 = tiled_tmem_store_f32.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STOREtInOut = thr_tmem_store_f32.partition_D(tInOut_i)
+        tTMEM_STORErInOut = cute.make_tensor(
+            cute.recast_ptr(tTMEM_LOADrS.iterator, dtype=self.acc_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        gate_val = cute.math.exp(gate, fastmath=True)
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtInOut_i = cute.make_tensor(
+                tTMEM_STOREtInOut.iterator + i * corr_tile_size,
+                tTMEM_STOREtInOut.layout,
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+
+            frg_tile = 16  # must <= 16
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+            tTMEM_STORErInOut_frg = cute.logical_divide(
+                tTMEM_STORErInOut, ((frg_tile, None), None)
+            )
+            sStateInput_frag = cute.logical_divide(
+                sStateInput, (((None, frg_tile), None))
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            idx_offset = i * corr_tile_size
+            for j in cutlass.range_constexpr(each_iter):
+                s_vec = tTMEM_LOADrS_frg[((None, j), 0), 0, 0].load()
+                s_vec_f16 = s_vec.to(self.q_dtype)
+                idx = idx_offset + j * frg_tile
+                bid = idx // 64
+                bid_inner = idx % 64 // 16
+                inner_idx = idx % 16 // frg_tile
+                sStateInput_frag[
+                    (thread_idx, (None, inner_idx)), 0, (bid_inner, bid), 0
+                ].store(s_vec_f16)
+                # tTMEM_STORErInOut_frg[((None, j), 0), 0, 0].store(s_vec * gate_val)
+
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_STORErInOut_frg[((inner_idx + 0, j), 0), 0, 0],
+                        tTMEM_STORErInOut_frg[((inner_idx + 1, j), 0), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (s_vec[inner_idx + 0], s_vec[inner_idx + 1]),
+                        (
+                            gate_val,
+                            gate_val,
+                        ),
+                    )
+            cute.copy(tiled_tmem_store_f32, tTMEM_STORErInOut, tTMEM_STOREtInOut_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_qk_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        tOut: cute.Tensor,
+        tGamma: cute.Tensor,  # causal gate mask
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Apply gamma mask to QK^T."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        tGamma_i = cute.make_tensor(tGamma.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        # Load Gamma
+        tiled_tmem_load_gamma = tcgen05.make_tmem_copy(tmem_load_atom, tGamma_i)
+        thr_tmem_load_gamma = tiled_tmem_load_gamma.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_LOADtG = thr_tmem_load_gamma.partition_S(tGamma_i)
+        tTMEM_LOADrG = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.i_dtype),
+            tTMEM_LOADrS.layout,
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+            tTMEM_LOADtG_i = cute.make_tensor(
+                tTMEM_LOADtG.iterator + i * corr_tile_size, tTMEM_LOADrG.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.copy(tiled_tmem_load_gamma, tTMEM_LOADtG_i, tTMEM_LOADrG)
+
+            frg_tile = 2
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+            tTMEM_LOADrG_frg = cute.logical_divide(
+                tTMEM_LOADrG, ((frg_tile, None), None)
+            )
+            tTMEM_STORErS_x4_e_frg = cute.logical_divide(
+                tTMEM_STORErS_x4_e, cute.make_layout(frg_tile)
+            )
+
+            each_iter = corr_tile_size // frg_tile
+            for j in cutlass.range_constexpr(each_iter):
+                for it in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_LOADrS_frg[((it + 0, j), 0), 0, 0],
+                        tTMEM_LOADrS_frg[((it + 1, j), 0), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrS_frg[((it + 0, j), 0), 0, 0],
+                            tTMEM_LOADrS_frg[((it + 1, j), 0), 0, 0],
+                        ),
+                        (
+                            tTMEM_LOADrG_frg[((it + 0, j), 0), 0, 0],
+                            tTMEM_LOADrG_frg[((it + 1, j), 0), 0, 0],
+                        ),
+                    )
+
+                s_vec = tTMEM_LOADrS_frg[((None, j), 0), 0, 0].load()
+                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.q_dtype))
+
+            # store
+            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtO_i)
+            cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def load_q_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        sQ: cute.Tensor,
+        tOut: cute.Tensor,
+        val: cutlass.Float32,  # exp(cumsum_gate) for per-token gating
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Load Q from smem, apply per-token gate."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sQ_frag = cute.logical_divide(sQ, (((None, 8), None)))
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS_f16 = thr_tmem_store.partition_S(cIn_i)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x8 = cute.make_rmem_tensor(tTMEM_STOREcS_f16.shape, self.i_dtype)
+        tTMEM_STORErS_x8_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.i_dtype),
+            tTMEM_STORErS_x8.layout,
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+
+            frg_tile = 8
+            tTMEM_STORErS_x8_e_frag = cute.logical_divide(
+                tTMEM_STORErS_x8_e, cute.make_layout(frg_tile)
+            )
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+                load_col = col
+                curr_val_ssa = sQ_frag[
+                    (load_row, (None, load_col % 2)), 0, (load_col // 2, i), 0
+                ].load()
+                tTMEM_STORErS_x8_e_frag[None, col].store(
+                    (curr_val_ssa * val).to(self.i_dtype)
+                )
+            # store
+            if cutlass.const_expr(mask):
+                if thread_idx >= tail_count:
+                    tTMEM_STORErS_x8_e_frag.fill(self.i_dtype(0))
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def store_k_epi(
+        self,
+        thr_mma: cute.ThrMma,
+        sK: cute.Tensor,
+        tOut: cute.Tensor,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Load K from smem and store to TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sK_frag = cute.logical_divide(sK, (((None, 8), None)))
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 64
+        corr_tile_size_f32 = corr_tile_size // 2
+
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size_f32))
+        )
+
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size_f32)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS_f16 = thr_tmem_store.partition_S(cIn_i)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+        tTMEM_STORErS_x8 = cute.make_rmem_tensor(tTMEM_STOREcS_f16.shape, self.i_dtype)
+        tTMEM_STORErS_x8_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.i_dtype),
+            tTMEM_STORErS_x8.layout,
+        )
+        frg_tile = 8
+        tTMEM_STORErS_x8_e_frag = cute.logical_divide(
+            tTMEM_STORErS_x8_e, cute.make_layout(frg_tile)
+        )
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size_f32, tTMEM_STOREtO.layout
+            )
+
+            for col in cutlass.range_constexpr(0, 8):
+                load_row = thread_idx
+
+                load_col = col
+                curr_val_ssa = sK_frag[
+                    (load_row, (None, load_col % 2)), 0, (load_col // 2, i), 0
+                ].load()
+                tTMEM_STORErS_x8_e_frag[None, col].store(curr_val_ssa)
+
+            # store
+            if cutlass.const_expr(mask):
+                if thread_idx >= tail_count:
+                    tTMEM_STORErS_x8_e_frag.fill(self.i_dtype(0))
+
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def reverse_smem_sub(
+        self,
+        reverse_result: cute.Tensor,
+        sIvt: cute.Tensor,
+    ):
+        """Compute the inverse of a 32x32 sub-block."""
+        lane_id = cute.arch.lane_idx()
+        sub_widx = cute.arch.warp_idx() % 4
+
+        reverse_result.fill(self.acc_dtype(0))
+
+        for row in cutlass.range_constexpr(1, 32, unroll=1):
+            for k in cutlass.range(1, row):
+                row_i_k = sIvt[(k, row), sub_widx]
+                reverse_result[row] -= reverse_result[k] * row_i_k
+            row_i_lane = self.acc_dtype(0)
+            if lane_id < row:
+                row_i_lane = sIvt[(lane_id, row), sub_widx]
+            reverse_result[row] -= row_i_lane
+        reverse_result[lane_id] = self.acc_dtype(1)
+
+    @cute.jit
+    def store_ivt_smem_l0_ss_a(
+        self,
+        reverse_result: cute.Tensor,
+        sReg: cute.Tensor,
+        sInvertSubSSL0A: cute.Tensor,
+    ):
+        """Store 32x32 sub-inverse results to smem."""
+
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+
+        # store sub result to shared memory
+        # (((4,128),8))
+        for row_bid in cutlass.range_constexpr(4):
+            for col_bid in cutlass.range_constexpr(8):
+                row_d = (lane_id // 4 + col_bid) % 8
+                row = row_bid * 8 + row_d
+                col_id = lane_id // 4
+                col_sub_id = lane_id % 4
+                sReg[(col_sub_id, sub_widx * 32 + row), col_id] = reverse_result[row]
+
+        cutlass.cute.arch.sync_warp()
+
+        if sub_widx == 1 or sub_widx == 3:
+            sub_id_row = sub_widx // 2
+            sInvertSubSSL0A_frag = cute.logical_divide(
+                sInvertSubSSL0A, ((None, 4), None)
+            )
+            for col in cutlass.range_constexpr(8):
+                sInvertSubSSL0A_frag[
+                    (sub_id_row * 32 + lane_id, (None, col % 2)), 0, col // 2, 0
+                ].store(sReg[(None, tidx % 128), col].load())
+
+    @cute.jit
+    def store_ivt_smem_l0_ss_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sInvertSubSSL0B: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # bidx, bidy, _ = cute.arch.block_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sub_widx = widx % 4
+
+        # load Tmem
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32  # must <= 32
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        sub_tile_size = 8
+        tmem_frag = cute.logical_divide(tTMEM_LOADrS, ((sub_tile_size, None), None))
+        sInvertSubSSL0B_frag = cute.logical_divide(
+            sInvertSubSSL0B, ((sub_tile_size, None), None)
+        )
+
+        # tile 0
+        tile_frags = corr_tile_size // sub_tile_size
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 1:
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL0B_frag[
+                        ((None, (col_true, 0)), lane_id % 8), 0, lane_id // 8, 0
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+        # tile 2
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + 64 + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 3:
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL0B_frag[
+                        ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8, 0
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def store_ivt_smem_l1_ss_b(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        sInvertSubSSL1B: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        # bidx, bidy, _ = cute.arch.block_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        sub_widx = widx % 4
+
+        # load Tmem
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 8
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        sub_tile_size = 8
+        tmem_frag = cute.logical_divide(tTMEM_LOADrS, ((sub_tile_size, None), None))
+        sInvertSubSSL1B_frag = cute.logical_divide(
+            sInvertSubSSL1B, ((sub_tile_size, None), None)
+        )
+        tile_frags = corr_tile_size // sub_tile_size
+
+        # tile 0
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 2 or sub_widx == 3:
+                sub_id_row = sub_widx - 2
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL1B_frag[
+                        ((None, (col_true, 0)), lane_id % 8),
+                        0,
+                        lane_id // 8 + sub_id_row * 4,
+                        0,
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+        # tile 1
+        for i in cutlass.range_constexpr(32 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + 32 + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            if sub_widx == 2 or sub_widx == 3:
+                sub_id_row = sub_widx - 2
+                idx = (i * corr_tile_size) // sub_tile_size
+                for j in cutlass.range_constexpr(tile_frags):
+                    col_true = (idx + j) % 8
+                    # todo: remove smem bank conflict
+                    sInvertSubSSL1B_frag[
+                        ((None, (col_true, 1)), lane_id % 8),
+                        0,
+                        lane_id // 8 + sub_id_row * 4,
+                        0,
+                    ].store(tmem_frag[((None, j), 0), 0, 0].load())
+
+    @cute.jit
+    def store_ivt_p1(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubTSL0B: cute.Tensor,
+    ):
+        """Store sub-inverse register results p1 to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+
+        sInvertSubTSL0B_frag = cute.logical_divide(sInvertSubTSL0B, ((4, None), None))
+        if sub_widx == 0 or sub_widx == 2:
+            sub_id_row = sub_widx // 2
+            for col in cutlass.range_constexpr(8):
+                col_true = (lane_id + col) % 8
+                sInvertSubTSL0B_frag[
+                    ((None, (col_true, sub_id_row)), lane_id % 8), 0, lane_id // 8, 0
+                ].store(sReg[(None, tidx % 128), col_true].load())
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def store_ivt_p2(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubSSL1A: cute.Tensor,
+    ):
+        """Store sub-inverse register results p2 to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+        sInvertSubSSL1A_frag = cute.logical_divide(sInvertSubSSL1A, ((None, 4), None))
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+        if sub_widx == 2 or sub_widx == 3:
+            sub_id_row = sub_widx - 2
+            for col in cutlass.range_constexpr(8):
+                sInvertSubSSL1A_frag[
+                    (sub_id_row * 32 + lane_id, (None, col % 2)),
+                    0,
+                    (col // 2, sub_id_row),
+                    0,
+                ].store(sReg[(None, tidx % 128), col].load())
+
+        if sub_widx == 0 or sub_widx == 1:
+            for col in cutlass.range_constexpr(4):
+                col_true = col + sub_widx * 4
+                sInvertSubSSL1A_frag[
+                    (lane_id, (None, col_true % 2)), 0, (col_true // 2, 1), 0
+                ].store(zeros)
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def store_ivt_p3(
+        self,
+        sReg: cute.Tensor,
+        sInvertSubTSL1B: cute.Tensor,
+    ):
+        """Store sub-inverse register results p3 to smem ."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+
+        sub_widx = widx % 4
+        sInvertSubTSL1B_frag = cute.logical_divide(sInvertSubTSL1B, ((4, None), None))
+        if sub_widx == 0 or sub_widx == 1:
+            sub_id_row = sub_widx
+            for col in cutlass.range_constexpr(8):
+                col_true = (lane_id + col) % 8
+                sInvertSubTSL1B_frag[
+                    ((None, (col_true, sub_id_row)), lane_id % 8),
+                    0,
+                    lane_id // 8 + 4 * sub_id_row,
+                    0,
+                ].store(sReg[(None, tidx % 128), col_true].load())
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+
+        if sub_widx == 2 or sub_widx == 3:
+            sub_id_row = sub_widx - 2
+            for col in cutlass.range_constexpr(4):
+                col_true = (lane_id + col + sub_id_row * 4) % 8
+                sInvertSubTSL1B_frag[
+                    ((None, (col_true, 1)), lane_id % 8), 0, lane_id // 8 + 0, 0
+                ].store(zeros)
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def load_store_tmem_tune(
+        self,
+        thr_mma: cute.ThrMma,
+        tIn: cute.Tensor,
+        tOut: cute.Tensor,  # unused utility for TMEM round-trip debugging
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 16
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMrO = cute.make_rmem_tensor(
+            (tTMEM_LOADcO.shape, 128 // corr_tile_size), self.acc_dtype
+        )
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMrO_i_ = tTMrO[None, i]
+            tTMrO_i_layout = cute.composition(
+                tTMrO_i_.layout, cute.make_layout(tTMrO.shape[0])
+            )
+            tTMrO_i = cute.make_tensor(tTMrO_i_.iterator, tTMrO_i_layout)
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO_i)
+
+            for j in cutlass.range_constexpr(0, cute.size(tTMrO_i), 2):
+                tTMrO_i[j], tTMrO_i[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tTMrO_i[j], tTMrO_i[j + 1]),
+                    (cutlass.Float32(1), cutlass.Float32(1)),
+                )
+
+            # store
+            cute.copy(tiled_tmem_store, tTMrO_i, tTMEM_STOREtO_i)
+
+    @cute.jit
+    def read_tmem_128(
+        self,
+        tIn: cute.Tensor,
+    ):
+        """Read a 128-element vector from TMEM into registers."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        return tTR_rO
+
+    @cute.jit
+    def load_v(
+        self,
+        tIn: cute.Tensor,
+        sNewV: cute.Tensor,
+    ):
+        """Load V_new from TMEM, convert to f16, store to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        frg_cnt = 16
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+
+        sNewV_frg = cute.logical_divide(sNewV, cute.make_layout(frg_tile))
+        for it in cutlass.range_constexpr(0, 16):
+            sNewV_frg[None, (it, thread_idx)].store(
+                tTR_rO_frg[None, it].load().to(self.i_dtype)
+            )
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def load_ivt_result(
+        self,
+        tIn: cute.Tensor,
+        sD: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tIn_layout = cute.composition(tIn.layout, cute.make_layout((tIn.shape)))
+        tIn = cute.make_tensor(tIn.iterator, tIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tIn)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tIn)
+        tTR_cO = thr_copy_t2r.partition_D(tIn)
+
+        tTR_rO = cute.make_rmem_tensor(tTR_cO.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+        tTR_rO = cute.group_modes(tTR_rO, 1, cute.rank(tTR_rO))
+        cute.copy(tiled_copy_t2r, tTR_tO, tTR_rO)
+        cute.arch.fence_view_async_tmem_load()
+
+        tTR_rO_e = cute.make_rmem_tensor(tTR_cO.shape, self.q_dtype)
+
+        frg_cnt = 2
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
+        for j in cutlass.range_constexpr(frg_cnt):
+            r_vec = -tTR_rO_frg[None, j].load()
+            tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+        tTR_rO_e_f32 = cute.recast_tensor(src=tTR_rO_e, dtype=cutlass.Float32)
+
+        for it in cutlass.range_constexpr(0, 8):
+            sD[
+                ((64 + warp_id * 16 + (lane_id // 4) + 0), (lane_id % 4, it % 2)),
+                it // 2,
+            ] = tTR_rO_e_f32[it * 2]
+            sD[
+                ((64 + warp_id * 16 + (lane_id // 4) + 8), (lane_id % 4, it % 2)),
+                it // 2,
+            ] = tTR_rO_e_f32[it * 2 + 1]
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def apply_gamma_beta(
+        self,
+        thr_mma: cute.ThrMma,
+        sIvt: cute.Tensor,
+        tIn: cute.Tensor,
+        beta_val: cutlass.Float32,
+        tGamma: cute.Tensor,
+    ):
+        """Apply gamma*beta to KK^T in TMEM."""
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+        sub_widx = warp_id % 4
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 32  # 32
+        tIn_i_layout = cute.composition(
+            tIn.layout, cute.make_layout((128, corr_tile_size))
+        )
+        cIn_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tIn_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+
+        tOut_i = cute.make_tensor(tIn.iterator, tIn_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cIn_i_layout)
+
+        tGamma_i = cute.make_tensor(tGamma.iterator, tIn_i_layout)
+        cIn_i = cute.make_tensor(cIn.iterator, cIn_i_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+
+        # Load In
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tIn_i)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+
+        # Load Gamma
+        tiled_tmem_load_gamma = tcgen05.make_tmem_copy(tmem_load_atom, tGamma_i)
+        thr_tmem_load_gamma = tiled_tmem_load_gamma.get_slice(thread_idx)
+
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tIn_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(cIn_i)
+
+        tTMEM_LOADtG = thr_tmem_load_gamma.partition_S(tGamma_i)
+        tTMEM_LOADrG = cute.make_rmem_tensor(tTMEM_LOADcO.shape, self.acc_dtype)
+
+        tTMEM_LOADrS = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS.iterator, dtype=self.acc_dtype),
+            tTMEM_LOADrG.layout,
+        )
+
+        frg_tile = 4
+
+        # Store to smem
+        # ((32, 32), 4)
+        lower_D_frag = cute.logical_divide(tTMEM_STORErS, ((4, None), None))
+        sIvt_frag = cute.logical_divide(sIvt, ((4, None), None))
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_LOADtO_i = cute.make_tensor(
+                tTMEM_LOADtO.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+            tTMEM_LOADtG_i = cute.make_tensor(
+                tTMEM_LOADtG.iterator + i * corr_tile_size, tTMEM_LOADtO.layout
+            )
+
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            cute.copy(tiled_tmem_load_gamma, tTMEM_LOADtG_i, tTMEM_LOADrG)
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMEM_LOADrS)
+            cute.arch.fence_view_async_tmem_load()
+            each_iter = corr_tile_size // frg_tile
+            tTMEM_LOADrG_frg = cute.logical_divide(
+                tTMEM_LOADrG, ((frg_tile, None), None)
+            )
+            for j in cutlass.range_constexpr(each_iter):
+                for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                    (
+                        tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                        tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (
+                            tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                            tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                        ),
+                        (
+                            beta_val,
+                            beta_val,
+                        ),
+                    )
+
+            tTMEM_LOADrS_frg = cute.logical_divide(
+                tTMEM_LOADrS, ((frg_tile, None), None)
+            )
+
+            if (i * corr_tile_size) < ((sub_widx + 1) * 32):
+                for j in cutlass.range_constexpr(each_iter):
+                    for inner_idx in cutlass.range_constexpr(0, frg_tile, 2):
+                        (
+                            tTMEM_LOADrS_frg[((inner_idx + 0, j), i), 0, 0],
+                            tTMEM_LOADrS_frg[((inner_idx + 1, j), i), 0, 0],
+                        ) = cute.arch.mul_packed_f32x2(
+                            (
+                                tTMEM_LOADrS_frg[((inner_idx + 0, j), i), 0, 0],
+                                tTMEM_LOADrS_frg[((inner_idx + 1, j), i), 0, 0],
+                            ),
+                            (
+                                tTMEM_LOADrG_frg[((inner_idx + 0, j), i), 0, 0],
+                                tTMEM_LOADrG_frg[((inner_idx + 1, j), i), 0, 0],
+                            ),
+                        )
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+
+            tile_frags = corr_tile_size // 4
+            if (i * corr_tile_size) >= sub_widx * 32 and (i * corr_tile_size) < (
+                sub_widx + 1
+            ) * 32:
+                idx = (i * corr_tile_size - sub_widx * 32) // 4
+                for j in cutlass.range_constexpr(tile_frags):
+                    true_col = j + idx
+                    sIvt_frag[((None, true_col), lane_id), sub_widx].store(
+                        lower_D_frag[((None, j), 0), 0, 0].load()
+                    )
+
+    @cute.jit
+    def compute_gamma_tmem(
+        self,
+        val: cutlass.Float32,
+        sGateCumsum: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        tOut: cute.Tensor,
+        bar_id: Int32,
+        mask: cutlass.Constexpr[cutlass.Boolean] = False,
+        tail_count: Int32 = 128,
+    ):
+        """Build the 128x128 causal gamma matrix in TMEM: gamma[i,j] = exp(cumsum[i] - cumsum[j]) for j <= i."""
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % 128
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        cIn = cute.make_identity_tensor((128, 128))
+        tOcO = thr_mma.partition_C(cIn)
+
+        corr_tile_size = 128
+
+        cOut_i_layout = cute.composition(
+            tOcO.layout, cute.make_layout((128, corr_tile_size))
+        )
+        tOut_i_layout = cute.composition(
+            tOut.layout, cute.make_layout((128, corr_tile_size))
+        )
+
+        tOut_i = cute.make_tensor(tOut.iterator, tOut_i_layout)
+        cOut_i = cute.make_tensor(tOcO.iterator, cOut_i_layout)
+
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.acc_dtype,
+        )
+
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOut_i)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+
+        tTMEM_STOREcS = thr_tmem_store.partition_S(cOut_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOut_i)
+
+        tTMEM_STORErS = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.acc_dtype)
+
+        frg_tile = 32
+        sGateCumsum_tile = cute.flat_divide(
+            sGateCumsum, cute.make_layout(corr_tile_size)
+        )
+        sGateCumsum_frag = cute.logical_divide(sGateCumsum_tile, (frg_tile, None))
+
+        zeros = cute.zeros_like(cute.make_layout((frg_tile, 1)), self.acc_dtype)
+
+        for i in cutlass.range_constexpr(128 // corr_tile_size):
+            tTMEM_STOREtO_i = cute.make_tensor(
+                tTMEM_STOREtO.iterator + i * corr_tile_size, tTMEM_STOREtO.layout
+            )
+
+            tTMEM_STORErS_frag = cute.logical_divide(
+                tTMEM_STORErS, cute.make_layout(frg_tile)
+            )
+            for it in cutlass.range_constexpr(corr_tile_size // frg_tile):
+                tile_offset = i * corr_tile_size + it * frg_tile
+
+                if (
+                    (
+                        tile_offset <= thread_idx
+                        and tile_offset < tail_count
+                        and thread_idx < tail_count
+                    )
+                    if cutlass.const_expr(mask)
+                    else (tile_offset <= thread_idx)
+                ):
+                    curr_val_frag_ssa = sGateCumsum_frag[(None, it), i].load()
+
+                    new_val_frag = cute.math.exp(val - curr_val_frag_ssa, fastmath=True)
+
+                    for inner_idx in cutlass.range_constexpr(0, frg_tile):
+                        offset = tile_offset + inner_idx
+                        curr_val = new_val_frag[inner_idx]
+
+                        if offset <= thread_idx:
+                            tTMEM_STORErS_frag[inner_idx, it] = curr_val
+                        else:
+                            tTMEM_STORErS_frag[inner_idx, it] = cutlass.Float32(0)
+                else:
+                    tTMEM_STORErS_frag[None, it].store(zeros)
+
+            # store
+            cute.copy(tiled_tmem_store, tTMEM_STORErS, tTMEM_STOREtO_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def chunk_local_cumsum(
+        self,
+        sGate: cute.Tensor,
+        sGateCumsum: cute.Tensor,
+        bar_id: Int32,
+    ) -> cutlass.Float32:
+        """Compute inclusive prefix sum of gate values within a 128-token chunk."""
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_id = tidx % 32
+        warp_id = cute.arch.warp_idx() % 4
+        tidx_in_group = tidx % 128
+
+        val = sGate[tidx_in_group]
+        for step in cutlass.range_constexpr(5):
+            stride = 1 << step
+            shfl_value = cute.arch.shuffle_sync_op(
+                value=val,
+                offset=stride,
+                mask_and_clamp=0,
+                kind=nvvm.ShflKind.up,
+            )
+            if lane_id >= stride:
+                val += shfl_value
+        if lane_id == 31:
+            sGateCumsum[warp_id] = val
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        if warp_id == 1:
+            pre_warp_val = sGateCumsum[0]
+            val = val + pre_warp_val
+        if warp_id == 2:
+            sGateCumsum_f2 = cute.flat_divide(sGateCumsum, (2, 1))
+            warp_sum = sGateCumsum_f2[None, 0, 0, 0]
+            pre_warp_val = warp_sum[0] + warp_sum[1]
+            val = val + pre_warp_val
+        if warp_id == 3:
+            sGateCumsum_f4 = cute.flat_divide(sGateCumsum, (4, 1))
+            warp_sum = sGateCumsum_f4[None, 0, 0, 0]
+            pre_warp_val = warp_sum[0] + warp_sum[1] + warp_sum[2]
+            val = val + pre_warp_val
+
+        cute.arch.barrier(
+            barrier_id=bar_id,
+            number_of_threads=len(self.cudacore_warp_ids) * 32,
+        )
+
+        sGateCumsum[tidx_in_group] = val
+
+        return val
+
+    @cute.jit
+    def save_tmem(
+        self,
+        tSIn: cute.Tensor,
+        sD: cute.Tensor,
+    ) -> cute.Tensor:
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[None, 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        tTR_rO_e = cute.make_rmem_tensor(tTR_rO.shape, self.q_dtype)
+        frg_cnt = 2
+        frg_tile = cute.size(tTR_rO) // frg_cnt
+        tTR_rO_frg = cute.logical_divide(tTR_rO, cute.make_layout(frg_tile))
+        tTR_rO_e_frg = cute.logical_divide(tTR_rO_e, cute.make_layout(frg_tile))
+        tTR_rO_e_f32 = cute.recast_tensor(src=tTR_rO_e, dtype=cutlass.Float32)
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                for j in cutlass.range_constexpr(frg_cnt):
+                    r_vec = -tTR_rO_frg[None, j].load()
+                    tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+                for it in cutlass.range_constexpr(0, 4):
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 0
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2]
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 8
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2 + 1]
+
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                for j in cutlass.range_constexpr(frg_cnt):
+                    r_vec = -tTR_rO_frg[None, j].load()
+                    tTR_rO_e_frg[None, j].store(r_vec.to(self.q_dtype))
+
+                for it in cutlass.range_constexpr(0, 4):
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 0
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2]
+                    sD[
+                        (
+                            (
+                                32
+                                + (sub_widx // 2) * 64
+                                + (sub_widx % 2) * 16
+                                + (lane_id // 4)
+                                + 8
+                            ),
+                            (lane_id % 4, it % 2),
+                        ),
+                        it // 2 + (sub_widx // 2) * 4,
+                    ] = tTR_rO_e_f32[it * 2 + 1]
+
+    @cute.jit
+    def load_ivt_ts_l0(
+        self,
+        tSIn: cute.Tensor,
+        sInvertSubSSL1A: cute.Tensor,
+        sInvertSubTSL1B: cute.Tensor,
+    ) -> cute.Tensor:
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x128bOp(tcgen05.copy.Repetition(8)),  # todo
+            self.acc_dtype,
+        )
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[None, 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_rO_s = cute.make_tensor(
+            cute.recast_ptr(tTR_rO.iterator, dtype=self.acc_dtype),
+            cute.shape(tTR_cO_one_iter)[0],
+        )
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                sInvertSubTSL1B_frag = cute.logical_divide(
+                    sInvertSubTSL1B, ((4, None), None)
+                )
+                sub_id_row = sub_widx
+                for col_true in cutlass.range_constexpr(0, 8):
+                    sInvertSubTSL1B_frag[
+                        ((lane_id % 4, (col_true, 0)), lane_id // 4),
+                        0,
+                        4 + sub_id_row * 2 + 0,
+                        0,
+                    ] = -tTR_rO_s[(0, col_true), 0]
+                    sInvertSubTSL1B_frag[
+                        ((lane_id % 4, (col_true, 0)), lane_id // 4),
+                        0,
+                        4 + sub_id_row * 2 + 1,
+                        0,
+                    ] = -tTR_rO_s[(1, col_true), 0]
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                tTR_rO_s_frag_f1 = cute.logical_divide(
+                    cute.flatten(tTR_rO_s[None, 0]), (1, None)
+                )
+                sInvertSubSSL1A_frag_f1 = cute.logical_divide(
+                    sInvertSubSSL1A, ((None, 1), None)
+                )
+                sub_id_row = sub_widx - 2
+                for it in cutlass.range_constexpr(0, 8):
+                    col_offset = it % 2 * 4
+                    sInvertSubSSL1A_frag_f1[
+                        (
+                            32 + sub_id_row * 16 + 0 + lane_id // 4,
+                            (None, col_offset + lane_id % 4),
+                        ),
+                        0,
+                        (it // 2, 0),
+                        0,
+                    ].store(-tTR_rO_s_frag_f1[(None, 0), it].load())
+                    sInvertSubSSL1A_frag_f1[
+                        (
+                            32 + sub_id_row * 16 + 8 + lane_id // 4,
+                            (None, col_offset + lane_id % 4),
+                        ),
+                        0,
+                        (it // 2, 0),
+                        0,
+                    ].store(-tTR_rO_s_frag_f1[(None, 1), it].load())
+
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
+    def store_ivt_c(
+        self,
+        sD: cute.Tensor,
+    ):
+        """Zero out off-diagonal blocks in the assembled inverse matrix (block identity structure)."""
+        widx = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        sub_widx = widx % 4
+
+        zeros = cute.zeros_like(cute.make_layout((4, 1)), self.acc_dtype)
+        for it in cutlass.range_constexpr(0, 4):
+            row = sub_widx // 2 * 32 + lane_id
+            col_block_inner = it % 2
+            col_block = 4 + (sub_widx % 2) * 2 + it // 2
+            sD[(row, (None, col_block_inner)), col_block].store(zeros[None, 0])
+        for it in cutlass.range_constexpr(0, 2):
+            row = sub_widx // 2 * 64 + lane_id
+            col_block_inner = sub_widx % 2
+            col_block = (sub_widx // 2) * 4 + 2 + it
+            sD[(row, (None, col_block_inner)), col_block].store(zeros[None, 0])
+
+    @cute.jit
+    def load_ivt_ss_l0(
+        self,
+        tSIn: cute.Tensor,
+        tSOut: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        sub_widx = widx % 4
+
+        thread_idx = tidx % (self.threads_per_warp * (len(self.cudacore_warp_ids)))
+
+        tSIn_layout = cute.composition(tSIn.layout, cute.make_layout((tSIn.shape)))
+        tSIn0 = cute.make_tensor(tSIn.iterator, tSIn_layout)
+
+        # Load from tmem
+        copy_atom_t2r = cute.make_copy_atom(
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(4)),  # 4*8 = 32
+            self.acc_dtype,
+        )
+
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tSIn0)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(thread_idx)
+        tTR_tO = thr_copy_t2r.partition_S(tSIn0)
+        tTR_cO = thr_copy_t2r.partition_D(tSIn0)
+        tTR_cO_one_iter = tTR_cO[(None), 0, 0, 0]
+        tTR_rO = cute.make_rmem_tensor(tTR_cO_one_iter.shape, self.acc_dtype)
+
+        tTR_tO = cute.group_modes(tTR_tO, 1, cute.rank(tTR_tO))
+
+        tSOut_layout = cute.make_layout(
+            (((16, 4), 32), 1, 1), stride=(((65536, 2097152), 1), 0, 0)
+        )
+        tSOut0 = cute.make_tensor(tSOut.iterator, tSOut_layout)
+        copy_atom_r2t = cute.make_copy_atom(
+            tcgen05.copy.St16x256bOp(tcgen05.copy.Repetition(4)),
+            self.acc_dtype,
+        )
+        tiled_copy_r2t = tcgen05.make_tmem_copy(copy_atom_r2t, tSOut0)
+        thr_copy_r2t = tiled_copy_r2t.get_slice(thread_idx)
+        tRT_cO = thr_copy_r2t.partition_S(tSOut0)
+        tRT_tO = thr_copy_r2t.partition_D(tSOut0)
+        tRT_cO_one_iter = tRT_cO[(None), None, 0, 0]  #
+        tRT_rO = cute.make_rmem_tensor(tRT_cO_one_iter.shape, self.acc_dtype)
+
+        for subtile_idx in cutlass.range_constexpr(2):
+            tTR_tO_mn = tTR_tO[(None, subtile_idx)]
+            cute.copy(tiled_copy_t2r, tTR_tO_mn, tTR_rO)
+            cute.arch.fence_view_async_tmem_load()
+
+            if (sub_widx == 0 or sub_widx == 1) and subtile_idx == 0:
+                for eid in cutlass.range_constexpr(16):
+                    tRT_rO[eid] = tTR_rO[eid]
+
+            if (sub_widx == 2 or sub_widx == 3) and subtile_idx == 1:
+                for eid in cutlass.range_constexpr(16):
+                    tRT_rO[eid] = tTR_rO[eid]
+
+        tRT_tO = cute.group_modes(tRT_tO, 2, cute.rank(tRT_tO))
+        for subtile_idx in cutlass.range_constexpr(0, 1):
+            tRT_tO_mn = tRT_tO[(None, None, subtile_idx)]
+            cute.copy(tiled_copy_r2t, tRT_rO, tRT_tO_mn)
+
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def store_ivt_ad(
+        self,
+        sReg: cute.Tensor,
+        sD: cute.Tensor,
+    ):
+        """Store diagonal block inverse (A/D blocks) from registers to smem."""
+        tidx, _, _ = cute.arch.thread_idx()
+        widx = cute.arch.warp_idx()
+        sub_widx = widx % 4
+
+        reg_layout = cute.make_layout((4, 2))
+        result_e = cute.make_rmem_tensor(reg_layout.shape, self.acc_dtype)
+        for it in cutlass.range_constexpr(0, 4):
+            result_e[None, 0].store(sReg[(None, tidx % 128), it * 2 + 0].load())
+            result_e[None, 1].store(sReg[(None, tidx % 128), it * 2 + 1].load())
+            sD[(tidx % 128, (None, it % 2)), 0, sub_widx * 2 + it // 2, 0].store(
+                result_e[None].load().to(self.q_dtype)
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        q_iter: cute.Pointer,
+        k_iter: cute.Pointer,
+        v_iter: cute.Pointer,
+        o_iter: cute.Pointer,
+        g_iter: cute.Pointer,
+        beta_iter: cute.Pointer,
+        problem_size: Tuple[
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+            cutlass.Int32,
+        ],
+        initial_state_f32_iter: Optional[cute.Pointer],
+        state_output: Optional[cute.Pointer],
+        scale: Optional[float],
+        cum_seqlen: Optional[cute.Pointer] = None,
+        stream: cuda.CUstream = None,
+    ):
+        """Host-side entry: build tensor layouts, TMA descriptors, smem storage, and launch the kernel."""
+
+        b, s_q, s_sum, h_q, h_v, d = problem_size
+
+        cum_seqlen_q = (
+            None
+            if cum_seqlen is None
+            else cute.make_tensor(cum_seqlen, cute.make_layout((b)))
+        )
+
+        h_r = h_v // h_q
+        o_offset = 0 if cum_seqlen_q is None else (-s_q * d * h_r * h_q)
+        b_qk = b if cum_seqlen_q is None else s_sum
+        b_o = b if cum_seqlen_q is None else s_q * (1 + b)
+        b_v = b if cum_seqlen_q is None else s_sum
+
+        stride_b_qk = h_q * s_q * d if cum_seqlen_q is None else d * h_q
+        stride_b_vo = h_r * h_q * s_q * d if cum_seqlen_q is None else d * h_q * h_r
+
+        b_gb = b if cum_seqlen_q is None else 1
+        stride_b_gb = h_r * h_q * s_sum if cum_seqlen_q is None else 0
+        q_layout = cute.make_layout(
+            (s_sum, d, ((h_r, h_q), b_qk)),
+            stride=(d * h_q, 1, ((0, d), stride_b_qk)),
+        )
+        q = cute.make_tensor(q_iter, q_layout)
+
+        k_layout = cute.make_layout(
+            (s_sum, d, ((h_r, h_q), b_qk)),
+            stride=(d * h_q, 1, ((0, d), stride_b_qk)),
+        )
+        k = cute.make_tensor(k_iter, k_layout)
+        v_layout = cute.make_layout(
+            (d, s_sum, ((h_r, h_q), b_v)),
+            stride=(1, d * h_q * h_r, ((d, d * h_r), stride_b_vo)),
+        )
+        v = cute.make_tensor(v_iter, v_layout)
+        o_layout = cute.make_layout(
+            (s_q, d, ((h_r, h_q), b_o)),
+            stride=(d * h_r * h_q, 1, ((d, d * h_r), stride_b_vo)),
+        )
+        o = cute.make_tensor(o_iter + o_offset, o_layout)
+
+        state_layout = cute.make_layout(
+            (self.head_dim, self.head_dim, ((h_r, h_q), b)),
+            stride=(
+                self.head_dim,
+                1,
+                (
+                    (
+                        self.head_dim * self.head_dim,
+                        h_r * self.head_dim * self.head_dim,
+                    ),
+                    h_q * h_r * self.head_dim * self.head_dim,
+                ),
+            ),
+        )
+
+        state_input_f32 = (
+            None
+            if cutlass.const_expr(initial_state_f32_iter is None)
+            else cute.make_tensor(initial_state_f32_iter, state_layout)
+        )
+        state_output = (
+            None
+            if cutlass.const_expr(state_output is None)
+            else cute.make_tensor(state_output, state_layout)
+        )
+
+        gb_layout = cute.make_layout(
+            (s_sum, 1, ((h_r, h_q), b_gb)),
+            stride=(h_r * h_q, 0, ((1, h_r), stride_b_gb)),
+        )
+        gate = cute.make_tensor(g_iter, gb_layout)
+        beta = cute.make_tensor(beta_iter, gb_layout)
+
+        if cutlass.const_expr(scale is None):
+            scale = 1.0 / cute.math.sqrt(cutlass.Float32(d))
+
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q.element_type
+        self.k_dtype = k.element_type
+        self.v_dtype = v.element_type
+        self.o_dtype = o.element_type
+        self.g_dtype = gate.element_type
+        self.beta_dtype = beta.element_type
+
+        self.i_dtype = self.q_dtype
+
+        self.tile_sched_params, grid = self._compute_grid(
+            cute.shape((s_q, d, ((h_r, h_q), b))),
+            self.cta_tiler,
+            self.is_persistent,
+        )
+
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.s_output = utils.LayoutEnum.ROW_MAJOR
+
+        cta_group = tcgen05.CtaGroup.ONE
+
+        qk_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+
+        update_s_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.MN,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.update_s_mma_tiler[:2],
+        )
+
+        o_intra_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.o_intra_mma_tiler[:2],
+        )
+
+        o_intra_tiled_ts_mma_new = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.o_intra_mma_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        qs_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+            self.acc_dtype,
+            cta_group,
+            self.qs_mma_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        kkt_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            self.k_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.kkt_mma_tiler[:2],
+        )
+
+        kst_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.i_dtype,
+            self.k_major_mode,
+            self.k_major_mode,
+            self.acc_dtype,
+            cta_group,
+            self.kst_mma_tiler[:2],
+        )
+
+        invert_sub_tiled_mma_ss_l0 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l0_tiler[:2],
+        )
+        invert_sub_tiled_mma_ts_l0 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l0_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        invert_sub_tiled_mma_ss_l1 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l1_tiler[:2],
+        )
+        invert_sub_tiled_mma_ts_l1 = sm100_utils.make_trivial_tiled_mma(
+            self.invert_type_ab,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.invert_acc_type,
+            cta_group,
+            self.invert_mma_sub_l1_tiler[:2],
+            tcgen05.OperandSource.TMEM,
+        )
+
+        tuw_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.k_dtype,
+            self.k_major_mode,
+            tcgen05.OperandMajorMode.MN,
+            self.acc_dtype,
+            cta_group,
+            self.tuw_mma_tiler[:2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.kv_stage,
+        )
+
+        qk_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.i_dtype,
+            self.qk_stage,
+        )
+
+        state_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            kst_tiled_mma,
+            self.kst_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        o_intra_smem_layout_staged_a = make_smem_layout_a_kind(
+            o_intra_tiled_mma,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        o_intra_smem_layout_staged_b = make_smem_layout_b_kind(
+            o_intra_tiled_mma,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        o_intra_smem_layout_staged_a_new = make_smem_layout_a_kind(
+            o_intra_tiled_ts_mma_new,
+            self.o_intra_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        qs_smem_layout_staged_a = sm100_utils.make_smem_layout_a(
+            qs_tiled_mma,
+            self.qs_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        qs_smem_layout_staged_b = sm100_utils.make_smem_layout_b(
+            qs_tiled_mma,
+            self.qs_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+        )
+
+        update_s_smem_layout_staged_a = make_smem_layout_a_kind(
+            update_s_tiled_mma,
+            self.update_s_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        update_s_smem_layout_staged_b = make_smem_layout_b_kind(
+            update_s_tiled_mma,
+            self.update_s_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        state_output_smem_layout_staged = make_smem_layout_epi_kind(
+            self.state_dtype,
+            self.s_output,
+            self.state_output_tiler,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        o_output_smem_layout_staged = make_smem_layout_epi_kind(
+            self.i_dtype,
+            self.o_layout,
+            self.o_output_tiler,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        ivt_smem_layout = cute.make_layout(
+            ((36, 32), 4)
+        )  # padding, remove smem bank conflict
+        # ivt_smem_layout = cute.make_layout(((32, 32), 4))  # padding, remove smem bank conflict
+
+        sub_inner_smem_layout_staged = make_smem_layout_a_kind(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.sub_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        invert_sub_smem_layout_staged_ss_l0_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l0_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ss_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l0_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ts_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l0_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ts_l0,
+            self.invert_mma_sub_l0_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l1_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ss_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ss_l1_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ss_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l1_a = sm100_utils.make_smem_layout_a(
+            invert_sub_tiled_mma_ts_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        invert_sub_smem_layout_staged_ts_l1_b = sm100_utils.make_smem_layout_b(
+            invert_sub_tiled_mma_ts_l1,
+            self.invert_mma_sub_l1_tiler,
+            self.invert_type_ab,
+            self.invert_sub_stage,
+        )
+
+        # tuw
+        tuw_smem_layout_staged_a = make_smem_layout_a_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.q_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_INTER,
+        )
+
+        tuw_smem_layout_staged_b = make_smem_layout_b_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.q_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        v_smem_layout_staged_b = make_smem_layout_b_kind(
+            tuw_tiled_mma,
+            self.tuw_mma_tiler,
+            self.i_dtype,
+            self.one_stage,
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_INTER,
+        )
+
+        # TMA
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        # TMA load for Q
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged_b, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.tuw_mma_tiler,
+            tuw_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        fake_state_tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.state_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.state_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+        state_smem_layout_f32_staged = sm100_utils.make_smem_layout_b(
+            fake_state_tiled_mma,
+            self.qk_mma_tiler,
+            self.state_dtype,
+            self.one_stage,
+        )
+        state_smem_layout_f32 = cute.select(
+            state_smem_layout_f32_staged, mode=[0, 1, 2]
+        )
+        tma_atom_state_f32, tma_tensor_state_f32 = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                state_input_f32,
+                state_smem_layout_f32,
+                self.qk_mma_tiler,
+                fake_state_tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+            if cutlass.const_expr(state_input_f32 is not None)
+            else (None, None)
+        )
+
+        state_smem_layout_output = cute.select(
+            state_output_smem_layout_staged, mode=[0, 1]
+        )
+        tma_atom_state_output, tma_tensor_state_output = (
+            cutlass.cute.nvgpu.cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                state_output,
+                state_smem_layout_output,
+                cute.composition(
+                    cute.make_identity_layout(state_output.shape),
+                    self.state_output_tiler,
+                ),
+            )
+            if cutlass.const_expr(state_output is not None)
+            else (None, None)
+        )
+
+        o_cta_v_layout = cute.composition(
+            cute.make_identity_layout(o.shape), self.o_output_tiler
+        )
+        o_smem_layout_output = cute.select(o_output_smem_layout_staged, mode=[0, 1])
+        tma_atom_o_output, tma_tensor_o_output = (
+            cutlass.cute.nvgpu.cpasync.make_tiled_tma_atom(
+                tma_store_op,
+                o,
+                o_smem_layout_output,
+                o_cta_v_layout,
+            )
+        )
+
+        gate_smem_layout_staged = cute.make_layout(
+            (self.chunk_size, 1, self.gate_stage)
+        )
+        gate_smem_layout = cute.select(gate_smem_layout_staged, mode=[0, 1])
+
+        beta_smem_layout_staged = cute.make_layout(
+            (self.chunk_size, 1, self.beta_stage)
+        )
+        beta_smem_layout = cute.select(beta_smem_layout_staged, mode=[0, 1])
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
+        state_copy_size = cute.size_in_bytes(self.i_dtype, state_smem_layout_f32)
+        state_f32_copy_size = cute.size_in_bytes(
+            self.state_dtype, state_smem_layout_f32
+        )
+        gate_copy_size = cute.size_in_bytes(self.g_dtype, gate_smem_layout)
+        beta_copy_size = cute.size_in_bytes(self.beta_dtype, beta_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size
+        self.tma_copy_kv_bytes = k_copy_size
+        self.tma_copy_v_bytes = v_copy_size
+        self.tma_copy_state_bytes = state_copy_size
+        self.tma_copy_state_f32_bytes = state_f32_copy_size
+        self.tma_copy_gate_bytes = gate_copy_size
+        self.tma_copy_beta_bytes = beta_copy_size
+
+        # Shared memory storage
+        @cute.struct
+        class SharedStorage:
+            load_qk_mbar_ptr: cute.struct.MemRange[Int64, self.qk_stage * 2]
+            load_v_mbar_ptr: cute.struct.MemRange[Int64, self.one_stage * 2]
+            load_state_mbar_ptr: cute.struct.MemRange[Int64, self.one_stage * 2]
+            mma_cudacore_mbar_ptr0: cute.struct.MemRange[Int64, 2]
+            mma_qk_mbar_ptr0: cute.struct.MemRange[Int64, self.mma_qk_stage * 2]
+
+            w0_epi_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            epi_w0_mbar_ptr: cute.struct.MemRange[Int64, 2]
+            gb_w0_mbar_ptr: cute.struct.MemRange[Int64, self.gate_stage * 2]
+
+            tmem_dealloc_mbar_ptr: cute.struct.MemRange[Int64, 1]
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+
+            sV: cute.struct.Align[
+                cute.struct.MemRange[self.i_dtype, cute.cosize(v_smem_layout_staged_b)],
+                self.buffer_align_bytes,
+            ]
+
+            sQK: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(qk_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+
+            sIvt: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(ivt_smem_layout)],
+                self.buffer_align_bytes,
+            ]
+
+            sGate: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype, cute.cosize(gate_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sGateCumsum: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype,
+                    cute.cosize(cute.select(gate_smem_layout_staged, mode=[0, 1])),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sBeta: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.g_beta_dtype, cute.cosize(beta_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSubInner: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.invert_type_ab, cute.cosize(sub_inner_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+            sState: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.i_dtype, cute.cosize(state_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        if cutlass.const_expr(stream is None):
+            stream = cutlass.cuda.default_stream()
+
+        # Launch kernel
+        self.kernel(
+            qk_tiled_mma,
+            o_intra_tiled_mma,
+            o_intra_tiled_ts_mma_new,
+            qs_tiled_mma,
+            update_s_tiled_mma,
+            kkt_tiled_mma,
+            kst_tiled_mma,
+            fake_state_tiled_mma,
+            invert_sub_tiled_mma_ss_l0,
+            invert_sub_tiled_mma_ts_l0,
+            invert_sub_tiled_mma_ss_l1,
+            invert_sub_tiled_mma_ts_l1,
+            tuw_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_state_f32,
+            tma_tensor_state_f32,
+            gate,
+            beta,
+            o,
+            tma_atom_state_output,
+            tma_tensor_state_output,
+            tma_atom_o_output,
+            tma_tensor_o_output,
+            cum_seqlen_q,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            qk_smem_layout_staged,
+            o_intra_smem_layout_staged_a,
+            o_intra_smem_layout_staged_b,
+            o_intra_smem_layout_staged_a_new,
+            qs_smem_layout_staged_a,
+            qs_smem_layout_staged_b,
+            update_s_smem_layout_staged_a,
+            update_s_smem_layout_staged_b,
+            state_smem_layout_staged,
+            state_smem_layout_f32_staged,
+            state_output_smem_layout_staged,
+            o_output_smem_layout_staged,
+            gate_smem_layout_staged,
+            beta_smem_layout_staged,
+            ivt_smem_layout,
+            sub_inner_smem_layout_staged,
+            invert_sub_smem_layout_staged_ss_l0_a,
+            invert_sub_smem_layout_staged_ss_l0_b,
+            invert_sub_smem_layout_staged_ts_l0_a,
+            invert_sub_smem_layout_staged_ts_l0_b,
+            invert_sub_smem_layout_staged_ss_l1_a,
+            invert_sub_smem_layout_staged_ss_l1_b,
+            invert_sub_smem_layout_staged_ts_l1_a,
+            invert_sub_smem_layout_staged_ts_l1_b,
+            tuw_smem_layout_staged_a,
+            tuw_smem_layout_staged_b,
+            v_smem_layout_staged_b,
+            scale,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @staticmethod
+    def _compute_grid(
+        o_shape: cute.Shape,
+        cta_tiler: Tuple[int, int, int],
+        is_persistent: bool,
+    ) -> Tuple[GdnStaticTileSchedulerParams, Tuple[int, int, int]]:
+        tile_sched_params = create_gdn_static_tile_scheduler_params(
+            is_persistent,
+            (
+                cute.ceil_div(cute.size(o_shape[1]), cta_tiler[2]),
+                cute.size(o_shape[2][0]),
+                cute.size(o_shape[2][1]),
+            ),
+        )
+        grid = GdnStaticTileScheduler.get_grid_shape(tile_sched_params)
+        return tile_sched_params, grid
+
+
+# ============================================================================
+# FlashInfer API Layer
+# ============================================================================
+
+
+@functools.lru_cache(maxsize=128)
+def _get_problem_size(q_shape, v_shape, cu_seqlens_tuple):
+    """Compute problem_size, cached by (q_shape, v_shape, cu_seqlens tuple).
+
+    Args:
+        q_shape: Tuple of (b, s_q, h_q, d).
+        v_shape: Tuple of (b, s_v, h_v, d).
+        cu_seqlens_tuple: Tuple of cumulative sequence lengths, or None.
+    """
+    b, s_q, h_q, d = q_shape
+    _, _, h_v, _ = v_shape
+    max_s_q = s_q
+    sum_s_q = s_q
+    if cu_seqlens_tuple is not None:
+        sum_s_q = cu_seqlens_tuple[-1]
+        b = len(cu_seqlens_tuple) - 1
+        max_s_q = max(cu_seqlens_tuple[i + 1] - cu_seqlens_tuple[i] for i in range(b))
+        return (b, max_s_q, sum_s_q, h_q, h_v, d)
+    return (b, max_s_q, sum_s_q, h_q, h_v, d)
+
+
+@functools.cache
+def _get_compiled_gdn_prefill_kernel(
+    problem_size,
+    dtype: torch.dtype,
+    is_varlen: bool,
+    is_initial_state: bool,
+    is_output_state: bool,
+    scale: float,
+    device_idx: int = 0,
+):
+    """Cache compiled kernel for given configuration."""
+    return {}
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """Public API: compile (on first call) and run the GDN chunked linear attention kernel.
+
+    Args:
+        q, k: (B, T, H_qk, D) query and key tensors (f16/bf16).
+        v:     (B, T, H_v, D) value tensor (f16/bf16). H_v must be a multiple of H_qk.
+        g:     (1, total_seq_len, H_v) gate values (f32, log-space).
+        beta:  (1, total_seq_len, H_v) beta values (f32, sigmoid-space).
+        scale: Scale factor for the attention scores. Defaults to 1/sqrt(D).
+        initial_state: (B, H_v, D, D) recurrent state (f32), or None for zero init.
+        output_final_state: If True, return the final state alongside output.
+        cu_seqlens: Cumulative sequence lengths for variable-length batching.
+        use_qk_l2norm_in_kernel: If True, use L2 norm of QK in the kernel.(Not supported yet)
+        output: Pre-allocated output tensor, or None to allocate internally.
+        output_state: Pre-allocated state output tensor, or None.
+
+    Returns:
+        output or (output, output_state) depending on output_final_state.
+    """
+
+    # Allocate output if needed
+    if output is None:
+        output = torch.empty_like(v)
+
+    # Check if supported
+    if not GDN.can_implement(
+        tuple(q.shape),
+        tuple(v.shape),
+        q.dtype,
+        output.dtype,
+        beta.dtype,
+        use_qk_l2norm_in_kernel,
+    ):
+        raise ValueError("Unsupported input shape or dtype")
+    cu_seqlens_tuple = tuple(cu_seqlens.tolist()) if cu_seqlens is not None else None
+    problem_size = _get_problem_size(tuple(q.shape), tuple(v.shape), cu_seqlens_tuple)
+
+    # Allocate output_state if needed
+    if output_final_state and (output_state is None):
+        output_state = torch.empty(
+            (problem_size[0], problem_size[4], problem_size[5], problem_size[5]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    # Compile kernel with TVM FFI (cached)
+    is_varlen = cu_seqlens is not None
+    is_initial_state = initial_state is not None
+    cache_problem_size = problem_size[5]
+    cache_key = (
+        cache_problem_size,
+        q.dtype,
+        is_varlen,
+        is_initial_state,
+        output_final_state,
+        scale,
+    )
+    device_idx = q.device.index
+    cache_key = cache_key + (device_idx,)
+    cache = _get_compiled_gdn_prefill_kernel(*cache_key)
+
+    with torch.cuda.device(device_idx):
+        current_stream = cuda.CUstream(
+            torch.cuda.current_stream(device_idx).cuda_stream
+        )
+
+        if "compiled_gdn" not in cache:
+            gdn = GDN()
+            q_tensor = from_dlpack(q, assumed_align=16, enable_tvm_ffi=True)
+            k_tensor = from_dlpack(k, assumed_align=16, enable_tvm_ffi=True)
+            v_tensor = from_dlpack(v, assumed_align=16, enable_tvm_ffi=True)
+            o_tensor = from_dlpack(output, assumed_align=16, enable_tvm_ffi=True)
+            gate_tensor = from_dlpack(g, assumed_align=16, enable_tvm_ffi=True)
+            beta_tensor = from_dlpack(beta, assumed_align=16, enable_tvm_ffi=True)
+            cu_seqlens_tensor = (
+                from_dlpack(cu_seqlens, assumed_align=16, enable_tvm_ffi=True)
+                if cu_seqlens is not None
+                else None
+            )
+            state_tensor = (
+                from_dlpack(initial_state, assumed_align=16, enable_tvm_ffi=True)
+                if initial_state is not None
+                else None
+            )
+            state_output_tensor = (
+                from_dlpack(output_state, assumed_align=16, enable_tvm_ffi=True)
+                if output_final_state
+                else None
+            )
+
+            options = EnableTVMFFI
+            compiled_gdn = cute.compile[options](
+                gdn,
+                q_tensor.iterator,
+                k_tensor.iterator,
+                v_tensor.iterator,
+                o_tensor.iterator,
+                gate_tensor.iterator,
+                beta_tensor.iterator,
+                problem_size,
+                state_tensor.iterator if state_tensor is not None else None,
+                state_output_tensor.iterator if output_final_state else None,
+                scale,
+                cu_seqlens_tensor.iterator if cu_seqlens_tensor is not None else None,
+                stream=current_stream,
+            )
+            cache["compiled_gdn"] = compiled_gdn
+
+        compiled_gdn = cache["compiled_gdn"]
+
+        compiled_gdn(
+            q.data_ptr(),
+            k.data_ptr(),
+            v.data_ptr(),
+            output.data_ptr(),
+            g.data_ptr(),
+            beta.data_ptr(),
+            problem_size,
+            initial_state.data_ptr() if initial_state is not None else None,
+            output_state.data_ptr() if output_final_state else None,
+            scale,
+            cu_seqlens.data_ptr() if is_varlen else None,
+            stream=current_stream,
+        )
+
+    if output_final_state:
+        return output, output_state
+    else:
+        return output

--- a/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn.py
+++ b/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn.py
@@ -182,7 +182,6 @@ class GDN:
         in_dtype: Type[cutlass.Numeric],
         out_dtype: Type[cutlass.Numeric],
         g_beta_dtype: Type[cutlass.Numeric],
-        use_qk_l2norm_in_kernel: bool = False,
     ) -> bool:
         """
         Check if the gdn can be implemented
@@ -193,10 +192,6 @@ class GDN:
         # Unpack parameters
         b, s_q, h_q, d = q_shape
         b_, _, h_v, d_ = v_shape
-
-        if use_qk_l2norm_in_kernel:
-            warnings.warn("use_qk_l2norm_in_kernel is not supported yet", stacklevel=2)
-            can_implement = False
 
         if b != b_:
             warnings.warn("q & k must have the same batch size", stacklevel=2)
@@ -4511,13 +4506,35 @@ def chunk_gated_delta_rule(
         initial_state: (B, H_v, D, D) recurrent state (f32), or None for zero init.
         output_final_state: If True, return the final state alongside output.
         cu_seqlens: Cumulative sequence lengths for variable-length batching.
-        use_qk_l2norm_in_kernel: If True, use L2 norm of QK in the kernel.(Not supported yet)
+        use_qk_l2norm_in_kernel: If True, apply L2 normalization to q and k before the kernel.
         output: Pre-allocated output tensor, or None to allocate internally.
         output_state: Pre-allocated state output tensor, or None.
 
     Returns:
         output or (output, output_state) depending on output_final_state.
     """
+
+    # Apply L2 normalization to q and k if requested
+    if use_qk_l2norm_in_kernel:
+        from rtp_llm.models_py.triton_kernels.fla.l2norm import (
+            l2norm_fwd,
+            l2norm_fwd_qk,
+        )
+
+        # Try fused qk path if q and k are adjacent in memory (from same split)
+        if (
+            q.stride() == k.stride()
+            and q.shape == k.shape
+            and not q.is_contiguous()
+            and q.stride(-1) == 1
+            and q.ndim >= 3
+            and k.data_ptr()
+            == q.data_ptr() + q.shape[-2] * q.shape[-1] * q.element_size()
+        ):
+            q, k = l2norm_fwd_qk(q, k)
+        else:
+            q = l2norm_fwd(q)
+            k = l2norm_fwd(k)
 
     # Allocate output if needed
     if output is None:
@@ -4530,7 +4547,6 @@ def chunk_gated_delta_rule(
         q.dtype,
         output.dtype,
         beta.dtype,
-        use_qk_l2norm_in_kernel,
     ):
         raise ValueError("Unsupported input shape or dtype")
     cu_seqlens_tuple = tuple(cu_seqlens.tolist()) if cu_seqlens is not None else None

--- a/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn_helpers.py
+++ b/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn_helpers.py
@@ -1,0 +1,177 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Type, Union
+
+import cutlass
+import cutlass.cute as cute
+
+
+def make_smem_layout_a_kind(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: cute.Tile,
+    a_dtype: Type[cutlass.Numeric],
+    num_stages: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps with:
+    1. Get the partitioned shape of the A tensor based on the tiled_mma & MMA tiler.
+    2. Select the heuristic SMEM layout atom based on the A tensor's majorness, the data type, and the major mode size.
+    3. cute.Tile the SMEM layout atom to the MMA tile shape.
+    4. Stage the SMEM layout based on the number of stages.
+
+    :param tiled_mma: The tiled MMA used to partition tensor A
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The MMA tile shape
+    :type mma_tiler_mnk: cute.cute.Tile
+    :param a_dtype: The element type for tensor A
+    :type a_dtype: Type[Numeric]
+    :param num_stages: The number of pipeline stages for tensor A
+    :type num_stages: int
+    :param kind:         The kind of layout Atom
+    :type kind:          SmemLayoutAtomKind
+
+    :return: SMEM layout for tensor A
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    is_k_major = (
+        tiled_mma.op.a_major_mode == cutlass.cute.nvgpu.tcgen05.OperandMajorMode.K
+    )
+    a_smem_shape = tiled_mma.partition_shape_A(
+        cute.dice(mma_tiler_mnk, (1, None, 1), loc=loc, ip=ip)
+    )
+    a_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        a_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    a_smem_layout_staged = cute.nvgpu.tcgen05.tile_to_mma_shape(
+        a_smem_layout_atom,
+        cute.append(a_smem_shape, num_stages, loc=loc, ip=ip),
+        order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+    return a_smem_layout_staged
+
+
+def make_smem_layout_b_kind(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: cute.Tile,
+    b_dtype: Type[cutlass.Numeric],
+    num_stages: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps:
+    1. Get the partitioned shape of the B tensor based on the tiled_mma & MMA tiler.
+    2. Select the heuristic SMEM layout atom based on the B tensor's majorness, the data type, and the major mode size.
+    3. cute.Tile the SMEM layout atom to the MMA tile shape.
+    4. Stage the SMEM layout based on the number of stages.
+
+    :param tiled_mma: The tiled MMA which is used to partition the B tensor.
+    :type tiled_mma: cute.TiledMma
+    :param mma_tiler_mnk: The MMA tile shape.
+    :type mma_tiler_mnk: cute.cute.Tile
+    :param b_dtype: The element type for the B tensor.
+    :type b_dtype: Type[Numeric]
+    :param num_stages: The stage of the B tensor.
+    :type num_stages: int
+    :param kind:         The kind of layout Atom
+    :type kind:          SmemLayoutAtomKind
+
+    :return: SMEM layout for the B tensor.
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    is_k_major = (
+        tiled_mma.op.b_major_mode == cutlass.cute.nvgpu.tcgen05.OperandMajorMode.K
+    )
+    b_smem_shape = tiled_mma.partition_shape_B(
+        cute.dice(mma_tiler_mnk, (None, 1, 1), loc=loc, ip=ip)
+    )
+    b_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        b_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    b_smem_layout_staged = cute.nvgpu.tcgen05.tile_to_mma_shape(
+        b_smem_layout_atom,
+        cute.append(b_smem_shape, num_stages, loc=loc, ip=ip),
+        order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+
+    return b_smem_layout_staged
+
+
+def make_smem_layout_epi_kind(
+    epi_dtype: Type[cutlass.Numeric],
+    epi_layout: cutlass.utils.LayoutEnum,
+    epi_tile: cute.Tile,
+    epi_stage: int,
+    kind: cute.nvgpu.tcgen05.SmemLayoutAtomKind,
+    *,
+    loc=None,
+    ip=None,
+) -> Union[cute.Layout, cute.ComposedLayout]:
+    """This function helps:
+    1. Select the heuristic SMEM layout atom based on the epilog tile shape,
+       the epilog tensor's majorness, and the element type.
+    2. cute.Tile the SMEM layout atom to the epilog tile shape.
+    3. Stage the SMEM layout based on the number of stages.
+
+    :param epi_dtype: The element type for the epilog tensor.
+    :type epi_dtype: Type[Numeric]
+    :param epi_layout: The layout enum for the epilog tensor.
+    :type epi_layout: LayoutEnum
+    :param epi_tile: The epilogue tile shape.
+    :type epi_tile: cute.cute.Tile
+    :param epi_stage: The stage of the epilog tensor.
+    :type epi_stage: int
+
+    :return: SMEM layout for epilog tensors (usually C & D which are processed in the epilog)
+    :rtype: Union[cute.Layout, cute.ComposedLayout]
+    """
+
+    epilog_shape = cute.product_each(
+        cute.shape(epi_tile, loc=loc, ip=ip), loc=loc, ip=ip
+    )
+
+    c_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+        kind,
+        epi_dtype,
+        loc=loc,
+        ip=ip,
+    )
+    epi_smem_layout_staged = cute.tile_to_shape(
+        c_smem_layout_atom,
+        cute.append(epilog_shape, epi_stage, loc=loc, ip=ip),
+        order=((1, 0, 2) if not epi_layout.is_n_major_c() else (0, 1, 2)),
+        loc=loc,
+        ip=ip,
+    )
+
+    return epi_smem_layout_staged

--- a/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn_tile_scheduler.py
+++ b/rtp_llm/models_py/triton_kernels/fla/blackwell_prefill/gdn_tile_scheduler.py
@@ -1,0 +1,164 @@
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+from cutlass.cute.typing import Boolean, Int32
+
+
+class GdnStaticTileSchedulerParams:
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mbh: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.is_persistent = is_persistent
+        self.problem_shape_mbh = problem_shape_mbh
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.is_persistent, self.problem_shape_mbh]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip(
+            [self.is_persistent, self.problem_shape_mbh], self._values_pos, strict=True
+        ):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return GdnStaticTileSchedulerParams(
+            *(tuple(obj_list)), loc=self._loc, ip=self._ip
+        )
+
+
+def create_gdn_static_tile_scheduler_params(
+    is_persistent: bool,
+    problem_shape_mbh: cute.Shape,
+) -> GdnStaticTileSchedulerParams:
+    return GdnStaticTileSchedulerParams(is_persistent, problem_shape_mbh)
+
+
+class GdnStaticTileScheduler:
+    def __init__(
+        self,
+        params: GdnStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mbh = cute.make_layout(
+            params.problem_shape_mbh, loc=loc, ip=ip
+        )
+        self._num_blocks = cute.size(self._problem_shape_mbh, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: GdnStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        if params.is_persistent:
+            hardware_info = cutlass.utils.HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                cutlass.min(
+                    sm_count, cute.size(params.problem_shape_mbh, loc=loc, ip=ip)
+                ),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mbh
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> utils.WorkTileInfo:
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mbh.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return utils.WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        values = cutlass.extract_mlir_values(self._params)
+        values.extend(cutlass.extract_mlir_values(self._current_work_linear_idx))
+        values.extend(cutlass.extract_mlir_values(self._blk_coord))
+        values.extend(cutlass.extract_mlir_values(self._grid_shape))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 10
+        new_params = cutlass.new_from_mlir_values(self._params, values[0:3])
+        new_current_work_linear_idx = cutlass.new_from_mlir_values(
+            self._current_work_linear_idx, [values[3]]
+        )
+        new_blk_coord = cutlass.new_from_mlir_values(self._blk_coord, values[4:7])
+        new_grid_shape = cutlass.new_from_mlir_values(self._grid_shape, values[7:])
+        return GdnStaticTileScheduler(
+            new_params,
+            new_current_work_linear_idx,
+            new_blk_coord,
+            new_grid_shape,
+            loc=self._loc,
+            ip=self._ip,
+        )
+
+
+def create_gdn_static_tile_scheduler(
+    params: GdnStaticTileSchedulerParams,
+    blk_coord: cute.Coord,
+    grid_shape: cute.Shape,
+) -> GdnStaticTileScheduler:
+    return GdnStaticTileScheduler(params, blk_coord[0], blk_coord, grid_shape)

--- a/rtp_llm/models_py/triton_kernels/fla/block.py
+++ b/rtp_llm/models_py/triton_kernels/fla/block.py
@@ -217,3 +217,89 @@ def store_ssm_state_to_block_map(
         CONV_STRIDE_TOKEN=token_stride_ssm_state,
         CHUNK_SIZE=chunk_size,
     )
+
+
+@triton.jit(do_not_specialize=["max_block_size"])
+def store_final_state_to_block_map_kernel(
+    final_states: tl.tensor,
+    prefix_lengths: tl.tensor,
+    cu_seqlens: tl.tensor,
+    block_map: tl.tensor,
+    ssm_states: tl.tensor,
+    max_block_size: tl.int32,
+    HEAD_NUM: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+    SEQ_SIZE_PER_BLOCK: tl.constexpr,
+    CONV_STRIDE_TOKEN: tl.constexpr,
+):
+    """Store only final_state per sequence (no intermediate chunk states)."""
+    i_b, i_h, i_v = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+
+    SSM_PER_HEAD = K * V
+    SSM_PER_BATCH = SSM_PER_HEAD * HEAD_NUM
+    v_offset = i_v * BLOCK_V
+
+    prefix = tl.load(prefix_lengths + i_b)
+    bos = tl.load(cu_seqlens + i_b).to(tl.int32)
+    eos = tl.load(cu_seqlens + i_b + 1).to(tl.int32)
+    input_len = eos - bos
+
+    if input_len <= 0:
+        return
+
+    dest_block_pos = (prefix + input_len - 1) // SEQ_SIZE_PER_BLOCK
+    block_idx = tl.load(block_map + i_b * max_block_size + dest_block_pos).to(tl.int64)
+
+    if block_idx <= 0:
+        return
+
+    source_ptr = final_states + i_b * SSM_PER_BATCH + i_h * SSM_PER_HEAD
+    dest_ptr = ssm_states + block_idx * CONV_STRIDE_TOKEN + i_h * SSM_PER_HEAD
+
+    p_in = tl.make_block_ptr(
+        source_ptr, (V, K), (K, 1), (v_offset, 0), (BLOCK_V, K), (1, 0)
+    )
+    p_out = tl.make_block_ptr(
+        dest_ptr, (V, K), (K, 1), (v_offset, 0), (BLOCK_V, K), (1, 0)
+    )
+
+    tl.store(
+        p_out,
+        tl.load(p_in, boundary_check=(0, 1)).to(ssm_states.dtype.element_ty),
+        boundary_check=(0, 1),
+    )
+
+
+def store_final_state_only_to_block_map(
+    final_states: torch.Tensor,
+    prefix_lengths: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    block_map: torch.Tensor,
+    ssm_states: torch.Tensor,
+    seq_size_per_block: int,
+    block_v: int = 64,
+):
+    """Store only final_state per sequence to block map (no intermediate chunk states).
+    Used when the kernel only returns final_state, not per-chunk states."""
+    assert final_states.dtype == torch.float32, "final_states must be float32"
+    batch_size = prefix_lengths.shape[0]
+    _, head_num, v, k = ssm_states.shape
+    max_block_size = block_map.shape[1]
+    token_stride = ssm_states.stride(0)
+    grid = (batch_size, head_num, triton.cdiv(v, block_v))
+    store_final_state_to_block_map_kernel[grid](
+        final_states,
+        prefix_lengths,
+        cu_seqlens,
+        block_map,
+        ssm_states,
+        max_block_size,
+        HEAD_NUM=head_num,
+        V=v,
+        K=k,
+        BLOCK_V=block_v,
+        SEQ_SIZE_PER_BLOCK=seq_size_per_block,
+        CONV_STRIDE_TOKEN=token_stride,
+    )

--- a/rtp_llm/models_py/triton_kernels/fla/chunk.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk.py
@@ -12,6 +12,7 @@ from rtp_llm.models_py.triton_kernels.fla.chunk_delta_h import (
 )
 from rtp_llm.models_py.triton_kernels.fla.chunk_o import chunk_fwd_o
 from rtp_llm.models_py.triton_kernels.fla.chunk_scaled_dot_kkt import (
+    chunk_cumsum_kkt_fwd,
     chunk_scaled_dot_kkt_fwd,
 )
 from rtp_llm.models_py.triton_kernels.fla.cumsum import chunk_local_cumsum
@@ -20,6 +21,7 @@ from rtp_llm.models_py.triton_kernels.fla.solve_tril import solve_tril
 from rtp_llm.models_py.triton_kernels.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
+    custom_device_ctx,
     input_guard,
 )
 from rtp_llm.models_py.triton_kernels.fla.wy_fast import recompute_w_u_fwd
@@ -36,10 +38,10 @@ def chunk_gated_delta_rule_fwd(
     output_final_state: bool,
     cu_seqlens: Optional[torch.LongTensor] = None,
 ):
-    g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
-    # obtain WY representation. u is actually the new v.
-    A = chunk_scaled_dot_kkt_fwd(
-        k=k, beta=beta, g_cumsum=g, cu_seqlens=cu_seqlens, output_dtype=torch.float32
+    # Fused cumsum + KKT: computes g_cumsum and A in a single kernel launch,
+    # avoiding the intermediate g_cumsum global memory round-trip.
+    g, A = chunk_cumsum_kkt_fwd(
+        k=k, beta=beta, g=g, cu_seqlens=cu_seqlens, output_dtype=torch.float32
     )
     A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
     w, u = recompute_w_u_fwd(
@@ -74,7 +76,6 @@ def chunk_gated_delta_rule_fwd(
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
 
     @staticmethod
-    @input_guard
     @autocast_custom_fwd
     def forward(
         ctx,
@@ -89,25 +90,30 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens: Optional[torch.LongTensor] = None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
-        q_orig = q
-        k_orig = k
+        # q, k, v may be non-contiguous views from packed qkv split;
+        # l2norm_fwd handles non-contiguous q/k via reshape, and
+        # recompute_w_u_fwd handles non-contiguous v via stride param.
+        # g, beta, initial_state, cu_seqlens should already be contiguous.
+        with custom_device_ctx(q.device.index):
+            q_orig = q
+            k_orig = k
 
-        if use_qk_l2norm_in_kernel:
-            q = l2norm_fwd(q)
-            k = l2norm_fwd(k)
+            if use_qk_l2norm_in_kernel:
+                q = l2norm_fwd(q)
+                k = l2norm_fwd(k)
 
-        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            scale=scale,
-            initial_state=initial_state,
-            output_final_state=output_final_state,
-            cu_seqlens=cu_seqlens,
-        )
-        return o.to(q.dtype), h, final_state
+            g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+            )
+            return o.to(q.dtype), h, final_state
 
 
 @torch.compiler.disable

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_o.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_o.py
@@ -152,7 +152,7 @@ def chunk_fwd_o(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    o = torch.zeros_like(v)
+    o = torch.empty_like(v)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * H)

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_scaled_dot_kkt.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_scaled_dot_kkt.py
@@ -18,15 +18,6 @@ from rtp_llm.models_py.triton_kernels.fla.op import safe_exp
         "USE_G": lambda args: args["g_cumsum"] is not None,
     }
 )
-# @triton.autotune(
-#     configs=[
-#         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
-#         for BK in [32, 64, 128]
-#         for num_warps in [2, 4, 8]
-#         for num_stages in [2, 3, 4]
-#     ],
-#     key=["H", "K", "BT", "IS_VARLEN"],
-# )
 @triton.jit(do_not_specialize=["T"])
 def chunk_scaled_dot_kkt_fwd_kernel(
     k,
@@ -83,6 +74,90 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         b_g = tl.load(p_g, boundary_check=(0,))
         b_g_diff = b_g[:, None] - b_g[None, :]
         b_A = b_A * safe_exp(b_g_diff)
+
+    b_A *= b_beta[:, None]
+    b_A = tl.where(o_t[:, None] > o_t[None, :], b_A, 0)
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (BT * H, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_cumsum_kkt_fwd_kernel(
+    k,
+    beta,
+    g_raw,
+    g_cumsum_out,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Fused chunk-local cumsum of g + scaled KK^T computation.
+
+    Computes g_cumsum = chunk_local_cumsum(g) and
+    A = lower_tri(beta * exp(g_diff) * K @ K^T) in a single kernel.
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    o_t = tl.arange(0, BT)
+
+    # --- Inline cumsum of g ---
+    p_g_in = tl.make_block_ptr(
+        g_raw + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    b_g_raw = tl.load(p_g_in, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.cumsum(b_g_raw, axis=0)
+    # Store g_cumsum for downstream kernels (recompute_w_u, fwd_h, fwd_o)
+    p_g_out = tl.make_block_ptr(
+        g_cumsum_out + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    tl.store(p_g_out, b_g.to(p_g_out.dtype.element_ty), boundary_check=(0,))
+
+    # --- KK^T computation ---
+    p_beta = tl.make_block_ptr(
+        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_A += tl.dot(b_k, tl.trans(b_k))
+
+    # Apply gating directly from registers (no global memory re-read)
+    b_g_diff = b_g[:, None] - b_g[None, :]
+    b_A = b_A * safe_exp(b_g_diff)
 
     b_A *= b_beta[:, None]
     b_A = tl.where(o_t[:, None] > o_t[None, :], b_A, 0)
@@ -149,3 +224,41 @@ def chunk_scaled_dot_kkt_fwd(
         num_stages=3,
     )
     return A
+
+
+def chunk_cumsum_kkt_fwd(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32,
+) -> tuple:
+    """Fused cumsum + KKT: computes g_cumsum and A in a single kernel launch."""
+    B, T, Hg, K = k.shape
+    H = beta.shape[-1]
+    BT = chunk_size
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+    g_cumsum = torch.empty_like(g, dtype=torch.float32)
+    chunk_cumsum_kkt_fwd_kernel[(NT, B * H)](
+        k=k,
+        beta=beta,
+        g_raw=g,
+        g_cumsum_out=g_cumsum,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        BT=BT,
+        BK=64,
+        num_warps=8,
+        num_stages=3,
+    )
+    return g_cumsum, A

--- a/rtp_llm/models_py/triton_kernels/fla/index.py
+++ b/rtp_llm/models_py/triton_kernels/fla/index.py
@@ -13,23 +13,39 @@ def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
     return cu_seqlens[1:] - cu_seqlens[:-1]
 
 
+def _cdiv_cpu(lens: torch.LongTensor, chunk_size: int):
+    """Ceiling division on CPU to avoid GPU kernel launches for tiny tensors."""
+    lens_cpu = lens.tolist()
+    return [triton.cdiv(l, chunk_size) for l in lens_cpu]
+
+
 @tensor_cache
 def prepare_chunk_indices(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
-    indices = torch.cat(
-        [
-            torch.arange(n)
-            for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
-        ]
+    # Build indices entirely on CPU, then transfer to GPU once.
+    # Each entry is (batch_idx, chunk_idx_within_seq).
+    chunks_per_seq = _cdiv_cpu(prepare_lens(cu_seqlens), chunk_size)
+    batch_ids = []
+    chunk_ids = []
+    for seq_idx, n_chunks in enumerate(chunks_per_seq):
+        batch_ids.extend([seq_idx] * n_chunks)
+        chunk_ids.extend(range(n_chunks))
+    result = torch.tensor(
+        list(zip(batch_ids, chunk_ids)),
+        dtype=cu_seqlens.dtype,
+        device=cu_seqlens.device,
     )
-    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+    return result
 
 
 @tensor_cache
 def prepare_chunk_offsets(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
-    return torch.cat(
-        [cu_seqlens.new_tensor([0]), triton.cdiv(prepare_lens(cu_seqlens), chunk_size)]
-    ).cumsum(-1)
+    chunks = _cdiv_cpu(prepare_lens(cu_seqlens), chunk_size)
+    # Cumsum on CPU (only batch+1 elements), then transfer to GPU once
+    import itertools
+
+    offsets = list(itertools.accumulate([0] + chunks))
+    return torch.tensor(offsets, dtype=cu_seqlens.dtype, device=cu_seqlens.device)

--- a/rtp_llm/models_py/triton_kernels/fla/l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/l2norm.py
@@ -187,6 +187,94 @@ def l2norm_fwd(
     return y.view(x_shape_og)
 
 
+@triton.jit
+def l2norm_fwd_qk_kernel(
+    x,
+    y_q,
+    y_k,
+    stride_x_row: tl.int64,
+    D,
+    BD: tl.constexpr,
+    H_K: tl.constexpr,
+    eps,
+):
+    """L2-normalize q and k heads from a packed non-contiguous input into
+    two separate contiguous outputs in a single kernel launch.
+
+    Input: packed [token0: q_h0..q_h{H_K-1}, k_h0..k_h{H_K-1}, ...][token1: ...]
+           with tokens separated by stride_x_row.
+    Output: y_q is contiguous [T*H_K, D], y_k is contiguous [T*H_K, D].
+
+    program_id(0) iterates over T * H_K * 2 rows total.
+    """
+    i_t = tl.program_id(0)
+    total_heads = H_K * 2
+    token = i_t // total_heads
+    head_in_token = i_t % total_heads
+    is_k = head_in_token >= H_K
+    head_local = tl.where(is_k, head_in_token - H_K, head_in_token)
+
+    # Input: strided by token, q+k heads adjacent within token
+    x += token * stride_x_row + head_in_token * D
+
+    # Output: separate contiguous buffers
+    out_row = token * H_K + head_local
+    y = tl.where(is_k, y_k, y_q)
+    y += out_row * D
+
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_var = tl.sum(b_x * b_x, axis=0)
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+
+
+def l2norm_fwd_qk(
+    q: torch.Tensor, k: torch.Tensor, eps: float = 1e-6
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused l2-normalize q and k in a single kernel launch.
+
+    q and k must come from the same torch.split (adjacent per-token in memory)
+    with identical strides and shapes.
+
+    Returns contiguous (q_normed, k_normed) each with shape matching input.
+    """
+    assert q.stride() == k.stride(), "q and k must have identical strides"
+    assert q.shape == k.shape, "q and k must have identical shapes"
+    assert q.stride(-1) == 1 and q.ndim >= 3, "last dim must be contiguous"
+    H_k = q.shape[-2]
+    D = q.shape[-1]
+    assert (
+        k.data_ptr() == q.data_ptr() + H_k * D * q.element_size()
+    ), "q and k must be adjacent in memory (from same torch.split)"
+
+    stride_token = q.stride(-3)
+    num_tokens = q.numel() // (H_k * D)
+    total_rows = num_tokens * H_k * 2
+
+    BD = min(65536 // q.element_size(), triton.next_power_of_2(D))
+
+    q_out = torch.empty(num_tokens * H_k, D, dtype=q.dtype, device=q.device)
+    k_out = torch.empty(num_tokens * H_k, D, dtype=k.dtype, device=k.device)
+
+    l2norm_fwd_qk_kernel[(total_rows,)](
+        q,
+        q_out,
+        k_out,
+        stride_x_row=stride_token,
+        eps=eps,
+        D=D,
+        BD=BD,
+        H_K=H_k,
+        num_warps=8,
+        num_stages=3,
+    )
+
+    return q_out.view(q.shape), k_out.view(k.shape)
+
+
 class L2NormFunction(torch.autograd.Function):
 
     @staticmethod

--- a/rtp_llm/models_py/triton_kernels/fla/l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/l2norm.py
@@ -117,36 +117,9 @@ def l2norm_fwd(
     if D > BD:
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
-    # Fast path: non-contiguous input with contiguous last dim (e.g. from torch.split + view).
-    # Directly read strided input and write contiguous output — avoids the implicit copy
-    # that .reshape() would trigger.
-    if not x.is_contiguous() and x.stride(-1) == 1 and x.ndim >= 3:
-        # x is (..., heads, D) where heads*D is contiguous per-token but tokens are strided
-        heads = x.shape[-2]
-        num_tokens = x.numel() // (heads * D)
-        # token stride in elements (the non-contiguous gap)
-        stride_token = x.stride(-3)
-        total_rows = num_tokens * heads
-
-        if output_dtype is None:
-            y = torch.empty(total_rows, D, dtype=x.dtype, device=x.device)
-        else:
-            y = torch.empty(total_rows, D, dtype=output_dtype, device=x.device)
-
-        l2norm_fwd_strided_kernel[(total_rows,)](
-            x,
-            y,
-            stride_x_row=stride_token,
-            eps=eps,
-            D=D,
-            BD=BD,
-            HEADS_PER_TOKEN=heads,
-            num_warps=8,
-            num_stages=3,
-        )
-        return y.view(x_shape_og)
-
-    # Standard path: contiguous input
+    # Always use contiguous path — the strided kernel has poor memory access patterns
+    # that cause 10-30x slowdown on large token counts (e.g. 2M rows from 64K prefill).
+    # The implicit copy from .reshape() is much cheaper than strided reads.
     x = x.reshape(-1, x.shape[-1])
     if output_dtype is None:
         y = torch.empty_like(x)
@@ -155,12 +128,16 @@ def l2norm_fwd(
     assert y.stride(-1) == 1
     T = x.shape[0]
 
-    if D <= 512 and T <= 128:
-        NB = triton.cdiv(T, 2048)
+    if D <= 512:
+        # Batched kernel: process BT rows per block to reduce launch count.
+        # For D=128 with 2M rows, this reduces blocks from 2M to ~32K.
+        BT = max(16, min(64, 8192 // BD))
+        num_warps = min(max(BT * BD // 256, 1), 8)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]),)
 
+        NB = triton.cdiv(T, 2048)
         l2norm_fwd_kernel[grid](
             x,
             y,
@@ -169,18 +146,19 @@ def l2norm_fwd(
             T=T,
             D=D,
             BD=BD,
-            BT=16,
-            num_warps=8,
+            BT=BT,
+            num_warps=num_warps,
             num_stages=3,
         )
     else:
+        num_warps = min(max(BD // 256, 1), 8)
         l2norm_fwd_kernel1[(T,)](
             x,
             y,
             eps=eps,
             D=D,
             BD=BD,
-            num_warps=8,
+            num_warps=num_warps,
             num_stages=3,
         )
 
@@ -234,45 +212,12 @@ def l2norm_fwd_qk_kernel(
 def l2norm_fwd_qk(
     q: torch.Tensor, k: torch.Tensor, eps: float = 1e-6
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fused l2-normalize q and k in a single kernel launch.
+    """L2-normalize q and k, returning contiguous outputs.
 
-    q and k must come from the same torch.split (adjacent per-token in memory)
-    with identical strides and shapes.
-
-    Returns contiguous (q_normed, k_normed) each with shape matching input.
+    Uses the standard contiguous l2norm path which has much better memory
+    access patterns than the strided kernel (10-30x faster for large prefills).
     """
-    assert q.stride() == k.stride(), "q and k must have identical strides"
-    assert q.shape == k.shape, "q and k must have identical shapes"
-    assert q.stride(-1) == 1 and q.ndim >= 3, "last dim must be contiguous"
-    H_k = q.shape[-2]
-    D = q.shape[-1]
-    assert (
-        k.data_ptr() == q.data_ptr() + H_k * D * q.element_size()
-    ), "q and k must be adjacent in memory (from same torch.split)"
-
-    stride_token = q.stride(-3)
-    num_tokens = q.numel() // (H_k * D)
-    total_rows = num_tokens * H_k * 2
-
-    BD = min(65536 // q.element_size(), triton.next_power_of_2(D))
-
-    q_out = torch.empty(num_tokens * H_k, D, dtype=q.dtype, device=q.device)
-    k_out = torch.empty(num_tokens * H_k, D, dtype=k.dtype, device=k.device)
-
-    l2norm_fwd_qk_kernel[(total_rows,)](
-        q,
-        q_out,
-        k_out,
-        stride_x_row=stride_token,
-        eps=eps,
-        D=D,
-        BD=BD,
-        H_K=H_k,
-        num_warps=8,
-        num_stages=3,
-    )
-
-    return q_out.view(q.shape), k_out.view(k.shape)
+    return l2norm_fwd(q, eps), l2norm_fwd(k, eps)
 
 
 class L2NormFunction(torch.autograd.Function):

--- a/rtp_llm/models_py/triton_kernels/fla/l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/l2norm.py
@@ -43,6 +43,41 @@ def l2norm_fwd_kernel1(
     tl.store(y + cols, b_y, mask=mask)
 
 
+@triton.jit
+def l2norm_fwd_strided_kernel(
+    x,
+    y,
+    stride_x_row: tl.int64,
+    D,
+    BD: tl.constexpr,
+    HEADS_PER_TOKEN: tl.constexpr,
+    eps,
+):
+    """L2-normalize rows from a non-contiguous input into contiguous output.
+
+    Input layout:  each token has HEADS_PER_TOKEN * D contiguous elements,
+                   but tokens are separated by stride_x_row (> HEADS_PER_TOKEN * D).
+    Output layout: fully contiguous (T * HEADS_PER_TOKEN, D).
+
+    program_id(0) iterates over T * HEADS_PER_TOKEN rows.
+    """
+    i_t = tl.program_id(0)
+    # Map flat row index to (token, head_within_token)
+    token = i_t // HEADS_PER_TOKEN
+    head = i_t % HEADS_PER_TOKEN
+    # Input: strided by token, contiguous within token
+    x += token * stride_x_row + head * D
+    # Output: always contiguous
+    y += i_t * D
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_var = tl.sum(b_x * b_x, axis=0)
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+
+
 # @triton.autotune(
 #     configs=[
 #         triton.Config({"BT": BT}, num_warps=num_warps)
@@ -75,23 +110,51 @@ def l2norm_fwd(
     x: torch.Tensor, eps: float = 1e-6, output_dtype: Optional[torch.dtype] = None
 ):
     x_shape_og = x.shape
-    x = x.view(-1, x.shape[-1])
-    # allocate output
-    if output_dtype is None:
-        y = torch.empty_like(x)
-    else:
-        y = torch.empty_like(x, dtype=output_dtype)
-    assert y.stride(-1) == 1
-    T, D = x.shape[0], x.shape[-1]
-    # rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
-    # Less than 64KB per feature: enqueue fused kernel
+    D = x.shape[-1]
+
     MAX_FUSED_SIZE = 65536 // x.element_size()
     BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
     if D > BD:
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
-    # Not use this path since different batch will always go into compile， since T is different,
-    # and compile time is too long (70ms) compared to kernel execution time (under 1ms)
+    # Fast path: non-contiguous input with contiguous last dim (e.g. from torch.split + view).
+    # Directly read strided input and write contiguous output — avoids the implicit copy
+    # that .reshape() would trigger.
+    if not x.is_contiguous() and x.stride(-1) == 1 and x.ndim >= 3:
+        # x is (..., heads, D) where heads*D is contiguous per-token but tokens are strided
+        heads = x.shape[-2]
+        num_tokens = x.numel() // (heads * D)
+        # token stride in elements (the non-contiguous gap)
+        stride_token = x.stride(-3)
+        total_rows = num_tokens * heads
+
+        if output_dtype is None:
+            y = torch.empty(total_rows, D, dtype=x.dtype, device=x.device)
+        else:
+            y = torch.empty(total_rows, D, dtype=output_dtype, device=x.device)
+
+        l2norm_fwd_strided_kernel[(total_rows,)](
+            x,
+            y,
+            stride_x_row=stride_token,
+            eps=eps,
+            D=D,
+            BD=BD,
+            HEADS_PER_TOKEN=heads,
+            num_warps=8,
+            num_stages=3,
+        )
+        return y.view(x_shape_og)
+
+    # Standard path: contiguous input
+    x = x.reshape(-1, x.shape[-1])
+    if output_dtype is None:
+        y = torch.empty_like(x)
+    else:
+        y = torch.empty_like(x, dtype=output_dtype)
+    assert y.stride(-1) == 1
+    T = x.shape[0]
+
     if D <= 512 and T <= 128:
         NB = triton.cdiv(T, 2048)
 

--- a/rtp_llm/models_py/triton_kernels/fla/solve_tril.py
+++ b/rtp_llm/models_py/triton_kernels/fla/solve_tril.py
@@ -393,6 +393,268 @@ def merge_16x16_to_64x64_inverse_kernel(
     )
 
 
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T"])
+def solve_tril_merge_64x64_kernel(
+    A,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Fused 16×16 solve + merge into 64×64 inverse in a single kernel.
+
+    Each thread block handles one 64×64 tile: solves 4 diagonal 16×16 blocks,
+    then merges them using the block-triangular inverse formula.
+    """
+    BT: tl.constexpr = 64
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    A_base = A + (bos * H + i_h) * BT
+    o_i = tl.arange(0, 16)
+
+    # --- Phase 1: Solve 4 diagonal 16×16 blocks ---
+    # Block 0: rows [0:16], cols [0:16]
+    p0 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64, 0), (16, 16), (1, 0)
+    )
+    b0 = tl.load(p0, boundary_check=(0, 1)).to(tl.float32)
+    b0 = -tl.where(o_i[:, None] > o_i[None, :], b0, 0)
+    for i in range(1, 16):
+        row = -tl.load(A_base + (i_t * 64 + i) * H * BT + o_i + 0)
+        row = row + tl.sum(row[:, None] * b0, 0)
+        b0 = tl.where((o_i == i)[:, None], row, b0)
+    Ai_11 = b0 + (o_i[:, None] == o_i[None, :]).to(tl.float32)
+
+    # Block 1: rows [16:32], cols [16:32]
+    p1 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 16, 16), (16, 16), (1, 0)
+    )
+    b1 = tl.load(p1, boundary_check=(0, 1)).to(tl.float32)
+    b1 = -tl.where(o_i[:, None] > o_i[None, :], b1, 0)
+    for i in range(1, 16):
+        row = -tl.load(A_base + (i_t * 64 + 16 + i) * H * BT + o_i + 16)
+        row = row + tl.sum(row[:, None] * b1, 0)
+        b1 = tl.where((o_i == i)[:, None], row, b1)
+    Ai_22 = b1 + (o_i[:, None] == o_i[None, :]).to(tl.float32)
+
+    # Block 2: rows [32:48], cols [32:48]
+    p2 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 32, 32), (16, 16), (1, 0)
+    )
+    b2 = tl.load(p2, boundary_check=(0, 1)).to(tl.float32)
+    b2 = -tl.where(o_i[:, None] > o_i[None, :], b2, 0)
+    for i in range(1, 16):
+        row = -tl.load(A_base + (i_t * 64 + 32 + i) * H * BT + o_i + 32)
+        row = row + tl.sum(row[:, None] * b2, 0)
+        b2 = tl.where((o_i == i)[:, None], row, b2)
+    Ai_33 = b2 + (o_i[:, None] == o_i[None, :]).to(tl.float32)
+
+    # Block 3: rows [48:64], cols [48:64]
+    p3 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 48, 48), (16, 16), (1, 0)
+    )
+    b3 = tl.load(p3, boundary_check=(0, 1)).to(tl.float32)
+    b3 = -tl.where(o_i[:, None] > o_i[None, :], b3, 0)
+    for i in range(1, 16):
+        row = -tl.load(A_base + (i_t * 64 + 48 + i) * H * BT + o_i + 48)
+        row = row + tl.sum(row[:, None] * b3, 0)
+        b3 = tl.where((o_i == i)[:, None], row, b3)
+    Ai_44 = b3 + (o_i[:, None] == o_i[None, :]).to(tl.float32)
+
+    # --- Phase 2: Merge (block-triangular inverse formula) ---
+    Ai_base = Ai + (bos * H + i_h) * BT
+
+    p_A_21 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 16, 0), (16, 16), (1, 0)
+    )
+    p_A_32 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 32, 16), (16, 16), (1, 0)
+    )
+    p_A_31 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 32, 0), (16, 16), (1, 0)
+    )
+    p_A_43 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 48, 32), (16, 16), (1, 0)
+    )
+    p_A_42 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 48, 16), (16, 16), (1, 0)
+    )
+    p_A_41 = tl.make_block_ptr(
+        A_base, (T, BT), (H * BT, 1), (i_t * 64 + 48, 0), (16, 16), (1, 0)
+    )
+
+    A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
+    A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
+    A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
+    A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
+    A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
+
+    Ai_21 = -tl.dot(
+        tl.dot(Ai_22, A_21, input_precision="ieee"), Ai_11, input_precision="ieee"
+    )
+    Ai_32 = -tl.dot(
+        tl.dot(Ai_33, A_32, input_precision="ieee"), Ai_22, input_precision="ieee"
+    )
+    Ai_43 = -tl.dot(
+        tl.dot(Ai_44, A_43, input_precision="ieee"), Ai_33, input_precision="ieee"
+    )
+    Ai_31 = -tl.dot(
+        Ai_33,
+        tl.dot(A_31, Ai_11, input_precision="ieee")
+        + tl.dot(A_32, Ai_21, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    Ai_42 = -tl.dot(
+        Ai_44,
+        tl.dot(A_42, Ai_22, input_precision="ieee")
+        + tl.dot(A_43, Ai_32, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    Ai_41 = -tl.dot(
+        Ai_44,
+        tl.dot(A_41, Ai_11, input_precision="ieee")
+        + tl.dot(A_42, Ai_21, input_precision="ieee")
+        + tl.dot(A_43, Ai_31, input_precision="ieee"),
+        input_precision="ieee",
+    )
+
+    # --- Phase 3: Store all 16 blocks ---
+    fill_zeros = tl.zeros((16, 16), dtype=tl.float32)
+    stride_row = H * BT
+    base_t = i_t * 64
+
+    # Diagonal
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t, 0), (16, 16), (1, 0)
+        ),
+        Ai_11.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 16, 16), (16, 16), (1, 0)
+        ),
+        Ai_22.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 32, 32), (16, 16), (1, 0)
+        ),
+        Ai_33.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 48, 48), (16, 16), (1, 0)
+        ),
+        Ai_44.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    # Lower triangular
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 16, 0), (16, 16), (1, 0)
+        ),
+        Ai_21.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 32, 0), (16, 16), (1, 0)
+        ),
+        Ai_31.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 32, 16), (16, 16), (1, 0)
+        ),
+        Ai_32.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 48, 0), (16, 16), (1, 0)
+        ),
+        Ai_41.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 48, 16), (16, 16), (1, 0)
+        ),
+        Ai_42.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 48, 32), (16, 16), (1, 0)
+        ),
+        Ai_43.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    # Upper triangular (zeros)
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t, 16), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t, 32), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t, 48), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 16, 32), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 16, 48), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        tl.make_block_ptr(
+            Ai_base, (T, BT), (stride_row, 1), (base_t + 32, 48), (16, 16), (1, 0)
+        ),
+        fill_zeros.to(Ai_base.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+
 @input_guard
 def solve_tril(
     A: torch.Tensor,
@@ -418,10 +680,10 @@ def solve_tril(
     assert A.shape[-1] in [16, 32, 64]
 
     B, T, H, BT = A.shape
+
     Ad = torch.empty(
         B, T, H, 16, device=A.device, dtype=torch.float if BT != 16 else output_dtype
     )
-
     chunk_indices = (
         prepare_chunk_indices(cu_seqlens, 16) if cu_seqlens is not None else None
     )

--- a/rtp_llm/models_py/triton_kernels/fla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/fla/test/BUILD
@@ -49,3 +49,15 @@ py_test(
     visibility = ["//visibility:public"],
     exec_properties = {'gpu':'H20'},
 )
+
+py_test(
+    name = "test_gdn_prefill_perf",
+    srcs = [
+        "test_gdn_prefill_perf.py"
+    ],
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:fla",
+    ] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
+    visibility = ["//visibility:public"],
+    exec_properties = {'gpu':'H20'},
+)

--- a/rtp_llm/models_py/triton_kernels/fla/test/bench_gdn_8layer_64k.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/bench_gdn_8layer_64k.py
@@ -1,0 +1,144 @@
+"""
+Benchmark: 8-layer GDN prefill @ 64K tokens (TP2 Qwen3.5-35B config).
+Measures full gating + chunk_gated_delta_rule pipeline per layer,
+run 8 times sequentially to simulate 8 linear attention layers.
+Also produces a Chrome trace JSON for timeline analysis.
+"""
+
+import json
+import os
+import time
+
+import torch
+import torch.nn.functional as F
+
+from rtp_llm.models_py.triton_kernels.fla.chunk import chunk_gated_delta_rule
+from rtp_llm.models_py.triton_kernels.fla.gdn_gating import fused_gdn_gating
+
+DEVICE = "cuda"
+NUM_LAYERS = 8
+SEQ_LEN = 65536
+NUM_K_HEADS = 8
+NUM_V_HEADS = 32
+HEAD_K_DIM = 128
+HEAD_V_DIM = 128
+DTYPE = torch.bfloat16
+WARMUP = 5
+REPEAT = 20
+
+
+def make_layer_inputs():
+    qkv_dim = NUM_K_HEADS * HEAD_K_DIM * 2 + NUM_V_HEADS * HEAD_V_DIM
+    mixed_qkv = torch.randn(SEQ_LEN, qkv_dim, dtype=DTYPE, device=DEVICE)
+    A_log = torch.randn(NUM_V_HEADS, dtype=DTYPE, device=DEVICE)
+    a = torch.randn(SEQ_LEN, NUM_V_HEADS, dtype=DTYPE, device=DEVICE)
+    b = torch.randn(SEQ_LEN, NUM_V_HEADS, dtype=DTYPE, device=DEVICE)
+    dt_bias = torch.randn(NUM_V_HEADS, dtype=DTYPE, device=DEVICE)
+    cu_seqlens = torch.tensor([0, SEQ_LEN], dtype=torch.int32, device=DEVICE)
+    initial_state = torch.randn(
+        1,
+        NUM_V_HEADS,
+        HEAD_V_DIM,
+        HEAD_K_DIM,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    return mixed_qkv, A_log, a, b, dt_bias, cu_seqlens, initial_state
+
+
+def run_one_layer(mixed_qkv, A_log, a, b, dt_bias, cu_seqlens, initial_state):
+    g, beta = fused_gdn_gating(A_log, a, b, dt_bias)
+
+    query, key, value = torch.split(
+        mixed_qkv,
+        [NUM_K_HEADS * HEAD_K_DIM, NUM_K_HEADS * HEAD_K_DIM, NUM_V_HEADS * HEAD_V_DIM],
+        dim=-1,
+    )
+    query = query.view(1, query.shape[0], NUM_K_HEADS, HEAD_K_DIM)
+    key = key.view(1, key.shape[0], NUM_K_HEADS, HEAD_K_DIM)
+    value = value.view(1, value.shape[0], NUM_V_HEADS, HEAD_V_DIM)
+
+    attn_out, h, final_state = chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+    )
+    return attn_out
+
+
+def run_8_layers(all_inputs):
+    for i in range(NUM_LAYERS):
+        run_one_layer(*all_inputs[i])
+
+
+def main():
+    print(f"=== GDN 8-layer 64K Prefill Benchmark ===")
+    print(
+        f"seq_len={SEQ_LEN}, layers={NUM_LAYERS}, h_k={NUM_K_HEADS}, h_v={NUM_V_HEADS}, d={HEAD_K_DIM}"
+    )
+    print(f"dtype={DTYPE}, warmup={WARMUP}, repeat={REPEAT}")
+
+    torch.manual_seed(42)
+    all_inputs = [make_layer_inputs() for _ in range(NUM_LAYERS)]
+
+    # Warmup
+    print("Warming up...")
+    for _ in range(WARMUP):
+        run_8_layers(all_inputs)
+    torch.cuda.synchronize()
+
+    # Benchmark with CUDA events
+    print("Benchmarking...")
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(REPEAT)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(REPEAT)]
+
+    for i in range(REPEAT):
+        start_events[i].record()
+        run_8_layers(all_inputs)
+        end_events[i].record()
+    torch.cuda.synchronize()
+
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    times.sort()
+    trim = len(times) // 10
+    trimmed = times[trim:-trim] if trim > 0 else times
+    avg_ms = sum(trimmed) / len(trimmed)
+    per_layer = avg_ms / NUM_LAYERS
+
+    print(f"\n--- Results (8 layers total) ---")
+    print(
+        f"  Total:     avg={avg_ms:.3f}ms  min={min(times):.3f}ms  max={max(times):.3f}ms"
+    )
+    print(f"  Per-layer: avg={per_layer:.3f}ms")
+    print(f"  p50={times[len(times)//2]:.3f}ms  p90={times[int(len(times)*0.9)]:.3f}ms")
+
+    # Profile with torch profiler and export Chrome trace
+    trace_path = "/home/wangyin.yx/workspace/RTP-LLM/gdn_8layer_64k_trace.json"
+    print(f"\nRecording profiler trace -> {trace_path}")
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
+        record_shapes=True,
+        with_stack=False,
+    ) as prof:
+        run_8_layers(all_inputs)
+        torch.cuda.synchronize()
+
+    prof.export_chrome_trace(trace_path)
+    print(f"Trace saved: {trace_path}")
+
+    # Print kernel summary
+    print("\n--- Top 30 CUDA Kernels ---")
+    print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_prefill_perf.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_prefill_perf.py
@@ -1,0 +1,533 @@
+# -*- coding: utf-8 -*-
+"""
+Correctness and performance tests for the GDN (Gated Delta Net) prefill pipeline.
+
+Tests the full _fla computation:
+  fused_gdn_gating -> chunk_gated_delta_rule (with optional l2norm)
+
+Correctness is validated against a token-by-token recurrent reference impl.
+Performance is benchmarked with CUDA events across Qwen3.5 model configs.
+"""
+
+import logging
+import os
+import time
+import unittest
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from rtp_llm.models_py.triton_kernels.fla.chunk import chunk_gated_delta_rule
+from rtp_llm.models_py.triton_kernels.fla.gdn_gating import fused_gdn_gating
+from rtp_llm.models_py.triton_kernels.fla.utils import assert_close
+
+logging.basicConfig(
+    level="INFO",
+    format="[%(asctime)s.%(msecs)03d][%(filename)s:%(lineno)s][%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+DEVICE = "cuda"
+
+
+# ---------------------------------------------------------------------------
+# Reference implementations (fp32, token-by-token)
+# ---------------------------------------------------------------------------
+
+
+def gdn_gating_ref(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Reference gating: g = -exp(A_log) * softplus(a + dt_bias), beta = sigmoid(b)."""
+    x = a.float() + dt_bias.float()
+    g = -torch.exp(A_log.float()) * F.softplus(x)
+    beta = b.float().sigmoid()
+    # reshape to match fused kernel output: (1, seq_len, num_heads)
+    g = g.unsqueeze(0)
+    beta = beta.unsqueeze(0)
+    return g, beta
+
+
+def recurrent_gated_delta_rule_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Token-by-token recurrent reference (fp32) for GDN with GVA support.
+
+    Handles Grouped Value Attention where H_v can be a multiple of H_k.
+    q, k: (B, T, H_k, K), v: (B, T, H_v, V), g, beta: (B, T, H_v).
+    State h: (B, H_v, K, V).
+    """
+    B, T, H_k, K = q.shape
+    H_v = v.shape[2]
+    V = v.shape[-1]
+    GVA_ratio = H_v // H_k
+
+    q = q.transpose(1, 2).contiguous().to(torch.float32)  # (B, H_k, T, K)
+    k = k.transpose(1, 2).contiguous().to(torch.float32)  # (B, H_k, T, K)
+    v = v.transpose(1, 2).contiguous().to(torch.float32)  # (B, H_v, T, V)
+    beta = beta.transpose(1, 2).contiguous().to(torch.float32)  # (B, H_v, T)
+    g = g.transpose(1, 2).contiguous().to(torch.float32)  # (B, H_v, T)
+
+    o = torch.zeros(B, H_v, T, V, device=v.device, dtype=v.dtype)
+    h = torch.zeros(B, H_v, K, V, device=v.device, dtype=v.dtype)
+    if initial_state is not None:
+        h = initial_state.float()
+    if scale is None:
+        scale = K**-0.5
+
+    for i in range(T):
+        for j in range(H_v):
+            k_head = j // GVA_ratio
+            b_q = q[:, k_head, i] * scale  # (B, K)
+            b_k = k[:, k_head, i]  # (B, K)
+            b_v = v[:, j, i].clone()  # (B, V)
+            h[:, j] = h[:, j].clone() * g[:, j, i].exp().unsqueeze(-1).unsqueeze(-1)
+            b_beta = beta[:, j, i]  # (B,)
+            b_v = b_v - (h[:, j].clone() * b_k.unsqueeze(-1)).sum(-2)
+            b_v = b_v * b_beta.unsqueeze(-1)
+            h[:, j] = h[:, j].clone() + b_k.unsqueeze(-1) * b_v.unsqueeze(-2)
+            o[:, j, i] = (b_q.unsqueeze(-1) * h[:, j]).sum(-2)
+    if not output_final_state:
+        h = None
+    o = o.transpose(1, 2).contiguous()
+    return o, h
+
+
+def full_gdn_prefill_ref(
+    mixed_qkv: torch.Tensor,
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    cu_seqlens: torch.Tensor,
+    initial_state: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Full GDN prefill reference: gating + l2norm(q,k) + recurrent with GVA."""
+    g_ref, beta_ref = gdn_gating_ref(A_log, a, b, dt_bias)
+
+    query, key, value = torch.split(
+        mixed_qkv.float(),
+        [num_k_heads * head_k_dim, num_k_heads * head_k_dim, num_v_heads * head_v_dim],
+        dim=-1,
+    )
+    # (1, T, H_k, K) and (1, T, H_v, V)
+    query = F.normalize(
+        query.view(1, query.shape[0], num_k_heads, head_k_dim), p=2, dim=-1
+    )
+    key = F.normalize(key.view(1, key.shape[0], num_k_heads, head_k_dim), p=2, dim=-1)
+    value = value.view(1, value.shape[0], num_v_heads, head_v_dim)
+    # g_ref, beta_ref: (1, T, H_v)
+
+    N = len(cu_seqlens) - 1
+    refs = []
+    ref_states = []
+    for i in range(N):
+        s, e = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+        h0_i = initial_state[i : i + 1] if initial_state is not None else None
+        ref_o, ref_h = recurrent_gated_delta_rule_ref(
+            q=query[:, s:e],
+            k=key[:, s:e],
+            v=value[:, s:e],
+            beta=beta_ref[:, s:e],
+            g=g_ref[:, s:e],
+            initial_state=h0_i,
+            output_final_state=True,
+        )
+        refs.append(ref_o)
+        ref_states.append(ref_h)
+    ref_out = torch.cat(refs, dim=1).squeeze(0)
+    ref_final_state = torch.cat(ref_states, dim=0) if ref_states else None
+    return ref_out, ref_final_state
+
+
+# ---------------------------------------------------------------------------
+# The actual GDN prefill under test (mirrors _fla logic)
+# ---------------------------------------------------------------------------
+
+
+def gdn_prefill_under_test(
+    mixed_qkv: torch.Tensor,
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    cu_seqlens: torch.Tensor,
+    initial_state: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Runs the actual fused gating + chunk_gated_delta_rule pipeline."""
+    g, beta = fused_gdn_gating(A_log, a, b, dt_bias)
+
+    query, key, value = torch.split(
+        mixed_qkv,
+        [num_k_heads * head_k_dim, num_k_heads * head_k_dim, num_v_heads * head_v_dim],
+        dim=-1,
+    )
+    query = query.view(1, query.shape[0], num_k_heads, head_k_dim)
+    key = key.view(1, key.shape[0], num_k_heads, head_k_dim)
+    value = value.view(1, value.shape[0], num_v_heads, head_v_dim)
+
+    attn_out, h, final_state = chunk_gated_delta_rule(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=True,
+    )
+    return attn_out.squeeze(0), h, final_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_test_inputs(
+    total_seq_len: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    cu_seqlens: List[int],
+    dtype: torch.dtype = torch.bfloat16,
+    with_initial_state: bool = False,
+):
+    """Create random inputs for GDN prefill testing."""
+    torch.manual_seed(42)
+    qkv_dim = num_k_heads * head_k_dim * 2 + num_v_heads * head_v_dim
+    mixed_qkv = torch.randn(total_seq_len, qkv_dim, dtype=dtype, device=DEVICE)
+    A_log = torch.randn(num_v_heads, dtype=dtype, device=DEVICE)
+    a = torch.randn(total_seq_len, num_v_heads, dtype=dtype, device=DEVICE)
+    b = torch.randn(total_seq_len, num_v_heads, dtype=dtype, device=DEVICE)
+    dt_bias = torch.randn(num_v_heads, dtype=dtype, device=DEVICE)
+    cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=DEVICE)
+
+    N = len(cu_seqlens) - 1
+    initial_state = None
+    if with_initial_state:
+        initial_state = torch.randn(
+            N,
+            num_v_heads,
+            head_v_dim,
+            head_k_dim,
+            dtype=torch.float32,
+            device=DEVICE,
+        )
+
+    return mixed_qkv, A_log, a, b, dt_bias, cu_seqlens_t, initial_state
+
+
+# ---------------------------------------------------------------------------
+# Qwen3.5-35B-A3B model configs (per-TP shard)
+# ---------------------------------------------------------------------------
+
+# Qwen3.5-35B-A3B: h_k=16, h_v=64, d=128, GVA ratio=4
+QWEN35_35B_CONFIGS = {
+    "tp1": {"num_k_heads": 16, "num_v_heads": 64, "head_k_dim": 128, "head_v_dim": 128},
+    "tp2": {"num_k_heads": 8, "num_v_heads": 32, "head_k_dim": 128, "head_v_dim": 128},
+    "tp4": {"num_k_heads": 4, "num_v_heads": 16, "head_k_dim": 128, "head_v_dim": 128},
+}
+
+
+class TestGDNPrefillCorrectness(unittest.TestCase):
+    """Correctness tests comparing fused pipeline vs token-by-token reference."""
+
+    def _run_correctness(
+        self,
+        cu_seqlens: List[int],
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        dtype: torch.dtype,
+        with_initial_state: bool,
+        output_rtol: float = 0.005,
+        state_rtol: float = 0.005,
+    ):
+        total_seq_len = cu_seqlens[-1]
+        mixed_qkv, A_log, a, b, dt_bias, cu_seqlens_t, initial_state = make_test_inputs(
+            total_seq_len,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            cu_seqlens,
+            dtype,
+            with_initial_state,
+        )
+
+        # Run the actual pipeline
+        out, h, final_state = gdn_prefill_under_test(
+            mixed_qkv,
+            A_log,
+            a,
+            b,
+            dt_bias,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            cu_seqlens_t,
+            initial_state,
+        )
+
+        # Run reference
+        ref_out, ref_final_state = full_gdn_prefill_ref(
+            mixed_qkv,
+            A_log,
+            a,
+            b,
+            dt_bias,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            cu_seqlens_t,
+            initial_state,
+        )
+
+        tag = (
+            f"h_k={num_k_heads} h_v={num_v_heads} d={head_k_dim} "
+            f"seqlens={cu_seqlens} init_state={with_initial_state}"
+        )
+        assert_close(f"output {tag}", ref_out.float(), out.float(), output_rtol)
+        if final_state is not None and ref_final_state is not None:
+            assert_close(
+                f"final_state {tag}",
+                ref_final_state.float(),
+                final_state.float(),
+                state_rtol,
+            )
+
+    # --- Single sequence tests ---
+
+    def test_single_short_seq_bf16(self):
+        """Single short sequence, bf16, no initial state."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 128], **cfg, dtype=torch.bfloat16, with_initial_state=False
+        )
+
+    def test_single_medium_seq_bf16(self):
+        """Single medium sequence, bf16, no initial state."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 512], **cfg, dtype=torch.bfloat16, with_initial_state=False
+        )
+
+    def test_single_seq_with_initial_state(self):
+        """Single sequence with initial state (simulates incremental prefill)."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 256], **cfg, dtype=torch.bfloat16, with_initial_state=True
+        )
+
+    def test_single_seq_non_chunk_aligned(self):
+        """Sequence length not aligned to chunk_size=64."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 100], **cfg, dtype=torch.bfloat16, with_initial_state=False
+        )
+
+    def test_single_seq_fp16(self):
+        """fp16 precision."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 256], **cfg, dtype=torch.float16, with_initial_state=False
+        )
+
+    # --- Variable length (batched) tests ---
+
+    def test_varlen_two_seqs(self):
+        """Two sequences with different lengths."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 128, 384], **cfg, dtype=torch.bfloat16, with_initial_state=True
+        )
+
+    def test_varlen_four_seqs(self):
+        """Four sequences with varying lengths."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 64, 192, 320, 512],
+            **cfg,
+            dtype=torch.bfloat16,
+            with_initial_state=True,
+        )
+
+    def test_varlen_uneven_seqs(self):
+        """Uneven sequence lengths (not chunk-aligned)."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 37, 100, 213],
+            **cfg,
+            dtype=torch.bfloat16,
+            with_initial_state=False,
+        )
+
+    # --- Different TP configs ---
+
+    def test_tp1_config(self):
+        """TP1 config (full model heads)."""
+        cfg = QWEN35_35B_CONFIGS["tp1"]
+        self._run_correctness(
+            [0, 128], **cfg, dtype=torch.bfloat16, with_initial_state=False
+        )
+
+    def test_tp4_config(self):
+        """TP4 config (fewer heads)."""
+        cfg = QWEN35_35B_CONFIGS["tp4"]
+        self._run_correctness(
+            [0, 256], **cfg, dtype=torch.bfloat16, with_initial_state=True
+        )
+
+    # --- Edge cases ---
+
+    def test_minimal_seq(self):
+        """Minimal sequence (1 token)."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 1], **cfg, dtype=torch.bfloat16, with_initial_state=False
+        )
+
+    def test_exactly_one_chunk(self):
+        """Exactly one chunk (64 tokens)."""
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._run_correctness(
+            [0, 64], **cfg, dtype=torch.bfloat16, with_initial_state=True
+        )
+
+
+class TestGDNPrefillBenchmark(unittest.TestCase):
+    """Performance benchmarks for GDN prefill pipeline."""
+
+    def _benchmark(
+        self,
+        label: str,
+        total_seq_len: int,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        cu_seqlens: List[int],
+        dtype: torch.dtype = torch.bfloat16,
+        warmup: int = 10,
+        repeat: int = 50,
+    ):
+        mixed_qkv, A_log, a, b, dt_bias, cu_seqlens_t, initial_state = make_test_inputs(
+            total_seq_len,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            cu_seqlens,
+            dtype,
+            with_initial_state=True,
+        )
+
+        def run():
+            return gdn_prefill_under_test(
+                mixed_qkv,
+                A_log,
+                a,
+                b,
+                dt_bias,
+                num_k_heads,
+                num_v_heads,
+                head_k_dim,
+                head_v_dim,
+                cu_seqlens_t,
+                initial_state,
+            )
+
+        # Warmup
+        for _ in range(warmup):
+            run()
+        torch.cuda.synchronize()
+
+        # Benchmark with CUDA events
+        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(repeat)]
+        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(repeat)]
+        for i in range(repeat):
+            start_events[i].record()
+            run()
+            end_events[i].record()
+        torch.cuda.synchronize()
+
+        times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+        times.sort()
+        # Use median of middle 80% to remove outliers
+        trim = len(times) // 10
+        trimmed = times[trim:-trim] if trim > 0 else times
+        avg_ms = sum(trimmed) / len(trimmed)
+        min_ms = min(times)
+        max_ms = max(times)
+        p50 = times[len(times) // 2]
+        p90 = times[int(len(times) * 0.9)]
+
+        logger.info(
+            f"[BENCHMARK] {label}: avg={avg_ms:.3f}ms min={min_ms:.3f}ms "
+            f"max={max_ms:.3f}ms p50={p50:.3f}ms p90={p90:.3f}ms "
+            f"(seq_len={total_seq_len}, h_k={num_k_heads}, h_v={num_v_heads}, d={head_k_dim})"
+        )
+        return avg_ms
+
+    def test_bench_tp2_seq256(self):
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._benchmark("TP2 seq=256", 256, **cfg, cu_seqlens=[0, 256])
+
+    def test_bench_tp2_seq1024(self):
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._benchmark("TP2 seq=1024", 1024, **cfg, cu_seqlens=[0, 1024])
+
+    def test_bench_tp2_seq4096(self):
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._benchmark("TP2 seq=4096", 4096, **cfg, cu_seqlens=[0, 4096])
+
+    def test_bench_tp2_seq8192(self):
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._benchmark("TP2 seq=8192", 8192, **cfg, cu_seqlens=[0, 8192])
+
+    def test_bench_tp1_seq4096(self):
+        cfg = QWEN35_35B_CONFIGS["tp1"]
+        self._benchmark("TP1 seq=4096", 4096, **cfg, cu_seqlens=[0, 4096])
+
+    def test_bench_tp4_seq4096(self):
+        cfg = QWEN35_35B_CONFIGS["tp4"]
+        self._benchmark("TP4 seq=4096", 4096, **cfg, cu_seqlens=[0, 4096])
+
+    def test_bench_tp2_batch4_varlen(self):
+        cfg = QWEN35_35B_CONFIGS["tp2"]
+        self._benchmark(
+            "TP2 batch4 varlen",
+            4096,
+            **cfg,
+            cu_seqlens=[0, 1024, 2048, 3072, 4096],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/triton_kernels/fla/wy_fast.py
+++ b/rtp_llm/models_py/triton_kernels/fla/wy_fast.py
@@ -40,6 +40,7 @@ def recompute_w_u_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    s_v_t=0,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -64,11 +65,12 @@ def recompute_w_u_fwd_kernel(
     b_A = tl.load(p_A, boundary_check=(0, 1))
     b_g = tl.exp(tl.load(p_g, boundary_check=(0,)))
 
+    s_u_t = H * V
     for i_v in range(tl.cdiv(V, BV)):
         p_v = tl.make_block_ptr(
-            v + (bos * H + i_h) * V,
+            v + bos * s_v_t + i_h * V,
             (T, V),
-            (H * V, 1),
+            (s_v_t, 1),
             (i_t * BT, i_v * BV),
             (BT, BV),
             (1, 0),
@@ -76,7 +78,7 @@ def recompute_w_u_fwd_kernel(
         p_u = tl.make_block_ptr(
             u + (bos * H + i_h) * V,
             (T, V),
-            (H * V, 1),
+            (s_u_t, 1),
             (i_t * BT, i_v * BV),
             (BT, BV),
             (1, 0),
@@ -127,8 +129,9 @@ def recompute_w_u_fwd(
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BK = 64
     BV = 64
-    u = torch.empty_like(v)
+    u = torch.empty(v.shape, dtype=v.dtype, device=v.device)
     w = k.new_empty(B, T, H, K)
+    s_v_t = v.stride(-3)
     recompute_w_u_fwd_kernel[(NT, B * H)](
         k=k,
         v=v,
@@ -147,6 +150,7 @@ def recompute_w_u_fwd(
         BT=BT,
         BK=BK,
         BV=BV,
+        s_v_t=s_v_t,
         num_warps=4,
         num_stages=3,
     )

--- a/rtp_llm/test/perf_test/batch_perf_impl.py
+++ b/rtp_llm/test/perf_test/batch_perf_impl.py
@@ -46,7 +46,7 @@ def _curl_server_single_worker(
 
     if profile:
         req["gen_timeline"] = True
-        req["profile_step"] = 1
+        req["profile_step"] = 3
     try:
         response = requests.post(
             f"http://127.0.0.1:{base_port}", json=req, timeout=wait_time
@@ -148,6 +148,10 @@ class BatchPerfImpl(object):
         results = self._curl_server()
         if self.profile:
             _ = self._curl_server(True)
+            _ = self._curl_server()
+            import time
+
+            time.sleep(5)
         return results
 
     def _set_concurrency(self):


### PR DESCRIPTION
## Summary
- Add Blackwell GDN CUTLASS prefill kernel for Qwen3.5 models
- Optimize Blackwell GDN pipeline (chunk scheduling, tile scheduler)
- Optimize prefill kernels: L2Norm, RmsNormGated, FP8 v2
- Qwen3.5 end-to-end optimization fixes
- Fix MTP model to match updated DecoderLayer interface

## Test plan
- [ ] CI passes
- [ ] Smoke tests for Qwen3.5 models
- [ ] Prefill performance benchmarks on GB200