### PR TITLE
feat(rocm): support Qwen3/3.5 VL model on ROCm

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -62,12 +62,14 @@ xft_dep = select({
 arch_dep = select({
     "@//:using_arm": [],
     "@//:using_cuda12_arm": [],
+    "@//:using_rocm": [],
     "//conditions:default": [":decord", ":av"],
 })
 
 arch_with_version_dep = select({
     "@//:using_arm": [],
     "@//:using_cuda12_arm": [],
+    "@//:using_rocm": [],
     "//conditions:default": ["decord==0.6.0", "av==16.1.0"],
 })
 

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -464,8 +464,7 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     // (non-Mrope models pay zero memory and the captured graph never references it).
     if (position_id_len_factor_ > 0) {
         inputs.combo_position_ids =
-            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cpu_int32_);
-        inputs.combo_position_ids                  = inputs.combo_position_ids.pin_memory();
+            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cuda_int32_);
         inputs.attention_inputs.combo_position_ids = inputs.combo_position_ids;
     }
 

--- a/rtp_llm/cpp/model_utils/RopeConfig.cc
+++ b/rtp_llm/cpp/model_utils/RopeConfig.cc
@@ -19,8 +19,8 @@ std::string RopeConfig::DebugRopeConfigStr() const {
     oss << "  mrope_dim1: " << mrope_dim1 << std::endl;
     oss << "  mrope_dim2: " << mrope_dim2 << std::endl;
     oss << "  mrope_dim3: " << mrope_dim3 << std::endl;
+    oss << "  mrope_interleaved: " << mrope_interleaved << std::endl;
     return oss.str();
 }
 
 }  // namespace rtp_llm
-

--- a/rtp_llm/cpp/model_utils/RopeConfig.h
+++ b/rtp_llm/cpp/model_utils/RopeConfig.h
@@ -34,6 +34,7 @@ struct RopeConfig {
     int   mrope_dim1            = 0;
     int   mrope_dim2            = 0;
     int   mrope_dim3            = 0;
+    bool  mrope_interleaved     = false;
     bool  is_neox_style         = true;
     bool  indexer_is_neox_style = true;
 

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1304,6 +1304,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("mrope_dim1", &RopeConfig::mrope_dim1)
         .def_readwrite("mrope_dim2", &RopeConfig::mrope_dim2)
         .def_readwrite("mrope_dim3", &RopeConfig::mrope_dim3)
+        .def_readwrite("mrope_interleaved", &RopeConfig::mrope_interleaved)
         .def_readwrite("is_neox_style", &RopeConfig::is_neox_style)
         .def_readwrite("indexer_is_neox_style", &RopeConfig::indexer_is_neox_style);
 

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -203,6 +203,7 @@ class Qwen35Moe(Qwen3NextBase):
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = mrope_interleaved
         config.mm_model_config.mm_position_ids_style = 2
 
     @classmethod
@@ -223,9 +224,10 @@ class Qwen35Moe(Qwen3NextBase):
         max_generate_batch_size = self.max_generate_batch_size
 
         from rtp_llm.models_py.utils.arch import is_cuda
+        from rtp_llm.device.device_type import is_hip
 
-        if not is_cuda():
-            raise RuntimeError("Qwen3Next is only supported in cuda arch")
+        if not is_cuda() and not is_hip():
+            raise RuntimeError("Qwen3Next is only supported in cuda/rocm arch")
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -106,6 +106,9 @@ class QWen3_VL(QwenV3):
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = config_json[
+            "rope_scaling"
+        ].get("mrope_interleaved", True)
         config.mm_model_config.mm_position_ids_style = 2
 
         config.mm_related_params.config["ckpt_path"] = config.ckpt_path

--- a/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
+++ b/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
@@ -1015,7 +1015,7 @@ __device__ inline void context_rope(RopeConfig    rope_config,
         input_len = input_len + prefix_prompt_length;
         seqidx    = seqidx + prefix_prompt_length;
     }
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         seqidx = position_id;
     }
 
