### PR TITLE
feat: compact KV cache gather for paged prefill to reduce rocm ttft latency

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -178,6 +178,7 @@ class AiterPrefillAttnOp:
         self.tokens_per_block = attn_configs.kernel_tokens_per_block
         self.is_causal = attn_configs.is_causal
         self.v1_kv_layout = v1_kv_layout
+        self._compact_arange: Optional[torch.Tensor] = None
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True
@@ -251,6 +252,79 @@ class AiterPrefillAttnOp:
             v_cache = flat[:, 1, :, :].view(block_num, hk, ps // vs, hd, vs)
 
         return k_cache, v_cache
+
+    def _gather_and_reshape_kv_compact(self, kv_cache_base, block_table):
+        """Gather only blocks referenced by block_table, then reshape to VECTORIZED_LAYOUT.
+
+        For v1_kv_layout=True (non-ASM, non-FP8) path, the V cache needs a
+        permute+contiguous to convert from linear [hd, ps] to vectorized
+        [ps//vs, hd, vs] layout.  Doing this on the full KV cache pool
+        (e.g. 14 GB+) is extremely expensive.  This method gathers only the
+        blocks actually used by the current prefill batch (typically ~hundreds),
+        performs the layout conversion on that compact tensor, and returns an
+        identity block_table so mha_batch_prefill_func indexes into the
+        compact buffer directly.
+
+        This also avoids the int32 offset overflow in aiter CK kernel when
+        block_num * batch_stride_k > INT32_MAX (single-layer K cache > 2 GB).
+
+        Args:
+            kv_cache_base: Full pool — [block_num, 2, hk, ps, hd] (5D) or 2D flat.
+            block_table:   [batch_size, max_blocks_per_seq] int32 on GPU.
+
+        Returns:
+            (k_compact, v_compact, compact_block_table)
+        """
+        hk = self.head_num_kv
+        ps = self.tokens_per_block
+        hd = self.head_dim
+        vs = 16 // kv_cache_base.element_size()
+
+        # Flatten block_table to get all referenced block indices
+        block_indices = block_table.reshape(-1).to(torch.int64)
+        num_gathered = block_indices.numel()
+
+        if kv_cache_base.ndim >= 4:
+            # 5D path: [block_num, 2, hk, ps, hd]
+            k_4d = kv_cache_base.select(1, 0)  # [block_num, hk, ps, hd]
+            v_4d = kv_cache_base.select(1, 1)  # [block_num, hk, ps, hd]
+            k_used = k_4d.index_select(0, block_indices)  # [n, hk, ps, hd]
+            v_used = v_4d.index_select(0, block_indices)  # [n, hk, ps, hd]
+            k_compact = k_used.view(num_gathered, hk, hd // vs, ps, vs)
+            v_compact = (
+                v_used.reshape(num_gathered, hk, hd, ps // vs, vs)
+                .permute(0, 1, 3, 2, 4)
+                .contiguous()
+            )
+        else:
+            # 2D flat buffer path
+            block_num = kv_cache_base.shape[0]
+            expected_elems = 2 * hk * ps * hd
+            flat = kv_cache_base[:, :expected_elems].reshape(block_num, 2, hk, ps * hd)
+            k_used = flat[:, 0, :, :].index_select(0, block_indices)
+            v_used = flat[:, 1, :, :].index_select(0, block_indices)
+            k_compact = k_used.view(num_gathered, hk, hd // vs, ps, vs).contiguous()
+            v_compact = (
+                v_used.view(num_gathered, hk, hd, ps // vs, vs)
+                .permute(0, 1, 3, 2, 4)
+                .contiguous()
+            )
+
+        # Build identity block_table: [0, 1, 2, ...] so aiter indexes into
+        # the compact buffer instead of the original full pool.
+        cached_arange = self._compact_arange
+        if (
+            cached_arange is None
+            or cached_arange.numel() < num_gathered
+            or cached_arange.device != block_table.device
+        ):
+            cached_arange = torch.arange(
+                max(num_gathered, 1024), dtype=torch.int32, device=block_table.device
+            )
+            self._compact_arange = cached_arange
+        compact_block_table = cached_arange[:num_gathered].view_as(block_table)
+
+        return k_compact, v_compact, compact_block_table
 
     def _split_qkv_fp8(self, qkv_fp8):
         return split_qkv_fp8(qkv_fp8, self.head_num, self.head_num_kv, self.head_dim)
@@ -342,9 +416,16 @@ class AiterPrefillAttnOp:
         if q_tensor.dim() == 2:
             q_tensor = q_tensor.view(q_tensor.size(0), self.head_num, self.head_dim)
 
-        k_cache, v_cache = self._reshape_kv_cache_vectorized(kv_cache.kv_cache_base)
-
         block_table = fmha_params.kv_cache_block_id_device
+        is_fp8 = kv_cache.kv_cache_base.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+        use_compact = self.v1_kv_layout and not is_fp8
+
+        if use_compact:
+            k_cache, v_cache, block_table = self._gather_and_reshape_kv_compact(
+                kv_cache.kv_cache_base, block_table
+            )
+        else:
+            k_cache, v_cache = self._reshape_kv_cache_vectorized(kv_cache.kv_cache_base)
         # cu_seqlens are already created on GPU in FMHAParams.__init__
         cu_seqlens_q = fmha_params.cu_seqlens_q
         # Ensure cu_seqlens_q is on the same device as q_tensor

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -467,5 +467,150 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
             self._call_update(stub, inputs)
 
 
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOp module")
+class TestCompactGatherReshape(unittest.TestCase):
+    """Regression tests for _gather_and_reshape_kv_compact.
+
+    Validates that the compact gather path produces the same K/V layout as
+    _reshape_kv_cache_vectorized for the referenced blocks, and that the
+    identity block_table is correctly constructed.
+
+    These tests run on CPU (no aiter kernel needed) — they only exercise the
+    tensor reshape / gather logic.
+    """
+
+    def _make_op(self, head_num_kv=4, head_dim=128, tokens_per_block=16):
+        cfg = _make_attn_configs(
+            head_num=8,
+            head_num_kv=head_num_kv,
+            head_dim=head_dim,
+            tokens_per_block=tokens_per_block,
+        )
+        return AiterPrefillAttnOp(cfg, v1_kv_layout=True)
+
+    def _make_kv_cache_5d(self, num_blocks, hk, ps, hd, dtype=torch.float16):
+        """Create a 5D KV cache: [num_blocks, 2, hk, ps, hd]."""
+        return torch.randn(num_blocks, 2, hk, ps, hd, dtype=dtype)
+
+    def _make_kv_cache_2d(self, num_blocks, hk, ps, hd, dtype=torch.float16):
+        """Create a 2D flat KV cache: [num_blocks, 2*hk*ps*hd]."""
+        return torch.randn(num_blocks, 2 * hk * ps * hd, dtype=dtype)
+
+    def _assert_compact_equiv(self, op, kv_cache, block_table):
+        """Assert compact gather output equals full reshape indexed by block_table."""
+        k_full, v_full = op._reshape_kv_cache_vectorized(kv_cache)
+        k_compact, v_compact, compact_bt = op._gather_and_reshape_kv_compact(
+            kv_cache, block_table
+        )
+
+        # compact_bt should be identity: [0, 1, 2, ...] reshaped
+        flat_bt = compact_bt.reshape(-1)
+        expected_ids = torch.arange(flat_bt.numel(), dtype=torch.int32)
+        self.assertTrue(torch.equal(flat_bt, expected_ids))
+
+        # Index full K/V by original block_table and compare
+        orig_indices = block_table.reshape(-1).to(torch.int64)
+        torch.testing.assert_close(k_compact, k_full[orig_indices])
+        torch.testing.assert_close(v_compact, v_full[orig_indices])
+
+    # ---- 5D cache path ----------------------------------------------------
+
+    def test_5d_single_batch(self):
+        op = self._make_op()
+        kv = self._make_kv_cache_5d(32, 4, 16, 128)
+        bt = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    def test_5d_multi_batch(self):
+        op = self._make_op()
+        kv = self._make_kv_cache_5d(64, 4, 16, 128)
+        bt = torch.tensor([[0, 5, 10], [1, 6, 11]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    def test_5d_repeated_blocks(self):
+        """Same block referenced multiple times (e.g. shared prefix)."""
+        op = self._make_op()
+        kv = self._make_kv_cache_5d(16, 4, 16, 128)
+        bt = torch.tensor([[0, 0, 1], [0, 2, 2]], dtype=torch.int32)
+        k_compact, v_compact, compact_bt = op._gather_and_reshape_kv_compact(kv, bt)
+        # Rows that map to the same original block should have identical data
+        k_full, _ = op._reshape_kv_cache_vectorized(kv)
+        orig_indices = bt.reshape(-1).to(torch.int64)
+        torch.testing.assert_close(k_compact, k_full[orig_indices])
+
+    def test_5d_non_contiguous_blocks(self):
+        """Block indices are sparse across a large pool."""
+        op = self._make_op()
+        kv = self._make_kv_cache_5d(1024, 4, 16, 128)
+        bt = torch.tensor([[3, 500, 1023]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    # ---- 2D flat cache path -----------------------------------------------
+
+    def test_2d_single_batch(self):
+        op = self._make_op()
+        kv = self._make_kv_cache_2d(32, 4, 16, 128)
+        bt = torch.tensor([[0, 1, 2]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    def test_2d_multi_batch(self):
+        op = self._make_op()
+        kv = self._make_kv_cache_2d(64, 4, 16, 128)
+        bt = torch.tensor([[0, 5, 10], [1, 6, 11]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    def test_2d_repeated_blocks(self):
+        op = self._make_op()
+        kv = self._make_kv_cache_2d(16, 4, 16, 128)
+        bt = torch.tensor([[0, 0, 1], [0, 2, 2]], dtype=torch.int32)
+        k_compact, v_compact, compact_bt = op._gather_and_reshape_kv_compact(kv, bt)
+        k_full, _ = op._reshape_kv_cache_vectorized(kv)
+        orig_indices = bt.reshape(-1).to(torch.int64)
+        torch.testing.assert_close(k_compact, k_full[orig_indices])
+
+    # ---- FP8 fallback: compact should NOT be used -------------------------
+
+    def test_fp8_uses_full_reshape(self):
+        """When kv_cache is FP8, _forward_paged should use the full reshape path."""
+        op = self._make_op()
+        fp8_dtype = torch.float8_e4m3fn
+        kv = torch.randn(16, 2, 4, 16, 128, dtype=torch.float16).to(fp8_dtype)
+        is_fp8 = kv.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+        self.assertTrue(is_fp8)
+        # Compact path condition: v1_kv_layout=True AND not FP8
+        use_compact = op.v1_kv_layout and not is_fp8
+        self.assertFalse(use_compact)
+
+    # ---- arange cache reuse -----------------------------------------------
+
+    def test_arange_cache_grows(self):
+        """The cached _compact_arange grows to accommodate larger block_tables."""
+        op = self._make_op()
+        kv = self._make_kv_cache_5d(2048, 4, 16, 128)
+        # First call with small block_table
+        bt_small = torch.tensor([[0, 1]], dtype=torch.int32)
+        op._gather_and_reshape_kv_compact(kv, bt_small)
+        first_size = op._compact_arange.numel()
+        # Second call with larger block_table
+        bt_large = torch.arange(2048, dtype=torch.int32).unsqueeze(0)
+        op._gather_and_reshape_kv_compact(kv, bt_large)
+        self.assertGreaterEqual(op._compact_arange.numel(), 2048)
+        self.assertGreaterEqual(op._compact_arange.numel(), first_size)
+
+    # ---- different head_dim / tokens_per_block configs --------------------
+
+    def test_5d_small_head_dim(self):
+        op = self._make_op(head_num_kv=2, head_dim=64, tokens_per_block=8)
+        kv = self._make_kv_cache_5d(32, 2, 8, 64)
+        bt = torch.tensor([[0, 3, 7], [1, 4, 8]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+    def test_2d_small_head_dim(self):
+        op = self._make_op(head_num_kv=2, head_dim=64, tokens_per_block=8)
+        kv = self._make_kv_cache_2d(32, 2, 8, 64)
+        bt = torch.tensor([[0, 3, 7], [1, 4, 8]], dtype=torch.int32)
+        self._assert_compact_equiv(op, kv, bt)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -53,6 +53,12 @@ def rocm_oss_suites():
                 smoke_args="--quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --use_asm_pa 0 --fp8_kv_cache 1 --enable_cuda_graph 1 --warm_up 1 --act_type BF16 --reserver_runtime_mem_mb 70000 --test_block_num 1000",
                 gpu_type=["MI308X-ROCM7"],
             ),
+            smoke_test(
+                name="rocm_dense_qwen3_8b_ptpc_no_asm_pa",
+                task_info="data/model/qwen3/ptpc_q_r_8b.json",
+                smoke_args="--quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --use_asm_pa 0 --disable_flash_infer 1 --warm_up 0 --use_aiter_pa 1 --seq_size_per_block 16 --act_type BF16 --test_block_num 1000 --reserver_runtime_mem_mb 70000",
+                gpu_type=["MI308X-ROCM7"],
+            ),
         ],
     )
 


### PR DESCRIPTION
**Background**
On ROCm, the paged prefill path (mha_batch_prefill_func) with v1_kv_layout=True (non-ASM, non-FP8) requires converting V cache from linear layout [hd, ps] to vectorized layout [ps//vs, hd, vs] via permute + contiguous. The current implementation performs this on the entire KV cache pool (14 GB+), causing:

**Performance**: 
A full-pool copy per attention layer, significantly increasing TTFT

**Solution**
Add _gather_and_reshape_kv_compact: gather only the blocks referenced by the current prefill batch's block_table (typically ~hundreds), perform layout conversion on the compact tensor, and return an identity block_table so mha_batch_prefill_func indexes into the compact buffer directly.

- FP8 path unaffected: FP8 KV cache already uses vectorized layout, no permute needed
- ASM path unaffected: ASM kernel writes vectorized layout natively
- Only v1_kv_layout=True and not is_fp8 takes the compact gather path