### PR TITLE
optimize fused_l2norm_qk: rsqrt+mul, BT-tiled for all T

### DIFF
--- a/rtp_llm/models_py/triton_kernels/fla/chunk.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk.py
@@ -15,12 +15,13 @@ from rtp_llm.models_py.triton_kernels.fla.chunk_scaled_dot_kkt import (
     chunk_scaled_dot_kkt_fwd,
 )
 from rtp_llm.models_py.triton_kernels.fla.cumsum import chunk_local_cumsum
-from rtp_llm.models_py.triton_kernels.fla.l2norm import fused_l2norm_qk
+from rtp_llm.models_py.triton_kernels.fla.l2norm import fused_l2norm_qk, l2norm_fwd
 from rtp_llm.models_py.triton_kernels.fla.solve_tril import solve_tril
 from rtp_llm.models_py.triton_kernels.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
     input_guard,
+    is_amd,
 )
 from rtp_llm.models_py.triton_kernels.fla.wy_fast import recompute_w_u_fwd
 
@@ -93,7 +94,13 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         k_orig = k
 
         if use_qk_l2norm_in_kernel:
-            q, k = fused_l2norm_qk(q, k)
+            if is_amd:
+                q, k = fused_l2norm_qk(q, k)
+            else:
+                # NOTE: fused_l2norm_qk is only validated on AMD/ROCm backend.
+                # On CUDA, fall back to l2norm_fwd until the fused kernel is verified.
+                q = l2norm_fwd(q)
+                k = l2norm_fwd(k)
 
         g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
             q=q,

--- a/rtp_llm/models_py/triton_kernels/fla/chunk.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk.py
@@ -15,7 +15,7 @@ from rtp_llm.models_py.triton_kernels.fla.chunk_scaled_dot_kkt import (
     chunk_scaled_dot_kkt_fwd,
 )
 from rtp_llm.models_py.triton_kernels.fla.cumsum import chunk_local_cumsum
