### PR TITLE
perf(rocm): scatter q/k/v in GDN prefill via Triton kernel to eliminate view copies

### DIFF
--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -29,6 +29,7 @@ from rtp_llm.models_py.triton_kernels.causal_conv1d import (
     prepare_causal_conv1d_metadata,
 )
 from rtp_llm.models_py.triton_kernels.common.layernorm_gated import RmsNormGated
+from rtp_llm.models_py.triton_kernels.common.scatter_qkv import scatter_qkv
 from rtp_llm.models_py.triton_kernels.fla.block import (
     load_initial_state_from_block_map,
     store_ssm_state_to_block_map,
@@ -236,18 +237,34 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 initial_states,
                 seq_size_per_block,
             )
-        query, key, value = torch.split(
-            mixed_qkv,
-            [
-                self.local_num_k_heads * self.head_k_dim,
-                self.local_num_k_heads * self.head_k_dim,
-                self.local_num_v_heads * self.head_v_dim,
-            ],
-            dim=-1,
-        )
-        query = query.view(1, query.shape[0], self.local_num_k_heads, self.head_k_dim)
-        key = key.view(1, key.shape[0], self.local_num_k_heads, self.head_k_dim)
-        value = value.view(1, value.shape[0], self.local_num_v_heads, self.head_v_dim)
+        # M >= 2048: scatter_qkv (Triton, SGLang port) avoids the .view() ->
+        # .contiguous() copies that torch.split + view triggers. Below 2048,
+        # kernel launch overhead beats the savings (microbench measured).
+        if mixed_qkv.shape[0] >= 2048 and self.head_k_dim == self.head_v_dim:
+            query, key, value = scatter_qkv(
+                mixed_qkv,
+                self.local_num_k_heads,
+                self.local_num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+            )
+        else:
+            query, key, value = torch.split(
+                mixed_qkv,
+                [
+                    self.local_num_k_heads * self.head_k_dim,
+                    self.local_num_k_heads * self.head_k_dim,
+                    self.local_num_v_heads * self.head_v_dim,
+                ],
+                dim=-1,
+            )
+            query = query.view(
+                1, query.shape[0], self.local_num_k_heads, self.head_k_dim
+            )
+            key = key.view(1, key.shape[0], self.local_num_k_heads, self.head_k_dim)
+            value = value.view(
+                1, value.shape[0], self.local_num_v_heads, self.head_v_dim
+            )
         attn_out, h, final_state = chunk_gated_delta_rule(
             query,
             key,
@@ -662,18 +679,27 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 seq_size_per_block,
             )
 
