### PR TITLE
feat(omni): add omni multi-stage pipeline framework (Phase 1) + Qwen2.5-Omni stage models (Phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-omni-phase2-qwen25-models.md
+++ b/docs/superpowers/plans/2026-06-04-omni-phase2-qwen25-models.md
@@ -1,0 +1,1312 @@
+# Qwen2.5-Omni Phase 2: Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three Qwen2.5-Omni stage models (Thinker, Talker, Token2Wav) so that OmniEngine can instantiate each as a separate BaseModel, load weights from the unified HuggingFace checkpoint, and register the `qwen2_5_omni` pipeline topology.
+
+**Architecture:** Each stage is a registered rtp-llm model (`register_model`) with its own Weight class extending `QWenV2Weight` (or `ModelDeployWeightInfo` for Token2Wav). The Weight classes use checkpoint prefixes (`thinker.model.`, `talker.model.`, `token2wav.`) to load from the single unified `.safetensors` checkpoint. `OmniEngine.from_pipeline_config` is enhanced to instantiate each stage's `BaseModel` via `ModelFactory.get_model_cls(stage.model_cls)`, call `from_config`, and wrap in a `Pipeline`. The pipeline topology is registered via `OmniPipelineRegistry.register()` at module import time.
+
+**Tech Stack:** Python 3.10+, PyTorch, existing rtp-llm C++ engine, transformers (for Whisper feature extraction), unittest
+
+## Context
+
+Phase 1 (commits `c19250deb`, `d07b98809`) built the core framework: `OmniPipelineConfig`, `OmniOrchestrator`, `OmniStagePool`, `SharedMemoryConnector`, `OmniOutputProcessor`, `OmniEngine`, pipeline registry, and `ModelFactory` integration. All framework classes exist but are shells — `OmniEngine` creates stage pools without actual `Pipeline` instances, and no real model is registered.
+
+Phase 2 fills in the model layer: actual model classes that the framework instantiates. The HF checkpoint (`Qwen/Qwen2.5-Omni-7B`) stores all component weights in flat sharded safetensors with prefixes: `thinker.model.*`, `thinker.audio_tower.*`, `thinker.lm_head.*`, `talker.model.*`, `talker.codec_head.*`, `talker.thinker_to_talker_proj.*`, `token2wav.dit.*`, `token2wav.bigvgan.*`.
+
+---
+
+## File Structure
+
+```
+rtp_llm/omni/models/                          # NEW package
+├── __init__.py                                # Package init
+├── qwen2_5_omni/
+│   ├── __init__.py                            # Imports + PIPELINE registration
+│   ├── pipeline_config.py                     # QWEN2_5_OMNI_PIPELINE topology definition
+│   ├── thinker.py                             # Qwen2_5OmniThinker model + weight class
+│   ├── thinker_audio.py                       # Audio tower (Whisper encoder) for thinker
+│   ├── thinker_vision.py                      # Vision encoder for thinker (NaViT)
+│   ├── thinker_processor.py                   # Multimodal preprocessor (audio+vision)
+│   ├── talker.py                              # Qwen2_5OmniTalker model + weight class
+│   ├── token2wav.py                           # Qwen2_5OmniToken2Wav model (DiT + BigVGAN)
+│   ├── token2wav_dit.py                       # DiT flow-matching model
+│   ├── token2wav_bigvgan.py                   # BigVGAN vocoder
+│   └── stage_processors.py                    # thinker2talker, talker2code2wav transforms
+rtp_llm/omni/engine/omni_engine.py             # MODIFY — add real stage model instantiation
+rtp_llm/omni/__init__.py                       # MODIFY — import models subpackage
+rtp_llm/test/omni/                             # Tests
+├── test_thinker.py                            # Thinker weight/config tests
+├── test_talker.py                             # Talker weight/config tests
+├── test_token2wav.py                          # Token2Wav model tests
+├── test_stage_processors.py                   # Stage processor tests
+├── test_pipeline_config_qwen25.py             # Pipeline topology tests
+└── test_omni_engine_integration.py            # OmniEngine real integration test
+```
+
+---
+
+### Task 1: Pipeline Topology Registration (`pipeline_config.py`)
+
+**Files:**
+- Create: `rtp_llm/omni/models/__init__.py`
+- Create: `rtp_llm/omni/models/qwen2_5_omni/__init__.py`
+- Create: `rtp_llm/omni/models/qwen2_5_omni/pipeline_config.py`
+- Create: `rtp_llm/test/omni/test_pipeline_config_qwen25.py`
+
+This task defines the `QWEN2_5_OMNI_PIPELINE` topology constant and registers it with `OmniPipelineRegistry`. It's the glue that tells the framework "model_type=qwen2_5_omni has 3 stages".
+
+- [ ] **Step 1: Write the failing test for pipeline config**
+
+```python
+# rtp_llm/test/omni/test_pipeline_config_qwen25.py
+import unittest
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.config.stage_config import StageExecutionType
+
+
+class TestQwen25OmniPipelineConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Import triggers registration
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+
+    def test_pipeline_registered(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+        self.assertEqual(config.model_type, "qwen2_5_omni")
+        self.assertEqual(config.model_arch, "Qwen2_5OmniModel")
+
+    def test_pipeline_has_three_stages(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertEqual(len(config.stages), 3)
+
+    def test_thinker_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        thinker = config.get_stage(0)
+        self.assertEqual(thinker.model_stage, "thinker")
+        self.assertEqual(thinker.execution_type, StageExecutionType.LLM_AR)
+        self.assertEqual(thinker.model_cls, "qwen2_5_omni_thinker")
+        self.assertTrue(thinker.final_output)
+        self.assertEqual(thinker.final_output_type, "text")
+        self.assertTrue(thinker.requires_multimodal_data)
+
+    def test_talker_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        talker = config.get_stage(1)
+        self.assertEqual(talker.model_stage, "talker")
+        self.assertEqual(talker.execution_type, StageExecutionType.LLM_AR)
+        self.assertEqual(talker.model_cls, "qwen2_5_omni_talker")
+        self.assertEqual(talker.input_sources, (0,))
+
+    def test_code2wav_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        c2w = config.get_stage(2)
+        self.assertEqual(c2w.model_stage, "code2wav")
+        self.assertEqual(c2w.execution_type, StageExecutionType.LLM_GENERATION)
+        self.assertEqual(c2w.model_cls, "qwen2_5_omni_token2wav")
+        self.assertTrue(c2w.final_output)
+        self.assertEqual(c2w.final_output_type, "audio")
+
+    def test_final_output_stages(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        finals = config.get_final_output_stages()
+        types = {s.final_output_type for s in finals}
+        self.assertEqual(types, {"text", "audio"})
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/test_pipeline_config_qwen25.py -v 2>&1 | head -30`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create package scaffolding and implement pipeline config**
+
+```python
+# rtp_llm/omni/models/__init__.py
+```
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/pipeline_config.py
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+
+QWEN2_5_OMNI_PIPELINE = OmniPipelineConfig(
+    model_type="qwen2_5_omni",
+    model_arch="Qwen2_5OmniModel",
+    stages=(
+        OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="qwen2_5_omni_thinker",
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+        ),
+        OmniStageConfig(
+            stage_id=1,
+            model_stage="talker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="qwen2_5_omni_talker",
+            input_sources=(0,),
+            engine_output_type="latent",
+            stage_processor="qwen2_5_omni.thinker2talker",
+        ),
+        OmniStageConfig(
+            stage_id=2,
+            model_stage="code2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            model_cls="qwen2_5_omni_token2wav",
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="audio",
+            stage_processor="qwen2_5_omni.talker2code2wav",
+        ),
+    ),
+)
+```
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/__init__.py
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.models.qwen2_5_omni.pipeline_config import QWEN2_5_OMNI_PIPELINE
+
+OmniPipelineRegistry.register(QWEN2_5_OMNI_PIPELINE)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/test_pipeline_config_qwen25.py -v 2>&1 | head -30`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rtp_llm/omni/models/__init__.py rtp_llm/omni/models/qwen2_5_omni/__init__.py rtp_llm/omni/models/qwen2_5_omni/pipeline_config.py rtp_llm/test/omni/test_pipeline_config_qwen25.py
+git commit -m "feat(omni): add Qwen2.5-Omni pipeline topology registration
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Thinker Model — Weight Class and Model Registration
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/thinker.py`
+- Create: `rtp_llm/test/omni/test_thinker.py`
+
+The thinker's text decoder is architecturally identical to Qwen2.5 (28 layers, GQA, SiLU). Its weights live at `thinker.model.*` and `thinker.lm_head.*` in the checkpoint. We subclass `QWenV2Weight` with `prefix="thinker."` and `QWenV2` with config overrides from `thinker_config.text_config`.
+
+- [ ] **Step 1: Write the failing test for thinker weight and model**
+
+```python
+# rtp_llm/test/omni/test_thinker.py
+import unittest
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+from rtp_llm.model_factory_register import _model_factory
+
+
+class TestQwen25OmniThinkerRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_thinker", _model_factory)
+
+    def test_model_class_name(self):
+        model_cls = _model_factory["qwen2_5_omni_thinker"]
+        self.assertEqual(model_cls.__name__, "Qwen25OmniThinker")
+
+
+class TestQwen25OmniThinkerWeight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker import Qwen25OmniThinkerWeight
+        cls.weight_cls = Qwen25OmniThinkerWeight
+
+    def test_prefix_is_thinker(self):
+        w = self.weight_cls(num_layers=28, hidden_size=3584, head_num=28, head_num_kv=4, size_per_head=128, inter_size=18944)
+        self.assertEqual(w.prefix, "thinker.")
+
+    def test_transformer_prefix(self):
+        w = self.weight_cls(num_layers=28, hidden_size=3584, head_num=28, head_num_kv=4, size_per_head=128, inter_size=18944)
+        w._process_meta([{}], [])
+        self.assertEqual(w.transformer_prefix, "thinker.model.")
+
+
+class TestQwen25OmniThinkerConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker import Qwen25OmniThinker
+
+        # Create a mock config.json matching Qwen2.5-Omni-7B structure
+        config_json = {
+            "architectures": ["Qwen2_5OmniModel"],
+            "model_type": "qwen2_5_omni",
+            "thinker_config": {
+                "text_config": {
+                    "hidden_size": 3584,
+                    "intermediate_size": 18944,
+                    "num_attention_heads": 28,
+                    "num_key_value_heads": 4,
+                    "num_hidden_layers": 28,
+                    "vocab_size": 152064,
+                    "rms_norm_eps": 1e-06,
+                    "rope_theta": 1000000.0,
+                    "tie_word_embeddings": False,
+                    "torch_dtype": "bfloat16",
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+
+            config = Qwen25OmniThinker._create_config(tmpdir)
+            self.assertEqual(config.hidden_size, 3584)
+            self.assertEqual(config.num_layers, 28)
+            self.assertEqual(config.attn_config.head_num, 28)
+            self.assertEqual(config.attn_config.kv_head_num, 4)
+            self.assertEqual(config.inter_size, 18944)
+            self.assertEqual(config.vocab_size, 152064)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/test_thinker.py -v 2>&1 | head -30`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement Thinker model and weight class**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/thinker.py
+import json
+import os
+from typing import Any, Dict, List
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
+from rtp_llm.utils.util import get_config_from_path
+
+
+class Qwen25OmniThinkerWeight(QWenV2Weight):
+    def __init__(self, **kwargs: Any):
+        super().__init__(prefix="thinker.", **kwargs)
+
+
+class Qwen25OmniThinker(QWenV2):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = ModelConfig()
+        config.ckpt_path = ckpt_path
+        config.max_seq_len = 32768
+        config.attn_config.rope_config.dim = 128
+        config.attn_config.rope_config.style = 1
+        config.has_pre_decoder_layernorm = False
+        config.special_tokens.bos_token_id = 151644
+        config.special_tokens.eos_token_id = 151645
+
+        config_json = get_config_from_path(ckpt_path)
+        if config_json and "thinker_config" in config_json:
+            text_config = config_json["thinker_config"].get("text_config", {})
+            QWenV2._from_config_json(config, text_config)
+        else:
+            cls._from_hf(config, ckpt_path)
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen25OmniThinkerWeight
+
+
+register_model("qwen2_5_omni_thinker", Qwen25OmniThinker)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/test_thinker.py -v 2>&1 | head -40`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rtp_llm/omni/models/qwen2_5_omni/thinker.py rtp_llm/test/omni/test_thinker.py
+git commit -m "feat(omni): add Qwen2.5-Omni thinker stage model and weight class
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Thinker Multimodal — Audio Tower (Whisper Encoder)
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/thinker_audio.py`
+- Modify: `rtp_llm/omni/models/qwen2_5_omni/thinker.py` (add multimodal mixin)
+
+The thinker has a Whisper-style audio encoder at `thinker.audio_tower.*` (32 layers, d_model=1280, 20 heads, 128 mel bins). This is similar to the existing `rtp_llm/models/qwen_v2_audio/` but with different weight prefixes and config structure.
+
+The existing `Qwen2AudioEncoder` in `rtp_llm/models/qwen_v2_audio/modeling_qwen2_audio.py` can be reused — it's the same Whisper architecture. We just need a new `Processor` that reads from the omni config structure (`thinker_config.audio_config`) instead of `audio_config`.
+
+- [ ] **Step 1: Write the failing test for thinker audio processor**
+
+```python
+# Add to rtp_llm/test/omni/test_thinker.py
+
+class TestQwen25OmniThinkerAudioProcessor(unittest.TestCase):
+    def test_processor_class_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker_audio import OmniAudioProcessor
+        self.assertTrue(callable(OmniAudioProcessor))
+
+    def test_processor_reads_omni_audio_config(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker_audio import OmniAudioProcessor
+        # Verify it accepts audio_config dict format from thinker_config
+        audio_config = {
+            "d_model": 1280,
+            "encoder_attention_heads": 20,
+            "encoder_ffn_dim": 5120,
+            "encoder_layers": 32,
+            "num_mel_bins": 128,
+            "output_dim": 3584,
+            "max_source_positions": 1500,
+            "n_window": 100,
+        }
+        # Should not raise
+        OmniAudioProcessor.validate_config(audio_config)
+```
+
+- [ ] **Step 2: Implement OmniAudioProcessor**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/thinker_audio.py
+import torch
+from typing import Dict
+
+from rtp_llm.models.qwen_v2_audio.modeling_qwen2_audio import Qwen2AudioEncoder
+from rtp_llm.models.qwen_v2_audio.configuration_qwen2_audio import Qwen2AudioEncoderConfig
+
+
+class OmniAudioProcessor:
+    """Audio encoder for Qwen2.5-Omni thinker stage.
+
+    Wraps the same Whisper-based encoder used by qwen_v2_audio, but
+    reads config from thinker_config.audio_config format.
+    """
+
+    def __init__(self, audio_config_dict: Dict):
+        encoder_config = Qwen2AudioEncoderConfig.from_dict(audio_config_dict)
+        self.audio_tower = Qwen2AudioEncoder._from_config(encoder_config)
+
+    @staticmethod
+    def validate_config(audio_config: Dict) -> None:
+        required = ["d_model", "encoder_attention_heads", "encoder_layers", "num_mel_bins"]
+        for key in required:
+            if key not in audio_config:
+                raise ValueError(f"Missing required audio config key: {key}")
+
+    @property
+    def device(self):
+        return next(self.audio_tower.parameters()).device
+
+    @torch.inference_mode()
+    def encode(self, input_features: torch.Tensor, attention_mask: torch.Tensor = None) -> torch.Tensor:
+        return self.audio_tower(input_features, attention_mask=attention_mask)
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 4: Thinker Multimodal — Vision Encoder (NaViT)
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/thinker_vision.py`
+
+The vision encoder uses the same architecture as Qwen2.5-VL (`rtp_llm/models/qwen2_5_vl/`). Weights are at `thinker.visual.*`. Reuse `rtp_llm/models/qwen2_5_vl/modeling_qwen2_5_vl.py` for the ViT model.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_thinker.py — append
+
+class TestQwen25OmniVisionEncoder(unittest.TestCase):
+    def test_vision_processor_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker_vision import OmniVisionProcessor
+        self.assertTrue(callable(OmniVisionProcessor))
+
+    def test_vision_config_from_omni(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker_vision import OmniVisionProcessor
+        vision_config = {
+            "depth": 32,
+            "embed_dim": 1280,
+            "hidden_size": 1280,
+            "num_heads": 16,
+            "patch_size": 14,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 3584,
+        }
+        OmniVisionProcessor.validate_config(vision_config)
+```
+
+- [ ] **Step 2: Implement OmniVisionProcessor**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/thinker_vision.py
+import torch
+from typing import Dict
+
+
+class OmniVisionProcessor:
+    """Vision encoder for Qwen2.5-Omni thinker stage.
+
+    Reuses Qwen2.5-VL's ViT with NaViT patches.
+    """
+
+    def __init__(self, vision_config_dict: Dict):
+        self.config = vision_config_dict
+        # Lazy init — actual ViT model loaded during weight loading
+
+    @staticmethod
+    def validate_config(vision_config: Dict) -> None:
+        required = ["depth", "embed_dim", "num_heads", "patch_size"]
+        for key in required:
+            if key not in vision_config:
+                raise ValueError(f"Missing required vision config key: {key}")
+
+    @torch.inference_mode()
+    def encode(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor = None) -> torch.Tensor:
+        return self.vit(pixel_values, grid_thw=grid_thw)
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+### Task 5: Thinker Multimodal Processor Integration
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/thinker_processor.py`
+- Modify: `rtp_llm/omni/models/qwen2_5_omni/thinker.py` — add MultiModalMixin
+
+Integrates audio + vision processors into the thinker model using the existing `MultiModalMixin` pattern (same as `QWenV2Audio`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_thinker.py — append
+
+class TestQwen25OmniThinkerMultimodal(unittest.TestCase):
+    def test_thinker_has_multimodal_mixin(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker import Qwen25OmniThinker
+        from rtp_llm.models.multimodal.multimodal_mixin import MultiModalMixin
+        self.assertTrue(issubclass(Qwen25OmniThinker, MultiModalMixin))
+```
+
+- [ ] **Step 2: Implement thinker processor and modify thinker model**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/thinker_processor.py
+from io import BytesIO
+from typing import Dict
+
+import torch
+from rtp_llm.config.model_config import VitParameters
+from rtp_llm.models.multimodal.multimodal_common import AudioEmbeddingInterface
+from rtp_llm.omni.models.qwen2_5_omni.thinker_audio import OmniAudioProcessor
+from rtp_llm.utils.util import get_config_from_path
+
+
+class OmniThinkerProcessor(AudioEmbeddingInterface):
+    def __init__(self, mm_related_params: VitParameters, ckpt_path: str):
+        self.mm_related_params = mm_related_params
+        config_json = get_config_from_path(ckpt_path)
+        thinker_cfg = config_json.get("thinker_config", {})
+
+        audio_config = thinker_cfg.get("audio_config", {})
+        if audio_config:
+            self.audio_processor = OmniAudioProcessor(audio_config)
+        else:
+            self.audio_processor = None
+
+    @property
+    def _device(self):
+        if self.audio_processor:
+            return self.audio_processor.device
+        return torch.device("cpu")
+
+    @torch.inference_mode()
+    def audio_embedding(self, features_dict: Dict[str, torch.Tensor]) -> torch.Tensor:
+        input_features = features_dict["input_features"].to(self._device)
+        return self.audio_processor.encode(input_features)
+```
+
+Then modify `thinker.py` to add `MultiModalMixin` inheritance (same pattern as `QWenV2Audio`):
+
+```python
+# Modify Qwen25OmniThinker to extend both QWenV2 and MultiModalMixin
+class Qwen25OmniThinker(QWenV2, MultiModalMixin):
+    def _init_multimodal(self, mm_model_config, vit_config):
+        self.mm_part = OmniThinkerProcessor(
+            self.model_config.mm_related_params,
+            self.model_config.ckpt_path,
+        )
+        # ... set vit_weights for weight loading
+```
+
+Weight class also needs `BaseMultiModalWeightInfo` mixin:
+
+```python
+class Qwen25OmniThinkerWeight(QWenV2Weight, BaseMultiModalWeightInfo):
+    def __init__(self, vit_weights=None, **kwargs):
+        QWenV2Weight.__init__(self, prefix="thinker.", **kwargs)
+        BaseMultiModalWeightInfo.__init__(self, vit_weights=vit_weights, **kwargs)
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+### Task 6: Talker Model — Weight Class and Model Registration
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/talker.py`
+- Create: `rtp_llm/test/omni/test_talker.py`
+
+The talker is a smaller Qwen2 model (24 layers, hidden=896, 12 heads, 4 KV heads, vocab=8448). Weights at `talker.model.*`, `talker.codec_head.*`, `talker.thinker_to_talker_proj.*`.
+
+Key differences from standard QWenV2:
+- `prefix = "talker."` for all weights
+- `codec_head` instead of `lm_head` for the output projection
+- `thinker_to_talker_proj` as an additional weight (cross-model projection)
+- Different vocab size (8448 for codec tokens)
+- `embedding_size=3584` (thinker hidden dim) for the cross-attention projection
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_talker.py
+import unittest
+import json
+import os
+import tempfile
+
+from rtp_llm.model_factory_register import _model_factory
+
+
+class TestQwen25OmniTalkerRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_talker", _model_factory)
+
+
+class TestQwen25OmniTalkerWeight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from rtp_llm.omni.models.qwen2_5_omni.talker import Qwen25OmniTalkerWeight
+        cls.weight_cls = Qwen25OmniTalkerWeight
+
+    def test_prefix_is_talker(self):
+        w = self.weight_cls(num_layers=24, hidden_size=896, head_num=12, head_num_kv=4, size_per_head=128, inter_size=18944)
+        self.assertEqual(w.prefix, "talker.")
+
+    def test_transformer_prefix(self):
+        w = self.weight_cls(num_layers=24, hidden_size=896, head_num=12, head_num_kv=4, size_per_head=128, inter_size=18944)
+        w._process_meta([{}], [])
+        self.assertEqual(w.transformer_prefix, "talker.model.")
+
+
+class TestQwen25OmniTalkerConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.talker import Qwen25OmniTalker
+
+        config_json = {
+            "architectures": ["Qwen2_5OmniModel"],
+            "model_type": "qwen2_5_omni",
+            "talker_config": {
+                "hidden_size": 896,
+                "intermediate_size": 18944,
+                "num_attention_heads": 12,
+                "num_key_value_heads": 4,
+                "num_hidden_layers": 24,
+                "vocab_size": 8448,
+                "rms_norm_eps": 1e-06,
+                "rope_theta": 1000000.0,
+                "embedding_size": 3584,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+
+            config = Qwen25OmniTalker._create_config(tmpdir)
+            self.assertEqual(config.hidden_size, 896)
+            self.assertEqual(config.num_layers, 24)
+            self.assertEqual(config.attn_config.head_num, 12)
+            self.assertEqual(config.attn_config.kv_head_num, 4)
+            self.assertEqual(config.vocab_size, 8448)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/test_talker.py -v 2>&1 | head -30`
+Expected: FAIL
+
+- [ ] **Step 3: Implement Talker model and weight class**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/talker.py
+import functools
+from typing import Any, List
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.model_loader.weight_module import AtomicWeight
+from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
+from rtp_llm.utils.util import get_config_from_path
+
+
+class Qwen25OmniTalkerWeight(QWenV2Weight):
+    def __init__(self, **kwargs: Any):
+        super().__init__(prefix="talker.", **kwargs)
+
+    def _get_hf_weight_info(self):
+        weight_info = super()._get_hf_weight_info()
+        # Override lm_head to use codec_head
+        for i, w in enumerate(weight_info.weights):
+            if w.name == W.lm_head:
+                weight_info.weights[i] = AtomicWeight(
+                    W.lm_head,
+                    [CkptWeightInfo("talker.codec_head.weight", identity)],
+                    identity,
+                )
+                break
+        # Add thinker_to_talker_proj as misc weight
+        weight_info.weights.append(
+            AtomicWeight(
+                "thinker_to_talker_proj_weight",
+                [CkptWeightInfo("talker.thinker_to_talker_proj.weight", identity)],
+                identity,
+            )
+        )
+        weight_info.weights.append(
+            AtomicWeight(
+                "thinker_to_talker_proj_bias",
+                [CkptWeightInfo("talker.thinker_to_talker_proj.bias", identity)],
+                identity,
+            )
+        )
+        return weight_info
+
+
+class Qwen25OmniTalker(QWenV2):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = ModelConfig()
+        config.ckpt_path = ckpt_path
+        config.max_seq_len = 32768
+        config.attn_config.rope_config.dim = 128
+        config.attn_config.rope_config.style = 1
+        config.has_pre_decoder_layernorm = False
+
+        config_json = get_config_from_path(ckpt_path)
+        if config_json and "talker_config" in config_json:
+            talker_cfg = config_json["talker_config"]
+            QWenV2._from_config_json(config, talker_cfg)
+        else:
+            cls._from_hf(config, ckpt_path)
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen25OmniTalkerWeight
+
+
+register_model("qwen2_5_omni_talker", Qwen25OmniTalker)
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 7: Token2Wav — DiT Flow-Matching Model
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/token2wav_dit.py`
+- Create: `rtp_llm/test/omni/test_token2wav.py`
+
+The DiT (Diffusion Transformer) is a flow-matching model: 22 transformer layers, dim=1024, 16 heads, head_dim=64. It takes codec embeddings + speaker embeddings and produces mel spectrograms. This is a completely new architecture — no existing rtp-llm model to reuse.
+
+Checkpoint weights: `token2wav.dit.*`
+
+The DiT has these sub-components:
+- Codec embedding: `num_embeds=8193`, `emb_dim=512`
+- Speaker encoder: ECAPA-TDNN style (enc_channels=[256,256,256,256,768])
+- Transformer blocks: 22 layers with AdaLN-Zero conditioning
+- Mel projection head: projects to `mel_dim=80`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_token2wav.py
+import unittest
+import torch
+
+
+class TestOmniDiT(unittest.TestCase):
+    def test_dit_model_class_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import OmniDiT
+        self.assertTrue(callable(OmniDiT))
+
+    def test_dit_config_from_dict(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import OmniDiTConfig
+        config = OmniDiTConfig.from_dict({
+            "depth": 22, "dim": 1024, "heads": 16, "head_dim": 64,
+            "ff_mult": 2, "mel_dim": 80, "num_embeds": 8193,
+            "emb_dim": 512, "dropout": 0.1,
+        })
+        self.assertEqual(config.depth, 22)
+        self.assertEqual(config.dim, 1024)
+
+    def test_dit_forward_shape(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import OmniDiT, OmniDiTConfig
+        config = OmniDiTConfig(
+            depth=2, dim=64, heads=4, head_dim=16,
+            ff_mult=2, mel_dim=80, num_embeds=100, emb_dim=32,
+            dropout=0.0,
+        )
+        model = OmniDiT(config)
+        # batch=1, seq_len=10, mel_dim=80
+        x = torch.randn(1, 10, 80)
+        t = torch.tensor([0.5])
+        codec_ids = torch.randint(0, 100, (1, 10))
+        out = model(x, t, codec_ids)
+        self.assertEqual(out.shape, (1, 10, 80))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Implement OmniDiT**
+
+The DiT architecture follows the flow-matching pattern:
+- Sinusoidal time embedding
+- Codec token embedding
+- N transformer blocks with AdaLN-Zero
+- Final layer norm + projection to mel dim
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/token2wav_dit.py
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class OmniDiTConfig:
+    depth: int = 22
+    dim: int = 1024
+    heads: int = 16
+    head_dim: int = 64
+    ff_mult: int = 2
+    mel_dim: int = 80
+    num_embeds: int = 8193
+    emb_dim: int = 512
+    dropout: float = 0.1
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "OmniDiTConfig":
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+class SinusoidalPosEmb(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        half = self.dim // 2
+        emb = math.log(10000) / (half - 1)
+        emb = torch.exp(torch.arange(half, device=t.device, dtype=torch.float32) * -emb)
+        emb = t.unsqueeze(-1) * emb.unsqueeze(0)
+        return torch.cat([emb.sin(), emb.cos()], dim=-1)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, head_dim: int, ff_mult: int, dropout: float):
+        super().__init__()
+        inner_dim = heads * head_dim
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = nn.MultiheadAttention(dim, heads, dropout=dropout, batch_first=True)
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff = nn.Sequential(
+            nn.Linear(dim, dim * ff_mult),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * ff_mult, dim),
+            nn.Dropout(dropout),
+        )
+        # AdaLN-Zero: 6 parameters per block (gamma1, beta1, alpha1, gamma2, beta2, alpha2)
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(dim, 6 * dim),
+        )
+
+    def forward(self, x: torch.Tensor, cond: torch.Tensor) -> torch.Tensor:
+        mod = self.adaLN_modulation(cond).unsqueeze(1)
+        gamma1, beta1, alpha1, gamma2, beta2, alpha2 = mod.chunk(6, dim=-1)
+
+        h = self.norm1(x) * (1 + gamma1) + beta1
+        h, _ = self.attn(h, h, h)
+        x = x + alpha1 * h
+
+        h = self.norm2(x) * (1 + gamma2) + beta2
+        h = self.ff(h)
+        x = x + alpha2 * h
+        return x
+
+
+class OmniDiT(nn.Module):
+    def __init__(self, config: OmniDiTConfig):
+        super().__init__()
+        self.config = config
+        self.input_proj = nn.Linear(config.mel_dim, config.dim)
+        self.codec_embed = nn.Embedding(config.num_embeds, config.emb_dim)
+        self.codec_proj = nn.Linear(config.emb_dim, config.dim)
+        self.time_embed = nn.Sequential(
+            SinusoidalPosEmb(config.dim),
+            nn.Linear(config.dim, config.dim),
+            nn.SiLU(),
+            nn.Linear(config.dim, config.dim),
+        )
+        self.blocks = nn.ModuleList([
+            DiTBlock(config.dim, config.heads, config.head_dim, config.ff_mult, config.dropout)
+            for _ in range(config.depth)
+        ])
+        self.final_norm = nn.LayerNorm(config.dim)
+        self.output_proj = nn.Linear(config.dim, config.mel_dim)
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor, codec_ids: torch.Tensor,
+                spk_emb: torch.Tensor = None) -> torch.Tensor:
+        # x: (B, T, mel_dim), t: (B,), codec_ids: (B, T)
+        h = self.input_proj(x)
+        codec_h = self.codec_proj(self.codec_embed(codec_ids))
+        h = h + codec_h
+        t_emb = self.time_embed(t)
+
+        for block in self.blocks:
+            h = block(h, t_emb)
+
+        h = self.final_norm(h)
+        return self.output_proj(h)
+```
+
+- [ ] **Step 3: Run tests, verify pass**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 8: Token2Wav — BigVGAN Vocoder
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/token2wav_bigvgan.py`
+- Modify: `rtp_llm/test/omni/test_token2wav.py` (append tests)
+
+BigVGAN converts mel spectrograms to raw audio waveforms. Checkpoint weights: `token2wav.bigvgan.*`.
+
+Config from HF: upsample_rates=[5,3,2,2,2,2] (total 240x), upsample_initial_channel=1536, resblock_kernel_sizes=[3,7,11], resblock_dilation_sizes=[[1,3,5],[1,3,5],[1,3,5]], mel_dim=80.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Append to rtp_llm/test/omni/test_token2wav.py
+
+class TestBigVGAN(unittest.TestCase):
+    def test_bigvgan_class_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_bigvgan import BigVGAN
+        self.assertTrue(callable(BigVGAN))
+
+    def test_bigvgan_forward_shape(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_bigvgan import BigVGAN, BigVGANConfig
+        config = BigVGANConfig(
+            mel_dim=80,
+            upsample_rates=[2, 2],
+            upsample_initial_channel=64,
+            upsample_kernel_sizes=[4, 4],
+            resblock_kernel_sizes=[3],
+            resblock_dilation_sizes=[[1, 2]],
+        )
+        model = BigVGAN(config)
+        # (B, mel_dim, T)
+        mel = torch.randn(1, 80, 10)
+        wav = model(mel)
+        # upsample 2*2 = 4x
+        self.assertEqual(wav.shape[0], 1)
+        self.assertEqual(wav.shape[1], 1)
+        self.assertEqual(wav.shape[2], 40)
+```
+
+- [ ] **Step 2: Implement BigVGAN**
+
+Standard HiFi-GAN / BigVGAN architecture with multi-receptive-field fusion (MRF) residual blocks and transposed convolution upsampling.
+
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+### Task 9: Token2Wav — Combined Model Registration
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/token2wav.py`
+- Modify: `rtp_llm/test/omni/test_token2wav.py` (append tests)
+
+Combines DiT + BigVGAN into a single `Qwen25OmniToken2Wav` model class that is registered as `qwen2_5_omni_token2wav`. The model takes codec token IDs → DiT generates mel → BigVGAN generates waveform.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestQwen25OmniToken2WavRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_token2wav", _model_factory)
+
+
+class TestQwen25OmniToken2WavConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav import Qwen25OmniToken2Wav
+        config_json = {
+            "token2wav_config": {
+                "dit_config": {
+                    "depth": 22, "dim": 1024, "heads": 16, "head_dim": 64,
+                    "ff_mult": 2, "mel_dim": 80, "num_embeds": 8193, "emb_dim": 512,
+                },
+                "bigvgan_config": {
+                    "mel_dim": 80,
+                    "upsample_rates": [5, 3, 2, 2, 2, 2],
+                    "upsample_initial_channel": 1536,
+                    "upsample_kernel_sizes": [11, 7, 4, 4, 4, 4],
+                    "resblock_kernel_sizes": [3, 7, 11],
+                    "resblock_dilation_sizes": [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+            config = Qwen25OmniToken2Wav._create_config(tmpdir)
+            self.assertIsNotNone(config)
+```
+
+- [ ] **Step 2: Implement Token2Wav model**
+
+The `Qwen25OmniToken2Wav` does NOT extend `BaseModel` in the standard way since it's a non-AR model. Instead it registers as a standalone model class that the `OmniStagePool` invokes directly (similar to `StageExecutionType.LLM_GENERATION`). Its weight class (`Qwen25OmniToken2WavWeight`) extends `ModelDeployWeightInfo` directly with custom weight mapping for `token2wav.dit.*` and `token2wav.bigvgan.*`.
+
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+### Task 10: Stage Processors — thinker2talker and talker2code2wav
+
+**Files:**
+- Create: `rtp_llm/omni/models/qwen2_5_omni/stage_processors.py`
+- Create: `rtp_llm/test/omni/test_stage_processors.py`
+
+Stage processors transform `StageOutput` between stages:
+
+1. **thinker2talker**: Extracts hidden state embeddings from thinker output → formats as talker input (applies `thinker_to_talker_proj`)
+2. **talker2code2wav**: Converts talker's codec token IDs → Token2Wav input format
+
+Both extend `StageProcessorBase` from Phase 1.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_stage_processors.py
+import unittest
+import torch
+
+from rtp_llm.omni.engine.stage_connector import StageOutput
+
+
+class TestThinker2TalkerProcessor(unittest.TestCase):
+    def test_processor_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import Thinker2TalkerProcessor
+        self.assertTrue(callable(Thinker2TalkerProcessor))
+
+    def test_process_extracts_embeddings(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import Thinker2TalkerProcessor
+        proc = Thinker2TalkerProcessor()
+        thinker_output = StageOutput(
+            token_ids=[1, 2, 3],
+            embeddings=torch.randn(1, 10, 3584),
+            metadata={"text": "hello"},
+        )
+        talker_input = proc.process(thinker_output)
+        self.assertIsNotNone(talker_input.embeddings)
+        self.assertEqual(talker_input.embeddings.shape[-1], 3584)
+
+
+class TestTalker2Code2WavProcessor(unittest.TestCase):
+    def test_processor_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import Talker2Code2WavProcessor
+        self.assertTrue(callable(Talker2Code2WavProcessor))
+
+    def test_process_converts_tokens(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import Talker2Code2WavProcessor
+        proc = Talker2Code2WavProcessor()
+        talker_output = StageOutput(
+            token_ids=[10, 20, 30, 40, 50],
+            metadata={"codec_tokens": True},
+        )
+        c2w_input = proc.process(talker_output)
+        self.assertIsNotNone(c2w_input.token_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Implement stage processors**
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/stage_processors.py
+import torch
+from rtp_llm.omni.engine.stage_connector import StageOutput
+from rtp_llm.omni.engine.stage_processor_base import StageProcessorBase
+
+
+class Thinker2TalkerProcessor(StageProcessorBase):
+    def process(self, source_output: StageOutput) -> StageOutput:
+        return StageOutput(
+            embeddings=source_output.embeddings,
+            metadata={
+                "source_token_ids": source_output.token_ids,
+                "source_text": source_output.metadata.get("text", ""),
+            },
+        )
+
+
+class Talker2Code2WavProcessor(StageProcessorBase):
+    def process(self, source_output: StageOutput) -> StageOutput:
+        return StageOutput(
+            token_ids=source_output.token_ids,
+            metadata={"from_talker": True},
+        )
+```
+
+- [ ] **Step 3: Run tests, verify pass**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 11: OmniEngine Enhancement — Real Stage Instantiation
+
+**Files:**
+- Modify: `rtp_llm/omni/engine/omni_engine.py`
+- Create: `rtp_llm/test/omni/test_omni_engine_integration.py`
+
+Currently `OmniEngine.__init__` creates `OmniStagePool` instances without actual `Pipeline` replicas. This task enhances `OmniEngine.from_pipeline_config` to:
+1. For each stage, look up the model class via `ModelFactory.get_model_cls(stage.model_cls)`
+2. Create a per-stage `ModelConfig` by calling `model_cls._create_config(ckpt_path)`
+3. Call `model_cls.from_config(...)` to instantiate the model
+4. Create a `Pipeline` instance wrapping the C++ engine
+5. Add the pipeline as a replica in `OmniStagePool`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_omni_engine_integration.py
+import unittest
+from unittest.mock import MagicMock, patch
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+
+
+class TestOmniEngineStageInstantiation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+
+    def test_engine_resolves_stage_model_classes(self):
+        from rtp_llm.omni.engine.omni_engine import OmniEngine
+        from rtp_llm.model_factory_register import _model_factory
+
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+
+        for stage in config.stages:
+            self.assertIn(stage.model_cls, _model_factory,
+                f"Stage model_cls '{stage.model_cls}' not registered")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Enhance OmniEngine.from_pipeline_config**
+
+Add `_init_stage_models` method that iterates over stages and resolves model classes. The actual model instantiation (weight loading, Pipeline creation) requires a real GPU and checkpoint, so we gate it behind a `lazy_init` flag — on init, we validate that all stage model classes are registered; actual Pipeline creation happens in a `start()` call.
+
+```python
+# In omni_engine.py, add:
+from rtp_llm.model_factory_register import _model_factory
+
+class OmniEngine:
+    def _validate_stage_models(self) -> None:
+        for stage in self.pipeline_config.stages:
+            if stage.model_cls not in _model_factory:
+                raise ValueError(
+                    f"Stage model '{stage.model_cls}' not registered. "
+                    f"Import the model module first."
+                )
+
+    @classmethod
+    def from_pipeline_config(cls, pipeline_config, model_config=None, engine_config=None):
+        engine = cls(
+            pipeline_config=pipeline_config,
+            model_config=model_config,
+            engine_config=engine_config,
+        )
+        engine._validate_stage_models()
+        return engine
+```
+
+- [ ] **Step 3: Run tests, verify pass**
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 12: Module Imports and Package Wiring
+
+**Files:**
+- Modify: `rtp_llm/omni/__init__.py` — import models subpackage
+- Modify: `rtp_llm/omni/models/qwen2_5_omni/__init__.py` — import all stage models
+
+Ensure that importing `rtp_llm.omni` transitively registers all Qwen2.5-Omni stage models and the pipeline topology.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# rtp_llm/test/omni/test_omni_engine_integration.py — append
+
+class TestOmniImportChain(unittest.TestCase):
+    def test_importing_omni_registers_pipeline(self):
+        import rtp_llm.omni  # noqa: F401
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+
+    def test_importing_omni_registers_all_stage_models(self):
+        import rtp_llm.omni  # noqa: F401
+        from rtp_llm.model_factory_register import _model_factory
+        for model_name in ["qwen2_5_omni_thinker", "qwen2_5_omni_talker", "qwen2_5_omni_token2wav"]:
+            self.assertIn(model_name, _model_factory, f"{model_name} not registered")
+```
+
+- [ ] **Step 2: Update imports**
+
+```python
+# rtp_llm/omni/__init__.py — add at end:
+import rtp_llm.omni.models  # noqa: F401
+```
+
+```python
+# rtp_llm/omni/models/qwen2_5_omni/__init__.py — add imports:
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.models.qwen2_5_omni.pipeline_config import QWEN2_5_OMNI_PIPELINE
+import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+OmniPipelineRegistry.register(QWEN2_5_OMNI_PIPELINE)
+```
+
+- [ ] **Step 3: Run all omni tests**
+
+Run: `cd /Users/stmatengss/Temp/rtp-llm && python -m pytest rtp_llm/test/omni/ -v 2>&1 | tail -30`
+Expected: All PASS (including existing Phase 1 tests)
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 13: Run Full Test Suite and Verify No Regressions
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all omni tests**
+
+Run on remote dev server:
+```bash
+ssh root@mateng04 "cd /path/to/rtp-llm && python -m pytest rtp_llm/test/omni/ -v 2>&1"
+```
+
+- [ ] **Step 2: Run existing model tests to verify no regressions**
+
+```bash
+ssh root@mateng04 "cd /path/to/rtp-llm && python -m pytest rtp_llm/test/ -k 'not gpu and not cuda' --timeout=120 -v 2>&1 | tail -50"
+```
+
+- [ ] **Step 3: Verify import chain doesn't break existing models**
+
+```bash
+python -c "import rtp_llm.models; import rtp_llm.omni; print('OK')"
+```
+
+---
+
+## Key Design Decisions
+
+1. **Weight prefix pattern**: Each stage's Weight class extends `QWenV2Weight` with a different `prefix` (`"thinker."`, `"talker."`). This leverages the existing `prefix + model_prefix + "layers.{i}..."` pattern — no changes to the weight loading infrastructure.
+
+2. **Token2Wav is non-standard**: It doesn't follow the AR decoder pattern, so it extends `ModelDeployWeightInfo` directly rather than `QWenV2Weight`. The DiT and BigVGAN are pure PyTorch `nn.Module`s.
+
+3. **Lazy stage initialization**: `OmniEngine.from_pipeline_config` validates model registrations but doesn't load weights or create Pipelines — that requires GPU access and happens at engine start time. This keeps the cold path fast and testable without GPU.
+
+4. **Reuse existing encoders**: The audio tower reuses `Qwen2AudioEncoder` from `rtp_llm/models/qwen_v2_audio/`. The vision encoder reuses patterns from `rtp_llm/models/qwen2_5_vl/`.
+
+## Verification
+
+1. **Unit tests**: `python -m pytest rtp_llm/test/omni/ -v` — all pass
+2. **Import smoke test**: `python -c "import rtp_llm.omni; print('OK')"` — no import errors
+3. **Weight prefix verification** (requires checkpoint): Load `Qwen/Qwen2.5-Omni-7B` and verify weight keys match prefixes
+4. **E2E test** (requires GPU): Full pipeline inference with text+audio output — this is Phase 2's final validation, likely deferred to after all tasks complete and done on remote dev server (`ssh root@mateng04`)

--- a/docs/superpowers/specs/2026-06-01-omni-architecture-support-design.md
+++ b/docs/superpowers/specs/2026-06-01-omni-architecture-support-design.md
@@ -1,0 +1,396 @@
+# Omni Architecture Support for rtp-llm
+
+**Date**: 2026-06-01
+**Status**: Draft
+**Target Models**: Qwen2.5-Omni, Qwen3-Omni (initial), extensible to all vllm-omni models
+
+## 1. Problem Statement
+
+rtp-llm currently supports multimodal **input** (vision, audio understanding) through the `MultiModalMixin` pattern, where encoders (ViT, Whisper) preprocess inputs before the LLM decoder. However, it has no support for multimodal **output** — no TTS/speech generation, no image generation, no video generation.
+
+Modern "omni" models (Qwen2.5-Omni, Qwen3-Omni, Bagel, GLM-Image) require a **multi-stage pipeline** architecture: an LLM "thinker" generates text + hidden embeddings, a "talker" converts embeddings to speech tokens, and a "code2wav" module converts speech tokens to audio waveforms. Image/video generation models use diffusion transformers (DiT) as a pipeline stage.
+
+This design adds omni architecture support to rtp-llm by porting vllm-omni's multi-stage pipeline framework, enabling rtp-llm to serve models that produce text, audio, image, and video outputs.
+
+## 2. Architecture Overview
+
+### 2.1 Multi-Stage Pipeline Framework
+
+The core addition is a DAG-based pipeline framework where each stage runs its own rtp-llm C++ engine instance, orchestrated by a Python-level coordinator.
+
+```
+                    ┌─────────────────────────────────────────────────────────────┐
+                    │                     OmniEngine                              │
+                    │                                                             │
+  User Request ──►  │  OmniOrchestrator                                           │
+                    │      │                                                      │
+                    │      ├──► StagePool[0] ──► Pipeline[Thinker]  (C++ AR)      │
+                    │      │        │                                              │
+                    │      │    StageConnector (shared memory)                     │
+                    │      │        │                                              │
+                    │      ├──► StagePool[1] ──► Pipeline[Talker]   (C++ AR)      │
+                    │      │        │                                              │
+                    │      │    StageConnector (shared memory)                     │
+                    │      │        │                                              │
+                    │      └──► StagePool[2] ──► Pipeline[Code2Wav] (Generation)  │
+                    │                                     │                       │
+                    │              ◄─── audio waveform ───┘                       │
+                    └─────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Key Abstractions
+
+| Abstraction | Source (vllm-omni) | rtp-llm Name | Responsibility |
+|---|---|---|---|
+| `PipelineConfig` | `vllm_omni.config.stage_config` | `OmniPipelineConfig` | Frozen DAG topology definition |
+| `StagePipelineConfig` | `vllm_omni.config.stage_config` | `OmniStageConfig` | Per-stage config (type, inputs, outputs) |
+| `StageExecutionType` | `vllm_omni.config.stage_config` | `StageExecutionType` | `LLM_AR`, `LLM_GENERATION`, `DIFFUSION` |
+| `Orchestrator` | `vllm_omni.engine.orchestrator` | `OmniOrchestrator` | Request lifecycle across stages |
+| `StagePool` | `vllm_omni.engine.stage_pool` | `OmniStagePool` | Manages replicas of one stage |
+| `OmniConnectorBase` | `vllm_omni.distributed.omni_connectors` | `StageConnector` | Inter-stage data transfer |
+| `OutputProcessor` | `vllm_omni.engine.output_processor` | `OmniOutputProcessor` | Multimodal output assembly |
+| `DiffusionEngine` | `vllm_omni.diffusion.diffusion_engine` | `DiffusionEngine` | Non-AR diffusion execution |
+
+### 2.3 Execution Types
+
+Three stage execution types, matching vllm-omni:
+
+- **LLM_AR**: Autoregressive token generation with KV cache. Used for thinker and talker stages. Runs on rtp-llm's existing C++ engine.
+- **LLM_GENERATION**: Non-autoregressive LLM-based generation (e.g., code2wav). Uses the C++ engine but without KV cache management and with different scheduling.
+- **DIFFUSION**: Iterative denoising (DiT models). Requires a separate diffusion engine with its own scheduler.
+
+## 3. Module Structure
+
+```
+rtp_llm/omni/
+├── __init__.py
+├── config/
+│   ├── __init__.py
+│   ├── stage_config.py              # StageExecutionType, OmniStageConfig, OmniPipelineConfig
+│   ├── pipeline_registry.py         # Central lazy registry of pipeline topologies
+│   └── output_modality.py           # OutputModality flag enum (text, audio, image, video)
+├── engine/
+│   ├── __init__.py
+│   ├── omni_engine.py               # OmniEngine: wraps multiple stage engines
+│   ├── orchestrator.py              # Request lifecycle, stage-to-stage routing
+│   ├── stage_pool.py                # Replica management per stage
+│   ├── stage_connector.py           # Inter-stage data transfer (shared memory)
+│   ├── stage_processor_base.py      # Base class for inter-stage data transforms
+│   └── output_processor.py          # Multimodal output assembly and encoding
+├── models/
+│   ├── __init__.py
+│   ├── qwen2_5_omni/
+│   │   ├── __init__.py
+│   │   ├── pipeline.py              # QWEN2_5_OMNI_PIPELINE topology
+│   │   ├── thinker.py               # Thinker stage model (extends existing Qwen model)
+│   │   ├── talker.py                # Talker stage model
+│   │   ├── token2wav.py             # Code2Wav stage model
+│   │   └── stage_processors.py      # thinker2talker, talker2code2wav transforms
+│   └── qwen3_omni/
+│       ├── __init__.py
+│       ├── pipeline.py              # QWEN3_OMNI_PIPELINE topology
+│       ├── thinker.py
+│       ├── talker.py
+│       ├── code2wav.py
+│       └── stage_processors.py
+├── diffusion/
+│   ├── __init__.py
+│   ├── diffusion_engine.py          # Non-AR diffusion execution loop
+│   ├── executor.py                  # Model executor for diffusion models
+│   ├── scheduler.py                 # Diffusion request scheduling
+│   └── registry.py                  # Diffusion model registry
+└── serving/
+    ├── __init__.py
+    ├── openai_omni.py               # OpenAI-compatible omni API extensions
+    ├── audio_utils.py               # Audio encoding/decoding (WAV, base64)
+    └── protocol.py                  # Omni-specific request/response types
+```
+
+## 4. Integration with Existing rtp-llm
+
+### 4.1 Model Registration and Factory
+
+Each stage model registers independently via `register_model()`. The `OmniPipelineConfig` maps HF `architectures` to multi-stage topologies.
+
+```python
+# In model_factory.py - detect omni models
+class ModelFactory:
+    @staticmethod
+    def _create_model(model_config, engine_config, ...):
+        model_type = model_config.model_type
+        
+        # Check if this is an omni model with multi-stage pipeline
+        pipeline_config = OmniPipelineRegistry.get(model_type)
+        if pipeline_config is not None:
+            return OmniEngine.from_pipeline_config(
+                pipeline_config, model_config, engine_config
+            )
+        
+        # Existing single-model path
+        model_cls = ModelFactory.get_model_cls(model_type)
+        ...
+```
+
+### 4.2 Engine Lifecycle
+
+1. `ModelFactory.create()` detects omni model type via pipeline registry
+2. `OmniEngine` reads `OmniPipelineConfig` (e.g., 3 stages for Qwen2.5-Omni)
+3. For each stage:
+   - Load stage-specific model weights from the HF checkpoint
+   - Create a `BaseModel` subclass instance via the stage's registered model class
+   - Instantiate a `Pipeline` with its own C++ engine, KV cache, and scheduler
+4. `OmniOrchestrator` starts in a background asyncio loop
+5. `OmniStagePool` wraps each stage's pipeline for replica management
+
+### 4.3 Request Flow (Qwen2.5-Omni Example)
+
+```
+1. OpenAI API: POST /v1/chat/completions
+   {messages: [...], modalities: ["text", "audio"]}
+
+2. OmniOrchestrator.submit(request)
+   → Create OmniRequestState (tracks progress across stages)
+
+3. Stage 0 (Thinker):
+   - Multimodal input preprocessing (images, audio → embeddings via existing MultiModalMixin)
+   - Autoregressive text generation with C++ engine
+   - Output: text tokens (streamed to client) + hidden state embeddings (latent)
+   
+4. Stage Processor: thinker2talker()
+   - Extract hidden states from thinker output
+   - Format as talker input prompt + embeddings
+
+5. Stage 1 (Talker):
+   - Receives text embeddings as prompt_embeds
+   - Autoregressive speech token generation with C++ engine
+   - Output: speech token sequence
+
+6. Stage Processor: talker2code2wav()
+   - Convert speech tokens to code2wav input format
+
+7. Stage 2 (Code2Wav):
+   - Non-autoregressive waveform generation
+   - Output: audio waveform tensor
+
+8. Output Processor:
+   - Encode waveform as WAV → base64
+   - Assemble final response with text + audio
+   - Return to API server
+```
+
+### 4.4 Reused Components
+
+- **MultiModalMixin**: Multimodal input processing for thinker stage (images, audio, video)
+- **Pipeline + BackendRPCServerVisitor**: Per-stage inference execution
+- **ModelFactory + register_model()**: Stage model registration
+- **Tokenizer infrastructure**: Per-stage tokenizer support
+- **OpenAI renderer framework**: Extended with audio/image output renderers
+- **KV cache management**: Per-stage independent KV caches in C++ engine
+
+## 5. Inter-Stage Data Transfer
+
+### 5.1 StageConnector Interface
+
+```python
+class StageConnector(ABC):
+    def put(self, request_id: str, stage_id: int, data: StageOutput) -> bool:
+        """Store stage output for downstream consumption."""
+        ...
+    
+    def get(self, request_id: str, stage_id: int) -> StageOutput | None:
+        """Retrieve stage output for next stage input."""
+        ...
+    
+    def cleanup(self, request_id: str) -> None:
+        """Release all resources for a completed request."""
+        ...
+```
+
+### 5.2 StageOutput Data
+
+```python
+@dataclass
+class StageOutput:
+    token_ids: list[int] | None = None
+    embeddings: torch.Tensor | None = None       # Hidden state embeddings
+    audio_waveform: torch.Tensor | None = None    # Generated audio
+    image_tensor: torch.Tensor | None = None      # Generated image
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+### 5.3 Implementation: SharedMemoryConnector
+
+Initial implementation uses in-process shared memory (Python dict + torch tensors on GPU):
+- Zero-copy for GPU tensors when stages run on same device
+- Keyed by `(request_id, source_stage_id)`
+- Automatic cleanup on request completion
+
+Future: RDMA connector for disaggregated multi-node deployment.
+
+## 6. Diffusion Engine
+
+For image/video generation stages (`StageExecutionType.DIFFUSION`):
+
+### 6.1 Architecture
+
+```python
+class DiffusionEngine:
+    def __init__(self, model, config):
+        self.model = model                    # DiT model
+        self.scheduler = DiffusionScheduler() # Request batching
+        self.executor = DiffusionExecutor()   # Denoising loop
+    
+    async def generate(self, request: DiffusionRequest) -> DiffusionOutput:
+        """Run iterative denoising to generate image/video."""
+        latents = self.initialize_latents(request)
+        for step in range(request.num_steps):
+            latents = self.executor.denoise_step(latents, step)
+        return self.decode_latents(latents)
+```
+
+### 6.2 Key Differences from AR Engine
+
+- No KV cache — each step processes the full latent
+- Batched execution of multiple denoising steps
+- Different scheduling: request-level rather than token-level
+- Output: image/video tensor instead of token sequence
+
+## 7. API Extensions
+
+### 7.1 Chat Completions (Extended)
+
+```json
+// Request
+{
+  "model": "Qwen2.5-Omni-7B",
+  "messages": [{"role": "user", "content": "Tell me a story"}],
+  "modalities": ["text", "audio"],
+  "audio": {"voice": "alloy", "format": "wav"}
+}
+
+// Response  
+{
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "content": "Once upon a time...",
+      "audio": {
+        "data": "<base64-encoded-wav>",
+        "format": "wav"
+      }
+    }
+  }]
+}
+```
+
+### 7.2 New Endpoints
+
+- `POST /v1/audio/speech`: Dedicated TTS endpoint
+- `POST /v1/images/generations`: Image generation endpoint
+- Both endpoints follow OpenAI's API format for compatibility
+
+### 7.3 Streaming
+
+- Text output streams immediately via SSE (existing behavior)
+- Audio/image output delivered as final chunk when generation completes
+- Each stage's output can be independently streamed to the next stage
+
+## 8. Pipeline Configuration (Qwen2.5-Omni Example)
+
+```python
+QWEN2_5_OMNI_PIPELINE = OmniPipelineConfig(
+    model_type="qwen2_5_omni",
+    model_arch="Qwen2_5OmniForConditionalGeneration",
+    stages=(
+        OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="Qwen2_5OmniThinker",
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+        ),
+        OmniStageConfig(
+            stage_id=1,
+            model_stage="talker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="Qwen2_5OmniTalker",
+            input_sources=(0,),
+            engine_output_type="latent",
+            stage_processor="qwen2_5_omni.thinker2talker",
+        ),
+        OmniStageConfig(
+            stage_id=2,
+            model_stage="code2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            model_cls="Qwen2_5OmniToken2Wav",
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="audio",
+            stage_processor="qwen2_5_omni.talker2code2wav",
+        ),
+    ),
+)
+```
+
+## 9. Implementation Phases
+
+### Phase 1: Core Pipeline Framework
+- `OmniPipelineConfig`, `OmniStageConfig`, `StageExecutionType`
+- Pipeline registry with lazy loading
+- `OmniOrchestrator` with request lifecycle management
+- `OmniStagePool` wrapping rtp-llm `Pipeline` instances
+- `SharedMemoryConnector` for inter-stage transfer
+- `OmniOutputProcessor` for multimodal output assembly
+
+### Phase 2: Qwen2.5-Omni Support
+- Thinker stage model (extends existing Qwen architecture)
+- Talker stage model
+- Token2Wav (Code2Wav) stage model
+- Stage processors for inter-stage data transformation
+- Weight loading for multi-component HF checkpoints
+- E2E testing with Qwen2.5-Omni-7B
+
+### Phase 3: Qwen3-Omni Support
+- Qwen3-Omni MoE thinker, talker, code2wav stages
+- Reuse pipeline framework from Phase 2
+- MoE-specific optimizations
+
+### Phase 4: API and Serving
+- OpenAI-compatible API extensions (modalities, audio output)
+- `/v1/audio/speech` endpoint
+- Audio encoding utilities (WAV, base64)
+- Streaming support for multi-stage outputs
+
+### Phase 5: Diffusion Engine
+- `DiffusionEngine` for non-AR generation
+- `DiffusionExecutor` and `DiffusionScheduler`
+- Integration as `StageExecutionType.DIFFUSION` in pipeline
+- Image/video generation model support (GLM-Image, Bagel)
+- `/v1/images/generations` endpoint
+
+### Phase 6: Distributed Execution
+- RDMA-based `StageConnector` for multi-node deployment
+- Per-stage device placement and parallelism
+- Dynamic replica scaling per stage
+
+## 10. Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| C++ engine doesn't support latent/embedding output | Add output mode to C++ engine to return hidden states alongside tokens |
+| Weight loading complexity for multi-component checkpoints | Extend `ModelLoader` to load weights per-stage from subdirectories |
+| Memory pressure from multiple engines | Support model offloading between stages; lazy engine initialization |
+| Stage coordination latency | Shared memory connector minimizes transfer overhead; async overlap |
+| Diffusion engine is a large scope addition | Phase it separately; start with AR-only omni models |
+
+## 11. Success Criteria
+
+1. Qwen2.5-Omni-7B generates correct text + audio output via OpenAI API
+2. Qwen3-Omni generates correct text + audio output
+3. Latency is within 20% of vllm-omni for same models on same hardware
+4. Pipeline framework supports adding new omni models without framework changes
+5. Existing single-model (non-omni) rtp-llm functionality is unaffected

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -23,6 +23,7 @@ from rtp_llm.config.py_config_modules import (
     VitConfig,
 )
 from rtp_llm.model_factory_register import _model_factory
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
 from rtp_llm.ops import ProfilingDebugLoggingConfig, SpeculativeType, VitSeparation
 from rtp_llm.utils.util import check_with_info
 
@@ -70,6 +71,15 @@ class ModelFactory:
             merge_lora: Whether to merge LoRA weights
         """
         model_type = model_config.model_type
+
+        pipeline_config = OmniPipelineRegistry.get(model_type)
+        if pipeline_config is not None:
+            from rtp_llm.omni.engine.omni_engine import OmniEngine
+            logging.info(f"Detected omni model type: {model_type}, creating OmniEngine")
+            return OmniEngine.from_pipeline_config(
+                pipeline_config, model_config, engine_config
+            )
+
         model_cls = ModelFactory.get_model_cls(model_type)
 
         # Get model_name from model_config (default to model class name if not set)

--- a/rtp_llm/models/__init__.py
+++ b/rtp_llm/models/__init__.py
@@ -45,5 +45,7 @@ from .qwen3_next.qwen3_next_mtp import Qwen3NextMTP
 from .qwen_v2_moe import Qwen2Moe
 from .qwen_v3_moe import Qwen3Moe
 
+import rtp_llm.omni  # noqa: F401
+
 if has_internal_source():
     import internal_source.rtp_llm.models.internal_init

--- a/rtp_llm/omni/__init__.py
+++ b/rtp_llm/omni/__init__.py
@@ -1,0 +1,18 @@
+from rtp_llm.omni.config import (
+    OmniPipelineConfig,
+    OmniPipelineRegistry,
+    OmniStageConfig,
+    OutputModality,
+    StageExecutionType,
+)
+from rtp_llm.omni.engine import (
+    OmniEngine,
+    OmniOrchestrator,
+    OmniOutputProcessor,
+    OmniRequestState,
+    OmniStagePool,
+    SharedMemoryConnector,
+    StageConnector,
+    StageOutput,
+    StageProcessorBase,
+)

--- a/rtp_llm/omni/__init__.py
+++ b/rtp_llm/omni/__init__.py
@@ -16,3 +16,5 @@ from rtp_llm.omni.engine import (
     StageOutput,
     StageProcessorBase,
 )
+
+import rtp_llm.omni.models  # noqa: F401

--- a/rtp_llm/omni/config/__init__.py
+++ b/rtp_llm/omni/config/__init__.py
@@ -1,0 +1,7 @@
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+from rtp_llm.omni.config.output_modality import OutputModality
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry

--- a/rtp_llm/omni/config/output_modality.py
+++ b/rtp_llm/omni/config/output_modality.py
@@ -1,0 +1,8 @@
+from enum import Flag, auto
+
+
+class OutputModality(Flag):
+    TEXT = auto()
+    AUDIO = auto()
+    IMAGE = auto()
+    VIDEO = auto()

--- a/rtp_llm/omni/config/pipeline_registry.py
+++ b/rtp_llm/omni/config/pipeline_registry.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Dict, List, Optional
+
+from rtp_llm.omni.config.stage_config import OmniPipelineConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OmniPipelineRegistry:
+    _registry: Dict[str, OmniPipelineConfig] = {}
+    _arch_registry: Dict[str, str] = {}
+
+    @classmethod
+    def register(cls, config: OmniPipelineConfig) -> None:
+        if config.model_type in cls._registry:
+            raise ValueError(
+                f"Pipeline already registered for model_type={config.model_type}"
+            )
+        cls._registry[config.model_type] = config
+        cls._arch_registry[config.model_arch] = config.model_type
+        logger.info(
+            f"Registered omni pipeline: model_type={config.model_type}, "
+            f"model_arch={config.model_arch}, stages={len(config.stages)}"
+        )
+
+    @classmethod
+    def get(cls, model_type: str) -> Optional[OmniPipelineConfig]:
+        return cls._registry.get(model_type)
+
+    @classmethod
+    def get_by_arch(cls, model_arch: str) -> Optional[OmniPipelineConfig]:
+        model_type = cls._arch_registry.get(model_arch)
+        if model_type is None:
+            return None
+        return cls._registry.get(model_type)
+
+    @classmethod
+    def list_all(cls) -> List[OmniPipelineConfig]:
+        return list(cls._registry.values())

--- a/rtp_llm/omni/config/pipeline_registry.py
+++ b/rtp_llm/omni/config/pipeline_registry.py
@@ -16,6 +16,11 @@ class OmniPipelineRegistry:
             raise ValueError(
                 f"Pipeline already registered for model_type={config.model_type}"
             )
+        if config.model_arch in cls._arch_registry:
+            raise ValueError(
+                f"Architecture already registered: model_arch={config.model_arch} "
+                f"(used by model_type={cls._arch_registry[config.model_arch]})"
+            )
         cls._registry[config.model_type] = config
         cls._arch_registry[config.model_arch] = config.model_type
         logger.info(

--- a/rtp_llm/omni/config/stage_config.py
+++ b/rtp_llm/omni/config/stage_config.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+
+class StageExecutionType(Enum):
+    LLM_AR = "llm_ar"
+    LLM_GENERATION = "llm_generation"
+    DIFFUSION = "diffusion"
+
+
+@dataclass(frozen=True)
+class OmniStageConfig:
+    stage_id: int
+    model_stage: str
+    execution_type: StageExecutionType
+    model_cls: str
+    input_sources: Tuple[int, ...] = ()
+    final_output: bool = False
+    final_output_type: Optional[str] = None
+    requires_multimodal_data: bool = False
+    engine_output_type: Optional[str] = None
+    stage_processor: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OmniPipelineConfig:
+    model_type: str
+    model_arch: str
+    stages: Tuple[OmniStageConfig, ...]
+
+    def get_final_output_stages(self) -> list:
+        return [s for s in self.stages if s.final_output]
+
+    def get_stage(self, stage_id: int) -> OmniStageConfig:
+        for s in self.stages:
+            if s.stage_id == stage_id:
+                return s
+        raise KeyError(f"Stage {stage_id} not found in pipeline {self.model_type}")

--- a/rtp_llm/omni/engine/__init__.py
+++ b/rtp_llm/omni/engine/__init__.py
@@ -1,0 +1,10 @@
+from rtp_llm.omni.engine.omni_engine import OmniEngine
+from rtp_llm.omni.engine.orchestrator import OmniOrchestrator, OmniRequestState
+from rtp_llm.omni.engine.output_processor import OmniOutputProcessor
+from rtp_llm.omni.engine.stage_connector import (
+    SharedMemoryConnector,
+    StageConnector,
+    StageOutput,
+)
+from rtp_llm.omni.engine.stage_pool import OmniStagePool
+from rtp_llm.omni.engine.stage_processor_base import StageProcessorBase

--- a/rtp_llm/omni/engine/omni_engine.py
+++ b/rtp_llm/omni/engine/omni_engine.py
@@ -1,0 +1,58 @@
+import logging
+from typing import Any, Dict, Optional
+
+from rtp_llm.omni.config.stage_config import OmniPipelineConfig
+from rtp_llm.omni.engine.orchestrator import OmniOrchestrator
+from rtp_llm.omni.engine.output_processor import OmniOutputProcessor
+from rtp_llm.omni.engine.stage_connector import SharedMemoryConnector, StageConnector
+from rtp_llm.omni.engine.stage_pool import OmniStagePool
+
+logger = logging.getLogger(__name__)
+
+
+class OmniEngine:
+    def __init__(
+        self,
+        pipeline_config: OmniPipelineConfig,
+        connector: Optional[StageConnector] = None,
+    ):
+        self.pipeline_config = pipeline_config
+        self.connector = connector or SharedMemoryConnector()
+        self.output_processor = OmniOutputProcessor()
+
+        self.stage_pools: Dict[int, OmniStagePool] = {}
+        for stage_config in pipeline_config.stages:
+            self.stage_pools[stage_config.stage_id] = OmniStagePool(
+                stage_config=stage_config
+            )
+
+        self.orchestrator = OmniOrchestrator(
+            pipeline_config=pipeline_config,
+            connector=self.connector,
+            stage_pools=self.stage_pools,
+        )
+
+        logger.info(
+            f"OmniEngine created for {pipeline_config.model_type} "
+            f"with {len(pipeline_config.stages)} stages"
+        )
+
+    @property
+    def num_stages(self) -> int:
+        return len(self.pipeline_config.stages)
+
+    def get_final_output_types(self) -> Dict[str, int]:
+        result = {}
+        for stage in self.pipeline_config.stages:
+            if stage.final_output and stage.final_output_type:
+                result[stage.final_output_type] = stage.stage_id
+        return result
+
+    @classmethod
+    def from_pipeline_config(
+        cls,
+        pipeline_config: OmniPipelineConfig,
+        model_config: Any = None,
+        engine_config: Any = None,
+    ) -> "OmniEngine":
+        return cls(pipeline_config=pipeline_config)

--- a/rtp_llm/omni/engine/omni_engine.py
+++ b/rtp_llm/omni/engine/omni_engine.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
+from rtp_llm.model_factory_register import _model_factory
 from rtp_llm.omni.config.stage_config import OmniPipelineConfig
 from rtp_llm.omni.engine.orchestrator import OmniOrchestrator
 from rtp_llm.omni.engine.output_processor import OmniOutputProcessor
@@ -52,6 +53,14 @@ class OmniEngine:
                 result[stage.final_output_type] = stage.stage_id
         return result
 
+    def _validate_stage_models(self) -> None:
+        for stage in self.pipeline_config.stages:
+            if stage.model_cls not in _model_factory:
+                raise ValueError(
+                    f"Stage model '{stage.model_cls}' not registered. "
+                    f"Import the model module first."
+                )
+
     @classmethod
     def from_pipeline_config(
         cls,
@@ -59,8 +68,10 @@ class OmniEngine:
         model_config: Any = None,
         engine_config: Any = None,
     ) -> "OmniEngine":
-        return cls(
+        engine = cls(
             pipeline_config=pipeline_config,
             model_config=model_config,
             engine_config=engine_config,
         )
+        engine._validate_stage_models()
+        return engine

--- a/rtp_llm/omni/engine/omni_engine.py
+++ b/rtp_llm/omni/engine/omni_engine.py
@@ -15,8 +15,12 @@ class OmniEngine:
         self,
         pipeline_config: OmniPipelineConfig,
         connector: Optional[StageConnector] = None,
+        model_config: Any = None,
+        engine_config: Any = None,
     ):
         self.pipeline_config = pipeline_config
+        self.model_config = model_config
+        self.engine_config = engine_config
         self.connector = connector or SharedMemoryConnector()
         self.output_processor = OmniOutputProcessor()
 
@@ -55,4 +59,8 @@ class OmniEngine:
         model_config: Any = None,
         engine_config: Any = None,
     ) -> "OmniEngine":
-        return cls(pipeline_config=pipeline_config)
+        return cls(
+            pipeline_config=pipeline_config,
+            model_config=model_config,
+            engine_config=engine_config,
+        )

--- a/rtp_llm/omni/engine/orchestrator.py
+++ b/rtp_llm/omni/engine/orchestrator.py
@@ -17,6 +17,10 @@ class OmniRequestState:
         self.is_complete = False
 
     def advance(self) -> None:
+        if self.is_complete:
+            raise RuntimeError(
+                f"Request {self.request_id} is already complete, cannot advance"
+            )
         self.stage_status[self.current_stage] = "completed"
         self.current_stage += 1
         if self.current_stage >= self._num_stages:
@@ -36,6 +40,11 @@ class OmniOrchestrator:
         self._requests: Dict[str, OmniRequestState] = {}
 
     def submit(self, request_id: str) -> OmniRequestState:
+        if request_id in self._requests:
+            raise ValueError(
+                f"Request {request_id} already submitted to pipeline "
+                f"{self._pipeline_config.model_type}"
+            )
         state = OmniRequestState(
             request_id=request_id,
             num_stages=len(self._pipeline_config.stages),

--- a/rtp_llm/omni/engine/orchestrator.py
+++ b/rtp_llm/omni/engine/orchestrator.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+from rtp_llm.omni.config.stage_config import OmniPipelineConfig
+from rtp_llm.omni.engine.stage_connector import StageConnector, StageOutput
+from rtp_llm.omni.engine.stage_pool import OmniStagePool
+
+logger = logging.getLogger(__name__)
+
+
+class OmniRequestState:
+    def __init__(self, request_id: str, num_stages: int):
+        self.request_id = request_id
+        self.current_stage = 0
+        self._num_stages = num_stages
+        self.stage_status: List[str] = ["pending"] * num_stages
+        self.is_complete = False
+
+    def advance(self) -> None:
+        self.stage_status[self.current_stage] = "completed"
+        self.current_stage += 1
+        if self.current_stage >= self._num_stages:
+            self.is_complete = True
+
+
+class OmniOrchestrator:
+    def __init__(
+        self,
+        pipeline_config: OmniPipelineConfig,
+        connector: StageConnector,
+        stage_pools: Dict[int, OmniStagePool],
+    ):
+        self._pipeline_config = pipeline_config
+        self._connector = connector
+        self._stage_pools = stage_pools
+        self._requests: Dict[str, OmniRequestState] = {}
+
+    def submit(self, request_id: str) -> OmniRequestState:
+        state = OmniRequestState(
+            request_id=request_id,
+            num_stages=len(self._pipeline_config.stages),
+        )
+        self._requests[request_id] = state
+        logger.info(
+            f"Submitted request {request_id} to pipeline "
+            f"{self._pipeline_config.model_type}"
+        )
+        return state
+
+    def get_execution_order(self) -> List[int]:
+        return [s.stage_id for s in self._pipeline_config.stages]
+
+    def get_request_state(self, request_id: str) -> Optional[OmniRequestState]:
+        return self._requests.get(request_id)
+
+    def cleanup(self, request_id: str) -> None:
+        self._connector.cleanup(request_id)
+        self._requests.pop(request_id, None)
+        logger.info(f"Cleaned up request {request_id}")

--- a/rtp_llm/omni/engine/output_processor.py
+++ b/rtp_llm/omni/engine/output_processor.py
@@ -2,7 +2,7 @@ import base64
 import io
 import logging
 import struct
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 
@@ -43,8 +43,11 @@ class OmniOutputProcessor:
     def encode_audio_base64(
         waveform: torch.Tensor,
         sample_rate: int = 16000,
-        format: str = "wav",
+        audio_format: str = "wav",
     ) -> str:
+        if audio_format != "wav":
+            raise ValueError(f"Unsupported audio format: {audio_format}")
+
         audio_data = waveform.squeeze().cpu().numpy()
         buf = io.BytesIO()
         num_samples = len(audio_data)

--- a/rtp_llm/omni/engine/output_processor.py
+++ b/rtp_llm/omni/engine/output_processor.py
@@ -1,0 +1,69 @@
+import base64
+import io
+import logging
+import struct
+from typing import Any, Dict, Optional
+
+import torch
+
+from rtp_llm.omni.engine.stage_connector import StageOutput
+
+logger = logging.getLogger(__name__)
+
+
+class OmniOutputProcessor:
+    def assemble(
+        self,
+        stage_outputs: Dict[int, StageOutput],
+        final_output_types: Dict[str, int],
+    ) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+
+        for output_type, stage_id in final_output_types.items():
+            stage_out = stage_outputs.get(stage_id)
+            if stage_out is None:
+                continue
+
+            if output_type == "text":
+                result["text"] = stage_out.metadata.get("text", "")
+            elif output_type == "audio":
+                result["audio"] = {
+                    "waveform": stage_out.audio_waveform,
+                    "metadata": stage_out.metadata,
+                }
+            elif output_type == "image":
+                result["image"] = {
+                    "tensor": stage_out.image_tensor,
+                    "metadata": stage_out.metadata,
+                }
+
+        return result
+
+    @staticmethod
+    def encode_audio_base64(
+        waveform: torch.Tensor,
+        sample_rate: int = 16000,
+        format: str = "wav",
+    ) -> str:
+        audio_data = waveform.squeeze().cpu().numpy()
+        buf = io.BytesIO()
+        num_samples = len(audio_data)
+        num_channels = 1
+        sample_width = 4  # float32
+        # WAV header
+        buf.write(b"RIFF")
+        data_size = num_samples * num_channels * sample_width
+        buf.write(struct.pack("<I", 36 + data_size))
+        buf.write(b"WAVE")
+        buf.write(b"fmt ")
+        buf.write(struct.pack("<I", 16))
+        buf.write(struct.pack("<H", 3))  # IEEE float
+        buf.write(struct.pack("<H", num_channels))
+        buf.write(struct.pack("<I", sample_rate))
+        buf.write(struct.pack("<I", sample_rate * num_channels * sample_width))
+        buf.write(struct.pack("<H", num_channels * sample_width))
+        buf.write(struct.pack("<H", sample_width * 8))
+        buf.write(b"data")
+        buf.write(struct.pack("<I", data_size))
+        buf.write(audio_data.tobytes())
+        return base64.b64encode(buf.getvalue()).decode("utf-8")

--- a/rtp_llm/omni/engine/stage_connector.py
+++ b/rtp_llm/omni/engine/stage_connector.py
@@ -1,0 +1,57 @@
+import logging
+import threading
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StageOutput:
+    token_ids: Optional[List[int]] = None
+    embeddings: Optional[torch.Tensor] = None
+    audio_waveform: Optional[torch.Tensor] = None
+    image_tensor: Optional[torch.Tensor] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class StageConnector(ABC):
+    @abstractmethod
+    def put(self, request_id: str, stage_id: int, data: StageOutput) -> bool:
+        ...
+
+    @abstractmethod
+    def get(self, request_id: str, stage_id: int) -> Optional[StageOutput]:
+        ...
+
+    @abstractmethod
+    def cleanup(self, request_id: str) -> None:
+        ...
+
+
+class SharedMemoryConnector(StageConnector):
+    def __init__(self):
+        self._store: Dict[Tuple[str, int], StageOutput] = {}
+        self._lock = threading.Lock()
+
+    def put(self, request_id: str, stage_id: int, data: StageOutput) -> bool:
+        key = (request_id, stage_id)
+        with self._lock:
+            self._store[key] = data
+        return True
+
+    def get(self, request_id: str, stage_id: int) -> Optional[StageOutput]:
+        key = (request_id, stage_id)
+        with self._lock:
+            return self._store.get(key)
+
+    def cleanup(self, request_id: str) -> None:
+        with self._lock:
+            keys_to_remove = [
+                k for k in self._store if k[0] == request_id
+            ]
+            for k in keys_to_remove:
+                del self._store[k]

--- a/rtp_llm/omni/engine/stage_pool.py
+++ b/rtp_llm/omni/engine/stage_pool.py
@@ -35,6 +35,6 @@ class OmniStagePool:
                     f"No replicas available for stage {self.stage_id} "
                     f"({self.stage_config.model_stage})"
                 )
-            replica = self._replicas[self._index % len(self._replicas)]
-            self._index += 1
+            replica = self._replicas[self._index]
+            self._index = (self._index + 1) % len(self._replicas)
             return replica

--- a/rtp_llm/omni/engine/stage_pool.py
+++ b/rtp_llm/omni/engine/stage_pool.py
@@ -1,0 +1,40 @@
+import logging
+import threading
+from typing import Any, List
+
+from rtp_llm.omni.config.stage_config import OmniStageConfig
+
+logger = logging.getLogger(__name__)
+
+
+class OmniStagePool:
+    def __init__(self, stage_config: OmniStageConfig):
+        self.stage_config = stage_config
+        self.stage_id = stage_config.stage_id
+        self._replicas: List[Any] = []
+        self._index = 0
+        self._lock = threading.Lock()
+
+    @property
+    def num_replicas(self) -> int:
+        return len(self._replicas)
+
+    def add_replica(self, pipeline: Any) -> None:
+        with self._lock:
+            self._replicas.append(pipeline)
+            logger.info(
+                f"Added replica for stage {self.stage_id} "
+                f"({self.stage_config.model_stage}), "
+                f"total replicas: {len(self._replicas)}"
+            )
+
+    def get_replica(self) -> Any:
+        with self._lock:
+            if not self._replicas:
+                raise RuntimeError(
+                    f"No replicas available for stage {self.stage_id} "
+                    f"({self.stage_config.model_stage})"
+                )
+            replica = self._replicas[self._index % len(self._replicas)]
+            self._index += 1
+            return replica

--- a/rtp_llm/omni/engine/stage_processor_base.py
+++ b/rtp_llm/omni/engine/stage_processor_base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from rtp_llm.omni.engine.stage_connector import StageOutput
+
+
+class StageProcessorBase(ABC):
+    @abstractmethod
+    def process(self, source_output: StageOutput) -> StageOutput:
+        ...

--- a/rtp_llm/omni/models/qwen2_5_omni/__init__.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/__init__.py
@@ -1,0 +1,9 @@
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.models.qwen2_5_omni.pipeline_config import QWEN2_5_OMNI_PIPELINE
+
+import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+if OmniPipelineRegistry.get("qwen2_5_omni") is None:
+    OmniPipelineRegistry.register(QWEN2_5_OMNI_PIPELINE)

--- a/rtp_llm/omni/models/qwen2_5_omni/pipeline_config.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/pipeline_config.py
@@ -1,0 +1,42 @@
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+
+QWEN2_5_OMNI_PIPELINE = OmniPipelineConfig(
+    model_type="qwen2_5_omni",
+    model_arch="Qwen2_5OmniModel",
+    stages=(
+        OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="qwen2_5_omni_thinker",
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+        ),
+        OmniStageConfig(
+            stage_id=1,
+            model_stage="talker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="qwen2_5_omni_talker",
+            input_sources=(0,),
+            engine_output_type="latent",
+            stage_processor="qwen2_5_omni.thinker2talker",
+        ),
+        OmniStageConfig(
+            stage_id=2,
+            model_stage="code2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            model_cls="qwen2_5_omni_token2wav",
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="audio",
+            stage_processor="qwen2_5_omni.talker2code2wav",
+        ),
+    ),
+)

--- a/rtp_llm/omni/models/qwen2_5_omni/stage_processors.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/stage_processors.py
@@ -1,0 +1,21 @@
+from rtp_llm.omni.engine.stage_connector import StageOutput
+from rtp_llm.omni.engine.stage_processor_base import StageProcessorBase
+
+
+class Thinker2TalkerProcessor(StageProcessorBase):
+    def process(self, source_output: StageOutput) -> StageOutput:
+        return StageOutput(
+            embeddings=source_output.embeddings,
+            metadata={
+                "source_token_ids": source_output.token_ids,
+                "source_text": source_output.metadata.get("text", ""),
+            },
+        )
+
+
+class Talker2Code2WavProcessor(StageProcessorBase):
+    def process(self, source_output: StageOutput) -> StageOutput:
+        return StageOutput(
+            token_ids=source_output.token_ids,
+            metadata={"from_talker": True},
+        )

--- a/rtp_llm/omni/models/qwen2_5_omni/talker.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/talker.py
@@ -1,0 +1,52 @@
+from typing import Any
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.model_loader.model_weight_info import ModelWeightInfo
+from rtp_llm.model_loader.weight_module import AtomicWeight
+from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
+from rtp_llm.utils.model_weight import W, CkptWeightInfo, identity
+from rtp_llm.utils.util import get_config_from_path
+
+
+class Qwen25OmniTalkerWeight(QWenV2Weight):
+    def __init__(self, **kwargs: Any):
+        super().__init__(prefix="talker.", **kwargs)
+
+    def _get_hf_weight_info(self) -> ModelWeightInfo:
+        weight_info = super()._get_hf_weight_info()
+        for i, w in enumerate(weight_info.weights):
+            if w.name == W.lm_head:
+                weight_info.weights[i] = AtomicWeight(
+                    W.lm_head,
+                    [CkptWeightInfo("talker.codec_head.weight", identity)],
+                    identity,
+                )
+                break
+        return weight_info
+
+
+class Qwen25OmniTalker(QWenV2):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = ModelConfig()
+        config.ckpt_path = ckpt_path
+        config.max_seq_len = 32768
+        config.attn_config.rope_config.dim = 128
+        config.attn_config.rope_config.style = 1
+        config.has_pre_decoder_layernorm = False
+
+        config_json = get_config_from_path(ckpt_path)
+        if config_json and "talker_config" in config_json:
+            talker_cfg = config_json["talker_config"]
+            QWenV2._from_config_json(config, talker_cfg)
+        else:
+            cls._from_hf(config, ckpt_path)
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen25OmniTalkerWeight
+
+
+register_model("qwen2_5_omni_talker", Qwen25OmniTalker)

--- a/rtp_llm/omni/models/qwen2_5_omni/thinker.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/thinker.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
+from rtp_llm.utils.util import get_config_from_path
+
+
+class Qwen25OmniThinkerWeight(QWenV2Weight):
+    def __init__(self, **kwargs: Any):
+        super().__init__(prefix="thinker.", **kwargs)
+
+
+class Qwen25OmniThinker(QWenV2):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = ModelConfig()
+        config.ckpt_path = ckpt_path
+        config.max_seq_len = 32768
+        config.attn_config.rope_config.dim = 128
+        config.attn_config.rope_config.style = 1
+        config.has_pre_decoder_layernorm = False
+        config.special_tokens.bos_token_id = 151644
+        config.special_tokens.eos_token_id = 151645
+        config.special_tokens.stop_words_id_list = [[151645], [151644]]
+
+        config_json = get_config_from_path(ckpt_path)
+        if config_json and "thinker_config" in config_json:
+            text_config = config_json["thinker_config"].get("text_config", {})
+            QWenV2._from_config_json(config, text_config)
+        else:
+            cls._from_hf(config, ckpt_path)
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen25OmniThinkerWeight
+
+
+register_model("qwen2_5_omni_thinker", Qwen25OmniThinker)

--- a/rtp_llm/omni/models/qwen2_5_omni/thinker_audio.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/thinker_audio.py
@@ -1,0 +1,38 @@
+from typing import Dict
+
+import torch
+
+from rtp_llm.models.qwen_v2_audio.configuration_qwen2_audio import (
+    Qwen2AudioEncoderConfig,
+)
+from rtp_llm.models.qwen_v2_audio.modeling_qwen2_audio import Qwen2AudioEncoder
+
+
+class OmniAudioProcessor:
+    def __init__(self, audio_config_dict: Dict):
+        encoder_config = Qwen2AudioEncoderConfig.from_dict(audio_config_dict)
+        self.audio_tower = Qwen2AudioEncoder._from_config(encoder_config)
+
+    @staticmethod
+    def validate_config(audio_config: Dict) -> None:
+        required = [
+            "d_model",
+            "encoder_attention_heads",
+            "encoder_layers",
+            "num_mel_bins",
+        ]
+        for key in required:
+            if key not in audio_config:
+                raise ValueError(f"Missing required audio config key: {key}")
+
+    @property
+    def device(self):
+        return next(self.audio_tower.parameters()).device
+
+    @torch.inference_mode()
+    def encode(
+        self,
+        input_features: torch.Tensor,
+        attention_mask: torch.Tensor = None,
+    ) -> torch.Tensor:
+        return self.audio_tower(input_features, attention_mask=attention_mask)

--- a/rtp_llm/omni/models/qwen2_5_omni/thinker_processor.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/thinker_processor.py
@@ -1,0 +1,54 @@
+from typing import Dict
+
+import torch
+
+from rtp_llm.config.model_config import VitParameters
+from rtp_llm.models.multimodal.multimodal_common import AudioEmbeddingInterface
+from rtp_llm.omni.models.qwen2_5_omni.thinker_audio import OmniAudioProcessor
+from rtp_llm.omni.models.qwen2_5_omni.thinker_vision import OmniVisionProcessor
+from rtp_llm.utils.util import get_config_from_path
+
+
+class OmniThinkerProcessor(AudioEmbeddingInterface):
+    def __init__(self, mm_related_params: VitParameters, ckpt_path: str):
+        self.mm_related_params = mm_related_params
+        config_json = get_config_from_path(ckpt_path)
+        thinker_cfg = config_json.get("thinker_config", {})
+
+        audio_config = thinker_cfg.get("audio_config", {})
+        if audio_config:
+            self.audio_processor = OmniAudioProcessor(audio_config)
+        else:
+            self.audio_processor = None
+
+        vision_config = thinker_cfg.get("vision_config", {})
+        if vision_config:
+            self.vision_processor = OmniVisionProcessor(vision_config)
+        else:
+            self.vision_processor = None
+
+    @property
+    def _device(self):
+        if self.audio_processor:
+            return self.audio_processor.device
+        return torch.device("cpu")
+
+    @torch.inference_mode()
+    def audio_embedding(
+        self, features_dict: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        if self.audio_processor is None:
+            raise RuntimeError("Audio processor not initialized")
+        input_features = features_dict["input_features"].to(self._device)
+        attention_mask = features_dict.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(self._device)
+        return self.audio_processor.encode(input_features, attention_mask)
+
+    @torch.inference_mode()
+    def vision_embedding(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor = None
+    ) -> torch.Tensor:
+        if self.vision_processor is None:
+            raise RuntimeError("Vision processor not initialized")
+        return self.vision_processor.encode(pixel_values, grid_thw)

--- a/rtp_llm/omni/models/qwen2_5_omni/thinker_vision.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/thinker_vision.py
@@ -1,0 +1,26 @@
+from typing import Dict
+
+import torch
+
+
+class OmniVisionProcessor:
+    def __init__(self, vision_config_dict: Dict):
+        self.config = vision_config_dict
+        self.vit = None
+
+    @staticmethod
+    def validate_config(vision_config: Dict) -> None:
+        required = ["depth", "embed_dim", "num_heads", "patch_size"]
+        for key in required:
+            if key not in vision_config:
+                raise ValueError(f"Missing required vision config key: {key}")
+
+    @torch.inference_mode()
+    def encode(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor = None,
+    ) -> torch.Tensor:
+        if self.vit is None:
+            raise RuntimeError("Vision model not initialized. Load weights first.")
+        return self.vit(pixel_values, grid_thw=grid_thw)

--- a/rtp_llm/omni/models/qwen2_5_omni/token2wav.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/token2wav.py
@@ -1,0 +1,87 @@
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.model_factory_register import register_model
+from rtp_llm.model_loader.model_weight_info import ModelDeployWeightInfo, ModelWeightInfo
+from rtp_llm.model_loader.weight_module import AtomicWeight
+from rtp_llm.models.base_model import BaseModel
+from rtp_llm.omni.models.qwen2_5_omni.token2wav_bigvgan import BigVGAN, BigVGANConfig
+from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import OmniDiT, OmniDiTConfig
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
+from rtp_llm.utils.util import get_config_from_path
+
+
+class Qwen25OmniToken2WavWeight(ModelDeployWeightInfo):
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+
+    def _get_weight_info(self):
+        weights: List[AtomicWeight] = []
+        return ModelWeightInfo(layer_weights=[], weights=weights)
+
+
+class Qwen25OmniToken2Wav(BaseModel):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = ModelConfig()
+        config.ckpt_path = ckpt_path
+
+        config_json = get_config_from_path(ckpt_path)
+        if config_json and "token2wav_config" in config_json:
+            t2w_cfg = config_json["token2wav_config"]
+            dit_cfg = t2w_cfg.get("dit_config", {})
+            bigvgan_cfg = t2w_cfg.get("bigvgan_config", {})
+
+            config.hidden_size = dit_cfg.get("dim", 1024)
+            config.num_layers = dit_cfg.get("depth", 22)
+            config.vocab_size = dit_cfg.get("num_embeds", 8193)
+
+        return config
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen25OmniToken2WavWeight
+
+    def _create_python_model(self):
+        config_json = get_config_from_path(self.model_config.ckpt_path)
+        if config_json and "token2wav_config" in config_json:
+            t2w_cfg = config_json["token2wav_config"]
+            self.dit = OmniDiT(OmniDiTConfig.from_dict(t2w_cfg.get("dit_config", {})))
+            self.bigvgan = BigVGAN(
+                BigVGANConfig.from_dict(t2w_cfg.get("bigvgan_config", {}))
+            )
+        else:
+            self.dit = OmniDiT(OmniDiTConfig())
+            self.bigvgan = BigVGAN(BigVGANConfig())
+
+    @torch.inference_mode()
+    def generate_audio(
+        self,
+        codec_ids: torch.Tensor,
+        num_steps: int = 32,
+        spk_emb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        batch_size, seq_len = codec_ids.shape
+        mel_dim = self.dit.config.mel_dim
+
+        x = torch.randn(
+            batch_size, seq_len, mel_dim, device=codec_ids.device
+        )
+
+        dt = 1.0 / num_steps
+        for i in range(num_steps):
+            t_val = i * dt
+            t = torch.full(
+                (batch_size,), t_val, device=codec_ids.device, dtype=x.dtype
+            )
+            v = self.dit(x, t, codec_ids, spk_emb)
+            x = x + v * dt
+
+        mel = x.transpose(1, 2)
+        waveform = self.bigvgan(mel)
+        return waveform
+
+
+register_model("qwen2_5_omni_token2wav", Qwen25OmniToken2Wav)

--- a/rtp_llm/omni/models/qwen2_5_omni/token2wav_bigvgan.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/token2wav_bigvgan.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class BigVGANConfig:
+    mel_dim: int = 80
+    upsample_rates: List[int] = field(default_factory=lambda: [5, 3, 2, 2, 2, 2])
+    upsample_initial_channel: int = 1536
+    upsample_kernel_sizes: List[int] = field(
+        default_factory=lambda: [11, 7, 4, 4, 4, 4]
+    )
+    resblock_kernel_sizes: List[int] = field(default_factory=lambda: [3, 7, 11])
+    resblock_dilation_sizes: List[List[int]] = field(
+        default_factory=lambda: [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+    )
+    use_bias_at_final: bool = False
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "BigVGANConfig":
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+class ResBlock(nn.Module):
+    def __init__(self, channels: int, kernel_size: int, dilations: List[int]):
+        super().__init__()
+        self.convs1 = nn.ModuleList()
+        self.convs2 = nn.ModuleList()
+        for d in dilations:
+            padding = (kernel_size * d - d) // 2
+            self.convs1.append(
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    dilation=d,
+                    padding=padding,
+                )
+            )
+            self.convs2.append(
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    dilation=1,
+                    padding=(kernel_size - 1) // 2,
+                )
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for c1, c2 in zip(self.convs1, self.convs2):
+            xt = F.leaky_relu(x, 0.1)
+            xt = c1(xt)
+            xt = F.leaky_relu(xt, 0.1)
+            xt = c2(xt)
+            x = xt + x
+        return x
+
+
+class BigVGAN(nn.Module):
+    def __init__(self, config: BigVGANConfig):
+        super().__init__()
+        self.config = config
+        ch = config.upsample_initial_channel
+
+        self.conv_pre = nn.Conv1d(config.mel_dim, ch, 7, padding=3)
+
+        self.ups = nn.ModuleList()
+        self.resblocks = nn.ModuleList()
+
+        for i, (u, k) in enumerate(
+            zip(config.upsample_rates, config.upsample_kernel_sizes)
+        ):
+            out_ch = ch // 2
+            self.ups.append(
+                nn.ConvTranspose1d(
+                    ch,
+                    out_ch,
+                    k,
+                    stride=u,
+                    padding=(k - u) // 2,
+                )
+            )
+            for j, (rk, rd) in enumerate(
+                zip(config.resblock_kernel_sizes, config.resblock_dilation_sizes)
+            ):
+                self.resblocks.append(ResBlock(out_ch, rk, rd))
+            ch = out_ch
+
+        self.conv_post = nn.Conv1d(
+            ch, 1, 7, padding=3, bias=config.use_bias_at_final
+        )
+        self.num_kernels = len(config.resblock_kernel_sizes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv_pre(x)
+        for i, up in enumerate(self.ups):
+            x = F.leaky_relu(x, 0.1)
+            x = up(x)
+            xs = None
+            for j in range(self.num_kernels):
+                idx = i * self.num_kernels + j
+                if xs is None:
+                    xs = self.resblocks[idx](x)
+                else:
+                    xs += self.resblocks[idx](x)
+            x = xs / self.num_kernels
+        x = F.leaky_relu(x)
+        x = self.conv_post(x)
+        x = torch.tanh(x)
+        return x

--- a/rtp_llm/omni/models/qwen2_5_omni/token2wav_dit.py
+++ b/rtp_llm/omni/models/qwen2_5_omni/token2wav_dit.py
@@ -1,0 +1,126 @@
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class OmniDiTConfig:
+    depth: int = 22
+    dim: int = 1024
+    heads: int = 16
+    head_dim: int = 64
+    ff_mult: int = 2
+    mel_dim: int = 80
+    num_embeds: int = 8193
+    emb_dim: int = 512
+    dropout: float = 0.1
+
+    @classmethod
+    def from_dict(cls, d: Dict) -> "OmniDiTConfig":
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+class SinusoidalPosEmb(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        half = self.dim // 2
+        emb = math.log(10000) / (half - 1)
+        emb = torch.exp(
+            torch.arange(half, device=t.device, dtype=torch.float32) * -emb
+        )
+        emb = t.unsqueeze(-1) * emb.unsqueeze(0)
+        return torch.cat([emb.sin(), emb.cos()], dim=-1)
+
+
+class DiTBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        heads: int,
+        head_dim: int,
+        ff_mult: int,
+        dropout: float,
+    ):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = nn.MultiheadAttention(
+            dim, heads, dropout=dropout, batch_first=True
+        )
+        self.norm2 = nn.LayerNorm(dim)
+        self.ff = nn.Sequential(
+            nn.Linear(dim, dim * ff_mult),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * ff_mult, dim),
+            nn.Dropout(dropout),
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(dim, 6 * dim),
+        )
+
+    def forward(self, x: torch.Tensor, cond: torch.Tensor) -> torch.Tensor:
+        mod = self.adaLN_modulation(cond).unsqueeze(1)
+        gamma1, beta1, alpha1, gamma2, beta2, alpha2 = mod.chunk(6, dim=-1)
+
+        h = self.norm1(x) * (1 + gamma1) + beta1
+        h, _ = self.attn(h, h, h)
+        x = x + alpha1 * h
+
+        h = self.norm2(x) * (1 + gamma2) + beta2
+        h = self.ff(h)
+        x = x + alpha2 * h
+        return x
+
+
+class OmniDiT(nn.Module):
+    def __init__(self, config: OmniDiTConfig):
+        super().__init__()
+        self.config = config
+        self.input_proj = nn.Linear(config.mel_dim, config.dim)
+        self.codec_embed = nn.Embedding(config.num_embeds, config.emb_dim)
+        self.codec_proj = nn.Linear(config.emb_dim, config.dim)
+        self.time_embed = nn.Sequential(
+            SinusoidalPosEmb(config.dim),
+            nn.Linear(config.dim, config.dim),
+            nn.SiLU(),
+            nn.Linear(config.dim, config.dim),
+        )
+        self.blocks = nn.ModuleList(
+            [
+                DiTBlock(
+                    config.dim,
+                    config.heads,
+                    config.head_dim,
+                    config.ff_mult,
+                    config.dropout,
+                )
+                for _ in range(config.depth)
+            ]
+        )
+        self.final_norm = nn.LayerNorm(config.dim)
+        self.output_proj = nn.Linear(config.dim, config.mel_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        codec_ids: torch.Tensor,
+        spk_emb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        h = self.input_proj(x)
+        codec_h = self.codec_proj(self.codec_embed(codec_ids))
+        h = h + codec_h
+        t_emb = self.time_embed(t)
+
+        for block in self.blocks:
+            h = block(h, t_emb)
+
+        h = self.final_norm(h)
+        return self.output_proj(h)

--- a/rtp_llm/test/omni/test_model_factory_omni.py
+++ b/rtp_llm/test/omni/test_model_factory_omni.py
@@ -1,5 +1,6 @@
 import unittest
 
+from rtp_llm.model_factory_register import _model_factory
 from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
 from rtp_llm.omni.config.stage_config import (
     OmniPipelineConfig,
@@ -9,10 +10,18 @@ from rtp_llm.omni.config.stage_config import (
 from rtp_llm.omni.engine.omni_engine import OmniEngine
 
 
+class _FakeThinker:
+    pass
+
+
 class TestModelFactoryOmniDetection(unittest.TestCase):
     def setUp(self):
         OmniPipelineRegistry._registry.clear()
         OmniPipelineRegistry._arch_registry.clear()
+        _model_factory["TestThinker"] = _FakeThinker
+
+    def tearDown(self):
+        _model_factory.pop("TestThinker", None)
 
     def test_registry_lookup_for_omni_model(self):
         pipeline = OmniPipelineConfig(

--- a/rtp_llm/test/omni/test_model_factory_omni.py
+++ b/rtp_llm/test/omni/test_model_factory_omni.py
@@ -1,0 +1,61 @@
+import unittest
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+from rtp_llm.omni.engine.omni_engine import OmniEngine
+
+
+class TestModelFactoryOmniDetection(unittest.TestCase):
+    def setUp(self):
+        OmniPipelineRegistry._registry.clear()
+        OmniPipelineRegistry._arch_registry.clear()
+
+    def test_registry_lookup_for_omni_model(self):
+        pipeline = OmniPipelineConfig(
+            model_type="test_omni_model",
+            model_arch="TestOmniArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                ),
+            ),
+        )
+        OmniPipelineRegistry.register(pipeline)
+
+        result = OmniPipelineRegistry.get("test_omni_model")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.model_type, "test_omni_model")
+
+    def test_registry_returns_none_for_regular_model(self):
+        result = OmniPipelineRegistry.get("qwen_2")
+        self.assertIsNone(result)
+
+    def test_omni_engine_from_pipeline_config(self):
+        pipeline = OmniPipelineConfig(
+            model_type="test_omni_model",
+            model_arch="TestOmniArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                ),
+            ),
+        )
+        engine = OmniEngine.from_pipeline_config(pipeline)
+        self.assertIsInstance(engine, OmniEngine)
+        self.assertEqual(engine.num_stages, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_omni_engine.py
+++ b/rtp_llm/test/omni/test_omni_engine.py
@@ -1,0 +1,69 @@
+import unittest
+
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+from rtp_llm.omni.engine.omni_engine import OmniEngine
+
+
+class TestOmniEngine(unittest.TestCase):
+    def _make_pipeline_config(self):
+        return OmniPipelineConfig(
+            model_type="test_omni",
+            model_arch="TestOmniArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                    final_output=True,
+                    final_output_type="text",
+                ),
+                OmniStageConfig(
+                    stage_id=1,
+                    model_stage="talker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestTalker",
+                    input_sources=(0,),
+                    final_output=True,
+                    final_output_type="audio",
+                ),
+            ),
+        )
+
+    def test_create_omni_engine(self):
+        config = self._make_pipeline_config()
+        engine = OmniEngine(pipeline_config=config)
+        self.assertEqual(engine.pipeline_config.model_type, "test_omni")
+        self.assertEqual(engine.num_stages, 2)
+
+    def test_get_final_output_types(self):
+        config = self._make_pipeline_config()
+        engine = OmniEngine(pipeline_config=config)
+        output_types = engine.get_final_output_types()
+        self.assertEqual(output_types, {"text": 0, "audio": 1})
+
+    def test_stage_pools_initialized(self):
+        config = self._make_pipeline_config()
+        engine = OmniEngine(pipeline_config=config)
+        self.assertEqual(len(engine.stage_pools), 2)
+        self.assertIn(0, engine.stage_pools)
+        self.assertIn(1, engine.stage_pools)
+
+    def test_orchestrator_initialized(self):
+        config = self._make_pipeline_config()
+        engine = OmniEngine(pipeline_config=config)
+        self.assertIsNotNone(engine.orchestrator)
+
+    def test_connector_initialized(self):
+        config = self._make_pipeline_config()
+        engine = OmniEngine(pipeline_config=config)
+        self.assertIsNotNone(engine.connector)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_omni_engine_integration.py
+++ b/rtp_llm/test/omni/test_omni_engine_integration.py
@@ -1,0 +1,70 @@
+import unittest
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+
+
+class TestOmniEngineStageInstantiation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+    def test_engine_resolves_stage_model_classes(self):
+        from rtp_llm.model_factory_register import _model_factory
+
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+
+        for stage in config.stages:
+            self.assertIn(
+                stage.model_cls,
+                _model_factory,
+                f"Stage model_cls '{stage.model_cls}' not registered",
+            )
+
+    def test_engine_from_pipeline_config_validates(self):
+        from rtp_llm.omni.engine.omni_engine import OmniEngine
+
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        engine = OmniEngine.from_pipeline_config(config)
+        self.assertEqual(engine.num_stages, 3)
+
+    def test_engine_final_output_types(self):
+        from rtp_llm.omni.engine.omni_engine import OmniEngine
+
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        engine = OmniEngine.from_pipeline_config(config)
+        output_types = engine.get_final_output_types()
+        self.assertIn("text", output_types)
+        self.assertIn("audio", output_types)
+
+
+class TestOmniImportChain(unittest.TestCase):
+    def test_importing_omni_models_registers_pipeline(self):
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+
+    def test_all_stage_models_registered(self):
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+        import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+        from rtp_llm.model_factory_register import _model_factory
+
+        for model_name in [
+            "qwen2_5_omni_thinker",
+            "qwen2_5_omni_talker",
+            "qwen2_5_omni_token2wav",
+        ]:
+            self.assertIn(
+                model_name, _model_factory, f"{model_name} not registered"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_orchestrator.py
+++ b/rtp_llm/test/omni/test_orchestrator.py
@@ -1,0 +1,111 @@
+import unittest
+
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+from rtp_llm.omni.engine.orchestrator import OmniOrchestrator, OmniRequestState
+from rtp_llm.omni.engine.stage_connector import SharedMemoryConnector
+
+
+class TestOmniRequestState(unittest.TestCase):
+    def test_create_request_state(self):
+        state = OmniRequestState(
+            request_id="req_1",
+            num_stages=3,
+        )
+        self.assertEqual(state.request_id, "req_1")
+        self.assertEqual(state.current_stage, 0)
+        self.assertFalse(state.is_complete)
+        self.assertEqual(len(state.stage_status), 3)
+        self.assertTrue(all(s == "pending" for s in state.stage_status))
+
+    def test_advance_stage(self):
+        state = OmniRequestState(request_id="req_1", num_stages=3)
+        state.advance()
+        self.assertEqual(state.current_stage, 1)
+        self.assertEqual(state.stage_status[0], "completed")
+
+    def test_complete_on_last_stage(self):
+        state = OmniRequestState(request_id="req_1", num_stages=2)
+        state.advance()
+        state.advance()
+        self.assertTrue(state.is_complete)
+
+
+class TestOmniOrchestrator(unittest.TestCase):
+    def _make_pipeline_config(self):
+        return OmniPipelineConfig(
+            model_type="test_omni",
+            model_arch="TestOmniArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                    final_output=True,
+                    final_output_type="text",
+                ),
+                OmniStageConfig(
+                    stage_id=1,
+                    model_stage="talker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestTalker",
+                    input_sources=(0,),
+                    final_output=True,
+                    final_output_type="audio",
+                ),
+            ),
+        )
+
+    def test_create_orchestrator(self):
+        config = self._make_pipeline_config()
+        connector = SharedMemoryConnector()
+        orchestrator = OmniOrchestrator(
+            pipeline_config=config,
+            connector=connector,
+            stage_pools={},
+        )
+        self.assertIsNotNone(orchestrator)
+
+    def test_submit_creates_request_state(self):
+        config = self._make_pipeline_config()
+        connector = SharedMemoryConnector()
+        orchestrator = OmniOrchestrator(
+            pipeline_config=config,
+            connector=connector,
+            stage_pools={},
+        )
+        state = orchestrator.submit("req_1")
+        self.assertIsInstance(state, OmniRequestState)
+        self.assertEqual(state.request_id, "req_1")
+
+    def test_get_execution_order(self):
+        config = self._make_pipeline_config()
+        connector = SharedMemoryConnector()
+        orchestrator = OmniOrchestrator(
+            pipeline_config=config,
+            connector=connector,
+            stage_pools={},
+        )
+        order = orchestrator.get_execution_order()
+        self.assertEqual(order, [0, 1])
+
+    def test_cleanup_request(self):
+        config = self._make_pipeline_config()
+        connector = SharedMemoryConnector()
+        orchestrator = OmniOrchestrator(
+            pipeline_config=config,
+            connector=connector,
+            stage_pools={},
+        )
+        orchestrator.submit("req_1")
+        orchestrator.cleanup("req_1")
+        self.assertNotIn("req_1", orchestrator._requests)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_orchestrator.py
+++ b/rtp_llm/test/omni/test_orchestrator.py
@@ -33,6 +33,13 @@ class TestOmniRequestState(unittest.TestCase):
         state.advance()
         self.assertTrue(state.is_complete)
 
+    def test_advance_past_complete_raises(self):
+        state = OmniRequestState(request_id="req_1", num_stages=1)
+        state.advance()
+        self.assertTrue(state.is_complete)
+        with self.assertRaises(RuntimeError):
+            state.advance()
+
 
 class TestOmniOrchestrator(unittest.TestCase):
     def _make_pipeline_config(self):
@@ -93,6 +100,18 @@ class TestOmniOrchestrator(unittest.TestCase):
         )
         order = orchestrator.get_execution_order()
         self.assertEqual(order, [0, 1])
+
+    def test_submit_duplicate_raises(self):
+        config = self._make_pipeline_config()
+        connector = SharedMemoryConnector()
+        orchestrator = OmniOrchestrator(
+            pipeline_config=config,
+            connector=connector,
+            stage_pools={},
+        )
+        orchestrator.submit("req_1")
+        with self.assertRaises(ValueError):
+            orchestrator.submit("req_1")
 
     def test_cleanup_request(self):
         config = self._make_pipeline_config()

--- a/rtp_llm/test/omni/test_output_modality.py
+++ b/rtp_llm/test/omni/test_output_modality.py
@@ -1,0 +1,26 @@
+import unittest
+
+from rtp_llm.omni.config.output_modality import OutputModality
+
+
+class TestOutputModality(unittest.TestCase):
+    def test_flag_values(self):
+        self.assertEqual(OutputModality.TEXT.value, 1)
+        self.assertEqual(OutputModality.AUDIO.value, 2)
+        self.assertEqual(OutputModality.IMAGE.value, 4)
+        self.assertEqual(OutputModality.VIDEO.value, 8)
+
+    def test_flag_combination(self):
+        combined = OutputModality.TEXT | OutputModality.AUDIO
+        self.assertIn(OutputModality.TEXT, combined)
+        self.assertIn(OutputModality.AUDIO, combined)
+        self.assertNotIn(OutputModality.IMAGE, combined)
+
+    def test_all_modalities(self):
+        all_mod = OutputModality.TEXT | OutputModality.AUDIO | OutputModality.IMAGE | OutputModality.VIDEO
+        self.assertIn(OutputModality.TEXT, all_mod)
+        self.assertIn(OutputModality.VIDEO, all_mod)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_output_processor.py
+++ b/rtp_llm/test/omni/test_output_processor.py
@@ -1,0 +1,50 @@
+import base64
+import unittest
+
+import torch
+
+from rtp_llm.omni.engine.output_processor import OmniOutputProcessor
+from rtp_llm.omni.engine.stage_connector import StageOutput
+
+
+class TestOmniOutputProcessor(unittest.TestCase):
+    def test_assemble_text_only(self):
+        processor = OmniOutputProcessor()
+        stage_outputs = {
+            0: StageOutput(token_ids=[1, 2, 3], metadata={"text": "Hello world"}),
+        }
+        result = processor.assemble(stage_outputs, final_output_types={"text": 0})
+        self.assertEqual(result["text"], "Hello world")
+        self.assertNotIn("audio", result)
+
+    def test_assemble_text_and_audio(self):
+        processor = OmniOutputProcessor()
+        waveform = torch.randn(1, 16000)
+        stage_outputs = {
+            0: StageOutput(metadata={"text": "Hello"}),
+            2: StageOutput(audio_waveform=waveform),
+        }
+        result = processor.assemble(
+            stage_outputs,
+            final_output_types={"text": 0, "audio": 2},
+        )
+        self.assertEqual(result["text"], "Hello")
+        self.assertIn("audio", result)
+        self.assertIsInstance(result["audio"]["waveform"], torch.Tensor)
+
+    def test_assemble_empty_outputs(self):
+        processor = OmniOutputProcessor()
+        result = processor.assemble({}, final_output_types={})
+        self.assertEqual(result, {})
+
+    def test_encode_audio_wav_base64(self):
+        processor = OmniOutputProcessor()
+        waveform = torch.zeros(1, 100, dtype=torch.float32)
+        encoded = processor.encode_audio_base64(waveform, sample_rate=16000)
+        self.assertIsInstance(encoded, str)
+        decoded_bytes = base64.b64decode(encoded)
+        self.assertGreater(len(decoded_bytes), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_pipeline_config_qwen25.py
+++ b/rtp_llm/test/omni/test_pipeline_config_qwen25.py
@@ -1,0 +1,57 @@
+import unittest
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.config.stage_config import StageExecutionType
+
+
+class TestQwen25OmniPipelineConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni  # noqa: F401
+
+    def test_pipeline_registered(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertIsNotNone(config)
+        self.assertEqual(config.model_type, "qwen2_5_omni")
+        self.assertEqual(config.model_arch, "Qwen2_5OmniModel")
+
+    def test_pipeline_has_three_stages(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        self.assertEqual(len(config.stages), 3)
+
+    def test_thinker_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        thinker = config.get_stage(0)
+        self.assertEqual(thinker.model_stage, "thinker")
+        self.assertEqual(thinker.execution_type, StageExecutionType.LLM_AR)
+        self.assertEqual(thinker.model_cls, "qwen2_5_omni_thinker")
+        self.assertTrue(thinker.final_output)
+        self.assertEqual(thinker.final_output_type, "text")
+        self.assertTrue(thinker.requires_multimodal_data)
+
+    def test_talker_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        talker = config.get_stage(1)
+        self.assertEqual(talker.model_stage, "talker")
+        self.assertEqual(talker.execution_type, StageExecutionType.LLM_AR)
+        self.assertEqual(talker.model_cls, "qwen2_5_omni_talker")
+        self.assertEqual(talker.input_sources, (0,))
+
+    def test_code2wav_stage(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        c2w = config.get_stage(2)
+        self.assertEqual(c2w.model_stage, "code2wav")
+        self.assertEqual(c2w.execution_type, StageExecutionType.LLM_GENERATION)
+        self.assertEqual(c2w.model_cls, "qwen2_5_omni_token2wav")
+        self.assertTrue(c2w.final_output)
+        self.assertEqual(c2w.final_output_type, "audio")
+
+    def test_final_output_stages(self):
+        config = OmniPipelineRegistry.get("qwen2_5_omni")
+        finals = config.get_final_output_stages()
+        types = {s.final_output_type for s in finals}
+        self.assertEqual(types, {"text", "audio"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_pipeline_registry.py
+++ b/rtp_llm/test/omni/test_pipeline_registry.py
@@ -1,0 +1,68 @@
+import unittest
+
+from rtp_llm.omni.config.pipeline_registry import OmniPipelineRegistry
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+
+
+class TestOmniPipelineRegistry(unittest.TestCase):
+    def setUp(self):
+        OmniPipelineRegistry._registry.clear()
+        OmniPipelineRegistry._arch_registry.clear()
+
+    def _make_pipeline(self, model_type="test_omni"):
+        return OmniPipelineConfig(
+            model_type=model_type,
+            model_arch=f"TestOmniArch_{model_type}",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                ),
+            ),
+        )
+
+    def test_register_and_get(self):
+        pipeline = self._make_pipeline()
+        OmniPipelineRegistry.register(pipeline)
+        result = OmniPipelineRegistry.get("test_omni")
+        self.assertIs(result, pipeline)
+
+    def test_get_returns_none_for_unknown(self):
+        result = OmniPipelineRegistry.get("nonexistent")
+        self.assertIsNone(result)
+
+    def test_get_by_arch(self):
+        pipeline = self._make_pipeline()
+        OmniPipelineRegistry.register(pipeline)
+        result = OmniPipelineRegistry.get_by_arch("TestOmniArch_test_omni")
+        self.assertIs(result, pipeline)
+
+    def test_get_by_arch_returns_none_for_unknown(self):
+        result = OmniPipelineRegistry.get_by_arch("NonexistentArch")
+        self.assertIsNone(result)
+
+    def test_register_duplicate_raises(self):
+        pipeline1 = self._make_pipeline()
+        pipeline2 = self._make_pipeline()
+        OmniPipelineRegistry.register(pipeline1)
+        with self.assertRaises(ValueError):
+            OmniPipelineRegistry.register(pipeline2)
+
+    def test_list_all(self):
+        p1 = self._make_pipeline("a")
+        p2 = self._make_pipeline("b")
+        OmniPipelineRegistry.register(p1)
+        OmniPipelineRegistry.register(p2)
+        all_pipelines = OmniPipelineRegistry.list_all()
+        self.assertEqual(len(all_pipelines), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_pipeline_registry.py
+++ b/rtp_llm/test/omni/test_pipeline_registry.py
@@ -55,6 +55,37 @@ class TestOmniPipelineRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             OmniPipelineRegistry.register(pipeline2)
 
+    def test_register_duplicate_arch_raises(self):
+        p1 = OmniPipelineConfig(
+            model_type="type_a",
+            model_arch="SharedArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                ),
+            ),
+        )
+        p2 = OmniPipelineConfig(
+            model_type="type_b",
+            model_arch="SharedArch",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="TestThinker",
+                    input_sources=(),
+                ),
+            ),
+        )
+        OmniPipelineRegistry.register(p1)
+        with self.assertRaises(ValueError):
+            OmniPipelineRegistry.register(p2)
+
     def test_list_all(self):
         p1 = self._make_pipeline("a")
         p2 = self._make_pipeline("b")

--- a/rtp_llm/test/omni/test_stage_config.py
+++ b/rtp_llm/test/omni/test_stage_config.py
@@ -1,0 +1,145 @@
+import unittest
+
+from rtp_llm.omni.config.stage_config import (
+    OmniPipelineConfig,
+    OmniStageConfig,
+    StageExecutionType,
+)
+
+
+class TestStageExecutionType(unittest.TestCase):
+    def test_enum_values_exist(self):
+        self.assertEqual(StageExecutionType.LLM_AR.value, "llm_ar")
+        self.assertEqual(StageExecutionType.LLM_GENERATION.value, "llm_generation")
+        self.assertEqual(StageExecutionType.DIFFUSION.value, "diffusion")
+
+    def test_enum_members_count(self):
+        self.assertEqual(len(StageExecutionType), 3)
+
+
+class TestOmniStageConfig(unittest.TestCase):
+    def test_create_stage_config(self):
+        stage = OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="Qwen2_5OmniThinker",
+            input_sources=(),
+        )
+        self.assertEqual(stage.stage_id, 0)
+        self.assertEqual(stage.model_stage, "thinker")
+        self.assertEqual(stage.execution_type, StageExecutionType.LLM_AR)
+        self.assertEqual(stage.model_cls, "Qwen2_5OmniThinker")
+        self.assertEqual(stage.input_sources, ())
+        self.assertFalse(stage.final_output)
+        self.assertIsNone(stage.final_output_type)
+        self.assertFalse(stage.requires_multimodal_data)
+        self.assertIsNone(stage.engine_output_type)
+        self.assertIsNone(stage.stage_processor)
+
+    def test_stage_config_with_all_fields(self):
+        stage = OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="Qwen2_5OmniThinker",
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+            stage_processor=None,
+        )
+        self.assertTrue(stage.final_output)
+        self.assertEqual(stage.final_output_type, "text")
+        self.assertTrue(stage.requires_multimodal_data)
+        self.assertEqual(stage.engine_output_type, "latent")
+
+    def test_stage_config_is_frozen(self):
+        stage = OmniStageConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="Qwen2_5OmniThinker",
+            input_sources=(),
+        )
+        with self.assertRaises(AttributeError):
+            stage.stage_id = 1
+
+
+class TestOmniPipelineConfig(unittest.TestCase):
+    def _make_pipeline(self):
+        return OmniPipelineConfig(
+            model_type="qwen2_5_omni",
+            model_arch="Qwen2_5OmniForConditionalGeneration",
+            stages=(
+                OmniStageConfig(
+                    stage_id=0,
+                    model_stage="thinker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="Qwen2_5OmniThinker",
+                    input_sources=(),
+                    final_output=True,
+                    final_output_type="text",
+                    requires_multimodal_data=True,
+                    engine_output_type="latent",
+                ),
+                OmniStageConfig(
+                    stage_id=1,
+                    model_stage="talker",
+                    execution_type=StageExecutionType.LLM_AR,
+                    model_cls="Qwen2_5OmniTalker",
+                    input_sources=(0,),
+                    engine_output_type="latent",
+                    stage_processor="qwen2_5_omni.thinker2talker",
+                ),
+                OmniStageConfig(
+                    stage_id=2,
+                    model_stage="code2wav",
+                    execution_type=StageExecutionType.LLM_GENERATION,
+                    model_cls="Qwen2_5OmniToken2Wav",
+                    input_sources=(1,),
+                    final_output=True,
+                    final_output_type="audio",
+                    stage_processor="qwen2_5_omni.talker2code2wav",
+                ),
+            ),
+        )
+
+    def test_pipeline_config_fields(self):
+        pipeline = self._make_pipeline()
+        self.assertEqual(pipeline.model_type, "qwen2_5_omni")
+        self.assertEqual(pipeline.model_arch, "Qwen2_5OmniForConditionalGeneration")
+        self.assertEqual(len(pipeline.stages), 3)
+
+    def test_pipeline_config_is_frozen(self):
+        pipeline = self._make_pipeline()
+        with self.assertRaises(AttributeError):
+            pipeline.model_type = "other"
+
+    def test_pipeline_stage_access(self):
+        pipeline = self._make_pipeline()
+        self.assertEqual(pipeline.stages[0].model_stage, "thinker")
+        self.assertEqual(pipeline.stages[1].model_stage, "talker")
+        self.assertEqual(pipeline.stages[2].model_stage, "code2wav")
+
+    def test_pipeline_get_final_output_stages(self):
+        pipeline = self._make_pipeline()
+        final_stages = pipeline.get_final_output_stages()
+        self.assertEqual(len(final_stages), 2)
+        self.assertEqual(final_stages[0].stage_id, 0)
+        self.assertEqual(final_stages[1].stage_id, 2)
+
+    def test_pipeline_get_stage_by_id(self):
+        pipeline = self._make_pipeline()
+        stage = pipeline.get_stage(1)
+        self.assertEqual(stage.model_stage, "talker")
+
+    def test_pipeline_get_stage_by_id_not_found(self):
+        pipeline = self._make_pipeline()
+        with self.assertRaises(KeyError):
+            pipeline.get_stage(99)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_stage_connector.py
+++ b/rtp_llm/test/omni/test_stage_connector.py
@@ -1,0 +1,73 @@
+import unittest
+
+import torch
+
+from rtp_llm.omni.engine.stage_connector import (
+    SharedMemoryConnector,
+    StageConnector,
+    StageOutput,
+)
+
+
+class TestStageOutput(unittest.TestCase):
+    def test_default_fields(self):
+        output = StageOutput()
+        self.assertIsNone(output.token_ids)
+        self.assertIsNone(output.embeddings)
+        self.assertIsNone(output.audio_waveform)
+        self.assertIsNone(output.image_tensor)
+        self.assertEqual(output.metadata, {})
+
+    def test_with_token_ids(self):
+        output = StageOutput(token_ids=[1, 2, 3])
+        self.assertEqual(output.token_ids, [1, 2, 3])
+
+    def test_with_embeddings(self):
+        emb = torch.randn(10, 128)
+        output = StageOutput(embeddings=emb)
+        self.assertTrue(torch.equal(output.embeddings, emb))
+
+
+class TestSharedMemoryConnector(unittest.TestCase):
+    def setUp(self):
+        self.connector = SharedMemoryConnector()
+
+    def test_put_and_get(self):
+        output = StageOutput(token_ids=[1, 2, 3])
+        result = self.connector.put("req_1", 0, output)
+        self.assertTrue(result)
+
+        retrieved = self.connector.get("req_1", 0)
+        self.assertIsNotNone(retrieved)
+        self.assertEqual(retrieved.token_ids, [1, 2, 3])
+
+    def test_get_nonexistent_returns_none(self):
+        result = self.connector.get("nonexistent", 0)
+        self.assertIsNone(result)
+
+    def test_cleanup(self):
+        self.connector.put("req_1", 0, StageOutput(token_ids=[1]))
+        self.connector.put("req_1", 1, StageOutput(token_ids=[2]))
+        self.connector.put("req_2", 0, StageOutput(token_ids=[3]))
+
+        self.connector.cleanup("req_1")
+
+        self.assertIsNone(self.connector.get("req_1", 0))
+        self.assertIsNone(self.connector.get("req_1", 1))
+        self.assertIsNotNone(self.connector.get("req_2", 0))
+
+    def test_cleanup_nonexistent_is_noop(self):
+        self.connector.cleanup("nonexistent")
+
+    def test_put_overwrites_existing(self):
+        self.connector.put("req_1", 0, StageOutput(token_ids=[1]))
+        self.connector.put("req_1", 0, StageOutput(token_ids=[2]))
+        retrieved = self.connector.get("req_1", 0)
+        self.assertEqual(retrieved.token_ids, [2])
+
+    def test_is_abstract_base(self):
+        self.assertIsInstance(self.connector, StageConnector)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_stage_pool.py
+++ b/rtp_llm/test/omni/test_stage_pool.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import MagicMock
+
+from rtp_llm.omni.config.stage_config import OmniStageConfig, StageExecutionType
+from rtp_llm.omni.engine.stage_pool import OmniStagePool
+
+
+class TestOmniStagePool(unittest.TestCase):
+    def _make_stage_config(self, stage_id=0):
+        return OmniStageConfig(
+            stage_id=stage_id,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            model_cls="TestThinker",
+            input_sources=(),
+        )
+
+    def test_create_pool(self):
+        config = self._make_stage_config()
+        pool = OmniStagePool(stage_config=config)
+        self.assertEqual(pool.stage_config, config)
+        self.assertEqual(pool.stage_id, 0)
+        self.assertEqual(pool.num_replicas, 0)
+
+    def test_add_replica(self):
+        config = self._make_stage_config()
+        pool = OmniStagePool(stage_config=config)
+        mock_pipeline = MagicMock()
+        pool.add_replica(mock_pipeline)
+        self.assertEqual(pool.num_replicas, 1)
+
+    def test_get_replica_round_robin(self):
+        config = self._make_stage_config()
+        pool = OmniStagePool(stage_config=config)
+        p1 = MagicMock(name="pipeline_1")
+        p2 = MagicMock(name="pipeline_2")
+        pool.add_replica(p1)
+        pool.add_replica(p2)
+        self.assertIs(pool.get_replica(), p1)
+        self.assertIs(pool.get_replica(), p2)
+        self.assertIs(pool.get_replica(), p1)
+
+    def test_get_replica_empty_raises(self):
+        config = self._make_stage_config()
+        pool = OmniStagePool(stage_config=config)
+        with self.assertRaises(RuntimeError):
+            pool.get_replica()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_stage_processor_base.py
+++ b/rtp_llm/test/omni/test_stage_processor_base.py
@@ -1,0 +1,27 @@
+import unittest
+
+from rtp_llm.omni.engine.stage_connector import StageOutput
+from rtp_llm.omni.engine.stage_processor_base import StageProcessorBase
+
+
+class MockProcessor(StageProcessorBase):
+    def process(self, source_output: StageOutput) -> StageOutput:
+        new_ids = [x + 100 for x in source_output.token_ids] if source_output.token_ids else None
+        return StageOutput(token_ids=new_ids, metadata={"transformed": True})
+
+
+class TestStageProcessorBase(unittest.TestCase):
+    def test_is_abstract(self):
+        with self.assertRaises(TypeError):
+            StageProcessorBase()
+
+    def test_concrete_processor(self):
+        proc = MockProcessor()
+        source = StageOutput(token_ids=[1, 2, 3])
+        result = proc.process(source)
+        self.assertEqual(result.token_ids, [101, 102, 103])
+        self.assertTrue(result.metadata["transformed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_stage_processors.py
+++ b/rtp_llm/test/omni/test_stage_processors.py
@@ -1,0 +1,72 @@
+import unittest
+
+import torch
+
+from rtp_llm.omni.engine.stage_connector import StageOutput
+
+
+class TestThinker2TalkerProcessor(unittest.TestCase):
+    def test_processor_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import (
+            Thinker2TalkerProcessor,
+        )
+
+        self.assertTrue(callable(Thinker2TalkerProcessor))
+
+    def test_process_extracts_embeddings(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import (
+            Thinker2TalkerProcessor,
+        )
+
+        proc = Thinker2TalkerProcessor()
+        thinker_output = StageOutput(
+            token_ids=[1, 2, 3],
+            embeddings=torch.randn(1, 10, 3584),
+            metadata={"text": "hello"},
+        )
+        talker_input = proc.process(thinker_output)
+        self.assertIsNotNone(talker_input.embeddings)
+        self.assertEqual(talker_input.embeddings.shape[-1], 3584)
+        self.assertEqual(talker_input.metadata["source_text"], "hello")
+
+    def test_process_preserves_source_token_ids(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import (
+            Thinker2TalkerProcessor,
+        )
+
+        proc = Thinker2TalkerProcessor()
+        thinker_output = StageOutput(
+            token_ids=[10, 20, 30],
+            embeddings=torch.randn(1, 5, 3584),
+            metadata={},
+        )
+        talker_input = proc.process(thinker_output)
+        self.assertEqual(talker_input.metadata["source_token_ids"], [10, 20, 30])
+
+
+class TestTalker2Code2WavProcessor(unittest.TestCase):
+    def test_processor_exists(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import (
+            Talker2Code2WavProcessor,
+        )
+
+        self.assertTrue(callable(Talker2Code2WavProcessor))
+
+    def test_process_converts_tokens(self):
+        from rtp_llm.omni.models.qwen2_5_omni.stage_processors import (
+            Talker2Code2WavProcessor,
+        )
+
+        proc = Talker2Code2WavProcessor()
+        talker_output = StageOutput(
+            token_ids=[10, 20, 30, 40, 50],
+            metadata={"codec_tokens": True},
+        )
+        c2w_input = proc.process(talker_output)
+        self.assertIsNotNone(c2w_input.token_ids)
+        self.assertEqual(c2w_input.token_ids, [10, 20, 30, 40, 50])
+        self.assertTrue(c2w_input.metadata["from_talker"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_talker.py
+++ b/rtp_llm/test/omni/test_talker.py
@@ -1,0 +1,80 @@
+import json
+import os
+import tempfile
+import unittest
+
+from rtp_llm.model_factory_register import _model_factory
+from rtp_llm.models.qwen_v2 import QWenV2Weight
+
+
+class TestQwen25OmniTalkerRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.talker  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_talker", _model_factory)
+
+    def test_model_class_name(self):
+        model_cls = _model_factory["qwen2_5_omni_talker"]
+        self.assertEqual(model_cls.__name__, "Qwen25OmniTalker")
+
+
+class TestQwen25OmniTalkerWeight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from rtp_llm.omni.models.qwen2_5_omni.talker import Qwen25OmniTalkerWeight
+
+        cls.weight_cls = Qwen25OmniTalkerWeight
+
+    def test_inherits_from_qwen_v2_weight(self):
+        self.assertTrue(issubclass(self.weight_cls, QWenV2Weight))
+
+    def test_prefix_is_talker(self):
+        w = self.weight_cls.__new__(self.weight_cls)
+        w.prefix = "talker."
+        w.model_prefix = "model."
+        self.assertEqual(w.prefix, "talker.")
+
+    def test_transformer_prefix(self):
+        w = self.weight_cls.__new__(self.weight_cls)
+        w.prefix = "talker."
+        w.model_prefix = "model."
+        w.weight_style = None
+        w._process_meta([{}], [])
+        self.assertEqual(w.transformer_prefix, "talker.model.")
+
+
+class TestQwen25OmniTalkerConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.talker import Qwen25OmniTalker
+
+        config_json = {
+            "architectures": ["Qwen2_5OmniModel"],
+            "model_type": "qwen2_5_omni",
+            "talker_config": {
+                "hidden_size": 896,
+                "intermediate_size": 18944,
+                "num_attention_heads": 12,
+                "num_key_value_heads": 4,
+                "num_hidden_layers": 24,
+                "vocab_size": 8448,
+                "rms_norm_eps": 1e-06,
+                "rope_theta": 1000000.0,
+                "embedding_size": 3584,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+
+            config = Qwen25OmniTalker._create_config(tmpdir)
+            self.assertEqual(config.hidden_size, 896)
+            self.assertEqual(config.num_layers, 24)
+            self.assertEqual(config.attn_config.head_num, 12)
+            self.assertEqual(config.attn_config.kv_head_num, 4)
+            self.assertEqual(config.vocab_size, 8448)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_thinker.py
+++ b/rtp_llm/test/omni/test_thinker.py
@@ -1,0 +1,84 @@
+import json
+import os
+import tempfile
+import unittest
+
+from rtp_llm.model_factory_register import _model_factory
+from rtp_llm.models.qwen_v2 import QWenV2Weight
+
+
+class TestQwen25OmniThinkerRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.thinker  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_thinker", _model_factory)
+
+    def test_model_class_name(self):
+        model_cls = _model_factory["qwen2_5_omni_thinker"]
+        self.assertEqual(model_cls.__name__, "Qwen25OmniThinker")
+
+
+class TestQwen25OmniThinkerWeight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker import Qwen25OmniThinkerWeight
+
+        cls.weight_cls = Qwen25OmniThinkerWeight
+
+    def test_inherits_from_qwen_v2_weight(self):
+        self.assertTrue(issubclass(self.weight_cls, QWenV2Weight))
+
+    def test_prefix_is_thinker(self):
+        w = self.weight_cls.__new__(self.weight_cls)
+        w.prefix = "thinker."
+        w.model_prefix = "model."
+        self.assertEqual(w.prefix, "thinker.")
+
+    def test_transformer_prefix(self):
+        w = self.weight_cls.__new__(self.weight_cls)
+        w.prefix = "thinker."
+        w.model_prefix = "model."
+        w.weight_style = None
+        w._process_meta([{}], [])
+        self.assertEqual(w.transformer_prefix, "thinker.model.")
+
+
+class TestQwen25OmniThinkerConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.thinker import Qwen25OmniThinker
+
+        config_json = {
+            "architectures": ["Qwen2_5OmniModel"],
+            "model_type": "qwen2_5_omni",
+            "thinker_config": {
+                "text_config": {
+                    "hidden_size": 3584,
+                    "intermediate_size": 18944,
+                    "num_attention_heads": 28,
+                    "num_key_value_heads": 4,
+                    "num_hidden_layers": 28,
+                    "vocab_size": 152064,
+                    "rms_norm_eps": 1e-06,
+                    "rope_theta": 1000000.0,
+                    "tie_word_embeddings": False,
+                    "torch_dtype": "bfloat16",
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+
+            config = Qwen25OmniThinker._create_config(tmpdir)
+            self.assertEqual(config.hidden_size, 3584)
+            self.assertEqual(config.num_layers, 28)
+            self.assertEqual(config.attn_config.head_num, 28)
+            self.assertEqual(config.attn_config.kv_head_num, 4)
+            self.assertEqual(config.inter_size, 18944)
+            self.assertEqual(config.vocab_size, 152064)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/omni/test_token2wav.py
+++ b/rtp_llm/test/omni/test_token2wav.py
@@ -1,0 +1,142 @@
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.model_factory_register import _model_factory
+
+
+class TestOmniDiTConfig(unittest.TestCase):
+    def test_dit_config_from_dict(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import OmniDiTConfig
+
+        config = OmniDiTConfig.from_dict(
+            {
+                "depth": 22,
+                "dim": 1024,
+                "heads": 16,
+                "head_dim": 64,
+                "ff_mult": 2,
+                "mel_dim": 80,
+                "num_embeds": 8193,
+                "emb_dim": 512,
+                "dropout": 0.1,
+            }
+        )
+        self.assertEqual(config.depth, 22)
+        self.assertEqual(config.dim, 1024)
+        self.assertEqual(config.heads, 16)
+
+
+class TestOmniDiTForward(unittest.TestCase):
+    def test_dit_forward_shape(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_dit import (
+            OmniDiT,
+            OmniDiTConfig,
+        )
+
+        config = OmniDiTConfig(
+            depth=2,
+            dim=64,
+            heads=4,
+            head_dim=16,
+            ff_mult=2,
+            mel_dim=80,
+            num_embeds=100,
+            emb_dim=32,
+            dropout=0.0,
+        )
+        model = OmniDiT(config)
+        x = torch.randn(1, 10, 80)
+        t = torch.tensor([0.5])
+        codec_ids = torch.randint(0, 100, (1, 10))
+        out = model(x, t, codec_ids)
+        self.assertEqual(out.shape, (1, 10, 80))
+
+
+class TestBigVGANConfig(unittest.TestCase):
+    def test_bigvgan_config_from_dict(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_bigvgan import BigVGANConfig
+
+        config = BigVGANConfig.from_dict(
+            {
+                "mel_dim": 80,
+                "upsample_rates": [5, 3, 2, 2, 2, 2],
+                "upsample_initial_channel": 1536,
+            }
+        )
+        self.assertEqual(config.mel_dim, 80)
+        self.assertEqual(config.upsample_rates, [5, 3, 2, 2, 2, 2])
+
+
+class TestBigVGANForward(unittest.TestCase):
+    def test_bigvgan_forward_shape(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav_bigvgan import (
+            BigVGAN,
+            BigVGANConfig,
+        )
+
+        config = BigVGANConfig(
+            mel_dim=80,
+            upsample_rates=[2, 2],
+            upsample_initial_channel=64,
+            upsample_kernel_sizes=[4, 4],
+            resblock_kernel_sizes=[3],
+            resblock_dilation_sizes=[[1, 2]],
+        )
+        model = BigVGAN(config)
+        mel = torch.randn(1, 80, 10)
+        wav = model(mel)
+        self.assertEqual(wav.shape[0], 1)
+        self.assertEqual(wav.shape[1], 1)
+        self.assertEqual(wav.shape[2], 40)
+
+
+class TestQwen25OmniToken2WavRegistration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import rtp_llm.omni.models.qwen2_5_omni.token2wav  # noqa: F401
+
+    def test_model_registered(self):
+        self.assertIn("qwen2_5_omni_token2wav", _model_factory)
+
+
+class TestQwen25OmniToken2WavConfig(unittest.TestCase):
+    def test_create_config_from_omni_checkpoint(self):
+        from rtp_llm.omni.models.qwen2_5_omni.token2wav import Qwen25OmniToken2Wav
+
+        config_json = {
+            "token2wav_config": {
+                "dit_config": {
+                    "depth": 22,
+                    "dim": 1024,
+                    "heads": 16,
+                    "head_dim": 64,
+                    "ff_mult": 2,
+                    "mel_dim": 80,
+                    "num_embeds": 8193,
+                    "emb_dim": 512,
+                },
+                "bigvgan_config": {
+                    "mel_dim": 80,
+                    "upsample_rates": [5, 3, 2, 2, 2, 2],
+                    "upsample_initial_channel": 1536,
+                    "upsample_kernel_sizes": [11, 7, 4, 4, 4, 4],
+                    "resblock_kernel_sizes": [3, 7, 11],
+                    "resblock_dilation_sizes": [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "config.json"), "w") as f:
+                json.dump(config_json, f)
+            config = Qwen25OmniToken2Wav._create_config(tmpdir)
+            self.assertIsNotNone(config)
+            self.assertEqual(config.hidden_size, 1024)
+            self.assertEqual(config.num_layers, 22)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds support for **omni (multi-modal output) models** in rtp-llm via a multi-stage pipeline framework, with Qwen2.5-Omni as the first concrete model.

### Phase 1 — Core Pipeline Framework (commits `eec73dfcf`, `c19250deb`, `d07b98809`)

- Design spec: `docs/superpowers/specs/2026-06-01-omni-architecture-support-design.md`
- New package `rtp_llm/omni/` with:
  - `OmniPipelineConfig`, `OmniStageConfig`, `StageExecutionType` (DAG topology)
  - `OmniPipelineRegistry` (lazy registry of pipeline topologies, keyed by model_type / model_arch)
  - `OmniOrchestrator` — per-request lifecycle across stages
  - `OmniStagePool` — replica management per stage
  - `StageConnector` ABC + `SharedMemoryConnector` (inter-stage transfer)
  - `StageProcessorBase` — base class for inter-stage data transforms
  - `OmniOutputProcessor` — multimodal output assembly (text/audio/image), WAV+base64 encoding
  - `OmniEngine` — wraps the multi-stage pipeline as a single engine
- `ModelFactory._create_model` detects omni model_type and returns `OmniEngine` instead of single-model engine

### Phase 2 — Qwen2.5-Omni Stage Models (commit `da50648b5`)

- `Qwen25OmniThinker` (extends `QWenV2`) — text decoder with Whisper audio + NaViT vision encoders, weight prefix `thinker.`
- `Qwen25OmniTalker` (extends `QWenV2`) — small Qwen2 (24L, hidden=896, vocab=8448) with codec_head output, weight prefix `talker.`
- `Qwen25OmniToken2Wav` — DiT flow-matching transformer + BigVGAN vocoder for codec-token → waveform synthesis
- Stage processors: `Thinker2TalkerProcessor`, `Talker2Code2WavProcessor`
- `QWEN2_5_OMNI_PIPELINE` topology registered with `OmniPipelineRegistry`
- `OmniEngine.from_pipeline_config` now validates that all stage model classes are registered before construction

### Design Notes

- All stage weight classes derive `prefix` from the unified Qwen2.5-Omni HF checkpoint (`thinker.*`, `talker.*`, `token2wav.*`) — no checkpoint splitting required
- Whisper encoder is reused from `rtp_llm/models/qwen_v2_audio/`
- Token2Wav is non-AR and standalone — `StageExecutionType.LLM_GENERATION`

## Test Plan

- [x] `python -m pytest rtp_llm/test/omni/ -v` — **91 passed, 0 failed**
- [ ] E2E inference with real `Qwen/Qwen2.5-Omni-7B` checkpoint (requires GPU, deferred to follow-up)
- [ ] Regression: existing model tests still pass (verify in CI)

## What's Next (out of scope for this PR)

- Phase 3: Qwen3-Omni support (MoE variant)
- Phase 4: OpenAI API extensions for `modalities=["text", "audio"]`, `/v1/audio/speech` endpoint
- Phase 5: Diffusion engine (image/video generation)
- Phase 6: Distributed execution (RDMA StageConnector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)