### PR TITLE
Feat/fuse remap local ids triton

### DIFF
--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -17,6 +17,9 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
     FusedMoEQuantConfig,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
+from rtp_llm.models_py.triton_kernels.moe.remap_local_ids_kernel import (
+    remap_to_local_ids,
+)
 
 
 class MoriEpIntranodeRouter(FusedMoeDataRouter):
@@ -69,16 +72,7 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         """
         local_start = self.ep_rank * self.expert_num_per_rank
         local_end = local_start + self.expert_num_per_rank
-        non_local_mask = (dispatch_ids < local_start) | (dispatch_ids >= local_end)
-
-        local_ids = dispatch_ids.clone()
-        local_ids[non_local_mask] = local_start
-        local_ids = local_ids - local_start
-
-        local_weights = dispatch_weights.to(torch.float32).clone()
-        local_weights[non_local_mask] = 0.0
-
-        return local_ids, local_weights
+        return remap_to_local_ids(dispatch_ids, dispatch_weights, local_start, local_end)
 
     def prepare(
         self,

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -17,9 +17,6 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
     FusedMoEQuantConfig,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
-from rtp_llm.models_py.triton_kernels.moe.remap_local_ids_kernel import (
-    remap_to_local_ids,
-)
 
 
 class MoriEpIntranodeRouter(FusedMoeDataRouter):
@@ -70,6 +67,10 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         Non-local experts are mapped to local index 0 (safe fallback) so the
         fused kernel computes valid output that is zeroed by weight=0.
         """
+        from rtp_llm.models_py.triton_kernels.moe.remap_local_ids_kernel import (
+            remap_to_local_ids,
+        )
+
         local_start = self.ep_rank * self.expert_num_per_rank
         local_end = local_start + self.expert_num_per_rank
         return remap_to_local_ids(dispatch_ids, dispatch_weights, local_start, local_end)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
@@ -147,6 +147,7 @@ def _install_rtp_llm_stubs_for_moriep_wrapper() -> None:
 # ---------------------------------------------------------------------------
 
 _FUSED_MOE_DEFS_DIR = _MODELS_PY / "modules" / "factory" / "fused_moe" / "defs"
