### PR TITLE
fix(rocm): apply RoPE for embedding models without KV cache

### DIFF
--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -35,9 +35,8 @@ static void copyTensorExactInPlace(torch::Tensor& dst, const torch::Tensor& src,
     }
     torch::Tensor dst_flat = dst.reshape({-1});
     if (dst_flat.numel() != src_flat.numel()) {
-        throw std::runtime_error(
-            std::string("prepare_in_place tensor size mismatch for ")
-            + name + ": capture=" + std::to_string(dst_flat.numel()) + ", replay=" + std::to_string(src_flat.numel()));
+        throw std::runtime_error(std::string("prepare_in_place tensor size mismatch for ") + name + ": capture="
+                                 + std::to_string(dst_flat.numel()) + ", replay=" + std::to_string(src_flat.numel()));
     }
 
     torch::Tensor src_match = src_flat;
@@ -66,8 +65,7 @@ void updateKvCacheOffset(CKAttn& params, const torch::Tensor& kv_cache_block_id_
 }
 
 void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inputs) {
-    const bool has_prefix =
-        attn_inputs.prefix_lengths.defined() && attn_inputs.prefix_lengths.numel() > 0;
+    const bool has_prefix = attn_inputs.prefix_lengths.defined() && attn_inputs.prefix_lengths.numel() > 0;
 
     if (has_prefix && params.prefix_lengths.defined() && params.prefix_lengths.numel() > 0
         && params.prefix_lengths.data_ptr() != attn_inputs.prefix_lengths.data_ptr()) {
@@ -120,8 +118,8 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
     bool has_prefix = attn_inputs.prefix_lengths.defined() && attn_inputs.prefix_lengths.numel() > 0;
 
     const bool use_fmha_fp8 = attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
-    CKAttnPtr attn_params;
-    auto      params =
+    CKAttnPtr  attn_params;
+    auto       params =
         PrepareCKAttn(attn_configs_, kv_cache_kernel_block_id_device, attn_inputs.input_lengths.size(0), use_fmha_fp8);
     if (params) {
         attn_params = CKAttnPtr(params, (CKAttn*)params.get());
@@ -164,21 +162,23 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
     const int size_per_head     = attn_configs_.size_per_head;
     const int token_num         = qkv.size(0);
     const int batch_size        = params->cu_seqlens.size(0) - 1;
-    const int seq_len = params->prefill_runtime_max_seq_len >= 0 ? params->prefill_runtime_max_seq_len : params->max_seq_len;
-    const int max_prefix_length = params->prefill_runtime_max_prefix_len >= 0 ? params->prefill_runtime_max_prefix_len : 0;
+    const int seq_len =
+        params->prefill_runtime_max_seq_len >= 0 ? params->prefill_runtime_max_seq_len : params->max_seq_len;
+    const int max_prefix_length =
+        params->prefill_runtime_max_prefix_len >= 0 ? params->prefill_runtime_max_prefix_len : 0;
     const int seq_len_with_prefix = seq_len + max_prefix_length;
 
     const int  q_output_token_num = (use_paged_fmha && pad_query) ? batch_size * seq_len : token_num;
-    const bool paged_fp8 = use_paged_fmha && attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
-    const auto q_opts = torch::TensorOptions(qkv.dtype()).device(qkv.device());
+    const bool paged_fp8          = use_paged_fmha && attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
+    const auto q_opts             = torch::TensorOptions(qkv.dtype()).device(qkv.device());
 
     // pad_query=false: q_output is packed [token_num, heads, dim] and the kernel writes
     // every cell — skip the zero-fill. pad_query=true: padded slots between sequences
     // are not written by the kernel, so they must be zero-initialized for downstream
     // FMHA correctness.
-    torch::Tensor q_output = (use_paged_fmha && pad_query)
-        ? torch::zeros({q_output_token_num, local_head_num, size_per_head}, q_opts)
-        : torch::empty({q_output_token_num, local_head_num, size_per_head}, q_opts);
+    torch::Tensor q_output = (use_paged_fmha && pad_query) ?
+                                 torch::zeros({q_output_token_num, local_head_num, size_per_head}, q_opts) :
+                                 torch::empty({q_output_token_num, local_head_num, size_per_head}, q_opts);
     torch::Tensor q_fp8_buf;
     if (paged_fp8) {
         q_fp8_buf = torch::empty({q_output_token_num, local_head_num, size_per_head},
@@ -224,14 +224,16 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
         //       Please run with BF16 activation instead (set environment variable ACT_TYPE=bf16)
         use_fmha_fp8 = false;
     }
-    // FP8 path: keep original behavior (store QKV linearly for flash_attn_varlen_fp8)
-    // Non-FP8 path: paged layout only (Q packed-token, K/V in paged cache).
-    //   store_kv=false because K/V go directly into paged cache via store_cache;
-    //   writing k_output/v_output would be wasted HBM bandwidth.
-    bool store_qkv = use_fmha_fp8 ? !use_paged_fmha : false;
+    // FP8 path: keep original behavior (store QKV linearly for flash_attn_varlen_fp8).
+    // Non-FP8 with paged cache: K/V go directly into the cache via store_cache, so
+    //   store_kv=false (writing k_output/v_output would be wasted HBM bandwidth).
+    // Non-FP8 without paged cache (embedding models): store_kv=true so K/V are
+    //   returned as padded buffers for downstream varlen attention; RoPE must still
+    //   run for positional encoding.
+    bool store_qkv   = use_fmha_fp8 ? !use_paged_fmha : false;
     bool store_q     = true;
-    bool store_kv    = use_fmha_fp8 ? !use_paged_fmha : false;
     bool store_cache = kv_cache.has_value();
+    bool store_kv    = use_fmha_fp8 ? !use_paged_fmha : !store_cache;
 
     // Allocate K/V output buffers only when the kernel actually writes them,
     // avoiding unnecessary GPU memory allocation and zero-fill.
@@ -289,45 +291,46 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
             pad_query,
             stream_);
     } else {
-        DISPATCH_CUDA_FUNCTION_DATA_TYPE(torchDTypeToDataType(qkv.dtype()),
-                                         invokeAddFusedQKVBiasTransposePrefillV1,
-                                         q_output.data_ptr(),
-                                         k_output_ptr,
-                                         v_output_ptr,
-                                         &prefix_prompt_param,
-                                         qkv.data_ptr(),
-                                         paged_fp8 ? q_fp8_buf.data_ptr() :
-                                                     (use_fmha_fp8 && qkv_buf_fp8.defined() ? qkv_buf_fp8.data_ptr() : nullptr),
-                                         nullptr,  // position_ids: V1 falls back to context_rope's
-                                                   // built-in prefix-aware seq_idx; V3 self-computes
-                                         nullptr,
-                                         params->padding_offset.data_ptr<int>(),
-                                         params->cu_seqlens.data_ptr<int>(),
-                                         batch_size,
-                                         seq_len,
-                                         token_num,
-                                         local_head_num,
-                                         local_head_num_kv,
-                                         size_per_head,
-                                         attn_configs_.rope_config,
-                                         attn_configs_.use_logn_attn,
-                                         nullptr,
-                                         0,
-                                         use_fmha_fp8 ? use_paged_fmha :
-                                                        true,  // FP8: original flag; non-FP8: always paged
-                                         store_qkv,
-                                         store_q,
-                                         store_kv,
-                                         store_cache,
-                                         nullptr,
-                                         stream_);
+        DISPATCH_CUDA_FUNCTION_DATA_TYPE(
+            torchDTypeToDataType(qkv.dtype()),
+            invokeAddFusedQKVBiasTransposePrefillV1,
+            q_output.data_ptr(),
+            k_output_ptr,
+            v_output_ptr,
+            &prefix_prompt_param,
+            qkv.data_ptr(),
+            paged_fp8 ? q_fp8_buf.data_ptr() :
+                        (use_fmha_fp8 && qkv_buf_fp8.defined() ? qkv_buf_fp8.data_ptr() : nullptr),
+            nullptr,  // position_ids: V1 falls back to context_rope's
+                      // built-in prefix-aware seq_idx; V3 self-computes
+            nullptr,
+            params->padding_offset.data_ptr<int>(),
+            params->cu_seqlens.data_ptr<int>(),
+            batch_size,
+            seq_len,
+            token_num,
+            local_head_num,
+            local_head_num_kv,
+            size_per_head,
+            attn_configs_.rope_config,
+            attn_configs_.use_logn_attn,
+            nullptr,
+            0,
+            use_fmha_fp8 ? use_paged_fmha : true,  // FP8: original flag; non-FP8: always paged
+            store_qkv,
+            store_q,
+            store_kv,
+            store_cache,
+            nullptr,
+            stream_);
     }
     // FP8 path: paged returns Q-only fp8 buf; non-paged returns full qkv fp8 buf
     if (use_fmha_fp8) {
         return std::make_tuple(paged_fp8 ? q_fp8_buf : qkv_buf_fp8, torch::Tensor(), torch::Tensor());
     }
-    // Non-FP8: return bf16 Q (K/V in paged cache).
-    return std::make_tuple(q_output, torch::Tensor(), torch::Tensor());
+    // Non-FP8 with paged cache: return bf16 Q (K/V are already written into the cache).
+    // Non-FP8 without paged cache: also return padded K/V for flash_attn_varlen_func.
+    return std::make_tuple(q_output, k_output, v_output);
 }
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -530,7 +530,7 @@ class AiterPrefillAttnOp:
         # regardless of kv_cache presence — the caller provides K/V explicitly.
         # NOTE on head_dim=256: aiter.mha_batch_prefill_func supports head_dim in {64,128,256}
         # since aiter 0.1.13.dev4 (commit 9ed3e3490). No varlen fallback needed here.
-        if kv_cache is not None and hasattr(kv_cache, 'kv_cache_base'):
+        if kv_cache is not None and hasattr(kv_cache, "kv_cache_base"):
             return self._forward_paged(q_tensor, kv_cache, fmha_params)
 
         # FP8 non-paged path: C++ returns full qkv_buf_fp8 (Q+K+V concatenated in FP8).
@@ -686,8 +686,12 @@ class AiterPrefillAttnOpPaged:
             self.prepare_cuda_graph(fmha_params, attn_inputs)
         return fmha_params
 
-    def prepare_cuda_graph(self, fmha_params: FMHAParams, attn_inputs: PyAttentionInputs) -> None:
-        graph_block_table = getattr(attn_inputs, "kv_cache_kernel_block_id_device", None)
+    def prepare_cuda_graph(
+        self, fmha_params: FMHAParams, attn_inputs: PyAttentionInputs
+    ) -> None:
+        graph_block_table = getattr(
+            attn_inputs, "kv_cache_kernel_block_id_device", None
+        )
         if graph_block_table is None:
             graph_block_table = getattr(attn_inputs, "kv_cache_block_id_device", None)
         self.graph_device = _infer_cuda_graph_device(
@@ -1354,7 +1358,14 @@ class AiterPrefillImplAsm(FMHAImplBase):
         layer_idx: int = 0,
     ) -> torch.Tensor:
         if kv_cache is None:
-            return self.fmha_impl.forward(qkv, kv_cache, self.fmha_params)
+            # Embedding models still need positional encoding even without a KV cache.
+            if self.need_rope_kv_cache:
+                fmha_input = self.rope_kvcache_impl.forward(
+                    qkv, kv_cache, self.rope_params
+                )
+            else:
+                fmha_input = qkv
+            return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
 
         # Apply RoPE and KV Cache processing
         if self.need_rope_kv_cache:
@@ -1407,7 +1418,14 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
         layer_idx: int = 0,
     ) -> torch.Tensor:
         if kv_cache is None:
