### PR TITLE
fix(openai): streaming spec compliance — SSE chunk split, content preservation, min_new_tokens enforcement

### DIFF
--- a/rtp_llm/openai/api_datatype.py
+++ b/rtp_llm/openai/api_datatype.py
@@ -121,6 +121,16 @@ class GPTToolDefinition(BaseModel):
     function: GPTFunctionDefinition
 
 
+class StreamOptions(BaseModel):
+    # OpenAI streaming option. When set to True, a trailing chunk with
+    # `choices=[]` carrying `usage` is appended to the SSE stream. When
+    # False, `usage` is suppressed from the stream entirely. When omitted
+    # (None), rtp-llm preserves the legacy behavior of bundling `usage`
+    # on the finish chunk for backward compatibility with internal
+    # consumers that predate the OpenAI spec layout.
+    include_usage: Optional[bool] = None
+
+
 class ChatCompletionRequest(BaseModel):
     model: Optional[str] = None
     messages: List[ChatMessage]
@@ -131,6 +141,7 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
+    stream_options: Optional[StreamOptions] = None
     user: Optional[str] = None
     seed: Optional[int] = None
     n: Optional[int] = None

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -319,7 +319,7 @@ class OpenaiEndpoint(object):
                             index=i,
                             message=ChatMessage(
                                 role=choice.delta.role or RoleEnum.assistant,
-                                content=choice.delta.content if choice.delta.content is not None else "",
+                                content=choice.delta.content,
                                 function_call=choice.delta.function_call or None,
                                 tool_calls=choice.delta.tool_calls or None,
                             ),
@@ -335,14 +335,11 @@ class OpenaiEndpoint(object):
                     )
             else:
                 for i in range(len(all_choices)):
+                    delta_content = response.choices[i].delta.content
                     if all_choices[i].message.content is None:
-                        all_choices[i].message.content = (
-                            response.choices[i].delta.content or ""
-                        )
-                    else:
-                        all_choices[i].message.content += (
-                            response.choices[i].delta.content or ""
-                        )
+                        all_choices[i].message.content = delta_content
+                    elif delta_content is not None:
+                        all_choices[i].message.content += delta_content
                     if all_choices[i].message.reasoning_content == None:
                         all_choices[i].message.reasoning_content = (
                             response.choices[i].delta.reasoning_content or None
@@ -392,9 +389,6 @@ class OpenaiEndpoint(object):
                     for output_ids in extra_outputs.output_ids
                 ]
 
-        for choice in all_choices:
-            if choice.message.content is None:
-                choice.message.content = ""
         return ChatCompletionResponse(
             choices=all_choices,
             usage=usage,
@@ -409,6 +403,7 @@ class OpenaiEndpoint(object):
         choice_generator: AsyncGenerator[StreamResponseObject, None],
         debug_info: Optional[DebugInfo],
         tokenizer: Optional[Any] = None,
+        include_usage: Optional[bool] = None,
     ) -> CompleteResponseAsyncGenerator:
         async def response_generator():
             debug_info_responded = False
@@ -427,18 +422,26 @@ class OpenaiEndpoint(object):
                         for output_ids in response.extra_outputs.output_ids
                     ]
 
-                # OpenAI Chat Completions streaming protocol: when a chunk
-                # carries `usage`, that chunk must have `choices=[]`.
-                # Spec-compliant clients expect the trailing usage payload
-                # in a standalone chunk after the chunk that contained
-                # `finish_reason`, and may ignore usage when it is bundled
-                # with choices in the same chunk. Emit the final usage in
-                # its own choices-empty chunk.
-                if (
+                # Usage emission policy is determined by stream_options.include_usage:
+                #   - True  -> OpenAI Chat Completions streaming spec: emit the
+                #             trailing `usage` in its own chunk with choices=[],
+                #             after the chunk that carried `finish_reason`.
+                #             Spec-compliant clients (e.g. vllm bench, OpenAI
+                #             Python SDK) only inspect `usage` on choices-empty
+                #             chunks, so bundling drops the payload.
+                #   - False -> Suppress `usage` from the stream entirely
+                #             (matches OpenAI's behavior when the client does
+                #             not opt in).
+                #   - None  -> Legacy rtp-llm behavior: bundle `usage` on the
+                #             same chunk as `finish_reason`. Kept as the
+                #             default for backward compatibility with internal
+                #             consumers that predate the spec layout.
+                has_finish_usage = (
                     response.usage is not None
                     and response.choices
                     and any(c.finish_reason for c in response.choices)
-                ):
+                )
+                if include_usage is True and has_finish_usage:
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=None,
@@ -454,7 +457,17 @@ class OpenaiEndpoint(object):
                         debug_info=None,
                         extra_outputs=None,
                     )
+                elif include_usage is False:
+                    yield ChatCompletionStreamResponse(
+                        choices=response.choices,
+                        usage=None,
+                        aux_info=response.aux_info,
+                        debug_info=debug_info if not debug_info_responded else output,
+                        extra_outputs=response.extra_outputs,
+                    )
+                    debug_info_responded = True
                 else:
+                    # include_usage is None: legacy bundled behavior.
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=response.usage,
@@ -549,8 +562,13 @@ class OpenaiEndpoint(object):
             chat_request,
         )
 
+        include_usage = (
+            chat_request.stream_options.include_usage
+            if chat_request.stream_options is not None
+            else None
+        )
         return self._complete_stream_response(
-            choice_generator, debug_info, self.tokenizer
+            choice_generator, debug_info, self.tokenizer, include_usage
         )
 
     def _prepare_chat_input(self, request_id: int, chat_request):

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -441,7 +441,13 @@ class OpenaiEndpoint(object):
                     and response.choices
                     and any(c.finish_reason for c in response.choices)
                 )
-                if include_usage is True and has_finish_usage:
+                if include_usage is True:
+                    # Spec layout: only emit `usage` once, in a trailing
+                    # choices=[] chunk after the chunk that carried
+                    # finish_reason. Suppress `usage` on every other chunk
+                    # (the backend tags every chunk with running totals, but
+                    # spec-compliant clients only inspect the choices-empty
+                    # chunk).
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=None,
@@ -450,13 +456,14 @@ class OpenaiEndpoint(object):
                         extra_outputs=response.extra_outputs,
                     )
                     debug_info_responded = True
-                    yield ChatCompletionStreamResponse(
-                        choices=[],
-                        usage=response.usage,
-                        aux_info=None,
-                        debug_info=None,
-                        extra_outputs=None,
-                    )
+                    if has_finish_usage:
+                        yield ChatCompletionStreamResponse(
+                            choices=[],
+                            usage=response.usage,
+                            aux_info=None,
+                            debug_info=None,
+                            extra_outputs=None,
+                        )
                 elif include_usage is False:
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -340,14 +340,11 @@ class OpenaiEndpoint(object):
                         all_choices[i].message.content = delta_content
                     elif delta_content is not None:
                         all_choices[i].message.content += delta_content
-                    if all_choices[i].message.reasoning_content == None:
-                        all_choices[i].message.reasoning_content = (
-                            response.choices[i].delta.reasoning_content or None
-                        )
-                    else:
-                        all_choices[i].message.reasoning_content += (
-                            response.choices[i].delta.reasoning_content or ""
-                        )
+                    delta_reasoning = response.choices[i].delta.reasoning_content
+                    if all_choices[i].message.reasoning_content is None:
+                        all_choices[i].message.reasoning_content = delta_reasoning
+                    elif delta_reasoning is not None:
+                        all_choices[i].message.reasoning_content += delta_reasoning
                     all_choices[i].message.role = (
                         response.choices[i].delta.role or all_choices[i].message.role
                     )

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -427,31 +427,11 @@ class OpenaiEndpoint(object):
                     ]
 
                 # See StreamOptions for include_usage semantics.
-                if include_usage is True:
-                    # Spec layout: suppress `usage` on every content chunk;
-                    # emit it exactly once in a trailing choices=[] chunk
-                    # after the choice_generator is fully drained (see the
-                    # post-loop emission below). This guarantees the usage
-                    # chunk is the final chunk on the wire and reflects
-                    # final stream state -- correct for n>=2 where choices
-                    # finish on different chunks. Backend usage-only frames
-                    # (choices=[]) are captured into `last_usage` above and
-                    # not forwarded as redundant empty chunks.
-                    if not response.choices:
-                        continue
-                    yield ChatCompletionStreamResponse(
-                        choices=response.choices,
-                        usage=None,
-                        aux_info=response.aux_info,
-                        debug_info=debug_info if not debug_info_responded else output,
-                        extra_outputs=response.extra_outputs,
-                    )
-                    debug_info_responded = True
-                elif include_usage is False:
-                    # Symmetric with the include_usage=True path: do not
-                    # forward backend usage-only frames (choices=[]) as
-                    # redundant empty chunks. With usage suppressed they
-                    # would carry no signal at all.
+                if include_usage is not None:
+                    # include_usage=True/False: suppress per-chunk usage
+                    # and skip backend usage-only frames (choices=[]).
+                    # When True, a trailing choices=[] usage chunk is
+                    # emitted after the loop (see below).
                     if not response.choices:
                         continue
                     yield ChatCompletionStreamResponse(

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -302,6 +302,16 @@ class OpenaiEndpoint(object):
         aux_info = None
         extra_outputs = None
         async for response in choice_generator:
+            # Per the Chat Completions streaming protocol, a chunk that
+            # carries `usage` arrives with `choices=[]` after the chunk that
+            # contained `finish_reason`. Capture usage/aux_info/extra_outputs
+            # first so usage-only chunks are accounted for, then skip the
+            # per-choice merge below.
+            usage = response.usage or usage
+            aux_info = response.aux_info or aux_info
+            extra_outputs = response.extra_outputs or extra_outputs
+            if not response.choices:
+                continue
             if len(response.choices) != len(all_choices):
                 if all_choices == []:
                     all_choices = [
@@ -309,7 +319,7 @@ class OpenaiEndpoint(object):
                             index=i,
                             message=ChatMessage(
                                 role=choice.delta.role or RoleEnum.assistant,
-                                content=choice.delta.content or None,
+                                content=choice.delta.content if choice.delta.content is not None else "",
                                 function_call=choice.delta.function_call or None,
                                 tool_calls=choice.delta.tool_calls or None,
                             ),
@@ -325,9 +335,9 @@ class OpenaiEndpoint(object):
                     )
             else:
                 for i in range(len(all_choices)):
-                    if all_choices[i].message.content == None:
+                    if all_choices[i].message.content is None:
                         all_choices[i].message.content = (
-                            response.choices[i].delta.content or None
+                            response.choices[i].delta.content or ""
                         )
                     else:
                         all_choices[i].message.content += (
@@ -365,9 +375,6 @@ class OpenaiEndpoint(object):
                             ].logprobs.content
                     else:
                         all_choices[i].logprobs = response.choices[i].logprobs
-            usage = response.usage or usage
-            aux_info = response.aux_info or aux_info
-            extra_outputs = response.extra_outputs or extra_outputs
 
         if usage == None:
             logging.warning(f"No usage returned from stream response. use empty value.")
@@ -385,6 +392,9 @@ class OpenaiEndpoint(object):
                     for output_ids in extra_outputs.output_ids
                 ]
 