@@ -1046,7 +1046,7 @@ __device__ inline void attention_rope(RopeConfig rope_config,
         prefix_prompt_length = 0;
     }
 
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         tlength = position_id;
     }
 

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -84,22 +84,15 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
-    }
-}
-
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
+    // MRoPE with mrope_interleaved=false is not supported: the kernel's
+    // RotaryHalfRead pairing assumes interleaved cos/sin layout.
+    if (attn_configs.rope_config.style == RopeStyle::Mrope && !attn_configs.rope_config.mrope_interleaved) {
+        throw std::runtime_error(
+            "ROCm FusedRopeKVCache does not support MRoPE with mrope_interleaved=false. "
+            "Use mrope_interleaved=true or disable the fused rope path.");
+    }
 }
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
@@ -145,6 +138,23 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
     }
     attn_params->kv_block_array.cache_type = attn_configs_.kv_cache_dtype;
     attn_params->position_ids = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error(
+                "MRoPE prefill requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num = int(attn_inputs.input_lengths.sum().item<int64_t>());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error(
+                "MRoPE prefill combo_position_ids too small: got " + std::to_string(attn_params->position_ids.numel())
+                + ", expected at least " + std::to_string(min_expected)
+                + " (token_num=" + std::to_string(token_num)
+                + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
 
 // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
@@ -353,7 +363,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
+    // MRoPE with mrope_interleaved=false is not supported: the kernel's
+    // RotaryHalfRead pairing assumes interleaved cos/sin layout.
+    if (attn_configs.rope_config.style == RopeStyle::Mrope && !attn_configs.rope_config.mrope_interleaved) {
+        throw std::runtime_error(
+            "ROCm FusedRopeKVCache does not support MRoPE with mrope_interleaved=false. "
+            "Use mrope_interleaved=true or disable the fused rope path.");
+    }
 }
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
@@ -392,6 +408,23 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     attn_params->prefix_lengths            = attn_inputs.prefix_lengths;
     attn_params->padding_offset            = attn_inputs.padding_offset;
     attn_params->position_ids              = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error(
+                "MRoPE requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num = int(attn_inputs.sequence_lengths.numel());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error(
+                "MRoPE combo_position_ids too small: got " + std::to_string(attn_params->position_ids.numel())
+                + ", expected at least " + std::to_string(min_expected)
+                + " (token_num=" + std::to_string(token_num)
+                + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
     // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
         attn_params->position_ids =

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -101,6 +101,48 @@ inline __device__ type_out* reinterpret_ptr(void* ptr, size_t offset) {
     return reinterpret_cast<type_out*>(reinterpret_cast<type_in*>(ptr) + offset);
 }
 
+__device__ __forceinline__ int get_mrope_position_dim(const RopeConfig& rope_config, const int tidx) {
+    const int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
+    if (rope_dim <= 0) {
+        return 0;
+    }
+
+    // Qwen MRoPE uses contiguous-section pair->axis mapping:
+    //   [0, dim1)         -> axis 0 (temporal)
+    //   [dim1, dim1+dim2) -> axis 1 (height)
+    //   rest              -> axis 2 (width)
+    //
+    // NOTE: This mapping is only valid for mrope_interleaved=true. When
+    // mrope_interleaved=false the cos/sin cache is built with contiguous
+    // sections but RotaryHalfRead pairs smem[i] with smem[i + head_dim/2],
+    // which crosses section boundaries and assigns wrong position_ids.
+    // The fused kernel currently rejects mrope_interleaved=false at init
+    // (see FusedRopeKVCacheOp.cc); aiter.py also disables fused rope for
+    // that case so RoPE falls back to the Python-layer implementation.
+    // If interleaved=false support is needed in the future, this function
+    // must be updated to map by rotary-pair start index instead of tidx.
+    const int now_idx = tidx % rope_dim;
+    if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
+        return 2;
+    }
+    if (now_idx >= rope_config.mrope_dim1) {
+        return 1;
+    }
+    return 0;
+}
+
+__device__ __forceinline__ int
+get_rope_position_id(const RopeConfig& rope_config, const int* position_ids, const int token_idx, const int tidx) {
+    if (!position_ids) {
+        return -1;
+    }
+    if (rope_config.style == RopeStyle::Mrope) {
+        const int now_dim = get_mrope_position_dim(rope_config, tidx);
+        return position_ids[token_idx * rope_config.index_factor + now_dim];
+    }
+    return position_ids[token_idx * rope_config.index_factor];
+}
+
 inline __device__ void convert_to_fp8(__hip_fp8x2_e4m3_fnuz* v, const amd_bfloat162 u) {
     __hip_bfloat162_raw   raw_bf16  = *reinterpret_cast<const __hip_bfloat162_raw*>(&u);
     __hip_fp8x2_storage_t raw_fp8x2 = __hip_cvt_bfloat16raw2_to_fp8x2(raw_bf16, __HIP_SATFINITE, __HIP_E4M3_FNUZ);
@@ -215,19 +257,7 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
+    int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
     const int pre_len   = cu_seqlens[batch_idx];
     const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
@@ -849,19 +879,7 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel(T*                   
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
+    int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
     const int pre_len   = cu_seqlens[batch_idx];
     const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
@@ -1200,7 +1218,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;
@@ -1360,7 +1378,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -16,7 +16,7 @@ from rtp_llm.models_py.modules.factory.attention.rocm_impl._attn_utils import (
     split_raw_qkv,
     unpad_kv_vectorized,
 )
-from rtp_llm.ops import AttentionConfigs, FMHAType, KvCacheDataType, ParallelismConfig
+from rtp_llm.ops import AttentionConfigs, FMHAType, KvCacheDataType, ParallelismConfig, RopeStyle
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOpAsm,
     FusedRopeKVCacheDecodeOpNonAsm,
@@ -1399,6 +1399,10 @@ class AiterPrefillImplAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # ROCm fused rope kernel does not support MRoPE with mrope_interleaved=false
+        if (attn_configs.rope_config.style == RopeStyle.Mrope
+                and not attn_configs.rope_config.mrope_interleaved):
+            return False
         return True
 
     def forward(
@@ -1459,6 +1463,10 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # ROCm fused rope kernel does not support MRoPE with mrope_interleaved=false
+        if (attn_configs.rope_config.style == RopeStyle.Mrope
+                and not attn_configs.rope_config.mrope_interleaved):
+            return False
         return True
 
     def forward(
@@ -1718,6 +1726,10 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # ROCm fused rope kernel does not support MRoPE with mrope_interleaved=false
+        if (attn_configs.rope_config.style == RopeStyle.Mrope
+                and not attn_configs.rope_config.mrope_interleaved):
+            return False
         return True
 
     def forward(
@@ -1765,6 +1777,10 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # ROCm fused rope kernel does not support MRoPE with mrope_interleaved=false
+        if (attn_configs.rope_config.style == RopeStyle.Mrope
+                and not attn_configs.rope_config.mrope_interleaved):
+            return False
         return True
 
     def forward(
@@ -1811,6 +1827,10 @@ class AiterDecodeImplTriton(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # ROCm fused rope kernel does not support MRoPE with mrope_interleaved=false
+        if (attn_configs.rope_config.style == RopeStyle.Mrope
+                and not attn_configs.rope_config.mrope_interleaved):
+            return False
         return True
 
     def forward(

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -54,6 +54,7 @@ test_suite(
         ":smoke_rocm_basic",
         ":smoke_rocm_dense",
         ":smoke_rocm_moe",
+        ":smoke_rocm_vl",
         ":smoke_rocm_eagle",
         ":smoke_rocm_pd",
         ":smoke_rocm_embedding",

--- a/rtp_llm/test/smoke/data/model/qwen_vl/q_r_3_moe_rocm.json
+++ b/rtp_llm/test/smoke/data/model/qwen_vl/q_r_3_moe_rocm.json
@@ -1,0 +1,60 @@
+{
+    "model_type": "qwen3_vl_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3-VL-30B-A3B-Instruct/",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen3-VL-30B-A3B-Instruct/",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data/model/qwen_vl/1.jpeg"
+                                }
+                            },
+                            {
+                                "type": "text",
+                                "text": "Describe this image."
+                            }
+                        ]
+                    }
+                ],
+                "extra_configs": {
+                    "add_vision_id": false
+                },
+                "max_tokens": 20,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1705334081,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Of course, here is a detailed description of the image.\n\nThis is a heartwarming and serene",                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 964,
+                    "total_tokens": 984,
+                    "completion_tokens": 20,
+                    "prompt_tokens_details": {
+                        "image_tokens": 950
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -189,3 +189,16 @@ def rocm_oss_suites():
         ],
     )
 
+    # ROCm VL (Qwen3-VL-30B MoE)
+    native.test_suite(
+        name = "smoke_rocm_vl",
+        tests = [
+            smoke_test(
+                name="rocm_vl_qwen3_vl_moe",
+                task_info="data/model/qwen_vl/q_r_3_moe_rocm.json",
+                smoke_args="--act_type BF16 --reserver_runtime_mem_mb 51200 --tp_size 1 --world_size 1",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+        ],
+    )
+


### PR DESCRIPTION
Enable Qwen3-VL and Qwen3.5-VL multimodal models on ROCm (MI308X):

- Support MRoPE (multi-axis rotary position embedding) in ROCm fused rope kernels for both prefill and decode, including interleaved mode for Qwen3.5

- Wire hw_kernel_config to qwen3vl_moe pymodel

- Fix qwen VL renderer chat template for text-only and image-only inputs

- Add ROCm smoke test for Qwen3-VL-30B-A3B-Instruct