### PR TITLE
feat: improve XQA decode attention and CUDA graph support

### DIFF
--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
@@ -54,7 +54,7 @@ public:
         params.kernel_tokens_per_block      = static_cast<int>(kernel_tokens_per_block);
         params.num_tokens_per_bs            = 1;
         params.hidden_size                  = static_cast<size_t>(hidden_size);
-        params.model_data_type              = c10::ScalarType::Half;
+        params.model_data_type              = c10::ScalarType::BFloat16;
         params.max_context_batch_size       = 128;
         params.decode_capture_batch_sizes   = std::move(decode_capture_batch_sizes);
         params.kv_cache_layer_to_group      = {};  // test: no hybrid kv cache

--- a/rtp_llm/models_py/kernels/cuda/test/BUILD
+++ b/rtp_llm/models_py/kernels/cuda/test/BUILD
@@ -58,15 +58,15 @@ py_test (
     exec_properties = {'gpu':'H20'},
 )
 
-# py_test(
-#     name = "test_xqa_batch_decode",
-#     srcs = ["test_xqa_batch_decode.py"],
-#     deps = py_test_deps + select({
-#         "@//:using_cuda12_9_x86": ["//rtp_llm:flashinfer-python"],
-#         "@//:cuda_pre_12_9": ["//rtp_llm:flashinfer-python"],
-#         "//conditions:default": []
-#     }),
-# #     tags = ["H20"],
-#     exec_properties = {'gpu':'H20'},
-# )
+py_test(
+    name = "test_xqa_batch_decode",
+    srcs = ["test_xqa_batch_decode.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": ["//rtp_llm:flashinfer-python"],
+        "@//:cuda_pre_12_9": ["//rtp_llm:flashinfer-python"],
+        "//conditions:default": []
+    }),
+    tags = ["H20"],
+    exec_properties = {'gpu':'H20'},
+)
 

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -69,6 +69,7 @@ else:
             FlashInferTRTLLMSpecDecodeImpl,
         )
         from rtp_llm.models_py.modules.factory.attention.cuda_impl.xqa import (
+            XQAImpl,
             get_xqa_impl,
         )
 
@@ -85,7 +86,14 @@ else:
             ]
         )
         DECODE_MHA_IMPS.extend([FlashInferTRTLLMDecodeImpl])
