### PR TITLE
fix(rocm): preserve column-major layout in GDN qkvz+ba fusion to fix swizzle core dump

### DIFF
--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -583,32 +583,22 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             ba_w = weights[W.linear_attn_ba_w]
             self._qkvz_size = qkvz_w.shape[1]
             self._ba_size = ba_w.shape[1]
-            # Allocate the fused buffer ONCE; copy qkvz/ba into it; then
-            # replace the original dict entries with VIEWS into the fused
-            # buffer. This achieves two goals at once:
-            #
-            #  (a) Memory: avoids the ~48MB-per-layer redundant copy from
-            #      torch.cat. The originals get released when this method
-            #      returns (the local vars go out of scope and the dict
-            #      entries no longer reference them).
-            #
-            #  (b) Online weight update: WeightManager.update_layer_weight
-            #      runs `ori_tensor.copy_(data)` against the dict entries.
-            #      With the entries now being views into the fused buffer,
-            #      an update writes directly into the right slice of the
-            #      fused buffer, so in_proj_fused.weight (which references
-            #      the same buffer) sees the update on the next forward.
-            #      copy_ accepts non-contig destinations, so the view's
-            #      stride mismatch is fine.
-            K = qkvz_w.shape[0]
-            fused_w = torch.empty(
-                K,
-                self._qkvz_size + self._ba_size,
-                dtype=qkvz_w.dtype,
-                device=qkvz_w.device,
-            )
-            fused_w[:, : self._qkvz_size].copy_(qkvz_w)
-            fused_w[:, self._qkvz_size :].copy_(ba_w)
+            _is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+            if _is_rocm:
+                # ROCm: cat in [N, K] space then .t() to preserve column-major
+                # physical layout that hipb_mm / swizzle kernels expect.
+                fused_w = torch.cat([qkvz_w.t(), ba_w.t()], dim=0).t()
+            else:
+                # CUDA: row-major contiguous buffer (cuBLAS compatible).
+                K = qkvz_w.shape[0]
+                fused_w = torch.empty(
+                    K,
+                    self._qkvz_size + self._ba_size,
+                    dtype=qkvz_w.dtype,
+                    device=qkvz_w.device,
+                )
+                fused_w[:, : self._qkvz_size].copy_(qkvz_w)
+                fused_w[:, self._qkvz_size :].copy_(ba_w)
             weights[W.linear_attn_qkvz_w] = fused_w[:, : self._qkvz_size]
             weights[W.linear_attn_ba_w] = fused_w[:, self._qkvz_size :]
             del qkvz_w, ba_w

--- a/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
+++ b/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
@@ -226,9 +226,17 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
 
         # Same underlying storage as in_proj_fused.weight (the fused buffer).
         self.assertEqual(qkvz_view.data_ptr(), fused_buf.data_ptr())
+        # ROCm uses column-major layout (cat in [N,K] then .t()),
+        # CUDA uses row-major (torch.empty + copy_).
+        _is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+        K = fused_buf.shape[0]
+        if _is_rocm:
+            expected_offset = module._qkvz_size * K * fused_buf.element_size()
+        else:
+            expected_offset = module._qkvz_size * fused_buf.element_size()
         self.assertEqual(
             ba_view.data_ptr(),
-            fused_buf.data_ptr() + module._qkvz_size * fused_buf.element_size(),
+            fused_buf.data_ptr() + expected_offset,
         )
 
     def test_online_weight_update_changes_forward_output(self) -> None:


### PR DESCRIPTION
The fused weight buffer was allocated with torch.empty (row-major) and filled via copy_, which transposed the physical memory layout from column-major to row-major.  hipb_mm with bpreshuffle=True reads data directly by physical address assuming the swizzle pattern is laid out in column-major order, so the row-major buffer caused corrupted GEMM output and a core dump during CUDA graph capture.

Fix: use torch.cat in [N, K] contiguous space then .t() to produce a column-major [K, N_total] buffer identical in physical layout to the original individual swizzled weights.