+        for choice in all_choices:
+            if choice.message.content is None:
+                choice.message.content = ""
         return ChatCompletionResponse(
             choices=all_choices,
             usage=usage,
@@ -417,14 +427,42 @@ class OpenaiEndpoint(object):
                         for output_ids in response.extra_outputs.output_ids
                     ]
 
-                yield ChatCompletionStreamResponse(
-                    choices=response.choices,
-                    usage=response.usage,
-                    aux_info=response.aux_info,
-                    debug_info=debug_info if not debug_info_responded else output,
-                    extra_outputs=response.extra_outputs,
-                )
-                debug_info_responded = True
+                # OpenAI Chat Completions streaming protocol: when a chunk
+                # carries `usage`, that chunk must have `choices=[]`.
+                # Spec-compliant clients expect the trailing usage payload
+                # in a standalone chunk after the chunk that contained
+                # `finish_reason`, and may ignore usage when it is bundled
+                # with choices in the same chunk. Emit the final usage in
+                # its own choices-empty chunk.
+                if (
+                    response.usage is not None
+                    and response.choices
+                    and any(c.finish_reason for c in response.choices)
+                ):
+                    yield ChatCompletionStreamResponse(
+                        choices=response.choices,
+                        usage=None,
+                        aux_info=response.aux_info,
+                        debug_info=debug_info if not debug_info_responded else output,
+                        extra_outputs=response.extra_outputs,
+                    )
+                    debug_info_responded = True
+                    yield ChatCompletionStreamResponse(
+                        choices=[],
+                        usage=response.usage,
+                        aux_info=None,
+                        debug_info=None,
+                        extra_outputs=None,
+                    )
+                else:
+                    yield ChatCompletionStreamResponse(
+                        choices=response.choices,
+                        usage=response.usage,
+                        aux_info=response.aux_info,
+                        debug_info=debug_info if not debug_info_responded else output,
+                        extra_outputs=response.extra_outputs,
+                    )
+                    debug_info_responded = True
 
         complete_response_collect_func = partial(
             OpenaiEndpoint._collect_complete_response,

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -404,8 +404,15 @@ class OpenaiEndpoint(object):
     ) -> CompleteResponseAsyncGenerator:
         async def response_generator():
             debug_info_responded = False
+            # Track last-seen usage so we can emit a trailing chunk even
+            # when usage and finish_reason arrive on different chunks.
+            last_usage = None
+            usage_emitted = False
 
             async for response in choice_generator:
+                if response.usage is not None:
+                    last_usage = response.usage
+
                 output = None
                 if (
                     debug_info is not None
@@ -433,18 +440,14 @@ class OpenaiEndpoint(object):
                 #             same chunk as `finish_reason`. Kept as the
                 #             default for backward compatibility with internal
                 #             consumers that predate the spec layout.
-                has_finish_usage = (
-                    response.usage is not None
-                    and response.choices
+                has_finish = (
+                    response.choices
                     and any(c.finish_reason for c in response.choices)
                 )
                 if include_usage is True:
-                    # Spec layout: only emit `usage` once, in a trailing
-                    # choices=[] chunk after the chunk that carried
-                    # finish_reason. Suppress `usage` on every other chunk
-                    # (the backend tags every chunk with running totals, but
-                    # spec-compliant clients only inspect the choices-empty
-                    # chunk).
+                    # Spec layout: suppress `usage` on every content chunk;
+                    # emit it once in a trailing choices=[] chunk after the
+                    # chunk that carried finish_reason.
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=None,
@@ -453,14 +456,15 @@ class OpenaiEndpoint(object):
                         extra_outputs=response.extra_outputs,
                     )
                     debug_info_responded = True
-                    if has_finish_usage:
+                    if has_finish and last_usage is not None:
                         yield ChatCompletionStreamResponse(
                             choices=[],
-                            usage=response.usage,
+                            usage=last_usage,
                             aux_info=None,
                             debug_info=None,
                             extra_outputs=None,
                         )
+                        usage_emitted = True
                 elif include_usage is False:
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
@@ -480,6 +484,23 @@ class OpenaiEndpoint(object):
                         extra_outputs=response.extra_outputs,
                     )
                     debug_info_responded = True
+
+            # Fallback: if include_usage=True and we accumulated usage but
+            # never emitted it (usage arrived on a different chunk than
+            # finish_reason, or as a standalone usage-only chunk), emit the
+            # trailing usage chunk now so it is never silently lost.
+            if include_usage is True and last_usage is not None and not usage_emitted:
+                logging.warning(
+                    "Usage was not co-located with finish_reason; "
+                    "emitting deferred trailing usage chunk."
+                )
+                yield ChatCompletionStreamResponse(
+                    choices=[],
+                    usage=last_usage,
+                    aux_info=None,
+                    debug_info=None,
+                    extra_outputs=None,
+                )
 
         complete_response_collect_func = partial(
             OpenaiEndpoint._collect_complete_response,

--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -320,6 +320,7 @@ class OpenaiEndpoint(object):
                             message=ChatMessage(
                                 role=choice.delta.role or RoleEnum.assistant,
                                 content=choice.delta.content,
+                                reasoning_content=choice.delta.reasoning_content,
                                 function_call=choice.delta.function_call or None,
                                 tool_calls=choice.delta.tool_calls or None,
                             ),
@@ -407,7 +408,6 @@ class OpenaiEndpoint(object):
             # Track last-seen usage so we can emit a trailing chunk even
             # when usage and finish_reason arrive on different chunks.
             last_usage = None
-            usage_emitted = False
 
             async for response in choice_generator:
                 if response.usage is not None:
@@ -426,28 +426,19 @@ class OpenaiEndpoint(object):
                         for output_ids in response.extra_outputs.output_ids
                     ]
 
-                # Usage emission policy is determined by stream_options.include_usage:
-                #   - True  -> OpenAI Chat Completions streaming spec: emit the
-                #             trailing `usage` in its own chunk with choices=[],
-                #             after the chunk that carried `finish_reason`.
-                #             Spec-compliant clients (e.g. vllm bench, OpenAI
-                #             Python SDK) only inspect `usage` on choices-empty
-                #             chunks, so bundling drops the payload.
-                #   - False -> Suppress `usage` from the stream entirely
-                #             (matches OpenAI's behavior when the client does
-                #             not opt in).
-                #   - None  -> Legacy rtp-llm behavior: bundle `usage` on the
-                #             same chunk as `finish_reason`. Kept as the
-                #             default for backward compatibility with internal
-                #             consumers that predate the spec layout.
-                has_finish = (
-                    response.choices
-                    and any(c.finish_reason for c in response.choices)
-                )
+                # See StreamOptions for include_usage semantics.
                 if include_usage is True:
                     # Spec layout: suppress `usage` on every content chunk;
-                    # emit it once in a trailing choices=[] chunk after the
-                    # chunk that carried finish_reason.
+                    # emit it exactly once in a trailing choices=[] chunk
+                    # after the choice_generator is fully drained (see the
+                    # post-loop emission below). This guarantees the usage
+                    # chunk is the final chunk on the wire and reflects
+                    # final stream state -- correct for n>=2 where choices
+                    # finish on different chunks. Backend usage-only frames
+                    # (choices=[]) are captured into `last_usage` above and
+                    # not forwarded as redundant empty chunks.
+                    if not response.choices:
+                        continue
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=None,
@@ -456,16 +447,13 @@ class OpenaiEndpoint(object):
                         extra_outputs=response.extra_outputs,
                     )
                     debug_info_responded = True
-                    if has_finish and last_usage is not None:
-                        yield ChatCompletionStreamResponse(
-                            choices=[],
-                            usage=last_usage,
-                            aux_info=None,
-                            debug_info=None,
-                            extra_outputs=None,
-                        )
-                        usage_emitted = True
                 elif include_usage is False:
+                    # Symmetric with the include_usage=True path: do not
+                    # forward backend usage-only frames (choices=[]) as
+                    # redundant empty chunks. With usage suppressed they
+                    # would carry no signal at all.
+                    if not response.choices:
+                        continue
                     yield ChatCompletionStreamResponse(
                         choices=response.choices,
                         usage=None,
@@ -485,15 +473,12 @@ class OpenaiEndpoint(object):
                     )
                     debug_info_responded = True
 
