### PR TITLE
fix: fix flashinfer decode cudagraph

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -666,6 +666,43 @@ class PyFlashinferDecodeAttnOp(object):
         """Set the params object to be used by this op."""
         self.fmha_params = params
 
+    def _get_kv_data_type(self, attn_inputs: PyAttentionInputs) -> torch.dtype:
+        if self.kv_cache_dtype == KvCacheDataType.INT8:
+            return torch.int8
+        if self.kv_cache_dtype == KvCacheDataType.FP8:
+            return torch.float8_e4m3fn
+        return get_scalar_type(attn_inputs.dtype)
+
+    def _requires_fa2_cuda_graph_replan(self) -> bool:
+        # FlashInfer BatchDecode routes tensor-core decode through fa2 BatchPrefill.
+        # fa3 prefill paths do not need this replay-time plan refresh.
+        return self.use_tensor_core
+
+    def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
+        if self._requires_fa2_cuda_graph_replan():
+            page_indptr = self.fmha_params.decode_page_indptr_h
+            page_indice = self.fmha_params.page_indice_h
+            last_page_len = self.fmha_params.paged_kv_last_page_len_h
+            plan_kwargs = {"non_blocking": True}
+        else:
+            page_indptr = self.fmha_params.decode_page_indptr_d
+            page_indice = self.fmha_params.page_indice_d
+            last_page_len = self.fmha_params.paged_kv_last_page_len_d
+            plan_kwargs = {}
+
+        self.decode_wrapper.plan(
+            page_indptr,
+            page_indice,
+            last_page_len,
+            self.local_head_num,
+            self.local_kv_head_num,
+            self.head_dim_qk,
+            self.seq_size_per_block,
+            q_data_type=get_scalar_type(attn_inputs.dtype),
+            kv_data_type=self._get_kv_data_type(attn_inputs),
+            **plan_kwargs,
+        )
+
     def prepare(
         self,
         attn_inputs: PyAttentionInputs,
@@ -676,14 +713,6 @@ class PyFlashinferDecodeAttnOp(object):
 
         forbid_realloc: True only when called from prepare_cuda_graph (replay); forbids buffer realloc.
         """
-        # Convert kv_cache_dtype to torch dtype
-        if self.kv_cache_dtype == KvCacheDataType.INT8:
-            kv_datatype = torch.int8
-        elif self.kv_cache_dtype == KvCacheDataType.FP8:
-            kv_datatype = torch.float8_e4m3fn
-        else:  # BASE
-            kv_datatype = get_scalar_type(attn_inputs.dtype)
-
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
@@ -696,6 +725,8 @@ class PyFlashinferDecodeAttnOp(object):
         if self.enable_cuda_graph and self.decode_wrapper._fixed_batch_size == 0:
             batch_size = attn_inputs.input_lengths.size(0)
             self.decode_wrapper._use_cuda_graph = True
+            # Both decode backends read these buffers during run(); replay only
+            # updates fmha_params in-place, so the wrapper must hold these views.
             self.decode_wrapper._paged_kv_indptr_buf = (
                 self.fmha_params.decode_page_indptr_d
             )
@@ -711,28 +742,11 @@ class PyFlashinferDecodeAttnOp(object):
                     device=self.g_workspace_buffer.device,
                 )
 
-        self.decode_wrapper.plan(
-            self.fmha_params.decode_page_indptr_d,
-            self.fmha_params.page_indice_d,
-            self.fmha_params.paged_kv_last_page_len_d,
-            self.local_head_num,
-            self.local_kv_head_num,
-            self.head_dim_qk,
-            self.seq_size_per_block,
-            q_data_type=get_scalar_type(attn_inputs.dtype),
-            kv_data_type=kv_datatype,
-        )
+        self._plan_decode_wrapper(attn_inputs)
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
-        """Update buffer contents for CUDA graph replay without calling plan().
-
-        During CUDA graph replay, we must NOT call plan() because it may launch
-        GPU kernels on the current stream while the graph replays on the capture
-        stream, causing a race condition. We only need to update the page table
-        buffers in-place via fill_params — the pre-allocated buffers are already
-        wired into the decode_wrapper from the initial prepare() call.
-        """
+        """Refresh FlashInfer runtime buffers before replaying the captured graph."""
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
@@ -741,6 +755,8 @@ class PyFlashinferDecodeAttnOp(object):
             self.seq_size_per_block,
             forbid_realloc=True,
         )
+        if self._requires_fa2_cuda_graph_replan():
+            self._plan_decode_wrapper(attn_inputs)
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True
@@ -784,7 +800,7 @@ class PyFlashinferDecodeImpl(FMHAImplBase):
         self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
-        """Prepare for CUDA graph replay; only updates buffer contents, no plan()."""
+        """Prepare FlashInfer/RoPE buffers and metadata for CUDA graph replay."""
         self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
         # Update rope params for correct position encoding during cuda graph replay
         new_rope_params = self.rope_impl.prepare(attn_inputs)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -11,7 +11,12 @@ from base_attention_test import BaseAttentionTest, compare_tensors
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferDecodeAttnOp,
 )
-from rtp_llm.ops.compute_ops import PyAttentionInputs, fill_mla_params, get_typemeta, rtp_llm_ops
+from rtp_llm.ops.compute_ops import (
+    PyAttentionInputs,
+    fill_mla_params,
+    get_typemeta,
+    rtp_llm_ops,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -289,8 +294,8 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     Verifies the critical invariants that the C++ CUDA graph runner depends on:
     1. prepare() with is_cuda_graph=True sets _fixed_batch_size and wires up
        the decode_wrapper's internal buffers for graph capture.
-    2. prepare_for_cuda_graph_replay() only calls fill_params (no plan()),
-       correctly updating page tables without reallocating buffers.
+    2. prepare_for_cuda_graph_replay() refreshes both page tables and, only
+       for FlashInfer fa2, cached plan metadata without reallocating buffers.
 
     Full forward correctness under CUDA graph capture/replay cannot be tested
     at the Python UT level — that path is exercised by smoke tests with real
@@ -311,7 +316,9 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
 
         seq_t = torch.tensor(sequence_lengths, dtype=torch.int32)
         attn_inputs.sequence_lengths = (seq_t - 1).pin_memory()
-        attn_inputs.input_lengths = torch.ones(batch_size, dtype=torch.int32).pin_memory()
+        attn_inputs.input_lengths = torch.ones(
+            batch_size, dtype=torch.int32
+        ).pin_memory()
         attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32).pin_memory()
 
         kv_cache_block_id = self._create_kv_cache_block_ids(
@@ -332,7 +339,9 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         capture_bs = 4
         seq_lens = [64, 128, 256, 512]
         inputs = self._create_cuda_graph_inputs(
-            capture_bs, seq_lens, config.seq_size_per_block,
+            capture_bs,
+            seq_lens,
+            config.seq_size_per_block,
         )
 
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
@@ -347,46 +356,111 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
         logging.info("_fixed_batch_size correctly set after prepare()")
 
-    def test_replay_does_not_replan(self):
-        """prepare_for_cuda_graph_replay() must not call plan().
-
-        Verifies that only fill_params is called by checking that the
-        _fixed_batch_size remains unchanged (plan() would reset it).
-        """
+    def test_replay_refreshes_plan_metadata(self):
+        """prepare_for_cuda_graph_replay() must refresh FlashInfer fa2 plan metadata."""
         config = self._create_config()
         capture_bs = 8
         capture_seq_lens = [64, 128, 256, 512, 64, 128, 256, 512]
 
         capture_inputs = self._create_cuda_graph_inputs(
-            capture_bs, capture_seq_lens, config.seq_size_per_block,
+            capture_bs,
+            capture_seq_lens,
+            config.seq_size_per_block,
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertTrue(attn_op.use_tensor_core)
+        self.assertTrue(attn_op._requires_fa2_cuda_graph_replan())
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
         attn_op.prepare(capture_inputs)
 
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
 
-        run_bs = 3
-        run_seq_lens = [100, 200, 300]
+        original_plan = attn_op.decode_wrapper.plan
+        plan_calls = []
+
+        def counted_plan(*args, **kwargs):
+            plan_calls.append((args, kwargs))
+            return original_plan(*args, **kwargs)
+
+        attn_op.decode_wrapper.plan = counted_plan
+
+        run_seq_lens = [100, 200, 300, 400, 64, 128, 256, 512]
         run_inputs = self._create_cuda_graph_inputs(
-            run_bs, run_seq_lens, config.seq_size_per_block,
+            capture_bs,
+            run_seq_lens,
+            config.seq_size_per_block,
         )
         attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
-        # _fixed_batch_size must stay at capture_bs (replay doesn't replan)
+        self.assertEqual(len(plan_calls), 1)
+        plan_args, plan_kwargs = plan_calls[0]
+        self.assertFalse(plan_args[0].is_cuda)
+        self.assertFalse(plan_args[1].is_cuda)
+        self.assertFalse(plan_args[2].is_cuda)
+        self.assertTrue(plan_kwargs["non_blocking"])
+
+        # _fixed_batch_size must stay at the captured graph size.
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
 
-        # fill_params must have updated the page table buffers on the device
         page_indptr = fmha_params.decode_page_indptr_h
         self.assertIsNotNone(page_indptr)
-        # The indptr for run_bs=3 should have run_bs+1 meaningful entries
-        # (the rest is padding from capture_bs allocation)
-        self.assertGreaterEqual(len(page_indptr), run_bs + 1)
+        self.assertGreaterEqual(len(page_indptr), capture_bs + 1)
         logging.info(
             f"Replay OK: _fixed_batch_size={attn_op.decode_wrapper._fixed_batch_size}, "
-            f"page_indptr[:4]={page_indptr[:run_bs+1].tolist()}"
+            f"page_indptr={page_indptr.tolist()}"
         )
+
+    def test_non_fa2_replay_does_not_replan(self):
+        """Non-fa2 decode keeps the original replay contract: fill params only."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_bs = 4
+        capture_seq_lens = [64, 128, 256, 512]
+
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            capture_seq_lens,
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertFalse(attn_op.use_tensor_core)
+        self.assertFalse(attn_op._requires_fa2_cuda_graph_replan())
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+
+        self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
+        self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(),
+            fmha_params.decode_page_indptr_d.data_ptr(),
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(),
+            fmha_params.page_indice_d.data_ptr(),
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
+            fmha_params.paged_kv_last_page_len_d.data_ptr(),
+        )
+        self.assertFalse(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
+
+        plan_calls = []
+
+        def counted_plan(*args, **kwargs):
+            plan_calls.append((args, kwargs))
+
+        attn_op.decode_wrapper.plan = counted_plan
+
+        run_seq_lens = [100, 200, 256, 512]
+        run_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            run_seq_lens,
+            config.seq_size_per_block,
+        )
+        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+
+        self.assertEqual(len(plan_calls), 0)
 
     def test_replay_updates_page_tables(self):
         """Page table buffers must reflect the replay inputs, not capture inputs."""
