### PR TITLE
feat: add ROCm aiter custom and quick allreduce support

### DIFF
--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -82,24 +82,22 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     params.prefill_runtime_seq_len_with_prefix = params.max_seq_len + max_prefix_len;
 
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
-}
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
+    // Refresh position_ids for Mrope: the C++ graph runner copies new
+    // combo_position_ids data into the capture-time buffer via
+    // optimizedCopyAsync, so params.position_ids (which points to that
+    // buffer) sees the updated values automatically. If the pointers
+    // diverge (e.g. a non-graph caller reuses prepareInPlace), fall back
+    // to an explicit in-place copy.
+    if (attn_inputs.combo_position_ids.defined() && params.position_ids.defined()
+        && attn_inputs.combo_position_ids.data_ptr() != params.position_ids.data_ptr()) {
+        copyTensorExactInPlace(params.position_ids, attn_inputs.combo_position_ids, "position_ids");
     }
 }
 
+
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
 }
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
@@ -270,6 +268,11 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
     }
     if (params->position_ids.defined()) {
         position_ids = params->position_ids.data_ptr<int>();
+    } else if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        throw std::runtime_error(
+            "FusedRopeKVCachePrefillOp: Mrope requires combo_position_ids but "
+            "none were provided. Ensure combo_position_ids is set in "
+            "PyAttentionInputs before calling prefill.");
     }
 
     auto    rope_cache = getRopeCacheOnce(attn_configs_.rope_config, attn_configs_.max_seq_len, false);
@@ -353,7 +356,6 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
 }
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
@@ -457,6 +459,11 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
     int* position_ids_ptr = nullptr;
     if (params->position_ids.defined()) {
         position_ids_ptr = params->position_ids.data_ptr<int>();
+    } else if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        throw std::runtime_error(
+            "FusedRopeKVCacheDecodeOp: Mrope requires combo_position_ids but "
+            "none were provided. This typically means CUDA graph capture is "
+            "running with Mrope, which is not yet supported on ROCm.");
     } else {
         position_ids_ptr = params->sequence_lengths.data_ptr<int>();
     }

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -17,6 +17,17 @@ from rtp_llm.models_py.distributed.symm_mem import (
 )
 from rtp_llm.ops import NcclCommConfig, ParallelismConfig
 
+# ---------------------------------------------------------------------------
+# ROCm AllReduce strategy — reuse rocm_rccl as the single source of truth.
+# Parsing/validation/logging is done in rocm_rccl at import time; here we
+# just import the resulting flags so both modules cannot drift.
+# ---------------------------------------------------------------------------
+_is_rocm_runtime = rocm_rccl.is_available_runtime()
+_rocm_allreduce_strategies = rocm_rccl._rocm_allreduce_strategies
+_enable_quick_allreduce = rocm_rccl._enable_quick_allreduce
+_enable_trtllm_allreduce = rocm_rccl._enable_trtllm_allreduce
+_enable_aiter_custom_ar = rocm_rccl._enable_aiter_custom_ar
+
 # ParallelMode enum values matching C++ rtp_llm::ParallelMode in OpData.h
 _CPP_PARALLEL_MODE_TP = 0
 _CPP_PARALLEL_MODE_DP = 1
@@ -561,8 +572,106 @@ def broadcast(tensor: torch.Tensor, src: int, group: Group) -> None:
     torch.distributed.broadcast(tensor, src, group=process_group)
 
 
