### PR TITLE
fix(stream): avoid self-deadlock in waitLoadCacheDone via reportError…

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -503,6 +503,10 @@ void GenerateStream::reportEventWithoutLock(StreamEvents::EventType event,
 
 void GenerateStream::reportError(ErrorCode error_code, const std::string& error_msg) {
     std::lock_guard<std::mutex> lock(*mutex_);
+    reportErrorWithoutLock(error_code, error_msg);
+}
+
+void GenerateStream::reportErrorWithoutLock(ErrorCode error_code, const std::string& error_msg) {
     generate_status_->reportEvent(StreamEvents::Error, error_code, error_msg);
 }
 

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -232,6 +232,7 @@ public:
                                 const std::string&      error_msg  = "");
 
     void         reportError(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
+    void         reportErrorWithoutLock(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
     bool         hasEvent(StreamEvents::EventType event) const;
     virtual bool hasError() const;
     ErrorInfo    statusInfo();

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -608,7 +608,7 @@ void StreamCacheResource::waitLoadCacheDone(const std::shared_ptr<AsyncContext>&
         RTP_LLM_LOG_WARNING(
             "load cache done but not success, stream: [%ld], error: %s", stream_->streamId(), error.ToString().c_str());
         if (error.hasError()) {
-            stream_->reportError(error.code(), error.ToString());
+            stream_->reportErrorWithoutLock(error.code(), error.ToString());
         }
         return;
     }


### PR DESCRIPTION
…WithoutLock

The scheduler thread enters GenerateStream::moveToNext() which acquires the stream's *mutex_ before dispatching to the state machine (handleLoading -> StreamCacheResource::loadCacheDone -> waitLoadCacheDone). When load_context fails, waitLoadCacheDone calls stream_->reportError() which tries to acquire the same *mutex_ a second time. std::mutex is not recursive — under glibc this hangs the thread silently, taking down the engine's scheduling loop on that rank.

Split reportError into a locked wrapper plus reportErrorWithoutLock body, and have waitLoadCacheDone call the unlocked variant since its caller already holds the lock.