### PR TITLE
feat(ci): trigger CI on PR approval instead of push, add rebase check

### DIFF
--- a/.github/scripts/check-rebase-freshness.sh
+++ b/.github/scripts/check-rebase-freshness.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Check if PR branch is up to date with main using GitHub API.
+# Usage: check-rebase-freshness.sh <PR_NUMBER> <COMMIT_ID> <REPOSITORY>
+# Requires: GITHUB_TOKEN env var
+set -euo pipefail
+
+PR_NUMBER=$1
+COMMIT_ID=$2
+REPOSITORY=$3
+
+COMPARE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/${REPOSITORY}/compare/${COMMIT_ID}...main")
+
+if [ $? -ne 0 ] || [ -z "$COMPARE" ]; then
+  echo "::warning::Failed to query GitHub compare API, skipping rebase check"
+  exit 0
+fi
+
+BEHIND_BY=$(echo "$COMPARE" | jq '.ahead_by // 0')
+
+if [ "$BEHIND_BY" -eq 0 ] 2>/dev/null; then
+  echo "PR #${PR_NUMBER} is up to date with main"
+  exit 0
+fi
+
+echo "::error::PR #${PR_NUMBER} is ${BEHIND_BY} commit(s) behind main. Please rebase before CI can run."
+exit 1

--- a/.github/workflows/CI-request-trigger.yml
+++ b/.github/workflows/CI-request-trigger.yml
@@ -4,8 +4,10 @@ name: CI Request Trigger
 
 # Controls when the workflow will run
 on:
-  pull_request:
-    branches: [ "main" ]
+  # Trigger CI only after a PR review is submitted (approved)
+  pull_request_review:
+    types: [submitted]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,6 +20,10 @@ concurrency:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved')
     # The type of runner that the job will run on
     runs-on: [self-hosted, Linux]
     # work on CI script dir
@@ -45,14 +51,23 @@ jobs:
 
       # Runs trigger CI
       - name: Make the script files executable
-        run: chmod +x pre-check-CI-result.sh trigger-CI.sh get-CI-result.sh get-branch-info.sh add-comment.sh
+        run: chmod +x pre-check-CI-result.sh trigger-CI.sh get-CI-result.sh get-branch-info.sh add-comment.sh check-rebase-freshness.sh
+
+      - name: Check rebase freshness
+        if: github.event_name == 'pull_request_review'
+        run: |
+          COMMIT_ID="${{ github.event.pull_request.head.sha }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          ./check-rebase-freshness.sh "$PR_NUMBER" "$COMMIT_ID" "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Pre-check if CI already completed
       - name: Pre-check CI status
         id: pre-check
         run: |
           echo "=== Task started at: $(date '+%Y-%m-%d %H:%M:%S') ==="
-          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
+          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request_review" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
           echo "Pre-checking CI status for Commit ID: $COMMIT_ID"
           
           if ./pre-check-CI-result.sh "$COMMIT_ID" "${{ secrets.CI_SECRET }}" "${{ github.repository }}"; then
@@ -66,7 +81,7 @@ jobs:
         if: steps.pre-check.outputs.skip_ci != 'true'
         run: |
           echo "=== Task started at: $(date '+%Y-%m-%d %H:%M:%S') ==="
-          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
+          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request_review" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
           echo "Using Commit ID: $COMMIT_ID"
           echo "$GITHUB_REF"
           PR_ID=$(echo "$GITHUB_REF" | sed 's@refs/pull/\([0-9]\+\)/.*@\1@')
@@ -83,7 +98,7 @@ jobs:
           COMMENT="internal source has been updated, please review the changes!"
           SOURCE="RTP"
           MAIN_BRANCH="main-internal"
-          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
+          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request_review" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
           echo "BRANCH_NAME is $BRANCH_NAME"
 
           BRANCH_INFO=$(./get-branch-info.sh "${BRANCH_NAME}" "${REPOSITORY}" "${COMMIT_ID}")
@@ -124,6 +139,6 @@ jobs:
         if: steps.pre-check.outputs.skip_ci != 'true'
         run: |
           echo "=== Task started at: $(date '+%Y-%m-%d %H:%M:%S') ==="
-          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
+          COMMIT_ID=$([ "${{ github.event_name }}" == "pull_request_review" ] && echo "${{ github.event.pull_request.head.sha }}" || echo "${{ github.sha }}")
           echo "Using Commit ID: $COMMIT_ID"
           ./get-CI-result.sh "$COMMIT_ID" "${{ secrets.CI_SECRET }}" "${{ github.repository }}"


### PR DESCRIPTION
- Change workflow trigger from `on: pull_request` to `on: pull_request_review` with `types: [submitted]`, filtered to only run on approved reviews
- Add rebase freshness check before triggering internal CI: uses GitHub compare API to verify PR branch is not behind main (behind_by == 0)
- workflow_dispatch (manual trigger) skips the rebase check
- Update event_name references from "pull_request" to "pull_request_review"