-        DECODE_MHA_IMPS.append(get_xqa_impl())
+        # XQAImpl (TRT GMMA) before XQADecodeImpl (FlashInfer HMMA): different
+        # accumulation paths produce <1 ULP divergence that flips tokens in long
+        # generations.  Existing golden data was generated with XQAImpl, so keep
+        # it higher-priority to avoid unnecessary golden refreshes.
+        DECODE_MHA_IMPS.append(XQAImpl)
+        _xqa_decode_impl = get_xqa_impl()
+        if _xqa_decode_impl is not XQAImpl:
+            DECODE_MHA_IMPS.append(_xqa_decode_impl)
 
         from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla_wrapper import (
             MlaFlashInferDecodeImpl,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
@@ -73,6 +73,9 @@ class XQAImpl(FMHAImplBase):
         self.fmha_params = self.fmha_impl.prepare(attn_inputs)
         self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
         self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+        # C++ XQAParams.sequence_lengths shares storage with this tensor.
+        # Keep a reference so prepare_cuda_graph can update it in-place.
+        self._captured_seq_lens = attn_inputs.sequence_lengths
 
     @classmethod
     def support(
@@ -106,6 +109,12 @@ class XQAImpl(FMHAImplBase):
             self.rope_params,
             attn_inputs,
         )
+        # update_trt_params only copies kv_cache_offset. The TRT XQA kernel also
+        # reads sequence_lengths via the captured data_ptr(), so we must update
+        # the data in-place at the address recorded during CUDA graph capture.
+        new_seq_lens = attn_inputs.sequence_lengths
+        n = min(self._captured_seq_lens.numel(), new_seq_lens.numel())
+        self._captured_seq_lens[:n].copy_(new_seq_lens[:n], non_blocking=True)
 
 
 class XQADecodeImpl(FMHAImplBase):
@@ -158,7 +167,9 @@ class XQADecodeImpl(FMHAImplBase):
         return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
-        new_fmha_params = self.fmha_impl.prepare(attn_inputs)
+        self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
+
+        new_fmha_params = self.fmha_impl.make_params(attn_inputs)
         self.fmha_params.page_table = new_fmha_params.page_table
         self.fmha_params.seq_lens = new_fmha_params.seq_lens
         self.fmha_params.batch_size = new_fmha_params.batch_size
@@ -168,6 +179,30 @@ class XQADecodeImpl(FMHAImplBase):
         new_offset = new_rope_params.kv_cache_offset
         old_offset = self.rope_params.kv_cache_offset
         common.copy_kv_cache_offset(old_offset, new_offset)
+
+
+def _load_xqa_fn():
+    """Load the XQA kernel function, handling rtp_kernel/flashinfer API differences.
+
+    Always prefer flashinfer.xqa.xqa directly over rtp_kernel.xqa.xqa, because
+    rtp_kernel's wrapper calls load_xqa_best_config() which overrides the caller's
+    nb_sub_seq_per_seq / use_qgmma with a config-file lookup (defaulting to
+    nb_sub_seq=4 when no config file exists). XQAWrapper.forward() already
+    computes these values adaptively, so the rtp_kernel override is harmful.
+    """
+    import inspect
+
+    try:
+        from flashinfer.xqa import xqa as fi_xqa
+
+        needs_sf = "k_sf_cache" in inspect.signature(fi_xqa).parameters
+        return fi_xqa, needs_sf
+    except ImportError:
+        pass
+
+    from rtp_kernel.xqa import xqa
+
+    return xqa, False
 
 
 class XQAWrapper:
@@ -182,6 +217,25 @@ class XQAWrapper:
         assert not self.attn_inputs.is_prefill, "XQA is not supported"
         self.workspace_buffer = get_xqa_workspace_buffer()
         self.semaphores = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+        self.enable_pdl = False
+        self._sm_count = 1
+        try:
+            compute_capability = torch.cuda.get_device_capability()
+            self.enable_pdl = compute_capability[0] >= 9
+            self._sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+        except Exception as e:
+            logging.warning(
+                f"[XQA] Failed to get GPU compute capability, PDL optimization disabled: {e}"
+            )
+
+        self._xqa_fn, self._xqa_needs_sf_cache = _load_xqa_fn()
+
+        self._batch_size: int = 0
+        self._q_len_per_req: int = 0
+        self._spec_mask: Optional[torch.Tensor] = None
+        self._output_buffer: Optional[torch.Tensor] = None
+        self._seq_lens_4d: Optional[torch.Tensor] = None
 
     def __del__(self):
         release_xqa_workspace_buffer(self.workspace_buffer)
@@ -205,7 +259,76 @@ class XQAWrapper:
             and page_size_supported
         )
 
