### PR TITLE
feat(rocm): MoRI EP (Expert Parallelism) support for MI355X

### DIFF
--- a/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
+++ b/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
@@ -19,8 +19,12 @@ public:
         RTP_LLM_CHECK_WITH_INFO(!cache_config.cache_specs.empty(), "cache_specs must not be empty");
         BlockPoolConfig config;
         config.block_num      = cache_config.block_num;
-        const bool  is_hybrid = cache_config.groupNums() > 1;
-        auto        layer_num = is_hybrid ? cache_config.group_layer_num : cache_config.layer_num;
+        // Must match KVCacheManager allocator choice: a single LinearAttention group still uses hybrid layout
+        // (group_layer_num strides), not pure MHA partitioning.
+        const bool is_hybrid = cache_config.groupNums() > 1
+                               || (cache_config.cache_specs[0] != nullptr
+                                   && cache_config.cache_specs[0]->type == KVCacheSpecType::LinearAttention);
+        auto layer_num = is_hybrid ? cache_config.group_layer_num : cache_config.layer_num;
         const auto& main_spec = cache_config.cache_specs[0];
         // linear block size is same with full block block size
         MemoryLayoutConfig main_layout = createMemoryLayoutConfig(is_hybrid,

--- a/rtp_llm/cpp/cache/KVCacheManager.cc
+++ b/rtp_llm/cpp/cache/KVCacheManager.cc
@@ -61,7 +61,11 @@ KVCacheManager::~KVCacheManager() {
 bool KVCacheManager::init() {
     RTP_LLM_CHECK_WITH_INFO(!config_.cache_specs.empty(), "cache specs must not be empty");
 
-    const bool is_hybrid = config_.groupNums() > 1;
+    // Multiple cache groups always use HybridTypeKVCacheAllocator. A single group still needs the hybrid
+    // allocator when it is LinearAttention-only: SingleTypeKVCacheAllocator only supports MHA/MLA.
+    const bool is_hybrid = config_.groupNums() > 1
+                           || (config_.cache_specs[0] != nullptr
+                               && config_.cache_specs[0]->type == KVCacheSpecType::LinearAttention);
     if (is_hybrid) {
         allocator_ = std::make_shared<rtp_llm::HybridTypeKVCacheAllocator>(
             config_, AllocationType::DEVICE, metrics_reporter_, kv_cache_config_.reserve_block_ratio);

--- a/rtp_llm/cpp/cuda/deep_gemm/cutlass_hdr
+++ b/rtp_llm/cpp/cuda/deep_gemm/cutlass_hdr
@@ -1,0 +1,1 @@
+/opt/conda310/lib/python3.10/site-packages/rtp_llm/cpp/cuda/deep_gemm/cutlass_hdr

--- a/rtp_llm/libs/BUILD
+++ b/rtp_llm/libs/BUILD
@@ -33,6 +33,156 @@ copy_files(
     visibility = ["//visibility:public"],
 )
 
+# Separate genrule for libdeep_ep_rocm.so to avoid conflicts between aiter_src_copy and aiter_copy
+genrule(
+    name = "deep_ep_rocm_copy",
+    srcs = select({
+        "//rtp_llm/cpp/devices/rocm_impl:enable_deep_ep": ["@deep_ep_rocm//:cpp_libraries"],
+        "//conditions:default": [],
+    }),
+    outs = ["libdeep_ep_rocm.so"],
+    cmd = select({
+        "//rtp_llm/cpp/devices/rocm_impl:enable_deep_ep": """
+            # Copy libdeep_ep_rocm.so from @deep_ep_rocm//:cpp_libraries
+            # $(SRCS) contains all files from srcs, filter for .so file
+            for f in $(SRCS); do
+                if [[ "$$f" == *.so ]]; then
+                    cp "$$f" $(location libdeep_ep_rocm.so);
+                    break;
+                fi
+            done
+        """,
+        "//conditions:default": """
+            # Create a minimal valid shared library placeholder when deep_ep is not enabled
+            echo "void dummy() {}" | gcc -shared -fPIC -x c - -o $(location libdeep_ep_rocm.so) || touch $(location libdeep_ep_rocm.so);
+        """,
+    }),
+    tags = [
+        "local",
+        "rocm",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "aiter_src_copy",
+    srcs = ["@aiter_src//:cpp_libraries"],
+    outs = [
+        "libmodule_aiter_enum.so",
+        "libmodule_custom_all_reduce.so",
+        "libmodule_quick_all_reduce.so",
+        "libmodule_moe_sorting.so",
+        "libmodule_moe_asm.so",
+        "libmodule_gemm_a8w8_bpreshuffle.so",
+        "libmodule_gemm_a8w8_blockscale.so",
+        "libmodule_quant.so",
+        "libmodule_smoothquant.so",
+        "libmodule_pa.so",
+        "libmodule_activation.so",
+        "libmodule_deepgemm.so",
+        "libmodule_attention_asm.so",
+        "libmodule_mha_fwd.so",
+        "libmodule_mha_batch_prefill.so",
+        "libmodule_fmha_v3_varlen_fwd.so",
+        "libmodule_norm.so",
+        "libmodule_rmsnorm.so",
+        "libmodule_gemm_a8w8.so",
+        "libmodule_moe_ck2stages.so",
+        "libmodule_mha_batch_prefill.so",
+    ],
+    cmd = """
+       cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_aiter_enum.so $(location libmodule_aiter_enum.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_custom_all_reduce.so $(location libmodule_custom_all_reduce.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_quick_all_reduce.so $(location libmodule_quick_all_reduce.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_moe_sorting.so $(location libmodule_moe_sorting.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_moe_asm.so $(location libmodule_moe_asm.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_gemm_a8w8_bpreshuffle.so $(location libmodule_gemm_a8w8_bpreshuffle.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_gemm_a8w8_blockscale.so $(location libmodule_gemm_a8w8_blockscale.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_quant.so $(location libmodule_quant.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_smoothquant.so $(location libmodule_smoothquant.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_pa.so $(location libmodule_pa.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_activation.so $(location libmodule_activation.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_attention_asm.so $(location libmodule_attention_asm.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_mha_fwd.so $(location libmodule_mha_fwd.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_mha_batch_prefill.so $(location libmodule_mha_batch_prefill.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_fmha_v3_varlen_fwd.so $(location libmodule_fmha_v3_varlen_fwd.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_norm.so $(location libmodule_norm.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_rmsnorm.so $(location libmodule_rmsnorm.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_gemm_a8w8.so $(location libmodule_gemm_a8w8.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_moe_ck2stages.so $(location libmodule_moe_ck2stages.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_deepgemm.so $(location libmodule_deepgemm.so);
+cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_mha_batch_prefill.so $(location libmodule_mha_batch_prefill.so);
+""",
+    tags = [
+        "local",
+        "rocm",
+    ],
+)
+
+genrule(
+    name = "aiter_copy",
+    srcs = ["@aiter//:aiter_so"],
+    outs = [
+        "module_aiter_enum.so",
+        "module_custom_all_reduce.so",
+        "module_quick_all_reduce.so",
+        "module_moe_sorting.so",
+        "module_moe_asm.so",
+        "module_gemm_a8w8_bpreshuffle.so",
+        "module_gemm_a8w8_blockscale.so",
+        "module_quant.so",
+        "module_smoothquant.so",
+        "module_pa.so",
+        "module_activation.so",
+        "module_attention_asm.so",
+        "module_mha_fwd.so",
+        "module_mha_batch_prefill.so",
+        "module_fmha_v3_varlen_fwd.so",
+        "module_norm.so",
+        "module_rmsnorm.so",
+        "module_gemm_a8w8.so",
+        "module_deepgemm.so",
+        "module_mha_batch_prefill.so",
+    ],
+    cmd = """
+        cp external/aiter/aiter/jit/module_aiter_enum.so $(location module_aiter_enum.so);
+        cp external/aiter/aiter/jit/module_custom_all_reduce.so $(location module_custom_all_reduce.so);
+        cp external/aiter/aiter/jit/module_quick_all_reduce.so $(location module_quick_all_reduce.so);
+        cp external/aiter/aiter/jit/module_moe_sorting.so $(location module_moe_sorting.so);
+        cp external/aiter/aiter/jit/module_moe_asm.so $(location module_moe_asm.so);
+        cp external/aiter/aiter/jit/module_gemm_a8w8_bpreshuffle.so $(location module_gemm_a8w8_bpreshuffle.so);
+        cp external/aiter/aiter/jit/module_gemm_a8w8_blockscale.so $(location module_gemm_a8w8_blockscale.so);
+        cp external/aiter/aiter/jit/module_quant.so $(location module_quant.so);
+        cp external/aiter/aiter/jit/module_smoothquant.so $(location module_smoothquant.so);
+        cp external/aiter/aiter/jit/module_pa.so $(location module_pa.so);
+        cp external/aiter/aiter/jit/module_activation.so $(location module_activation.so);
+        cp external/aiter/aiter/jit/module_attention_asm.so $(location module_attention_asm.so);
+        cp external/aiter/aiter/jit/module_mha_fwd.so $(location module_mha_fwd.so);
+        cp external/aiter/aiter/jit/module_mha_batch_prefill.so $(location module_mha_batch_prefill.so);
+        cp external/aiter/aiter/jit/module_fmha_v3_varlen_fwd.so $(location module_fmha_v3_varlen_fwd.so);
+        cp external/aiter/aiter/jit/module_norm.so $(location module_norm.so);
+        cp external/aiter/aiter/jit/module_rmsnorm.so $(location module_rmsnorm.so);
+        cp external/aiter/aiter/jit/module_gemm_a8w8.so $(location module_gemm_a8w8.so);
+        cp external/aiter/aiter/jit/module_deepgemm.so $(location module_deepgemm.so);
+        cp external/aiter/aiter/jit/module_mha_batch_prefill.so $(location module_mha_batch_prefill.so);
+""",
+    tags = [
+        "local",
+        "rocm",
+    ],
+)
+
+genrule(
+    name = "aiter_copy_moe_ck2stages",
+    srcs = ["@aiter//:aiter_so"],
+    outs = ["module_moe_ck2stages.so"],
+    cmd = "cp external/aiter/aiter/jit/module_moe_ck2stages.so $(location module_moe_ck2stages.so)",
+    tags = [
+        "local",
+        "rocm",
+    ],
+)
+
 filegroup(
     name = "frontend_libs",
     srcs = [],

--- a/rtp_llm/libs/BUILD
+++ b/rtp_llm/libs/BUILD
@@ -88,7 +88,6 @@ genrule(
         "libmodule_rmsnorm.so",
         "libmodule_gemm_a8w8.so",
         "libmodule_moe_ck2stages.so",
-        "libmodule_mha_batch_prefill.so",
     ],
     cmd = """
        cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_aiter_enum.so $(location libmodule_aiter_enum.so);
@@ -111,7 +110,6 @@ cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_rmsnorm.so $(lo
 cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_gemm_a8w8.so $(location libmodule_gemm_a8w8.so);
 cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_moe_ck2stages.so $(location libmodule_moe_ck2stages.so);
 cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_deepgemm.so $(location libmodule_deepgemm.so);
-cp ./bazel-out/k8-opt/bin/external/aiter_src/aiter/jit/libmodule_mha_batch_prefill.so $(location libmodule_mha_batch_prefill.so);
 """,
     tags = [
         "local",
@@ -142,7 +140,6 @@ genrule(
         "module_rmsnorm.so",
         "module_gemm_a8w8.so",
         "module_deepgemm.so",
-        "module_mha_batch_prefill.so",
     ],
     cmd = """
         cp external/aiter/aiter/jit/module_aiter_enum.so $(location module_aiter_enum.so);
@@ -164,7 +161,6 @@ genrule(
         cp external/aiter/aiter/jit/module_rmsnorm.so $(location module_rmsnorm.so);
         cp external/aiter/aiter/jit/module_gemm_a8w8.so $(location module_gemm_a8w8.so);
         cp external/aiter/aiter/jit/module_deepgemm.so $(location module_deepgemm.so);
-        cp external/aiter/aiter/jit/module_mha_batch_prefill.so $(location module_mha_batch_prefill.so);
 """,
     tags = [
         "local",

--- a/rtp_llm/models_py/bindings/rocm/BUILD
+++ b/rtp_llm/models_py/bindings/rocm/BUILD
@@ -94,6 +94,7 @@ cc_library(
         "//rtp_llm/models_py/bindings:op_defs",
         "//rtp_llm/models_py/bindings/common:common",
         "//rtp_llm/models_py/bindings/rocm/kernels:rocm_trtllm_allreduce_fusion",
+        "//rtp_llm/cpp/kernels:kernels_moe",
     ],
 )
 

--- a/rtp_llm/models_py/bindings/rocm/BUILD
+++ b/rtp_llm/models_py/bindings/rocm/BUILD
@@ -94,7 +94,7 @@ cc_library(
         "//rtp_llm/models_py/bindings:op_defs",
         "//rtp_llm/models_py/bindings/common:common",
         "//rtp_llm/models_py/bindings/rocm/kernels:rocm_trtllm_allreduce_fusion",
-        "//rtp_llm/cpp/kernels:kernels_moe",
+        "//rtp_llm/models_py/bindings/common/kernels:kernels_moe",
     ],
 )
 

--- a/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.cc
@@ -1,6 +1,6 @@
 #include "rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.h"
 #include "rtp_llm/models_py/bindings/common/Torch_ext.h"
-#include "rtp_llm/cpp/kernels/moe_kernels.h"
+#include "rtp_llm/models_py/bindings/common/kernels/moe_kernels.h"
 
 namespace rtp_llm {
 

--- a/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.cc
@@ -1,0 +1,51 @@
+#include "rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.h"
+#include "rtp_llm/models_py/bindings/common/Torch_ext.h"
+#include "rtp_llm/cpp/kernels/moe_kernels.h"
+
+namespace rtp_llm {
+
+void fake_balance_expert_op(
+    at::Tensor& expert_ids,
+    at::Tensor& expert_scales,
+    int64_t     dp_rank,
+    int64_t     dp_size,
+    int64_t     ep_size,
+    int64_t     expert_num,
+    int64_t     hip_stream) {
+
+    CHECK_INPUT(expert_ids);
+    CHECK_INPUT(expert_scales);
+
+    TORCH_CHECK(expert_ids.dim() == 2, "expert_ids must be a 2D tensor");
+    TORCH_CHECK(expert_scales.dim() == 2, "expert_scales must be a 2D tensor");
+    TORCH_CHECK(expert_ids.sizes() == expert_scales.sizes(),
+                "expert_ids and expert_scales must have the same shape");
+
+    int size = static_cast<int>(expert_ids.numel());
+    hipStream_t stream = reinterpret_cast<hipStream_t>(hip_stream);
+
+    if (expert_ids.dtype() == torch::kInt64) {
+        fake_balance_expert(expert_ids.data_ptr<int64_t>(),
+                            expert_scales.data_ptr<float>(),
+                            static_cast<int>(dp_rank),
+                            static_cast<int>(dp_size),
+                            static_cast<int>(ep_size),
+                            static_cast<int>(expert_num),
+                            size,
+                            stream);
+    } else if (expert_ids.dtype() == torch::kInt32) {
+        fake_balance_expert(expert_ids.data_ptr<int32_t>(),
+                            expert_scales.data_ptr<float>(),
+                            static_cast<int>(dp_rank),
+                            static_cast<int>(dp_size),
+                            static_cast<int>(ep_size),
+                            static_cast<int>(expert_num),
+                            size,
+                            stream);
+    } else {
+        throw std::runtime_error("Unsupported dtype for fake_balance_expert_op: " +
+                                 std::string(expert_ids.dtype().name()));
+    }
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.h
+++ b/rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <torch/extension.h>
+#include <torch/all.h>
+
+namespace rtp_llm {
+
+void fake_balance_expert_op(
+    at::Tensor& expert_ids,
+    at::Tensor& expert_scales,
+    int64_t     dp_rank,
+    int64_t     dp_size,
+    int64_t     ep_size,
+    int64_t     expert_num,
+    int64_t     hip_stream);
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/rocm/RegisterBaseBindings.hpp
+++ b/rtp_llm/models_py/bindings/rocm/RegisterBaseBindings.hpp
@@ -7,6 +7,8 @@
 #include "rtp_llm/models_py/bindings/common/CudaGraphPrefillCopy.h"
 #include "rtp_llm/models_py/bindings/rocm/TrtllmAllReduceFusion.h"
 #include "rtp_llm/models_py/bindings/rocm/hip_host_utils.h"
+#include "rtp_llm/models_py/bindings/rocm/FakeBalanceExpertOp.h"
+
 namespace py = pybind11;
 
 namespace rtp_llm {
@@ -103,6 +105,18 @@ void registerBasicRocmOps(py::module& rtp_ops_m) {
 
     // TRT-LLM AllReduce Fusion — registered as a pybind11 class
     registerTrtllmArFusionHandle(rtp_ops_m);
+
+    // Fake balance expert kernel for MoE load-balance testing
+    rtp_ops_m.def("fake_balance_expert",
+                  &rtp_llm::fake_balance_expert_op,
+                  "Fake balance expert kernel (deterministic token->expert assignment)",
+                  py::arg("expert_ids"),
+                  py::arg("expert_scales"),
+                  py::arg("dp_rank"),
+                  py::arg("dp_size"),
+                  py::arg("ep_size"),
+                  py::arg("expert_num"),
+                  py::arg("hip_stream") = 0);
 }
 
 void registerBaseRocmBindings(py::module& rtp_ops_m) {

--- a/rtp_llm/models_py/distributed/moriep_wrapper.py
+++ b/rtp_llm/models_py/distributed/moriep_wrapper.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.utils.util import to_torch_dtype
 
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
@@ -86,7 +87,7 @@ class MoriEPWrapperConfig:
             hidden_dim=model_config.hidden_size,
             scale_dim=0,  # TODO: support scale_dim
             scale_type_size=0,  # sizeof(config.data_type)
-            max_token_type_size=torch.tensor([], dtype=model_config.data_type).element_size(),
+            max_token_type_size=torch.tensor([], dtype=to_torch_dtype(model_config.data_type)).element_size(),
             max_num_inp_token_per_rank=max_num_tokens,
             num_experts_per_rank=model_config.expert_num // parallelism_config.ep_size,
             num_experts_per_token=model_config.moe_k,
@@ -254,10 +255,7 @@ def init_moriep_wrapper(
         enable_cuda_graph=enable_cuda_graph,
     )
     mori_config = MoriEPWrapperConfig.from_config_adapter(mori_config_adapter)
-    try:
-        logging.info("Start initialize MoriEP wrapper")
-        MoriEPWrapper._create(mori_config, shmem_group_name=shmem_group_name)
-        logging.info("Finish initialize MoriEP wrapper")
-    except Exception as e:
-        logging.error(f"Failed to initialize MoriEP wrapper: {e}")
+    logging.info("Start initialize MoriEP wrapper")
+    MoriEPWrapper._create(mori_config, shmem_group_name=shmem_group_name)
+    logging.info("Finish initialize MoriEP wrapper")
 

--- a/rtp_llm/models_py/distributed/moriep_wrapper.py
+++ b/rtp_llm/models_py/distributed/moriep_wrapper.py
@@ -1,0 +1,182 @@
+import threading
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import mori
+import torch
+
+__all__ = [
+    "MoriEPWrapperConfig",
+    "MoriEPWrapper",
+    "init_moriep_wrapper",
+]
+
+
+@dataclass(eq=True)
+class MoriEPWrapperConfig:
+    """Config for MORI EP dispatch/combine wrapper."""
+
+    data_type: Any
+    rank: int
+    world_size: int
+    hidden_dim: int
+    scale_dim: int
+    scale_type_size: int
+    max_token_type_size: int
+    max_num_inp_token_per_rank: int
+    num_experts_per_rank: int
+    num_experts_per_token: int
+    warp_num_per_block: int = 16
+    block_num: int = 80
+    use_external_inp_buf: bool = True
+    kernel_type: mori.ops.EpDispatchCombineKernelType = (
+        mori.ops.EpDispatchCombineKernelType.IntraNode
+    )
+    gpu_per_node: Optional[int] = None
+    rdma_block_num: int = 0
+    num_qp_per_pe: int = 1
+    quant_type: str = "none"
+
+    def to_mori_kwargs(self) -> dict[str, Any]:
+        return {
+            "data_type": self.data_type,
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "hidden_dim": self.hidden_dim,
+            "scale_dim": self.scale_dim,
+            "scale_type_size": self.scale_type_size,
+            "max_token_type_size": self.max_token_type_size,
+            "max_num_inp_token_per_rank": self.max_num_inp_token_per_rank,
+            "num_experts_per_rank": self.num_experts_per_rank,
+            "num_experts_per_token": self.num_experts_per_token,
+            "warp_num_per_block": self.warp_num_per_block,
+            "block_num": self.block_num,
+            "use_external_inp_buf": self.use_external_inp_buf,
+            "kernel_type": self.kernel_type,
+            "gpu_per_node": (
+                self.world_size if self.gpu_per_node is None else self.gpu_per_node
+            ),
+            "rdma_block_num": self.rdma_block_num,
+            "num_qp_per_pe": self.num_qp_per_pe,
+            "quant_type": self.quant_type,
+        }
+
+
+class MoriEPWrapper:
+    """Thread-safe singleton wrapper around MORI EpDispatchCombineOp."""
+
+    _instance: Optional["MoriEPWrapper"] = None
+    _lock: threading.Lock = threading.Lock()
+    _initialized: bool = False
+
+    def __init__(self, config: MoriEPWrapperConfig, shmem_group_name: str) -> None:
+        self._config = config
+        self._shmem_group_name = shmem_group_name
+        self._op = None
+        self._init_op()
+
+    @classmethod
+    def supported(cls) -> bool:
+        try:
+            import mori
+
+            return True
+        except ImportError:
+            return False
+
+    @classmethod
+    def is_initialized(cls) -> bool:
+        return cls._initialized
+
+    @classmethod
+    def get_instance(cls) -> Optional["MoriEPWrapper"]:
+        """返回已初始化的单例，未初始化则返回 None。"""
+        with cls._lock:
+            return cls._instance if cls._initialized else None
+
+    @classmethod
+    def _create(
+        cls,
+        config: MoriEPWrapperConfig,
+        shmem_group_name: str,
+    ) -> "MoriEPWrapper":
+        """内部创建方法，仅由 init_moriep_wrapper 调用。"""
+        with cls._lock:
+            if cls._initialized:
+                if cls._instance is None:
+                    raise RuntimeError("MoriEP state is inconsistent")
+                if cls._instance._config != config:
+                    raise RuntimeError(
+                        f"MoriEP already initialized with different config, "
+                        f"origin: {cls._instance._config}, new: {config}"
+                    )
+                if cls._instance._shmem_group_name != shmem_group_name:
+                    raise RuntimeError(
+                        f"MoriEP already initialized with different shmem group, "
+                        f"origin: {cls._instance._shmem_group_name}, new: {shmem_group_name}"
+                    )
+                return cls._instance
+
+            if not cls.supported():
+                raise RuntimeError("MORI is not supported in current environment")
+            if not torch.distributed.is_initialized():
+                raise RuntimeError("Distributed environment is not initialized")
+
+            cls._instance = cls(config, shmem_group_name)
+            cls._initialized = True
+            return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance._op = None
+                cls._instance = None
+            cls._initialized = False
+
+    @property
+    def config(self) -> MoriEPWrapperConfig:
+        return self._config
+
+    @property
+    def op(self) -> Any:
+        if self._op is None:
+            raise RuntimeError("MORI EpDispatchCombineOp is not initialized")
+        return self._op
+
+    def dispatch(self, *args: Any, **kwargs: Any) -> Any:
+        return self.op.dispatch(*args, **kwargs)
+
+    def combine(self, *args: Any, **kwargs: Any) -> Any:
+        return self.op.combine(*args, **kwargs)
+
+    def reset_op(self) -> None:
+        if self._op is not None and hasattr(self._op, "reset"):
+            self._op.reset()
+
+    def _init_op(self) -> None:
+        mori_config = mori.ops.EpDispatchCombineConfig(**self._config.to_mori_kwargs())
+        self._op = mori.ops.EpDispatchCombineOp(mori_config)
+
+
+def init_moriep_wrapper(
+    config: MoriEPWrapperConfig,
+    shmem_group_name: str = "default",
+) -> None:
+    """注册 shmem process group + 创建 MoriEPWrapper 单例。
+
+    必须在 torch.distributed.init_process_group() 之后调用。
+    """
+    if not torch.distributed.is_initialized():
+        raise RuntimeError(
+            "Distributed environment is not initialized. "
+            "Call torch.distributed.init_process_group() first."
+        )
+
+    # 注册 WORLD group 并初始化 mori shmem
+    world_group = torch.distributed.group.WORLD
+    assert world_group is not None
+    torch._C._distributed_c10d._register_process_group(shmem_group_name, world_group)
+    mori.shmem.shmem_torch_process_group_init(shmem_group_name)
+
+    MoriEPWrapper._create(config, shmem_group_name=shmem_group_name)

--- a/rtp_llm/models_py/distributed/moriep_wrapper.py
+++ b/rtp_llm/models_py/distributed/moriep_wrapper.py
@@ -1,6 +1,14 @@
 import threading
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
+
+from rtp_llm.config.engine_config import EngineConfig
+from rtp_llm.config.model_config import ModelConfig
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
 
 import mori
 import torch
@@ -36,6 +44,59 @@ class MoriEPWrapperConfig:
     rdma_block_num: int = 0
     num_qp_per_pe: int = 1
     quant_type: str = "none"
+
+    @classmethod
+    def from_config_adapter(
+        cls, config_adapter: MoEConfigAdapter, ll_num_max_token_per_rank: int = 0
+    ) -> "MoriEPWrapperConfig":
+        """Create MoriEPWrapperConfig from MoEConfigAdapter.
+
+        Args:
+            config_adapter: The full configuration adapter
+
+        Returns:
+            A new MoriEPWrapperConfig instance with extracted parameters
+        """
+        model_config = config_adapter.model_config
+        parallelism_config = config_adapter.parallelism_config
+        moe_config = config_adapter.moe_config
+        max_num_tokens = (
+            moe_config.ll_num_max_token + parallelism_config.tp_size - 1
+        ) // parallelism_config.tp_size
+        if parallelism_config.world_size > parallelism_config.local_world_size:
+            mori_kernel_type = mori.ops.EpDispatchCombineKernelType.InterNodeV1
+            # on_gfx942():
+            warp_num_per_block = 16
+            block_num = 32
+            rdma_block_num = 16
+            # on_gfx950():
+            # warp_num_per_block = 8
+            # block_num = 64
+            # rdma_block_num = 32
+        else:
+            mori_kernel_type = mori.ops.EpDispatchCombineKernelType.IntraNode
+            rdma_block_num = 0
+            warp_num_per_block = 16
+            block_num = 80
+
+        return cls(
+            data_type=model_config.data_type,
+            rank=parallelism_config.ep_rank,
+            world_size=parallelism_config.world_size,
+            hidden_dim=model_config.hidden_size,
+            scale_dim=0,  # TODO: support scale_dim
+            scale_type_size=0,  # sizeof(config.data_type)
+            max_token_type_size=torch.tensor([], dtype=model_config.data_type).element_size(),
+            max_num_inp_token_per_rank=max_num_tokens,
+            num_experts_per_rank=model_config.expert_num // parallelism_config.ep_size,
+            num_experts_per_token=model_config.moe_k,
+            use_external_inp_buf=True,
+            kernel_type=mori_kernel_type,
+            gpu_per_node=min(8, parallelism_config.ep_size),
+            rdma_block_num=rdma_block_num,
+            warp_num_per_block=warp_num_per_block,
+            block_num=block_num,
+        )
 
     def to_mori_kwargs(self) -> dict[str, Any]:
         return {
@@ -160,7 +221,7 @@ class MoriEPWrapper:
 
 
 def init_moriep_wrapper(
-    config: MoriEPWrapperConfig,
+    engine_config: EngineConfig, model_config: ModelConfig,
     shmem_group_name: str = "default",
 ) -> None:
     """注册 shmem process group + 创建 MoriEPWrapper 单例。
@@ -179,4 +240,24 @@ def init_moriep_wrapper(
     torch._C._distributed_c10d._register_process_group(shmem_group_name, world_group)
     mori.shmem.shmem_torch_process_group_init(shmem_group_name)
 
-    MoriEPWrapper._create(config, shmem_group_name=shmem_group_name)
+    enable_cuda_graph = (
+        engine_config.hw_kernel_config.enable_cuda_graph
+        if engine_config.hw_kernel_config is not None
+        else False
+    )
+
+    mori_config_adapter = MoEConfigAdapter(
+        model_config=model_config,
+        parallelism_config=engine_config.parallelism_config,
+        moe_config=engine_config.moe_config,
+        quant_config=model_config.quant_config,
+        enable_cuda_graph=enable_cuda_graph,
+    )
+    mori_config = MoriEPWrapperConfig.from_config_adapter(mori_config_adapter)
+    try:
+        logging.info("Start initialize MoriEP wrapper")
+        MoriEPWrapper._create(mori_config, shmem_group_name=shmem_group_name)
+        logging.info("Finish initialize MoriEP wrapper")
+    except Exception as e:
+        logging.error(f"Failed to initialize MoriEP wrapper: {e}")
+

--- a/rtp_llm/models_py/distributed/moriep_wrapper.py
+++ b/rtp_llm/models_py/distributed/moriep_wrapper.py
@@ -62,9 +62,11 @@ class MoriEPWrapperConfig:
         model_config = config_adapter.model_config
         parallelism_config = config_adapter.parallelism_config
         moe_config = config_adapter.moe_config
-        max_num_tokens = (
-            moe_config.ll_num_max_token + parallelism_config.tp_size - 1
-        ) // parallelism_config.tp_size
+        # In EP+TP mode, TP splits the weight matrices (hidden dimension) but
+        # does NOT split the token dimension – every rank sees all tokens.
+        # Therefore max_num_inp_token_per_rank must equal the full
+        # ll_num_max_token so that MORI combine can return enough tokens.
+        max_num_tokens = moe_config.ll_num_max_token
         if parallelism_config.world_size > parallelism_config.local_world_size:
             mori_kernel_type = mori.ops.EpDispatchCombineKernelType.InterNodeV1
             # on_gfx942():

--- a/rtp_llm/models_py/distributed/moriep_wrapper.py
+++ b/rtp_llm/models_py/distributed/moriep_wrapper.py
@@ -18,6 +18,7 @@ __all__ = [
     "MoriEPWrapperConfig",
     "MoriEPWrapper",
     "init_moriep_wrapper",
+    "init_moriep_wrapper_from_config",
 ]
 
 
@@ -219,6 +220,30 @@ class MoriEPWrapper:
     def _init_op(self) -> None:
         mori_config = mori.ops.EpDispatchCombineConfig(**self._config.to_mori_kwargs())
         self._op = mori.ops.EpDispatchCombineOp(mori_config)
+
+
+def init_moriep_wrapper_from_config(
+    moriep_config: MoriEPWrapperConfig,
+    shmem_group_name: str = "default",
+) -> None:
+    """初始化 MoriEP wrapper，直接接受 MoriEPWrapperConfig（无需 EngineConfig/ModelConfig）。
+
+    必须在 torch.distributed.init_process_group() 之后调用。
+    """
+    if not torch.distributed.is_initialized():
+        raise RuntimeError(
+            "Distributed environment is not initialized. "
+            "Call torch.distributed.init_process_group() first."
+        )
+
+    world_group = torch.distributed.group.WORLD
+    assert world_group is not None
+    torch._C._distributed_c10d._register_process_group(shmem_group_name, world_group)
+    mori.shmem.shmem_torch_process_group_init(shmem_group_name)
+
+    logging.info("Start initialize MoriEP wrapper (from_config)")
+    MoriEPWrapper._create(moriep_config, shmem_group_name=shmem_group_name)
+    logging.info("Finish initialize MoriEP wrapper (from_config)")
 
 
 def init_moriep_wrapper(

--- a/rtp_llm/models_py/distributed/test/moriep_test.py
+++ b/rtp_llm/models_py/distributed/test/moriep_test.py
@@ -1,0 +1,382 @@
+import importlib.util
+import os
+import pathlib
+import socket
+import sys
+import unittest
+
+import mori
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+# 通过 rtp-llm 路径加载 moriep_wrapper 需要整体编译，这里用 importlib 按文件路径加载，能够整体编译后应该去掉这部分
+# from rtp_llm.models_py.distributed.moriep_wrapper import MoriEPWrapper, MoriEPWrapperConfig, init_moriep_wrapper
+
+_DIST_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load_module(name: str, path: pathlib.Path):
+    """Load a single Python file as *name* in sys.modules."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_wrapper_mod = _load_module(
+    "moriep_wrapper_under_test", _DIST_DIR / "moriep_wrapper.py"
+)
+MoriEPWrapper = _wrapper_mod.MoriEPWrapper
+MoriEPWrapperConfig = _wrapper_mod.MoriEPWrapperConfig
+init_moriep_wrapper = _wrapper_mod.init_moriep_wrapper
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def _init_dist(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="cpu:gloo,cuda:nccl",
+        rank=rank,
+        world_size=world_size,
+        device_id=torch.device("cuda", rank),
+    )
+
+
+def _cleanup_dist() -> None:
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# Test data generation & correctness checks
+# (参考 mori/tests/python/ops/test_dispatch_combine.py 中 EpDispatchCombineTestCase)
+# ---------------------------------------------------------------------------
+
+
+def _gen_test_data(config: MoriEPWrapperConfig, device: torch.device):
+    rng = torch.Generator(device=device)
+    rng.manual_seed(42)
+
+    num_tokens = config.max_num_inp_token_per_rank
+    num_total_experts = config.num_experts_per_rank * config.world_size
+
+    all_rank_num_token = torch.full(
+        (config.world_size,),
+        num_tokens,
+        device=device,
+        dtype=torch.int64,
+    )
+
+    all_rank_indices = []
+    for _ in range(config.world_size):
+        indices = torch.empty(
+            num_tokens, config.num_experts_per_token, dtype=torch.int64
+        )
+        for i in range(num_tokens):
+            perm = torch.randperm(num_total_experts, generator=rng, device=device)
+            indices[i] = perm[: config.num_experts_per_token]
+        all_rank_indices.append(indices.to(torch.int32).to(device))
+
+    all_rank_weights = [
+        torch.rand(
+            num_tokens,
+            config.num_experts_per_token,
+            dtype=torch.float32,
+            generator=rng,
+            device=device,
+        )
+        for _ in range(config.world_size)
+    ]
+
+    all_rank_scales = [
+        torch.empty(num_tokens, config.scale_dim, dtype=torch.float32, device=device)
+        for _ in range(config.world_size)
+    ]
+
+    all_rank_input = []
+    for _ in range(config.world_size):
+        inp = torch.randn(
+            num_tokens,
+            config.hidden_dim,
+            dtype=torch.float32,
+            generator=rng,
+            device=device,
+        ).to(config.data_type)
+        all_rank_input.append(inp)
+
+    return (
+        all_rank_num_token,
+        all_rank_indices,
+        all_rank_input,
+        all_rank_weights,
+        all_rank_scales,
+    )
+
+
+def _check_dispatch_result(
+    config: MoriEPWrapperConfig,
+    op,
+    test_data,
+    dispatch_output,
+    dispatch_weights,
+    dispatch_scales,
+    dispatch_indices,
+    dispatch_recv_num_token,
+):
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    _, all_rank_indices, all_rank_input, all_rank_weights, all_rank_scales = test_data
+    src_token_pos = op.get_dispatch_src_token_pos()
+
+    for i, pos in enumerate(src_token_pos):
+        src_rank = int(pos) // config.max_num_inp_token_per_rank
+        src_id = int(pos) % config.max_num_inp_token_per_rank
+
+        assert torch.equal(
+            all_rank_input[src_rank][src_id], dispatch_output[i]
+        ), f"token {i}: data mismatch (src_rank={src_rank}, src_id={src_id})"
+
+        if dispatch_weights is not None:
+            assert torch.equal(
+                all_rank_weights[src_rank][src_id], dispatch_weights[i]
+            ), f"token {i}: weight mismatch"
+
+        if dispatch_scales is not None:
+            assert torch.equal(
+                all_rank_scales[src_rank][src_id], dispatch_scales[i]
+            ), f"token {i}: scale mismatch"
+
+        assert torch.equal(
+            all_rank_indices[src_rank][src_id], dispatch_indices[i]
+        ), f"token {i}: index mismatch"
+
+    assert len(torch.unique(src_token_pos)) == len(
+        src_token_pos
+    ), "duplicate src_token_pos"
+    assert len(src_token_pos) == dispatch_recv_num_token[0], "recv count mismatch"
+
+
+def _check_combine_result(
+    config: MoriEPWrapperConfig,
+    test_data,
+    combine_output,
+):
+    torch.cuda.synchronize()
+    dist.barrier()
+
+    all_rank_num_token, all_rank_indices, all_rank_input, _, _ = test_data
+    rank = config.rank
+
+    for i in range(all_rank_num_token[rank]):
+        pes = [
+            int(idx) // config.num_experts_per_rank
+            for idx in all_rank_indices[rank][i].cpu().tolist()
+        ]
+        unique_pes = len(set(pes))
+
+        expected = (all_rank_input[rank][i].to(torch.float32) * unique_pes).to(
+            config.data_type
+        )
+        got = combine_output[i]
+
+        atol, rtol = 1e-2, 1e-2
+        assert torch.allclose(got.float(), expected.float(), atol=atol, rtol=rtol), (
+            f"Rank[{rank}] token {i}: combine mismatch, "
+            f"pes={pes}, unique_pes={unique_pes}, got={got}, expected={expected}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker: single-rank correctness test
+# ---------------------------------------------------------------------------
+
+
+def _run_moriep_correctness(
+    rank: int,
+    world_size: int,
+    port: int,
+    data_type: torch.dtype,
+    max_inp_token_per_rank: int,
+    use_external_inp_buf: bool,
+) -> None:
+
+    try:
+        _init_dist(rank, world_size, port)
+
+        config = MoriEPWrapperConfig(
+            data_type=data_type,
+            rank=rank,
+            world_size=world_size,
+            hidden_dim=1024,
+            scale_dim=0,
+            scale_type_size=0,
+            max_token_type_size=torch.tensor([], dtype=data_type).element_size(),
+            max_num_inp_token_per_rank=max_inp_token_per_rank,
+            num_experts_per_rank=4,
+            num_experts_per_token=2,
+            use_external_inp_buf=use_external_inp_buf,
+            gpu_per_node=world_size,
+            kernel_type=mori.ops.EpDispatchCombineKernelType.IntraNode,
+            rdma_block_num=0,
+            num_qp_per_pe=1,
+            quant_type="none",
+        )
+        init_moriep_wrapper(config, shmem_group_name="default")
+        wrapper = MoriEPWrapper.get_instance()
+        device = torch.device("cuda", rank)
+
+        test_data = _gen_test_data(config, device)
+        _, all_rank_indices, all_rank_input, all_rank_weights, all_rank_scales = (
+            test_data
+        )
+
+        # ---- dispatch ----
+        (
+            dispatch_output,
+            dispatch_weights,
+            dispatch_scales,
+            dispatch_indices,
+            dispatch_recv_num_token,
+        ) = wrapper.dispatch(
+            all_rank_input[rank],
+            all_rank_weights[rank],
+            all_rank_scales[rank],
+            all_rank_indices[rank],
+            block_num=64,
+            warp_per_block=16,
+        )
+
+        _check_dispatch_result(
+            config,
+            wrapper.op,
+            test_data,
+            dispatch_output,
+            dispatch_weights,
+            dispatch_scales,
+            dispatch_indices,
+            dispatch_recv_num_token,
+        )
+
+        # ---- combine ----
+        total_recv_num_token = int(dispatch_recv_num_token[0].item())
+
+        if not config.use_external_inp_buf:
+            combine_input = wrapper.op.get_registered_combine_input_buffer(
+                config.data_type,
+                hidden_dim=dispatch_output.size(1),
+            )
+            combine_input[:total_recv_num_token, :].copy_(
+                dispatch_output[:total_recv_num_token, :]
+            )
+            combine_source = combine_input
+        else:
+            combine_source = dispatch_output
+
+        combine_output, _ = wrapper.combine(
+            combine_source,
+            None,
+            dispatch_indices,
+            block_num=64,
+            warp_per_block=16,
+        )
+
+        _check_combine_result(config, test_data, combine_output)
+
+        if rank == 0:
+            print(
+                f"[PASS] dtype={data_type}, world_size={world_size}, "
+                f"use_external_inp_buf={use_external_inp_buf}, "
+                f"recv_tokens={total_recv_num_token}"
+            )
+
+        wrapper.reset_op()
+        MoriEPWrapper.reset()
+        if hasattr(mori.shmem, "shmem_finalize"):
+            mori.shmem.shmem_finalize()
+    finally:
+        _cleanup_dist()
+
+
+# ---------------------------------------------------------------------------
+# Test cases: world_size = 2, 4, 8, data_type = bf16, fp8_e4m3fn, num_tokens = 128, 4096, 8192, use_external_inp_buf = True, False
+# ---------------------------------------------------------------------------
+
+
+class MoriEPWrapperIntegrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            mp.set_start_method("spawn", force=True)
+        except RuntimeError:
+            pass
+
+    def _require_mori(self):
+        try:
+            import mori  # noqa: F401
+        except ImportError:
+            self.skipTest("mori is not available")
+
+    def _require_gpus(self, n: int):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+        if torch.cuda.device_count() < n:
+            self.skipTest(f"Need at least {n} CUDA devices")
+
+    def _run(
+        self,
+        world_size: int,
+        data_type: torch.dtype,
+        max_inp_token_per_rank: int,
+        use_external_inp_buf: bool,
+    ):
+        self._require_gpus(world_size)
+        self._require_mori()
+        port = _get_free_port()
+        mp.spawn(
+            _run_moriep_correctness,
+            args=(
+                world_size,
+                port,
+                data_type,
+                max_inp_token_per_rank,
+                use_external_inp_buf,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+
+    _world_size_list = [2, 4, 8]
+    _dtype_list = [torch.bfloat16, torch.float8_e4m3fn]
+    _max_inp_token_per_rank_list = [128]
+
+    def test_dispatch_combine_correctness(self):
+        for dtype in self._dtype_list:
+            for ws in self._world_size_list:
+                for max_inp_token_per_rank in self._max_inp_token_per_rank_list:
+                    for use_external_inp_buf in [True, False]:
+                        with self.subTest(
+                            dtype=dtype,
+                            world_size=ws,
+                            max_inp_token_per_rank=max_inp_token_per_rank,
+                            use_external_inp_buf=use_external_inp_buf,
+                        ):
+                            self._run(
+                                ws, dtype, max_inp_token_per_rank, use_external_inp_buf
+                            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/test/moriep_test.py
+++ b/rtp_llm/models_py/distributed/test/moriep_test.py
@@ -33,6 +33,7 @@ _wrapper_mod = _load_module(
 MoriEPWrapper = _wrapper_mod.MoriEPWrapper
 MoriEPWrapperConfig = _wrapper_mod.MoriEPWrapperConfig
 init_moriep_wrapper = _wrapper_mod.init_moriep_wrapper
+init_moriep_wrapper_from_config = _wrapper_mod.init_moriep_wrapper_from_config
 
 
 def _get_free_port() -> int:
@@ -234,7 +235,7 @@ def _run_moriep_correctness(
             num_qp_per_pe=1,
             quant_type="none",
         )
-        init_moriep_wrapper(config, shmem_group_name="default")
+        init_moriep_wrapper_from_config(config, shmem_group_name="default")
         wrapper = MoriEPWrapper.get_instance()
         device = torch.device("cuda", rank)
 
@@ -358,7 +359,7 @@ class MoriEPWrapperIntegrationTest(unittest.TestCase):
             join=True,
         )
 
-    _world_size_list = [2, 4, 8]
+    _world_size_list = [2]
     _dtype_list = [torch.bfloat16, torch.float8_e4m3fn]
     _max_inp_token_per_rank_list = [128]
 

--- a/rtp_llm/models_py/modules/base/rocm/select_topk.py
+++ b/rtp_llm/models_py/modules/base/rocm/select_topk.py
@@ -2,6 +2,7 @@ import aiter
 import torch
 from torch import nn
 
+import rtp_llm.ops.compute_ops as compute_ops
 from rtp_llm.config.model_config import ModelConfig
 
 
@@ -10,6 +11,11 @@ class SelectTopk(nn.Module):
         super().__init__()
         self.config = config
         self.top_k = config.moe_k
+        self.fake_balance_expert = fake_balance_expert
+        self.dp_rank = dp_rank
+        self.dp_size = dp_size
+        self.ep_size = ep_size
+        self.expert_num = config.expert_num
 
     def forward(
         self,
@@ -30,3 +36,13 @@ class SelectTopk(nn.Module):
             router_logits_fp32,  # TODO(woosuk): Optimize this.
             True,
         )
+
+        if self.fake_balance_expert:
+            compute_ops.fake_balance_expert(
+                topk_ids,
+                topk_weights,
+                self.dp_rank,
+                self.dp_size,
+                self.ep_size,
+                self.expert_num,
+            )

--- a/rtp_llm/models_py/modules/base/rocm/select_topk.py
+++ b/rtp_llm/models_py/modules/base/rocm/select_topk.py
@@ -20,7 +20,9 @@ class SelectTopk(nn.Module):
         token_expert_indicies = torch.empty(
             topk_ids.shape[0], self.top_k, dtype=torch.int32, device=topk_ids.device
         )
-        topk_ids = topk_ids.int()
+        # Ensure topk_ids is int32 for aiter.topk_softmax
+        if topk_ids.dtype != torch.int32:
+            topk_ids = topk_ids.to(torch.int32)
         aiter.topk_softmax(
             topk_weights,
             topk_ids,

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/type.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/type.py
@@ -12,6 +12,8 @@ class RouterType(Enum):
     DEEPEP_NORMAL = 2  # DeepEP normal mode
     DEEPEP_LOW_LATENCY = 4  # DeepEP low latency mode (best communication)
     PURE_TP = 5  # optimize when EP=TP, use all_reduce as gather
+    MORI_EP_INTRANODE = 6  # MORI intra-node EP router
+    MORI_EP_INTERNODE = 7  # MORI inter-node EP router
 
 
 class ExecutorType(Enum):

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -69,6 +69,10 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         if a1_scale is not None or a2_scale is not None:
             raise ValueError("MoriEpIntranode a1_scale or a2_scale should be None")
 
+        # Mori expects int32 for topk_ids
+        if topk_ids.dtype != torch.int32:
+            topk_ids = topk_ids.to(torch.int32)
+
         (
             dispatch_a1,
             dispatch_weights,
@@ -96,5 +100,15 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         apply_router_weight_on_input: bool,
         extra_finalize_args: Optional[Dict[str, Any]],
     ) -> torch.Tensor:
+        # Mori expects int32 for topk_ids
+        if topk_ids.dtype != torch.int32:
+            topk_ids = topk_ids.to(torch.int32)
         recv_x = self.mori_buffer_wrapper.op.combine(payload.fused_expert_output, None, topk_ids)[0]
+
+        # MoriEP returns fixed-size buffer (aligned to expert_alignment), need to slice to original size
+        if extra_finalize_args is not None and "original_num_tokens" in extra_finalize_args:
+            original_num_tokens = extra_finalize_args["original_num_tokens"]
+            if recv_x.shape[0] > original_num_tokens:
+                recv_x = recv_x[:original_num_tokens]
+
         return recv_x

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -1,0 +1,100 @@
+from typing import Any, Dict, Optional
+import torch
+
+from rtp_llm.models_py.distributed.moriep_wrapper import MoriEPWrapper
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    ExpertTokensMetadata,
+    FusedMoeDataRouter,
+)
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
+
+class MoriEpIntranodeRouter(FusedMoeDataRouter):
+    @classmethod
+    def router_type(cls):
+        return RouterType.MORI_EP_INTRANODE
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        """Check if MoriEpIntranodeRouter can handle the configuration"""
+        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+            MoeConfigResolver,
+        )
+
+        resolver = MoeConfigResolver()
+        checker.check(resolver.is_ep_enabled(config))
+        checker.check(not resolver.use_low_latency(config))
+        checker.check(MoriEPWrapper.supported())
+
+    def __init__(
+        self,
+        config: MoEConfigAdapter,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(config, quant_config)
+
+        self.tp_size = config.tp_size
+        self.tp_rank = config.tp_rank
+        self.dp_size = config.dp_size
+        self.dp_rank = config.dp_rank
+        self.ep_size = config.ep_size
+        self.ep_rank = config.ep_rank
+        self.expert_num = config.expert_num
+        self.expert_num_per_rank = self.expert_num // self.ep_size
+        self.top_k = config.moe_topk_group
+        self.mori_buffer_wrapper = MoriEPWrapper.get_instance()
+        self.use_fp8 = True
+        self.async_mode = False
+        self.expert_alignment = 128
+    
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        a1_scale: Optional[torch.Tensor],
+        a2_scale: Optional[torch.Tensor],
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> ExpertForwardPayload:
+        # TODO: implement fp8 quantization
+        if a1_scale is not None or a2_scale is not None:
+            raise ValueError("MoriEpIntranode a1_scale or a2_scale should be None")
+
+        (
+            dispatch_a1,
+            dispatch_weights,
+            dispatch_scale,
+            dispatch_ids,
+            dispatch_recv_token_num,
+        ) = self.mori_buffer_wrapper.op.dispatch(a1, topk_weights, None, topk_ids)
+        return ExpertForwardPayload(
+            expert_x=dispatch_a1,
+            expert_x_scale=dispatch_scale,
+            expert_x_origin_dtype=None,
+            expert_topk_ids=dispatch_ids,
+            expert_topk_weights=dispatch_weights,
+            expert_tokens_meta=ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=dispatch_recv_token_num,
+            ),
+        )
+
+    def finalize(
+        self,
+        payload: CombineForwardPayload,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        extra_finalize_args: Optional[Dict[str, Any]],
+    ) -> torch.Tensor:
+        recv_x = self.mori_buffer_wrapper.op.combine(payload.fused_expert_output, None, topk_ids)[0]
+        return recv_x

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 import torch
 
 from rtp_llm.models_py.distributed.moriep_wrapper import MoriEPWrapper
@@ -57,6 +57,13 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         self.async_mode = False
         self.expert_alignment = 128
         self._dispatch_ids = None  # cached global dispatch_ids for finalize
+        self._is_chunked = False
+        self._chunk_dispatch_ids: Optional[List[torch.Tensor]] = None
+        self._chunk_recv_sizes: Optional[List[int]] = None
+        self._chunk_input_sizes: Optional[List[int]] = None
+
+    def _get_max_inp_tokens(self) -> int:
+        return self.mori_buffer_wrapper.config.max_num_inp_token_per_rank
 
     def prepare(
         self,
@@ -73,6 +80,21 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         # Mori expects int32 for topk_ids
         if topk_ids.dtype != torch.int32:
             topk_ids = topk_ids.to(torch.int32)
+
+        max_tokens = self._get_max_inp_tokens()
+        num_tokens = a1.shape[0]
+
+        if num_tokens <= max_tokens:
+            return self._prepare_single(a1, topk_weights, topk_ids)
+        return self._prepare_chunked(a1, topk_weights, topk_ids, max_tokens)
+
+    def _prepare_single(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> ExpertForwardPayload:
+        self._is_chunked = False
 
         (
             dispatch_a1,
@@ -112,6 +134,86 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
             ),
         )
 
+    def _prepare_chunked(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        chunk_size: int,
+    ) -> ExpertForwardPayload:
+        self._is_chunked = True
+        self._chunk_dispatch_ids = []
+        self._chunk_recv_sizes = []
+        self._chunk_input_sizes = []
+
+        all_dispatch_a1 = []
+        all_dispatch_scale = []
+        all_local_ids = []
+        all_local_weights = []
+        total_recv_token_nums = None
+
+        local_start = self.ep_rank * self.expert_num_per_rank
+        local_end = local_start + self.expert_num_per_rank
+        num_tokens = a1.shape[0]
+
+        for start in range(0, num_tokens, chunk_size):
+            end = min(start + chunk_size, num_tokens)
+
+            (
+                dispatch_a1,
+                dispatch_weights,
+                dispatch_scale,
+                dispatch_ids,
+                dispatch_recv_token_num,
+            ) = self.mori_buffer_wrapper.op.dispatch(
+                a1[start:end], topk_weights[start:end], None, topk_ids[start:end]
+            )
+
+            self._chunk_dispatch_ids.append(dispatch_ids)
+            self._chunk_recv_sizes.append(dispatch_a1.shape[0])
+            self._chunk_input_sizes.append(end - start)
+
+            all_dispatch_a1.append(dispatch_a1)
+            if dispatch_scale is not None:
+                all_dispatch_scale.append(dispatch_scale)
+
+            non_local_mask = (dispatch_ids < local_start) | (dispatch_ids >= local_end)
+
+            local_ids = dispatch_ids.clone()
+            local_ids[non_local_mask] = local_start
+            local_ids = local_ids - local_start
+
+            local_weights_chunk = dispatch_weights.to(torch.float32).clone()
+            local_weights_chunk[non_local_mask] = 0.0
+
+            all_local_ids.append(local_ids)
+            all_local_weights.append(local_weights_chunk)
+
+            if isinstance(dispatch_recv_token_num, torch.Tensor):
+                recv_list = dispatch_recv_token_num.tolist()
+            else:
+                recv_list = list(dispatch_recv_token_num)
+            if total_recv_token_nums is None:
+                total_recv_token_nums = recv_list
+            else:
+                for i in range(len(total_recv_token_nums)):
+                    total_recv_token_nums[i] += recv_list[i]
+
+        return ExpertForwardPayload(
+            expert_x=torch.cat(all_dispatch_a1, dim=0),
+            expert_x_scale=(
+                torch.cat(all_dispatch_scale, dim=0) if all_dispatch_scale else None
+            ),
+            expert_x_origin_dtype=None,
+            expert_topk_ids=torch.cat(all_local_ids, dim=0),
+            expert_topk_weights=torch.cat(all_local_weights, dim=0),
+            expert_ids_are_local=True,
+            expert_tokens_meta=ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=total_recv_token_nums,
+            ),
+        )
+
     def finalize(
         self,
         payload: CombineForwardPayload,
@@ -121,13 +223,22 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         extra_finalize_args: Optional[Dict[str, Any]],
         skip_allreduce: bool = False,
     ) -> torch.Tensor:
+        fused_out = payload.fused_expert_output
+
+        if self._is_chunked:
+            return self._finalize_chunked(fused_out, extra_finalize_args)
+        return self._finalize_single(fused_out, extra_finalize_args)
+
+    def _finalize_single(
+        self,
+        fused_out: torch.Tensor,
+        extra_finalize_args: Optional[Dict[str, Any]],
+    ) -> torch.Tensor:
         # Use the cached global dispatch_ids for combine, not the local_ids
         # that were set as expert_topk_ids for the fused_moe kernel.
         global_dispatch_ids = self._dispatch_ids
         if global_dispatch_ids.dtype != torch.int32:
             global_dispatch_ids = global_dispatch_ids.to(torch.int32)
-
-        fused_out = payload.fused_expert_output
 
         recv_x = self.mori_buffer_wrapper.op.combine(fused_out, None, global_dispatch_ids)[0]
 
@@ -138,3 +249,34 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
                 recv_x = recv_x[:original_num_tokens]
 
         return recv_x
+
+    def _finalize_chunked(
+        self,
+        fused_out: torch.Tensor,
+        extra_finalize_args: Optional[Dict[str, Any]],
+    ) -> torch.Tensor:
+        results = []
+        offset = 0
+
+        for chunk_ids, recv_size, input_size in zip(
+            self._chunk_dispatch_ids,
+            self._chunk_recv_sizes,
+            self._chunk_input_sizes,
+        ):
+            if chunk_ids.dtype != torch.int32:
+                chunk_ids = chunk_ids.to(torch.int32)
+
+            chunk_out = fused_out[offset : offset + recv_size]
+            recv_x = self.mori_buffer_wrapper.op.combine(chunk_out, None, chunk_ids)[0]
+
+            if recv_x.shape[0] > input_size:
+                recv_x = recv_x[:input_size]
+
+            results.append(recv_x)
+            offset += recv_size
+
+        self._chunk_dispatch_ids = None
+        self._chunk_recv_sizes = None
+        self._chunk_input_sizes = None
+
+        return torch.cat(results, dim=0)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -99,6 +99,7 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         extra_finalize_args: Optional[Dict[str, Any]],
+        skip_allreduce: bool = False,
     ) -> torch.Tensor:
         # Mori expects int32 for topk_ids
         if topk_ids.dtype != torch.int32:

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -56,7 +56,8 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         self.use_fp8 = True
         self.async_mode = False
         self.expert_alignment = 128
-    
+        self._dispatch_ids = None  # cached global dispatch_ids for finalize
+
     def prepare(
         self,
         a1: torch.Tensor,
@@ -80,6 +81,25 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
             dispatch_ids,
             dispatch_recv_token_num,
         ) = self.mori_buffer_wrapper.op.dispatch(a1, topk_weights, None, topk_ids)
+
+        local_start = self.ep_rank * self.expert_num_per_rank
+        local_end = local_start + self.expert_num_per_rank
+        non_local_mask = (dispatch_ids < local_start) | (dispatch_ids >= local_end)
+
+        # Cache global dispatch_ids for use in finalize()'s combine call.
+        self._dispatch_ids = dispatch_ids
+
+        # Remap global expert IDs to local 0-based indices.
+        # Non-local experts get mapped to index 0 (safe fallback) so the
+        # FP4 kernel computes a valid output that is then zeroed by weight=0.
+        local_ids = dispatch_ids.clone()
+        local_ids[non_local_mask] = local_start
+        local_ids = local_ids - local_start
+
+        # Preserve original routing weights for local experts; zero non-local.
+        local_weights = dispatch_weights.to(torch.float32).clone()
+        local_weights[non_local_mask] = 0.0
+
         return ExpertForwardPayload(
             expert_x=dispatch_a1,
             expert_x_scale=dispatch_scale,
@@ -101,10 +121,15 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         extra_finalize_args: Optional[Dict[str, Any]],
         skip_allreduce: bool = False,
     ) -> torch.Tensor:
-        # Mori expects int32 for topk_ids
-        if topk_ids.dtype != torch.int32:
-            topk_ids = topk_ids.to(torch.int32)
-        recv_x = self.mori_buffer_wrapper.op.combine(payload.fused_expert_output, None, topk_ids)[0]
+        # Use the cached global dispatch_ids for combine, not the local_ids
+        # that were set as expert_topk_ids for the fused_moe kernel.
+        global_dispatch_ids = self._dispatch_ids
+        if global_dispatch_ids.dtype != torch.int32:
+            global_dispatch_ids = global_dispatch_ids.to(torch.int32)
+
+        fused_out = payload.fused_expert_output
+
+        recv_x = self.mori_buffer_wrapper.op.combine(fused_out, None, global_dispatch_ids)[0]
 
         # MoriEP returns fixed-size buffer (aligned to expert_alignment), need to slice to original size
         if extra_finalize_args is not None and "original_num_tokens" in extra_finalize_args:

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
@@ -23,16 +23,33 @@ class RocmEpNormalStrategy(MoeStrategy):
         from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
             FusedMoeExecutor,
         )
-        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.deepep_normal_router import (
-            DeepepNormalRouter,
-        )
-
         quant_config = FusedMoEQuantConfig(quant_dtype=None)
-        return StrategyAttributes(
-            router_class=DeepepNormalRouter,
-            executor_class=FusedMoeExecutor,
-            quant_config=quant_config,
-        )
+        try:
+            import deep_ep
+
+            from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.deepep_normal_router import (
+                DeepepNormalRouter,
+            )
+            return StrategyAttributes(
+                router_class=DeepepNormalRouter,
+                executor_class=FusedMoeExecutor,
+                quant_config=quant_config,
+            )
+        except ImportError:
+            pass
+        try:
+            import mori
+            from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.mori_ep_intranode_router import (
+                MoriEpIntranodeRouter,
+            )
+            return StrategyAttributes(
+                router_class=MoriEpIntranodeRouter,
+                executor_class=FusedMoeExecutor,
+                quant_config=quant_config,
+            )
+        except ImportError:
+            pass
+        raise ValueError("No EP router and executor found, please install deep_ep or mori")
 
 
 class RocmEpLowLatencyStrategy(MoeStrategy):

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
@@ -1,5 +1,7 @@
 """ROCm Expert Parallelism strategies"""
 
+import logging
+import os
 from typing import Any, Dict
 
 import torch
@@ -15,6 +17,8 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.strategy_base import MoeStrategy
 
+logger = logging.getLogger(__name__)
+
 
 class RocmEpNormalStrategy(MoeStrategy):
     """ROCm EP normal mode strategy"""
@@ -23,32 +27,71 @@ class RocmEpNormalStrategy(MoeStrategy):
         from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.deepep_normal_fused_moe_executor import (
             FusedMoeExecutor,
         )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
+            RocmExpertsBf16,
+        )
         quant_config = FusedMoEQuantConfig(quant_dtype=None)
+
+        # Check if user wants to force use MoriEP
+        use_mori_ep = os.environ.get("USE_MORI_EP", "0").lower() in ("1", "true", "on")
+
+        if use_mori_ep:
+            logger.info("USE_MORI_EP is set, forcing mori router selection")
+            try:
+                import mori
+                from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.mori_ep_intranode_router import (
+                    MoriEpIntranodeRouter,
+                )
+                logger.info(
+                    "ROCm EP strategy selected mori router: %s, executor: %s",
+                    MoriEpIntranodeRouter.__name__,
+                    RocmExpertsBf16.__name__,
+                )
+                return StrategyAttributes(
+                    router_class=MoriEpIntranodeRouter,
+                    executor_class=RocmExpertsBf16,
+                    quant_config=quant_config,
+                )
+            except ImportError as e:
+                logger.warning("mori not available even though USE_MORI_EP is set. detail: %s", e)
+                raise ValueError("USE_MORI_EP is set but mori is not available")
+
+        logger.info("ROCm EP strategy selection start: try deep_ep first, then mori fallback")
         try:
             import deep_ep
 
             from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.deepep_normal_router import (
                 DeepepNormalRouter,
             )
+            logger.info(
+                "ROCm EP strategy selected deep_ep router: %s, executor: %s",
+                DeepepNormalRouter.__name__,
+                FusedMoeExecutor.__name__,
+            )
             return StrategyAttributes(
                 router_class=DeepepNormalRouter,
                 executor_class=FusedMoeExecutor,
                 quant_config=quant_config,
             )
-        except ImportError:
-            pass
+        except ImportError as e:
+            logger.warning("deep_ep not available, fallback to mori. detail: %s", e)
         try:
             import mori
             from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.mori_ep_intranode_router import (
                 MoriEpIntranodeRouter,
             )
+            logger.info(
+                "ROCm EP strategy selected mori router: %s, executor: %s",
+                MoriEpIntranodeRouter.__name__,
+                RocmExpertsBf16.__name__,
+            )
             return StrategyAttributes(
                 router_class=MoriEpIntranodeRouter,
-                executor_class=FusedMoeExecutor,
+                executor_class=RocmExpertsBf16,
                 quant_config=quant_config,
             )
-        except ImportError:
-            pass
+        except ImportError as e:
+            logger.warning("mori not available after deep_ep fallback. detail: %s", e)
         raise ValueError("No EP router and executor found, please install deep_ep or mori")
 
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
@@ -36,3 +36,16 @@ py_test (
     exec_properties = {'gpu':'MI308X-ROCM7'},
 )
 
+# 依赖 mori；无 mori 时脚本 __main__ 会 exit 0
+# py_test (
+#     name = "moriep_intranode_router_test",
+#     srcs = ["moriep_intranode_router_test.py"],
+#     deps = py_test_deps + [
+#         "//rtp_llm/models_py:models",
+#     ],
+#     timeout = "eternal",
+#     env = test_envs,
+#     tags = ["rocm"],
+#     exec_properties = {'gpu':'MI308X'},
+# )
+

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
@@ -1,0 +1,515 @@
+"""Multi-GPU tests for Mori EP router 行为（prepare / finalize 与 mori_ep_intranode_router 对齐）。
+
+与 distributed/test/moriep_test.py 相同策略：
+- 用 importlib 按文件路径加载 moriep_wrapper.py，无需整包安装/编译 rtp_llm；
+- 在加载前注入最小 rtp_llm 桩模块，满足 moriep_wrapper.py 顶层 import；
+- 分布式使用 torch.distributed 直接 init（同 moriep_test），不依赖 collective_torch / PortManager；
+- prepare/finalize 逻辑内联自 mori_ep_intranode_router.py，避免再 import fused_moe 等。
+
+依赖：mori、多卡 CUDA/ROCm。无 mori 时 __main__ 退出 0。
+
+spawn 多进程时父进程勿用 torch.cuda（见 _gpu_count_without_parent_cuda_init）；
+可设环境变量 MORIEP_TEST_MAX_GPUS=8 指定卡数，避免走兜底 torch.cuda.device_count()。
+
+调试：默认 MORIEP_TEST_DEBUG=1 打印各阶段（含 rank/pid/相对时间）；
+关闭详细日志：MORIEP_TEST_DEBUG=0
+"""
+from __future__ import annotations
+
+import importlib.util
+import multiprocessing as mp
+import os
+import pathlib
+import random
+import re
+import time
+import socket
+import subprocess
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+# ---------------------------------------------------------------------------
+# 路径：models_py/distributed/moriep_wrapper.py（与 moriep_test 中 _DIST_DIR 相对关系一致）
+# 本文件: .../models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
+# parents[6] -> models_py
+# ---------------------------------------------------------------------------
+_MODELS_PY = pathlib.Path(__file__).resolve().parents[6]
+_DIST_DIR = _MODELS_PY / "distributed"
+_MORIEP_WRAPPER_PATH = _DIST_DIR / "moriep_wrapper.py"
+
+# 调试：MORIEP_TEST_DEBUG=0 可关闭；MORIEP_TEST_DEBUG=1（默认）打印各阶段
+_T0 = time.monotonic()
+
+
+def _moriep_debug_enabled() -> bool:
+    return os.environ.get("MORIEP_TEST_DEBUG", "1").strip() != "0"
+
+
+def _moriep_log(rank: Optional[int], msg: str) -> None:
+    if not _moriep_debug_enabled():
+        return
+    elapsed = time.monotonic() - _T0
+    pid = os.getpid()
+    r = "?" if rank is None else str(rank)
+    print(
+        f"[moriep_intranode_router_test +{elapsed:8.3f}s pid={pid} rank={r}] {msg}",
+        flush=True,
+    )
+
+
+def _load_module(name: str, path: pathlib.Path):
+    """Load a single Python file as *name* in sys.modules."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ensure_packages_up_to(full_name: str) -> None:
+    """注册 package 链，如 rtp_llm.models_py.modules..."""
+    parts = full_name.split(".")
+    for i in range(1, len(parts) + 1):
+        p = ".".join(parts[:i])
+        if p in sys.modules:
+            continue
+        m = types.ModuleType(p)
+        if i < len(parts):
+            m.__path__ = []
+        sys.modules[p] = m
+
+
+def _register_stub_module(full_name: str, **attrs: Any) -> None:
+    """注册叶子模块（如 rtp_llm.config.engine_config）并挂属性。"""
+    parent = full_name.rsplit(".", 1)[0]
+    _ensure_packages_up_to(parent)
+    mod = types.ModuleType(full_name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[full_name] = mod
+
+
+def _install_rtp_llm_stubs_for_moriep_wrapper() -> None:
+    """满足 moriep_wrapper.py 顶层 `from rtp_llm... import ...`，无需安装 rtp_llm。"""
+    _register_stub_module(
+        "rtp_llm.config.engine_config",
+        EngineConfig=type("EngineConfig", (), {}),
+    )
+    _register_stub_module(
+        "rtp_llm.config.model_config",
+        ModelConfig=type("ModelConfig", (), {}),
+    )
+    _register_stub_module(
+        "rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter",
+        MoEConfigAdapter=type("MoEConfigAdapter", (), {}),
+    )
+
+
+def _load_moriep_wrapper():
+    """importlib 加载 moriep_wrapper.py（需先桩 rtp_llm）。"""
+    _install_rtp_llm_stubs_for_moriep_wrapper()
+    mod = _load_module("moriep_wrapper_under_test", _MORIEP_WRAPPER_PATH)
+    return mod.MoriEPWrapper, mod.MoriEPWrapperConfig
+
+
+# 延迟到 worker / main 中赋值，避免 import 时即依赖 mori
+MoriEPWrapper: Any = None
+MoriEPWrapperConfig: Any = None
+
+
+def _ensure_moriep_symbols_loaded() -> None:
+    global MoriEPWrapper, MoriEPWrapperConfig
+    if MoriEPWrapper is None:
+        MoriEPWrapper, MoriEPWrapperConfig = _load_moriep_wrapper()
+
+
+# ---------------------------------------------------------------------------
+# 与 mori_ep_intranode_router.py 中 dataclass 字段对齐的最小结构（仅本测试使用）
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExpertTokensMetadata:
+    expected_m: Optional[int] = None
+    expert_num_tokens: Optional[torch.Tensor] = None
+    expert_num_tokens_cpu: Optional[Any] = None
+
+
+@dataclass
+class ExpertForwardPayload:
+    expert_x: torch.Tensor
+    expert_x_origin_dtype: Optional[torch.dtype] = None
+    expert_x_scale: Optional[torch.Tensor] = None
+    expert_tokens_meta: Optional[ExpertTokensMetadata] = None
+    expert_topk_ids: Optional[torch.Tensor] = None
+    expert_topk_weights: Optional[torch.Tensor] = None
+
+
+@dataclass
+class CombineForwardPayload:
+    fused_expert_output: torch.Tensor
+
+
+def router_prepare(
+    mori_buffer_wrapper: Any,
+    a1: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> ExpertForwardPayload:
+    """与 MoriEpIntranodeRouter.prepare 一致。"""
+    (
+        dispatch_a1,
+        dispatch_weights,
+        dispatch_scale,
+        dispatch_ids,
+        dispatch_recv_token_num,
+    ) = mori_buffer_wrapper.op.dispatch(a1, topk_weights, None, topk_ids)
+    return ExpertForwardPayload(
+        expert_x=dispatch_a1,
+        expert_x_scale=dispatch_scale,
+        expert_x_origin_dtype=None,
+        expert_topk_ids=dispatch_ids,
+        expert_topk_weights=dispatch_weights,
+        expert_tokens_meta=ExpertTokensMetadata(
+            expert_num_tokens=None,
+            expert_num_tokens_cpu=dispatch_recv_token_num,
+        ),
+    )
+
+
+def router_finalize(
+    mori_buffer_wrapper: Any,
+    payload: CombineForwardPayload,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    """与 MoriEpIntranodeRouter.finalize 一致。"""
+    recv_x = mori_buffer_wrapper.op.combine(
+        payload.fused_expert_output, None, topk_ids
+    )[0]
+    return recv_x
+
+
+# ---------------------------------------------------------------------------
+# 分布式 & Mori shmem（对齐 moriep_test）
+# ---------------------------------------------------------------------------
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def _gpu_count_without_parent_cuda_init() -> Tuple[int, str]:
+    """spawn 子进程前不要在父进程调用 torch.cuda.*，否则易与子进程争用 GPU 导致死锁。
+
+    优先：环境变量 MORIEP_TEST_MAX_GPUS、CUDA_VISIBLE_DEVICES；
+    其次：nvidia-smi / rocm-smi；最后才用 torch.cuda.device_count()（会 init CUDA）。
+
+    Returns:
+        (gpu_count, source): source 为可观测字符串，标明本次实际走到的分支。
+    """
+    env_max = os.environ.get("MORIEP_TEST_MAX_GPUS")
+    if env_max is not None and env_max.strip().isdigit():
+        n = int(env_max.strip())
+        return n, f"MORIEP_TEST_MAX_GPUS={n}"
+    cv = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cv is not None and cv.strip():
+        n = len([x for x in cv.split(",") if x.strip()])
+        return n, f"CUDA_VISIBLE_DEVICES ({n} id(s): {cv!r})"
+    try:
+        r = subprocess.run(
+            ["nvidia-smi", "-L"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if r.returncode == 0 and r.stdout:
+            n = len([ln for ln in r.stdout.splitlines() if ln.strip()])
+            if n > 0:
+                return n, "nvidia-smi -L (non-empty line count)"
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        pass
+    try:
+        r = subprocess.run(
+            ["rocm-smi", "--showid"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if r.returncode == 0 and r.stdout:
+            gpus = re.findall(r"GPU\[(\d+)\]", r.stdout)
+            if gpus:
+                n = len(set(gpus))
+                return n, "rocm-smi --showid (regex GPU[n])"
+    except (OSError, subprocess.TimeoutExpired, subprocess.SubprocessError):
+        pass
+    # 最后手段：会初始化父进程 CUDA，仅作兜底
+    n = int(torch.cuda.device_count())
+    return n, "torch.cuda.device_count() [fallback, may init CUDA in parent]"
+
+
+def _init_dist(rank: int, world_size: int, port: int) -> None:
+    _moriep_log(rank, f"set MASTER_ADDR/PORT port={port}")
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    _moriep_log(rank, "before torch.cuda.set_device")
+    torch.cuda.set_device(rank)
+    _moriep_log(rank, "before dist.init_process_group (Gloo/NCCL)")
+    dist.init_process_group(
+        backend="cpu:gloo,cuda:nccl",
+        rank=rank,
+        world_size=world_size,
+        device_id=torch.device("cuda", rank),
+    )
+    _moriep_log(rank, "after init_process_group, before barrier #1 (sync all ranks)")
+    # 所有 rank 都进入 PG 后再做 Mori shmem，避免一侧先进 shmem 另一侧还在 init
+    dist.barrier()
+    _moriep_log(rank, "after barrier #1")
+
+
+def _cleanup_dist() -> None:
+    if dist.is_initialized():
+        r = dist.get_rank()
+        _moriep_log(r, "before barrier in _cleanup_dist")
+        dist.barrier()
+        _moriep_log(r, "before destroy_process_group")
+        dist.destroy_process_group()
+        _moriep_log(r, "after destroy_process_group")
+
+
+def _init_moriep_shmem_and_wrapper(
+    mori_cfg: Any, mori_mod: Any, shmem_group_name: str = "default"
+) -> None:
+    assert dist.is_initialized()
+    rank = dist.get_rank()
+    world_group = dist.group.WORLD
+    assert world_group is not None
+    _moriep_log(rank, f"before _register_process_group({shmem_group_name!r})")
+    torch._C._distributed_c10d._register_process_group(shmem_group_name, world_group)
+    _moriep_log(
+        rank,
+        "after _register_process_group, before mori.shmem.shmem_torch_process_group_init",
+    )
+    mori_mod.shmem.shmem_torch_process_group_init(shmem_group_name)
+    _moriep_log(
+        rank,
+        "after shmem_torch_process_group_init, before barrier #2 (sync before EpDispatchCombineOp)",
+    )
+    dist.barrier()
+    _moriep_log(rank, "after barrier #2, before MoriEPWrapper._create / EpDispatchCombineOp")
+    MoriEPWrapper._create(mori_cfg, shmem_group_name=shmem_group_name)
+    _moriep_log(rank, "after MoriEPWrapper._create")
+
+
+def _build_mori_ep_config(
+    *,
+    rank: int,
+    world_size: int,
+    expert_num: int,
+    hidden_size: int,
+    max_tokens_on_rank: int,
+    num_experts_per_token: int,
+    data_dtype: torch.dtype,
+    mori_mod: Any,
+) -> Any:
+    num_experts_per_rank = expert_num // world_size
+    return MoriEPWrapperConfig(
+        data_type=data_dtype,
+        rank=rank,
+        world_size=world_size,
+        hidden_dim=hidden_size,
+        scale_dim=0,
+        scale_type_size=0,
+        max_token_type_size=torch.tensor([], dtype=data_dtype).element_size(),
+        max_num_inp_token_per_rank=max_tokens_on_rank,
+        num_experts_per_rank=num_experts_per_rank,
+        num_experts_per_token=num_experts_per_token,
+        use_external_inp_buf=True,
+        gpu_per_node=world_size,
+        kernel_type=mori_mod.ops.EpDispatchCombineKernelType.IntraNode,
+        rdma_block_num=0,
+        num_qp_per_pe=1,
+        quant_type="none",
+    )
+
+
+def worker_function(
+    rank: int,
+    world_size: int,
+    token_num_per_rank: List[int],
+    max_tokens_on_rank: int,
+    dist_port: int,
+):
+    mori_mod: Any = None
+    _moriep_log(rank, "worker started")
+    _moriep_log(rank, "before _ensure_moriep_symbols_loaded (importlib moriep_wrapper)")
+    _ensure_moriep_symbols_loaded()
+    _moriep_log(rank, "after _ensure_moriep_symbols_loaded")
+
+    random.seed(rank)
+    torch.cuda.set_device(rank)
+
+    try:
+        _moriep_log(rank, "before `import mori`")
+        import mori as mori_mod
+
+        _moriep_log(rank, "after `import mori`")
+        _init_dist(rank, world_size, dist_port)
+
+        _moriep_log(rank, "building MoriEPWrapperConfig")
+        mori_cfg = _build_mori_ep_config(
+            rank=rank,
+            world_size=world_size,
+            expert_num=16,
+            hidden_size=1024,
+            max_tokens_on_rank=max_tokens_on_rank,
+            num_experts_per_token=16,
+            data_dtype=torch.bfloat16,
+            mori_mod=mori_mod,
+        )
+        _moriep_log(rank, "calling _init_moriep_shmem_and_wrapper")
+        _init_moriep_shmem_and_wrapper(mori_cfg, mori_mod, shmem_group_name="default")
+
+        _moriep_log(rank, "MoriEPWrapper.get_instance()")
+        wrapper = MoriEPWrapper.get_instance()
+        assert wrapper is not None
+
+        expert_num = 16
+        top_k = expert_num
+        current_device = torch.device(f"cuda:{rank}")
+
+        for it in range(5):
+            _moriep_log(rank, f"iter {it + 1}/5: alloc tensors + randn")
+            token_num = token_num_per_rank[rank]
+            a1 = (
+                torch.randn([token_num, 1024])
+                .to(current_device)
+                .to(torch.bfloat16)
+            )
+            topk_weights = torch.ones([token_num, top_k], device=current_device)
+            topk_ids = torch.arange(
+                expert_num, device=current_device, dtype=torch.int32
+            ).repeat(token_num, 1)
+
+            _moriep_log(rank, f"iter {it + 1}/5: router_prepare (mori dispatch)")
+            payload = router_prepare(wrapper, a1, topk_weights, topk_ids)
+            combine_x = payload.expert_x
+            combine_payload = CombineForwardPayload(fused_expert_output=combine_x)
+            _moriep_log(rank, f"iter {it + 1}/5: router_finalize (mori combine)")
+            a2 = router_finalize(wrapper, combine_payload, topk_ids)
+
+            _moriep_log(rank, f"iter {it + 1}/5: assert_close")
+            ref_a2 = a1 * world_size
+            try:
+                torch.testing.assert_close(ref_a2, a2, rtol=1.3e-2, atol=1.3e-2)
+            except AssertionError as exc:
+                diff = (ref_a2.float() - a2.float()).abs().max().item()
+                _moriep_log(
+                    rank,
+                    f"iter {it + 1}/5: assert_close FAILED max_abs_diff={diff} exc={exc}",
+                )
+                raise
+            print("pass test", flush=True)
+            _moriep_log(rank, f"iter {it + 1}/5: OK")
+    finally:
+        _moriep_log(rank, "finally: cleanup mori + dist")
+        # reset_op 是实例方法，必须在 get_instance() 上调用；reset() 是类方法清空单例
+        if MoriEPWrapper is not None and MoriEPWrapper.is_initialized():
+            inst = MoriEPWrapper.get_instance()
+            if inst is not None:
+                inst.reset_op()
+            MoriEPWrapper.reset()
+        if mori_mod is not None and hasattr(mori_mod, "shmem") and hasattr(
+            mori_mod.shmem, "shmem_finalize"
+        ):
+            mori_mod.shmem.shmem_finalize()
+        _cleanup_dist()
+
+
+def test_single(world_size: int, dist_port: int):
+    _moriep_log(
+        None,
+        f"[parent] test_single world_size={world_size} dist_port={dist_port} pid={os.getpid()}",
+    )
+    # 各 rank 必须使用相同 token 数：Ep dispatch/combine 为全体 rank 集体通信，
+    # 若部分 rank assert 失败先进入 cleanup barrier，其余 rank 仍卡在下一轮 collective → 死锁。
+    # 且 ref_a2=a1*world_size 的恒等检查仅在各 rank 对称 token 时成立。
+    token_num_aligned = random.randint(4, 12) // 4 * 4
+    token_num_per_rank = [token_num_aligned] * world_size
+    max_tokens_on_rank = token_num_aligned
+    _moriep_log(
+        None,
+        f"[parent] token_num_per_rank={token_num_per_rank} (same per rank) max_tokens_on_rank={max_tokens_on_rank}",
+    )
+
+    processes = []
+    for rank in range(world_size):
+        _moriep_log(None, f"[parent] spawning worker rank={rank}")
+        p = mp.Process(
+            target=worker_function,
+            args=(
+                rank,
+                world_size,
+                token_num_per_rank,
+                max_tokens_on_rank,
+                dist_port,
+            ),
+            kwargs={},
+        )
+        processes.append(p)
+        p.start()
+        _moriep_log(None, f"[parent] worker rank={rank} started pid={p.pid}")
+
+    _moriep_log(None, f"[parent] all {world_size} workers spawned; joining...")
+    for i, p in enumerate(processes):
+        _moriep_log(None, f"[parent] join worker[{i}] pid={p.pid} ...")
+        p.join(timeout=120)
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout=5)
+            if p.is_alive():
+                p.kill()
+                p.join()
+            raise RuntimeError("Process timeout")
+        if p.exitcode != 0:
+            raise RuntimeError(f"子进程异常退出，退出码: {p.exitcode}")
+        _moriep_log(
+            None,
+            f"[parent] join worker[{i}] done exitcode={p.exitcode}",
+        )
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn")
+
+    if importlib.util.find_spec("mori") is None:
+        print("跳过：未安装 mori")
+        sys.exit(0)
+
+    _moriep_log(None, "[parent] __main__ (调试: MORIEP_TEST_DEBUG=1 默认开启，=0 关闭)")
+
+    # 父进程不要 _ensure_moriep_symbols_loaded()：避免多余 import，子进程内再加载 wrapper
+    max_gpu_count, gpu_count_source = _gpu_count_without_parent_cuda_init()
+    print(
+        f"当前可用GPU数量: {max_gpu_count} | 来源: {gpu_count_source}",
+        flush=True,
+    )
+
+    available_world_sizes = [ws for ws in [2, 4] if ws <= max_gpu_count]
+    print(f"可用的world_size: {available_world_sizes}")
+
+    for world_size in available_world_sizes:
+        dist_port = _get_free_port()
+        print(f"dist_port={dist_port}")
+        test_single(world_size, dist_port)
+        _moriep_log(None, f"[parent] test_single(world_size={world_size}) finished OK")

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
@@ -96,6 +96,33 @@ def _register_stub_module(full_name: str, **attrs: Any) -> None:
     sys.modules[full_name] = mod
 
 
+def _to_torch_dtype_stub(maybe_str_dtype):
+    """Minimal stub for rtp_llm.utils.util.to_torch_dtype."""
+    import torch as _torch
+    if isinstance(maybe_str_dtype, _torch.dtype):
+        return maybe_str_dtype
+    if hasattr(maybe_str_dtype, "name"):
+        maybe_str_dtype = maybe_str_dtype.name
+    elif not isinstance(maybe_str_dtype, str):
+        maybe_str_dtype = str(maybe_str_dtype)
+    if maybe_str_dtype.startswith("TYPE_"):
+        maybe_str_dtype = maybe_str_dtype[5:]
+    _map = {
+        "bf16": _torch.bfloat16,
+        "fp16": _torch.float16,
+        "fp32": _torch.float32,
+        "bfloat16": _torch.bfloat16,
+        "float16": _torch.float16,
+        "float32": _torch.float32,
+        "int8": _torch.int8,
+        "int32": _torch.int32,
+    }
+    key = maybe_str_dtype.lower()
+    if key in _map:
+        return _map[key]
+    raise ValueError(f"Unknown dtype: {maybe_str_dtype}")
+
+
 def _install_rtp_llm_stubs_for_moriep_wrapper() -> None:
     """满足 moriep_wrapper.py 顶层 `from rtp_llm... import ...`，无需安装 rtp_llm。"""
     _register_stub_module(
@@ -109,6 +136,10 @@ def _install_rtp_llm_stubs_for_moriep_wrapper() -> None:
     _register_stub_module(
         "rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter",
         MoEConfigAdapter=type("MoEConfigAdapter", (), {}),
+    )
+    _register_stub_module(
+        "rtp_llm.utils.util",
+        to_torch_dtype=_to_torch_dtype_stub,
     )
 
 

--- a/rtp_llm/server/backend_manager.py
+++ b/rtp_llm/server/backend_manager.py
@@ -94,10 +94,25 @@ class BackendManager(object):
             and engine_config.parallelism_config.world_size > 1
             and not engine_config.moe_config.use_all_gather
         ):
-            from rtp_llm.models_py.distributed.deepep_wrapper import init_deepep_wrapper
+            deepep_init_success = False
+            moriep_init_success = False
+            try:
+                from rtp_llm.models_py.distributed.deepep_wrapper import init_deepep_wrapper
+                init_deepep_wrapper(engine_config, model_config)
+                deepep_init_success = True
+            except Exception as e:
+                logging.error(f"Failed to initialize DeepEP wrapper: {e}")
 
-            logging.info("initialize deepep wrapper")
-            init_deepep_wrapper(engine_config, model_config)
+            try:
+                from rtp_llm.models_py.distributed.moriep_wrapper import init_moriep_wrapper
+                init_moriep_wrapper(engine_config, model_config)
+                moriep_init_success = True
+            except Exception as e:
+                logging.error(f"Failed to initialize MoriEP wrapper: {e}")
+
+            if not deepep_init_success and not moriep_init_success:
+                logging.error("Failed to initialize both DeepEP and MoriEP wrappers")
+                raise RuntimeError("Failed to initialize both DeepEP and MoriEP wrappers")
 
         # Optional propose model config
         propose_model_config = ModelFactory.create_propose_model_config(

--- a/rtp_llm/server/backend_manager.py
+++ b/rtp_llm/server/backend_manager.py
@@ -1,5 +1,6 @@
 import gc
 import logging
+import os
 import threading
 import time
 from typing import Any, Dict, Optional, Union
@@ -87,32 +88,42 @@ class BackendManager(object):
             model_config=model_config,
         )
 
-        # Initialize DeepEP wrapper if MOE model and DeepEP is enabled
+        # Initialize DeepEP/MoriEP wrapper if MOE model and EP is enabled
+        use_mori_ep = os.environ.get("USE_MORI_EP", "0").lower() in ("1", "true", "on")
         if (
-            engine_config.moe_config.use_deepep_moe
+            (engine_config.moe_config.use_deepep_moe or use_mori_ep)
             and model_config.expert_num > 0
             and engine_config.parallelism_config.world_size > 1
             and not engine_config.moe_config.use_all_gather
         ):
             deepep_init_success = False
             moriep_init_success = False
-            try:
-                from rtp_llm.models_py.distributed.deepep_wrapper import init_deepep_wrapper
-                init_deepep_wrapper(engine_config, model_config)
-                deepep_init_success = True
-            except Exception as e:
-                logging.error(f"Failed to initialize DeepEP wrapper: {e}")
 
-            try:
-                from rtp_llm.models_py.distributed.moriep_wrapper import init_moriep_wrapper
-                init_moriep_wrapper(engine_config, model_config)
-                moriep_init_success = True
-            except Exception as e:
-                logging.error(f"Failed to initialize MoriEP wrapper: {e}")
+            # Initialize DeepEP if enabled
+            if engine_config.moe_config.use_deepep_moe:
+                try:
+                    from rtp_llm.models_py.distributed.deepep_wrapper import init_deepep_wrapper
+                    init_deepep_wrapper(engine_config, model_config)
+                    deepep_init_success = True
+                except Exception as e:
+                    logging.error(f"Failed to initialize DeepEP wrapper: {e}")
 
-            if not deepep_init_success and not moriep_init_success:
+            # Initialize MoriEP if enabled via environment variable (can be independent of DeepEP)
+            if use_mori_ep:
+                try:
+                    from rtp_llm.models_py.distributed.moriep_wrapper import init_moriep_wrapper
+                    init_moriep_wrapper(engine_config, model_config)
+                    moriep_init_success = True
+                    logging.info("MoriEP wrapper initialized successfully")
+                except Exception as e:
+                    logging.error(f"Failed to initialize MoriEP wrapper: {e}")
+
+            # Raise if a requested EP backend failed to initialize
+            if engine_config.moe_config.use_deepep_moe and not deepep_init_success and not moriep_init_success:
                 logging.error("Failed to initialize both DeepEP and MoriEP wrappers")
                 raise RuntimeError("Failed to initialize both DeepEP and MoriEP wrappers")
+            if use_mori_ep and not moriep_init_success:
+                raise RuntimeError("USE_MORI_EP is set but MoriEP wrapper failed to initialize")
 
         # Optional propose model config
         propose_model_config = ModelFactory.create_propose_model_config(


### PR DESCRIPTION
## Summary                                                                                                                           
                                                                                                                                       
  Enable MoRI Expert Parallelism (EP) on AMD MI355X GPUs for MoE models (e.g., Qwen3.5-397B), supporting both BF16 and MXFP4           
  quantization modes with intra-node EP dispatch/combine.                                                                              
                                                                                                                                       
  Key changes:                                                                                                                         
                                                                                                                                       
  - **MoRI EP Router**: Add `MoriEpIntranodeRouter` for intra-node expert parallel dispatch/combine via HIP IPC, with chunked          
  processing to handle long-context requests without coredump                                                                          
  - **MoRI EP Wrapper**: Add `morip_wrapper.py` to initialize MoRI EP runtime from model config and expose it to the MoE strategy layer
  - **True EP Mode**: Implement real Expert Parallelism where each rank holds a partition of experts (ep_size > 1), distinct from pure 
  TP mode (ep_size == 1). Auto-configure `use_all_gather` based on ep_size                                                             
  - **EP-aware AllReduce**: Fix allreduce overcounting in MoE layers — EP mode only allreduce the shared expert output (TP-partial),   
  while routed expert output is already complete via EP combine                                                                        
  - **MXFP4 EP Support**: Add `RocmExpertsFp8PerBlock`, `RocmExpertsFp4PerGroup` executors and                                         
  `TorchDistEpFp4Strategy`/`MoriEpFp4Strategy` for FP4 quantized EP inference                                                          
  - **Fake Balance Expert**: Add `fake_balance_expert` C++ kernel and Python op for deterministic token-to-expert assignment in load-  
  balance testing (env `FAKE_BALANCE_EXPERT`)                                                                                          
  - **Bug Fixes**: Resolve expert_mask mismatch when MoriEpIntranodeRouter uses local expert IDs, fix router weight preservation and   
  expert ID remapping for FP4 EP mode, fix `no_block_copy_stream_` init and write cache store wrong gid