### PR TITLE
add input embedding for pg

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -329,6 +329,13 @@ void GenerateStream::setReuseLength(int reuse_length) {
             }
         }
     }
+    // Cap reuseLength so it doesn't exceed any input_embeddings location.
+    // Otherwise the adjusted loc (loc - reuseLength) would become negative.
+    if (generate_input_->input_embeddings_locs) {
+        for (int32_t loc : generate_input_->input_embeddings_locs.value()) {
+            reuse_length_ = std::min(reuse_length_, loc);
+        }
+    }
 }
 
 void GenerateStream::setLocalReuseLength(int length) {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -428,6 +428,26 @@ torch::Tensor GenerateStream::multimodalLocations() const {
     return mm_locs.slice(0, reuse_mm_length_, mm_locs.numel());
 }
 
+bool GenerateStream::hasInputEmbeddings() const {
+    return generate_input_->input_embeddings.has_value();
+}
+
+std::vector<torch::Tensor> GenerateStream::inputEmbeddings() const {
+    if (generate_input_->input_embeddings.has_value()) {
+        return generate_input_->input_embeddings.value();
+    } else {
+        return std::vector<torch::Tensor>();
+    }
+}
+
+std::vector<int32_t> GenerateStream::inputEmbeddingsLocs() const {
+    if (generate_input_->input_embeddings_locs) {
+        return generate_input_->input_embeddings_locs.value();
+    } else {
+        return std::vector<int32_t>();
+    }
+}
+
 vector<int> GenerateStream::textTokensMask() const {
     if (!generate_input_->text_tokens_mask) {
         return {};

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -221,6 +221,10 @@ public:
     int                        multimodalFeaturesLength() const;
     torch::Tensor              multimodalLocations() const;
 
+    bool                       hasInputEmbeddings() const;
+    std::vector<torch::Tensor> inputEmbeddings() const;
+    std::vector<int32_t>       inputEmbeddingsLocs() const;
+
     int64_t getTimeoutMs() const;
     void    checkTimeout();
 

--- a/rtp_llm/cpp/engine_base/stream/GenerateTypes.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateTypes.h
@@ -53,6 +53,10 @@ public:
     std::optional<torch::Tensor>                mm_locs;           // multimodal input locations
     std::optional<std::vector<torch::Tensor>>   mm_position_ids;
 
+    // extra input embeddings
+    std::optional<std::vector<torch::Tensor>> input_embeddings;
+    std::optional<std::vector<int32_t>>       input_embeddings_locs;
+
     int     prefix_length = 0;
     int64_t begin_time_us = 0;
 

--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -127,6 +127,27 @@ std::shared_ptr<GenerateInput> QueryConverter::transQuery(const GenerateInputPB*
         generate_input->batch_group_id = input->batch_group_id().value();
     }
 
+    // 转换 input_embeddings
+    if (input->has_input_embeddings() && input->input_embeddings().embeddings_size() > 0) {
+        const auto&                input_embeddings_pb = input->input_embeddings();
+        std::vector<torch::Tensor> embeddings;
+        std::vector<int32_t>       embedding_locs;
+
+        // 转换 embeddings
+        for (int i = 0; i < input_embeddings_pb.embeddings_size(); i++) {
+            embeddings.push_back(transTensor(input_embeddings_pb.embeddings(i)));
+        }
+
+        // 转换 embedding_locs
+        embedding_locs.resize(input_embeddings_pb.embedding_locs_size());
+        memcpy(embedding_locs.data(),
+               input_embeddings_pb.embedding_locs().data(),
+               input_embeddings_pb.embedding_locs_size() * sizeof(int32_t));
+
+        generate_input->input_embeddings      = embeddings;
+        generate_input->input_embeddings_locs = embedding_locs;
+    }
+
     return generate_input;
 }
 

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -24,7 +24,12 @@ from rtp_llm.utils.base_model_datatypes import (
     GenerateOutputs,
 )
 from rtp_llm.utils.grpc_host_channel_pool import GrpcHostChannelPool
-from rtp_llm.utils.grpc_util import trans_option, trans_option_cast, trans_tensor
+from rtp_llm.utils.grpc_util import (
+    trans_from_tensor,
+    trans_option,
+    trans_option_cast,
+    trans_tensor,
+)
 
 MAX_GRPC_TIMEOUT_SECONDS = 3600
 
@@ -56,6 +61,8 @@ def trans_input(input_py: GenerateInput):
         input_pb.batch_group_id.value = input_py.batch_group_id
 
     trans_multimodal_input(input_py, input_pb, input_py.generate_config)
+
+    trans_embedding_inputs(input_py, input_pb)
     # check generate config is valid before enter into engine
     input_py.generate_config.validate()
 
@@ -197,6 +204,21 @@ def trans_multimodal_input(
         mm_preprocess_config_pb.min_frames = mm_input.config.min_frames
         mm_preprocess_config_pb.max_frames = mm_input.config.max_frames
         input_pb.multimodal_inputs.append(mm_input_pb)
+
+
+def trans_embedding_inputs(input_py: GenerateInput, input_pb: GenerateInputPB):
+    if input_py.input_embeddings is None:
+        return
+
+    input_embeddings_pb = input_pb.input_embeddings
+    embedding_inputs = input_py.input_embeddings
+
+    # 转换 embeddings
+    tensor_pbs = [trans_from_tensor(emb) for emb in embedding_inputs.embeddings]
+    input_embeddings_pb.embeddings.extend(tensor_pbs)
+
+    # 转换 embedding_locs
+    input_embeddings_pb.embedding_locs.extend(embedding_inputs.embedding_locs)
 
 
 # 假设 trans_tensor 函数将 Protobuf 的 TensorPB 转换为 numpy array

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -131,6 +131,11 @@ message MultimodalOutputsPB {
     repeated MultimodalOutputPB multimodal_outputs = 1;
 }
 
+message InputEmbeddingsPB {
+    repeated TensorPB embeddings = 1;   // 和embedding_locs一一对应
+    repeated int32 embedding_locs = 2;  // embedding的在token ids中的起始位置
+}
+
 message GenerateInputPB {
     int64 request_id = 1;
     repeated int32 token_ids = 2;
@@ -140,6 +145,7 @@ message GenerateInputPB {
     int64 start_time = 6;
     int32 batch_group_size = 7;
     google.protobuf.Int64Value batch_group_id = 8;
+    InputEmbeddingsPB input_embeddings = 9;
 }
 
 message AuxInfoPB {

--- a/rtp_llm/cpp/model_rpc/test/QueryConverterTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/QueryConverterTest.cc
@@ -193,4 +193,139 @@ TEST_F(QueryConverterTest, TransTensorPB_UnsupportedType) {
     EXPECT_THROW(QueryConverter::transTensorPB(&tensor_pb, tensor), std::runtime_error);
 }
 
+TEST_F(QueryConverterTest, testTransInputWithInputEmbeddings_FP32) {
+    GenerateInputPB input;
+    input.add_token_ids(0);
+    input.add_token_ids(1);
+
+    // 创建 input_embeddings
+    auto* input_embeddings_pb = input.mutable_input_embeddings();
+
+    // 添加第一个 embedding (FP32, shape [2, 3])
+    auto* embedding1_pb = input_embeddings_pb->add_embeddings();
+    embedding1_pb->set_data_type(TensorPB::FP32);
+    embedding1_pb->add_shape(2);
+    embedding1_pb->add_shape(3);
+    std::vector<float> embedding1_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    embedding1_pb->set_fp32_data(reinterpret_cast<const char*>(embedding1_data.data()),
+                                 embedding1_data.size() * sizeof(float));
+
+    // 添加第二个 embedding (FP32, shape [1, 4])
+    auto* embedding2_pb = input_embeddings_pb->add_embeddings();
+    embedding2_pb->set_data_type(TensorPB::FP32);
+    embedding2_pb->add_shape(1);
+    embedding2_pb->add_shape(4);
+    std::vector<float> embedding2_data = {7.0f, 8.0f, 9.0f, 10.0f};
+    embedding2_pb->set_fp32_data(reinterpret_cast<const char*>(embedding2_data.data()),
+                                 embedding2_data.size() * sizeof(float));
+
+    // 添加 embedding_locs
+    input_embeddings_pb->add_embedding_locs(5);
+    input_embeddings_pb->add_embedding_locs(10);
+
+    auto generate_input = QueryConverter::transQuery(&input);
+
+    // 验证 input_embeddings 转换
+    ASSERT_TRUE(generate_input->input_embeddings.has_value());
+    ASSERT_TRUE(generate_input->input_embeddings_locs.has_value());
+
+    const auto& embeddings = generate_input->input_embeddings.value();
+    const auto& locs       = generate_input->input_embeddings_locs.value();
+
+    ASSERT_EQ(embeddings.size(), 2);
+    ASSERT_EQ(locs.size(), 2);
+
+    // 验证第一个 embedding
+    ASSERT_EQ(embeddings[0].dtype(), torch::kFloat32);
+    ASSERT_EQ(embeddings[0].dim(), 2);
+    ASSERT_EQ(embeddings[0].size(0), 2);
+    ASSERT_EQ(embeddings[0].size(1), 3);
+    auto embedding1_ptr = embeddings[0].data_ptr<float>();
+    for (int i = 0; i < 6; ++i) {
+        EXPECT_FLOAT_EQ(embedding1_ptr[i], embedding1_data[i]);
+    }
+
+    // 验证第二个 embedding
+    ASSERT_EQ(embeddings[1].dtype(), torch::kFloat32);
+    ASSERT_EQ(embeddings[1].dim(), 2);
+    ASSERT_EQ(embeddings[1].size(0), 1);
+    ASSERT_EQ(embeddings[1].size(1), 4);
+    auto embedding2_ptr = embeddings[1].data_ptr<float>();
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_FLOAT_EQ(embedding2_ptr[i], embedding2_data[i]);
+    }
+
+    // 验证 embedding_locs
+    EXPECT_EQ(locs[0], 5);
+    EXPECT_EQ(locs[1], 10);
+}
+
+TEST_F(QueryConverterTest, testTransInputWithInputEmbeddings_FP16) {
+    GenerateInputPB input;
+    input.add_token_ids(0);
+
+    // 创建 input_embeddings (FP16)
+    auto* input_embeddings_pb = input.mutable_input_embeddings();
+    auto* embedding_pb        = input_embeddings_pb->add_embeddings();
+    embedding_pb->set_data_type(TensorPB::FP16);
+    embedding_pb->add_shape(2);
+    embedding_pb->add_shape(2);
+
+    std::vector<c10::Half> embedding_data = {1.0f, 2.0f, 3.0f, 4.0f};
+    embedding_pb->set_fp16_data(reinterpret_cast<const char*>(embedding_data.data()),
+                                embedding_data.size() * sizeof(c10::Half));
+
+    input_embeddings_pb->add_embedding_locs(3);
+
+    auto generate_input = QueryConverter::transQuery(&input);
+
+    ASSERT_TRUE(generate_input->input_embeddings.has_value());
+    const auto& embeddings = generate_input->input_embeddings.value();
+    const auto& locs       = generate_input->input_embeddings_locs.value();
+
+    ASSERT_EQ(embeddings.size(), 1);
+    ASSERT_EQ(embeddings[0].dtype(), torch::kFloat16);
+    ASSERT_EQ(embeddings[0].dim(), 2);
+    EXPECT_EQ(locs[0], 3);
+}
+
+TEST_F(QueryConverterTest, testTransInputWithInputEmbeddings_BF16) {
+    GenerateInputPB input;
+    input.add_token_ids(0);
+
+    // 创建 input_embeddings (BF16)
+    auto* input_embeddings_pb = input.mutable_input_embeddings();
+    auto* embedding_pb        = input_embeddings_pb->add_embeddings();
+    embedding_pb->set_data_type(TensorPB::BF16);
+    embedding_pb->add_shape(1);
+    embedding_pb->add_shape(3);
+
+    std::vector<c10::BFloat16> embedding_data = {1.0f, 2.0f, 3.0f};
+    embedding_pb->set_bf16_data(reinterpret_cast<const char*>(embedding_data.data()),
+                                embedding_data.size() * sizeof(c10::BFloat16));
+
+    input_embeddings_pb->add_embedding_locs(2);
+
+    auto generate_input = QueryConverter::transQuery(&input);
+
+    ASSERT_TRUE(generate_input->input_embeddings.has_value());
+    const auto& embeddings = generate_input->input_embeddings.value();
+
+    ASSERT_EQ(embeddings.size(), 1);
+    ASSERT_EQ(embeddings[0].dtype(), torch::kBFloat16);
+    ASSERT_EQ(embeddings[0].dim(), 2);
+}
+
+TEST_F(QueryConverterTest, testTransInputWithoutInputEmbeddings) {
+    GenerateInputPB input;
+    input.add_token_ids(0);
+    input.add_token_ids(1);
+
+    auto generate_input = QueryConverter::transQuery(&input);
+
+    // 验证没有 input_embeddings 时，字段为空
+    ASSERT_FALSE(generate_input->input_embeddings.has_value());
+    ASSERT_FALSE(generate_input->input_embeddings_locs.has_value());
+}
+
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
@@ -141,6 +141,21 @@ void gatherMultimodalFeaturesForContextBatch(const GenerateStreamPtr&    stream,
     memcpy(ctx.merged_text_mask + ctx.token_idx, text_token_mask.data(), text_token_mask.size() * sizeof(int));
 }
 
+void gatherInputEmbeddingsForContextBatch(const GenerateStreamPtr&       stream,
+                                          const GatherModelInputContext& ctx,
+                                          std::vector<torch::Tensor>&    gathered_input_embeddings,
+                                          std::vector<int32_t>&          gathered_input_embedding_locs) {
+    if (!stream->hasInputEmbeddings()) {
+        return;
+    }
+    for (const auto& embedding : stream->inputEmbeddings()) {
+        gathered_input_embeddings.emplace_back(embedding.clone());
+    }
+    for (int32_t loc : stream->inputEmbeddingsLocs()) {
+        gathered_input_embedding_locs.push_back(loc - stream->reuseLength() + ctx.token_idx);
+    }
+}
+
 void addCacheUpdateCopy(GatherModelInputContext& ctx, const std::vector<BlockIdPair>& update_mapping) {
     if (!ctx.kv_cache_update_mapping) {
         return;
@@ -271,6 +286,8 @@ absl::Status NormalModelInputGatherer::processDecodeStreams(GptModelInputs&     
 absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&     model_input,
                                                              const StreamGroups& stream_groups) const {
     std::vector<torch::Tensor> gathered_mm_features;
+    std::vector<torch::Tensor> gathered_input_embeddings;
+    std::vector<int32_t>       gathered_input_embedding_locs;
     auto ctx = createGatherContext(config_, model_input, stream_groups, GatherContextMode::CONTEXT);
 
     for (const auto& stream : stream_groups.contextStreams()) {
@@ -309,6 +326,7 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
             ctx.lm_output_lengths[ctx.batch_idx]  = 1;
 
             gatherMultimodalFeaturesForContextBatch(stream, ctx, gathered_mm_features);
+            gatherInputEmbeddingsForContextBatch(stream, ctx, gathered_input_embeddings, gathered_input_embedding_locs);
 
             if (ctx.need_cal_position_id) {
                 auto context_pos_ids = stream->generateContextPositionIds();
@@ -342,6 +360,13 @@ absl::Status NormalModelInputGatherer::processContextStreams(GptModelInputs&    
 
     if (config_.is_multimodal && !gathered_mm_features.empty()) {
         model_input.multimodal_features = std::move(gathered_mm_features);
+    }
+    if (!gathered_input_embeddings.empty()) {
+        model_input.input_embeddings      = std::move(gathered_input_embeddings);
+        model_input.input_embeddings_locs = torch::from_blob(gathered_input_embedding_locs.data(),
+                                                             {(int64_t)gathered_input_embedding_locs.size()},
+                                                             torch::kInt32)
+                                                .clone();
     }
     return absl::OkStatus();
 }

--- a/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalModelInputGatherer.cc
@@ -149,7 +149,11 @@ void gatherInputEmbeddingsForContextBatch(const GenerateStreamPtr&       stream,
         return;
     }
     for (const auto& embedding : stream->inputEmbeddings()) {
-        gathered_input_embeddings.emplace_back(embedding.clone());
+        if (embedding.is_cuda()) {
+            gathered_input_embeddings.emplace_back(embedding);
+        } else {
+            gathered_input_embeddings.emplace_back(embedding.to(torch::kCUDA));
+        }
     }
     for (int32_t loc : stream->inputEmbeddingsLocs()) {
         gathered_input_embedding_locs.push_back(loc - stream->reuseLength() + ctx.token_idx);

--- a/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
@@ -368,7 +368,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
 
     // 创建带有 input_embeddings 的 stream 1
     std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
-    query1->input_ids                     = createBuffer<int32_t>({5}, {1, 2, 3, 4, 5}, AllocationType::HOST);
+    query1->input_ids                     = hostIntBuffer({1, 2, 3, 4, 5});
     query1->generate_config               = make_shared<GenerateConfig>();
     query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat32), torch::rand({2, 10}, torch::kFloat32)};
     query1->input_embeddings_locs = {1, 3};
@@ -378,7 +378,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
 
     // 创建带有 input_embeddings 的 stream 2
     std::shared_ptr<GenerateInput> query2 = make_shared<GenerateInput>();
-    query2->input_ids                     = createBuffer<int32_t>({3}, {6, 7, 8}, AllocationType::HOST);
+    query2->input_ids                     = hostIntBuffer({6, 7, 8});
     query2->generate_config               = make_shared<GenerateConfig>();
     query2->input_embeddings              = {torch::rand({1, 10}, torch::kFloat32)};
     query2->input_embeddings_locs         = {0};
@@ -388,7 +388,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
 
     // 创建没有 input_embeddings 的 stream 3
     std::shared_ptr<GenerateInput> query3 = make_shared<GenerateInput>();
-    query3->input_ids                     = createBuffer<int32_t>({4}, {9, 10, 11, 12}, AllocationType::HOST);
+    query3->input_ids                     = hostIntBuffer({9, 10, 11, 12});
     query3->generate_config               = make_shared<GenerateConfig>();
     GenerateStreamPtr stream3 =
         make_shared<NormalGenerateStream>(query3, model_config, runtime_config, resource_context, nullptr);
@@ -400,7 +400,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
     streams.emplace_back(stream3);
 
     for (const auto& stream : streams) {
-        stream->setRunning();
+        stream->generate_status_->status = StreamState::RUNNING;
     }
 
     StreamGroups stream_groups(streams);
@@ -420,15 +420,16 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
     EXPECT_EQ(embeddings.size(), 3);
 
     // 验证每个 embedding 的大小
-    EXPECT_EQ(embeddings[0]->size(), 2 * 10);  // stream1 的第一个 embedding
-    EXPECT_EQ(embeddings[1]->size(), 2 * 10);  // stream1 的第二个 embedding
-    EXPECT_EQ(embeddings[2]->size(), 1 * 10);  // stream2 的 embedding
+    EXPECT_EQ(embeddings[0].numel(), 2 * 10);  // stream1 的第一个 embedding
+    EXPECT_EQ(embeddings[1].numel(), 2 * 10);  // stream1 的第二个 embedding
+    EXPECT_EQ(embeddings[2].numel(), 1 * 10);  // stream2 的 embedding
 
     // 验证位置信息
     // stream1: 原始位置 [1, 3]，reuseLength=0，token_idx=0 -> 调整后 [1, 3]
     // stream2: 原始位置 [0]，reuseLength=0，token_idx=5 -> 调整后 [5]
     // stream3: 无 input_embeddings
-    auto locs_vec = buffer2vector<int>(*locs);
+    auto*                locs_ptr = locs.data_ptr<int32_t>();
+    std::vector<int32_t> locs_vec(locs_ptr, locs_ptr + locs.numel());
     EXPECT_EQ(locs_vec.size(), 3);
     EXPECT_EQ(locs_vec[0], 1);
     EXPECT_EQ(locs_vec[1], 3);
@@ -451,7 +452,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsWithReuseLength) {
 
     // 创建带有 reuseLength 的 stream
     std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
-    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->input_ids                     = hostIntBuffer({1, 2, 3});
     query1->generate_config               = make_shared<GenerateConfig>();
     query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat32), torch::rand({2, 10}, torch::kFloat32)};
     query1->input_embeddings_locs = {1, 2};
@@ -461,7 +462,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsWithReuseLength) {
     stream1->setReuseLength(1);  // 设置 reuseLength
     std::list<GenerateStreamPtr> streams;
     streams.emplace_back(stream1);
-    stream1->setRunning();
+    stream1->generate_status_->status = StreamState::RUNNING;
     StreamGroups stream_groups(streams);
     auto         merge_input_status = processor.gatherModelInput(stream_groups);
     EXPECT_TRUE(merge_input_status.ok());
@@ -471,13 +472,14 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsWithReuseLength) {
     const auto& locs       = model_input.input_embeddings_locs;
     EXPECT_EQ(embeddings.size(), 2);
     // 验证位置调整：原始位置 [1, 2] - reuseLength(1) + token_idx(0) = [0, 1]
-    auto locs_vec = buffer2vector<int>(*locs);
+    auto*                locs_ptr = locs.data_ptr<int32_t>();
+    std::vector<int32_t> locs_vec(locs_ptr, locs_ptr + locs.numel());
     EXPECT_EQ(locs_vec.size(), 2);
     EXPECT_EQ(locs_vec[0], 0);
     EXPECT_EQ(locs_vec[1], 1);
 }
 
-TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams) {
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsReuseLengthCapped) {
     ResourceContext resource_context;
     ModelConfig     model_config;
     model_config.max_seq_len                = 2048;
@@ -491,20 +493,68 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams
     NormalBatchStreamProcessor  processor(
         model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
 
+    // reuseLength=5 但 embedding loc 最小为 2，应被 cap 到 2
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = hostIntBuffer({1, 2, 3, 4, 5, 6, 7, 8});
+    query1->generate_config               = make_shared<GenerateConfig>();
+    query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat32), torch::rand({2, 10}, torch::kFloat32)};
+    query1->input_embeddings_locs = {2, 6};
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(true);
+    stream1->setReuseLength(5);
+
+    // reuseLength 应被 cap 到 min(loc) = 2
+    EXPECT_EQ(stream1->reuseLength(), 2);
+
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+    stream1->generate_status_->status = StreamState::RUNNING;
+    StreamGroups stream_groups(streams);
+    auto         merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+    auto& model_input = merge_input_status.value();
+    EXPECT_TRUE(model_input.input_embeddings.has_value());
+    const auto& locs = model_input.input_embeddings_locs;
+    // 调整后位置：[2 - 2 + 0, 6 - 2 + 0] = [0, 4]
+    auto*                locs_ptr = locs.data_ptr<int32_t>();
+    std::vector<int32_t> locs_vec(locs_ptr, locs_ptr + locs.numel());
+    EXPECT_EQ(locs_vec.size(), 2);
+    EXPECT_EQ(locs_vec[0], 0);
+    EXPECT_EQ(locs_vec[1], 4);
+}
+
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    cache_config.group_types = {CacheGroupType::FULL};
+    RuntimeConfig              runtime_config;
+    NormalBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
     // 创建 decode stream
     std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
-    query1->input_ids                     = createBuffer<int32_t>({1}, {1}, AllocationType::HOST);
+    query1->input_ids                     = hostIntBuffer({1});
     query1->generate_config               = make_shared<GenerateConfig>();
     GenerateStreamPtr stream1 =
         make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
     stream1->setIsContextStream(false);
     BatchKVCacheResource addr1;
-    addr1.batch_block_id = {{1, 2, 3, 4}};
+    addr1.resetBatchSize(1);
+    addr1.initGroups(1, 3, {0, 0, 0});
+    addr1.setBatchBlocks(0, 0, {1, 2, 3, 4});
     stream1->setKVCache(addr1);
 
     // 创建带有 input_embeddings 的 context stream
     std::shared_ptr<GenerateInput> query2 = make_shared<GenerateInput>();
-    query2->input_ids                     = createBuffer<int32_t>({3}, {2, 3, 4}, AllocationType::HOST);
+    query2->input_ids                     = hostIntBuffer({2, 3, 4});
     query2->generate_config               = make_shared<GenerateConfig>();
     query2->input_embeddings              = {torch::rand({1, 10}, torch::kFloat32)};
     query2->input_embeddings_locs         = {1};
@@ -517,7 +567,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams
     streams.emplace_back(stream2);
 
     for (const auto& stream : streams) {
-        stream->setRunning();
+        stream->generate_status_->status = StreamState::RUNNING;
     }
 
     StreamGroups stream_groups(streams);
@@ -535,7 +585,8 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams
 
     // 验证位置调整：原始位置 [1] - reuseLength(0) + token_idx(1) = [2]
     // token_idx = 1 因为前面有一个 decode stream
-    auto locs_vec = buffer2vector<int>(*locs);
+    auto*                locs_ptr = locs.data_ptr<int32_t>();
+    std::vector<int32_t> locs_vec(locs_ptr, locs_ptr + locs.numel());
     EXPECT_EQ(locs_vec.size(), 1);
     EXPECT_EQ(locs_vec[0], 2);
 }
@@ -556,7 +607,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsFP16) {
 
     // 创建 FP16 类型的 input_embeddings
     std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
-    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->input_ids                     = hostIntBuffer({1, 2, 3});
     query1->generate_config               = make_shared<GenerateConfig>();
     query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat16), torch::rand({2, 10}, torch::kFloat16)};
     query1->input_embeddings_locs = {0, 1};
