### PR TITLE
fix: pin cache store workers to local device

### DIFF
--- a/rtp_llm/cpp/disaggregate/cache_store/BUILD
+++ b/rtp_llm/cpp/disaggregate/cache_store/BUILD
@@ -70,6 +70,7 @@ cc_library(
     deps = [
         ":cache_store_interface",
         "//rtp_llm/cpp/disaggregate/cache_store/proto:cache_store_service_cc_proto",
+        "//rtp_llm/cpp/utils:device_pin",
         "//rtp_llm/cpp/utils:time_util",
         "//:rtp_compute_ops",
         ":arpc_dep",

--- a/rtp_llm/cpp/disaggregate/cache_store/InitParams.h
+++ b/rtp_llm/cpp/disaggregate/cache_store/InitParams.h
@@ -11,6 +11,7 @@ struct MessagerInitParams {
     uint32_t io_thread_count     = 2;
     uint32_t worker_thread_count = 4;
     uint32_t worker_queue_size   = 100;
+    int      device_id           = -1;
 
     uint32_t rdma_server_port         = 0;
     uint32_t rdma_io_thread_count     = 1;
@@ -44,6 +45,7 @@ public:
     uint32_t messager_worker_thread_count = 32;
 
     kmonitor::MetricsReporterPtr metrics_reporter;
+    int                          device_id{-1};
 
     // for test
     std::shared_ptr<MemoryUtil> memory_util;

--- a/rtp_llm/cpp/disaggregate/cache_store/NormalCacheStore.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/NormalCacheStore.cpp
@@ -1,5 +1,6 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/NormalCacheStore.h"
 #include "rtp_llm/cpp/disaggregate/cache_store/Interface.h"
+#include "rtp_llm/cpp/utils/DevicePin.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 
 #include "autil/LockFreeThreadPool.h"
@@ -30,7 +31,8 @@ std::shared_ptr<NormalCacheStore> NormalCacheStore::createNormalCacheStore(const
 }
 
 bool NormalCacheStore::init(const CacheStoreInitParams& params) {
-    params_ = params;
+    params_    = params;
+    device_id_ = params.device_id;
 
     if (params_.memory_util != nullptr) {
         memory_util_ = params.memory_util;
@@ -54,6 +56,7 @@ bool NormalCacheStore::init(const CacheStoreInitParams& params) {
     messager_init_params.io_thread_count              = params.messager_io_thread_count;
     messager_init_params.worker_thread_count          = params.messager_worker_thread_count;
     messager_init_params.worker_queue_size            = params.queue_size;
+    messager_init_params.device_id                    = params.device_id;
 
     if (!messager_->init(messager_init_params)) {
         RTP_LLM_LOG_ERROR("normal cache store init failed : init messager failed");
@@ -68,6 +71,7 @@ bool NormalCacheStore::init(const CacheStoreInitParams& params) {
     }
 
     auto check_task_readiness = [this]() {
+        pinThreadToDeviceOnce(this->device_id_);
         while (!thread_pool_close_) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
             std::unique_lock<std::shared_mutex> lock(store_tasks_mutex_);
@@ -115,6 +119,7 @@ void NormalCacheStore::store(const std::shared_ptr<RequestBlockBuffer>& request_
         metrics_reporter_, request_block_buffer->getBlocksCount(), request_block_buffer->getBlocksSize());
     // task 只在threadpool中运行, threadpool退出前会清理所有running task, 用this是安全的
     auto task = [this, request_block_buffer, callback, collector]() {
+        pinThreadToDeviceOnce(this->device_id_);
         this->runStoreTask(request_block_buffer, callback, collector);
     };
 
@@ -193,6 +198,7 @@ void NormalCacheStore::load(const std::shared_ptr<RequestBlockBuffer>& request_b
                  collector,
                  partition_count,
                  partition_id]() {
+        pinThreadToDeviceOnce(this->device_id_);
         this->runLoadTask(
             request_block_buffer, callback, ip, port, rdma_port, timeout_ms, collector, partition_count, partition_id);
     };

--- a/rtp_llm/cpp/disaggregate/cache_store/NormalCacheStore.h
+++ b/rtp_llm/cpp/disaggregate/cache_store/NormalCacheStore.h
@@ -80,6 +80,7 @@ private:
 
 private:
     bool                                                                             thread_pool_close_{false};
+    int                                                                              device_id_{-1};
     CacheStoreInitParams                                                             params_;
     std::shared_ptr<MemoryUtil>                                                      memory_util_;
     std::shared_ptr<RequestBlockBufferStore>                                         request_block_buffer_store_;

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.cpp
@@ -3,6 +3,7 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/MemoryUtil.h"
 #include <torch/torch.h>
 #include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreUtil.h"
+#include "rtp_llm/cpp/utils/DevicePin.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 
 namespace rtp_llm {
@@ -20,6 +21,7 @@ TcpCacheStoreLoadServiceClosure::~TcpCacheStoreLoadServiceClosure() {
 }
 
 void TcpCacheStoreLoadServiceClosure::Run() {
+    pinThreadToDeviceOnce(device_id_);
     collector_->markRequestCallEnd(currentTimeUs() - response_->response_send_start_time_us());
 
     if (controller_->Failed()) {

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.h
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.h
@@ -18,14 +18,16 @@ public:
                                     CacheLoadRequest*                                            request,
                                     CacheLoadResponse*                                           response,
                                     CacheStoreLoadDoneCallback                                   callback,
-                                    const std::shared_ptr<CacheStoreClientLoadMetricsCollector>& collector):
+                                    const std::shared_ptr<CacheStoreClientLoadMetricsCollector>& collector,
+                                    int                                                          device_id = -1):
         memory_util_(memory_util),
         request_block_buffer_(request_block_buffer),
         controller_(controller),
         request_(request),
         response_(response),
         callback_(callback),
-        collector_(collector) {}
+        collector_(collector),
+        device_id_(device_id) {}
 
     ~TcpCacheStoreLoadServiceClosure();
 
@@ -43,6 +45,7 @@ private:
     CacheLoadResponse*                                    response_{nullptr};
     CacheStoreLoadDoneCallback                            callback_{nullptr};
     std::shared_ptr<CacheStoreClientLoadMetricsCollector> collector_;
+    int                                                   device_id_{-1};
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpMessager.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpMessager.cpp
@@ -73,7 +73,8 @@ void TcpMessager::load(const std::shared_ptr<LoadRequest>&                      
                                                         load_request,
                                                         load_response,
                                                         request->callback,
-                                                        collector);
+                                                        collector,
+                                                        init_params_.device_id);
 
     collector->markRequestCallBegin();
     KvCacheStoreService_Stub stub((::google::protobuf::RpcChannel*)(channel.get()),

--- a/rtp_llm/cpp/model_rpc/RemoteRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/RemoteRpcServer.cc
@@ -79,6 +79,7 @@ void RemoteRpcServer::initCacheStore(const EngineInitParams&                init
     params.messager_io_thread_count     = init_params.cache_store_config.messager_io_thread_count;
     params.messager_worker_thread_count = init_params.cache_store_config.messager_worker_thread_count;
     params.metrics_reporter             = metrics_reporter_;
+    params.device_id                    = static_cast<int>(init_params.parallelism_config.local_rank);
     RTP_LLM_LOG_INFO("cache store listen port is [%ld], rdma listen port is [%ld] rdma_mode is [%d]",
                      params.listen_port,
                      params.rdma_listen_port,

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -335,7 +335,7 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         throw std::runtime_error("PyWrappedModel constructor: Python model initialization failed.");
     }
 
-    cache_store_async_writer_ = std::make_unique<CacheStoreAsyncWriter>();
+    cache_store_async_writer_ = std::make_unique<CacheStoreAsyncWriter>(params.parallelism_config.local_rank);
 
     if (device_props_.enable_prefill_cp) {
         context_parallel_processor_ =

--- a/rtp_llm/cpp/utils/BUILD
+++ b/rtp_llm/cpp/utils/BUILD
@@ -55,6 +55,28 @@ cc_library(
 )
 
 cc_library(
+    name = "device_pin",
+    hdrs = [
+        "DevicePin.h",
+    ],
+    deps = [
+        ":core_utils",
+    ] + torch_deps() + select({
+        "//:using_cuda": [
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:rocm",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = copts(),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "error_code",
     hdrs = [
         "ErrorCode.h",

--- a/rtp_llm/cpp/utils/DevicePin.h
+++ b/rtp_llm/cpp/utils/DevicePin.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "rtp_llm/cpp/utils/Logger.h"
+
+#if USING_CUDA
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#elif USING_ROCM
+#include <ATen/hip/HIPContext.h>
+#include <hip/hip_runtime.h>
+#endif
+
+namespace rtp_llm {
+
+inline void pinThreadToDeviceOnce(int device_id) {
+    if (device_id < 0) {
+        return;
+    }
+
+#if USING_CUDA
+    thread_local int pinned_device = -1;
+    if (pinned_device == device_id) {
+        return;
+    }
+    const auto rc = cudaSetDevice(device_id);
+    if (rc != cudaSuccess) {
+        RTP_LLM_LOG_WARNING("cudaSetDevice(%d) failed: %s", device_id, cudaGetErrorString(rc));
+        return;
+    }
+    at::cuda::set_device(device_id);
+    at::cuda::setCurrentCUDAStream(at::cuda::getDefaultCUDAStream(device_id));
+    pinned_device = device_id;
+#elif USING_ROCM
+    thread_local int pinned_device = -1;
+    if (pinned_device == device_id) {
+        return;
+    }
+    const auto rc = hipSetDevice(device_id);
+    if (rc != hipSuccess) {
+        RTP_LLM_LOG_WARNING("hipSetDevice(%d) failed: %s", device_id, hipGetErrorString(rc));
+        return;
+    }
+    at::hip::set_device(device_id);
+    pinned_device = device_id;
+#else
+    (void)device_id;
+#endif
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/core/BUILD
+++ b/rtp_llm/models_py/bindings/core/BUILD
@@ -308,6 +308,7 @@ cc_library(
     srcs = ["CacheStoreAsyncWriter.cc"],
     deps = [
         "//rtp_llm/cpp/utils:core_utils",
+        "//rtp_llm/cpp/utils:device_pin",
         "@havenask//aios/autil:lock_free",
     ],
     visibility = ["//visibility:public"],

--- a/rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter.cc
+++ b/rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter.cc
@@ -1,10 +1,11 @@
 #include "rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter.h"
 #include "autil/LockFreeThreadPool.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
+#include "rtp_llm/cpp/utils/DevicePin.h"
 
 namespace rtp_llm {
 
-CacheStoreAsyncWriter::CacheStoreAsyncWriter() {
+CacheStoreAsyncWriter::CacheStoreAsyncWriter(int device_id): device_id_(device_id) {
     constexpr size_t kThreadCount = 3;
     constexpr size_t kQueueSize   = 10000;
     auto pool = std::make_shared<autil::LockFreeThreadPool>(kThreadCount, kQueueSize, nullptr, "CacheStoreAsync");
@@ -43,6 +44,7 @@ void CacheStoreAsyncWriter::submit(std::function<void()> task) {
     pending_count_.fetch_add(1, std::memory_order_acq_rel);
 
     auto wrapped = [this, task = std::move(task)]() {
+        pinThreadToDeviceOnce(device_id_);
         try {
             task();
         } catch (...) {

--- a/rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter.h
+++ b/rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter.h
@@ -17,7 +17,7 @@ namespace rtp_llm {
 // Lifecycle: init() -> submit()* -> waitAllDone() -> init() -> ...
 class CacheStoreAsyncWriter {
 public:
-    CacheStoreAsyncWriter();
+    explicit CacheStoreAsyncWriter(int device_id = -1);
     ~CacheStoreAsyncWriter();
 
     void init();
@@ -38,6 +38,7 @@ private:
     std::mutex               exception_mutex_;
     std::exception_ptr       stored_exception_;
     State                    state_{State::IDLE};
+    int                      device_id_{-1};
 };
 
 }  // namespace rtp_llm


### PR DESCRIPTION
# DeepSeek-V4 PD CUDA Primary Context Leak Fix Report

## Summary

Fixed the rank>0 CUDA primary context leaks reproduced in DeepSeek-V4 PD-separation for both prefill and decode.

The leaks were caused by cache-store worker/RPC callback threads running CUDA/ATen work without setting the thread-local current device. On rank>0, those threads defaulted to local cuda:0 and retained the wrong primary context.

## Root Cause

Two missing paths were confirmed:

- `rtp_llm/models_py/bindings/core/CacheStoreAsyncWriter`
- `rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure`

`CacheStoreAsyncWriter` creates an independent `autil::LockFreeThreadPool` named `CacheStoreAsync`. During PD prefill, `WriteCacheStoreOp` submits work to this pool. The submitted lambda captures tensors, cache-store inputs, and a CUDA event. When those captures are destroyed on an unpinned worker thread, the CUDA runtime/ATen path touches local cuda:0.

`TcpCacheStoreLoadServiceClosure::Run()` is executed on `ANetIOWorker`. In TCP cache-load response handling it creates CUDA tensors and calls `execNoBlockCopy()`. Without a current-device pin, `torch::from_blob(... device(torch::kCUDA))` and `c10::cuda::getStreamFromPool()` use local cuda:0. On decode rank-1, local cuda:0 maps to global GPU2, which produced the 682 MiB leak.

Temporary `LD_PRELOAD` open/openat tracing confirmed the prefill stack:

```text
pid=<prefill rank-1> thread=CacheStoreAsync path=/dev/nvidia0
... libcuda.so cuDevicePrimaryCtxRetain
... libcudart.so cudaSetDevice
... libc10_cuda.so c10::cuda::SetDevice
... shared_ptr release
... autil::LockFreeThreadPool::consumeItem
```

The decode reproduction stack was:

```text
pid=<decode rank-1> thread=ANetIOWorker path=/dev/nvidia2
... libcuda.so cuDevicePrimaryCtxRetain
... libcudart.so cudaStreamCreateWithPriority
... libc10_cuda.so c10::cuda::getStreamFromPool
... rtp_llm::execNoBlockCopy
... rtp_llm::TcpCacheStoreLoadServiceClosure::Run
... arpc::SharedClientPacketHandler::doHandlePacket
... anet::IoWorker::eventLoop
```

Temporary hook code and raw logs were deleted after diagnosis.

## Fix

- `CacheStoreAsyncWriter` accepts a `device_id`, and every async writer task pins before running user work.
- `PyWrappedModel` passes `params.parallelism_config.local_rank` when constructing `CacheStoreAsyncWriter`.
- `NormalCacheStore` task workers receive the same local-rank device id and pin before polling/submitted store/load work.
- `TcpMessager` passes the local-rank device id into `TcpCacheStoreLoadServiceClosure`, and the closure pins before processing TCP cache-load responses.
- Broader HTTP/P2P/all-RPC/NormalEngine/DSV4 barrier experiments were rolled back.
- Python-side changes in `collective_torch.py`, `symm_mem.py`, and `deepseek_v4_model.py` were rolled back from the final open-source diff.

The shared helper `rtp_llm/cpp/utils/DevicePin.h` sets both CUDA runtime current device and ATen current device.
