### PR TITLE
Fix/kimi linear flaky

### DIFF
--- a/rtp_llm/models_py/triton_kernels/BUILD
+++ b/rtp_llm/models_py/triton_kernels/BUILD
@@ -1,3 +1,9 @@
+alias(
+    name = "autotune_cache",
+    actual = "//rtp_llm/models_py/triton_kernels/autotune_cache",
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "fla",
     srcs = glob(["fla/*.py"]),
@@ -8,7 +14,11 @@ py_library(
 py_library(
     name = "kimi_kda",
     srcs = glob(["kimi_kda/*.py"]),
-    deps = [":common"],
+    deps = [
+        ":autotune_cache",
+        ":common",
+        ":fla",
+    ],
     visibility = ["//visibility:public"]
 )
 
@@ -39,6 +49,7 @@ py_library(
 py_library(
     name = "triton_kernels",
     deps = [
+        ":autotune_cache",
         ":fla",
         ":kimi_kda",
         ":causal_conv1d",

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/BUILD
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/BUILD
@@ -1,0 +1,11 @@
+py_library(
+    name = "autotune_cache",
+    srcs = [
+        "__init__.py",
+        "cache.py",
+        "decorator.py",
+        "export.py",
+    ],
+    data = glob(["configs/**/*.json"]),
+    visibility = ["//visibility:public"],
+)

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/__init__.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/__init__.py
@@ -1,0 +1,62 @@
+"""Generic Triton autotune cache for rtp-llm.
+
+Public surface:
+
+  cuda_cached_autotune(...)   - drop-in replacement for `triton.autotune` that
+                                consults checked-in JSON configs under
+                                `autotune_cache/configs/{GPU}/{kernel}.json`
+                                before falling back to Triton benchmark.
+  cached_autotune(...)        - same as above but assumes CUDA is available
+                                (no torch.cuda.is_available guard).
+  CacheMode                   - enum of lookup modes (disabled / cached).
+  KernelConfigFile            - validated in-memory representation of a
+                                {kernel}.json file.
+  CachedAutotuner             - Triton Autotuner subclass; usually you want
+                                the decorator instead.
+  get_config_dir() / get_gpu_info()
+                              - resolve where this process reads JSON from.
+  load_cached_default_config(kernel_name)
+                              - return the default_config dict for a kernel,
+                                or None. Exposed for tests/tooling that want
+                                the parsed JSON without launching a kernel.
+  autotune_cache_kwargs       - spread at autotune call sites to opt in to
+                                Triton's on-disk benchmark cache when
+                                supported (Triton >= 3.4); no-op otherwise.
+  SUPPORTS_AUTOTUNE_CACHE     - bool: whether triton.autotune accepts a
+                                `cache_results` kwarg in this Triton version.
+
+Environment variables:
+  TRITON_AUTOTUNE_CACHE_MODE     - "disabled" (default) | "cached"
+  TRITON_AUTOTUNE_CONFIG_DIR     - override JSON root
+  TRITON_AUTOTUNE_GPU_NAME       - override GPU model id used for path lookup
+"""
+
+from rtp_llm.models_py.triton_kernels.autotune_cache.cache import (
+    SUPPORTS_AUTOTUNE_CACHE,
+    CachedAutotuner,
+    CacheMode,
+    KernelConfigFile,
+    autotune_cache_kwargs,
+    cached_autotune,
+    get_config_dir,
+    get_gpu_info,
+    load_cached_default_config,
+    sanitize_gpu_name,
+)
+from rtp_llm.models_py.triton_kernels.autotune_cache.decorator import (
+    cuda_cached_autotune,
+)
+
+__all__ = [
+    "CacheMode",
+    "CachedAutotuner",
+    "KernelConfigFile",
+    "SUPPORTS_AUTOTUNE_CACHE",
+    "autotune_cache_kwargs",
+    "cached_autotune",
+    "cuda_cached_autotune",
+    "get_config_dir",
+    "get_gpu_info",
+    "load_cached_default_config",
+    "sanitize_gpu_name",
+]

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/cache.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/cache.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Generic Triton autotune cache infrastructure for rtp-llm. Replaces
+# `triton.autotune` with a `CachedAutotuner` that consults checked-in
+# per-kernel JSON configs under `autotune_cache/configs/{GPU}/` before
+# falling back to Triton's normal benchmark-and-pick autotune.
+#
+# Each per-kernel JSON file holds a single `default_config` block that is
+# installed as the winner.
+#
+# Environment variables:
+#   TRITON_AUTOTUNE_CACHE_MODE     - "disabled" | "cached"; default "disabled"
+#   TRITON_AUTOTUNE_CONFIG_DIR     - override JSON root; default <this_dir>/configs/{GPU}/
+#   TRITON_AUTOTUNE_GPU_NAME       - override GPU model id used for path lookup
+
+import dataclasses
+import enum
+import inspect
+import json
+import logging
+import os
+import re
+from functools import cache, lru_cache
+from pathlib import Path
+from typing import Any
+
+import torch
+import triton
+from packaging import version
+from triton.runtime.autotuner import Autotuner
+
+TRITON_ABOVE_3_5_1 = version.parse(triton.__version__) >= version.parse("3.5.1")
+
+
+logger = logging.getLogger(__name__)
+
+
+# Detect whether triton.autotune accepts a `cache_results` kwarg (added in
+# Triton 3.4).
+try:
+    SUPPORTS_AUTOTUNE_CACHE = (
+        "cache_results" in inspect.signature(triton.autotune).parameters
+    )
+except Exception:
+    SUPPORTS_AUTOTUNE_CACHE = False
+
+
+# Spread `**autotune_cache_kwargs` at the autotune call site to opt in to
+# Triton's on-disk benchmark caching when available (Triton >= 3.4); no-op
+# on older Triton. Hardcoded on — debug-time invalidation goes via
+# `TRITON_CACHE_DIR` rather than a separate env knob.
+autotune_cache_kwargs = {"cache_results": True} if SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+class CacheMode(enum.Enum):
+    """How the cache loads kernel configs (TRITON_AUTOTUNE_CACHE_MODE env var).
+
+    DISABLED - skip all cache lookups, always fall back to Triton autotune
+               (default when the env var is unset).
+    CACHED   - use the top-level `default_config` of the kernel JSON file.
+               If the file is missing or has no default_config, fall back
+               to Triton autotune. CI default.
+    """
+
+    DISABLED = "disabled"
+    CACHED = "cached"
+
+    @classmethod
+    def from_env(cls) -> "CacheMode":
+        mode_str = os.environ.get("TRITON_AUTOTUNE_CACHE_MODE", cls.DISABLED.value)
+        try:
+            return cls(mode_str)
+        except ValueError:
+            valid = [m.value for m in cls]
+            raise ValueError(
+                f"Invalid TRITON_AUTOTUNE_CACHE_MODE={mode_str!r}. "
+                f"Valid values: {valid}"
+            ) from None
+
+
+@lru_cache(maxsize=1)
+def _get_cache_mode() -> CacheMode:
+    return CacheMode.from_env()
+
+
+def sanitize_gpu_name(gpu_name: str) -> str:
+    sanitized = re.sub(r"[^0-9A-Za-z]+", "_", gpu_name)
+    sanitized = sanitized.strip("_")
+    return sanitized or "unknown_gpu"
+
+
+@lru_cache(maxsize=1)
+def get_gpu_info() -> str:
+    """Get GPU model identifier (sanitized).
+
+    Priority: TRITON_AUTOTUNE_GPU_NAME env var > torch.cuda. CUDA-only —
+    other backends are not in scope for this cache. Falls back to "unknown"
+    so the module still imports on a host without a usable GPU (tests, dev
+    machines); the kernel-side decorator no-ops in that case.
+    """
+    gpu_name = os.environ.get("TRITON_AUTOTUNE_GPU_NAME")
+    if gpu_name is None and torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+    if gpu_name:
+        return sanitize_gpu_name(gpu_name)
+    return "unknown"
+
+
+def get_config_dir() -> Path:
+    """Triton autotune config directory.
+
+    Override with `TRITON_AUTOTUNE_CONFIG_DIR`. Default is the
+    `configs/{GPU}/` subdirectory next to this file.
+    """
+    override = os.environ.get("TRITON_AUTOTUNE_CONFIG_DIR")
+    if override is not None:
+        return Path(override)
+    return Path(__file__).parent / "configs" / get_gpu_info()
+
+
+@dataclasses.dataclass(frozen=True)
+class KernelConfigFile:
+    """Validated in-memory representation of a {kernel_name}.json config file."""
+
+    kernel_name: str | None
+    triton_version: str | None
+    default_config: dict[str, Any] | None
+
+    @classmethod
+    def from_dict(cls, config_file: Path, data: Any) -> "KernelConfigFile | None":
+        """Parse and validate a raw JSON dict. Returns None (with a warning)
+        if malformed.
+        """
+        if not isinstance(data, dict):
+            logger.warning(
+                "Malformed config %s: root is %s, expected dict",
+                config_file,
+                type(data).__name__,
+            )
+            return None
+        default_config = data.get("default_config")
+        if default_config is not None and not isinstance(default_config, dict):
+            logger.warning(
+                "Malformed config %s: 'default_config' is %s, expected dict",
+                config_file,
+                type(default_config).__name__,
+            )
+            return None
+        return cls(
+            kernel_name=data.get("kernel_name"),
+            triton_version=data.get("triton_version"),
+            default_config=default_config,
+        )
+
+    @classmethod
+    def from_file(cls, config_file: Path) -> "KernelConfigFile | None":
+        config_data = load_config_file(config_file)
+        if config_data is None:
+            return None
+        return cls.from_dict(config_file, config_data)
+
+
+@cache
+def load_config_file(config_file: Path) -> dict[str, Any] | None:
+    try:
+        with open(config_file) as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning("Error reading config file %s: %s", config_file, e)
+        return None
+
+
+def load_cached_default_config(kernel_name: str) -> dict[str, Any] | None:
+    """Return the `default_config` dict for a kernel, or None.
+
+    Returns None when: cache mode is disabled, file is missing/malformed,
+    or the file has no `default_config` field.
+    """
+    if _get_cache_mode() is CacheMode.DISABLED:
+        return None
+
+    config_file = get_config_dir() / f"{kernel_name}.json"
+    if not config_file.exists():
+        return None
+
+    config = KernelConfigFile.from_file(config_file)
+    if config is None:
+        return None
+    return config.default_config
+
+
+def _build_triton_config(cfg: dict[str, Any]) -> triton.Config:
+    extra = (
+        {
+            "num_ctas": cfg.get("num_ctas", 1),
+            "maxnreg": cfg.get("maxnreg"),
+            "pre_hook": None,
+            "ir_override": cfg.get("ir_override"),
+        }
+        if TRITON_ABOVE_3_5_1
+        else {}
+    )
+    return triton.Config(
+        cfg["kwargs"],
+        num_warps=cfg["num_warps"],
+        num_stages=cfg["num_stages"],
+        **extra,
+    )
+
+
+class CachedAutotuner(Autotuner):
+    """Triton Autotuner subclass that consults checked-in JSON configs first.
+
+    On the first call (in CACHED mode), if a JSON `default_config` is
+    available, replaces `self.configs` with `[default_cfg]`. Triton's own
+    `Autotuner.run()` short-circuits when `len(self.configs) == 1`: no key
+    building, no benchmark, just returns `self.configs[0]`. This keeps us
+    decoupled from Triton's internal key-extraction logic.
+
+    If CACHED mode is active but no JSON / no default_config is available,
+    behavior degrades to plain triton.autotune (benchmark-and-pick over the
+    original config list).
+    """
+
+    def __init__(
+        self, fn, arg_names, configs, key, reset_to_zero, restore_value, **kwargs
+    ):
+        super().__init__(
+            fn, arg_names, configs, key, reset_to_zero, restore_value, **kwargs
+        )
+        self.kernel_name = fn.fn.__name__ if hasattr(fn, "fn") else fn.__name__
+        self._default_cfg_resolved = False
+
+    def _resolve_default_cfg_once(self) -> None:
+        if self._default_cfg_resolved:
+            return
+        self._default_cfg_resolved = True
+        raw = load_cached_default_config(self.kernel_name)
+        if raw is None:
+            logger.info(
+                "No cached config for %s; falling back to Triton autotune",
+                self.kernel_name,
+            )
+            return
+        try:
+            self.configs = [_build_triton_config(raw)]
+            logger.info(
+                "Loaded cached default_config for %s: %s",
+                self.kernel_name,
+                raw,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to materialize default_config for %s: %s; "
+                "falling back to Triton autotune",
+                self.kernel_name,
+                e,
+            )
+
+    def run(self, *args, **kwargs):
+        if _get_cache_mode() is CacheMode.CACHED:
+            self._resolve_default_cfg_once()
+        return super().run(*args, **kwargs)
+
+
+def cached_autotune(
+    configs,
+    key=None,
+    prune_configs_by=None,
+    reset_to_zero=None,
+    restore_value=None,
+    pre_hook=None,
+    post_hook=None,
+    warmup=None,
+    rep=None,
+    use_cuda_graph=False,
+    do_bench=None,
+    cache_results=False,
+):
+    """Decorator for auto-tuning a `triton.jit`'d function with checked-in
+    JSON config support.
+
+    Extends `triton.autotune` to load `default_config` from per-kernel JSON
+    under `autotune_cache/configs/{GPU}/` (overridable via
+    `TRITON_AUTOTUNE_CONFIG_DIR`). Lookup is gated by the
+    `TRITON_AUTOTUNE_CACHE_MODE` env var. When disabled or when no config
+    is available, behavior is identical to plain `triton.autotune`.
+    """
+    if key is None:
+        key = []
+
+    def decorator(fn):
+        kwargs = {}
+        if SUPPORTS_AUTOTUNE_CACHE:
+            kwargs = {"cache_results": cache_results}
+
+        return CachedAutotuner(
+            fn,
+            fn.arg_names,
+            configs,
+            key,
+            reset_to_zero,
+            restore_value,
+            pre_hook=pre_hook,
+            post_hook=post_hook,
+            prune_configs_by=prune_configs_by,
+            warmup=warmup,
+            rep=rep,
+            use_cuda_graph=use_cuda_graph,
+            do_bench=do_bench,
+            **kwargs,
+        )
+
+    return decorator

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_gated_delta_rule_fwd_kernel_h_blockdim64.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_gated_delta_rule_fwd_kernel_h_blockdim64.json
@@ -1,0 +1,12 @@
+{
+  "kernel_name": "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BV": 32
+    },
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_gla_fwd_kernel_o.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_gla_fwd_kernel_o.json
@@ -1,0 +1,13 @@
+{
+  "kernel_name": "chunk_gla_fwd_kernel_o",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BK": 64,
+      "BV": 64
+    },
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 2
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_inter_solve_fused.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_inter_solve_fused.json
@@ -1,0 +1,12 @@
+{
+  "kernel_name": "chunk_kda_fwd_kernel_inter_solve_fused",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BK": 32
+    },
+    "num_warps": 1,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_intra_sub_chunk.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_intra_sub_chunk.json
@@ -1,0 +1,10 @@
+{
+  "kernel_name": "chunk_kda_fwd_kernel_intra_sub_chunk",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {},
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_intra_token_parallel.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/chunk_kda_fwd_kernel_intra_token_parallel.json
@@ -1,0 +1,12 @@
+{
+  "kernel_name": "chunk_kda_fwd_kernel_intra_token_parallel",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BH": 8
+    },
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/kda_gate_chunk_cumsum_vector_kernel.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/kda_gate_chunk_cumsum_vector_kernel.json
@@ -1,0 +1,12 @@
+{
+  "kernel_name": "kda_gate_chunk_cumsum_vector_kernel",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BS": 32
+    },
+    "num_warps": 2,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/kda_gate_fwd_kernel.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/kda_gate_fwd_kernel.json
@@ -1,0 +1,12 @@
+{
+  "kernel_name": "kda_gate_fwd_kernel",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {
+      "BT": 64
+    },
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 2
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/recompute_w_u_fwd_kda_kernel.json
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/configs/NVIDIA_H20/recompute_w_u_fwd_kda_kernel.json
@@ -1,0 +1,10 @@
+{
+  "kernel_name": "recompute_w_u_fwd_kda_kernel",
+  "triton_version": "3.4.0",
+  "default_config": {
+    "kwargs": {},
+    "num_warps": 4,
+    "num_ctas": 1,
+    "num_stages": 3
+  }
+}

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/decorator.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/decorator.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""CUDA-availability-guarded wrapper for the cache-aware autotune decorator."""
+
+import torch
+
+
+def cuda_cached_autotune(*args, **kwargs):
+    """Wrapper for the cache-aware autotune decorator.
+
+    Same surface as `triton.autotune` but routes through `CachedAutotuner`
+    (in `autotune_cache/cache.py`), which consults checked-in JSON configs
+    under `autotune_cache/configs/{GPU}/` before falling back to Triton's
+    benchmark-and-pick autotune. This eliminates inter-process autotune
+    flake on shapes/GPUs that have a generated config in the repo, while
+    retaining a safe fallback on uncovered combinations.
+
+    Lookup behavior is controlled by the `TRITON_AUTOTUNE_CACHE_MODE` env
+    var (see `CacheMode`: "disabled" | "cached"); when unset (default), the
+    cache is disabled and behavior is identical to plain `triton.autotune`.
+
+    On hosts without a usable CUDA GPU (import-time, tests, dev machines),
+    returns a no-op decorator so the kernel module still imports
+    successfully. `get_gpu_info()` resolves to "unknown" in that case and
+    JSON lookup never happens because we don't enter `cached_autotune`.
+
+    Usage:
+        @cuda_cached_autotune(
+            configs=[...],
+            key=[...],
+            **autotune_cache_kwargs,
+        )
+        @triton.jit
+        def my_kernel(...):
+            ...
+    """
+    if torch.cuda.is_available():
+        from rtp_llm.models_py.triton_kernels.autotune_cache.cache import (
+            cached_autotune,
+        )
+
+        return cached_autotune(*args, **kwargs)
+    else:
+        return lambda f: f

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/export.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/export.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Reads `*.autotune.json` files produced by Triton autotune (one per kernel
+# per benchmark run) and writes per-kernel `default_config` JSON to
+# autotune_cache/configs/{GPU}/.
+
+import copy
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import triton
+
+from rtp_llm.models_py.triton_kernels.autotune_cache.cache import KernelConfigFile
+
+
+def _timing_value_key(value: object) -> float:
+    """Sort key for picking the fastest config.
+
+    Triton's `Autotuner._bench` calls `do_bench(..., quantiles=(0.5, 0.2, 0.8))`,
+    which returns `[p50, p20, p80]` — we pick by p50 (median). The other
+    quantiles are tie-breakers in theory but floats are effectively never
+    equal in practice, so they don't matter. On Triton's failure path
+    (OOM / compile error) the timing is `[inf, inf, inf]`, also handled.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (list, tuple)) and value:
+        return float(value[0])
+    return float("inf")
+
+
+def _normalize_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Canonical shape for comparison and writing. Strips run-specific /
+    Triton-version-specific fields so two configs that differ only in
+    incidental metadata compare equal.
+    """
+    kwargs = cfg.get("kwargs") or {}
+    return {
+        "kwargs": copy.deepcopy(kwargs),
+        "num_warps": cfg.get("num_warps"),
+        "num_ctas": cfg.get("num_ctas", 1),
+        "num_stages": cfg.get("num_stages"),
+    }
+
+
+@dataclass(frozen=True)
+class WinnerSample:
+    """Winner config extracted from one `*.autotune.json` produced by one
+    benchmark run.
+    """
+
+    kernel_name: str
+    source_file: str
+    config: dict[str, Any]
+    timing: Any
+
+    @classmethod
+    def from_file(cls, autotune_file: Path) -> "WinnerSample | None":
+        try:
+            with open(autotune_file) as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f"Error reading {autotune_file}: {e}")
+            return None
+        if not isinstance(data, dict) or "configs_timings" not in data:
+            return None
+        configs_timings = data["configs_timings"]
+        if not configs_timings:
+            return None
+        parts = autotune_file.stem.split(".")
+        kernel_name = parts[0] if parts else "unknown_kernel"
+        best = min(configs_timings, key=lambda e: _timing_value_key(e[1]))
+        return cls(
+            kernel_name=kernel_name,
+            source_file=str(autotune_file),
+            config=best[0],
+            timing=best[1],
+        )
+
+
+def collect_winners(triton_cache_dir: Path) -> list[WinnerSample]:
+    """Scan one Triton cache dir for `*.autotune.json`, return winner per file."""
+    winners: list[WinnerSample] = []
+    for f in triton_cache_dir.rglob("*.autotune.json"):
+        w = WinnerSample.from_file(f)
+        if w is not None:
+            winners.append(w)
+    return winners
+
+
+def write_default_config_json(
+    output_file: Path,
+    kernel_name: str,
+    default_config: dict[str, Any],
+) -> str:
+    """Write a minimal `{kernel}.json` containing only default_config.
+
+    Returns "created", "updated", or "unchanged" based on existing disk state.
+    """
+    existing = KernelConfigFile.from_file(output_file) if output_file.exists() else None
+    payload = {
+        "kernel_name": kernel_name,
+        "triton_version": triton.__version__,
+        "default_config": _normalize_config(default_config),
+    }
+    if existing is not None and existing.default_config == payload["default_config"]:
+        return "unchanged"
+    with open(output_file, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    if existing is None:
+        return "created"
+    return "updated"

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/__init__.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/__init__.py
@@ -1,0 +1,13 @@
+# Triton autotune cache generation/extraction tools.
+#
+# These scripts populate
+# rtp_llm/models_py/triton_kernels/autotune_cache/configs/{GPU}/*.json by:
+#   1. Running representative kernels (one driver per op family under
+#      generators/) under triton.autotune to fill the Triton on-disk cache
+#      (~/.triton/cache/.../*.autotune.json).
+#   2. Reading those raw cache files and writing per-kernel best-config
+#      JSONs that ship with the wheel.
+#
+# Usage:
+#   python -m rtp_llm.models_py.triton_kernels.autotune_cache.scripts.extract \
+#       --init-default --op kda

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/extract.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/extract.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Generate per-kernel `default_config` from one Triton autotune benchmark run
+# and write each `default_config` to `configs/{GPU}/{kernel}.json`.
+#
+# Usage:
+#     # Run op benchmark once, compare the picked config vs. the existing
+#     # committed JSON without modifying files:
+#     python -m rtp_llm.models_py.triton_kernels.autotune_cache.scripts.extract \
+#         --init-default --op kda --dry-run
+#
+#     # Same but actually write:
+#     python -m rtp_llm.models_py.triton_kernels.autotune_cache.scripts.extract \
+#         --init-default --op kda
+#
+#     # Extract from an existing Triton cache directory (no benchmark), write existing config:
+#     python -m rtp_llm.models_py.triton_kernels.autotune_cache.scripts.extract \
+#         --extract-once --triton-cache-dir ~/.triton/cache
+#
+#     # Just list *.autotune.json files:
+#     python -m rtp_llm.models_py.triton_kernels.autotune_cache.scripts.extract \
+#         --list-only --triton-cache-dir ~/.triton/cache
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _clear_triton_cache_dir(path: Path) -> None:
+    """Remove any prior autotune output so the next run re-benchmarks."""
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _timing_less(a: Any, b: Any) -> bool:
+    """Treat timing as lexicographic tuple of floats (matches Triton schema)."""
+
+    def _t(x: Any) -> tuple[float, ...]:
+        if isinstance(x, (int, float)):
+            return (float(x),)
+        if isinstance(x, (list, tuple)):
+            return tuple(float(v) for v in x)
+        return (float("inf"),)
+
+    return _t(a) < _t(b)
+
+
+def _run_benchmark(op: str, cache_dir: Path) -> None:
+    """Run the op's generator once into `cache_dir` as TRITON_CACHE_DIR."""
+    import torch
+
+    from rtp_llm.models_py.triton_kernels.autotune_cache.scripts.generators import (
+        REGISTRY,
+        available_ops,
+    )
+    from rtp_llm.models_py.triton_kernels.fla.utils import device
+
+    if op not in REGISTRY:
+        raise ValueError(f"Unsupported op: {op!r}. Available: {available_ops()}")
+
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+    _clear_triton_cache_dir(cache_dir)
+    os.environ["TRITON_CACHE_DIR"] = str(cache_dir)
+    REGISTRY[op](device)
+
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+
+def _collect_winners(cache_dir: Path) -> dict[str, Any]:
+    """Scan Triton cache dir and return {kernel_name: fastest winner config}.
+
+    If multiple *.autotune.json exist per kernel (multiple shapes in one run),
+    pick the one with the smallest timing.
+    """
+    from rtp_llm.models_py.triton_kernels.autotune_cache.export import (
+        WinnerSample,
+        collect_winners,
+    )
+
+    best: dict[str, WinnerSample] = {}
+    for w in collect_winners(cache_dir):
+        prev = best.get(w.kernel_name)
+        if prev is None or _timing_less(w.timing, prev.timing):
+            best[w.kernel_name] = w
+    return {k: v.config for k, v in best.items()}
+
+
+def init_default(
+    op: str,
+    output_dir: Path,
+    cache_dir: Path,
+    dry_run: bool = False,
+) -> int:
+    """Run one op benchmark and write each kernel's default_config.
+
+    In dry-run, runs benchmark + compares against existing JSON, but does
+    not write. Returns 0 on success, 2 if no winners were collected.
+    """
+    from rtp_llm.models_py.triton_kernels.autotune_cache.cache import KernelConfigFile
+    from rtp_llm.models_py.triton_kernels.autotune_cache.export import (
+        _normalize_config,
+        write_default_config_json,
+    )
+
+    if not dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[benchmark] running {op} into {cache_dir}")
+    _run_benchmark(op, cache_dir)
+    winners = _collect_winners(cache_dir)
+    if not winners:
+        print(
+            "ERROR: no *.autotune.json produced under "
+            f"{cache_dir}. Check that the generator actually invokes "
+            "triton.autotune (TRITON_AUTOTUNE_CACHE_MODE=disabled is forced)."
+        )
+        return 2
+
+    print("\n" + "=" * 60)
+    print(f"Picked winner for {len(winners)} kernel(s)")
+    print("=" * 60)
+
+    written_count = 0
+    unchanged_count = 0
+    matches_existing_count = 0
+    differs_from_existing_count = 0
+    no_existing_count = 0
+    for kernel_name in sorted(winners):
+        cfg = winners[kernel_name]
+        chosen_norm = _normalize_config(cfg)
+        output_file = output_dir / f"{kernel_name}.json"
+
+        existing = (
+            KernelConfigFile.from_file(output_file) if output_file.exists() else None
+        )
+        existing_default = existing.default_config if existing is not None else None
+        if existing_default is None:
+            cmp_label = "NO_EXISTING"
+            no_existing_count += 1
+        elif existing_default == chosen_norm:
+            cmp_label = "MATCHES_EXISTING"
+            matches_existing_count += 1
+        else:
+            cmp_label = "DIFFERS_FROM_EXISTING"
+            differs_from_existing_count += 1
+
+        print(f"\n  kernel: {kernel_name}")
+        print(f"    sampled: {chosen_norm}")
+        if existing_default is not None:
+            print(f"    existing: {existing_default}")
+        print(f"    -> {cmp_label}")
+
+        if dry_run:
+            print(f"    (dry-run, not writing) {output_file}")
+        else:
+            status = write_default_config_json(output_file, kernel_name, cfg)
+            print(f"    {status}: {output_file}")
+            if status == "unchanged":
+                unchanged_count += 1
+            else:
+                written_count += 1
+
+    print("\n" + "=" * 60)
+    if dry_run:
+        print("DRY RUN — no files written")
+        print(f"matches existing        : {matches_existing_count}")
+        print(f"differs from existing   : {differs_from_existing_count}")
+        print(f"no existing file        : {no_existing_count}")
+    else:
+        print(f"written                 : {written_count}")
+        print(f"unchanged               : {unchanged_count}")
+    print("=" * 60)
+    if differs_from_existing_count > 0:
+        print(
+            "\nNOTE: one or more kernels produced a different winner than the\n"
+            "committed JSON. A single benchmark sample is inherently noisy and\n"
+            "the winner set tends to fall into a small number of numerically\n"
+            "equivalent clusters. Before committing, validate by running smoke\n"
+            "× N rounds and comparing output against golden data."
+        )
+    return 0
+
+
+def extract_once(triton_cache_dir: Path, output_dir: Path) -> None:
+    """Single-shot: take the best config from each *.autotune.json in
+    `triton_cache_dir` and write it as that kernel's default_config.
+    No fresh benchmark run — consumes whatever's already there.
+    """
+    from rtp_llm.models_py.triton_kernels.autotune_cache.export import (
+        collect_winners,
+        write_default_config_json,
+    )
+
+    if not triton_cache_dir.exists():
+        print(
+            f"Triton cache directory not found: {triton_cache_dir}. Nothing to extract."
+        )
+        sys.exit(1)
+
+    winners = collect_winners(triton_cache_dir)
+    if not winners:
+        print(f"No *.autotune.json files found in {triton_cache_dir}")
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Found {len(winners)} winner config(s). Writing to {output_dir}")
+    per_kernel_best: dict[str, Any] = {}
+    for w in winners:
+        prev = per_kernel_best.get(w.kernel_name)
+        if prev is None or _timing_less(w.timing, prev[1]):
+            per_kernel_best[w.kernel_name] = (w.config, w.timing)
+
+    for kernel_name, (cfg, _timing) in sorted(per_kernel_best.items()):
+        output_file = output_dir / f"{kernel_name}.json"
+        status = write_default_config_json(output_file, kernel_name, cfg)
+        print(f"  {status}: {output_file}")
+
+
+def list_autotune_cache_files(triton_cache_dir: Path) -> None:
+    if not triton_cache_dir.exists():
+        print(f"Triton cache directory not found: {triton_cache_dir}")
+        return
+
+    autotune_files = list(triton_cache_dir.rglob("*.autotune.json"))
+    print(f"Found {len(autotune_files)} .autotune.json files in {triton_cache_dir}:\n")
+    for i, file in enumerate(autotune_files, 1):
+        print(f"{i}. {file}")
+
+
+def _get_default_triton_cache_dir() -> Path:
+    """Isolated Triton cache directory for bootstrap runs."""
+    from triton.runtime.cache import knobs
+
+    return Path(knobs.cache.dir) / "rtp_llm_autotune_bootstrap"
+
+
+def _resolve_output_dir(output_dir: str | None) -> Path:
+    if output_dir is not None:
+        return Path(output_dir)
+
+    from rtp_llm.models_py.triton_kernels.autotune_cache.cache import get_config_dir
+
+    return get_config_dir()
+
+
+def main() -> int:
+    os.environ["TRITON_AUTOTUNE_CACHE_MODE"] = "disabled"
+
+    from rtp_llm.models_py.triton_kernels.autotune_cache.scripts.generators import (
+        available_ops,
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Generate per-kernel default_config via one Triton autotune run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        help="Output directory (default: $TRITON_AUTOTUNE_CONFIG_DIR or "
+        "rtp_llm/models_py/triton_kernels/autotune_cache/configs/{GPU})",
+    )
+    parser.add_argument(
+        "--triton-cache-dir",
+        type=str,
+        help="Isolated Triton cache directory. "
+        "Default: <triton default cache>/rtp_llm_autotune_bootstrap.",
+    )
+    parser.add_argument(
+        "--init-default",
+        action="store_true",
+        help="Primary entry: run benchmark once, extract winner per kernel, "
+        "write default_config.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only valid with --init-default: run benchmark and compare "
+        "against existing JSON, but do not modify any files.",
+    )
+    parser.add_argument(
+        "--extract-once",
+        action="store_true",
+        help="Advanced: take existing *.autotune.json under --triton-cache-dir "
+        "as a single-shot extract (no fresh benchmark).",
+    )
+    parser.add_argument(
+        "--list-only",
+        "-l",
+        action="store_true",
+        help="Only list *.autotune.json files under --triton-cache-dir.",
+    )
+    parser.add_argument(
+        "--op",
+        choices=available_ops(),
+        default="kda",
+        help=f"Op family to exercise (default: kda; available: {available_ops()}).",
+    )
+    args = parser.parse_args()
+
+    modes_selected = sum([args.init_default, args.extract_once, args.list_only])
+    if modes_selected != 1:
+        parser.error(
+            "Choose exactly one of --init-default / --extract-once / --list-only."
+        )
+    if args.dry_run and not args.init_default:
+        parser.error("--dry-run is only valid with --init-default.")
+
+    output_dir = _resolve_output_dir(args.output_dir)
+
+    if args.list_only:
+        triton_cache_dir = (
+            Path(args.triton_cache_dir)
+            if args.triton_cache_dir is not None
+            else _get_default_triton_cache_dir()
+        )
+        list_autotune_cache_files(triton_cache_dir)
+        return 0
+
+    if args.extract_once:
+        triton_cache_dir = (
+            Path(args.triton_cache_dir)
+            if args.triton_cache_dir is not None
+            else _get_default_triton_cache_dir()
+        )
+        extract_once(triton_cache_dir, output_dir)
+        return 0
+
+    # --init-default
+    cache_dir = (
+        Path(args.triton_cache_dir)
+        if args.triton_cache_dir is not None
+        else _get_default_triton_cache_dir()
+    )
+    return init_default(
+        op=args.op,
+        output_dir=output_dir,
+        cache_dir=cache_dir,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/generators/__init__.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/generators/__init__.py
@@ -1,0 +1,33 @@
+"""Registry of op-specific cache generators.
+
+Each generator is a callable ``generate(device) -> None`` that exercises the
+kernels of one op family under ``triton.autotune`` so that Triton's on-disk
+cache is populated.  The ``extract`` driver then reads that cache and writes
+per-kernel JSON.
+
+Shape parameters (head_dim, chunk_size, etc.) are kernel-specific and owned
+by each generator.
+
+To add a new op family:
+  1. Drop a ``<op>.py`` next to this file with a generator class.
+  2. Register a launcher in ``REGISTRY`` below.
+"""
+
+from typing import Callable, Dict
+
+
+def _kda_generate(device):
+    from rtp_llm.models_py.triton_kernels.autotune_cache.scripts.generators.kda import (
+        KDACacheGenerator,
+    )
+
+    KDACacheGenerator(head_dim=128, device=device).generate_kda()
+
+
+REGISTRY: Dict[str, Callable] = {
+    "kda": _kda_generate,
+}
+
+
+def available_ops() -> tuple[str, ...]:
+    return tuple(sorted(REGISTRY))

--- a/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/generators/kda.py
+++ b/rtp_llm/models_py/triton_kernels/autotune_cache/scripts/generators/kda.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+#
+# Adapted for rtp-llm
+
+
+class KDACacheGenerator:
+    """Run kimi_kda kernels to populate a Triton autotune cache for one head_dim.
+
+    Forward-only, prefill-only. Exercises chunk_kda + fused_kda_gate using the
+    exact production/CI call path (use_gate_in_kernel=True, safe_gate=False,
+    lower_bound=None, IS_VARLEN=True) so each kernel produces a single
+    autotune result for the key signature CI actually hits.
+
+    fused_recurrent_kda (decode) is intentionally excluded — it is not
+    autotuned (@triton.jit + @triton.heuristics only), so it produces no
+    winners to cache.
+    """
+
+    def __init__(self, head_dim: int, *, device):
+        self.head_dim = head_dim
+        self.device = device
+        self._tensors: tuple | None = None
+
+    @property
+    def tensors(self) -> tuple:
+        if self._tensors is None:
+            self._tensors = self._prepare_tensors()
+        return self._tensors
+
+    def _prepare_tensors(self) -> tuple:
+        import torch
+
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        # Varlen layout: [1, total_tokens, H, D] + cu_seqlens.
+        # Matches the IS_VARLEN=True path used by Kimi-Linear runtime inference.
+        N, T_per_seq, H, D = 2, 1504, 4, self.head_dim
+        T_total = N * T_per_seq
+        print(
+            f"Generating cache with head_dim={D}, varlen "
+            f"(N={N}, T_per_seq={T_per_seq}, total_tokens={T_total})"
+        )
+
+        q = torch.rand(1, T_total, H, D, dtype=dtype)
+        k = torch.rand(1, T_total, H, D, dtype=dtype)
+        v = torch.rand(1, T_total, H, D, dtype=dtype)
+        g = torch.randn(1, T_total, H, D, dtype=torch.float32)
+        A_log = torch.randn(H, dtype=torch.float)
+        dt_bias = torch.randn(H * D, dtype=torch.float)
+        beta = torch.randn(1, T_total, H, dtype=dtype).sigmoid()
+        # Initial states: one per sequence — shape [N, H, D, D].
+        h0 = torch.randn(N, H, D, D, dtype=torch.float32)
+        cu_seqlens = torch.tensor(
+            [i * T_per_seq for i in range(N + 1)], dtype=torch.int32
+        )
+
+        # Forward-only: no requires_grad needed.
+        A_log = A_log.to(self.device)
+        dt_bias = dt_bias.to(self.device)
+        q = q.to(self.device)
+        k = k.to(self.device)
+        v = v.to(self.device)
+        beta = beta.to(self.device)
+        h0 = h0.to(self.device)
+        g = g.to(self.device)
+        cu_seqlens = cu_seqlens.to(self.device)
+        return q, k, v, g, beta, h0, A_log, dt_bias, cu_seqlens
+
+    def generate_kda(self) -> None:
+        from rtp_llm.models_py.triton_kernels.kimi_kda import chunk_kda, fused_kda_gate
+
+        q, k, v, g, beta, h0, A_log, dt_bias, cu_seqlens = self.tensors
+
+        # Exercise only the production call path: use_gate_in_kernel=True,
+        # safe_gate=False (default), lower_bound=None, IS_VARLEN=True.
+        chunk_kda(
+            q=q.clone(),
+            k=k.clone(),
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            A_log=A_log.clone(),
+            dt_bias=dt_bias.clone(),
+            scale=None,
+            initial_state=h0.clone(),
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens.clone(),
+            use_gate_in_kernel=True,
+        )
+
+        # fused_kda_gate standalone: covers kda_gate_fwd_kernel
+        # Call without lower_bound to match production.
+        _ = fused_kda_gate(
+            g=g.clone(),
+            A_log=A_log.clone(),
+            dt_bias=dt_bias.clone(),
+        )

--- a/rtp_llm/models_py/triton_kernels/fla/utils.py
+++ b/rtp_llm/models_py/triton_kernels/fla/utils.py
@@ -334,20 +334,5 @@ else:
         return torch.cuda.device(index)
 
 
-# Triton autotune cache support
-import inspect as _inspect
-
-try:
-    _SUPPORTS_AUTOTUNE_CACHE = (
-        "cache_results" in _inspect.signature(triton.autotune.__init__).parameters
-    )
-except Exception:
-    _SUPPORTS_AUTOTUNE_CACHE = False
-
-_FLA_CACHE_RESULTS = os.environ.get("FLA_CACHE_RESULTS", "1") == "1"
-autotune_cache_kwargs = (
-    {"cache_results": _FLA_CACHE_RESULTS} if _SUPPORTS_AUTOTUNE_CACHE else {}
-)
-
 # 1/ln(2) constant for log2-space gate computation
 RCP_LN2 = 1.0 / 0.6931471805599453

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_delta_h.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_delta_h.py
@@ -11,21 +11,15 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
 )
 from rtp_llm.models_py.triton_kernels.fla.op import exp, exp2
-from rtp_llm.models_py.triton_kernels.fla.utils import (
-    autotune_cache_kwargs,
-    check_shared_mem,
-)
-from rtp_llm.models_py.triton_kernels.fla.utils import (
-    is_nvidia_hopper as IS_NVIDIA_HOPPER,
-)
-from rtp_llm.models_py.triton_kernels.fla.utils import use_cuda_graph as USE_CUDA_GRAPH
-
-NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
 
 
 @triton.heuristics(
@@ -38,15 +32,14 @@ NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4]
-        for num_stages in ([2, 3, 4] if check_shared_mem("ampere") else [2, 1])
-        for BV in ([32, 64] if check_shared_mem("ada") else [32])
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
     ],
     key=["H", "HV", "K", "V", "BT", "USE_EXP2", "TRANSPOSE_STATE"],
-    use_cuda_graph=USE_CUDA_GRAPH,
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_intra.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_intra.py
@@ -11,9 +11,12 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 from rtp_llm.models_py.triton_kernels.fla.op import exp2
-from rtp_llm.models_py.triton_kernels.fla.utils import autotune_cache_kwargs
 from rtp_llm.models_py.triton_kernels.fla.utils import (
     is_gather_supported as IS_GATHER_SUPPORTED,
 )
@@ -40,7 +43,7 @@ else:
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BK": BK}, num_warps=num_warps)
         for BK in [32, 64]
@@ -425,7 +428,7 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [1, 2, 4, 8]

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_intra_token_parallel.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_intra_token_parallel.py
@@ -12,8 +12,11 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.op import exp2
-from rtp_llm.models_py.triton_kernels.fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics(
@@ -21,7 +24,7 @@ from rtp_llm.models_py.triton_kernels.fla.utils import autotune_cache_kwargs
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BH": BH}, num_warps=num_warps)
         for BH in [1, 2, 4, 8]

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_o.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/chunk_o.py
@@ -12,9 +12,12 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 from rtp_llm.models_py.triton_kernels.fla.op import exp, exp2
-from rtp_llm.models_py.triton_kernels.fla.utils import autotune_cache_kwargs
 
 
 @triton.heuristics(
@@ -22,7 +25,7 @@ from rtp_llm.models_py.triton_kernels.fla.utils import autotune_cache_kwargs
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
         for BK in [32, 64]

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/gate.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/gate.py
@@ -13,15 +13,15 @@ import torch.nn.functional as F
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 from rtp_llm.models_py.triton_kernels.fla.op import exp, softplus
-from rtp_llm.models_py.triton_kernels.fla.utils import (
-    autotune_cache_kwargs,
-    check_shared_mem,
-)
 from rtp_llm.models_py.triton_kernels.fla.utils import is_amd as IS_AMD
 
-BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+BS_LIST = [32, 64]
 BT_LIST_AUTOTUNE = [32, 64, 128]
 NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [4, 8, 16, 32]
 
@@ -33,7 +33,7 @@ NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if IS_AMD else [4, 8, 16, 32]
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BT": BT}, num_warps=num_warps, num_stages=num_stages)
         for BT in BT_LIST_AUTOTUNE
@@ -159,7 +159,7 @@ def fused_kda_gate(
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({"BS": BS}, num_warps=num_warps)
         for BS in BS_LIST

--- a/rtp_llm/models_py/triton_kernels/kimi_kda/wy_fast.py
+++ b/rtp_llm/models_py/triton_kernels/kimi_kda/wy_fast.py
@@ -11,12 +11,12 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.autotune_cache import (
+    autotune_cache_kwargs,
+    cuda_cached_autotune,
+)
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 from rtp_llm.models_py.triton_kernels.fla.op import exp2
-from rtp_llm.models_py.triton_kernels.fla.utils import (
-    autotune_cache_kwargs,
-    check_shared_mem,
-)
 
 
 @triton.heuristics(
@@ -26,7 +26,7 @@ from rtp_llm.models_py.triton_kernels.fla.utils import (
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
-@triton.autotune(
+@cuda_cached_autotune(
     configs=[
         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
         for num_warps in [2, 4, 8]

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_cuda_graph.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_cuda_graph.json
@@ -26,7 +26,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**\n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**\n3. **你是否使用过“听写”或“跟读”练习？这些方法对你提升",
+                            "content": "当然可以！以下是围绕“英语听力方法”主题提出的几个有深度、启发性的问题，适合用于课堂讨论、自我反思或教学研究：\n\n---\n\n### 一、方法类问题\n1. **你通常如何训练英语听力？你觉得自己最有效的方法是什么？为什么？**  \n2. **你是否尝试过“精听”和“泛听”结合的方法？你觉得哪种对你帮助更大？**  \n3. **你是否使用过“听写”或“跟读”练习？这些方法",
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -91,7 +91,7 @@
             "result": {
                 "response_batch": [
                     {
-                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
+                        "response": "\n\nCAP theorem states that a distributed system can only",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -123,7 +123,7 @@
                         }
                     },
                     {
-                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
+                        "response": "\n\nCAP theorem states that a distributed system can only",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,
@@ -155,7 +155,7 @@
                         }
                     },
                     {
-                        "response": "\n\nCAP theorem states that any distributed system can guarantee",
+                        "response": "\n\nCAP theorem states that a distributed system can only",
                         "response_alternatives": null,
                         "hidden_states": null,
                         "logits": null,

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -335,24 +335,28 @@ def h20_oss_suites():
                 name="kimi_bf16_basic",
                 task_info="data/model/kimi_linear/q_r_bf16_tp2.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 2048 --tp_size 2 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192",
+                envs=["TRITON_AUTOTUNE_CACHE_MODE=cached"],
                 gpu_type=["H20"],
             ),
             smoke_test(
                 name="kimi_kernel_block",
                 task_info="data/model/kimi_linear/q_r_bf16_tp2_kernel_block_size_64.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 2048 --tp_size 2 --kernel_seq_size_per_block 64 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192",
+                envs=["TRITON_AUTOTUNE_CACHE_MODE=cached"],
                 gpu_type=["H20"],
             ),
             smoke_test(
                 name="kimi_cudagraph",
                 task_info="data/model/kimi_linear/q_r_cuda_graph.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 2048 --max_seq_len 128 --enable_cuda_graph 1 --warm_up 0 --concurrency_limit 8 --reserver_runtime_mem_mb 8192 --tp_size 2 --ssm_state_dtype fp32",
+                envs=["TRITON_AUTOTUNE_CACHE_MODE=cached"],
                 gpu_type=["H20"],
             ),
             smoke_test(
                 name="kimi_long_reuse_memcache",
                 task_info="data/model/kimi_linear/q_r_bf16_tp2_long_input_reuse_cache.json",
                 smoke_args="--tp_size 2 --act_type BF16 --max_seq_len 16384 --seq_size_per_block 2048 --linear_step 2 --reuse_cache 1 --enable_memory_cache 1 --memory_cache_size_mb 2048 --write_cache_sync 1 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192",
+                envs=["TRITON_AUTOTUNE_CACHE_MODE=cached"],
                 gpu_type=["H20"],
             ),
             smoke_test(
@@ -361,6 +365,10 @@ def h20_oss_suites():
                 smoke_args= {
                     "prefill": "--seq_size_per_block 2048 --act_type BF16 --role_type PREFILL --cache_store_rdma_mode 0 --use_local 1 --tp_size 2 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192",
                     "decode": "--seq_size_per_block 2048 --act_type BF16 --role_type DECODE --cache_store_rdma_mode 0 --use_local 1 --tp_size 2 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192"
+                },
+                envs={
+                    "prefill": ["TRITON_AUTOTUNE_CACHE_MODE=cached"],
+                    "decode": ["TRITON_AUTOTUNE_CACHE_MODE=cached"],
                 },
                 gpu_type=["H20"],
             ),


### PR DESCRIPTION
a. turn off triton.autotune to ensure consistent actual data output, and pin the BV/BK/num_warps/num_stages .etc.
b. adjust golden data output with the pinned config.