@@ -395,11 +469,13 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         config = self._create_config(seq_size_per_block=64)
         capture_bs = 4
         capture_seq_lens = [64, 128, 256, 512]
-        run_bs = 2
-        run_seq_lens = [100, 200]
+        active_bs = 2
+        run_seq_lens = [100, 200, 256, 512]
 
         capture_inputs = self._create_cuda_graph_inputs(
-            capture_bs, capture_seq_lens, config.seq_size_per_block,
+            capture_bs,
+            capture_seq_lens,
+            config.seq_size_per_block,
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
@@ -407,32 +483,40 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         attn_op.prepare(capture_inputs)
 
         run_inputs = self._create_cuda_graph_inputs(
-            run_bs, run_seq_lens, config.seq_size_per_block,
+            capture_bs,
+            run_seq_lens,
+            config.seq_size_per_block,
         )
         attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
         # Verify page_indptr matches run_seq_lens
         page_indptr = fmha_params.decode_page_indptr_h.tolist()
-        expected_blocks = [math.ceil(s / 64) for s in run_seq_lens]
+        expected_blocks = [math.ceil(s / 64) for s in run_seq_lens[:active_bs]]
         expected_indptr = [0]
         for nb in expected_blocks:
             expected_indptr.append(expected_indptr[-1] + nb)
 
-        for i in range(run_bs + 1):
+        for i in range(active_bs + 1):
             self.assertEqual(
-                page_indptr[i], expected_indptr[i],
+                page_indptr[i],
+                expected_indptr[i],
                 f"page_indptr[{i}] mismatch: expected {expected_indptr[i]}, got {page_indptr[i]}",
             )
 
         # Verify last_page_len
         last_page_len = fmha_params.paged_kv_last_page_len_h.tolist()
-        for i, seq_len in enumerate(run_seq_lens):
+        for i, seq_len in enumerate(run_seq_lens[:active_bs]):
             expected = seq_len % 64 or 64
             self.assertEqual(
-                last_page_len[i], expected,
+                last_page_len[i],
+                expected,
                 f"last_page_len[{i}] mismatch: expected {expected}, got {last_page_len[i]}",
             )
-        logging.info(f"Page table update OK: indptr={expected_indptr}, last_page_len={[s % 64 or 64 for s in run_seq_lens]}")
+        expected_last_page_lens = [s % 64 or 64 for s in run_seq_lens[:active_bs]]
+        logging.info(
+            f"Page table update OK: indptr={expected_indptr}, "
+            f"last_page_len={expected_last_page_lens}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

FlashInfer decode 在 CUDA Graph replay 场景下，tensor-core decode 路径会复用 fa2 相关的 cached plan metadata。原逻辑在 replay 前只更新 page table buffer，没有刷新这部分 plan metadata，导致 replay 时可能使用过期的计划信息，引发服务卡住。

## 修改内容

- 抽出 FlashInfer decode 的 plan 逻辑，统一处理 kv dtype 和 page table 参数。
- 仅在 tensor-core decode 路径下，在 CUDA Graph replay 前重新刷新 fa2 plan metadata。
- 非 tensor-core decode 保持原 replay 行为，只更新 params，不额外 replan。
- 保留 CUDA Graph wrapper 对 page table device buffer 的引用，避免 replay 阶段 buffer 视图失效。
- 补充单测覆盖：
  - tensor-core replay 会刷新 plan metadata；
  - 非 tensor-core replay 不触发 replan；
  - replay 输入的 page table 能正确更新。

## 验证

- `python3 -m py_compile ...`
- `git diff --check`
- `bazelisk test //rtp_llm/models_py/modules/factory/attention/cuda_impl/test:test_py_flashinfer_mha_decode`
- 本地服务启动及流式请求验证通过，未复现卡住问题。

## 风险

改动范围限定在 FlashInfer decode CUDA Graph replay 准备逻辑。非 tensor-core decode 路径保持原有行为，主要风险集中在 tensor-core decode replay 前额外刷新 plan metadata 的兼容性，已通过单测和本地服务请求验证。