### PR TITLE
feat: PureCP/PureDP allgather+RS routing for FP8 per-block MoE

### DIFF
--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -70,21 +70,45 @@ def auto_configure_deepep(
             "to allow MoriEP router selection"
         )
 
-    # allgather is valid only in "pure" parallel modes:
-    #   - single GPU (ep==1)
-    #   - pure TP                 (tp>1, dp==1, ep==tp, prefill CP disabled)
-    #   - pure CP attention + EP  (tp>1, dp==1, ep==tp, prefill CP enabled)
-    #   - pure DP attention + EP  (tp==1, dp>1, ep==dp)
-    # Mixed tp>1 with dp>1 is intentionally routed back to DeepEP.
-    cp_enabled = parallelism_config.prefill_cp_config.is_enabled()
+    # allgather default applies only to single GPU and pure TP (no CP).
+    # PureCP / PureDP routers exist but must be opted in via --moe_strategy
+    # (auto-selection falls back to DeepEP). CP-enabled topologies share the
+    # tp>1 / dp==1 / ep==tp shape with pure TP, so they must be excluded here
+    # to avoid silently disabling DeepEP without selecting PureCP.
+    prefill_cp_enabled = parallelism_config.prefill_cp_config.is_enabled()
     is_single_gpu = ep_size == 1