-            # Fallback: if include_usage=True and we accumulated usage but
-            # never emitted it (usage arrived on a different chunk than
-            # finish_reason, or as a standalone usage-only chunk), emit the
-            # trailing usage chunk now so it is never silently lost.
-            if include_usage is True and last_usage is not None and not usage_emitted:
-                logging.warning(
-                    "Usage was not co-located with finish_reason; "
-                    "emitting deferred trailing usage chunk."
-                )
+            # Trailing usage chunk: emitted after the stream is fully
+            # drained so it is always the final chunk on the wire and
+            # carries the last-seen usage. This is correct for n>=2 where
+            # choices finish on different chunks -- the usage emit must
+            # not happen mid-stream when only some choices have finished.
+            if include_usage is True and last_usage is not None:
                 yield ChatCompletionStreamResponse(
                     choices=[],
                     usage=last_usage,
@@ -587,9 +572,15 @@ class OpenaiEndpoint(object):
             chat_request,
         )
 
+        # stream_options only applies to streaming responses. For the
+        # non-streaming (stream=False) path the collect aggregator needs the
+        # legacy bundled `usage` to be present on the finish chunk, otherwise
+        # `include_usage=False` would silently drop usage from the final
+        # ChatCompletionResponse. Force include_usage=None (legacy bundle)
+        # whenever the client did not request a streaming response.
         include_usage = (
             chat_request.stream_options.include_usage
-            if chat_request.stream_options is not None
+            if chat_request.stream and chat_request.stream_options is not None
             else None
         )
         return self._complete_stream_response(

--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -56,15 +56,7 @@ _MIN_NEW_TOKENS_CV: ContextVar[int] = ContextVar("_min_new_tokens", default=0)
 
 
 def _bind_min_new_tokens(generate_config) -> Token:
-    """Normalize and bind `min_new_tokens` into the task-scoped ContextVar.
-
-    Returns the ``contextvars.Token`` produced by ``ContextVar.set``,
-    which must be passed to ``_MIN_NEW_TOKENS_CV.reset(token)`` in a
-    ``finally`` block to undo the binding when the request completes.
-
-    GenerateConfig.min_new_tokens is ``Union[List[int], int]``; a list is
-    collapsed to its ``max`` (empty list → 0).
-    """
+    """Bind min_new_tokens into task-scoped ContextVar; returns reset token."""
     mnt = generate_config.min_new_tokens
     if isinstance(mnt, list):
         mnt = max(mnt) if mnt else 0

--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -1462,7 +1462,7 @@ class CustomChatRenderer:
                                 index=i,
                                 message=ChatMessage(
                                     role=choice.delta.role or RoleEnum.assistant,
-                                    content=content or None,
+                                    content=content if content is not None else "",
                                     reasoning_content=reasoning_content or None,
                                     function_call=choice.delta.function_call or None,
                                 ),
@@ -1477,9 +1477,9 @@ class CustomChatRenderer:
                     )
             else:
                 for i in range(len(all_choices)):
-                    if all_choices[i].message.content == None:
+                    if all_choices[i].message.content is None:
                         all_choices[i].message.content = (
-                            response.choices[i].delta.content or None
+                            response.choices[i].delta.content or ""
                         )
                     else:
                         all_choices[i].message.content += (
@@ -1514,6 +1514,9 @@ class CustomChatRenderer:
         if usage == None:
             logging.warning(f"No usage returned from stream response. use empty value.")
             usage = UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0)
+        for choice in all_choices:
+            if choice.message.content is None:
+                choice.message.content = ""
         chat_response = ChatCompletionResponse(
             choices=all_choices,
             usage=usage,

--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -961,7 +961,27 @@ class CustomChatRenderer:
         # Bind min_new_tokens for this request's asyncio Task scope. The value
         # is read by _check_finish_reason; using a ContextVar avoids touching
         # the _update_single_status signature (which subclasses override).
-        _MIN_NEW_TOKENS_CV.set(int(generate_config.min_new_tokens or 0))
+        # GenerateConfig.min_new_tokens is Union[List[int], int]; collapse a
+        # list to its max so the floor still applies for variable-N requests.
+        mnt = generate_config.min_new_tokens
+        if isinstance(mnt, list):
+            mnt = max(mnt) if mnt else 0
+        _min_new_tokens_token = _MIN_NEW_TOKENS_CV.set(int(mnt or 0))
+        try:
+            yield_gen = self._render_response_stream_body(
+                output_generator, request, generate_config
+            )
+            async for resp in yield_gen:
+                yield resp
+        finally:
+            _MIN_NEW_TOKENS_CV.reset(_min_new_tokens_token)
+
+    async def _render_response_stream_body(
+        self,
+        output_generator: AsyncGenerator[GenerateOutputs, None],
+        request: ChatCompletionRequest,
+        generate_config: GenerateConfig,
+    ) -> AsyncGenerator[StreamResponseObject, None]:
         stop_word_slice_list = get_stop_word_slices(generate_config.stop_words_str)
         nums_output = request.n if request.n is not None else 1
         # FIXME(zhangjianning.zjn): for variable width beam search,
@@ -1474,7 +1494,7 @@ class CustomChatRenderer:
                                 index=i,
                                 message=ChatMessage(
                                     role=choice.delta.role or RoleEnum.assistant,
-                                    content=content if content is not None else "",
+                                    content=content,
                                     reasoning_content=reasoning_content or None,
                                     function_call=choice.delta.function_call or None,
                                 ),
@@ -1489,14 +1509,11 @@ class CustomChatRenderer:
                     )
             else:
                 for i in range(len(all_choices)):
+                    delta_content = response.choices[i].delta.content
                     if all_choices[i].message.content is None:
-                        all_choices[i].message.content = (
-                            response.choices[i].delta.content or ""
-                        )
-                    else:
-                        all_choices[i].message.content += (
-                            response.choices[i].delta.content or ""
-                        )
+                        all_choices[i].message.content = delta_content
+                    elif delta_content is not None:
+                        all_choices[i].message.content += delta_content
                     content, reasoning_content = split_think_tag(
                         all_choices[i].message.content
                     )
@@ -1526,9 +1543,6 @@ class CustomChatRenderer:
         if usage == None:
             logging.warning(f"No usage returned from stream response. use empty value.")
             usage = UsageInfo(prompt_tokens=0, total_tokens=0, completion_tokens=0)
-        for choice in all_choices:
-            if choice.message.content is None:
-                choice.message.content = ""
         chat_response = ChatCompletionResponse(
             choices=all_choices,
             usage=usage,

--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -3,6 +3,7 @@ import functools
 import json
 import logging
 import os
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncGenerator, List, Optional, Tuple, Union
@@ -45,6 +46,13 @@ from rtp_llm.utils.word_util import (
     is_truncated,
     truncate_response_with_stop_words,
 )
+
+
+# Per-request floor on generated tokens, threaded through asyncio Tasks via
+# ContextVar so concurrent requests cannot clobber each other's value. Read
+# by CustomChatRenderer._check_finish_reason; set per request at the top of
+# render_response_stream. Default 0 preserves prior behavior.
+_MIN_NEW_TOKENS_CV: ContextVar[int] = ContextVar("_min_new_tokens", default=0)
 
 
 def _get_think_config(generate_env_config):
@@ -950,6 +958,10 @@ class CustomChatRenderer:
         request: ChatCompletionRequest,
         generate_config: GenerateConfig,
     ) -> AsyncGenerator[StreamResponseObject, None]:
+        # Bind min_new_tokens for this request's asyncio Task scope. The value
+        # is read by _check_finish_reason; using a ContextVar avoids touching
+        # the _update_single_status signature (which subclasses override).
+        _MIN_NEW_TOKENS_CV.set(int(generate_config.min_new_tokens or 0))
         stop_word_slice_list = get_stop_word_slices(generate_config.stop_words_str)
         nums_output = request.n if request.n is not None else 1
         # FIXME(zhangjianning.zjn): for variable width beam search,
@@ -1535,6 +1547,14 @@ class CustomChatRenderer:
             return FinisheReason.length
         if len(token_ids) + input_token_length >= self.max_seq_len:
             return FinisheReason.length
+        # min_new_tokens is a hard floor: do not terminate on EOS or stop-words
+        # before the requested minimum is generated. The length-based checks
+        # above still take precedence (max_new_tokens / max_seq_len). The value
+        # is read from a ContextVar set per-request in render_response_stream,
+        # which keeps the subclass _update_single_status signatures unchanged.
+        min_new_tokens = _MIN_NEW_TOKENS_CV.get()
+        if min_new_tokens > 0 and len(token_ids) < min_new_tokens:
+            return None
         if token_ids and token_ids[-1] == self.eos_token_id:
             return FinisheReason.stop
         for stop_word_ids in stop_word_ids_list_all:

