### PR TITLE
feat: support input_embeddings in inference pipeline

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -420,6 +420,24 @@ int GenerateStream::multimodalFeaturesLength() const {
     return multimodalFeatures().size() * currentBatchSize();
 }
 
+torch::Tensor GenerateStream::inputEmbeddings() const {
+    if (generate_input_->input_embeddings) {
+        return generate_input_->input_embeddings.value();
+    }
+    return torch::Tensor();
+}
+
+torch::Tensor GenerateStream::inputEmbeddingLocs() const {
+    if (generate_input_->input_embedding_locs) {
+        return generate_input_->input_embedding_locs.value();
+    }
+    return torch::Tensor();
+}
+
+bool GenerateStream::hasInputEmbeddings() const {
+    return generate_input_->input_embeddings.has_value();
+}
+
 torch::Tensor GenerateStream::multimodalLocations() const {
     if (!generate_input_->mm_locs) {
         return torch::Tensor();

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -221,6 +221,10 @@ public:
     int                        multimodalFeaturesLength() const;
     torch::Tensor              multimodalLocations() const;
 
+    torch::Tensor              inputEmbeddings() const;
+    torch::Tensor              inputEmbeddingLocs() const;
+    bool                       hasInputEmbeddings() const;
+
     int64_t getTimeoutMs() const;
     void    checkTimeout();
 

--- a/rtp_llm/cpp/engine_base/stream/GenerateTypes.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateTypes.h
@@ -53,6 +53,10 @@ public:
     std::optional<torch::Tensor>                mm_locs;           // multimodal input locations
     std::optional<std::vector<torch::Tensor>>   mm_position_ids;
 
+    // For prompt embedding replacement
+    std::optional<torch::Tensor>                input_embeddings;      // pre-computed embeddings [num_locs, hidden_size]
+    std::optional<torch::Tensor>                input_embedding_locs;  // token positions to replace [num_locs], int32
+
     int     prefix_length = 0;
     int64_t begin_time_us = 0;
 

--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -127,6 +127,17 @@ std::shared_ptr<GenerateInput> QueryConverter::transQuery(const GenerateInputPB*
         generate_input->batch_group_id = input->batch_group_id().value();
     }
 
+    if (input->input_embeddings().shape_size() > 0 && input->input_embeddings().shape(0) > 0) {
+        generate_input->input_embeddings = transTensor(input->input_embeddings());
+    }
+    if (input->input_embedding_locs_size() > 0) {
+        generate_input->input_embedding_locs =
+            torch::from_blob(const_cast<int*>(input->input_embedding_locs().data()),
+                             {(int64_t)input->input_embedding_locs_size()},
+                             torch::kInt32)
+                .clone();
+    }
+
     return generate_input;
 }
 

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -23,7 +23,7 @@ from rtp_llm.utils.base_model_datatypes import (
     GenerateOutputs,
 )
 from rtp_llm.utils.grpc_host_channel_pool import GrpcHostChannelPool
-from rtp_llm.utils.grpc_util import trans_option, trans_option_cast, trans_tensor
+from rtp_llm.utils.grpc_util import trans_from_tensor, trans_option, trans_option_cast, trans_tensor
 
 MAX_GRPC_TIMEOUT_SECONDS = 3600
 
@@ -53,6 +53,11 @@ def trans_input(input_py: GenerateInput):
     input_pb.batch_group_size = input_py.batch_group_size
     if hasattr(input_py, "batch_group_id") and input_py.batch_group_id != -1:
         input_pb.batch_group_id.value = input_py.batch_group_id
+
+    if input_py.input_embeddings is not None:
+        input_pb.input_embeddings.CopyFrom(trans_from_tensor(input_py.input_embeddings))
+    if input_py.input_embedding_locs is not None:
+        input_pb.input_embedding_locs.extend(input_py.input_embedding_locs)
 
     trans_multimodal_input(input_py, input_pb, input_py.generate_config)
     # check generate config is valid before enter into engine

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -140,6 +140,8 @@ message GenerateInputPB {
     int64 start_time = 6;
     int32 batch_group_size = 7;
     google.protobuf.Int64Value batch_group_id = 8;
+    TensorPB input_embeddings = 9;
+    repeated int32 input_embedding_locs = 10;
 }
 
 message AuxInfoPB {

--- a/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
@@ -271,6 +271,8 @@ absl::Status NormalModelInputGatherer::processDecodeStreams(GptModelInputs&     
 absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&     model_input,
                                                              const StreamGroups& stream_groups) const {
     std::vector<torch::Tensor> gathered_mm_features;
+    std::vector<torch::Tensor> gathered_input_embeddings;
+    std::vector<int>           gathered_input_embedding_locs;
     auto ctx = createGatherContext(config_, model_input, stream_groups, GatherContextMode::CONTEXT);
 
     for (const auto& stream : stream_groups.contextStreams()) {
@@ -310,6 +312,23 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
 
             gatherMultimodalFeaturesForContextBatch(stream, ctx, gathered_mm_features);
 
+            if (stream->hasInputEmbeddings()) {
+                torch::Tensor emb      = stream->inputEmbeddings();
+                torch::Tensor emb_locs = stream->inputEmbeddingLocs();
+                if (emb.defined() && emb_locs.defined()) {
+                    if (!emb.is_cuda()) {
+                        gathered_input_embeddings.emplace_back(emb.to(torch::kCUDA));
+                    } else {
+                        gathered_input_embeddings.emplace_back(emb);
+                    }
+                    auto* locs_data = emb_locs.data_ptr<int>();
+                    for (int loc_idx = 0; loc_idx < emb_locs.numel(); ++loc_idx) {
+                        gathered_input_embedding_locs.push_back(
+                            locs_data[loc_idx] + ctx.token_idx - stream->reuseLength());
+                    }
+                }
+            }
+
             if (ctx.need_cal_position_id) {
                 auto context_pos_ids = stream->generateContextPositionIds();
                 int  reuse_offset    = stream->reuseLength() * config_.position_id_len_factor;
@@ -342,6 +361,10 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
 
     if (config_.is_multimodal && !gathered_mm_features.empty()) {
         model_input.multimodal_features = std::move(gathered_mm_features);
+    }
+    if (!gathered_input_embeddings.empty()) {
+        model_input.input_embeddings      = std::move(gathered_input_embeddings);
+        model_input.input_embeddings_locs = torch::tensor(gathered_input_embedding_locs, torch::kInt32);
     }
     return absl::OkStatus();
 }

--- a/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
@@ -313,19 +313,10 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
             gatherMultimodalFeaturesForContextBatch(stream, ctx, gathered_mm_features);
 
             if (stream->hasInputEmbeddings()) {
-                torch::Tensor emb      = stream->inputEmbeddings();
-                torch::Tensor emb_locs = stream->inputEmbeddingLocs();
-                if (emb.defined() && emb_locs.defined()) {
-                    if (!emb.is_cuda()) {
-                        gathered_input_embeddings.emplace_back(emb.to(torch::kCUDA));
-                    } else {
-                        gathered_input_embeddings.emplace_back(emb);
-                    }
-                    auto* locs_data = emb_locs.data_ptr<int>();
-                    for (int loc_idx = 0; loc_idx < emb_locs.numel(); ++loc_idx) {
-                        gathered_input_embedding_locs.push_back(
-                            locs_data[loc_idx] + ctx.token_idx - stream->reuseLength());
-                    }
+                torch::Tensor emb = stream->inputEmbeddings();
+                if (emb.defined()) {
+                    gathered_input_embeddings.emplace_back(emb.cpu());
+                    gathered_input_embedding_locs.push_back(ctx.token_idx);
                 }
             }
 
@@ -364,7 +355,10 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
     }
     if (!gathered_input_embeddings.empty()) {
         model_input.input_embeddings      = std::move(gathered_input_embeddings);
-        model_input.input_embeddings_locs = torch::tensor(gathered_input_embedding_locs, torch::kInt32);
+        model_input.input_embeddings_locs = torch::from_blob(gathered_input_embedding_locs.data(),
+                                                             {(int64_t)gathered_input_embedding_locs.size()},
+                                                             torch::kInt32)
+                                                .clone();
     }
     return absl::OkStatus();
 }

--- a/rtp_llm/utils/base_model_datatypes.py
+++ b/rtp_llm/utils/base_model_datatypes.py
@@ -36,6 +36,8 @@ class GenerateInput:
     token_type_ids: List[int] = field(default_factory=list)
     batch_group_size: int = 1
     batch_group_id: int = -1  # Batch group ID for force batch grouping, -1 means not set
+    input_embeddings: Optional[torch.Tensor] = None
+    input_embedding_locs: Optional[List[int]] = None
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
## What

Support passing pre-computed `input_embeddings` through the gRPC inference pipeline, allowing users to replace token embeddings at specified positions with custom embeddings.

## Changes

- **`base_model_datatypes.py`**: Add `input_embeddings` and `input_embedding_locs` fields to `GenerateInput`
- **`model_rpc_service.proto`**: Add `input_embeddings` (TensorPB) and `input_embedding_locs` (repeated int32) to `GenerateInputPB`
- **`model_rpc_client.py`**: Serialize `input_embeddings` and `input_embedding_locs` in `trans_input()`
- **`GenerateTypes.h`**: Add `input_embeddings` and `input_embedding_locs` to C++ `GenerateInput`
- **`QueryConverter.cc`**: Deserialize `input_embeddings` and `input_embedding_locs` from protobuf
- **`GenerateStream.h/.cc`**: Add `inputEmbeddings()`, `inputEmbeddingLocs()`, `hasInputEmbeddings()` accessor methods
- **`NormalModelInputGatherer.cc`**: Gather `input_embeddings` from streams and pass to `GptModelInputs`

## Use Case

This enables scenarios where users need to inject custom embeddings (e.g., from a projection layer) into the model input, replacing the default token embeddings at specified positions.