### PR TITLE
feat: add DeepGEMM JIT kernel warmup integrated into C++ engine startup

### DIFF
--- a/rtp_llm/config/model_args.py
+++ b/rtp_llm/config/model_args.py
@@ -29,6 +29,7 @@ class ModelArgs:
         "json_model_override_args",
         "phy2log_path",
         "enable_fp32_lm_head",
+        "deepgemm_warmup_mode",
     ]
 
     def __init__(self):
@@ -61,3 +62,6 @@ class ModelArgs:
 
         # LM head precision
         self.enable_fp32_lm_head: Optional[bool] = None
+
+        # DeepGEMM warmup mode: "skip" (default), "relax", or "full"
+        self.deepgemm_warmup_mode: str = "skip"

--- a/rtp_llm/config/model_args.py
+++ b/rtp_llm/config/model_args.py
@@ -63,5 +63,5 @@ class ModelArgs:
         # LM head precision
         self.enable_fp32_lm_head: Optional[bool] = None
 
-        # DeepGEMM warmup mode: "skip" (default), "relax", or "full"
-        self.deepgemm_warmup_mode: str = "skip"
+        # DeepGEMM warmup mode: "relax" (default), "skip", or "full"
+        self.deepgemm_warmup_mode: str = "relax"

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -85,6 +85,7 @@ class ModelConfig(CppModelConfig):
         "phy2log_path",
         "lora_infos",
         "headwise_config",
+        "deepgemm_warmup_mode",
     }
 
     # Known C++ ModelConfig members (from ModelConfig.h)
@@ -523,6 +524,7 @@ class ModelConfig(CppModelConfig):
         self.render_config: Optional[Any] = None  # RenderConfig for renderer factory
         self.mm_related_params = VitParameters()
         self.quant_config = None
+        self.deepgemm_warmup_mode: str = "skip"  # "skip", "relax", or "full"
 
     def apply_override_args(self, json_model_override_args: str) -> None:
         """Apply model override arguments to ModelConfig.
@@ -863,6 +865,9 @@ def build_model_config(
 
     if model_args.enable_fp32_lm_head is not None:
         model_config.enable_fp32_lm_head = model_args.enable_fp32_lm_head
+
+    # DeepGEMM warmup mode
+    model_config.deepgemm_warmup_mode = model_args.deepgemm_warmup_mode
 
     # Apply model override args
     if model_args.json_model_override_args:

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -524,7 +524,7 @@ class ModelConfig(CppModelConfig):
         self.render_config: Optional[Any] = None  # RenderConfig for renderer factory
         self.mm_related_params = VitParameters()
         self.quant_config = None
-        self.deepgemm_warmup_mode: str = "skip"  # "skip", "relax", or "full"
+        self.deepgemm_warmup_mode: str = "relax"  # "skip", "relax", or "full"
 
     def apply_override_args(self, json_model_override_args: str) -> None:
         """Apply model override arguments to ModelConfig.

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -74,6 +74,19 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
 
     std::optional<WarmUpResult> warm_up_result = std::nullopt;
 #if USING_CUDA