--- a/rtp_llm/openai/renderers/custom_renderer.py
+++ b/rtp_llm/openai/renderers/custom_renderer.py
@@ -3,7 +3,7 @@ import functools
 import json
 import logging
 import os
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncGenerator, List, Optional, Tuple, Union
@@ -53,6 +53,22 @@ from rtp_llm.utils.word_util import (
 # by CustomChatRenderer._check_finish_reason; set per request at the top of
 # render_response_stream. Default 0 preserves prior behavior.
 _MIN_NEW_TOKENS_CV: ContextVar[int] = ContextVar("_min_new_tokens", default=0)
+
+
+def _bind_min_new_tokens(generate_config) -> Token:
+    """Normalize and bind `min_new_tokens` into the task-scoped ContextVar.
+
+    Returns the ``contextvars.Token`` produced by ``ContextVar.set``,
+    which must be passed to ``_MIN_NEW_TOKENS_CV.reset(token)`` in a
+    ``finally`` block to undo the binding when the request completes.
+
+    GenerateConfig.min_new_tokens is ``Union[List[int], int]``; a list is
+    collapsed to its ``max`` (empty list → 0).
+    """
+    mnt = generate_config.min_new_tokens
+    if isinstance(mnt, list):
+        mnt = max(mnt) if mnt else 0
+    return _MIN_NEW_TOKENS_CV.set(int(mnt or 0))
 
 
 def _get_think_config(generate_env_config):
@@ -958,15 +974,7 @@ class CustomChatRenderer:
         request: ChatCompletionRequest,
         generate_config: GenerateConfig,
     ) -> AsyncGenerator[StreamResponseObject, None]:
-        # Bind min_new_tokens for this request's asyncio Task scope. The value
-        # is read by _check_finish_reason; using a ContextVar avoids touching
-        # the _update_single_status signature (which subclasses override).
-        # GenerateConfig.min_new_tokens is Union[List[int], int]; collapse a
-        # list to its max so the floor still applies for variable-N requests.
-        mnt = generate_config.min_new_tokens
-        if isinstance(mnt, list):
-            mnt = max(mnt) if mnt else 0
-        _min_new_tokens_token = _MIN_NEW_TOKENS_CV.set(int(mnt or 0))
+        _min_new_tokens_token = _bind_min_new_tokens(generate_config)
         try:
             yield_gen = self._render_response_stream_body(
                 output_generator, request, generate_config
@@ -1495,7 +1503,7 @@ class CustomChatRenderer:
                                 message=ChatMessage(
                                     role=choice.delta.role or RoleEnum.assistant,
                                     content=content,
-                                    reasoning_content=reasoning_content or None,
+                                    reasoning_content=reasoning_content,
                                     function_call=choice.delta.function_call or None,
                                 ),
                                 finish_reason=choice.finish_reason,

--- a/rtp_llm/openai/renderers/qwen_agent_renderer.py
+++ b/rtp_llm/openai/renderers/qwen_agent_renderer.py
@@ -24,6 +24,7 @@ from rtp_llm.openai.renderer_factory_register import register_renderer
 from rtp_llm.openai.renderers.basic_renderer import BasicRenderer
 from rtp_llm.openai.renderers.custom_renderer import (
     _MIN_NEW_TOKENS_CV,
+    _bind_min_new_tokens,
     CustomChatRenderer,
     RenderedInputs,
     RendererParams,
@@ -183,14 +184,7 @@ class QwenAgentRenderer(CustomChatRenderer):
         request: ChatCompletionRequest,
         generate_config: GenerateConfig,
     ) -> AsyncGenerator[StreamResponseObject, None]:
-        # Bind min_new_tokens floor for this request. CustomChatRenderer's
-        # _check_finish_reason reads this ContextVar; subclasses that
-        # override render_response_stream (like this one) must keep it in
-        # sync or the floor is silently ignored.
-        mnt = generate_config.min_new_tokens
-        if isinstance(mnt, list):
-            mnt = max(mnt) if mnt else 0
-        _min_new_tokens_token = _MIN_NEW_TOKENS_CV.set(int(mnt or 0))
+        _min_new_tokens_token = _bind_min_new_tokens(generate_config)
         try:
             async for resp in self._render_response_stream_impl(
                 output_generator, request, generate_config

--- a/rtp_llm/openai/renderers/qwen_agent_renderer.py
+++ b/rtp_llm/openai/renderers/qwen_agent_renderer.py
@@ -23,8 +23,6 @@ from rtp_llm.openai.api_datatype import (
 from rtp_llm.openai.renderer_factory_register import register_renderer
 from rtp_llm.openai.renderers.basic_renderer import BasicRenderer
 from rtp_llm.openai.renderers.custom_renderer import (
-    _MIN_NEW_TOKENS_CV,
-    _bind_min_new_tokens,
     CustomChatRenderer,
     RenderedInputs,
     RendererParams,
@@ -178,24 +176,12 @@ class QwenAgentRenderer(CustomChatRenderer):
             output_str = output_str.replace(stop_word, "")
         return ProcessedOutput(output_str, output_length, finish_reason)
 
-    async def render_response_stream(
+    # Override only the body -- base class CustomChatRenderer.render_response_stream
+    # owns the min_new_tokens ContextVar bind/reset lifecycle, so subclasses do
+    # not need to import private symbols or duplicate the try/finally pattern.
+    async def _render_response_stream_body(
         self,
         output_generator: AsyncGenerator[GenerateOutputs, None],
-        request: ChatCompletionRequest,
-        generate_config: GenerateConfig,
-    ) -> AsyncGenerator[StreamResponseObject, None]:
-        _min_new_tokens_token = _bind_min_new_tokens(generate_config)
-        try:
-            async for resp in self._render_response_stream_impl(
-                output_generator, request, generate_config
-            ):
-                yield resp
-        finally:
-            _MIN_NEW_TOKENS_CV.reset(_min_new_tokens_token)
-
-    async def _render_response_stream_impl(
-        self,
-        output_generator,
         request: ChatCompletionRequest,
         generate_config: GenerateConfig,
     ) -> AsyncGenerator[StreamResponseObject, None]:

--- a/rtp_llm/openai/renderers/qwen_agent_renderer.py
+++ b/rtp_llm/openai/renderers/qwen_agent_renderer.py
@@ -23,6 +23,7 @@ from rtp_llm.openai.api_datatype import (
 from rtp_llm.openai.renderer_factory_register import register_renderer
 from rtp_llm.openai.renderers.basic_renderer import BasicRenderer
 from rtp_llm.openai.renderers.custom_renderer import (
+    _MIN_NEW_TOKENS_CV,
     CustomChatRenderer,
     RenderedInputs,
     RendererParams,
@@ -179,6 +180,28 @@ class QwenAgentRenderer(CustomChatRenderer):
     async def render_response_stream(
         self,
         output_generator: AsyncGenerator[GenerateOutputs, None],
+        request: ChatCompletionRequest,
+        generate_config: GenerateConfig,
+    ) -> AsyncGenerator[StreamResponseObject, None]:
+        # Bind min_new_tokens floor for this request. CustomChatRenderer's
+        # _check_finish_reason reads this ContextVar; subclasses that
+        # override render_response_stream (like this one) must keep it in
+        # sync or the floor is silently ignored.
+        mnt = generate_config.min_new_tokens
+        if isinstance(mnt, list):
+            mnt = max(mnt) if mnt else 0
+        _min_new_tokens_token = _MIN_NEW_TOKENS_CV.set(int(mnt or 0))
+        try:
+            async for resp in self._render_response_stream_impl(
+                output_generator, request, generate_config
+            ):
+                yield resp
+        finally:
+            _MIN_NEW_TOKENS_CV.reset(_min_new_tokens_token)
+
+    async def _render_response_stream_impl(
+        self,
+        output_generator,
         request: ChatCompletionRequest,
         generate_config: GenerateConfig,
     ) -> AsyncGenerator[StreamResponseObject, None]:

--- a/rtp_llm/openai/test/BUILD
+++ b/rtp_llm/openai/test/BUILD
@@ -5,3 +5,11 @@ py_test(
         "//rtp_llm:testlib",
     ],
 )
+
+py_test(
+    name = "test_stream_content_preservation",
+    srcs = ["test_stream_content_preservation.py"],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+)

--- a/rtp_llm/openai/test/BUILD
+++ b/rtp_llm/openai/test/BUILD
@@ -1,0 +1,7 @@
+py_test(
+    name = "test_stream_usage_split",
+    srcs = ["test_stream_usage_split.py"],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+)

--- a/rtp_llm/openai/test/BUILD
+++ b/rtp_llm/openai/test/BUILD
@@ -13,3 +13,11 @@ py_test(
         "//rtp_llm:testlib",
     ],
 )
+
+py_test(
+    name = "test_min_new_tokens",
+    srcs = ["test_min_new_tokens.py"],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+)

--- a/rtp_llm/openai/test/test_min_new_tokens.py
+++ b/rtp_llm/openai/test/test_min_new_tokens.py
@@ -104,3 +104,74 @@ class TestMinNewTokensEnforcement(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRenderResponseStreamCVLifecycle(unittest.TestCase):
+    """`render_response_stream` must set the CV on entry and reset it on
+    exit so that one request's `min_new_tokens` cannot leak into another
+    request running on the same asyncio Task (e.g. background pool reuse)."""
+
+    def test_cv_resets_after_generator_close(self):
+        import asyncio
+
+        from rtp_llm.config.generate_config import GenerateConfig
+        from rtp_llm.openai.api_datatype import ChatCompletionRequest, ChatMessage
+
+        async def _empty_outputs():
+            if False:
+                yield None  # async generator that produces nothing
+            return
+
+        async def run():
+            renderer = _bare_renderer()
+            renderer.in_think_mode = lambda req: False
+            renderer.should_process_think = lambda req: False
+            async def _async_empty(n, req):
+                return []
+            renderer._create_status_list = _async_empty
+            request = ChatCompletionRequest(
+                messages=[ChatMessage(role="user", content="hi")], n=1
+            )
+            gen_config = GenerateConfig()
+            gen_config.min_new_tokens = 42
+
+            # Pre-set the CV to a sentinel so we can verify it's restored
+            outer_token = _MIN_NEW_TOKENS_CV.set(7)
+            try:
+                gen = renderer.render_response_stream(
+                    _empty_outputs(), request, gen_config
+                )
+                async for _ in gen:
+                    pass
+                # After the generator is drained the CV must be back to 7.
+                self.assertEqual(_MIN_NEW_TOKENS_CV.get(), 7)
+            finally:
+                _MIN_NEW_TOKENS_CV.reset(outer_token)
+
+        asyncio.run(run())
+
+
+class TestMinNewTokensListInput(unittest.TestCase):
+    """`GenerateConfig.min_new_tokens` is `Union[List[int], int]`. The
+    renderer must accept both forms without crashing on `int([...])`."""
+
+    def test_list_input_collapses_to_max(self):
+        # Simulate what render_response_stream does with a list.
+        from rtp_llm.config.generate_config import GenerateConfig
+
+        gen_config = GenerateConfig()
+        gen_config.min_new_tokens = [3, 5, 1]
+        mnt = gen_config.min_new_tokens
+        if isinstance(mnt, list):
+            mnt = max(mnt) if mnt else 0
+        self.assertEqual(int(mnt or 0), 5)
+
+    def test_empty_list_input_becomes_zero(self):
+        from rtp_llm.config.generate_config import GenerateConfig
+
+        gen_config = GenerateConfig()
+        gen_config.min_new_tokens = []
+        mnt = gen_config.min_new_tokens
+        if isinstance(mnt, list):
+            mnt = max(mnt) if mnt else 0
+        self.assertEqual(int(mnt or 0), 0)

--- a/rtp_llm/openai/test/test_min_new_tokens.py
+++ b/rtp_llm/openai/test/test_min_new_tokens.py
@@ -1,0 +1,106 @@
+"""Tests for min_new_tokens enforcement in CustomChatRenderer (Fix D).
+
+`min_new_tokens` is a hard floor: EOS and stop-words must not terminate
+generation before the floor is met. The length-based guards
+(`max_new_tokens`, `max_seq_len`) still take precedence.
+
+The value is threaded through an asyncio.Task-scoped ContextVar set at the
+top of `render_response_stream`, so subclass `_update_single_status`
+signatures are unchanged.
+"""
+
+import unittest
+
+from rtp_llm.openai.api_datatype import FinisheReason
+from rtp_llm.openai.renderers.custom_renderer import (
+    _MIN_NEW_TOKENS_CV,
+    CustomChatRenderer,
+)
+
+
+def _bare_renderer(
+    *, max_seq_len: int = 100_000, eos_token_id: int = 999
+) -> CustomChatRenderer:
+    """Construct a renderer without running __init__, populated only with the
+    attributes _check_finish_reason reads."""
+    r = CustomChatRenderer.__new__(CustomChatRenderer)
+    r.max_seq_len = max_seq_len
+    r.eos_token_id = eos_token_id
+    r.stop_words_id_list = []
+    r.extra_stop_words = []
+    r.extra_stop_word_ids_list = []
+    r.tokenize_words = lambda _words: []
+    return r
+
+
+class TestMinNewTokensEnforcement(unittest.TestCase):
+    def setUp(self):
+        _MIN_NEW_TOKENS_CV.set(0)
+
+    def test_default_zero_preserves_eos_stop_behavior(self):
+        r = _bare_renderer(eos_token_id=999)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 999], input_token_length=0
+        )
+        self.assertEqual(result, FinisheReason.stop)
+
+    def test_eos_suppressed_below_floor(self):
+        r = _bare_renderer(eos_token_id=999)
+        _MIN_NEW_TOKENS_CV.set(10)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 999], input_token_length=0
+        )
+        self.assertIsNone(result)
+
+    def test_eos_allowed_at_floor(self):
+        r = _bare_renderer(eos_token_id=999)
+        _MIN_NEW_TOKENS_CV.set(3)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 999], input_token_length=0
+        )
+        self.assertEqual(result, FinisheReason.stop)
+
+    def test_stop_word_suppressed_below_floor(self):
+        r = _bare_renderer(eos_token_id=999)
+        r.stop_words_id_list = [[42, 43]]
+        _MIN_NEW_TOKENS_CV.set(20)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 42, 43], input_token_length=0
+        )
+        self.assertIsNone(result)
+
+    def test_stop_word_allowed_at_floor(self):
+        r = _bare_renderer(eos_token_id=999)
+        r.stop_words_id_list = [[42, 43]]
+        _MIN_NEW_TOKENS_CV.set(4)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 42, 43], input_token_length=0
+        )
+        self.assertEqual(result, FinisheReason.stop)
+
+    def test_max_new_tokens_still_wins_above_floor(self):
+        r = _bare_renderer(eos_token_id=999)
+        _MIN_NEW_TOKENS_CV.set(100)
+        result = r._check_finish_reason(
+            token_ids=list(range(5)), input_token_length=0, max_new_tokens=5
+        )
+        self.assertEqual(result, FinisheReason.length)
+
+    def test_max_seq_len_still_wins(self):
+        r = _bare_renderer(max_seq_len=8, eos_token_id=999)
+        _MIN_NEW_TOKENS_CV.set(100)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 3, 4], input_token_length=4
+        )
+        self.assertEqual(result, FinisheReason.length)
+
+    def test_no_termination_when_no_signal(self):
+        r = _bare_renderer(eos_token_id=999)
+        result = r._check_finish_reason(
+            token_ids=[1, 2, 3], input_token_length=0
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/openai/test/test_min_new_tokens.py
+++ b/rtp_llm/openai/test/test_min_new_tokens.py
@@ -102,10 +102,6 @@ class TestMinNewTokensEnforcement(unittest.TestCase):
         self.assertIsNone(result)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestRenderResponseStreamCVLifecycle(unittest.TestCase):
     """`render_response_stream` must set the CV on entry and reset it on
     exit so that one request's `min_new_tokens` cannot leak into another
@@ -175,3 +171,7 @@ class TestMinNewTokensListInput(unittest.TestCase):
         if isinstance(mnt, list):
             mnt = max(mnt) if mnt else 0
         self.assertEqual(int(mnt or 0), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/openai/test/test_stream_content_preservation.py
+++ b/rtp_llm/openai/test/test_stream_content_preservation.py
@@ -1,10 +1,24 @@
-"""Tests for empty-string content preservation in stream aggregators (Fix C).
+"""Tests for stream aggregator `content` semantics.
 
-When a chat completion is truncated mid-`<think>`, every `delta.content`
-chunk is the empty string. The aggregators previously collapsed `''` to
-`None`, and `model_dump(exclude_none=True)` then dropped the `content` key
-entirely from the response payload. Downstream consumers received a
-message with no `content` field at all, violating the Chat Completions spec.
+Two cases the aggregator must preserve correctly:
+
+1. When every `delta.content` is the empty string (e.g. chat completion
+   truncated mid-`<think>`), the aggregated message must keep
+   `content=""`, not collapse to `None`. Previously the aggregator
+   coerced `""` to `None` via `delta.content or ""` /
+   `delta.content or None`; after `model_dump(exclude_none=True)` the
+   `content` key was dropped entirely, violating the spec which
+   requires the field to be present.
+
+2. When every `delta.content` is `None` (e.g. a tool-call only
+   message), the aggregated message must keep `content=None` so that
+   `exclude_none=True` correctly drops the field. The previous defense
+   -in-depth pass coerced `None` to `""`, which leaked an empty content
+   string into tool-call payloads.
+
+The fix is a simple pass-through: don't coerce `""` to `None`, and don't
+coerce `None` to `""`. Pydantic + `exclude_none` does the right thing
+when the aggregator preserves the source delta semantics exactly.
 """
 
 import asyncio
@@ -59,7 +73,10 @@ class TestContentPreservation(unittest.TestCase):
         self.assertIn("content", payload["choices"][0]["message"])
         self.assertEqual(payload["choices"][0]["message"]["content"], "")
 
-    def test_none_delta_content_does_not_collapse_to_missing_key(self):
+    def test_all_none_delta_content_preserves_none(self):
+        # Tool-call style stream: every delta.content is None. The
+        # aggregator must NOT coerce None to "", otherwise tool-call
+        # messages leak an empty content string into the JSON payload.
         items = [
             StreamResponseObject(choices=[_choice(None)]),
             StreamResponseObject(
@@ -72,9 +89,10 @@ class TestContentPreservation(unittest.TestCase):
                 _gen(items), debug_info=None, tokenizer=None
             )
         )
-        self.assertEqual(resp.choices[0].message.content, "")
+        self.assertIsNone(resp.choices[0].message.content)
         payload = json.loads(resp.model_dump_json(exclude_none=True))
-        self.assertIn("content", payload["choices"][0]["message"])
+        # exclude_none should drop the content key entirely.
+        self.assertNotIn("content", payload["choices"][0]["message"])
 
     def test_normal_text_unaffected(self):
         items = [
@@ -91,6 +109,27 @@ class TestContentPreservation(unittest.TestCase):
             )
         )
         self.assertEqual(resp.choices[0].message.content, "hello world")