-    is_pure_tp = tp_size > 1 and dp_size == 1 and ep_size == tp_size and not cp_enabled
-    is_pure_cp_ep = tp_size > 1 and dp_size == 1 and ep_size == tp_size and cp_enabled
-    is_pure_dp_ep = tp_size == 1 and dp_size > 1 and ep_size == dp_size
+    is_pure_tp = (
+        tp_size > 1
+        and dp_size == 1
+        and ep_size == tp_size
+        and not prefill_cp_enabled
+    )
+    # Explicit opt-in via --moe_strategy must preserve use_all_gather, otherwise
+    # the matching strategy's check_conditions (which requires use_all_gather)
+    # will never be satisfied. Topology is validated here to keep the auto path
+    # falling back to DeepEP when --moe_strategy and shape disagree.
+    explicit_pure_dp = (
+        moe_config.moe_strategy == "fp8_per_block_pure_dp"
+        and tp_size == 1
+        and dp_size > 1
+        and ep_size == dp_size
+    )
+    explicit_pure_cp = (
+        moe_config.moe_strategy == "fp8_per_block_pure_cp"
+        and tp_size > 1
+        and dp_size == 1
+        and ep_size == tp_size
+        and prefill_cp_enabled
+    )
+
+    # use_deepep_moe disables use_all_gather only when a viable DeepEP path
+    # exists (ep_size > 1). On single-GPU configs there is no DeepEP path,
+    # so honor the implicit allgather fallback even if --use_deepep_moe was set.
     moe_config.use_all_gather = (
         moe_config.use_all_gather
         and not deep_ep_config.use_deepep_low_latency
-        and (is_single_gpu or is_pure_tp or is_pure_cp_ep or is_pure_dp_ep)
+        and (is_single_gpu or not deep_ep_config.use_deepep_moe)
+        and (is_single_gpu or is_pure_tp or explicit_pure_dp or explicit_pure_cp)
     )
     if moe_config.use_all_gather:
         moe_config.use_deepep_moe = False

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -53,9 +53,12 @@ def auto_configure_deepep(
     - PD separation + Decode node + Multi-node multi-GPU (>=9 GPUs): 1, 1, 1
     """
 
-    # in cp mode, do not use all gather, tp_size set to 1
-    tp_size = parallelism_config.get_attn_tp_size()
+    # MoE uses physical TP topology, not attention TP. get_attn_tp_size()
+    # returns 1 when CP is enabled, which would incorrectly disable
+    # use_all_gather for ep_size == tp_size configurations.
+    tp_size = parallelism_config.tp_size
     ep_size = parallelism_config.ep_size
+    dp_size = parallelism_config.dp_size
     moe_config.ll_num_max_token = ll_num_max_token
 
     # Explicit MoriEP is incompatible with use_all_gather (PURE_TP router).
@@ -67,10 +70,21 @@ def auto_configure_deepep(
             "to allow MoriEP router selection"
         )
 
+    # allgather is valid only in "pure" parallel modes:
+    #   - single GPU (ep==1)
+    #   - pure TP                 (tp>1, dp==1, ep==tp, prefill CP disabled)
+    #   - pure CP attention + EP  (tp>1, dp==1, ep==tp, prefill CP enabled)
+    #   - pure DP attention + EP  (tp==1, dp>1, ep==dp)
+    # Mixed tp>1 with dp>1 is intentionally routed back to DeepEP.
+    cp_enabled = parallelism_config.prefill_cp_config.is_enabled()
+    is_single_gpu = ep_size == 1
+    is_pure_tp = tp_size > 1 and dp_size == 1 and ep_size == tp_size and not cp_enabled
+    is_pure_cp_ep = tp_size > 1 and dp_size == 1 and ep_size == tp_size and cp_enabled
+    is_pure_dp_ep = tp_size == 1 and dp_size > 1 and ep_size == dp_size
     moe_config.use_all_gather = (
         moe_config.use_all_gather
         and not deep_ep_config.use_deepep_low_latency
-        and (ep_size == tp_size or ep_size == 1)
+        and (is_single_gpu or is_pure_tp or is_pure_cp_ep or is_pure_dp_ep)
     )
     if moe_config.use_all_gather:
         moe_config.use_deepep_moe = False

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -5,6 +5,7 @@ py_library(
     srcs = glob([
         "utils/*.py",
     ]),
+    visibility = ["//visibility:public"],
 )
 
 # flashinfer-python is only available for CUDA12

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -634,6 +634,39 @@ def all_gather(tensor: torch.Tensor, group: Group) -> torch.Tensor:
     # return torch.cat(tensor_list, dim=0)
 
 
+def reduce_scatter(input_tensor: torch.Tensor, group: Group) -> torch.Tensor:
+    """Reduce-scatter a tensor across all ranks in the group.
+
+    Reduces (sums) the input tensor across all ranks and scatters the result
+    so that each rank receives a 1/world_size chunk of the reduced tensor.
+
+    Args:
+        input_tensor: Full-size tensor to reduce-scatter
+            (shape: [world_size * chunk_size] + remaining_dims)
+        group: Process group to use
+
+    Returns:
+        Scattered chunk of the reduced tensor for this rank
+        (shape: [chunk_size] + remaining_dims)
+    """
+    process_group = _get_group(group)
+    world_size = torch.distributed.get_world_size(process_group)
+    assert input_tensor.shape[0] % world_size == 0, (
+        f"reduce_scatter: input dim 0 ({input_tensor.shape[0]}) "
+        f"must be divisible by world_size ({world_size})"
+    )
+    chunk_size = input_tensor.shape[0] // world_size
+    output_tensor = torch.empty(
+        [chunk_size] + list(input_tensor.shape[1:]),
+        device=input_tensor.device,
+        dtype=input_tensor.dtype,
+    )
+    torch.distributed.reduce_scatter_tensor(
+        output_tensor, input_tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
+    )
+    return output_tensor
+
+
 def barrier(group: Group) -> None:
     """Barrier all ranks in the group.
 
@@ -655,5 +688,6 @@ __all__ = [
     "broadcast",
     "all_reduce",
     "all_gather",
+    "reduce_scatter",
     "barrier",
 ]

--- a/rtp_llm/models_py/distributed/test/BUILD
+++ b/rtp_llm/models_py/distributed/test/BUILD
@@ -61,3 +61,17 @@ py_test(
    tags = ["open_skip", "H20"],
    exec_properties = {'gpu':'H20', 'gpu_count':'4'},
 )
+
+py_test(
+    name = "cp_moe_allgather_rs_test",
+    srcs = ["cp_moe_allgather_rs_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py:modules",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = 'moderate',
+    env = {"GPU_COUNT": "4"},
+    tags = ["open_skip", "H20"],
+    exec_properties = {'gpu':'H20', 'gpu_count':'4'},
+)

--- a/rtp_llm/models_py/distributed/test/collective_torch_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_test.py
@@ -23,6 +23,7 @@ from rtp_llm.models_py.distributed.collective_torch import (
     distributed_environment_initialized,
     init_distributed_environment,
     recv,
+    reduce_scatter,
     send,
 )
 from rtp_llm.ops import NcclCommConfig, ParallelismConfig
@@ -230,6 +231,121 @@ def _test_all_gather_collective(
     torch.distributed.barrier()
 
 
+def _test_reduce_scatter_collective(
+    rank: int,
+    parallelism_config: ParallelismConfig,
+    world_size: int,
+    tp_size: int,
+    dp_size: int,
+    get_process_group_and_ranks,
+):
+    """Test reduce_scatter collective operation across all groups"""
+    logging.info(f"Rank {rank} testing reduce_scatter")
+    for group_type in [Group.DP_AND_TP, Group.DP, Group.TP]:
+        if group_type == Group.DP and dp_size == 1:
+            continue
+        if group_type == Group.TP and tp_size == 1:
+            continue
+
+        process_group, group_ranks = get_process_group_and_ranks(group_type)
+
+        if rank in group_ranks:
+            group_size = len(group_ranks)
+            local_idx = group_ranks.index(rank)
+            chunk_size = 2
+
+            # Each rank creates a full-size tensor [group_size * chunk_size, hidden_dim]
+            # where each rank contributes its rank value to all chunks
+            hidden_dim = 3
+            input_tensor = torch.ones(
+                group_size * chunk_size, hidden_dim,
+                device=f"cuda:{parallelism_config.local_rank}",
+            ) * (rank + 1)
+
+            result = reduce_scatter(input_tensor, group=group_type)
+            torch.cuda.synchronize()
+            torch.distributed.barrier(group=process_group)
+
+            # After reduce_scatter: each rank gets chunk [local_idx*chunk_size : (local_idx+1)*chunk_size]
+            # of the sum of all inputs. Since each rank contributed (rank+1) uniformly,
+            # the sum is sum(r+1 for r in group_ranks) for every element.
+            expected_sum = sum(r + 1 for r in group_ranks)
+            expected = torch.ones(
+                chunk_size, hidden_dim,
+                device=f"cuda:{parallelism_config.local_rank}",
+            ) * expected_sum
+
+            assert result.shape == (chunk_size, hidden_dim), (
+                f"Rank {rank} reduce_scatter {group_type}: "
+                f"Expected shape {(chunk_size, hidden_dim)}, got {result.shape}"
+            )
+            assert torch.allclose(result, expected), (
+                f"Rank {rank} reduce_scatter {group_type}: "
+                f"Expected {expected.cpu()}, got {result.cpu()}"
+            )
+
+    torch.distributed.barrier()
+
+
+def _test_allgather_reduce_scatter_roundtrip(
+    rank: int,
+    parallelism_config: ParallelismConfig,
+    world_size: int,
+    tp_size: int,
+    dp_size: int,
+    get_process_group_and_ranks,
+):
+    """Test that all_gather followed by reduce_scatter recovers the original data.
+
+    This validates the core communication pattern used for CP MoE:
+    scattered -> all_gather -> (compute partial results) -> reduce_scatter -> scattered
+    """
+    logging.info(f"Rank {rank} testing allgather+reduce_scatter roundtrip")
+    for group_type in [Group.DP_AND_TP, Group.TP]:
+        if group_type == Group.TP and tp_size == 1:
+            continue
+
+        process_group, group_ranks = get_process_group_and_ranks(group_type)
+
+        if rank in group_ranks:
+            group_size = len(group_ranks)
+            local_idx = group_ranks.index(rank)
+            chunk_size = 4
+            hidden_dim = 8
+
+            # Each rank starts with its own scattered chunk
+            original = torch.randn(
+                chunk_size, hidden_dim,
+                device=f"cuda:{parallelism_config.local_rank}",
+            )
+
+            # Step 1: all_gather (scattered -> full)
+            gathered = all_gather(original, group=group_type)
+            assert gathered.shape == (group_size * chunk_size, hidden_dim)
+
+            # Step 2: simulate partial MoE compute — each rank contributes
+            # 1/group_size of the result. We divide by group_size so that
+            # reduce_scatter (which sums) recovers the original gathered tensor.
+            partial_result = gathered / group_size
+
+            # Step 3: reduce_scatter (full -> scattered)
+            result = reduce_scatter(partial_result, group=group_type)
+            torch.cuda.synchronize()
+            torch.distributed.barrier(group=process_group)
+
+            # Result should equal the original chunk
+            assert result.shape == original.shape, (
+                f"Rank {rank} roundtrip {group_type}: "
+                f"Expected shape {original.shape}, got {result.shape}"
+            )
+            assert torch.allclose(result, original, atol=1e-5), (
+                f"Rank {rank} roundtrip {group_type}: "
+                f"Max diff = {(result - original).abs().max().item()}"
+            )
+
+    torch.distributed.barrier()
+
+
 def _test_all_collectives_worker(
     rank: int, world_size: int, tp_size: int, dp_size: int, nccl_port: int
 ):
@@ -306,6 +422,22 @@ def _test_all_collectives_worker(
             _get_process_group_and_ranks,
         )
         _test_all_gather_collective(
+            rank,
+            parallelism_config,
+            world_size,
+            tp_size,
+            dp_size,
+            _get_process_group_and_ranks,
+        )
+        _test_reduce_scatter_collective(
+            rank,
+            parallelism_config,
+            world_size,
+            tp_size,
+            dp_size,
+            _get_process_group_and_ranks,
+        )
+        _test_allgather_reduce_scatter_roundtrip(
             rank,
             parallelism_config,
             world_size,

--- a/rtp_llm/models_py/distributed/test/collective_torch_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_test.py
@@ -253,34 +253,41 @@ def _test_reduce_scatter_collective(
             group_size = len(group_ranks)
             local_idx = group_ranks.index(rank)
             chunk_size = 2
-
-            # Each rank creates a full-size tensor [group_size * chunk_size, hidden_dim]
-            # where each rank contributes its rank value to all chunks
             hidden_dim = 3
-            input_tensor = torch.ones(
+
+            # Make each chunk position carry a distinct value so a chunk
+            # mis-scatter (e.g. wrong offset) cannot be hidden by uniform
+            # inputs. Chunk c on rank r holds the value (r+1) * (c+1).
+            input_tensor = torch.empty(
                 group_size * chunk_size, hidden_dim,
                 device=f"cuda:{parallelism_config.local_rank}",
-            ) * (rank + 1)
+            )
+            for c in range(group_size):
+                input_tensor[c * chunk_size : (c + 1) * chunk_size] = (
+                    (rank + 1) * (c + 1)
+                )
 
             result = reduce_scatter(input_tensor, group=group_type)
             torch.cuda.synchronize()
             torch.distributed.barrier(group=process_group)
 
-            # After reduce_scatter: each rank gets chunk [local_idx*chunk_size : (local_idx+1)*chunk_size]
-            # of the sum of all inputs. Since each rank contributed (rank+1) uniformly,
-            # the sum is sum(r+1 for r in group_ranks) for every element.
+            # After reduce_scatter, the rank at position local_idx receives
+            # chunk local_idx of the summed tensor:
+            #   sum_r((r+1) * (local_idx+1)) = (local_idx+1) * sum(r+1).
+            # If reduce_scatter mis-aligned chunks, expected != observed.
             expected_sum = sum(r + 1 for r in group_ranks)
+            expected_chunk_value = expected_sum * (local_idx + 1)
             expected = torch.ones(
                 chunk_size, hidden_dim,
                 device=f"cuda:{parallelism_config.local_rank}",
-            ) * expected_sum
+            ) * expected_chunk_value
 
             assert result.shape == (chunk_size, hidden_dim), (
                 f"Rank {rank} reduce_scatter {group_type}: "
                 f"Expected shape {(chunk_size, hidden_dim)}, got {result.shape}"
             )
             assert torch.allclose(result, expected), (
-                f"Rank {rank} reduce_scatter {group_type}: "
+                f"Rank {rank} reduce_scatter {group_type} (local_idx={local_idx}): "
                 f"Expected {expected.cpu()}, got {result.cpu()}"
             )
 

--- a/rtp_llm/models_py/distributed/test/cp_moe_allgather_rs_test.py
+++ b/rtp_llm/models_py/distributed/test/cp_moe_allgather_rs_test.py
@@ -1,0 +1,160 @@
+"""Tests for the allgather + reduce_scatter communication pattern used by
+PureCpRouter / PureDpRouter (router-level path B).
+
+The router internally does:
+    prepare:  allgather(scattered_tokens) -> full_tokens
+    execute:  partial MoE compute (each rank holds 1/N of experts)
+    finalize: reduce_scatter(partial_output) -> scattered_output
+
+This file verifies the underlying NCCL roundtrip is correct using a
+multi-process simulation.
+"""
+
+import logging
+import multiprocessing as mp
+import os
+import unittest
+
+logging.basicConfig(level=logging.INFO)
+
+import torch
+
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    destroy_distributed_environment,
+    init_distributed_environment,
+    reduce_scatter,
+)
+from rtp_llm.ops import NcclCommConfig, ParallelismConfig
+from rtp_llm.test.utils.port_util import PortManager
+
+
+def _test_cp_moe_roundtrip_worker(
+    rank: int, world_size: int, tp_size: int, dp_size: int, nccl_port: int
+):
+    """Worker: verify allgather -> partial_compute -> reduce_scatter recovers data.
+
+    Simulates the router-level CP/DP MoE pattern:
+    1. Each rank starts with scattered tokens (chunk_size tokens)
+    2. allgather: each rank gets full tokens (world_size * chunk_size)
+    3. Each rank computes partial result (1/world_size of final answer)
+    4. reduce_scatter: sum partials and scatter back
+    Expected: output == original scattered chunk (within fp tolerance)
+    """
+    try:
+        parallelism_config = ParallelismConfig()
+        base_port = nccl_port + 11
+        nccl_comm_config = NcclCommConfig(
+            nccl_ip="127.0.0.1",
+            tp_nccl_port=base_port - 2,
+            dp_tp_nccl_port=base_port - 10,
+            ffn_tp_nccl_port=base_port - 5,
+        )
+        parallelism_config.world_rank = rank
+        parallelism_config.world_size = world_size
+        parallelism_config.local_rank = (
+            rank % torch.cuda.device_count() if torch.cuda.is_available() else 0
+        )
+        parallelism_config.tp_size = tp_size
+        parallelism_config.dp_size = dp_size
+
+        torch.cuda.set_device(parallelism_config.local_rank)
+        torch.set_default_device(f"cuda:{parallelism_config.local_rank}")
+        init_distributed_environment(
+            parallelism_config,
+            nccl_comm_config=nccl_comm_config,
+            nccl_init_port=nccl_port,
+            backend="nccl",
+            timeout=60,
+        )
+
+        chunk_size = 8
+        hidden_dim = 16
+        device = f"cuda:{parallelism_config.local_rank}"
+
+        # Simulate scattered hidden_states (each rank has its own chunk)
+        torch.manual_seed(42 + rank)
+        hidden_scattered = torch.randn(chunk_size, hidden_dim, device=device)
+        residual_scattered = torch.randn(chunk_size, hidden_dim, device=device)
+
+        # Step 1: allgather
+        hidden_full = all_gather(hidden_scattered, group=Group.TP)
+        residual_full = all_gather(residual_scattered, group=Group.TP)
+        assert hidden_full.shape[0] == tp_size * chunk_size
+
+        # Step 2: simulate MoE partial compute (each rank does 1/tp_size)
+        hidden_partial = hidden_full / tp_size
+        residual_partial = residual_full / tp_size
+
+        # Step 3: reduce_scatter
+        hidden_out = reduce_scatter(hidden_partial, group=Group.TP)
+        residual_out = reduce_scatter(residual_partial, group=Group.TP)
+        torch.cuda.synchronize()
+
+        # Verify: output should match original scattered chunk
+        assert hidden_out.shape == hidden_scattered.shape, (
+            f"Rank {rank}: shape mismatch {hidden_out.shape} vs {hidden_scattered.shape}"
+        )
+        assert torch.allclose(hidden_out, hidden_scattered, atol=1e-5), (
+            f"Rank {rank}: hidden max diff = {(hidden_out - hidden_scattered).abs().max().item()}"
+        )
+        assert torch.allclose(residual_out, residual_scattered, atol=1e-5), (
+            f"Rank {rank}: residual max diff = {(residual_out - residual_scattered).abs().max().item()}"
+        )
+
+        torch.distributed.barrier()
+        torch.cuda.synchronize()
+        destroy_distributed_environment()
+    except Exception as e:
+        print(f"Rank {rank} error: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+class TestCpMoeRoundtrip(unittest.TestCase):
+    """Test allgather+reduce_scatter roundtrip with real NCCL (multi-GPU)."""
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA not available")
+        try:
+            mp.set_start_method("spawn", force=True)
+        except RuntimeError:
+            pass
+        self.port_manager = PortManager()
+
+    def _run_test(self, worker_func, world_size, tp_size, dp_size):
+        ports, locks = self.port_manager.get_consecutive_ports(1)
+        nccl_port = ports[0]
+        try:
+            processes = []
+            for rank in range(world_size):
+                p = mp.Process(
+                    target=worker_func,
+                    args=(rank, world_size, tp_size, dp_size, nccl_port),
+                    name=f"rank-{rank}",
+                )
+                p.start()
+                processes.append(p)
+            for p in processes:
+                p.join(timeout=120)
+                if p.exitcode != 0:
+                    raise RuntimeError(f"Process {p.name} exited with code {p.exitcode}")
+        finally:
+            for lock in locks:
+                lock.__exit__(None, None, None)
+
+    def test_roundtrip_tp4(self):
+        """allgather+reduce_scatter roundtrip with tp_size=4"""
+        self._run_test(_test_cp_moe_roundtrip_worker, world_size=4, tp_size=4, dp_size=1)
+
+    def test_roundtrip_tp2_dp2(self):
+        """allgather+reduce_scatter roundtrip with tp_size=2, dp_size=2"""
+        self._run_test(_test_cp_moe_roundtrip_worker, world_size=4, tp_size=2, dp_size=2)
+
+
+if __name__ == "__main__":
+    os.environ["NCCL_DEBUG"] = "INFO"
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
@@ -64,6 +64,8 @@ else:
 
     # MoE strategies
     from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.strategy import (
+        CudaFp8PerBlockPureCPStrategy,
+        CudaFp8PerBlockPureDPStrategy,
         CudaFp8PerBlockEpLowLatencyStrategy,
         CudaFp8PerBlockEpNormalStrategy,
         CudaFp8PerBlockNoDPMaskedStrategy,
@@ -84,6 +86,8 @@ else:
     registry.register(CudaFp8PerTensorEpNormalStrategy())
     registry.register(CudaFp8PerBlockEpLowLatencyStrategy())
     registry.register(CudaFp8PerBlockEpNormalStrategy())
+    registry.register(CudaFp8PerBlockPureCPStrategy())
+    registry.register(CudaFp8PerBlockPureDPStrategy())
     registry.register(CudaFp8PerBlockNoDPMaskedStrategy())
     registry.register(CudaFp8PerBlockNoDPStrategy())
     registry.register(CudaFp8PerTensorNoDPStrategy())

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/config_adapter.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/config_adapter.py
@@ -32,6 +32,11 @@ class MoEConfigAdapter:
         # Provide shortcut access to commonly used attributes
         self.ep_size = parallelism_config.ep_size
         self.ep_rank = parallelism_config.ep_rank
+        # tp_size/tp_rank reflect the attention/MoE-input view: when CP is
+        # enabled, get_attn_tp_size() returns 1, so MoE input slicing
+        # (deepep narrow/allgather) stays a no-op. Router selectors that
+        # need the physical TP topology (e.g. pure_cp_router) read raw
+        # parallelism_config.tp_size via is_cp_equal_ep().
         self.tp_size = parallelism_config.get_attn_tp_size()
         self.tp_rank = parallelism_config.get_attn_tp_rank()
         self.dp_size = parallelism_config.dp_size

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
@@ -1,0 +1,163 @@
+"""Pure CP router using allgather + reduce_scatter.
+
+For Context Parallel (CP) MoE: each rank holds the same experts but processes
+different chunks of the context sequence. The router:
+
+  prepare:  allgather(scattered_tokens, TP) -> full_tokens
+  execute:  MoE on full_tokens (each rank computes partial sums)
+  finalize: reduce_scatter(partial_output, TP) -> scattered_output
+
+Unlike the DP router, no padding is needed because CP splits the context
+evenly across ranks, guaranteeing equal token counts on every rank.
+Shared expert handling is done at the layer level, not in this router.
+"""
+
+from abc import abstractmethod
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    reduce_scatter,
+)
+from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import is_deep_gemm_e8m0_used
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+    sgl_per_token_group_quant_fp8,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    ExpertTokensMetadata,
+    FusedMoeDataRouter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
+from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+    MoeConfigResolver,
+)
+from rtp_llm.models_py.triton_kernels.moe.ep_kernels import (
+    recompute_topk_ids_sum_expert_count,
+)
+from rtp_llm.ops.compute_ops import trt_fp8_quantize_128
+
+
+class PureCpRouterBase(FusedMoeDataRouter):
+    """Base class for pure CP routers using allgather + reduce_scatter.
+
+    In CP mode, tp_size == ep_size and each rank has all experts but only a
+    portion of the context tokens. This router:
+    - In prepare(): allgathers scattered tokens across TP group to get full tokens
+    - In finalize(): reduce_scatters the partial MoE output back to scattered form
+
+    No padding is needed because CP guarantees equal token counts across ranks.
+    """
+
+    @classmethod
+    def router_type(cls):
+        return RouterType.PURE_TP
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        # Pure CP + EP only: dp_size must be 1, physical tp == ep > 1.
+        # is_cp_equal_ep reads raw parallelism_config.tp_size so it works
+        # whether or not CP is enabled (in CP mode adapter tp_size==1).
+        # Mixed tp>1+dp>1 is intentionally routed back to DeepEP.
+        checker.check(config.dp_size == 1)
+        checker.check(resolver.is_cp_equal_ep(config))
+        checker.check(config.ep_size > 1)
+        checker.check(resolver.use_all_gather(config))
+
+    def __init__(
+        self,
+        config: MoEConfigAdapter,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(config, quant_config)
+
+        # Use physical tp_size to match the all_gather(group=Group.TP) below.
+        self.tp_size = config.parallelism_config.tp_size
+        self.ep_size = config.ep_size
+        self.ep_rank = config.ep_rank
+        self.expert_num = config.expert_num
+        self.expert_num_per_rank = self.expert_num // self.ep_size
+        self.expert_start_id = self.ep_rank * self.expert_num_per_rank
+
+    @abstractmethod
+    def _do_quant(
+        self, a1: torch.Tensor
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        raise NotImplementedError
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        a1_scale: Optional[torch.Tensor],
+        a2_scale: Optional[torch.Tensor],
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> ExpertForwardPayload:
+        assert a1_scale is None and a2_scale is None, "not support quanted moe"
+
+        a1_full = all_gather(a1, group=Group.TP)
+        topk_weights_full = all_gather(topk_weights, group=Group.TP)
+        topk_ids_full = all_gather(topk_ids, group=Group.TP)
+
+        expert_x, expert_x_scale = self._do_quant(a1_full)
+
+        adjusted_topk_ids, num_recv_tokens_per_expert = (
+            recompute_topk_ids_sum_expert_count(
+                topk_ids_full, self.expert_start_id, self.expert_num_per_rank
+            )
+        )
+
+        return ExpertForwardPayload(
+            expert_x,
+            a1.dtype,
+            expert_x_scale,
+            ExpertTokensMetadata(None, num_recv_tokens_per_expert, None),
+            adjusted_topk_ids,
+            topk_weights_full,
+        )
+
+    def finalize(
+        self,
+        payload: CombineForwardPayload,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        extra_finalize_args: Optional[Dict[str, Any]],
+    ) -> torch.Tensor:
+        return reduce_scatter(payload.fused_expert_output, group=Group.TP)
+
+
+class PureCpRouterFp8PerBlock(PureCpRouterBase):
+    """Pure CP router with FP8 per-block quantization."""
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        super().check_conditions(checker, config)
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method == "FP8_PER_BLOCK")
+
+    def _do_quant(
+        self, a1: torch.Tensor
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if is_deep_gemm_e8m0_used():
+            return sgl_per_token_group_quant_fp8(
+                a1,
+                128,
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+            )
+        else:
+            return trt_fp8_quantize_128(a1, False)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
@@ -66,13 +66,17 @@ class PureCpRouterBase(FusedMoeDataRouter):
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
         resolver = MoeConfigResolver()
-        # Pure CP + EP only: dp_size must be 1, physical tp == ep > 1.
+        # Pure CP + EP only: dp_size must be 1, physical tp == ep > 1, and
+        # prefill CP must actually be enabled (CudaFp8PerBlockPureCPStrategy
+        # also asserts this — keep both as a defensive check so the router
+        # can be selected via paths that bypass the strategy gate).
         # is_cp_equal_ep reads raw parallelism_config.tp_size so it works
         # whether or not CP is enabled (in CP mode adapter tp_size==1).
         # Mixed tp>1+dp>1 is intentionally routed back to DeepEP.
         checker.check(config.dp_size == 1)
         checker.check(resolver.is_cp_equal_ep(config))
         checker.check(config.ep_size > 1)
+        checker.check(config.parallelism_config.prefill_cp_config.is_enabled())
         checker.check(resolver.use_all_gather(config))
 
     def __init__(

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
@@ -1,0 +1,196 @@
+"""Pure DP router using allgather + reduce_scatter.
+
+Replaces the per-token all_reduce pattern in PureTpRouter with a communication
+pattern designed for Data Parallel (DP) MoE:
+
+  prepare:  allgather(scattered_tokens, DP_AND_TP) -> full_tokens
+  execute:  MoE on full_tokens (each rank computes partial sums)
+  finalize: reduce_scatter(partial_output, DP_AND_TP) -> scattered_output
+
+This avoids DeepEP entirely and uses standard NCCL collectives.
+
+In DP mode, different ranks may have different batch sizes (real requests vs
+fake/empty batches). Since NCCL allgather requires equal tensor sizes across
+ranks, this router pads tensors to the max batch size before allgather and
+trims the output after reduce_scatter.
+"""
+
+from abc import abstractmethod
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    reduce_scatter,
+)
+from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import is_deep_gemm_e8m0_used
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+    sgl_per_token_group_quant_fp8,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    ExpertTokensMetadata,
+    FusedMoeDataRouter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
+from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+    MoeConfigResolver,
+)
+from rtp_llm.models_py.triton_kernels.moe.ep_kernels import (
+    recompute_topk_ids_sum_expert_count,
+)
+from rtp_llm.ops.compute_ops import trt_fp8_quantize_128
+
+
+class PureDpRouterBase(FusedMoeDataRouter):
+    """Base class for pure DP routers using allgather + reduce_scatter.
+
+    Instead of all_reduce at finalize time, this router:
+    - In prepare(): allgathers scattered tokens across DP_AND_TP group
+    - In finalize(): reduce_scatters the partial MoE output back
+
+    In DP mode, ranks may have different batch sizes (real vs fake streams).
+    Tensors are padded to the max batch size before allgather and trimmed after
+    reduce_scatter.
+    """
+
+    @classmethod
+    def router_type(cls):
+        return RouterType.PURE_TP
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        # Pure DP + EP only: physical tp must be 1, dp > 1, ep == dp.
+        # Read raw parallelism_config.tp_size so future CP+DP topologies
+        # (where adapter tp_size==1 but physical tp>1) aren't misclassified.
+        # Mixed tp>1+dp>1 (i.e. tp*dp == ep with tp>1) is intentionally
+        # routed back to DeepEP.
+        checker.check(config.parallelism_config.tp_size == 1)
+        checker.check(config.dp_size > 1)
+        checker.check(config.ep_size == config.dp_size)
+        checker.check(resolver.use_all_gather(config))
+
+    def __init__(
+        self,
+        config: MoEConfigAdapter,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(config, quant_config)
+
+        self.tp_size = config.tp_size
+        self.ep_size = config.ep_size
+        self.ep_rank = config.ep_rank
+        self.expert_num = config.expert_num
+        self.expert_num_per_rank = self.expert_num // self.ep_size
+        self.expert_start_id = self.ep_rank * self.expert_num_per_rank
+        self._local_batch_size: int = 0
+
+    @abstractmethod
+    def _do_quant(
+        self, a1: torch.Tensor
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        raise NotImplementedError
+
+    def _pad_to_max(
+        self, a1: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """Pad tensors to the max batch size across all EP ranks.
+
+        Returns padded tensors and the max batch size. Sets self._local_batch_size.
+        """
+        local_n = a1.shape[0]
+        self._local_batch_size = local_n
+
+        n_tensor = torch.tensor([local_n], device=a1.device, dtype=torch.int64)
+        all_n = all_gather(n_tensor, group=Group.DP_AND_TP)
+        max_n = int(all_n.max().item())
+
+        if local_n < max_n:
+            pad_n = max_n - local_n
+            a1 = F.pad(a1, (0, 0, 0, pad_n))
+            topk_weights = F.pad(topk_weights, (0, 0, 0, pad_n))
+            topk_ids = F.pad(topk_ids, (0, 0, 0, pad_n), value=-1)
+
+        return a1, topk_weights, topk_ids, max_n
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        a1_scale: Optional[torch.Tensor],
+        a2_scale: Optional[torch.Tensor],
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> ExpertForwardPayload:
+        assert a1_scale is None and a2_scale is None, "not support quanted moe"
+
+        a1, topk_weights, topk_ids, _ = self._pad_to_max(a1, topk_weights, topk_ids)
+
+        a1_full = all_gather(a1, group=Group.DP_AND_TP)
+        topk_weights_full = all_gather(topk_weights, group=Group.DP_AND_TP)
+        topk_ids_full = all_gather(topk_ids, group=Group.DP_AND_TP)
+
+        expert_x, expert_x_scale = self._do_quant(a1_full)
+
+        adjusted_topk_ids, num_recv_tokens_per_expert = (
+            recompute_topk_ids_sum_expert_count(
+                topk_ids_full, self.expert_start_id, self.expert_num_per_rank
+            )
+        )
+
+        return ExpertForwardPayload(
+            expert_x,
+            a1.dtype,
+            expert_x_scale,
+            ExpertTokensMetadata(None, num_recv_tokens_per_expert, None),
+            adjusted_topk_ids,
+            topk_weights_full,
+        )
+
+    def finalize(
+        self,
+        payload: CombineForwardPayload,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        extra_finalize_args: Optional[Dict[str, Any]],
+    ) -> torch.Tensor:
+        output = reduce_scatter(payload.fused_expert_output, group=Group.DP_AND_TP)
+        if output.shape[0] > self._local_batch_size:
+            output = output[: self._local_batch_size]
+        return output
+
+
+class PureDpRouterFp8PerBlock(PureDpRouterBase):
+    """Pure DP router with FP8 per-block quantization."""
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        super().check_conditions(checker, config)
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method == "FP8_PER_BLOCK")
+
+    def _do_quant(
+        self, a1: torch.Tensor
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if is_deep_gemm_e8m0_used():
+            return sgl_per_token_group_quant_fp8(
+                a1,
+                128,
+                column_major_scales=True,
+                scale_tma_aligned=True,
+                scale_ue8m0=True,
+            )
+        else:
+            return trt_fp8_quantize_128(a1, False)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
@@ -80,6 +80,11 @@ class PureDpRouterBase(FusedMoeDataRouter):
         checker.check(config.dp_size > 1)
         checker.check(config.ep_size == config.dp_size)
         checker.check(resolver.use_all_gather(config))
+        # CUDA Graph capture/replay freezes shapes; PureDP _pad_to_max derives
+        # max_n via runtime all_gather + .item(), which is graph-unsafe (D2H
+        # sync mid-capture, dynamic pad shape on replay). Force fallback to
+        # DeepEP when CUDA Graph is on.
+        checker.check(not config.enable_cuda_graph)
 
     def __init__(
         self,
@@ -94,7 +99,6 @@ class PureDpRouterBase(FusedMoeDataRouter):
         self.expert_num = config.expert_num
         self.expert_num_per_rank = self.expert_num // self.ep_size
         self.expert_start_id = self.ep_rank * self.expert_num_per_rank
-        self._local_batch_size: int = 0
 
     @abstractmethod
     def _do_quant(
@@ -107,11 +111,15 @@ class PureDpRouterBase(FusedMoeDataRouter):
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
         """Pad tensors to the max batch size across all EP ranks.
 
-        Returns padded tensors and the max batch size. Sets self._local_batch_size.
+        Returns the padded tensors plus the max batch size. The local (unpadded)
+        batch size is recovered in finalize() from extra_finalize_args
+        ("original_num_tokens"), so this method holds no instance state.
         """
         local_n = a1.shape[0]
-        self._local_batch_size = local_n
 
+        # TODO(perf): .item() forces a D2H sync on every MoE layer's hot path.
+        # Plan to lift max_n to step-level host metadata (computed once before
+        # entering the MoE stack) in a follow-up PR. Tracked on PR #968 review.
         n_tensor = torch.tensor([local_n], device=a1.device, dtype=torch.int64)
         all_n = all_gather(n_tensor, group=Group.DP_AND_TP)
         max_n = int(all_n.max().item())
@@ -165,9 +173,18 @@ class PureDpRouterBase(FusedMoeDataRouter):
         apply_router_weight_on_input: bool,
         extra_finalize_args: Optional[Dict[str, Any]],
     ) -> torch.Tensor:
+        # Read the local batch size from extra_finalize_args (injected by
+        # FusedMoeDataRouter.forward as original_num_tokens) instead of relying
+        # on cross-call instance state. Same pattern as deepep_normal_router.
+        assert (
+            extra_finalize_args is not None
+            and "original_num_tokens" in extra_finalize_args
+        ), "PureDpRouter.finalize requires extra_finalize_args['original_num_tokens']"
+        local_batch_size: int = extra_finalize_args["original_num_tokens"]
+
         output = reduce_scatter(payload.fused_expert_output, group=Group.DP_AND_TP)
-        if output.shape[0] > self._local_batch_size:
-            output = output[: self._local_batch_size]
+        if output.shape[0] > local_batch_size:
+            output = output[:local_batch_size]
         return output
 
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/__init__.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/__init__.py
@@ -5,6 +5,8 @@ from .fp8_per_block import (
     CudaFp8PerBlockEpNormalStrategy,
     CudaFp8PerBlockNoDPMaskedStrategy,
     CudaFp8PerBlockNoDPStrategy,
+    CudaFp8PerBlockPureCPStrategy,
+    CudaFp8PerBlockPureDPStrategy,
 )
 from .fp8_per_tensor import (
     CudaFp8PerTensorEpLowLatencyStrategy,
@@ -34,6 +36,8 @@ __all__ = [
     # FP8 PerBlock
     "CudaFp8PerBlockNoDPMaskedStrategy",
     "CudaFp8PerBlockNoDPStrategy",
+    "CudaFp8PerBlockPureCPStrategy",
+    "CudaFp8PerBlockPureDPStrategy",
     "CudaFp8PerBlockEpLowLatencyStrategy",
     "CudaFp8PerBlockEpNormalStrategy",
     # FP8 PerTensor

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
@@ -97,11 +97,8 @@ class CudaFp8PerBlockPureDPStrategy(MoeStrategy):
             and config.dp_size > 1
             and config.ep_size == config.dp_size
         )
-        is_explicit = config.moe_strategy == "fp8_per_block_pure_dp"
-        is_auto_dp = config.moe_strategy == "auto" and is_pure_dp_ep
-        checker.check(is_explicit or is_auto_dp)
-        if is_explicit:
-            checker.check(is_pure_dp_ep)
+        checker.check(config.moe_strategy == "fp8_per_block_pure_dp")
+        checker.check(is_pure_dp_ep)
 
     def get_attributes(self) -> StrategyAttributes:
         from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_masked_executor_v2 import (
@@ -141,11 +138,8 @@ class CudaFp8PerBlockPureCPStrategy(MoeStrategy):
             and config.ep_size > 1
             and config.parallelism_config.prefill_cp_config.is_enabled()
         )
-        is_explicit = config.moe_strategy == "fp8_per_block_pure_cp"
-        is_auto_cp = config.moe_strategy == "auto" and is_pure_cp_ep
-        checker.check(is_explicit or is_auto_cp)
-        if is_explicit:
-            checker.check(is_pure_cp_ep)
+        checker.check(config.moe_strategy == "fp8_per_block_pure_cp")
+        checker.check(is_pure_cp_ep)
 
     def get_attributes(self) -> StrategyAttributes:
         from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_hybrid_executor import (

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/fp8_per_block.py
@@ -80,6 +80,92 @@ class CudaFp8PerBlockNoDPMaskedStrategy(MoeStrategy):
         )
 
 
+class CudaFp8PerBlockPureDPStrategy(MoeStrategy):
+    """CUDA FP8 PerBlock pure DP+EP strategy using allgather+reduce_scatter.
+
+    Pure DP attention + EP MoE only: tp_size == 1, dp_size > 1, ep_size == dp_size.
+    Mixed tp>1+dp>1 deliberately falls through to DeepEP strategies.
+    """
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method == "FP8_PER_BLOCK")
+        is_pure_dp_ep = (
+            config.parallelism_config.tp_size == 1
+            and config.dp_size > 1
+            and config.ep_size == config.dp_size
+        )
+        is_explicit = config.moe_strategy == "fp8_per_block_pure_dp"
+        is_auto_dp = config.moe_strategy == "auto" and is_pure_dp_ep
+        checker.check(is_explicit or is_auto_dp)
+        if is_explicit:
+            checker.check(is_pure_dp_ep)
+
+    def get_attributes(self) -> StrategyAttributes:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_masked_executor_v2 import (
+            DeepGemmMaskedExecutorV2,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.pure_dp_router import (
+            PureDpRouterFp8PerBlock,
+        )
+
+        quant_config = FusedMoEQuantConfig(
+            quant_dtype=torch.float8_e4m3fn,
+            block_shape=[128, 128],
+        )
+        return StrategyAttributes(
+            router_class=PureDpRouterFp8PerBlock,
+            executor_class=DeepGemmMaskedExecutorV2,
+            quant_config=quant_config,
+        )
+
+
+class CudaFp8PerBlockPureCPStrategy(MoeStrategy):
+    """CUDA FP8 PerBlock pure CP+EP strategy using allgather+reduce_scatter.
+
+    Pure CP attention + EP MoE only: tp_size > 1, dp_size == 1,
+    ep_size == tp_size, prefill CP enabled. No padding needed since CP
+    splits context evenly across ranks.
+    """
+
+    @classmethod
+    def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method == "FP8_PER_BLOCK")
+        is_pure_cp_ep = (
+            config.dp_size == 1
+            and resolver.is_cp_equal_ep(config)
+            and config.ep_size > 1
+            and config.parallelism_config.prefill_cp_config.is_enabled()
+        )
+        is_explicit = config.moe_strategy == "fp8_per_block_pure_cp"
+        is_auto_cp = config.moe_strategy == "auto" and is_pure_cp_ep
+        checker.check(is_explicit or is_auto_cp)
+        if is_explicit:
+            checker.check(is_pure_cp_ep)
+
+    def get_attributes(self) -> StrategyAttributes:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.executors.deepgemm_hybrid_executor import (
+            DeepGemmHybridExecutor,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.pure_cp_router import (
+            PureCpRouterFp8PerBlock,
+        )
+
+        quant_config = FusedMoEQuantConfig(
+            quant_dtype=torch.float8_e4m3fn,
+            block_shape=[128, 128],
+        )
+        return StrategyAttributes(
+            router_class=PureCpRouterFp8PerBlock,
+            executor_class=DeepGemmHybridExecutor,
+            quant_config=quant_config,
+        )
+
+
 class CudaFp8PerBlockEpLowLatencyStrategy(MoeStrategy):
     """CUDA FP8 PerBlock EP low latency strategy"""
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_config_resolver.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_config_resolver.py
@@ -12,7 +12,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
-from rtp_llm.ops import MoeConfig, ParallelismConfig
+from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig
 
 
 def create_config_adapter(
@@ -22,6 +22,7 @@ def create_config_adapter(
     quant_config=None,
     use_deepep_low_latency: bool = False,
     data_type: str = "fp16",
+    cp_enabled: bool = False,
 ) -> MoEConfigAdapter:
     """Helper function to create MoEConfigAdapter for testing"""
     model_config = ModelConfig()
@@ -42,6 +43,8 @@ def create_config_adapter(
     parallelism_config.world_rank = 0
     parallelism_config.local_rank = 0
     parallelism_config.local_world_size = 1
+    if cp_enabled:
+        parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
 
     moe_config = MoeConfig()
     moe_config.use_deepep_low_latency = use_deepep_low_latency
@@ -125,6 +128,29 @@ class TestMoeConfigResolver(unittest.TestCase):
         """Test TP equals EP"""
         config = create_config_adapter(ep_size=4, tp_size=4)
         self.assertTrue(self.resolver.is_tp_equal_ep(config))
+
+    def test_is_tp_equal_ep_false_in_cp_mode(self):
+        """Adapter tp_size collapses to attn_tp (=1) when CP is enabled, so
+        is_tp_equal_ep returns False even though physical tp == ep. This is
+        the expected behavior — CP topologies should select via is_cp_equal_ep
+        and route to pure_cp_router instead of pure_tp_router."""
+        config = create_config_adapter(ep_size=2, tp_size=2, cp_enabled=True)
+        self.assertFalse(self.resolver.is_tp_equal_ep(config))
+
+    def test_is_cp_equal_ep_true_in_cp_mode(self):
+        """is_cp_equal_ep reads raw parallelism_config.tp_size, so it returns
+        True in CP+EP topologies regardless of the adapter's collapsed tp_size."""
+        config = create_config_adapter(ep_size=2, tp_size=2, cp_enabled=True)
+        self.assertTrue(self.resolver.is_cp_equal_ep(config))
+
+    def test_is_cp_equal_ep_true_without_cp(self):
+        """Without CP, is_cp_equal_ep behaves the same as is_tp_equal_ep."""
+        config = create_config_adapter(ep_size=4, tp_size=4)
+        self.assertTrue(self.resolver.is_cp_equal_ep(config))
+
+    def test_is_cp_equal_ep_false_when_mismatch(self):
+        config = create_config_adapter(ep_size=4, tp_size=2, cp_enabled=True)
+        self.assertFalse(self.resolver.is_cp_equal_ep(config))
 
     def test_is_pure_tp_mode_single_gpu(self):
         """Test pure TP mode with single GPU (tp=1, dp=1, ep=1)"""

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
@@ -566,8 +566,8 @@ class TestCudaFp8PerBlockPureCPStrategy(unittest.TestCase):
         self.assertTrue(strategy.can_handle(config))
 
     @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
-    def test_can_handle_pure_cp_ep_auto(self, mock_has_deep_gemm: Any) -> None:
-        """moe_strategy=auto + pure CP+EP topology should be selected."""
+    def test_can_handle_false_auto_falls_back_to_deepep(self, mock_has_deep_gemm: Any) -> None:
+        """moe_strategy=auto + pure CP+EP topology should NOT auto-select PureCP (falls back to DeepEP)."""
         mock_has_deep_gemm.return_value = True
 
         config = create_moe_config_adapter(
@@ -579,7 +579,7 @@ class TestCudaFp8PerBlockPureCPStrategy(unittest.TestCase):
         )
 
         strategy = CudaFp8PerBlockPureCPStrategy()
-        self.assertTrue(strategy.can_handle(config))
+        self.assertFalse(strategy.can_handle(config))
 
     @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
     def test_can_handle_false_dp_gt_1(self, mock_has_deep_gemm: Any) -> None:
@@ -685,8 +685,8 @@ class TestCudaFp8PerBlockPureDPStrategy(unittest.TestCase):
         self.assertTrue(strategy.can_handle(config))
 
     @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
-    def test_can_handle_pure_dp_ep_auto(self, mock_has_deep_gemm: Any) -> None:
-        """moe_strategy=auto + pure DP+EP topology should be selected."""
+    def test_can_handle_false_auto_falls_back_to_deepep(self, mock_has_deep_gemm: Any) -> None:
+        """moe_strategy=auto + pure DP+EP topology should NOT auto-select PureDP (falls back to DeepEP)."""
         mock_has_deep_gemm.return_value = True
 
         config = create_moe_config_adapter(
@@ -698,7 +698,7 @@ class TestCudaFp8PerBlockPureDPStrategy(unittest.TestCase):
         )
 
         strategy = CudaFp8PerBlockPureDPStrategy()
-        self.assertTrue(strategy.can_handle(config))
+        self.assertFalse(strategy.can_handle(config))
 
     @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
     def test_can_handle_false_tp_gt_1(self, mock_has_deep_gemm: Any) -> None:
@@ -762,6 +762,27 @@ class TestCudaFp8PerBlockPureDPStrategy(unittest.TestCase):
         )
 
         strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_cuda_graph(self, mock_has_deep_gemm: Any) -> None:
+        """enable_cuda_graph=True must reject PureDP (graph-unsafe .item() in _pad_to_max)."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=2, tp_size=1, dp_size=2
+            ),
+            moe_config=create_moe_config(
+                use_all_gather=True, moe_strategy="fp8_per_block_pure_dp"
+            ),
+            enable_cuda_graph=False,
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertTrue(strategy.can_handle(config))
+        config.enable_cuda_graph = True
         self.assertFalse(strategy.can_handle(config))
 
     def test_priority(self) -> None:

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
@@ -25,10 +25,12 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.strategy import (
     CudaFp8PerBlockEpNormalStrategy,
     CudaFp8PerBlockNoDPMaskedStrategy,
     CudaFp8PerBlockNoDPStrategy,
+    CudaFp8PerBlockPureCPStrategy,
+    CudaFp8PerBlockPureDPStrategy,
     CudaFp8PerTensorNoDPStrategy,
     CudaW4a8Int4PerChannelNoDPStrategy,
 )
-from rtp_llm.ops import MoeConfig, ParallelismConfig
+from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig
 
 
 # Helper functions for creating configuration objects
@@ -64,19 +66,30 @@ def create_model_config_with_w4a8_int4_per_channel_quant() -> ModelConfig:
 
 
 def create_parallelism_config(
-    ep_size: int = 1, tp_size: int = 1, dp_size: int = 1
+    ep_size: int = 1,
+    tp_size: int = 1,
+    dp_size: int = 1,
+    enable_cp: bool = False,
 ) -> ParallelismConfig:
     """Create ParallelismConfig with specified parallelism settings
 
     Args:
         ep_size: Expert parallelism size
-        tp_size: Tensor parallelism size
+        tp_size: Physical tensor parallelism size (raw parallelism_config.tp_size).
+            When enable_cp=True this is the CP size; the adapter's tp_size view
+            (get_attn_tp_size()) will be 1.
         dp_size: Data parallelism size
+        enable_cp: If True, enable prefill CP (ALL_GATHER). This makes
+            get_attn_tp_size() return 1 while parallelism_config.tp_size keeps
+            the physical value — which is the configuration that PureCP
+            strategies expect.
     """
     parallelism_config = ParallelismConfig()
     parallelism_config.ep_size = ep_size
     parallelism_config.tp_size = tp_size
     parallelism_config.dp_size = dp_size
+    if enable_cp:
+        parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
     return parallelism_config
 
 
@@ -518,6 +531,244 @@ class TestCudaW4a8Int4PerChannelNoDPStrategy(unittest.TestCase):
         strategy = CudaW4a8Int4PerChannelNoDPStrategy()
         router_type = RouterType.PURE_TP
         executor_type = ExecutorType.CUTLASS_W4A8_INT4_PER_CHANNEL
+        expected_priority = router_type.value * 10 + executor_type.value
+
+        attributes = strategy.get_attributes()
+        self.assertEqual(attributes.router_class.router_type(), router_type)
+        self.assertEqual(attributes.executor_class.executor_type(), executor_type)
+        self.assertEqual(strategy.priority, expected_priority)
+
+
+class TestCudaFp8PerBlockPureCPStrategy(unittest.TestCase):
+    """Test CUDA FP8 PerBlock pure CP+EP strategy.
+
+    Pure CP requires: dp_size == 1, physical tp == ep > 1, prefill CP enabled,
+    use_all_gather. The strategy also gates on moe_strategy being either
+    "fp8_per_block_pure_cp" (explicit) or "auto" with matching topology.
+    """
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_pure_cp_ep_explicit(self, mock_has_deep_gemm: Any) -> None:
+        """Explicit moe_strategy=fp8_per_block_pure_cp on a pure CP+EP topology."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=4, dp_size=1, enable_cp=True
+            ),
+            moe_config=create_moe_config(
+                use_all_gather=True, moe_strategy="fp8_per_block_pure_cp"
+            ),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertTrue(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_pure_cp_ep_auto(self, mock_has_deep_gemm: Any) -> None:
+        """moe_strategy=auto + pure CP+EP topology should be selected."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=4, dp_size=1, enable_cp=True
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertTrue(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_dp_gt_1(self, mock_has_deep_gemm: Any) -> None:
+        """dp_size > 1 disqualifies pure CP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=4, dp_size=2, enable_cp=True
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_tp_ne_ep(self, mock_has_deep_gemm: Any) -> None:
+        """Physical tp != ep disqualifies pure CP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=2, dp_size=1, enable_cp=True
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_cp_disabled(self, mock_has_deep_gemm: Any) -> None:
+        """tp==ep but CP not enabled — must not auto-select pure CP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=4, dp_size=1, enable_cp=False
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_no_all_gather(self, mock_has_deep_gemm: Any) -> None:
+        """use_all_gather=False routes back to DeepEP, not pure CP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=4, dp_size=1, enable_cp=True
+            ),
+            moe_config=create_moe_config(use_all_gather=False),
+        )
+
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    def test_priority(self) -> None:
+        """Test priority"""
+        strategy = CudaFp8PerBlockPureCPStrategy()
+        router_type = RouterType.PURE_TP
+        executor_type = ExecutorType.DEEPGEMM_CONTINUOUS
+        expected_priority = router_type.value * 10 + executor_type.value
+
+        attributes = strategy.get_attributes()
+        self.assertEqual(attributes.router_class.router_type(), router_type)
+        self.assertEqual(attributes.executor_class.executor_type(), executor_type)
+        self.assertEqual(strategy.priority, expected_priority)
+
+
+class TestCudaFp8PerBlockPureDPStrategy(unittest.TestCase):
+    """Test CUDA FP8 PerBlock pure DP+EP strategy.
+
+    Pure DP requires: physical tp == 1, dp > 1, ep == dp, use_all_gather.
+    The strategy also gates on moe_strategy being either
+    "fp8_per_block_pure_dp" (explicit) or "auto" with matching topology.
+    """
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_pure_dp_ep_explicit(self, mock_has_deep_gemm: Any) -> None:
+        """Explicit moe_strategy=fp8_per_block_pure_dp on a pure DP+EP topology."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=2, tp_size=1, dp_size=2
+            ),
+            moe_config=create_moe_config(
+                use_all_gather=True, moe_strategy="fp8_per_block_pure_dp"
+            ),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertTrue(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_pure_dp_ep_auto(self, mock_has_deep_gemm: Any) -> None:
+        """moe_strategy=auto + pure DP+EP topology should be selected."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=2, tp_size=1, dp_size=2
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertTrue(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_tp_gt_1(self, mock_has_deep_gemm: Any) -> None:
+        """Physical tp > 1 (mixed tp+dp+ep) falls back to DeepEP, not pure DP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=2, dp_size=2
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_dp_eq_1(self, mock_has_deep_gemm: Any) -> None:
+        """dp_size == 1 disqualifies pure DP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=2, tp_size=1, dp_size=1
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_ep_ne_dp(self, mock_has_deep_gemm: Any) -> None:
+        """ep_size != dp_size disqualifies pure DP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=4, tp_size=1, dp_size=2
+            ),
+            moe_config=create_moe_config(use_all_gather=True),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    @patch("rtp_llm.models_py.kernels.cuda.deepgemm_wrapper.has_deep_gemm")
+    def test_can_handle_false_no_all_gather(self, mock_has_deep_gemm: Any) -> None:
+        """use_all_gather=False routes back to DeepEP, not pure DP."""
+        mock_has_deep_gemm.return_value = True
+
+        config = create_moe_config_adapter(
+            model_config=create_model_config_with_fp8_block_quant(),
+            parallelism_config=create_parallelism_config(
+                ep_size=2, tp_size=1, dp_size=2
+            ),
+            moe_config=create_moe_config(use_all_gather=False),
+        )
+
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        self.assertFalse(strategy.can_handle(config))
+
+    def test_priority(self) -> None:
+        """Test priority"""
+        strategy = CudaFp8PerBlockPureDPStrategy()
+        router_type = RouterType.PURE_TP
+        executor_type = ExecutorType.DEEPGEMM_MASKED
         expected_priority = router_type.value * 10 + executor_type.value
 
         attributes = strategy.get_attributes()

--- a/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
@@ -101,16 +101,24 @@ class MoeConfigResolver:
 
     @staticmethod
     def is_tp_equal_ep(config: MoEConfigAdapter) -> bool:
-        """Check if TP size equals EP size
+        """Check if attention TP size equals EP size.
 
-        Args:
-            config: MOE configuration adapter
-
-        Returns:
-            Whether TP size equals EP size
+        Uses MoEConfigAdapter.tp_size, which reflects the attention/MoE-input
+        view (= get_attn_tp_size(), == 1 when CP is enabled). In CP mode this
+        returns False even if physical TP equals EP — use is_cp_equal_ep for
+        the physical-topology check.
         """
-        # in cp mode, tp_size is set to 1
         return config.tp_size == config.ep_size
+
+    @staticmethod
+    def is_cp_equal_ep(config: MoEConfigAdapter) -> bool:
+        """Check if physical TP (= CP size when CP is enabled) equals EP size.
+
+        Reads raw parallelism_config.tp_size, bypassing the adapter's tp_size
+        which is squashed to 1 in CP mode. Used by router selectors that need
+        to know the underlying TP topology (e.g. pure_cp_router).
+        """
+        return config.parallelism_config.tp_size == config.ep_size
 
     @staticmethod
     def is_pure_tp_mode(config: MoEConfigAdapter) -> bool:

--- a/rtp_llm/models_py/triton_kernels/BUILD
+++ b/rtp_llm/models_py/triton_kernels/BUILD
@@ -31,7 +31,8 @@ py_library(
 py_library(
     name = "moe",
     srcs = glob(["moe/*.py"]),
-    visibility = ["//visibility:public"]
+    deps = ["//rtp_llm/models_py:utils"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/rtp_llm/models_py/triton_kernels/moe/ep_kernels.py
+++ b/rtp_llm/models_py/triton_kernels/moe/ep_kernels.py
@@ -555,12 +555,18 @@ def recompute_topk_ids_sum_expert_count(
     Recompute topk_ids by subtracting current_expert_start_id and count expert tokens.
 
     Args:
-        topk_ids: Tensor of shape [num_tokens, topk] containing expert IDs
+        topk_ids: Tensor of shape [num_tokens, topk] containing expert IDs.
+            Sentinel value -1 is allowed and treated as a padding/invalid slot.
         current_expert_start_id: Starting expert ID to subtract
         num_local_experts: Number of local experts
 
     Returns:
         tuple: (adjusted_topk_ids, expert_count)
+
+    Sentinel contract (relied on by PureDpRouter padding):
+        - Input slots equal to -1 are NOT counted in expert_count.
+        - Output adjusted_topk_ids preserves -1 in those slots (no remap).
+        - Out-of-range expert ids (after subtraction) also collapse to -1.
     """
     device = topk_ids.device
     num_tokens, topk = topk_ids.shape

--- a/rtp_llm/models_py/triton_kernels/moe/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/moe/test/BUILD
@@ -1,6 +1,6 @@
 load("@arch_config//:arch_select.bzl", "requirement")
 
-requirement(["triton", "torch"])
+requirement(["triton", "torch", "numpy"])
 
 py_test(
     name = "test_remap_local_ids",
@@ -11,4 +11,14 @@ py_test(
     env = {"GPU_COUNT": "1"},
     tags = ["rocm"],
     exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)
+
+py_test(
+    name = "test_ep_kernels",
+    srcs = ["test_ep_kernels.py"],
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:moe",
+    ] + [":triton", ":torch", ":numpy"],
+    visibility = ["//visibility:public"],
+    exec_properties = {"gpu": "H20"},
 )

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_ep_kernels.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_ep_kernels.py
@@ -1,0 +1,164 @@
+"""Unit tests for ep_kernels.recompute_topk_ids_sum_expert_count.
+
+Pins the -1 sentinel contract that PureDpRouter relies on when padding
+short batches before allgather:
+- input slots equal to -1 must NOT be counted in expert_count
+- output adjusted_topk_ids must keep -1 unchanged in those slots
+- out-of-range expert ids collapse to -1 the same way
+
+Run with bazel:
+    bazel test //rtp_llm/models_py/triton_kernels/moe/test:test_ep_kernels --config=cuda12
+"""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.moe.ep_kernels import (
+    recompute_topk_ids_sum_expert_count,
+)
+
+
+class TestRecomputeTopkIdsSentinel(unittest.TestCase):
+    """-1 sentinel contract for recompute_topk_ids_sum_expert_count."""
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA required for triton kernel test")
+        self.device = torch.device("cuda")
+
+    def _ref_count(
+        self, topk_ids: torch.Tensor, start: int, num_local: int
+    ) -> torch.Tensor:
+        """Reference: count tokens per local expert, ignoring -1 slots."""
+        adj = topk_ids - start
+        valid = (topk_ids != -1) & (adj >= 0) & (adj < num_local)
+        flat = adj[valid].to(torch.int32)
+        out = torch.zeros(num_local, dtype=torch.int32, device=topk_ids.device)
+        if flat.numel() > 0:
+            out.scatter_add_(
+                0, flat.to(torch.int64), torch.ones_like(flat, dtype=torch.int32)
+            )
+        return out
+
+    def test_sentinel_rows_not_counted(self) -> None:
+        """A row of all -1 contributes nothing to expert_count."""
+        # 4 tokens, topk=2; rank 0 owns experts [0, 4)
+        start, num_local = 0, 4
+        topk_ids = torch.tensor(
+            [
+                [0, 1],
+                [-1, -1],  # padded row
+                [2, 3],
+                [-1, -1],  # padded row
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        adjusted, count = recompute_topk_ids_sum_expert_count(
+            topk_ids, start, num_local
+        )
+
+        # adjusted: -1 rows preserved, others remapped (start=0 → identity)
+        expected_adj = topk_ids.clone()
+        self.assertTrue(torch.equal(adjusted, expected_adj))
+
+        # count: each of experts [0,1,2,3] gets exactly 1, padded rows ignored
+        expected_count = torch.tensor([1, 1, 1, 1], dtype=torch.int32, device=self.device)
+        self.assertTrue(torch.equal(count, expected_count))
+
+    def test_mixed_sentinel_and_out_of_range(self) -> None:
+        """-1 sentinels and out-of-range ids both collapse to -1, neither counted."""
+        # rank 1 owns experts [4, 8) — adjusted by start=4, num_local=4
+        start, num_local = 4, 4
+        topk_ids = torch.tensor(
+            [
+                [4, 5],   # both local → adjusted (0, 1)
+                [0, 6],   # 0 is remote (out of range) → -1; 6 → adjusted 2
+                [-1, 7],  # sentinel + adjusted 3
+                [-1, -1], # padded row
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        adjusted, count = recompute_topk_ids_sum_expert_count(
+            topk_ids, start, num_local
+        )
+
+        # adjusted: locals remapped, remotes/sentinels → -1
+        expected_adj = torch.tensor(
+            [
+                [0, 1],
+                [-1, 2],
+                [-1, 3],
+                [-1, -1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.assertTrue(
+            torch.equal(adjusted, expected_adj),
+            f"adjusted mismatch:\n  got={adjusted}\n  want={expected_adj}",
+        )
+
+        # count: experts 0,1,2,3 each get exactly 1; out-of-range and -1 contribute 0
+        expected_count = torch.tensor([1, 1, 1, 1], dtype=torch.int32, device=self.device)
+        self.assertTrue(
+            torch.equal(count, expected_count),
+            f"count mismatch:\n  got={count}\n  want={expected_count}",
+        )
+
+    def test_all_sentinel_input(self) -> None:
+        """All-sentinel input → adjusted preserves -1, count is all zero."""
+        start, num_local = 0, 8
+        topk_ids = torch.full(
+            (5, 4), -1, dtype=torch.int32, device=self.device
+        )
+
+        adjusted, count = recompute_topk_ids_sum_expert_count(
+            topk_ids, start, num_local
+        )
+
+        self.assertTrue(torch.equal(adjusted, topk_ids))
+        self.assertTrue(
+            torch.equal(
+                count,
+                torch.zeros(num_local, dtype=torch.int32, device=self.device),
+            )
+        )
+
+    def test_matches_reference_random(self) -> None:
+        """Random input with sentinels: kernel matches CPU reference."""
+        torch.manual_seed(0)
+        num_tokens, topk = 64, 8
+        num_total_experts, num_local = 32, 8
+        start = 16  # rank 2 owns [16, 24)
+
+        topk_ids = torch.randint(
+            0, num_total_experts, (num_tokens, topk), dtype=torch.int32, device=self.device
+        )
+        # Inject -1 sentinels into random positions
+        sentinel_mask = torch.rand(num_tokens, topk, device=self.device) < 0.2
+        topk_ids[sentinel_mask] = -1
+
+        adjusted, count = recompute_topk_ids_sum_expert_count(
+            topk_ids, start, num_local
+        )
+        ref_count = self._ref_count(topk_ids, start, num_local)
+
+        # Sentinel rows in input must remain -1 in output
+        self.assertTrue(
+            (adjusted[sentinel_mask] == -1).all(),
+            "sentinel slots must stay -1 in adjusted output",
+        )
+        # Count matches reference (which excludes both -1 and out-of-range)
+        self.assertTrue(
+            torch.equal(count, ref_count),
+            f"count mismatch:\n  got={count}\n  want={ref_count}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/server/server_args/moe_group_args.py
+++ b/rtp_llm/server/server_args/moe_group_args.py
@@ -170,6 +170,8 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
             "fp8_per_block_no_dp",
             "fp8_per_block_ep_low_latency",
             "fp8_per_block_ep_normal",
+            "fp8_per_block_pure_cp",
+            "fp8_per_block_pure_dp",
             "fp8_per_tensor_no_dp",
             "fp8_per_tensor_ep_low_latency",
             "fp8_per_tensor_ep_normal",

--- a/rtp_llm/test/auto_configure_deepep_test.py
+++ b/rtp_llm/test/auto_configure_deepep_test.py
@@ -2,7 +2,7 @@ from unittest import TestCase, main
 
 from rtp_llm.config.py_config_modules import DeepEPConfig
 from rtp_llm.config.server_config_setup import auto_configure_deepep
-from rtp_llm.ops import MoeConfig, ParallelismConfig, RoleType
+from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig, RoleType
 
 
 class AutoConfigureDeepepTest(TestCase):
@@ -646,6 +646,255 @@ class AutoConfigureDeepepTest(TestCase):
             ll_num_max_token=256,
         )
         self.assertEqual(self.moe_config.ll_num_max_token, 256)
+
+    # --- CP+EP auto configuration tests ---
+    # Topology: tp_size > 1, dp_size == 1, ep_size == tp_size with CP enabled.
+    # Shape matches pure TP, but CP is on. Must NOT be classified as pure TP:
+    # use_all_gather should be cleared and DeepEP auto-config should kick in.
+    # Opting into PureCP allgather+RS still requires explicit --moe_strategy.
+
+    def test_cp_plus_ep_inference_falls_back_to_deepep(self):
+        """CP enabled with tp==ep==2 (PDFUSION) must NOT match is_pure_tp."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        self.moe_config.use_all_gather = True  # default-on flag from MoeConfig
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        # CP enabled => pure TP path skipped => use_all_gather cleared
+        self.assertFalse(self.moe_config.use_all_gather)
+        # Inference + single-node multi-GPU => DeepEP on
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
+
+    def test_cp_plus_ep_prefill_falls_back_to_deepep(self):
+        """CP enabled with tp==ep==2 in PD-separation PREFILL also falls back."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PREFILL
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertFalse(self.moe_config.use_all_gather)
+        # PD prefill + single-node multi-GPU => DeepEP on, low_latency off
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
+
+    def test_cp_plus_ep_alltoall_method_also_falls_back(self):
+        """Any non-DISABLED/PREFILL_CP/UNKNOWN method counts as CP enabled."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.ALLTOALL
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertFalse(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
+
+    def test_pure_tp_without_cp_still_uses_allgather(self):
+        """Regression guard: same shape (tp==ep==2, dp==1) but CP DISABLED is pure TP."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.DISABLED
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        # Pure TP path: use_all_gather stays on, DeepEP all disabled
+        self.assertTrue(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=False, low_latency=False, internode=False)
+
+    def test_prefill_cp_method_is_not_treated_as_cp_enabled(self):
+        """CPRotateMethod.PREFILL_CP must not flip is_pure_tp off (is_enabled() returns False)."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.PREFILL_CP
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        # PREFILL_CP method is not "is_enabled()" per ConfigModules.h, so pure TP path holds
+        self.assertTrue(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=False, low_latency=False, internode=False)
+
+    # --- Explicit --moe_strategy opt-in tests ---
+    # use_all_gather must survive auto_configure_deepep when the user explicitly
+    # opts into the PureCP / PureDP allgather+RS routers, otherwise the matching
+    # strategy's check_conditions (which requires use_all_gather) never holds.
+
+    def test_explicit_pure_dp_preserves_allgather(self):
+        """--moe_strategy=fp8_per_block_pure_dp on DP+EP topology keeps use_all_gather."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=1, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 2
+        self.moe_config.use_all_gather = True
+        self.moe_config.moe_strategy = "fp8_per_block_pure_dp"
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertTrue(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=False, low_latency=False, internode=False)
+
+    def test_explicit_pure_cp_preserves_allgather(self):
+        """--moe_strategy=fp8_per_block_pure_cp on CP+EP topology keeps use_all_gather."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.parallel_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        self.moe_config.use_all_gather = True
+        self.moe_config.moe_strategy = "fp8_per_block_pure_cp"
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertTrue(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=False, low_latency=False, internode=False)
+
+    def test_explicit_pure_dp_wrong_topology_falls_back(self):
+        """--moe_strategy=fp8_per_block_pure_dp on mixed tp+dp must NOT preserve use_all_gather."""
+        # tp>1 fails explicit_pure_dp (requires tp==1); dp>1 fails is_pure_tp (requires dp==1).
+        # Neither allow-list condition matches => use_all_gather cleared, DeepEP auto-selected.
+        self._setup_parallel_info(
+            world_size=4, tp_size=2, ep_size=4, local_world_size=8
+        )
+        self.parallel_config.dp_size = 2
+        self.moe_config.use_all_gather = True
+        self.moe_config.moe_strategy = "fp8_per_block_pure_dp"
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertFalse(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
+
+    def test_single_gpu_with_use_deepep_moe_keeps_allgather(self):
+        """Single GPU + --use_deepep_moe 1 must keep use_all_gather (no DeepEP path on 1 GPU).
+
+        Regression guard for moe_headwise smoke (world_size=1, tp_size=1, ep_size=1
+        with --use_deepep_moe 1): use_deepep_moe must NOT silently disable
+        use_all_gather on a single GPU, otherwise no MoE strategy matches.
+        """
+        self._setup_parallel_info(
+            world_size=1, tp_size=1, ep_size=1, local_world_size=8
+        )
+        self.deep_ep_config.use_deepep_moe = True
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertTrue(self.moe_config.use_all_gather)
+        # use_all_gather wins => DeepEP forcibly cleared
+        self._assert_deepep_config(moe=False, low_latency=False, internode=False)
+
+    def test_multi_gpu_use_deepep_moe_disables_allgather(self):
+        """Multi-GPU + --use_deepep_moe 1 --use_deepep_low_latency 0: use_all_gather cleared."""
+        # Mirror the CLI shape: user sets both DeepEP flags explicitly so the
+        # else-branch copies both onto moe_config; otherwise use_deepep_low_latency
+        # keeps its MoeConfig default (True).
+        self._setup_parallel_info(
+            world_size=2, tp_size=2, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 1
+        self.deep_ep_config.use_deepep_moe = True
+        self.deep_ep_config.use_deepep_low_latency = False
+        self.moe_config.use_all_gather = True
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertFalse(self.moe_config.use_all_gather)
+        self.assertTrue(self.moe_config.use_deepep_moe)
+        self.assertFalse(self.moe_config.use_deepep_low_latency)
+
+    def test_auto_strategy_does_not_preserve_allgather_on_dp(self):
+        """Regression: moe_strategy=auto on DP topology must clear use_all_gather."""
+        self._setup_parallel_info(
+            world_size=2, tp_size=1, ep_size=2, local_world_size=8
+        )
+        self.parallel_config.dp_size = 2
+        self.moe_config.use_all_gather = True
+        self.moe_config.moe_strategy = "auto"
+        role_type = RoleType.PDFUSION
+
+        auto_configure_deepep(
+            moe_config=self.moe_config,
+            deep_ep_config=self.deep_ep_config,
+            parallelism_config=self.parallel_config,
+            role_type=role_type,
+        )
+
+        self.assertFalse(self.moe_config.use_all_gather)
+        self._assert_deepep_config(moe=True, low_latency=False, internode=False)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_30b_py_pure_dp_tp1_dp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_30b_py_pure_dp_tp1_dp2.json
@@ -1,0 +1,131 @@
+{
+  "model_type": "qwen_3_moe",
+  "model_path": "/mnt/nas1/hf/Qwen3-30B-A3B-Instruct-2507-FP8",
+  "query_result": [
+    {
+      "query": {
+        "prompt": "$prompt:s1",
+        "generate_config": {
+          "max_new_tokens": 32,
+          "temperature": 0.0,
+          "top_p": 0.1,
+          "top_k": 1
+        }
+      },
+      "result": {
+        "response": " explain in simple terms\n\nSure! Let's break down the **CAP Theorem** in simple terms.\n\n---\n\n### 🌐 What is the CAP Theorem",
+        "response_alternatives": null,
+        "hidden_states": null,
+        "logits": null,
+        "loss": null,
+        "input_ids": null,
+        "output_ids": null,
+        "aux_info": {
+          "input_len": 6,
+          "prefix_len": 0,
+          "reuse_len": 0,
+          "local_reuse_len": 0,
+          "remote_reuse_len": 0,
+          "memory_reuse_len": 0,
+          "prefill_total_reuse_len": 0,
+          "prefill_local_reuse_len": 0,
+          "prefill_remote_reuse_len": 0,
+          "prefill_memory_reuse_len": 0,
+          "decode_total_reuse_len": 0,
+          "decode_local_reuse_len": 0,
+          "decode_remote_reuse_len": 0,
+          "decode_memory_reuse_len": 0,
+          "output_len": 32,
+          "step_output_len": 32,
+          "iter_count": 32,
+          "cum_log_probs": [],
+          "beam_responses": [],
+          "pd_sep": false,
+          "softmax_probs": []
+        }
+      }
+    },
+    {
+      "query": {
+        "prompt_batch": [
+          "$prompt:s1",
+          "$prompt:s3"
+        ],
+        "generate_config": {
+          "max_new_tokens": 32,
+          "temperature": 0.0,
+          "top_p": 0.1,
+          "top_k": 1
+        }
+      },
+      "result": {
+        "response_batch": [
+          {
+            "response": " explain in simple terms\n\nSure! Let's break down the **CAP Theorem** in simple terms.\n\n---\n\n### 🌐 What is the CAP Theorem",
+            "response_alternatives": null,
+            "hidden_states": null,
+            "logits": null,
+            "loss": null,
+            "input_ids": null,
+            "output_ids": null,
+            "aux_info": {
+              "input_len": 6,
+              "prefix_len": 0,
+              "reuse_len": 0,
+              "local_reuse_len": 0,
+              "remote_reuse_len": 0,
+              "memory_reuse_len": 0,
+              "prefill_total_reuse_len": 0,
+              "prefill_local_reuse_len": 0,
+              "prefill_remote_reuse_len": 0,
+              "prefill_memory_reuse_len": 0,
+              "decode_total_reuse_len": 0,
+              "decode_local_reuse_len": 0,
+              "decode_remote_reuse_len": 0,
+              "decode_memory_reuse_len": 0,
+              "output_len": 32,
+              "step_output_len": 32,
+              "iter_count": 32,
+              "cum_log_probs": [],
+              "beam_responses": [],
+              "pd_sep": false,
+              "softmax_probs": []
+            }
+          },
+          {
+            "response": "\n\nThe error `NameError: name 'screen_manager' is not defined` means that you're trying to use a variable or object called `screen_manager`,",
+            "response_alternatives": null,
+            "hidden_states": null,
+            "logits": null,
+            "loss": null,
+            "input_ids": null,
+            "output_ids": null,
+            "aux_info": {
+              "input_len": 12,
+              "prefix_len": 0,
+              "reuse_len": 0,
+              "local_reuse_len": 0,
+              "remote_reuse_len": 0,
+              "memory_reuse_len": 0,
+              "prefill_total_reuse_len": 0,
+              "prefill_local_reuse_len": 0,
+              "prefill_remote_reuse_len": 0,
+              "prefill_memory_reuse_len": 0,
+              "decode_total_reuse_len": 0,
+              "decode_local_reuse_len": 0,
+              "decode_remote_reuse_len": 0,
+              "decode_memory_reuse_len": 0,
+              "output_len": 32,
+              "step_output_len": 32,
+              "iter_count": 32,
+              "cum_log_probs": [],
+              "beam_responses": [],
+              "pd_sep": false,
+              "softmax_probs": []
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -94,6 +94,18 @@ def h20_oss_suites():
                 gpu_type=["H20"]
             ),
             smoke_test(
+                name="mla_pure_cp_pd",
+                task_info="data/model/glm5/glm_5_fp8_q_r_h20_cp.json",
+                envs={
+                    "prefill": [],
+                    "decode": []},
+                smoke_args={
+                    "prefill": "--fp8_kv_cache 1 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --reserver_runtime_mem_mb 8192 --role_type PREFILL --seq_size_per_block 64 --dp_size 1 --tp_size 2 --ep_size 2 --world_size 2 --warm_up 0 --use_deepep_moe 0 --use_all_gather 1 --moe_strategy fp8_per_block_pure_cp --cp_rotate_method ALL_GATHER",
+                    "decode": "--fp8_kv_cache 1 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --reserver_runtime_mem_mb 8192 --role_type DECODE --seq_size_per_block 64 --ep_size 2 --dp_size 2 --world_size 2 --warm_up 0 --use_deepep_moe 1 --use_deepep_low_latency 1 --cp_rotate_method PREFILL_CP --use_all_gather=0"
+                },
+                gpu_type=["H20"]
+            ),
+            smoke_test(
                 name="mla_load_quant_tp2",
                 task_info="data/model/deepseek-r1-4layer/r1_fp8_q_r_h20.json",
                 smoke_args="--cache_store_rdma_mode 0 --use_local 1 --seq_size_per_block 64 --decode_entrance 1 --act_type bf16 --quantization FP8_PER_BLOCK --tp_size 2 --reserver_runtime_mem_mb 5026",
@@ -111,6 +123,12 @@ def h20_oss_suites():
                 name="moe_masked_fp8_tp2",
                 task_info="data/model/qwen3_moe/q_r_30b_py_masked_without_deepep_tp2.json",
                 smoke_args="--moe_strategy fp8_per_block_no_dp_masked --quantization FP8_PER_BLOCK --warm_up 0 --act_type BF16 --tp_size 2 --world_size 2 --reserver_runtime_mem_mb 16005 --seq_size_per_block 64 --concurrency_limit 64",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="moe_pure_dp_fp8_dp2",
+                task_info="data/model/qwen3_moe/q_r_30b_py_pure_dp_tp1_dp2.json",
+                smoke_args="--moe_strategy fp8_per_block_pure_dp --quantization FP8_PER_BLOCK --warm_up 0 --act_type BF16 --tp_size 1 --dp_size 2 --ep_size 2 --world_size 2 --use_deepep_moe 0 --use_all_gather 1 --reserver_runtime_mem_mb 16005 --seq_size_per_block 64 --concurrency_limit 64",
                 gpu_type=["H20"],
             ),
             smoke_test(

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -101,7 +101,7 @@ def h20_oss_suites():
                     "decode": []},
                 smoke_args={
                     "prefill": "--fp8_kv_cache 1 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --reserver_runtime_mem_mb 8192 --role_type PREFILL --seq_size_per_block 64 --dp_size 1 --tp_size 2 --ep_size 2 --world_size 2 --warm_up 0 --use_deepep_moe 0 --use_all_gather 1 --moe_strategy fp8_per_block_pure_cp --cp_rotate_method ALL_GATHER",
-                    "decode": "--fp8_kv_cache 1 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --reserver_runtime_mem_mb 8192 --role_type DECODE --seq_size_per_block 64 --ep_size 2 --dp_size 2 --world_size 2 --warm_up 0 --use_deepep_moe 1 --use_deepep_low_latency 1 --cp_rotate_method PREFILL_CP --use_all_gather=0"
+                    "decode": "--fp8_kv_cache 1 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --reserver_runtime_mem_mb 8192 --role_type DECODE --seq_size_per_block 64 --ep_size 2 --dp_size 2 --world_size 2 --warm_up 0 --use_deepep_moe 1 --use_deepep_low_latency 1 --cp_rotate_method PREFILL_CP --use_all_gather 0"
                 },
                 gpu_type=["H20"]
             ),


### PR DESCRIPTION
## 实现内容

为 FP8 per-block MoE 增加两种基于 allgather + reduce_scatter 的路由方式，作为 DeepEP 之外的选项。

### 路由实现
- `pure_cp_router.py`：CP 组内 allgather token，本地完成 dispatch / expert 计算后 reduce_scatter 回收
- `pure_dp_router.py`：DP 组内 allgather，配合 EP 完成专家计算后 reduce_scatter

### 策略注册
- 新增策略 `fp8_per_block_pure_cp` / `fp8_per_block_pure_dp`，挂入 strategy 工厂
- 在 `--moe_strategy` 的 choices 列表里加上这两个名字

### 分布式工具
- `collective_torch.py`：补充 torch 通信原语 wrapper
- `triton_kernels/moe/ep_kernels.py`：调整 EP kernel 适配新路由

### 启动参数

| 参数 | Pure CP | Pure DP |
|------|---------|---------|
| `--moe_strategy` | `fp8_per_block_pure_cp` | `fp8_per_block_pure_dp` |
| 并行配置 | `--tp_size 2 --dp_size 1 --ep_size 2` | `--tp_size 1 --dp_size 2 --ep_size 2` |
| 其它 | `--cp_rotate_method ALL_GATHER` | — |

### 默认行为

**PureCP / PureDP 不在默认 `use_all_gather` 白名单内**——`moe_strategy=auto` 时这两种拓扑默认走 DeepEP。
想走 allgather+RS 路径需显式指定 `--moe_strategy=fp8_per_block_pure_cp` / `fp8_per_block_pure_dp`。

PureTP（`tp>1, dp=1, ep=tp, no CP`）和单卡仍默认走 allgather。


PD 分离场景下 prefill / decode 可独立配置，例如 `mla_pure_cp_pd`：prefill 用 pure CP allgather + RS，decode 仍走 DeepEP low-latency。

### 测试
- 单测：`cp_moe_allgather_rs_test.py`、`collective_torch_test.py`、`test_ep_kernels.py`、扩展 `test_cuda_strategies.py`
- H20 smoke：
  - `mla_pure_cp_pd`：GLM-5 PD 分离，prefill 切 allgather+RS
  - `moe_pure_dp_fp8_dp2`：Qwen3-30B-A3B FP8，tp=1 dp=2 ep=2 纯 DP
 
### 性能评测数据
https://alidocs.dingtalk.com/i/nodes/Gl6Pm2Db8DMGQKRat9rD92QBWxLq0Ee4