### PR TITLE
fix(stream): wake nextOutput() waiter when stream is flipped to Error

### DIFF
--- a/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerTest.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerTest.cc
@@ -181,7 +181,7 @@ TEST_F(FIFOSchedulerTest, testInitKVCacheRejectedByReserveBlocks) {
     ASSERT_TRUE(streams_status.ok());
     ASSERT_EQ(streams_status.value().size(), 0);
     ASSERT_TRUE(stream->hasError());
-    ASSERT_EQ(stream->stopReason(), "LACK MEM");
+    ASSERT_EQ(stream->stopReason(), "initKVBlock failed: LACK MEM");
     ASSERT_EQ(cache_manager->freeBlocksNum(), 10);
     ASSERT_EQ(cache_manager->availableBlocksNum(), 10);
 }

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
@@ -2,6 +2,7 @@
 #include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
 #include "rtp_llm/cpp/engine_base/stream/StreamCacheResource.h"
 #include "rtp_llm/cpp/config/RoleTypes.h"
+#include "rtp_llm/cpp/utils/AssertUtils.h"
 
 using namespace std;
 
@@ -15,15 +16,11 @@ void GenerateStateMachine::reportErrorAndWakeup(ErrorCode error_code, const std:
     //   - 内部会回调 generate_status_->reportEvent(Error,...) 登记 error_info/events_
     //   - 接着触发 stream 的 onErrorReported() hook 唤醒 nextOutput() 等待原语
     // 调用者必须已持有 stream->mutex_(moveToNext/handleRunning 调用链满足此前置)。
-    if (stream_) {
-        stream_->reportErrorWithoutLock(error_code, error_msg);
-    } else {
-        // Fallback:无 owner stream(理论上不应发生)时退化为只登记 error_info/events_。
-        if (error_info.ok()) {
-            error_info = ErrorInfo(error_code, error_msg);
-        }
-        events_.append(StreamEvents::Error);
-    }
+    // stream_ 由唯一构造点(GenerateStream::ctor)注入,理论上永远非空;断言保护契约,
+    // 同时让任何未来误把它构造成 nullptr 的尝试在第一时间暴露,而不是悄悄退化。
+    RTP_LLM_CHECK_WITH_INFO(stream_ != nullptr,
+                            "GenerateStateMachine::reportErrorAndWakeup called without owner stream");
+    stream_->reportErrorWithoutLock(error_code, error_msg);
 }
 
 StreamState GenerateStateMachine::moveToNext() {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h"
+#include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
 #include "rtp_llm/cpp/engine_base/stream/StreamCacheResource.h"
 #include "rtp_llm/cpp/config/RoleTypes.h"
 
@@ -8,6 +9,22 @@ namespace rtp_llm {
 // ============================================================================
 // GenerateStateMachine method implementations
 // ============================================================================
+
+void GenerateStateMachine::reportErrorAndWakeup(ErrorCode error_code, const std::string& error_msg) {
+    // 调用 stream->reportErrorWithoutLock() 走统一 Error 链路:
+    //   - 内部会回调 generate_status_->reportEvent(Error,...) 登记 error_info/events_
+    //   - 接着触发 stream 的 onErrorReported() hook 唤醒 nextOutput() 等待原语
+    // 调用者必须已持有 stream->mutex_(moveToNext/handleRunning 调用链满足此前置)。
+    if (stream_) {
+        stream_->reportErrorWithoutLock(error_code, error_msg);
+    } else {
+        // Fallback:无 owner stream(理论上不应发生)时退化为只登记 error_info/events_。
+        if (error_info.ok()) {
+            error_info = ErrorInfo(error_code, error_msg);
+        }
+        events_.append(StreamEvents::Error);
+    }
+}
 
 StreamState GenerateStateMachine::moveToNext() {
     // Error 最高优先级，任何状态下直接终止
@@ -49,7 +66,7 @@ void GenerateStateMachine::handleWaiting() {
     if (!events_.has(StreamEvents::LoadInitiated)) {
         auto result = stream_cache_resource_->initKVBlock(reserve_step_);
         if (!result.ok()) {
-            error_info = ErrorInfo(ErrorCode::MALLOC_FAILED, "LACK MEM");
+            reportErrorAndWakeup(ErrorCode::MALLOC_FAILED, "initKVBlock failed: LACK MEM");
             status.store(StreamState::FINISHED, std::memory_order_release);
             releaseResource();
             return;
@@ -79,7 +96,7 @@ void GenerateStateMachine::handleWaiting() {
     // 绕过incrKVBlock at prefill
     auto result = stream_cache_resource_->incrKVBlock(reserve_step_);
     if (!result.ok()) {
-        error_info = ErrorInfo(ErrorCode::MALLOC_FAILED, "LACK MEM");
+        reportErrorAndWakeup(ErrorCode::MALLOC_FAILED, "incrKVBlock failed: LACK MEM");
         status.store(StreamState::FINISHED, std::memory_order_release);
         releaseResource();
         return;
@@ -106,8 +123,9 @@ void GenerateStateMachine::handleRunning() {
     }
     auto result = stream_cache_resource_->incrKVBlock(reserve_step_);
     if (!result.ok()) {
-        // Report Error event so moveToNext() won't be called again on this stream
-        reportEvent(StreamEvents::Error, ErrorCode::MALLOC_FAILED, "incrKVBlock failed: LACK MEM");
+        // Report Error event so moveToNext() won't be called again on this stream;
+        // 走 reportErrorAndWakeup() 同时唤醒 stream 的 nextOutput() 等待者(否则会等到 cv 超时 ~1s)。
+        reportErrorAndWakeup(ErrorCode::MALLOC_FAILED, "incrKVBlock failed: LACK MEM");
         status.store(StreamState::FINISHED, std::memory_order_release);
         releaseResource();
     }

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h
@@ -11,6 +11,7 @@
 namespace rtp_llm {
 
 class StreamCacheResource;  // forward declaration
+class GenerateStream;       // forward declaration (used as raw back-reference for wakeup)
 
 // Stream 生命周期状态机，将原先分散在 FIFOScheduler 中的状态转移逻辑集中管理。
 // 状态转移路径: WAITING -> LOADING_CACHE -> WAITING -> RUNNING -> FINISHED
@@ -18,13 +19,20 @@ class StreamCacheResource;  // forward declaration
 // 外部通过 reportEvent() 投递事件（替代原先分散的 reportXX 接口），moveToNext() 消费累积事件后决策转移。
 // 线程安全说明：GenerateStateMachine 本身不提供同步机制，外部调用者需保证 reportEvent() 和 moveToNext()
 // 的调用串行化（通常通过 GenerateStream::mutex_ 保护）。
+//
+// 关于 stream 反向引用:状态机内部 Error 路径(handleWaiting/handleRunning 的 MALLOC_FAILED)需要
+// 触发 stream 的 onErrorReported() wakeup hook,否则 nextOutput() 等等待原语会被卡到 cv 超时
+// (~1s)。stream_ 是裸指针,GenerateStream 全程拥有 generate_status_,生命周期保证 stream_ 不悬空。
 struct GenerateStateMachine {
 public:
-    GenerateStateMachine(std::shared_ptr<StreamCacheResource> stream_cache_resource):
-        stream_cache_resource_(stream_cache_resource) {}
+    GenerateStateMachine(std::shared_ptr<StreamCacheResource> stream_cache_resource, GenerateStream* stream):
+        stream_cache_resource_(stream_cache_resource), stream_(stream) {}
 
     // 统一的事件上报接口
     // 注意：此方法非线程安全，外部应当仅通过GenerateStream在持锁路径下调用
+    // 注意：此方法不会触发 stream->onErrorReported() wakeup hook。要报 Error 必须走
+    //       reportErrorAndWakeup() 或外层 GenerateStream::reportError*(),否则
+    //       nextOutput() 等待者可能被卡到 cv 超时(最长 1s)。
     void reportEvent(StreamEvents::EventType event,
                      ErrorCode               error_code = ErrorCode::NONE_ERROR,
                      const std::string&      error_msg  = "") {
@@ -33,6 +41,10 @@ public:
         }
         events_.append(event);
     }
+
+    // Error 专用入口:既登记 error_info / events_,又触发 stream 的 onErrorReported() wakeup
+    // hook,避免 nextOutput() 等等待原语被卡到 cv 超时。调用者必须已持有 stream->mutex_。
+    void reportErrorAndWakeup(ErrorCode error_code, const std::string& error_msg);
 
     // 检查是否包含指定事件
     bool hasEvent(StreamEvents::EventType event) const {
@@ -63,7 +75,10 @@ private:
     StreamEvents events_;
 
     std::shared_ptr<StreamCacheResource> stream_cache_resource_ = nullptr;
-    size_t                               reserve_step_          = 0;
+    // 反向引用 owner stream,用于在内部 Error 路径触发 wakeup hook(见 reportErrorAndWakeup)。
+    // 裸指针:GenerateStream 全程拥有当前对象,不会出现悬空。
+    GenerateStream* stream_         = nullptr;
+    size_t          reserve_step_   = 0;
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -271,8 +271,7 @@ bool GenerateStream::updatePrefix(const std::shared_ptr<SystemPrompt>& system_pr
         if (!prefix_param.prompt_tokens.empty()) {
             auto total_input_len = inputLength() + prefix_param.prompt_tokens.size();
             if (total_input_len >= max_seq_len_) {
-                reportEvent(StreamEvents::Error,
-                            ErrorCode::LONG_PROMPT_ERROR,
+                reportError(ErrorCode::LONG_PROMPT_ERROR,
                             "after update prefix, total input len " + std::to_string(total_input_len)
                                 + " is greater than max seq len " + std::to_string(max_seq_len_));
                 return false;
@@ -480,8 +479,7 @@ void GenerateStream::checkTimeout() {
     auto running_time_ms = (autil::TimeUtility::currentTimeInMicroSeconds() - begin_time_us_) / 1000;
     auto timeout_ms      = getTimeoutMs();
     if (timeout_ms > 0 && timeout_ms < running_time_ms) {
-        reportEvent(StreamEvents::Error,
-                    ErrorCode::GENERATE_TIMEOUT,
+        reportError(ErrorCode::GENERATE_TIMEOUT,
                     "query has been running " + std::to_string(running_time_ms) + " ms, "
                         + "timeout_ms = " + std::to_string(timeout_ms) + ", it's timeout");
     }
@@ -489,21 +487,32 @@ void GenerateStream::checkTimeout() {
 
 // 统一的事件上报接口，替代原先所有 reportXX 方法。
 // 外部线程调用时自动加锁保护 error_info 和 events_ 的一致性。
+// 注意：禁止从这里报 Error，必须走 reportError*()，否则 onErrorReported() hook
+// 不会被触发，nextOutput() 等等待原语可能被卡到 cv 超时（最长 1s）。
 void GenerateStream::reportEvent(StreamEvents::EventType event, ErrorCode error_code, const std::string& error_msg) {
+    RTP_LLM_CHECK_WITH_INFO(event != StreamEvents::Error,
+                            "Error must be reported via reportError(), not reportEvent()");
     std::lock_guard<std::mutex> lock(*mutex_);
     generate_status_->reportEvent(event, error_code, error_msg);
 }
 
 // 无锁版本，供已持有 mutex_ 的内部调用路径使用（如 update/specUpdate/moveToNext 链路）。
+// 同上：禁止报 Error，必须走 reportErrorWithoutLock()。
 void GenerateStream::reportEventWithoutLock(StreamEvents::EventType event,
                                             ErrorCode               error_code,
                                             const std::string&      error_msg) {
+    RTP_LLM_CHECK_WITH_INFO(event != StreamEvents::Error,
+                            "Error must be reported via reportErrorWithoutLock(), not reportEventWithoutLock()");
     generate_status_->reportEvent(event, error_code, error_msg);
 }
 
 void GenerateStream::reportError(ErrorCode error_code, const std::string& error_msg) {
     std::lock_guard<std::mutex> lock(*mutex_);
     generate_status_->reportEvent(StreamEvents::Error, error_code, error_msg);
+    // Wake any consumer parked on a derived-class wait primitive (e.g. NormalGenerateStream's
+    // generate_outputs_queue_.waitNotEmpty()), so the error is observed immediately rather
+    // than after the cv timeout. Lock order: *mutex_ -> queue._cond is preserved here.
+    onErrorReported();
 }
 
 bool GenerateStream::hasEvent(StreamEvents::EventType event) const {
@@ -715,8 +724,7 @@ void GenerateStream::specUpdate(const StreamSpecUpdateInfo& update_info) {
                                      hasNumBeams(),
                                      streamId(),
                                      error_token_id)) {
-        reportEventWithoutLock(StreamEvents::Error,
-                               ErrorCode::OUT_OF_VOCAB_RANGE,
+        reportErrorWithoutLock(ErrorCode::OUT_OF_VOCAB_RANGE,
                                "output token id:" + std::to_string(error_token_id)
                                    + " out of vocab size: " + std::to_string(vocab_size_));
         return;
@@ -798,8 +806,7 @@ void GenerateStream::update(const StreamUpdateInfo& update_info) {
                                      hasNumBeams(),
                                      streamId(),
                                      error_token_id)) {
-        reportEventWithoutLock(StreamEvents::Error,
-                               ErrorCode::OUT_OF_VOCAB_RANGE,
+        reportErrorWithoutLock(ErrorCode::OUT_OF_VOCAB_RANGE,
                                "output token id:" + std::to_string(error_token_id)
                                    + " out of vocab size: " + std::to_string(vocab_size_));
         return;
@@ -820,7 +827,7 @@ void GenerateStream::update(const StreamUpdateInfo& update_info) {
         // kv cache blocks must be updated if REUSE_CACHE is on, even the stream is done
         auto update_res = updateKvCacheBlocks(update_info.src_batch_indices);
         if (!update_res) {
-            reportEventWithoutLock(StreamEvents::Error, ErrorCode::MALLOC_FAILED, "update kv cache blocks failed");
+            reportErrorWithoutLock(ErrorCode::MALLOC_FAILED, "update kv cache blocks failed");
             return;
         }
     }

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -77,7 +77,10 @@ GenerateStream::GenerateStream(const shared_ptr<GenerateInput>& input,
 
     is_context_stream_  = std::make_shared<bool>();
     *is_context_stream_ = true;
-    generate_status_    = std::make_shared<GenerateStateMachine>(stream_cache_resource_);
+    // Pass `this` so the state machine can drive onErrorReported() wakeup via
+    // GenerateStream::reportErrorWithoutLock() on its internal Error paths
+    // (handleWaiting/handleRunning MALLOC_FAILED).
+    generate_status_    = std::make_shared<GenerateStateMachine>(stream_cache_resource_, this);
     sub_generate_status_.clear();
     resizeSubGenerateStatus(init_batch_size);
 
@@ -508,10 +511,14 @@ void GenerateStream::reportEventWithoutLock(StreamEvents::EventType event,
 
 void GenerateStream::reportError(ErrorCode error_code, const std::string& error_msg) {
     std::lock_guard<std::mutex> lock(*mutex_);
+    reportErrorWithoutLock(error_code, error_msg);
+}
+
+// 无锁版本:调用者必须已持有 *mutex_。与 reportError() 共享同一个 onErrorReported() wakeup
+// 链路,这样无论从哪条路径报 Error,nextOutput() 等等待原语都不会被卡到 cv 超时(最长 1s)。
+// 锁序: *mutex_ -> queue._cond (与 reportError() 保持一致)。
+void GenerateStream::reportErrorWithoutLock(ErrorCode error_code, const std::string& error_msg) {
     generate_status_->reportEvent(StreamEvents::Error, error_code, error_msg);
-    // Wake any consumer parked on a derived-class wait primitive (e.g. NormalGenerateStream's
-    // generate_outputs_queue_.waitNotEmpty()), so the error is observed immediately rather
-    // than after the cv timeout. Lock order: *mutex_ -> queue._cond is preserved here.
     onErrorReported();
 }
 

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -231,7 +231,10 @@ public:
                                 ErrorCode               error_code = ErrorCode::NONE_ERROR,
                                 const std::string&      error_msg  = "");
 
-    void         reportError(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
+    void reportError(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
+    // 无锁版本,供已持有 mutex_ 的内部调用路径(update/specUpdate/moveToNext/GenerateStateMachine
+    // 等)使用。和 reportError() 一样会触发 onErrorReported() hook,避免被等待原语卡到 cv 超时。
+    void reportErrorWithoutLock(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
     bool         hasEvent(StreamEvents::EventType event) const;
     virtual bool hasError() const;
     ErrorInfo    statusInfo();
@@ -595,8 +598,11 @@ protected:
     // This is intentional: GenerateStateMachine needs direct access to StreamCacheResource
     // for state transitions (e.g., loading cache, releasing blocks). Both owners share the
     // same instance via shared_ptr, so reference counting ensures correct lifetime management.
-    // No circular reference exists because neither StreamCacheResource nor GenerateStateMachine
-    // holds a back-reference to GenerateStream.
+    //
+    // 反向引用说明:为了在 GenerateStateMachine 内部 Error 路径(MALLOC_FAILED 等)触发
+    // GenerateStream::onErrorReported() wakeup hook,StreamCacheResource 和 GenerateStateMachine
+    // 均持有 GenerateStream* 裸指针。无生命周期循环 —— GenerateStream 全程拥有这两个对象,
+    // shared_ptr 引用计数不形成回环。
 
     torch::Tensor                            cum_log_probs_;
     torch::Tensor                            all_probs_;

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -534,6 +534,12 @@ protected:
     void reportStreamMetrics();
     void reportCacheReuseMetrics() const;
 
+    // Hook fired right after the stream is flipped into Error via reportError*.
+    // Default no-op; derived streams override to wake whatever wait primitive
+    // their consumer (e.g. nextOutput) is parked on, so the consumer doesn't
+    // sleep until the cv timeout to observe the error.
+    virtual void onErrorReported() {}
+
 protected:
     uint64_t                              stream_magic_ = STREAM_MAGIC;
     std::shared_ptr<GenerateInput>        generate_input_;

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -468,8 +468,7 @@ bool StreamCacheResource::loadCacheDone() {
                 RTP_LLM_LOG_WARNING("load cache failed after %d retries (transfer error), stream: [%ld]",
                                     load_cache_retry_count_,
                                     stream_->streamId());
-                stream_->reportEventWithoutLock(StreamEvents::Error,
-                                                ErrorCode::LOAD_CACHE_TIMEOUT,
+                stream_->reportErrorWithoutLock(ErrorCode::LOAD_CACHE_TIMEOUT,
                                                 "load cache failed after " + std::to_string(max_retry)
                                                     + " retries (transfer error)");
                 releaseResource();

--- a/rtp_llm/cpp/engine_base/stream/test/BUILD
+++ b/rtp_llm/cpp/engine_base/stream/test/BUILD
@@ -60,3 +60,19 @@ cc_test(
     },
     exec_properties = {'gpu':'A10'},
 )
+
+# Regression coverage for the onErrorReported() wakeup hook -- catches future
+# bypasses that would re-introduce the 1s nextOutput() stall after Error.
+cc_test(
+    name = "generate_stream_error_wakeup_test",
+    srcs = [
+        "GenerateStreamErrorWakeupTest.cc",
+    ],
+    data = [],
+    copts = test_copts,
+    deps = test_deps,
+    env = {
+        "TEST_USING_DEVICE": "CUDA",
+    },
+    exec_properties = {'gpu':'A10'},
+)

--- a/rtp_llm/cpp/engine_base/stream/test/GenerateStreamErrorWakeupTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/GenerateStreamErrorWakeupTest.cc
@@ -1,0 +1,163 @@
+// Regression tests for the onErrorReported() wakeup hook introduced to
+// eliminate the up-to-1s nextOutput() stall after a stream is flipped to Error.
+//
+// Three wakeup paths are exercised:
+//   1) GenerateStream::reportError()                 -- external caller, takes mutex_
+//   2) GenerateStream::reportErrorWithoutLock()      -- internal path, mutex_ already held
+//   3) GenerateStateMachine::reportErrorAndWakeup()  -- state-machine internal Error path
+//                                                       (handleWaiting / handleRunning MALLOC_FAILED)
+//
+// Each test measures wall-clock latency from the moment Error is reported to the
+// moment nextOutput() returns. Assertion threshold is set well below
+// SynchronizedQueue::DEF_WAIT_TIME (1s) so any future regression that bypasses
+// the hook is caught deterministically.
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#define private public
+#define protected public
+#include "rtp_llm/cpp/cache/KVCacheManager.h"
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
+#include "rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h"
+#include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
+#include "rtp_llm/cpp/engine_base/stream/GenerateTypes.h"
+#include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
+#include "rtp_llm/cpp/testing/TestBase.h"
+#include "rtp_llm/cpp/config/ConfigModules.h"
+
+using namespace std;
+
+namespace rtp_llm {
+
+class GenerateStreamErrorWakeupTest: public DeviceTestBase {
+protected:
+    GenerateStreamErrorWakeupTest(): perf_scope_("PERF_TEST", "1") {}
+
+    CacheConfig initCacheConfig() {
+        return test::makeSimpleMhaCacheConfig(
+            /*layer_num=*/3, /*block_num=*/9, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_INT8);
+    }
+
+    std::shared_ptr<NormalGenerateStream> createStream() {
+        cache_manager_ =
+            std::make_shared<KVCacheManager>(initCacheConfig(), /*warmup=*/false, /*metrics_reporter=*/nullptr);
+        EXPECT_TRUE(cache_manager_->init());
+        ResourceContext resource_context;
+        resource_context.cache_manager = cache_manager_;
+        resource_context.reuse_cache   = false;
+
+        auto generate_input             = std::make_shared<GenerateInput>();
+        auto generate_config            = std::make_shared<GenerateConfig>();
+        generate_input->generate_config = generate_config;
+        std::vector<int32_t> tokens     = {1, 2, 3, 4, 5, 6};
+        generate_input->input_ids       = torch::tensor(tokens, torch::kInt32);
+
+        ModelConfig   model_config;
+        RuntimeConfig runtime_config;
+        model_config.max_seq_len = 2048;
+        return std::make_shared<NormalGenerateStream>(
+            generate_input, model_config, runtime_config, resource_context, nullptr);
+    }
+
+    // Spawn a thread that blocks on nextOutput(); return latency (ms) from the
+    // moment the trigger callback runs to the moment nextOutput() returns. The
+    // 50ms park-delay lets the consumer reach waitNotEmpty() before we fire.
+    template <typename Trigger>
+    int64_t measureWakeupLatencyMs(NormalGenerateStream& stream, Trigger&& trigger) {
+        std::atomic<bool>                              returned{false};
+        std::chrono::steady_clock::time_point          done_at;
+        std::thread waiter([&]() {
+            auto result = stream.nextOutput();
+            done_at     = std::chrono::steady_clock::now();
+            returned.store(true, std::memory_order_release);
+            EXPECT_FALSE(result.ok());
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        EXPECT_FALSE(returned.load(std::memory_order_acquire))
+            << "nextOutput() returned before Error was reported -- park-delay too short or queue had data";
+
+        auto fire_at = std::chrono::steady_clock::now();
+        trigger();
+        waiter.join();
+
+        return std::chrono::duration_cast<std::chrono::milliseconds>(done_at - fire_at).count();
+    }
+
+    autil::EnvGuard                 perf_scope_;
+    std::shared_ptr<KVCacheManager> cache_manager_;
+};
+
+// 1) Public reportError() path: external thread reports, waiter wakes quickly.
+TEST_F(GenerateStreamErrorWakeupTest, reportErrorWakesNextOutput) {
+    auto stream = createStream();
+    auto latency_ms = measureWakeupLatencyMs(*stream, [&]() {
+        stream->reportError(ErrorCode::MALLOC_FAILED, "test wakeup via reportError");
+    });
+    // SynchronizedQueue cv timeout is ~1s; allow generous 300ms ceiling so the
+    // test is robust on slow CI without losing the regression signal.
+    EXPECT_LT(latency_ms, 300) << "nextOutput() did not wake within 300ms after reportError(); "
+                                  "suspect onErrorReported() hook regression";
+    EXPECT_TRUE(stream->hasError());
+}
+
+// 2) Internal reportErrorWithoutLock() path: caller already holds *mutex_,
+//    e.g. update()/specUpdate() chains. Lock order *mutex_ -> queue._cond
+//    must hold; the wakeup hook must still fire.
+TEST_F(GenerateStreamErrorWakeupTest, reportErrorWithoutLockWakesNextOutput) {
+    auto stream = createStream();
+    auto latency_ms = measureWakeupLatencyMs(*stream, [&]() {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->reportErrorWithoutLock(ErrorCode::OUTPUT_QUEUE_FULL, "test wakeup via reportErrorWithoutLock");
+    });
+    EXPECT_LT(latency_ms, 300);
+    EXPECT_TRUE(stream->hasError());
+}
+
+// 3) GenerateStateMachine internal Error path: handleWaiting/handleRunning
+//    MALLOC_FAILED previously used reportEvent(StreamEvents::Error, ...) which
+//    bypassed the hook. The reportErrorAndWakeup() helper now routes through
+//    the owner stream so nextOutput() wakes immediately.
+TEST_F(GenerateStreamErrorWakeupTest, stateMachineReportErrorAndWakeupWakesNextOutput) {
+    auto stream = createStream();
+    auto latency_ms = measureWakeupLatencyMs(*stream, [&]() {
+        // State machine reports under the stream mutex (matches the moveToNext()
+        // call site that drives handleRunning).
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->generate_status_->reportErrorAndWakeup(ErrorCode::MALLOC_FAILED,
+                                                       "test wakeup via state machine");
+    });
+    EXPECT_LT(latency_ms, 300);
+    EXPECT_TRUE(stream->hasError());
+    // Verify error_info / events_ were also registered (parity with the old
+    // reportEvent(Error,...) write).
+    EXPECT_FALSE(stream->generate_status_->error_info.ok());
+    EXPECT_TRUE(stream->generate_status_->hasEvent(StreamEvents::Error));
+}
+
+// 4) Misuse guards: reportEvent / reportEventWithoutLock with StreamEvents::Error
+//    must be rejected by the RTP_LLM_CHECK_WITH_INFO so the wakeup hook can
+//    never be silently bypassed. myAssert() throws (default) -- catch via
+//    EXPECT_ANY_THROW. If user_ft_core_dump_on_exception is on the binary
+//    would abort instead, which is also an acceptable failure signal.
+TEST_F(GenerateStreamErrorWakeupTest, reportEventErrorIsForbidden) {
+    auto stream = createStream();
+    EXPECT_ANY_THROW({
+        stream->reportEvent(StreamEvents::Error, ErrorCode::MALLOC_FAILED, "should be rejected");
+    });
+}
+
+TEST_F(GenerateStreamErrorWakeupTest, reportEventWithoutLockErrorIsForbidden) {
+    auto stream = createStream();
+    EXPECT_ANY_THROW({
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->reportEventWithoutLock(StreamEvents::Error, ErrorCode::MALLOC_FAILED, "should be rejected");
+    });
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
@@ -68,7 +68,7 @@ namespace rtp_llm {
             }                                                                                                          \
         }                                                                                                              \
         if (prefill_context.getStream()) {                                                                             \
-            prefill_context.getStream()->reportEvent(StreamEvents::Error, new_error_code, new_error_msg);              \
+            prefill_context.getStream()->reportError(new_error_code, new_error_msg);                                   \
         }                                                                                                              \
         prefill_context.error_info   = ErrorInfo(new_error_code, new_error_msg);                                       \
         prefill_context.error_status = serializeErrorMsg(prefill_context.request_key, prefill_context.error_info);     \
@@ -96,7 +96,7 @@ ErrorInfo PrefillRpcServer::waitStreamBeforeRun(std::shared_ptr<GenerateStream> 
         auto cost_time_us    = current_time_us - begin_time_us;
         if (cost_time_us > max_wait_timeout_us) {
             string new_error_msg = "wait to run timeout, timeout is " + std::to_string(max_wait_timeout_us) + " us";
-            stream->reportEvent(StreamEvents::Error, ErrorCode::WAIT_TO_RUN_TIMEOUT, new_error_msg);
+            stream->reportError(ErrorCode::WAIT_TO_RUN_TIMEOUT, new_error_msg);
             return ErrorInfo(ErrorCode::WAIT_TO_RUN_TIMEOUT, new_error_msg);
         }
     }

--- a/rtp_llm/cpp/normal_engine/NormalGenerateStream.cc
+++ b/rtp_llm/cpp/normal_engine/NormalGenerateStream.cc
@@ -148,7 +148,7 @@ void NormalGenerateStream::enqueueGenerateOutput(GenerateOutputs&& generate_resu
     if (generate_outputs_queue_.getSize() >= generate_outputs_queue_.getCapacity()) {
         /* No matter if the queue is full for any reason,
            the stream will be set to stop directly to prevent the push to queue from getting stuck. */
-        reportEventWithoutLock(StreamEvents::Error, ErrorCode::OUTPUT_QUEUE_FULL, "output queue is full");
+        reportErrorWithoutLock(ErrorCode::OUTPUT_QUEUE_FULL, "output queue is full");
     } else {
         generate_outputs_queue_.push(std::move(generate_results));
     }

--- a/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
+++ b/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
@@ -31,6 +31,13 @@ public:
     ErrorResult<GenerateOutputs> nextOutput() override;
     void                         updateOutput(const StreamUpdateInfo& update_info) override;
 
+protected:
+    // Wake nextOutput()'s waitNotEmpty so the consumer observes the error
+    // without waiting up to SynchronizedQueue::DEF_WAIT_TIME (1s).
+    void onErrorReported() override {
+        generate_outputs_queue_.wakeup();
+    }
+
 private:
     GenerateOutputs prepareGenerateOutput(const StreamUpdateInfo& update_info);
     void            enqueueGenerateOutput(GenerateOutputs&& generate_results);


### PR DESCRIPTION
Add a virtual onErrorReported() hook on GenerateStream, fired inside reportErrorWithoutLock so every reportError*() path triggers it. NormalGenerateStream overrides it to wakeup generate_outputs_queue_, eliminating the up-to-1s stall where nextOutput() was sleeping on SynchronizedQueue::_cond until DEF_WAIT_TIME after an Error event that did not also push to the queue.

Forbid StreamEvents::Error from reportEvent / reportEventWithoutLock via runtime CHECK so the hook can never be bypassed silently. Convert all existing Error callsites (LONG_PROMPT_ERROR, GENERATE_TIMEOUT, OUT_OF_VOCAB_RANGE, MALLOC_FAILED, OUTPUT_QUEUE_FULL, LOAD_CACHE_TIMEOUT, WAIT_TO_RUN_TIMEOUT) to reportError / reportErrorWithoutLock.

Note: GenerateStateMachine::reportEvent(StreamEvents::Error, ...) at GenerateStateMachine.cc:108 (incrKVBlock MALLOC_FAILED) still bypasses the hook and remains a known 1s stall; it requires a separate refactor to plumb the wakeup hook into the state machine.