-from rtp_llm.models_py.triton_kernels.fla.l2norm import l2norm_fwd
+from rtp_llm.models_py.triton_kernels.fla.l2norm import fused_l2norm_qk
 from rtp_llm.models_py.triton_kernels.fla.solve_tril import solve_tril
 from rtp_llm.models_py.triton_kernels.fla.utils import (
     SUPPRESS_LEVEL,
@@ -93,8 +93,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         k_orig = k
 
         if use_qk_l2norm_in_kernel:
-            q = l2norm_fwd(q)
-            k = l2norm_fwd(k)
+            q, k = fused_l2norm_qk(q, k)
 
         g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
             q=q,

--- a/rtp_llm/models_py/triton_kernels/fla/l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/l2norm.py
@@ -43,6 +43,65 @@ def l2norm_fwd_kernel1(
     tl.store(y + cols, b_y, mask=mask)
 
 
+@triton.jit
+def fused_l2norm_qk_kernel_small(
+    q,
+    k,
+    q_out,
+    k_out,
+    eps,
+    T,
+    D,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+
+    rows = i_t * BT + tl.arange(0, BT)
+    cols = tl.arange(0, BD)
+    row_mask = rows < T
+    col_mask = cols < D
+    mask = row_mask[:, None] & col_mask[None, :]
+    offs = rows[:, None] * D + cols[None, :]
+
+    b_q = tl.load(q + offs, mask=mask, other=0.0).to(tl.float32)
+    b_q_var = tl.sum(b_q * b_q, axis=1)
+    b_q_out = b_q / tl.sqrt(b_q_var + eps)[:, None]
+    tl.store(q_out + offs, b_q_out.to(q_out.dtype.element_ty), mask=mask)
+
+    b_k = tl.load(k + offs, mask=mask, other=0.0).to(tl.float32)
+    b_k_var = tl.sum(b_k * b_k, axis=1)
+    b_k_out = b_k / tl.sqrt(b_k_var + eps)[:, None]
+    tl.store(k_out + offs, b_k_out.to(k_out.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def fused_l2norm_qk_kernel(
+    q,
+    k,
+    q_out,
+    k_out,
+    D,
+    BD: tl.constexpr,
+    eps,
+):
+    i_t = tl.program_id(0)
+
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    offs = i_t * D + cols
+
+    b_q = tl.load(q + offs, mask=mask, other=0.0).to(tl.float32)
+    b_q_var = tl.sum(b_q * b_q, axis=0)
+    b_q_out = b_q / tl.sqrt(b_q_var + eps)
+    tl.store(q_out + offs, b_q_out.to(q_out.dtype.element_ty), mask=mask)
+
+    b_k = tl.load(k + offs, mask=mask, other=0.0).to(tl.float32)
+    b_k_var = tl.sum(b_k * b_k, axis=0)
+    b_k_out = b_k / tl.sqrt(b_k_var + eps)
+    tl.store(k_out + offs, b_k_out.to(k_out.dtype.element_ty), mask=mask)
+
+
 # @triton.autotune(
 #     configs=[
 #         triton.Config({"BT": BT}, num_warps=num_warps)
@@ -122,6 +181,70 @@ def l2norm_fwd(
         )
 
     return y.view(x_shape_og)
+
+
+def fused_l2norm_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert (
+        q.shape == k.shape
+    ), f"fused_l2norm_qk expects q and k to share shape, got {q.shape} vs {k.shape}"
+    assert (
+        q.dtype == k.dtype
+    ), f"fused_l2norm_qk expects q and k to share dtype, got {q.dtype} vs {k.dtype}"
+    shape_og = q.shape
+    q_flat = q.reshape(-1, q.shape[-1])
+    k_flat = k.reshape(-1, k.shape[-1])
+    tokens, hidden_dim = q_flat.shape
+
+    if output_dtype is None:
+        q_out = torch.empty_like(q_flat)
+        k_out = torch.empty_like(k_flat)
+    else:
+        q_out = torch.empty_like(q_flat, dtype=output_dtype)
+        k_out = torch.empty_like(k_flat, dtype=output_dtype)
+    assert q_out.stride(-1) == 1 and k_out.stride(-1) == 1
+
+    MAX_FUSED_SIZE = 65536 // q.element_size()
+    BLOCK_D = min(MAX_FUSED_SIZE, triton.next_power_of_2(hidden_dim))
+    if hidden_dim > BLOCK_D:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    # tokens, hidden_dim are runtime args of the BT-tiled kernel, so no recompile across batches.
+    # BT-tiled is ~8x faster than the per-row kernel for prefill (tokens>>1) since the
+    # per-row path uses 512 threads to process hidden_dim<=512 elements (under-utilized).
+    if hidden_dim <= 512:
+        BT = 8
+        fused_l2norm_qk_kernel_small[(triton.cdiv(tokens, BT),)](
+            q_flat,
+            k_flat,
+            q_out,
+            k_out,
+            eps,
+            tokens,
+            hidden_dim,
+            BT=BT,
+            BD=BLOCK_D,
+            num_warps=2,
+            num_stages=1,
+        )
+    else:
+        fused_l2norm_qk_kernel[(tokens,)](
+            q_flat,
+            k_flat,
+            q_out,
+            k_out,
+            eps=eps,
+            D=hidden_dim,
+            BD=BLOCK_D,
+            num_warps=8,
+            num_stages=3,
+        )
+
+    return q_out.reshape(shape_og), k_out.reshape(shape_og)
 
 
 class L2NormFunction(torch.autograd.Function):

--- a/rtp_llm/models_py/triton_kernels/fla/l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/l2norm.py
@@ -66,12 +66,14 @@ def fused_l2norm_qk_kernel_small(
 
     b_q = tl.load(q + offs, mask=mask, other=0.0).to(tl.float32)
     b_q_var = tl.sum(b_q * b_q, axis=1)
-    b_q_out = b_q / tl.sqrt(b_q_var + eps)[:, None]
+    b_q_rstd = tl.math.rsqrt(b_q_var + eps)
+    b_q_out = b_q * b_q_rstd[:, None]
     tl.store(q_out + offs, b_q_out.to(q_out.dtype.element_ty), mask=mask)
 
     b_k = tl.load(k + offs, mask=mask, other=0.0).to(tl.float32)
     b_k_var = tl.sum(b_k * b_k, axis=1)
-    b_k_out = b_k / tl.sqrt(b_k_var + eps)[:, None]
+    b_k_rstd = tl.math.rsqrt(b_k_var + eps)
+    b_k_out = b_k * b_k_rstd[:, None]
     tl.store(k_out + offs, b_k_out.to(k_out.dtype.element_ty), mask=mask)
 
 
@@ -93,12 +95,14 @@ def fused_l2norm_qk_kernel(
 
     b_q = tl.load(q + offs, mask=mask, other=0.0).to(tl.float32)
     b_q_var = tl.sum(b_q * b_q, axis=0)
-    b_q_out = b_q / tl.sqrt(b_q_var + eps)
+    b_q_rstd = tl.math.rsqrt(b_q_var + eps)
+    b_q_out = b_q * b_q_rstd
     tl.store(q_out + offs, b_q_out.to(q_out.dtype.element_ty), mask=mask)
 
     b_k = tl.load(k + offs, mask=mask, other=0.0).to(tl.float32)
     b_k_var = tl.sum(b_k * b_k, axis=0)
-    b_k_out = b_k / tl.sqrt(b_k_var + eps)
+    b_k_rstd = tl.math.rsqrt(b_k_var + eps)
+    b_k_out = b_k * b_k_rstd
     tl.store(k_out + offs, b_k_out.to(k_out.dtype.element_ty), mask=mask)
 
 

--- a/rtp_llm/models_py/triton_kernels/fla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/fla/test/BUILD
@@ -45,7 +45,7 @@ py_test(
     ],
     deps = [
         "//rtp_llm/models_py/triton_kernels:fla",
-    ] + [":triton", ":torch"],
+    ] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
     visibility = ["//visibility:public"],
     exec_properties = {'gpu':'H20'},
 )
@@ -58,9 +58,9 @@ py_test(
     main = "test_l2norm.py",
     deps = [
         "//rtp_llm/models_py/triton_kernels:fla",
-    ] + [":triton", ":torch"],
+    ] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
     visibility = ["//visibility:public"],
     tags = ["rocm"],
-    exec_properties = {'gpu':'MI308X'},
+    exec_properties = {'gpu':'MI308X-ROCM7'},
 )
 

--- a/rtp_llm/models_py/triton_kernels/fla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/fla/test/BUILD
@@ -49,3 +49,18 @@ py_test(
     visibility = ["//visibility:public"],
     exec_properties = {'gpu':'H20'},
 )
+
+py_test(
+    name = "test_l2norm_rocm",
+    srcs = [
+        "test_l2norm.py"
+    ],
+    main = "test_l2norm.py",
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:fla",
+    ] + [":triton", ":torch"],
+    visibility = ["//visibility:public"],
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X'},
+)
+

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_l2norm.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_l2norm.py
@@ -6,7 +6,12 @@ import unittest
 
 import torch
 
-from rtp_llm.models_py.triton_kernels.fla.l2norm import L2Norm, l2norm
+from rtp_llm.models_py.triton_kernels.fla.l2norm import (
+    L2Norm,
+    fused_l2norm_qk,
+    l2norm,
+    l2norm_fwd,
+)
 
 
 def l2norm_reference(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
@@ -200,6 +205,77 @@ class TestL2Norm(unittest.TestCase):
         )
 
         print("\n多维输入测试通过")
+
+
+class TestFusedL2NormQK(unittest.TestCase):
+    """fused_l2norm_qk 测试：必须与两次独立的 l2norm_fwd 完全一致。"""
+
+    def setUp(self):
+        torch.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.eps = 1e-6
+
+    def _check_parity(self, T, D, dtype):
+        # qwen3-next 实际形状: [B=1, T, H, K]
+        H = 4
+        torch.manual_seed(0)
+        q = torch.randn(1, T, H, D, device=self.device, dtype=dtype)
+        k = torch.randn(1, T, H, D, device=self.device, dtype=dtype)
+
+        q_ref = l2norm_fwd(q, eps=self.eps)
+        k_ref = l2norm_fwd(k, eps=self.eps)
+        q_fused, k_fused = fused_l2norm_qk(q, k, eps=self.eps)
+
+        self.assertEqual(q_fused.shape, q.shape)
+        self.assertEqual(k_fused.shape, k.shape)
+        # Same fp32 reduction tree → match within fma-reorder rounding.
+        if dtype == torch.float32:
+            rtol, atol = 1e-5, 1e-6
+        else:
+            # bf16 has 1-ULP ≈ 2^{-9} ≈ 0.00195; keep tolerance just above that.
+            rtol, atol = 2e-3, 2e-3
+        torch.testing.assert_close(q_fused, q_ref, rtol=rtol, atol=atol)
+        torch.testing.assert_close(k_fused, k_ref, rtol=rtol, atol=atol)
+
+    def test_parity_qwen3_next_shapes(self):
+        # 主要 prefill 形状：D=128, T 大变化
+        for T in [16, 64, 128, 1024, 8192, 65536]:
+            with self.subTest(T=T, D=128, dtype="bf16"):
+                self._check_parity(T, 128, torch.bfloat16)
+
+    def test_parity_dispatch_branches(self):
+        # D<=512 uses BT-tiled small kernel; D>512 uses per-row kernel
+        for T, D in [(64, 128), (128, 256), (129, 128), (4096, 128), (256, 1024)]:
+            with self.subTest(T=T, D=D):
+                self._check_parity(T, D, torch.bfloat16)
+                self._check_parity(T, D, torch.float16)
+                self._check_parity(T, D, torch.float32)
+
+    def test_output_dtype(self):
+        """output_dtype 参数：bf16 输入 → fp32 输出。"""
+        T, D, H = 64, 128, 4
+        torch.manual_seed(0)
+        q = torch.randn(1, T, H, D, device=self.device, dtype=torch.bfloat16)
+        k = torch.randn(1, T, H, D, device=self.device, dtype=torch.bfloat16)
+
+        q_out, k_out = fused_l2norm_qk(q, k, eps=self.eps, output_dtype=torch.float32)
+
+        self.assertEqual(q_out.dtype, torch.float32)
+        self.assertEqual(k_out.dtype, torch.float32)
+
+        q_ref = l2norm_fwd(q, eps=self.eps, output_dtype=torch.float32)
+        k_ref = l2norm_fwd(k, eps=self.eps, output_dtype=torch.float32)
+        torch.testing.assert_close(q_out, q_ref, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(k_out, k_ref, rtol=1e-5, atol=1e-6)
+
+    def test_shape_dtype_assert(self):
+        q = torch.randn(1, 16, 4, 128, device=self.device, dtype=torch.bfloat16)
+        k_bad_shape = torch.randn(1, 16, 8, 128, device=self.device, dtype=torch.bfloat16)
+        with self.assertRaises(AssertionError):
+            fused_l2norm_qk(q, k_bad_shape)
+        k_bad_dtype = torch.randn(1, 16, 4, 128, device=self.device, dtype=torch.float16)
+        with self.assertRaises(AssertionError):
+            fused_l2norm_qk(q, k_bad_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- kernel: replace x/sqrt(var) with x*rsqrt(var) — div is multi-instruction rcp+NR on AMD/NV, broadcasting it across BT*BD becomes the bottleneck
- dispatcher: drop the T<=128 gate, make T/D runtime args so the BT-tiled path no longer recompiles per-shape; num_warps 8->2

Measured on MI308X, 9B prefill T=122936 D=128 bf16:
  before  842us  ->  after 49us  (17x), beats sgl 100us by 2.0x