-        query, key, value = torch.split(
-            full_mixed_qkv,
-            [
-                gdn.local_num_k_heads * gdn.head_k_dim,
-                gdn.local_num_k_heads * gdn.head_k_dim,
-                gdn.local_num_v_heads * gdn.head_v_dim,
-            ],
-            dim=-1,
-        )
-        query = query.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
-        key = key.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
-        value = value.view(1, -1, gdn.local_num_v_heads, gdn.head_v_dim)
+        if full_mixed_qkv.shape[0] >= 2048 and gdn.head_k_dim == gdn.head_v_dim:
+            query, key, value = scatter_qkv(
+                full_mixed_qkv,
+                gdn.local_num_k_heads,
+                gdn.local_num_v_heads,
+                gdn.head_k_dim,
+                gdn.head_v_dim,
+            )
+        else:
+            query, key, value = torch.split(
+                full_mixed_qkv,
+                [
+                    gdn.local_num_k_heads * gdn.head_k_dim,
+                    gdn.local_num_k_heads * gdn.head_k_dim,
+                    gdn.local_num_v_heads * gdn.head_v_dim,
+                ],
+                dim=-1,
+            )
+            query = query.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
+            key = key.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
+            value = value.view(1, -1, gdn.local_num_v_heads, gdn.head_v_dim)
 
         attn_out, h, final_state = chunk_gated_delta_rule(
             query,

--- a/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
+++ b/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
@@ -1,0 +1,97 @@
+# Adapted from SGLang `gdn_fused_proj.py:_scatter_fused_proj_kernel`.
+# Splits a packed [Q|K|V] tensor into three contiguous buffers shaped as
+# (1, M, n_heads, head_dim), avoiding the .view() -> .contiguous() copy that
+# torch.split + view triggers when the slice stride doesn't match the target
+# contig stride.
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_qkv_kernel(
+    src_ptr,
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    stride_src_row,
+    K_DIM: tl.constexpr,
+    V_DIM: tl.constexpr,
+    BLK_QK: tl.constexpr,
+    BLK_V: tl.constexpr,
+):
+    row = tl.program_id(0)
+    src = row * stride_src_row
+
+    offs_qk = tl.arange(0, BLK_QK)
+    mask_qk = offs_qk < K_DIM
+    q_dst = row * K_DIM + offs_qk
+    k_dst = row * K_DIM + offs_qk
+    tl.store(
+        q_ptr + q_dst, tl.load(src_ptr + src + offs_qk, mask=mask_qk), mask=mask_qk
+    )
+    tl.store(
+        k_ptr + k_dst,
+        tl.load(src_ptr + src + K_DIM + offs_qk, mask=mask_qk),
+        mask=mask_qk,
+    )
+
+    offs_v = tl.arange(0, BLK_V)
+    mask_v = offs_v < V_DIM
+    v_dst = row * V_DIM + offs_v
+    tl.store(
+        v_ptr + v_dst,
+        tl.load(src_ptr + src + 2 * K_DIM + offs_v, mask=mask_v),
+        mask=mask_v,
+    )
+
+
+def scatter_qkv(
+    mixed_qkv: torch.Tensor,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split a packed (M, k_dim*2 + v_dim) tensor into (1, M, n_heads, head_dim) buffers.
+
+    Replaces:
+        q, k, v = torch.split(mixed_qkv, [k_dim, k_dim, v_dim], dim=-1)
+        q = q.view(1, M, num_k_heads, head_k_dim)       # triggers .contiguous()
+        k = k.view(1, M, num_k_heads, head_k_dim)       # triggers .contiguous()
+        v = v.view(1, M, num_v_heads, head_v_dim)       # triggers .contiguous()
+    """
+    assert mixed_qkv.dim() == 2 and mixed_qkv.is_contiguous(), (
+        f"mixed_qkv must be 2D contiguous, got shape={tuple(mixed_qkv.shape)} "
+        f"stride={mixed_qkv.stride()} contig={mixed_qkv.is_contiguous()}"
+    )
+    M = mixed_qkv.shape[0]
+    k_dim = num_k_heads * head_k_dim
+    v_dim = num_v_heads * head_v_dim
+    assert (
+        mixed_qkv.shape[1] == 2 * k_dim + v_dim
+    ), f"expected last dim 2*{k_dim} + {v_dim} = {2*k_dim + v_dim}, got {mixed_qkv.shape[1]}"
+
+    dtype, device = mixed_qkv.dtype, mixed_qkv.device
+    q = torch.empty((1, M, num_k_heads, head_k_dim), dtype=dtype, device=device)
+    k = torch.empty((1, M, num_k_heads, head_k_dim), dtype=dtype, device=device)
+    v = torch.empty((1, M, num_v_heads, head_v_dim), dtype=dtype, device=device)
+
+    BLK_QK = triton.next_power_of_2(k_dim)
+    BLK_V = triton.next_power_of_2(v_dim)
+    _scatter_qkv_kernel[(M,)](
+        mixed_qkv,
+        q,
+        k,
+        v,
+        mixed_qkv.stride(0),
+        K_DIM=k_dim,
+        V_DIM=v_dim,
+        BLK_QK=BLK_QK,
+        BLK_V=BLK_V,
+        num_warps=4,
+    )
+    return q, k, v

--- a/rtp_llm/models_py/triton_kernels/common/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/common/test/BUILD
@@ -20,3 +20,14 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "scatter_qkv_test",
+    srcs = ["scatter_qkv_test.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)

--- a/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
@@ -1,0 +1,161 @@
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.common.scatter_qkv import scatter_qkv
+
+
+def _split_view_baseline(
+    mixed_qkv: torch.Tensor,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+):
+    """Reference implementation: torch.split + view (the path scatter_qkv replaces).
+
+    This is the exact code that lived in Qwen3NextGatedDeltaNetPrefill._fla
+    before the scatter_qkv optimization landed.
+    """
+    M = mixed_qkv.shape[0]
+    k_dim = num_k_heads * head_k_dim
+    v_dim = num_v_heads * head_v_dim
+    q, k, v = torch.split(mixed_qkv, [k_dim, k_dim, v_dim], dim=-1)
+    q = q.view(1, M, num_k_heads, head_k_dim).contiguous()
+    k = k.view(1, M, num_k_heads, head_k_dim).contiguous()
+    v = v.view(1, M, num_v_heads, head_v_dim).contiguous()
+    return q, k, v
+
+
+class TestScatterQKV(unittest.TestCase):
+    """Equivalence tests for scatter_qkv vs torch.split + view baseline.
+
+    scatter_qkv is a pure data-movement kernel (no math), so equality must be
+    bit-exact (torch.equal), not numerically close.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        self.device = torch.device("cuda:0")
+
+    def _assert_equivalent(
+        self,
+        M: int,
+        num_k: int,
+        num_v: int,
+        head_k: int,
+        head_v: int,
+        dtype: torch.dtype,
+    ) -> None:
+        torch.manual_seed(M * 1000 + num_k * 100 + num_v * 10 + head_k)
+        total = 2 * num_k * head_k + num_v * head_v
+        x = torch.randn(M, total, dtype=dtype, device=self.device)
+
+        q_ref, k_ref, v_ref = _split_view_baseline(x, num_k, num_v, head_k, head_v)
+        q_new, k_new, v_new = scatter_qkv(x, num_k, num_v, head_k, head_v)
+
+        for name, new, ref in (
+            ("q", q_new, q_ref),
+            ("k", k_new, k_ref),
+            ("v", v_new, v_ref),
+        ):
+            self.assertEqual(new.shape, ref.shape, f"{name} shape mismatch")
+            self.assertEqual(new.dtype, ref.dtype, f"{name} dtype mismatch")
+            self.assertTrue(new.is_contiguous(), f"{name} must be contiguous")
+            self.assertTrue(
+                torch.equal(new, ref),
+                f"{name} value mismatch (max abs diff = {(new - ref).abs().max().item()})",
+            )
+
+    def test_qwen3_next_tp2_prefill_15k(self) -> None:
+        """Production case: Qwen3.5-9B TP=2 GDN, 15K-token prefill (the trace baseline)."""
+        self._assert_equivalent(15384, 8, 16, 128, 128, torch.bfloat16)
+
+    def test_threshold_boundary_M(self) -> None:
+        """qwen3_next.py uses M>=2048 to gate scatter_qkv; the kernel itself must
+        produce correct output at the boundary regardless."""
+        for M in (2047, 2048, 2049):
+            with self.subTest(M=M):
+                self._assert_equivalent(M, 8, 16, 128, 128, torch.bfloat16)
+
+    def test_dtypes(self) -> None:
+        """bf16 is the production dtype; fp16/fp32 should also work."""
+        for dtype in (torch.bfloat16, torch.float16, torch.float32):
+            with self.subTest(dtype=dtype):
+                self._assert_equivalent(4096, 8, 16, 128, 128, dtype)
+
+    def test_head_configurations(self) -> None:
+        """Cover Qwen3-Next TP=1/2/4 head splits, plus a few atypical layouts."""
+        configs = [
+            # (num_k_heads, num_v_heads, head_k_dim, head_v_dim)
+            (16, 32, 128, 128),  # Qwen3-Next TP=1
+            (8, 16, 128, 128),  # Qwen3-Next TP=2
+            (4, 8, 128, 128),  # Qwen3-Next TP=4
+            (2, 4, 128, 128),  # small MQA-like
+            (4, 4, 64, 64),  # 1:1 head ratio, smaller head dim
+        ]
+        for num_k, num_v, head_k, head_v in configs:
+            with self.subTest(num_k=num_k, num_v=num_v, head_k=head_k, head_v=head_v):
+                self._assert_equivalent(
+                    4096, num_k, num_v, head_k, head_v, torch.bfloat16
+                )
+
+    def test_small_M(self) -> None:
+        """Even though scatter_qkv is gated to M>=2048 in production, the kernel
+        itself must still be correct at small M (chunked-prefill / unit tests)."""
+        for M in (1, 16, 256, 1024):
+            with self.subTest(M=M):
+                self._assert_equivalent(M, 8, 16, 128, 128, torch.bfloat16)
+
+    def test_qwen3_next_call_path(self) -> None:
+        """Mirror the exact call site in Qwen3NextGatedDeltaNetPrefill._fla:
+        mixed_qkv shape (M, k_dim*2 + v_dim) contiguous from causal_conv1d.transpose
+        -> scatter_qkv -> (q, k, v) shaped (1, M, n_heads, head_dim) contig
+        """
+        M = 4096
+        num_k, num_v, head_dim = 8, 16, 128
+        total = 2 * num_k * head_dim + num_v * head_dim
+        mixed_qkv = torch.randn(M, total, dtype=torch.bfloat16, device=self.device)
+
+        q, k, v = scatter_qkv(mixed_qkv, num_k, num_v, head_dim, head_dim)
+        self.assertEqual(tuple(q.shape), (1, M, num_k, head_dim))
+        self.assertEqual(tuple(k.shape), (1, M, num_k, head_dim))
+        self.assertEqual(tuple(v.shape), (1, M, num_v, head_dim))
+        self.assertTrue(q.is_contiguous() and k.is_contiguous() and v.is_contiguous())
+
+        q_ref, k_ref, v_ref = _split_view_baseline(
+            mixed_qkv, num_k, num_v, head_dim, head_dim
+        )
+        self.assertTrue(torch.equal(q, q_ref))
+        self.assertTrue(torch.equal(k, k_ref))
+        self.assertTrue(torch.equal(v, v_ref))
+
+    def test_input_assertions(self) -> None:
+        """scatter_qkv must reject malformed inputs."""
+        # 3D input
+        with self.assertRaises(AssertionError):
+            scatter_qkv(
+                torch.randn(2, 4096, 4096, dtype=torch.bfloat16, device=self.device),
+                8,
+                16,
+                128,
+                128,
+            )
+        # Non-contiguous input
+        x = torch.randn(15384, 8192, dtype=torch.bfloat16, device=self.device)
+        with self.assertRaises(AssertionError):
+            scatter_qkv(x[:, :4096], 8, 16, 128, 128)  # slice -> non-contig
+        # Wrong last-dim
+        with self.assertRaises(AssertionError):
+            scatter_qkv(
+                torch.randn(4096, 4097, dtype=torch.bfloat16, device=self.device),
+                8,
+                16,
+                128,
+                128,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In Qwen3-Next GDN prefill, splitting mixed_qkv along the channel dim and then .view(1, M, n_heads, head_dim) triggers an implicit .contiguous() copy per q/k/v slice because the slice stride doesn't match the contig stride required by the target shape. With 24 GDN layers this is ~72 direct_copy kernel events per prefill.

This replaces the split + view chain with scatter_qkv (Triton kernel, adapted from SGLang's scatter_fused_proj) which reads mixed_qkv contig and writes 3 contig (1, M, n_heads, head_dim) buffers in one pass.

Threshold M >= 2048 to avoid kernel-launch overhead at small batches (microbench: scatter wins from M=4096, neutral around M=2048, loses ~2us below). Decode path uses a different reshape+split that doesn't trigger view copies, so this only applies to prefill (Prefill._fla and GatedDeltaNet._forward_cp_prefill).

Measured on Qwen3.5-9B TP2, 15K prefill + 100 decode (n=10, unique prompts to avoid REUSE_CACHE hits):
  - TTFT:  1036.37 ms -> 1026.21 ms   (-10.16 ms, -0.98%)
  - TPOT:   6.992 ms ->   6.852 ms    (-0.14 ms, -2.0%)
  - direct_copy events per prefill: 107 -> 38 (-69 events, -3.50 ms)
  - scatter_qkv adds 24 events / +1.97 ms; net copy time -1.53 ms
  - TTFT savings exceed raw copy time savings, suggesting better cache
    locality for downstream FLA chunk_gated_delta_rule