-            return self.fmha_impl.forward(qkv, kv_cache, self.fmha_params)
+            # Embedding models still need positional encoding even without a KV cache.
+            if self.need_rope_kv_cache:
+                fmha_input = self.rope_kvcache_impl.forward(
+                    qkv, kv_cache, self.rope_params
+                )
+            else:
+                fmha_input = qkv
+            return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
 
         # Apply RoPE and KV Cache processing
         if self.need_rope_kv_cache:
@@ -1462,7 +1480,9 @@ class AiterPrefillImplPaged(FMHAImplBase):
             return False
         return int(pl.max().item()) > 0
 
-    def _update_prefill_params_for_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
+    def _update_prefill_params_for_cuda_graph(
+        self, attn_inputs: PyAttentionInputs
+    ) -> None:
         input_lengths = attn_inputs.input_lengths
 
         fmha_params = self.fmha_params

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -358,25 +358,6 @@ class AiterPrefillAttnOp:
             token_kv_num,
         )
 
-    @staticmethod
-    def _unpad_kv(kv_padded: torch.Tensor, cu_seqlens_k: torch.Tensor) -> torch.Tensor:
-        """Unpad 4D [B, H_kv, max_seqlen, D] → 3D [total_tokens, H_kv, D].
-
-        This reverses the padding applied by C++ FusedRopeKVCachePrefillOp which
-        emits K/V in [B, H_kv, max_seqlen_k, D] layout.
-        """
-        batch_size = kv_padded.shape[0]
-        head_num_kv = kv_padded.shape[1]
-        head_dim = kv_padded.shape[3]
-        cu_seqlens_cpu = cu_seqlens_k.cpu()
-        chunks = []
-        for i in range(batch_size):
-            seq_len = int(cu_seqlens_cpu[i + 1].item() - cu_seqlens_cpu[i].item())
-            # kv_padded[i] is [H_kv, max_seqlen, D], take first seq_len tokens
-            # and transpose to [seq_len, H_kv, D]
-            chunks.append(kv_padded[i, :, :seq_len, :].permute(1, 0, 2))
-        return torch.cat(chunks, dim=0)
-
     def _forward_varlen(self, qkv, fmha_params):
         """Varlen path using flash_attn_varlen_func.
 
@@ -391,16 +372,16 @@ class AiterPrefillAttnOp:
             # Ensure Q is 3D [tokens, heads, head_dim]
             if query.dim() == 2:
                 query = query.view(-1, self.head_num, self.head_dim)
-            # K/V from C++ FusedRopeKVCachePrefillOp are 4D padded [B, H_kv, max_seqlen, D].
-            # Unpad them to [total_kv_tokens, H_kv, D] using cu_seqlens_k.
-            if key.dim() == 4:
-                key = self._unpad_kv(key, fmha_params.cu_seqlens_k)
-            elif key.dim() == 2:
-                key = key.view(-1, self.head_num_kv, self.head_dim)
-            if value.dim() == 4:
-                value = self._unpad_kv(value, fmha_params.cu_seqlens_k)
-            elif value.dim() == 2:
-                value = value.view(-1, self.head_num_kv, self.head_dim)
+            # K/V from C++ FusedRopeKVCachePrefillOp are 4D padded
+            # [B, H_kv, max_seqlen, D]. Unpad on device via vectorized gather to
+            # avoid per-layer D2H sync and Python batch loop on the hot path.
+            if key.dim() == 4 and value.dim() == 4:
+                key, value = unpad_kv_vectorized(key, value, fmha_params.cu_seqlens_k)
+            else:
+                if key.dim() == 2:
+                    key = key.view(-1, self.head_num_kv, self.head_dim)
+                if value.dim() == 2:
+                    value = value.view(-1, self.head_num_kv, self.head_dim)
         else:
             query, key, value = self._split_raw_qkv(
                 qkv, fmha_params.token_q_num, fmha_params.token_kv_num

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -38,10 +38,13 @@ try:
     from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
         AiterPrefillAttnOp,
         AiterPrefillAttnOpPaged,
+        AiterPrefillImplAsm,
+        AiterPrefillImplNonAsm,
         AiterPrefillImplPaged,
         FMHAParams,
     )
-    from rtp_llm.ops import AttentionConfigs, PyAttentionInputs
+    from rtp_llm.ops import AttentionConfigs, PyAttentionInputs, RopeConfig, RopeStyle
+    from rtp_llm.ops.compute_ops import get_typemeta
 
     _OPS_IMPORTABLE = True
 except ImportError:
@@ -77,6 +80,92 @@ def _make_prefill_inputs(input_lengths: List[int], device: torch.device):
     )
     attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32, device=device)
     return attn_inputs
+
+
+def _make_rope_attn_configs(
+    head_num: int,
+    head_num_kv: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    tokens_per_block: int = 16,
+):
+    """AttentionConfigs configured for need_rope_kv_cache=True with base RoPE.
+
+    Mirrors the embedding-model setup so AiterPrefillImplAsm/NonAsm wire up the
+    real FusedRopeKVCachePrefillOp during __init__.
+    """
+    cfg = _make_attn_configs(head_num, head_num_kv, head_dim, tokens_per_block)
+    cfg.dtype = dtype
+    cfg.need_rope_kv_cache = True
+    rope = RopeConfig()
+    rope.dim = head_dim
+    rope.base = 10000
+    rope.scale = 1.0
+    rope.style = RopeStyle.Base
+    cfg.rope_config = rope
+    return cfg
+
+
+def _make_rope_prefill_inputs(
+    input_lengths: List[int], device: torch.device, dtype: torch.dtype
+):
+    """PyAttentionInputs populated with the cu_seqlens / padding_offset /
+    dtype fields the C++ RoPE op reads during prepare()."""
+    attn_inputs = _make_prefill_inputs(input_lengths, device)
+    attn_inputs.dtype = get_typemeta(torch.empty(1, dtype=dtype))
+    # The C++ op reads input_lengths from CPU pinned memory in production.
+    attn_inputs.input_lengths = torch.tensor(
+        input_lengths, dtype=torch.int32, device="cpu"
+    ).pin_memory()
+    attn_inputs.sequence_lengths = torch.tensor(
+        input_lengths, dtype=torch.int32, device="cpu"
+    ).pin_memory()
+    attn_inputs.prefix_lengths = torch.zeros(
+        len(input_lengths), dtype=torch.int32, device="cpu"
+    )
+
+    cu = [0]
+    for seq_len in input_lengths:
+        cu.append(cu[-1] + seq_len)
+    cu_seqlens = torch.tensor(cu, dtype=torch.int32, device=device)
+    attn_inputs.cu_seqlens = cu_seqlens
+    attn_inputs.cu_kv_seqlens = cu_seqlens
+
+    max_seq_len = max(input_lengths)
+    padding_offset = []
+    for batch_idx, seq_len in enumerate(input_lengths):
+        offset = batch_idx * max_seq_len - cu[batch_idx]
+        padding_offset.extend([offset] * seq_len)
+    attn_inputs.padding_offset = torch.tensor(
+        padding_offset, dtype=torch.int32, device=device
+    )
+    return attn_inputs
+
+
+def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int]):
+    """Torch reference for base RoPE (style=Base, base=10000) — matches the
+    RopeConfig produced by _make_rope_attn_configs. Used to validate the C++
+    FusedRopeKVCachePrefillOp output without depending on any HF model code."""
+    head_dim = q.shape[-1]
+    half = head_dim // 2
+    positions = []
+    for seq_len in input_lengths:
+        positions.extend(range(seq_len))
+    pos = torch.tensor(positions, dtype=torch.float32, device=q.device)
+    inv_freq = 10000 ** (
+        -2.0 * torch.arange(half, dtype=torch.float32, device=q.device) / head_dim
+    )
+    angle = pos.unsqueeze(1) * inv_freq.unsqueeze(0)
+    cos = torch.cos(angle)
+    sin = torch.sin(angle)
+
+    def rot(x):
+        lo, hi = x[..., :half], x[..., half:]
+        cos_b = cos.unsqueeze(1)
+        sin_b = sin.unsqueeze(1)
+        return torch.cat([lo * cos_b - hi * sin_b, hi * cos_b + lo * sin_b], dim=-1)
+
+    return rot(q).to(q.dtype), rot(k).to(k.dtype)
 
 
 def _sdpa_reference(
@@ -305,6 +394,7 @@ class TestAiterPrefillImplPagedSupport(unittest.TestCase):
 
     def _make_attn_inputs(self, prefix_lengths):
         from types import SimpleNamespace
+
         return SimpleNamespace(
             prefix_lengths=prefix_lengths,
             is_cuda_graph=False,
@@ -325,12 +415,16 @@ class TestAiterPrefillImplPagedSupport(unittest.TestCase):
     def test_support_false_for_zero_prefix(self):
         """All-zero prefix_lengths => support() returns False (ASM/NonAsm preferred)."""
         pl = torch.zeros(4, dtype=torch.int32)
-        self.assertFalse(AiterPrefillImplPaged.support(None, self._make_attn_inputs(pl)))
+        self.assertFalse(
+            AiterPrefillImplPaged.support(None, self._make_attn_inputs(pl))
+        )
 
     def test_support_false_for_empty_prefix_lengths(self):
         """Empty prefix_lengths tensor => support() returns False."""
         pl = torch.empty(0, dtype=torch.int32)
-        self.assertFalse(AiterPrefillImplPaged.support(None, self._make_attn_inputs(pl)))
+        self.assertFalse(
+            AiterPrefillImplPaged.support(None, self._make_attn_inputs(pl))
+        )
 
 
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillImplPaged module")
@@ -344,6 +438,7 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
     def _make_stub(self, batch_size):
         """Build a minimal object with fmha_params matching capture-time batch_size."""
         from types import SimpleNamespace
+
         fmha_params = SimpleNamespace(
             cu_seqlens_q=torch.zeros(batch_size + 1, dtype=torch.int32),
             cu_seqlens_k=torch.zeros(batch_size + 1, dtype=torch.int32),
@@ -358,10 +453,16 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         stub = SimpleNamespace(fmha_params=fmha_params)
         return stub
 
-    def _make_attn_inputs(self, input_lengths, prefix_lengths=None,
-                          cu_seqlens=None, cu_kv_seqlens=None,
-                          kv_block_id=None):
+    def _make_attn_inputs(
+        self,
+        input_lengths,
+        prefix_lengths=None,
+        cu_seqlens=None,
+        cu_kv_seqlens=None,
+        kv_block_id=None,
+    ):
         from types import SimpleNamespace
+
         batch_size = len(input_lengths)
         if kv_block_id is None:
             kv_block_id = torch.zeros(batch_size, 4, dtype=torch.int32)
@@ -461,6 +562,7 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
     def test_missing_kv_block_id_raises(self):
         """Missing kv_cache block ids raises ValueError."""
         from types import SimpleNamespace
+
         stub = self._make_stub(batch_size=2)
         inputs = SimpleNamespace(
             input_lengths=torch.tensor([5, 5], dtype=torch.int32),
@@ -910,6 +1012,128 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
             head_dim=64,
             tokens_per_block=16,
         )
+
+
+# ============================================================================
+# no-cache RoPE wrapper regression — kv_cache=None + need_rope_kv_cache=True
+# ============================================================================
+
+
+class _FakeRopeKvCachePrefillOp:
+    def __init__(self, output):
+        self.calls = []
+        self.output = output
+
+    def forward(self, qkv, kv_cache, rope_params):
+        self.calls.append((qkv, kv_cache, rope_params))
+        return self.output
+
+
+class _FakeFmhaOp:
+    def __init__(self):
+        self.calls = []
+        self.output = object()
+
+    def forward(self, fmha_input, kv_cache, fmha_params):
+        self.calls.append((fmha_input, kv_cache, fmha_params))
+        return self.output
+
+
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplNoKvRopeWrapper(unittest.TestCase):
+    """Without a KV cache, embedding-style prefill still needs RoPE applied to
+    Q/K. Both ASM and NonASM wrappers must call rope_kvcache_impl before fmha_impl
+    and pass the RoPE output straight through — bypassing the prior shortcut
+    that fed raw QKV into FMHA.
+
+    Real RoPE/FMHA kernels are covered by TestAiterPrefillImplNoKvRopeRealOp
+    below; this class isolates the wrapper logic with fakes so it runs anywhere.
+    """
+
+    def _check_no_kv_rope_path(self, impl_cls):
+        impl = object.__new__(impl_cls)
+        impl.need_rope_kv_cache = True
+        qkv = torch.randn(4, 16)
+        rope_output = (
+            torch.randn(4, 2, 4),
+            torch.randn(1, 1, 4, 4),
+            torch.randn(1, 1, 4, 4),
+        )
+        impl.rope_kvcache_impl = _FakeRopeKvCachePrefillOp(rope_output)
+        impl.fmha_impl = _FakeFmhaOp()
+        impl.rope_params = object()
+        impl.fmha_params = object()
+
+        actual = impl.forward(qkv, kv_cache=None, layer_idx=0)
+
+        self.assertIs(actual, impl.fmha_impl.output)
+        self.assertEqual(len(impl.rope_kvcache_impl.calls), 1)
+        self.assertEqual(len(impl.fmha_impl.calls), 1)
+        self.assertEqual(impl.rope_kvcache_impl.calls[0], (qkv, None, impl.rope_params))
+        self.assertEqual(
+            impl.fmha_impl.calls[0],
+            (impl.rope_kvcache_impl.output, None, impl.fmha_params),
+        )
+
+    def test_asm_no_kv_cache_still_applies_rope(self):
+        self._check_no_kv_rope_path(AiterPrefillImplAsm)
+
+    def test_nonasm_no_kv_cache_still_applies_rope(self):
+        self._check_no_kv_rope_path(AiterPrefillImplNonAsm)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplNoKvRopeRealOp(unittest.TestCase):
+    """End-to-end numerical regression for the wrapper path with the real C++
+    FusedRopeKVCachePrefillOp + AiterPrefillAttnOp on ROCm. Exercises both ASM
+    and NonASM wrappers with varied-length GQA batches and asserts the output
+    matches RoPE(Q,K) → flash attention reference."""
+
+    def setUp(self):
+        torch.manual_seed(1)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_real_no_kv_rope_path(self, impl_cls):
+        input_lengths = [5, 3]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 64
+        cfg = _make_rope_attn_configs(head_num, head_num_kv, head_dim, dtype=self.dtype)
+        attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        impl = impl_cls(cfg, attn_inputs)
+
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+
+        actual = impl.forward(qkv, kv_cache=None, layer_idx=0)
+        q_rope, k_rope = _apply_base_rope(q, k, input_lengths)
+        ref = _sdpa_reference(
+            q_rope,
+            k_rope,
+            v,
+            attn_inputs.cu_seqlens,
+            attn_inputs.cu_kv_seqlens,
+            causal=True,
+        )
+        torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
+
+    def test_asm_no_kv_rope_real_op_matches_reference(self):
+        self._check_real_no_kv_rope_path(AiterPrefillImplAsm)
+
+    def test_nonasm_no_kv_rope_real_op_matches_reference(self):
+        self._check_real_no_kv_rope_path(AiterPrefillImplNonAsm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When kv_cache is None (embedding models), AiterPrefillImplAsm and AiterPrefillImplNonAsm skipped RoPE and went straight to _forward_varlen. This caused severe output divergence for models that require positional encoding (e.g. tbstars with rope_theta=10000).

Also update _forward_varlen to handle the (q, k_padded, v_padded) tuple returned by the RoPE C++ op via unpad_kv_vectorized.