### PR TITLE
feat(kimi-linear): enable tool-call protocol and add e2e smoke

### DIFF
--- a/rtp_llm/openai/renderers/kimik2_renderer.py
+++ b/rtp_llm/openai/renderers/kimik2_renderer.py
@@ -203,5 +203,6 @@ class KimiK2Renderer(ReasoningToolBaseRenderer):
 
 
 register_renderer("kimi_k2", KimiK2Renderer)
+register_renderer("kimi_linear", KimiK2Renderer)
 # `kimi_k25` is registered by `kimi_k25_renderer.KimiK25Renderer`, which adds
 # multimodal handling on top of this text-only renderer.

--- a/rtp_llm/test/openai_response_test.py
+++ b/rtp_llm/test/openai_response_test.py
@@ -1399,6 +1399,15 @@ class OpenaiResponseTest(IsolatedAsyncioTestCase):
                 response_delta.tool_calls is None
             ), f"Expected tool_calls to be None, got: {response_delta.tool_calls}"
 
+    class KimiLinearTestSuite(KimiK2TestSuite):
+        """Kimi-Linear 与 Kimi-K2 共用同一套 tool-call 协议（标签、id 格式、停止词
+        全部相同），只是 model_type 不同。复用 K2 的 token 序列与断言，只覆写 model_type
+        """
+
+        @override
+        def _get_model_type(self):
+            return "kimi_linear"
+
     class ChatGLM45TestSuite(BaseToolCallTestSuite):
         """GLM45相关测试的内嵌测试套件"""
 
@@ -2163,6 +2172,21 @@ class OpenaiResponseTest(IsolatedAsyncioTestCase):
     async def test_parse_kimik2_advanced_tool_call_no_stream_stop_words(self):
         """测试KimiK2工具调用非流式场景（包含停止词）"""
         kimi_suite = self.KimiK2AdvancedTestSuite(self)
+        await kimi_suite.test_no_stream_stop_words()
+
+    async def test_parse_kimi_linear_tool_call_streaming_case(self):
+        """测试 Kimi-Linear 工具调用流式场景：复用 K2 协议 + KimiK2Renderer"""
+        kimi_suite = self.KimiLinearTestSuite(self)
+        await kimi_suite.test_streaming_case()
+
+    async def test_parse_kimi_linear_tool_call_no_stream(self):
+        """测试 Kimi-Linear 工具调用非流式场景"""
+        kimi_suite = self.KimiLinearTestSuite(self)
+        await kimi_suite.test_no_stream()
+
+    async def test_parse_kimi_linear_tool_call_no_stream_stop_words(self):
+        """测试 Kimi-Linear 工具调用非流式场景（包含 <|im_end|> 停止词）"""
+        kimi_suite = self.KimiLinearTestSuite(self)
         await kimi_suite.test_no_stream_stop_words()
 
     async def test_parse_chatglm45_tool_call_streaming_case(self):

