### PR TITLE
docs: fix typos ('comming soon', 'not suport')

### DIFF
--- a/docs/release/v0.2.0/package.md
+++ b/docs/release/v0.2.0/package.md
@@ -23,4 +23,4 @@
 | **Frontend**           | https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/package/daily/2025_11_26/rtp_llm-0.2.0-0.2.0-2025_11_26_10_16_dd9cb964d-frontend-cp310-cp310-manylinux1_x86_64.whl |
 | **AMD**           | https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/package/daily/2025_11_26/rtp_llm-0.2.0-0.2.0-2025_11_26_10_16_dd9cb964d-rocm-cp310-cp310-manylinux1_x86_64.whl |
 
-Images of Master is coming soon
+Images of Master are coming soon

--- a/docs/release/v0.2.0/package.md
+++ b/docs/release/v0.2.0/package.md
@@ -23,4 +23,4 @@
 | **Frontend**           | https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/package/daily/2025_11_26/rtp_llm-0.2.0-0.2.0-2025_11_26_10_16_dd9cb964d-frontend-cp310-cp310-manylinux1_x86_64.whl |
 | **AMD**           | https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/package/daily/2025_11_26/rtp_llm-0.2.0-0.2.0-2025_11_26_10_16_dd9cb964d-rocm-cp310-cp310-manylinux1_x86_64.whl |
 
-Images of Master is comming soon
+Images of Master is coming soon

--- a/docs/supported_models/embedding_models.md
+++ b/docs/supported_models/embedding_models.md
@@ -80,4 +80,4 @@ for endpoint in endpoints:
 |-------------------------------------------------|-----------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | **Qwen3 Embedding/Reranker**      | `Qwen/Qwen3-Embedding-8B`             | N/A           | Support all size of qwen3 embedding/reranker                   |
 |
-| **BGE (BgeEmbeddingModel)**                     | `BAAI/bge-large-en-v1.5`                        | N/A                 | only support BGE family with model_type=`Bert/Roberta/Qwen2`  including bge_m3, not suport `ModernBert` or `NewModel` . Specially, please set `model_type=qwen_2_embedding` for `Alibaba-NLP/gte-Qwen2-7B-instruct`  |
+| **BGE (BgeEmbeddingModel)**                     | `BAAI/bge-large-en-v1.5`                        | N/A                 | only support BGE family with model_type=`Bert/Roberta/Qwen2`  including bge_m3, not support `ModernBert` or `NewModel` . Specially, please set `model_type=qwen_2_embedding` for `Alibaba-NLP/gte-Qwen2-7B-instruct`  |

--- a/docs/supported_models/embedding_models.md
+++ b/docs/supported_models/embedding_models.md
@@ -80,4 +80,4 @@ for endpoint in endpoints:
 |-------------------------------------------------|-----------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | **Qwen3 Embedding/Reranker**      | `Qwen/Qwen3-Embedding-8B`             | N/A           | Support all size of qwen3 embedding/reranker                   |
 |
-| **BGE (BgeEmbeddingModel)**                     | `BAAI/bge-large-en-v1.5`                        | N/A                 | only support BGE family with model_type=`Bert/Roberta/Qwen2`  including bge_m3, not support `ModernBert` or `NewModel` . Specially, please set `model_type=qwen_2_embedding` for `Alibaba-NLP/gte-Qwen2-7B-instruct`  |
+| **BGE (BgeEmbeddingModel)**                     | `BAAI/bge-large-en-v1.5`                        | N/A                 | only support BGE family with model_type=`Bert/Roberta/Qwen2`  including bge_m3, not support `ModernBert` or `NewModel` . Specifically, please set `model_type=qwen_2_embedding` for `Alibaba-NLP/gte-Qwen2-7B-instruct`  |


### PR DESCRIPTION
## Summary
Two small documentation typo fixes:

- `docs/release/v0.2.0/package.md`: `comming soon` → `coming soon`
- `docs/supported_models/embedding_models.md`: `not suport` → `not support`

No code changes.

## Test plan
- [x] Word-level edits only; markdown rendering unaffected.