+
+    def test_mixed_none_then_text_starts_clean(self):
+        # If the first delta is None (tool-call hint) and later deltas
+        # carry text, the aggregator should not concatenate "None" or
+        # double-coerce. Once content becomes a string it stays a string.
+        items = [
+            StreamResponseObject(choices=[_choice(None)]),
+            StreamResponseObject(choices=[_choice("hi")]),
+            StreamResponseObject(
+                choices=[_choice("", finish_reason=FinisheReason.stop)],
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        # The first None initializes content to None; then "hi" replaces
+        # it (since content is None, not a string we can += to).
+        self.assertEqual(resp.choices[0].message.content, "hi")
 
 
 if __name__ == "__main__":

--- a/rtp_llm/openai/test/test_stream_content_preservation.py
+++ b/rtp_llm/openai/test/test_stream_content_preservation.py
@@ -1,0 +1,97 @@
+"""Tests for empty-string content preservation in stream aggregators (Fix C).
+
+When a chat completion is truncated mid-`<think>`, every `delta.content`
+chunk is the empty string. The aggregators previously collapsed `''` to
+`None`, and `model_dump(exclude_none=True)` then dropped the `content` key
+entirely from the response payload. Downstream consumers received a
+message with no `content` field at all, violating the Chat Completions spec.
+"""
+
+import asyncio
+import json
+import unittest
+
+from rtp_llm.openai.api_datatype import (
+    ChatCompletionResponseStreamChoice,
+    DeltaMessage,
+    FinisheReason,
+    RoleEnum,
+    UsageInfo,
+)
+from rtp_llm.openai.openai_endpoint import OpenaiEndpoint
+from rtp_llm.openai.renderers.custom_renderer import StreamResponseObject
+
+
+def _choice(content, finish_reason=None):
+    return ChatCompletionResponseStreamChoice(
+        index=0,
+        delta=DeltaMessage(role=RoleEnum.assistant, content=content),
+        finish_reason=finish_reason,
+    )
+
+
+async def _gen(items):
+    for it in items:
+        yield it
+
+
+class TestContentPreservation(unittest.TestCase):
+    def test_all_empty_string_chunks_yield_empty_string(self):
+        usage = UsageInfo(prompt_tokens=2, completion_tokens=4, total_tokens=6)
+        items = [
+            StreamResponseObject(choices=[_choice("")]),
+            StreamResponseObject(choices=[_choice("")]),
+            StreamResponseObject(
+                choices=[_choice("", finish_reason=FinisheReason.length)],
+                usage=usage,
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertEqual(len(resp.choices), 1)
+        self.assertEqual(resp.choices[0].message.content, "")
+        self.assertIsNotNone(resp.choices[0].message.content)
+
+        payload = json.loads(resp.model_dump_json(exclude_none=True))
+        self.assertIn("content", payload["choices"][0]["message"])
+        self.assertEqual(payload["choices"][0]["message"]["content"], "")
+
+    def test_none_delta_content_does_not_collapse_to_missing_key(self):
+        items = [
+            StreamResponseObject(choices=[_choice(None)]),
+            StreamResponseObject(
+                choices=[_choice(None, finish_reason=FinisheReason.stop)],
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=0, total_tokens=1),
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertEqual(resp.choices[0].message.content, "")
+        payload = json.loads(resp.model_dump_json(exclude_none=True))
+        self.assertIn("content", payload["choices"][0]["message"])
+
+    def test_normal_text_unaffected(self):
+        items = [
+            StreamResponseObject(choices=[_choice("hello ")]),
+            StreamResponseObject(choices=[_choice("world")]),
+            StreamResponseObject(
+                choices=[_choice("", finish_reason=FinisheReason.stop)],
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertEqual(resp.choices[0].message.content, "hello world")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/openai/test/test_stream_content_preservation.py
+++ b/rtp_llm/openai/test/test_stream_content_preservation.py
@@ -132,5 +132,54 @@ class TestContentPreservation(unittest.TestCase):
         self.assertEqual(resp.choices[0].message.content, "hi")
 
 
+class TestReasoningContentPreservation(unittest.TestCase):
+    """reasoning_content must get the same pass-through treatment as content:
+    empty string stays empty string, None stays None."""
+
+    def _choice_rc(self, content=None, reasoning_content=None, finish_reason=None):
+        return ChatCompletionResponseStreamChoice(
+            index=0,
+            delta=DeltaMessage(
+                role=RoleEnum.assistant,
+                content=content,
+                reasoning_content=reasoning_content,
+            ),
+            finish_reason=finish_reason,
+        )
+
+    def test_empty_string_reasoning_content_preserved(self):
+        usage = UsageInfo(prompt_tokens=2, completion_tokens=4, total_tokens=6)
+        items = [
+            StreamResponseObject(choices=[self._choice_rc(content="hi", reasoning_content="")]),
+            StreamResponseObject(
+                choices=[self._choice_rc(content="", reasoning_content="", finish_reason=FinisheReason.length)],
+                usage=usage,
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        # reasoning_content="" must NOT collapse to None
+        self.assertEqual(resp.choices[0].message.reasoning_content, "")
+
+    def test_none_reasoning_content_stays_none(self):
+        usage = UsageInfo(prompt_tokens=2, completion_tokens=1, total_tokens=3)
+        items = [
+            StreamResponseObject(choices=[self._choice_rc(content="ok", reasoning_content=None)]),
+            StreamResponseObject(
+                choices=[self._choice_rc(content="", reasoning_content=None, finish_reason=FinisheReason.stop)],
+                usage=usage,
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertIsNone(resp.choices[0].message.reasoning_content)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/openai/test/test_stream_usage_split.py
+++ b/rtp_llm/openai/test/test_stream_usage_split.py
@@ -103,6 +103,39 @@ class TestIncludeUsageTrue(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertTrue(all(r.usage is None for r in out))
 
+    def test_mid_stream_usage_suppressed(self):
+        # The backend tags every chunk with running usage totals. When
+        # include_usage=True, only the trailing choices=[] chunk should
+        # carry `usage`; intermediate chunks must drop the field.
+        usage_running = UsageInfo(prompt_tokens=4, completion_tokens=1, total_tokens=5)
+        usage_final = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+        items = [
+            StreamResponseObject(
+                choices=[_make_choice(content="a")], usage=usage_running
+            ),
+            StreamResponseObject(
+                choices=[_make_choice(content="b", finish_reason=FinisheReason.stop)],
+                usage=usage_final,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+        self.assertEqual(len(out), 3)
+        # Mid-stream chunk has choices but no usage.
+        self.assertEqual(len(out[0].choices), 1)
+        self.assertIsNone(out[0].usage)
+        # Finish chunk has choices but no usage.
+        self.assertEqual(len(out[1].choices), 1)
+        self.assertIsNone(out[1].usage)
+        # Tail chunk has usage only.
+        self.assertEqual(out[2].choices, [])
+        self.assertEqual(out[2].usage.completion_tokens, 8)
+
 
 class TestIncludeUsageFalse(unittest.TestCase):
     """include_usage=False -> usage suppressed from the stream entirely."""

--- a/rtp_llm/openai/test/test_stream_usage_split.py
+++ b/rtp_llm/openai/test/test_stream_usage_split.py
@@ -228,5 +228,99 @@ class TestCollectCompleteResponseHandlesEmptyChoices(unittest.TestCase):
         self.assertEqual(resp.choices[0].message.content, "hi")
 
 
+class TestIncludeUsageTrueUsageOnSeparateChunk(unittest.TestCase):
+    """include_usage=True with usage arriving on a different chunk than
+    finish_reason. The trailing usage chunk must still be emitted."""
+
+    def test_usage_after_finish_on_separate_chunk(self):
+        """Backend sends finish_reason first, then a standalone usage-only
+        chunk. The trailing choices=[] usage chunk must still appear."""
+        usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hello")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+            ),
+            # Usage arrives on a standalone chunk with no choices.
+            StreamResponseObject(choices=[], usage=usage),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # 3 original chunks forwarded + 1 trailing usage chunk
+        self.assertEqual(len(out), 4)
+        # Content chunk
+        self.assertIsNone(out[0].usage)
+        self.assertEqual(len(out[0].choices), 1)
+        # Finish chunk (usage suppressed)
+        self.assertIsNone(out[1].usage)
+        self.assertEqual(out[1].choices[0].finish_reason, FinisheReason.stop)
+        # Standalone usage-only chunk forwarded with usage=None
+        self.assertIsNone(out[2].usage)
+        self.assertEqual(out[2].choices, [])
+        # Trailing usage chunk emitted by fallback
+        self.assertEqual(out[3].choices, [])
+        self.assertIsNotNone(out[3].usage)
+        self.assertEqual(out[3].usage.completion_tokens, 8)
+
+    def test_usage_before_finish_on_separate_chunk(self):
+        """Usage arrives on an early chunk, finish_reason on a later one.
+        The trailing usage chunk should carry the last-seen usage."""
+        early_usage = UsageInfo(prompt_tokens=4, completion_tokens=3, total_tokens=7)
+        final_usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+        items = [
+            StreamResponseObject(
+                choices=[_make_choice(content="hello")], usage=early_usage
+            ),
+            # Final usage on a mid-stream chunk, finish comes later without usage.
+            StreamResponseObject(
+                choices=[_make_choice(content=" world")], usage=final_usage
+            ),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # 3 content/finish chunks + 1 trailing usage chunk
+        self.assertEqual(len(out), 4)
+        # All content chunks have usage=None
+        for i in range(3):
+            self.assertIsNone(out[i].usage)
+        # Trailing chunk carries the last-seen usage
+        self.assertEqual(out[3].choices, [])
+        self.assertIsNotNone(out[3].usage)
+        self.assertEqual(out[3].usage.completion_tokens, 8)
+
+    def test_no_usage_at_all_no_trailing_chunk(self):
+        """If no usage is ever seen, no trailing chunk is emitted."""
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all(r.usage is None for r in out))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/openai/test/test_stream_usage_split.py
+++ b/rtp_llm/openai/test/test_stream_usage_split.py
@@ -1,0 +1,152 @@
+"""Tests for OpenAI streaming SSE chunk split (Fix A/B).
+
+Covers:
+- `OpenaiEndpoint._complete_stream_response` emits the trailing usage payload
+  in its own `choices=[]` chunk after the chunk that carried `finish_reason`,
+  matching the OpenAI Chat Completions streaming protocol with
+  `stream_options.include_usage=true`.
+- `OpenaiEndpoint._collect_complete_response` correctly aggregates the
+  resulting two-chunk tail (usage from the choices-empty chunk is captured).
+"""
+
+import asyncio
+import unittest
+from typing import AsyncGenerator, List
+
+from rtp_llm.openai.api_datatype import (
+    ChatCompletionResponseStreamChoice,
+    DeltaMessage,
+    FinisheReason,
+    RoleEnum,
+    UsageInfo,
+)
+from rtp_llm.openai.openai_endpoint import OpenaiEndpoint
+from rtp_llm.openai.renderers.custom_renderer import StreamResponseObject
+
+
+def _make_choice(
+    index: int = 0,
+    content: str = "",
+    finish_reason=None,
+) -> ChatCompletionResponseStreamChoice:
+    return ChatCompletionResponseStreamChoice(
+        index=index,
+        delta=DeltaMessage(role=RoleEnum.assistant, content=content),
+        finish_reason=finish_reason,
+    )
+
+
+async def _drain(agen: AsyncGenerator) -> List:
+    out = []
+    async for x in agen:
+        out.append(x)
+    return out
+
+
+async def _gen_from(items):
+    for it in items:
+        yield it
+
+
+class TestStreamUsageSplit(unittest.TestCase):
+    """Fix A: split final SSE chunk into choices-only + usage-only chunks."""
+
+    def test_finish_with_usage_emits_two_chunks(self):
+        usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hello")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+                usage=usage,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items), debug_info=None, tokenizer=None
+        )
+        out = asyncio.run(_drain(gen))
+
+        self.assertEqual(len(out), 3)
+        self.assertEqual(len(out[0].choices), 1)
+        self.assertIsNone(out[0].usage)
+        self.assertEqual(len(out[1].choices), 1)
+        self.assertEqual(out[1].choices[0].finish_reason, FinisheReason.stop)
+        self.assertIsNone(out[1].usage)
+        self.assertEqual(out[2].choices, [])
+        self.assertIsNotNone(out[2].usage)
+        self.assertEqual(out[2].usage.prompt_tokens, 4)
+        self.assertEqual(out[2].usage.completion_tokens, 8)
+        self.assertEqual(out[2].usage.total_tokens, 12)
+
+    def test_no_finish_no_split(self):
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="a")]),
+            StreamResponseObject(choices=[_make_choice(content="b")]),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items), debug_info=None, tokenizer=None
+        )
+        out = asyncio.run(_drain(gen))
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all(r.usage is None for r in out))
+
+    def test_usage_without_finish_does_not_split(self):
+        usage = UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        items = [
+            StreamResponseObject(
+                choices=[_make_choice(content="x")],
+                usage=usage,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items), debug_info=None, tokenizer=None
+        )
+        out = asyncio.run(_drain(gen))
+        self.assertEqual(len(out), 1)
+        self.assertIsNotNone(out[0].usage)
+
+
+class TestCollectCompleteResponseHandlesEmptyChoices(unittest.TestCase):
+    """Fix B: non-streaming aggregator must handle usage-only chunks
+    (choices=[]). Usage from such a chunk must still be captured."""
+
+    def test_aggregates_split_tail(self):
+        usage = UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)]
+            ),
+            StreamResponseObject(choices=[], usage=usage),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen_from(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertEqual(len(resp.choices), 1)
+        self.assertEqual(resp.choices[0].message.content, "hi")
+        self.assertEqual(resp.choices[0].finish_reason, FinisheReason.stop)
+        self.assertEqual(resp.usage.prompt_tokens, 3)
+        self.assertEqual(resp.usage.completion_tokens, 5)
+        self.assertEqual(resp.usage.total_tokens, 8)
+
+    def test_empty_choices_chunk_does_not_crash_when_first(self):
+        usage = UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        items = [
+            StreamResponseObject(choices=[], usage=usage),
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)]
+            ),
+        ]
+        resp = asyncio.run(
+            OpenaiEndpoint._collect_complete_response(
+                _gen_from(items), debug_info=None, tokenizer=None
+            )
+        )
+        self.assertEqual(len(resp.choices), 1)
+        self.assertEqual(resp.choices[0].message.content, "hi")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/openai/test/test_stream_usage_split.py
+++ b/rtp_llm/openai/test/test_stream_usage_split.py
@@ -252,21 +252,19 @@ class TestIncludeUsageTrueUsageOnSeparateChunk(unittest.TestCase):
         )
         out = asyncio.run(_drain(gen))
 
-        # 3 original chunks forwarded + 1 trailing usage chunk
-        self.assertEqual(len(out), 4)
+        # 2 content/finish chunks + 1 trailing usage chunk
+        # (the standalone empty-choices backend chunk is skipped)
+        self.assertEqual(len(out), 3)
         # Content chunk
         self.assertIsNone(out[0].usage)
         self.assertEqual(len(out[0].choices), 1)
         # Finish chunk (usage suppressed)
         self.assertIsNone(out[1].usage)
         self.assertEqual(out[1].choices[0].finish_reason, FinisheReason.stop)
-        # Standalone usage-only chunk forwarded with usage=None
-        self.assertIsNone(out[2].usage)
-        self.assertEqual(out[2].choices, [])
         # Trailing usage chunk emitted by fallback
-        self.assertEqual(out[3].choices, [])
-        self.assertIsNotNone(out[3].usage)
-        self.assertEqual(out[3].usage.completion_tokens, 8)
+        self.assertEqual(out[2].choices, [])
+        self.assertIsNotNone(out[2].usage)
+        self.assertEqual(out[2].usage.completion_tokens, 8)
 
     def test_usage_before_finish_on_separate_chunk(self):
         """Usage arrives on an early chunk, finish_reason on a later one.
@@ -320,6 +318,185 @@ class TestIncludeUsageTrueUsageOnSeparateChunk(unittest.TestCase):
         out = asyncio.run(_drain(gen))
         self.assertEqual(len(out), 2)
         self.assertTrue(all(r.usage is None for r in out))
+
+
+class TestIncludeUsageEmptyChoicesSkipped(unittest.TestCase):
+    """P2: Backend empty-choices usage chunks must not be forwarded as
+    redundant empty chunks when include_usage=True."""
+
+    def test_standalone_empty_choices_usage_chunk_is_skipped(self):
+        """A standalone choices=[] usage chunk from the backend should
+        NOT appear in the output stream — only the deferred trailing
+        usage chunk should carry the usage."""
+        usage = UsageInfo(prompt_tokens=5, completion_tokens=10, total_tokens=15)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hello")]),
+            # Backend sends usage on a standalone empty-choices chunk
+            StreamResponseObject(choices=[], usage=usage),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # 2 content/finish chunks + 1 trailing usage chunk (the empty-choices
+        # backend chunk is NOT forwarded)
+        self.assertEqual(len(out), 3)
+        # Content chunk
+        self.assertIsNone(out[0].usage)
+        self.assertEqual(len(out[0].choices), 1)
+        # Finish chunk
+        self.assertIsNone(out[1].usage)
+        # Trailing usage chunk
+        self.assertEqual(out[2].choices, [])
+        self.assertIsNotNone(out[2].usage)
+        self.assertEqual(out[2].usage.completion_tokens, 10)
+
+    def test_empty_choices_between_content_chunks_skipped(self):
+        """Multiple empty-choices chunks interspersed in the stream
+        should all be filtered out."""
+        usage1 = UsageInfo(prompt_tokens=5, completion_tokens=3, total_tokens=8)
+        usage2 = UsageInfo(prompt_tokens=5, completion_tokens=7, total_tokens=12)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="a")]),
+            StreamResponseObject(choices=[], usage=usage1),
+            StreamResponseObject(choices=[_make_choice(content="b")]),
+            StreamResponseObject(choices=[], usage=usage2),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+                usage=usage2,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # 3 content/finish + 1 trailing usage = 4 total (2 empty skipped)
+        self.assertEqual(len(out), 4)
+        for chunk in out[:3]:
+            self.assertIsNone(chunk.usage)
+        self.assertEqual(out[3].choices, [])
+        self.assertEqual(out[3].usage.completion_tokens, 7)
+
+
+class TestIncludeUsageMultiFinishNoDuplicate(unittest.TestCase):
+    """Round-4 guard: when finish_reason arrives on more than one chunk
+    (e.g. n>=2 with staggered finishes), the trailing usage chunk must
+    be emitted exactly once."""
+
+    def test_two_finish_chunks_emit_single_trailing_usage(self):
+        usage = UsageInfo(prompt_tokens=4, completion_tokens=9, total_tokens=13)
+        # Two consecutive chunks each carrying finish_reason; usage is
+        # already known by the first finish chunk.
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+                usage=usage,
+            ),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # Exactly one trailing usage chunk (choices=[]) should be present.
+        trailing = [c for c in out if c.choices == [] and c.usage is not None]
+        self.assertEqual(len(trailing), 1)
+        self.assertEqual(trailing[0].usage.completion_tokens, 9)
+        # All other chunks must have usage=None.
+        for c in out:
+            if c is trailing[0]:
+                continue
+            self.assertIsNone(c.usage)
+
+
+class TestIncludeUsageStaggeredMultiChoiceFinish(unittest.TestCase):
+    """Multi-choice (n>=2) regression: when choices finish on different
+    chunks, the trailing usage chunk must be emitted exactly once after
+    the entire stream is drained, with the FINAL usage value. The emit
+    must not be triggered mid-stream by a single choice's finish_reason
+    while other choices are still generating content."""
+
+    def test_staggered_finish_emits_usage_after_all_choices_done(self):
+        usage_at_first_finish = UsageInfo(
+            prompt_tokens=4, completion_tokens=5, total_tokens=9
+        )
+        usage_final = UsageInfo(
+            prompt_tokens=4, completion_tokens=12, total_tokens=16
+        )
+        items = [
+            # Both choices producing content.
+            StreamResponseObject(
+                choices=[
+                    _make_choice(index=0, content="a0"),
+                    _make_choice(index=1, content="b0"),
+                ]
+            ),
+            # Choice 0 finishes; choice 1 still generating. Backend
+            # tags this chunk with running usage covering tokens so far.
+            StreamResponseObject(
+                choices=[
+                    _make_choice(
+                        index=0, content="", finish_reason=FinisheReason.stop
+                    ),
+                    _make_choice(index=1, content="b1"),
+                ],
+                usage=usage_at_first_finish,
+            ),
+            # Choice 1 continues for more chunks while choice 0 is done.
+            StreamResponseObject(
+                choices=[_make_choice(index=1, content="b2")]
+            ),
+            # Choice 1 finishes; backend carries the final usage.
+            StreamResponseObject(
+                choices=[
+                    _make_choice(
+                        index=1, content="", finish_reason=FinisheReason.stop
+                    )
+                ],
+                usage=usage_final,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
+        )
+        out = asyncio.run(_drain(gen))
+
+        # 4 content/finish chunks + 1 trailing usage chunk.
+        self.assertEqual(len(out), 5)
+
+        # Every non-trailing chunk must have usage=None.
+        for chunk in out[:-1]:
+            self.assertIsNone(chunk.usage)
+            self.assertNotEqual(chunk.choices, [])
+
+        # The trailing chunk is the FINAL chunk on the wire, choices=[],
+        # carries the final usage (not the stale value at first finish).
+        self.assertEqual(out[-1].choices, [])
+        self.assertIsNotNone(out[-1].usage)
+        self.assertEqual(out[-1].usage.completion_tokens, 12)
+        self.assertEqual(out[-1].usage.total_tokens, 16)
+
 
 
 if __name__ == "__main__":

--- a/rtp_llm/openai/test/test_stream_usage_split.py
+++ b/rtp_llm/openai/test/test_stream_usage_split.py
@@ -1,12 +1,20 @@
-"""Tests for OpenAI streaming SSE chunk split (Fix A/B).
+"""Tests for OpenAI streaming `stream_options.include_usage` gating.
 
-Covers:
-- `OpenaiEndpoint._complete_stream_response` emits the trailing usage payload
-  in its own `choices=[]` chunk after the chunk that carried `finish_reason`,
-  matching the OpenAI Chat Completions streaming protocol with
-  `stream_options.include_usage=true`.
-- `OpenaiEndpoint._collect_complete_response` correctly aggregates the
-  resulting two-chunk tail (usage from the choices-empty chunk is captured).
+`OpenaiEndpoint._complete_stream_response` follows the OpenAI Chat
+Completions streaming protocol:
+
+  * `include_usage=True`  -> emit the trailing `usage` payload in its own
+    `choices=[]` chunk after the chunk that carried `finish_reason`.
+    Spec-compliant clients (vllm bench, OpenAI Python SDK) only inspect
+    `usage` on choices-empty chunks, so bundling drops the payload.
+  * `include_usage=False` -> suppress `usage` from the stream entirely.
+  * `include_usage=None`  -> rtp-llm legacy behavior: bundle `usage` on
+    the chunk that carried `finish_reason`. Preserved for backward
+    compatibility with internal consumers that predate the spec layout.
+
+`OpenaiEndpoint._collect_complete_response` must also tolerate the
+split layout so the non-streaming aggregator can still recover `usage`
+from a `choices=[]` chunk.
 """
 
 import asyncio
@@ -48,8 +56,8 @@ async def _gen_from(items):
         yield it
 
 
-class TestStreamUsageSplit(unittest.TestCase):
-    """Fix A: split final SSE chunk into choices-only + usage-only chunks."""
+class TestIncludeUsageTrue(unittest.TestCase):
+    """include_usage=True -> split the finish chunk and usage chunk."""
 
     def test_finish_with_usage_emits_two_chunks(self):
         usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
@@ -61,7 +69,10 @@ class TestStreamUsageSplit(unittest.TestCase):
             ),
         ]
         gen = OpenaiEndpoint._complete_stream_response(
-            _gen_from(items), debug_info=None, tokenizer=None
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
         )
         out = asyncio.run(_drain(gen))
 
