### PR TITLE
perf(rocm): remove torch.unique from compact KV gather to eliminate memset stalls

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -185,6 +185,7 @@ class AiterPrefillAttnOp:
         self.is_causal = attn_configs.is_causal
         self.v1_kv_layout = v1_kv_layout
         self._block_positions: Optional[torch.Tensor] = None
+        self._compact_arange: Optional[torch.Tensor] = None
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True
@@ -259,12 +260,18 @@ class AiterPrefillAttnOp:
 
         return k_cache, v_cache
 
-    def _sanitize_block_table(self, block_table, block_num: int, seqlen_k=None, max_seqlen_k=None):
+    def _sanitize_block_table(
+        self, block_table, block_num: int, seqlen_k=None, max_seqlen_k=None
+    ):
         """Sanitize + pad block_table via shared helper."""
         if max_seqlen_k is None:
             max_seqlen_k = 0
         result, self._block_positions = _sanitize_and_pad_block_table(
-            block_table, seqlen_k, self.tokens_per_block, max_seqlen_k, self._block_positions
+            block_table,
+            seqlen_k,
+            self.tokens_per_block,
+            max_seqlen_k,
+            self._block_positions,
         )
         return result
 
@@ -274,9 +281,11 @@ class AiterPrefillAttnOp:
         For v1_kv_layout=True (non-ASM, non-FP8) path, the V cache needs a
         permute+contiguous to convert from linear [hd, ps] to vectorized
         [ps//vs, hd, vs] layout. Doing this on the full KV cache pool is
-        extremely expensive. This method gathers unique blocks referenced by
-        the current prefill batch and remaps block_table so
-        mha_batch_prefill_func indexes into the compact buffer directly.
+        extremely expensive. This method gathers all referenced blocks
+        (including duplicates) from the current prefill batch and remaps
+        block_table so mha_batch_prefill_func indexes into the compact
+        buffer directly. Dedup via torch.unique was removed to eliminate
+        stream-0 memset stalls caused by its internal workspace allocation.
 
         This also avoids the int32 offset overflow in aiter CK kernel when
         block_num * batch_stride_k > INT32_MAX (single-layer K cache > 2 GB).
@@ -293,21 +302,24 @@ class AiterPrefillAttnOp:
         hd = self.head_dim
         vs = 16 // kv_cache_base.element_size()
 
-        # Flatten block_table to get referenced block indices. Keep only unique
-        # blocks; reuse-cache pressure can otherwise duplicate long shared
-        # prefixes and padding into a very large temporary K/V buffer.
+        # Flatten block_table to get all referenced block indices.
+        # NOTE: we intentionally skip torch.unique dedup here — unique's
+        # internal workspace allocation triggers stream-0 memset stalls that
+        # block the compute stream on every prefill batch. The tradeoff is
+        # that prefix-sharing scenarios will gather duplicate blocks, inflating
+        # the compact buffer up to block_table.numel() entries (still bounded
+        # by the original KV pool size). If this becomes a memory bottleneck
+        # under heavy prefix caching, consider a sort-based dedup path
+        # (torch.sort + torch.diff) which avoids the memset issue.
         block_indices = block_table.reshape(-1).to(torch.int64)
-        unique_indices, inverse_indices = torch.unique(
-            block_indices, sorted=True, return_inverse=True
-        )
-        num_gathered = unique_indices.numel()
+        num_gathered = block_indices.numel()
 
         if kv_cache_base.ndim >= 4:
             # 5D path: [block_num, 2, hk, ps, hd]
             k_4d = kv_cache_base.select(1, 0)  # [block_num, hk, ps, hd]
             v_4d = kv_cache_base.select(1, 1)  # [block_num, hk, ps, hd]
-            k_used = k_4d.index_select(0, unique_indices)  # [n, hk, ps, hd]
-            v_used = v_4d.index_select(0, unique_indices)  # [n, hk, ps, hd]
+            k_used = k_4d.index_select(0, block_indices)  # [n, hk, ps, hd]
+            v_used = v_4d.index_select(0, block_indices)  # [n, hk, ps, hd]
             k_compact = k_used.view(num_gathered, hk, hd // vs, ps, vs)
             v_compact = (
                 v_used.reshape(num_gathered, hk, hd, ps // vs, vs)
@@ -319,8 +331,8 @@ class AiterPrefillAttnOp:
             block_num = kv_cache_base.shape[0]
             expected_elems = 2 * hk * ps * hd
             flat = kv_cache_base[:, :expected_elems].reshape(block_num, 2, hk, ps * hd)
-            k_used = flat[:, 0, :, :].index_select(0, unique_indices)
-            v_used = flat[:, 1, :, :].index_select(0, unique_indices)
+            k_used = flat[:, 0, :, :].index_select(0, block_indices)
+            v_used = flat[:, 1, :, :].index_select(0, block_indices)
             k_compact = k_used.view(num_gathered, hk, hd // vs, ps, vs).contiguous()
             v_compact = (
                 v_used.view(num_gathered, hk, hd, ps // vs, vs)
@@ -328,7 +340,19 @@ class AiterPrefillAttnOp:
                 .contiguous()
             )
 
-        compact_block_table = inverse_indices.to(torch.int32).view_as(block_table)
+        # Build identity block_table: [0, 1, 2, ...] so aiter indexes into
+        # the compact buffer instead of the original full pool.
+        cached_arange = self._compact_arange
+        if (
+            cached_arange is None
+            or cached_arange.numel() < num_gathered
+            or cached_arange.device != block_table.device
+        ):
+            cached_arange = torch.arange(
+                max(num_gathered, 1024), dtype=torch.int32, device=block_table.device
+            )
+            self._compact_arange = cached_arange
+        compact_block_table = cached_arange[:num_gathered].view_as(block_table)
 
         # Append one dummy zero-block to k/v compact buffers. CK kernel may
         # speculatively read beyond the last valid block_table entry; having a
@@ -416,7 +440,10 @@ class AiterPrefillAttnOp:
         if q_tensor.dim() == 2:
             q_tensor = q_tensor.view(q_tensor.size(0), self.head_num, self.head_dim)
 
-        is_fp8 = kv_cache.kv_cache_base.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+        is_fp8 = kv_cache.kv_cache_base.dtype in (
+            torch.float8_e4m3fnuz,
+            torch.float8_e4m3fn,
+        )
         # cu_seqlens are already created on GPU in FMHAParams.__init__
         cu_seqlens_q = fmha_params.cu_seqlens_q
         # Ensure cu_seqlens_q is on the same device as q_tensor
@@ -598,7 +625,9 @@ def _sanitize_and_pad_block_table(
     # Use kN0=128 (conservative upper bound for all head_dim configs).
     _CK_KN0 = 128
     extra_pages = (_CK_KN0 + tokens_per_block - 1) // tokens_per_block
-    required_cols = (max_seqlen_k + tokens_per_block - 1) // tokens_per_block + extra_pages
+    required_cols = (
+        max_seqlen_k + tokens_per_block - 1
+    ) // tokens_per_block + extra_pages
     if block_table.shape[1] < required_cols:
         pad_cols = required_cols - block_table.shape[1]
         last_col = block_table[:, -1:].expand(-1, pad_cols)
@@ -764,7 +793,11 @@ class AiterPrefillAttnOpPaged:
 
         # Apply sanitize + pad to prevent CK speculative prefetch OOB.
         sanitized_bt, self._block_positions = _sanitize_and_pad_block_table(
-            block_table, seqlen_k, self.tokens_per_block, max_seqlen_k, self._block_positions
+            block_table,
+            seqlen_k,
+            self.tokens_per_block,
+            max_seqlen_k,
+            self._block_positions,
         )
         if graph_ready:
             # CUDA graph replay requires stable tensor addresses. Copy the

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -621,9 +621,9 @@ class TestCompactGatherReshape(unittest.TestCase):
         orig_indices = block_table.reshape(-1).to(torch.int64)
         torch.testing.assert_close(k_compact[flat_bt], k_full[orig_indices])
         torch.testing.assert_close(v_compact[flat_bt], v_full[orig_indices])
-        # Compact buffer has unique blocks + 1 trailing dummy zero-block for
-        # CK speculative prefetch safety.
-        self.assertEqual(k_compact.shape[0], torch.unique(orig_indices).numel() + 1)
+        # Compact buffer has all referenced blocks + 1 trailing dummy zero-block
+        # for CK speculative prefetch safety (no dedup since torch.unique removed).
+        self.assertEqual(k_compact.shape[0], orig_indices.numel() + 1)
 
     # ---- 5D cache path ----------------------------------------------------
 
@@ -651,8 +651,8 @@ class TestCompactGatherReshape(unittest.TestCase):
         torch.testing.assert_close(
             k_compact[compact_bt.reshape(-1).to(torch.int64)], k_full[orig_indices]
         )
-        # 3 unique blocks + 1 trailing dummy zero-block
-        self.assertEqual(k_compact.shape[0], 4)
+        # All referenced blocks (no dedup) + 1 trailing dummy zero-block
+        self.assertEqual(k_compact.shape[0], bt.numel() + 1)
 
     def test_5d_non_contiguous_blocks(self):
         """Block indices are sparse across a large pool."""
@@ -685,8 +685,8 @@ class TestCompactGatherReshape(unittest.TestCase):
         torch.testing.assert_close(
             k_compact[compact_bt.reshape(-1).to(torch.int64)], k_full[orig_indices]
         )
-        # 3 unique blocks + 1 trailing dummy zero-block
-        self.assertEqual(k_compact.shape[0], 4)
+        # All referenced blocks (no dedup) + 1 trailing dummy zero-block
+        self.assertEqual(k_compact.shape[0], bt.numel() + 1)
 
     # ---- FP8 fallback: compact should NOT be used -------------------------
 
@@ -714,7 +714,9 @@ class TestCompactGatherReshape(unittest.TestCase):
         seqlen_k = torch.tensor([16, 33], dtype=torch.int32)
         # Row 0: valid_blocks=ceil(16/16)=1 → only col0 is valid, rest filled with bt[0,0]=3
         # Row 1: valid_blocks=ceil(33/16)=3 → cols 0-2 valid, col3 filled with bt[1,2]=9
-        sanitized = op._sanitize_block_table(bt, block_num=8, seqlen_k=seqlen_k, max_seqlen_k=33)
+        sanitized = op._sanitize_block_table(
+            bt, block_num=8, seqlen_k=seqlen_k, max_seqlen_k=33
+        )
         # Check the first 4 columns (original width) for sanitize correctness.
         first_4 = sanitized[:, :4].tolist()
         self.assertEqual(first_4, [[3, 3, 3, 3], [7, 8, 9, 9]])
@@ -722,8 +724,10 @@ class TestCompactGatherReshape(unittest.TestCase):
         if sanitized.shape[1] > 4:
             for row_idx, expected_fill in enumerate([3, 9]):
                 pad_vals = sanitized[row_idx, 4:].tolist()
-                self.assertTrue(all(v == expected_fill for v in pad_vals),
-                                f"Row {row_idx} pad columns should all be {expected_fill}, got {pad_vals}")
+                self.assertTrue(
+                    all(v == expected_fill for v in pad_vals),
+                    f"Row {row_idx} pad columns should all be {expected_fill}, got {pad_vals}",
+                )
 
     # ---- different head_dim / tokens_per_block configs --------------------
 
@@ -800,8 +804,12 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
 
             # Build prefix-causal attention mask: Q[i] attends to K[j] where j <= p_len + i
             # i.e. for each Q position i, the valid KV range is [0, p_len + i].
-            q_positions = torch.arange(q_len, device=q.device).unsqueeze(1) + p_len  # [q_len, 1]
-            k_positions = torch.arange(kv_len, device=q.device).unsqueeze(0)  # [1, kv_len]
+            q_positions = (
+                torch.arange(q_len, device=q.device).unsqueeze(1) + p_len
+            )  # [q_len, 1]
+            k_positions = torch.arange(kv_len, device=q.device).unsqueeze(
+                0
+            )  # [1, kv_len]
             # mask[i, j] = True means BLOCKED (will be set to -inf)
             causal_mask = k_positions > q_positions  # [q_len, kv_len]
 
@@ -851,8 +859,13 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
         # Allocate paged KV cache pool with random data
         num_pool_blocks = batch_size * blocks_per_seq + 8
         kv_cache_base = torch.randn(
-            num_pool_blocks, 2, head_num_kv, tokens_per_block, head_dim,
-            dtype=dtype, device=device,
+            num_pool_blocks,
+            2,
+            head_num_kv,
+            tokens_per_block,
+            head_dim,
+            dtype=dtype,
+            device=device,
         )
 
         # Build block_table with extra padding columns (-1) to exercise sanitize.
@@ -862,7 +875,9 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
         )
         block_offset = 0
         for b in range(batch_size):
-            num_valid_blocks = (kv_lengths[b] + tokens_per_block - 1) // tokens_per_block
+            num_valid_blocks = (
+                kv_lengths[b] + tokens_per_block - 1
+            ) // tokens_per_block
             for col in range(num_valid_blocks):
                 block_table[b, col] = block_offset + col
             block_offset += num_valid_blocks
@@ -898,7 +913,9 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
                 k_logical = k_vec.permute(0, 2, 1, 3).reshape(
                     head_num_kv, tokens_per_block, head_dim
                 )
-                k_tokens.append(k_logical[:, :num_toks, :].permute(1, 0, 2))  # [num_toks, hk, hd]
+                k_tokens.append(
+                    k_logical[:, :num_toks, :].permute(1, 0, 2)
+                )  # [num_toks, hk, hd]
 
                 # V: v_vec[h, a, b, c] = V[h, token=a*x+c, dim=b]
                 # Read logical V[h, t, d] = v_vec[h, t//x, d, t%x]
@@ -908,13 +925,17 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
                 v_logical = v_vec.permute(0, 1, 3, 2).reshape(
                     head_num_kv, tokens_per_block, head_dim
                 )
-                v_tokens.append(v_logical[:, :num_toks, :].permute(1, 0, 2))  # [num_toks, hk, hd]
+                v_tokens.append(
+                    v_logical[:, :num_toks, :].permute(1, 0, 2)
+                )  # [num_toks, hk, hd]
 
             all_k_flat.append(torch.cat(k_tokens, dim=0))
             all_v_flat.append(torch.cat(v_tokens, dim=0))
 
         # Generate Q tokens (only input_lengths, not prefix)
-        q_flat = torch.randn(total_q_tokens, head_num, head_dim, dtype=dtype, device=device)
+        q_flat = torch.randn(
+            total_q_tokens, head_num, head_dim, dtype=dtype, device=device
+        )
 
         # Build operator
         cfg = _make_attn_configs(head_num, head_num_kv, head_dim, tokens_per_block)
@@ -954,9 +975,14 @@ class TestPagedPrefillKernelE2E(unittest.TestCase):
         k_all = torch.cat(all_k_flat, dim=0)
         v_all = torch.cat(all_v_flat, dim=0)
         ref = self._prefix_causal_sdpa_reference(
-            q_flat, k_all, v_all,
-            input_lengths, prefix_lengths,
-            head_num, head_num_kv, head_dim,
+            q_flat,
+            k_all,
+            v_all,
+            input_lengths,
+            prefix_lengths,
+            head_num,
+            head_num_kv,
+            head_dim,
         )
 
         # Numerical regression: kernel output must match reference within fp16 tolerance.


### PR DESCRIPTION
torch.unique in the compact KV gather path triggers implicit stream-0 memset stalls due to internal workspace allocation, blocking the compute stream on every prefill   
  batch.
                                                                                                                                                                           
  Fix:                                                                                                                                                                     
   
  - Remove torch.unique + inverse_indices: gather KV blocks directly via flattened block_indices with index_select, trading dedup for stall-free execution                 
  - Replace inverse_indices-based compact block table with a cached torch.arange identity mapping, avoiding per-call small-tensor allocations on the hot path
  - Pre-allocate arange buffer with min size 1024 and cache on self._compact_arange, only re-allocate when batch requires more entries or device changes 