### PR TITLE
Qwen35 chunkgdn amd1

### DIFF
--- a/rtp_llm/models_py/triton_kernels/fla/chunk.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk.py
@@ -10,6 +10,9 @@ from einops import rearrange
 from rtp_llm.models_py.triton_kernels.fla.chunk_delta_h import (
     chunk_gated_delta_rule_fwd_h,
 )
+from rtp_llm.models_py.triton_kernels.fla.chunk_fwd import (
+    chunk_gated_delta_rule_fwd_intra,
+)
 from rtp_llm.models_py.triton_kernels.fla.chunk_o import chunk_fwd_o
 from rtp_llm.models_py.triton_kernels.fla.chunk_scaled_dot_kkt import (
     chunk_scaled_dot_kkt_fwd,
@@ -25,6 +28,8 @@ from rtp_llm.models_py.triton_kernels.fla.utils import (
 )
 from rtp_llm.models_py.triton_kernels.fla.wy_fast import recompute_w_u_fwd
 
+RCP_LN2 = 1.0 / 0.6931471805599453
+
 
 def chunk_gated_delta_rule_fwd(
     q: torch.Tensor,
@@ -37,20 +42,42 @@ def chunk_gated_delta_rule_fwd(
     output_final_state: bool,
     cu_seqlens: Optional[torch.LongTensor] = None,
 ):
-    g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
-    # obtain WY representation. u is actually the new v.
-    A = chunk_scaled_dot_kkt_fwd(
-        k=k, beta=beta, g_cumsum=g, cu_seqlens=cu_seqlens, output_dtype=torch.float32
-    )
-    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
-    w, u = recompute_w_u_fwd(
-        k=k,
-        v=v,
-        beta=beta,
-        A=A,
-        g_cumsum=g,
-        cu_seqlens=cu_seqlens,
-    )
+    # AMD: scale g to log2 domain (multiply cumsum by 1/ln2) so AMD-side
+    # downstream kernels can use the single-instruction exp2.
+    # NVIDIA: keep the original natural-log domain. The RCP_LN2 (~1.4427) scale
+    # is not bit-exact in bf16/fp16 and accumulates non-trivial drift over long
+    # contexts, which has been observed to change generation outputs on CUDA.
+    if is_amd:
+        g = chunk_local_cumsum(
+            g,
+            chunk_size=64,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+        )
+        # AMD-optimized: fused kkt + solve_tril + recompute_w_u
+        w, u, A = chunk_gated_delta_rule_fwd_intra(
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+        )
+    else:
+        g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
+        # Original pipeline: separate kkt -> solve_tril -> recompute_w_u
+        A = chunk_scaled_dot_kkt_fwd(
+            k=k, beta=beta, g_cumsum=g, cu_seqlens=cu_seqlens, output_dtype=torch.float32
+        )
+        A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
+        w, u = recompute_w_u_fwd(
+            k=k,
+            v=v,
+            beta=beta,
+            A=A,
+            g_cumsum=g,
+            cu_seqlens=cu_seqlens,
+        )
+
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
         k=k,
         w=w,

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
@@ -12,8 +12,13 @@ from rtp_llm.models_py.triton_kernels.fla.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
 )
-from rtp_llm.models_py.triton_kernels.fla.op import exp, safe_exp
-from rtp_llm.models_py.triton_kernels.fla.utils import is_nvidia_hopper
+from rtp_llm.models_py.triton_kernels.fla.op import exp, exp2, safe_exp
+from rtp_llm.models_py.triton_kernels.fla.utils import (
+    is_amd,
+    is_amd_cdna3,
+    is_amd_cdna4,
+    is_nvidia_hopper,
+)
 
 NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
 
@@ -64,6 +69,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    IS_LOG2: tl.constexpr,
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -182,13 +188,31 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
-            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
-            b_v = b_v * safe_exp(b_g_last - b_g)[:, None]
-            b_g_last = exp(b_g_last)
+            if IS_LOG2:
+                # AMD path: g is in log2 domain (RCP_LN2-scaled cumsum upstream).
+                # The fp32 promotions, int64 index and m_t mask are robustness
+                # tweaks added together with the log2 rewrite for MI355X/MI308X.
+                m_t = (i_t * BT + tl.arange(0, BT)) < T
+                b_g_last = tl.load(
+                    g + (bos * H + last_idx * H + i_h).to(tl.int64)
+                ).to(tl.float32)
+                p_g = tl.make_block_ptr(
+                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+                )
+                b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+                b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
+                b_g_last = exp2(b_g_last)
+            else:
+                # NVIDIA path: g is in natural-log domain. Keep the original
+                # exp/safe_exp formulation and integer indexing for bit-level
+                # parity with the pre-optimization implementation.
+                b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+                p_g = tl.make_block_ptr(
+                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+                )
+                b_g = tl.load(p_g, boundary_check=(0,))
+                b_v = b_v * safe_exp(b_g_last - b_g)[:, None]
+                b_g_last = exp(b_g_last)
             b_h1 = b_h1 * b_g_last
             if K > 64:
                 b_h2 = b_h2 * b_g_last
@@ -204,7 +228,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 mask=(o_k1 < K),
                 other=0.0,
             )
-            b_h1 *= exp(b_gk_last1)[:, None]
+            if IS_LOG2:
+                b_h1 *= exp2(b_gk_last1.to(tl.float32))[:, None]
+            else:
+                b_h1 *= exp(b_gk_last1)[:, None]
             if K > 64:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
@@ -212,7 +239,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     mask=(o_k2 < K),
                     other=0.0,
                 )
-                b_h2 *= exp(b_gk_last2)[:, None]
+                if IS_LOG2:
+                    b_h2 *= exp2(b_gk_last2.to(tl.float32))[:, None]
+                else:
+                    b_h2 *= exp(b_gk_last2)[:, None]
             if K > 128:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
@@ -220,7 +250,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     mask=(o_k3 < K),
                     other=0.0,
                 )
-                b_h3 *= exp(b_gk_last3)[:, None]
+                if IS_LOG2:
+                    b_h3 *= exp2(b_gk_last3.to(tl.float32))[:, None]
+                else:
+                    b_h3 *= exp(b_gk_last3)[:, None]
             if K > 192:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
@@ -228,7 +261,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                     mask=(o_k4 < K),
                     other=0.0,
                 )