@@ -567,7 +618,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsFP16) {
     std::list<GenerateStreamPtr> streams;
     streams.emplace_back(stream1);
 
-    stream1->setRunning();
+    stream1->generate_status_->status = StreamState::RUNNING;
 
     StreamGroups stream_groups(streams);
 
@@ -580,8 +631,8 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsFP16) {
     const auto& embeddings = model_input.input_embeddings.value();
 
     EXPECT_EQ(embeddings.size(), 2);
-    EXPECT_EQ(embeddings[0]->size(), 2 * 10);
-    EXPECT_EQ(embeddings[1]->size(), 2 * 10);
+    EXPECT_EQ(embeddings[0].numel(), 2 * 10);
+    EXPECT_EQ(embeddings[1].numel(), 2 * 10);
 }
 
 TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsEmpty) {
@@ -600,7 +651,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsEmpty) {
 
     // 创建没有 input_embeddings 的 stream
     std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
-    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->input_ids                     = hostIntBuffer({1, 2, 3});
     query1->generate_config               = make_shared<GenerateConfig>();
     GenerateStreamPtr stream1 =
         make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
@@ -608,7 +659,7 @@ TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsEmpty) {
 
     std::list<GenerateStreamPtr> streams;
     streams.emplace_back(stream1);
-    stream1->setRunning();
+    stream1->generate_status_->status = StreamState::RUNNING;
     StreamGroups stream_groups(streams);
     auto         merge_input_status = processor.gatherModelInput(stream_groups);
     EXPECT_TRUE(merge_input_status.ok());

--- a/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
@@ -352,4 +352,269 @@ TEST_F(NormalBatchStreamProcessorTest, testMultimodalGatherBatch) {
     }
 }
 
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsGatherBatch) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    RuntimeConfig               runtime_config;
+    NormalBatchStreamProcessor  processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    // 创建带有 input_embeddings 的 stream 1
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = createBuffer<int32_t>({5}, {1, 2, 3, 4, 5}, AllocationType::HOST);
+    query1->generate_config               = make_shared<GenerateConfig>();
+    query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat32), torch::rand({2, 10}, torch::kFloat32)};
+    query1->input_embeddings_locs = {1, 3};
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(true);
+
+    // 创建带有 input_embeddings 的 stream 2
+    std::shared_ptr<GenerateInput> query2 = make_shared<GenerateInput>();
+    query2->input_ids                     = createBuffer<int32_t>({3}, {6, 7, 8}, AllocationType::HOST);
+    query2->generate_config               = make_shared<GenerateConfig>();
+    query2->input_embeddings              = {torch::rand({1, 10}, torch::kFloat32)};
+    query2->input_embeddings_locs         = {0};
+    GenerateStreamPtr stream2 =
+        make_shared<NormalGenerateStream>(query2, model_config, runtime_config, resource_context, nullptr);
+    stream2->setIsContextStream(true);
+
+    // 创建没有 input_embeddings 的 stream 3
+    std::shared_ptr<GenerateInput> query3 = make_shared<GenerateInput>();
+    query3->input_ids                     = createBuffer<int32_t>({4}, {9, 10, 11, 12}, AllocationType::HOST);
+    query3->generate_config               = make_shared<GenerateConfig>();
+    GenerateStreamPtr stream3 =
+        make_shared<NormalGenerateStream>(query3, model_config, runtime_config, resource_context, nullptr);
+    stream3->setIsContextStream(true);
+
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+    streams.emplace_back(stream2);
+    streams.emplace_back(stream3);
+
+    for (const auto& stream : streams) {
+        stream->setRunning();
+    }
+
+    StreamGroups stream_groups(streams);
+
+    auto merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+
+    auto& model_input = merge_input_status.value();
+
+    // 验证 input_embeddings 被正确收集
+    EXPECT_TRUE(model_input.input_embeddings.has_value());
+
+    const auto& embeddings = model_input.input_embeddings.value();
+    const auto& locs       = model_input.input_embeddings_locs;
+
+    // 应该有 3 个 embeddings (stream1 有 2 个，stream2 有 1 个，stream3 有 0 个)
+    EXPECT_EQ(embeddings.size(), 3);
+
+    // 验证每个 embedding 的大小
+    EXPECT_EQ(embeddings[0]->size(), 2 * 10);  // stream1 的第一个 embedding
+    EXPECT_EQ(embeddings[1]->size(), 2 * 10);  // stream1 的第二个 embedding
+    EXPECT_EQ(embeddings[2]->size(), 1 * 10);  // stream2 的 embedding
+
+    // 验证位置信息
+    // stream1: 原始位置 [1, 3]，reuseLength=0，token_idx=0 -> 调整后 [1, 3]
+    // stream2: 原始位置 [0]，reuseLength=0，token_idx=5 -> 调整后 [5]
+    // stream3: 无 input_embeddings
+    auto locs_vec = buffer2vector<int>(*locs);
+    EXPECT_EQ(locs_vec.size(), 3);
+    EXPECT_EQ(locs_vec[0], 1);
+    EXPECT_EQ(locs_vec[1], 3);
+    EXPECT_EQ(locs_vec[2], 5);
+}
+
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsWithReuseLength) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    RuntimeConfig               runtime_config;
+    NormalBatchStreamProcessor  processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    // 创建带有 reuseLength 的 stream
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->generate_config               = make_shared<GenerateConfig>();
+    query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat32), torch::rand({2, 10}, torch::kFloat32)};
+    query1->input_embeddings_locs = {1, 2};
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(true);
+    stream1->setReuseLength(1);  // 设置 reuseLength
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+    stream1->setRunning();
+    StreamGroups stream_groups(streams);
+    auto         merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+    auto& model_input = merge_input_status.value();
+    EXPECT_TRUE(model_input.input_embeddings.has_value());
+    const auto& embeddings = model_input.input_embeddings.value();
+    const auto& locs       = model_input.input_embeddings_locs;
+    EXPECT_EQ(embeddings.size(), 2);
+    // 验证位置调整：原始位置 [1, 2] - reuseLength(1) + token_idx(0) = [0, 1]
+    auto locs_vec = buffer2vector<int>(*locs);
+    EXPECT_EQ(locs_vec.size(), 2);
+    EXPECT_EQ(locs_vec[0], 0);
+    EXPECT_EQ(locs_vec[1], 1);
+}
+
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsMixedWithDecodeStreams) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    RuntimeConfig               runtime_config;
+    NormalBatchStreamProcessor  processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    // 创建 decode stream
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = createBuffer<int32_t>({1}, {1}, AllocationType::HOST);
+    query1->generate_config               = make_shared<GenerateConfig>();
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(false);
+    BatchKVCacheResource addr1;
+    addr1.batch_block_id = {{1, 2, 3, 4}};
+    stream1->setKVCache(addr1);
+
+    // 创建带有 input_embeddings 的 context stream
+    std::shared_ptr<GenerateInput> query2 = make_shared<GenerateInput>();
+    query2->input_ids                     = createBuffer<int32_t>({3}, {2, 3, 4}, AllocationType::HOST);
+    query2->generate_config               = make_shared<GenerateConfig>();
+    query2->input_embeddings              = {torch::rand({1, 10}, torch::kFloat32)};
+    query2->input_embeddings_locs         = {1};
+    GenerateStreamPtr stream2 =
+        make_shared<NormalGenerateStream>(query2, model_config, runtime_config, resource_context, nullptr);
+    stream2->setIsContextStream(true);
+
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+    streams.emplace_back(stream2);
+
+    for (const auto& stream : streams) {
+        stream->setRunning();
+    }
+
+    StreamGroups stream_groups(streams);
+
+    auto merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+
+    auto& model_input = merge_input_status.value();
+
+    EXPECT_TRUE(model_input.input_embeddings.has_value());
+    const auto& embeddings = model_input.input_embeddings.value();
+    const auto& locs       = model_input.input_embeddings_locs;
+
+    EXPECT_EQ(embeddings.size(), 1);
+
+    // 验证位置调整：原始位置 [1] - reuseLength(0) + token_idx(1) = [2]
+    // token_idx = 1 因为前面有一个 decode stream
+    auto locs_vec = buffer2vector<int>(*locs);
+    EXPECT_EQ(locs_vec.size(), 1);
+    EXPECT_EQ(locs_vec[0], 2);
+}
+
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsFP16) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    RuntimeConfig               runtime_config;
+    NormalBatchStreamProcessor  processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    // 创建 FP16 类型的 input_embeddings
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->generate_config               = make_shared<GenerateConfig>();
+    query1->input_embeddings      = {torch::rand({2, 10}, torch::kFloat16), torch::rand({2, 10}, torch::kFloat16)};
+    query1->input_embeddings_locs = {0, 1};
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(true);
+
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+
+    stream1->setRunning();
+
+    StreamGroups stream_groups(streams);
+
+    auto merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+
+    auto& model_input = merge_input_status.value();
+
+    EXPECT_TRUE(model_input.input_embeddings.has_value());
+    const auto& embeddings = model_input.input_embeddings.value();
+
+    EXPECT_EQ(embeddings.size(), 2);
+    EXPECT_EQ(embeddings[0]->size(), 2 * 10);
+    EXPECT_EQ(embeddings[1]->size(), 2 * 10);
+}
+
+TEST_F(NormalBatchStreamProcessorTest, testInputEmbeddingsEmpty) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len                = 2048;
+    model_config.vocab_size                 = 2048;
+    model_config.num_layers                 = 2;
+    model_config.attn_config.kv_cache_dtype = KvCacheDataType::INT8;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    RuntimeConfig               runtime_config;
+    NormalBatchStreamProcessor  processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    // 创建没有 input_embeddings 的 stream
+    std::shared_ptr<GenerateInput> query1 = make_shared<GenerateInput>();
+    query1->input_ids                     = createBuffer<int32_t>({3}, {1, 2, 3}, AllocationType::HOST);
+    query1->generate_config               = make_shared<GenerateConfig>();
+    GenerateStreamPtr stream1 =
+        make_shared<NormalGenerateStream>(query1, model_config, runtime_config, resource_context, nullptr);
+    stream1->setIsContextStream(true);
+
+    std::list<GenerateStreamPtr> streams;
+    streams.emplace_back(stream1);
+    stream1->setRunning();
+    StreamGroups stream_groups(streams);
+    auto         merge_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(merge_input_status.ok());
+    auto& model_input = merge_input_status.value();
+    // 验证没有 input_embeddings 时，字段为空
+    EXPECT_FALSE(model_input.input_embeddings.has_value());
+}
+
 }  // namespace rtp_llm