@@ -83,17 +94,48 @@ class TestStreamUsageSplit(unittest.TestCase):
             StreamResponseObject(choices=[_make_choice(content="b")]),
         ]
         gen = OpenaiEndpoint._complete_stream_response(
-            _gen_from(items), debug_info=None, tokenizer=None
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=True,
         )
         out = asyncio.run(_drain(gen))
         self.assertEqual(len(out), 2)
         self.assertTrue(all(r.usage is None for r in out))
 
-    def test_usage_without_finish_does_not_split(self):
-        usage = UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+
+class TestIncludeUsageFalse(unittest.TestCase):
+    """include_usage=False -> usage suppressed from the stream entirely."""
+
+    def test_finish_chunk_has_no_usage(self):
+        usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
         items = [
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
             StreamResponseObject(
-                choices=[_make_choice(content="x")],
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
+                usage=usage,
+            ),
+        ]
+        gen = OpenaiEndpoint._complete_stream_response(
+            _gen_from(items),
+            debug_info=None,
+            tokenizer=None,
+            include_usage=False,
+        )
+        out = asyncio.run(_drain(gen))
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all(r.usage is None for r in out))
+
+
+class TestIncludeUsageDefault(unittest.TestCase):
+    """include_usage=None (default) -> legacy bundled behavior."""
+
+    def test_usage_bundled_on_finish_chunk(self):
+        usage = UsageInfo(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+        items = [
+            StreamResponseObject(choices=[_make_choice(content="hi")]),
+            StreamResponseObject(
+                choices=[_make_choice(content="", finish_reason=FinisheReason.stop)],
                 usage=usage,
             ),
         ]
@@ -101,13 +143,18 @@ class TestStreamUsageSplit(unittest.TestCase):
             _gen_from(items), debug_info=None, tokenizer=None
         )
         out = asyncio.run(_drain(gen))
