### PR TITLE
fix(rocm): propagate hw_kernel_config to qwen35 layers

### DIFF
--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -929,6 +929,7 @@ class RocmImpl(GpuImpl):
             W.moe_gate,
             W.multi_tokens_predict_eh_proj,
             W.linear_attn_qkvz_w,
+            W.linear_attn_ba_w,
             W.linear_attn_out_w,
         ]:
             if self.py_env_configs.py_hw_kernel_config.use_swizzleA:

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -86,7 +86,11 @@ class GenericMoeLayer(nn.Module):
         self.add_shared_expert = config.moe_style == 2
         if self.add_shared_expert:
             self.shared_expert = DenseMLP(
-                config.activation_type, parallelism_config, weights, quant_config
+                config.activation_type,
+                parallelism_config,
+                weights,
+                quant_config,
+                hw_kernel_config=hw_kernel_config,
             )
         else:
             self.shared_expert = None

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -458,13 +458,24 @@ class Qwen3NextAttention(CausalAttention):
         weights: Dict[str, torch.Tensor],
         layernorm_eps: float,
         quant_config: Optional[object] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
     ):
         super().__init__(
-            attn_config, parallelism_config, weights, layernorm_eps, quant_config
+            attn_config,
+            parallelism_config,
+            weights,
+            layernorm_eps,
+            quant_config,
+            hw_kernel_config=hw_kernel_config,
         )
         # maybe fuse gate in qkv_proj later
         self.gate = LinearFactory.create_linear_from_weights(
-            weights, W.attn_gate_w, W.attn_gate_s, None, quant_config
+            weights,
+            W.attn_gate_w,
+            W.attn_gate_s,
+            None,
+            quant_config,
+            hw_kernel_config=hw_kernel_config,
         )
 
     def forward(
@@ -488,6 +499,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         weights: Dict[str, torch.Tensor],
         layernorm_eps: float,
         quant_config: Optional[object] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
     ):
         super().__init__()
         self.linear_attn_config = linear_attn_config
@@ -496,11 +508,20 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         self.quant_config = quant_config
         # in_proj_qkvz is bf16 / fp8
         self.in_proj_qkvz = LinearFactory.create_linear_from_weights(
-            weights, W.linear_attn_qkvz_w, W.linear_attn_qkvz_s, None, quant_config
+            weights,
+            W.linear_attn_qkvz_w,
+            W.linear_attn_qkvz_s,
+            None,
+            quant_config,
+            hw_kernel_config=hw_kernel_config,
         )
-        # in_proj_ba is bf16
         self.in_proj_ba = LinearFactory.create_linear_from_weights(
-            weights, W.linear_attn_ba_w, None, None, quant_config
+            weights,
+            W.linear_attn_ba_w,
+            None,
+            None,
+            quant_config,
+            hw_kernel_config=hw_kernel_config,
         )
         self.head_k_dim = linear_attn_config.linear_key_head_dim
         self.head_v_dim = linear_attn_config.linear_value_head_dim
@@ -523,7 +544,12 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             group_size=linear_attn_config.linear_value_head_dim,
         )
         self.out_proj = LinearFactory.create_linear_from_weights(
-            weights, W.linear_attn_out_w, W.linear_attn_out_s, None, quant_config
+            weights,
+            W.linear_attn_out_w,
+            W.linear_attn_out_s,
+            None,
+            quant_config,
+            hw_kernel_config=hw_kernel_config,
         )
 
     # mixed_qkvz, mixed_ba -> q, k, v, z, b, a
@@ -749,6 +775,7 @@ class Qwen3NextDecoderLayer(nn.Module):
         moe_config,
         max_generate_batch_size: int = 0,
         enable_cuda_graph: bool = False,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -762,6 +789,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 weights,
                 config.layernorm_eps,
                 config.quant_config,
+                hw_kernel_config=hw_kernel_config,
             )
         else:
             attn_configs = config.getAttentionConfigs(
@@ -773,6 +801,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 weights,
                 config.layernorm_eps,
                 config.quant_config,
+                hw_kernel_config=hw_kernel_config,
             )
 
         if config.moe_style == 2:
@@ -783,10 +812,15 @@ class Qwen3NextDecoderLayer(nn.Module):
                 moe_config,
                 max_generate_batch_size,
                 enable_cuda_graph,
+                hw_kernel_config=hw_kernel_config,
             )
         elif config.moe_style == 0:
             self.mlp = DenseMLP(
-                config.activation_type, parallelism_config, weights, config.quant_config
+                config.activation_type,
+                parallelism_config,
+                weights,
+                config.quant_config,
+                hw_kernel_config=hw_kernel_config,
             )
 
         self.input_layernorm = RMSNorm(
@@ -863,6 +897,7 @@ class Qwen3NextModel(GptModelBase):
                     moe_config,
                     max_generate_batch_size,
                     enable_cuda_graph,
+                    hw_kernel_config=py_hw_kernel_config,
                 )
                 for idx in range(self.layer_num)
             ]

--- a/rtp_llm/models_py/model_desc/qwen3_next_mtp.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next_mtp.py
@@ -50,7 +50,9 @@ class Qwen3NextMTPModel(GptModelBase):
             eps=model_config.layernorm_eps,
         )
         self.fc = LinearFactory.create_linear_from_weights(
-            weights.global_weights, W.multi_tokens_predict_eh_proj
+            weights.global_weights,
+            W.multi_tokens_predict_eh_proj,
+            hw_kernel_config=py_hw_kernel_config,
         )
         self.norm = RMSNorm(
             weights.global_weights[W.final_ln_gamma], eps=model_config.layernorm_eps
@@ -71,6 +73,7 @@ class Qwen3NextMTPModel(GptModelBase):
                     moe_config,
                     max_generate_batch_size,
                     enable_cuda_graph,
+                    hw_kernel_config=py_hw_kernel_config,
                 )
                 for idx in range(self.layer_num)
             ]


### PR DESCRIPTION
## 概述                                                                                                                                                                                                                                                                                                 
  修复 ROCm 上 Qwen3-Next 在 `USE_SWIZZLEA=1` 时无法走通 swizzled-A hipBLASLt 路径导致精度发散的问题。                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                          
  - 在 `RocmImpl` 的 swizzle-A 权重列表中补上 `W.linear_attn_ba_w`，让 `in_proj_ba` 与其他 linear attention 权重一起完成预 swizzle。
  - 将 `hw_kernel_config` 从 `Qwen3NextModel` 一路透传到 `Qwen3NextDecoderLayer` → `Qwen3NextAttention` / `Qwen3NextGatedDeltaNet` / `DenseMLP`，以及 `GenericMoeLayer` 的 shared expert，使 `LinearFactory.create_linear_from_weights` 能正确选中 swizzled-A kernel。