+_TRITON_MOE_DIR = _MODELS_PY / "triton_kernels" / "moe"
 _ROUTER_FILE = (
     _MODELS_PY
     / "modules"
@@ -182,6 +183,12 @@ def _load_production_router_modules() -> None:
     _load_module(
         "rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe",
         _FUSED_MOE_DEFS_DIR / "fused_moe.py",
+    )
+    # 5. remap_local_ids_kernel (lazy-imported by router._remap_to_local_ids)
+    _ensure_packages_up_to("rtp_llm.models_py.triton_kernels.moe")
+    _load_module(
+        "rtp_llm.models_py.triton_kernels.moe.remap_local_ids_kernel",
+        _TRITON_MOE_DIR / "remap_local_ids_kernel.py",
     )
 
 

--- a/rtp_llm/models_py/triton_kernels/moe/remap_local_ids_kernel.py
+++ b/rtp_llm/models_py/triton_kernels/moe/remap_local_ids_kernel.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _remap_to_local_ids_kernel(
+    ids_ptr,
+    weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    local_start,
+    local_end,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < N
+
+    ids = tl.load(ids_ptr + offsets, mask=mask, other=0)
+    weights = tl.load(weights_ptr + offsets, mask=mask, other=0.0)
+
+    is_local = (ids >= local_start) & (ids < local_end)
+    local_ids = tl.where(is_local, ids - local_start, 0)
+    local_weights = tl.where(is_local, weights, 0.0)
+
+    tl.store(out_ids_ptr + offsets, local_ids, mask=mask)
+    tl.store(out_weights_ptr + offsets, local_weights, mask=mask)
+
+
+def remap_to_local_ids(
+    dispatch_ids: torch.Tensor,
+    dispatch_weights: torch.Tensor,
+    local_start: int,
+    local_end: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert dispatch_ids.is_contiguous()
+    assert dispatch_weights.is_contiguous()
+
+    N = dispatch_ids.numel()
+    local_ids = torch.empty_like(dispatch_ids, dtype=torch.int32)
+    local_weights = torch.empty(
+        dispatch_ids.shape, dtype=torch.float32, device=dispatch_ids.device
+    )
+
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(N, BLOCK_SIZE),)
+
+    _remap_to_local_ids_kernel[grid](
+        dispatch_ids.view(-1),
+        dispatch_weights.to(torch.float32).view(-1),
+        local_ids.view(-1),
+        local_weights.view(-1),
+        local_start,
+        local_end,
+        N,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return local_ids, local_weights

--- a/rtp_llm/models_py/triton_kernels/moe/remap_local_ids_kernel.py
+++ b/rtp_llm/models_py/triton_kernels/moe/remap_local_ids_kernel.py
@@ -39,6 +39,14 @@ def remap_to_local_ids(
     assert dispatch_weights.is_contiguous()
 
     N = dispatch_ids.numel()
+
+    if N == 0:
+        local_ids = torch.empty_like(dispatch_ids, dtype=torch.int32)
+        local_weights = torch.empty(
+            dispatch_ids.shape, dtype=torch.float32, device=dispatch_ids.device
+        )
+        return local_ids, local_weights
+
     local_ids = torch.empty_like(dispatch_ids, dtype=torch.int32)
     local_weights = torch.empty(
         dispatch_ids.shape, dtype=torch.float32, device=dispatch_ids.device

--- a/rtp_llm/models_py/triton_kernels/moe/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/moe/test/BUILD
@@ -1,0 +1,14 @@
+load("@arch_config//:arch_select.bzl", "requirement")
+
+requirement(["triton", "torch"])
+
+py_test(
+    name = "test_remap_local_ids",
+    srcs = ["test_remap_local_ids.py"],
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:moe",
+    ] + [":triton", ":torch"],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_remap_local_ids.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_remap_local_ids.py
@@ -1,0 +1,159 @@
+"""
+Tests for remap_to_local_ids Triton kernel.
+Verifies equivalence with reference torch implementation across edge cases.
+Requires ROCm or CUDA GPU; skipped when no GPU is available.
+"""
+import unittest
+
+import torch
+
+HAS_GPU = torch.cuda.is_available()
+
+if HAS_GPU:
+    from rtp_llm.models_py.triton_kernels.moe.remap_local_ids_kernel import (
+        remap_to_local_ids,
+    )
+
+
+def remap_to_local_ids_ref(
+    dispatch_ids: torch.Tensor,
+    dispatch_weights: torch.Tensor,
+    local_start: int,
+    local_end: int,
+) -> tuple:
+    """Reference implementation in pure PyTorch."""
+    is_local = (dispatch_ids >= local_start) & (dispatch_ids < local_end)
+    local_ids = torch.where(is_local, dispatch_ids - local_start, torch.zeros_like(dispatch_ids))
+    local_weights = torch.where(is_local, dispatch_weights, torch.zeros_like(dispatch_weights))
+    return local_ids.to(torch.int32), local_weights.to(torch.float32)
+
+
+DEVICE = torch.device("cuda") if HAS_GPU else None
+
+
+@unittest.skipUnless(HAS_GPU, "No GPU available, skipping Triton kernel tests")
+class TestRemapToLocalIds(unittest.TestCase):
+    """Parameterized tests for remap_to_local_ids kernel."""
+
+    def test_empty_dispatch_n0(self):
+        """P1: N=0 should not launch kernel, return empty tensors."""
+        ids = torch.empty((0, 4), dtype=torch.int32, device=DEVICE)
+        weights = torch.empty((0, 4), dtype=torch.float32, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 0, 8)
+        self.assertEqual(local_ids.shape, (0, 4))
+        self.assertEqual(local_weights.shape, (0, 4))
+        self.assertEqual(local_ids.dtype, torch.int32)
+        self.assertEqual(local_weights.dtype, torch.float32)
+
+    def test_all_local(self):
+        """All experts belong to this rank."""
+        ids = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.5, 0.3, 0.1, 0.1], [0.4, 0.3, 0.2, 0.1]], dtype=torch.float32, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 0, 4)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, 0, 4)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_all_non_local(self):
+        """No experts belong to this rank — all weights should be zeroed."""
+        ids = torch.tensor([[8, 9, 10, 11]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.3, 0.3, 0.2, 0.2]], dtype=torch.float32, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 0, 8)
+        self.assertTrue((local_ids == 0).all())
+        self.assertTrue((local_weights == 0.0).all())
+
+    def test_mixed_local_non_local(self):
+        """Mix of local and non-local experts."""
+        ids = torch.tensor([[4, 5, 12, 15], [6, 7, 0, 1]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.3, 0.3, 0.2, 0.2], [0.4, 0.3, 0.2, 0.1]], dtype=torch.float32, device=DEVICE)
+        local_start, local_end = 4, 8
+        local_ids, local_weights = remap_to_local_ids(ids, weights, local_start, local_end)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, local_start, local_end)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_weight_dtype_fp16(self):
+        """Kernel should handle fp16 input weights (output is always fp32)."""
+        ids = torch.tensor([[2, 5, 7, 10]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.25, 0.25, 0.25, 0.25]], dtype=torch.float16, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 4, 8)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, 4, 8)
+        self.assertEqual(local_weights.dtype, torch.float32)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights, atol=1e-3))
+
+    def test_weight_dtype_bf16(self):
+        """Kernel should handle bf16 input weights (output is always fp32)."""
+        ids = torch.tensor([[2, 5, 7, 10]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.25, 0.25, 0.25, 0.25]], dtype=torch.bfloat16, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 4, 8)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, 4, 8)
+        self.assertEqual(local_weights.dtype, torch.float32)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights, atol=1e-3))
+
+    def test_weight_dtype_fp32(self):
+        """Kernel should handle fp32 input weights."""
+        ids = torch.tensor([[2, 5, 7, 10]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.25, 0.25, 0.25, 0.25]], dtype=torch.float32, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 4, 8)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, 4, 8)
+        self.assertEqual(local_weights.dtype, torch.float32)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_topk_1(self):
+        """topk=1."""
+        M, topk, num_experts = 16, 1, 64
+        local_start, local_end = 8, 16
+        ids = torch.randint(0, num_experts, (M, topk), dtype=torch.int32, device=DEVICE)
+        weights = torch.randn(M, topk, dtype=torch.float32, device=DEVICE).abs()
+        local_ids, local_weights = remap_to_local_ids(ids, weights, local_start, local_end)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, local_start, local_end)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_topk_8(self):
+        """topk=8."""
+        M, topk, num_experts = 16, 8, 64
+        local_start, local_end = 8, 16
+        ids = torch.randint(0, num_experts, (M, topk), dtype=torch.int32, device=DEVICE)
+        weights = torch.randn(M, topk, dtype=torch.float32, device=DEVICE).abs()
+        local_ids, local_weights = remap_to_local_ids(ids, weights, local_start, local_end)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, local_start, local_end)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_large_batch(self):
+        """Stress test with large token count (exceeds single Triton block)."""
+        M, topk, num_experts = 4096, 8, 128
+        local_start, local_end = 64, 80
+        ids = torch.randint(0, num_experts, (M, topk), dtype=torch.int32, device=DEVICE)
+        weights = torch.randn(M, topk, dtype=torch.float32, device=DEVICE).abs()
+        local_ids, local_weights = remap_to_local_ids(ids, weights, local_start, local_end)
+        ref_ids, ref_weights = remap_to_local_ids_ref(ids, weights, local_start, local_end)
+        self.assertTrue(torch.equal(local_ids, ref_ids))
+        self.assertTrue(torch.allclose(local_weights, ref_weights))
+
+    def test_single_element(self):
+        """Edge case: single token, single expert."""
+        ids = torch.tensor([[5]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[1.0]], dtype=torch.float32, device=DEVICE)
+        local_ids, local_weights = remap_to_local_ids(ids, weights, 4, 8)
+        self.assertEqual(local_ids.item(), 1)  # 5 - 4 = 1
+        self.assertEqual(local_weights.item(), 1.0)
+
+    def test_boundary_expert_ids(self):
+        """Expert IDs exactly at local_start and local_end boundaries."""
+        ids = torch.tensor([[3, 4, 7, 8]], dtype=torch.int32, device=DEVICE)
+        weights = torch.tensor([[0.25, 0.25, 0.25, 0.25]], dtype=torch.float32, device=DEVICE)
+        local_start, local_end = 4, 8
+        local_ids, local_weights = remap_to_local_ids(ids, weights, local_start, local_end)
+        expected_ids = torch.tensor([[0, 0, 3, 0]], dtype=torch.int32, device=DEVICE)
+        expected_weights = torch.tensor([[0.0, 0.25, 0.25, 0.0]], dtype=torch.float32, device=DEVICE)
+        self.assertTrue(torch.equal(local_ids, expected_ids))
+        self.assertTrue(torch.allclose(local_weights, expected_weights))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace 6 separate elementwise HIP kernel launches (2x compare, 1x OR, 2x masked_fill, 1x add) in MoriEpIntranodeRouter with a single fused Triton kernel that performs the same remap logic in one pass. Reduces per-layer decode overhead by ~39us (6 launches → 1 launch).