-                b_h4 *= exp(b_gk_last4)[:, None]
+                if IS_LOG2:
+                    b_h4 *= exp2(b_gk_last4.to(tl.float32))[:, None]
+                else:
+                    b_h4 *= exp(b_gk_last4)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
         p_k = tl.make_block_ptr(
@@ -284,10 +320,55 @@ def chunk_gated_delta_rule_fwd_h(
     gk: Optional[torch.Tensor] = None,
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
-    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    chunk_size: int = 64,
     save_new_value: bool = True,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    state_dtype: Optional[torch.dtype] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Args:
+        state_dtype: dtype of the per-chunk hidden state buffer ``h``.
+            If explicitly provided by the caller, it is honored on both the
+            generic Triton fallback path and the Gluon/AMD CDNA4 path.
+            If ``None``, defaults to fp32 on all backends to preserve
+            precision (the kernel accumulates in fp32 internally).
+    """
+    # Gluon dispatch for AMD CDNA4 (MI355X): ~10-18% faster for TP2 H≤32 T≤64K
+    try:
+        from rtp_llm.models_py.triton_kernels.fla.chunk_delta_h_gluon import (
+            _is_gluon_beneficial,
+            chunk_gated_delta_rule_fwd_h_gluon,
+        )
+
+        _gluon_available = True
+    except ImportError:
+        _gluon_available = False
+
+    if _gluon_available:
+        H = u.shape[-2]
+        T = k.shape[1]
+        K = k.shape[-1]
+        V = u.shape[-1]
+        # Pass k.dtype, V and cu_seqlens so the dispatcher can also block
+        # configs that would silently break correctness (non-{64,128} K,
+        # non-16-aligned V, non-bf16 dtype, or any sequence whose length
+        # is not a multiple of BT=64, which would OOB the prologue /
+        # prefetch / v_new-store tail) — see ``_is_gluon_beneficial`` docstring.
+        if gk is None and _is_gluon_beneficial(
+            H, T, K, k_dtype=k.dtype, v_dim=V, cu_seqlens=cu_seqlens
+        ):
+            return chunk_gated_delta_rule_fwd_h_gluon(
+                k=k,
+                w=w,
+                u=u,
+                g=g,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                chunk_size=chunk_size,
+                save_new_value=save_new_value,
+                cu_seqlens=cu_seqlens,
+                state_dtype=state_dtype,
+            )
     B, T, Hg, K, V = *k.shape, u.shape[-1]
     H = u.shape[-2]
     BT = chunk_size
@@ -308,7 +389,16 @@ def chunk_gated_delta_rule_fwd_h(
         )
     assert K <= 256, "current kernel does not support head dimension larger than 256."
 
-    h = k.new_empty(B, NT, H, K, V, dtype=torch.float32)
+    # Generic Triton fallback: the kernel accumulates ``b_h*`` in fp32 and
+    # only casts on store. Defaulting to fp32 here preserves precision and
+    # matches upstream fla. Callers that knowingly want a narrower buffer
+    # (e.g. to save memory) must opt in by passing ``state_dtype`` explicitly,
+    # rather than having it silently inferred from ``k.dtype``.
+    if state_dtype is None:
+        h_dtype = torch.float32
+    else:
+        h_dtype = state_dtype
+    h = k.new_empty(B, NT, H, K, V, dtype=h_dtype)
     final_state = (
         k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
     )
@@ -336,7 +426,8 @@ def chunk_gated_delta_rule_fwd_h(
         K=K,
         V=V,
         BT=BT,
-        BV=32,
+        BV=64 if is_amd_cdna3 else (16 if is_amd_cdna4 else 32),
+        IS_LOG2=is_amd,
         num_warps=4,
         num_stages=2,
     )

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h_gluon.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h_gluon.py
@@ -1,0 +1,434 @@
+# Gluon implementation of chunk_gated_delta_rule_fwd_h for AMD CDNA4 (MI355X/gfx950)
+# Optimized for TP2 (H≤32) with T≤65536. Falls back to Triton for other configs.
+# Key optimizations: convert_layout for narrow tiles, k_width=8, manual buffer_load prefetch.
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+
+try:
+    from triton.experimental import gluon
+    from triton.experimental.gluon import language as gl
+    GLUON_AVAILABLE = True
+except ImportError:
+    GLUON_AVAILABLE = False
+
+from rtp_llm.models_py.triton_kernels.fla.index import (
+    prepare_chunk_offsets,
+)
+
+# Maximum H and T for Gluon advantage (empirically determined)
+GLUON_MAX_H = 32
+# Block tile width hardcoded inside the kernel (two 64-wide tiles when K>64).
+# K must be exactly 64 or 128, otherwise the kernel will read past the K
+# dimension and segfault / corrupt memory.
+GLUON_K_ALLOWED = (64, 128)
+# BV is hardcoded to 16 in the kernel and there are no per-element V masks
+# on the buffer_load/store ops, so V must be a multiple of BV.
+GLUON_BV = 16
+# All shared-memory layouts and dot-operand casts inside the kernel are
+# pinned to bfloat16. Feeding fp16 (or anything else) would silently
+# bit-reinterpret the data and produce scrambled outputs without raising.
+GLUON_SUPPORTED_DTYPES = (torch.bfloat16,)
+# Chunk size baked into the kernel: every per-iteration buffer_load /
+# buffer_store along the T axis (prologue + main-loop prefetch + v_new
+# store) walks a full BT-sized tile *without* a per-row mask. If T is
+# not a multiple of BT, the tail iteration reads past the end of
+# k/v/w/v_new and — most dangerously — writes past the end of v_new,
+# corrupting whatever tensor was allocated next.
+GLUON_BT = 64
+
+def _is_gluon_beneficial(
+    H: int,
+    T: int,
+    K: int = 128,
+    *,
+    k_dtype: Optional[torch.dtype] = None,
+    v_dim: Optional[int] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+) -> bool:
+    """Check if Gluon V2 fwd_h is both *correct* and faster than Triton.
+
+    .. note::
+
+       Gluon auto-dispatch is **temporarily disabled** because there is no
+       gfx950/MI355X CI runner to cover this path. All calls fall back to
+       the generic Triton kernel until automated test coverage is added.
+       To re-enable, remove the early ``return False`` below.
+
+    The Gluon kernel makes several hardcoded assumptions that the dispatcher
+    must enforce, otherwise correctness is silently broken:
+      * K ∈ {64, 128} — the kernel allocates exactly one or two 64-wide
+        tiles and uses ``if K > 64`` to add the second tile; any K not in
+        this set will read/write past the actual K dim.
+      * V % 16 == 0 — h/v offsets step by ``i_v * BV`` (BV=16) without
+        per-element masks.
+      * inputs are bf16 — smem is allocated as gl.bfloat16 and every
+        ``.to()`` cast inside the kernel targets bfloat16.
+      * every per-sequence T is a multiple of BT (=64) — the prologue and
+        the main-loop prefetch issue full-tile buffer_load/buffer_store on
+        k/v/w/v_new with no row mask. A non-aligned tail therefore reads
+        garbage into b_v_pre (which feeds the last mfma into b_h, i.e.
+        the *output*) and writes the bf16 v_new tile past the real T,
+        clobbering neighboring allocations.
+
+    Performance side: K<=128, H<=32, gfx950. Both bf16 and fp32 state win
+    at all T (fp32: +6-14% across T=4K-64K on MI355X, measured 2026-04-30).
+    """
+    # DISABLED: no gfx950 CI coverage yet — fall back to Triton unconditionally.
+    # Remove this guard once MI355X test infrastructure is available.
+    return False
+
+    if not GLUON_AVAILABLE:
+        return False
+    try:
+        target = triton.runtime.driver.active.get_current_target()
+        if target.backend != "hip" or "gfx950" not in target.arch:
+            return False
+    except AttributeError:
+        return False
+    # Performance gate
+    if H > GLUON_MAX_H:
+        return False
+    # Correctness gates (kernel hardcoded assumptions)
+    if K not in GLUON_K_ALLOWED:
+        return False
+    if v_dim is not None and v_dim % GLUON_BV != 0:
+        return False
+    if k_dtype is not None and k_dtype not in GLUON_SUPPORTED_DTYPES:
+        return False
+    # T-alignment gate: avoid the tail-iteration OOB read/write described
+    # above. For varlen, every individual sequence length must be aligned
+    # because the kernel re-derives T = eos - bos per program.
+    if cu_seqlens is None:
+        if T % GLUON_BT != 0:
+            return False
+    else:
+        # One device->host sync per dispatcher call. This runs once per
+        # prefill (not per token), so the cost is dwarfed by the kernel
+        # itself, and it is strictly cheaper than the OOB it prevents.
+        seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
+        if bool((seqlens % GLUON_BT != 0).any().item()):
+            return False
+    return True
+
+
+if GLUON_AVAILABLE:
+    @triton.heuristics({
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    })
+    @gluon.jit
+    def gluon_chunk_fwd_kernel_h(
+        k, v, w, v_new, g, h, h0, ht,
+        cu_seqlens, chunk_offsets,
+        T,
+        H: gl.constexpr,
+        Hg: gl.constexpr,
+        K: gl.constexpr,
+        V: gl.constexpr,
+        BT: gl.constexpr,
+        BV: gl.constexpr,
+        USE_G: gl.constexpr,
+        USE_INITIAL_STATE: gl.constexpr,
+        STORE_FINAL_STATE: gl.constexpr,
+        SAVE_NEW_VALUE: gl.constexpr,
+        H_FP32: gl.constexpr,
+        IS_VARLEN: gl.constexpr,
+        NUM_WARPS: gl.constexpr,
+    ):
+        i_v = gl.program_id(0)
+        i_nh = gl.program_id(1)
+        i_n = i_nh // H
+        i_h = i_nh % H
+
+        if IS_VARLEN:
+            bos = gl.load(cu_seqlens + i_n).to(gl.int32)
+            eos = gl.load(cu_seqlens + i_n + 1).to(gl.int32)
+            T = eos - bos
+            NT = gl.cdiv(T, BT)
+            boh = gl.load(chunk_offsets + i_n).to(gl.int32)
+        else:
+            bos = i_n * T
+            NT = gl.cdiv(T, BT)
+            boh = i_n * NT
+
+        mma: gl.constexpr = gl.amd.AMDMFMALayout(
+            version=4, instr_shape=[16, 16],
+            transposed=True, warps_per_cta=[NUM_WARPS, 1],
+        )
+        dot_op0: gl.constexpr = gl.DotOperandLayout(operand_index=0, parent=mma, k_width=8)
+        dot_op1: gl.constexpr = gl.DotOperandLayout(operand_index=1, parent=mma, k_width=8)
+
+        shared_layout: gl.constexpr = gl.SwizzledSharedLayout(8, 2, 8, order=[1, 0])
+        shared_layout_t: gl.constexpr = gl.SwizzledSharedLayout(8, 2, 8, order=[0, 1])
+
+        blocked_wk: gl.constexpr = gl.BlockedLayout(
+            size_per_thread=[1, 8], threads_per_warp=[8, 8],
+            warps_per_cta=[NUM_WARPS, 1], order=[1, 0])
+        blocked_kt: gl.constexpr = gl.BlockedLayout(
+            size_per_thread=[8, 1], threads_per_warp=[8, 8],
+            warps_per_cta=[1, NUM_WARPS], order=[0, 1])
+
+        h_base = h + (boh * H + i_h) * K * V
+        v_base = v + (bos * H + i_h) * V
+        k_base = k + (bos * Hg + i_h // (H // Hg)) * K
+        w_base = w + (bos * H + i_h) * K
+
+        stride_v = H * V
+        stride_h = H * K * V
+        stride_k = Hg * K
+        stride_w = H * K
+
+        b_h1 = gl.zeros((64, BV), dtype=gl.float32, layout=mma)
+        if K > 64:
+            b_h2 = gl.zeros((64, BV), dtype=gl.float32, layout=mma)
+
+        if USE_INITIAL_STATE:
+            h0_base = h0 + i_nh * K * V
+            h0_row = gl.arange(0, 64, layout=gl.SliceLayout(1, mma))
+            h0_col = gl.arange(0, BV, layout=gl.SliceLayout(0, mma))
+            h0_offs = gl.cast(h0_row[:, None] * V + (i_v * BV + h0_col[None, :]), gl.int32)
+            b_h1 = b_h1 + gl.amd.cdna4.buffer_load(ptr=h0_base, offsets=h0_offs).to(gl.float32)
+            if K > 64:
+                h0_offs2 = ((64 + h0_row[:, None]) * V + (i_v * BV + h0_col[None, :])).to(gl.int32)
+                b_h2 = b_h2 + gl.amd.cdna4.buffer_load(ptr=h0_base, offsets=h0_offs2).to(gl.float32)
+
+        # 4 independent smem buffers for full double-buffer pipeline
+        smem_w1 = gl.allocate_shared_memory(gl.bfloat16, [64, 64], shared_layout)
+        smem_w2 = gl.allocate_shared_memory(gl.bfloat16, [64, 64], shared_layout)
+        smem_k1 = gl.allocate_shared_memory(gl.bfloat16, [64, 64], shared_layout_t)
+        smem_k2 = gl.allocate_shared_memory(gl.bfloat16, [64, 64], shared_layout_t)
+
+        m_row = gl.arange(0, 64, layout=gl.SliceLayout(1, mma))
+        m_col_bv = gl.arange(0, BV, layout=gl.SliceLayout(0, mma))
+        m_row_bt = gl.arange(0, BT, layout=gl.SliceLayout(1, mma))
+        blocked_v: gl.constexpr = gl.BlockedLayout(
+            size_per_thread=[1, 4], threads_per_warp=[16, 4],
+            warps_per_cta=[NUM_WARPS, 1], order=[1, 0])
+        v_row_b2 = gl.arange(0, BT, layout=gl.SliceLayout(1, blocked_v))
+        v_col_b2 = gl.arange(0, BV, layout=gl.SliceLayout(0, blocked_v))
+
+        w_row = gl.arange(0, BT, layout=gl.SliceLayout(1, blocked_wk))
+        w_col = gl.arange(0, 64, layout=gl.SliceLayout(0, blocked_wk))
+        kt_row = gl.arange(0, 64, layout=gl.SliceLayout(1, blocked_kt))
+        kt_col = gl.arange(0, BT, layout=gl.SliceLayout(0, blocked_kt))
+
+        h_offs_base1 = gl.cast(m_row[:, None] * V + (i_v * BV + m_col_bv[None, :]), gl.int32)
+        if K > 64:
+            h_offs_base2 = gl.cast(64 * V + m_row[:, None] * V + (i_v * BV + m_col_bv[None, :]), gl.int32)
+        w_offs_base1 = gl.cast(w_row[:, None] * stride_w + w_col[None, :], gl.int32)
+        if K > 64:
+            w_offs_base2 = gl.cast(w_row[:, None] * stride_w + (64 + w_col[None, :]), gl.int32)
+        v_offs_base = gl.cast(v_row_b2[:, None] * stride_v + (i_v * BV + v_col_b2[None, :]), gl.int32)
+        kt_offs_base1 = gl.cast(kt_row[:, None] + kt_col[None, :] * stride_k, gl.int32)
+        if K > 64:
+            kt_offs_base2 = gl.cast(64 + kt_row[:, None] + kt_col[None, :] * stride_k, gl.int32)
+
+        if USE_G:
+            g_base = g + bos * H + i_h
+            g_offs_base = (m_row_bt * H).to(gl.int32)
+        if SAVE_NEW_VALUE:
+            vn_base = v_new + (bos * H + i_h) * V
+
+        # Prologue: load iter 0 data → smem
+        b_w1_buf = gl.amd.cdna4.buffer_load(ptr=w_base, offsets=w_offs_base1)
+        if K > 64:
+            b_w2_buf = gl.amd.cdna4.buffer_load(ptr=w_base, offsets=w_offs_base2)
+        b_v_pre = gl.amd.cdna4.buffer_load(ptr=v_base, offsets=v_offs_base)
+        b_kt1_buf = gl.amd.cdna4.buffer_load(ptr=k_base, offsets=kt_offs_base1)
+        if K > 64:
+            b_kt2_buf = gl.amd.cdna4.buffer_load(ptr=k_base, offsets=kt_offs_base2)
+
+        smem_w1.store(b_w1_buf)
+        if K > 64:
+            smem_w2.store(b_w2_buf)
+        smem_k1.store(b_kt1_buf)
+        if K > 64:
+            smem_k2.store(b_kt2_buf)
+
+        # Main loop: N-1 iterations with full pipeline
+        for i_t in range(NT - 1):
+            i_t_bt = (i_t * BT).to(gl.int32)
+            next_bt = i_t_bt + BT
+
+            h_off_iter = (i_t * stride_h).to(gl.int32)
+            h_val1 = b_h1 if H_FP32 else b_h1.to(gl.bfloat16)
+            gl.amd.cdna4.buffer_store(
+                stored_value=h_val1, ptr=h_base, offsets=h_offs_base1 + h_off_iter)
+            if K > 64:
+                h_val2 = b_h2 if H_FP32 else b_h2.to(gl.bfloat16)
+                gl.amd.cdna4.buffer_store(
+                    stored_value=h_val2, ptr=h_base, offsets=h_offs_base2 + h_off_iter)
+
+            b_w1_buf = gl.amd.cdna4.buffer_load(ptr=w_base, offsets=w_offs_base1 + next_bt * stride_w)
+            if K > 64:
+                b_w2_buf = gl.amd.cdna4.buffer_load(ptr=w_base, offsets=w_offs_base2 + next_bt * stride_w)
+
+            w_dot = smem_w1.load(dot_op0)
+            h_dot = gl.convert_layout(b_h1.to(gl.bfloat16), dot_op1)
+            b_wh = gl.zeros((BT, BV), dtype=gl.float32, layout=mma)
+            b_wh = gl.amd.cdna4.mfma(w_dot, h_dot, b_wh)
+            if K > 64:
+                w_dot2 = smem_w2.load(dot_op0)
+                h_dot2 = gl.convert_layout(b_h2.to(gl.bfloat16), dot_op1)
+                b_wh = gl.amd.cdna4.mfma(w_dot2, h_dot2, b_wh)
+
+            b_v_pre_next = gl.amd.cdna4.buffer_load(ptr=v_base, offsets=v_offs_base + next_bt * stride_v)
+            b_v = gl.convert_layout(b_v_pre, mma).to(gl.float32) - b_wh
+
+            if SAVE_NEW_VALUE:
+                vn_offs = ((i_t * BT + m_row_bt[:, None]) * stride_v + (i_v * BV + m_col_bv[None, :])).to(gl.int32)
+                gl.amd.cdna4.buffer_store(
+                    stored_value=b_v.to(gl.bfloat16), ptr=vn_base, offsets=vn_offs)
+
+            if USE_G:
+                last_idx = min((i_t + 1) * BT, T) - 1
+                m_t = (i_t * BT + m_row_bt) < T
+                b_g_last = gl.load(g_base + last_idx * H).to(gl.float32)
+                b_g = gl.amd.cdna4.buffer_load(
+                    ptr=g_base, offsets=g_offs_base + i_t_bt * H, mask=m_t).to(gl.float32)
+                b_scale = gl.where(m_t, gl.exp2(b_g_last - b_g), 0.0)
+                b_g_last_val = gl.exp2(b_g_last)
+                b_v = b_v * b_scale[:, None]
+                b_h1 = b_h1 * b_g_last_val
+                if K > 64:
+                    b_h2 = b_h2 * b_g_last_val
+
+            b_kt1_buf = gl.amd.cdna4.buffer_load(ptr=k_base, offsets=kt_offs_base1 + next_bt * stride_k)
+            if K > 64:
+                b_kt2_buf = gl.amd.cdna4.buffer_load(ptr=k_base, offsets=kt_offs_base2 + next_bt * stride_k)
+
+            v_dot = gl.convert_layout(b_v.to(gl.bfloat16), dot_op1)
+            k_dot = smem_k1.load(dot_op0)
+            b_h1 = gl.amd.cdna4.mfma(k_dot, v_dot, b_h1)
+            if K > 64:
+                k_dot2 = smem_k2.load(dot_op0)
+                b_h2 = gl.amd.cdna4.mfma(k_dot2, v_dot, b_h2)
+
+            smem_w1.store(b_w1_buf)
+            if K > 64:
+                smem_w2.store(b_w2_buf)
+            smem_k1.store(b_kt1_buf)
+            if K > 64:
+                smem_k2.store(b_kt2_buf)
+            b_v_pre = b_v_pre_next
+
+        # Epilogue: last iteration (no prefetch)
+        if NT > 0:
+            i_t_last = NT - 1
+            i_t_bt = (i_t_last * BT).to(gl.int32)
+
+            h_off_iter = (i_t_last * stride_h).to(gl.int32)
+            h_val1 = b_h1 if H_FP32 else b_h1.to(gl.bfloat16)
+            gl.amd.cdna4.buffer_store(
+                stored_value=h_val1, ptr=h_base, offsets=h_offs_base1 + h_off_iter)
+            if K > 64:
+                h_val2 = b_h2 if H_FP32 else b_h2.to(gl.bfloat16)
+                gl.amd.cdna4.buffer_store(
+                    stored_value=h_val2, ptr=h_base, offsets=h_offs_base2 + h_off_iter)
+
+            w_dot = smem_w1.load(dot_op0)
+            h_dot = gl.convert_layout(b_h1.to(gl.bfloat16), dot_op1)
+            b_wh = gl.zeros((BT, BV), dtype=gl.float32, layout=mma)
+            b_wh = gl.amd.cdna4.mfma(w_dot, h_dot, b_wh)
+            if K > 64:
+                w_dot2 = smem_w2.load(dot_op0)
+                h_dot2 = gl.convert_layout(b_h2.to(gl.bfloat16), dot_op1)
+                b_wh = gl.amd.cdna4.mfma(w_dot2, h_dot2, b_wh)
+
+            b_v = gl.convert_layout(b_v_pre, mma).to(gl.float32) - b_wh
+
+            if SAVE_NEW_VALUE:
+                vn_offs = ((i_t_last * BT + m_row_bt[:, None]) * stride_v + (i_v * BV + m_col_bv[None, :])).to(gl.int32)
+                gl.amd.cdna4.buffer_store(
+                    stored_value=b_v.to(gl.bfloat16), ptr=vn_base, offsets=vn_offs)
+
+            if USE_G:
+                last_idx = min((i_t_last + 1) * BT, T) - 1
+                m_t = (i_t_last * BT + m_row_bt) < T
+                b_g_last = gl.load(g_base + last_idx * H).to(gl.float32)
+                b_g = gl.amd.cdna4.buffer_load(
+                    ptr=g_base, offsets=g_offs_base + i_t_bt * H, mask=m_t).to(gl.float32)
+                b_scale = gl.where(m_t, gl.exp2(b_g_last - b_g), 0.0)
+                b_g_last_val = gl.exp2(b_g_last)
+                b_v = b_v * b_scale[:, None]
+                b_h1 = b_h1 * b_g_last_val
+                if K > 64:
+                    b_h2 = b_h2 * b_g_last_val
+
+            v_dot = gl.convert_layout(b_v.to(gl.bfloat16), dot_op1)
+            k_dot = smem_k1.load(dot_op0)
+            b_h1 = gl.amd.cdna4.mfma(k_dot, v_dot, b_h1)
+            if K > 64:
+                k_dot2 = smem_k2.load(dot_op0)
+                b_h2 = gl.amd.cdna4.mfma(k_dot2, v_dot, b_h2)
+
+        if STORE_FINAL_STATE:
+            ht_base = ht + i_nh * K * V
+            ht_offs1 = (m_row[:, None] * V + (i_v * BV + m_col_bv[None, :])).to(gl.int32)
+            gl.amd.cdna4.buffer_store(stored_value=b_h1, ptr=ht_base, offsets=ht_offs1)
+            if K > 64:
+                ht_offs2 = ((64 + m_row[:, None]) * V + (i_v * BV + m_col_bv[None, :])).to(gl.int32)
+                gl.amd.cdna4.buffer_store(stored_value=b_h2, ptr=ht_base, offsets=ht_offs2)
+
+
+def chunk_gated_delta_rule_fwd_h_gluon(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    save_new_value: bool = True,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    state_dtype: Optional[torch.dtype] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Gluon fwd_h — drop-in replacement for chunk_gated_delta_rule_fwd_h.
+
+    Optimized for AMD MI355X (gfx950/CDNA4), TP2 (H≤32), T≤65536.
+
+    Args:
+        state_dtype: dtype of the per-chunk hidden state buffer ``h``.
+            If explicitly provided, it is honored as-is. If ``None``,
+            defaults to fp32 to preserve precision and stay consistent
+            with the generic Triton fallback path.
+    """
+    B, T, Hg, K, V = *k.shape, u.shape[-1]
+    H = u.shape[-2]
+    assert K <= 128, f"Gluon fwd_h only supports K<=128 (two 64-wide tiles), got K={K}"
+    BT = chunk_size
+    BV = 16
+    NUM_WARPS = 4
+
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        N = len(cu_seqlens) - 1
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
+        NT = int(chunk_offsets[-1])  # exact total chunk count across all sequences
+
+    if state_dtype is None:
+        state_dtype = torch.float32
+    h = k.new_empty(B, NT, H, K, V, dtype=state_dtype)
+    final_state = k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    v_new = torch.empty_like(u) if save_new_value else None
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    gluon_chunk_fwd_kernel_h[grid](
+        k=k, v=u, w=w, v_new=v_new, g=g,
+        h=h, h0=initial_state, ht=final_state,
+        cu_seqlens=cu_seqlens, chunk_offsets=chunk_offsets,
+        T=T, H=H, Hg=Hg, K=K, V=V, BT=BT, BV=BV,
+        H_FP32=(state_dtype == torch.float32),
+        NUM_WARPS=NUM_WARPS,
+        num_warps=NUM_WARPS, num_stages=1,
+    )
+    return h, v_new, final_state

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_fwd.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_fwd.py
@@ -1,0 +1,355 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/gated_delta_rule/chunk_fwd.py
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
+from rtp_llm.models_py.triton_kernels.fla.op import exp2
+from rtp_llm.models_py.triton_kernels.fla.wy_fast import recompute_w_u_fwd
+
+
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_kkt_solve_kernel(
+    k,
+    g,
+    beta,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    k += (bos * Hg + i_h // (H // Hg)) * K
+    A += (bos * H + i_h) * BT
+
+    o_i = tl.arange(0, BC)
+    m_tc0 = (i_tc0 + o_i) < T
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    p_b0 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+    p_b1 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+    p_b2 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+    p_b3 = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+    b_b0 = tl.load(p_b0, boundary_check=(0,)).to(tl.float32)
+    b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+    b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+    b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+
+    if USE_G:
+        p_g0 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc0,), (BC,), (0,))
+        p_g1 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc1,), (BC,), (0,))
+        p_g2 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc2,), (BC,), (0,))
+        p_g3 = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_tc3,), (BC,), (0,))
+
+        b_g0 = tl.load(p_g0, boundary_check=(0,)).to(tl.float32)
+        b_g1 = tl.load(p_g1, boundary_check=(0,)).to(tl.float32)
+        b_g2 = tl.load(p_g2, boundary_check=(0,)).to(tl.float32)
+        b_g3 = tl.load(p_g3, boundary_check=(0,)).to(tl.float32)
+
+    # Step 1: compute all 10 lower-triangular [BC, BC] blocks of K @ K^T
+    b_A00 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A11 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A22 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A33 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_A10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_A32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k0 = tl.make_block_ptr(
+            k, (T, K), (Hg * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1))
+        b_A00 += tl.dot(b_k0, tl.trans(b_k0))
+
+        if i_tc1 < T:
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (Hg * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+            b_A11 += tl.dot(b_k1, tl.trans(b_k1))
+            b_A10 += tl.dot(b_k1, tl.trans(b_k0))
+
+            if i_tc2 < T:
+                p_k2 = tl.make_block_ptr(
+                    k, (T, K), (Hg * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+                b_A22 += tl.dot(b_k2, tl.trans(b_k2))
+                b_A20 += tl.dot(b_k2, tl.trans(b_k0))
+                b_A21 += tl.dot(b_k2, tl.trans(b_k1))
+
+                if i_tc3 < T:
+                    p_k3 = tl.make_block_ptr(
+                        k, (T, K), (Hg * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+                    b_A33 += tl.dot(b_k3, tl.trans(b_k3))
+                    b_A30 += tl.dot(b_k3, tl.trans(b_k0))
+                    b_A31 += tl.dot(b_k3, tl.trans(b_k1))
+                    b_A32 += tl.dot(b_k3, tl.trans(b_k2))
+
+    # Step 2: apply gate and beta scaling
+    m_d = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    if USE_G:
+        b_A00 *= tl.where(
+            m_d & m_tc0[:, None] & m_tc0[None, :],
+            exp2(b_g0[:, None] - b_g0[None, :]),
+            0.0,
+        )
+        b_A11 *= tl.where(
+            m_d & m_tc1[:, None] & m_tc1[None, :],
+            exp2(b_g1[:, None] - b_g1[None, :]),
+            0.0,
+        )
+        b_A22 *= tl.where(
+            m_d & m_tc2[:, None] & m_tc2[None, :],
+            exp2(b_g2[:, None] - b_g2[None, :]),
+            0.0,
+        )
+        b_A33 *= tl.where(
+            m_d & m_tc3[:, None] & m_tc3[None, :],
+            exp2(b_g3[:, None] - b_g3[None, :]),
+            0.0,
+        )
+
+        b_A10 *= tl.where(
+            m_tc1[:, None] & m_tc0[None, :],
+            exp2(b_g1[:, None] - b_g0[None, :]),
+            0.0,
+        )
+        b_A20 *= tl.where(
+            m_tc2[:, None] & m_tc0[None, :],
+            exp2(b_g2[:, None] - b_g0[None, :]),
+            0.0,
+        )
+        b_A21 *= tl.where(
+            m_tc2[:, None] & m_tc1[None, :],
+            exp2(b_g2[:, None] - b_g1[None, :]),
+            0.0,
+        )
+        b_A30 *= tl.where(
+            m_tc3[:, None] & m_tc0[None, :],
+            exp2(b_g3[:, None] - b_g0[None, :]),
+            0.0,
+        )
+        b_A31 *= tl.where(
+            m_tc3[:, None] & m_tc1[None, :],
+            exp2(b_g3[:, None] - b_g1[None, :]),
+            0.0,
+        )
+        b_A32 *= tl.where(
+            m_tc3[:, None] & m_tc2[None, :],
+            exp2(b_g3[:, None] - b_g2[None, :]),
+            0.0,
+        )
+    else:
+        b_A00 = tl.where(m_d, b_A00, 0.0)
+        b_A11 = tl.where(m_d, b_A11, 0.0)
+        b_A22 = tl.where(m_d, b_A22, 0.0)
+        b_A33 = tl.where(m_d, b_A33, 0.0)
+
+    b_A00 = b_A00 * b_b0[:, None]
+    b_A11 = b_A11 * b_b1[:, None]
+    b_A22 = b_A22 * b_b2[:, None]
+    b_A33 = b_A33 * b_b3[:, None]
+
+    b_A10 = b_A10 * b_b1[:, None]
+    b_A20 = b_A20 * b_b2[:, None]
+    b_A21 = b_A21 * b_b2[:, None]
+    b_A30 = b_A30 * b_b3[:, None]
+    b_A31 = b_A31 * b_b3[:, None]
+    b_A32 = b_A32 * b_b3[:, None]
+
+    # Step 3: forward substitution on diagonal blocks -> (I + A_diag)^{-1}
+    b_Ai00 = -b_A00
+    b_Ai11 = -b_A11
+    b_Ai22 = -b_A22
+    b_Ai33 = -b_A33
+
+    # Loop to BC (compile-time constant); out-of-bounds rows are zeroed by m_tc* masks
+    # applied in Step 2, so the forward-substitution is safe for T%BT != 0.
+    for i in range(2, BC):
+        b_a00 = tl.sum(tl.where((o_i == i)[:, None], -b_A00, 0.0), 0)
+        b_a00 = tl.where(o_i < i, b_a00, 0.0)
+        b_a00 = b_a00 + tl.sum(b_a00[:, None] * b_Ai00, 0)
+        b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+    for i in range(2, BC):
+        b_a11 = tl.sum(tl.where((o_i == i)[:, None], -b_A11, 0.0), 0)
+        b_a11 = tl.where(o_i < i, b_a11, 0.0)
+        b_a11 = b_a11 + tl.sum(b_a11[:, None] * b_Ai11, 0)
+        b_Ai11 = tl.where((o_i == i)[:, None], b_a11, b_Ai11)
+    for i in range(2, BC):
+        b_a22 = tl.sum(tl.where((o_i == i)[:, None], -b_A22, 0.0), 0)
+        b_a22 = tl.where(o_i < i, b_a22, 0.0)
+        b_a22 = b_a22 + tl.sum(b_a22[:, None] * b_Ai22, 0)
+        b_Ai22 = tl.where((o_i == i)[:, None], b_a22, b_Ai22)
+    for i in range(2, BC):
+        b_a33 = tl.sum(tl.where((o_i == i)[:, None], -b_A33, 0.0), 0)
+        b_a33 = tl.where(o_i < i, b_a33, 0.0)
+        b_a33 = b_a33 + tl.sum(b_a33[:, None] * b_Ai33, 0)
+        b_Ai33 = tl.where((o_i == i)[:, None], b_a33, b_Ai33)
+
+    b_Ai00 += m_I
+    b_Ai11 += m_I
+    b_Ai22 += m_I
+    b_Ai33 += m_I
+
+    # Step 4: block merge -> full (I + A)^{-1}
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_A10, input_precision="ieee"), b_Ai00, input_precision="ieee"
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_A21, input_precision="ieee"), b_Ai11, input_precision="ieee"
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_A32, input_precision="ieee"), b_Ai22, input_precision="ieee"
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_A20, b_Ai00, input_precision="ieee")
+        + tl.dot(b_A21, b_Ai10, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A31, b_Ai11, input_precision="ieee")
+        + tl.dot(b_A32, b_Ai21, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_A30, b_Ai00, input_precision="ieee")
+        + tl.dot(b_A31, b_Ai10, input_precision="ieee")
+        + tl.dot(b_A32, b_Ai20, input_precision="ieee"),
+        input_precision="ieee",
+    )
+
+    # Step 5: store full (I + A)^{-1} to output A
+    p_A00 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_A10 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_A11 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+    p_A20 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+    p_A21 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+    p_A22 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_A30 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+    p_A31 = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+    p_A32 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_A33 = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+    )
+
+    tl.store(p_A00, b_Ai00.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A10, b_Ai10.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A11, b_Ai11.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A20, b_Ai20.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A21, b_Ai21.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A22, b_Ai22.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A30, b_Ai30.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A31, b_Ai31.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A32, b_Ai32.to(A.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_A33, b_Ai33.to(A.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gated_delta_rule_fwd_intra(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+    chunk_indices: Optional[torch.LongTensor] = None,
+):
+    B, T, Hg, K = k.shape
+    H = beta.shape[2]
+    BT = chunk_size
+    BC = 16
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    A = torch.zeros(B, T, H, BT, device=k.device, dtype=k.dtype)
+    chunk_gated_delta_rule_fwd_kkt_solve_kernel[(NT, B * H)](
+        k=k,
+        g=g,
+        beta=beta,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=64,
+        # num_warps=1 is optimal on AMD CDNA: this kernel is memory-bound with
+        # 10 small BC×BC dot products per tile; extra warps increase VGPR pressure
+        # without improving occupancy. Verified via rocprof PMC on MI355X.
+        num_warps=1,
+        num_stages=1,
+    )
+
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+    )
+    return w, u, A

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_o.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_o.py
@@ -9,9 +9,11 @@ import triton
 import triton.language as tl
 
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
-from rtp_llm.models_py.triton_kernels.fla.op import exp, safe_exp
+from rtp_llm.models_py.triton_kernels.fla.op import exp, exp2, safe_exp
 from rtp_llm.models_py.triton_kernels.fla.utils import (
     check_shared_mem,
+    is_amd,
+    is_amd_cdna3,
     is_nvidia_hopper,
 )
 
@@ -56,6 +58,7 @@ def chunk_fwd_kernel_o(
     BV: tl.constexpr,
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    IS_LOG2: tl.constexpr,
 ):
     i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_b, i_h = i_bh // H, i_bh % H
@@ -111,11 +114,30 @@ def chunk_fwd_kernel_o(
         g += bos * H + i_h
         p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
-        b_o = b_o * exp(b_g)[:, None]
-        b_A = b_A * safe_exp(b_g[:, None] - b_g[None, :])
+        if IS_LOG2:
+            # AMD path: g is in log2 domain (RCP_LN2-scaled cumsum upstream).
+            # Within each chunk b_g[i] - b_g[j] ≤ 0 for i ≥ j (cumsum of
+            # logsigmoid ≤ 0), so exp2 ∈ (0, 1]. The m_A mask below zeros
+            # out i < j entries.
+            b_o = b_o * exp2(b_g)[:, None]
+            b_A = b_A * exp2(b_g[:, None] - b_g[None, :])
+        else:
+            # NVIDIA path: g is in natural-log domain, keep exp/safe_exp to
+            # preserve bit-level semantics with the original implementation.
+            b_o = b_o * exp(b_g)[:, None]
+            b_A = b_A * safe_exp(b_g[:, None] - b_g[None, :])
 
-    o_i = tl.arange(0, BT)
-    m_A = o_i[:, None] >= o_i[None, :]
+    if IS_LOG2:
+        # AMD path: also mask out OOB rows/cols at the last chunk so b_A
+        # accumulator never multiplies garbage data when T % BT != 0.
+        o_t = i_t * BT + tl.arange(0, BT)
+        m_t = o_t < T
+        m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    else:
+        # NVIDIA path: keep the original lower-triangular mask only, to be
+        # bit-level identical to the pre-optimization implementation.
+        o_i = tl.arange(0, BT)
+        m_A = o_i[:, None] >= o_i[None, :]
     b_A = tl.where(m_A, b_A, 0)
 
     p_v = tl.make_block_ptr(
@@ -137,7 +159,7 @@ def chunk_fwd_o(
     k: torch.Tensor,
     v: torch.Tensor,
     h: torch.Tensor,
-    g: Optional[torch.Tensor] = None,  # cumsum of log decay
+    g: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_size: int = 64,
@@ -173,9 +195,10 @@ def chunk_fwd_o(
         K=K,
         V=V,
         BT=BT,
-        BK=128,
-        BV=64,
-        num_warps=4,
-        num_stages=2,
+        BK=64 if is_amd else 128,
+        BV=128 if is_amd else 64,
+        IS_LOG2=is_amd,
+        num_warps=(4 if h.dtype == torch.float32 else 1) if is_amd else 4,
+        num_stages=1 if is_amd_cdna3 else 2,
     )
     return o

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_scaled_dot_kkt.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_scaled_dot_kkt.py
@@ -9,7 +9,8 @@ import triton
 import triton.language as tl
 
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
-from rtp_llm.models_py.triton_kernels.fla.op import safe_exp
+from rtp_llm.models_py.triton_kernels.fla.op import exp2, safe_exp
+from rtp_llm.models_py.triton_kernels.fla.utils import is_amd
 
 
 @triton.heuristics(
@@ -43,6 +44,7 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     BK: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_G: tl.constexpr,
+    IS_LOG2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -82,7 +84,15 @@ def chunk_scaled_dot_kkt_fwd_kernel(
         )
         b_g = tl.load(p_g, boundary_check=(0,))
         b_g_diff = b_g[:, None] - b_g[None, :]
-        b_A = b_A * safe_exp(b_g_diff)
+        if IS_LOG2:
+            # AMD path: g is in log2 domain (scaled by RCP_LN2 in
+            # chunk_local_cumsum). b_g_diff ≤ 0 within each chunk
+            # (cumsum of logsigmoid ≤ 0), so exp2 ∈ (0, 1].
+            b_A = b_A * exp2(b_g_diff)
+        else:
+            # NVIDIA path: g is in natural-log domain (no RCP_LN2 scaling),
+            # keep the original safe_exp to preserve bit-level semantics.
+            b_A = b_A * safe_exp(b_g_diff)
 
     b_A *= b_beta[:, None]
     b_A = tl.where(o_t[:, None] > o_t[None, :], b_A, 0)
@@ -145,6 +155,7 @@ def chunk_scaled_dot_kkt_fwd(
         K=K,
         BT=BT,
         BK=64,
+        IS_LOG2=is_amd,
         num_warps=8,
         num_stages=3,
     )

--- a/rtp_llm/models_py/triton_kernels/fla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/fla/test/BUILD
@@ -38,6 +38,28 @@ py_test(
     exec_properties = {'gpu':'H20'},
 )
 
+# Reuse test_chunk_prefill on AMD to verify chunk-gdn Triton path on ROCm.
+# NOTE: The Gluon fwd_h kernel uses CDNA4-specific instructions (e.g.
+# v_mfma_f32_32x32x16_f16, ds_read_b128 with k_width=8) that are only
+# available on gfx950 (MI355X). It will NOT work on gfx942 (MI308X) —
+# attempting to run on gfx942 will fail with illegal-instruction errors.
+# This CI target runs on MI308X and therefore only exercises the Triton
+# fallback path. When CI gains gfx950 machines, the Gluon kernel will be
+# auto-dispatched via _is_gluon_beneficial.
+py_test(
+    name = "test_chunk_prefill_amd",
+    srcs = [
+        "test_chunk_prefill.py"
+    ],
+    main = "test_chunk_prefill.py",
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:fla",
+    ] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
+    visibility = ["//visibility:public"],
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7'},
+)
+
 py_test(
     name = "test_l2norm",
     srcs = [

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_chunk_prefill.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_chunk_prefill.py
@@ -151,9 +151,14 @@ def test_chunk_varlen(
     mask_p: float,
     cu_seqlens: List[int],
     dtype: torch.dtype,
+    state_dtype: torch.dtype = None,
 ):
     torch.manual_seed(42)
     os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    # state_dtype controls initial_state (h0) precision, simulating --ssm_state_dtype
+    if state_dtype is None:
+        state_dtype = dtype
+
     # randomly split the sequence into N segments
     cu_seqlens = torch.LongTensor(cu_seqlens).to(device)
     T = cu_seqlens[-1]
@@ -166,7 +171,7 @@ def test_chunk_varlen(
     g = F.logsigmoid(torch.rand(1, T, H, dtype=dtype))
     g = g * (torch.rand_like(g) > mask_p)
     beta = torch.rand(1, T, H, dtype=dtype).sigmoid()
-    h0 = torch.randn((N, H, D, D), dtype=dtype)
+    h0 = torch.randn((N, H, D, D), dtype=state_dtype)
 
     q, k, v, beta, g, h0 = map(
         lambda x: x.to(device).requires_grad_(), (q, k, v, beta, g, h0)
@@ -207,8 +212,12 @@ def test_chunk_varlen(
 
 if __name__ == "__main__":
     test_params = [
+        # (H, D, mask_p, cu_seqlens, dtype, state_dtype)
         (4, 64, 0, [0, 15], torch.bfloat16),
         (4, 64, 0, [0, 256, 500, 1000], torch.bfloat16),
+        # fp32 ssm_state_dtype: inputs bf16, initial_state fp32
+        (4, 64, 0, [0, 15], torch.bfloat16, torch.float32),
+        (4, 64, 0, [0, 256, 500, 1000], torch.bfloat16, torch.float32),
     ]
     for test in test_params:
         logging.info(f"Testing test_chunk_varlen with params: {test}")

--- a/rtp_llm/models_py/triton_kernels/fla/utils.py
+++ b/rtp_llm/models_py/triton_kernels/fla/utils.py
@@ -258,6 +258,12 @@ device_torch_lib = getattr(torch, device)
 device_platform = _check_platform()
 
 is_amd = device_platform == "amd"
+is_amd_cdna3 = is_amd and "gfx942" in getattr(
+    torch.cuda.get_device_properties(0), "gcnArchName", ""
+)
+is_amd_cdna4 = is_amd and "gfx950" in getattr(
+    torch.cuda.get_device_properties(0), "gcnArchName", ""
+)
 is_intel = device_platform == "intel"
 is_nvidia = device_platform == "nvidia"
 is_intel_alchemist = is_intel and "Intel(R) Arc(TM) A" in torch.xpu.get_device_name(0)

--- a/rtp_llm/models_py/triton_kernels/fla/wy_fast.py
+++ b/rtp_llm/models_py/triton_kernels/fla/wy_fast.py
@@ -9,6 +9,8 @@ import triton
 import triton.language as tl
 
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
+from rtp_llm.models_py.triton_kernels.fla.op import exp, exp2
+from rtp_llm.models_py.triton_kernels.fla.utils import is_amd
 
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
@@ -40,6 +42,7 @@ def recompute_w_u_fwd_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    IS_LOG2: tl.constexpr,
 ):
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
@@ -62,7 +65,13 @@ def recompute_w_u_fwd_kernel(
     )
     b_beta = tl.load(p_beta, boundary_check=(0,))
     b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_g = tl.exp(tl.load(p_g, boundary_check=(0,)))
+    if IS_LOG2:
+        # AMD path: g is in log2 domain (RCP_LN2-scaled cumsum upstream).
+        b_g = exp2(tl.load(p_g, boundary_check=(0,)))
+    else:
+        # NVIDIA path: g is in natural-log domain, keep tl.exp for bit-level
+        # parity with the original implementation.
+        b_g = exp(tl.load(p_g, boundary_check=(0,)))
 
     for i_v in range(tl.cdiv(V, BV)):
         p_v = tl.make_block_ptr(
@@ -126,7 +135,7 @@ def recompute_w_u_fwd(
     )
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
     BK = 64
-    BV = 64
+    BV = min(128, V) if is_amd else 64
     u = torch.empty_like(v)
     w = k.new_empty(B, T, H, K)
     recompute_w_u_fwd_kernel[(NT, B * H)](
@@ -147,6 +156,7 @@ def recompute_w_u_fwd(
         BT=BT,
         BK=BK,
         BV=BV,
+        IS_LOG2=is_amd,
         num_warps=4,
         num_stages=3,
     )


### PR DESCRIPTION
amd后端优化chunk-gdn算子，397b-tp2 64k输入，chunk-gdn单算子从5.6ms优化至4.1ms。
各个kernel优化项：
| # | Kernel | 时间 (us) | 占比 | 最优 |
|---|--------|----------|------|------|
| 1 | cumsum | 60 | 1.4% | Triton |
| 2-3 | fused_kkt_solve | 479 | 11.5% | Triton (vs 分离 2.39x) |
| 4 | recompute_w_u | 624 | 15.0% | Triton |
| 5 | **fwd_h** | **2276** | **54.7%** | **Gluon (+13%)** |
| 6 | fwd_o | 683 | 16.4% | Triton |

<h3 style="box-sizing: border-box; padding: 0px; margin: 24px 0px 16px; font-weight: 600; line-height: 1.25; color: rgb(204, 204, 204); font-size: 1.25em; font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">P1 — h 缓冲区 dtype 由 fp32 改为 state_dtype</h3><p node="[object Object]" style="box-sizing: border-box; padding: 0px; margin: 0px 0px 16px; min-height: 1rem; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; padding: 0px; margin: 0px; font-weight: 600;">h buffer 的 dtype 不影响最终输出精度</strong>，原因是<span> </span><code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">chunk_fwd_o</code><span> </span>kernel 在从 h 读取后会立即 cast 到<span> </span><code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">b_q.dtype</code>（即 bf16）再做 dot product：</p><div style="box-sizing: border-box; padding: 0px; margin: 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"></div><div class="code-wrap" style="box-sizing: border-box; padding: 0px; margin: 0px; position: relative; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="code-action-toolbar" style="box-sizing: border-box; padding: 0px; margin: 0px; display: flex; position: absolute; top: 2px; right: 10px; height: 26px; z-index: 10; align-items: center; justify-content: center; border-radius: 2px; background-color: transparent;"><div class="code-action-item dm-copy-code" title="复制代码" style="box-sizing: border-box; padding: 0px; margin: 1px; line-height: 1.3rem; height: 24px; width: 24px; cursor: pointer; display: flex; align-items: center; justify-content: center; opacity: 0.8;"><i class="devmindfont icon-copy dm-copy-code-icon" style="box-sizing: border-box; padding: 0px; margin: 0px; font-size: 16px; font-style: normal; -webkit-font-smoothing: antialiased; font-family: devmindfont !important; display: flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 2px;"></i></div></div><pre style="box-sizing: border-box; padding: 0px; margin: 0px 0px 16px; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.05px; display: flex; flex-direction: column; overflow-wrap: normal; overflow: auto; line-height: 1.45; color: rgb(212, 212, 212); border-radius: 6px; border-color: rgba(255, 255, 255, 0.1); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch;"><div class="code-path-wrap" title="Python" style="box-sizing: border-box; padding: 0px 10px; margin: 0px; display: flex; align-items: center; color: rgb(212, 212, 212); height: 28px; width: 828.835px; border-top-left-radius: 4px; border-top-right-radius: 4px; line-height: 28px; text-align: left; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; background-color: rgba(255, 255, 255, 0.1);">Python</div><code class="hljs language-python" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(212, 212, 212); background: none 0% 0% / auto repeat scroll padding-box border-box rgb(30, 30, 30); padding: 1em; border-radius: 0px 0px 4px 4px; box-sizing: border-box; margin: 0px; font-size: 11.05px; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; overflow-wrap: normal; line-height: inherit; tab-size: 4; hyphens: none; user-select: text; position: relative; border: 0px; display: block; overflow: auto visible;"><span class="hljs-comment" style="box-sizing: border-box; padding: 0px; margin: 0px; color: rgb(139, 148, 158);"># chunk_o.py line ~103</span>
b_o += tl.dot(b_q, b_h.to(b_q.dtype))
</code></pre></div><p node="[object Object]" style="box-sizing: border-box; padding: 0px; margin: 0px 0px 16px; min-height: 1rem; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">因此无论 h 是 fp32 还是 bf16 存储，进入计算路径时都会被截断为 bf16。两者的区别仅在于 h buffer 的显存占用（bf16 减半）。</p><p node="[object Object]" style="box-sizing: border-box; padding: 0px; margin: 0px 0px 16px; min-height: 1rem; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; padding: 0px; margin: 0px; font-weight: 600;">NVIDIA H20 实测精度对比（h=fp32 vs h=bf16 → output o）：</strong></p>
B | T | H | K | h0_dtype | h=fp32 o_max | h=bf16 o_max | fp32 cosine | bf16 cosine | fp32 vs bf16 | exact
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 15 | 4 | 64 | bf16 | 3.42e-03 | 3.42e-03 | 0.999997 | 0.999997 | 0.0 | YES
1 | 64 | 4 | 64 | bf16 | 3.42e-03 | 3.42e-03 | 0.999996 | 0.999996 | 0.0 | YES
1 | 256 | 4 | 64 | bf16 | 6.01e-03 | 6.01e-03 | 0.999995 | 0.999995 | 0.0 | YES
1 | 1000 | 4 | 64 | bf16 | 6.01e-03 | 6.01e-03 | 0.999994 | 0.999994 | 0.0 | YES
1 | 2048 | 4 | 64 | bf16 | 6.01e-03 | 6.01e-03 | 0.999994 | 0.999994 | 0.0 | YES
4 | 1024 | 4 | 64 | bf16 | 7.25e-03 | 7.25e-03 | 0.999995 | 0.999995 | 0.0 | YES
1 | 256 | 32 | 128 | bf16 | 6.76e-03 | 6.76e-03 | 0.999996 | 0.999996 | 0.0 | YES
1 | 1000 | 32 | 128 | bf16 | 7.49e-03 | 7.49e-03 | 0.999995 | 0.999995 | 0.0 | YES
1 | 256 | 4 | 64 | fp32 | 6.01e-03 | 6.01e-03 | 0.999995 | 0.999995 | 0.0 | YES
1 | 1000 | 4 | 64 | fp32 | 6.01e-03 | 6.01e-03 | 0.999994 | 0.999994 | 0.0 | YES
1 | 1000 | 32 | 128 | fp32 | 8.17e-03 | 8.17e-03 | 0.999995 | 0.999995 | 0.0 | YES

<p node="[object Object]" style="box-sizing: border-box; padding: 0px; margin: 0px 0px 16px; min-height: 1rem; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; padding: 0px; margin: 0px; font-weight: 600;">结论</strong>：所有 shape、两种<span> </span><code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">h0_dtype</code>（bf16/fp32）下，h buffer 用 fp32 和 bf16 的输出<span> </span><strong style="box-sizing: border-box; padding: 0px; margin: 0px; font-weight: 600;">bitwise 完全一致</strong>，对 fp32 recurrent reference 的误差也完全相同。<code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">state_dtype</code><span> </span>通过<span> </span><code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">--ssm_state_dtype</code><span> </span>由调用方显式控制，默认跟随<span> </span><code class="" style="font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 0.2em 0.4em; border-radius: 4px; box-sizing: border-box; margin: 0px 3px; font-size: 11.05px; white-space: break-spaces; user-select: text; position: relative;">initial_state.dtype</code>（历史行为即为 bf16）。</p>