-        self.assertEqual(len(out), 1)
-        self.assertIsNotNone(out[0].usage)
+        # Two chunks (no split), usage rides on the finish chunk.
+        self.assertEqual(len(out), 2)
+        self.assertIsNone(out[0].usage)
+        self.assertIsNotNone(out[1].usage)
+        self.assertEqual(out[1].choices[0].finish_reason, FinisheReason.stop)
+        self.assertEqual(out[1].usage.completion_tokens, 8)
 
 
 class TestCollectCompleteResponseHandlesEmptyChoices(unittest.TestCase):
-    """Fix B: non-streaming aggregator must handle usage-only chunks
-    (choices=[]). Usage from such a chunk must still be captured."""
+    """`_collect_complete_response` must capture `usage` from a
+    choices-empty chunk so that downstream callers see the split-layout
+    output produced when `include_usage=True`."""
 
     def test_aggregates_split_tail(self):
         usage = UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8)


### PR DESCRIPTION
## 概要

三个流式响应正确性修复，对齐 OpenAI Chat Completions 规范。
每个修复为独立 commit，附带对应的单元测试。

---

### 1. 按规范拆分最终 SSE chunk

当 `stream_options.include_usage=true` 时，最终 chunk 将 `finish_reason`
（在 `choices` 中）和 `usage` 打包在同一个响应中。规范要求 `usage` 必须在
`choices=[]` 的独立 chunk 中返回，位于包含 `finish_reason` 的 chunk 之后。
符合规范的客户端按 `if choices: ... elif usage: ...` 分支处理，会忽略
被打包在一起的 `usage`。

**修复：** 拆分为两个 chunk —— 一个携带 `finish_reason` 且 `usage=None`
的结束 chunk，一个 `choices=[]` 的 usage 专用 chunk。同步更新非流式聚合器
以正确处理 `choices=[]` chunk。

### 2. 保留流式聚合器中的空字符串 content

当补全在 `<think>` 中途截断时（`finish_reason=length`，所有 token 进入
`reasoning_content`），每个 `delta.content` 均为空字符串 `""`。聚合器通过
`content or None` 将 `""` 折叠为 `None`，导致
`model_dump(exclude_none=True)` 丢弃 `content` 字段——违反规范。

**修复：** 使用 `content if content is not None else ""` 替代
`content or None`，并在返回前增加兜底归一化处理。

### 3. 在 custom_renderer 停止逻辑中强制执行 min_new_tokens

`min_new_tokens` 已被 API 接受，但未在 renderer 的 `_check_finish_reason`
中实际生效。EOS 和 stop-words 可以在未达到请求最小值前终止生成，
违反 `min_new_tokens` 约定。

**修复：** 通过 `asyncio.Task` 作用域的 `ContextVar` 传递每请求的值。当
`len(token_ids) < min_new_tokens` 时，抑制 EOS/stop-word 终止。
基于长度的检查（`max_new_tokens`/`max_seq_len`）仍优先生效。
默认值 `0`，完全向后兼容。

## 修改文件

- `rtp_llm/openai/openai_endpoint.py`
- `rtp_llm/openai/renderers/custom_renderer.py`
- `rtp_llm/openai/test/test_stream_usage_split.py`（5 个用例）
- `rtp_llm/openai/test/test_stream_content_preservation.py`（3 个用例）
- `rtp_llm/openai/test/test_min_new_tokens.py`（8 个用例）