-    def prepare(
+    def _compute_batch_geometry(self, attn_inputs: PyAttentionInputs) -> None:
+        cu_seqlens = attn_inputs.decode_cu_seqlens_d
+        seqlens = torch.diff(cu_seqlens).cpu().tolist()
+        assert (
+            len(set(seqlens)) == 1
+        ), f"All sequences must have the same length for XQA, got lengths: {seqlens}"
+        self._q_len_per_req = seqlens[0]
+        self._batch_size = len(seqlens)
+
+    def _compute_spec_mask(self, device: str = "cuda") -> None:
+        q_len = self._q_len_per_req
+        bs = self._batch_size
+        if q_len <= 1:
+            self._spec_mask = None
+            return
+        num_packed_masks_per_token = (q_len + 31) // 32
+        q_indices = torch.arange(q_len, device=device, dtype=torch.int32).unsqueeze(1)
+        kv_indices = torch.arange(q_len, device=device, dtype=torch.int32).unsqueeze(0)
+        causal_bool_mask = kv_indices <= q_indices
+
+        padded_seq_len = num_packed_masks_per_token * 32
+        if padded_seq_len > q_len:
+            padding = torch.zeros(
+                q_len,
+                padded_seq_len - q_len,
+                device=device,
+                dtype=torch.bool,
+            )
+            causal_bool_mask = torch.cat([causal_bool_mask, padding], dim=1)
+
+        causal_bool_mask = causal_bool_mask.view(q_len, num_packed_masks_per_token, 32)
+        bit_positions = torch.tensor(
+            [1 << i for i in range(32)], device=device, dtype=torch.int64
+        )
+        mask_uint32 = (
+            (causal_bool_mask.to(torch.int64) * bit_positions)
+            .sum(dim=-1)
+            .to(torch.uint32)
+        )
+        mask_uint32 = (
+            mask_uint32.unsqueeze(0)
+            .expand(bs, q_len, num_packed_masks_per_token)
+            .contiguous()
+        )
+        self._spec_mask = mask_uint32.view(torch.uint16)
+
+    def _alloc_buffers(
+        self, num_heads: int, head_dim: int, dtype: torch.dtype, device: str = "cuda"
+    ) -> None:
+        bs = self._batch_size
+        q_len = self._q_len_per_req
+        self._output_buffer = torch.zeros(
+            bs,
+            1,
+            q_len,
+            num_heads,
+            head_dim,
+            dtype=dtype,
+            device=device,
+        )
+        self._seq_lens_4d = torch.zeros(bs, 1, dtype=torch.uint32, device=device)
+
+    def _update_seq_lens_4d(self, seq_lens: torch.Tensor) -> None:
+        """Update _seq_lens_4d from CPU seq_lens. Must be called OUTSIDE CUDA graph capture."""
+        assert self._seq_lens_4d is not None
+        bs = self._batch_size
+        new_seq_lens = (seq_lens[:bs] + self._q_len_per_req).to(torch.uint32)
+        self._seq_lens_4d[:bs].copy_(new_seq_lens.unsqueeze(1), non_blocking=True)
+
+    def make_params(
         self,
         attn_inputs: PyAttentionInputs,
         q_scale: float = 1.0,
@@ -226,49 +349,26 @@ class XQAWrapper:
             o_scale=o_scale,
         )
 
-    def init_spec_mask(self, q_4d: torch.Tensor):
-        q_len_per_req = q_4d.shape[1]
-        batch_size = q_4d.shape[0]
-        if q_len_per_req > 1:
-            num_packed_masks_per_token = (q_len_per_req + 31) // 32
-            q_indices = torch.arange(
-                q_len_per_req, device=q_4d.device, dtype=torch.int32
-            ).unsqueeze(1)
-            kv_indices = torch.arange(
-                q_len_per_req, device=q_4d.device, dtype=torch.int32
-            ).unsqueeze(0)
-            causal_bool_mask = kv_indices <= q_indices
+    def prepare(
+        self,
+        attn_inputs: PyAttentionInputs,
+        q_scale: float = 1.0,
+        kv_scale: float = 1.0,
+        o_scale: float = 1.0,
+    ) -> XQAParams:
+        self._compute_batch_geometry(attn_inputs)
+        self._compute_spec_mask()
+        self._alloc_buffers(
+            self.config.head_num,
+            self.config.size_per_head,
+            self.config.dtype,
+        )
+        self._update_seq_lens_4d(attn_inputs.sequence_lengths)
+        return self.make_params(attn_inputs, q_scale, kv_scale, o_scale)
 
-            padded_seq_len = num_packed_masks_per_token * 32
-            if padded_seq_len > q_len_per_req:
-                padding = torch.zeros(
-                    q_len_per_req,
-                    padded_seq_len - q_len_per_req,
-                    device=q_4d.device,
-                    dtype=torch.bool,
-                )
-                causal_bool_mask = torch.cat([causal_bool_mask, padding], dim=1)
-
-            causal_bool_mask = causal_bool_mask.view(
-                q_len_per_req, num_packed_masks_per_token, 32
-            )
-            bit_positions = torch.tensor(
-                [1 << i for i in range(32)], device=q_4d.device, dtype=torch.int64
-            )
-            mask_uint32 = (
-                (causal_bool_mask.to(torch.int64) * bit_positions)
-                .sum(dim=-1)
-                .to(torch.uint32)
-            )
-            mask_uint32 = (
-                mask_uint32.unsqueeze(0)
-                .expand(batch_size, q_len_per_req, num_packed_masks_per_token)
-                .contiguous()
-            )
-            mask = mask_uint32.view(torch.uint16)
-            return mask
-        else:
-            return None
+    def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
+        self._compute_batch_geometry(attn_inputs)
+        self._update_seq_lens_4d(attn_inputs.sequence_lengths)
 
     def forward(
         self,
@@ -280,71 +380,62 @@ class XQAWrapper:
         k_cache = kv_cache.kv_cache_base[:, 0, ...]
         v_cache = kv_cache.kv_cache_base[:, 1, ...]
         page_table = fmha_params.page_table
-        seq_lens = fmha_params.seq_lens
         num_kv_heads = k_cache.shape[1]
         page_size = k_cache.shape[2]
-        kv_layout = "HND"
 
-        seqlens = torch.diff(self.attn_inputs.decode_cu_seqlens_d).cpu().tolist()
-        assert (
-            len(set(seqlens)) == 1
-        ), f"All sequences must have the same length for XQA, got lengths: {seqlens}"
-        q_len_per_req = seqlens[0]
-        batch_size = len(seqlens)
+        batch_size = self._batch_size
+        q_len_per_req = self._q_len_per_req
+
         q_4d = q.reshape(batch_size, q_len_per_req, q.shape[1], q.shape[2])
 
-        if seq_lens.dim() == 1:
-            new_seq_lens = seq_lens + q_len_per_req
-            seq_lens_4d = new_seq_lens.unsqueeze(1).to(torch.uint32).to(q.device)
-        else:
-            new_seq_lens = seq_lens[:, 0] + q_len_per_req
-            seq_lens_4d = new_seq_lens.to(torch.uint32).to(q.device)
+        seq_lens_4d = self._seq_lens_4d[:batch_size]
 
-        enable_pdl = False
-        try:
-            compute_capability = torch.cuda.get_device_capability(q.device)
-            enable_pdl = compute_capability[0] >= 9
-        except Exception as e:
-            logging.warning(
-                f"[XQA] Failed to get GPU compute capability, PDL optimization disabled: {e}"
-            )
-
-        spec_mask = self.init_spec_mask(q_4d)
         q_4d = q_4d.unsqueeze(1).contiguous()
-        output = torch.zeros_like(q_4d)
-
-        try:
-            from rtp_kernel.xqa import xqa
-        except ImportError:
-            from flashinfer.xqa import xqa
+        assert self._output_buffer is not None
+        self._output_buffer.zero_()
+        output = self._output_buffer
 
         q_scale = fmha_params.q_scale
         kv_scale = fmha_params.kv_scale
         o_scale = fmha_params.o_scale
         rcp_out_scale = 1.0 / o_scale if o_scale != 1.0 else 1.0
 
-        xqa(
-            q_4d,
-            k_cache,
-            v_cache,
-            page_table,
-            seq_lens_4d,
-            output,
+        # Adaptive multi-block: split KV across CTAs to fill SMs at small batch sizes.
+        # Matches TRT-LLM XQA's formula in mha.cu. flashinfer >= 0.6.11 auto-tunes
+        # internally (this becomes a no-op), but older versions (e.g. 0.6.6) respect
+        # this parameter and need it for bs=1 performance.
+        _XQA_TILE_TOKENS = 64
+        nb_sub_seq = max(1, min(
+            self._sm_count // max(1, batch_size * num_kv_heads),
+            (fmha_params.max_seq_len + _XQA_TILE_TOKENS - 1) // _XQA_TILE_TOKENS,
+        ))
+
+        xqa_kwargs = dict(
+            q=q_4d,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            page_table=page_table,
+            seq_lens=seq_lens_4d,
+            output=output,
             workspace_buffer=self.workspace_buffer,
             semaphores=self.semaphores,
             num_kv_heads=num_kv_heads,
             page_size=page_size,
-            kv_layout=kv_layout,
-            enable_pdl=enable_pdl,
+            kv_layout="HND",
+            enable_pdl=self.enable_pdl,
             q_seq_len=q_len_per_req,
-            mask=spec_mask,
-            nb_sub_seq_per_seq=1,
+            mask=self._spec_mask,
+            nb_sub_seq_per_seq=nb_sub_seq,
             use_qgmma=True,
             sinks=None,
             q_scale=q_scale,
             kv_scale=kv_scale,
             rcp_out_scale=rcp_out_scale,
         )
+        if self._xqa_needs_sf_cache:
+            xqa_kwargs["k_sf_cache"] = None
+            xqa_kwargs["v_sf_cache"] = None
+        self._xqa_fn(**xqa_kwargs)
         return output
 
 
@@ -355,27 +446,24 @@ def get_xqa_impl() -> Type[FMHAImplBase]:
     Returns XQADecodeImpl if CUDA >= 12.8 and flashinfer.xqa is available,
     otherwise falls back to XQAImpl.
     """
-    logging.info(f"using XQA Kernel implementation")
-    return XQAImpl
-    # TODO: cudagraph bazel ut cant pass
-    # try:
-    #     major, minor = map(int, torch.version.cuda.split(".")[:2])
-    #     if (major, minor) >= (12, 8):
-    #         try:
-    #             from flashinfer.xqa import xqa
+    try:
+        major, minor = map(int, torch.version.cuda.split(".")[:2])
+        if (major, minor) >= (12, 8):
+            try:
+                from flashinfer.xqa import xqa
 
-    #             logging.info(
-    #                 "CUDA >= 12.8 and flashinfer.xqa available, using XQADecodeImpl"
-    #             )
-    #             return XQADecodeImpl
-    #         except (ImportError, AttributeError) as e:
-    #             logging.info(
-    #                 f"CUDA >= 12.8 but flashinfer.xqa not available ({e}), falling back to XQAImpl"
-    #             )
-    #             return XQAImpl
-    #     else:
-    #         logging.info(f"CUDA version {major}.{minor} < 12.8, using XQAImpl")
-    #         return XQAImpl
-    # except Exception as e:
-    #     logging.warning(f"Failed to check CUDA version ({e}), using XQAImpl")
-    #     return XQAImpl
+                logging.info(
+                    "CUDA >= 12.8 and flashinfer.xqa available, using XQADecodeImpl"
+                )
+                return XQADecodeImpl
+            except (ImportError, AttributeError) as e:
+                logging.info(
+                    f"CUDA >= 12.8 but flashinfer.xqa not available ({e}), falling back to XQAImpl"
+                )
+                return XQAImpl
+        else:
+            logging.info(f"CUDA version {major}.{minor} < 12.8, using XQAImpl")
+            return XQAImpl
+    except Exception as e:
+        logging.warning(f"Failed to check CUDA version ({e}), using XQAImpl")
+        return XQAImpl

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -172,6 +172,20 @@ class FusedRopeKVCachePrefillOpQOut(FusedRopeKVCachePrefillOpBase):
 class FusedRopeKVCacheDecodeOp:
     def __init__(self, attn_configs: AttentionConfigs) -> None:
         self.attn_configs = attn_configs
+        self._dummy_scale: Optional[torch.Tensor] = None
+
+    def _get_kv_scale(self, kv_cache: LayerKVCache) -> Optional[torch.Tensor]:
+        if kv_cache.kv_scale_base is not None:
+            return kv_cache.kv_scale_base
+        if kv_cache.kv_cache_base.dtype == torch.float8_e4m3fn:
+            num_pages = kv_cache.kv_cache_base.shape[0]
+            # convert_offset_to_block_array encodes K offset = page*2, V offset = page*2+1,
+            # so max offset is 2*num_pages-1 and scale buffer needs 2*num_pages blocks.
+            needed = 2 * num_pages * self.attn_configs.kernel_tokens_per_block * self.attn_configs.kv_head_num
+            if self._dummy_scale is None or self._dummy_scale.numel() < needed:
+                self._dummy_scale = torch.ones(needed, dtype=torch.float32, device=kv_cache.kv_cache_base.device)
+            return self._dummy_scale
+        return None
 
     def forward(
         self,
@@ -194,7 +208,7 @@ class FusedRopeKVCacheDecodeOp:
             params.kv_cache_offset,
             tokens_per_block=self.attn_configs.kernel_tokens_per_block,
             store_kv=False,
-            kv_cache_scale=kv_cache.kv_scale_base,
+            kv_cache_scale=self._get_kv_scale(kv_cache),
             kv_cache_offset_h=params.kv_cache_offset_h,
             rope_cache=(
                 rope_cache.data if check_rope_cache(rope_config, rope_cache) else None


### PR DESCRIPTION
1. Fix XQA decode CUDA graph replay: update sequence_lengths in-place and split prepare into make_params + prepare_for_cuda_graph_replay
2. Re-enable XQADecodeImpl (FlashInfer HMMA, CUDA >= 12.8) with correct priority ordering alongside XQAImpl (TRT GMMA)
3. Add adaptive multi-block scheduling (nb_sub_seq_per_seq) for small batch SM utilization
4. Pre-allocate buffers to avoid memory allocation during CUDA graph capture
5. Add FP8 KV cache scale fallback in FusedRopeKVCacheDecodeOp
6. Re-enable test_xqa_batch_decode test