### PR TITLE
feat: migrate flashinfer renorm kernel

### DIFF
--- a/3rdparty/flashinfer/flashinfer.h
+++ b/3rdparty/flashinfer/flashinfer.h
@@ -18,18 +18,6 @@ void top_k_top_p_sampling_from_probs(at::Tensor probs, at::Tensor uniform_sample
                                      std::optional<at::Tensor> maybe_top_p_arr, double top_p_val,
                                      bool deterministic, int64_t cuda_stream);
 
-void top_p_renorm_probs(at::Tensor                probs,
-                        at::Tensor                renorm_probs,
-                        std::optional<at::Tensor> maybe_top_p_arr,
-                        double                    top_p_val,
-                        int64_t                   cuda_stream);
-
-void top_k_renorm_probs(at::Tensor                probs,
-                        at::Tensor                renorm_probs,
-                        std::optional<at::Tensor> maybe_top_k_arr,
-                        int64_t                   top_k_val,
-                        int64_t                   cuda_stream);
-
 void silu_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);
 
 void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, int64_t cuda_stream);

--- a/rtp_llm/models_py/bindings/core/BUILD
+++ b/rtp_llm/models_py/bindings/core/BUILD
@@ -222,6 +222,9 @@ cc_library(
             "@local_config_rocm//rocm:rocm_headers",
             "@local_config_rocm//rocm:rocm",
         ],
+        "@//:using_cuda": [
+            "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
+        ],
         "//conditions:default": [],
     }),
     copts = copts(),
@@ -269,6 +272,9 @@ cc_library(
             "//3rdparty/trt_beam_search:trt_beam_search_impl",
             "@local_config_rocm//rocm:rocm_headers",
             "@local_config_rocm//rocm:rocm",
+        ],
+        "@//:using_cuda": [
+            "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
         ],
         "//conditions:default": [],
     }),

--- a/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
+++ b/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
@@ -7,6 +7,7 @@
 #include "rtp_llm/models_py/bindings/common/kernels/sampling_penalty_kernels.h"
 #include "rtp_llm/models_py/bindings/common/kernels/banRepeatNgram.h"
 #include "rtp_llm/cpp/utils/DebugUtils.h"
+#include "rtp_llm/models_py/bindings/cuda/kernels/sampling/sampling.h"
 #include "3rdparty/flashinfer/flashinfer.h"
 #include <cstddef>
 #include <random>

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/BUILD
@@ -1,0 +1,27 @@
+load("//:def.bzl", "cuda_copts")
+load("//bazel:arch_select.bzl", "torch_deps")
+
+package(default_visibility = ["//rtp_llm:__subpackages__"])
+
+cc_library(
+    name = "sampling",
+    srcs = ["api.cu"],
+    hdrs = [
+        "sampling.h",
+        "flashinfer/air_top_p.cuh",
+        "flashinfer/allocator.h",
+        "flashinfer/exception.h",
+        "flashinfer/math.cuh",
+        "flashinfer/sampling.cuh",
+        "flashinfer/topk.cuh",
+        "flashinfer/topk_common.cuh",
+        "flashinfer/utils.cuh",
+        "flashinfer/vec_dtypes.cuh",
+    ],
+    deps = [
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart",
+    ] + torch_deps(),
+    copts = cuda_copts(),
+    visibility = ["//visibility:public"],
+)

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/BUILD
@@ -1,5 +1,5 @@
 load("//:def.bzl", "cuda_copts")
-load("//bazel:arch_select.bzl", "torch_deps")
+load("@arch_config//:arch_select.bzl", "torch_deps")
 
 package(default_visibility = ["//rtp_llm:__subpackages__"])
 

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/api.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/api.cu
@@ -1,0 +1,193 @@
+#include "sampling.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include "flashinfer/air_top_p.cuh"
+#include "flashinfer/sampling.cuh"
+
+namespace rtp_llm {
+namespace {
+
+void check_renorm_inputs(const torch::Tensor& probs, const torch::Tensor& renorm_probs) {
+    TORCH_CHECK(probs.is_cuda(), "probs must be a CUDA tensor");
+    TORCH_CHECK(renorm_probs.is_cuda(), "renorm_probs must be a CUDA tensor");
+    TORCH_CHECK(probs.dim() == 2, "probs must be a 2D tensor");
+    TORCH_CHECK(renorm_probs.dim() == 2, "renorm_probs must be a 2D tensor");
+    TORCH_CHECK(probs.sizes() == renorm_probs.sizes(), "renorm_probs shape must match probs shape");
+    TORCH_CHECK(probs.scalar_type() == renorm_probs.scalar_type(), "renorm_probs dtype must match probs dtype");
+    TORCH_CHECK(probs.device() == renorm_probs.device(), "renorm_probs device must match probs device");
+    TORCH_CHECK(probs.is_contiguous(), "probs must be contiguous");
+    TORCH_CHECK(renorm_probs.is_contiguous(), "renorm_probs must be contiguous");
+}
+
+torch::Tensor prepare_optional_param(const std::optional<torch::Tensor>& maybe_param,
+                                     int64_t                             batch_size,
+                                     c10::Device                         device,
+                                     c10::ScalarType                     dtype,
+                                     const char*                         name) {
+    if (!maybe_param.has_value()) {
+        return torch::Tensor();
+    }
+
+    const auto& param = maybe_param.value();
+    TORCH_CHECK(param.dim() == 1, name, " must be a 1D tensor with shape [batch_size]");
+    TORCH_CHECK(param.numel() == batch_size,
+                name,
+                " length must match batch_size, got ",
+                param.numel(),
+                " vs ",
+                batch_size);
+
+    return param.to(torch::TensorOptions().device(device).dtype(dtype), /*non_blocking=*/true, /*copy=*/true)
+        .contiguous();
+}
+
+cudaStream_t resolve_stream(int64_t cuda_stream) {
+    if (cuda_stream == 0) {
+        return at::cuda::getCurrentCUDAStream().stream();
+    }
+    return reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+}
+
+template<bool IsDeterministic, typename DType>
+size_t air_top_p_workspace_size(uint32_t batch_size, uint32_t vocab_size) {
+    namespace air = flashinfer::sampling::air_top_p;
+    auto align256 = [](size_t x) { return ((x + 255) / 256) * 256; };
+
+    using HistT = air::HisT<IsDeterministic, DType>;
+    const auto buf_len = static_cast<size_t>(air::calcBufLen<DType>(static_cast<air::IdxT>(vocab_size)));
+
+    const size_t counters_size = align256(sizeof(air::Counter<DType>) * batch_size);
+    const size_t hist_size     = align256(sizeof(HistT) * air::NUM_BUCKETS * batch_size);
+    const size_t count_size    = align256(sizeof(air::IdxT) * air::NUM_BUCKETS * batch_size);
+    const size_t buf_size      = align256(sizeof(DType) * buf_len * batch_size);
+    return counters_size + hist_size + count_size + 2 * buf_size;
+}
+
+void check_cuda_status(cudaError_t status, const char* kernel_name) {
+    TORCH_CHECK(status == cudaSuccess, kernel_name, " failed with error code ", cudaGetErrorString(status));
+    status = cudaGetLastError();
+    TORCH_CHECK(status == cudaSuccess, kernel_name, " launch failed with error code ", cudaGetErrorString(status));
+}
+
+}  // namespace
+
+void top_p_renorm_probs(torch::Tensor                probs,
+                        torch::Tensor                renorm_probs,
+                        std::optional<torch::Tensor> maybe_top_p_arr,
+                        double                       top_p_val,
+                        int64_t                      cuda_stream) {
+    check_renorm_inputs(probs, renorm_probs);
+    TORCH_CHECK(probs.scalar_type() == at::kFloat, "top_p_renorm_probs currently expects float32 probs");
+
+    at::cuda::CUDAGuard device_guard(probs.device());
+    const auto          batch_size = static_cast<uint32_t>(probs.size(0));
+    const auto          vocab_size = static_cast<uint32_t>(probs.size(1));
+    auto                top_p      = prepare_optional_param(maybe_top_p_arr, batch_size, probs.device(), at::kFloat, "top_p");
+    auto                stream     = resolve_stream(cuda_stream);
+    float*              top_p_ptr  = top_p.defined() ? static_cast<float*>(top_p.data_ptr()) : nullptr;
+
+    cudaError_t status = cudaSuccess;
+    if (vocab_size < flashinfer::sampling::air_top_p::NUM_BUCKETS) {
+        status = flashinfer::sampling::TopPRenormProb<float>(static_cast<float*>(probs.data_ptr()),
+                                                             static_cast<float*>(renorm_probs.data_ptr()),
+                                                             top_p_ptr,
+                                                             batch_size,
+                                                             static_cast<float>(top_p_val),
+                                                             vocab_size,
+                                                             stream);
+        check_cuda_status(status, "TopPRenormProb");
+        return;
+    }
+
+    constexpr bool deterministic = false;
+    const auto     workspace_size = air_top_p_workspace_size<deterministic, float>(batch_size, vocab_size);
+    auto workspace = torch::empty({static_cast<int64_t>(workspace_size)}, probs.options().dtype(at::kByte));
+
+    status = flashinfer::sampling::air_top_p::AirTopPRenormProb<deterministic, float>(
+        static_cast<float*>(probs.data_ptr()),
+        static_cast<float*>(renorm_probs.data_ptr()),
+        top_p_ptr,
+        batch_size,
+        static_cast<float>(top_p_val),
+        vocab_size,
+        workspace.data_ptr(),
+        stream);
+    check_cuda_status(status, "AirTopPRenormProb");
+}
+
+void top_k_renorm_probs(torch::Tensor                probs,
+                        torch::Tensor                renorm_probs,
+                        std::optional<torch::Tensor> maybe_top_k_arr,
+                        int64_t                      top_k_val,
+                        int64_t                      cuda_stream) {
+    check_renorm_inputs(probs, renorm_probs);
+    TORCH_CHECK(probs.scalar_type() == at::kFloat || probs.scalar_type() == at::kHalf
+                    || probs.scalar_type() == at::kBFloat16,
+                "top_k_renorm_probs expects float32, float16, or bfloat16 probs");
+
+    at::cuda::CUDAGuard device_guard(probs.device());
+    const auto          batch_size = static_cast<uint32_t>(probs.size(0));
+    const auto          vocab_size = static_cast<uint32_t>(probs.size(1));
+    auto                top_k      = prepare_optional_param(maybe_top_k_arr, batch_size, probs.device(), at::kInt, "top_k");
+    auto                stream     = resolve_stream(cuda_stream);
+    int*                top_k_ptr  = top_k.defined() ? static_cast<int*>(top_k.data_ptr()) : nullptr;
+    const auto          top_k_limit =
+        static_cast<uint32_t>(top_k_val <= 0 ? vocab_size :
+                                             std::min<int64_t>(top_k_val, std::numeric_limits<uint32_t>::max()));
+
+    auto row_states =
+        torch::zeros({1024 * 1024}, probs.options().dtype(at::kByte));
+    auto* row_states_ptr = reinterpret_cast<flashinfer::sampling::RadixRowState*>(row_states.data_ptr());
+
+    cudaError_t status = cudaSuccess;
+    switch (probs.scalar_type()) {
+        case at::kFloat:
+            status = flashinfer::sampling::RadixTopKRenormProbMultiCTA<float, int>(
+                static_cast<float*>(probs.data_ptr()),
+                static_cast<float*>(renorm_probs.data_ptr()),
+                top_k_ptr,
+                batch_size,
+                top_k_limit,
+                vocab_size,
+                row_states_ptr,
+                stream);
+            break;
+        case at::kHalf:
+            status = flashinfer::sampling::RadixTopKRenormProbMultiCTA<half, int>(
+                reinterpret_cast<half*>(probs.data_ptr()),
+                reinterpret_cast<half*>(renorm_probs.data_ptr()),
+                top_k_ptr,
+                batch_size,
+                top_k_limit,
+                vocab_size,
+                row_states_ptr,
+                stream);
+            break;
+        case at::kBFloat16:
+            status = flashinfer::sampling::RadixTopKRenormProbMultiCTA<nv_bfloat16, int>(
+                reinterpret_cast<nv_bfloat16*>(probs.data_ptr()),
+                reinterpret_cast<nv_bfloat16*>(renorm_probs.data_ptr()),
+                top_k_ptr,
+                batch_size,
+                top_k_limit,
+                vocab_size,
+                row_states_ptr,
+                stream);
+            break;
+        default:
+            TORCH_CHECK(false, "unsupported dtype for top_k_renorm_probs");
+    }
+    check_cuda_status(status, "RadixTopKRenormProbMultiCTA");
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/air_top_p.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/air_top_p.cuh
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// AIR Top-P Renorm: radix-based top-p threshold finding + renormalization.
+// Core algorithm from TensorRT-LLM's AIR Top-P (samplingAirTopPKernels.cu),
+// adapted as a standalone header with no TRT-LLM dependencies.
+
+#pragma once
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+
+#include <cub/cub.cuh>
+#include <cuda/atomic>
+#include <cuda/std/limits>
+#include <type_traits>
+
+namespace flashinfer {
+namespace sampling {
+namespace air_top_p {
+
+using IdxT = int;
+using AccT = float;
+
+static constexpr int BITS_PER_PASS = 11;
+static constexpr int NUM_BUCKETS = 1 << BITS_PER_PASS;
+static constexpr int BLOCK_SIZE = 512;
+using WideT = float4;
+
+template <typename T>
+static constexpr int NUM_PASSES = (sizeof(T) * 8 + BITS_PER_PASS - 1) / BITS_PER_PASS;
+
+template <bool IsDeterministic, typename T>
+using HisT =
+    std::conditional_t<IsDeterministic,
+                       std::conditional_t<std::is_same_v<T, float>, uint64_t, uint32_t>, float>;
+
+// ======================== Counter ========================
+
+template <typename T>
+struct alignas(128) Counter {
+  T const* in;
+  IdxT oriLen;
+  AccT sum;
+  IdxT len;
+  float p;
+  IdxT previousLen;
+  typename cub::Traits<T>::UnsignedBits kthValueBits;
+  alignas(128) IdxT filterCnt;
+  alignas(128) uint32_t finishedBlockCnt;
+};
+
+// ======================== Helpers ========================
+
+template <typename IntType>
+constexpr __host__ __device__ IntType ceilDiv(IntType a, IntType b) {
+  return (a + b - 1) / b;
+}
+
+template <typename IntType>
+constexpr __host__ __device__ IntType alignTo(IntType a, IntType b) {
+  return ceilDiv(a, b) * b;
+}
+
+template <typename T>
+__device__ int constexpr calcStartBit(int pass) {
+  int startBit = static_cast<int>(sizeof(T) * 8) - (pass + 1) * BITS_PER_PASS;
+  return startBit < 0 ? 0 : startBit;
+}
+
+template <typename T>
+__device__ uint32_t constexpr calcMask(int pass) {
+  int numBits = calcStartBit<T>(pass - 1) - calcStartBit<T>(pass);
+  return (1 << numBits) - 1;
+}
+
+template <typename T>
+__device__ typename cub::Traits<T>::UnsignedBits twiddleIn(T key, bool selectMin) {
+  auto bits = reinterpret_cast<typename cub::Traits<T>::UnsignedBits&>(key);
+  bits = cub::Traits<T>::TwiddleIn(bits);
+  if (!selectMin) bits = ~bits;
+  return bits;
+}
+
+template <typename T>
+__device__ T twiddleOut(typename cub::Traits<T>::UnsignedBits bits, bool selectMin) {
+  if (!selectMin) bits = ~bits;
+  bits = cub::Traits<T>::TwiddleOut(bits);
+  return reinterpret_cast<T&>(bits);
+}
+
+template <typename T>
+__device__ int calcBucket(T x, int startBit, uint32_t mask) {
+  return (twiddleIn(x, false) >> startBit) & mask;
+}
+
+template <typename T>
+__host__ __device__ IdxT calcBufLen(IdxT len) {
+  IdxT constexpr ratio = 2 + sizeof(IdxT) * 2 / sizeof(T);
+  IdxT bufLen = len / (ratio * 8);
+  bufLen = alignTo(bufLen, 256);
+  return bufLen;
+}
+
+template <typename T>
+__host__ __device__ void setBufPointers(T const* in, T* buf1, T* buf2, int pass, T const*& inBuf,
+                                        T*& outBuf) {
+  if (pass == 0) {
+    inBuf = in;
+    outBuf = nullptr;
+  } else if (pass == 1) {
+    inBuf = in;
+    outBuf = buf1;
+  } else if (pass % 2 == 0) {
+    inBuf = buf1;
+    outBuf = buf2;
+  } else {
+    inBuf = buf2;
+    outBuf = buf1;
+  }
+}
+
+// ======================== Deterministic helpers ========================
+
+__device__ inline uint32_t calcMantissa(float value) {
+  union {
+    uint32_t bits;
+    float value;
+  } input;
+  input.value = value;
+  constexpr uint32_t numMantissa = 23;
+  return input.bits & ((1u << numMantissa) - 1);
+}
+
+__device__ inline uint32_t calcExponent(float value) {
+  union {
+    uint32_t bits;
+    float value;
+  } input;
+  input.value = value;
+  constexpr uint32_t numMantissa = 23;
+  return input.bits & ~((1u << numMantissa) - 1);
+}
+
+__device__ inline float calcFloatValue(uint32_t count, uint32_t exponent, uint64_t bitSum) {
+  constexpr uint32_t numTotalBits = 64;
+  constexpr uint32_t numMantissa = 23;
+  uint64_t extraInMantissa = (bitSum >> numMantissa);
+  extraInMantissa = (exponent == 0) ? extraInMantissa : extraInMantissa + count;
+  uint32_t numExtra = numTotalBits - __clzll(extraInMantissa);
+  int numNorm = (exponent == 0) ? 0 : -1;
+  exponent = exponent + ((numExtra + numNorm) << numMantissa);
+  uint32_t mantissa;
+  if (extraInMantissa != 0) {
+    int numMove = numMantissa - (numExtra - 1);
+    uint32_t mask = (1u << (numExtra - 1)) - 1;
+    extraInMantissa = extraInMantissa & mask;
+    if (numMove > 0) {
+      extraInMantissa = extraInMantissa << numMove;
+      mask = (1u << numMantissa) - 1;
+      mantissa = ((bitSum & mask) >> (numExtra - 1)) | extraInMantissa;
+    } else {
+      mantissa = extraInMantissa >> (-1 * numMove);
+    }
+  } else {
+    mantissa = bitSum;
+  }
+  uint32_t bitFloat = exponent | mantissa;
+  return reinterpret_cast<float&>(bitFloat);
+}
+
+template <bool IsDeterministic, typename T, typename HisT_>
+__device__ constexpr void histAtomicAdd(HisT_* dst, T value) {
+  if constexpr (IsDeterministic) {
+    uint32_t m = calcMantissa(value);
+    atomicAdd(reinterpret_cast<unsigned long long*>(dst), static_cast<uint64_t>(m));
+  } else {
+    atomicAdd(dst, static_cast<float>(value));
+  }
+}
+
+// ======================== Vectorized process ========================
+
+template <typename T, typename Func>
+__device__ void vectorizedProcess(size_t threadRank, size_t numThreads, T const* in, IdxT len,
+                                  Func f) {
+  if constexpr (sizeof(T) >= sizeof(WideT)) {
+    for (IdxT i = threadRank; i < len; i += numThreads) f(in[i], i);
+  } else {
+    static_assert(sizeof(WideT) % sizeof(T) == 0);
+    constexpr int itemsPerScalar = sizeof(WideT) / sizeof(T);
+    union {
+      WideT scalar;
+      T array[itemsPerScalar];
+    } wide;
+    int skipCnt = (reinterpret_cast<size_t>(in) % sizeof(WideT))
+                      ? ((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT)) / sizeof(T))
+                      : 0;
+    if (skipCnt > len) skipCnt = len;
+    WideT const* inCast = reinterpret_cast<decltype(inCast)>(in + skipCnt);
+    IdxT const lenCast = (len - skipCnt) / itemsPerScalar;
+    for (IdxT i = threadRank; i < lenCast; i += numThreads) {
+      wide.scalar = inCast[i];
+      IdxT const real_i = skipCnt + i * itemsPerScalar;
+#pragma unroll
+      for (int j = 0; j < itemsPerScalar; ++j) f(wide.array[j], real_i + j);
+    }
+    if (static_cast<IdxT>(threadRank) < skipCnt) f(in[threadRank], static_cast<IdxT>(threadRank));
+    IdxT const remain_i = skipCnt + lenCast * itemsPerScalar + threadRank;
+    if (remain_i < len) f(in[remain_i], remain_i);
+  }
+}
+
+// ======================== Filter + Histogram ========================
+
+template <bool IsDeterministic, typename T, typename HisT_>
+__device__ __forceinline__ void filterAndHistogram(T const* inBuf, T* outBuf, int previousLen,
+                                                   Counter<T>* counter, HisT_* histogram,
+                                                   IdxT* countHistogram, HisT_* histogramSmem,
+                                                   IdxT* countHistogramSmem, int pass) {
+  for (IdxT i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+    histogramSmem[i] = 0;
+    countHistogramSmem[i] = 0;
+  }
+  __syncthreads();
+  int const startBit = calcStartBit<T>(pass);
+  uint32_t const mask = calcMask<T>(pass);
+  if (pass == 0) {
+    auto f = [startBit, mask, histogramSmem, countHistogramSmem](T value, IdxT) {
+      int bucket = calcBucket<T>(value, startBit, mask);
+      histAtomicAdd<IsDeterministic, T>(histogramSmem + bucket, value);
+      atomicAdd(countHistogramSmem + bucket, static_cast<IdxT>(1));
+    };
+    vectorizedProcess<T>(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                         static_cast<size_t>(blockDim.x) * gridDim.x, inBuf, previousLen, f);
+  } else {
+    IdxT* pFilterCnt = &counter->filterCnt;
+    auto const kthValueBits = counter->kthValueBits;
+    int const previousStartBit = calcStartBit<T>(pass - 1);
+    auto f = [outBuf, startBit, mask, previousStartBit, kthValueBits, pFilterCnt, histogramSmem,
+              countHistogramSmem](T value, IdxT) {
+      auto const previousBits = (twiddleIn(value, false) >> previousStartBit) << previousStartBit;
+      if (previousBits == kthValueBits) {
+        if (outBuf) {
+          IdxT pos = atomicAdd(pFilterCnt, static_cast<IdxT>(1));
+          outBuf[pos] = value;
+        }
+        int bucket = calcBucket<T>(value, startBit, mask);
+        histAtomicAdd<IsDeterministic, T>(histogramSmem + bucket, value);
+        atomicAdd(countHistogramSmem + bucket, static_cast<IdxT>(1));
+      }
+    };
+    vectorizedProcess<T>(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                         static_cast<size_t>(blockDim.x) * gridDim.x, inBuf, previousLen, f);
+  }
+  __syncthreads();
+  for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+    if (histogramSmem[i] != 0) {
+      if constexpr (IsDeterministic)
+        atomicAdd(reinterpret_cast<unsigned long long*>(histogram + i),
+                  static_cast<unsigned long long>(histogramSmem[i]));
+      else
+        atomicAdd(histogram + i, histogramSmem[i]);
+    }
+    if (countHistogramSmem[i] != 0) atomicAdd(countHistogram + i, countHistogramSmem[i]);
+  }
+}
+
+// ======================== Main radix kernel ========================
+
+template <bool IsDeterministic, typename T>
+__global__ void AirTopPRenormRadixKernel(Counter<T>* counters, HisT<IsDeterministic, T>* histograms,
+                                         IdxT* countHistograms, int const pass, T* buf1, T* buf2) {
+  using HisT_ = HisT<IsDeterministic, T>;
+  int const batchId = blockIdx.y;
+  auto counter = counters + batchId;
+  AccT currentSum;
+  IdxT previousLen, currentLen;
+  if (pass == 0) {
+    currentSum = 0;
+    previousLen = counter->len;
+    currentLen = counter->len;
+  } else {
+    currentSum = counter->sum;
+    currentLen = counter->len;
+    previousLen = counter->previousLen;
+  }
+  if (currentLen == 0) return;
+  IdxT const bufLen = calcBufLen<T>(counter->oriLen);
+  T const* inBuf = nullptr;
+  T* outBuf = nullptr;
+  setBufPointers(counter->in, buf1 + bufLen * batchId, buf2 + bufLen * batchId, pass, inBuf,
+                 outBuf);
+  if (pass == 0 || pass == 1 || previousLen > bufLen) {
+    inBuf = counter->in;
+    previousLen = counter->oriLen;
+  }
+  if (pass == 0 || currentLen > bufLen) {
+    outBuf = nullptr;
+  }
+  auto histogram = histograms + batchId * NUM_BUCKETS;
+  auto countHistogram = countHistograms + batchId * NUM_BUCKETS;
+  __shared__ HisT_ histogramSmem[NUM_BUCKETS];
+  __shared__ IdxT countHistogramSmem[NUM_BUCKETS];
+  filterAndHistogram<IsDeterministic, T, HisT_>(inBuf, outBuf, previousLen, counter, histogram,
+                                                countHistogram, histogramSmem, countHistogramSmem,
+                                                pass);
+  __syncthreads();
+  __threadfence();
+  bool isLastBlock = false;
+  if (threadIdx.x == 0) {
+    uint32_t finished = atomicInc(&counter->finishedBlockCnt, gridDim.x - 1);
+    isLastBlock = (finished == (gridDim.x - 1));
+  }
+  if (__syncthreads_or(isLastBlock)) {
+    AccT* histValueSmem = reinterpret_cast<AccT*>(histogramSmem);
+    if constexpr (IsDeterministic) {
+      for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+        uint64_t value = static_cast<uint64_t>(histogram[i]);
+        IdxT count = countHistogram[i];
+        if (count != 0) {
+          uint32_t sb = calcStartBit<T>(pass);
+          uint32_t bv = counter->kthValueBits;
+          if (pass == 0) bv = i << sb;
+          histValueSmem[i] = calcFloatValue(static_cast<uint32_t>(count),
+                                            calcExponent(twiddleOut<T>(bv, false)), value);
+        } else {
+          histValueSmem[i] = 0.0f;
+        }
+      }
+      __syncthreads();
+    }
+    constexpr int WARP_SIZE = 32;
+    constexpr int WARP_COUNT = NUM_BUCKETS / WARP_SIZE;
+    namespace cg = cooperative_groups;
+    cg::thread_block block = cg::this_thread_block();
+    cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+    AccT* histPtr = IsDeterministic ? histValueSmem : reinterpret_cast<AccT*>(histogram);
+    __shared__ AccT warpSum[WARP_COUNT];
+    __shared__ cuda::atomic<AccT, cuda::thread_scope_block> blockSum;
+    if constexpr (BITS_PER_PASS != 11) {
+      for (int i = threadIdx.x; i < NUM_BUCKETS; i += BLOCK_SIZE) warpSum[i] = 0;
+      __syncthreads();
+    }
+    for (int i = threadIdx.x; i < NUM_BUCKETS; i += BLOCK_SIZE)
+      reduce_store_async(warp, warpSum + i / WARP_SIZE, histPtr[i], cg::plus<float>{});
+    __syncthreads();
+    if (threadIdx.x < WARP_SIZE) {
+      reduce_store_async(warp, blockSum, warpSum[threadIdx.x], cg::plus<float>{});
+      if constexpr (BITS_PER_PASS == 11)
+        reduce_update_async(warp, blockSum, warpSum[threadIdx.x + WARP_SIZE], cg::plus<float>{});
+    }
+    __syncthreads();
+    if (pass == 0) currentSum = blockSum * counter->p;
+    if (threadIdx.x == 0) {
+      AccT prev = 0;
+      int targetStep = 0;
+      for (int i = 0; i < WARP_COUNT; i++) {
+        if (warpSum[i]) {
+          targetStep = i;
+          if ((prev + warpSum[i]) >= currentSum) break;
+          prev += warpSum[i];
+        }
+      }
+      int targetIdx = 0;
+      for (int i = targetStep * WARP_SIZE; i < NUM_BUCKETS; i++) {
+        if (countHistogram[i]) {
+          targetIdx = i;
+          if ((prev + histPtr[i]) >= currentSum) break;
+          prev += histPtr[i];
+        }
+      }
+      counter->sum = currentSum - prev;
+      counter->len = countHistogram[targetIdx];
+      typename cub::Traits<T>::UnsignedBits bucket = targetIdx;
+      counter->kthValueBits |= bucket << calcStartBit<T>(pass);
+    }
+    __syncthreads();
+    if (pass != NUM_PASSES<T> - 1) {
+      for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+        histogram[i] = 0;
+        countHistogram[i] = 0;
+      }
+    }
+    if (threadIdx.x == 0) {
+      counter->previousLen = currentLen;
+      counter->filterCnt = 0;
+    }
+  }
+}
+
+// ======================== Init kernel ========================
+
+template <typename T, typename HisT_>
+__global__ void AirTopPRenormInitKernel(Counter<T>* counters, int len, T const* in,
+                                        float* top_p_arr, float top_p_val, HisT_* histograms,
+                                        IdxT* countHistograms) {
+  auto const batchIdx = blockIdx.x;
+  Counter<T>* counter = counters + batchIdx;
+  if (threadIdx.x == 0) {
+    counter->in = in + batchIdx * len;
+    counter->len = len;
+    counter->oriLen = len;
+    counter->previousLen = len;
+    counter->p = top_p_arr ? top_p_arr[batchIdx] : top_p_val;
+    counter->sum = 0;
+    counter->kthValueBits = 0;
+    counter->finishedBlockCnt = 0;
+    counter->filterCnt = 0;
+  }
+  HisT_* hist = histograms + batchIdx * NUM_BUCKETS;
+  IdxT* cntHist = countHistograms + batchIdx * NUM_BUCKETS;
+  for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+    hist[i] = 0;
+    cntHist[i] = 0;
+  }
+}
+
+// ======================== Renorm apply kernel ========================
+
+template <typename T>
+__global__ void AirTopPRenormApplyKernel(T const* probs, T* renormedProbs, Counter<T>* counters,
+                                         int vocabSize) {
+  int const batchId = blockIdx.x;
+  int const tid = threadIdx.x;
+  T const threshold = twiddleOut<T>(counters[batchId].kthValueBits, false);
+  float threadSum = 0.0f;
+  for (int i = tid; i < vocabSize; i += blockDim.x) {
+    T val = probs[batchId * vocabSize + i];
+    if (val >= threshold) threadSum += static_cast<float>(val);
+  }
+  typedef cub::BlockReduce<float, 1024> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp;
+  float totalSum = BlockReduce(temp).Sum(threadSum);
+  __shared__ float sharedNorm;
+  if (tid == 0) sharedNorm = (totalSum > 1e-8f) ? (1.0f / totalSum) : 1.0f;
+  __syncthreads();
+  float norm = sharedNorm;
+  for (int i = tid; i < vocabSize; i += blockDim.x) {
+    T val = probs[batchId * vocabSize + i];
+    renormedProbs[batchId * vocabSize + i] =
+        (val >= threshold) ? static_cast<T>(static_cast<float>(val) * norm) : static_cast<T>(0);
+  }
+}
+
+// ======================== Block num calculation ========================
+
+template <bool IsDeterministic, typename T>
+uint32_t CalcAirTopPBlockNum(int batchSize, int len, int smCnt) {
+  constexpr int VECTORIZED_READ_SIZE = 16;
+  int activeBlocks;
+  cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &activeBlocks, AirTopPRenormRadixKernel<IsDeterministic, T>, BLOCK_SIZE, 0);
+  activeBlocks *= smCnt;
+  IdxT bestNumBlocks = 0;
+  float bestTailWavePenalty = 1.0f;
+  IdxT const maxNumBlocks = ceilDiv<IdxT>(len, VECTORIZED_READ_SIZE / (int)sizeof(T) * BLOCK_SIZE);
+  for (int numWaves = 1;; ++numWaves) {
+    IdxT numBlocks =
+        std::min(maxNumBlocks, static_cast<IdxT>(std::max(numWaves * activeBlocks / batchSize, 1)));
+    IdxT itemsPerThread = ceilDiv<IdxT>(len, numBlocks * BLOCK_SIZE);
+    itemsPerThread = alignTo<IdxT>(itemsPerThread, VECTORIZED_READ_SIZE / (int)sizeof(T));
+    numBlocks = ceilDiv<IdxT>(len, itemsPerThread * BLOCK_SIZE);
+    float actualNumWaves = static_cast<float>(numBlocks) * batchSize / activeBlocks;
+    float tailWavePenalty = (ceilf(actualNumWaves) - actualNumWaves) / ceilf(actualNumWaves);
+    if (tailWavePenalty < 0.15f) {
+      bestNumBlocks = numBlocks;
+      break;
+    } else if (tailWavePenalty < bestTailWavePenalty) {
+      bestNumBlocks = numBlocks;
+      bestTailWavePenalty = tailWavePenalty;
+    }
+    if (numBlocks == maxNumBlocks) break;
+  }
+  return bestNumBlocks;
+}
+
+// ======================== Host launcher ========================
+
+template <bool IsDeterministic, typename DType>
+cudaError_t AirTopPRenormProb(DType* probs, DType* renormed_prob, float* top_p_arr,
+                              uint32_t batch_size, float top_p_val, uint32_t d, void* workspace,
+                              cudaStream_t stream = 0) {
+  using HisT_ = HisT<IsDeterministic, DType>;
+
+  int dev, smCnt;
+  cudaGetDevice(&dev);
+  cudaDeviceGetAttribute(&smCnt, cudaDevAttrMultiProcessorCount, dev);
+  uint32_t blockNum = CalcAirTopPBlockNum<IsDeterministic, DType>(batch_size, d, smCnt);
+  IdxT const bufLen = calcBufLen<DType>(d);
+
+  auto align256 = [](size_t x) { return ((x + 255) / 256) * 256; };
+  size_t countersSize = align256(sizeof(Counter<DType>) * batch_size);
+  size_t histSize = align256(sizeof(HisT_) * NUM_BUCKETS * batch_size);
+  size_t countHistSize = align256(sizeof(IdxT) * NUM_BUCKETS * batch_size);
+  size_t buf1Size = align256(sizeof(DType) * bufLen * batch_size);
+
+  uint8_t* ws = static_cast<uint8_t*>(workspace);
+  Counter<DType>* counters = reinterpret_cast<Counter<DType>*>(ws);
+  HisT_* histograms = reinterpret_cast<HisT_*>(ws + countersSize);
+  IdxT* countHistograms = reinterpret_cast<IdxT*>(ws + countersSize + histSize);
+  DType* buf1 = reinterpret_cast<DType*>(ws + countersSize + histSize + countHistSize);
+  DType* buf2 = reinterpret_cast<DType*>(ws + countersSize + histSize + countHistSize + buf1Size);
+
+  AirTopPRenormInitKernel<DType, HisT_><<<batch_size, 256, 0, stream>>>(
+      counters, d, probs, top_p_arr, top_p_val, histograms, countHistograms);
+
+  dim3 grid(blockNum, batch_size);
+  constexpr int numPasses = NUM_PASSES<DType>;
+  for (int pass = 0; pass < numPasses; ++pass) {
+    AirTopPRenormRadixKernel<IsDeterministic, DType>
+        <<<grid, BLOCK_SIZE, 0, stream>>>(counters, histograms, countHistograms, pass, buf1, buf2);
+  }
+
+  AirTopPRenormApplyKernel<DType>
+      <<<batch_size, 1024, 0, stream>>>(probs, renormed_prob, counters, d);
+
+  return cudaSuccess;
+}
+
+}  // namespace air_top_p
+}  // namespace sampling
+}  // namespace flashinfer

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/allocator.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/allocator.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ALLOCATOR_H_
+#define FLASHINFER_ALLOCATOR_H_
+
+#include <memory>
+#include <sstream>
+
+#include "exception.h"
+
+namespace flashinfer {
+
+// create a function that returns T* from base pointer and offset
+template <typename T>
+T* GetPtrFromBaseOffset(void* base_ptr, int64_t offset) {
+  return reinterpret_cast<T*>(reinterpret_cast<char*>(base_ptr) + offset);
+}
+
+struct AlignedAllocator {
+  void* base_ptr;
+  void* cur_ptr;
+  size_t remaining_space;
+  AlignedAllocator(void* buf, size_t space) : base_ptr(buf), cur_ptr(buf), remaining_space(space) {}
+  template <typename T>
+  T* aligned_alloc(size_t size, size_t alignment, std::string name) {
+    if (std::align(alignment, size, cur_ptr, remaining_space)) {
+      T* result = reinterpret_cast<T*>(cur_ptr);
+      cur_ptr = (char*)cur_ptr + size;
+      remaining_space -= size;
+      return result;
+    } else {
+      std::ostringstream oss;
+      oss << "Buffer overflow when allocating memory for " << name << " with size " << size
+          << " and alignment " << alignment << ", but only " << remaining_space
+          << " bytes available in AlignedAllocator. Increase the workspace buffer size.";
+      FLASHINFER_ERROR(oss.str());
+    }
+    return nullptr;
+  }
+
+  size_t aligned_alloc_offset(size_t size, size_t alignment, std::string name) {
+    return (char*)aligned_alloc<char>(size, alignment, name) - (char*)base_ptr;
+  }
+
+  size_t num_allocated_bytes() { return (char*)cur_ptr - (char*)base_ptr; }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ALLOCATOR_H_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/exception.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/exception.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_EXCEPTION_H_
+#define FLASHINFER_EXCEPTION_H_
+
+#include <exception>
+#include <iostream>
+#include <sstream>
+
+#define FLASHINFER_ERROR(message) throw flashinfer::Error(__FUNCTION__, __FILE__, __LINE__, message)
+
+// Base case for empty arguments
+inline void write_to_stream(std::ostringstream& oss) {
+  // No-op for empty arguments
+}
+
+template <typename T>
+void write_to_stream(std::ostringstream& oss, T&& val) {
+  oss << std::forward<T>(val);
+}
+
+template <typename T, typename... Args>
+void write_to_stream(std::ostringstream& oss, T&& val, Args&&... args) {
+  oss << std::forward<T>(val) << " ";
+  write_to_stream(oss, std::forward<Args>(args)...);
+}
+
+// Helper macro to handle empty __VA_ARGS__
+#define FLASHINFER_CHECK_IMPL(condition, message) \
+  if (!(condition)) {                             \
+    FLASHINFER_ERROR(message);                    \
+  }
+
+// Main macro that handles both cases
+#define FLASHINFER_CHECK(condition, ...)   \
+  do {                                     \
+    if (!(condition)) {                    \
+      std::ostringstream oss;              \
+      write_to_stream(oss, ##__VA_ARGS__); \
+      std::string msg = oss.str();         \
+      if (msg.empty()) {                   \
+        msg = "Check failed: " #condition; \
+      }                                    \
+      FLASHINFER_ERROR(msg);               \
+    }                                      \
+  } while (0)
+
+// Warning macro
+#define FLASHINFER_WARN(...)                                           \
+  do {                                                                 \
+    std::ostringstream oss;                                            \
+    write_to_stream(oss, ##__VA_ARGS__);                               \
+    std::string msg = oss.str();                                       \
+    if (msg.empty()) {                                                 \
+      msg = "Warning triggered";                                       \
+    }                                                                  \
+    flashinfer::Warning(__FUNCTION__, __FILE__, __LINE__, msg).emit(); \
+  } while (0)
+
+namespace flashinfer {
+class Error : public std::exception {
+ private:
+  std::string message_;
+
+ public:
+  Error(const std::string& func, const std::string& file, int line, const std::string& message) {
+    std::ostringstream oss;
+    oss << "Error in function '" << func << "' "
+        << "at " << file << ":" << line << ": " << message;
+    message_ = oss.str();
+  }
+
+  virtual const char* what() const noexcept override { return message_.c_str(); }
+};
+
+class Warning {
+ private:
+  std::string message_;
+
+ public:
+  Warning(const std::string& func, const std::string& file, int line, const std::string& message) {
+    std::ostringstream oss;
+    oss << "Warning in function '" << func << "' "
+        << "at " << file << ":" << line << ": " << message;
+    message_ = oss.str();
+  }
+
+  void emit() const { std::cerr << message_ << std::endl; }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_EXCEPTION_H_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/math.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/math.cuh
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_MATH_CUH_
+#define FLASHINFER_MATH_CUH_
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+namespace flashinfer {
+namespace math {
+
+// log2(e)
+constexpr float log2e = 1.44269504088896340736f;
+
+constexpr float loge2 = 0.693147180559945309417f;
+
+constexpr float inf = 5e4;
+
+__forceinline__ __device__ half2 uint32_as_half2(uint32_t x) { return *(half2*)&x; }
+
+__forceinline__ __device__ uint32_t half2_as_uint32(half2 x) { return *(uint32_t*)&x; }
+
+/*!
+ * \brief Wrapper of PTX ex2.approx instruction, which computes 2^x
+ * \param x input
+ */
+__forceinline__ __device__ float ptx_exp2(float x) {
+  float y;
+  asm volatile("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX lg2.approx instruction, which computes log2(x)
+ * \param x input
+ */
+__forceinline__ __device__ float ptx_log2(float x) {
+  float y;
+  asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX ex2.approx.f16x2 instruction, which computes 2^x
+ * \param x input
+ */
+__forceinline__ __device__ half2 ptx_exp2(half2 x) {
+  uint32_t y_u32;
+  uint32_t x_u32 = half2_as_uint32(x);
+  asm volatile("ex2.approx.f16x2 %0, %1;" : "=r"(y_u32) : "r"(x_u32));
+  return uint32_as_half2(y_u32);
+}
+
+/*!
+ * \brief Wrapper of PTX ex2.approx.f16 instruction, which computes 2^x
+ * \param x input
+ */
+__forceinline__ __device__ half ptx_exp2(half x) {
+  ushort y_u16;
+  asm volatile("ex2.approx.f16 %0, %1;" : "=h"(y_u16) : "h"(__half_as_ushort(x)));
+  return __ushort_as_half(y_u16);
+}
+
+/*!
+ * \brief Wrapper of PTX rcp.approx instruction, which computes 1/x
+ * \param x input
+ */
+__forceinline__ __device__ float ptx_rcp(float x) {
+  float y;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX shfl.sync.bfly instruction, which performs a butterfly shuffle
+ *   between threads in a warp.
+ * \param x The value in the source lane
+ * \param lane_mask The mask to perform thread index xor with: y[i] <- x[i ^ delta]
+ */
+__forceinline__ __device__ float shfl_xor_sync(float x, int lane_mask) {
+  float y;
+  asm volatile("shfl.sync.bfly.b32 %0, %1, %2, 0x1f, 0xffffffff;"
+               : "=f"(y)
+               : "f"(x), "r"(lane_mask));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX shfl.sync.bfly instruction on half2, which performs a butterfly
+ *   shuffle between threads in a warp.
+ * \param x The value in the source lane
+ * \param lane_mask The mask to perform thread index xor with: y[i] <- x[i ^ lane_mask]
+ */
+__forceinline__ __device__ half2 shfl_xor_sync(half2 x, int lane_mask) {
+  return __shfl_xor_sync(0xffffffff, x, lane_mask);
+}
+
+/*!
+ * \brief Wrapper of PTX rsqrt approximation instruction, which computes 1/sqrt(x)
+ * \param x input
+ */
+__forceinline__ __device__ float rsqrt(float x) {
+  float y;
+  asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX tanh.approx.f32 instruction, which computes tanh(x)
+ * \param x input
+ */
+__forceinline__ __device__ float tanh(float x) {
+  float y;
+  asm volatile("tanh.approx.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+/*!
+ * \brief Wrapper of PTX tanh.approx.f16x2 instruction, which computes tanh(x)
+ * \param x input
+ */
+__forceinline__ __device__ half2 tanh(half2 x) {
+  uint32_t y_u32;
+  uint32_t x_u32 = half2_as_uint32(x);
+  asm volatile("tanh.approx.f16x2 %0, %1;" : "=r"(y_u32) : "r"(x_u32));
+  return uint32_as_half2(y_u32);
+}
+
+/*!
+ * \brief Wrapper of PTX tanh.approx.f16 instruction, which computes tanh(x)
+ * \param x input
+ */
+__forceinline__ __device__ half tanh(half x) {
+  ushort y_u16;
+  asm volatile("tanh.approx.f16 %0, %1;" : "=h"(y_u16) : "h"(__half_as_ushort(x)));
+  return __ushort_as_half(y_u16);
+}
+
+}  // namespace math
+}  // namespace flashinfer
+#endif  // FLASHINFER_MATH_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/sampling.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/sampling.cuh
@@ -1,0 +1,2039 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_SAMPLING_CUH_
+#define FLASHINFER_SAMPLING_CUH_
+
+#include <cuda.h>
+#include <curand.h>
+#include <curand_kernel.h>
+#include <curand_philox4x32_x.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <cub/cub.cuh>
+#include <cuda/functional>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <limits>
+#include <numeric>
+#include <tuple>
+
+#include "allocator.h"
+#include "math.cuh"
+#include "topk.cuh"
+#include "utils.cuh"
+#include "vec_dtypes.cuh"
+
+using MaxReduceOp = cuda::maximum<>;
+using MinReduceOp = cuda::minimum<>;
+
+namespace flashinfer {
+
+namespace sampling {
+
+using namespace cub;
+
+// IEEE-754 compliant arithmetic via inline PTX (no .ftz modifier).
+// Under -use_fast_math, the compiler emits .ftz variants that flush subnormal
+// results to zero.  These helpers bypass that for operations where subnormal
+// correctness matters (see #769, #774).
+__device__ __forceinline__ float ieee_mul(float a, float b) {
+  float r;
+  asm("mul.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+__device__ __forceinline__ float ieee_add(float a, float b) {
+  float r;
+  asm("add.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+__device__ __forceinline__ float ieee_div(float a, float b) {
+  float r;
+  asm("div.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+  return r;
+}
+
+#define DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, ...) \
+  if (deterministic) {                                            \
+    constexpr bool DETERMINISTIC = true;                          \
+    __VA_ARGS__                                                   \
+  } else {                                                        \
+    constexpr bool DETERMINISTIC = false;                         \
+    __VA_ARGS__                                                   \
+  }
+
+#define DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, ...) \
+  if (compute_capacity.first >= 8) {                                           \
+    constexpr uint32_t BLOCK_THREADS = 1024;                                   \
+    __VA_ARGS__                                                                \
+  } else {                                                                     \
+    constexpr uint32_t BLOCK_THREADS = 512;                                    \
+    __VA_ARGS__                                                                \
+  }
+
+#define DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, ...) \
+  if (cache_input) {                                                \
+    constexpr bool CACHE_INPUT = true;                              \
+    __VA_ARGS__                                                     \
+  } else {                                                          \
+    constexpr bool CACHE_INPUT = false;                             \
+    __VA_ARGS__                                                     \
+  }
+
+constexpr BlockScanAlgorithm SCAN_ALGO = BLOCK_SCAN_WARP_SCANS;
+constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
+
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
+#define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+#endif
+
+template <typename T>
+struct ValueCount {
+  T value;
+  int count;
+
+  __device__ ValueCount operator+(const ValueCount& other) const {
+    return {value + other.value, count + other.count};
+  }
+  __device__ ValueCount& operator+=(const ValueCount& other) {
+    value += other.value;
+    count += other.count;
+    return *this;
+  }
+};
+
+struct BoolDiffOp {
+  __device__ __forceinline__ bool operator()(const bool& lhs, const bool& rhs) const {
+    return lhs != rhs;
+  }
+};
+
+struct Float2SoftmaxReduceOp {
+  __device__ __forceinline__ float2 operator()(const float2& a, const float2& b) const {
+    if (isinf(a.x)) return b;
+    if (isinf(b.x)) return a;
+
+    float new_max = max(a.x, b.x);
+    float new_denom = a.y * __expf(a.x - new_max) + b.y * __expf(b.x - new_max);
+    return make_float2(new_max, new_denom);
+  }
+};
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM>
+struct SamplingTempStorage {
+  union {
+    float deterministic_scan[BLOCK_THREADS / 32];
+    typename BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>::TempStorage scan;
+    typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce;
+    typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_int;
+    typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage
+        reduce_value_count;
+    typename BlockAdjacentDifference<bool, BLOCK_THREADS>::TempStorage adj_diff;
+  } block_prim;
+  struct {
+    int32_t sampled_id;
+    int32_t last_valid_id;
+    float max_val;
+    union {
+      float value;
+      ValueCount<float> pair;
+    } block_aggregate;
+  };
+};
+
+template <uint32_t BLOCK_THREADS>
+struct OnlineSoftmaxTempStorage {
+  union {
+    typename cub::BlockReduce<float, BLOCK_THREADS>::TempStorage reduce;
+    typename cub::BlockReduce<float2, BLOCK_THREADS>::TempStorage reduce_pair;
+  } block_prim;
+
+  struct {
+    float max_val;
+    float denominator;
+  } shared_state;
+};
+
+struct PartialSoftmaxResult {
+  float max_val;
+  float denominator;
+};
+
+/*!
+ * \brief Deterministic inclusive scan implementation, use Belloch scan algorithm.
+ * \note This implementation is slower than the cub::BlockScan, but it is deterministic.
+ */
+template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM>
+__device__ __forceinline__ void DeterministicInclusiveSum(
+    const float* in_data, float* out_data,
+    SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+  float* smem_prefix_sum = temp_storage->block_prim.deterministic_scan;
+  float thread_data[VEC_SIZE];
+  float thread_sum = 0;
+#pragma unroll
+  for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+    thread_sum += in_data[i];
+    thread_data[i] = thread_sum;
+  }
+
+  float thread_exclusive_prefix_sum = thread_sum;
+
+#pragma unroll
+  for (uint32_t offset = 1; offset < 32; offset *= 2) {
+    float tmp = __shfl_up_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+    if ((threadIdx.x + 1) % (offset * 2) == 0) {
+      thread_exclusive_prefix_sum += tmp;
+    }
+  }
+
+  float warp_sum = __shfl_sync(0xffffffff, thread_exclusive_prefix_sum, threadIdx.x | 0xffffffff);
+  if (threadIdx.x % 32 == 31) {
+    thread_exclusive_prefix_sum = 0;
+  }
+
+#pragma unroll
+  for (uint32_t offset = 16; offset >= 1; offset /= 2) {
+    float tmp = __shfl_xor_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+    if ((threadIdx.x + 1) % (offset * 2) == 0) {
+      thread_exclusive_prefix_sum = tmp + thread_exclusive_prefix_sum;
+    }
+    if ((threadIdx.x + 1) % (offset * 2) == offset) {
+      thread_exclusive_prefix_sum = tmp;
+    }
+  }
+
+  smem_prefix_sum[threadIdx.x / 32] = warp_sum;
+  __syncthreads();
+
+  if (threadIdx.x < 32) {
+    float warp_exclusive_prefix_sum =
+        (threadIdx.x < BLOCK_THREADS / 32) ? smem_prefix_sum[threadIdx.x] : 0;
+
+#pragma unroll
+    for (uint32_t offset = 1; offset < 32; offset *= 2) {
+      float tmp = __shfl_up_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+      if ((threadIdx.x + 1) % (offset * 2) == 0) {
+        warp_exclusive_prefix_sum += tmp;
+      }
+    }
+
+    if (threadIdx.x % 32 == 31) {
+      warp_exclusive_prefix_sum = 0;
+    }
+
+#pragma unroll
+    for (uint32_t offset = 16; offset >= 1; offset /= 2) {
+      float tmp = __shfl_xor_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+      if ((threadIdx.x + 1) % (offset * 2) == 0) {
+        warp_exclusive_prefix_sum = tmp + warp_exclusive_prefix_sum;
+      }
+      if ((threadIdx.x + 1) % (offset * 2) == offset) {
+        warp_exclusive_prefix_sum = tmp;
+      }
+    }
+    if (threadIdx.x < BLOCK_THREADS / 32) {
+      smem_prefix_sum[threadIdx.x] = warp_exclusive_prefix_sum;
+    }
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+    out_data[i] = smem_prefix_sum[threadIdx.x / 32] + thread_exclusive_prefix_sum + thread_data[i];
+  }
+}
+
+template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM,
+          typename TempStorage>
+__device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, uint32_t d,
+                                             TempStorage& temp_storage) {
+  const uint32_t tx = threadIdx.x;
+  vec_t<float, VEC_SIZE> in_data_vec;
+
+  // Thread-local max accumulation (deferred reduction)
+  float thread_max = 0.0f;
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    in_data_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      in_data_vec.cast_load(in_data + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      thread_max = max(thread_max, static_cast<float>(in_data_vec[j]));
+    }
+  }
+
+  // Single block reduction after loop completes
+  float max_val =
+      BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+          .Reduce(thread_max, MaxReduceOp{});
+  if (tx == 0) {
+    temp_storage.max_val = max_val;
+  }
+  __syncthreads();
+  return temp_storage.max_val;
+}
+
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
+__global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr,
+                                         DType temperature_val, uint32_t d) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
+
+  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
+
+  DType* smem_vec_base = nullptr;
+  if constexpr (CACHE_INPUT) {
+    constexpr size_t vec_alignment = alignof(vec_t<DType, VEC_SIZE>);
+    size_t aligned_offset = round_up(sizeof(TempStorage), vec_alignment);
+    smem_vec_base = reinterpret_cast<DType*>(smem + aligned_offset);
+  }
+
+  vec_t<DType, VEC_SIZE> logits_vec;
+
+  float running_max = -cuda::std::numeric_limits<float>::infinity();
+  float running_denominator = 0.0f;
+  float threadlocal_running_denominator = 0.0f;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  // Pass 1: Compute running max and denominator
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        logits_vec[j] *= inv_temp;
+      }
+
+      if constexpr (CACHE_INPUT) {
+        logits_vec.store(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+    }
+
+    float thread_max = -cuda::std::numeric_limits<float>::infinity();
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      thread_max = max(thread_max, logits_vec[j]);
+    }
+    float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                          .Reduce(thread_max, MaxReduceOp{});
+
+    if (tx == 0) {
+      temp_storage.shared_state.max_val = block_max;
+    }
+    __syncthreads();
+    block_max = temp_storage.shared_state.max_val;
+    // if block_max is -inf, then this block contains all -inf values, so we can skip updating
+    if (!isinf(block_max)) {
+      float threadlocal_sum = 0.0f;
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        threadlocal_sum += __expf(logits_vec[j] - block_max);
+      }
+      float new_max = max(running_max, block_max);
+      threadlocal_running_denominator =
+          threadlocal_running_denominator * __expf(running_max - new_max) +
+          threadlocal_sum * __expf(block_max - new_max);
+      running_max = new_max;
+    }
+  }
+
+  running_denominator = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                            .Sum(threadlocal_running_denominator);
+  if (tx == 0) {
+    temp_storage.shared_state.denominator = running_denominator;
+  }
+  __syncthreads();
+  running_denominator = temp_storage.shared_state.denominator;
+
+  const float final_max = running_max;
+  const float inv_denominator = 1.0f / running_denominator;
+
+  // Pass 2: Normalize in place
+  vec_t<DType, VEC_SIZE> prob_vec;
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    if constexpr (CACHE_INPUT) {
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        logits_vec.load(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+    } else {
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          logits_vec[j] *= inv_temp;
+        }
+      }
+    }
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
+      prob_vec[j] = static_cast<DType>(p);
+    }
+
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
+__global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* partial_results,
+                                       DType* temperature_arr, float temperature_val, uint32_t d,
+                                       uint32_t num_slices) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t by = blockIdx.y;  // slice index
+  const uint32_t tx = threadIdx.x;
+  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
+
+  const uint32_t vec_alignment_elems = alignof(vec_t<DType, VEC_SIZE>) / sizeof(DType);
+  const uint32_t slice_stride = round_up(ceil_div(d, num_slices), vec_alignment_elems);
+  const uint32_t slice_start = by * slice_stride;
+  const uint32_t slice_size = min((by + 1) * slice_stride, d) - slice_start;
+
+  if (slice_start >= d) return;
+
+  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
+
+  vec_t<DType, VEC_SIZE> logits_vec;
+  float running_max = -cuda::std::numeric_limits<float>::infinity();
+  float running_denominator = 0.0f;
+  float threadlocal_running_denominator = 0.0f;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(slice_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < slice_size) {
+      logits_vec.cast_load(logits + bx * d + slice_start + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+
+    float thread_max = -cuda::std::numeric_limits<float>::infinity();
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      logits_vec[j] *= inv_temp;
+      thread_max = max(thread_max, logits_vec[j]);
+    }
+
+    float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                          .Reduce(thread_max, MaxReduceOp{});
+
+    if (tx == 0) {
+      temp_storage.shared_state.max_val = block_max;
+    }
+    __syncthreads();
+    block_max = temp_storage.shared_state.max_val;
+
+    // if block_max is -inf, then this block contains all -inf values, so we can skip updating
+    if (!isinf(block_max)) {
+      float threadlocal_sum = 0.0f;
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        threadlocal_sum += __expf(logits_vec[j] - block_max);
+      }
+      float new_max = max(running_max, block_max);
+      threadlocal_running_denominator =
+          threadlocal_running_denominator * __expf(running_max - new_max) +
+          threadlocal_sum * __expf(block_max - new_max);
+      running_max = new_max;
+    }
+  }
+
+  running_denominator = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                            .Sum(threadlocal_running_denominator);
+  if (tx == 0) {
+    temp_storage.shared_state.denominator = running_denominator;
+  }
+  __syncthreads();
+  running_denominator = temp_storage.shared_state.denominator;
+
+  if (tx == 0) {
+    partial_results[bx * num_slices + by] = {running_max, running_denominator};
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
+__global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
+                                          PartialSoftmaxResult* partial_results,
+                                          DType* temperature_arr, float temperature_val, uint32_t d,
+                                          uint32_t num_slices) {
+  const uint32_t bx = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
+
+  // Reduce slice results
+  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
+
+  const Float2SoftmaxReduceOp reduce_op;
+
+  float2 thread_aggregate = make_float2(-cuda::std::numeric_limits<float>::infinity(), 0.0f);
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  for (uint32_t i = tx; i < num_slices; i += BLOCK_THREADS) {
+    PartialSoftmaxResult partial = partial_results[bx * num_slices + i];
+    float2 partial_pair = make_float2(partial.max_val, partial.denominator);
+    thread_aggregate = reduce_op(thread_aggregate, partial_pair);
+  }
+
+  float2 block_result = cub::BlockReduce<float2, BLOCK_THREADS>(temp_storage.block_prim.reduce_pair)
+                            .Reduce(thread_aggregate, reduce_op);
+
+  if (tx == 0) {
+    temp_storage.shared_state.max_val = block_result.x;
+    temp_storage.shared_state.denominator = block_result.y;
+  }
+  __syncthreads();
+
+  block_result =
+      make_float2(temp_storage.shared_state.max_val, temp_storage.shared_state.denominator);
+
+  const float final_max = temp_storage.shared_state.max_val;
+  const float inv_denominator = 1.0f / temp_storage.shared_state.denominator;
+
+  // Apply normalization
+  vec_t<DType, VEC_SIZE> logits_vec;
+  vec_t<DType, VEC_SIZE> prob_vec;
+
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      logits_vec[j] *= inv_temp;
+      float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
+      prob_vec[j] = static_cast<DType>(p);
+    }
+
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+  }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, bool DETERMINISTIC, typename Predicate>
+__device__ __forceinline__ void DeviceSamplingFromProb(
+    uint32_t i, uint32_t d, Predicate pred, float u, vec_t<float, VEC_SIZE> prob_vec,
+    float& aggregate,
+    SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+  const uint32_t tx = threadIdx.x;
+  float prob_greater_than_threshold[VEC_SIZE];
+  float inclusive_cdf[VEC_SIZE];
+  bool greater_than_u[VEC_SIZE], valid[VEC_SIZE];
+#pragma unroll
+  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+    prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : 0;
+    valid[j] = pred(prob_vec[j]) && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
+  }
+  float aggregate_local =
+      BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
+          .template Sum<VEC_SIZE>(prob_greater_than_threshold);
+  if (tx == 0) {
+    temp_storage->block_aggregate.value = aggregate_local;
+  }
+  __syncthreads();
+  aggregate_local = temp_storage->block_aggregate.value;
+
+  if (aggregate + aggregate_local > u) {
+    if constexpr (DETERMINISTIC) {
+      DeterministicInclusiveSum<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>(
+          prob_greater_than_threshold, inclusive_cdf, temp_storage);
+    } else {
+      BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>(temp_storage->block_prim.scan)
+          .template InclusiveSum<VEC_SIZE>(prob_greater_than_threshold, inclusive_cdf);
+
+      __syncthreads();
+    }
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      greater_than_u[j] = (inclusive_cdf[j] + aggregate > u) && valid[j];
+    }
+
+    bool greater_than_u_diff[VEC_SIZE];
+#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+        .SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
+#else
+    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+        .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
+#endif
+    __syncthreads();
+
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      if (greater_than_u_diff[j]) {
+        atomicMin(&(temp_storage->sampled_id), (i * BLOCK_THREADS + tx) * VEC_SIZE + j);
+      }
+    }
+    __syncthreads();
+  }
+
+  // update the last valid index
+  int valid_index[VEC_SIZE];
+#pragma unroll
+  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+    if (valid[j]) {
+      valid_index[j] = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+    } else {
+      valid_index[j] = -1;
+    }
+  }
+  int max_valid_index =
+      BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce_int)
+          .Reduce(valid_index, MaxReduceOp{});
+  if (tx == 0 && max_valid_index != -1 && max_valid_index < (int)d) {
+    temp_storage->last_valid_id = max_valid_index;
+  }
+  __syncthreads();
+  aggregate += aggregate_local;
+}
+
+template <typename DType, typename IdType>
+struct DataAndIndex {
+  DType data;
+  IdType index;
+
+  __device__ DataAndIndex operator+(const DataAndIndex& other) const {
+    if (data > other.data) {
+      return {data, index};
+    } else {
+      return {other.data, other.index};
+    }
+  }
+  __device__ DataAndIndex& operator+=(const DataAndIndex& other) {
+    if (data > other.data) {
+      return *this;
+    } else {
+      data = other.data;
+      index = other.index;
+      return *this;
+    }
+  }
+};
+
+template <typename DType, uint32_t VEC_SIZE>
+__device__ __forceinline__ vec_t<DType, VEC_SIZE> GenerateGumbelNoise(uint64_t philox_seed,
+                                                                      uint64_t philox_offset,
+                                                                      uint64_t subsequence) {
+  curandStatePhilox4_32_10_t state;
+  vec_t<float, VEC_SIZE> noise;
+  constexpr float kSCALE = 1.0f - cuda::std::numeric_limits<float>::epsilon();
+  constexpr float kLOG2 = 0.6931471806f;
+  auto uniform2gumbel = [](float x) {
+    // NB: cuRAND returns strictly positive normal floating point numbers, up to
+    //     and including 1.0. kSCALE is used to exclude 1.0, s.t.
+    //         1.18e-38 <= x * kSCALE <= 1.0f - epsilon
+    //      => -4.47    <= -log(-log(...))       <= 15.9
+    // log2f maps to a single PTX LG2 instruction on NVIDIA GPUs, while logf
+    // internally computes log2f * ln(2). Using log2f with a single kLOG2
+    // multiplication is more efficient (3 ops vs 4 ops).
+    return -kLOG2 * log2f(-log2f((x * kSCALE)));
+  };
+#pragma unroll
+  for (uint32_t i = 0; i + 4 <= VEC_SIZE; i += 4) {
+    curand_init(philox_seed, subsequence + i, philox_offset, &state);
+    float4 noise_vec = curand_uniform4(&state);
+    noise[i] = uniform2gumbel(noise_vec.x);
+    noise[i + 1] = uniform2gumbel(noise_vec.y);
+    noise[i + 2] = uniform2gumbel(noise_vec.z);
+    noise[i + 3] = uniform2gumbel(noise_vec.w);
+  }
+  if constexpr (VEC_SIZE % 4 != 0) {
+    curand_init(philox_seed, subsequence + VEC_SIZE / 4 * 4, philox_offset, &state);
+    float4 noise_vec = curand_uniform4(&state);
+    if constexpr (VEC_SIZE % 4 == 1) {
+      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.x);
+    } else if constexpr (VEC_SIZE % 4 == 2) {
+      noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.x);
+      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.y);
+    } else if constexpr (VEC_SIZE % 4 == 3) {
+      noise[VEC_SIZE - 3] = uniform2gumbel(noise_vec.x);
+      noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.y);
+      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.z);
+    }
+  }
+
+  if constexpr (std::is_same_v<DType, float>) {
+    return noise;
+  } else {
+    vec_t<DType, VEC_SIZE> ret;
+#pragma unroll
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+      ret[i] = static_cast<DType>(noise[i]);
+    }
+    return ret;
+  }
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* indices, uint32_t d,
+                                         uint64_t* seed_arr, uint64_t seed_val,
+                                         uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  using SharedMem = typename BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS,
+                                         REDUCE_ALGORITHM>::TempStorage;
+  extern __shared__ __align__(alignof(SharedMem)) uint8_t smem_sampling_logit[];
+  auto& temp_storage = reinterpret_cast<SharedMem&>(smem_sampling_logit);
+
+  vec_t<DType, VEC_SIZE> logits_vec;
+  DataAndIndex<DType, IdType> max_data = {-cuda::std::numeric_limits<DType>::infinity(), 0};
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      logits_vec.cast_load(logits + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+    }
+
+    vec_t<DType, VEC_SIZE> gumbel_noise = GenerateGumbelNoise<DType, VEC_SIZE>(
+        philox_seed, philox_offset,
+        static_cast<uint64_t>(bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE));
+    DataAndIndex<DType, IdType> cur_data[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      cur_data[j].data = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d
+                             ? logits_vec[j] + gumbel_noise[j]
+                             : -cuda::std::numeric_limits<DType>::infinity();
+      cur_data[j].index = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+    }
+
+    max_data +=
+        BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage)
+            .template Sum<VEC_SIZE>(cur_data);
+  }
+  if (tx == 0) {
+    output[bx] = max_data.index;
+  }
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void SamplingFromProbKernel(DType* probs, IdType* output, bool* valid, IdType* indices,
+                                       uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                       uint64_t* offset_arr, uint64_t offset_val) {
+  curandStatePhilox4_32_10_t state;
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  curand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+  temp_storage.sampled_id = d;
+  temp_storage.last_valid_id = -1;
+  __syncthreads();
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate(0);
+  float u = curand_uniform(&state);
+
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+    }
+
+    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                           DETERMINISTIC>(
+        i, d, [](float x) { return x > 0; }, u, probs_vec, aggregate, &temp_storage);
+    if (float(aggregate) > u) {
+      break;
+    }
+  }
+  int sampled_id = temp_storage.sampled_id;
+  if (sampled_id == d) {
+    // NOTE(Zihao): this would happen when u is very close to 1
+    // and the sum of probabilities is smaller than u
+    // In this case, we use the last valid index as the sampled id
+    if (temp_storage.last_valid_id == -1) {
+      if (tx == 0) {
+        output[bx] = 0;
+        valid[bx] = false;
+      }
+      return;
+    }
+    sampled_id = temp_storage.last_valid_id;
+  }
+  if (tx == 0) {
+    output[bx] = sampled_id;
+    valid[bx] = true;
+  }
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
+                                           IdType* indices, IdType* top_k_arr, uint32_t top_k_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t batch_size = gridDim.x;
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[bx];
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate;
+  float q = 1;
+  float low = 0, high = 1.f;
+  int sampled_id;
+  int round = 0;
+  do {
+    round += 1;
+    temp_storage.sampled_id = d;
+    temp_storage.last_valid_id = -1;
+    __syncthreads();
+    float u = curand_uniform(&state) * q;
+    aggregate = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                             DETERMINISTIC>(
+          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+      if (aggregate > u) {
+        break;
+      }
+    }
+    __syncthreads();
+    sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+      // NOTE(Zihao): this would happen when u is very close to 1
+      // and the sum of probabilities is smaller than u
+      // In this case, we use the last valid index as the sampled id
+      if (temp_storage.last_valid_id == -1) {
+        if (tx == 0) {
+          output[bx] = 0;
+          valid[bx] = false;
+        }
+        return;
+      }
+      sampled_id = temp_storage.last_valid_id;
+    }
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+    float pivot_0 = probs[row_idx * d + sampled_id];
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+    ValueCount<float> threadlocal_gt_pivot_0{0, 0}, threadlocal_gt_pivot_1{0, 0};
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        probs_gt_pivot_0[j] = {
+            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
+            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        probs_gt_pivot_1[j] = {
+            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
+            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        threadlocal_gt_pivot_0 += probs_gt_pivot_0[j];
+        threadlocal_gt_pivot_1 += probs_gt_pivot_1[j];
+      }
+    }
+    aggregate_gt_pivot_0 += BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(
+                                temp_storage.block_prim.reduce_value_count)
+                                .Sum(threadlocal_gt_pivot_0);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
+
+    aggregate_gt_pivot_1 += BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(
+                                temp_storage.block_prim.reduce_value_count)
+                                .Sum(threadlocal_gt_pivot_1);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
+    if (aggregate_gt_pivot_0.count < k) {
+      // case 1: pivot_0 accepted
+      break;
+    }
+    if (aggregate_gt_pivot_1.count < k) {
+      // case 2: pivot_0 rejected, pivot_1 accepted
+      low = pivot_0;
+      high = pivot_1;
+      q = aggregate_gt_pivot_0.value;
+    } else {
+      // case 3: pivot_0 rejected, pivot_1 rejected
+      low = pivot_1;
+      q = aggregate_gt_pivot_1.value;
+    }
+  } while (low < high);
+  __syncthreads();
+  if (tx == 0) {
+    output[bx] = sampled_id;
+    valid[bx] = true;
+  }
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
+                                           IdType* indices, float* top_p_arr, float top_p_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t batch_size = gridDim.x;
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  float top_p = (top_p_arr == nullptr) ? top_p_val : top_p_arr[row_idx];
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate;
+  float q = 1;
+  float low = 0, high = 1.f;
+  int sampled_id;
+  do {
+    temp_storage.sampled_id = d;
+    temp_storage.last_valid_id = -1;
+    __syncthreads();
+    float u = curand_uniform(&state) * q;
+    aggregate = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                             DETERMINISTIC>(
+          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+      if (aggregate > u) {
+        break;
+      }
+    }
+    __syncthreads();
+    sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+      // NOTE(Zihao): this would happen when u is very close to 1
+      // and the sum of probabilities is smaller than u
+      // In this case, we use the last valid index as the sampled id
+      if (temp_storage.last_valid_id == -1) {
+        if (tx == 0) {
+          output[bx] = 0;
+          valid[bx] = false;
+        }
+        return;
+      }
+      sampled_id = temp_storage.last_valid_id;
+    }
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+    float pivot_0 = probs[row_idx * d + sampled_id];
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+    float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
+    float threadlocal_aggregate_gt_pivot_0 = 0;
+    float threadlocal_aggregate_gt_pivot_1 = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
+        probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
+        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+      }
+    }
+    aggregate_gt_pivot_0 += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                                .Sum(threadlocal_aggregate_gt_pivot_0);
+    if (tx == 0) {
+      temp_storage.block_aggregate.value = aggregate_gt_pivot_0;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_0 = temp_storage.block_aggregate.value;
+
+    aggregate_gt_pivot_1 += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                                .Sum(threadlocal_aggregate_gt_pivot_1);
+    if (tx == 0) {
+      temp_storage.block_aggregate.value = aggregate_gt_pivot_1;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_1 = temp_storage.block_aggregate.value;
+
+    if (aggregate_gt_pivot_0 < top_p) {
+      // case 1: pivot_0 accepted
+      break;
+    }
+    if (aggregate_gt_pivot_1 < top_p) {
+      // case 2: pivot_0 rejected, pivot_1 accepted
+      low = pivot_0;
+      high = pivot_1;
+      q = aggregate_gt_pivot_0;
+    } else {
+      // case 3: pivot_0 rejected, pivot_1 rejected
+      low = pivot_1;
+      q = aggregate_gt_pivot_1;
+    }
+  } while (low < high);
+  __syncthreads();
+  if (tx == 0) {
+    output[bx] = sampled_id;
+    valid[bx] = true;
+  }
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdType* output,
+                                           bool* valid, IdType* indices, float min_p_val,
+                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
+                                           uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  float p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+
+  float max_val = GetMaxValue<VEC_SIZE, BLOCK_THREADS, REDUCE_ALGORITHM,
+                              SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>>(
+      probs, row_idx, d, temp_storage);
+  float pivot = max_val * p;
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate_gt_pivot = 0;
+  float threadlocal_aggregate_gt_pivot = 0;
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+
+    float probs_gt_pivot[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      probs_gt_pivot[j] = (probs_vec[j] >= pivot) ? probs_vec[j] : 0;
+      threadlocal_aggregate_gt_pivot += probs_gt_pivot[j];
+    }
+  }
+
+  aggregate_gt_pivot += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
+                            .Sum(threadlocal_aggregate_gt_pivot);
+  if (tx == 0) {
+    temp_storage.block_aggregate.value = aggregate_gt_pivot;
+  }
+  __syncthreads();
+
+  float aggregate = 0;
+  float q = temp_storage.block_aggregate.value;
+
+  int sampled_id;
+  temp_storage.sampled_id = d;
+  temp_storage.last_valid_id = -1;
+  __syncthreads();
+  float u = curand_uniform(&state) * q;
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+    }
+
+    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                           DETERMINISTIC>(
+        i, d, [&](float x) { return x >= pivot; }, u, probs_vec, aggregate, &temp_storage);
+    if (aggregate > u) {
+      break;
+    }
+  }
+  sampled_id = temp_storage.sampled_id;
+  if (sampled_id == d) {
+    // NOTE(Zihao): this would happen when u is very close to 1
+    // and the sum of probabilities is smaller than u
+    // In this case, we use the last valid index as the sampled id
+    if (temp_storage.last_valid_id == -1) {
+      if (tx == 0) {
+        output[bx] = 0;
+        valid[bx] = false;
+      }
+      return;
+    }
+    sampled_id = temp_storage.last_valid_id;
+  }
+  output[bx] = sampled_id;
+  valid[bx] = true;
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, float* top_p_arr,
+                                               IdType* output, bool* valid, IdType* indices,
+                                               IdType top_k_val, float top_p_val, uint32_t d,
+                                               uint64_t* seed_arr, uint64_t seed_val,
+                                               uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t batch_size = gridDim.x;
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  curandStatePhilox4_32_10_t state;
+  curand_init(philox_seed, bx, philox_offset, &state);
+  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+  const float p = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+
+  vec_t<float, VEC_SIZE> probs_vec;
+  float aggregate;
+  float q = 1;
+  float low = 0, high = 1.f;
+  int sampled_id;
+  do {
+    temp_storage.sampled_id = d;
+    temp_storage.last_valid_id = -1;
+    __syncthreads();
+    float u = curand_uniform(&state) * q;
+    aggregate = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                             DETERMINISTIC>(
+          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+      if (aggregate > u) {
+        break;
+      }
+    }
+    __syncthreads();
+    sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+      // NOTE(Zihao): this would happen when u is very close to 1
+      // and the sum of probabilities is smaller than u
+      // In this case, we use the last valid index as the sampled id
+      sampled_id = temp_storage.last_valid_id;
+      if (temp_storage.last_valid_id == -1) {
+        if (tx == 0) {
+          output[bx] = 0;
+          valid[bx] = false;
+        }
+        return;
+      }
+    }
+    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+    float pivot_0 = probs[row_idx * d + sampled_id];
+    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+    ValueCount<float> threadlocal_aggregate_gt_pivot_0{0, 0};
+    ValueCount<float> threadlocal_aggregate_gt_pivot_1{0, 0};
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+      }
+
+      ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        probs_gt_pivot_0[j] = {
+            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
+            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        probs_gt_pivot_1[j] = {
+            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
+            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+      }
+    }
+    aggregate_gt_pivot_0 +=
+        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+            .Sum(threadlocal_aggregate_gt_pivot_0);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
+
+    aggregate_gt_pivot_1 +=
+        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+            .Sum(threadlocal_aggregate_gt_pivot_1);
+    if (tx == 0) {
+      temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
+    if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
+      // case 1: pivot_0 accepted
+      break;
+    }
+    if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
+      // case 2: pivot_0 rejected, pivot_1 accepted
+      low = pivot_0;
+      high = pivot_1;
+      q = aggregate_gt_pivot_0.value;
+    } else {
+      // case 3: pivot_0 rejected, pivot_1 rejected
+      low = pivot_1;
+      q = aggregate_gt_pivot_1.value;
+    }
+  } while (low < high);
+  __syncthreads();
+  if (tx == 0) {
+    output[bx] = sampled_id;
+    valid[bx] = true;
+  }
+}
+
+template <typename DType>
+cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uint32_t d,
+                          DType* temperature_arr, DType temperature_val, void* workspace_buffer,
+                          size_t workspace_buffer_size_in_bytes, bool enable_pdl,
+                          cudaStream_t stream = 0) {
+  constexpr uint32_t SMALL_BATCH_THRESHOLD = 128;
+  constexpr uint32_t LARGE_VOCAB_THRESHOLD = 24576;
+  constexpr uint32_t DEFAULT_SLICE_SIZE = 8192;
+
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+  auto compute_capacity = GetCudaComputeCapability();
+
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(
+      compute_capacity, BLOCK_THREADS, {DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        if (batch_size <= SMALL_BATCH_THRESHOLD && d >= LARGE_VOCAB_THRESHOLD) {
+          // Path A: Vocab-Splitting Strategy for small-batch & large-vocab
+          uint32_t num_slices = ceil_div(d, DEFAULT_SLICE_SIZE);
+
+          const size_t partial_buffer_size = batch_size * num_slices * sizeof(PartialSoftmaxResult);
+          if (workspace_buffer_size_in_bytes < partial_buffer_size) {
+            return cudaErrorInvalidValue;
+          }
+
+          AlignedAllocator allocator(workspace_buffer, workspace_buffer_size_in_bytes);
+          auto partial_results = allocator.aligned_alloc<PartialSoftmaxResult>(
+              partial_buffer_size, alignof(PartialSoftmaxResult), "softmax_workspace");
+
+          // Phase 1: Map-Reduce across vocab slices
+          dim3 phase1_nblks(batch_size, num_slices);
+          dim3 phase1_nthrs(BLOCK_THREADS);
+          size_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>);
+
+          auto phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+          void* phase1_args[] = {&logits, &partial_results, &temperature_arr, &temperature_val,
+                                 &d,      &num_slices};
+
+          FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
+              phase1_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+          if (enable_pdl) {
+            cudaLaunchAttribute attribute[1];
+            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+            cudaLaunchConfig_t config;
+            config.gridDim = phase1_nblks;
+            config.blockDim = phase1_nthrs;
+            config.dynamicSmemBytes = smem_size;
+            config.stream = stream;
+            config.attrs = attribute;
+            config.numAttrs = 1;
+
+            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, logits, partial_results,
+                                                    temperature_arr, temperature_val, d,
+                                                    num_slices));
+          } else {
+            FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase1_kernel, phase1_nblks, phase1_nthrs,
+                                                  phase1_args, smem_size, stream));
+          }
+
+          // Phase 2: Final reduction and apply normalization
+          dim3 phase2_nblks(batch_size);
+          dim3 phase2_nthrs(BLOCK_THREADS);
+
+          auto phase2_kernel = OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+          void* phase2_args[] = {&logits,          &output, &partial_results, &temperature_arr,
+                                 &temperature_val, &d,      &num_slices};
+
+          FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
+              phase2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+          if (enable_pdl) {
+            cudaLaunchAttribute attribute[1];
+            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+            cudaLaunchConfig_t config;
+            config.gridDim = phase2_nblks;
+            config.blockDim = phase2_nthrs;
+            config.dynamicSmemBytes = smem_size;
+            config.stream = stream;
+            config.attrs = attribute;
+            config.numAttrs = 1;
+
+            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase2_kernel, logits, output,
+                                                    partial_results, temperature_arr,
+                                                    temperature_val, d, num_slices));
+          } else {
+            FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase2_kernel, phase2_nblks, phase2_nthrs,
+                                                  phase2_args, smem_size, stream));
+          }
+        } else {
+          // Path B: Single-Block Strategy
+          // Switch input cache
+          uint32_t cache_threshold;
+          if (batch_size <= 16) {
+            cache_threshold = 4096;
+          } else if (batch_size <= 32) {
+            cache_threshold = 2048;
+          } else {
+            cache_threshold = 0;
+          }
+          const bool cache_input = d <= cache_threshold;
+
+          dim3 nblks(batch_size);
+          dim3 nthrs(BLOCK_THREADS);
+          void* args[] = {&logits, &output, &temperature_arr, &temperature_val, &d};
+
+          const size_t smem_logits_bytes = (round_up(d, VEC_SIZE) + VEC_SIZE) * sizeof(DType);
+
+          uint32_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>) +
+                               (cache_input ? smem_logits_bytes : 0);
+
+          DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, {
+            auto kernel = OnlineSoftmaxFusedKernel<BLOCK_THREADS, VEC_SIZE, DType, CACHE_INPUT>;
+            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+            if (enable_pdl) {
+              cudaLaunchAttribute attribute[1];
+              attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+              attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+              cudaLaunchConfig_t config;
+              config.gridDim = nblks;
+              config.blockDim = nthrs;
+              config.dynamicSmemBytes = smem_size;
+              config.stream = stream;
+              config.attrs = attribute;
+              config.numAttrs = 1;
+
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, logits, output,
+                                                      temperature_arr, temperature_val, d));
+            } else {
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            }
+          });
+        }
+      })});
+  return cudaSuccess;
+}
+
+template <typename T, typename IdType>
+cudaError_t SamplingFromLogits(T* logits, IdType* output, IdType* indices, uint32_t batch_size,
+                               uint32_t d, bool deterministic, uint64_t* seed_arr,
+                               uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val,
+                               cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&logits, &output, &indices, &d, &seed_arr, &seed_val, &offset_arr, &offset_val};
+    const uint32_t smem_size = sizeof(
+        typename BlockReduce<DataAndIndex<T, IdType>, BLOCK_THREADS, REDUCE_ALGO>::TempStorage);
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = SamplingFromLogitsKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                                 DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <typename T, typename IdType>
+cudaError_t SamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
+                             uint32_t batch_size, uint32_t d, bool deterministic,
+                             uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
+                             uint64_t offset_val, cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs,    &output,   &valid,      &indices,   &d,
+                    &seed_arr, &seed_val, &offset_arr, &offset_val};
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = SamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                               DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <typename T, typename IdType>
+cudaError_t TopKSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
+                                 T* top_k_arr, uint32_t batch_size, uint32_t top_k_val, uint32_t d,
+                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
+                                 uint64_t* offset_arr, uint64_t offset_val,
+                                 cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs, &output,   &valid,    &indices,    &top_k_arr, &top_k_val,
+                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = TopKSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                                   DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <typename T, typename IdType>
+cudaError_t TopPSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
+                                 T* top_p_arr, uint32_t batch_size, T top_p_val, uint32_t d,
+                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
+                                 uint64_t* offset_arr, uint64_t offset_val,
+                                 cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs, &output,   &valid,    &indices,    &top_p_arr, &top_p_val,
+                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = TopPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                                   DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <typename T, typename IdType>
+cudaError_t MinPSamplingFromProb(T* probs, T* min_p_arr, IdType* output, bool* valid,
+                                 IdType* indices, uint32_t batch_size, float min_p_val, uint32_t d,
+                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
+                                 uint64_t* offset_arr, uint64_t offset_val,
+                                 cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs, &min_p_arr, &output,   &valid,      &indices,   &min_p_val,
+                    &d,     &seed_arr,  &seed_val, &offset_arr, &offset_val};
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = MinPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                                   DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <typename T, typename IdType>
+cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, IdType* output,
+                                     bool* valid, IdType* indices, uint32_t batch_size,
+                                     IdType top_k_val, T top_p_val, uint32_t d, bool deterministic,
+                                     uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
+                                     uint64_t offset_val, cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs,    &top_k_arr,  &top_p_arr, &output, &valid,
+                    &indices,  &top_k_val,  &top_p_val, &d,      &seed_arr,
+                    &seed_val, &offset_arr, &offset_val};
+
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = TopKTopPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
+                                                       VEC_SIZE, DETERMINISTIC, T, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM>
+struct RenormTempStorage {
+  union {
+    typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce;
+    typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_int;
+    typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage
+        reduce_value_count;
+  } block_prim;
+  struct {
+    float max_val;
+    float min_val;
+    float row_sum;
+    union {
+      struct {
+        float values[2];
+      };
+      struct {
+        int counts[2];
+      };
+      struct {
+        ValueCount<float> pairs[2];
+      };
+    } block_aggregate;
+  };
+};
+
+template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE,
+          typename DType>
+__global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* top_p_arr,
+                                     float top_p_val, uint32_t d) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  const uint32_t row_idx = bx;
+  float p = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
+
+  extern __shared__ __align__(alignof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>))
+      uint8_t smem_renorm[];
+  auto& temp_storage =
+      reinterpret_cast<RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>&>(smem_renorm);
+  vec_t<float, VEC_SIZE> probs_vec;
+
+  // Fast-path: when p >= 1.0 (e.g., p == 1.0), perform simple sum and normalization
+  if (p >= 1.0f) {
+    // Stage A: per-thread float accumulation over assigned lanes (vectorized)
+    float thread_sum = 0.0f;
+    const uint32_t num_iters = ceil_div(d, BLOCK_THREADS * VEC_SIZE);
+    for (uint32_t i = 0; i < num_iters; ++i) {
+      probs_vec.fill(0.0f);
+      const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+      if (base_idx < d) {
+        probs_vec.cast_load(probs + row_idx * d + base_idx);
+      }
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        const uint32_t idx = base_idx + j;
+        if (idx < d) thread_sum += probs_vec[j];
+      }
+    }
+
+    // Block reduce (float)
+    float row_sum =
+        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+            .Sum(thread_sum);
+    // Broadcast via shared
+    if (tx == 0) temp_storage.row_sum = row_sum;
+    __syncthreads();
+    row_sum = temp_storage.row_sum;
+
+    // Guard against zero sum
+    const float denom = (row_sum <= 1e-8f) ? 1.0f : row_sum;
+    const float normalizer = math::ptx_rcp(denom);
+
+    // Stage B: normalize and store
+    for (uint32_t i = 0; i < num_iters; ++i) {
+      probs_vec.fill(0.0f);
+      const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+      if (base_idx < d) {
+        probs_vec.cast_load(probs + row_idx * d + base_idx);
+      }
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        const uint32_t idx = base_idx + j;
+        float v = probs_vec[j];
+        probs_vec[j] = (idx < d) ? (v * normalizer) : 0.0f;
+      }
+      if (base_idx < d) {
+        probs_vec.cast_store(renormed_prob + row_idx * d + base_idx);
+      }
+    }
+    return;  // Exit after fast-path processing
+  }
+
+  // Original Top-P renormalization logic
+  temp_storage.max_val = 0;
+  float max_val = GetMaxValue<VEC_SIZE, BLOCK_THREADS, REDUCE_ALGORITHM,
+                              RenormTempStorage<BLOCK_THREADS, REDUCE_ALGORITHM>>(probs, row_idx, d,
+                                                                                  temp_storage);
+
+  float low = 0, high = max_val;
+  float min_gt_low, max_le_high;
+  float sum_low = 1;
+  // f(x) = sum(probs[probs > x]), f(x) is non-increasing
+  // min_gt_low = min{p \in probs | p > low}, max_le_high = max{p \in probs | p <= high}
+  // loop invariant:
+  // - f(low) >= p, f(high) < p
+  // - f(low) > f(min_gt_low) >= f(max_le_high) == f(high)
+  // stopping condition
+  // - f(low) >= p, f(min_gt_low) == f(max_le_high) == f(high) < p
+  do {
+    // Use IEEE-754 arithmetic (no FTZ) to prevent -use_fast_math from flushing
+    // subnormal pivots to zero, which would stall the search (#769, #774).
+    float pivot_0 = ieee_div(ieee_add(high, ieee_mul(2.f, low)), 3.f);
+    float pivot_1 = ieee_div(ieee_add(ieee_mul(2.f, high), low), 3.f);
+
+    float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
+    min_gt_low = high;
+    max_le_high = low;
+    float threadlocal_aggregate_gt_pivot_0 = 0;
+    float threadlocal_aggregate_gt_pivot_1 = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+      probs_vec.fill(0);
+      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+        probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      }
+
+      float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
+        probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
+
+        if (probs_vec[j] > low && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
+          min_gt_low = min(min_gt_low, probs_vec[j]);
+        }
+        if (probs_vec[j] <= high && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
+          max_le_high = max(max_le_high, probs_vec[j]);
+        }
+        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+      }
+    }
+    aggregate_gt_pivot_0 =
+        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+            .Sum(threadlocal_aggregate_gt_pivot_0);
+    __syncthreads();
+    aggregate_gt_pivot_1 =
+        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+            .Sum(threadlocal_aggregate_gt_pivot_1);
+    __syncthreads();
+
+    min_gt_low = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                     .Reduce(min_gt_low, MinReduceOp{});
+    __syncthreads();
+    max_le_high =
+        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+            .Reduce(max_le_high, MaxReduceOp{});
+    if (tx == 0) {
+      temp_storage.block_aggregate.values[0] = aggregate_gt_pivot_0;
+      temp_storage.block_aggregate.values[1] = aggregate_gt_pivot_1;
+      temp_storage.min_val = min_gt_low;
+      temp_storage.max_val = max_le_high;
+    }
+    __syncthreads();
+    aggregate_gt_pivot_0 = temp_storage.block_aggregate.values[0];
+    aggregate_gt_pivot_1 = temp_storage.block_aggregate.values[1];
+    min_gt_low = temp_storage.min_val;
+    max_le_high = temp_storage.max_val;
+
+    if (aggregate_gt_pivot_1 >= p) {
+      low = pivot_1;
+      sum_low = aggregate_gt_pivot_1;
+    } else if (aggregate_gt_pivot_0 >= p) {
+      low = pivot_0;
+      high = min(pivot_1, max_le_high);
+      sum_low = aggregate_gt_pivot_0;
+    } else {
+      high = min(pivot_0, max_le_high);
+    }
+  } while (min_gt_low != max_le_high);
+
+  float normalizer = math::ptx_rcp(max(sum_low, 1e-8));
+
+  // normalize
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    probs_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      probs_vec[j] = (probs_vec[j] > low) ? probs_vec[j] * normalizer : 0;
+    }
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      probs_vec.cast_store(renormed_prob + row_idx * d + i * BLOCK_THREADS * VEC_SIZE +
+                           tx * VEC_SIZE);
+    }
+  }
+}
+
+template <typename DType>
+cudaError_t TopPRenormProb(DType* probs, DType* renormed_prob, float* top_p_arr,
+                           uint32_t batch_size, float top_p_val, uint32_t d,
+                           cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&probs, &renormed_prob, &top_p_arr, &top_p_val, &d};
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+      auto kernel = TopPRenormProbKernel<BLOCK_THREADS, REDUCE_ALGO, VEC_SIZE, DType>;
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    });
+    return cudaSuccess;
+  });
+}
+
+template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
+          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
+          typename DType, typename IdType>
+__global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
+                                         DType* target_probs, IdType* output_token_ids,
+                                         IdType* output_accepted_token_num,
+                                         IdType* output_emitted_draft_token_num,
+                                         uint32_t num_speculative_tokens, uint32_t d,
+                                         uint64_t* seed_arr, uint64_t seed_val,
+                                         uint64_t* offset_arr, uint64_t offset_val) {
+  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+  const uint32_t row_idx = bx;
+
+  // Resolve seed/offset from tensor or scalar
+  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
+  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+  curandStatePhilox4_32_10_t curand_state;
+  curand_init(philox_seed, bx, philox_offset, &curand_state);
+
+  extern __shared__ __align__(
+      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+      uint8_t smem_sampling[];
+  auto& temp_storage =
+      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
+          smem_sampling);
+
+  uint32_t pos = num_speculative_tokens;
+  for (uint32_t i = 0; i < num_speculative_tokens; ++i) {
+    IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+    float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
+          p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
+    float u = curand_uniform(&curand_state);
+    if (u * p < q) {
+      // accept the draft models output
+      output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
+    } else {
+      pos = i;
+      break;
+    }
+  }
+
+  uint32_t emitted_token_num = pos;
+  uint32_t accepted_token_num = pos;
+  for (uint32_t i = pos; i < num_speculative_tokens; ++i) {
+    int draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+    float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
+          p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
+    float u = curand_uniform(&curand_state);
+    if (u * p < q) {
+      ++accepted_token_num;
+    }
+  }
+
+  if (tx == 0) {
+    output_accepted_token_num[row_idx] += accepted_token_num;
+    output_emitted_draft_token_num[row_idx] += emitted_token_num;
+  }
+
+  // sample from relu(target_probs - draft_probs)
+  float sum_relu_q_minus_p = 0;
+  vec_t<float, VEC_SIZE> q_vec, p_vec;
+  float relu_q_minus_p[VEC_SIZE];
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    q_vec.fill(0);
+    p_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d +
+                      i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      if (pos != num_speculative_tokens) {
+        // there is no draft_probs for the bonus token
+        p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d +
+                        i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      }
+    }
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0.0f);
+    }
+    sum_relu_q_minus_p +=
+        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+            .Sum<VEC_SIZE>(relu_q_minus_p);
+    __syncthreads();
+  }
+  if (tx == 0) {
+    temp_storage.block_aggregate.value = sum_relu_q_minus_p;
+  }
+  // init the first rejected token to d
+  temp_storage.sampled_id = d;
+  __syncthreads();
+  sum_relu_q_minus_p = temp_storage.block_aggregate.value;
+  float u = curand_uniform(&curand_state) * sum_relu_q_minus_p;
+
+  float aggregate_relu_q_minus_p(0);
+#pragma unroll 2
+  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    q_vec.fill(0);
+    p_vec.fill(0);
+    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+      q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d +
+                      i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      if (pos != num_speculative_tokens) {
+        // there is no draft_probs for the bonus token
+        p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d +
+                        i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+      }
+    }
+
+    vec_t<float, VEC_SIZE> relu_q_minus_p_vec;
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0.0f);
+    }
+
+    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
+                           DETERMINISTIC>(
+        i, d, [&](float x) { return x > 0; }, u, relu_q_minus_p_vec, aggregate_relu_q_minus_p,
+        &temp_storage);
+    if (aggregate_relu_q_minus_p > u) {
+      break;
+    }
+  }
+  __syncthreads();
+  int sampled_id = temp_storage.sampled_id;
+  if (sampled_id == d) {
+    // NOTE(Zihao): this would happen when u is very close to 1
+    // and the sum of probabilities is smaller than u
+    // In this case, we use the last valid index as the sampled id
+    sampled_id = temp_storage.last_valid_id;
+  }
+  // set the first rejected token
+  output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = sampled_id;
+  // move to the next token
+  pos++;
+
+  // pad remaining tokens with -1
+  for (; pos < num_speculative_tokens + 1; ++pos) {
+    output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = -1;
+  }
+}
+
+template <typename DType, typename IdType>
+cudaError_t ChainSpeculativeSampling(
+    DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
+    IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num, uint32_t batch_size,
+    uint32_t num_speculative_tokens, uint32_t d, bool deterministic, uint64_t* seed_arr,
+    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val, cudaStream_t stream = 0) {
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3 nblks(batch_size);
+    dim3 nthrs(BLOCK_THREADS);
+    void* args[] = {&draft_probs,
+                    &draft_token_ids,
+                    &target_probs,
+                    &output_token_ids,
+                    &output_accepted_token_num,
+                    &output_emitted_draft_token_num,
+                    &num_speculative_tokens,
+                    &d,
+                    &seed_arr,
+                    &seed_val,
+                    &offset_arr,
+                    &offset_val};
+    DISPATCH_ALIGNED_VEC_SIZE(
+        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+          auto kernel = ChainSpeculativeSampling<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
+                                                 DETERMINISTIC, DType, IdType>;
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          FLASHINFER_CUDA_CALL(
+              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        })});
+    return cudaSuccess;
+  });
+}
+
+}  // namespace sampling
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_SAMPLING_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/sampling.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/sampling.cuh
@@ -37,8 +37,15 @@
 #include "utils.cuh"
 #include "vec_dtypes.cuh"
 
+// Define reduction operators based on CUDA version
+// CUDA 13 (12.9+) deprecated cub::Max/Min in favor of cuda::maximum/minimum
+#if CUDA_VERSION >= 12090
 using MaxReduceOp = cuda::maximum<>;
 using MinReduceOp = cuda::minimum<>;
+#else
+using MaxReduceOp = cub::Max;
+using MinReduceOp = cub::Min;
+#endif
 
 namespace flashinfer {
 
@@ -51,1985 +58,2169 @@ using namespace cub;
 // results to zero.  These helpers bypass that for operations where subnormal
 // correctness matters (see #769, #774).
 __device__ __forceinline__ float ieee_mul(float a, float b) {
-  float r;
-  asm("mul.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
-  return r;
+    float r;
+    asm("mul.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+    return r;
 }
 __device__ __forceinline__ float ieee_add(float a, float b) {
-  float r;
-  asm("add.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
-  return r;
+    float r;
+    asm("add.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+    return r;
 }
 __device__ __forceinline__ float ieee_div(float a, float b) {
-  float r;
-  asm("div.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
-  return r;
+    float r;
+    asm("div.rn.f32 %0, %1, %2;" : "=f"(r) : "f"(a), "f"(b));
+    return r;
 }
 
-#define DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, ...) \
-  if (deterministic) {                                            \
-    constexpr bool DETERMINISTIC = true;                          \
-    __VA_ARGS__                                                   \
-  } else {                                                        \
-    constexpr bool DETERMINISTIC = false;                         \
-    __VA_ARGS__                                                   \
-  }
+#define DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, ...)                                                      \
+    if (deterministic) {                                                                                               \
+        constexpr bool DETERMINISTIC = true;                                                                           \
+        __VA_ARGS__                                                                                                    \
+    } else {                                                                                                           \
+        constexpr bool DETERMINISTIC = false;                                                                          \
+        __VA_ARGS__                                                                                                    \
+    }
 
-#define DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, ...) \
-  if (compute_capacity.first >= 8) {                                           \
-    constexpr uint32_t BLOCK_THREADS = 1024;                                   \
-    __VA_ARGS__                                                                \
-  } else {                                                                     \
-    constexpr uint32_t BLOCK_THREADS = 512;                                    \
-    __VA_ARGS__                                                                \
-  }
+#define DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, ...)                                         \
+    if (compute_capacity.first >= 8) {                                                                                 \
+        constexpr uint32_t BLOCK_THREADS = 1024;                                                                       \
+        __VA_ARGS__                                                                                                    \
+    } else {                                                                                                           \
+        constexpr uint32_t BLOCK_THREADS = 512;                                                                        \
+        __VA_ARGS__                                                                                                    \
+    }
 
-#define DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, ...) \
-  if (cache_input) {                                                \
-    constexpr bool CACHE_INPUT = true;                              \
-    __VA_ARGS__                                                     \
-  } else {                                                          \
-    constexpr bool CACHE_INPUT = false;                             \
-    __VA_ARGS__                                                     \
-  }
+#define DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, ...)                                                    \
+    if (cache_input) {                                                                                                 \
+        constexpr bool CACHE_INPUT = true;                                                                             \
+        __VA_ARGS__                                                                                                    \
+    } else {                                                                                                           \
+        constexpr bool CACHE_INPUT = false;                                                                            \
+        __VA_ARGS__                                                                                                    \
+    }
 
-constexpr BlockScanAlgorithm SCAN_ALGO = BLOCK_SCAN_WARP_SCANS;
+constexpr BlockScanAlgorithm   SCAN_ALGO   = BLOCK_SCAN_WARP_SCANS;
 constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
 
 #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
 #define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
 #endif
 
-template <typename T>
+template<typename T>
 struct ValueCount {
-  T value;
-  int count;
+    T   value;
+    int count;
 
-  __device__ ValueCount operator+(const ValueCount& other) const {
-    return {value + other.value, count + other.count};
-  }
-  __device__ ValueCount& operator+=(const ValueCount& other) {
-    value += other.value;
-    count += other.count;
-    return *this;
-  }
+    __device__ ValueCount operator+(const ValueCount& other) const {
+        return {value + other.value, count + other.count};
+    }
+    __device__ ValueCount& operator+=(const ValueCount& other) {
+        value += other.value;
+        count += other.count;
+        return *this;
+    }
 };
 
 struct BoolDiffOp {
-  __device__ __forceinline__ bool operator()(const bool& lhs, const bool& rhs) const {
-    return lhs != rhs;
-  }
+    __device__ __forceinline__ bool operator()(const bool& lhs, const bool& rhs) const {
+        return lhs != rhs;
+    }
 };
 
 struct Float2SoftmaxReduceOp {
-  __device__ __forceinline__ float2 operator()(const float2& a, const float2& b) const {
-    if (isinf(a.x)) return b;
-    if (isinf(b.x)) return a;
+    __device__ __forceinline__ float2 operator()(const float2& a, const float2& b) const {
+        if (isinf(a.x))
+            return b;
+        if (isinf(b.x))
+            return a;
 
-    float new_max = max(a.x, b.x);
-    float new_denom = a.y * __expf(a.x - new_max) + b.y * __expf(b.x - new_max);
-    return make_float2(new_max, new_denom);
-  }
+        float new_max   = max(a.x, b.x);
+        float new_denom = a.y * __expf(a.x - new_max) + b.y * __expf(b.x - new_max);
+        return make_float2(new_max, new_denom);
+    }
 };
 
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM>
+template<uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM, BlockReduceAlgorithm REDUCE_ALGORITHM>
 struct SamplingTempStorage {
-  union {
-    float deterministic_scan[BLOCK_THREADS / 32];
-    typename BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>::TempStorage scan;
-    typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce;
-    typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_int;
-    typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage
-        reduce_value_count;
-    typename BlockAdjacentDifference<bool, BLOCK_THREADS>::TempStorage adj_diff;
-  } block_prim;
-  struct {
-    int32_t sampled_id;
-    int32_t last_valid_id;
-    float max_val;
     union {
-      float value;
-      ValueCount<float> pair;
-    } block_aggregate;
-  };
+        float                                                                 deterministic_scan[BLOCK_THREADS / 32];
+        typename BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>::TempStorage scan;
+        typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage             reduce;
+        typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage               reduce_int;
+        typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_value_count;
+        typename BlockAdjacentDifference<bool, BLOCK_THREADS>::TempStorage                    adj_diff;
+    } block_prim;
+    struct {
+        int32_t sampled_id;
+        int32_t last_valid_id;
+        float   max_val;
+        union {
+            float             value;
+            ValueCount<float> pair;
+        } block_aggregate;
+    };
 };
 
-template <uint32_t BLOCK_THREADS>
+template<uint32_t BLOCK_THREADS>
 struct OnlineSoftmaxTempStorage {
-  union {
-    typename cub::BlockReduce<float, BLOCK_THREADS>::TempStorage reduce;
-    typename cub::BlockReduce<float2, BLOCK_THREADS>::TempStorage reduce_pair;
-  } block_prim;
+    union {
+        typename cub::BlockReduce<float, BLOCK_THREADS>::TempStorage  reduce;
+        typename cub::BlockReduce<float2, BLOCK_THREADS>::TempStorage reduce_pair;
+    } block_prim;
 
-  struct {
-    float max_val;
-    float denominator;
-  } shared_state;
+    struct {
+        float max_val;
+        float denominator;
+    } shared_state;
 };
 
 struct PartialSoftmaxResult {
-  float max_val;
-  float denominator;
+    float max_val;
+    float denominator;
 };
 
 /*!
  * \brief Deterministic inclusive scan implementation, use Belloch scan algorithm.
  * \note This implementation is slower than the cub::BlockScan, but it is deterministic.
  */
-template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM>
-__device__ __forceinline__ void DeterministicInclusiveSum(
-    const float* in_data, float* out_data,
-    SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
-  float* smem_prefix_sum = temp_storage->block_prim.deterministic_scan;
-  float thread_data[VEC_SIZE];
-  float thread_sum = 0;
+template<uint32_t             VEC_SIZE,
+         uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM>
+__device__ __forceinline__ void
+DeterministicInclusiveSum(const float*                                                          in_data,
+                          float*                                                                out_data,
+                          SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+    float* smem_prefix_sum = temp_storage->block_prim.deterministic_scan;
+    float  thread_data[VEC_SIZE];
+    float  thread_sum = 0;
 #pragma unroll
-  for (uint32_t i = 0; i < VEC_SIZE; ++i) {
-    thread_sum += in_data[i];
-    thread_data[i] = thread_sum;
-  }
-
-  float thread_exclusive_prefix_sum = thread_sum;
-
-#pragma unroll
-  for (uint32_t offset = 1; offset < 32; offset *= 2) {
-    float tmp = __shfl_up_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
-    if ((threadIdx.x + 1) % (offset * 2) == 0) {
-      thread_exclusive_prefix_sum += tmp;
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+        thread_sum += in_data[i];
+        thread_data[i] = thread_sum;
     }
-  }
 
-  float warp_sum = __shfl_sync(0xffffffff, thread_exclusive_prefix_sum, threadIdx.x | 0xffffffff);
-  if (threadIdx.x % 32 == 31) {
-    thread_exclusive_prefix_sum = 0;
-  }
-
-#pragma unroll
-  for (uint32_t offset = 16; offset >= 1; offset /= 2) {
-    float tmp = __shfl_xor_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
-    if ((threadIdx.x + 1) % (offset * 2) == 0) {
-      thread_exclusive_prefix_sum = tmp + thread_exclusive_prefix_sum;
-    }
-    if ((threadIdx.x + 1) % (offset * 2) == offset) {
-      thread_exclusive_prefix_sum = tmp;
-    }
-  }
-
-  smem_prefix_sum[threadIdx.x / 32] = warp_sum;
-  __syncthreads();
-
-  if (threadIdx.x < 32) {
-    float warp_exclusive_prefix_sum =
-        (threadIdx.x < BLOCK_THREADS / 32) ? smem_prefix_sum[threadIdx.x] : 0;
+    float thread_exclusive_prefix_sum = thread_sum;
 
 #pragma unroll
     for (uint32_t offset = 1; offset < 32; offset *= 2) {
-      float tmp = __shfl_up_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
-      if ((threadIdx.x + 1) % (offset * 2) == 0) {
-        warp_exclusive_prefix_sum += tmp;
-      }
+        float tmp = __shfl_up_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+        if ((threadIdx.x + 1) % (offset * 2) == 0) {
+            thread_exclusive_prefix_sum += tmp;
+        }
     }
 
+    float warp_sum = __shfl_sync(0xffffffff, thread_exclusive_prefix_sum, threadIdx.x | 0xffffffff);
     if (threadIdx.x % 32 == 31) {
-      warp_exclusive_prefix_sum = 0;
+        thread_exclusive_prefix_sum = 0;
     }
 
 #pragma unroll
     for (uint32_t offset = 16; offset >= 1; offset /= 2) {
-      float tmp = __shfl_xor_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
-      if ((threadIdx.x + 1) % (offset * 2) == 0) {
-        warp_exclusive_prefix_sum = tmp + warp_exclusive_prefix_sum;
-      }
-      if ((threadIdx.x + 1) % (offset * 2) == offset) {
-        warp_exclusive_prefix_sum = tmp;
-      }
+        float tmp = __shfl_xor_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+        if ((threadIdx.x + 1) % (offset * 2) == 0) {
+            thread_exclusive_prefix_sum = tmp + thread_exclusive_prefix_sum;
+        }
+        if ((threadIdx.x + 1) % (offset * 2) == offset) {
+            thread_exclusive_prefix_sum = tmp;
+        }
     }
-    if (threadIdx.x < BLOCK_THREADS / 32) {
-      smem_prefix_sum[threadIdx.x] = warp_exclusive_prefix_sum;
-    }
-  }
-  __syncthreads();
+
+    smem_prefix_sum[threadIdx.x / 32] = warp_sum;
+    __syncthreads();
+
+    if (threadIdx.x < 32) {
+        float warp_exclusive_prefix_sum = (threadIdx.x < BLOCK_THREADS / 32) ? smem_prefix_sum[threadIdx.x] : 0;
 
 #pragma unroll
-  for (uint32_t i = 0; i < VEC_SIZE; ++i) {
-    out_data[i] = smem_prefix_sum[threadIdx.x / 32] + thread_exclusive_prefix_sum + thread_data[i];
-  }
-}
+        for (uint32_t offset = 1; offset < 32; offset *= 2) {
+            float tmp = __shfl_up_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+            if ((threadIdx.x + 1) % (offset * 2) == 0) {
+                warp_exclusive_prefix_sum += tmp;
+            }
+        }
 
-template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM,
-          typename TempStorage>
-__device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, uint32_t d,
-                                             TempStorage& temp_storage) {
-  const uint32_t tx = threadIdx.x;
-  vec_t<float, VEC_SIZE> in_data_vec;
-
-  // Thread-local max accumulation (deferred reduction)
-  float thread_max = 0.0f;
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    in_data_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      in_data_vec.cast_load(in_data + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      thread_max = max(thread_max, static_cast<float>(in_data_vec[j]));
-    }
-  }
-
-  // Single block reduction after loop completes
-  float max_val =
-      BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-          .Reduce(thread_max, MaxReduceOp{});
-  if (tx == 0) {
-    temp_storage.max_val = max_val;
-  }
-  __syncthreads();
-  return temp_storage.max_val;
-}
-
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
-__global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr,
-                                         DType temperature_val, uint32_t d) {
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
-  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
-
-  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
-  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
-  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
-
-  DType* smem_vec_base = nullptr;
-  if constexpr (CACHE_INPUT) {
-    constexpr size_t vec_alignment = alignof(vec_t<DType, VEC_SIZE>);
-    size_t aligned_offset = round_up(sizeof(TempStorage), vec_alignment);
-    smem_vec_base = reinterpret_cast<DType*>(smem + aligned_offset);
-  }
-
-  vec_t<DType, VEC_SIZE> logits_vec;
-
-  float running_max = -cuda::std::numeric_limits<float>::infinity();
-  float running_denominator = 0.0f;
-  float threadlocal_running_denominator = 0.0f;
-
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
-#endif
-
-  // Pass 1: Compute running max and denominator
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        if (threadIdx.x % 32 == 31) {
+            warp_exclusive_prefix_sum = 0;
+        }
 
 #pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        logits_vec[j] *= inv_temp;
-      }
-
-      if constexpr (CACHE_INPUT) {
-        logits_vec.store(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-    }
-
-    float thread_max = -cuda::std::numeric_limits<float>::infinity();
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      thread_max = max(thread_max, logits_vec[j]);
-    }
-    float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                          .Reduce(thread_max, MaxReduceOp{});
-
-    if (tx == 0) {
-      temp_storage.shared_state.max_val = block_max;
+        for (uint32_t offset = 16; offset >= 1; offset /= 2) {
+            float tmp = __shfl_xor_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+            if ((threadIdx.x + 1) % (offset * 2) == 0) {
+                warp_exclusive_prefix_sum = tmp + warp_exclusive_prefix_sum;
+            }
+            if ((threadIdx.x + 1) % (offset * 2) == offset) {
+                warp_exclusive_prefix_sum = tmp;
+            }
+        }
+        if (threadIdx.x < BLOCK_THREADS / 32) {
+            smem_prefix_sum[threadIdx.x] = warp_exclusive_prefix_sum;
+        }
     }
     __syncthreads();
-    block_max = temp_storage.shared_state.max_val;
-    // if block_max is -inf, then this block contains all -inf values, so we can skip updating
-    if (!isinf(block_max)) {
-      float threadlocal_sum = 0.0f;
+
 #pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        threadlocal_sum += __expf(logits_vec[j] - block_max);
-      }
-      float new_max = max(running_max, block_max);
-      threadlocal_running_denominator =
-          threadlocal_running_denominator * __expf(running_max - new_max) +
-          threadlocal_sum * __expf(block_max - new_max);
-      running_max = new_max;
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+        out_data[i] = smem_prefix_sum[threadIdx.x / 32] + thread_exclusive_prefix_sum + thread_data[i];
     }
-  }
+}
 
-  running_denominator = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                            .Sum(threadlocal_running_denominator);
-  if (tx == 0) {
-    temp_storage.shared_state.denominator = running_denominator;
-  }
-  __syncthreads();
-  running_denominator = temp_storage.shared_state.denominator;
+template<uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, typename TempStorage>
+__device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, uint32_t d, TempStorage& temp_storage) {
+    const uint32_t         tx = threadIdx.x;
+    vec_t<float, VEC_SIZE> in_data_vec;
 
-  const float final_max = running_max;
-  const float inv_denominator = 1.0f / running_denominator;
+    // Thread-local max accumulation (deferred reduction)
+    float thread_max = 0.0f;
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        in_data_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            in_data_vec.cast_load(in_data + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            thread_max = max(thread_max, static_cast<float>(in_data_vec[j]));
+        }
+    }
 
-  // Pass 2: Normalize in place
-  vec_t<DType, VEC_SIZE> prob_vec;
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+    // Single block reduction after loop completes
+    float max_val = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                        .Reduce(thread_max, MaxReduceOp{});
+    if (tx == 0) {
+        temp_storage.max_val = max_val;
+    }
+    __syncthreads();
+    return temp_storage.max_val;
+}
+
+template<uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
+__global__ void
+OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr, DType temperature_val, uint32_t d) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+    float          temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+    const float    inv_temp    = (temperature == 0.f) ? 0.f : 1.f / temperature;
+
+    using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+    extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+    auto&                                                     temp_storage = reinterpret_cast<TempStorage&>(smem);
+
+    DType* smem_vec_base = nullptr;
     if constexpr (CACHE_INPUT) {
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        logits_vec.load(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-    } else {
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        constexpr size_t vec_alignment  = alignof(vec_t<DType, VEC_SIZE>);
+        size_t           aligned_offset = round_up(sizeof(TempStorage), vec_alignment);
+        smem_vec_base                   = reinterpret_cast<DType*>(smem + aligned_offset);
+    }
+
+    vec_t<DType, VEC_SIZE> logits_vec;
+
+    float running_max                     = -cuda::std::numeric_limits<float>::infinity();
+    float running_denominator             = 0.0f;
+    float threadlocal_running_denominator = 0.0f;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    // Pass 1: Compute running max and denominator
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                logits_vec[j] *= inv_temp;
+            }
+
+            if constexpr (CACHE_INPUT) {
+                logits_vec.store(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+        }
+
+        float thread_max = -cuda::std::numeric_limits<float>::infinity();
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            thread_max = max(thread_max, logits_vec[j]);
+        }
+        float block_max =
+            cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Reduce(thread_max, MaxReduceOp{});
+
+        if (tx == 0) {
+            temp_storage.shared_state.max_val = block_max;
+        }
+        __syncthreads();
+        block_max = temp_storage.shared_state.max_val;
+        // if block_max is -inf, then this block contains all -inf values, so we can skip updating
+        if (!isinf(block_max)) {
+            float threadlocal_sum = 0.0f;
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                threadlocal_sum += __expf(logits_vec[j] - block_max);
+            }
+            float new_max                   = max(running_max, block_max);
+            threadlocal_running_denominator = threadlocal_running_denominator * __expf(running_max - new_max)
+                                              + threadlocal_sum * __expf(block_max - new_max);
+            running_max = new_max;
+        }
+    }
+
+    running_denominator =
+        cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Sum(threadlocal_running_denominator);
+    if (tx == 0) {
+        temp_storage.shared_state.denominator = running_denominator;
+    }
+    __syncthreads();
+    running_denominator = temp_storage.shared_state.denominator;
+
+    const float final_max       = running_max;
+    const float inv_denominator = 1.0f / running_denominator;
+
+    // Pass 2: Normalize in place
+    vec_t<DType, VEC_SIZE> prob_vec;
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        if constexpr (CACHE_INPUT) {
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                logits_vec.load(smem_vec_base + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+        } else {
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+
+#pragma unroll
+                for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                    logits_vec[j] *= inv_temp;
+                }
+            }
+        }
 
 #pragma unroll
         for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-          logits_vec[j] *= inv_temp;
+            float p     = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
+            prob_vec[j] = static_cast<DType>(p);
         }
-      }
-    }
 
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
-      prob_vec[j] = static_cast<DType>(p);
-    }
-
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-  }
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
-#endif
-}
-
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* partial_results,
-                                       DType* temperature_arr, float temperature_val, uint32_t d,
-                                       uint32_t num_slices) {
-  const uint32_t bx = blockIdx.x;
-  const uint32_t by = blockIdx.y;  // slice index
-  const uint32_t tx = threadIdx.x;
-  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
-  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
-
-  const uint32_t vec_alignment_elems = alignof(vec_t<DType, VEC_SIZE>) / sizeof(DType);
-  const uint32_t slice_stride = round_up(ceil_div(d, num_slices), vec_alignment_elems);
-  const uint32_t slice_start = by * slice_stride;
-  const uint32_t slice_size = min((by + 1) * slice_stride, d) - slice_start;
-
-  if (slice_start >= d) return;
-
-  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
-  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
-  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
-
-  vec_t<DType, VEC_SIZE> logits_vec;
-  float running_max = -cuda::std::numeric_limits<float>::infinity();
-  float running_denominator = 0.0f;
-  float threadlocal_running_denominator = 0.0f;
-
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
-#endif
-
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(slice_size, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
-
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < slice_size) {
-      logits_vec.cast_load(logits + bx * d + slice_start + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-
-    float thread_max = -cuda::std::numeric_limits<float>::infinity();
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      logits_vec[j] *= inv_temp;
-      thread_max = max(thread_max, logits_vec[j]);
-    }
-
-    float block_max = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                          .Reduce(thread_max, MaxReduceOp{});
-
-    if (tx == 0) {
-      temp_storage.shared_state.max_val = block_max;
-    }
-    __syncthreads();
-    block_max = temp_storage.shared_state.max_val;
-
-    // if block_max is -inf, then this block contains all -inf values, so we can skip updating
-    if (!isinf(block_max)) {
-      float threadlocal_sum = 0.0f;
-#pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        threadlocal_sum += __expf(logits_vec[j] - block_max);
-      }
-      float new_max = max(running_max, block_max);
-      threadlocal_running_denominator =
-          threadlocal_running_denominator * __expf(running_max - new_max) +
-          threadlocal_sum * __expf(block_max - new_max);
-      running_max = new_max;
-    }
-  }
-
-  running_denominator = cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                            .Sum(threadlocal_running_denominator);
-  if (tx == 0) {
-    temp_storage.shared_state.denominator = running_denominator;
-  }
-  __syncthreads();
-  running_denominator = temp_storage.shared_state.denominator;
-
-  if (tx == 0) {
-    partial_results[bx * num_slices + by] = {running_max, running_denominator};
-  }
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
-#endif
-}
-
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
-                                          PartialSoftmaxResult* partial_results,
-                                          DType* temperature_arr, float temperature_val, uint32_t d,
-                                          uint32_t num_slices) {
-  const uint32_t bx = blockIdx.x;
-  const uint32_t tx = threadIdx.x;
-  float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
-  const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
-
-  // Reduce slice results
-  using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
-  extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
-  auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
-
-  const Float2SoftmaxReduceOp reduce_op;
-
-  float2 thread_aggregate = make_float2(-cuda::std::numeric_limits<float>::infinity(), 0.0f);
-
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.wait;");
-#endif
-
-  for (uint32_t i = tx; i < num_slices; i += BLOCK_THREADS) {
-    PartialSoftmaxResult partial = partial_results[bx * num_slices + i];
-    float2 partial_pair = make_float2(partial.max_val, partial.denominator);
-    thread_aggregate = reduce_op(thread_aggregate, partial_pair);
-  }
-
-  float2 block_result = cub::BlockReduce<float2, BLOCK_THREADS>(temp_storage.block_prim.reduce_pair)
-                            .Reduce(thread_aggregate, reduce_op);
-
-  if (tx == 0) {
-    temp_storage.shared_state.max_val = block_result.x;
-    temp_storage.shared_state.denominator = block_result.y;
-  }
-  __syncthreads();
-
-  block_result =
-      make_float2(temp_storage.shared_state.max_val, temp_storage.shared_state.denominator);
-
-  const float final_max = temp_storage.shared_state.max_val;
-  const float inv_denominator = 1.0f / temp_storage.shared_state.denominator;
-
-  // Apply normalization
-  vec_t<DType, VEC_SIZE> logits_vec;
-  vec_t<DType, VEC_SIZE> prob_vec;
-
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
-
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      logits_vec[j] *= inv_temp;
-      float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
-      prob_vec[j] = static_cast<DType>(p);
-    }
-
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-  }
-#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  asm volatile("griddepcontrol.launch_dependents;");
-#endif
-}
-
-template <uint32_t VEC_SIZE, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, bool DETERMINISTIC, typename Predicate>
-__device__ __forceinline__ void DeviceSamplingFromProb(
-    uint32_t i, uint32_t d, Predicate pred, float u, vec_t<float, VEC_SIZE> prob_vec,
-    float& aggregate,
-    SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
-  const uint32_t tx = threadIdx.x;
-  float prob_greater_than_threshold[VEC_SIZE];
-  float inclusive_cdf[VEC_SIZE];
-  bool greater_than_u[VEC_SIZE], valid[VEC_SIZE];
-#pragma unroll
-  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-    prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : 0;
-    valid[j] = pred(prob_vec[j]) && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
-  }
-  float aggregate_local =
-      BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
-          .template Sum<VEC_SIZE>(prob_greater_than_threshold);
-  if (tx == 0) {
-    temp_storage->block_aggregate.value = aggregate_local;
-  }
-  __syncthreads();
-  aggregate_local = temp_storage->block_aggregate.value;
-
-  if (aggregate + aggregate_local > u) {
-    if constexpr (DETERMINISTIC) {
-      DeterministicInclusiveSum<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>(
-          prob_greater_than_threshold, inclusive_cdf, temp_storage);
-    } else {
-      BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>(temp_storage->block_prim.scan)
-          .template InclusiveSum<VEC_SIZE>(prob_greater_than_threshold, inclusive_cdf);
-
-      __syncthreads();
-    }
-
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      greater_than_u[j] = (inclusive_cdf[j] + aggregate > u) && valid[j];
-    }
-
-    bool greater_than_u_diff[VEC_SIZE];
-#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
-    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
-        .SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
-#else
-    BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
-        .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
-#endif
-    __syncthreads();
-
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      if (greater_than_u_diff[j]) {
-        atomicMin(&(temp_storage->sampled_id), (i * BLOCK_THREADS + tx) * VEC_SIZE + j);
-      }
-    }
-    __syncthreads();
-  }
-
-  // update the last valid index
-  int valid_index[VEC_SIZE];
-#pragma unroll
-  for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-    if (valid[j]) {
-      valid_index[j] = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
-    } else {
-      valid_index[j] = -1;
-    }
-  }
-  int max_valid_index =
-      BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce_int)
-          .Reduce(valid_index, MaxReduceOp{});
-  if (tx == 0 && max_valid_index != -1 && max_valid_index < (int)d) {
-    temp_storage->last_valid_id = max_valid_index;
-  }
-  __syncthreads();
-  aggregate += aggregate_local;
-}
-
-template <typename DType, typename IdType>
-struct DataAndIndex {
-  DType data;
-  IdType index;
-
-  __device__ DataAndIndex operator+(const DataAndIndex& other) const {
-    if (data > other.data) {
-      return {data, index};
-    } else {
-      return {other.data, other.index};
-    }
-  }
-  __device__ DataAndIndex& operator+=(const DataAndIndex& other) {
-    if (data > other.data) {
-      return *this;
-    } else {
-      data = other.data;
-      index = other.index;
-      return *this;
-    }
-  }
-};
-
-template <typename DType, uint32_t VEC_SIZE>
-__device__ __forceinline__ vec_t<DType, VEC_SIZE> GenerateGumbelNoise(uint64_t philox_seed,
-                                                                      uint64_t philox_offset,
-                                                                      uint64_t subsequence) {
-  curandStatePhilox4_32_10_t state;
-  vec_t<float, VEC_SIZE> noise;
-  constexpr float kSCALE = 1.0f - cuda::std::numeric_limits<float>::epsilon();
-  constexpr float kLOG2 = 0.6931471806f;
-  auto uniform2gumbel = [](float x) {
-    // NB: cuRAND returns strictly positive normal floating point numbers, up to
-    //     and including 1.0. kSCALE is used to exclude 1.0, s.t.
-    //         1.18e-38 <= x * kSCALE <= 1.0f - epsilon
-    //      => -4.47    <= -log(-log(...))       <= 15.9
-    // log2f maps to a single PTX LG2 instruction on NVIDIA GPUs, while logf
-    // internally computes log2f * ln(2). Using log2f with a single kLOG2
-    // multiplication is more efficient (3 ops vs 4 ops).
-    return -kLOG2 * log2f(-log2f((x * kSCALE)));
-  };
-#pragma unroll
-  for (uint32_t i = 0; i + 4 <= VEC_SIZE; i += 4) {
-    curand_init(philox_seed, subsequence + i, philox_offset, &state);
-    float4 noise_vec = curand_uniform4(&state);
-    noise[i] = uniform2gumbel(noise_vec.x);
-    noise[i + 1] = uniform2gumbel(noise_vec.y);
-    noise[i + 2] = uniform2gumbel(noise_vec.z);
-    noise[i + 3] = uniform2gumbel(noise_vec.w);
-  }
-  if constexpr (VEC_SIZE % 4 != 0) {
-    curand_init(philox_seed, subsequence + VEC_SIZE / 4 * 4, philox_offset, &state);
-    float4 noise_vec = curand_uniform4(&state);
-    if constexpr (VEC_SIZE % 4 == 1) {
-      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.x);
-    } else if constexpr (VEC_SIZE % 4 == 2) {
-      noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.x);
-      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.y);
-    } else if constexpr (VEC_SIZE % 4 == 3) {
-      noise[VEC_SIZE - 3] = uniform2gumbel(noise_vec.x);
-      noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.y);
-      noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.z);
-    }
-  }
-
-  if constexpr (std::is_same_v<DType, float>) {
-    return noise;
-  } else {
-    vec_t<DType, VEC_SIZE> ret;
-#pragma unroll
-    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
-      ret[i] = static_cast<DType>(noise[i]);
-    }
-    return ret;
-  }
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* indices, uint32_t d,
-                                         uint64_t* seed_arr, uint64_t seed_val,
-                                         uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-  using SharedMem = typename BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS,
-                                         REDUCE_ALGORITHM>::TempStorage;
-  extern __shared__ __align__(alignof(SharedMem)) uint8_t smem_sampling_logit[];
-  auto& temp_storage = reinterpret_cast<SharedMem&>(smem_sampling_logit);
-
-  vec_t<DType, VEC_SIZE> logits_vec;
-  DataAndIndex<DType, IdType> max_data = {-cuda::std::numeric_limits<DType>::infinity(), 0};
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      logits_vec.cast_load(logits + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-    }
-
-    vec_t<DType, VEC_SIZE> gumbel_noise = GenerateGumbelNoise<DType, VEC_SIZE>(
-        philox_seed, philox_offset,
-        static_cast<uint64_t>(bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE));
-    DataAndIndex<DType, IdType> cur_data[VEC_SIZE];
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      cur_data[j].data = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d
-                             ? logits_vec[j] + gumbel_noise[j]
-                             : -cuda::std::numeric_limits<DType>::infinity();
-      cur_data[j].index = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
-    }
-
-    max_data +=
-        BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage)
-            .template Sum<VEC_SIZE>(cur_data);
-  }
-  if (tx == 0) {
-    output[bx] = max_data.index;
-  }
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void SamplingFromProbKernel(DType* probs, IdType* output, bool* valid, IdType* indices,
-                                       uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                       uint64_t* offset_arr, uint64_t offset_val) {
-  curandStatePhilox4_32_10_t state;
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  curand_init(philox_seed, bx, philox_offset, &state);
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-  temp_storage.sampled_id = d;
-  temp_storage.last_valid_id = -1;
-  __syncthreads();
-
-  vec_t<float, VEC_SIZE> probs_vec;
-  float aggregate(0);
-  float u = curand_uniform(&state);
-
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    probs_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-    }
-
-    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                           DETERMINISTIC>(
-        i, d, [](float x) { return x > 0; }, u, probs_vec, aggregate, &temp_storage);
-    if (float(aggregate) > u) {
-      break;
-    }
-  }
-  int sampled_id = temp_storage.sampled_id;
-  if (sampled_id == d) {
-    // NOTE(Zihao): this would happen when u is very close to 1
-    // and the sum of probabilities is smaller than u
-    // In this case, we use the last valid index as the sampled id
-    if (temp_storage.last_valid_id == -1) {
-      if (tx == 0) {
-        output[bx] = 0;
-        valid[bx] = false;
-      }
-      return;
-    }
-    sampled_id = temp_storage.last_valid_id;
-  }
-  if (tx == 0) {
-    output[bx] = sampled_id;
-    valid[bx] = true;
-  }
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void TopKSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
-                                           IdType* indices, IdType* top_k_arr, uint32_t top_k_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t batch_size = gridDim.x;
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  curandStatePhilox4_32_10_t state;
-  curand_init(philox_seed, bx, philox_offset, &state);
-  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[bx];
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-
-  vec_t<float, VEC_SIZE> probs_vec;
-  float aggregate;
-  float q = 1;
-  float low = 0, high = 1.f;
-  int sampled_id;
-  int round = 0;
-  do {
-    round += 1;
-    temp_storage.sampled_id = d;
-    temp_storage.last_valid_id = -1;
-    __syncthreads();
-    float u = curand_uniform(&state) * q;
-    aggregate = 0;
-#pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                             DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
-      if (aggregate > u) {
-        break;
-      }
-    }
-    __syncthreads();
-    sampled_id = temp_storage.sampled_id;
-    if (sampled_id == d) {
-      // NOTE(Zihao): this would happen when u is very close to 1
-      // and the sum of probabilities is smaller than u
-      // In this case, we use the last valid index as the sampled id
-      if (temp_storage.last_valid_id == -1) {
-        if (tx == 0) {
-          output[bx] = 0;
-          valid[bx] = false;
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
         }
+    }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template<uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
+__global__ void OnlineSoftmaxMapKernel(DType*                logits,
+                                       PartialSoftmaxResult* partial_results,
+                                       DType*                temperature_arr,
+                                       float                 temperature_val,
+                                       uint32_t              d,
+                                       uint32_t              num_slices) {
+    const uint32_t bx          = blockIdx.x;
+    const uint32_t by          = blockIdx.y;  // slice index
+    const uint32_t tx          = threadIdx.x;
+    float          temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+    const float    inv_temp    = (temperature == 0.f) ? 0.f : 1.f / temperature;
+
+    const uint32_t vec_alignment_elems = alignof(vec_t<DType, VEC_SIZE>) / sizeof(DType);
+    const uint32_t slice_stride        = round_up(ceil_div(d, num_slices), vec_alignment_elems);
+    const uint32_t slice_start         = by * slice_stride;
+    const uint32_t slice_size          = min((by + 1) * slice_stride, d) - slice_start;
+
+    if (slice_start >= d)
         return;
-      }
-      sampled_id = temp_storage.last_valid_id;
-    }
-    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
-    float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
-    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
-    ValueCount<float> threadlocal_gt_pivot_0{0, 0}, threadlocal_gt_pivot_1{0, 0};
+    using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+    extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+    auto&                                                     temp_storage = reinterpret_cast<TempStorage&>(smem);
+
+    vec_t<DType, VEC_SIZE> logits_vec;
+    float                  running_max                     = -cuda::std::numeric_limits<float>::infinity();
+    float                  running_denominator             = 0.0f;
+    float                  threadlocal_running_denominator = 0.0f;
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
+
 #pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
+    for (uint32_t i = 0; i < ceil_div(slice_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
 
-      ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
-#pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = {
-            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        probs_gt_pivot_1[j] = {
-            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        threadlocal_gt_pivot_0 += probs_gt_pivot_0[j];
-        threadlocal_gt_pivot_1 += probs_gt_pivot_1[j];
-      }
-    }
-    aggregate_gt_pivot_0 += BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(
-                                temp_storage.block_prim.reduce_value_count)
-                                .Sum(threadlocal_gt_pivot_0);
-    if (tx == 0) {
-      temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
-
-    aggregate_gt_pivot_1 += BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(
-                                temp_storage.block_prim.reduce_value_count)
-                                .Sum(threadlocal_gt_pivot_1);
-    if (tx == 0) {
-      temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
-    if (aggregate_gt_pivot_0.count < k) {
-      // case 1: pivot_0 accepted
-      break;
-    }
-    if (aggregate_gt_pivot_1.count < k) {
-      // case 2: pivot_0 rejected, pivot_1 accepted
-      low = pivot_0;
-      high = pivot_1;
-      q = aggregate_gt_pivot_0.value;
-    } else {
-      // case 3: pivot_0 rejected, pivot_1 rejected
-      low = pivot_1;
-      q = aggregate_gt_pivot_1.value;
-    }
-  } while (low < high);
-  __syncthreads();
-  if (tx == 0) {
-    output[bx] = sampled_id;
-    valid[bx] = true;
-  }
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void TopPSamplingFromProbKernel(DType* probs, IdType* output, bool* valid,
-                                           IdType* indices, float* top_p_arr, float top_p_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t batch_size = gridDim.x;
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  curandStatePhilox4_32_10_t state;
-  curand_init(philox_seed, bx, philox_offset, &state);
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-  float top_p = (top_p_arr == nullptr) ? top_p_val : top_p_arr[row_idx];
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-
-  vec_t<float, VEC_SIZE> probs_vec;
-  float aggregate;
-  float q = 1;
-  float low = 0, high = 1.f;
-  int sampled_id;
-  do {
-    temp_storage.sampled_id = d;
-    temp_storage.last_valid_id = -1;
-    __syncthreads();
-    float u = curand_uniform(&state) * q;
-    aggregate = 0;
-#pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                             DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
-      if (aggregate > u) {
-        break;
-      }
-    }
-    __syncthreads();
-    sampled_id = temp_storage.sampled_id;
-    if (sampled_id == d) {
-      // NOTE(Zihao): this would happen when u is very close to 1
-      // and the sum of probabilities is smaller than u
-      // In this case, we use the last valid index as the sampled id
-      if (temp_storage.last_valid_id == -1) {
-        if (tx == 0) {
-          output[bx] = 0;
-          valid[bx] = false;
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < slice_size) {
+            logits_vec.cast_load(logits + bx * d + slice_start + (i * BLOCK_THREADS + tx) * VEC_SIZE);
         }
-        return;
-      }
-      sampled_id = temp_storage.last_valid_id;
-    }
-    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
-    float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
-    float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
-    float threadlocal_aggregate_gt_pivot_0 = 0;
-    float threadlocal_aggregate_gt_pivot_1 = 0;
-#pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+        float thread_max = -cuda::std::numeric_limits<float>::infinity();
 #pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
-        probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
-        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
-        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
-      }
-    }
-    aggregate_gt_pivot_0 += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                                .Sum(threadlocal_aggregate_gt_pivot_0);
-    if (tx == 0) {
-      temp_storage.block_aggregate.value = aggregate_gt_pivot_0;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_0 = temp_storage.block_aggregate.value;
-
-    aggregate_gt_pivot_1 += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                                .Sum(threadlocal_aggregate_gt_pivot_1);
-    if (tx == 0) {
-      temp_storage.block_aggregate.value = aggregate_gt_pivot_1;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_1 = temp_storage.block_aggregate.value;
-
-    if (aggregate_gt_pivot_0 < top_p) {
-      // case 1: pivot_0 accepted
-      break;
-    }
-    if (aggregate_gt_pivot_1 < top_p) {
-      // case 2: pivot_0 rejected, pivot_1 accepted
-      low = pivot_0;
-      high = pivot_1;
-      q = aggregate_gt_pivot_0;
-    } else {
-      // case 3: pivot_0 rejected, pivot_1 rejected
-      low = pivot_1;
-      q = aggregate_gt_pivot_1;
-    }
-  } while (low < high);
-  __syncthreads();
-  if (tx == 0) {
-    output[bx] = sampled_id;
-    valid[bx] = true;
-  }
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void MinPSamplingFromProbKernel(DType* probs, float* min_p_arr, IdType* output,
-                                           bool* valid, IdType* indices, float min_p_val,
-                                           uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-                                           uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  float p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
-  curandStatePhilox4_32_10_t state;
-  curand_init(philox_seed, bx, philox_offset, &state);
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-
-  float max_val = GetMaxValue<VEC_SIZE, BLOCK_THREADS, REDUCE_ALGORITHM,
-                              SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>>(
-      probs, row_idx, d, temp_storage);
-  float pivot = max_val * p;
-
-  vec_t<float, VEC_SIZE> probs_vec;
-  float aggregate_gt_pivot = 0;
-  float threadlocal_aggregate_gt_pivot = 0;
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    probs_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-
-    float probs_gt_pivot[VEC_SIZE];
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      probs_gt_pivot[j] = (probs_vec[j] >= pivot) ? probs_vec[j] : 0;
-      threadlocal_aggregate_gt_pivot += probs_gt_pivot[j];
-    }
-  }
-
-  aggregate_gt_pivot += BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce)
-                            .Sum(threadlocal_aggregate_gt_pivot);
-  if (tx == 0) {
-    temp_storage.block_aggregate.value = aggregate_gt_pivot;
-  }
-  __syncthreads();
-
-  float aggregate = 0;
-  float q = temp_storage.block_aggregate.value;
-
-  int sampled_id;
-  temp_storage.sampled_id = d;
-  temp_storage.last_valid_id = -1;
-  __syncthreads();
-  float u = curand_uniform(&state) * q;
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    probs_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-    }
-
-    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                           DETERMINISTIC>(
-        i, d, [&](float x) { return x >= pivot; }, u, probs_vec, aggregate, &temp_storage);
-    if (aggregate > u) {
-      break;
-    }
-  }
-  sampled_id = temp_storage.sampled_id;
-  if (sampled_id == d) {
-    // NOTE(Zihao): this would happen when u is very close to 1
-    // and the sum of probabilities is smaller than u
-    // In this case, we use the last valid index as the sampled id
-    if (temp_storage.last_valid_id == -1) {
-      if (tx == 0) {
-        output[bx] = 0;
-        valid[bx] = false;
-      }
-      return;
-    }
-    sampled_id = temp_storage.last_valid_id;
-  }
-  output[bx] = sampled_id;
-  valid[bx] = true;
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, float* top_p_arr,
-                                               IdType* output, bool* valid, IdType* indices,
-                                               IdType top_k_val, float top_p_val, uint32_t d,
-                                               uint64_t* seed_arr, uint64_t seed_val,
-                                               uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t batch_size = gridDim.x;
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  curandStatePhilox4_32_10_t state;
-  curand_init(philox_seed, bx, philox_offset, &state);
-  const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
-  const uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
-  const float p = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-
-  vec_t<float, VEC_SIZE> probs_vec;
-  float aggregate;
-  float q = 1;
-  float low = 0, high = 1.f;
-  int sampled_id;
-  do {
-    temp_storage.sampled_id = d;
-    temp_storage.last_valid_id = -1;
-    __syncthreads();
-    float u = curand_uniform(&state) * q;
-    aggregate = 0;
-#pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
-
-      DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                             DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
-      if (aggregate > u) {
-        break;
-      }
-    }
-    __syncthreads();
-    sampled_id = temp_storage.sampled_id;
-    if (sampled_id == d) {
-      // NOTE(Zihao): this would happen when u is very close to 1
-      // and the sum of probabilities is smaller than u
-      // In this case, we use the last valid index as the sampled id
-      sampled_id = temp_storage.last_valid_id;
-      if (temp_storage.last_valid_id == -1) {
-        if (tx == 0) {
-          output[bx] = 0;
-          valid[bx] = false;
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            logits_vec[j] *= inv_temp;
+            thread_max = max(thread_max, logits_vec[j]);
         }
-        return;
-      }
-    }
-    // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
-    float pivot_0 = probs[row_idx * d + sampled_id];
-    float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
 
-    ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
-    ValueCount<float> threadlocal_aggregate_gt_pivot_0{0, 0};
-    ValueCount<float> threadlocal_aggregate_gt_pivot_1{0, 0};
-#pragma unroll 2
-    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
-      }
+        float block_max =
+            cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Reduce(thread_max, MaxReduceOp{});
 
-      ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+        if (tx == 0) {
+            temp_storage.shared_state.max_val = block_max;
+        }
+        __syncthreads();
+        block_max = temp_storage.shared_state.max_val;
+
+        // if block_max is -inf, then this block contains all -inf values, so we can skip updating
+        if (!isinf(block_max)) {
+            float threadlocal_sum = 0.0f;
 #pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = {
-            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        probs_gt_pivot_1[j] = {
-            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
-        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
-      }
-    }
-    aggregate_gt_pivot_0 +=
-        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
-            .Sum(threadlocal_aggregate_gt_pivot_0);
-    if (tx == 0) {
-      temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
-
-    aggregate_gt_pivot_1 +=
-        BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
-            .Sum(threadlocal_aggregate_gt_pivot_1);
-    if (tx == 0) {
-      temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
-    }
-    __syncthreads();
-    aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
-    if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
-      // case 1: pivot_0 accepted
-      break;
-    }
-    if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
-      // case 2: pivot_0 rejected, pivot_1 accepted
-      low = pivot_0;
-      high = pivot_1;
-      q = aggregate_gt_pivot_0.value;
-    } else {
-      // case 3: pivot_0 rejected, pivot_1 rejected
-      low = pivot_1;
-      q = aggregate_gt_pivot_1.value;
-    }
-  } while (low < high);
-  __syncthreads();
-  if (tx == 0) {
-    output[bx] = sampled_id;
-    valid[bx] = true;
-  }
-}
-
-template <typename DType>
-cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uint32_t d,
-                          DType* temperature_arr, DType temperature_val, void* workspace_buffer,
-                          size_t workspace_buffer_size_in_bytes, bool enable_pdl,
-                          cudaStream_t stream = 0) {
-  constexpr uint32_t SMALL_BATCH_THRESHOLD = 128;
-  constexpr uint32_t LARGE_VOCAB_THRESHOLD = 24576;
-  constexpr uint32_t DEFAULT_SLICE_SIZE = 8192;
-
-  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
-  auto compute_capacity = GetCudaComputeCapability();
-
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(
-      compute_capacity, BLOCK_THREADS, {DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
-        if (batch_size <= SMALL_BATCH_THRESHOLD && d >= LARGE_VOCAB_THRESHOLD) {
-          // Path A: Vocab-Splitting Strategy for small-batch & large-vocab
-          uint32_t num_slices = ceil_div(d, DEFAULT_SLICE_SIZE);
-
-          const size_t partial_buffer_size = batch_size * num_slices * sizeof(PartialSoftmaxResult);
-          if (workspace_buffer_size_in_bytes < partial_buffer_size) {
-            return cudaErrorInvalidValue;
-          }
-
-          AlignedAllocator allocator(workspace_buffer, workspace_buffer_size_in_bytes);
-          auto partial_results = allocator.aligned_alloc<PartialSoftmaxResult>(
-              partial_buffer_size, alignof(PartialSoftmaxResult), "softmax_workspace");
-
-          // Phase 1: Map-Reduce across vocab slices
-          dim3 phase1_nblks(batch_size, num_slices);
-          dim3 phase1_nthrs(BLOCK_THREADS);
-          size_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>);
-
-          auto phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DType>;
-          void* phase1_args[] = {&logits, &partial_results, &temperature_arr, &temperature_val,
-                                 &d,      &num_slices};
-
-          FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
-              phase1_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-
-          if (enable_pdl) {
-            cudaLaunchAttribute attribute[1];
-            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-            attribute[0].val.programmaticStreamSerializationAllowed = 1;
-
-            cudaLaunchConfig_t config;
-            config.gridDim = phase1_nblks;
-            config.blockDim = phase1_nthrs;
-            config.dynamicSmemBytes = smem_size;
-            config.stream = stream;
-            config.attrs = attribute;
-            config.numAttrs = 1;
-
-            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase1_kernel, logits, partial_results,
-                                                    temperature_arr, temperature_val, d,
-                                                    num_slices));
-          } else {
-            FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase1_kernel, phase1_nblks, phase1_nthrs,
-                                                  phase1_args, smem_size, stream));
-          }
-
-          // Phase 2: Final reduction and apply normalization
-          dim3 phase2_nblks(batch_size);
-          dim3 phase2_nthrs(BLOCK_THREADS);
-
-          auto phase2_kernel = OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DType>;
-          void* phase2_args[] = {&logits,          &output, &partial_results, &temperature_arr,
-                                 &temperature_val, &d,      &num_slices};
-
-          FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
-              phase2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-
-          if (enable_pdl) {
-            cudaLaunchAttribute attribute[1];
-            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-            attribute[0].val.programmaticStreamSerializationAllowed = 1;
-
-            cudaLaunchConfig_t config;
-            config.gridDim = phase2_nblks;
-            config.blockDim = phase2_nthrs;
-            config.dynamicSmemBytes = smem_size;
-            config.stream = stream;
-            config.attrs = attribute;
-            config.numAttrs = 1;
-
-            FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, phase2_kernel, logits, output,
-                                                    partial_results, temperature_arr,
-                                                    temperature_val, d, num_slices));
-          } else {
-            FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)phase2_kernel, phase2_nblks, phase2_nthrs,
-                                                  phase2_args, smem_size, stream));
-          }
-        } else {
-          // Path B: Single-Block Strategy
-          // Switch input cache
-          uint32_t cache_threshold;
-          if (batch_size <= 16) {
-            cache_threshold = 4096;
-          } else if (batch_size <= 32) {
-            cache_threshold = 2048;
-          } else {
-            cache_threshold = 0;
-          }
-          const bool cache_input = d <= cache_threshold;
-
-          dim3 nblks(batch_size);
-          dim3 nthrs(BLOCK_THREADS);
-          void* args[] = {&logits, &output, &temperature_arr, &temperature_val, &d};
-
-          const size_t smem_logits_bytes = (round_up(d, VEC_SIZE) + VEC_SIZE) * sizeof(DType);
-
-          uint32_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>) +
-                               (cache_input ? smem_logits_bytes : 0);
-
-          DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, {
-            auto kernel = OnlineSoftmaxFusedKernel<BLOCK_THREADS, VEC_SIZE, DType, CACHE_INPUT>;
-            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
-                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-
-            if (enable_pdl) {
-              cudaLaunchAttribute attribute[1];
-              attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-              attribute[0].val.programmaticStreamSerializationAllowed = 1;
-
-              cudaLaunchConfig_t config;
-              config.gridDim = nblks;
-              config.blockDim = nthrs;
-              config.dynamicSmemBytes = smem_size;
-              config.stream = stream;
-              config.attrs = attribute;
-              config.numAttrs = 1;
-
-              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, logits, output,
-                                                      temperature_arr, temperature_val, d));
-            } else {
-              FLASHINFER_CUDA_CALL(
-                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                threadlocal_sum += __expf(logits_vec[j] - block_max);
             }
-          });
+            float new_max                   = max(running_max, block_max);
+            threadlocal_running_denominator = threadlocal_running_denominator * __expf(running_max - new_max)
+                                              + threadlocal_sum * __expf(block_max - new_max);
+            running_max = new_max;
         }
-      })});
-  return cudaSuccess;
+    }
+
+    running_denominator =
+        cub::BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Sum(threadlocal_running_denominator);
+    if (tx == 0) {
+        temp_storage.shared_state.denominator = running_denominator;
+    }
+    __syncthreads();
+    running_denominator = temp_storage.shared_state.denominator;
+
+    if (tx == 0) {
+        partial_results[bx * num_slices + by] = {running_max, running_denominator};
+    }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
 }
 
-template <typename T, typename IdType>
-cudaError_t SamplingFromLogits(T* logits, IdType* output, IdType* indices, uint32_t batch_size,
-                               uint32_t d, bool deterministic, uint64_t* seed_arr,
-                               uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val,
-                               cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+template<uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
+__global__ void OnlineSoftmaxReduceKernel(DType*                logits,
+                                          DType*                output,
+                                          PartialSoftmaxResult* partial_results,
+                                          DType*                temperature_arr,
+                                          float                 temperature_val,
+                                          uint32_t              d,
+                                          uint32_t              num_slices) {
+    const uint32_t bx          = blockIdx.x;
+    const uint32_t tx          = threadIdx.x;
+    float          temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
+    const float    inv_temp    = (temperature == 0.f) ? 0.f : 1.f / temperature;
 
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&logits, &output, &indices, &d, &seed_arr, &seed_val, &offset_arr, &offset_val};
-    const uint32_t smem_size = sizeof(
-        typename BlockReduce<DataAndIndex<T, IdType>, BLOCK_THREADS, REDUCE_ALGO>::TempStorage);
+    // Reduce slice results
+    using TempStorage = OnlineSoftmaxTempStorage<BLOCK_THREADS>;
+    extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
+    auto&                                                     temp_storage = reinterpret_cast<TempStorage&>(smem);
 
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = SamplingFromLogitsKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                                 DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
+    const Float2SoftmaxReduceOp reduce_op;
+
+    float2 thread_aggregate = make_float2(-cuda::std::numeric_limits<float>::infinity(), 0.0f);
+
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    for (uint32_t i = tx; i < num_slices; i += BLOCK_THREADS) {
+        PartialSoftmaxResult partial      = partial_results[bx * num_slices + i];
+        float2               partial_pair = make_float2(partial.max_val, partial.denominator);
+        thread_aggregate                  = reduce_op(thread_aggregate, partial_pair);
+    }
+
+    float2 block_result = cub::BlockReduce<float2, BLOCK_THREADS>(temp_storage.block_prim.reduce_pair)
+                              .Reduce(thread_aggregate, reduce_op);
+
+    if (tx == 0) {
+        temp_storage.shared_state.max_val     = block_result.x;
+        temp_storage.shared_state.denominator = block_result.y;
+    }
+    __syncthreads();
+
+    block_result = make_float2(temp_storage.shared_state.max_val, temp_storage.shared_state.denominator);
+
+    const float final_max       = temp_storage.shared_state.max_val;
+    const float inv_denominator = 1.0f / temp_storage.shared_state.denominator;
+
+    // Apply normalization
+    vec_t<DType, VEC_SIZE> logits_vec;
+    vec_t<DType, VEC_SIZE> prob_vec;
+
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            logits_vec[j] *= inv_temp;
+            float p     = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
+            prob_vec[j] = static_cast<DType>(p);
+        }
+
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            prob_vec.cast_store(output + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+    }
+#if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
 }
 
-template <typename T, typename IdType>
-cudaError_t SamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
-                             uint32_t batch_size, uint32_t d, bool deterministic,
-                             uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-                             uint64_t offset_val, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+template<uint32_t             VEC_SIZE,
+         uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         bool                 DETERMINISTIC,
+         typename Predicate>
+__device__ __forceinline__ void
+DeviceSamplingFromProb(uint32_t                                                              i,
+                       uint32_t                                                              d,
+                       Predicate                                                             pred,
+                       float                                                                 u,
+                       vec_t<float, VEC_SIZE>                                                prob_vec,
+                       float&                                                                aggregate,
+                       SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+    const uint32_t tx = threadIdx.x;
+    float          prob_greater_than_threshold[VEC_SIZE];
+    float          inclusive_cdf[VEC_SIZE];
+    bool           greater_than_u[VEC_SIZE], valid[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : 0;
+        valid[j]                       = pred(prob_vec[j]) && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
+    }
+    float aggregate_local = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
+                                .template Sum<VEC_SIZE>(prob_greater_than_threshold);
+    if (tx == 0) {
+        temp_storage->block_aggregate.value = aggregate_local;
+    }
+    __syncthreads();
+    aggregate_local = temp_storage->block_aggregate.value;
 
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs,    &output,   &valid,      &indices,   &d,
-                    &seed_arr, &seed_val, &offset_arr, &offset_val};
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    if (aggregate + aggregate_local > u) {
+        if constexpr (DETERMINISTIC) {
+            DeterministicInclusiveSum<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>(
+                prob_greater_than_threshold, inclusive_cdf, temp_storage);
+        } else {
+            BlockScan<float, BLOCK_THREADS, SCAN_ALGORITHM>(temp_storage->block_prim.scan)
+                .template InclusiveSum<VEC_SIZE>(prob_greater_than_threshold, inclusive_cdf);
 
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = SamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                               DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
+            __syncthreads();
+        }
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            greater_than_u[j] = (inclusive_cdf[j] + aggregate > u) && valid[j];
+        }
+
+        bool greater_than_u_diff[VEC_SIZE];
+#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+        BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+            .SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
+#else
+        BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+            .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
+#endif
+        __syncthreads();
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            if (greater_than_u_diff[j]) {
+                atomicMin(&(temp_storage->sampled_id), (i * BLOCK_THREADS + tx) * VEC_SIZE + j);
+            }
+        }
+        __syncthreads();
+    }
+
+    // update the last valid index
+    int valid_index[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        if (valid[j]) {
+            valid_index[j] = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+        } else {
+            valid_index[j] = -1;
+        }
+    }
+    int max_valid_index = BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce_int)
+                              .Reduce(valid_index, MaxReduceOp{});
+    if (tx == 0 && max_valid_index != -1 && max_valid_index < (int)d) {
+        temp_storage->last_valid_id = max_valid_index;
+    }
+    __syncthreads();
+    aggregate += aggregate_local;
 }
 
-template <typename T, typename IdType>
-cudaError_t TopKSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
-                                 T* top_k_arr, uint32_t batch_size, uint32_t top_k_val, uint32_t d,
-                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
-                                 uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+template<typename DType, typename IdType>
+struct DataAndIndex {
+    DType  data;
+    IdType index;
 
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &output,   &valid,    &indices,    &top_k_arr, &top_k_val,
-                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
-
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = TopKSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                                   DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
-}
-
-template <typename T, typename IdType>
-cudaError_t TopPSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
-                                 T* top_p_arr, uint32_t batch_size, T top_p_val, uint32_t d,
-                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
-                                 uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
-
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &output,   &valid,    &indices,    &top_p_arr, &top_p_val,
-                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
-
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = TopPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                                   DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
-}
-
-template <typename T, typename IdType>
-cudaError_t MinPSamplingFromProb(T* probs, T* min_p_arr, IdType* output, bool* valid,
-                                 IdType* indices, uint32_t batch_size, float min_p_val, uint32_t d,
-                                 bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
-                                 uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
-
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &min_p_arr, &output,   &valid,      &indices,   &min_p_val,
-                    &d,     &seed_arr,  &seed_val, &offset_arr, &offset_val};
-
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = MinPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                                   DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
-}
-
-template <typename T, typename IdType>
-cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, IdType* output,
-                                     bool* valid, IdType* indices, uint32_t batch_size,
-                                     IdType top_k_val, T top_p_val, uint32_t d, bool deterministic,
-                                     uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-                                     uint64_t offset_val, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
-
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs,    &top_k_arr,  &top_p_arr, &output, &valid,
-                    &indices,  &top_k_val,  &top_p_val, &d,      &seed_arr,
-                    &seed_val, &offset_arr, &offset_val};
-
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = TopKTopPSamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO,
-                                                       VEC_SIZE, DETERMINISTIC, T, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        })});
-    return cudaSuccess;
-  });
-}
-
-template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM>
-struct RenormTempStorage {
-  union {
-    typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce;
-    typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_int;
-    typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage
-        reduce_value_count;
-  } block_prim;
-  struct {
-    float max_val;
-    float min_val;
-    float row_sum;
-    union {
-      struct {
-        float values[2];
-      };
-      struct {
-        int counts[2];
-      };
-      struct {
-        ValueCount<float> pairs[2];
-      };
-    } block_aggregate;
-  };
+    __device__ DataAndIndex operator+(const DataAndIndex& other) const {
+        if (data > other.data) {
+            return {data, index};
+        } else {
+            return {other.data, other.index};
+        }
+    }
+    __device__ DataAndIndex& operator+=(const DataAndIndex& other) {
+        if (data > other.data) {
+            return *this;
+        } else {
+            data  = other.data;
+            index = other.index;
+            return *this;
+        }
+    }
 };
 
-template <uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE,
-          typename DType>
-__global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* top_p_arr,
-                                     float top_p_val, uint32_t d) {
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-  const uint32_t row_idx = bx;
-  float p = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
-
-  extern __shared__ __align__(alignof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>))
-      uint8_t smem_renorm[];
-  auto& temp_storage =
-      reinterpret_cast<RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>&>(smem_renorm);
-  vec_t<float, VEC_SIZE> probs_vec;
-
-  // Fast-path: when p >= 1.0 (e.g., p == 1.0), perform simple sum and normalization
-  if (p >= 1.0f) {
-    // Stage A: per-thread float accumulation over assigned lanes (vectorized)
-    float thread_sum = 0.0f;
-    const uint32_t num_iters = ceil_div(d, BLOCK_THREADS * VEC_SIZE);
-    for (uint32_t i = 0; i < num_iters; ++i) {
-      probs_vec.fill(0.0f);
-      const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
-      if (base_idx < d) {
-        probs_vec.cast_load(probs + row_idx * d + base_idx);
-      }
+template<typename DType, uint32_t VEC_SIZE>
+__device__ __forceinline__ vec_t<DType, VEC_SIZE>
+                           GenerateGumbelNoise(uint64_t philox_seed, uint64_t philox_offset, uint64_t subsequence) {
+    curandStatePhilox4_32_10_t state;
+    vec_t<float, VEC_SIZE>     noise;
+    constexpr float            kSCALE = 1.0f - cuda::std::numeric_limits<float>::epsilon();
+    constexpr float            kLOG2  = 0.6931471806f;
+    auto                       uniform2gumbel = [](float x) {
+        // NB: cuRAND returns strictly positive normal floating point numbers, up to
+        //     and including 1.0. kSCALE is used to exclude 1.0, s.t.
+        //         1.18e-38 <= x * kSCALE <= 1.0f - epsilon
+        //      => -4.47    <= -log(-log(...))       <= 15.9
+        // log2f maps to a single PTX LG2 instruction on NVIDIA GPUs, while logf
+        // internally computes log2f * ln(2). Using log2f with a single kLOG2
+        // multiplication is more efficient (3 ops vs 4 ops).
+        return -kLOG2 * log2f(-log2f((x * kSCALE)));
+    };
 #pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        const uint32_t idx = base_idx + j;
-        if (idx < d) thread_sum += probs_vec[j];
-      }
+    for (uint32_t i = 0; i + 4 <= VEC_SIZE; i += 4) {
+        curand_init(philox_seed, subsequence + i, philox_offset, &state);
+        float4 noise_vec = curand_uniform4(&state);
+        noise[i]         = uniform2gumbel(noise_vec.x);
+        noise[i + 1]     = uniform2gumbel(noise_vec.y);
+        noise[i + 2]     = uniform2gumbel(noise_vec.z);
+        noise[i + 3]     = uniform2gumbel(noise_vec.w);
+    }
+    if constexpr (VEC_SIZE % 4 != 0) {
+        curand_init(philox_seed, subsequence + VEC_SIZE / 4 * 4, philox_offset, &state);
+        float4 noise_vec = curand_uniform4(&state);
+        if constexpr (VEC_SIZE % 4 == 1) {
+            noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.x);
+        } else if constexpr (VEC_SIZE % 4 == 2) {
+            noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.x);
+            noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.y);
+        } else if constexpr (VEC_SIZE % 4 == 3) {
+            noise[VEC_SIZE - 3] = uniform2gumbel(noise_vec.x);
+            noise[VEC_SIZE - 2] = uniform2gumbel(noise_vec.y);
+            noise[VEC_SIZE - 1] = uniform2gumbel(noise_vec.z);
+        }
     }
 
-    // Block reduce (float)
-    float row_sum =
-        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Sum(thread_sum);
-    // Broadcast via shared
-    if (tx == 0) temp_storage.row_sum = row_sum;
+    if constexpr (std::is_same_v<DType, float>) {
+        return noise;
+    } else {
+        vec_t<DType, VEC_SIZE> ret;
+#pragma unroll
+        for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+            ret[i] = static_cast<DType>(noise[i]);
+        }
+        return ret;
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void SamplingFromLogitsKernel(DType*    logits,
+                                         IdType*   output,
+                                         IdType*   indices,
+                                         uint32_t  d,
+                                         uint64_t* seed_arr,
+                                         uint64_t  seed_val,
+                                         uint64_t* offset_arr,
+                                         uint64_t  offset_val) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+    using SharedMem = typename BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage;
+    extern __shared__ __align__(alignof(SharedMem)) uint8_t smem_sampling_logit[];
+    auto& temp_storage = reinterpret_cast<SharedMem&>(smem_sampling_logit);
+
+    vec_t<DType, VEC_SIZE>      logits_vec;
+    DataAndIndex<DType, IdType> max_data = {-cuda::std::numeric_limits<DType>::infinity(), 0};
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            logits_vec.cast_load(logits + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+        }
+
+        vec_t<DType, VEC_SIZE> gumbel_noise = GenerateGumbelNoise<DType, VEC_SIZE>(
+            philox_seed, philox_offset, static_cast<uint64_t>(bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE));
+        DataAndIndex<DType, IdType> cur_data[VEC_SIZE];
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            cur_data[j].data  = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d ?
+                                    logits_vec[j] + gumbel_noise[j] :
+                                    -cuda::std::numeric_limits<DType>::infinity();
+            cur_data[j].index = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+        }
+
+        max_data += BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage)
+                        .template Sum<VEC_SIZE>(cur_data);
+    }
+    if (tx == 0) {
+        output[bx] = max_data.index;
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void SamplingFromProbKernel(DType*    probs,
+                                       IdType*   output,
+                                       bool*     valid,
+                                       IdType*   indices,
+                                       uint32_t  d,
+                                       uint64_t* seed_arr,
+                                       uint64_t  seed_val,
+                                       uint64_t* offset_arr,
+                                       uint64_t  offset_val) {
+    curandStatePhilox4_32_10_t state;
+    const uint32_t             bx = blockIdx.x, tx = threadIdx.x;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    curand_init(philox_seed, bx, philox_offset, &state);
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+    temp_storage.sampled_id    = d;
+    temp_storage.last_valid_id = -1;
     __syncthreads();
-    row_sum = temp_storage.row_sum;
 
-    // Guard against zero sum
-    const float denom = (row_sum <= 1e-8f) ? 1.0f : row_sum;
-    const float normalizer = math::ptx_rcp(denom);
+    vec_t<float, VEC_SIZE> probs_vec;
+    float                  aggregate(0);
+    float                  u = curand_uniform(&state);
 
-    // Stage B: normalize and store
-    for (uint32_t i = 0; i < num_iters; ++i) {
-      probs_vec.fill(0.0f);
-      const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
-      if (base_idx < d) {
-        probs_vec.cast_load(probs + row_idx * d + base_idx);
-      }
-#pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        const uint32_t idx = base_idx + j;
-        float v = probs_vec[j];
-        probs_vec[j] = (idx < d) ? (v * normalizer) : 0.0f;
-      }
-      if (base_idx < d) {
-        probs_vec.cast_store(renormed_prob + row_idx * d + base_idx);
-      }
-    }
-    return;  // Exit after fast-path processing
-  }
-
-  // Original Top-P renormalization logic
-  temp_storage.max_val = 0;
-  float max_val = GetMaxValue<VEC_SIZE, BLOCK_THREADS, REDUCE_ALGORITHM,
-                              RenormTempStorage<BLOCK_THREADS, REDUCE_ALGORITHM>>(probs, row_idx, d,
-                                                                                  temp_storage);
-
-  float low = 0, high = max_val;
-  float min_gt_low, max_le_high;
-  float sum_low = 1;
-  // f(x) = sum(probs[probs > x]), f(x) is non-increasing
-  // min_gt_low = min{p \in probs | p > low}, max_le_high = max{p \in probs | p <= high}
-  // loop invariant:
-  // - f(low) >= p, f(high) < p
-  // - f(low) > f(min_gt_low) >= f(max_le_high) == f(high)
-  // stopping condition
-  // - f(low) >= p, f(min_gt_low) == f(max_le_high) == f(high) < p
-  do {
-    // Use IEEE-754 arithmetic (no FTZ) to prevent -use_fast_math from flushing
-    // subnormal pivots to zero, which would stall the search (#769, #774).
-    float pivot_0 = ieee_div(ieee_add(high, ieee_mul(2.f, low)), 3.f);
-    float pivot_1 = ieee_div(ieee_add(ieee_mul(2.f, high), low), 3.f);
-
-    float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
-    min_gt_low = high;
-    max_le_high = low;
-    float threadlocal_aggregate_gt_pivot_0 = 0;
-    float threadlocal_aggregate_gt_pivot_1 = 0;
 #pragma unroll 2
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-      probs_vec.fill(0);
-      if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-        probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-      }
-
-      float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
-#pragma unroll
-      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
-        probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
-
-        if (probs_vec[j] > low && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
-          min_gt_low = min(min_gt_low, probs_vec[j]);
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
         }
-        if (probs_vec[j] <= high && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
-          max_le_high = max(max_le_high, probs_vec[j]);
+
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+            i, d, [](float x) { return x > 0; }, u, probs_vec, aggregate, &temp_storage);
+        if (float(aggregate) > u) {
+            break;
         }
-        threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
-        threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
-      }
     }
-    aggregate_gt_pivot_0 =
-        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Sum(threadlocal_aggregate_gt_pivot_0);
-    __syncthreads();
-    aggregate_gt_pivot_1 =
-        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Sum(threadlocal_aggregate_gt_pivot_1);
-    __syncthreads();
-
-    min_gt_low = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-                     .Reduce(min_gt_low, MinReduceOp{});
-    __syncthreads();
-    max_le_high =
-        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Reduce(max_le_high, MaxReduceOp{});
+    int sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+        // NOTE(Zihao): this would happen when u is very close to 1
+        // and the sum of probabilities is smaller than u
+        // In this case, we use the last valid index as the sampled id
+        if (temp_storage.last_valid_id == -1) {
+            if (tx == 0) {
+                output[bx] = 0;
+                valid[bx]  = false;
+            }
+            return;
+        }
+        sampled_id = temp_storage.last_valid_id;
+    }
     if (tx == 0) {
-      temp_storage.block_aggregate.values[0] = aggregate_gt_pivot_0;
-      temp_storage.block_aggregate.values[1] = aggregate_gt_pivot_1;
-      temp_storage.min_val = min_gt_low;
-      temp_storage.max_val = max_le_high;
+        output[bx] = sampled_id;
+        valid[bx]  = true;
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void TopKSamplingFromProbKernel(DType*    probs,
+                                           IdType*   output,
+                                           bool*     valid,
+                                           IdType*   indices,
+                                           IdType*   top_k_arr,
+                                           uint32_t  top_k_val,
+                                           uint32_t  d,
+                                           uint64_t* seed_arr,
+                                           uint64_t  seed_val,
+                                           uint64_t* offset_arr,
+                                           uint64_t  offset_val) {
+    const uint32_t batch_size = gridDim.x;
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    curandStatePhilox4_32_10_t state;
+    curand_init(philox_seed, bx, philox_offset, &state);
+    const uint32_t k       = top_k_arr == nullptr ? top_k_val : top_k_arr[bx];
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    vec_t<float, VEC_SIZE> probs_vec;
+    float                  aggregate;
+    float                  q   = 1;
+    float                  low = 0, high = 1.f;
+    int                    sampled_id;
+    int                    round = 0;
+    do {
+        round += 1;
+        temp_storage.sampled_id    = d;
+        temp_storage.last_valid_id = -1;
+        __syncthreads();
+        float u   = curand_uniform(&state) * q;
+        aggregate = 0;
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+                i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+            if (aggregate > u) {
+                break;
+            }
+        }
+        __syncthreads();
+        sampled_id = temp_storage.sampled_id;
+        if (sampled_id == d) {
+            // NOTE(Zihao): this would happen when u is very close to 1
+            // and the sum of probabilities is smaller than u
+            // In this case, we use the last valid index as the sampled id
+            if (temp_storage.last_valid_id == -1) {
+                if (tx == 0) {
+                    output[bx] = 0;
+                    valid[bx]  = false;
+                }
+                return;
+            }
+            sampled_id = temp_storage.last_valid_id;
+        }
+        // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+        float pivot_0 = probs[row_idx * d + sampled_id];
+        float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+        ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+        ValueCount<float> threadlocal_gt_pivot_0{0, 0}, threadlocal_gt_pivot_1{0, 0};
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                probs_gt_pivot_0[j] = {(probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
+                                       (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+                probs_gt_pivot_1[j] = {(probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
+                                       (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+                threadlocal_gt_pivot_0 += probs_gt_pivot_0[j];
+                threadlocal_gt_pivot_1 += probs_gt_pivot_1[j];
+            }
+        }
+        aggregate_gt_pivot_0 +=
+            BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce_value_count)
+                .Sum(threadlocal_gt_pivot_0);
+        if (tx == 0) {
+            temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
+
+        aggregate_gt_pivot_1 +=
+            BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce_value_count)
+                .Sum(threadlocal_gt_pivot_1);
+        if (tx == 0) {
+            temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
+        if (aggregate_gt_pivot_0.count < k) {
+            // case 1: pivot_0 accepted
+            break;
+        }
+        if (aggregate_gt_pivot_1.count < k) {
+            // case 2: pivot_0 rejected, pivot_1 accepted
+            low  = pivot_0;
+            high = pivot_1;
+            q    = aggregate_gt_pivot_0.value;
+        } else {
+            // case 3: pivot_0 rejected, pivot_1 rejected
+            low = pivot_1;
+            q   = aggregate_gt_pivot_1.value;
+        }
+    } while (low < high);
+    __syncthreads();
+    if (tx == 0) {
+        output[bx] = sampled_id;
+        valid[bx]  = true;
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void TopPSamplingFromProbKernel(DType*    probs,
+                                           IdType*   output,
+                                           bool*     valid,
+                                           IdType*   indices,
+                                           float*    top_p_arr,
+                                           float     top_p_val,
+                                           uint32_t  d,
+                                           uint64_t* seed_arr,
+                                           uint64_t  seed_val,
+                                           uint64_t* offset_arr,
+                                           uint64_t  offset_val) {
+    const uint32_t batch_size = gridDim.x;
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    curandStatePhilox4_32_10_t state;
+    curand_init(philox_seed, bx, philox_offset, &state);
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+    float          top_p   = (top_p_arr == nullptr) ? top_p_val : top_p_arr[row_idx];
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    vec_t<float, VEC_SIZE> probs_vec;
+    float                  aggregate;
+    float                  q   = 1;
+    float                  low = 0, high = 1.f;
+    int                    sampled_id;
+    do {
+        temp_storage.sampled_id    = d;
+        temp_storage.last_valid_id = -1;
+        __syncthreads();
+        float u   = curand_uniform(&state) * q;
+        aggregate = 0;
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+                i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+            if (aggregate > u) {
+                break;
+            }
+        }
+        __syncthreads();
+        sampled_id = temp_storage.sampled_id;
+        if (sampled_id == d) {
+            // NOTE(Zihao): this would happen when u is very close to 1
+            // and the sum of probabilities is smaller than u
+            // In this case, we use the last valid index as the sampled id
+            if (temp_storage.last_valid_id == -1) {
+                if (tx == 0) {
+                    output[bx] = 0;
+                    valid[bx]  = false;
+                }
+                return;
+            }
+            sampled_id = temp_storage.last_valid_id;
+        }
+        // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+        float pivot_0 = probs[row_idx * d + sampled_id];
+        float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+        float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
+        float threadlocal_aggregate_gt_pivot_0 = 0;
+        float threadlocal_aggregate_gt_pivot_1 = 0;
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
+                probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
+                threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+                threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+            }
+        }
+        aggregate_gt_pivot_0 +=
+            BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Sum(threadlocal_aggregate_gt_pivot_0);
+        if (tx == 0) {
+            temp_storage.block_aggregate.value = aggregate_gt_pivot_0;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_0 = temp_storage.block_aggregate.value;
+
+        aggregate_gt_pivot_1 +=
+            BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Sum(threadlocal_aggregate_gt_pivot_1);
+        if (tx == 0) {
+            temp_storage.block_aggregate.value = aggregate_gt_pivot_1;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_1 = temp_storage.block_aggregate.value;
+
+        if (aggregate_gt_pivot_0 < top_p) {
+            // case 1: pivot_0 accepted
+            break;
+        }
+        if (aggregate_gt_pivot_1 < top_p) {
+            // case 2: pivot_0 rejected, pivot_1 accepted
+            low  = pivot_0;
+            high = pivot_1;
+            q    = aggregate_gt_pivot_0;
+        } else {
+            // case 3: pivot_0 rejected, pivot_1 rejected
+            low = pivot_1;
+            q   = aggregate_gt_pivot_1;
+        }
+    } while (low < high);
+    __syncthreads();
+    if (tx == 0) {
+        output[bx] = sampled_id;
+        valid[bx]  = true;
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void MinPSamplingFromProbKernel(DType*    probs,
+                                           float*    min_p_arr,
+                                           IdType*   output,
+                                           bool*     valid,
+                                           IdType*   indices,
+                                           float     min_p_val,
+                                           uint32_t  d,
+                                           uint64_t* seed_arr,
+                                           uint64_t  seed_val,
+                                           uint64_t* offset_arr,
+                                           uint64_t  offset_val) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    float                      p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
+    curandStatePhilox4_32_10_t state;
+    curand_init(philox_seed, bx, philox_offset, &state);
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    float max_val = GetMaxValue<VEC_SIZE,
+                                BLOCK_THREADS,
+                                REDUCE_ALGORITHM,
+                                SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>>(
+        probs, row_idx, d, temp_storage);
+    float pivot = max_val * p;
+
+    vec_t<float, VEC_SIZE> probs_vec;
+    float                  aggregate_gt_pivot             = 0;
+    float                  threadlocal_aggregate_gt_pivot = 0;
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
+
+        float probs_gt_pivot[VEC_SIZE];
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            probs_gt_pivot[j] = (probs_vec[j] >= pivot) ? probs_vec[j] : 0;
+            threadlocal_aggregate_gt_pivot += probs_gt_pivot[j];
+        }
+    }
+
+    aggregate_gt_pivot +=
+        BlockReduce<float, BLOCK_THREADS>(temp_storage.block_prim.reduce).Sum(threadlocal_aggregate_gt_pivot);
+    if (tx == 0) {
+        temp_storage.block_aggregate.value = aggregate_gt_pivot;
     }
     __syncthreads();
-    aggregate_gt_pivot_0 = temp_storage.block_aggregate.values[0];
-    aggregate_gt_pivot_1 = temp_storage.block_aggregate.values[1];
-    min_gt_low = temp_storage.min_val;
-    max_le_high = temp_storage.max_val;
 
-    if (aggregate_gt_pivot_1 >= p) {
-      low = pivot_1;
-      sum_low = aggregate_gt_pivot_1;
-    } else if (aggregate_gt_pivot_0 >= p) {
-      low = pivot_0;
-      high = min(pivot_1, max_le_high);
-      sum_low = aggregate_gt_pivot_0;
-    } else {
-      high = min(pivot_0, max_le_high);
-    }
-  } while (min_gt_low != max_le_high);
+    float aggregate = 0;
+    float q         = temp_storage.block_aggregate.value;
 
-  float normalizer = math::ptx_rcp(max(sum_low, 1e-8));
-
-  // normalize
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    probs_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-    }
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      probs_vec[j] = (probs_vec[j] > low) ? probs_vec[j] * normalizer : 0;
-    }
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      probs_vec.cast_store(renormed_prob + row_idx * d + i * BLOCK_THREADS * VEC_SIZE +
-                           tx * VEC_SIZE);
-    }
-  }
-}
-
-template <typename DType>
-cudaError_t TopPRenormProb(DType* probs, DType* renormed_prob, float* top_p_arr,
-                           uint32_t batch_size, float top_p_val, uint32_t d,
-                           cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
-
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &renormed_prob, &top_p_arr, &top_p_val, &d};
-    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
-      auto kernel = TopPRenormProbKernel<BLOCK_THREADS, REDUCE_ALGO, VEC_SIZE, DType>;
-      FLASHINFER_CUDA_CALL(
-          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-    });
-    return cudaSuccess;
-  });
-}
-
-template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
-          BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, bool DETERMINISTIC,
-          typename DType, typename IdType>
-__global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
-                                         DType* target_probs, IdType* output_token_ids,
-                                         IdType* output_accepted_token_num,
-                                         IdType* output_emitted_draft_token_num,
-                                         uint32_t num_speculative_tokens, uint32_t d,
-                                         uint64_t* seed_arr, uint64_t seed_val,
-                                         uint64_t* offset_arr, uint64_t offset_val) {
-  const uint32_t bx = blockIdx.x, tx = threadIdx.x;
-  const uint32_t row_idx = bx;
-
-  // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
-
-  curandStatePhilox4_32_10_t curand_state;
-  curand_init(philox_seed, bx, philox_offset, &curand_state);
-
-  extern __shared__ __align__(
-      alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
-      uint8_t smem_sampling[];
-  auto& temp_storage =
-      reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(
-          smem_sampling);
-
-  uint32_t pos = num_speculative_tokens;
-  for (uint32_t i = 0; i < num_speculative_tokens; ++i) {
-    IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
-    float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
-          p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
-    float u = curand_uniform(&curand_state);
-    if (u * p < q) {
-      // accept the draft models output
-      output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
-    } else {
-      pos = i;
-      break;
-    }
-  }
-
-  uint32_t emitted_token_num = pos;
-  uint32_t accepted_token_num = pos;
-  for (uint32_t i = pos; i < num_speculative_tokens; ++i) {
-    int draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
-    float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
-          p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
-    float u = curand_uniform(&curand_state);
-    if (u * p < q) {
-      ++accepted_token_num;
-    }
-  }
-
-  if (tx == 0) {
-    output_accepted_token_num[row_idx] += accepted_token_num;
-    output_emitted_draft_token_num[row_idx] += emitted_token_num;
-  }
-
-  // sample from relu(target_probs - draft_probs)
-  float sum_relu_q_minus_p = 0;
-  vec_t<float, VEC_SIZE> q_vec, p_vec;
-  float relu_q_minus_p[VEC_SIZE];
-#pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    q_vec.fill(0);
-    p_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d +
-                      i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-      if (pos != num_speculative_tokens) {
-        // there is no draft_probs for the bonus token
-        p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d +
-                        i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-      }
-    }
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0.0f);
-    }
-    sum_relu_q_minus_p +=
-        BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
-            .Sum<VEC_SIZE>(relu_q_minus_p);
+    int sampled_id;
+    temp_storage.sampled_id    = d;
+    temp_storage.last_valid_id = -1;
     __syncthreads();
-  }
-  if (tx == 0) {
-    temp_storage.block_aggregate.value = sum_relu_q_minus_p;
-  }
-  // init the first rejected token to d
-  temp_storage.sampled_id = d;
-  __syncthreads();
-  sum_relu_q_minus_p = temp_storage.block_aggregate.value;
-  float u = curand_uniform(&curand_state) * sum_relu_q_minus_p;
-
-  float aggregate_relu_q_minus_p(0);
+    float u = curand_uniform(&state) * q;
 #pragma unroll 2
-  for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    q_vec.fill(0);
-    p_vec.fill(0);
-    if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
-      q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d +
-                      i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-      if (pos != num_speculative_tokens) {
-        // there is no draft_probs for the bonus token
-        p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d +
-                        i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
-      }
-    }
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+        }
 
-    vec_t<float, VEC_SIZE> relu_q_minus_p_vec;
-#pragma unroll
-    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0.0f);
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+            i, d, [&](float x) { return x >= pivot; }, u, probs_vec, aggregate, &temp_storage);
+        if (aggregate > u) {
+            break;
+        }
     }
-
-    DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
-                           DETERMINISTIC>(
-        i, d, [&](float x) { return x > 0; }, u, relu_q_minus_p_vec, aggregate_relu_q_minus_p,
-        &temp_storage);
-    if (aggregate_relu_q_minus_p > u) {
-      break;
+    sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+        // NOTE(Zihao): this would happen when u is very close to 1
+        // and the sum of probabilities is smaller than u
+        // In this case, we use the last valid index as the sampled id
+        if (temp_storage.last_valid_id == -1) {
+            if (tx == 0) {
+                output[bx] = 0;
+                valid[bx]  = false;
+            }
+            return;
+        }
+        sampled_id = temp_storage.last_valid_id;
     }
-  }
-  __syncthreads();
-  int sampled_id = temp_storage.sampled_id;
-  if (sampled_id == d) {
-    // NOTE(Zihao): this would happen when u is very close to 1
-    // and the sum of probabilities is smaller than u
-    // In this case, we use the last valid index as the sampled id
-    sampled_id = temp_storage.last_valid_id;
-  }
-  // set the first rejected token
-  output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = sampled_id;
-  // move to the next token
-  pos++;
-
-  // pad remaining tokens with -1
-  for (; pos < num_speculative_tokens + 1; ++pos) {
-    output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = -1;
-  }
+    output[bx] = sampled_id;
+    valid[bx]  = true;
 }
 
-template <typename DType, typename IdType>
-cudaError_t ChainSpeculativeSampling(
-    DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
-    IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num, uint32_t batch_size,
-    uint32_t num_speculative_tokens, uint32_t d, bool deterministic, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val, cudaStream_t stream = 0) {
-  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void TopKTopPSamplingFromProbKernel(DType*    probs,
+                                               IdType*   top_k_arr,
+                                               float*    top_p_arr,
+                                               IdType*   output,
+                                               bool*     valid,
+                                               IdType*   indices,
+                                               IdType    top_k_val,
+                                               float     top_p_val,
+                                               uint32_t  d,
+                                               uint64_t* seed_arr,
+                                               uint64_t  seed_val,
+                                               uint64_t* offset_arr,
+                                               uint64_t  offset_val) {
+    const uint32_t batch_size = gridDim.x;
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
-  auto compute_capacity = GetCudaComputeCapability();
-  DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
-    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
-    dim3 nblks(batch_size);
-    dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&draft_probs,
-                    &draft_token_ids,
-                    &target_probs,
-                    &output_token_ids,
-                    &output_accepted_token_num,
-                    &output_emitted_draft_token_num,
-                    &num_speculative_tokens,
-                    &d,
-                    &seed_arr,
-                    &seed_val,
-                    &offset_arr,
-                    &offset_val};
-    DISPATCH_ALIGNED_VEC_SIZE(
-        vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
-          auto kernel = ChainSpeculativeSampling<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,
-                                                 DETERMINISTIC, DType, IdType>;
-          FLASHINFER_CUDA_CALL(
-              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    curandStatePhilox4_32_10_t state;
+    curand_init(philox_seed, bx, philox_offset, &state);
+    const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
+    const uint32_t k       = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+    const float    p       = top_p_arr == nullptr ? top_p_val : top_p_arr[row_idx];
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    vec_t<float, VEC_SIZE> probs_vec;
+    float                  aggregate;
+    float                  q   = 1;
+    float                  low = 0, high = 1.f;
+    int                    sampled_id;
+    do {
+        temp_storage.sampled_id    = d;
+        temp_storage.last_valid_id = -1;
+        __syncthreads();
+        float u   = curand_uniform(&state) * q;
+        aggregate = 0;
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+                i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+            if (aggregate > u) {
+                break;
+            }
+        }
+        __syncthreads();
+        sampled_id = temp_storage.sampled_id;
+        if (sampled_id == d) {
+            // NOTE(Zihao): this would happen when u is very close to 1
+            // and the sum of probabilities is smaller than u
+            // In this case, we use the last valid index as the sampled id
+            sampled_id = temp_storage.last_valid_id;
+            if (temp_storage.last_valid_id == -1) {
+                if (tx == 0) {
+                    output[bx] = 0;
+                    valid[bx]  = false;
+                }
+                return;
+            }
+        }
+        // IEEE-754 arithmetic (no FTZ) for pivot computation.  See #769 / #774.
+        float pivot_0 = probs[row_idx * d + sampled_id];
+        float pivot_1 = ieee_mul(ieee_add(pivot_0, high), 0.5f);
+
+        ValueCount<float> aggregate_gt_pivot_0{0, 0}, aggregate_gt_pivot_1{0, 0};
+        ValueCount<float> threadlocal_aggregate_gt_pivot_0{0, 0};
+        ValueCount<float> threadlocal_aggregate_gt_pivot_1{0, 0};
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
+            }
+
+            ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                probs_gt_pivot_0[j] = {(probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
+                                       (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+                probs_gt_pivot_1[j] = {(probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
+                                       (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+                threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+                threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+            }
+        }
+        aggregate_gt_pivot_0 +=
+            BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+                .Sum(threadlocal_aggregate_gt_pivot_0);
+        if (tx == 0) {
+            temp_storage.block_aggregate.pair = aggregate_gt_pivot_0;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_0 = temp_storage.block_aggregate.pair;
+
+        aggregate_gt_pivot_1 +=
+            BlockReduce<ValueCount<float>, BLOCK_THREADS>(temp_storage.block_prim.reduce_value_count)
+                .Sum(threadlocal_aggregate_gt_pivot_1);
+        if (tx == 0) {
+            temp_storage.block_aggregate.pair = aggregate_gt_pivot_1;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_1 = temp_storage.block_aggregate.pair;
+        if (aggregate_gt_pivot_0.count < k && aggregate_gt_pivot_0.value < p) {
+            // case 1: pivot_0 accepted
+            break;
+        }
+        if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
+            // case 2: pivot_0 rejected, pivot_1 accepted
+            low  = pivot_0;
+            high = pivot_1;
+            q    = aggregate_gt_pivot_0.value;
+        } else {
+            // case 3: pivot_0 rejected, pivot_1 rejected
+            low = pivot_1;
+            q   = aggregate_gt_pivot_1.value;
+        }
+    } while (low < high);
+    __syncthreads();
+    if (tx == 0) {
+        output[bx] = sampled_id;
+        valid[bx]  = true;
+    }
+}
+
+template<typename DType>
+cudaError_t OnlineSoftmax(DType*       logits,
+                          DType*       output,
+                          uint32_t     batch_size,
+                          uint32_t     d,
+                          DType*       temperature_arr,
+                          DType        temperature_val,
+                          void*        workspace_buffer,
+                          size_t       workspace_buffer_size_in_bytes,
+                          bool         enable_pdl,
+                          cudaStream_t stream = 0) {
+    constexpr uint32_t SMALL_BATCH_THRESHOLD = 128;
+    constexpr uint32_t LARGE_VOCAB_THRESHOLD = 24576;
+    constexpr uint32_t DEFAULT_SLICE_SIZE    = 8192;
+
+    const uint32_t vec_size         = std::gcd(16 / sizeof(DType), d);
+    auto           compute_capacity = GetCudaComputeCapability();
+
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(
+        compute_capacity, BLOCK_THREADS, {DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+            if (batch_size <= SMALL_BATCH_THRESHOLD && d >= LARGE_VOCAB_THRESHOLD) {
+                // Path A: Vocab-Splitting Strategy for small-batch & large-vocab
+                uint32_t num_slices = ceil_div(d, DEFAULT_SLICE_SIZE);
+
+                const size_t partial_buffer_size = batch_size * num_slices * sizeof(PartialSoftmaxResult);
+                if (workspace_buffer_size_in_bytes < partial_buffer_size) {
+                    return cudaErrorInvalidValue;
+                }
+
+                AlignedAllocator allocator(workspace_buffer, workspace_buffer_size_in_bytes);
+                auto             partial_results = allocator.aligned_alloc<PartialSoftmaxResult>(
+                    partial_buffer_size, alignof(PartialSoftmaxResult), "softmax_workspace");
+
+                // Phase 1: Map-Reduce across vocab slices
+                dim3   phase1_nblks(batch_size, num_slices);
+                dim3   phase1_nthrs(BLOCK_THREADS);
+                size_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>);
+
+                auto  phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+                void* phase1_args[] = {&logits, &partial_results, &temperature_arr, &temperature_val, &d, &num_slices};
+
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(phase1_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+                if (enable_pdl) {
+                    cudaLaunchAttribute attribute[1];
+                    attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+                    attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+                    cudaLaunchConfig_t config;
+                    config.gridDim          = phase1_nblks;
+                    config.blockDim         = phase1_nthrs;
+                    config.dynamicSmemBytes = smem_size;
+                    config.stream           = stream;
+                    config.attrs            = attribute;
+                    config.numAttrs         = 1;
+
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config,
+                                                            phase1_kernel,
+                                                            logits,
+                                                            partial_results,
+                                                            temperature_arr,
+                                                            temperature_val,
+                                                            d,
+                                                            num_slices));
+                } else {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel(
+                        (void*)phase1_kernel, phase1_nblks, phase1_nthrs, phase1_args, smem_size, stream));
+                }
+
+                // Phase 2: Final reduction and apply normalization
+                dim3 phase2_nblks(batch_size);
+                dim3 phase2_nthrs(BLOCK_THREADS);
+
+                auto  phase2_kernel = OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+                void* phase2_args[] = {
+                    &logits, &output, &partial_results, &temperature_arr, &temperature_val, &d, &num_slices};
+
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(phase2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+                if (enable_pdl) {
+                    cudaLaunchAttribute attribute[1];
+                    attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+                    attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+                    cudaLaunchConfig_t config;
+                    config.gridDim          = phase2_nblks;
+                    config.blockDim         = phase2_nthrs;
+                    config.dynamicSmemBytes = smem_size;
+                    config.stream           = stream;
+                    config.attrs            = attribute;
+                    config.numAttrs         = 1;
+
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config,
+                                                            phase2_kernel,
+                                                            logits,
+                                                            output,
+                                                            partial_results,
+                                                            temperature_arr,
+                                                            temperature_val,
+                                                            d,
+                                                            num_slices));
+                } else {
+                    FLASHINFER_CUDA_CALL(cudaLaunchKernel(
+                        (void*)phase2_kernel, phase2_nblks, phase2_nthrs, phase2_args, smem_size, stream));
+                }
+            } else {
+                // Path B: Single-Block Strategy
+                // Switch input cache
+                uint32_t cache_threshold;
+                if (batch_size <= 16) {
+                    cache_threshold = 4096;
+                } else if (batch_size <= 32) {
+                    cache_threshold = 2048;
+                } else {
+                    cache_threshold = 0;
+                }
+                const bool cache_input = d <= cache_threshold;
+
+                dim3  nblks(batch_size);
+                dim3  nthrs(BLOCK_THREADS);
+                void* args[] = {&logits, &output, &temperature_arr, &temperature_val, &d};
+
+                const size_t smem_logits_bytes = (round_up(d, VEC_SIZE) + VEC_SIZE) * sizeof(DType);
+
+                uint32_t smem_size =
+                    sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>) + (cache_input ? smem_logits_bytes : 0);
+
+                DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, {
+                    auto kernel = OnlineSoftmaxFusedKernel<BLOCK_THREADS, VEC_SIZE, DType, CACHE_INPUT>;
+                    FLASHINFER_CUDA_CALL(
+                        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+                    if (enable_pdl) {
+                        cudaLaunchAttribute attribute[1];
+                        attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+                        attribute[0].val.programmaticStreamSerializationAllowed = 1;
+
+                        cudaLaunchConfig_t config;
+                        config.gridDim          = nblks;
+                        config.blockDim         = nthrs;
+                        config.dynamicSmemBytes = smem_size;
+                        config.stream           = stream;
+                        config.attrs            = attribute;
+                        config.numAttrs         = 1;
+
+                        FLASHINFER_CUDA_CALL(
+                            cudaLaunchKernelEx(&config, kernel, logits, output, temperature_arr, temperature_val, d));
+                    } else {
+                        FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+                    }
+                });
+            }
         })});
     return cudaSuccess;
-  });
+}
+
+template<typename T, typename IdType>
+cudaError_t SamplingFromLogits(T*           logits,
+                               IdType*      output,
+                               IdType*      indices,
+                               uint32_t     batch_size,
+                               uint32_t     d,
+                               bool         deterministic,
+                               uint64_t*    seed_arr,
+                               uint64_t     seed_val,
+                               uint64_t*    offset_arr,
+                               uint64_t     offset_val,
+                               cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&logits, &output, &indices, &d, &seed_arr, &seed_val, &offset_arr, &offset_val};
+        const uint32_t smem_size =
+            sizeof(typename BlockReduce<DataAndIndex<T, IdType>, BLOCK_THREADS, REDUCE_ALGO>::TempStorage);
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel =
+                    SamplingFromLogitsKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE, DETERMINISTIC, T, IdType>;
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<typename T, typename IdType>
+cudaError_t SamplingFromProb(T*           probs,
+                             IdType*      output,
+                             bool*        valid,
+                             IdType*      indices,
+                             uint32_t     batch_size,
+                             uint32_t     d,
+                             bool         deterministic,
+                             uint64_t*    seed_arr,
+                             uint64_t     seed_val,
+                             uint64_t*    offset_arr,
+                             uint64_t     offset_val,
+                             cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs, &output, &valid, &indices, &d, &seed_arr, &seed_val, &offset_arr, &offset_val};
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel =
+                    SamplingFromProbKernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE, DETERMINISTIC, T, IdType>;
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<typename T, typename IdType>
+cudaError_t TopKSamplingFromProb(T*           probs,
+                                 IdType*      output,
+                                 bool*        valid,
+                                 IdType*      indices,
+                                 T*           top_k_arr,
+                                 uint32_t     batch_size,
+                                 uint32_t     top_k_val,
+                                 uint32_t     d,
+                                 bool         deterministic,
+                                 uint64_t*    seed_arr,
+                                 uint64_t     seed_val,
+                                 uint64_t*    offset_arr,
+                                 uint64_t     offset_val,
+                                 cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs,
+                                 &output,
+                                 &valid,
+                                 &indices,
+                                 &top_k_arr,
+                                 &top_k_val,
+                                 &d,
+                                 &seed_arr,
+                                 &seed_val,
+                                 &offset_arr,
+                                 &offset_val};
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel = TopKSamplingFromProbKernel<BLOCK_THREADS,
+                                                         SCAN_ALGO,
+                                                         REDUCE_ALGO,
+                                                         VEC_SIZE,
+                                                         DETERMINISTIC,
+                                                         T,
+                                                         IdType>;
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<typename T, typename IdType>
+cudaError_t TopPSamplingFromProb(T*           probs,
+                                 IdType*      output,
+                                 bool*        valid,
+                                 IdType*      indices,
+                                 T*           top_p_arr,
+                                 uint32_t     batch_size,
+                                 T            top_p_val,
+                                 uint32_t     d,
+                                 bool         deterministic,
+                                 uint64_t*    seed_arr,
+                                 uint64_t     seed_val,
+                                 uint64_t*    offset_arr,
+                                 uint64_t     offset_val,
+                                 cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs,
+                                 &output,
+                                 &valid,
+                                 &indices,
+                                 &top_p_arr,
+                                 &top_p_val,
+                                 &d,
+                                 &seed_arr,
+                                 &seed_val,
+                                 &offset_arr,
+                                 &offset_val};
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel = TopPSamplingFromProbKernel<BLOCK_THREADS,
+                                                         SCAN_ALGO,
+                                                         REDUCE_ALGO,
+                                                         VEC_SIZE,
+                                                         DETERMINISTIC,
+                                                         T,
+                                                         IdType>;
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<typename T, typename IdType>
+cudaError_t MinPSamplingFromProb(T*           probs,
+                                 T*           min_p_arr,
+                                 IdType*      output,
+                                 bool*        valid,
+                                 IdType*      indices,
+                                 uint32_t     batch_size,
+                                 float        min_p_val,
+                                 uint32_t     d,
+                                 bool         deterministic,
+                                 uint64_t*    seed_arr,
+                                 uint64_t     seed_val,
+                                 uint64_t*    offset_arr,
+                                 uint64_t     offset_val,
+                                 cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs,
+                                 &min_p_arr,
+                                 &output,
+                                 &valid,
+                                 &indices,
+                                 &min_p_val,
+                                 &d,
+                                 &seed_arr,
+                                 &seed_val,
+                                 &offset_arr,
+                                 &offset_val};
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel = MinPSamplingFromProbKernel<BLOCK_THREADS,
+                                                         SCAN_ALGO,
+                                                         REDUCE_ALGO,
+                                                         VEC_SIZE,
+                                                         DETERMINISTIC,
+                                                         T,
+                                                         IdType>;
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<typename T, typename IdType>
+cudaError_t TopKTopPSamplingFromProb(T*           probs,
+                                     IdType*      top_k_arr,
+                                     T*           top_p_arr,
+                                     IdType*      output,
+                                     bool*        valid,
+                                     IdType*      indices,
+                                     uint32_t     batch_size,
+                                     IdType       top_k_val,
+                                     T            top_p_val,
+                                     uint32_t     d,
+                                     bool         deterministic,
+                                     uint64_t*    seed_arr,
+                                     uint64_t     seed_val,
+                                     uint64_t*    offset_arr,
+                                     uint64_t     offset_val,
+                                     cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs,
+                                 &top_k_arr,
+                                 &top_p_arr,
+                                 &output,
+                                 &valid,
+                                 &indices,
+                                 &top_k_val,
+                                 &top_p_val,
+                                 &d,
+                                 &seed_arr,
+                                 &seed_val,
+                                 &offset_arr,
+                                 &offset_val};
+
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel = TopKTopPSamplingFromProbKernel<BLOCK_THREADS,
+                                                             SCAN_ALGO,
+                                                             REDUCE_ALGO,
+                                                             VEC_SIZE,
+                                                             DETERMINISTIC,
+                                                             T,
+                                                             IdType>;
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
+}
+
+template<uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM>
+struct RenormTempStorage {
+    union {
+        typename BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage             reduce;
+        typename BlockReduce<int, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage               reduce_int;
+        typename BlockReduce<ValueCount<float>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_value_count;
+    } block_prim;
+    struct {
+        float max_val;
+        float min_val;
+        float row_sum;
+        union {
+            struct {
+                float values[2];
+            };
+            struct {
+                int counts[2];
+            };
+            struct {
+                ValueCount<float> pairs[2];
+            };
+        } block_aggregate;
+    };
+};
+
+template<uint32_t BLOCK_THREADS, BlockReduceAlgorithm REDUCE_ALGORITHM, uint32_t VEC_SIZE, typename DType>
+__global__ void
+TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* top_p_arr, float top_p_val, uint32_t d) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+    const uint32_t row_idx = bx;
+    float          p       = top_p_arr == nullptr ? top_p_val : top_p_arr[bx];
+
+    extern __shared__ __align__(alignof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>)) uint8_t smem_renorm[];
+    auto&                  temp_storage = reinterpret_cast<RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>&>(smem_renorm);
+    vec_t<float, VEC_SIZE> probs_vec;
+
+    // Fast-path: when p >= 1.0 (e.g., p == 1.0), perform simple sum and normalization
+    if (p >= 1.0f) {
+        // Stage A: per-thread float accumulation over assigned lanes (vectorized)
+        float          thread_sum = 0.0f;
+        const uint32_t num_iters  = ceil_div(d, BLOCK_THREADS * VEC_SIZE);
+        for (uint32_t i = 0; i < num_iters; ++i) {
+            probs_vec.fill(0.0f);
+            const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+            if (base_idx < d) {
+                probs_vec.cast_load(probs + row_idx * d + base_idx);
+            }
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                const uint32_t idx = base_idx + j;
+                if (idx < d)
+                    thread_sum += probs_vec[j];
+            }
+        }
+
+        // Block reduce (float)
+        float row_sum =
+            BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce).Sum(thread_sum);
+        // Broadcast via shared
+        if (tx == 0)
+            temp_storage.row_sum = row_sum;
+        __syncthreads();
+        row_sum = temp_storage.row_sum;
+
+        // Guard against zero sum
+        const float denom      = (row_sum <= 1e-8f) ? 1.0f : row_sum;
+        const float normalizer = math::ptx_rcp(denom);
+
+        // Stage B: normalize and store
+        for (uint32_t i = 0; i < num_iters; ++i) {
+            probs_vec.fill(0.0f);
+            const uint32_t base_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE;
+            if (base_idx < d) {
+                probs_vec.cast_load(probs + row_idx * d + base_idx);
+            }
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                const uint32_t idx = base_idx + j;
+                float          v   = probs_vec[j];
+                probs_vec[j]       = (idx < d) ? (v * normalizer) : 0.0f;
+            }
+            if (base_idx < d) {
+                probs_vec.cast_store(renormed_prob + row_idx * d + base_idx);
+            }
+        }
+        return;  // Exit after fast-path processing
+    }
+
+    // Original Top-P renormalization logic
+    temp_storage.max_val = 0;
+    float max_val =
+        GetMaxValue<VEC_SIZE, BLOCK_THREADS, REDUCE_ALGORITHM, RenormTempStorage<BLOCK_THREADS, REDUCE_ALGORITHM>>(
+            probs, row_idx, d, temp_storage);
+
+    float low = 0, high = max_val;
+    float min_gt_low, max_le_high;
+    float sum_low = 1;
+    // f(x) = sum(probs[probs > x]), f(x) is non-increasing
+    // min_gt_low = min{p \in probs | p > low}, max_le_high = max{p \in probs | p <= high}
+    // loop invariant:
+    // - f(low) >= p, f(high) < p
+    // - f(low) > f(min_gt_low) >= f(max_le_high) == f(high)
+    // stopping condition
+    // - f(low) >= p, f(min_gt_low) == f(max_le_high) == f(high) < p
+    do {
+        // Use IEEE-754 arithmetic (no FTZ) to prevent -use_fast_math from flushing
+        // subnormal pivots to zero, which would stall the search (#769, #774).
+        float pivot_0 = ieee_div(ieee_add(high, ieee_mul(2.f, low)), 3.f);
+        float pivot_1 = ieee_div(ieee_add(ieee_mul(2.f, high), low), 3.f);
+
+        float aggregate_gt_pivot_0 = 0, aggregate_gt_pivot_1 = 0;
+        min_gt_low                             = high;
+        max_le_high                            = low;
+        float threadlocal_aggregate_gt_pivot_0 = 0;
+        float threadlocal_aggregate_gt_pivot_1 = 0;
+#pragma unroll 2
+        for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+            probs_vec.fill(0);
+            if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+                probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+
+            float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
+#pragma unroll
+            for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+                probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
+                probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
+
+                if (probs_vec[j] > low && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
+                    min_gt_low = min(min_gt_low, probs_vec[j]);
+                }
+                if (probs_vec[j] <= high && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d) {
+                    max_le_high = max(max_le_high, probs_vec[j]);
+                }
+                threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
+                threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
+            }
+        }
+        aggregate_gt_pivot_0 = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                                   .Sum(threadlocal_aggregate_gt_pivot_0);
+        __syncthreads();
+        aggregate_gt_pivot_1 = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                                   .Sum(threadlocal_aggregate_gt_pivot_1);
+        __syncthreads();
+
+        min_gt_low = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                         .Reduce(min_gt_low, MinReduceOp{});
+        __syncthreads();
+        max_le_high = BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                          .Reduce(max_le_high, MaxReduceOp{});
+        if (tx == 0) {
+            temp_storage.block_aggregate.values[0] = aggregate_gt_pivot_0;
+            temp_storage.block_aggregate.values[1] = aggregate_gt_pivot_1;
+            temp_storage.min_val                   = min_gt_low;
+            temp_storage.max_val                   = max_le_high;
+        }
+        __syncthreads();
+        aggregate_gt_pivot_0 = temp_storage.block_aggregate.values[0];
+        aggregate_gt_pivot_1 = temp_storage.block_aggregate.values[1];
+        min_gt_low           = temp_storage.min_val;
+        max_le_high          = temp_storage.max_val;
+
+        if (aggregate_gt_pivot_1 >= p) {
+            low     = pivot_1;
+            sum_low = aggregate_gt_pivot_1;
+        } else if (aggregate_gt_pivot_0 >= p) {
+            low     = pivot_0;
+            high    = min(pivot_1, max_le_high);
+            sum_low = aggregate_gt_pivot_0;
+        } else {
+            high = min(pivot_0, max_le_high);
+        }
+    } while (min_gt_low != max_le_high);
+
+    float normalizer = math::ptx_rcp(max(sum_low, 1e-8));
+
+    // normalize
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        probs_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            probs_vec.cast_load(probs + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+        }
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            probs_vec[j] = (probs_vec[j] > low) ? probs_vec[j] * normalizer : 0;
+        }
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            probs_vec.cast_store(renormed_prob + row_idx * d + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+        }
+    }
+}
+
+template<typename DType>
+cudaError_t TopPRenormProb(DType*       probs,
+                           DType*       renormed_prob,
+                           float*       top_p_arr,
+                           uint32_t     batch_size,
+                           float        top_p_val,
+                           uint32_t     d,
+                           cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(RenormTempStorage<BLOCK_THREADS, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&probs, &renormed_prob, &top_p_arr, &top_p_val, &d};
+        DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+            auto kernel = TopPRenormProbKernel<BLOCK_THREADS, REDUCE_ALGO, VEC_SIZE, DType>;
+            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+        });
+        return cudaSuccess;
+    });
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void ChainSpeculativeSampling(DType*    draft_probs,
+                                         IdType*   draft_token_ids,
+                                         DType*    target_probs,
+                                         IdType*   output_token_ids,
+                                         IdType*   output_accepted_token_num,
+                                         IdType*   output_emitted_draft_token_num,
+                                         uint32_t  num_speculative_tokens,
+                                         uint32_t  d,
+                                         uint64_t* seed_arr,
+                                         uint64_t  seed_val,
+                                         uint64_t* offset_arr,
+                                         uint64_t  offset_val) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+    const uint32_t row_idx = bx;
+
+    // Resolve seed/offset from tensor or scalar
+    uint64_t philox_seed   = seed_arr ? seed_arr[0] : seed_val;
+    uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+
+    curandStatePhilox4_32_10_t curand_state;
+    curand_init(philox_seed, bx, philox_offset, &curand_state);
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    uint32_t pos = num_speculative_tokens;
+    for (uint32_t i = 0; i < num_speculative_tokens; ++i) {
+        IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+        float  q        = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
+              p         = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
+        float u         = curand_uniform(&curand_state);
+        if (u * p < q) {
+            // accept the draft models output
+            output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
+        } else {
+            pos = i;
+            break;
+        }
+    }
+
+    uint32_t emitted_token_num  = pos;
+    uint32_t accepted_token_num = pos;
+    for (uint32_t i = pos; i < num_speculative_tokens; ++i) {
+        int   draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+        float q        = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
+              p        = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
+        float u        = curand_uniform(&curand_state);
+        if (u * p < q) {
+            ++accepted_token_num;
+        }
+    }
+
+    if (tx == 0) {
+        output_accepted_token_num[row_idx] += accepted_token_num;
+        output_emitted_draft_token_num[row_idx] += emitted_token_num;
+    }
+
+    // sample from relu(target_probs - draft_probs)
+    float                  sum_relu_q_minus_p = 0;
+    vec_t<float, VEC_SIZE> q_vec, p_vec;
+    float                  relu_q_minus_p[VEC_SIZE];
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(0);
+        p_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d
+                            + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d
+                                + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0.0f);
+        }
+        sum_relu_q_minus_p += BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                                  .Sum<VEC_SIZE>(relu_q_minus_p);
+        __syncthreads();
+    }
+    if (tx == 0) {
+        temp_storage.block_aggregate.value = sum_relu_q_minus_p;
+    }
+    // init the first rejected token to d
+    temp_storage.sampled_id = d;
+    __syncthreads();
+    sum_relu_q_minus_p = temp_storage.block_aggregate.value;
+    float u            = curand_uniform(&curand_state) * sum_relu_q_minus_p;
+
+    float aggregate_relu_q_minus_p(0);
+#pragma unroll 2
+    for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(0);
+        p_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
+            q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * d
+                            + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * d
+                                + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+
+        vec_t<float, VEC_SIZE> relu_q_minus_p_vec;
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0.0f);
+        }
+
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+            i, d, [&](float x) { return x > 0; }, u, relu_q_minus_p_vec, aggregate_relu_q_minus_p, &temp_storage);
+        if (aggregate_relu_q_minus_p > u) {
+            break;
+        }
+    }
+    __syncthreads();
+    int sampled_id = temp_storage.sampled_id;
+    if (sampled_id == d) {
+        // NOTE(Zihao): this would happen when u is very close to 1
+        // and the sum of probabilities is smaller than u
+        // In this case, we use the last valid index as the sampled id
+        sampled_id = temp_storage.last_valid_id;
+    }
+    // set the first rejected token
+    output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = sampled_id;
+    // move to the next token
+    pos++;
+
+    // pad remaining tokens with -1
+    for (; pos < num_speculative_tokens + 1; ++pos) {
+        output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = -1;
+    }
+}
+
+template<typename DType, typename IdType>
+cudaError_t ChainSpeculativeSampling(DType*       draft_probs,
+                                     IdType*      draft_token_ids,
+                                     DType*       target_probs,
+                                     IdType*      output_token_ids,
+                                     IdType*      output_accepted_token_num,
+                                     IdType*      output_emitted_draft_token_num,
+                                     uint32_t     batch_size,
+                                     uint32_t     num_speculative_tokens,
+                                     uint32_t     d,
+                                     bool         deterministic,
+                                     uint64_t*    seed_arr,
+                                     uint64_t     seed_val,
+                                     uint64_t*    offset_arr,
+                                     uint64_t     offset_val,
+                                     cudaStream_t stream = 0) {
+    const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+
+    auto compute_capacity = GetCudaComputeCapability();
+    DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
+        const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+        dim3           nblks(batch_size);
+        dim3           nthrs(BLOCK_THREADS);
+        void*          args[] = {&draft_probs,
+                                 &draft_token_ids,
+                                 &target_probs,
+                                 &output_token_ids,
+                                 &output_accepted_token_num,
+                                 &output_emitted_draft_token_num,
+                                 &num_speculative_tokens,
+                                 &d,
+                                 &seed_arr,
+                                 &seed_val,
+                                 &offset_arr,
+                                 &offset_val};
+        DISPATCH_ALIGNED_VEC_SIZE(
+            vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
+                auto kernel = ChainSpeculativeSampling<BLOCK_THREADS,
+                                                       SCAN_ALGO,
+                                                       REDUCE_ALGO,
+                                                       VEC_SIZE,
+                                                       DETERMINISTIC,
+                                                       DType,
+                                                       IdType>;
+                FLASHINFER_CUDA_CALL(
+                    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+                FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            })});
+        return cudaSuccess;
+    });
 }
 
 }  // namespace sampling

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/topk.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/topk.cuh
@@ -1,0 +1,3380 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_TOPK_CUH_
+#define FLASHINFER_TOPK_CUH_
+
+#include <cuda.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cub/cub.cuh>
+#include <cuda/std/limits>
+#include <numeric>
+#include <type_traits>
+
+#include "topk_common.cuh"
+#include "utils.cuh"
+#include "vec_dtypes.cuh"
+
+namespace flashinfer {
+
+namespace sampling {
+
+enum class TopKTieBreak : uint32_t {
+  None = 0,
+  Small = 1,
+  Large = 2,
+};
+
+template <uint32_t BLOCK_THREADS>
+inline size_t GetRadixTopKAvailableOrderedSmemBytes(size_t max_smem_per_block,
+                                                    size_t fixed_smem_aligned,
+                                                    bool reserve_launch_headroom) {
+  using RadixTopKDetBlockScanT =
+      cub::BlockScan<uint32_t, BLOCK_THREADS, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+  constexpr size_t RADIX_TOPK_DETERMINISTIC_BLOCK_SCAN_SMEM =
+      sizeof(typename RadixTopKDetBlockScanT::TempStorage);
+  constexpr size_t RADIX_TOPK_LAUNCH_SMEM_HEADROOM = 2 * RADIX_TOPK_DETERMINISTIC_BLOCK_SCAN_SMEM;
+  const size_t launch_headroom =
+      reserve_launch_headroom ? RADIX_TOPK_LAUNCH_SMEM_HEADROOM : size_t(0);
+  if (max_smem_per_block <= fixed_smem_aligned + launch_headroom) {
+    return 0;
+  }
+  // Reserve enough launch-time headroom for deterministic radix kernels that
+  // instantiate additional static shared scratch such as BlockScan temp storage.
+  return max_smem_per_block - fixed_smem_aligned - launch_headroom;
+}
+
+// ==================== Multi-CTA Top-K Implementation ====================
+
+// Acquire/Release primitives for inter-CTA synchronization
+__device__ __forceinline__ int ld_acquire(int* ptr) {
+  int state = 0;
+
+#if (__CUDA_ARCH__ >= 700)
+  // SM70 and newer use memory consistency qualifiers
+  // Acquire pattern using acquire modifier
+  asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr));
+#else
+  asm volatile("ld.cg.global.b32 %0, [%1];\n" : "=r"(state) : "l"(ptr));
+#endif
+
+  return state;
+}
+
+__device__ __forceinline__ void red_release(int* ptr, int val) {
+#if (__CUDA_ARCH__ >= 700)
+  // SM70 and newer use memory consistency qualifiers
+  // Release pattern using acq_rel fence + relaxed modifier
+  // (The fence also releases data that was weakly-written by other threads prior to the last
+  // syncthreads)
+  asm volatile("fence.acq_rel.gpu;\n");
+  asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(ptr), "r"(val));
+#else
+  __threadfence();
+  atomicAdd(ptr, val);
+#endif
+}
+
+__device__ __forceinline__ void st_release(int* ptr, int val) {
+#if (__CUDA_ARCH__ >= 700)
+  // SM70 and newer use memory consistency qualifiers
+  // Release pattern: fence + release store
+  asm volatile("fence.acq_rel.gpu;\n");
+  asm volatile("st.release.gpu.global.b32 [%0], %1;\n" : : "l"(ptr), "r"(val));
+#else
+  __threadfence();
+  atomicExch(ptr, val);
+#endif
+}
+
+// Wait until the value at ptr reaches target_val using acquire semantics
+// Only thread 0 spins, then all threads synchronize
+__device__ __forceinline__ void wait_ge(int* ptr, int target_val, int thread_idx) {
+  if (thread_idx == 0) {
+#pragma unroll 1
+    while (ld_acquire(ptr) < target_val) {
+    }
+  }
+  __syncthreads();
+}
+
+// ==================== Multi-CTA Radix Top-K Mask Logits ====================
+
+// Global state for multi-CTA radix reduction (one per group)
+struct RadixRowState {
+  uint32_t histogram[3][256];  // Triple-buffered histograms for 1-barrier-per-round
+  uint32_t remaining_k;        // Remaining k after current round
+  uint32_t prefix;             // Accumulated prefix (high bits of k-th element)
+  int arrival_counter;         // For inter-CTA synchronization
+  int output_counter;          // For collecting top-k indices (RadixTopK)
+  float sum_topk;              // For RenormProb: sum of top-k elements
+};
+
+constexpr uint32_t RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP = 256;
+
+struct RadixDeterministicCollectScratch {
+  uint32_t gt_count[RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP];
+  uint32_t eq_count[RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP];
+};
+
+inline RadixDeterministicCollectScratch* MaybeGetRadixDeterministicCollectScratchBuffer(
+    RadixRowState* row_states_buffer, uint32_t num_groups, bool single_cta, bool deterministic) {
+  return (single_cta || !deterministic || row_states_buffer == nullptr)
+             ? nullptr
+             : reinterpret_cast<RadixDeterministicCollectScratch*>(row_states_buffer + num_groups);
+}
+
+// ==================== Common Device Functions for Radix Top-K ====================
+/*!
+ * \brief Software barrier across all CTAs in the same radix group.
+ *
+ * Each CTA contributes exactly one arrival via tx==0, then waits until the
+ * group-wide arrival counter reaches the current phase target.
+ *
+ * \param state Per-group radix row state that owns the arrival counter
+ * \param barrier_phase Current software-barrier phase for this CTA group
+ * \param ctas_per_group Number of CTAs participating in the group barrier
+ * \param tx Thread index within the block
+ */
+__device__ __forceinline__ void AdvanceRadixGroupBarrier(RadixRowState* state, int& barrier_phase,
+                                                         uint32_t ctas_per_group, uint32_t tx) {
+  if (tx == 0) {
+    red_release(&state->arrival_counter, 1);
+  }
+  int target = (barrier_phase + 1) * ctas_per_group;
+  wait_ge(&state->arrival_counter, target, tx);
+  barrier_phase++;
+  __syncthreads();
+}
+
+/*!
+ * \brief Deterministically collect thread-strided matches with a full CTA scan.
+ *
+ * Threads traverse indices in the fixed order `tx, tx + BLOCK_THREADS, ...`, compute
+ * per-thread match counts over the full strided chain, exclusive-scan those counts across
+ * the CTA, then emit matches in that same deterministic thread-strided order.
+ *
+ * \tparam BLOCK_THREADS Number of threads in the CTA
+ * \param tx Thread index within the CTA
+ * \param length Number of elements to scan
+ * \param scan_temp_storage CUB BlockScan temp storage reused by the caller
+ * \param is_selected Predicate over the thread-strided index
+ * \param emit_limit Maximum number of selected elements to emit
+ * \param emit_selected Callback invoked as emit_selected(index, local_pos)
+ */
+template <uint32_t BLOCK_THREADS, typename TempStorage, typename Predicate, typename EmitFn>
+__device__ __forceinline__ void DeterministicThreadStridedCollect(uint32_t tx, uint32_t length,
+                                                                  TempStorage& scan_temp_storage,
+                                                                  Predicate is_selected,
+                                                                  uint32_t emit_limit,
+                                                                  EmitFn emit_selected) {
+  using BlockScan = cub::BlockScan<uint32_t, BLOCK_THREADS, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+
+  uint32_t thread_local_selected_count = 0;
+  for (uint32_t i = tx; i < length; i += BLOCK_THREADS) {
+    thread_local_selected_count += static_cast<uint32_t>(is_selected(i));
+  }
+
+  uint32_t thread_local_selected_prefix = 0;
+  BlockScan(scan_temp_storage)
+      .ExclusiveSum(thread_local_selected_count, thread_local_selected_prefix);
+
+  if (thread_local_selected_count > 0 && thread_local_selected_prefix < emit_limit) {
+    uint32_t thread_local_emit_pos = thread_local_selected_prefix;
+    const uint32_t thread_local_emit_end =
+        min(thread_local_selected_prefix + thread_local_selected_count, emit_limit);
+    for (uint32_t i = tx; i < length; i += BLOCK_THREADS) {
+      if (is_selected(i)) {
+        emit_selected(i, thread_local_emit_pos);
+        if (++thread_local_emit_pos == thread_local_emit_end) {
+          break;
+        }
+      }
+    }
+  }
+  __syncthreads();
+}
+
+/*!
+ * \brief Deterministically collect contiguous-order matches with a full CTA scan.
+ *
+ * Unlike DeterministicThreadStridedCollect, this helper traverses the row in contiguous index
+ * order across the CTA. This is used for row-global tie-breaking where we must prefer either
+ * smaller indices first or larger indices first for equal pivot values.
+ *
+ * \tparam BLOCK_THREADS Number of threads in the CTA
+ * \tparam REVERSE If true, traverse indices in reverse order (length-1 ... 0)
+ */
+template <uint32_t BLOCK_THREADS, bool REVERSE, typename TempStorage, typename Predicate,
+          typename EmitFn>
+__device__ __forceinline__ void DeterministicContiguousCollect(uint32_t tx, uint32_t length,
+                                                               TempStorage& scan_temp_storage,
+                                                               Predicate is_selected,
+                                                               uint32_t emit_limit,
+                                                               EmitFn emit_selected) {
+  if (emit_limit == 0 || length == 0) {
+    __syncthreads();
+    return;
+  }
+  using BlockScan = cub::BlockScan<uint32_t, BLOCK_THREADS, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+  // TODO: maybe tune ITEMS_PER_THREAD and vectorize
+  constexpr uint32_t ITEMS_PER_THREAD = 4;
+  constexpr uint32_t CHUNK_ITEMS = BLOCK_THREADS * ITEMS_PER_THREAD;
+  __shared__ uint32_t s_emitted;
+  __shared__ uint32_t s_chunk_base;
+  __shared__ uint32_t s_chunk_take;
+  if (tx == 0) {
+    s_emitted = 0;
+    s_chunk_base = 0;
+    s_chunk_take = 0;
+  }
+  __syncthreads();
+
+  const uint32_t num_chunks = ceil_div(length, CHUNK_ITEMS);
+  for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+    uint32_t row_idx_per_item[ITEMS_PER_THREAD];
+    uint32_t selected_per_item[ITEMS_PER_THREAD];
+    uint32_t thread_local_selected_count = 0;
+
+#pragma unroll
+    for (uint32_t item = 0; item < ITEMS_PER_THREAD; ++item) {
+      const uint32_t linear_idx = chunk * CHUNK_ITEMS + tx * ITEMS_PER_THREAD + item;
+      const bool in_range = linear_idx < length;
+      uint32_t row_idx = 0;
+      if (in_range) {
+        row_idx = REVERSE ? (length - 1u - linear_idx) : linear_idx;
+      }
+      row_idx_per_item[item] = row_idx;
+      const uint32_t selected = (in_range && is_selected(row_idx)) ? 1u : 0u;
+      selected_per_item[item] = selected;
+      thread_local_selected_count += selected;
+    }
+
+    uint32_t selected_prefix = 0;
+    uint32_t block_selected = 0;
+    BlockScan(scan_temp_storage)
+        .ExclusiveSum(thread_local_selected_count, selected_prefix, block_selected);
+
+    if (tx == 0) {
+      s_chunk_base = s_emitted;
+      const uint32_t remaining = (s_emitted < emit_limit) ? (emit_limit - s_emitted) : 0u;
+      s_chunk_take = min(remaining, block_selected);
+      s_emitted += s_chunk_take;
+    }
+    __syncthreads();
+
+    if (thread_local_selected_count > 0 && selected_prefix < s_chunk_take) {
+      uint32_t thread_emit_pos = selected_prefix;
+      const uint32_t thread_emit_end =
+          min(selected_prefix + thread_local_selected_count, s_chunk_take);
+#pragma unroll
+      for (uint32_t item = 0; item < ITEMS_PER_THREAD; ++item) {
+        if (selected_per_item[item]) {
+          emit_selected(row_idx_per_item[item], s_chunk_base + thread_emit_pos);
+          if (++thread_emit_pos == thread_emit_end) {
+            break;
+          }
+        }
+      }
+    }
+    __syncthreads();
+
+    if (s_emitted >= emit_limit) {
+      break;
+    }
+  }
+  __syncthreads();
+}
+
+/*!
+ * \brief Compute suffix sum in shared memory using parallel reduction.
+ *
+ * After this function, suffix_sum[i] contains the count of elements >= bucket i.
+ * This is computed by summing all histogram values from bucket i to 255.
+ *
+ * \param suffix_sum Shared memory array of size RADIX (256)
+ * \param tx Thread index within the block
+ */
+template <uint32_t BLOCK_THREADS>
+__device__ __forceinline__ void RadixSuffixSum(uint32_t* suffix_sum, uint32_t tx) {
+  constexpr uint32_t RADIX = 256;
+  // Parallel suffix sum: compute count of elements >= each bucket
+  for (uint32_t stride = 1; stride < RADIX; stride *= 2) {
+    uint32_t val = 0;
+    if (tx < RADIX) {
+      val = suffix_sum[tx];
+      if (tx + stride < RADIX) {
+        val += suffix_sum[tx + stride];
+      }
+    }
+    __syncthreads();
+    if (tx < RADIX) {
+      suffix_sum[tx] = val;
+    }
+    __syncthreads();
+  }
+}
+
+/*!
+ * \brief Find the threshold bucket that contains the k-th largest element.
+ *
+ * The threshold bucket satisfies: count_ge >= k && count_gt < k
+ * where count_ge = suffix_sum[bucket] and count_gt = suffix_sum[bucket+1].
+ *
+ * \param suffix_sum Shared memory array containing suffix sums
+ * \param remaining_k Number of top-k elements still to find
+ * \param found_bucket Output: the found threshold bucket
+ * \param found_remaining_k Output: remaining_k minus count of elements > threshold
+ * \param tx Thread index within the block
+ */
+__device__ __forceinline__ void RadixFindThresholdBucket(uint32_t* suffix_sum, uint32_t remaining_k,
+                                                         uint32_t* found_bucket,
+                                                         uint32_t* found_remaining_k, uint32_t tx) {
+  constexpr uint32_t RADIX = 256;
+  // Initialize (only thread 0)
+  if (tx == 0) {
+    *found_bucket = 0;
+    *found_remaining_k = remaining_k;
+  }
+  __syncthreads();
+
+  // All threads in RADIX range check their bucket
+  if (tx < RADIX) {
+    uint32_t count_ge = suffix_sum[tx];
+    uint32_t count_gt = (tx + 1 < RADIX) ? suffix_sum[tx + 1] : 0;
+    if (count_ge >= remaining_k && count_gt < remaining_k) {
+      *found_bucket = tx;
+      *found_remaining_k = remaining_k - count_gt;
+    }
+  }
+  __syncthreads();
+}
+
+/*!
+ * \brief Build local histogram for one round of radix select.
+ *
+ * Counts elements in shared_ordered that match the current prefix and bins them
+ * by their byte at the current shift position.
+ *
+ * \tparam OrderedType The ordered integer type (uint16_t or uint32_t)
+ * \param shared_ordered Shared memory containing ordered values
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param local_histogram Output shared memory histogram
+ * \param prefix Current prefix (high bits determined so far)
+ * \param shift Bit shift for extracting current byte
+ * \param round Current round (0 to NUM_ROUNDS-1)
+ * \param tx Thread index
+ */
+template <uint32_t BLOCK_THREADS, typename OrderedType>
+__device__ __forceinline__ void RadixBuildLocalHistogram(const OrderedType* shared_ordered,
+                                                         uint32_t actual_chunk_size,
+                                                         uint32_t* local_histogram, uint32_t prefix,
+                                                         uint32_t shift, uint32_t round,
+                                                         uint32_t tx) {
+  constexpr uint32_t ORDERED_BITS = sizeof(OrderedType) * 8;
+  constexpr uint32_t RADIX_BITS = 8;
+
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    OrderedType ordered = shared_ordered[i];
+
+    // Check if this element matches the prefix (high bits determined so far)
+    OrderedType mask =
+        (round == 0)
+            ? OrderedType(0)
+            : static_cast<OrderedType>(~OrderedType(0) << (ORDERED_BITS - round * RADIX_BITS));
+    if ((ordered & mask) == static_cast<OrderedType>(prefix)) {
+      uint32_t bucket = (ordered >> shift) & 0xFF;
+      atomicAdd(&local_histogram[bucket], 1);
+    }
+  }
+}
+
+/*!
+ * \brief Perform one round of radix select with optional multi-CTA synchronization.
+ *
+ * This is the core radix select logic used by all TopK kernels.
+ * It builds histogram, aggregates across CTAs (if multi-CTA), computes suffix sum,
+ * and finds the threshold bucket.
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam SINGLE_CTA True if single-CTA mode (no inter-CTA sync needed)
+ * \tparam OrderedType The ordered integer type
+ *
+ * \param shared_ordered Shared memory containing ordered values
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param local_histogram Shared memory for local histogram (size RADIX)
+ * \param suffix_sum Shared memory for suffix sum computation (size RADIX)
+ * \param state Pointer to RadixRowState for multi-CTA sync (nullptr if SINGLE_CTA)
+ * \param prefix Current prefix value
+ * \param remaining_k Current remaining k value
+ * \param round Current round (0 to NUM_ROUNDS-1)
+ * \param barrier_phase Reference to barrier phase counter
+ * \param ctas_per_group Number of CTAs per group
+ * \param tx Thread index
+ * \param out_new_prefix Output: updated prefix after this round
+ * \param out_new_remaining_k Output: updated remaining_k after this round
+ */
+template <uint32_t BLOCK_THREADS, bool SINGLE_CTA, typename OrderedType>
+__device__ __forceinline__ void RadixSelectOneRound(
+    const OrderedType* shared_ordered, uint32_t actual_chunk_size, uint32_t* local_histogram,
+    uint32_t* suffix_sum, uint32_t* shared_scalars, RadixRowState* state, uint32_t prefix,
+    uint32_t remaining_k, uint32_t round, uint32_t iter, int& barrier_phase,
+    uint32_t ctas_per_group, uint32_t cta_in_group, uint32_t tx, uint32_t* out_new_prefix,
+    uint32_t* out_new_remaining_k) {
+  constexpr uint32_t RADIX = 256;
+  constexpr uint32_t ORDERED_BITS = sizeof(OrderedType) * 8;
+  constexpr uint32_t RADIX_BITS = 8;
+  constexpr uint32_t NUM_ROUNDS = ORDERED_BITS / RADIX_BITS;
+  uint32_t shift = ORDERED_BITS - (round + 1) * RADIX_BITS;
+  uint32_t global_round = iter * NUM_ROUNDS + round;
+
+  // For multi-CTA: pointers to global histograms (triple buffer)
+  uint32_t* current_hist = nullptr;
+  uint32_t* next_hist = nullptr;
+  if constexpr (!SINGLE_CTA) {
+    current_hist = state->histogram[global_round % 3];
+    next_hist = state->histogram[(global_round + 1) % 3];
+  }
+
+  // Clear local histogram only
+  for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+    local_histogram[i] = 0;
+  }
+  __syncthreads();
+
+  // Build local histogram from shared memory
+  RadixBuildLocalHistogram<BLOCK_THREADS, OrderedType>(shared_ordered, actual_chunk_size,
+                                                       local_histogram, prefix, shift, round, tx);
+  __syncthreads();
+
+  // For multi-CTA: write -> (leading CTA clears next) -> barrier -> read
+  // For single-CTA: local_histogram is already the complete histogram
+  if constexpr (!SINGLE_CTA) {
+    // Accumulate local histogram to global
+    for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+      if (local_histogram[i] > 0) {
+        atomicAdd(&current_hist[i], local_histogram[i]);
+      }
+    }
+
+    // Only leading CTA clears next round's histogram BEFORE barrier
+    if (cta_in_group == 0) {
+      for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+        next_hist[i] = 0;
+      }
+    }
+
+    // Barrier: wait for all CTAs to finish atomicAdd and clearing
+    AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+    // Read current histogram (after barrier, all atomicAdds are complete)
+    for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+      suffix_sum[i] = current_hist[i];
+    }
+  } else {
+    // Single-CTA: copy local histogram directly to suffix_sum
+    for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+      suffix_sum[i] = local_histogram[i];
+    }
+  }
+  __syncthreads();
+
+  // Compute suffix sum
+  RadixSuffixSum<BLOCK_THREADS>(suffix_sum, tx);
+
+  // Find threshold bucket using shared_scalars for found_bucket and found_remaining_k
+  // shared_scalars[0] = found_bucket, shared_scalars[1] = found_remaining_k
+  RadixFindThresholdBucket(suffix_sum, remaining_k, &shared_scalars[0], &shared_scalars[1], tx);
+
+  // Output new prefix and remaining_k
+  *out_new_prefix = prefix | (shared_scalars[0] << shift);
+  *out_new_remaining_k = shared_scalars[1];
+}
+
+/*!
+ * \brief Load data from global memory to shared memory and convert to ordered representation.
+ *
+ * This is the common Stage 1 for all TopK kernels. It loads data using vectorized
+ * memory access and converts to ordered representation for radix select.
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam VEC_SIZE Vector size for memory access
+ * \tparam DType Data type (float, half, nv_bfloat16)
+ * \tparam Traits Type traits for DType
+ *
+ * \param input Pointer to input data row start (already offset by row)
+ * \param shared_ordered Shared memory for ordered values
+ * \param chunk_start Start index within the row for this CTA's chunk
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param tx Thread index
+ */
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, typename Traits>
+__device__ __forceinline__ void LoadToSharedOrdered(const DType* input,
+                                                    typename Traits::OrderedType* shared_ordered,
+                                                    uint32_t chunk_start,
+                                                    uint32_t actual_chunk_size, uint32_t tx) {
+  using OrderedType = typename Traits::OrderedType;
+  vec_t<DType, VEC_SIZE> input_vec;
+  const uint32_t aligned_size = (actual_chunk_size / VEC_SIZE) * VEC_SIZE;
+
+#pragma unroll 2
+  for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+    input_vec.cast_load(input + chunk_start + i);
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      shared_ordered[i + j] = Traits::ToOrdered(input_vec[j]);
+    }
+  }
+  // Handle tail
+  for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    shared_ordered[i] = Traits::ToOrdered(input[chunk_start + i]);
+  }
+  __syncthreads();
+}
+
+/*!
+ * \brief Find the k-th largest element using radix select from pre-loaded shared memory.
+ *
+ * This function assumes data has already been loaded into shared_ordered.
+ * It performs the complete radix select algorithm (initial barrier + NUM_ROUNDS)
+ * and returns the ordered pivot value.
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam SINGLE_CTA True if single-CTA mode
+ * \tparam OrderedType The ordered integer type
+ *
+ * \param shared_ordered Shared memory containing ordered values (pre-loaded)
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param k Number of top elements to select
+ * \param local_histogram Shared memory for local histogram (size RADIX)
+ * \param suffix_sum Shared memory for suffix sum (size RADIX)
+ * \param shared_scalars Shared memory for scalars [prefix_cache, remaining_k_cache, found_bucket,
+ * found_remaining_k, output_counter]
+ * \param state RadixRowState pointer for multi-CTA sync (nullptr if SINGLE_CTA)
+ * \param barrier_phase Reference to barrier phase counter
+ * \param ctas_per_group Number of CTAs per group
+ * \param cta_in_group CTA index within group
+ * \param tx Thread index
+ * \param iter Current iteration (for triple-buffer indexing)
+ * \return The pivot value in ordered representation
+ */
+template <uint32_t BLOCK_THREADS, bool SINGLE_CTA, typename OrderedType, bool TRACK_EQ_COUNT>
+__device__ __forceinline__ OrderedType RadixSelectFromSharedMemory(
+    const OrderedType* shared_ordered, uint32_t actual_chunk_size, uint32_t k,
+    uint32_t* local_histogram, uint32_t* suffix_sum, uint32_t* shared_scalars, RadixRowState* state,
+    int& barrier_phase, uint32_t ctas_per_group, uint32_t cta_in_group, uint32_t tx, uint32_t iter,
+    uint32_t& out_local_gt_count, uint32_t& out_local_eq_count) {
+  constexpr uint32_t RADIX = 256;
+  constexpr uint32_t RADIX_BITS = 8;
+  constexpr uint32_t ORDERED_BITS = sizeof(OrderedType) * 8;
+  constexpr uint32_t NUM_ROUNDS = ORDERED_BITS / RADIX_BITS;
+
+// Aliases for scalar shared variables
+#define prefix_cache shared_scalars[0]
+#define remaining_k_cache shared_scalars[1]
+#define found_bucket shared_scalars[2]
+#define found_remaining_k shared_scalars[3]
+#define shared_output_counter shared_scalars[4]
+
+  // Initialize local caches
+  if (tx == 0) {
+    prefix_cache = 0;
+    remaining_k_cache = k;
+    if constexpr (SINGLE_CTA) {
+      shared_output_counter = 0;
+    }
+  }
+  __syncthreads();
+
+  // Initial barrier (skip for single CTA)
+  if constexpr (!SINGLE_CTA) {
+    AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+    // CTA 0 clears output counter AFTER barrier
+    if (cta_in_group == 0 && tx == 0) {
+      st_release(&state->output_counter, 0);
+    }
+  }
+
+  // NUM_ROUNDS of radix select
+  for (uint32_t round = 0; round < NUM_ROUNDS; ++round) {
+    uint32_t global_round = iter * NUM_ROUNDS + round;
+    uint32_t shift = ORDERED_BITS - (round + 1) * RADIX_BITS;
+    uint32_t prefix = prefix_cache;
+    uint32_t remaining_k = remaining_k_cache;
+
+    // For multi-CTA: pointers to global histograms (triple buffer)
+    uint32_t* current_hist = nullptr;
+    uint32_t* next_hist = nullptr;
+    if constexpr (!SINGLE_CTA) {
+      current_hist = state->histogram[global_round % 3];
+      next_hist = state->histogram[(global_round + 1) % 3];
+    }
+
+    // Clear local histogram
+    for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+      local_histogram[i] = 0;
+    }
+    __syncthreads();
+
+    // Build local histogram
+#pragma unroll 2
+    for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+      OrderedType ordered = shared_ordered[i];
+      OrderedType mask =
+          (round == 0)
+              ? OrderedType(0)
+              : static_cast<OrderedType>(~OrderedType(0) << (ORDERED_BITS - round * RADIX_BITS));
+      if ((ordered & mask) == static_cast<OrderedType>(prefix)) {
+        uint32_t bucket = (ordered >> shift) & 0xFF;
+        atomicAdd(&local_histogram[bucket], 1);
+      }
+    }
+    __syncthreads();
+
+    // Multi-CTA: accumulate to global, barrier, read back
+    if constexpr (!SINGLE_CTA) {
+      for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+        if (local_histogram[i] > 0) {
+          atomicAdd(&current_hist[i], local_histogram[i]);
+        }
+      }
+      if (cta_in_group == 0) {
+        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+          next_hist[i] = 0;
+        }
+      }
+      AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+      for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+        suffix_sum[i] = current_hist[i];
+      }
+    } else {
+      for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+        suffix_sum[i] = local_histogram[i];
+      }
+    }
+    __syncthreads();
+
+    // Compute suffix sum
+    RadixSuffixSum<BLOCK_THREADS>(suffix_sum, tx);
+
+    // Find threshold bucket
+    if (tx == 0) {
+      found_bucket = 0;
+      found_remaining_k = remaining_k;
+    }
+    __syncthreads();
+
+    if (tx < RADIX) {
+      uint32_t count_ge = suffix_sum[tx];
+      uint32_t count_gt = (tx + 1 < RADIX) ? suffix_sum[tx + 1] : 0;
+      if (count_ge >= remaining_k && count_gt < remaining_k) {
+        found_bucket = tx;
+        found_remaining_k = remaining_k - count_gt;
+      }
+    }
+    __syncthreads();
+
+    // Update caches
+    if (tx == 0) {
+      prefix_cache = prefix | (found_bucket << shift);
+      remaining_k_cache = found_remaining_k;
+    }
+    __syncthreads();
+  }
+
+  OrderedType ordered_pivot = static_cast<OrderedType>(prefix_cache);
+
+  // Count > pivot (and optionally == pivot) elements by scanning shared_ordered.
+  // This is needed because suffix_sum only tracks elements matching the current prefix,
+  // not all elements > pivot (which includes elements with higher-order bits > pivot)
+  if (tx == 0) {
+    suffix_sum[0] = 0;
+    if constexpr (TRACK_EQ_COUNT) {
+      suffix_sum[1] = 0;
+    }
+  }
+  __syncthreads();
+
+  uint32_t my_gt_count = 0;
+  uint32_t my_eq_count = 0;
+#pragma unroll 2
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    const OrderedType ordered = shared_ordered[i];
+    if (ordered > ordered_pivot) {
+      my_gt_count++;
+    }
+    if constexpr (TRACK_EQ_COUNT) {
+      if (ordered == ordered_pivot) {
+        my_eq_count++;
+      }
+    }
+  }
+
+  // Warp-level reduction
+  for (int offset = 16; offset > 0; offset /= 2) {
+    my_gt_count += __shfl_down_sync(0xffffffff, my_gt_count, offset);
+    if constexpr (TRACK_EQ_COUNT) {
+      my_eq_count += __shfl_down_sync(0xffffffff, my_eq_count, offset);
+    }
+  }
+
+  // First thread of each warp atomics to shared
+  int lane = tx % 32;
+  if (lane == 0 && my_gt_count > 0) {
+    atomicAdd(&suffix_sum[0], my_gt_count);
+  }
+  if constexpr (TRACK_EQ_COUNT) {
+    if (lane == 0 && my_eq_count > 0) {
+      atomicAdd(&suffix_sum[1], my_eq_count);
+    }
+  }
+  __syncthreads();
+
+  out_local_gt_count = suffix_sum[0];
+  if constexpr (TRACK_EQ_COUNT) {
+    out_local_eq_count = suffix_sum[1];
+  } else {
+    out_local_eq_count = 0;
+  }
+
+#undef prefix_cache
+#undef remaining_k_cache
+#undef found_bucket
+#undef found_remaining_k
+#undef shared_output_counter
+
+  return ordered_pivot;
+}
+
+/*!
+ * \brief Load one CTA chunk into ordered shared memory, then find the pivot with radix select.
+ *
+ * This helper centralizes the shared-memory load and the exact k-th-element radix
+ * select. It returns the pivot in ordered representation. Callers can optionally request the
+ * CTA-local counts of elements
+ * `> pivot` and `== pivot`, which are needed by deterministic collect paths.
+ */
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, bool SINGLE_CTA, bool TRACK_EQ_COUNT,
+          typename DType>
+__device__ __forceinline__ typename RadixTopKTraits<DType>::OrderedType RadixSelectFindPivot(
+    const DType* input, typename RadixTopKTraits<DType>::OrderedType* shared_ordered,
+    uint32_t* local_histogram, uint32_t* suffix_sum, uint32_t* shared_scalars, RadixRowState* state,
+    uint32_t chunk_start, uint32_t actual_chunk_size, uint32_t k, int& barrier_phase,
+    uint32_t ctas_per_group, uint32_t cta_in_group, uint32_t tx, uint32_t iter,
+    uint32_t& out_local_gt_count, uint32_t& out_local_eq_count) {
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+
+  LoadToSharedOrdered<BLOCK_THREADS, VEC_SIZE, DType, Traits>(input, shared_ordered, chunk_start,
+                                                              actual_chunk_size, tx);
+  return RadixSelectFromSharedMemory<BLOCK_THREADS, SINGLE_CTA, OrderedType, TRACK_EQ_COUNT>(
+      shared_ordered, actual_chunk_size, k, local_histogram, suffix_sum, shared_scalars, state,
+      barrier_phase, ctas_per_group, cta_in_group, tx, iter, out_local_gt_count,
+      out_local_eq_count);
+}
+
+/*!
+ * \brief Collect top-k indices based on pivot value with custom output transform (Single Pass).
+ *
+ * This optimized version uses a single pass to write all elements:
+ * - > pivot: use shared memory atomic for local offset within CTA's allocation
+ * - == pivot: use global memory atomic, check if pos < k before writing
+ *
+ * The local_gt_count is computed during the last round of radix select, so we know
+ * exactly how many > pivot elements each CTA has. This allows batched global atomic
+ * (one per CTA) for > pivot elements.
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam SINGLE_CTA True if single-CTA mode
+ * \tparam OrderedType The ordered integer type
+ * \tparam OutputFunc Functor type: void(uint32_t original_idx, OrderedType ordered_val, int
+ * output_pos)
+ *
+ * \param shared_ordered Shared memory containing ordered values
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param chunk_start Start index in input for this chunk
+ * \param k Number of top elements to select
+ * \param ordered_pivot The pivot value in ordered representation
+ * \param local_gt_count Number of > pivot elements in this CTA (from radix select)
+ * \param local_histogram Shared memory for counters
+ * \param shared_output_counter Pointer to shared output counter (SINGLE_CTA mode)
+ * \param state RadixRowState pointer for multi-CTA sync (nullptr if SINGLE_CTA)
+ * \param barrier_phase Reference to barrier phase counter (unused in new implementation)
+ * \param ctas_per_group Number of CTAs per group
+ * \param tx Thread index
+ * \param output_func Functor called as output_func(original_idx, ordered_val, output_pos) for each
+ * element
+ */
+template <uint32_t BLOCK_THREADS, bool SINGLE_CTA, typename OrderedType, typename OutputFunc>
+__device__ __forceinline__ void RadixCollectIndices(
+    const OrderedType* shared_ordered, uint32_t actual_chunk_size, uint32_t chunk_start, uint32_t k,
+    OrderedType ordered_pivot, uint32_t local_gt_count, uint32_t* local_histogram,
+    uint32_t* shared_output_counter, RadixRowState* state, int& barrier_phase,
+    uint32_t ctas_per_group, uint32_t tx, OutputFunc output_func) {
+// Use local_histogram for counters:
+// [0]: local_offset_gt (local offset for > pivot elements within CTA's allocation)
+// [1]: global_base_gt (global base position for > pivot)
+#define local_offset_gt local_histogram[0]
+#define global_base_gt local_histogram[1]
+
+  // Get global base position for this CTA's > pivot elements (one atomic per CTA)
+  if (tx == 0) {
+    local_offset_gt = 0;
+    if (local_gt_count > 0) {
+      if constexpr (SINGLE_CTA) {
+        global_base_gt = atomicAdd(shared_output_counter, local_gt_count);
+      } else {
+        global_base_gt = atomicAdd(&state->output_counter, local_gt_count);
+      }
+    }
+  }
+  __syncthreads();
+
+  // Pass 1: Write elements > pivot
+  // These are guaranteed to be in top-k, use local offset within CTA's allocation
+#pragma unroll 2
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    OrderedType ordered_val = shared_ordered[i];
+    if (ordered_val > ordered_pivot) {
+      uint32_t local_pos = atomicAdd(&local_offset_gt, 1);
+      int pos = global_base_gt + local_pos;
+      output_func(chunk_start + i, ordered_val, pos);
+    }
+  }
+
+  // Barrier to ensure all > pivot elements are collected first (only for multi-CTA)
+  // This is critical: without this barrier, CTAs may write == pivot elements while
+  // other CTAs are still writing > pivot elements, causing incorrect positions.
+  if constexpr (!SINGLE_CTA) {
+    AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+  } else {
+    __syncthreads();
+  }
+
+  // Pass 2: Write elements == pivot
+  // Use global atomic directly since we need cross-CTA coordination to respect
+  // the k limit (some == pivot elements may be truncated).
+#pragma unroll 2
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    OrderedType ordered_val = shared_ordered[i];
+    if (ordered_val == ordered_pivot) {
+      int pos;
+      if constexpr (SINGLE_CTA) {
+        pos = atomicAdd(shared_output_counter, 1);
+      } else {
+        pos = atomicAdd(&state->output_counter, 1);
+      }
+      if (pos < static_cast<int>(k)) {
+        output_func(chunk_start + i, ordered_pivot, pos);
+      }
+    }
+  }
+
+#undef local_offset_gt
+#undef global_base_gt
+}
+
+struct DeterministicCollectCountPair {
+  uint32_t gt;
+  uint32_t eq;
+};
+
+struct DeterministicCollectCountPairSum {
+  __device__ __forceinline__ DeterministicCollectCountPair operator()(
+      const DeterministicCollectCountPair& lhs, const DeterministicCollectCountPair& rhs) const {
+    return {lhs.gt + rhs.gt, lhs.eq + rhs.eq};
+  }
+};
+
+/*!
+ * \brief Collect top-k indices with deterministic cross-CTA ordering.
+ *
+ * This variant preserves repeatable output by replacing cross-CTA atomic tie
+ * claiming with a fixed allocation scheme:
+ * - All > pivot elements are assigned output ranges in CTA order.
+ * - == pivot elements are then assigned deterministic prefixes from
+ *   per-CTA gt/eq counts stored in \p det_scratch.
+ *
+ * Single-CTA mode degenerates to a block-local deterministic collect without
+ * using \p det_scratch.
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam SINGLE_CTA True if single-CTA mode
+ * \tparam OrderedType The ordered integer type
+ * \tparam OutputFunc Functor type: void(uint32_t original_idx, OrderedType ordered_val, int
+ * output_pos)
+ *
+ * \param shared_ordered Shared memory containing ordered values
+ * \param actual_chunk_size Number of elements in this CTA's chunk
+ * \param chunk_start Start index in input for this chunk
+ * \param k Number of top elements to select
+ * \param ordered_pivot The pivot value in ordered representation
+ * \param cta_local_gt_count Number of > pivot elements in this CTA (from radix select)
+ * \param cta_local_eq_count Number of == pivot elements in this CTA (from radix select)
+ * \param local_histogram Shared memory scratch reused for deterministic collect state
+ * \param state RadixRowState pointer for multi-CTA sync (nullptr if SINGLE_CTA)
+ * \param det_scratch Per-group scratch for multi-CTA gt/eq counts (nullptr if SINGLE_CTA)
+ * \param barrier_phase Reference to barrier phase counter
+ * \param ctas_per_group Number of CTAs per group
+ * \param cta_in_group CTA index within the current group
+ * \param tx Thread index
+ * \param output_func Functor called as output_func(original_idx, ordered_val, output_pos) for each
+ * selected element
+ */
+template <uint32_t BLOCK_THREADS, bool SINGLE_CTA, typename OrderedType, typename OutputFunc>
+__device__ __forceinline__ void RadixCollectIndicesDeterministic(
+    const OrderedType* shared_ordered, uint32_t actual_chunk_size, uint32_t chunk_start, uint32_t k,
+    OrderedType ordered_pivot, uint32_t cta_local_gt_count, uint32_t cta_local_eq_count,
+    uint32_t* local_histogram, RadixRowState* state, RadixDeterministicCollectScratch* det_scratch,
+    int& barrier_phase, uint32_t ctas_per_group, uint32_t cta_in_group, uint32_t tx,
+    OutputFunc output_func) {
+// Use local_histogram for counters:
+// [0]: s_cta_local_gt_prefix   - total >pivot count from earlier CTAs
+// [1]: s_cta_local_eq_prefix   - total ==pivot count from earlier CTAs
+// [2]: s_row_total_gt_count    - row-wide >pivot count across all CTAs
+// [3]: s_row_eq_needed         - number of ==pivot entries still needed after >pivot writes
+// [4]: s_cta_local_eq_take     - this CTA's assigned ==pivot quota
+#define s_cta_local_gt_prefix local_histogram[0]
+#define s_cta_local_eq_prefix local_histogram[1]
+#define s_row_total_gt_count local_histogram[2]
+#define s_row_eq_needed local_histogram[3]
+#define s_cta_local_eq_take local_histogram[4]
+  uint32_t cta_local_eq_emit_limit = 0;
+  uint32_t cta_local_eq_output_base = 0;
+  if constexpr (SINGLE_CTA) {
+    if (tx == 0) {
+      s_cta_local_gt_prefix = 0;
+      s_cta_local_eq_prefix = 0;
+      s_row_total_gt_count = cta_local_gt_count;
+      s_row_eq_needed = (k > cta_local_gt_count) ? (k - cta_local_gt_count) : 0;
+      s_cta_local_eq_take = 0;
+    }
+    __syncthreads();
+    // Single-CTA: keep the full ==pivot suffix contiguous after all >pivot entries.
+    cta_local_eq_emit_limit = s_row_eq_needed;
+    cta_local_eq_output_base = s_row_total_gt_count;
+  } else {
+    // Each CTA writes its local >pivot / ==pivot counts
+    if (tx == 0) {
+      s_cta_local_eq_prefix = 0;
+      s_cta_local_eq_take = 0;
+      det_scratch->gt_count[cta_in_group] = cta_local_gt_count;
+      det_scratch->eq_count[cta_in_group] = cta_local_eq_count;
+    }
+    AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+    // Each CTA reads all >pivot / ==pivot counts
+    if (tx == 0) {
+      uint32_t cta_local_gt_prefix_accum = 0;
+      uint32_t row_total_gt = 0;
+      uint32_t cta_local_eq_prefix_accum = 0;
+      for (uint32_t c = 0; c < ctas_per_group; ++c) {
+        const uint32_t c_gt = det_scratch->gt_count[c];
+        const uint32_t c_eq = det_scratch->eq_count[c];
+        if (c < cta_in_group) {
+          cta_local_gt_prefix_accum += c_gt;
+          cta_local_eq_prefix_accum += c_eq;
+        }
+        row_total_gt += c_gt;
+      }
+      s_cta_local_gt_prefix = cta_local_gt_prefix_accum;
+      s_row_total_gt_count = row_total_gt;
+      s_row_eq_needed = (k > row_total_gt) ? (k - row_total_gt) : 0;
+      s_cta_local_eq_prefix = cta_local_eq_prefix_accum;
+      s_cta_local_eq_take = 0;
+      if (s_row_eq_needed > cta_local_eq_prefix_accum) {
+        s_cta_local_eq_take = min(cta_local_eq_count, s_row_eq_needed - cta_local_eq_prefix_accum);
+      }
+    }
+    __syncthreads();
+    // Multi-CTA: only emit this CTA's assigned ==pivot quota at its deterministic output base.
+    cta_local_eq_emit_limit = s_cta_local_eq_take;
+    cta_local_eq_output_base = s_row_total_gt_count + s_cta_local_eq_prefix;
+  }
+  const uint32_t cta_local_gt_output_base = s_cta_local_gt_prefix;
+  const uint32_t cta_local_gt_emit_limit =
+      (k > cta_local_gt_output_base) ? (k - cta_local_gt_output_base) : 0;
+
+#undef s_cta_local_gt_prefix
+#undef s_cta_local_eq_prefix
+#undef s_row_total_gt_count
+#undef s_row_eq_needed
+#undef s_cta_local_eq_take
+
+  using ScalarBlockScan = cub::BlockScan<uint32_t, BLOCK_THREADS, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+  using PairBlockScan =
+      cub::BlockScan<DeterministicCollectCountPair, BLOCK_THREADS, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+  union DeterministicCollectScanTempStorage {
+    typename ScalarBlockScan::TempStorage scalar;
+    typename PairBlockScan::TempStorage pair;
+  };
+  __shared__ DeterministicCollectScanTempStorage scan_temp_storage;
+
+  if (cta_local_eq_emit_limit == 0) {  // gt-only collect
+    DeterministicThreadStridedCollect<BLOCK_THREADS>(
+        tx, actual_chunk_size, scan_temp_storage.scalar,
+        [&](uint32_t i) { return shared_ordered[i] > ordered_pivot; }, cta_local_gt_emit_limit,
+        [&](uint32_t i, uint32_t local_pos) {
+          output_func(chunk_start + i, shared_ordered[i], cta_local_gt_output_base + local_pos);
+        });
+    return;
+  }
+
+  // Collect gt and eq elements
+  DeterministicCollectCountPair thread_local_counts = {0, 0};
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    const OrderedType ordered = shared_ordered[i];
+    thread_local_counts.gt += static_cast<uint32_t>(ordered > ordered_pivot);
+    thread_local_counts.eq += static_cast<uint32_t>(ordered == ordered_pivot);
+  }
+
+  DeterministicCollectCountPair thread_local_prefix = {0, 0};
+  PairBlockScan(scan_temp_storage.pair)
+      .ExclusiveScan(thread_local_counts, thread_local_prefix, DeterministicCollectCountPair{0, 0},
+                     DeterministicCollectCountPairSum{});
+
+  DeterministicCollectCountPair thread_local_pos = thread_local_prefix;
+  for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+    const OrderedType ordered = shared_ordered[i];
+    if (ordered > ordered_pivot && thread_local_pos.gt < cta_local_gt_emit_limit) {
+      output_func(chunk_start + i, ordered, cta_local_gt_output_base + thread_local_pos.gt);
+      ++thread_local_pos.gt;
+    } else if (ordered == ordered_pivot && thread_local_pos.eq < cta_local_eq_emit_limit) {
+      output_func(chunk_start + i, ordered, cta_local_eq_output_base + thread_local_pos.eq);
+      ++thread_local_pos.eq;
+    }
+  }
+  __syncthreads();
+}
+
+// ==================== Unified Radix Top-K Kernel with Epilogue Modes ====================
+
+/*!
+ * \brief Epilogue mode for unified RadixTopK kernel.
+ */
+enum class RadixTopKMode {
+  Basic,               ///< Returns (indices, values) pairs
+  PageTableTransform,  ///< Gathers indices through page table
+  RaggedTransform,     ///< Adds offset to indices
+};
+
+/*!
+ * \brief Unified Multi-CTA Radix Top-K kernel with mode-specific epilogues.
+ *
+ * This kernel unifies three top-k variants:
+ * - Basic: Returns top-k indices and values
+ * - PageTableTransform: Gathers top-k indices through a page table
+ * - RaggedTransform: Adds per-row offset to top-k indices
+ *
+ * \tparam BLOCK_THREADS Number of threads per block
+ * \tparam VEC_SIZE Vector size for memory access
+ * \tparam SINGLE_CTA True if single-CTA mode
+ * \tparam DETERMINISTIC True to use deterministic collect path
+ * \tparam MODE Epilogue mode (Basic, PageTableTransform, or RaggedTransform)
+ * \tparam DType Data type (float, half, nv_bfloat16)
+ * \tparam IdType Index type
+ */
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, bool SINGLE_CTA, bool DETERMINISTIC,
+          RadixTopKMode MODE, typename DType, typename IdType>
+__global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
+    DType* input,            // [num_rows, stride]
+    IdType* output_indices,  // [num_rows, top_k] - indices or page table entries
+    DType* output_values,    // [num_rows, top_k] - only used in Basic mode, nullptr otherwise
+    const IdType*
+        aux_data,  // Mode-specific: top_k_arr (Basic), src_page_table (PageTable), offsets (Ragged)
+    IdType* lengths,             // [num_rows] per-row lengths, nullptr for Basic (uses stride)
+    const IdType* row_starts,    // [num_rows] per-row start indices, nullptr => 0
+    const IdType* row_to_batch,  // [num_rows] batch mapping for PageTable, nullptr otherwise
+    int64_t aux_stride,          // src_page_table stride for PageTable mode, 0 otherwise
+    uint32_t top_k_val, uint32_t stride, uint32_t num_rows, RadixRowState* row_states,
+    RadixDeterministicCollectScratch* det_scratches, uint32_t chunk_size, uint32_t ctas_per_group) {
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+  constexpr uint32_t RADIX = 256;
+
+  const uint32_t global_cta_id = blockIdx.x;
+  const uint32_t group_id = global_cta_id / ctas_per_group;
+  const uint32_t cta_in_group = global_cta_id % ctas_per_group;
+  const uint32_t tx = threadIdx.x;
+
+  extern __shared__ uint8_t smem[];
+
+  constexpr size_t num_scalars = SINGLE_CTA ? 5 : 4;
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (RADIX + RADIX + num_scalars);
+  uint32_t* local_histogram = reinterpret_cast<uint32_t*>(smem);
+  uint32_t* suffix_sum = local_histogram + RADIX;
+  uint32_t* shared_scalars = suffix_sum + RADIX;
+
+  size_t ordered_offset = ((fixed_smem_size + 15) / 16) * 16;
+  OrderedType* shared_ordered = reinterpret_cast<OrderedType*>(smem + ordered_offset);
+
+#define shared_output_counter shared_scalars[4]
+
+  RadixRowState* state = nullptr;
+  if constexpr (!SINGLE_CTA) {
+    state = &row_states[group_id];
+  }
+  RadixDeterministicCollectScratch* det_scratch = nullptr;
+  if constexpr (!SINGLE_CTA && DETERMINISTIC) {
+    det_scratch = &det_scratches[group_id];
+  }
+  uint32_t num_groups = gridDim.x / ctas_per_group;
+  uint32_t total_iterations = (num_rows + num_groups - 1) / num_groups;
+
+  int barrier_phase = 0;
+
+  for (uint32_t iter = 0; iter < total_iterations; iter++) {
+    uint32_t row_idx = group_id + iter * num_groups;
+    if (row_idx >= num_rows) break;
+    const uint32_t row_start =
+        (row_starts != nullptr && MODE != RadixTopKMode::Basic) ? row_starts[row_idx] : 0;
+    DType* row_input = input + static_cast<size_t>(row_idx) * stride + row_start;
+
+    // Mode-specific: get row length and k value
+    uint32_t length, k;
+    if constexpr (MODE == RadixTopKMode::Basic) {
+      length = stride;                                            // Fixed length for all rows
+      k = (aux_data != nullptr) ? aux_data[row_idx] : top_k_val;  // aux_data = top_k_arr
+    } else {
+      length = lengths[row_idx];  // Per-row length
+      k = top_k_val;              // Fixed k
+    }
+
+    // Mode-specific: output pointers and auxiliary data
+    IdType* row_output = output_indices + row_idx * top_k_val;
+
+    // Handle trivial cases
+    if constexpr (MODE == RadixTopKMode::Basic) {
+      if (k >= length) {
+        // k >= vocab_size: return all indices
+        const uint32_t chunk_start = cta_in_group * chunk_size;
+        const uint32_t chunk_end = min(chunk_start + chunk_size, length);
+        const uint32_t actual_chunk_size = ((chunk_start < length) ? (chunk_end - chunk_start) : 0);
+
+        for (uint32_t i = tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+          if (chunk_start + i < k) {
+            row_output[chunk_start + i] = static_cast<IdType>(chunk_start + i);
+            output_values[row_idx * top_k_val + chunk_start + i] =
+                input[static_cast<size_t>(row_idx) * stride + chunk_start + i];
+          }
+        }
+        // Clear histogram for next iteration (in case it's k < length)
+        if constexpr (!SINGLE_CTA) {
+          constexpr uint32_t NUM_ROUNDS = sizeof(OrderedType) * 8 / 8;
+          uint32_t next_first_hist_idx = ((iter + 1) * NUM_ROUNDS) % 3;
+          if (cta_in_group == 0) {
+            for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+              state->histogram[next_first_hist_idx][i] = 0;
+            }
+          }
+        }
+        continue;
+      }
+    } else if constexpr (MODE == RadixTopKMode::PageTableTransform) {
+      uint32_t batch_idx = (row_to_batch != nullptr) ? row_to_batch[row_idx] : row_idx;
+      const IdType* src_page_entry = aux_data + batch_idx * aux_stride;
+      if (length <= top_k_val) {
+        for (uint32_t i = tx; i < top_k_val; i += BLOCK_THREADS) {
+          row_output[i] = (i < length) ? src_page_entry[row_start + i] : static_cast<IdType>(-1);
+        }
+        // Clear histogram for next iteration
+        if constexpr (!SINGLE_CTA) {
+          constexpr uint32_t NUM_ROUNDS = sizeof(OrderedType) * 8 / 8;
+          uint32_t next_first_hist_idx = ((iter + 1) * NUM_ROUNDS) % 3;
+          if (cta_in_group == 0) {
+            for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+              state->histogram[next_first_hist_idx][i] = 0;
+            }
+          }
+        }
+        continue;
+      }
+    } else {  // RaggedTransform
+      IdType offset = aux_data[row_idx];
+      if (length <= top_k_val) {
+        for (uint32_t i = tx; i < top_k_val; i += BLOCK_THREADS) {
+          row_output[i] = (i < length) ? static_cast<IdType>(i) + offset : static_cast<IdType>(-1);
+        }
+        // Clear histogram for next iteration
+        if constexpr (!SINGLE_CTA) {
+          constexpr uint32_t NUM_ROUNDS = sizeof(OrderedType) * 8 / 8;
+          uint32_t next_first_hist_idx = ((iter + 1) * NUM_ROUNDS) % 3;
+          if (cta_in_group == 0) {
+            for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+              state->histogram[next_first_hist_idx][i] = 0;
+            }
+          }
+        }
+        continue;
+      }
+    }
+
+    const uint32_t chunk_start = cta_in_group * chunk_size;
+    const uint32_t chunk_end = min(chunk_start + chunk_size, length);
+    const uint32_t actual_chunk_size = ((chunk_start < length) ? (chunk_end - chunk_start) : 0);
+
+    // Stage 1: Load the chunk into shared memory, then radix-select the pivot.
+    uint32_t cta_local_gt_count = 0;
+    uint32_t cta_local_eq_count = 0;
+    OrderedType ordered_pivot =
+        RadixSelectFindPivot<BLOCK_THREADS, VEC_SIZE, SINGLE_CTA, DETERMINISTIC, DType>(
+            row_input, shared_ordered, local_histogram, suffix_sum, shared_scalars, state,
+            chunk_start, actual_chunk_size, k, barrier_phase, ctas_per_group, cta_in_group, tx,
+            iter, cta_local_gt_count, cta_local_eq_count);
+
+    auto collect_indices = [&](auto&& output_func) {
+      if constexpr (DETERMINISTIC) {
+        RadixCollectIndicesDeterministic<BLOCK_THREADS, SINGLE_CTA, OrderedType>(
+            shared_ordered, actual_chunk_size, chunk_start, k, ordered_pivot, cta_local_gt_count,
+            cta_local_eq_count, local_histogram, state, det_scratch, barrier_phase, ctas_per_group,
+            cta_in_group, tx, output_func);
+      } else {
+        RadixCollectIndices<BLOCK_THREADS, SINGLE_CTA, OrderedType>(
+            shared_ordered, actual_chunk_size, chunk_start, k, ordered_pivot, cta_local_gt_count,
+            local_histogram, &shared_output_counter, state, barrier_phase, ctas_per_group, tx,
+            output_func);
+      }
+    };
+
+    // Stage 2: Collect indices with mode-specific epilogue (single pass)
+    if constexpr (MODE == RadixTopKMode::Basic) {
+      DType* row_output_values = output_values + row_idx * top_k_val;
+      collect_indices([&](uint32_t original_idx, OrderedType ordered_val, int pos) {
+        row_output[pos] = static_cast<IdType>(original_idx);
+        row_output_values[pos] = Traits::FromOrdered(ordered_val);
+      });
+    } else if constexpr (MODE == RadixTopKMode::PageTableTransform) {
+      uint32_t batch_idx = (row_to_batch != nullptr) ? row_to_batch[row_idx] : row_idx;
+      const IdType* src_page_entry = aux_data + batch_idx * aux_stride;
+
+      // Collect raw indices first
+      collect_indices([&](uint32_t original_idx, OrderedType /*ordered_val*/, int pos) {
+        row_output[pos] = static_cast<IdType>(original_idx);
+      });
+
+      if constexpr (SINGLE_CTA) {
+        __syncthreads();
+        // Transform through page table with coalesced access
+        for (uint32_t i = tx; i < k; i += BLOCK_THREADS) {
+          IdType idx = row_output[i];
+          row_output[i] = src_page_entry[row_start + idx];
+        }
+      } else {
+        // Barrier to ensure all CTAs finished writing indices
+        AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+        // All CTAs participate in page table transform (coalesced access)
+        uint32_t elems_per_cta = (k + ctas_per_group - 1) / ctas_per_group;
+        uint32_t my_start = cta_in_group * elems_per_cta;
+        uint32_t my_end = min(my_start + elems_per_cta, k);
+        for (uint32_t i = my_start + tx; i < my_end; i += BLOCK_THREADS) {
+          IdType idx = row_output[i];
+          row_output[i] = src_page_entry[row_start + idx];
+        }
+      }
+    } else {  // RaggedTransform
+      IdType offset = aux_data[row_idx];
+      collect_indices([&](uint32_t original_idx, OrderedType /*ordered_val*/, int pos) {
+        row_output[pos] = static_cast<IdType>(original_idx) + offset;
+      });
+    }
+  }
+
+  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  if constexpr (!SINGLE_CTA) {
+    if (cta_in_group == 0) {
+      for (uint32_t buf = 0; buf < 3; ++buf) {
+        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+          state->histogram[buf][i] = 0;
+        }
+      }
+      if constexpr (DETERMINISTIC) {
+        static_assert(sizeof(RadixDeterministicCollectScratch) % sizeof(uint32_t) == 0);
+        uint32_t* det_words = reinterpret_cast<uint32_t*>(det_scratch);
+        constexpr uint32_t DET_WORDS = sizeof(RadixDeterministicCollectScratch) / sizeof(uint32_t);
+        for (uint32_t i = tx; i < DET_WORDS; i += BLOCK_THREADS) {
+          det_words[i] = 0;
+        }
+      }
+      if (tx == 0) {
+        st_release(&state->arrival_counter, 0);
+      }
+    }
+  }
+
+#undef shared_output_counter
+}
+
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, bool SINGLE_CTA, typename DType,
+          typename IdType>
+__global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKMaskLogitsKernel_MultiCTA(
+    DType* logits,         // [batch, vocab_size]
+    DType* masked_logits,  // [batch, vocab_size]
+    IdType* top_k_arr,     // [batch] or nullptr
+    uint32_t top_k_val, uint32_t vocab_size, uint32_t batch_size,
+    RadixRowState* row_states,  // [num_groups] (nullptr if SINGLE_CTA)
+    uint32_t chunk_size,        // elements per CTA
+    uint32_t ctas_per_group)    // CTAs per row (1 if SINGLE_CTA)
+{
+  // Type traits for FP16/BF16/FP32 support
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+
+  constexpr uint32_t RADIX = 256;  // 8-bit radix
+
+  const uint32_t global_cta_id = blockIdx.x;
+  const uint32_t group_id = global_cta_id / ctas_per_group;
+  const uint32_t cta_in_group = global_cta_id % ctas_per_group;
+  const uint32_t tx = threadIdx.x;
+
+  // Shared memory layout: [fixed storage] [ordered values cache]
+  extern __shared__ uint8_t smem[];
+
+  // Fixed shared memory (at the beginning)
+  // histogram[256] + suffix[256] + 5 scalars (for RadixSelectFromSharedMemory)
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (RADIX + RADIX + 5);
+  uint32_t* local_histogram = reinterpret_cast<uint32_t*>(smem);
+  uint32_t* suffix_sum = local_histogram + RADIX;
+  uint32_t* shared_scalars = suffix_sum + RADIX;
+
+  // Align ordered values cache to 16 bytes
+  size_t ordered_offset = ((fixed_smem_size + 15) / 16) * 16;
+  OrderedType* shared_ordered = reinterpret_cast<OrderedType*>(smem + ordered_offset);
+
+  // State pointer only used when not SINGLE_CTA
+  RadixRowState* state = nullptr;
+  if constexpr (!SINGLE_CTA) {
+    state = &row_states[group_id];
+  }
+
+  // Calculate total number of iterations for persistent loop
+  uint32_t num_groups = gridDim.x / ctas_per_group;
+  uint32_t total_iterations = (batch_size + num_groups - 1) / num_groups;
+
+  int barrier_phase = 0;
+
+  // Persistent loop over rows
+  for (uint32_t iter = 0; iter < total_iterations; iter++) {
+    uint32_t row_idx = group_id + iter * num_groups;
+
+    if (row_idx >= batch_size) break;
+
+    const uint32_t chunk_start = cta_in_group * chunk_size;
+    const uint32_t chunk_end = min(chunk_start + chunk_size, vocab_size);
+    const uint32_t actual_chunk_size = chunk_end - chunk_start;
+
+    uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+
+    DType pivot = Traits::NegInf();
+
+    if (k >= vocab_size) {
+      // k >= vocab_size: no masking needed, just copy
+      vec_t<DType, VEC_SIZE> logits_vec_copy;
+      const uint32_t aligned_size = (actual_chunk_size / VEC_SIZE) * VEC_SIZE;
+#pragma unroll 2
+      for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+        logits_vec_copy.cast_load(logits + row_idx * vocab_size + chunk_start + i);
+        logits_vec_copy.store(masked_logits + row_idx * vocab_size + chunk_start + i);
+      }
+      // Handle tail
+      for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+        masked_logits[row_idx * vocab_size + chunk_start + i] =
+            logits[row_idx * vocab_size + chunk_start + i];
+      }
+
+      // Clear histogram for next iteration (in case it's k < vocab_size)
+      // Only needed for multi-CTA mode; single-CTA uses shared memory cleared each iteration
+      if constexpr (!SINGLE_CTA) {
+        constexpr uint32_t NUM_ROUNDS = sizeof(OrderedType) * 8 / 8;  // ORDERED_BITS / RADIX_BITS
+        uint32_t next_first_hist_idx = ((iter + 1) * NUM_ROUNDS) % 3;
+        if (cta_in_group == 0) {
+          for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+            state->histogram[next_first_hist_idx][i] = 0;
+          }
+        }
+        // No sync needed - next iteration's barrier will ensure visibility
+      }
+      continue;
+    }
+
+    // Stage 1: Load the chunk into shared memory, then radix-select the pivot.
+    uint32_t local_gt_count = 0;  // Not used in this kernel
+    uint32_t local_eq_count = 0;  // Not used in this kernel
+    OrderedType ordered_pivot =
+        RadixSelectFindPivot<BLOCK_THREADS, VEC_SIZE, SINGLE_CTA, false, DType>(
+            logits + row_idx * vocab_size, shared_ordered, local_histogram, suffix_sum,
+            shared_scalars, state, chunk_start, actual_chunk_size, k, barrier_phase, ctas_per_group,
+            cta_in_group, tx, iter, local_gt_count, local_eq_count);
+
+    pivot = Traits::FromOrdered(ordered_pivot);
+
+    // Stage 2: Final masking pass
+    const DType neg_inf = Traits::NegInf();
+    const uint32_t aligned_size = (actual_chunk_size / VEC_SIZE) * VEC_SIZE;
+    vec_t<DType, VEC_SIZE> logits_vec;
+
+#pragma unroll 2
+    for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+      logits_vec.cast_load(logits + row_idx * vocab_size + chunk_start + i);
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        logits_vec[j] = (logits_vec[j] >= pivot) ? logits_vec[j] : neg_inf;
+      }
+      logits_vec.store(masked_logits + row_idx * vocab_size + chunk_start + i);
+    }
+
+    // Handle tail
+    for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+      DType val = logits[row_idx * vocab_size + chunk_start + i];
+      masked_logits[row_idx * vocab_size + chunk_start + i] = (val >= pivot) ? val : neg_inf;
+    }
+  }
+
+  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  if constexpr (!SINGLE_CTA) {
+    // Only leading CTA clears the buffers using release semantics
+    if (cta_in_group == 0) {
+      for (uint32_t buf = 0; buf < 3; ++buf) {
+        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+          state->histogram[buf][i] = 0;
+        }
+      }
+
+      if (tx == 0) {
+        st_release(&state->arrival_counter, 0);
+      }
+    }
+  }
+}
+
+template <typename DType, typename IdType>
+cudaError_t RadixTopKMaskLogitsMultiCTA(DType* logits, DType* masked_logits, IdType* top_k_arr,
+                                        uint32_t batch_size, uint32_t top_k_val,
+                                        uint32_t vocab_size, RadixRowState* row_states_buffer,
+                                        cudaStream_t stream = 0) {
+  using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), vocab_size);
+
+  // Get device properties
+  int device;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int num_sms;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_smem_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  // Fixed shared memory overhead: histogram[256] + suffix_sum[256] + 5 scalars
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (256 + 256 + 5);
+  constexpr size_t fixed_smem_aligned = round_up(fixed_smem_size, 16);
+
+  // Calculate max chunk size that fits in shared memory
+  const size_t available_for_ordered = GetRadixTopKAvailableOrderedSmemBytes<BLOCK_THREADS>(
+      max_smem_per_block, fixed_smem_aligned, false);
+  if (available_for_ordered == 0) {
+    return cudaErrorInvalidValue;
+  }
+  uint32_t max_chunk_elements = available_for_ordered / sizeof(OrderedType);
+  max_chunk_elements = round_down(max_chunk_elements, vec_size);
+  const uint32_t min_chunk_size = vec_size * BLOCK_THREADS;
+  max_chunk_elements = std::max(max_chunk_elements, min_chunk_size);
+
+  uint32_t ctas_per_group = ceil_div(vocab_size, max_chunk_elements);
+  uint32_t chunk_size = ceil_div(vocab_size, ctas_per_group);
+  chunk_size = round_up(chunk_size, vec_size);
+  chunk_size = std::min(chunk_size, max_chunk_elements);
+
+  const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
+  const bool single_cta = (ctas_per_group == 1);
+
+  // Calculate number of groups (how many rows to process concurrently)
+  uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, batch_size);
+  if (num_groups == 0) num_groups = 1;
+  uint32_t total_ctas = num_groups * ctas_per_group;
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    if (single_cta) {
+      auto kernel =
+          RadixTopKMaskLogitsKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, true, DType, IdType>;
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+      dim3 nblks(total_ctas);
+      dim3 nthrs(BLOCK_THREADS);
+      void* args[] = {&logits,     &masked_logits,     &top_k_arr,  &top_k_val,     &vocab_size,
+                      &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    } else {
+      auto kernel =
+          RadixTopKMaskLogitsKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+      dim3 nblks(total_ctas);
+      dim3 nthrs(BLOCK_THREADS);
+      void* args[] = {&logits,     &masked_logits,     &top_k_arr,  &top_k_val,     &vocab_size,
+                      &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    }
+  });
+
+  return cudaSuccess;
+}
+
+// ==================== Multi-CTA Radix Top-K Renorm Probs ====================
+
+/*!
+ * \brief Multi-CTA Radix Top-K RenormProb kernel with unified single/multi-CTA paths.
+ *
+ * Finds the k-th largest probability, then normalizes all probs >= pivot to sum to 1,
+ * setting all others to 0. Reuses the shared load+radix-select helper.
+ */
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, bool SINGLE_CTA, typename DType,
+          typename IdType>
+__global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKRenormProbKernel_MultiCTA(
+    DType* probs,          // [batch, vocab_size]
+    DType* renormed_prob,  // [batch, vocab_size]
+    IdType* top_k_arr,     // [batch] or nullptr
+    uint32_t top_k_val, uint32_t vocab_size, uint32_t batch_size,
+    RadixRowState* row_states,  // [num_groups] (nullptr if SINGLE_CTA)
+    uint32_t chunk_size,        // elements per CTA
+    uint32_t ctas_per_group)    // CTAs per row (1 if SINGLE_CTA)
+{
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+
+  constexpr uint32_t RADIX = 256;  // 8-bit radix
+
+  const uint32_t global_cta_id = blockIdx.x;
+  const uint32_t group_id = global_cta_id / ctas_per_group;
+  const uint32_t cta_in_group = global_cta_id % ctas_per_group;
+  const uint32_t tx = threadIdx.x;
+
+  // Shared memory layout: [fixed storage] [ordered values cache]
+  extern __shared__ uint8_t smem[];
+
+  // Fixed shared memory (at the beginning)
+  // histogram[256] + suffix[256] + scalars[4] + sum_local[1]
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (RADIX + RADIX + 4) + sizeof(float);
+  uint32_t* local_histogram = reinterpret_cast<uint32_t*>(smem);
+  uint32_t* suffix_sum = local_histogram + RADIX;
+  uint32_t* shared_scalars = suffix_sum + RADIX;
+  float* shared_sum = reinterpret_cast<float*>(shared_scalars + 4);
+
+  // Align ordered values cache to 16 bytes
+  size_t ordered_offset = ((fixed_smem_size + 15) / 16) * 16;
+  OrderedType* shared_ordered = reinterpret_cast<OrderedType*>(smem + ordered_offset);
+
+  // State pointer only used when not SINGLE_CTA
+  RadixRowState* state = nullptr;
+  if constexpr (!SINGLE_CTA) {
+    state = &row_states[group_id];
+  }
+
+  // Calculate total number of iterations for persistent loop
+  uint32_t num_groups = gridDim.x / ctas_per_group;
+  uint32_t total_iterations = (batch_size + num_groups - 1) / num_groups;
+
+  int barrier_phase = 0;
+
+  // Persistent loop over rows
+  for (uint32_t iter = 0; iter < total_iterations; iter++) {
+    uint32_t row_idx = group_id + iter * num_groups;
+
+    if (row_idx >= batch_size) break;
+
+    const uint32_t chunk_start = cta_in_group * chunk_size;
+    const uint32_t chunk_end = min(chunk_start + chunk_size, vocab_size);
+    const uint32_t actual_chunk_size = chunk_end - chunk_start;
+
+    uint32_t k = top_k_arr == nullptr ? top_k_val : top_k_arr[row_idx];
+
+    // For RenormProb, pivot is compared with probs (must be non-negative)
+    DType pivot = DType(0);
+    float normalizer = 1.0f;
+
+    if (k >= vocab_size) {
+      // k >= vocab_size: no filtering needed, just compute sum and renormalize
+      // Stage 1: Compute sum
+      float thread_sum = 0.0f;
+      vec_t<DType, VEC_SIZE> data_vec;
+      const uint32_t aligned_size = (actual_chunk_size / VEC_SIZE) * VEC_SIZE;
+
+#pragma unroll 2
+      for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+        data_vec.cast_load(probs + row_idx * vocab_size + chunk_start + i);
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          thread_sum += float(data_vec[j]);
+        }
+      }
+      // Handle tail
+      for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+        thread_sum += float(probs[row_idx * vocab_size + chunk_start + i]);
+      }
+
+      // Block reduction for sum
+      typedef cub::BlockReduce<float, BLOCK_THREADS> BlockReduce;
+      __shared__ typename BlockReduce::TempStorage temp_storage;
+      float block_sum = BlockReduce(temp_storage).Sum(thread_sum);
+      __syncthreads();
+
+      if constexpr (!SINGLE_CTA) {
+        // Multi-CTA: atomic add to global sum
+        if (tx == 0) {
+          if (cta_in_group == 0) {
+            state->sum_topk = 0.0f;  // First CTA initializes
+          }
+        }
+        // Barrier for initialization
+        AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+        if (tx == 0 && block_sum > 0) {
+          atomicAdd(&state->sum_topk, block_sum);
+        }
+
+        // Barrier to ensure all CTAs have contributed
+        AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+        normalizer = math::ptx_rcp(max(state->sum_topk, 1e-8f));
+      } else {
+        // Single-CTA: use block_sum directly
+        if (tx == 0) {
+          *shared_sum = block_sum;
+        }
+        __syncthreads();
+        normalizer = math::ptx_rcp(max(*shared_sum, 1e-8f));
+      }
+
+      // Normalize and store
+#pragma unroll 2
+      for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+        data_vec.cast_load(probs + row_idx * vocab_size + chunk_start + i);
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+          data_vec[j] = DType(float(data_vec[j]) * normalizer);
+        }
+        data_vec.store(renormed_prob + row_idx * vocab_size + chunk_start + i);
+      }
+      for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+        renormed_prob[row_idx * vocab_size + chunk_start + i] =
+            DType(float(probs[row_idx * vocab_size + chunk_start + i]) * normalizer);
+      }
+
+      // Clear histogram for next iteration (in case it's k < vocab_size)
+      // Only needed for multi-CTA mode; single-CTA uses shared memory cleared each iteration
+      // Next iteration (iter+1) will use histogram[((iter+1)*NUM_ROUNDS) % 3] for its first round
+      if constexpr (!SINGLE_CTA) {
+        constexpr uint32_t NUM_ROUNDS = sizeof(OrderedType) * 8 / 8;  // ORDERED_BITS / RADIX_BITS
+        uint32_t next_first_hist_idx = ((iter + 1) * NUM_ROUNDS) % 3;
+        if (cta_in_group == 0) {
+          for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+            state->histogram[next_first_hist_idx][i] = 0;
+          }
+        }
+        // No sync needed - next iteration's barrier will ensure visibility
+      }
+      continue;
+    }
+
+    // ========== Stage 1: Find pivot ==========
+    uint32_t local_gt_count = 0;  // Not used in this kernel
+    uint32_t local_eq_count = 0;  // Not used in this kernel
+    auto ordered_pivot = RadixSelectFindPivot<BLOCK_THREADS, VEC_SIZE, SINGLE_CTA, false, DType>(
+        probs + row_idx * vocab_size, shared_ordered, local_histogram, suffix_sum, shared_scalars,
+        state, chunk_start, actual_chunk_size, k, barrier_phase, ctas_per_group, cta_in_group, tx,
+        iter, local_gt_count, local_eq_count);
+    pivot = Traits::FromOrdered(ordered_pivot);
+
+    // ========== Stage 2: Compute sum of elements >= pivot ==========
+    float thread_sum = 0.0f;
+    vec_t<DType, VEC_SIZE> data_vec;
+    const uint32_t aligned_size = (actual_chunk_size / VEC_SIZE) * VEC_SIZE;
+
+#pragma unroll 2
+    for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+      data_vec.cast_load(probs + row_idx * vocab_size + chunk_start + i);
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        if (data_vec[j] >= pivot) {
+          thread_sum += float(data_vec[j]);
+        }
+      }
+    }
+    // Handle tail
+    for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+      DType val = probs[row_idx * vocab_size + chunk_start + i];
+      if (val >= pivot) {
+        thread_sum += float(val);
+      }
+    }
+
+    // Block reduction for sum
+    typedef cub::BlockReduce<float, BLOCK_THREADS> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    float block_sum = BlockReduce(temp_storage).Sum(thread_sum);
+    __syncthreads();
+
+    if constexpr (!SINGLE_CTA) {
+      // Multi-CTA: atomic add to global sum
+      if (tx == 0) {
+        if (cta_in_group == 0) {
+          state->sum_topk = 0.0f;  // First CTA initializes
+        }
+      }
+      // Barrier for initialization
+      AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+
+      if (tx == 0 && block_sum > 0) {
+        atomicAdd(&state->sum_topk, block_sum);
+      }
+
+      // Barrier to ensure all CTAs have contributed
+      AdvanceRadixGroupBarrier(state, barrier_phase, ctas_per_group, tx);
+      normalizer = math::ptx_rcp(max(state->sum_topk, 1e-8f));
+    } else {
+      // Single-CTA: use block_sum directly
+      if (tx == 0) {
+        *shared_sum = block_sum;
+      }
+      __syncthreads();
+      normalizer = math::ptx_rcp(max(*shared_sum, 1e-8f));
+    }
+
+    // ========== Stage 3: Normalize elements >= pivot, set others to 0 ==========
+#pragma unroll 2
+    for (uint32_t i = tx * VEC_SIZE; i < aligned_size; i += BLOCK_THREADS * VEC_SIZE) {
+      data_vec.cast_load(probs + row_idx * vocab_size + chunk_start + i);
+#pragma unroll
+      for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        data_vec[j] = (data_vec[j] >= pivot) ? DType(float(data_vec[j]) * normalizer) : DType(0);
+      }
+      data_vec.store(renormed_prob + row_idx * vocab_size + chunk_start + i);
+    }
+    // Handle tail
+    for (uint32_t i = aligned_size + tx; i < actual_chunk_size; i += BLOCK_THREADS) {
+      DType val = probs[row_idx * vocab_size + chunk_start + i];
+      renormed_prob[row_idx * vocab_size + chunk_start + i] =
+          (val >= pivot) ? DType(float(val) * normalizer) : DType(0);
+    }
+  }
+
+  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  if constexpr (!SINGLE_CTA) {
+    // Only leading CTA clears the buffers using release semantics
+    if (cta_in_group == 0) {
+      for (uint32_t buf = 0; buf < 3; ++buf) {
+        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+          state->histogram[buf][i] = 0;
+        }
+      }
+
+      if (tx == 0) {
+        st_release(&state->arrival_counter, 0);
+      }
+    }
+  }
+}
+
+template <typename DType, typename IdType>
+cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdType* top_k_arr,
+                                        uint32_t batch_size, uint32_t top_k_val,
+                                        uint32_t vocab_size, RadixRowState* row_states_buffer,
+                                        cudaStream_t stream = 0) {
+  using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), vocab_size);
+
+  // Get device properties
+  int device;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int num_sms;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_smem_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  // Fixed shared memory overhead: histogram[256] + suffix_sum[256] + 4 scalars + 1 float
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (256 + 256 + 4) + sizeof(float);
+  constexpr size_t fixed_smem_aligned = round_up(fixed_smem_size, 16);
+
+  // Calculate max chunk size that fits in shared memory
+  const size_t available_for_ordered = GetRadixTopKAvailableOrderedSmemBytes<BLOCK_THREADS>(
+      max_smem_per_block, fixed_smem_aligned, false);
+  if (available_for_ordered == 0) {
+    return cudaErrorInvalidValue;
+  }
+  uint32_t max_chunk_elements = available_for_ordered / sizeof(OrderedType);
+  max_chunk_elements = round_down(max_chunk_elements, vec_size);
+  const uint32_t min_chunk_size = vec_size * BLOCK_THREADS;
+  max_chunk_elements = std::max(max_chunk_elements, min_chunk_size);
+
+  uint32_t ctas_per_group = ceil_div(vocab_size, max_chunk_elements);
+  uint32_t chunk_size = ceil_div(vocab_size, ctas_per_group);
+  chunk_size = round_up(chunk_size, vec_size);
+  chunk_size = std::min(chunk_size, max_chunk_elements);
+
+  const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
+  const bool single_cta = (ctas_per_group == 1);
+
+  // Calculate number of groups (how many rows to process concurrently)
+  uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, batch_size);
+  if (num_groups == 0) num_groups = 1;
+  uint32_t total_ctas = num_groups * ctas_per_group;
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    if (single_cta) {
+      auto kernel =
+          RadixTopKRenormProbKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, true, DType, IdType>;
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+      dim3 nblks(total_ctas);
+      dim3 nthrs(BLOCK_THREADS);
+      void* args[] = {&probs,      &renormed_prob,     &top_k_arr,  &top_k_val,     &vocab_size,
+                      &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    } else {
+      auto kernel =
+          RadixTopKRenormProbKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+      dim3 nblks(total_ctas);
+      dim3 nthrs(BLOCK_THREADS);
+      void* args[] = {&probs,      &renormed_prob,     &top_k_arr,  &top_k_val,     &vocab_size,
+                      &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    }
+  });
+
+  return cudaSuccess;
+}
+
+/*!
+ * \brief Launch multi-CTA Radix Top-K with Page Table Transform kernel.
+ *
+ * Performs top-k selection and gathers indices through a page table.
+ * Used for sparse attention's second stage in prefill mode.
+ *
+ * \param input Input scores tensor [num_rows, max_len]
+ * \param output_page_table Output page table entries [num_rows, top_k]
+ * \param src_page_table Source page table [batch_size, max_len]
+ * \param src_stride Stride of source page table (typically max_len)
+ * \param row_to_batch Mapping from row index to batch index [num_rows], or nullptr if 1:1
+ * \param lengths Sequence lengths per row [num_rows]
+ * \param row_starts Start indices per row [num_rows], or nullptr to use 0
+ * \param num_rows Number of rows to process
+ * \param top_k_val Number of top elements to select
+ * \param max_len Maximum sequence length (input stride)
+ * \param row_states_buffer Buffer for inter-CTA synchronization
+ * \param stream CUDA stream
+ */
+template <typename DType, typename IdType>
+cudaError_t RadixTopKPageTableTransformMultiCTA(DType* input, IdType* output_page_table,
+                                                const IdType* src_page_table, int64_t src_stride,
+                                                const IdType* row_to_batch, IdType* lengths,
+                                                const IdType* row_starts, uint32_t num_rows,
+                                                uint32_t top_k_val, uint32_t max_len,
+                                                RadixRowState* row_states_buffer,
+                                                bool deterministic, cudaStream_t stream = 0) {
+  using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = (row_starts != nullptr) ? 1 : std::gcd(16 / sizeof(DType), max_len);
+
+  int device;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int num_sms;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_smem_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (256 + 256 + 5);
+  constexpr size_t fixed_smem_aligned = round_up(fixed_smem_size, 16);
+  const size_t available_for_ordered = GetRadixTopKAvailableOrderedSmemBytes<BLOCK_THREADS>(
+      max_smem_per_block, fixed_smem_aligned, deterministic);
+  if (available_for_ordered == 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  uint32_t max_chunk_elements = available_for_ordered / sizeof(OrderedType);
+  max_chunk_elements = round_down(max_chunk_elements, vec_size);
+  const uint32_t min_chunk_size = vec_size * BLOCK_THREADS;
+  max_chunk_elements = std::max(max_chunk_elements, min_chunk_size);
+
+  uint32_t ctas_per_group = ceil_div(max_len, max_chunk_elements);
+  if (deterministic && ctas_per_group > RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP) {
+    return cudaErrorInvalidConfiguration;
+  }
+  uint32_t chunk_size = ceil_div(max_len, ctas_per_group);
+  chunk_size = round_up(chunk_size, vec_size);
+  chunk_size = std::min(chunk_size, max_chunk_elements);
+
+  const bool single_cta = (ctas_per_group == 1);
+  const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
+
+  uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, num_rows);
+  if (num_groups == 0) num_groups = 1;
+  uint32_t total_ctas = num_groups * ctas_per_group;
+  RadixDeterministicCollectScratch* det_scratch_buffer =
+      MaybeGetRadixDeterministicCollectScratchBuffer(row_states_buffer, num_groups, single_cta,
+                                                     deterministic);
+
+  // Unified kernel parameters
+  DType* output_values = nullptr;  // Not used in PageTableTransform mode
+  dim3 nblks(total_ctas);
+  dim3 nthrs(BLOCK_THREADS);
+  void* args[] = {
+      &input,      &output_page_table, &output_values,      &src_page_table, &lengths,
+      &row_starts, &row_to_batch,      &src_stride,         &top_k_val,      &max_len,
+      &num_rows,   &row_states_buffer, &det_scratch_buffer, &chunk_size,     &ctas_per_group};
+
+#define LAUNCH_PAGE_TABLE_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                              \
+  do {                                                                                            \
+    auto kernel = RadixTopKKernel_Unified<THREADS, VEC_SIZE, SINGLE_CTA_FLAG, DET_FLAG,           \
+                                          RadixTopKMode::PageTableTransform, DType, IdType>;      \
+    FLASHINFER_CUDA_CALL(                                                                         \
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+  } while (0)
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    if (single_cta) {
+      if (!deterministic) {
+        LAUNCH_PAGE_TABLE_KERNEL(BLOCK_THREADS, true, false);
+      } else {
+        LAUNCH_PAGE_TABLE_KERNEL(BLOCK_THREADS, true, true);
+      }
+    } else {
+      if (!deterministic) {
+        LAUNCH_PAGE_TABLE_KERNEL(BLOCK_THREADS, false, false);
+      } else {
+        LAUNCH_PAGE_TABLE_KERNEL(BLOCK_THREADS, false, true);
+      }
+    }
+  });
+
+#undef LAUNCH_PAGE_TABLE_KERNEL
+
+  return cudaSuccess;
+}
+
+/*!
+ * \brief Launch multi-CTA Radix Top-K with Ragged Index Transform kernel.
+ *
+ * Performs top-k selection and adds an offset to each index.
+ * Used for sparse attention's second stage with ragged KV cache.
+ *
+ * \param input Input scores tensor [num_rows, max_len]
+ * \param output_indices Output indices [num_rows, top_k]
+ * \param offsets Offset to add per row [num_rows]
+ * \param lengths Sequence lengths per row [num_rows]
+ * \param num_rows Number of rows to process
+ * \param top_k_val Number of top elements to select
+ * \param max_len Maximum sequence length (input stride)
+ * \param row_states_buffer Buffer for inter-CTA synchronization
+ * \param stream CUDA stream
+ */
+template <typename DType, typename IdType>
+cudaError_t RadixTopKRaggedTransformMultiCTA(DType* input, IdType* output_indices,
+                                             const IdType* offsets, IdType* lengths,
+                                             const IdType* row_starts, uint32_t num_rows,
+                                             uint32_t top_k_val, uint32_t max_len,
+                                             RadixRowState* row_states_buffer, bool deterministic,
+                                             cudaStream_t stream = 0) {
+  using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = (row_starts != nullptr) ? 1 : std::gcd(16 / sizeof(DType), max_len);
+
+  int device;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int num_sms;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_smem_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (256 + 256 + 5);
+  constexpr size_t fixed_smem_aligned = round_up(fixed_smem_size, 16);
+  const size_t available_for_ordered = GetRadixTopKAvailableOrderedSmemBytes<BLOCK_THREADS>(
+      max_smem_per_block, fixed_smem_aligned, deterministic);
+  if (available_for_ordered == 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  uint32_t max_chunk_elements = available_for_ordered / sizeof(OrderedType);
+  max_chunk_elements = round_down(max_chunk_elements, vec_size);
+  const uint32_t min_chunk_size = vec_size * BLOCK_THREADS;
+  max_chunk_elements = std::max(max_chunk_elements, min_chunk_size);
+
+  uint32_t ctas_per_group = ceil_div(max_len, max_chunk_elements);
+  if (deterministic && ctas_per_group > RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP) {
+    return cudaErrorInvalidConfiguration;
+  }
+  uint32_t chunk_size = ceil_div(max_len, ctas_per_group);
+  chunk_size = round_up(chunk_size, vec_size);
+  chunk_size = std::min(chunk_size, max_chunk_elements);
+
+  const bool single_cta = (ctas_per_group == 1);
+  const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
+
+  uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, num_rows);
+  if (num_groups == 0) num_groups = 1;
+  uint32_t total_ctas = num_groups * ctas_per_group;
+  RadixDeterministicCollectScratch* det_scratch_buffer =
+      MaybeGetRadixDeterministicCollectScratchBuffer(row_states_buffer, num_groups, single_cta,
+                                                     deterministic);
+
+  // Unified kernel parameters
+  DType* output_values = nullptr;        // Not used in RaggedTransform mode
+  const IdType* row_to_batch = nullptr;  // Not used in RaggedTransform mode
+  int64_t aux_stride = 0;                // Not used in RaggedTransform mode
+  dim3 nblks(total_ctas);
+  dim3 nthrs(BLOCK_THREADS);
+  void* args[] = {
+      &input,      &output_indices,    &output_values,      &offsets,    &lengths,
+      &row_starts, &row_to_batch,      &aux_stride,         &top_k_val,  &max_len,
+      &num_rows,   &row_states_buffer, &det_scratch_buffer, &chunk_size, &ctas_per_group};
+
+#define LAUNCH_RAGGED_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                                  \
+  do {                                                                                            \
+    auto kernel = RadixTopKKernel_Unified<THREADS, VEC_SIZE, SINGLE_CTA_FLAG, DET_FLAG,           \
+                                          RadixTopKMode::RaggedTransform, DType, IdType>;         \
+    FLASHINFER_CUDA_CALL(                                                                         \
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+  } while (0)
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    if (single_cta) {
+      if (!deterministic) {
+        LAUNCH_RAGGED_KERNEL(BLOCK_THREADS, true, false);
+      } else {
+        LAUNCH_RAGGED_KERNEL(BLOCK_THREADS, true, true);
+      }
+    } else {
+      if (!deterministic) {
+        LAUNCH_RAGGED_KERNEL(BLOCK_THREADS, false, false);
+      } else {
+        LAUNCH_RAGGED_KERNEL(BLOCK_THREADS, false, true);
+      }
+    }
+  });
+
+#undef LAUNCH_RAGGED_KERNEL
+
+  return cudaSuccess;
+}
+
+/*!
+ * \brief Launch multi-CTA Radix Top-K kernel (returns indices and values)
+ *
+ * \param input Input tensor [batch_size, vocab_size]
+ * \param output_indices Output indices tensor [batch_size, top_k]
+ * \param output_values Output values tensor [batch_size, top_k]
+ * \param top_k_arr Per-row top-k values or nullptr for uniform top_k
+ * \param batch_size Number of rows
+ * \param top_k_val Default top-k value (used when top_k_arr is nullptr)
+ * \param vocab_size Number of elements per row
+ * \param row_states_buffer Buffer for inter-CTA synchronization
+ * \param stream CUDA stream
+ */
+template <typename DType, typename IdType>
+cudaError_t RadixTopKMultiCTA(DType* input, IdType* output_indices, DType* output_values,
+                              IdType* top_k_arr, uint32_t batch_size, uint32_t top_k_val,
+                              uint32_t vocab_size, RadixRowState* row_states_buffer,
+                              bool deterministic, cudaStream_t stream = 0) {
+  using OrderedType = typename RadixTopKTraits<DType>::OrderedType;
+  constexpr uint32_t BLOCK_THREADS = 1024;
+  const uint32_t vec_size = std::gcd(16 / sizeof(DType), vocab_size);
+
+  int device;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int num_sms;
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device));
+  int max_smem_per_block;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&max_smem_per_block, cudaDevAttrMaxSharedMemoryPerBlockOptin, device));
+
+  // Fixed smem: histogram[256] + suffix_sum[256] + scalars
+  // Scalars: 5 for single-CTA, 4 for multi-CTA
+  constexpr size_t fixed_smem_size = sizeof(uint32_t) * (256 + 256 + 5);
+  constexpr size_t fixed_smem_aligned = round_up(fixed_smem_size, 16);
+  const size_t available_for_ordered = GetRadixTopKAvailableOrderedSmemBytes<BLOCK_THREADS>(
+      max_smem_per_block, fixed_smem_aligned, deterministic);
+  if (available_for_ordered == 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  uint32_t max_chunk_elements = available_for_ordered / sizeof(OrderedType);
+  max_chunk_elements = round_down(max_chunk_elements, vec_size);
+  const uint32_t min_chunk_size = vec_size * BLOCK_THREADS;
+  max_chunk_elements = std::max(max_chunk_elements, min_chunk_size);
+
+  uint32_t ctas_per_group = ceil_div(vocab_size, max_chunk_elements);
+  if (deterministic && ctas_per_group > RADIX_TOPK_MAX_DETERMINISTIC_CTAS_PER_GROUP) {
+    return cudaErrorInvalidConfiguration;
+  }
+  uint32_t chunk_size = ceil_div(vocab_size, ctas_per_group);
+  chunk_size = round_up(chunk_size, vec_size);
+  chunk_size = std::min(chunk_size, max_chunk_elements);
+
+  // Determine if we use single-CTA path
+  const bool single_cta = (ctas_per_group == 1);
+
+  // Calculate smem_size: fixed + ordered values
+  const uint32_t smem_size = fixed_smem_aligned + chunk_size * sizeof(OrderedType);
+
+  // Calculate number of groups (how many rows to process concurrently)
+  uint32_t num_groups = std::min(static_cast<uint32_t>(num_sms) / ctas_per_group, batch_size);
+  if (num_groups == 0) num_groups = 1;
+  uint32_t total_ctas = num_groups * ctas_per_group;
+  RadixDeterministicCollectScratch* det_scratch_buffer =
+      MaybeGetRadixDeterministicCollectScratchBuffer(row_states_buffer, num_groups, single_cta,
+                                                     deterministic);
+
+  // Unified kernel parameters
+  IdType* lengths = nullptr;             // Not used in Basic mode
+  const IdType* row_starts = nullptr;    // Not used in Basic mode
+  const IdType* row_to_batch = nullptr;  // Not used in Basic mode
+  int64_t aux_stride = 0;                // Not used in Basic mode
+  dim3 nblks(total_ctas);
+  dim3 nthrs(BLOCK_THREADS);
+  void* args[] = {
+      &input,      &output_indices,    &output_values,      &top_k_arr,  &lengths,
+      &row_starts, &row_to_batch,      &aux_stride,         &top_k_val,  &vocab_size,
+      &batch_size, &row_states_buffer, &det_scratch_buffer, &chunk_size, &ctas_per_group};
+
+#define LAUNCH_BASIC_KERNEL(THREADS, SINGLE_CTA_FLAG, DET_FLAG)                                   \
+  do {                                                                                            \
+    auto kernel = RadixTopKKernel_Unified<THREADS, VEC_SIZE, SINGLE_CTA_FLAG, DET_FLAG,           \
+                                          RadixTopKMode::Basic, DType, IdType>;                   \
+    FLASHINFER_CUDA_CALL(                                                                         \
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+  } while (0)
+
+  DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+    if (single_cta) {
+      if (!deterministic) {
+        LAUNCH_BASIC_KERNEL(BLOCK_THREADS, true, false);
+      } else {
+        LAUNCH_BASIC_KERNEL(BLOCK_THREADS, true, true);
+      }
+    } else {
+      if (!deterministic) {
+        LAUNCH_BASIC_KERNEL(BLOCK_THREADS, false, false);
+      } else {
+        LAUNCH_BASIC_KERNEL(BLOCK_THREADS, false, true);
+      }
+    }
+  });
+
+#undef LAUNCH_BASIC_KERNEL
+
+  return cudaSuccess;
+}
+// ==================== FilteredTopK Implementation ====================
+// Based on sgl-kernel's filter algorithm with multi-dtype support
+
+// FilteredTopK traits for different data types
+template <typename DType>
+struct FilteredTopKTraits;
+
+// Specialization for float (32-bit): coarse histogram uses FP16 high 8 bits, 4 refinement rounds
+template <>
+struct FilteredTopKTraits<float> {
+  using OrderedType = uint32_t;
+  static constexpr int NUM_REFINE_ROUNDS = 4;
+  static constexpr int FIRST_REFINE_SHIFT = 24;
+
+  __device__ __forceinline__ static uint8_t ToCoarseKey(float x) {
+    // Convert to FP16 representation and extract high 8 bits
+    __half h = __float2half_rn(x);
+    uint16_t bits = __half_as_ushort(h);
+    uint16_t key =
+        (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+    return static_cast<uint8_t>(key >> 8);
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(float x) {
+    uint32_t bits = __float_as_uint(x);
+    return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+  }
+};
+
+// Specialization for half (16-bit): coarse histogram uses high 8 bits, only need low 8 bits for
+// refinement Since coarse key = high 8 bits, refinement only needs to look at low 8 bits (no
+// additional rounds needed if we can determine topk from coarse pass alone)
+template <>
+struct FilteredTopKTraits<half> {
+  using OrderedType = uint16_t;
+  static constexpr int NUM_REFINE_ROUNDS = 1;   // Only 1 round for low 8 bits
+  static constexpr int FIRST_REFINE_SHIFT = 0;  // Start from bit 0 (low 8 bits)
+
+  __device__ __forceinline__ static uint8_t ToCoarseKey(half x) {
+    uint16_t bits = __half_as_ushort(x);
+    uint16_t key =
+        (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+    return static_cast<uint8_t>(key >> 8);
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(half x) {
+    uint16_t bits = __half_as_ushort(x);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+  }
+};
+
+// Specialization for nv_bfloat16 (16-bit): same as half
+template <>
+struct FilteredTopKTraits<nv_bfloat16> {
+  using OrderedType = uint16_t;
+  static constexpr int NUM_REFINE_ROUNDS = 1;
+  static constexpr int FIRST_REFINE_SHIFT = 0;
+
+  __device__ __forceinline__ static uint8_t ToCoarseKey(nv_bfloat16 x) {
+    uint16_t bits = __bfloat16_as_ushort(x);
+    uint16_t key =
+        (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+    return static_cast<uint8_t>(key >> 8);
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(nv_bfloat16 x) {
+    uint16_t bits = __bfloat16_as_ushort(x);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
+  }
+};
+
+// FilteredTopK constants
+constexpr uint32_t FILTERED_TOPK_MAX_K = 2048;
+constexpr uint32_t FILTERED_TOPK_BLOCK_THREADS = 1024;
+constexpr uint32_t FILTERED_TOPK_SMEM_INPUT_SIZE = 16 * 1024;  // 16K indices per buffer
+constexpr size_t FILTERED_TOPK_SMEM_DYNAMIC =
+    sizeof(int) * 2 * FILTERED_TOPK_SMEM_INPUT_SIZE;  // 128KB
+
+// Output modes for unified FilteredTopK kernel
+enum class FilteredTopKMode { Plain, PageTable, Ragged };
+
+/*!
+ * \brief Unified Filtered Top-K kernel supporting multiple output modes.
+ *
+ * \tparam DType Data type (float, half, nv_bfloat16)
+ * \tparam IdType Index type (int32_t)
+ * \tparam VEC_SIZE Vector size for input loads (1, 2, 4, or 8)
+ * \tparam MODE Output mode (Plain, PageTable, Ragged)
+ *
+ * Parameters vary by mode:
+ * - Plain: output = indices, aux_output = values, aux_input/aux_stride/row_to_batch unused
+ * - PageTable: output = dst_page_table, aux_input = src_page_table, aux_stride = src_stride
+ * - Ragged: output = indices, aux_input = offsets, aux_output/aux_stride/row_to_batch unused
+ */
+template <typename DType, typename IdType, int VEC_SIZE, bool DETERMINISTIC, FilteredTopKMode MODE,
+          TopKTieBreak TIE_BREAK>
+__global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
+    FilteredTopKUnifiedKernel(const DType* __restrict__ input, IdType* __restrict__ output,
+                              DType* __restrict__ aux_output,           // values for Plain mode
+                              const IdType* __restrict__ aux_input,     // page_table or offsets
+                              int64_t aux_stride,                       // src_stride for PageTable
+                              const IdType* __restrict__ row_to_batch,  // for PageTable
+                              const IdType* __restrict__ lengths,
+                              const IdType* __restrict__ row_starts,  // per-row score start
+                              uint32_t num_rows, uint32_t top_k, uint32_t max_len) {
+  constexpr uint32_t BLOCK_SIZE = FILTERED_TOPK_BLOCK_THREADS;
+  constexpr int RADIX = 256;
+  constexpr int SMEM_INPUT_SIZE = FILTERED_TOPK_SMEM_INPUT_SIZE;
+  static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of warp size");
+
+  const uint32_t bid = blockIdx.x;
+  const int tx = threadIdx.x;
+
+  if (bid >= num_rows) return;
+
+  const int length = (lengths != nullptr) ? lengths[bid] : static_cast<int>(max_len);
+  const IdType row_start =
+      (row_starts != nullptr && MODE != FilteredTopKMode::Plain) ? row_starts[bid] : 0;
+  const DType* score = input + static_cast<size_t>(bid) * max_len + row_start;
+  IdType* dst = output + bid * top_k;
+
+  // Mode-specific setup
+  [[maybe_unused]] const IdType* src_page_entry = nullptr;
+  [[maybe_unused]] IdType offset_val = 0;
+  [[maybe_unused]] DType* dst_values = nullptr;
+
+  if constexpr (MODE == FilteredTopKMode::PageTable) {
+    const uint32_t batch_idx = (row_to_batch != nullptr) ? row_to_batch[bid] : bid;
+    src_page_entry = aux_input + batch_idx * aux_stride;
+  } else if constexpr (MODE == FilteredTopKMode::Ragged) {
+    offset_val = aux_input[bid];
+  } else {  // Plain
+    dst_values = aux_output + bid * top_k;
+  }
+
+  // Trivial case: length <= top_k
+  if (length <= static_cast<int>(top_k)) {
+    for (int i = tx; i < static_cast<int>(top_k); i += BLOCK_SIZE) {
+      if constexpr (MODE == FilteredTopKMode::Plain) {
+        if (i < length) {
+          dst[i] = static_cast<IdType>(i);
+          dst_values[i] = score[i];
+        } else {
+          dst[i] = static_cast<IdType>(-1);
+          dst_values[i] = DType(0);
+        }
+      } else if constexpr (DETERMINISTIC) {
+        // In deterministic mode the page-table/ragged transform happens in SortTopKByIndexKernel
+        dst[i] = (i < length) ? static_cast<IdType>(i) : static_cast<IdType>(-1);
+      } else if constexpr (MODE == FilteredTopKMode::PageTable) {
+        dst[i] = (i < length) ? src_page_entry[row_start + i] : static_cast<IdType>(-1);
+      } else {  // Ragged
+        dst[i] = (i < length) ? static_cast<IdType>(i) + offset_val : static_cast<IdType>(-1);
+      }
+    }
+    return;
+  }
+
+  // Static shared memory
+  alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
+  __shared__ int s_counter;
+  __shared__ int s_threshold_bin_id;
+  // Per-round copies of s_threshold_bin_id for deterministic pivot rebuild.
+  __shared__ int s_refine_thresholds[4];
+  __shared__ int s_num_input[2];
+  alignas(128) __shared__ int s_indices[FILTERED_TOPK_MAX_K];
+  // Set 1 when s_input_idx overflows in tie-heavy workload
+  __shared__ int s_refine_overflow;
+  __shared__ int s_last_remain;
+
+  auto& s_histogram = s_histogram_buf[0];
+
+  // Dynamic shared memory for input double buffer
+  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+
+  using Traits = FilteredTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+  int topk = top_k;
+  if (tx == 0) s_refine_overflow = 0;
+  if constexpr (DETERMINISTIC) {
+    if (tx < 4) {
+      s_refine_thresholds[tx] = 0xFF;
+    }
+  }
+  if (tx < RADIX + 1) s_histogram[tx] = 0;
+  __syncthreads();
+
+  // Stage 1: (shared by deterministic and non-deterministic modes)
+  // build a coarse histogram and identify the threshold bin.
+  // The modes diverge later when collecting == pivot elements.
+  vec_t<DType, VEC_SIZE> score_vec;
+
+  const int aligned_length = (length / VEC_SIZE) * VEC_SIZE;
+  // Full-row scan helper (vectorized body + tail). Overflow fallback reuses this traversal.
+  auto for_each_score_full = [&](auto&& fn) {
+  // vectorized body
+#pragma unroll 2
+    for (int base = tx * VEC_SIZE; base < aligned_length; base += BLOCK_SIZE * VEC_SIZE) {
+      score_vec.cast_load(&score[base]);
+#pragma unroll
+      for (int j = 0; j < VEC_SIZE; ++j) {
+        fn(score_vec[j], base + j);
+      }
+    }
+    // tail
+    for (int i = aligned_length + tx; i < length; i += BLOCK_SIZE) {
+      fn(score[i], i);
+    }
+  };
+  auto accumulate_coarse_hist = [&](auto raw_input, int /*index*/) {
+    const auto bin = Traits::ToCoarseKey(raw_input);
+    atomicAdd(&s_histogram[bin], 1);
+  };
+  for_each_score_full(accumulate_coarse_hist);
+  __syncthreads();
+
+  // Suffix sum (Hillis Steele Scan)
+  const auto run_cumsum = [&]() {
+#pragma unroll 8
+    for (int i = 0; i < 8; ++i) {
+      if (tx < RADIX) {
+        const auto j = 1 << i;
+        const auto k = i & 1;
+        auto value = s_histogram_buf[k][tx];
+        if (tx < RADIX - j) {
+          value += s_histogram_buf[k][tx + j];
+        }
+        s_histogram_buf[k ^ 1][tx] = value;
+      }
+      __syncthreads();
+    }
+  };
+  auto update_refine_threshold = [&](int next_input_idx, auto reset_next_input_tag) {
+    constexpr bool RESET_NEXT_INPUT = decltype(reset_next_input_tag)::value;
+    run_cumsum();
+    if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+      s_threshold_bin_id = tx;
+      if constexpr (RESET_NEXT_INPUT) {
+        s_num_input[next_input_idx] = 0;
+      }
+      s_last_remain = topk - s_histogram[tx + 1];
+    }
+    __syncthreads();
+  };
+
+  run_cumsum();
+  if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
+    s_threshold_bin_id = tx;
+    s_num_input[0] = 0;
+    s_counter = 0;
+  }
+  __syncthreads();
+
+  const auto threshold_bin = s_threshold_bin_id;
+  topk -= s_histogram[threshold_bin + 1];
+  [[maybe_unused]] const int topk_after_coarse = topk;
+
+  constexpr int NUM_ROUNDS = Traits::NUM_REFINE_ROUNDS;
+  constexpr int FIRST_SHIFT = Traits::FIRST_REFINE_SHIFT;
+
+  // fp16/bf16: stop_round = 0; fp32: stop_round = 0,1,2,3
+  auto build_det_pivot = [&](int stop_round) -> OrderedType {
+    if constexpr (sizeof(OrderedType) == 2) {
+      return static_cast<OrderedType>((static_cast<uint32_t>(threshold_bin) << 8) |
+                                      static_cast<uint32_t>(s_refine_thresholds[0]));
+    } else {  // fp32
+      uint32_t pivot = 0;
+      for (int round = 0; round < NUM_ROUNDS; ++round) {
+        uint32_t byte =
+            (round <= stop_round) ? static_cast<uint32_t>(s_refine_thresholds[round]) : 0xFFu;
+        pivot |= (byte << (FIRST_SHIFT - round * 8));
+      }
+      return static_cast<OrderedType>(pivot);
+    }
+  };
+
+  if (topk == 0) {
+    // Collect indices where bin > threshold
+    auto collect_coarse_gt = [&](auto raw_input, int index) {
+      const auto bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+      if (bin > threshold_bin) {
+        const auto pos = atomicAdd(&s_counter, 1);
+        s_indices[pos] = index;
+      }
+    };
+    for_each_score_full(collect_coarse_gt);
+    __syncthreads();
+  } else {
+    __syncthreads();
+    if (tx < RADIX + 1) s_histogram[tx] = 0;
+    __syncthreads();
+
+    // Both non-det and det modes use atomicAdd to append >threshold winners here;
+    // only ==threshold handling diverges between the two modes.
+    auto collect_gt_and_nondet_eq_threshold = [&](auto value, auto threshold, int idx,
+                                                  bool collect_eq) {
+      if (value > threshold) {
+        const int pos = atomicAdd(&s_counter, 1);
+        s_indices[pos] = idx;
+      } else if constexpr (!DETERMINISTIC) {
+        if (collect_eq && value == threshold) {
+          const int pos = atomicAdd(&s_last_remain, -1);
+          if (pos > 0) {
+            s_indices[static_cast<int>(top_k) - pos] = idx;
+          }
+        }
+      }
+    };
+
+    auto collect_det_eq_pivot = [&](OrderedType pivot, int eq_needed) {
+      if (eq_needed > 0) {
+        using DetCollectBlockScan =
+            cub::BlockScan<uint32_t, BLOCK_SIZE, cub::BLOCK_SCAN_RAKING_MEMOIZE>;
+        __shared__ typename DetCollectBlockScan::TempStorage temp_storage;
+        auto emit_pivot_eq = [&](uint32_t idx, uint32_t local_pos) {
+          s_indices[static_cast<int>(top_k) - eq_needed + static_cast<int>(local_pos)] =
+              static_cast<int>(idx);
+        };
+        if constexpr (TIE_BREAK == TopKTieBreak::Small) {
+          DeterministicContiguousCollect<BLOCK_SIZE, false>(
+              tx, length, temp_storage,
+              [&](uint32_t idx) { return Traits::ToOrdered(score[idx]) == pivot; }, eq_needed,
+              emit_pivot_eq);
+        } else if constexpr (TIE_BREAK == TopKTieBreak::Large) {
+          DeterministicContiguousCollect<BLOCK_SIZE, true>(
+              tx, length, temp_storage,
+              [&](uint32_t idx) { return Traits::ToOrdered(score[idx]) == pivot; }, eq_needed,
+              emit_pivot_eq);
+        } else {
+          DeterministicThreadStridedCollect<BLOCK_SIZE>(
+              tx, length, temp_storage,
+              [&](uint32_t idx) { return Traits::ToOrdered(score[idx]) == pivot; }, eq_needed,
+              emit_pivot_eq);
+        }
+      }
+    };
+
+    // Filter + histogram for refinement
+    auto filter_and_add_to_histogram = [&](auto raw_input, int index) {
+      const auto bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+      if (bin > threshold_bin) {
+        const auto pos = atomicAdd(&s_counter, 1);
+        s_indices[pos] = index;
+      } else if (bin == threshold_bin) {
+        const auto pos = atomicAdd(&s_num_input[0], 1);
+        if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+          s_input_idx[0][pos] = index;
+          const auto ordered = Traits::ToOrdered(raw_input);
+          const auto sub_bin = (ordered >> FIRST_SHIFT) & 0xFF;
+          atomicAdd(&s_histogram[sub_bin], 1);
+        } else {
+          atomicOr(&s_refine_overflow, 1);
+        }
+      }
+    };
+    for_each_score_full(filter_and_add_to_histogram);
+    __syncthreads();
+
+    // Stage 2: refine with 8bit radix passes.
+    // If the threshold-bin candidate buffer overflows in 1-round refine mode
+    // (fp16/bf16), switch to a slow path that re-histograms the full threshold
+    // bin to preserve correctness.
+    auto collect_with_threshold_last_round = [&](int r_idx, int num_input, int offset,
+                                                 int threshold) {
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = score[idx];
+        const auto bin = (Traits::ToOrdered(raw_input) >> offset) & 0xFF;
+        collect_gt_and_nondet_eq_threshold(static_cast<int>(bin), threshold, idx,
+                                           /*allow_eq_claim=*/true);
+      }
+      __syncthreads();
+    };
+    auto collect_with_threshold_non_last_round = [&](int r_idx, int num_input, int offset,
+                                                     int threshold) {
+      const auto next_r_idx = r_idx ^ 1;
+      __syncthreads();
+      if (tx < RADIX + 1) s_histogram[tx] = 0;
+      __syncthreads();
+      for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+        const auto idx = s_input_idx[r_idx][i];
+        const auto raw_input = score[idx];
+        const auto bin = (Traits::ToOrdered(raw_input) >> offset) & 0xFF;
+        if (static_cast<int>(bin) > threshold) {
+          const auto pos = atomicAdd(&s_counter, 1);
+          s_indices[pos] = idx;
+        } else if (static_cast<int>(bin) == threshold) {
+          const auto pos = atomicAdd(&s_num_input[next_r_idx], 1);
+          if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
+            s_input_idx[next_r_idx][pos] = idx;
+            const auto bin32 = Traits::ToOrdered(raw_input);
+            const auto sub_bin = (bin32 >> (offset - 8)) & 0xFF;
+            atomicAdd(&s_histogram[sub_bin], 1);
+          } else {
+            atomicOr(&s_refine_overflow, 1);
+          }
+        }
+      }
+      __syncthreads();
+    };
+    // Returns true if this round fully resolves the pivot, i.e. no ==threshold
+    // elements need to be carried into another refine round.
+    auto run_refine_round = [&](int r_idx, int offset, auto is_last_round_tag) {
+      constexpr bool IS_LAST_ROUND = decltype(is_last_round_tag)::value;
+      const auto raw_num_input = s_num_input[r_idx];
+      const auto num_input = (raw_num_input < SMEM_INPUT_SIZE) ? raw_num_input : SMEM_INPUT_SIZE;
+
+      update_refine_threshold(r_idx ^ 1, std::true_type{});
+
+      const auto threshold = s_threshold_bin_id;
+      if constexpr (DETERMINISTIC) {
+        if (tx == 0) {
+          s_refine_thresholds[(FIRST_SHIFT - offset) / 8] = threshold;
+        }
+      }
+      topk -= s_histogram[threshold + 1];
+      if (topk == 0) {
+        // Final round reached: only collect bins strictly greater than threshold.
+        for (int i = tx; i < num_input; i += BLOCK_SIZE) {
+          const auto idx = s_input_idx[r_idx][i];
+          const auto bin = (Traits::ToOrdered(score[idx]) >> offset) & 0xFF;
+          if (static_cast<int>(bin) > threshold) {
+            const auto pos = atomicAdd(&s_counter, 1);
+            s_indices[pos] = idx;
+          }
+        }
+        __syncthreads();
+        return true;
+      }
+
+      if constexpr (IS_LAST_ROUND) {
+        collect_with_threshold_last_round(r_idx, num_input, offset, threshold);
+      } else {
+        collect_with_threshold_non_last_round(r_idx, num_input, offset, threshold);
+      }
+      return false;
+    };
+    if constexpr (NUM_ROUNDS == 1) {  // fast path for 1-round refine.
+      if (s_refine_overflow) {
+        if (tx < RADIX + 1) s_histogram[tx] = 0;
+        __syncthreads();
+
+        auto build_full_threshold_hist = [&](auto raw_input, int /*index*/) {
+          const auto coarse_bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+          if (coarse_bin == threshold_bin) {
+            const auto ordered = Traits::ToOrdered(raw_input);
+            const auto sub_bin = ordered & 0xFF;
+            atomicAdd(&s_histogram[sub_bin], 1);
+          }
+        };
+
+        for_each_score_full(build_full_threshold_hist);
+        __syncthreads();
+
+        if (tx == 0) {
+          s_threshold_bin_id = 0;
+          s_last_remain = 0;
+        }
+        __syncthreads();
+
+        update_refine_threshold(/*next_input_idx=*/0, std::false_type{});
+
+        const auto threshold = s_threshold_bin_id;
+
+        // Keep s_counter continuity: it already counts coarse_bin > threshold_bin
+        // elements collected in filter_and_add_to_histogram. Here we append
+        // threshold-bin refined winners after that prefix.
+        auto collect_from_full_threshold_bin = [&](auto raw_input, int index) {
+          const auto coarse_bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+          if (coarse_bin != threshold_bin) {
+            return;
+          }
+          const auto sub_bin = Traits::ToOrdered(raw_input) & 0xFF;
+          collect_gt_and_nondet_eq_threshold(static_cast<int>(sub_bin), threshold, index,
+                                             /*allow_eq_claim=*/true);
+        };
+
+        for_each_score_full(collect_from_full_threshold_bin);
+        __syncthreads();
+        if constexpr (DETERMINISTIC) {
+          int eq_needed = s_last_remain;
+          collect_det_eq_pivot(static_cast<OrderedType>((static_cast<int>(threshold_bin) << 8) |
+                                                        static_cast<int>(threshold)),
+                               eq_needed);
+        }
+      } else {
+        const int round = 0;
+        const auto r_idx = round % 2;
+        const int offset = FIRST_SHIFT;
+        run_refine_round(r_idx, offset, std::true_type{});
+        if constexpr (DETERMINISTIC) {
+          collect_det_eq_pivot(build_det_pivot(/*stop_round=*/0), topk);
+        }
+      }
+    } else {
+      // Multi-round refine path (float32): if any refine-buffer overflow is detected,
+      // switch to a correctness-first full rebuild of the threshold-bin selection.
+      // This fallback may be slower than the fast path, but avoids partial-state corruption.
+      int det_stop_round = NUM_ROUNDS - 1;
+      if (!s_refine_overflow) {
+#pragma unroll
+        for (int round = 0; round < NUM_ROUNDS; ++round) {
+          const auto r_idx = round % 2;
+          const int offset = FIRST_SHIFT - round * 8;
+          if (round == NUM_ROUNDS - 1) {
+            if (run_refine_round(r_idx, offset, std::true_type{})) {
+              det_stop_round = round;
+              break;
+            }
+          } else {
+            if (run_refine_round(r_idx, offset, std::false_type{})) {
+              det_stop_round = round;
+              break;
+            }
+          }
+          if (s_refine_overflow) {
+            break;
+          }
+        }
+      }
+      if constexpr (DETERMINISTIC) {
+        if (!s_refine_overflow) {
+          collect_det_eq_pivot(build_det_pivot(det_stop_round), topk);
+        }
+      }
+      // run_refine_round can set s_refine_overflow during the loop above, so this
+      // check is intentionally separate from the first if (!s_refine_overflow).
+      if (s_refine_overflow) {
+        static_assert(sizeof(OrderedType) == 4,
+                      "Multi-round overflow fallback expects 32-bit ordered keys.");
+
+        uint32_t topk_remain = static_cast<uint32_t>(topk_after_coarse);
+        uint8_t threshold_bytes[NUM_ROUNDS];
+#pragma unroll
+        for (int i = 0; i < NUM_ROUNDS; ++i) {
+          threshold_bytes[i] = 0xFF;
+        }
+        int stop_round = NUM_ROUNDS - 1;
+
+#pragma unroll
+        for (int round = 0; round < NUM_ROUNDS; ++round) {
+          const int offset = FIRST_SHIFT - round * 8;
+
+          if (tx < RADIX + 1) s_histogram[tx] = 0;
+          __syncthreads();
+
+          auto build_hist = [&](auto raw_input, int /*index*/) {
+            const auto coarse_bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+            if (coarse_bin != threshold_bin) {
+              return;
+            }
+            const auto ordered = static_cast<uint32_t>(Traits::ToOrdered(raw_input));
+            bool prefix_match = true;
+#pragma unroll
+            for (int prev = 0; prev < round; ++prev) {
+              const int prev_offset = FIRST_SHIFT - prev * 8;
+              if (static_cast<uint8_t>((ordered >> prev_offset) & 0xFF) != threshold_bytes[prev]) {
+                prefix_match = false;
+              }
+            }
+            if (prefix_match) {
+              const auto sub_bin = (ordered >> offset) & 0xFF;
+              atomicAdd(&s_histogram[sub_bin], 1);
+            }
+          };
+          for_each_score_full(build_hist);
+          __syncthreads();
+
+          run_cumsum();
+          if (tx < RADIX && s_histogram[tx] > static_cast<int>(topk_remain) &&
+              s_histogram[tx + 1] <= static_cast<int>(topk_remain)) {
+            s_threshold_bin_id = tx;
+          }
+          __syncthreads();
+
+          const int threshold = s_threshold_bin_id;
+          threshold_bytes[round] = static_cast<uint8_t>(threshold);
+          topk_remain -= static_cast<uint32_t>(s_histogram[threshold + 1]);
+
+          if (topk_remain == 0) {
+            stop_round = round;
+            break;
+          }
+        }
+
+        uint32_t pivot = 0;
+#pragma unroll
+        for (int round = 0; round < NUM_ROUNDS; ++round) {
+          const int offset = FIRST_SHIFT - round * 8;
+          uint32_t byte = static_cast<uint32_t>(threshold_bytes[round]);
+          if (topk_remain == 0 && round > stop_round) {
+            byte = 0xFFu;
+          }
+          pivot |= (byte << offset);
+        }
+        const int eq_needed = static_cast<int>(topk_remain);
+
+        // Overflow can happen after partial writes to s_indices/s_counter in earlier rounds.
+        // Reset and rebuild from full scans to avoid mixing stale partial state.
+        if (tx == 0) {
+          s_counter = 0;
+          s_last_remain = eq_needed;
+        }
+        __syncthreads();
+
+        // Re-collect all winners from scratch:
+        //   1) coarse_bin > threshold_bin
+        //   2) threshold_bin entries with ordered > pivot
+        //   3) first eq_needed entries where ordered == pivot
+        auto collect_by_pivot = [&](auto raw_input, int index) {
+          const auto coarse_bin = static_cast<int>(Traits::ToCoarseKey(raw_input));
+          if (coarse_bin > threshold_bin) {
+            collect_gt_and_nondet_eq_threshold(coarse_bin, threshold_bin, index,
+                                               /*allow_eq_claim=*/false);
+            return;
+          }
+          if (coarse_bin != threshold_bin) {
+            return;
+          }
+          const auto ordered = static_cast<uint32_t>(Traits::ToOrdered(raw_input));
+          collect_gt_and_nondet_eq_threshold(ordered, pivot, index, eq_needed > 0);
+        };
+        for_each_score_full(collect_by_pivot);
+        __syncthreads();
+        if constexpr (DETERMINISTIC) {
+          collect_det_eq_pivot(static_cast<OrderedType>(pivot), eq_needed);
+        }
+      }
+    }
+  }
+
+  // Output phase - mode-specific
+#pragma unroll 2
+  for (int base = tx; base < static_cast<int>(top_k); base += BLOCK_SIZE) {
+    const int idx = s_indices[base];
+    if constexpr (MODE == FilteredTopKMode::Plain) {
+      dst[base] = static_cast<IdType>(idx);
+      dst_values[base] = score[idx];
+    } else if constexpr (DETERMINISTIC) {  // transform in SortTopKByIndexKernel
+      dst[base] = static_cast<IdType>(idx);
+    } else if constexpr (MODE == FilteredTopKMode::PageTable) {
+      dst[base] = src_page_entry[row_start + idx];
+    } else {  // Ragged
+      dst[base] = static_cast<IdType>(idx) + offset_val;
+    }
+  }
+}
+
+// Helper to compute GCD for VEC_SIZE selection
+constexpr uint32_t gcd(uint32_t a, uint32_t b) {
+  while (b != 0) {
+    uint32_t t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+// Compute optimal VEC_SIZE based on max_len and dtype
+// Returns 1, 2, 4, or 8
+template <typename DType>
+constexpr int ComputeFilteredTopKVecSize(uint32_t max_len, bool dsa_graph_safe = false) {
+  if (dsa_graph_safe) {
+    return 1;
+  }
+  constexpr int MAX_VEC = 16 / sizeof(DType);  // 4 for float32, 8 for fp16/bf16
+  // Use GCD to find largest power-of-2 divisor
+  const uint32_t g = gcd(max_len, static_cast<uint32_t>(MAX_VEC));
+  return static_cast<int>(g);
+}
+
+template <bool WITH_VALUES, uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename DType>
+struct SortTopKByIndexBlockRadixSort;
+
+template <uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename DType>
+struct SortTopKByIndexBlockRadixSort<true, BLOCK_THREADS, ITEMS_PER_THREAD, DType> {
+  using Type = cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD, DType>;
+};
+
+template <uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename DType>
+struct SortTopKByIndexBlockRadixSort<false, BLOCK_THREADS, ITEMS_PER_THREAD, DType> {
+  using Type = cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD>;
+};
+
+template <FilteredTopKMode MODE, uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename DType,
+          typename IdType>
+__global__ void __launch_bounds__(BLOCK_THREADS)
+    SortTopKByIndexKernel(IdType* output_indices, DType* output_values, const IdType* aux_input,
+                          int64_t aux_stride, const IdType* row_starts, const IdType* row_to_batch,
+                          uint32_t top_k, uint32_t max_len) {
+  constexpr bool WITH_VALUES = (MODE == FilteredTopKMode::Plain);
+  using BlockRadixSortT = typename SortTopKByIndexBlockRadixSort<WITH_VALUES, BLOCK_THREADS,
+                                                                 ITEMS_PER_THREAD, DType>::Type;
+  __shared__ typename BlockRadixSortT::TempStorage temp_storage;
+
+  const uint32_t row = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  IdType* row_output = output_indices + static_cast<size_t>(row) * top_k;
+
+  uint32_t keys[ITEMS_PER_THREAD];
+  DType values[ITEMS_PER_THREAD];
+
+#pragma unroll
+  for (uint32_t i = 0; i < ITEMS_PER_THREAD; ++i) {
+    uint32_t pos = tx * ITEMS_PER_THREAD + i;
+    if (pos < top_k) {
+      IdType idx = row_output[pos];
+      keys[i] = (idx >= 0) ? static_cast<uint32_t>(idx) : ~0u;
+      if constexpr (MODE == FilteredTopKMode::Plain) {
+        values[i] = output_values[static_cast<size_t>(row) * top_k + pos];
+      }
+    } else {
+      keys[i] = ~0u;
+      if constexpr (MODE == FilteredTopKMode::Plain) {
+        values[i] = DType(0);
+      }
+    }
+  }
+
+  int end_bit = 32 - __clz(max_len);
+  if constexpr (MODE == FilteredTopKMode::Plain) {
+    BlockRadixSortT(temp_storage).Sort(keys, values, 0, end_bit);
+  } else {
+    BlockRadixSortT(temp_storage).Sort(keys, 0, end_bit);
+  }
+
+  const IdType* src_page_entry = nullptr;
+  IdType offset = 0;
+  IdType row_start = 0;
+  if constexpr (MODE == FilteredTopKMode::PageTable) {
+    const uint32_t batch_idx = (row_to_batch != nullptr) ? row_to_batch[row] : row;
+    src_page_entry = aux_input + static_cast<int64_t>(batch_idx) * aux_stride;
+    row_start = (row_starts != nullptr) ? row_starts[row] : 0;
+  } else if constexpr (MODE == FilteredTopKMode::Ragged) {
+    offset = aux_input[row];
+  }
+
+#pragma unroll
+  for (uint32_t i = 0; i < ITEMS_PER_THREAD; ++i) {
+    uint32_t pos = tx * ITEMS_PER_THREAD + i;
+    if (pos < top_k) {
+      uint32_t idx = keys[i];
+      if constexpr (MODE == FilteredTopKMode::Plain) {
+        row_output[pos] = static_cast<IdType>(idx);
+        output_values[static_cast<size_t>(row) * top_k + pos] = values[i];
+      } else if constexpr (MODE == FilteredTopKMode::PageTable) {
+        row_output[pos] = (idx != ~0u) ? src_page_entry[row_start + idx] : static_cast<IdType>(-1);
+      } else {  // Ragged
+        row_output[pos] =
+            (idx != ~0u) ? static_cast<IdType>(idx) + offset : static_cast<IdType>(-1);
+      }
+    }
+  }
+}
+
+template <FilteredTopKMode MODE, typename DType, typename IdType>
+cudaError_t LaunchSortTopKByIndex(IdType* output_indices, DType* output_values,
+                                  const IdType* aux_input, int64_t aux_stride,
+                                  const IdType* row_starts, const IdType* row_to_batch,
+                                  uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+                                  cudaStream_t stream = 0) {
+  // Block-local sort variants cover at most 256 * 8 = 2048 elements.
+  if (top_k_val > 2048) {
+    return cudaErrorInvalidValue;
+  }
+  if constexpr (MODE == FilteredTopKMode::Plain) {
+    if (top_k_val <= 1) {
+      return cudaSuccess;
+    }
+  }
+  if (top_k_val == 0) {
+    return cudaSuccess;
+  }
+
+  dim3 grid(num_rows);
+  void* args[] = {&output_indices, &output_values, &aux_input, &aux_stride,
+                  &row_starts,     &row_to_batch,  &top_k_val, &max_len};
+  auto launch_sort = [&](auto kernel, uint32_t threads) -> cudaError_t {
+    dim3 block(threads);
+    return cudaLaunchKernel((void*)kernel, grid, block, args, 0, stream);
+  };
+
+  cudaError_t status;
+  if (top_k_val <= 128) {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 32, 4, DType, IdType>, 32);
+  } else if (top_k_val <= 256) {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 32, 8, DType, IdType>, 32);
+  } else if (top_k_val <= 512) {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 64, 8, DType, IdType>, 64);
+  } else if (top_k_val <= 576) {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 64, 9, DType, IdType>, 64);
+  } else if (top_k_val <= 1024) {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 128, 8, DType, IdType>, 128);
+  } else {
+    status = launch_sort(SortTopKByIndexKernel<MODE, 256, 8, DType, IdType>, 256);
+  }
+  return status;
+}
+
+/*!
+ * \brief CUB stable radix sort: sorts top-k by value descending, carrying indices.
+ *
+ * Uses 32-bit flipped ordered value as key and 32-bit index as satellite data.
+ * Since radix sort is stable, equal values preserve their prior relative order.
+ * When preceded by an index sort, this yields (value desc, index asc) ordering.
+ */
+template <uint32_t BLOCK_THREADS, uint32_t ITEMS_PER_THREAD, typename IdType, typename DType>
+__global__ void __launch_bounds__(BLOCK_THREADS)
+    StableSortTopKByValueKernel(IdType* output_indices, DType* output_values, uint32_t k,
+                                uint32_t /*max_len*/) {
+  using Traits = RadixTopKTraits<DType>;
+  using OrderedType = typename Traits::OrderedType;
+  using BlockRadixSortT = cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD, uint32_t>;
+  __shared__ typename BlockRadixSortT::TempStorage temp_storage;
+
+  const uint32_t row = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+
+  IdType* row_indices = output_indices + static_cast<size_t>(row) * k;
+  DType* row_values = output_values + static_cast<size_t>(row) * k;
+
+  uint32_t keys[ITEMS_PER_THREAD];
+  uint32_t indices[ITEMS_PER_THREAD];
+
+#pragma unroll
+  for (uint32_t i = 0; i < ITEMS_PER_THREAD; i++) {
+    uint32_t pos = tx * ITEMS_PER_THREAD + i;
+    if (pos < k) {
+      OrderedType ordered = Traits::ToOrdered(row_values[pos]);
+      keys[i] = static_cast<uint32_t>(static_cast<OrderedType>(~ordered));
+      indices[i] = static_cast<uint32_t>(row_indices[pos]);
+    } else {
+      keys[i] = ~0u;
+      indices[i] = ~0u;
+    }
+  }
+
+  constexpr int end_bit = sizeof(OrderedType) * 8;
+  BlockRadixSortT(temp_storage).Sort(keys, indices, 0, end_bit);
+
+#pragma unroll
+  for (uint32_t i = 0; i < ITEMS_PER_THREAD; i++) {
+    uint32_t pos = tx * ITEMS_PER_THREAD + i;
+    if (pos < k) {
+      row_indices[pos] = static_cast<IdType>(indices[i]);
+      OrderedType ordered = static_cast<OrderedType>(~static_cast<OrderedType>(keys[i]));
+      row_values[pos] = Traits::FromOrdered(ordered);
+    }
+  }
+}
+
+template <typename DType, typename IdType>
+cudaError_t StableSortTopKByValue(IdType* output_indices, DType* output_values, uint32_t num_rows,
+                                  uint32_t top_k_val, uint32_t max_len, cudaStream_t stream = 0) {
+  // Block-local sort variants cover at most 256 * 8 = 2048 elements.
+  if (top_k_val > 2048) {
+    return cudaErrorInvalidValue;
+  }
+  if (top_k_val <= 1) {
+    return cudaSuccess;
+  }
+
+  dim3 grid(num_rows);
+  void* args[] = {&output_indices, &output_values, &top_k_val, &max_len};
+  auto launch_sort = [&](auto kernel, uint32_t threads) -> cudaError_t {
+    dim3 block(threads);
+    return cudaLaunchKernel((void*)kernel, grid, block, args, 0, stream);
+  };
+
+  cudaError_t status;
+  if (top_k_val <= 128) {
+    status = launch_sort(StableSortTopKByValueKernel<32, 4, IdType, DType>, 32);
+  } else if (top_k_val <= 256) {
+    status = launch_sort(StableSortTopKByValueKernel<32, 8, IdType, DType>, 32);
+  } else if (top_k_val <= 512) {
+    status = launch_sort(StableSortTopKByValueKernel<64, 8, IdType, DType>, 64);
+  } else if (top_k_val <= 576) {
+    status = launch_sort(StableSortTopKByValueKernel<64, 9, IdType, DType>, 64);
+  } else if (top_k_val <= 1024) {
+    status = launch_sort(StableSortTopKByValueKernel<128, 8, IdType, DType>, 128);
+  } else {
+    status = launch_sort(StableSortTopKByValueKernel<256, 8, IdType, DType>, 256);
+  }
+  return status;
+}
+
+template <FilteredTopKMode MODE, typename DType, typename IdType>
+cudaError_t LaunchFilteredTopKUnified(DType* input, IdType* output, DType* aux_output,
+                                      const IdType* aux_input, int64_t aux_stride,
+                                      const IdType* row_to_batch, const IdType* lengths,
+                                      const IdType* row_starts, uint32_t num_rows,
+                                      uint32_t top_k_val, uint32_t max_len,
+                                      bool deterministic = false,
+                                      TopKTieBreak tie_break = TopKTieBreak::None,
+                                      cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  constexpr size_t smem_size = FILTERED_TOPK_SMEM_DYNAMIC;
+  constexpr int MAX_VEC = 16 / sizeof(DType);
+
+  dim3 grid(num_rows);
+  dim3 block(FILTERED_TOPK_BLOCK_THREADS);
+  void* args[] = {&input,   &output,     &aux_output, &aux_input, &aux_stride, &row_to_batch,
+                  &lengths, &row_starts, &num_rows,   &top_k_val, &max_len};
+
+  const int vec_size = (row_starts != nullptr && MODE != FilteredTopKMode::Plain)
+                           ? 1
+                           : ComputeFilteredTopKVecSize<DType>(max_len, dsa_graph_safe);
+
+#define LAUNCH_FILTERED_KERNEL(VS, DET, TIE)                                                     \
+  do {                                                                                           \
+    auto kernel = FilteredTopKUnifiedKernel<DType, IdType, VS, DET, MODE, TIE>;                  \
+    FLASHINFER_CUDA_CALL(                                                                        \
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));   \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, grid, block, args, smem_size, stream)); \
+  } while (0)
+
+#define DISPATCH_VEC_SIZE(VS)                                  \
+  if (vec_size == VS) {                                        \
+    if (!deterministic) {                                      \
+      LAUNCH_FILTERED_KERNEL(VS, false, TopKTieBreak::None);   \
+    } else {                                                   \
+      if (tie_break == TopKTieBreak::Small) {                  \
+        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Small); \
+      } else if (tie_break == TopKTieBreak::Large) {           \
+        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::Large); \
+      } else {                                                 \
+        LAUNCH_FILTERED_KERNEL(VS, true, TopKTieBreak::None);  \
+      }                                                        \
+    }                                                          \
+    return cudaSuccess;                                        \
+  }
+
+  DISPATCH_VEC_SIZE(1)
+  DISPATCH_VEC_SIZE(2)
+  DISPATCH_VEC_SIZE(4)
+  if constexpr (MAX_VEC >= 8) {
+    DISPATCH_VEC_SIZE(8)
+  }
+#undef DISPATCH_VEC_SIZE
+#undef LAUNCH_FILTERED_KERNEL
+
+  return cudaSuccess;
+}
+
+// Launch functions with VEC_SIZE and BLOCK_THREADS dispatch - using unified kernel
+template <typename DType, typename IdType>
+cudaError_t FilteredTopKPageTableTransform(DType* input, IdType* output_page_table,
+                                           const IdType* src_page_table, int64_t src_stride,
+                                           const IdType* row_to_batch, IdType* lengths,
+                                           const IdType* row_starts, uint32_t num_rows,
+                                           uint32_t top_k_val, uint32_t max_len,
+                                           bool deterministic = false,
+                                           TopKTieBreak tie_break = TopKTieBreak::None,
+                                           cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  DType* aux_output = nullptr;  // Not used for PageTable mode
+  return LaunchFilteredTopKUnified<FilteredTopKMode::PageTable, DType, IdType>(
+      input, output_page_table, aux_output, src_page_table, src_stride, row_to_batch, lengths,
+      row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+}
+
+template <typename DType, typename IdType>
+cudaError_t FilteredTopKRaggedTransform(DType* input, IdType* output_indices, const IdType* offsets,
+                                        IdType* lengths, const IdType* row_starts,
+                                        uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+                                        bool deterministic = false,
+                                        TopKTieBreak tie_break = TopKTieBreak::None,
+                                        cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  DType* aux_output = nullptr;           // Not used for Ragged mode
+  int64_t aux_stride = 0;                // Not used for Ragged mode
+  const IdType* row_to_batch = nullptr;  // Not used for Ragged mode
+  return LaunchFilteredTopKUnified<FilteredTopKMode::Ragged, DType, IdType>(
+      input, output_indices, aux_output, offsets, aux_stride, row_to_batch, lengths, row_starts,
+      num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+}
+
+template <typename DType, typename IdType>
+cudaError_t FilteredTopK(DType* input, IdType* output_indices, DType* output_values,
+                         const IdType* lengths, uint32_t num_rows, uint32_t top_k_val,
+                         uint32_t max_len, bool deterministic = false,
+                         TopKTieBreak tie_break = TopKTieBreak::None, cudaStream_t stream = 0,
+                         bool dsa_graph_safe = false) {
+  const IdType* aux_input = nullptr;     // Not used for Plain mode
+  int64_t aux_stride = 0;                // Not used for Plain mode
+  const IdType* row_starts = nullptr;    // Not used for Plain mode
+  const IdType* row_to_batch = nullptr;  // Not used for Plain mode
+  return LaunchFilteredTopKUnified<FilteredTopKMode::Plain, DType, IdType>(
+      input, output_indices, output_values, aux_input, aux_stride, row_to_batch, lengths,
+      row_starts, num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe);
+}
+
+/*!
+ * \brief Check if the GPU supports enough shared memory for FilteredTopK algorithm.
+ *
+ * FilteredTopK requires 128KB dynamic shared memory. This function checks if the
+ * current GPU's max shared memory per SM is sufficient.
+ *
+ * \return true if GPU supports FilteredTopK, false otherwise
+ */
+inline bool CanImplementFilteredTopK() {
+  int device_id;
+  if (cudaGetDevice(&device_id) != cudaSuccess) return false;
+  int max_smem_per_sm;
+  if (cudaDeviceGetAttribute(&max_smem_per_sm, cudaDevAttrMaxSharedMemoryPerMultiprocessor,
+                             device_id) != cudaSuccess) {
+    return false;
+  }
+  return static_cast<size_t>(max_smem_per_sm) >= FILTERED_TOPK_SMEM_DYNAMIC;
+}
+
+// Algorithm override for benchmarking (controlled by FLASHINFER_TOPK_ALGO env var)
+enum class TopKAlgoOverride { AUTO, FILTERED, MULTI_CTA };
+
+inline TopKAlgoOverride GetTopKAlgoOverride() {
+  const char* env = std::getenv("FLASHINFER_TOPK_ALGO");
+  if (env == nullptr) return TopKAlgoOverride::AUTO;
+  if (std::strcmp(env, "filtered") == 0) return TopKAlgoOverride::FILTERED;
+  if (std::strcmp(env, "multi_cta") == 0) return TopKAlgoOverride::MULTI_CTA;
+  return TopKAlgoOverride::AUTO;
+}
+
+/*!
+ * \brief Unified heuristic to decide whether to use FilteredTopK or Multi-CTA RadixTopK.
+ *
+ * \tparam DType Data type (affects threshold due to memory bandwidth considerations)
+ * \param num_rows Number of rows (batch size)
+ * \param top_k_val Number of top elements to select
+ * \param max_len Maximum sequence length
+ * \param deterministic Whether deterministic top-k path is requested
+ * \param tie_break Mode of tie-break
+ * \return true if FilteredTopK should be used, false for Multi-CTA RadixTopK
+ */
+template <typename DType>
+inline bool ShouldUseFilteredTopK(uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+                                  bool deterministic, TopKTieBreak tie_break,
+                                  bool dsa_graph_safe = false) {
+  // DSA graph safe mode alwaus uses FilteredTopK
+  if (dsa_graph_safe) {
+    return true;
+  }
+  // Tie-break modes are only supported by FilteredTopK
+  if (tie_break != TopKTieBreak::None) {
+    return true;
+  }
+
+  // Check if GPU supports enough shared memory for FilteredTopK
+  const bool gpu_supports_filtered = CanImplementFilteredTopK();
+  const bool k_fits_filtered = (top_k_val <= FILTERED_TOPK_MAX_K) && (max_len > top_k_val);
+
+  if (!gpu_supports_filtered || !k_fits_filtered) {
+    return false;
+  }
+
+  // Check for algorithm override
+  const TopKAlgoOverride algo_override = GetTopKAlgoOverride();
+  if (algo_override == TopKAlgoOverride::FILTERED) return true;
+  if (algo_override == TopKAlgoOverride::MULTI_CTA) return false;
+
+  // 16-bit types: simpler threshold
+  // 32-bit types: more nuanced heuristic
+  if (deterministic) {
+    if constexpr (sizeof(DType) <= 2) {
+      return num_rows > (max_len / 256);
+    } else {
+      if (max_len <= 16384) {
+        return true;
+      } else {
+        const uint32_t batch_threshold = std::min(64u, std::max(16u, max_len / 4096));
+        return num_rows >= batch_threshold;
+      }
+    }
+  }
+
+  if constexpr (sizeof(DType) <= 2) {
+    return (max_len <= 16384);
+  } else {
+    if (max_len <= 32768) {
+      return true;
+    } else {
+      const uint32_t batch_threshold = max_len / 16384;
+      return (num_rows > batch_threshold);
+    }
+  }
+}
+
+// Dispatch functions with heuristics
+template <typename DType, typename IdType>
+cudaError_t TopKPageTableTransformDispatch(DType* input, IdType* output_page_table,
+                                           const IdType* src_page_table, int64_t src_stride,
+                                           IdType* lengths, const IdType* row_starts,
+                                           const IdType* row_to_batch, uint32_t num_rows,
+                                           uint32_t top_k_val, uint32_t max_len,
+                                           RadixRowState* row_states_buffer, bool deterministic,
+                                           TopKTieBreak tie_break = TopKTieBreak::None,
+                                           cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
+  if (tie_break != TopKTieBreak::None) {
+    deterministic = true;
+  }
+  if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
+    return cudaErrorNotSupported;
+  }
+  if (ShouldUseFilteredTopK<DType>(num_rows, top_k_val, max_len, deterministic, tie_break,
+                                   dsa_graph_safe)) {
+    FLASHINFER_CUDA_CALL((FilteredTopKPageTableTransform<DType, IdType>(
+        input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
+        num_rows, top_k_val, max_len, deterministic, tie_break, stream, dsa_graph_safe)));
+    if (deterministic) {
+      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::PageTable, uint8_t, IdType>(
+          output_page_table, static_cast<uint8_t*>(nullptr), src_page_table, src_stride, row_starts,
+          row_to_batch, num_rows, top_k_val, max_len, stream)));
+    }
+    return cudaSuccess;
+  }
+  return RadixTopKPageTableTransformMultiCTA<DType, IdType>(
+      input, output_page_table, src_page_table, src_stride, row_to_batch, lengths, row_starts,
+      num_rows, top_k_val, max_len, row_states_buffer, deterministic, stream);
+}
+
+template <typename DType, typename IdType>
+cudaError_t TopKRaggedTransformDispatch(DType* input, IdType* output_indices, const IdType* offsets,
+                                        IdType* lengths, const IdType* row_starts,
+                                        uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+                                        RadixRowState* row_states_buffer, bool deterministic,
+                                        TopKTieBreak tie_break = TopKTieBreak::None,
+                                        cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
+  if (tie_break != TopKTieBreak::None) {
+    deterministic = true;
+  }
+  if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
+    return cudaErrorNotSupported;
+  }
+  if (ShouldUseFilteredTopK<DType>(num_rows, top_k_val, max_len, deterministic, tie_break,
+                                   dsa_graph_safe)) {
+    FLASHINFER_CUDA_CALL((FilteredTopKRaggedTransform<DType, IdType>(
+        input, output_indices, offsets, lengths, row_starts, num_rows, top_k_val, max_len,
+        deterministic, tie_break, stream, dsa_graph_safe)));
+    if (deterministic) {
+      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::Ragged, uint8_t, IdType>(
+          output_indices, static_cast<uint8_t*>(nullptr), offsets, 0, row_starts, nullptr, num_rows,
+          top_k_val, max_len, stream)));
+    }
+    return cudaSuccess;
+  }
+  return RadixTopKRaggedTransformMultiCTA<DType, IdType>(input, output_indices, offsets, lengths,
+                                                         row_starts, num_rows, top_k_val, max_len,
+                                                         row_states_buffer, deterministic, stream);
+}
+
+template <typename DType, typename IdType>
+cudaError_t TopKDispatch(DType* input, IdType* output_indices, DType* output_values,
+                         uint32_t num_rows, uint32_t top_k_val, uint32_t max_len,
+                         RadixRowState* row_states_buffer, bool sorted_output = false,
+                         bool deterministic = false, TopKTieBreak tie_break = TopKTieBreak::None,
+                         cudaStream_t stream = 0, bool dsa_graph_safe = false) {
+  const bool require_filtered = dsa_graph_safe || tie_break != TopKTieBreak::None;
+  if (tie_break != TopKTieBreak::None) {
+    deterministic = true;
+  }
+  if (require_filtered && (top_k_val > FILTERED_TOPK_MAX_K || !CanImplementFilteredTopK())) {
+    return cudaErrorNotSupported;
+  }
+  if (ShouldUseFilteredTopK<DType>(num_rows, top_k_val, max_len, deterministic, tie_break,
+                                   dsa_graph_safe)) {
+    FLASHINFER_CUDA_CALL((FilteredTopK<DType, IdType>(input, output_indices, output_values, nullptr,
+                                                      num_rows, top_k_val, max_len, deterministic,
+                                                      tie_break, stream, dsa_graph_safe)));
+    if (deterministic) {
+      FLASHINFER_CUDA_CALL((LaunchSortTopKByIndex<FilteredTopKMode::Plain, DType, IdType>(
+          output_indices, output_values, nullptr, 0, nullptr, nullptr, num_rows, top_k_val, max_len,
+          stream)));
+    }
+  } else {
+    FLASHINFER_CUDA_CALL((RadixTopKMultiCTA<DType, IdType>(
+        input, output_indices, output_values, nullptr, num_rows, top_k_val, max_len,
+        row_states_buffer, deterministic, stream)));
+  }
+  if (sorted_output) {
+    FLASHINFER_CUDA_CALL((StableSortTopKByValue<DType, IdType>(
+        output_indices, output_values, num_rows, top_k_val, max_len, stream)));
+  }
+  return cudaSuccess;
+}
+
+}  // namespace sampling
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_TOPK_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/topk_common.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/topk_common.cuh
@@ -1,0 +1,106 @@
+#ifndef FLASHINFER_TOPK_COMMON_CUH_
+#define FLASHINFER_TOPK_COMMON_CUH_
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cuda/std/limits>
+#include <numeric>
+#include <type_traits>
+
+namespace flashinfer {
+namespace sampling {
+
+// ============================================================================
+// RadixTopK Type Traits - supports float, half, and bfloat16
+// OrderedType: uint32_t for float, uint16_t for half/bf16
+// NUM_ROUNDS is computed as: sizeof(OrderedType) * 8 / RADIX_BITS
+// ============================================================================
+template <typename DType>
+struct RadixTopKTraits;
+
+// Specialization for float (32-bit)
+template <>
+struct RadixTopKTraits<float> {
+  using OrderedType = uint32_t;
+
+  // Compute number of rounds based on radix bits (not hardcoded)
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(float val) {
+    uint32_t bits = __float_as_uint(val);
+    // For descending order: flip all bits if negative, else flip sign bit
+    return (bits & 0x80000000) ? ~bits : (bits ^ 0x80000000);
+  }
+
+  __device__ __forceinline__ static float FromOrdered(OrderedType ordered) {
+    uint32_t bits = (ordered & 0x80000000) ? (ordered ^ 0x80000000) : ~ordered;
+    return __uint_as_float(bits);
+  }
+
+  __device__ __forceinline__ static float NegInf() {
+    return -cuda::std::numeric_limits<float>::infinity();
+  }
+};
+
+// Specialization for half (16-bit)
+template <>
+struct RadixTopKTraits<half> {
+  using OrderedType = uint16_t;
+
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(half val) {
+    uint16_t bits = __half_as_ushort(val);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
+  }
+
+  __device__ __forceinline__ static half FromOrdered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
+                                       : static_cast<uint16_t>(~ordered);
+    return __ushort_as_half(bits);
+  }
+
+  __device__ __forceinline__ static half NegInf() {
+    return __ushort_as_half(static_cast<uint16_t>(0xFC00));  // -inf in fp16
+  }
+};
+
+// Specialization for nv_bfloat16 (16-bit)
+template <>
+struct RadixTopKTraits<nv_bfloat16> {
+  using OrderedType = uint16_t;
+
+  template <uint32_t RADIX_BITS>
+  static __host__ __device__ constexpr uint32_t num_rounds() {
+    return sizeof(OrderedType) * 8 / RADIX_BITS;
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(nv_bfloat16 val) {
+    uint16_t bits = __bfloat16_as_ushort(val);
+    return (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits ^ 0x8000);
+  }
+
+  __device__ __forceinline__ static nv_bfloat16 FromOrdered(OrderedType ordered) {
+    uint16_t bits = (ordered & 0x8000) ? static_cast<uint16_t>(ordered ^ 0x8000)
+                                       : static_cast<uint16_t>(~ordered);
+    return __ushort_as_bfloat16(bits);
+  }
+
+  __device__ __forceinline__ static nv_bfloat16 NegInf() {
+    return __ushort_as_bfloat16(static_cast<uint16_t>(0xFF80));  // -inf in bf16
+  }
+};
+
+}  // namespace sampling
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_TOPK_COMMON_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/utils.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/utils.cuh
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_UTILS_CUH_
+#define FLASHINFER_UTILS_CUH_
+#include <cuda_bf16.h>
+#include <cuda_device_runtime_api.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+#include "exception.h"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+// macro to turn off fp16 qk reduction to reduce binary
+#ifndef FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION
+#define FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION 0
+#endif
+
+#ifndef NDEBUG
+#define FLASHINFER_CUDA_CALL(func, ...)                                                     \
+  {                                                                                         \
+    cudaError_t e = (func);                                                                 \
+    if (e != cudaSuccess) {                                                                 \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(e) << " (" << e << ") " << __FILE__ \
+                << ": line " << __LINE__ << " at function " << STR(func) << std::endl;      \
+      return e;                                                                             \
+    }                                                                                       \
+  }
+#else
+#define FLASHINFER_CUDA_CALL(func, ...) \
+  {                                     \
+    cudaError_t e = (func);             \
+    if (e != cudaSuccess) {             \
+      return e;                         \
+    }                                   \
+  }
+#endif
+
+#define FLASHINFER_CUDA_CHECK(func)                                                         \
+  do {                                                                                      \
+    cudaError_t e = (func);                                                                 \
+    FLASHINFER_CHECK(e == cudaSuccess, "CUDA Error: ", cudaGetErrorString(e), " (", int(e), \
+                     ") at ", __FILE__, ":", __LINE__, " in ", STR(func));                  \
+  } while (0)
+
+#define FLASHINFER_CHECK_ALIGNMENT(ptr, size_bytes)                            \
+  FLASHINFER_CHECK(reinterpret_cast<uintptr_t>(ptr) % (size_bytes) == 0, #ptr, \
+                   " must be aligned to ", (size_bytes), " bytes, got address ", (uintptr_t)(ptr))
+
+#define FLASHINFER_CHECK_TMA_ALIGNED(ptr) FLASHINFER_CHECK_ALIGNMENT(ptr, 128)
+
+#define DISPATCH_USE_FP16_QK_REDUCTION(use_fp16_qk_reduction, USE_FP16_QK_REDUCTION, ...) \
+  if (use_fp16_qk_reduction) {                                                            \
+    FLASHINFER_ERROR("FP16_QK_REDUCTION disabled at compile time");                       \
+  } else {                                                                                \
+    constexpr bool USE_FP16_QK_REDUCTION = false;                                         \
+    __VA_ARGS__                                                                           \
+  }
+
+#define DISPATCH_NUM_MMA_Q(num_mma_q, NUM_MMA_Q, ...)  \
+  if (num_mma_q == 1) {                                \
+    constexpr size_t NUM_MMA_Q = 1;                    \
+    __VA_ARGS__                                        \
+  } else if (num_mma_q == 2) {                         \
+    constexpr size_t NUM_MMA_Q = 2;                    \
+    __VA_ARGS__                                        \
+  } else {                                             \
+    std::ostringstream err_msg;                        \
+    err_msg << "Unsupported num_mma_q: " << num_mma_q; \
+    FLASHINFER_ERROR(err_msg.str());                   \
+  }
+
+#define DISPATCH_NUM_MMA_KV(max_mma_kv, NUM_MMA_KV, ...) \
+  if (max_mma_kv >= 8) {                                 \
+    constexpr size_t NUM_MMA_KV = 8;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 4) {                          \
+    constexpr size_t NUM_MMA_KV = 4;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 2) {                          \
+    constexpr size_t NUM_MMA_KV = 2;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 1) {                          \
+    constexpr size_t NUM_MMA_KV = 1;                     \
+    __VA_ARGS__                                          \
+  } else {                                               \
+    std::ostringstream err_msg;                          \
+    err_msg << "Unsupported max_mma_kv: " << max_mma_kv; \
+    FLASHINFER_ERROR(err_msg.str());                     \
+  }
+
+#define DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, ...)   \
+  switch (cta_tile_q) {                                    \
+    case 128: {                                            \
+      constexpr uint32_t CTA_TILE_Q = 128;                 \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    case 64: {                                             \
+      constexpr uint32_t CTA_TILE_Q = 64;                  \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    case 16: {                                             \
+      constexpr uint32_t CTA_TILE_Q = 16;                  \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    default: {                                             \
+      std::ostringstream err_msg;                          \
+      err_msg << "Unsupported cta_tile_q: " << cta_tile_q; \
+      FLASHINFER_ERROR(err_msg.str());                     \
+    }                                                      \
+  }
+
+#define DISPATCH_GQA_GROUP_SIZE(group_size, GROUP_SIZE, ...) \
+  if (group_size == 1) {                                     \
+    constexpr size_t GROUP_SIZE = 1;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 2) {                              \
+    constexpr size_t GROUP_SIZE = 2;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 3) {                              \
+    constexpr size_t GROUP_SIZE = 3;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 4) {                              \
+    constexpr size_t GROUP_SIZE = 4;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 8) {                              \
+    constexpr size_t GROUP_SIZE = 8;                         \
+    __VA_ARGS__                                              \
+  } else {                                                   \
+    std::ostringstream err_msg;                              \
+    err_msg << "Unsupported group_size: " << group_size;     \
+    FLASHINFER_ERROR(err_msg.str());                         \
+  }
+
+#define DISPATCH_MASK_MODE(mask_mode, MASK_MODE, ...)             \
+  switch (mask_mode) {                                            \
+    case MaskMode::kNone: {                                       \
+      constexpr MaskMode MASK_MODE = MaskMode::kNone;             \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCausal: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCausal;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCustom: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCustom;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kMultiItemScoring: {                           \
+      constexpr MaskMode MASK_MODE = MaskMode::kMultiItemScoring; \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    default: {                                                    \
+      std::ostringstream err_msg;                                 \
+      err_msg << "Unsupported mask_mode: " << int(mask_mode);     \
+      FLASHINFER_ERROR(err_msg.str());                            \
+    }                                                             \
+  }
+
+// convert head_dim to compile-time constant
+#define DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, ...)     \
+  switch (head_dim) {                                  \
+    case 64: {                                         \
+      constexpr size_t HEAD_DIM = 64;                  \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 128: {                                        \
+      constexpr size_t HEAD_DIM = 128;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 256: {                                        \
+      constexpr size_t HEAD_DIM = 256;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 512: {                                        \
+      constexpr size_t HEAD_DIM = 512;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    default: {                                         \
+      std::ostringstream err_msg;                      \
+      err_msg << "Unsupported head_dim: " << head_dim; \
+      FLASHINFER_ERROR(err_msg.str());                 \
+    }                                                  \
+  }
+
+// convert interleave to compile-time constant
+#define DISPATCH_INTERLEAVE(interleave, INTERLEAVE, ...) \
+  if (interleave) {                                      \
+    constexpr bool INTERLEAVE = true;                    \
+    __VA_ARGS__                                          \
+  } else {                                               \
+    constexpr bool INTERLEAVE = false;                   \
+    __VA_ARGS__                                          \
+  }
+
+#define DISPATCH_ROPE_DIM(rope_dim, ROPE_DIM, ...)           \
+  switch (rope_dim) {                                        \
+    case 16: {                                               \
+      constexpr uint32_t ROPE_DIM = 16;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 32: {                                               \
+      constexpr uint32_t ROPE_DIM = 32;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 64: {                                               \
+      constexpr uint32_t ROPE_DIM = 64;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 128: {                                              \
+      constexpr uint32_t ROPE_DIM = 128;                     \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 256: {                                              \
+      constexpr uint32_t ROPE_DIM = 256;                     \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    default: {                                               \
+      std::ostringstream err_msg;                            \
+      err_msg << "Unsupported ROPE_DIM: " << rope_dim;       \
+      err_msg << ". Supported values: 16, 32, 64, 128, 256"; \
+      err_msg << " in DISPATCH_ROPE_DIM";                    \
+      FLASHINFER_ERROR(err_msg.str());                       \
+    }                                                        \
+  }
+
+#define DISPATCH_POS_ENCODING_MODE(pos_encoding_mode, POS_ENCODING_MODE, ...)    \
+  switch (pos_encoding_mode) {                                                   \
+    case PosEncodingMode::kNone: {                                               \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kNone;      \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    case PosEncodingMode::kRoPELlama: {                                          \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kRoPELlama; \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    case PosEncodingMode::kALiBi: {                                              \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kALiBi;     \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    default: {                                                                   \
+      std::ostringstream err_msg;                                                \
+      err_msg << "Unsupported pos_encoding_mode: " << int(pos_encoding_mode);    \
+      FLASHINFER_ERROR(err_msg.str());                                           \
+    }                                                                            \
+  }
+
+#define DISPATCH_ALIGNED_VEC_SIZE(aligned_vec_size, ALIGNED_VEC_SIZE, ...) \
+  switch (aligned_vec_size) {                                              \
+    case 16: {                                                             \
+      constexpr size_t ALIGNED_VEC_SIZE = 16;                              \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 8: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 8;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 4: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 4;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 2: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 2;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 1: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 1;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    default: {                                                             \
+      std::ostringstream err_msg;                                          \
+      err_msg << "Unsupported aligned_vec_size: " << aligned_vec_size;     \
+      FLASHINFER_ERROR(err_msg.str());                                     \
+    }                                                                      \
+  }
+
+#define DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, ...) \
+  if (compute_capacity.first >= 8) {                                                        \
+    constexpr uint32_t NUM_STAGES_SMEM = 2;                                                 \
+    __VA_ARGS__                                                                             \
+  } else {                                                                                  \
+    constexpr uint32_t NUM_STAGES_SMEM = 1;                                                 \
+    __VA_ARGS__                                                                             \
+  }
+
+namespace flashinfer {
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 ceil_div(const T1 x, const T2 y) noexcept {
+  return (x + y - 1) / y;
+}
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 round_up(const T1 x, const T2 y) noexcept {
+  return ceil_div(x, y) * y;
+}
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 round_down(const T1 x, const T2 y) noexcept {
+  return (x / y) * y;
+}
+
+inline std::pair<int, int> GetCudaComputeCapability() {
+  int device_id = 0;
+  cudaGetDevice(&device_id);
+  int major = 0, minor = 0;
+  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id);
+  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id);
+  return std::make_pair(major, minor);
+}
+
+// This function is thread-safe and cached the sm_count.
+// But it will only check the current CUDA device, thus assuming each process handles single GPU.
+inline int GetCudaMultiProcessorCount() {
+  static std::atomic<int> sm_count{0};
+  int cached = sm_count.load(std::memory_order_relaxed);
+  if (cached == 0) {
+    int device_id;
+    cudaGetDevice(&device_id);
+    cudaDeviceProp device_prop;
+    cudaGetDeviceProperties(&device_prop, device_id);
+    cached = device_prop.multiProcessorCount;
+    sm_count.store(cached, std::memory_order_relaxed);
+  }
+  return cached;
+}
+
+template <typename T>
+inline void DebugPrintCUDAArray(T* device_ptr, size_t size, std::string prefix = "") {
+  std::vector<T> host_array(size);
+  std::cout << prefix;
+  cudaMemcpy(host_array.data(), device_ptr, size * sizeof(T), cudaMemcpyDeviceToHost);
+  for (size_t i = 0; i < size; ++i) {
+    std::cout << host_array[i] << " ";
+  }
+  std::cout << std::endl;
+}
+
+inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_dim) {
+  if (avg_packed_qo_len > 64 && head_dim < 256) {
+    return 128;
+  } else {
+    auto compute_capacity = GetCudaComputeCapability();
+    if (compute_capacity.first >= 8) {
+      // Ampere or newer
+      if (avg_packed_qo_len > 16) {
+        // avg_packed_qo_len <= 64
+        return 64;
+      } else {
+        // avg_packed_qo_len <= 16
+        return 16;
+      }
+    } else {
+      // NOTE(Zihao): not enough shared memory on Turing for 1x4 warp layout
+      return 64;
+    }
+  }
+}
+
+inline int UpPowerOfTwo(int x) {
+  // Returns the smallest power of two greater than or equal to x
+  if (x <= 0) return 1;
+  --x;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return x + 1;
+}
+
+#define LOOP_SPLIT_MASK(iter, COND1, COND2, ...)       \
+  {                                                    \
+    _Pragma("unroll 1") for (; (COND1); (iter) -= 1) { \
+      constexpr bool WITH_MASK = true;                 \
+      __VA_ARGS__                                      \
+    }                                                  \
+    _Pragma("unroll 1") for (; (COND2); (iter) -= 1) { \
+      constexpr bool WITH_MASK = false;                \
+      __VA_ARGS__                                      \
+    }                                                  \
+  }
+
+/*!
+ * \brief Return x - y if x > y, otherwise return 0.
+ */
+__device__ __forceinline__ uint32_t sub_if_greater_or_zero(uint32_t x, uint32_t y) {
+  return (x > y) ? x - y : 0U;
+}
+
+// ======================= PTX Memory Utility Functions =======================
+// Non-atomic global memory access with cache streaming hint (cs)
+// These are useful for streaming memory access patterns where data is used once
+
+/*!
+ * \brief Get the lane ID within a warp (0-31)
+ */
+__forceinline__ __device__ int get_lane_id() {
+  int lane_id;
+  asm("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+}
+
+/*!
+ * \brief Non-atomic global load for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ short ld_na_global_s16(const short* addr) {
+  short val;
+  asm volatile("ld.global.cs.b16 %0, [%1];" : "=h"(val) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global store for short (2 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_s16(short* addr, short val) {
+  asm volatile("st.global.cs.b16 [%0], %1;" ::"l"(addr), "h"(val));
+}
+
+/*!
+ * \brief Non-atomic global load for int (4 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ int ld_na_global_v1(const int* addr) {
+  int val;
+  asm volatile("ld.global.cs.b32 %0, [%1];" : "=r"(val) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global load for int2 (8 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ int2 ld_na_global_v2(const int2* addr) {
+  int2 val;
+  asm volatile("ld.global.cs.v2.b32 {%0, %1}, [%2];" : "=r"(val.x), "=r"(val.y) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global store for int (4 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_v1(int* addr, int val) {
+  asm volatile("st.global.cs.b32 [%0], %1;" ::"l"(addr), "r"(val));
+}
+
+/*!
+ * \brief Non-atomic global store for int2 (8 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_v2(int2* addr, int2 val) {
+  asm volatile("st.global.cs.v2.b32 [%0], {%1, %2};" ::"l"(addr), "r"(val.x), "r"(val.y));
+}
+
+/*!
+ * \brief Prefetch data to L2 cache
+ */
+template <typename T>
+__forceinline__ __device__ void prefetch_L2(const T* addr) {
+  asm volatile("prefetch.global.L2 [%0];" ::"l"(addr));
+}
+
+__device__ __forceinline__ void swap(uint32_t& a, uint32_t& b) {
+  uint32_t tmp = a;
+  a = b;
+  b = tmp;
+}
+
+__device__ __forceinline__ uint32_t dim2_offset(const uint32_t& dim_a, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return idx_b * dim_a + idx_a;
+}
+
+__device__ __forceinline__ uint32_t dim3_offset(const uint32_t& dim_b, const uint32_t& dim_a,
+                                                const uint32_t& idx_c, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return (idx_c * dim_b + idx_b) * dim_a + idx_a;
+}
+
+__device__ __forceinline__ uint32_t dim4_offset(const uint32_t& dim_c, const uint32_t& dim_b,
+                                                const uint32_t& dim_a, const uint32_t& idx_d,
+                                                const uint32_t& idx_c, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return ((idx_d * dim_c + idx_c) * dim_b + idx_b) * dim_a + idx_a;
+}
+
+#define DEFINE_HAS_MEMBER(member)                                                              \
+  template <typename T, typename = void>                                                       \
+  struct has_##member : std::false_type {};                                                    \
+  template <typename T>                                                                        \
+  struct has_##member<T, std::void_t<decltype(std::declval<T>().member)>> : std::true_type {}; \
+  template <typename T>                                                                        \
+  inline constexpr bool has_##member##_v = has_##member<T>::value;
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_UTILS_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/vec_dtypes.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/flashinfer/vec_dtypes.cuh
@@ -1,0 +1,2194 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef VEC_DTYPES_CUH_
+#define VEC_DTYPES_CUH_
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#if CUDA_VERSION >= 12080
+#include <cuda_fp4.h>
+#endif
+#include <cuda_runtime.h>
+
+#include <type_traits>
+
+namespace flashinfer {
+
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
+#define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+#endif
+
+#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
+
+__device__ __forceinline__ void st_global_release(int4 const& val, int4* addr) {
+  asm volatile("st.release.global.sys.v4.b32 [%4], {%0, %1, %2, %3};" ::"r"(val.x), "r"(val.y),
+               "r"(val.z), "r"(val.w), "l"(addr));
+}
+
+__device__ __forceinline__ int4 ld_global_acquire(int4* addr) {
+  int4 val;
+  asm volatile("ld.acquire.global.sys.v4.b32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+}
+
+__device__ __forceinline__ void st_global_volatile(int4 const& val, int4* addr) {
+  asm volatile("st.volatile.global.v4.b32 [%4], {%0, %1, %2, %3};" ::"r"(val.x), "r"(val.y),
+               "r"(val.z), "r"(val.w), "l"(addr));
+}
+
+__device__ __forceinline__ int4 ld_global_volatile(int4* addr) {
+  int4 val;
+  asm volatile("ld.volatile.global.v4.b32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+}
+
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 < 120200) && \
+    (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+// CUDA version < 12.2 and GPU architecture < 80
+FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y) {
+  __nv_bfloat162 t;
+  t.x = x;
+  t.y = y;
+  return t;
+}
+
+FLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
+  __nv_bfloat16 val;
+  const float fa = __bfloat162float(a);
+  const float fb = __bfloat162float(b);
+  // avoid ftz in device code
+  val = __float2bfloat16(__fmaf_ieee_rn(fa, fb, -0.0f));
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+  __nv_bfloat162 val;
+  val.x = __hmul(a.x, b.x);
+  val.y = __hmul(a.y, b.y);
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __floats2bfloat162_rn(const float a, const float b) {
+  __nv_bfloat162 val;
+  val = __nv_bfloat162(__float2bfloat16_rn(a), __float2bfloat16_rn(b));
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __float22bfloat162_rn(const float2 a) {
+  __nv_bfloat162 val = __floats2bfloat162_rn(a.x, a.y);
+  return val;
+}
+FLASHINFER_INLINE float2 __bfloat1622float2(const __nv_bfloat162 a) {
+  float hi_float;
+  float lo_float;
+  lo_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).x);
+  hi_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).y);
+  return make_float2(lo_float, hi_float);
+}
+#endif
+
+/******************* vec_t type cast *******************/
+
+template <typename dst_t, typename src_t>
+struct vec_cast {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(dst_t* dst, const src_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = (dst_t)src[i];
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e4m3, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e4m3* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e4m3(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((__nv_fp8x2_storage_t*)dst)[i] =
+            __nv_cvt_float2_to_fp8x2(((float2*)src)[i], __NV_SATFINITE, __NV_E4M3);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e5m2, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e5m2* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e5m2(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((__nv_fp8x2_storage_t*)dst)[i] =
+            __nv_cvt_float2_to_fp8x2(((float2*)src)[i], __NV_SATFINITE, __NV_E5M2);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<float, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(float* dst, const half* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = (float)src[0];
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((float2*)dst)[i] = __half22float2(((half2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<half, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __float2half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((half2*)dst)[i] = __float22half2_rn(((float2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <typename T>
+constexpr FLASHINFER_INLINE int get_exponent_bits() {
+  if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+    return 4;
+  } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+    return 5;
+  } else if constexpr (std::is_same_v<T, half>) {
+    return 5;
+  } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return 8;
+  }
+}
+
+template <typename T>
+constexpr FLASHINFER_INLINE int get_mantissa_bits() {
+  if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+    return 3;
+  } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+    return 2;
+  } else if constexpr (std::is_same_v<T, half>) {
+    return 11;
+  } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return 7;
+  }
+}
+
+/*!
+ * \brief Fallback to software fast dequant implementation if hardware dequantization is not
+ * available.
+ * \note Inspired by Marlin's fast dequantization, but here we don't have to permute
+ * weights order.
+ * \ref
+ * https://github.com/vllm-project/vllm/blob/6dffa4b0a6120159ef2fe44d695a46817aff65bc/csrc/quantization/fp8/fp8_marlin.cu#L120
+ */
+template <typename fp8_dtype, typename fp16_dtype>
+__device__ void fast_dequant_f8f16x4(uint32_t* input, uint2* output) {
+  uint32_t q = *input;
+  if constexpr (std::is_same_v<fp8_dtype, __nv_fp8_e5m2> && std::is_same_v<fp16_dtype, half>) {
+    output->x = __byte_perm(0U, q, 0x5140);
+    output->y = __byte_perm(0U, q, 0x7362);
+  } else {
+    constexpr int FP8_EXPONENT = get_exponent_bits<fp8_dtype>();
+    constexpr int FP8_MANTISSA = get_mantissa_bits<fp8_dtype>();
+    constexpr int FP16_EXPONENT = get_exponent_bits<fp16_dtype>();
+
+    constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
+    // Calculate MASK for extracting mantissa and exponent
+    constexpr int MASK1 = 0x80000000;
+    constexpr int MASK2 = MASK1 >> (FP8_EXPONENT + FP8_MANTISSA);
+    constexpr int MASK3 = MASK2 & 0x7fffffff;
+    constexpr int MASK = MASK3 | (MASK3 >> 16);
+    q = __byte_perm(q, q, 0x1302);
+
+    // Extract and shift FP8 values to FP16 format
+    uint32_t Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+    uint32_t Out2 = ((q << 8) & 0x80008000) | (((q << 8) & MASK) >> RIGHT_SHIFT);
+
+    constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+    // Construct and apply exponent bias
+    if constexpr (std::is_same_v<fp16_dtype, half>) {
+      const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+      // Convert to half2 and apply bias
+      *(half2*)&(output->x) = __hmul2(*reinterpret_cast<const half2*>(&Out1), bias_reg);
+      *(half2*)&(output->y) = __hmul2(*reinterpret_cast<const half2*>(&Out2), bias_reg);
+    } else {
+      constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+      const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+      // Convert to bfloat162 and apply bias
+      *(nv_bfloat162*)&(output->x) =
+          __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out1), bias_reg);
+      *(nv_bfloat162*)&(output->y) =
+          __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out2), bias_reg);
+    }
+  }
+}
+
+template <>
+struct vec_cast<nv_bfloat16, __nv_fp8_e4m3> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e4m3* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = nv_bfloat16(src[0]);
+      dst[1] = nv_bfloat16(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e4m3, nv_bfloat16>((uint32_t*)&src[i * 4],
+                                                         (uint2*)&dst[i * 4]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<nv_bfloat16, __nv_fp8_e5m2> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e5m2* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = nv_bfloat16(src[0]);
+      dst[1] = nv_bfloat16(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e5m2, nv_bfloat16>((uint32_t*)&src[i * 4],
+                                                         (uint2*)&dst[i * 4]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e4m3, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e4m3* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e4m3(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint16_t y;
+        uint32_t x = *(uint32_t*)&src[i * 2];
+        asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+        *(uint16_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = __nv_fp8_e4m3(src[i]);
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e5m2, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e5m2* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e5m2(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint16_t y;
+        uint32_t x = *(uint32_t*)&src[i * 2];
+        asm volatile("cvt.rn.satfinite.e5m2x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+        *(uint16_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = __nv_fp8_e5m2(src[i]);
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<half, __nv_fp8_e4m3> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e4m3* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint32_t y;
+        uint16_t x = *(uint16_t*)&src[i * 2];
+        asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;" : "=r"(y) : "h"(x));
+        *(uint32_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = half(src[0]);
+      dst[1] = half(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e4m3, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+      }
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<half, __nv_fp8_e5m2> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e5m2* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint32_t y;
+        uint16_t x = *(uint16_t*)&src[i * 2];
+        asm volatile("cvt.rn.f16x2.e5m2x2 %0, %1;" : "=r"(y) : "h"(x));
+        *(uint32_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = half(src[0]);
+      dst[1] = half(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e5m2, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+      }
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+#if defined(FLASHINFER_ENABLE_FP4_E2M1) && CUDA_VERSION >= 12080
+// Convert __nv_fp4x2_e2m1 (2 fp4 values per byte) to fp16.
+// vec_size counts fp16 output elements; src has stride-2 layout:
+//   src[0] holds x0,x1  src[1] is padding
+//   src[2] holds x2,x3  src[3] is padding  ... etc.
+// Each valid byte encodes 2 fp4 values -> 2 fp16 via cvt.rn.f16x2.e2m1x2.
+template <>
+struct vec_cast<half, __nv_fp4x2_e2m1> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const __nv_fp4x2_e2m1* src) {
+    static_assert(vec_size % 2 == 0, "vec_size must be even for fp4x2 dequantization");
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      uint32_t y;
+      // Valid fp4x2 bytes are at even positions (stride 2); odd positions are padding.
+      uint32_t b = reinterpret_cast<const uint8_t*>(src)[i * 2];
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(y)
+          : "r"(b));
+      reinterpret_cast<uint32_t*>(dst)[i] = y;
+    }
+#else
+    // Software LUT fallback for arch < SM100.
+    // e2m1 encoding: bit[3]=sign, bit[2:0]=magnitude index in {0,0.5,1,1.5,2,3,4,6}.
+    // Each packed byte holds two fp4 values: bits[3:0]=first, bits[7:4]=second.
+    constexpr uint16_t lut[16] = {
+        0x0000,  // +0.0
+        0x3800,  // +0.5
+        0x3C00,  // +1.0
+        0x3E00,  // +1.5
+        0x4000,  // +2.0
+        0x4200,  // +3.0
+        0x4400,  // +4.0
+        0x4600,  // +6.0
+        0x8000,  // -0.0
+        0xB800,  // -0.5
+        0xBC00,  // -1.0
+        0xBE00,  // -1.5
+        0xC000,  // -2.0
+        0xC200,  // -3.0
+        0xC400,  // -4.0
+        0xC600,  // -6.0
+    };
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      uint8_t b = reinterpret_cast<const uint8_t*>(src)[i * 2];
+      reinterpret_cast<uint16_t*>(dst)[i * 2 + 0] = lut[b & 0x0F];
+      reinterpret_cast<uint16_t*>(dst)[i * 2 + 1] = lut[(b >> 4) & 0x0F];
+    }
+#endif
+  }
+};
+template <>
+struct vec_cast<nv_bfloat16, __nv_fp4x2_e2m1> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp4x2_e2m1* src) {
+    static_assert(vec_size % 2 == 0, "vec_size must be even for fp4x2 dequantization");
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      uint32_t y;
+      // Valid fp4x2 bytes are at even positions (stride 2); odd positions are padding.
+      uint32_t b = reinterpret_cast<const uint8_t*>(src)[i * 2];
+#if (defined __CUDACC_VER_MAJOR__) && (defined __CUDACC_VER_MINOR__) && \
+    ((__CUDACC_VER_MAJOR__ > 13) || ((__CUDACC_VER_MAJOR__ == 13) && (__CUDACC_VER_MINOR__ >= 2)))
+      // cvt.rn.bf16x2.e2m1x2 requires CUDA Toolkit >= 13.2
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.bf16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(y)
+          : "r"(b));
+#else
+      // Fallback: convert e2m1 -> fp16 -> bf16 when cvt.rn.bf16x2.e2m1x2 is unavailable
+      uint32_t fp16x2;
+      asm volatile(
+          "{\n"
+          ".reg .b8 fp4_byte;\n"
+          "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+          "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+          "}"
+          : "=r"(fp16x2)
+          : "r"(b));
+      __half2 h2 = reinterpret_cast<__half2&>(fp16x2);
+      __nv_bfloat162 bf16x2 = __float22bfloat162_rn(__half22float2(h2));
+      y = reinterpret_cast<uint32_t&>(bf16x2);
+#endif
+      reinterpret_cast<uint32_t*>(dst)[i] = y;
+    }
+#else
+    // Software LUT fallback for arch < SM100.
+    // e2m1 encoding: bit[3]=sign, bit[2:0]=magnitude index in {0,0.5,1,1.5,2,3,4,6}.
+    // Each packed byte holds two fp4 values: bits[3:0]=first, bits[7:4]=second.
+    constexpr uint16_t lut[16] = {
+        0x0000,  // +0.0
+        0x3F00,  // +0.5
+        0x3F80,  // +1.0
+        0x3FC0,  // +1.5
+        0x4000,  // +2.0
+        0x4040,  // +3.0
+        0x4080,  // +4.0
+        0x40C0,  // +6.0
+        0x8000,  // -0.0
+        0xBF00,  // -0.5
+        0xBF80,  // -1.0
+        0xBFC0,  // -1.5
+        0xC000,  // -2.0
+        0xC040,  // -3.0
+        0xC080,  // -4.0
+        0xC0C0,  // -6.0
+    };
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 2; ++i) {
+      uint8_t b = reinterpret_cast<const uint8_t*>(src)[i * 2];
+      reinterpret_cast<uint16_t*>(dst)[i * 2 + 0] = lut[b & 0x0F];
+      reinterpret_cast<uint16_t*>(dst)[i * 2 + 1] = lut[(b >> 4) & 0x0F];
+    }
+#endif
+  }
+};
+
+#endif  // FLASHINFER_ENABLE_FP4_E2M1 && CUDA_VERSION >= 12080
+
+template <>
+struct vec_cast<float, nv_bfloat16> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(float* dst, const nv_bfloat16* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = (float)src[0];
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((float2*)dst)[i] = __bfloat1622float2(((nv_bfloat162*)src)[i]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<nv_bfloat16, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((nv_bfloat162*)dst)[i] = __float22bfloat162_rn(((float2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <typename float_t, size_t vec_size>
+struct vec_t {
+  FLASHINFER_INLINE float_t& operator[](size_t i);
+  FLASHINFER_INLINE const float_t& operator[](size_t i) const;
+  FLASHINFER_INLINE void fill(float_t val);
+  FLASHINFER_INLINE void load(const float_t* ptr);
+  FLASHINFER_INLINE void store(float_t* ptr) const;
+  FLASHINFER_INLINE void load_global_acquire(float* addr);
+  FLASHINFER_INLINE void store_global_release(float* addr) const;
+  FLASHINFER_INLINE void load_global_volatile(float* addr);
+  FLASHINFER_INLINE void store_global_volatile(float* addr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src);
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr);
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const;
+  FLASHINFER_INLINE static void memcpy(float_t* dst, const float_t* src);
+  FLASHINFER_INLINE float_t* ptr();
+};
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_from_impl(vec_t<tgt_float_t, vec_size>& dst,
+                                      const vec_t<src_float_t, vec_size>& src) {
+  vec_cast<tgt_float_t, src_float_t>::cast<vec_size>(
+      dst.ptr(), const_cast<vec_t<src_float_t, vec_size>*>(&src)->ptr());
+}
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_load_impl(vec_t<tgt_float_t, vec_size>& dst,
+                                      const src_float_t* src_ptr) {
+  if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+    dst.load(src_ptr);
+  } else {
+    vec_t<src_float_t, vec_size> tmp;
+    tmp.load(src_ptr);
+    dst.cast_from(tmp);
+  }
+}
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_store_impl(tgt_float_t* dst_ptr,
+                                       const vec_t<src_float_t, vec_size>& src) {
+  if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+    src.store(dst_ptr);
+  } else {
+    vec_t<tgt_float_t, vec_size> tmp;
+    tmp.cast_from(src);
+    tmp.store(dst_ptr);
+  }
+}
+
+/******************* vec_t<__nv_fp8_e4m3> *******************/
+
+// __nv_fp8_e4m3 x 1
+template <>
+struct vec_t<__nv_fp8_e4m3, 1> {
+  __nv_fp8_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::fill(__nv_fp8_e4m3 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::load(const __nv_fp8_e4m3* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::store(__nv_fp8_e4m3* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *dst = *src;
+}
+
+// __nv_fp8_e4m3 x 2
+template <>
+struct vec_t<__nv_fp8_e4m3, 2> {
+  __nv_fp8x2_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::fill(__nv_fp8_e4m3 val) {
+  data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((__nv_fp8x2_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::store(__nv_fp8_e4m3* ptr) const {
+  *((__nv_fp8x2_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((__nv_fp8x2_e4m3*)dst) = *((__nv_fp8x2_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 4
+
+template <>
+struct vec_t<__nv_fp8_e4m3, 4> {
+  __nv_fp8x4_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::fill(__nv_fp8_e4m3 val) {
+  data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+             (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((__nv_fp8x4_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::store(__nv_fp8_e4m3* ptr) const {
+  *((__nv_fp8x4_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((__nv_fp8x4_e4m3*)dst) = *((__nv_fp8x4_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 8
+
+template <>
+struct vec_t<__nv_fp8_e4m3, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::fill(__nv_fp8_e4m3 val) {
+  ((__nv_fp8x4_e4m3*)(&data.x))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+  ((__nv_fp8x4_e4m3*)(&data.y))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::store(__nv_fp8_e4m3* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e4m3 x 16 or more
+template <size_t vec_size>
+struct vec_t<__nv_fp8_e4m3, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)data)[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)data)[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((__nv_fp8x4_e4m3*)(&(data[i].x)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].y)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].z)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].w)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp8_e4m3* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      *((int4*)(data + i)) = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp8_e4m3* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp8_e4m3* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp8_e4m3* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<__nv_fp8_e5m2> *******************/
+
+// __nv_fp8_e5m2 x 1
+template <>
+struct vec_t<__nv_fp8_e5m2, 1> {
+  __nv_fp8_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::fill(__nv_fp8_e5m2 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::load(const __nv_fp8_e5m2* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::store(__nv_fp8_e5m2* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *dst = *src;
+}
+
+// __nv_fp8_e5m2 x 2
+template <>
+struct vec_t<__nv_fp8_e5m2, 2> {
+  __nv_fp8x2_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::fill(__nv_fp8_e5m2 val) {
+  data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((__nv_fp8x2_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::store(__nv_fp8_e5m2* ptr) const {
+  *((__nv_fp8x2_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((__nv_fp8x2_e5m2*)dst) = *((__nv_fp8x2_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 4
+
+template <>
+struct vec_t<__nv_fp8_e5m2, 4> {
+  __nv_fp8x4_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::fill(__nv_fp8_e5m2 val) {
+  data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+             (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((__nv_fp8x4_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::store(__nv_fp8_e5m2* ptr) const {
+  *((__nv_fp8x4_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((__nv_fp8x4_e5m2*)dst) = *((__nv_fp8x4_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 8
+
+template <>
+struct vec_t<__nv_fp8_e5m2, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::fill(__nv_fp8_e5m2 val) {
+  ((__nv_fp8x4_e5m2*)(&data.x))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+  ((__nv_fp8x4_e5m2*)(&data.y))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::store(__nv_fp8_e5m2* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e5m2 x 16 or more
+
+template <size_t vec_size>
+struct vec_t<__nv_fp8_e5m2, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)data)[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)data)[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((__nv_fp8x4_e5m2*)(&(data[i].x)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].y)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].z)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].w)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp8_e5m2* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp8_e5m2* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp8_e5m2* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp8_e5m2* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+#if defined(FLASHINFER_ENABLE_FP4_E2M1) && CUDA_VERSION >= 12080
+/******************* vec_t<__nv_fp4_e2m1> *******************/
+
+// __nv_fp4_e2m1 x 2
+template <>
+struct vec_t<__nv_fp4_e2m1, 2> {
+  uint8_t data;
+  // index access is not supported for sub-byte data type
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    data = (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint8_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint8_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint8_t*)dst) = *((uint8_t*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 4
+template <>
+struct vec_t<__nv_fp4_e2m1, 4> {
+  uint16_t data;
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    data = (uint16_t(val8) << 8) | uint16_t(val8);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint16_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint16_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint16_t*)dst) = *((uint16_t*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 8
+template <>
+struct vec_t<__nv_fp4_e2m1, 8> {
+  uint32_t data;
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    data = (uint32_t(val16) << 16) | uint32_t(val16);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint32_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint32_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint32_t*)dst) = *((uint32_t*)src);
+  }
+};
+
+template <>
+struct vec_t<__nv_fp4_e2m1, 16> {
+  uint2 data;
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    uint32_t val32 = (uint32_t(val16) << 16) | uint32_t(val16);
+    data.x = val32;
+    data.y = val32;
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint2*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint2*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 16>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint2*)dst) = *((uint2*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 32 or more
+template <size_t vec_size>
+struct vec_t<__nv_fp4_e2m1, vec_size> {
+  static_assert(vec_size % 32 == 0, "Invalid vector size");
+  int4 data[vec_size / 32];
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    uint32_t val32 = (uint32_t(val16) << 16) | uint32_t(val16);
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp4_e2m1* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      st_global_release(*(int4*)&data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp4_e2m1* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      *(int4*)&data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp4_e2m1* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      st_global_volatile(*(int4*)&data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp4_e2m1* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      *(int4*)&data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+#endif  // FLASHINFER_ENABLE_FP4_E2M1 && CUDA_VERSION >= 12080
+
+/******************* vec_t<half> *******************/
+
+// half x 1
+template <>
+struct vec_t<half, 1> {
+  half data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 1>::fill(half val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::load(const half* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::store(half* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::memcpy(half* dst, const half* src) { *dst = *src; }
+
+// half x 2
+template <>
+struct vec_t<half, 2> {
+  half2 data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 2>::fill(half val) { data = make_half2(val, val); }
+
+FLASHINFER_INLINE void vec_t<half, 2>::load(const half* ptr) { data = *((half2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<half, 2>::store(half* ptr) const { *((half2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<half, 2>::memcpy(half* dst, const half* src) {
+  *((half2*)dst) = *((half2*)src);
+}
+
+// half x 4
+
+template <>
+struct vec_t<half, 4> {
+  uint2 data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 4>::fill(half val) {
+  *(half2*)(&data.x) = make_half2(val, val);
+  *(half2*)(&data.y) = make_half2(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<half, 4>::load(const half* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<half, 4>::store(half* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<half, 4>::memcpy(half* dst, const half* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// half x 8 or more
+
+template <size_t vec_size>
+struct vec_t<half, vec_size> {
+  static_assert(vec_size % 8 == 0, "Invalid vector size");
+  int4 data[vec_size / 8];
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)data)[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)data)[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      *(half2*)(&(data[i].x)) = make_half2(val, val);
+      *(half2*)(&(data[i].y)) = make_half2(val, val);
+      *(half2*)(&(data[i].z)) = make_half2(val, val);
+      *(half2*)(&(data[i].w)) = make_half2(val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const half* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(half* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(half* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(half* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(half* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(half* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 8));
+    }
+  }
+
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<nv_bfloat16> *******************/
+
+// nv_bfloat16 x 1
+template <>
+struct vec_t<nv_bfloat16, 1> {
+  nv_bfloat16 data;
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::fill(nv_bfloat16 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::load(const nv_bfloat16* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::store(nv_bfloat16* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *dst = *src;
+}
+
+// nv_bfloat16 x 2
+template <>
+struct vec_t<nv_bfloat16, 2> {
+  nv_bfloat162 data;
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::fill(nv_bfloat16 val) {
+  data = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::load(const nv_bfloat16* ptr) {
+  data = *((nv_bfloat162*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::store(nv_bfloat16* ptr) const {
+  *((nv_bfloat162*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *((nv_bfloat162*)dst) = *((nv_bfloat162*)src);
+}
+
+// nv_bfloat16 x 4
+
+template <>
+struct vec_t<nv_bfloat16, 4> {
+  uint2 data;
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::fill(nv_bfloat16 val) {
+  *(nv_bfloat162*)(&data.x) = make_bfloat162(val, val);
+  *(nv_bfloat162*)(&data.y) = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::load(const nv_bfloat16* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::store(nv_bfloat16* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// nv_bfloat16 x 8 or more
+
+template <size_t vec_size>
+struct vec_t<nv_bfloat16, vec_size> {
+  static_assert(vec_size % 8 == 0, "Invalid vector size");
+  int4 data[vec_size / 8];
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)data)[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)data)[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      *(nv_bfloat162*)(&(data[i].x)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].y)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].z)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].w)) = make_bfloat162(val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(nv_bfloat16* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(nv_bfloat16* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(nv_bfloat16* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(nv_bfloat16* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 8));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<uint8_t> *******************/
+
+// uint8_t x 1
+template <>
+struct vec_t<uint8_t, 1> {
+  uint8_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::fill(uint8_t val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::load(const uint8_t* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::store(uint8_t* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::memcpy(uint8_t* dst, const uint8_t* src) { *dst = *src; }
+
+// uint8_t x 2
+template <>
+struct vec_t<uint8_t, 2> {
+  uint16_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::fill(uint8_t val) {
+  data = (uint16_t(val) << 8) | uint16_t(val);
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::load(const uint8_t* ptr) { data = *((uint16_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::store(uint8_t* ptr) const { *((uint16_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint16_t*)dst) = *((uint16_t*)src);
+}
+
+// uint8_t x 4
+
+template <>
+struct vec_t<uint8_t, 4> {
+  uint32_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::fill(uint8_t val) {
+  data = (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::load(const uint8_t* ptr) { data = *((uint32_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::store(uint8_t* ptr) const { *((uint32_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint32_t*)dst) = *((uint32_t*)src);
+}
+
+// uint8_t x 8
+
+template <>
+struct vec_t<uint8_t, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::fill(uint8_t val) {
+  uint32_t val32 =
+      (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+  data.x = val32;
+  data.y = val32;
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::load(const uint8_t* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::store(uint8_t* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// uint8_t x 16 or more
+
+template <size_t vec_size>
+struct vec_t<uint8_t, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)data)[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const { return ((const uint8_t*)data)[i]; }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val) {
+    uint32_t val32 =
+        (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const uint8_t* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(uint8_t* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(uint8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(uint8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(uint8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(uint8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<float> *******************/
+
+// float x 1
+
+template <>
+struct vec_t<float, 1> {
+  float data;
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(&data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(&data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val);
+  FLASHINFER_INLINE void load(const float* ptr);
+  FLASHINFER_INLINE void store(float* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 1>::fill(float val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::load(const float* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::store(float* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::memcpy(float* dst, const float* src) { *dst = *src; }
+
+// float x 2
+
+template <>
+struct vec_t<float, 2> {
+  float2 data;
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(&data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(&data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val);
+  FLASHINFER_INLINE void load(const float* ptr);
+  FLASHINFER_INLINE void store(float* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 2>::fill(float val) { data = make_float2(val, val); }
+
+FLASHINFER_INLINE void vec_t<float, 2>::load(const float* ptr) { data = *((float2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<float, 2>::store(float* ptr) const { *((float2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<float, 2>::memcpy(float* dst, const float* src) {
+  *((float2*)dst) = *((float2*)src);
+}
+
+// float x 4 or more
+template <size_t vec_size>
+struct vec_t<float, vec_size> {
+  static_assert(vec_size % 4 == 0, "Invalid vector size");
+  float4 data[vec_size / 4];
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      data[i] = make_float4(val, val, val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const float* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      data[i] = ((float4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(float* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      ((float4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(float* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      st_global_release(*(int4*)(data + i), (int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(float* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      *((int4*)(data + i)) = ld_global_acquire((int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(float* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      st_global_volatile(*(int4*)(data + i), (int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(float* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      *((int4*)(data + i)) = ld_global_volatile((int4*)(addr + i * 4));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      ((float4*)dst)[i] = ((float4*)src)[i];
+    }
+  }
+};
+
+template <typename T>
+struct vec2_dtype {
+  using type = T;
+};
+
+template <>
+struct vec2_dtype<half> {
+  using type = half2;
+};
+
+template <>
+struct vec2_dtype<__nv_bfloat16> {
+  using type = __nv_bfloat162;
+};
+
+template <>
+struct vec2_dtype<__nv_fp8_e4m3> {
+  using type = __nv_fp8x2_e4m3;
+};
+
+template <>
+struct vec2_dtype<__nv_fp8_e5m2> {
+  using type = __nv_fp8x2_e5m2;
+};
+
+template <typename T>
+using vec2_dtype_t = typename vec2_dtype<T>::type;
+
+template <typename T, size_t VEC_SIZE>
+FLASHINFER_INLINE vec2_dtype_t<T> get_vec2_element(vec_t<T, VEC_SIZE>& vec, int i) {
+  static_assert(VEC_SIZE % 2 == 0, "VEC_SIZE must be a multiple of 2");
+  return ((vec2_dtype_t<T>*)&(vec[0]))[i];
+}
+
+}  // namespace flashinfer
+
+#endif  // VEC_DTYPES_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/sampling/sampling.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/sampling/sampling.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <torch/extension.h>
+
+namespace rtp_llm {
+
+void top_p_renorm_probs(torch::Tensor                probs,
+                        torch::Tensor                renorm_probs,
+                        std::optional<torch::Tensor> maybe_top_p_arr,
+                        double                       top_p_val,
+                        int64_t                      cuda_stream = 0);
+
+void top_k_renorm_probs(torch::Tensor                probs,
+                        torch::Tensor                renorm_probs,
+                        std::optional<torch::Tensor> maybe_top_k_arr,
+                        int64_t                      top_k_val,
+                        int64_t                      cuda_stream = 0);
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/ops/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/ops/BUILD
@@ -104,6 +104,7 @@ cc_library(
     deps = [
         ":gpu_base",
         "//rtp_llm/models_py/bindings/core/ops:torch_beam_search_op_impl",
+        "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
         "//rtp_llm/models_py/bindings/cuda/kernels:scaled_fp8_quant",
         "//rtp_llm/cpp/utils:debug_utils",
         ":flashinfer",


### PR DESCRIPTION
## Summary

Migrate FlashInfer-based renorm sampling kernels into the CUDA bindings

## Changes

- Add FlashInfer renorm sampling kernel sources and headers under CUDA bindings.
- Wire the new sampling kernel target into the CUDA ops build.
- Add CUDA API wrappers for renorm sampling.
- Update the `torch_deps` import path to use `@arch_config`.