### PR TITLE
fix: stuck at rtp_llm::PrefillRpcServer::waitStreamBeforeRun

### DIFF
--- a/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
@@ -90,7 +90,7 @@ grpc::Status PrefillRpcServer::init(const EngineInitParams&                     
 ErrorInfo PrefillRpcServer::waitStreamBeforeRun(std::shared_ptr<GenerateStream> stream) {
     static int max_wait_timeout_us = maga_init_params_.pd_sep_config.prefill_max_wait_timeout_ms * 1000;
     auto       begin_time_us       = currentTimeUs();
-    while (stream->getStatus() == StreamState::WAITING) {
+    while (!stream->hasError() && stream->getStatus() == StreamState::WAITING) {
         usleep(100);
         auto current_time_us = currentTimeUs();
         auto cost_time_us    = current_time_us - begin_time_us;


### PR DESCRIPTION
fix: stuck at rtp_llm::PrefillRpcServer::waitStreamBeforeRun