--- a/rtp_llm/utils/base_model_datatypes.py
+++ b/rtp_llm/utils/base_model_datatypes.py
@@ -6,6 +6,7 @@ import torch
 from rtp_llm.config.generate_config import GenerateConfig, RoleAddr
 from rtp_llm.utils.multimodal_util import MultimodalInput
 
+
 class EmbeddingOutput:
     text_embedding: torch.Tensor
     extra_input: Optional[torch.Tensor]
@@ -24,6 +25,16 @@ class EmbeddingOutput:
             self.extra_input = None
 
 
+class InputEmbeddings:
+    def __init__(
+        self,
+        embeddings: List[torch.Tensor],
+        embedding_locs: List[int],
+    ):
+        self.embeddings = embeddings
+        self.embedding_locs = embedding_locs
+
+
 # single batch prompt input
 @dataclass
 class GenerateInput:
@@ -35,7 +46,10 @@ class GenerateInput:
     prefix_length: int = 0
     token_type_ids: List[int] = field(default_factory=list)
     batch_group_size: int = 1
-    batch_group_id: int = -1  # Batch group ID for force batch grouping, -1 means not set
+    batch_group_id: int = (
+        -1
+    )  # Batch group ID for force batch grouping, -1 means not set
+    input_embeddings: InputEmbeddings | None = None
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
- 支持 generate input 携带 input_embeddings，允许用户传入额外的 embedding 向量替换指定位置的 token embedding
- 完整数据通路：Proto 定义 → RPC 序列化/反序列化 → GenerateStream 访问器 → NormalModelInputGatherer 收集
- 在 setReuseLength 中增加保护，将 reuseLength cap 到 min(embedding_locs)，防止 gather 时产生负索引