+# ---------------------------------------------------------------------------
+# AllReduce tier helpers — each returns Optional[Tensor]
+# ---------------------------------------------------------------------------
+
+
+def _finalize_inplace(
+    tensor: torch.Tensor,
+    result: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Preserve all_reduce's in-place contract.
+
+    Accelerated kernels (quick / aiter) write to a freshly allocated buffer.
+    Callers of ``all_reduce`` may still hold the original ``tensor`` and
+    expect it to be updated; copy the result back so storage identity and
+    return value match the NCCL/symm_mem branches.
+    """
+    if result is None:
+        return None
+    if result is not tensor:
+        tensor.copy_(result)
+    return tensor
+
+
+def _try_quick_allreduce(
+    tensor: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup,
+) -> Optional[torch.Tensor]:
+    """Tier 1: Quick AllReduce (opt-in, fastest, lossy quantization)."""
+    try:
+        from rtp_llm.models_py.modules.base.rocm.quick_allreduce import quick_ar_manager
+
+        device_id = torch.cuda.current_device()
+        if not quick_ar_manager.ensure_initialized(tp_group, device_id):
+            return None
+        if not quick_ar_manager.should_use(tensor, tp_group, device_id):
+            return None
+    except Exception as e:
+        logging.warning("Quick AllReduce eligibility check failed: %s", e)
+        return None
+    return quick_ar_manager.allreduce(tensor)
+
+
+def _try_trtllm_allreduce(
+    tensor: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup,
+) -> Optional[torch.Tensor]:
+    """Tier 2: trtllm allreduce (lossless, hidden-size restricted)."""
+    if not rocm_rccl._is_hidden_size_supported_for_trtllm(tensor.shape[-1]):
+        return None
+    if not rocm_rccl._is_trtllm_allreduce_ready():
+        return None
+    try:
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+            _trtllm_comm_manager,
+        )
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+            allreduce as trtllm_allreduce,
+        )
+
+        dist_env = _trtllm_comm_manager.dist_env
+        if dist_env is None or dist_env.disabled:
+            return None
+        device_id = torch.cuda.current_device()
+        if tensor.numel() * tensor.element_size() > dist_env.max_size_in_bytes:
+            return None
+    except Exception as e:
+        logging.warning("trtllm_allreduce eligibility check failed: %s", e)
+        return None
+    return trtllm_allreduce(
+        allreduce_in=tensor,
+        group=tp_group,
+        device_id=device_id,
+    )
+
+
+def _try_aiter_custom_allreduce(
+    tensor: torch.Tensor,
+    tp_group: torch.distributed.ProcessGroup,
+) -> Optional[torch.Tensor]:
+    """Tier 3: aiter CustomAllreduce (P2P, lossless)."""
+    try:
+        from rtp_llm.models_py.modules.base.rocm.aiter_custom_allreduce import (
+            aiter_ar_manager,
+        )
+
+        device_id = torch.cuda.current_device()
+        if not aiter_ar_manager.ensure_initialized(tp_group, device_id):
+            return None
+        if not aiter_ar_manager.should_use(tensor, tp_group, device_id):
+            return None
+    except Exception as e:
+        logging.warning("aiter CustomAllreduce eligibility check failed: %s", e)
+        return None
+    return aiter_ar_manager.allreduce(tensor)
+
+
 def all_reduce(tensor: torch.Tensor, group: Group) -> torch.Tensor:
     """All-reduce a tensor across all ranks in the group.
+
+    Priority: quick_AR → trtllm → aiter custom AR → symm_mem → NCCL
 
     Args:
         tensor: Tensor to all-reduce (will be modified in-place)
@@ -575,6 +684,33 @@ def all_reduce(tensor: torch.Tensor, group: Group) -> torch.Tensor:
     if rocm_rccl.should_use_capture_collectives(group == Group.TP):
         return rocm_rccl.capture_all_reduce(tensor, _get_group(group))
 
+    # ROCm TP accelerated allreduce — try enabled strategies in priority order
+    if (
+        _is_rocm_runtime
+        and group == Group.TP
+        and _rocm_allreduce_strategies != {"none"}
+    ):
+        tp_group = _get_group(group)
+
+        if _enable_quick_allreduce:
+            result = _finalize_inplace(tensor, _try_quick_allreduce(tensor, tp_group))
+            if result is not None:
+                return result
+
+        if _enable_trtllm_allreduce:
+            result = _finalize_inplace(tensor, _try_trtllm_allreduce(tensor, tp_group))
+            if result is not None:
+                return result
+
+        if _enable_aiter_custom_ar:
+            result = _finalize_inplace(
+                tensor,
+                _try_aiter_custom_allreduce(tensor, tp_group),
+            )
+            if result is not None:
+                return result
+
+    # symm_mem (CUDA only)
     if group == Group.TP:
         symm_mem_comm = get_symm_mem_communicator()
         if symm_mem_comm is not None and symm_mem_comm.should_torch_symm_mem_allreduce(
@@ -582,6 +718,7 @@ def all_reduce(tensor: torch.Tensor, group: Group) -> torch.Tensor:
         ):
             return symm_mem_comm.all_reduce(tensor)
 
+    # NCCL fallback
     process_group = _get_group(group)
     torch.distributed.all_reduce(
         tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
@@ -662,7 +799,10 @@ def reduce_scatter(input_tensor: torch.Tensor, group: Group) -> torch.Tensor:
         dtype=input_tensor.dtype,
     )
     torch.distributed.reduce_scatter_tensor(
-        output_tensor, input_tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
+        output_tensor,
+        input_tensor,
+        op=torch.distributed.ReduceOp.SUM,
+        group=process_group,
     )
     return output_tensor
 

--- a/rtp_llm/models_py/distributed/rocm_rccl.py
+++ b/rtp_llm/models_py/distributed/rocm_rccl.py
@@ -204,7 +204,9 @@ def _get_rccl_runtime(
         raise RuntimeError(
             "RCCL library is not available for HIPGraph capture collectives"
         )
-    if (_rccl_comm is None or _rccl_comm.value is None) and not _is_hipgraph_capture_active():
+    if (
+        _rccl_comm is None or _rccl_comm.value is None
+    ) and not _is_hipgraph_capture_active():
         _ensure_rccl_comm_from_process_group(process_group)
     if _rccl_comm is None or _rccl_comm.value is None:
         raise RuntimeError(
@@ -266,36 +268,140 @@ def set_hipgraph_capture_nccl_comm(
     # enter/exit capture should not clear this cache because replay relies on
     # stable addresses recorded during capture.
     _hipgraph_allgather_outputs.clear()
-    if _is_hipgraph_capture_active():
-        return
-    _pre_init_trtllm_allreduce()
+    # NOTE: Do NOT pre-init allreduce strategies here.
+    # The C++ comm-handle registration path doesn't know which torch
+    # ProcessGroup corresponds to the TP comm; pre-initializing with
+    # torch.distributed.group.WORLD is incorrect when TP < WORLD (multi-node)
+    # and would force a redundant re-init (with IPC-buffer churn) the moment
+    # `prepare_hipgraph_capture_rccl_comm_if_needed` runs with the right
+    # tp_group. Pre-init is the sole responsibility of the latter path.
 
-def _pre_init_trtllm_allreduce(
+
+# ---------------------------------------------------------------------------
+# ROCm AllReduce strategy flags (single source of truth — read once at import).
+#
+# ROCM_ALLREDUCE_STRATEGY is an *enable-set*, not a priority list. The env
+# value is parsed as a comma-separated set of tokens; token order is ignored.
+# Dispatch always uses a fixed precision/speed priority:
+#
+#     quick → trtllm → aiter → symm_mem → NCCL
+#
+# Valid tokens: quick, trtllm, aiter, none (default: none)
+#   quick  — aiter Quick AllReduce (quantised, fastest, lossy)
+#   trtllm — trtllm allreduce kernel (lossless, hidden-size restricted)
+#   aiter  — aiter P2P custom allreduce (lossless, most general)
+#   none   — no accelerated kernel, fall through to symm_mem / NCCL
+#
+# To opt out of a tier, omit it from the env value.
+# ---------------------------------------------------------------------------
+_VALID_STRATEGIES = {"quick", "trtllm", "aiter", "none"}
+
+
+def _parse_enabled_strategies() -> set:
+    """Parse ROCM_ALLREDUCE_STRATEGY into a set of enabled tier tokens.
+
+    Order of tokens in the env string is intentionally ignored — dispatch
+    priority is fixed by the call sites (quick → trtllm → aiter).
+    """
+    raw = os.environ.get("ROCM_ALLREDUCE_STRATEGY", "none").lower()
+    tokens = {s.strip() for s in raw.split(",") if s.strip()}
+    invalid = tokens - _VALID_STRATEGIES
+    if invalid:
+        logging.warning(
+            "ROCM_ALLREDUCE_STRATEGY: ignoring unknown strategies: %s", invalid
+        )
+        tokens -= invalid
+    return tokens if tokens else {"none"}
+
+
+_rocm_allreduce_strategies: set = (
+    _parse_enabled_strategies() if _is_rocm_runtime else {"none"}
+)
+_enable_quick_allreduce: bool = "quick" in _rocm_allreduce_strategies
+_enable_trtllm_allreduce: bool = "trtllm" in _rocm_allreduce_strategies
+_enable_aiter_custom_ar: bool = "aiter" in _rocm_allreduce_strategies
+
+if _is_rocm_runtime and _rocm_allreduce_strategies != {"none"}:
+    logging.info(
+        "ROCm AllReduce enabled tiers (dispatch order is fixed "
+        "quick→trtllm→aiter→symm_mem→NCCL): %s",
+        sorted(_rocm_allreduce_strategies - {"none"}),
+    )
+
+
+def _pre_init_allreduce_strategies(
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> None:
-    """Pre-initialize trt_allreduce before graph capture.
+    """Pre-initialize allreduce backends before graph capture.
 
-    Must be called before entering graph capture mode so that
-    TrtllmDistEnv.__init__ (which does hipMalloc and dist.all_gather_object)
-    runs outside of stream capture where those operations are forbidden.
+    Must be called before entering graph capture mode so that operations
+    like hipMalloc, all_gather_object, and init_custom_qr run outside of
+    stream capture where they are forbidden.
+
+    Pre-initializes every strategy enabled via ROCM_ALLREDUCE_STRATEGY,
+    including aiter custom AR (even though it is not used during capture)
+    so that the first eager-mode prefill doesn't pay the IPC-handshake
+    cost on the critical path.
+
+    Each manager owns its own intra-init dist.barrier(); calling them in
+    sequence yields N barriers when N strategies are enabled. Acceptable
+    one-time cost — kept in the manager so lazy-init paths stay correct.
     """
     if not _is_rocm_runtime:
         return
     if _rccl_world_size <= 1:
         return
-    try:
-        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
-            ensure_trtllm_comm_initialized,
-        )
-        if not torch.distributed.is_initialized():
-            return
-        if tp_group is None:
-            tp_group = torch.distributed.group.WORLD
-        device_id = torch.cuda.current_device()
-        ensure_trtllm_comm_initialized(group=tp_group, device_id=device_id)
-        logging.info("Pre-init trtllm_allreduce succeeded (device_id=%s)", device_id)
-    except Exception as exc:
-        logging.warning("Pre-init trtllm_allreduce failed (non-fatal): %s", exc)
+    if not torch.distributed.is_initialized():
+        return
+    if tp_group is None:
+        tp_group = torch.distributed.group.WORLD
+    device_id = torch.cuda.current_device()
+
+    if _enable_trtllm_allreduce:
+        try:
+            from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+                ensure_trtllm_comm_initialized,
+            )
+
+            ensure_trtllm_comm_initialized(group=tp_group, device_id=device_id)
+            logging.info(
+                "Pre-init trtllm_allreduce succeeded (device_id=%s)", device_id
+            )
+        except Exception as exc:
+            logging.warning("Pre-init trtllm_allreduce failed (non-fatal): %s", exc)
+
+    if _enable_quick_allreduce:
+        try:
+            from rtp_llm.models_py.modules.base.rocm.quick_allreduce import (
+                quick_ar_manager,
+            )
+
+            quick_ar_manager.ensure_initialized(group=tp_group, device_id=device_id)
+            logging.info("Pre-init quick_allreduce succeeded (device_id=%s)", device_id)
+        except Exception as exc:
+            logging.warning("Pre-init quick_allreduce failed (non-fatal): %s", exc)
+
+    if _enable_aiter_custom_ar:
+        # aiter custom AR is not used during graph capture, but pre-initializing
+        # here keeps the first-iteration latency predictable (avoids running
+        # all_gather_into_tensor + cudaSynchronize on the critical path of the
+        # first eager-mode prefill).
+        try:
+            from rtp_llm.models_py.modules.base.rocm.aiter_custom_allreduce import (
+                aiter_ar_manager,
+            )
+
+            aiter_ar_manager.ensure_initialized(group=tp_group, device_id=device_id)
+            logging.info(
+                "Pre-init aiter_custom_allreduce succeeded (device_id=%s)",
+                device_id,
+            )
+        except Exception as exc:
+            logging.warning(
+                "Pre-init aiter_custom_allreduce failed (non-fatal): %s",
+                exc,
+            )
+
 
 def _warmup_rccl_collectives(
     lib: ctypes.CDLL, comm: ctypes.c_void_p, world_size: int
@@ -310,23 +416,30 @@ def _warmup_rccl_collectives(
         nccl_float = _get_nccl_dtype(dummy_in)
 
         res = lib.ncclAllGather(
-            dummy_in.data_ptr(), ag_out.data_ptr(),
-            dummy_in.numel(), nccl_float, comm, stream,
+            dummy_in.data_ptr(),
+            ag_out.data_ptr(),
+            dummy_in.numel(),
+            nccl_float,
+            comm,
+            stream,
         )
         if res != _NCCL_SUCCESS:
             logging.warning("RCCL AllGather warmup returned error %d", res)
 
         res = lib.ncclAllReduce(
-            ar_out.data_ptr(), ar_out.data_ptr(),
-            ar_out.numel(), nccl_float, _NCCL_SUM, comm, stream,
+            ar_out.data_ptr(),
+            ar_out.data_ptr(),
+            ar_out.numel(),
+            nccl_float,
+            _NCCL_SUM,
+            comm,
+            stream,
         )
         if res != _NCCL_SUCCESS:
             logging.warning("RCCL AllReduce warmup returned error %d", res)
 
         torch.cuda.synchronize(device)
-        logging.info(
-            "RCCL collective warmup succeeded (world_size=%d)", world_size
-        )
+        logging.info("RCCL collective warmup succeeded (world_size=%d)", world_size)
     except Exception as e:
         logging.warning("RCCL collective warmup failed (non-fatal): %s", e)
 
@@ -411,9 +524,9 @@ def prepare_hipgraph_capture_rccl_comm_if_needed(
         return
     # IMPORTANT: bootstrap must happen before graph capture begins.
     bootstrap_hipgraph_capture_rccl_comm_from_tp_group(tp_group)
-    # Pre-initialize trt_allreduce with the correct TP group so that
-    # hipgraph_capture_all_reduce can use it during graph capture.
-    _pre_init_trtllm_allreduce(tp_group)
+    # Pre-initialize enabled allreduce strategies with the correct TP group
+    # so that hipgraph_capture_all_reduce can use them during graph capture.
+    _pre_init_allreduce_strategies(tp_group)
 
 
 def enter_hipgraph_capture_mode(
@@ -468,11 +581,7 @@ def finish_hipgraph_capture_session() -> None:
 
 
 def should_use_hipgraph_capture_rccl(is_tp_group: bool) -> bool:
-    return (
-        _is_rocm_runtime
-        and is_tp_group
-        and _is_hipgraph_capture_active()
-    )
+    return _is_rocm_runtime and is_tp_group and _is_hipgraph_capture_active()
 
 
 def ensure_tp_rccl_comm_for_capture(is_tp_group: bool) -> None:
@@ -494,69 +603,103 @@ def _is_hidden_size_supported_for_trtllm(hidden_size: int) -> bool:
         from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
             ALLREDUCE_SUPPORTED_HIDDEN_SIZES,
         )
+
         return hidden_size in ALLREDUCE_SUPPORTED_HIDDEN_SIZES
     except Exception:
         return False
 
+
 def _is_trtllm_allreduce_ready() -> bool:
     try:
-        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import is_trt_allreduce_ready
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+            is_trt_allreduce_ready,
+        )
+
         return is_trt_allreduce_ready()
     except ImportError:
         return False
 
+
 _trtllm_fallback_warned: bool = False
+_quick_fallback_warned: bool = False
 
 
 def hipgraph_capture_all_reduce(
     tensor: torch.Tensor,
     process_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> torch.Tensor:
-    """Allreduce during HIPGraph capture. Tries trt_allreduce first, falls back to ncclAllReduce."""
-    global _trtllm_fallback_warned
+    """Allreduce during HIPGraph capture.
 
+    Priority: quick_AR -> trtllm_AR -> ncclAllReduce.
+
+    Both quick_AR and trtllm_AR must have been pre-initialized via
+    _pre_init_allreduce_strategies() before capture begins, since their
+    init paths call hipMalloc/all_gather_object which are forbidden under
+    stream capture. ``should_use`` is therefore safe to call here because
+    it only triggers lazy init when ``initialized`` is False — which
+    cannot happen if pre-init ran for the enabled strategies.
+
+    Note: aiter P2P custom AR is intentionally skipped in capture mode
+    (its handshake/buffer-registration path is not graph-capture safe).
+    """
+    global _trtllm_fallback_warned, _quick_fallback_warned
+
+    # Tier 1: Quick AllReduce (opt-in, fastest)
+    if _enable_quick_allreduce and process_group is not None:
+        _quick_eligible = False
+        try:
+            from rtp_llm.models_py.modules.base.rocm.quick_allreduce import (
+                quick_ar_manager,
+            )
+
+            device_id = torch.cuda.current_device()
+            _quick_eligible = quick_ar_manager.should_use(tensor, process_group, device_id)
+        except Exception as exc:
+            if not _quick_fallback_warned:
+                logging.warning(
+                    "quick_allreduce eligibility check failed in graph capture: %s",
+                    exc,
+                )
+                _quick_fallback_warned = True
+        if _quick_eligible:
+            return quick_ar_manager.allreduce(tensor, inplace=True)
+
+    # Tier 2: trtllm allreduce
+    _trtllm_eligible = False
     if (
-        process_group is not None
+        _enable_trtllm_allreduce
+        and process_group is not None
         and _is_hidden_size_supported_for_trtllm(tensor.shape[-1])
         and _is_trtllm_allreduce_ready()
     ):
         try:
             from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
                 _trtllm_comm_manager,
+            )
+            from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
                 allreduce as trtllm_allreduce,
             )
-            # Size guard: fall through to NCCL when input exceeds the
-            # workspace `data_` capacity. Without this check,
-            # CommWorkspace::get_comm_data's gpuMemcpyAsync would write
-            # past the end of `data_` and corrupt neighbouring device
-            # allocations.
+
             if (
                 tensor.numel() * tensor.element_size()
                 <= _trtllm_comm_manager.dist_env.max_size_in_bytes
             ):
-                device_id = torch.cuda.current_device()
-                return trtllm_allreduce(
-                    allreduce_in=tensor,
-                    group=process_group,
-                    device_id=device_id,
-                )
+                _trtllm_eligible = True
         except ImportError as exc:
             if not _trtllm_fallback_warned:
                 logging.warning(
-                    "trtllm_allreduce import failed in graph capture mode, "
-                    "fallback to ncclAllReduce (further warnings suppressed): %s", exc,
+                    "trtllm_allreduce import failed in graph capture: %s", exc,
                 )
                 _trtllm_fallback_warned = True
-        except RuntimeError as exc:
-            if not _trtllm_fallback_warned:
-                logging.warning(
-                    "trtllm_allreduce failed in graph capture mode, "
-                    "fallback to ncclAllReduce (further warnings suppressed): %s",
-                    exc, exc_info=True,
-                )
-                _trtllm_fallback_warned = True
+    if _trtllm_eligible:
+        device_id = torch.cuda.current_device()
+        return trtllm_allreduce(
+            allreduce_in=tensor,
+            group=process_group,
+            device_id=device_id,
+        )
 
-    # Fallback to raw RCCL ncclAllReduce.
+    # Fallback to lib.ncclAllReduce (in-place, returns original tensor)
     lib, rccl_comm = _get_rccl_runtime(process_group)
     nccl_result = lib.ncclAllReduce(
         tensor.data_ptr(),
@@ -667,6 +810,42 @@ def capture_all_gather(
     return hipgraph_capture_all_gather(tensor, process_group)
 
 
+def _close_allreduce_strategies() -> None:
+    """Release IPC buffers held by enabled allreduce strategies.
+
+    Idempotent — safe to call when nothing was initialized. Wraps each
+    strategy in its own try/except so one failure cannot prevent the
+    others from cleaning up.
+    """
+    if _enable_quick_allreduce:
+        try:
+            from rtp_llm.models_py.modules.base.rocm.quick_allreduce import (
+                quick_ar_manager,
+            )
+
+            quick_ar_manager.close()
+        except Exception as exc:
+            logging.warning("quick_ar_manager.close() failed: %s", exc)
+    if _enable_aiter_custom_ar:
+        try:
+            from rtp_llm.models_py.modules.base.rocm.aiter_custom_allreduce import (
+                aiter_ar_manager,
+            )
+
+            aiter_ar_manager.close()
+        except Exception as exc:
+            logging.warning("aiter_ar_manager.close() failed: %s", exc)
+    if _enable_trtllm_allreduce:
+        try:
+            from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+                _trtllm_comm_manager,
+            )
+
+            _trtllm_comm_manager.cleanup()
+        except Exception as exc:
+            logging.warning("trtllm_comm_manager.cleanup() failed: %s", exc)
+
+
 def destroy_capture_comm() -> None:
     """Clean up RCCL capture comm state during distributed environment teardown.
 
@@ -675,6 +854,7 @@ def destroy_capture_comm() -> None:
     fresh communicator instead of reusing the stale one from the destroyed
     process group.
     """
+    _close_allreduce_strategies()
     _clear_hipgraph_capture_nccl_comm()
 
 

--- a/rtp_llm/models_py/distributed/test/BUILD
+++ b/rtp_llm/models_py/distributed/test/BUILD
@@ -47,6 +47,33 @@ py_test(
         "//rtp_llm/models_py/distributed:collective_torch",
     ],
     timeout = "short",
+    tags = ["rocm"],
+)
+
+py_test(
+    name = "collective_torch_allreduce_tier_test",
+    srcs = ["collective_torch_allreduce_tier_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = "short",
+    tags = ["rocm"],
+)
+
+py_test(
+    name = "rocm_allreduce_tier_integration_test",
+    srcs = ["rocm_allreduce_tier_integration_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+        "//rtp_llm/models_py:modules",
+        "//rtp_llm/models_py/modules/base/rocm:rocm_base",
+        "//rtp_llm/models_py/modules/base/rocm:trt_allreduce",
+    ],
+    timeout = "moderate",
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
 )
 
 py_test(

--- a/rtp_llm/models_py/distributed/test/collective_torch_allreduce_tier_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_allreduce_tier_test.py
@@ -1,0 +1,165 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from rtp_llm.models_py.distributed import collective_torch as ct
+from rtp_llm.models_py.distributed import rocm_rccl as hr
+
+
+class TestAllReduceTierDispatch(unittest.TestCase):
+    """Unit tests for the eager all_reduce five-tier fallback logic."""
+
+    def setUp(self):
+        self._orig_is_rocm = ct._is_rocm_runtime
+        self._orig_strategies = ct._rocm_allreduce_strategies
+        self._orig_quick = ct._enable_quick_allreduce
+        self._orig_trtllm = ct._enable_trtllm_allreduce
+        self._orig_aiter = ct._enable_aiter_custom_ar
+
+    def tearDown(self):
+        ct._is_rocm_runtime = self._orig_is_rocm
+        ct._rocm_allreduce_strategies = self._orig_strategies
+        ct._enable_quick_allreduce = self._orig_quick
+        ct._enable_trtllm_allreduce = self._orig_trtllm
+        ct._enable_aiter_custom_ar = self._orig_aiter
+
+    def _enable_rocm_tiers(self, quick=False, trtllm=False, aiter=False):
+        ct._is_rocm_runtime = True
+        ct._rocm_allreduce_strategies = {"quick", "trtllm", "custom"}
+        ct._enable_quick_allreduce = quick
+        ct._enable_trtllm_allreduce = trtllm
+        ct._enable_aiter_custom_ar = aiter
+
+    def _no_capture(self):
+        return (
+            patch.object(hr, "ensure_capture_comm_ready"),
+            patch.object(hr, "should_use_capture_collectives", return_value=False),
+        )
+
+    # ---- Test 1: quick allreduce success copies result back in-place ----
+
+    def test_quick_success_finalize_copies_back(self):
+        self._enable_rocm_tiers(quick=True)
+        tensor = torch.ones(4, dtype=torch.float16)
+        quick_result = torch.full((4,), 2.0, dtype=torch.float16)
+        mock_group = object()
+
+        with self._no_capture()[0], self._no_capture()[1], patch.object(
+            ct, "_get_group", return_value=mock_group
+        ), patch.object(ct, "_try_quick_allreduce", return_value=quick_result):
+            result = ct.all_reduce(tensor, ct.Group.TP)
+
+        self.assertIs(result, tensor)
+        self.assertTrue(torch.equal(tensor, quick_result))
+
+    # ---- Test 2: quick returns None → fallback to trtllm ----
+
+    def test_quick_none_falls_through_to_trtllm(self):
+        self._enable_rocm_tiers(quick=True, trtllm=True)
+        tensor = torch.ones(4, dtype=torch.float16)
+        trtllm_result = torch.full((4,), 3.0, dtype=torch.float16)
+        mock_group = object()
+
+        with self._no_capture()[0], self._no_capture()[1], patch.object(
+            ct, "_get_group", return_value=mock_group
+        ), patch.object(ct, "_try_quick_allreduce", return_value=None), patch.object(
+            ct, "_try_trtllm_allreduce", return_value=trtllm_result
+        ):
+            result = ct.all_reduce(tensor, ct.Group.TP)
+
+        self.assertIs(result, tensor)
+        self.assertTrue(torch.equal(tensor, trtllm_result))
+
+    # ---- Test 3: all ROCm tiers fail → NCCL fallback ----
+
+    def test_all_tiers_fail_falls_through_to_nccl(self):
+        self._enable_rocm_tiers(quick=True, trtllm=True, aiter=True)
+        tensor = torch.ones(4, dtype=torch.float16)
+        mock_group = object()
+
+        with self._no_capture()[0], self._no_capture()[1], patch.object(
+            ct, "_get_group", return_value=mock_group
+        ), patch.object(ct, "_try_quick_allreduce", return_value=None), patch.object(
+            ct, "_try_trtllm_allreduce", return_value=None
+        ), patch.object(
+            ct, "_try_aiter_custom_allreduce", return_value=None
+        ), patch.object(
+            ct, "get_symm_mem_communicator", return_value=None
+        ), patch(
+            "torch.distributed.all_reduce"
+        ) as mock_nccl:
+            result = ct.all_reduce(tensor, ct.Group.TP)
+
+        mock_nccl.assert_called_once()
+        self.assertIs(result, tensor)
+
+    # ---- Test 4: group != TP skips ROCm tiers entirely ----
+
+    def test_non_tp_group_skips_rocm_tiers(self):
+        self._enable_rocm_tiers(quick=True, trtllm=True, aiter=True)
+        tensor = torch.ones(4, dtype=torch.float16)
+        mock_group = object()
+
+        with self._no_capture()[0], self._no_capture()[1], patch.object(
+            ct, "_get_group", return_value=mock_group
+        ), patch.object(ct, "_try_quick_allreduce") as mock_quick, patch.object(
+            ct, "_try_trtllm_allreduce"
+        ) as mock_trtllm, patch.object(
+            ct, "_try_aiter_custom_allreduce"
+        ) as mock_aiter, patch.object(
+            ct, "get_symm_mem_communicator", return_value=None
+        ), patch(
+            "torch.distributed.all_reduce"
+        ):
+            ct.all_reduce(tensor, ct.Group.DP)
+
+        mock_quick.assert_not_called()
+        mock_trtllm.assert_not_called()
+        mock_aiter.assert_not_called()
+
+    # ---- Test 5: quick success means trtllm/aiter are never tried ----
+
+    def test_quick_success_short_circuits(self):
+        self._enable_rocm_tiers(quick=True, trtllm=True, aiter=True)
+        tensor = torch.ones(4, dtype=torch.float16)
+        quick_result = torch.full((4,), 2.0, dtype=torch.float16)
+        mock_group = object()
+
+        with self._no_capture()[0], self._no_capture()[1], patch.object(
+            ct, "_get_group", return_value=mock_group
+        ), patch.object(
+            ct, "_try_quick_allreduce", return_value=quick_result
+        ), patch.object(
+            ct, "_try_trtllm_allreduce"
+        ) as mock_trtllm, patch.object(
+            ct, "_try_aiter_custom_allreduce"
+        ) as mock_aiter:
+            ct.all_reduce(tensor, ct.Group.TP)
+
+        mock_trtllm.assert_not_called()
+        mock_aiter.assert_not_called()
+
+
+class TestFinalizeInplace(unittest.TestCase):
+    """Unit tests for _finalize_inplace helper."""
+
+    def test_none_result_returns_none(self):
+        tensor = torch.ones(4)
+        self.assertIsNone(ct._finalize_inplace(tensor, None))
+
+    def test_different_tensor_copies_back(self):
+        tensor = torch.ones(4)
+        result = torch.full((4,), 5.0)
+        ret = ct._finalize_inplace(tensor, result)
+        self.assertIs(ret, tensor)
+        self.assertTrue(torch.equal(tensor, result))
+
+    def test_same_tensor_returns_identity(self):
+        tensor = torch.ones(4)
+        ret = ct._finalize_inplace(tensor, tensor)
+        self.assertIs(ret, tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/test/rocm_allreduce_tier_integration_test.py
+++ b/rtp_llm/models_py/distributed/test/rocm_allreduce_tier_integration_test.py
@@ -1,0 +1,375 @@
+"""Integration tests for ROCm allreduce tier dispatch (2-rank, real GPU).
+
+Validates that the tiered allreduce path (quick → aiter → NCCL fallback)
+produces numerically correct results across multiple dtypes and tensor sizes.
+Requires ≥2 ROCm GPUs.
+
+Run:
+    python -m pytest rtp_llm/models_py/distributed/test/rocm_allreduce_tier_integration_test.py -v
+"""
+
+import os
+import socket
+import sys
+import unittest
+import warnings
+from typing import List, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+warnings.filterwarnings(
+    "ignore", message="barrier.*using the device under current context"
+)
+warnings.filterwarnings(
+    "ignore", message="Guessing device ID based on global rank"
+)
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _setup_distributed(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method="env://",
+        world_size=world_size,
+        rank=rank,
+        device_id=torch.device(f"cuda:{rank}"),
+    )
+
+
+def _cleanup_distributed():
+    try:
+        dist.barrier()
+        torch.cuda.synchronize()
+    except Exception:
+        pass
+    try:
+        dist.destroy_process_group()
+    except Exception:
+        pass
+
+
+def _nccl_reference(tensor: torch.Tensor, group) -> torch.Tensor:
+    ref = tensor.clone()
+    dist.all_reduce(ref, group=group)
+    return ref
+
+
+def _launch_workers(worker_fn, world_size: int, timeout: int = 120, **kwargs):
+    port = _get_free_port()
+    processes = []
+    for rank in range(world_size):
+        proc = mp.Process(
+            target=worker_fn,
+            args=(rank, world_size, port),
+            kwargs=kwargs,
+            name=f"rank-{rank}",
+        )
+        proc.start()
+        processes.append(proc)
+
+    failed = []
+    for proc in processes:
+        proc.join(timeout=timeout)
+        if proc.is_alive() or proc.exitcode != 0:
+            failed.append(proc)
+
+    if failed:
+        for proc in processes:
+            if proc.is_alive():
+                proc.terminate()
+        for proc in processes:
+            proc.join(timeout=5)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=5)
+        names = [f"{p.name}(exit={p.exitcode})" for p in failed]
+        raise RuntimeError(f"Worker(s) failed or timed out: {', '.join(names)}")
+
+
+# ---------------------------------------------------------------------------
+# Worker: quick allreduce
+# ---------------------------------------------------------------------------
+def _worker_quick_allreduce(
+    rank: int, world_size: int, port: int,
+    batch_size: int, hidden_size: int, dtype: torch.dtype,
+    quant_type: str,
+):
+    try:
+        os.environ["ROCM_ALLREDUCE_STRATEGY"] = "quick"
+        os.environ["ROCM_QUICK_AR_QUANTIZATION"] = quant_type
+        _setup_distributed(rank, world_size, port)
+
+        from rtp_llm.models_py.modules.base.rocm.quick_allreduce import (
+            quick_ar_manager,
+        )
+
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        device_id = rank
+
+        if not quick_ar_manager.ensure_initialized(group, device_id):
+            if rank == 0:
+                print("  [quick_allreduce] skipped: init failed")
+            return
+
+        torch.manual_seed(42 + rank)
+        tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+        ref = _nccl_reference(tensor.clone(), group)
+
+        if not quick_ar_manager.should_use(tensor, group, device_id):
+            if rank == 0:
+                print(f"  [quick_allreduce] skipped: should_use=False for {dtype}")
+            return
+
+        result = quick_ar_manager.allreduce(tensor)
+
+        diff = (result.float() - ref.float()).abs().max().item()
+        ref_max = ref.float().abs().max().item()
+        rel_diff = diff / ref_max if ref_max > 0 else 0
+
+        # Quick AR uses FP8 quantization, so tolerance is relaxed
+        rtol = 0.05 if quant_type == "FP" else 0.1
+        assert rel_diff < rtol, (
+            f"[Rank {rank}] quick allreduce mismatch: rel={rel_diff:.6e}, abs={diff:.6e}"
+        )
+        if rank == 0:
+            print(f"  [quick_allreduce] quant={quant_type} hidden={hidden_size} rel_diff={rel_diff:.2e} ✓")
+
+    except Exception as exc:
+        print(f"[Rank {rank}] quick_allreduce FAILED: {exc}", file=sys.stderr)
+        import traceback; traceback.print_exc()
+        raise
+    finally:
+        _cleanup_distributed()
+
+
+# ---------------------------------------------------------------------------
+# Worker: aiter custom allreduce
+# ---------------------------------------------------------------------------
+def _worker_aiter_allreduce(
+    rank: int, world_size: int, port: int,
+    batch_size: int, hidden_size: int, dtype: torch.dtype,
+):
+    try:
+        os.environ["ROCM_ALLREDUCE_STRATEGY"] = "aiter"
+        _setup_distributed(rank, world_size, port)
+
+        from rtp_llm.models_py.modules.base.rocm.aiter_custom_allreduce import (
+            aiter_ar_manager,
+        )
+
+        device = torch.device(f"cuda:{rank}")
+        group = dist.group.WORLD
+        device_id = rank
+
+        if not aiter_ar_manager.ensure_initialized(group, device_id):
+            if rank == 0:
+                print("  [aiter_allreduce] skipped: init failed")
+            return
+
+        torch.manual_seed(42 + rank)
+        tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+        ref = _nccl_reference(tensor.clone(), group)
+
+        if not aiter_ar_manager.should_use(tensor, group, device_id):
+            if rank == 0:
+                print(f"  [aiter_allreduce] skipped: should_use=False for {dtype}")
+            return
+
+        result = aiter_ar_manager.allreduce(tensor)
+
+        diff = (result.float() - ref.float()).abs().max().item()
+        ref_max = ref.float().abs().max().item()
+        rel_diff = diff / ref_max if ref_max > 0 else 0
+
+        rtol, atol = 1e-3, 1e-4
+        assert rel_diff < rtol or diff < atol, (
+            f"[Rank {rank}] aiter allreduce mismatch: rel={rel_diff:.6e}, abs={diff:.6e}"
+        )
+        if rank == 0:
+            print(f"  [aiter_allreduce] hidden={hidden_size} dtype={dtype} rel_diff={rel_diff:.2e} ✓")
+
+    except Exception as exc:
+        print(f"[Rank {rank}] aiter_allreduce FAILED: {exc}", file=sys.stderr)
+        import traceback; traceback.print_exc()
+        raise
+    finally:
+        _cleanup_distributed()
+
+
+# ---------------------------------------------------------------------------
+# Worker: full tier dispatch via collective_torch.all_reduce
+# ---------------------------------------------------------------------------
+def _worker_tier_dispatch(
+    rank: int, world_size: int, port: int,
+    batch_size: int, hidden_size: int, dtype: torch.dtype,
+    strategy: str,
+):
+    try:
+        os.environ["ROCM_ALLREDUCE_STRATEGY"] = strategy
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(port)
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        torch.cuda.set_device(rank)
+
+        from rtp_llm.models_py.distributed.collective_torch import (
+            destroy_distributed_environment,
+            init_distributed_environment,
+            all_reduce,
+            Group,
+        )
+        from rtp_llm.ops import NcclCommConfig, ParallelismConfig
+
+        device = torch.device(f"cuda:{rank}")
+
+        base_port = port + 11
+        pc = ParallelismConfig()
+        pc.world_size = world_size
+        pc.world_rank = rank
+        pc.tp_size = world_size
+        pc.tp_rank = rank
+        pc.dp_size = 1
+        pc.dp_rank = 0
+        pc.local_rank = rank
+        nccl_comm_config = NcclCommConfig(
+            nccl_ip="127.0.0.1",
+            tp_nccl_port=base_port - 2,
+            dp_tp_nccl_port=base_port - 10,
+            ffn_tp_nccl_port=base_port - 5,
+        )
+        init_distributed_environment(
+            pc,
+            nccl_comm_config=nccl_comm_config,
+            nccl_init_port=port,
+        )
+
+        torch.manual_seed(42 + rank)
+        tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+        ref = _nccl_reference(tensor.clone(), dist.group.WORLD)
+
+        result = all_reduce(tensor, Group.TP)
+
+        diff = (result.float() - ref.float()).abs().max().item()
+        ref_max = ref.float().abs().max().item()
+        rel_diff = diff / ref_max if ref_max > 0 else 0
+
+        rtol = 0.05 if "quick" in strategy else 1e-3
+        assert rel_diff < rtol, (
+            f"[Rank {rank}] tier dispatch mismatch: strategy={strategy} "
+            f"rel={rel_diff:.6e}, abs={diff:.6e}"
+        )
+        if rank == 0:
+            print(f"  [tier_dispatch] strategy={strategy} hidden={hidden_size} rel_diff={rel_diff:.2e} ✓")
+
+    except Exception as exc:
+        print(f"[Rank {rank}] tier_dispatch FAILED: {exc}", file=sys.stderr)
+        import traceback; traceback.print_exc()
+        raise
+    finally:
+        try:
+            destroy_distributed_environment()
+        except Exception:
+            _cleanup_distributed()
+
+
+# ===========================================================================
+# Test cases
+# ===========================================================================
+class TestROCmAllReduceTierIntegration(unittest.TestCase):
+    """2-rank integration tests for ROCm allreduce tiers."""
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm not available")
+        if not (hasattr(torch.version, "hip") and torch.version.hip):
+            self.skipTest("ROCm not available")
+        if torch.cuda.device_count() < 2:
+            self.skipTest(f"Need ≥2 GPUs, found {torch.cuda.device_count()}")
+        try:
+            mp.set_start_method("spawn", force=True)
+        except RuntimeError:
+            pass
+
+    # ---- Quick allreduce (FP quantization) ----
+
+    def test_quick_fp_bf16_hidden4096(self):
+        _launch_workers(
+            _worker_quick_allreduce, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.bfloat16,
+            quant_type="FP",
+        )
+
+    def test_quick_fp_bf16_hidden2048(self):
+        _launch_workers(
+            _worker_quick_allreduce, world_size=2,
+            batch_size=16, hidden_size=2048, dtype=torch.bfloat16,
+            quant_type="FP",
+        )
+
+    # ---- Aiter custom allreduce ----
+
+    def test_aiter_bf16_hidden4096(self):
+        _launch_workers(
+            _worker_aiter_allreduce, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.bfloat16,
+        )
+
+    def test_aiter_bf16_hidden2048(self):
+        _launch_workers(
+            _worker_aiter_allreduce, world_size=2,
+            batch_size=16, hidden_size=2048, dtype=torch.bfloat16,
+        )
+
+    def test_aiter_bf16_small_tensor(self):
+        _launch_workers(
+            _worker_aiter_allreduce, world_size=2,
+            batch_size=1, hidden_size=256, dtype=torch.bfloat16,
+        )
+
+    # ---- Dtype fallback: fp16/fp32 should gracefully skip to NCCL ----
+
+    def test_aiter_fp16_falls_through(self):
+        _launch_workers(
+            _worker_aiter_allreduce, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.float16,
+        )
+
+    # ---- Full tier dispatch ----
+
+    def test_dispatch_quick_strategy(self):
+        _launch_workers(
+            _worker_tier_dispatch, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.bfloat16,
+            strategy="quick",
+        )
+
+    def test_dispatch_aiter_strategy(self):
+        _launch_workers(
+            _worker_tier_dispatch, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.bfloat16,
+            strategy="aiter",
+        )
+
+    def test_dispatch_nccl_fallback(self):
+        _launch_workers(
+            _worker_tier_dispatch, world_size=2,
+            batch_size=8, hidden_size=4096, dtype=torch.bfloat16,
+            strategy="none",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/base/rocm/aiter_custom_allreduce.py
+++ b/rtp_llm/models_py/modules/base/rocm/aiter_custom_allreduce.py
@@ -1,0 +1,282 @@
+"""Aiter CustomAllreduce wrapper for ROCm prefill AllReduce.
+
+Uses aiter low-level ops (``init_custom_ar``, ``all_reduce``, etc.)
+directly, exchanging IPC handles via the NCCL group (same approach as
+the C++ ``CustomAllReduceComm``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_SIZE = 128 * 1024 * 1024  # 128 MB
+
+# Aiter custom AR kernel only handles BF16 and FP8 (e4m3fn / e4m3fnuz).
+# FP16/FP32 must fall through to the next tier; otherwise the BF16-typed
+# kernel reads them as garbage and produces wrong values.
+_SUPPORTED_DTYPES = (
+    torch.bfloat16,
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+)
+
+
+def _all_ranks_ok(ok: bool, group: ProcessGroup, world_size: int) -> bool:
+    """Return True only if every rank passed ok=True."""
+    try:
+        flags = [None] * world_size
+        dist.all_gather_object(flags, ok, group=group)
+        return all(flags)
+    except Exception:
+        return False
+
+
+class _AiterARManager:
+    """Singleton that manages aiter custom AllReduce via low-level ops."""
+
+    def __init__(self) -> None:
+        self.group: Optional[ProcessGroup] = None
+        self.device_id: Optional[int] = None
+        self.rank: int = 0
+        self.world_size: int = 1
+        self.fa: int = 0
+        self.buffer: Optional[Tensor] = None
+        self.max_size: int = _DEFAULT_MAX_SIZE
+        self.initialized = False
+        self.disabled = False
+
+    def _exchange_ipc_handles(self, local_buffer: Tensor):
+        """Exchange IPC handles via NCCL all_gather.
+
+        Same approach as C++ CustomAllReduceComm::prepareP2PBuffer_:
+        copy the local IPC handle to GPU, NCCL all_gather, then copy back.
+        """
+        import aiter as ops
+
+        handle_tensor = ops.get_meta_buffer_ipc_handle(local_buffer)
+        handle_size = handle_tensor.numel()
+
+        device = f"cuda:{self.device_id}"
+        local_gpu = torch.empty(handle_size, dtype=torch.uint8, device=device)
+        gathered_gpu = torch.empty(
+            handle_size * self.world_size, dtype=torch.uint8, device=device
+        )
+
+        local_gpu.copy_(handle_tensor)
+        dist.all_gather_into_tensor(gathered_gpu, local_gpu, group=self.group)
+        # Sync only the current stream — full device sync would block
+        # unrelated streams (e.g. another process group's collectives).
+        torch.cuda.current_stream().synchronize()
+
+        gathered_cpu = gathered_gpu.cpu()
+        handles = []
+        offsets = []
+        for i in range(self.world_size):
+            start = i * handle_size
+            end = start + handle_size
+            handles.append(gathered_cpu[start:end].clone())
+            offsets.append(0)
+        return handles, offsets
+
+    def initialize(self, group: ProcessGroup, device_id: int) -> None:
+        if self.initialized and group == self.group and device_id == self.device_id:
+            return
+        # If this is a re-init (different group/device), free the previous
+        # custom-AR handle and IPC buffer first to avoid leaking
+        # hipDeviceMallocUncached memory across re-inits.
+        if self.fa != 0:
+            try:
+                import aiter as ops
+
+                ops.dispose(self.fa)
+            except Exception as exc:
+                logger.warning("Aiter CustomAR dispose on re-init failed: %s", exc)
+            self.fa = 0
+        self.buffer = None
+        self._meta = None
+        self._rank_data = None
+        self.initialized = False
+        self.disabled = False
+        self.group = group
+        self.device_id = device_id
+
+        # Phase 0: every rank locally allocates the meta + buffer.
+        # We must reach a consensus that ALL ranks succeeded BEFORE issuing
+        # any collective (otherwise a peer's allocate_meta_buffer OOM would
+        # deadlock the survivors at all_gather_into_tensor).
+        local_ok = False
+        local_err: Optional[str] = None
+        meta = None
+        rank_data = None
+        buffer = None
+        try:
+            import aiter as ops
+
+            self.rank = dist.get_rank(group=group)
+            self.world_size = dist.get_world_size(group=group)
+
+            if self.world_size == 1 or self.world_size not in {2, 4, 6, 8}:
+                local_err = f"unsupported world_size={self.world_size}"
+            else:
+                torch.cuda.set_device(device_id)
+                meta = ops.allocate_meta_buffer(ops.meta_size() + self.max_size * 2)
+                rank_data = torch.empty(
+                    8 * 1024 * 1024,
+                    dtype=torch.uint8,
+                    device=f"cuda:{device_id}",
+                )
+                # Must use allocate_meta_buffer (hipDeviceMallocUncached)
+                # instead of torch.empty. On some ROCm platforms hipMalloc
+                # memory does not support IPC (hipIpcOpenMemHandle returns
+                # error 17).
+                buffer = ops.allocate_meta_buffer(self.max_size)
+                local_ok = True
+        except ImportError:
+            local_err = "aiter not available"
+        except Exception as exc:
+            local_err = f"local allocation failed: {exc}"
+
+        # Phase 1 consensus: every rank must succeed before IPC exchange.
+        if not _all_ranks_ok(local_ok, group, self.world_size):
+            logger.info(
+                "Aiter CustomAllreduce disabled: %s",
+                local_err or "a peer rank failed init",
+            )
+            self.disabled = True
+            self.initialized = True
+            return
+
+        # Phase 2: exchange IPC handles.
+        phase2_ready = meta is not None and buffer is not None and rank_data is not None
+        if not _all_ranks_ok(phase2_ready, group, self.world_size):
+            logger.info("Aiter CustomAllreduce disabled: a rank not ready for phase-2")
+            self.disabled = True
+            self.initialized = True
+            return
+
+        # Phase 2a: exchange meta handles (all ranks must reach all_gather)
+        phase2_ok = False
+        try:
+            import aiter as ops
+
+            meta_handles, meta_offsets = self._exchange_ipc_handles(meta)
+        except Exception as exc:
+            logger.warning("Aiter CustomAR meta handle exchange failed: %s", exc)
+            meta_handles = None
+
+        if not _all_ranks_ok(meta_handles is not None, group, self.world_size):
+            logger.info("Aiter CustomAllreduce disabled: meta handle exchange failed")
+            self.disabled = True
+            self.initialized = True
+            return
+
+        # Phase 2b: init custom AR + exchange buffer handles
+        try:
+            self.fa = ops.init_custom_ar(
+                meta, rank_data, meta_handles, meta_offsets,
+                self.rank, True,
+            )
+            buf_handles, buf_offsets = self._exchange_ipc_handles(buffer)
+            ops.register_buffer(self.fa, buffer, buf_handles, buf_offsets)
+            self.buffer = buffer
+            self._meta = meta
+            self._rank_data = rank_data
+            phase2_ok = True
+        except Exception as exc:
+            logger.warning("Aiter CustomAR phase-2 init/buffer exchange failed: %s", exc)
+
+        if not _all_ranks_ok(phase2_ok, group, self.world_size):
+            if self.fa != 0:
+                try:
+                    import aiter as ops
+
+                    ops.dispose(self.fa)
+                except Exception:
+                    pass
+                self.fa = 0
+            self.buffer = None
+            self._meta = None
+            self._rank_data = None
+            self.disabled = True
+            self.initialized = True
+            return
+
+        dist.barrier(group=group)
+        self.initialized = True
+
+    def close(self) -> None:
+        """Release the custom-AR handle and IPC buffer.
+
+        Safe to call multiple times. Call from teardown paths
+        (e.g. destroy_distributed_environment) so IPC buffers don't leak
+        across process-group re-creation cycles.
+        """
+        if self.fa != 0:
+            try:
+                import aiter as ops
+
+                ops.dispose(self.fa)
+            except Exception as exc:
+                logger.warning("Aiter CustomAR dispose on close failed: %s", exc)
+            self.fa = 0
+        self.buffer = None
+        self._meta = None
+        self._rank_data = None
+        self.disabled = True
+        self.initialized = False
+
+    def ensure_initialized(self, group: ProcessGroup, device_id: int) -> bool:
+        """Lazily initialize and return True if comm is usable."""
+        if not self.initialized:
+            self.initialize(group, device_id)
+        return self.initialized and not self.disabled
+
+    def should_use(self, tensor: Tensor, group: ProcessGroup, device_id: int) -> bool:
+        """Check whether *tensor* is eligible for aiter CustomAllreduce.
+
+        State-only — never triggers (re-)initialization. Call sites must
+        run ``ensure_initialized`` outside of stream capture beforehand.
+        """
+        if not self.initialized or self.disabled or self.fa == 0:
+            return False
+        if self.group is not group or self.device_id != device_id:
+            return False
+        if tensor.dtype not in _SUPPORTED_DTYPES:
+            return False
+        inp_size = tensor.numel() * tensor.element_size()
+        if inp_size % 16 != 0:
+            return False
+        # 2-stage allreduce write mode uses 2x temp buffer,
+        # so effective limit is max_size / 2
+        return inp_size <= self.max_size // 2
+
+    def allreduce(self, tensor: Tensor) -> Tensor:
+        """AllReduce *tensor* via aiter P2P custom allreduce.
+
+        Supports BF16 and FP8 dtypes.
+        """
+        import aiter as ops
+
+        out = torch.empty_like(tensor)
+        is_fp8 = tensor.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+
+        ops.all_reduce(
+            self.fa,
+            tensor,
+            out,
+            False,
+            is_fp8,
+            self.buffer,
+        )
+        return out
+
+
+aiter_ar_manager = _AiterARManager()

--- a/rtp_llm/models_py/modules/base/rocm/quick_allreduce.py
+++ b/rtp_llm/models_py/modules/base/rocm/quick_allreduce.py
@@ -1,0 +1,332 @@
+"""Aiter Quick AllReduce wrapper for ROCm.
+
+Quick AllReduce leverages quantization (FP, FP8, INT6, INT4) for further
+acceleration on ROCm MI300 series. It is designed as a complement to
+custom allreduce, providing better throughput at the cost of some precision.
+
+Uses aiter low-level ops (``init_custom_qr``, ``qr_all_reduce``, etc.)
+directly, exchanging IPC handles via the NCCL group.
+
+Environment variables:
+    ROCM_ALLREDUCE_STRATEGY: set to "quick" to enable Quick AllReduce
+    ROCM_QUICK_AR_QUANTIZATION: FP / FP8 / INT6 / INT4 (default: FP)
+    ROCM_QUICK_AR_CAST_BF16_TO_FP16: 1 / 0 (default: 1, cast bf16 to fp16 for faster kernels)
+    ROCM_QUICK_AR_MAX_SIZE_MB: max buffer size in MB (default: 0 = aiter default ~2GB)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch import Tensor
+from torch.distributed import ProcessGroup
+
+logger = logging.getLogger(__name__)
+
+_MB = 1024 * 1024
+
+_QUANT_MAP = {"FP": 0, "FP8": 1, "INT6": 2, "INT4": 3, "NONE": 4}
+
+_SUPPORTED_WORLD_SIZES = [2, 4, 8]
+_SUPPORTED_DTYPES = [torch.float16, torch.bfloat16]
+
+_BOOL_TRUE = {"1", "true", "yes", "on", "y", "t"}
+_BOOL_FALSE = {"0", "false", "no", "off", "n", "f"}
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    s = raw.strip().lower()
+    if s in _BOOL_TRUE:
+        return True
+    if s in _BOOL_FALSE:
+        return False
+    logger.warning(
+        "Quick AllReduce: invalid %s=%r, using default=%s",
+        name,
+        raw,
+        default,
+    )
+    return default
+
+
+def _parse_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Quick AllReduce: invalid %s=%r (expected int), using default=%d",
+            name,
+            raw,
+            default,
+        )
+        return default
+
+
+# Min size thresholds from aiter kernel tests (order: [FP, FP8, INT6, INT4], unit: bytes).
+# Source: aiter/dist/device_communicators/quick_all_reduce.py & quick_ar_comm.h
+#
+# A very large threshold (e.g. 2048MB) is the aiter authors' way of saying
+# "this quant level is not recommended for that (dtype, world_size)" — it
+# effectively disables that level via should_use(). It is NOT a typo.
+_QR_MIN_SIZE = {
+    (torch.float16, 2): [1 * _MB, 2 * _MB, 2 * _MB, 1 * _MB],
+    (torch.float16, 4): [1 * _MB, 16 * _MB, 4 * _MB, 2 * _MB],
+    (torch.float16, 8): [16 * _MB, 4 * _MB, 4 * _MB, 8 * _MB],
+    (torch.bfloat16, 2): [2 * _MB, 8 * _MB, 8 * _MB, 8 * _MB],
+    (torch.bfloat16, 4): [8 * _MB, 64 * _MB, 64 * _MB, 16 * _MB],
+    (torch.bfloat16, 8): [16 * _MB, 2048 * _MB, 2048 * _MB, 2048 * _MB],
+}
+
+
+def _all_ranks_ok(ok: bool, group: ProcessGroup, world_size: int) -> bool:
+    """Return True only if every rank passed ok=True."""
+    try:
+        flags = [None] * world_size
+        dist.all_gather_object(flags, ok, group=group)
+        return all(flags)
+    except Exception:
+        return False
+
+
+class _QuickARManager:
+    """Singleton that manages aiter Quick AllReduce."""
+
+    def __init__(self) -> None:
+        self.group: Optional[ProcessGroup] = None
+        self.device_id: Optional[int] = None
+        self.rank: int = 0
+        self.world_size: int = 1
+        self.ptr: int = 0
+        self.max_size: int = 0
+        self.quant_level: int = 4  # NONE
+        self.use_fp16_kernels: int = 1
+        self.initialized: bool = False
+        self.disabled: bool = False
+
+    def initialize(self, group: ProcessGroup, device_id: int) -> None:
+        if self.initialized and group == self.group and device_id == self.device_id:
+            return
+        # If this is a re-init (different group/device), free the previous
+        # IPC buffer first to avoid leaking hipDeviceMallocUncached memory.
+        if self.ptr != 0:
+            try:
+                import aiter as ops
+
+                ops.qr_destroy(self.ptr)
+            except Exception as exc:
+                logger.warning("Quick AllReduce qr_destroy on re-init failed: %s", exc)
+            self.ptr = 0
+        self.initialized = False
+        self.disabled = False
+        self.group = group
+        self.device_id = device_id
+
+        # Read quantization level from env (default: FP = lossless)
+        quant_str = os.environ.get("ROCM_QUICK_AR_QUANTIZATION", "FP").upper()
+        if quant_str not in _QUANT_MAP or quant_str == "NONE":
+            logger.warning(
+                "Quick AllReduce: invalid ROCM_QUICK_AR_QUANTIZATION=%s, "
+                "falling back to FP",
+                quant_str,
+            )
+            quant_str = "FP"
+
+        self.quant_level = _QUANT_MAP[quant_str]
+        self.use_fp16_kernels = (
+            1 if _parse_bool_env("ROCM_QUICK_AR_CAST_BF16_TO_FP16", True) else 0
+        )
+
+        # Two-phase init with all-rank consensus to avoid deadlocks when
+        # init succeeds on some ranks and fails on others (e.g. one rank
+        # OOMs in init_custom_qr but the others don't).
+        local_ok = False
+        local_err: Optional[str] = None
+        try:
+            import aiter as ops
+
+            self.rank = dist.get_rank(group=group)
+            self.world_size = dist.get_world_size(group=group)
+
+            if self.world_size == 1 or self.world_size not in _SUPPORTED_WORLD_SIZES:
+                local_err = f"unsupported world_size={self.world_size}"
+            else:
+                props = torch.cuda.get_device_properties(device_id)
+                gcn_arch = getattr(props, "gcnArchName", "")
+                supported_archs = ["gfx94", "gfx50"]
+                if not any(gfx in gcn_arch for gfx in supported_archs):
+                    local_err = f"unsupported arch {gcn_arch}"
+                else:
+                    torch.cuda.set_device(device_id)
+                    max_size_mb = _parse_int_env("ROCM_QUICK_AR_MAX_SIZE_MB", 0)
+                    max_size_bytes = max_size_mb * _MB if max_size_mb > 0 else 0
+
+                    self.ptr = ops.init_custom_qr(
+                        self.rank,
+                        self.world_size,
+                        max_size_bytes,
+                    )
+                    self.max_size = (
+                        max_size_bytes if max_size_bytes > 0 else ops.qr_max_size()
+                    )
+                    local_ok = True
+        except ImportError:
+            local_err = "aiter not available"
+        except Exception as exc:
+            local_err = f"init_custom_qr failed: {exc}"
+
+        # Phase 1 consensus: every rank must succeed before IPC exchange.
+        if not _all_ranks_ok(local_ok, group, self.world_size):
+            if local_ok and self.ptr != 0:
+                try:
+                    import aiter as ops
+
+                    ops.qr_destroy(self.ptr)
+                except Exception:
+                    pass
+                self.ptr = 0
+            logger.info(
+                "Quick AllReduce disabled: %s",
+                local_err or "a peer rank failed init",
+            )
+            self.disabled = True
+            self.initialized = True
+            return
+
+        # Phase 2: exchange IPC handles.
+        # Split into local handle acquisition → consensus → collective
+        # to prevent deadlock when one rank throws before all_gather.
+        handle = None
+        handle_ok = False
+        try:
+            import aiter as ops
+
+            handle = ops.qr_get_handle(self.ptr)
+            handle_ok = True
+        except Exception as exc:
+            logger.warning("Quick AllReduce phase-2 handle acquisition failed: %s", exc)
+
+        if not _all_ranks_ok(handle_ok, group, self.world_size):
+            logger.info("Quick AllReduce disabled: a rank failed handle acquisition")
+            try:
+                import aiter as ops
+                ops.qr_destroy(self.ptr)
+            except Exception:
+                pass
+            self.ptr = 0
+            self.disabled = True
+            self.initialized = True
+            return
+
+        phase2_ok = False
+        try:
+            handles = [None] * self.world_size
+            dist.all_gather_object(handles, handle, group=group)
+            ops.qr_open_handles(self.ptr, handles)
+            phase2_ok = True
+        except Exception as exc:
+            logger.warning("Quick AllReduce phase-2 IPC exchange failed: %s", exc)
+
+        if not _all_ranks_ok(phase2_ok, group, self.world_size):
+            try:
+                import aiter as ops
+
+                ops.qr_destroy(self.ptr)
+            except Exception:
+                pass
+            self.ptr = 0
+            self.disabled = True
+            self.initialized = True
+            return
+
+        dist.barrier(group=group)
+        self.initialized = True
+        logger.info(
+            "Quick AllReduce ready (device=%d, rank=%d, world_size=%d, "
+            "quant=%s, use_fp16=%d, max_size=%dMB)",
+            device_id,
+            self.rank,
+            self.world_size,
+            quant_str,
+            self.use_fp16_kernels,
+            self.max_size // _MB,
+        )
+
+    def close(self) -> None:
+        if self.ptr != 0:
+            try:
+                import aiter as ops
+
+                ops.qr_destroy(self.ptr)
+            except Exception as exc:
+                logger.warning("Quick AllReduce qr_destroy on close failed: %s", exc)
+            self.ptr = 0
+        self.disabled = True
+        self.initialized = False
+
+    def ensure_initialized(self, group: ProcessGroup, device_id: int) -> bool:
+        """Lazily initialize and return True if quick allreduce is usable."""
+        if not self.initialized:
+            self.initialize(group, device_id)
+        return self.initialized and not self.disabled
+
+    def should_use(self, tensor: Tensor, group: ProcessGroup, device_id: int) -> bool:
+        """Check whether *tensor* is eligible for quick allreduce."""
+        if not self.initialized or self.disabled or self.ptr == 0:
+            return False
+        if self.group is not group or self.device_id != device_id:
+            return False
+        if tensor.dtype not in _SUPPORTED_DTYPES:
+            return False
+
+        inp_size = tensor.numel() * tensor.element_size()
+
+        # Must be multiples of 16
+        if inp_size % 16 != 0:
+            return False
+
+        # Check max size
+        if inp_size > self.max_size:
+            return False
+
+        # Check min size threshold.
+        # When casting bf16→fp16 (use_fp16_kernels=1), the fp16 kernel thresholds
+        # are only safe for FP lossless mode (quant_level==0). For lossy quant
+        # levels the original dtype thresholds must be respected because aiter's
+        # high thresholds intentionally disable unreliable (dtype, world_size,
+        # quant) combinations.
+        if self.use_fp16_kernels and self.quant_level == 0:
+            dtype_for_check = torch.float16
+        else:
+            dtype_for_check = tensor.dtype
+        min_sizes = _QR_MIN_SIZE.get((dtype_for_check, self.world_size))
+        if min_sizes is not None and inp_size < min_sizes[self.quant_level]:
+            return False
+
+        return True
+
+    def allreduce(self, tensor: Tensor, inplace: bool = False) -> Tensor:
+        """AllReduce *tensor* via aiter quick reduce."""
+        import aiter as ops
+
+        out = tensor if inplace else torch.empty_like(tensor)
+        ops.qr_all_reduce(
+            self.ptr,
+            tensor,
+            out,
+            self.quant_level,
+            self.use_fp16_kernels,
+        )
+        return out
+
+
+quick_ar_manager = _QuickARManager()

--- a/rtp_llm/models_py/modules/base/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/base/rocm/test/BUILD
@@ -104,3 +104,13 @@ py_test(
     exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
 )
 
+py_test(
+    name = "test_aiter_custom_allreduce_dtype",
+    srcs = ["test_aiter_custom_allreduce_dtype.py"],
+    deps = [
+        "//rtp_llm/models_py/modules/base/rocm:rocm_base",
+    ],
+    timeout = "short",
+    tags = ["rocm"],
+)
+

--- a/rtp_llm/models_py/modules/base/rocm/test/test_aiter_custom_allreduce_dtype.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_aiter_custom_allreduce_dtype.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_AiterARManager.should_use`` dtype gating.
+
+The manager's ``allreduce`` kernel only handles BF16 and FP8 dtypes;
+unsupported dtypes (FP16/FP32) must fall through to the next tier
+rather than hitting the kernel and producing garbage. This test
+verifies that gating without requiring multiple GPUs by stubbing the
+manager state.
+"""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.modules.base.rocm.aiter_custom_allreduce import (
+    _SUPPORTED_DTYPES,
+    _AiterARManager,
+)
+
+
+class AiterCustomARDtypeTest(unittest.TestCase):
+    def _make_initialized_manager(self) -> _AiterARManager:
+        m = _AiterARManager()
+        # Stub the post-init invariants the dtype check runs after.
+        m.initialized = True
+        m.disabled = False
+        m.fa = 1  # any non-zero value
+        m.group = object()
+        m.device_id = 0
+        m.max_size = 128 * 1024 * 1024
+        return m
+
+    def _eligible_tensor(self, dtype: torch.dtype) -> torch.Tensor:
+        # Use CPU tensors and only check the dtype gate; numel * element_size
+        # is divisible by 16 so the size-alignment check still passes.
+        return torch.empty(1024, dtype=dtype)
+
+    def test_supported_dtypes_pass_gate(self):
+        m = self._make_initialized_manager()
+        for dtype in _SUPPORTED_DTYPES:
+            with self.subTest(dtype=dtype):
+                t = self._eligible_tensor(dtype)
+                self.assertTrue(m.should_use(t, m.group, m.device_id))
+
+    def test_unsupported_dtypes_fall_through(self):
+        m = self._make_initialized_manager()
+        for dtype in (torch.float16, torch.float32):
+            with self.subTest(dtype=dtype):
+                t = self._eligible_tensor(dtype)
+                self.assertFalse(m.should_use(t, m.group, m.device_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/base/rocm/trt_allreduce.py
+++ b/rtp_llm/models_py/modules/base/rocm/trt_allreduce.py
@@ -5,10 +5,14 @@
 from typing import Optional, Tuple
 from contextlib import contextmanager
 
+import logging
+
 import torch
 from torch import Tensor
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
+
+logger = logging.getLogger(__name__)
 
 def _get_handle_class():
     from rtp_llm.ops.compute_ops import rtp_llm_ops
@@ -48,6 +52,20 @@ class TrtllmDistEnv:
 
     _SUPPORTED_WORLD_SIZES = [2, 4, 8]
 
+    def _consensus(self, ok: bool) -> bool:
+        """Return True only if every rank passed ok=True."""
+        try:
+            flags = [None] * self.world_size
+            dist.all_gather_object(flags, ok, group=self.group)
+            return all(flags)
+        except Exception:
+            return False
+
+    def _abort(self, reason: str):
+        logger.info("TRT-LLM AllReduce disabled: %s", reason)
+        self.handle = None
+        self.disabled = True
+
     def __init__(
         self,
         group: ProcessGroup = None,
@@ -67,41 +85,58 @@ class TrtllmDistEnv:
         self._capture_handles_pending = False
         torch.cuda.set_device(self.device_id)
 
-        if self.world_size == 1:
-            return
-
-        if self.world_size not in self._SUPPORTED_WORLD_SIZES:
-            return
-
-        try:
-            TrtllmArFusionHandle = _get_handle_class()
-            self.handle = TrtllmArFusionHandle(
-                self.device_id, self.rank, self.world_size,
-                max_size_in_bytes, comm_ptrs_buf_len
-            )
-
-            barrier_handle = self.handle.get_barrier_handle()
-            data_handle = self.handle.get_data_handle()
-        except Exception as e:
-            import logging
-            logging.warning(
-                "TRT-LLM AllReduce initialization failed (likely insufficient GPU memory, "
-                "requested %d bytes for data buffer). Falling back to RCCL. Error: %s",
-                max_size_in_bytes * 2, e,
-            )
-            self.handle = None
+        if self.world_size == 1 or self.world_size not in self._SUPPORTED_WORLD_SIZES:
             self.disabled = True
             return
 
-        self._barrier()
+        # Phase 1: local allocation + consensus
+        local_ok = False
+        try:
+            Handle = _get_handle_class()
+            self.handle = Handle(
+                self.device_id, self.rank, self.world_size,
+                max_size_in_bytes, comm_ptrs_buf_len,
+            )
+            local_ok = True
+        except Exception as e:
+            logger.warning("TRT-LLM AllReduce local init failed: %s", e)
 
-        barrier_handle_list = [None] * self.world_size
-        data_handle_list = [None] * self.world_size
-        dist.all_gather_object(barrier_handle_list, barrier_handle, group=self.group)
-        dist.all_gather_object(data_handle_list, data_handle, group=self.group)
+        if not self._consensus(local_ok):
+            self._abort("local init failed" if not local_ok else "a peer rank failed")
+            return
 
-        self.handle.open_barrier_handles(barrier_handle_list)
-        self.handle.open_data_handles(data_handle_list)
+        # Phase 2a: local handle acquisition + consensus
+        local_bh = None
+        local_dh = None
+        handles_ok = False
+        try:
+            local_bh = self.handle.get_barrier_handle()
+            local_dh = self.handle.get_data_handle()
+            handles_ok = True
+        except Exception as e:
+            logger.warning("TRT-LLM AllReduce handle acquisition failed: %s", e)
+
+        if not self._consensus(handles_ok):
+            self._abort("handle acquisition failed" if not handles_ok else "a peer rank failed handle acquisition")
+            return
+
+        # Phase 2b: IPC handle exchange (all ranks guaranteed to participate)
+        phase2_ok = False
+        try:
+            self._barrier()
+            bh = [None] * self.world_size
+            dh = [None] * self.world_size
+            dist.all_gather_object(bh, local_bh, group=self.group)
+            dist.all_gather_object(dh, local_dh, group=self.group)
+            self.handle.open_barrier_handles(bh)
+            self.handle.open_data_handles(dh)
+            phase2_ok = True
+        except Exception as e:
+            logger.warning("TRT-LLM AllReduce IPC exchange failed: %s", e)
+
+        if not self._consensus(phase2_ok):
+            self._abort("IPC exchange failed" if not phase2_ok else "a peer rank failed exchange")
+            return
 
         self._barrier()
 


### PR DESCRIPTION
Introduce two new accelerated AllReduce strategies on the ROCm TP path and consolidate them, together with the existing trtllm allreduce, into a unified tiered-fallback framework:                                                                                                                     
                                                                                                                                                                                                                                                                                                          
  - Quick AllReduce: aiter-based, supports FP/FP8/INT6/INT4 quantization, trading acceptable precision loss for higher throughput on MI300-series GPUs.                                                                                                                                                   
  - Aiter Custom AllReduce: lossless P2P custom AllReduce that exchanges IPC handles via the NCCL group (same approach as the C++ CustomAllReduceComm).                                                                                                                                                 
  - Unified dispatch & switch: a single env var ROCM_ALLREDUCE_STRATEGY (comma-separated quick,trtllm,aiter,none) configures the enabled strategies. Parsed and validated once at import time, serving as the single source of truth across all related modules.                                          
  - Tiered priority: quick_AR → trtllm_AR → aiter custom AR → symm_mem → NCCL. Each tier falls back automatically on failure; fallback warnings are emitted only once. 