--- a/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_tool_call.json
+++ b/rtp_llm/test/smoke/data/model/kimi_linear/q_r_bf16_tp2_tool_call.json
@@ -1,0 +1,296 @@
+{
+    "_comment": "End-to-end tool-calling smoke for Kimi-Linear. Q0 (non-stream) and Q1 (stream) verify the KimiK2 detector + renderer; Q2 verifies multi-turn (tool result -> assistant text). Regenerate goldens via SAVE_RESPONSE=True if prompt/tool/model is changed.",
+    "model_type": "kimi_linear",
+    "model_path": "/mnt/nas1/hf/Kimi-Linear-48B-A3B-Instruct",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant. You have access to the provided tools. When the user asks a question that requires real-time, location-specific, or external information that you cannot answer from your own knowledge (for example current weather), you MUST call the appropriate tool with concrete arguments instead of guessing or asking the user. Do not output any explanation before the tool call.",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "What's the current weather in San Francisco right now? Use celsius.",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_weather",
+                            "description": "Get the current weather conditions for a given city. Returns temperature, humidity and a short text description.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "The city name, e.g. 'San Francisco' or 'Beijing'."
+                                    },
+                                    "unit": {
+                                        "type": "string",
+                                        "enum": [
+                                            "celsius",
+                                            "fahrenheit"
+                                        ],
+                                        "description": "Temperature unit to return."
+                                    }
+                                },
+                                "required": [
+                                    "location"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "max_tokens": 128,
+                "extra_configs": {
+                    "top_k": 1,
+                    "temperature": 0.0
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777441829,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_aaaaaaaaaaaaaaaaaaaaaaaa",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_current_weather",
+                                        "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+                                    }
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 203,
+                    "total_tokens": 230,
+                    "completion_tokens": 27,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 1324.313,
+                    "iter_count": 27,
+                    "input_len": 203,
+                    "output_len": 27,
+                    "step_output_len": 27,
+                    "first_token_cost_time": 136.156
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant. You have access to the provided tools. When the user asks a question that requires real-time, location-specific, or external information that you cannot answer from your own knowledge (for example current weather), you MUST call the appropriate tool with concrete arguments instead of guessing or asking the user. Do not output any explanation before the tool call.",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "What's the current weather in San Francisco right now? Use celsius.",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_weather",
+                            "description": "Get the current weather conditions for a given city. Returns temperature, humidity and a short text description.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "The city name, e.g. 'San Francisco' or 'Beijing'."
+                                    },
+                                    "unit": {
+                                        "type": "string",
+                                        "enum": [
+                                            "celsius",
+                                            "fahrenheit"
+                                        ],
+                                        "description": "Temperature unit to return."
+                                    }
+                                },
+                                "required": [
+                                    "location"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "max_tokens": 128,
+                "extra_configs": {
+                    "top_k": 1,
+                    "temperature": 0.0
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1777441830,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_aaaaaaaaaaaaaaaaaaaaaaaa",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_current_weather",
+                                        "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+                                    }
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 203,
+                    "total_tokens": 230,
+                    "completion_tokens": 27,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant. You have access to the provided tools. Always call a tool when one is appropriate, otherwise reply normally.",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "What's the current weather in San Francisco right now? Use celsius.",
+                        "partial": false
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "get_current_weather:0",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_current_weather",
+                                    "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "get_current_weather:0",
+                        "content": "{\"location\": \"San Francisco\", \"unit\": \"celsius\", \"temperature\": 17, \"humidity\": 72, \"description\": \"partly cloudy\"}"
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_current_weather",
+                            "description": "Get the current weather conditions for a given city. Returns temperature, humidity and a short text description.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "The city name."
+                                    },
+                                    "unit": {
+                                        "type": "string",
+                                        "enum": [
+                                            "celsius",
+                                            "fahrenheit"
+                                        ],
+                                        "description": "Temperature unit to return."
+                                    }
+                                },
+                                "required": [
+                                    "location"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "max_tokens": 128,
+                "extra_configs": {
+                    "top_k": 1,
+                    "temperature": 0.0
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777441831,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "The current weather in San Francisco is 17°C (62.6°F), with 72% humidity and partly cloudy skies."
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 225,
+                    "total_tokens": 252,
+                    "completion_tokens": 27,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 1222.809,
+                    "iter_count": 27,
+                    "input_len": 225,
+                    "output_len": 27,
+                    "step_output_len": 27,
+                    "first_token_cost_time": 82.586
+                },
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -378,6 +378,13 @@ def h20_oss_suites():
                 gpu_type=["H20"],
             ),
             smoke_test(
+                name="kimi_tool_call",
+                task_info="data/model/kimi_linear/q_r_bf16_tp2_tool_call.json",
+                smoke_args="--act_type BF16 --seq_size_per_block 2048 --tp_size 2 --ssm_state_dtype fp32 --reserver_runtime_mem_mb 8192",
+                envs=["TRITON_AUTOTUNE_CACHE_MODE=cached"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
                 name="kimi_pd",
                 task_info="data/model/kimi_linear/q_r_bf16_tp2_pd_sep.json",
                 smoke_args= {


### PR DESCRIPTION
- Register KimiK2Renderer for `kimi_linear` model_type.
- Add KimiLinearTestSuite reusing KimiK2 token sequences for streaming /
    non-stream / stop-words tool-call parsing.
- Add H20 BF16 TP2 e2e smoke `kimi_tool_call` covering non-stream emit,
    stream incremental parse, and multi-turn tool result follow-up.