+    // Independent of warm_up flag
+    if (!params.py_model.is_none() && !model_config_.mm_model_config.is_multimodal
+        && !ffn_disaggregate_config.enable_ffn_disaggregate) {
+        py::gil_scoped_acquire gil;
+        if (py::hasattr(params.py_model, "kernel_warmup")) {
+            try {
+                params.py_model.attr("kernel_warmup")();
+            } catch (const py::error_already_set& e) {
+                RTP_LLM_LOG_WARNING("Kernel warmup failed (non-fatal): %s", e.what());
+            }
+        }
+    }
+
     if (runtime_config.warm_up && (!model_config_.mm_model_config.is_multimodal)
         && !ffn_disaggregate_config.enable_ffn_disaggregate) {
         // warm up

--- a/rtp_llm/models_py/kernels/cuda/deepgemm_warmup.py
+++ b/rtp_llm/models_py/kernels/cuda/deepgemm_warmup.py
@@ -1,0 +1,360 @@
+import logging
+import os
+import time
+import torch
+
+logger = logging.getLogger(__name__)
+
+_FP8_GEMM_NT_WARMED: set[tuple[int, int]] = set()  # (N, K)
+_GROUPED_GEMM_WARMED: set[tuple[int, int, int]] = set()  # (E, N, K)
+
+
+def reset_warmed_caches() -> None:
+    """Clear warmup dedup caches (for model reload or tests)."""
+    _FP8_GEMM_NT_WARMED.clear()
+    _GROUPED_GEMM_WARMED.clear()
+
+
+BLOCK_M = 128
+
+def _get_local_rank_info() -> tuple[int, int]:
+    """Return (local_rank, local_world_size) from env vars.
+
+    Same-node ranks share DG_JIT_CACHE_DIR, so we split M values by
+    local_rank and let the shared file cache avoid redundant compilations.
+    """
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
+    return local_rank, local_world_size
+
+
+def _split_m_values(
+    m_values: list[int], local_rank: int, local_world_size: int
+) -> list[int]:
+    """Interleaved split: rank i gets m_values[i::world_size]."""
+    if local_world_size <= 1:
+        return m_values
+    return m_values[local_rank::local_world_size]
+
+
+# ---------------------------------------------------------------------------
+# M-value generation
+# ---------------------------------------------------------------------------
+def _generate_m_values(max_tokens: int, mode: str, n: int) -> list[int]:
+    """Generate M values that cover all possible DeepGEMM kernel configurations.
+
+    Reference: https://github.com/deepseek-ai/DeepGEMM/blob/79f48ee/csrc/jit_kernels/heuristics/common.hpp
+    """
+    if mode == "full":
+        return list(range(1, max_tokens + 1))
+
+    block_ms = [64, 128, 256]
+    block_ns = list(range(16, min(257, n + 1), 16))
+    try:
+        num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+    except Exception:
+        num_sms = 132  # H20 default
+
+    m_values: set[int] = set()
+
+    # Always include small cases 
+    m_values.update([1, 2, 4] + list(range(8, min(65, max_tokens + 1), 8)))
+
+    for block_m in block_ms:
+        for block_n in block_ns:
+            if block_n > n:
+                continue
+            # Add M boundaries for wave transitions
+            n_blocks = -(-n // block_n)  # cdiv(n, block_n)
+            for wave in range(1, 11):
+                target_blocks = wave * num_sms
+                m = target_blocks * block_m // n_blocks
+                if 1 <= m <= max_tokens:
+                    m_values.add(m)
+
+            # Add block_m multiples
+            for multiple in range(1, max_tokens // block_m + 1):
+                m = multiple * block_m
+                if m <= max_tokens:
+                    m_values.add(m)
+
+    return sorted(m_values)
+
+
+def _generate_grouped_m_values(
+    max_m_per_expert: int, block_m: int = BLOCK_M
+) -> list[int]:
+    values = list(range(block_m, max_m_per_expert + 1, block_m))
+    return values or [block_m]
+
+
+# ---------------------------------------------------------------------------
+# Multi-rank warmup helper
+# ---------------------------------------------------------------------------
+def _rank_warmup(
+    func,
+    all_values: list[int],
+    my_values: list[int],
+    local_world_size: int,
+):
+    """Phase 1: compile this rank's slice; Phase 2: load the rest from cache."""
+    # Phase 1: each rank compiles its own slice (JIT compile → shared cache)
+    for v in my_values:
+        func(v)
+    # Barrier: wait for all ranks to finish Phase 1
+    if local_world_size > 1 and torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    # Phase 2: load remaining kernels (all cache hits after barrier)
+    if local_world_size > 1:
+        remaining = [v for v in all_values if v not in set(my_values)]
+        for v in remaining:
+            func(v)
+
+
+# ---------------------------------------------------------------------------
+# Scan FP8 linear shapes from LinearBase
+# ---------------------------------------------------------------------------
+def _find_fp8_linear_weights(
+    model: torch.nn.Module,
+) -> dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]]:
+    from rtp_llm.models_py.modules.factory.linear import LinearBase
+
+    shape_to_tensors: dict[tuple[int, int], tuple[torch.Tensor, torch.Tensor]] = {}
+    for m in model.modules():
+        if not isinstance(m, LinearBase):
+            continue
+        w = getattr(m, "weight", None)
+        ws = getattr(m, "weight_scales", None)
+        if w is None or w.dtype != torch.float8_e4m3fn or w.dim() != 2:
+            continue
+        key = (w.shape[0], w.shape[1])  # (N, K)
+        if key not in shape_to_tensors:
+            shape_to_tensors[key] = (w, ws)
+    return shape_to_tensors
+
+
+# ---------------------------------------------------------------------------
+# Dense FP8 Linear warmup
+# ---------------------------------------------------------------------------
+def _warmup_fp8_linear(
+    model: torch.nn.Module,
+    max_tokens: int,
+    mode: str,
+    local_rank: int,
+    local_world_size: int,
+):
+    from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import fp8_gemm_nt
+
+    shape_to_tensors = _find_fp8_linear_weights(model)
+    if not shape_to_tensors:
+        return
+
+    for (N, K), (w, ws) in shape_to_tensors.items():
+        if (N, K) in _FP8_GEMM_NT_WARMED:
+            continue
+
+        all_m_values = [
+            m for m in _generate_m_values(max_tokens, mode, n=N) if m <= max_tokens
+        ]
+        my_m_values = _split_m_values(all_m_values, local_rank, local_world_size)
+
+        device = w.device
+        dummy_a = torch.empty(max_tokens, K, device=device, dtype=torch.float8_e4m3fn)
+        dummy_a_scales = torch.empty(
+            max_tokens, K // BLOCK_M, device=device, dtype=torch.float32
+        )
+        dummy_out = torch.empty(max_tokens, N, device=device, dtype=torch.bfloat16)
+
+        def _warmup_one_m(num_tokens, _a=dummy_a, _as=dummy_a_scales,
+                          _w=w, _ws=ws, _out=dummy_out):
+            fp8_gemm_nt(
+                (_a[:num_tokens], _as[:num_tokens]),
+                (_w, _ws),
+                _out[:num_tokens],
+            )
+
+        _rank_warmup(_warmup_one_m, all_m_values, my_m_values, local_world_size)
+        _FP8_GEMM_NT_WARMED.add((N, K))
+
+
+# ---------------------------------------------------------------------------
+# Scan MoE weights from FusedMoe modules
+# ---------------------------------------------------------------------------
+def _make_dummy_scale(
+    shape_prefix: tuple[int, ...], inner_dim: int, use_e8m0: bool, device: torch.device
+) -> torch.Tensor:
+    """Create dummy input scale tensor for grouped GEMM warmup.
+
+    For e8m0: column-major packed layout via transpose, matching
+    create_packed_scale_tensor / deep_gemm expected format.
+    """
+    groups = inner_dim // BLOCK_M
+    if use_e8m0:
+        packed = (groups + 3) // 4
+        storage = torch.ones(
+            (*shape_prefix[:-1], packed, shape_prefix[-1]),
+            dtype=torch.int32,
+            device=device,
+        )
+        storage.fill_(0x7F7F7F7F)
+        return storage.transpose(-2, -1)
+    else:
+        return torch.ones(
+            (*shape_prefix, groups),
+            dtype=torch.float32,
+            device=device,
+        )
+
+
+def _find_moe_weights(
+    model: torch.nn.Module,
+) -> dict[tuple[int, int, int], tuple]:
+    """Scan FusedMoe modules, return unique (E, N, K) with weight tensors.
+
+    FusedMoe is an nn.Module so model.modules() finds it directly.
+    We access its .fused_experts attribute to extract DeepGEMM executor weights.
+
+    Returns dict of (E, N, K) -> (w1, w1_scale, w2, w2_scale, needs_contiguous, top_k).
+    """
+    from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import FusedMoe
+    from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_hybrid_executor import (
+        DeepGemmHybridExecutor,
+    )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_masked_executor import (
+        DeepGemmMaskedExecutor,
+    )
+
+    result: dict[tuple[int, int, int], tuple] = {}
+    for m in model.modules():
+        if not isinstance(m, FusedMoe):
+            continue
+        ex = m.fused_experts
+        # DeepGemmMaskedExecutor: uses _w1/_w2/_E/_N/_K naming
+        if isinstance(ex, DeepGemmMaskedExecutor):
+            if not ex._use_fp8:
+                continue
+            key = (ex._E, ex._N, ex._K)
+            if key in result:
+                continue
+            needs_contiguous = ex.executor_type() == ExecutorType.DEEPGEMM_CONTINUOUS
+            top_k = getattr(ex, "top_k", None)
+            if top_k is None:
+                top_k = getattr(getattr(ex, "config", None), "moe_k", 1)
+            result[key] = (ex._w1, ex._w1_scale, ex._w2, ex._w2_scale, needs_contiguous, top_k)
+        # DeepGemmHybridExecutor (and V2 which inherits it): uses w13_weight/w2_weight/E/N/K
+        # V2.executor_type() returns DEEPGEMM_MASKED so needs_contiguous=False, correct.
+        elif isinstance(ex, DeepGemmHybridExecutor):
+            key = (ex.E, ex.N, ex.K)
+            if key in result:
+                continue
+            needs_contiguous = ex.executor_type() == ExecutorType.DEEPGEMM_CONTINUOUS
+            top_k = getattr(ex, "top_k", None)
+            if top_k is None:
+                top_k = getattr(getattr(ex, "config", None), "moe_k", 1)
+            result[key] = (
+                ex.w13_weight, ex.w13_weight_scale_inv,
+                ex.w2_weight, ex.w2_weight_scale_inv,
+                needs_contiguous, top_k,
+            )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# MoE grouped GEMM warmup
+# ---------------------------------------------------------------------------
+def _warmup_moe_grouped_gemm(
+    model: torch.nn.Module,
+    max_tokens: int,
+    mode: str,
+    local_rank: int,
+    local_world_size: int,
+):
+    from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
+        is_deep_gemm_e8m0_used,
+        m_grouped_fp8_gemm_nt_contiguous,
+        m_grouped_fp8_gemm_nt_masked,
+    )
+
+    shape_to_info = _find_moe_weights(model)
+    if not shape_to_info:
+        return
+
+    use_e8m0 = is_deep_gemm_e8m0_used()
+    disable_ue8m0_cast = not use_e8m0
+
+    for (E, N, K), (w1, w1s, w2, w2s, needs_contiguous, top_k) in shape_to_info.items():
+        if (E, N, K) in _GROUPED_GEMM_WARMED:
+            continue
+
+        device = w1.device
+        weight_pairs = [(w1, w1s, K, N), (w2, w2s, N // 2, K)]
+
+        # --- Masked warmup ---
+        max_m_per_expert = min((max_tokens + E - 1) // E, max_tokens)
+        max_m_aligned = (
+            (max_m_per_expert + BLOCK_M - 1) // BLOCK_M
+        ) * BLOCK_M or BLOCK_M
+        masked_m_values = _generate_grouped_m_values(max_m_aligned, BLOCK_M)
+
+        def _warmup_masked(expected_m, _wp=weight_pairs, _E=E, _dev=device):
+            masked_m = torch.full((_E,), expected_m, dtype=torch.int32, device=_dev)
+            for w, ws, in_dim, out_dim in _wp:
+                x = torch.empty(_E, expected_m, in_dim, dtype=torch.float8_e4m3fn, device=_dev)
+                x_scale = _make_dummy_scale((_E, expected_m), in_dim, use_e8m0, _dev)
+                out = torch.empty(_E, expected_m, out_dim, dtype=torch.bfloat16, device=_dev)
+                m_grouped_fp8_gemm_nt_masked(
+                    (x, x_scale), (w, ws), out, masked_m, expected_m,
+                    disable_ue8m0_cast=disable_ue8m0_cast,
+                )
+                del x, x_scale, out
+
+        my_masked = _split_m_values(masked_m_values, local_rank, local_world_size)
+        _rank_warmup(_warmup_masked, masked_m_values, my_masked, local_world_size)
+
+        # --- Contiguous warmup (HybridExecutor only) ---
+        if needs_contiguous:
+            max_m_cont = max_tokens * top_k + E * (BLOCK_M - 1)
+            max_m_cont = ((max_m_cont + BLOCK_M - 1) // BLOCK_M) * BLOCK_M
+            cont_m_values = list(range(BLOCK_M, max_m_cont + 1, BLOCK_M))
+
+            def _warmup_contiguous(total_tokens, _wp=weight_pairs, _E=E, _dev=device):
+                m_indices = torch.arange(total_tokens, dtype=torch.int32, device=_dev) % _E
+                for w, ws, in_dim, out_dim in _wp:
+                    x = torch.empty(total_tokens, in_dim, dtype=torch.float8_e4m3fn, device=_dev)
+                    x_scale = _make_dummy_scale((total_tokens,), in_dim, use_e8m0, _dev)
+                    out = torch.empty(total_tokens, out_dim, dtype=torch.bfloat16, device=_dev)
+                    m_grouped_fp8_gemm_nt_contiguous(
+                        (x, x_scale), (w, ws), out, m_indices,
+                        disable_ue8m0_cast=disable_ue8m0_cast,
+                    )
+                    del x, x_scale, out
+
+            my_cont = _split_m_values(cont_m_values, local_rank, local_world_size)
+            _rank_warmup(_warmup_contiguous, cont_m_values, my_cont, local_world_size)
+
+        _GROUPED_GEMM_WARMED.add((E, N, K))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def deep_gemm_warmup(
+    model: torch.nn.Module,
+    max_tokens: int,
+    mode: str = "skip",
+):
+    from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
+
+    _VALID_MODES = {"skip", "relax", "full"}
+    if mode not in _VALID_MODES:
+        logger.warning(f"Unknown deepgemm_warmup_mode='{mode}', falling back to 'skip'")
+        return
+    if mode == "skip" or not has_deep_gemm() or model is None:
+        return
+
+    local_rank, local_world_size = _get_local_rank_info()
+    t0 = time.time()
+    _warmup_fp8_linear(model, max_tokens, mode, local_rank, local_world_size)
+    _warmup_moe_grouped_gemm(model, max_tokens, mode, local_rank, local_world_size)
+    logger.info(f"DeepGEMM warmup completed in {time.time() - t0:.1f}s")

--- a/rtp_llm/models_py/kernels/cuda/deepgemm_warmup.py
+++ b/rtp_llm/models_py/kernels/cuda/deepgemm_warmup.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import time
+
 import torch
 
 logger = logging.getLogger(__name__)
@@ -17,16 +17,6 @@ def reset_warmed_caches() -> None:
 
 BLOCK_M = 128
 
-def _get_local_rank_info() -> tuple[int, int]:
-    """Return (local_rank, local_world_size) from env vars.
-
-    Same-node ranks share DG_JIT_CACHE_DIR, so we split M values by
-    local_rank and let the shared file cache avoid redundant compilations.
-    """
-    local_rank = int(os.environ.get("LOCAL_RANK", 0))
-    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", 1))
-    return local_rank, local_world_size
-
 
 def _split_m_values(
     m_values: list[int], local_rank: int, local_world_size: int
@@ -41,10 +31,6 @@ def _split_m_values(
 # M-value generation
 # ---------------------------------------------------------------------------
 def _generate_m_values(max_tokens: int, mode: str, n: int) -> list[int]:
-    """Generate M values that cover all possible DeepGEMM kernel configurations.
-
-    Reference: https://github.com/deepseek-ai/DeepGEMM/blob/79f48ee/csrc/jit_kernels/heuristics/common.hpp
-    """
     if mode == "full":
         return list(range(1, max_tokens + 1))
 
@@ -97,14 +83,12 @@ def _rank_warmup(
     my_values: list[int],
     local_world_size: int,
 ):
-    """Phase 1: compile this rank's slice; Phase 2: load the rest from cache."""
     # Phase 1: each rank compiles its own slice (JIT compile → shared cache)
     for v in my_values:
         func(v)
-    # Barrier: wait for all ranks to finish Phase 1
-    if local_world_size > 1 and torch.distributed.is_initialized():
-        torch.distributed.barrier()
-    # Phase 2: load remaining kernels (all cache hits after barrier)
+    # Phase 2: run remaining values — cache hit if other ranks finished, JIT compile otherwise.
+    # No barrier needed: correctness is guaranteed (DeepGEMM JIT is idempotent),
+    # worst case is some redundant compilation on fast-finishing ranks.
     if local_world_size > 1:
         remaining = [v for v in all_values if v not in set(my_values)]
         for v in remaining:
@@ -343,6 +327,8 @@ def deep_gemm_warmup(
     model: torch.nn.Module,
     max_tokens: int,
     mode: str = "skip",
+    local_rank: int = 0,
+    local_world_size: int = 1,
 ):
     from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
 
@@ -353,7 +339,6 @@ def deep_gemm_warmup(
     if mode == "skip" or not has_deep_gemm() or model is None:
         return
 
-    local_rank, local_world_size = _get_local_rank_info()
     t0 = time.time()
     _warmup_fp8_linear(model, max_tokens, mode, local_rank, local_world_size)
     _warmup_moe_grouped_gemm(model, max_tokens, mode, local_rank, local_world_size)

--- a/rtp_llm/models_py/kernels/cuda/test/BUILD
+++ b/rtp_llm/models_py/kernels/cuda/test/BUILD
@@ -3,6 +3,14 @@ py_test_deps = [
     "//rtp_llm/models_py/standalone:py_standalone_testlib",
 ]
 
+py_test(
+    name = "test_deepgemm_warmup",
+    srcs = ["test_deepgemm_warmup.py"],
+    deps = py_test_deps,
+    tags = ["open_skip", "H20"],
+    exec_properties = {'gpu': 'H20'},
+)
+
 py_test (
     name = "per_token_group_quant_8bit_test",
     srcs = ["per_token_group_quant_8bit_test.py"],

--- a/rtp_llm/models_py/kernels/cuda/test/test_deepgemm_warmup.py
+++ b/rtp_llm/models_py/kernels/cuda/test/test_deepgemm_warmup.py
@@ -3,6 +3,7 @@
 import logging
 import multiprocessing as mp
 import os
+import socket
 import tempfile
 import time
 from unittest import SkipTest, TestCase, main
@@ -80,16 +81,21 @@ def _build_model(device):
     return model
 
 
-def _warmup_worker(rank, num_ranks, cache_dir, barrier, results):
+def _find_free_port() -> int:
+    """Find an available port to avoid conflicts in parallel CI runs."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _warmup_worker(rank, num_ranks, cache_dir, barrier, results, master_port):
     """Subprocess entry for warmup benchmark."""
     os.environ["DG_JIT_CACHE_DIR"] = cache_dir
-    os.environ["LOCAL_RANK"] = str(rank)
-    os.environ["LOCAL_WORLD_SIZE"] = str(num_ranks)
     torch.cuda.set_device(rank)
 
     if num_ranks > 1:
         os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = "29500"
+        os.environ["MASTER_PORT"] = str(master_port)
         os.environ["NCCL_DEBUG"] = "WARN"
         torch.distributed.init_process_group(
             backend="nccl", world_size=num_ranks, rank=rank,
@@ -105,7 +111,10 @@ def _warmup_worker(rank, num_ranks, cache_dir, barrier, results):
         reset_warmed_caches()
         barrier.wait()
         t0 = time.time()
-        deep_gemm_warmup(model, max_tokens=1024, mode="relax")
+        deep_gemm_warmup(
+            model, max_tokens=1024, mode="relax",
+            local_rank=rank, local_world_size=num_ranks,
+        )
         results[rank] = time.time() - t0
     finally:
         if num_ranks > 1:
@@ -117,9 +126,10 @@ def _run_warmup(num_ranks: int, cache_dir: str) -> dict[int, float]:
     ctx = mp.get_context("spawn")
     barrier = ctx.Barrier(num_ranks)
     results = ctx.Manager().dict()
+    master_port = _find_free_port()
     procs = []
     for rank in range(num_ranks):
-        p = ctx.Process(target=_warmup_worker, args=(rank, num_ranks, cache_dir, barrier, results))
+        p = ctx.Process(target=_warmup_worker, args=(rank, num_ranks, cache_dir, barrier, results, master_port))
         p.start()
         procs.append(p)
     for p in procs:

--- a/rtp_llm/models_py/kernels/cuda/test/test_deepgemm_warmup.py
+++ b/rtp_llm/models_py/kernels/cuda/test/test_deepgemm_warmup.py
@@ -1,0 +1,202 @@
+"""DeepGEMM warmup tests — JIT cache correctness + multi-rank speedup."""
+
+import logging
+import multiprocessing as mp
+import os
+import tempfile
+import time
+from unittest import SkipTest, TestCase, main
+
+import torch
+import torch.nn as nn
+
+logging.basicConfig(level="INFO", format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _collect_cache_files(directory: str) -> set[str]:
+    result = set()
+    for root, _, files in os.walk(directory):
+        for f in files:
+            result.add(os.path.join(root, f))
+    return result
+
+
+def _count_cubin_files(directory: str) -> int:
+    """Count .cubin files in directory tree — each one is a unique JIT compilation."""
+    count = 0
+    for _, _, files in os.walk(directory):
+        count += sum(1 for f in files if f.endswith(".cubin"))
+    return count
+
+
+def _wrap_in_fused_moe(executor):
+    """Wrap an executor in a FusedMoe so model.modules() can discover it."""
+    from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import FusedMoe
+
+    moe = FusedMoe.__new__(FusedMoe)
+    nn.Module.__init__(moe)
+    moe.fused_experts = executor
+    return moe
+
+
+def _build_model(device):
+    from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear import (
+        CudaFp8DeepGEMMLinear,
+    )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_hybrid_executor import (
+        DeepGemmHybridExecutor,
+    )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_masked_executor import (
+        DeepGemmMaskedExecutor,
+    )
+
+    E, N, K = 4, 256, 512
+
+    # Dense FP8 linear
+    w = torch.randn(K, N, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    ws = torch.ones((K + 127) // 128, (N + 127) // 128, dtype=torch.float32, device=device)
+    linear = CudaFp8DeepGEMMLinear(weight=w, weight_scales=ws)
+
+    # MoE masked executor (wrapped in FusedMoe for discovery)
+    masked = DeepGemmMaskedExecutor.__new__(DeepGemmMaskedExecutor)
+    masked._E, masked._N, masked._K, masked._use_fp8, masked.top_k = E, N, K, True, 1
+    masked._w1 = torch.randn(E, N, K, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    masked._w2 = torch.randn(E, K, N // 2, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    masked._w1_scale = torch.ones(E, N // 128, K // 128, dtype=torch.float32, device=device)
+    masked._w2_scale = torch.ones(E, K // 128, (N // 2) // 128, dtype=torch.float32, device=device)
+
+    # MoE hybrid executor (contiguous path, wrapped in FusedMoe for discovery)
+    hybrid = DeepGemmHybridExecutor.__new__(DeepGemmHybridExecutor)
+    hybrid.E, hybrid.N, hybrid.K, hybrid.top_k = E, 512, 256, 1
+    hybrid.w13_weight = torch.randn(E, 512, 256, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    hybrid.w2_weight = torch.randn(E, 256, 256, dtype=torch.bfloat16, device=device).to(torch.float8_e4m3fn)
+    hybrid.w13_weight_scale_inv = torch.ones(E, 512 // 128, 256 // 128, dtype=torch.float32, device=device)
+    hybrid.w2_weight_scale_inv = torch.ones(E, 256 // 128, 256 // 128, dtype=torch.float32, device=device)
+
+    model = nn.Module()
+    model.add_module("linear", linear)
+    model.add_module("masked_moe", _wrap_in_fused_moe(masked))
+    model.add_module("hybrid_moe", _wrap_in_fused_moe(hybrid))
+    return model
+
+
+def _warmup_worker(rank, num_ranks, cache_dir, barrier, results):
+    """Subprocess entry for warmup benchmark."""
+    os.environ["DG_JIT_CACHE_DIR"] = cache_dir
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["LOCAL_WORLD_SIZE"] = str(num_ranks)
+    torch.cuda.set_device(rank)
+
+    if num_ranks > 1:
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = "29500"
+        os.environ["NCCL_DEBUG"] = "WARN"
+        torch.distributed.init_process_group(
+            backend="nccl", world_size=num_ranks, rank=rank,
+            device_id=torch.device(f"cuda:{rank}"),
+        )
+
+    from rtp_llm.models_py.kernels.cuda.deepgemm_warmup import (
+        deep_gemm_warmup, reset_warmed_caches,
+    )
+
+    try:
+        model = _build_model(f"cuda:{rank}")
+        reset_warmed_caches()
+        barrier.wait()
+        t0 = time.time()
+        deep_gemm_warmup(model, max_tokens=1024, mode="relax")
+        results[rank] = time.time() - t0
+    finally:
+        if num_ranks > 1:
+            torch.distributed.destroy_process_group()
+
+
+def _run_warmup(num_ranks: int, cache_dir: str) -> dict[int, float]:
+    """Spawn num_ranks processes, run warmup, return {rank: duration}."""
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(num_ranks)
+    results = ctx.Manager().dict()
+    procs = []
+    for rank in range(num_ranks):
+        p = ctx.Process(target=_warmup_worker, args=(rank, num_ranks, cache_dir, barrier, results))
+        p.start()
+        procs.append(p)
+    for p in procs:
+        p.join(timeout=600)
+        assert p.exitcode == 0, f"Rank process failed: exit={p.exitcode}"
+    return dict(results)
+
+
+class DeepGemmWarmupTest(TestCase):
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            raise SkipTest("CUDA not available")
+        try:
+            import deep_gemm
+            if not hasattr(deep_gemm, "fp8_gemm_nt"):
+                raise SkipTest("deep_gemm package incomplete")
+        except ImportError:
+            raise SkipTest("deep_gemm not available")
+
+    def test_jit_cache_correctness(self):
+        """Verify: first warmup writes cache files, second warmup reuses them (<1s)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Cold: JIT compile
+            results = _run_warmup(1, tmpdir)
+            cold_time = results[0]
+            files_after_cold = _collect_cache_files(tmpdir)
+            self.assertGreater(len(files_after_cold), 0, "No JIT cache files written")
+
+            # Warm: should reuse cache (no new files, <1s)
+            results = _run_warmup(1, tmpdir)
+            warm_time = results[0]
+            files_after_warm = _collect_cache_files(tmpdir)
+
+            new_files = files_after_warm - files_after_cold
+            self.assertEqual(new_files, set(), f"Unexpected new files: {new_files}")
+            self.assertLess(warm_time, 1.0,
+                            f"Cache hit should be <1s, got {warm_time:.1f}s")
+
+            cubin_count = _count_cubin_files(tmpdir)
+            logging.info(f"Cache correctness: cold={cold_time:.1f}s, warm={warm_time:.1f}s, "
+                         f"speedup={cold_time / max(warm_time, 0.01):.0f}x, "
+                         f"JIT compilations={cubin_count} .cubin files")
+
+            # Save for test_multi_rank_speedup
+            DeepGemmWarmupTest._single_rank_cold = cold_time
+            DeepGemmWarmupTest._single_rank_warm = warm_time
+
+    def test_multi_rank_speedup(self):
+        """Benchmark: 1/2/4 rank cold JIT compilation + cache hit."""
+        max_ranks = 4
+        if torch.cuda.device_count() < max_ranks:
+            raise SkipTest(f"Need {max_ranks} GPUs")
+
+        # Reuse test_jit_cache_correctness results for 1-rank
+        cold_1 = getattr(DeepGemmWarmupTest, "_single_rank_cold", None)
+        warm_1 = getattr(DeepGemmWarmupTest, "_single_rank_warm", None)
+        if cold_1 is None:
+            raise SkipTest("test_jit_cache_correctness must run first")
+
+        timings: dict[int, float] = {1: cold_1}
+
+        for n_ranks in [2, 4]:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                results = _run_warmup(n_ranks, tmpdir)
+                timings[n_ranks] = max(results.values())
+
+        # Print summary
+        logging.info("=" * 50)
+        logging.info("Multi-rank warmup benchmark (max_tokens=512)")
+        logging.info("-" * 50)
+        for n_ranks in [1, 2, 4]:
+            t = timings[n_ranks]
+            logging.info(f"  {n_ranks} rank(s) cold: {t:.1f}s  ({cold_1 / max(t, 0.01):.2f}x)")
+        logging.info(f"  1 rank   warm: {warm_1:.1f}s  ({cold_1 / max(warm_1, 0.01):.0f}x)")
+        logging.info("=" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -107,14 +107,18 @@ class GptModelBase(nn.Module):
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         raise NotImplementedError("forward method must be implemented in subclass")
 
-    DEEPGEMM_WARMUP_MAX_TOKENS = 8192
-
     def kernel_warmup(self) -> None:
         try:
             from rtp_llm.models_py.kernels.cuda.deepgemm_warmup import deep_gemm_warmup
 
-            mode = getattr(self.config, "deepgemm_warmup_mode", "skip")
-            max_tokens = min(self.config.max_seq_len, self.DEEPGEMM_WARMUP_MAX_TOKENS)
-            deep_gemm_warmup(self, max_tokens, mode=mode)
+            mode = getattr(self.config, "deepgemm_warmup_mode", "relax")
+            max_tokens = self.config.max_seq_len
+            deep_gemm_warmup(
+                self,
+                max_tokens,
+                mode=mode,
+                local_rank=self.parallelism_config.local_rank,
+                local_world_size=self.parallelism_config.local_world_size,
+            )
         except Exception as e:
             logging.warning(f"DeepGEMM warmup failed (non-fatal): {e}", exc_info=True)

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -106,3 +106,15 @@ class GptModelBase(nn.Module):
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         raise NotImplementedError("forward method must be implemented in subclass")
+
+    DEEPGEMM_WARMUP_MAX_TOKENS = 8192
+
+    def kernel_warmup(self) -> None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.deepgemm_warmup import deep_gemm_warmup
+
+            mode = getattr(self.config, "deepgemm_warmup_mode", "skip")
+            max_tokens = min(self.config.max_seq_len, self.DEEPGEMM_WARMUP_MAX_TOKENS)
+            deep_gemm_warmup(self, max_tokens, mode=mode)
+        except Exception as e:
+            logging.warning(f"DeepGEMM warmup failed (non-fatal): {e}", exc_info=True)

--- a/rtp_llm/server/server_args/model_group_args.py
+++ b/rtp_llm/server/server_args/model_group_args.py
@@ -101,3 +101,11 @@ def init_model_group_args(parser, model_args):
         default=None,
         help="是否将lm_head权重加载为fp32精度，默认为true",
     )
+    model_group.add_argument(
+        "--deepgemm_warmup_mode",
+        bind_to=(model_args, "deepgemm_warmup_mode"),
+        type=str,
+        default="skip",
+        choices=["skip", "relax", "full"],
+        help="DeepGEMM JIT kernel预热模式: skip(不预热), relax(启发式M值), full(所有M值)",
+    )

--- a/rtp_llm/server/server_args/model_group_args.py
+++ b/rtp_llm/server/server_args/model_group_args.py
@@ -105,7 +105,7 @@ def init_model_group_args(parser, model_args):
         "--deepgemm_warmup_mode",
         bind_to=(model_args, "deepgemm_warmup_mode"),
         type=str,
-        default="skip",
+        default="relax",
         choices=["skip", "relax", "full"],
         help="DeepGEMM JIT kernel预热模式: skip(不预热), relax(启发式M值), full(所有M值)",
     )


### PR DESCRIPTION
  - rtp_llm/models_py/kernels/cuda/deepgemm_warmup.py (new): DeepGEMM JIT warmup implementation — pre-compiles fp8_gemm_nt (dense) and m_grouped_fp8_gemm_nt_masked (MoE) kernels for representative M values to avoid first-request nvcc latency. GroupedGemmWarmupWrapper encapsulates MoE dummy tensor construction behind a forward() interface.

  - rtp_llm/models_py/model_desc/module_base.py: Add warmup_deep_gemm() method to GptModelBase, reads deepgemm_warmup config and delegates to deepgemm_warmup.deep_gemm_warmup().

  - rtp_llm/cpp/normal_engine/NormalEngine.cc: Call py_model.warmup_deep_gemm() in NormalEngine constructor before engine warmUp(), so JIT kernels are compiled before fake inference.

  - rtp_llm/config/model_config.py: Add deepgemm_warmup field to ModelConfig (1=enabled, 0=disabled, full=all M values).

  - rtp_llm/models_py/BUILD: Add visibility for kernels target to allow subpackage test access.

  - rtp_llm/models_py/kernels/cuda/test/BUILD + test_deepgemm_warmup.py (new): Unit tests verifying warmup calls fp8 linear forward() and MoE m_grouped_fp8_gemm_nt_masked, plus JIT cache file write/reuse.