### PR TITLE
perf(rocm): enable FlyDSL fused MoE for MI308X Qwen3.5 decode

### DIFF
--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -32,6 +32,17 @@ def is_gfx950(arch_fallback: Optional[str] = None) -> bool:
         return os.environ.get("ROCM_GFX_ARCH", "") == "950"
 
 
+def is_gfx942(arch_fallback: Optional[str] = None) -> bool:
+    """Detect whether the current ROCm device is gfx942 (MI308X/MI300X)."""
+    try:
+        prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+        return "gfx942" in getattr(prop, "gcnArchName", "")
+    except Exception:
+        if arch_fallback is not None:
+            return arch_fallback == "942"
+        return os.environ.get("ROCM_GFX_ARCH", "") == "942"
+
+
 class CpuImpl(DeviceBase):
     def __init__(self):
         super().__init__()

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -222,10 +222,6 @@ class Qwen35Moe(Qwen3NextBase):
         moe_config = self.moe_config
         max_generate_batch_size = self.max_generate_batch_size
 
-        from rtp_llm.models_py.utils.arch import is_cuda
-
-        if not is_cuda():
-            raise RuntimeError("Qwen3Next is only supported in cuda arch")
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -84,23 +84,8 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
-    }
-}
-
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCachePrefillOpBase(attn_configs) {}
@@ -352,9 +337,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 }
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCacheDecodeOpBase(attn_configs) {}

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -109,7 +109,9 @@ class GenericMoeLayer(nn.Module):
         # for group topk
         self.correction_bias = weights.get(W.e_score_correction_b, None)
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, is_prefill: Optional[bool] = None
+    ) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
         router_logits = self.gate(hidden_states)
         router_logits_fp32 = router_logits.float()
@@ -165,6 +167,9 @@ class GenericMoeLayer(nn.Module):
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             activation="SiGLU",
+            extra_expert_args=(
+                {"is_prefill": is_prefill} if is_prefill is not None else None
+            ),
         )
         if self.shared_expert is not None:
             shared_expert_output = self.shared_expert(

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -92,6 +92,15 @@ class Qwen3NextMetadata(object):
         return self.cp_restore_indices is not None
 
 
+def _use_qwen35_flydsl_moe_phase_hint(config: ModelConfig) -> bool:
+    return (
+        getattr(config, "moe_style", None) == 2
+        and getattr(config, "expert_num", None) == 512
+        and getattr(config, "moe_k", None) == 10
+        and getattr(config, "hidden_size", None) == 4096
+    )
+
+
 class Qwen3NextGatedDeltaNetBase(torch.nn.Module):
     def __init__(
         self,
@@ -978,6 +987,7 @@ class Qwen3NextDecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSResNorm(
             weights[W.post_ln_gamma], eps=config.layernorm_eps
         )
+        self._use_flydsl_moe_phase_hint = _use_qwen35_flydsl_moe_phase_hint(config)
 
     def forward(
         self,
@@ -1000,7 +1010,16 @@ class Qwen3NextDecoderLayer(nn.Module):
 
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
 
-        hidden_states = self.mlp(hidden_states)
+        if (
+            self._use_flydsl_moe_phase_hint
+            and isinstance(self.mlp, GenericMoeLayer)
+            and attention_inputs is not None
+        ):
+            hidden_states = self.mlp(
+                hidden_states, is_prefill=attention_inputs.is_prefill
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
 
         return hidden_states, residual
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -1,4 +1,6 @@
 import copy
+import logging
+import os
 from typing import Any, Dict, Optional
 
 import aiter
@@ -21,16 +23,208 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType
 from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
     get_rocm_fp8_dtype,
 )
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.flydsl.tuning import (
+    get_qwen_ptpc_fp8_tuning,
+)
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
 from rtp_llm.utils.model_weight import W
+
+logger = logging.getLogger(__name__)
+
+
+_FLYDSL_AVAILABLE = False
+_FLYDSL_IMPORT_ATTEMPTED = False
+_fused_moe_flydsl_fn = None
+_FlyDSLActivationType = None
+_FlyDSLQuantType = None
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _flydsl_fused_moe_enabled() -> bool:
+    return _env_flag("USE_FLYDSL") and _env_flag("USE_FLYDSL_MOE")
+
+
+def _load_flydsl_fused_moe() -> bool:
+    global _FLYDSL_AVAILABLE
+    global _FLYDSL_IMPORT_ATTEMPTED
+    global _fused_moe_flydsl_fn
+    global _FlyDSLActivationType
+    global _FlyDSLQuantType
+
+    if _FLYDSL_AVAILABLE:
+        return True
+    if _FLYDSL_IMPORT_ATTEMPTED:
+        return False
+    _FLYDSL_IMPORT_ATTEMPTED = True
+    try:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.flydsl.fused_moe_flydsl import (
+            fused_moe_flydsl as _fused_moe_flydsl_fn,
+        )
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.flydsl.fused_moe_helper import (
+            ActivationType as _FlyDSLActivationType,
+            QuantType as _FlyDSLQuantType,
+        )
+
+        _FLYDSL_AVAILABLE = True
+    except ImportError as e:
+        logger.debug("FlyDSL fused_moe failed to import, falling back to AITER: %s", e)
+    return _FLYDSL_AVAILABLE
 
 
 def _moe_activation_type(activation: str) -> aiter.ActivationType:
     if activation in ("silu", "SiGLU"):
         return aiter.ActivationType.Silu
     return aiter.ActivationType.Gelu
+
+
+def _flatten_per_channel_scale(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dim() == 3 and scale.shape[-1] == 1:
+        return scale.reshape(scale.shape[0], scale.shape[1]).contiguous()
+    return scale
+
+
+def _flydsl_fused_moe_unsupported_reason(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str,
+    effective_expert_mask: Optional[torch.Tensor],
+    expert_ids_are_local: bool,
+    num_experts: int,
+    local_num_experts: int,
+    ep_size: int,
+) -> Optional[str]:
+    if activation not in ("silu", "SiGLU"):
+        return f"activation={activation!r}"
+    if effective_expert_mask is not None:
+        return "expert_mask is set"
+    if expert_ids_are_local:
+        return "expert ids are already local"
+    if ep_size != 1 or num_experts != local_num_experts:
+        return f"non-pure-TP experts ep_size={ep_size}, global={num_experts}, local={local_num_experts}"
+    if hidden_states.dim() != 2 or topk_ids.dim() != 2:
+        return f"unexpected dims hidden={tuple(hidden_states.shape)}, topk_ids={tuple(topk_ids.shape)}"
+    if hidden_states.dtype not in (torch.float16, torch.bfloat16):
+        return f"hidden dtype={hidden_states.dtype}"
+    if w1.dim() != 3 or w2.dim() != 3:
+        return f"unexpected weight dims w1={tuple(w1.shape)}, w2={tuple(w2.shape)}"
+
+    batch_m = hidden_states.shape[0]
+    experts, w1_out, model_dim = w1.shape
+    w2_model_dim, inter_dim = w2.shape[1], w2.shape[2]
+    topk = topk_ids.shape[1]
+    if (experts, topk, model_dim) != (512, 10, 4096):
+        return f"shape E={experts}, topk={topk}, model_dim={model_dim}"
+    if w1_out != 2 * inter_dim or w2_model_dim != model_dim:
+        return f"inconsistent weights w1={tuple(w1.shape)}, w2={tuple(w2.shape)}"
+    tuning = get_qwen_ptpc_fp8_tuning(inter_dim)
+    if tuning is None:
+        return f"inter_dim={inter_dim}"
+
+    max_m = tuning.max_m
+    if max_m > 0 and batch_m > max_m:
+        return f"M={batch_m} exceeds FlyDSL tuned max M={max_m}"
+    return None
+
+
+def _log_flydsl_fallback(reason: str) -> None:
+    logger.debug("Falling back to AITER fused_moe: %s", reason)
+
+
+def _should_use_flydsl_fused_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str,
+    effective_expert_mask: Optional[torch.Tensor],
+    expert_ids_are_local: bool,
+    num_experts: int,
+    local_num_experts: int,
+    ep_size: int,
+) -> bool:
+    if not _flydsl_fused_moe_enabled():
+        return False
+
+    reason = _flydsl_fused_moe_unsupported_reason(
+        hidden_states,
+        w1,
+        w2,
+        topk_ids,
+        activation=activation,
+        effective_expert_mask=effective_expert_mask,
+        expert_ids_are_local=expert_ids_are_local,
+        num_experts=num_experts,
+        local_num_experts=local_num_experts,
+        ep_size=ep_size,
+    )
+    if reason is not None:
+        _log_flydsl_fallback(reason)
+        return False
+    if not _load_flydsl_fused_moe():
+        return False
+    return True
+
+
+def _aiter_fp8_per_channel_fused_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    activation: str,
+    effective_expert_mask: Optional[torch.Tensor],
+) -> torch.Tensor:
+    return fused_moe(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        quant_type=aiter.QuantType.per_Token,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        activation=_moe_activation_type(activation),
+        expert_mask=effective_expert_mask,
+    )
+
+
+def _flydsl_fused_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+) -> torch.Tensor:
+    s1 = _flatten_per_channel_scale(w1_scale)
+    s2 = _flatten_per_channel_scale(w2_scale)
+
+    return _fused_moe_flydsl_fn(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation=_FlyDSLActivationType.Silu,
+        quant_type=_FlyDSLQuantType.per_Token,
+        w1_scale=s1,
+        w2_scale=s2,
+    )
 
 
 def build_ep_expert_mask(
@@ -84,9 +278,7 @@ class RocmExpertsBf16(FusedMoeExpertExecutor):
         self.w1 = weights[W.moe_w1]
         self.w2 = weights[W.moe_w2]
 
-        self.expert_mask = build_ep_expert_mask(
-            self.num_experts, self.ep_rank, self.ep_size, self.w1
-        )
+        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
 
     @property
     def local_num_experts(self) -> int:
@@ -121,21 +313,15 @@ class RocmExpertsBf16(FusedMoeExpertExecutor):
         # When router has already remapped IDs to local indices (e.g. MoriEpIntranodeRouter),
         # expert_mask (which is based on global IDs) must not be applied.
         effective_expert_mask = (
-            None
-            if payload.expert_ids_are_local
-            else (expert_map if expert_map is not None else self.expert_mask)
+            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert (
-                topk_weights.dim() == 2
-            ), "`topk_weights` should be in shape (num_tokens, topk)"
+            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert (
-                topk == 1
-            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -166,9 +352,7 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
 
         resolver = MoeConfigResolver()
         quant_method = resolver.get_quant_method(config)
-        checker.check(
-            quant_method in ("FP8_PER_CHANNEL_COMPRESSED", "FP8_PER_CHANNEL_QUARK")
-        )
+        checker.check(quant_method in ("FP8_PER_CHANNEL_COMPRESSED", "FP8_PER_CHANNEL_QUARK"))
 
     @property
     def topk_ids_dtype(self) -> torch.dtype:
@@ -198,9 +382,7 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
 
-        self.expert_mask = build_ep_expert_mask(
-            self.num_experts, self.ep_rank, self.ep_size, self.w1
-        )
+        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
 
     @property
     def local_num_experts(self) -> int:
@@ -239,35 +421,64 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         assert self.w2.size(0) == self.local_num_experts
 
         effective_expert_mask = (
-            None
-            if payload.expert_ids_are_local
-            else (expert_map if expert_map is not None else self.expert_mask)
+            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
         if apply_router_weight_on_input:
-            assert (
-                topk_weights.dim() == 2
-            ), "`topk_weights` should be in shape (num_tokens, topk)"
+            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert (
-                topk == 1
-            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
-        output = fused_moe(
+        if _should_use_flydsl_fused_moe(
             hidden_states,
             self.w1,
             self.w2,
-            topk_weights,
             topk_ids,
-            quant_type=aiter.QuantType.per_Token,
-            w1_scale=self.w1_scale,
-            w2_scale=self.w2_scale,
-            activation=_moe_activation_type(activation),
-            expert_mask=effective_expert_mask,
-        )
+            activation=activation,
+            effective_expert_mask=effective_expert_mask,
+            expert_ids_are_local=payload.expert_ids_are_local,
+            num_experts=self.num_experts,
+            local_num_experts=self.local_num_experts,
+            ep_size=self.ep_size,
+        ):
+            try:
+                output = _flydsl_fused_moe(
+                    hidden_states,
+                    self.w1,
+                    self.w2,
+                    topk_weights,
+                    topk_ids,
+                    w1_scale=self.w1_scale,
+                    w2_scale=self.w2_scale,
+                )
+            except (NotImplementedError, ValueError) as e:
+                _log_flydsl_fallback(str(e))
+                output = _aiter_fp8_per_channel_fused_moe(
+                    hidden_states,
+                    self.w1,
+                    self.w2,
+                    topk_weights,
+                    topk_ids,
+                    self.w1_scale,
+                    self.w2_scale,
+                    activation,
+                    effective_expert_mask,
+                )
+        else:
+            output = _aiter_fp8_per_channel_fused_moe(
+                hidden_states,
+                self.w1,
+                self.w2,
+                topk_weights,
+                topk_ids,
+                self.w1_scale,
+                self.w2_scale,
+                activation,
+                effective_expert_mask,
+            )
 
         return CombineForwardPayload(fused_expert_output=output)
 
@@ -317,9 +528,8 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
 
-        self.expert_mask = build_ep_expert_mask(
-            self.num_experts, self.ep_rank, self.ep_size, self.w1
-        )
+        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
+
     @property
     def local_num_experts(self) -> int:
         return self.w1.size(0)
@@ -350,21 +560,15 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         assert self.w2.size(0) == self.local_num_experts
 
         effective_expert_mask = (
-            None
-            if payload.expert_ids_are_local
-            else (expert_map if expert_map is not None else self.expert_mask)
+            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert (
-                topk_weights.dim() == 2
-            ), "`topk_weights` should be in shape (num_tokens, topk)"
+            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert (
-                topk == 1
-            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -435,20 +639,14 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
         self.w2_scale = weights[W.moe_s2]
 
         self.hidden_size_raw = config.hidden_size
-        self.intermediate_size_raw = (
-            config.model_config.moe_inter_size // config.tp_size
-        )
+        self.intermediate_size_raw = config.model_config.moe_inter_size // config.tp_size
         packed_factor = 2 if self.w1.dtype == torch.uint8 else 1
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
         self.hidden_pad = max(0, self.hidden_size_padded - self.hidden_size_raw)
-        self.intermediate_pad = max(
-            0, self.intermediate_size_padded - self.intermediate_size_raw
-        )
+        self.intermediate_pad = max(0, self.intermediate_size_padded - self.intermediate_size_raw)
 
-        self.expert_mask = build_ep_expert_mask(
-            self.num_experts, self.ep_rank, self.ep_size, self.w1
-        )
+        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
 
     @property
     def local_num_experts(self) -> int:
@@ -483,13 +681,9 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert (
-                topk_weights.dim() == 2
-            ), "`topk_weights` should be in shape (num_tokens, topk)"
+            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert (
-                topk == 1
-            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -504,9 +698,7 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
             w2.is_shuffled = True
 
         effective_expert_mask = (
-            None
-            if payload.expert_ids_are_local
-            else (expert_map if expert_map is not None else self.expert_mask)
+            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         # CK moe_sorting kernel requires int32 topk_ids
@@ -579,9 +771,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
 
-        self.expert_mask = build_ep_expert_mask(
-            self.num_experts, self.ep_rank, self.ep_size, self.w1
-        )
+        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
 
     @property
     def local_num_experts(self) -> int:
@@ -616,16 +806,12 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert (
-                topk_weights.dim() == 2
-            ), "`topk_weights` should be in shape (num_tokens, topk)"
+            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert (
-                topk == 1
-            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-        
+
         # view w1 and w2 to float4_e2m1fn_x2 if they are uint8
         w1 = self.w1
         w2 = self.w2
@@ -637,9 +823,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             w2.is_shuffled = True
 
         effective_expert_mask = (
-            None
-            if payload.expert_ids_are_local
-            else (expert_map if expert_map is not None else self.expert_mask)
+            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         output = fused_moe(

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -7,7 +7,7 @@ import aiter
 import torch
 from aiter.fused_moe import fused_moe
 
-from rtp_llm.device.device_impl import is_gfx950
+from rtp_llm.device.device_impl import is_gfx942, is_gfx950
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -98,12 +98,17 @@ def _flydsl_fused_moe_unsupported_reason(
     topk_ids: torch.Tensor,
     *,
     activation: str,
+    is_prefill: bool = False,
     effective_expert_mask: Optional[torch.Tensor],
     expert_ids_are_local: bool,
     num_experts: int,
     local_num_experts: int,
     ep_size: int,
 ) -> Optional[str]:
+    if is_prefill:
+        return "prefill uses AITER fused_moe"
+    if not is_gfx942():
+        return "FlyDSL fused_moe is enabled only on MI308X/gfx942"
     if activation not in ("silu", "SiGLU"):
         return f"activation={activation!r}"
     if effective_expert_mask is not None:
@@ -148,6 +153,7 @@ def _should_use_flydsl_fused_moe(
     topk_ids: torch.Tensor,
     *,
     activation: str,
+    is_prefill: bool = False,
     effective_expert_mask: Optional[torch.Tensor],
     expert_ids_are_local: bool,
     num_experts: int,
@@ -163,6 +169,7 @@ def _should_use_flydsl_fused_moe(
         w2,
         topk_ids,
         activation=activation,
+        is_prefill=is_prefill,
         effective_expert_mask=effective_expert_mask,
         expert_ids_are_local=expert_ids_are_local,
         num_experts=num_experts,
@@ -171,8 +178,6 @@ def _should_use_flydsl_fused_moe(
     )
     if reason is not None:
         _log_flydsl_fallback(reason)
-        return False
-    if not _load_flydsl_fused_moe():
         return False
     return True
 
@@ -211,6 +216,9 @@ def _flydsl_fused_moe(
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
 ) -> torch.Tensor:
+    if not _load_flydsl_fused_moe():
+        raise RuntimeError("fused_moe_flydsl requires FlyDSL fused_moe imports")
+
     s1 = _flatten_per_channel_scale(w1_scale)
     s2 = _flatten_per_channel_scale(w2_scale)
 
@@ -246,6 +254,12 @@ def build_ep_expert_mask(
     return mask
 
 
+def _is_prefill_from_extra_args(extra_expert_args: Optional[dict[str, Any]]) -> bool:
+    if not extra_expert_args:
+        return False
+    return bool(extra_expert_args.get("is_prefill", False))
+
+
 class RocmExpertsBf16(FusedMoeExpertExecutor):
     """ROCm BF16 (no quantization) MoE expert executor."""
 
@@ -278,7 +292,9 @@ class RocmExpertsBf16(FusedMoeExpertExecutor):
         self.w1 = weights[W.moe_w1]
         self.w2 = weights[W.moe_w2]
 
-        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
+        self.expert_mask = build_ep_expert_mask(
+            self.num_experts, self.ep_rank, self.ep_size, self.w1
+        )
 
     @property
     def local_num_experts(self) -> int:
@@ -313,15 +329,21 @@ class RocmExpertsBf16(FusedMoeExpertExecutor):
         # When router has already remapped IDs to local indices (e.g. MoriEpIntranodeRouter),
         # expert_mask (which is based on global IDs) must not be applied.
         effective_expert_mask = (
-            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
+            None
+            if payload.expert_ids_are_local
+            else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
+            assert (
+                topk_weights.dim() == 2
+            ), "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert (
+                topk == 1
+            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -352,7 +374,9 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
 
         resolver = MoeConfigResolver()
         quant_method = resolver.get_quant_method(config)
-        checker.check(quant_method in ("FP8_PER_CHANNEL_COMPRESSED", "FP8_PER_CHANNEL_QUARK"))
+        checker.check(
+            quant_method in ("FP8_PER_CHANNEL_COMPRESSED", "FP8_PER_CHANNEL_QUARK")
+        )
 
     @property
     def topk_ids_dtype(self) -> torch.dtype:
@@ -382,7 +406,9 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
 
-        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
+        self.expert_mask = build_ep_expert_mask(
+            self.num_experts, self.ep_rank, self.ep_size, self.w1
+        )
 
     @property
     def local_num_experts(self) -> int:
@@ -421,14 +447,20 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         assert self.w2.size(0) == self.local_num_experts
 
         effective_expert_mask = (
-            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
+            None
+            if payload.expert_ids_are_local
+            else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
         if apply_router_weight_on_input:
-            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
+            assert (
+                topk_weights.dim() == 2
+            ), "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert (
+                topk == 1
+            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -438,35 +470,22 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             self.w2,
             topk_ids,
             activation=activation,
+            is_prefill=_is_prefill_from_extra_args(extra_expert_args),
             effective_expert_mask=effective_expert_mask,
             expert_ids_are_local=payload.expert_ids_are_local,
             num_experts=self.num_experts,
             local_num_experts=self.local_num_experts,
             ep_size=self.ep_size,
         ):
-            try:
-                output = _flydsl_fused_moe(
-                    hidden_states,
-                    self.w1,
-                    self.w2,
-                    topk_weights,
-                    topk_ids,
-                    w1_scale=self.w1_scale,
-                    w2_scale=self.w2_scale,
-                )
-            except (NotImplementedError, ValueError) as e:
-                _log_flydsl_fallback(str(e))
-                output = _aiter_fp8_per_channel_fused_moe(
-                    hidden_states,
-                    self.w1,
-                    self.w2,
-                    topk_weights,
-                    topk_ids,
-                    self.w1_scale,
-                    self.w2_scale,
-                    activation,
-                    effective_expert_mask,
-                )
+            output = _flydsl_fused_moe(
+                hidden_states,
+                self.w1,
+                self.w2,
+                topk_weights,
+                topk_ids,
+                w1_scale=self.w1_scale,
+                w2_scale=self.w2_scale,
+            )
         else:
             output = _aiter_fp8_per_channel_fused_moe(
                 hidden_states,
@@ -528,8 +547,9 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
 
-        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
-
+        self.expert_mask = build_ep_expert_mask(
+            self.num_experts, self.ep_rank, self.ep_size, self.w1
+        )
     @property
     def local_num_experts(self) -> int:
         return self.w1.size(0)
@@ -560,15 +580,21 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         assert self.w2.size(0) == self.local_num_experts
 
         effective_expert_mask = (
-            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
+            None
+            if payload.expert_ids_are_local
+            else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
+            assert (
+                topk_weights.dim() == 2
+            ), "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert (
+                topk == 1
+            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -639,14 +665,20 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
         self.w2_scale = weights[W.moe_s2]
 
         self.hidden_size_raw = config.hidden_size
-        self.intermediate_size_raw = config.model_config.moe_inter_size // config.tp_size
+        self.intermediate_size_raw = (
+            config.model_config.moe_inter_size // config.tp_size
+        )
         packed_factor = 2 if self.w1.dtype == torch.uint8 else 1
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
         self.hidden_pad = max(0, self.hidden_size_padded - self.hidden_size_raw)
-        self.intermediate_pad = max(0, self.intermediate_size_padded - self.intermediate_size_raw)
+        self.intermediate_pad = max(
+            0, self.intermediate_size_padded - self.intermediate_size_raw
+        )
 
-        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
+        self.expert_mask = build_ep_expert_mask(
+            self.num_experts, self.ep_rank, self.ep_size, self.w1
+        )
 
     @property
     def local_num_experts(self) -> int:
@@ -681,9 +713,13 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
+            assert (
+                topk_weights.dim() == 2
+            ), "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert (
+                topk == 1
+            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
 
@@ -698,7 +734,9 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
             w2.is_shuffled = True
 
         effective_expert_mask = (
-            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
+            None
+            if payload.expert_ids_are_local
+            else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         # CK moe_sorting kernel requires int32 topk_ids
@@ -771,7 +809,9 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
 
-        self.expert_mask = build_ep_expert_mask(self.num_experts, self.ep_rank, self.ep_size, self.w1)
+        self.expert_mask = build_ep_expert_mask(
+            self.num_experts, self.ep_rank, self.ep_size, self.w1
+        )
 
     @property
     def local_num_experts(self) -> int:
@@ -806,12 +846,16 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         hidden_states = payload.expert_x
 
         if apply_router_weight_on_input:
-            assert topk_weights.dim() == 2, "`topk_weights` should be in shape (num_tokens, topk)"
+            assert (
+                topk_weights.dim() == 2
+            ), "`topk_weights` should be in shape (num_tokens, topk)"
             _, topk = topk_weights.shape
-            assert topk == 1, "Only support topk=1 when `apply_router_weight_on_input` is True"
+            assert (
+                topk == 1
+            ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-
+        
         # view w1 and w2 to float4_e2m1fn_x2 if they are uint8
         w1 = self.w1
         w2 = self.w2
@@ -823,7 +867,9 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             w2.is_shuffled = True
 
         effective_expert_mask = (
-            None if payload.expert_ids_are_local else (expert_map if expert_map is not None else self.expert_mask)
+            None
+            if payload.expert_ids_are_local
+            else (expert_map if expert_map is not None else self.expert_mask)
         )
 
         output = fused_moe(

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fp8_quant.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fp8_quant.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Small per-token FP8 quantization helpers implemented in FlyDSL."""
+
+import functools
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl
+from flydsl.expr import Stream as _FlyStream
+from flydsl.expr.typing import T
+from flydsl.expr.vector import ReductionOp
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+
+_quant_cf_cache = {}
+
+
+def _launch_cached(cache, key, launch_fn, args, stream):
+    cf = cache.get(key)
+    stream_arg = _FlyStream(stream)
+    if cf is not None:
+        cf(*args, stream_arg)
+    else:
+        launch_fn(*args, stream=stream)
+        cf = flyc.compile(launch_fn, *args, stream_arg)
+        cache[key] = cf
+
+
+_FP8_E4M3FNUZ_MAX = 240.0
+_FP32_MIN_NORMAL = 1.1754943508222875e-38
+_WARP_SIZE = 64
+
+
+def _tile_config(n: int) -> tuple[int, int]:
+    if n == 128:
+        return 64, 2
+    if n == 256:
+        return 64, 4
+    if n % 2048 == 0:
+        return 256, 8
+    if n % 1024 == 0:
+        return 128, 8
+    if n % 256 == 0:
+        return 64, 4
+    return 256, 8
+
+
+@functools.lru_cache(maxsize=128)
+def compile_fp8_quant_per_token(
+    *,
+    n: int,
+    in_dtype: str,
+    use_row_weights: bool = False,
+    input_cache_modifier: int = 0,
+    output_cache_modifier: int = 0,
+):
+    if in_dtype not in ("bf16", "fp16"):
+        raise ValueError(f"in_dtype must be 'bf16' or 'fp16', got {in_dtype!r}")
+    block_threads, vec_width = _tile_config(int(n))
+    tile_cols = block_threads * vec_width
+    if int(n) % tile_cols != 0:
+        raise ValueError(
+            f"fp8 quant fast path requires n divisible by block_threads*vec_width, "
+            f"got n={n}, block_threads={block_threads}, vec_width={vec_width}"
+        )
+    num_tiles = int(n) // tile_cols
+    red_slots = max(1, block_threads // _WARP_SIZE)
+
+    allocator = SmemAllocator(None, arch=get_hip_arch())
+    red_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = red_offset + red_slots * 4
+
+    @flyc.kernel
+    def fp8_quant_kernel(
+        inp: fx.Tensor,
+        out: fx.Tensor,
+        scales: fx.Tensor,
+        row_weights: fx.Tensor,
+    ):
+        row = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        tid_i32 = arith.index_cast(T.i32, tid)
+
+        base_ptr = allocator.get_base()
+        s_red = SmemPtr(base_ptr, red_offset, T.f32, shape=(red_slots,))
+        s_red.get()
+
+        inp_rsrc = buffer_ops.create_buffer_resource(
+            inp,
+            max_size=False,
+            num_records_bytes=fx.Index(n * 2) * row + fx.Index(n * 2),
+        )
+        out_rsrc = buffer_ops.create_buffer_resource(
+            out,
+            max_size=False,
+            num_records_bytes=fx.Index(n) * row + fx.Index(n),
+        )
+        scale_rsrc = buffer_ops.create_buffer_resource(
+            scales, max_size=False, num_records_bytes=(row + fx.Index(1)) * fx.Index(4)
+        )
+        row_weight_rsrc = -1
+        if const_expr(use_row_weights):
+            row_weight_rsrc = buffer_ops.create_buffer_resource(
+                row_weights,
+                max_size=False,
+                num_records_bytes=(row + fx.Index(1)) * fx.Index(4),
+            )
+        in_elem = T.bf16 if const_expr(in_dtype == "bf16") else T.f16
+
+        def wave_reduce_max(val):
+            width = arith.constant(_WARP_SIZE, type=T.i32)
+            w = val
+            for shift in [32, 16, 8, 4, 2, 1]:
+                peer = w.shuffle_xor(arith.constant(shift, type=T.i32), width)
+                w = w.maximumf(peer)
+            return w
+
+        def block_reduce_max(val):
+            if const_expr(red_slots == 1):
+                return wave_reduce_max(val)
+
+            lane = tid_i32 % arith.constant(_WARP_SIZE, type=T.i32)
+            wave = tid_i32 // arith.constant(_WARP_SIZE, type=T.i32)
+            w = wave_reduce_max(val)
+            if lane == fx.Int32(0):
+                wave_idx = arith.index_cast(T.index, wave)
+                SmemPtr.store(s_red, w, [wave_idx])
+            gpu.barrier()
+
+            if wave == fx.Int32(0):
+                in_range = lane < arith.constant(red_slots, type=T.i32)
+                lane_safe = arith.select(in_range, lane, fx.Int32(0))
+                lane_safe_idx = arith.index_cast(T.index, lane_safe)
+                v = SmemPtr.load(s_red, [lane_safe_idx])
+                ww = arith.select(in_range, v, arith.constant(0.0, type=T.f32))
+                ww = wave_reduce_max(ww)
+                if lane == fx.Int32(0):
+                    SmemPtr.store(s_red, ww, [fx.Index(0)])
+            gpu.barrier()
+
+            return SmemPtr.load(s_red, [fx.Index(0)])
+
+        abs_mask = fx.Vector.filled(vec_width, 0x7FFFFFFF, fx.Int32)
+        local_max = arith.constant(0.0, type=T.f32)
+        cached_vecs = []
+        row_base = row * fx.Index(n)
+        thread_base = tid * fx.Index(vec_width)
+
+        for tile_i in range_constexpr(num_tiles):
+            elem_off = row_base + fx.Index(tile_i * tile_cols) + thread_base
+            raw = buffer_ops.buffer_load(
+                inp_rsrc,
+                elem_off,
+                vec_width=vec_width,
+                dtype=in_elem,
+                **({"cache_modifier": int(input_cache_modifier)} if int(input_cache_modifier) != 0 else {}),
+            )
+            vals = fx.Vector(raw).to(fx.Float32)
+            cached_vecs.append(vals)
+            vals_abs = (vals.bitcast(fx.Int32) & abs_mask).bitcast(fx.Float32)
+            chunk_max = vals_abs.reduce(ReductionOp.MAX)
+            local_max = local_max.maximumf(chunk_max.ir_value())
+
+        row_max = block_reduce_max(local_max)
+        scale = row_max / arith.constant(_FP8_E4M3FNUZ_MAX, type=T.f32)
+        safe_nonzero_scale = scale.maximumf(arith.constant(_FP32_MIN_NORMAL, type=T.f32))
+        final_scale = arith.select(
+            scale == arith.constant(0.0, type=T.f32),
+            arith.constant(1.0, type=T.f32),
+            safe_nonzero_scale,
+        )
+        scale_out = final_scale
+        if const_expr(use_row_weights):
+            scale_out = scale_out * buffer_ops.buffer_load(row_weight_rsrc, row, vec_width=1, dtype=T.f32)
+        if tid_i32 == fx.Int32(0):
+            buffer_ops.buffer_store(scale_out, scale_rsrc, row)
+
+        inv_scale = arith.constant(1.0, type=T.f32) / final_scale
+
+        for tile_i in range_constexpr(num_tiles):
+            vals = cached_vecs[tile_i] * inv_scale
+            elem_off = row_base + fx.Index(tile_i * tile_cols) + thread_base
+            if const_expr(vec_width == 2):
+                lo = rocdl.cvt_pk_fp8_f32(T.i32, vals[0], vals[1], fx.Int32(0), False)
+                byte0 = arith.trunci(T.i8, lo)
+                byte1 = arith.trunci(T.i8, lo >> arith.constant(8, type=T.i32))
+                buffer_ops.buffer_store(
+                    byte0,
+                    out_rsrc,
+                    elem_off,
+                    **({"cache_modifier": int(output_cache_modifier)} if int(output_cache_modifier) != 0 else {}),
+                )
+                buffer_ops.buffer_store(
+                    byte1,
+                    out_rsrc,
+                    elem_off + fx.Index(1),
+                    **({"cache_modifier": int(output_cache_modifier)} if int(output_cache_modifier) != 0 else {}),
+                )
+            else:
+                for wi in range_constexpr(vec_width // 4):
+                    base = wi * 4
+                    lo = rocdl.cvt_pk_fp8_f32(T.i32, vals[base], vals[base + 1], fx.Int32(0), False)
+                    packed = rocdl.cvt_pk_fp8_f32(T.i32, vals[base + 2], vals[base + 3], lo, True)
+                    word_off = (elem_off // fx.Index(4)) + fx.Index(wi)
+                    buffer_ops.buffer_store(
+                        packed,
+                        out_rsrc,
+                        word_off,
+                        **({"cache_modifier": int(output_cache_modifier)} if int(output_cache_modifier) != 0 else {}),
+                    )
+
+    @flyc.jit
+    def launch_fp8_quant(
+        inp: fx.Tensor,
+        out: fx.Tensor,
+        scales: fx.Tensor,
+        row_weights: fx.Tensor,
+        rows: fx.Int32,
+        stream: fx.Stream,
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        rows_idx = arith.index_cast(T.index, rows)
+        fp8_quant_kernel(inp, out, scales, row_weights).launch(
+            grid=(rows_idx, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_fp8_quant
+
+
+@functools.lru_cache(maxsize=128)
+def compile_fp8_quant_with_zero(
+    *,
+    n: int,
+    in_dtype: str,
+    zero_dtype: str,
+    zero_vec_width: int = 8,
+    use_row_weights: bool = False,
+    input_cache_modifier: int = 0,
+    output_cache_modifier: int = 0,
+):
+    """Compile fused FP8 quant + zero_fill: two kernels in one @flyc.jit dispatch."""
+    quant_launcher = compile_fp8_quant_per_token(
+        n=n,
+        in_dtype=in_dtype,
+        use_row_weights=use_row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+
+    from .zero_fill import compile_zero_fill
+
+    zero_launcher_inner = compile_zero_fill(dtype=zero_dtype, vec_width=zero_vec_width)
+
+    # Extract the kernel objects from the existing launchers by calling them
+    # in a new @flyc.jit that launches both sequentially on the same stream.
+    quant_block_threads, _ = _tile_config(int(n))
+
+    is_bf16_zero = zero_dtype == "bf16"
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def zero_fill_kernel_fused(out: fx.Tensor, i32_numel: fx.Int32):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        vec_id = bid * fx.Index(256) + tid
+        elem_base = vec_id * fx.Index(zero_vec_width)
+        numel_idx = arith.index_cast(T.index, i32_numel)
+        vec_count = numel_idx // fx.Index(zero_vec_width)
+        out_rsrc = buffer_ops.create_buffer_resource(out, max_size=False, num_records_bytes=numel_idx * fx.Index(2))
+        from flydsl.expr import vector
+
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_id, vec_count)
+        elem_type = T.bf16 if is_bf16_zero else T.f16
+        zero_scalar = arith.constant(0.0, type=elem_type)
+        zero_vec = vector.broadcast(T.vec(zero_vec_width, elem_type), zero_scalar)
+        buffer_ops.buffer_store(zero_vec, out_rsrc, elem_base, mask=in_range)
+
+    quant_allocator = SmemAllocator(None, arch=get_hip_arch())
+    quant_red_slots = max(1, quant_block_threads // _WARP_SIZE)
+    quant_red_offset = quant_allocator._align(quant_allocator.ptr, 16)
+    quant_allocator.ptr = quant_red_offset + quant_red_slots * 4
+
+    quant_compiled = compile_fp8_quant_per_token(
+        n=n,
+        in_dtype=in_dtype,
+        use_row_weights=use_row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+
+    @flyc.jit
+    def launch_fp8_quant_with_zero(
+        inp: fx.Tensor,
+        out: fx.Tensor,
+        scales: fx.Tensor,
+        row_weights: fx.Tensor,
+        rows: fx.Int32,
+        zero_out: fx.Tensor,
+        zero_numel: fx.Int32,
+        stream: fx.Stream,
+    ):
+        quant_compiled(inp, out, scales, row_weights, rows, stream=stream)
+        zero_numel_idx = arith.index_cast(T.index, zero_numel)
+        zero_vec_count = zero_numel_idx // fx.Index(zero_vec_width)
+        zero_blocks = (zero_vec_count + fx.Index(255)) // fx.Index(256)
+        zero_fill_kernel_fused(zero_out, zero_numel).launch(
+            grid=(zero_blocks, 1, 1),
+            block=(256, 1, 1),
+            stream=stream,
+        )
+
+    return launch_fp8_quant_with_zero
+
+
+_quant_zero_cf_cache = {}
+
+
+def fp8_quantize_per_token_with_zero(
+    x: torch.Tensor,
+    scale_shape,
+    zero_tensor: torch.Tensor,
+    *,
+    stream,
+    row_weights: torch.Tensor | None = None,
+    input_cache_modifier: int | None = None,
+    output_cache_modifier: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """FP8 per-token quantization + zero_fill in one dispatch (2 kernels, 1 Python call)."""
+    if x.dtype == torch.bfloat16:
+        in_dtype = "bf16"
+    elif x.dtype == torch.float16:
+        in_dtype = "fp16"
+    else:
+        raise ValueError(f"fp8 quant supports fp16/bf16 input, got {x.dtype}")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    zero_dtype = "bf16" if zero_tensor.dtype == torch.bfloat16 else "f16"
+    zero_numel = int(zero_tensor.numel())
+    zero_vec_width = 8
+    if zero_numel == 0 or zero_numel % zero_vec_width != 0:
+        raise ValueError(f"zero_tensor numel must be positive and divisible by {zero_vec_width}, got {zero_numel}")
+
+    n = int(x.shape[-1])
+    rows = int(x.numel() // n)
+    x_2d = x.reshape(rows, n)
+    out = torch.empty(x.shape, dtype=torch.float8_e4m3fnuz, device=x.device)
+    scales = torch.empty(scale_shape, dtype=torch.float32, device=x.device)
+    use_row_weights = row_weights is not None
+    if row_weights is None:
+        row_weights_arg = torch.empty((0,), dtype=torch.float32, device=x.device)
+    else:
+        row_weights_arg = row_weights.reshape(rows).contiguous()
+    if input_cache_modifier is None:
+        input_cache_modifier = 0
+    if output_cache_modifier is None:
+        output_cache_modifier = 0
+
+    launcher = compile_fp8_quant_with_zero(
+        n=n,
+        in_dtype=in_dtype,
+        zero_dtype=zero_dtype,
+        zero_vec_width=zero_vec_width,
+        use_row_weights=use_row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+    _qz_args = (
+        x_2d,
+        out.reshape(rows, n),
+        scales.reshape(rows),
+        row_weights_arg,
+        rows,
+        zero_tensor,
+        zero_numel,
+    )
+    _launch_cached(_quant_zero_cf_cache, id(launcher), launcher, _qz_args, stream)
+    return out, scales
+
+
+def fp8_quantize_per_token(
+    x: torch.Tensor,
+    scale_shape,
+    *,
+    stream,
+    row_weights: torch.Tensor | None = None,
+    input_cache_modifier: int | None = None,
+    output_cache_modifier: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.dtype == torch.bfloat16:
+        in_dtype = "bf16"
+    elif x.dtype == torch.float16:
+        in_dtype = "fp16"
+    else:
+        raise ValueError(f"fp8 quant supports fp16/bf16 input, got {x.dtype}")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    n = int(x.shape[-1])
+    rows = int(x.numel() // n)
+    x_2d = x.reshape(rows, n)
+    out = torch.empty(x.shape, dtype=torch.float8_e4m3fnuz, device=x.device)
+    scales = torch.empty(scale_shape, dtype=torch.float32, device=x.device)
+    use_row_weights = row_weights is not None
+    if row_weights is None:
+        row_weights_arg = torch.empty((0,), dtype=torch.float32, device=x.device)
+    else:
+        row_weights_arg = row_weights.reshape(rows).contiguous()
+    if input_cache_modifier is None:
+        input_cache_modifier = 0
+    if output_cache_modifier is None:
+        output_cache_modifier = 0
+    launcher = compile_fp8_quant_per_token(
+        n=n,
+        in_dtype=in_dtype,
+        use_row_weights=use_row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+    _q_args = (x_2d, out.reshape(rows, n), scales.reshape(rows), row_weights_arg, rows)
+    _launch_cached(_quant_cf_cache, id(launcher), launcher, _q_args, stream)
+    return out, scales

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_flydsl.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_flydsl.py
@@ -1,0 +1,756 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FlyDSL fused MoE entry point.
+
+This mirrors the current Gluon fused MoE fp8/no-quant call shape but keeps the
+implementation on a separate public API so existing Gluon behavior is untouched.
+Weights are expected to already be in the same preshuffled layout produced by
+`atrex.src.triton.fused_moe.fused_moe_helper.shuffle_weight`.
+"""
+
+from typing import Optional
+
+import torch
+
+import flydsl.compiler as flyc
+from flydsl.expr import Stream as _FlyStream
+
+from .fused_moe_helper import (
+    ActivationType,
+    QuantType,
+    get_block_size_m,
+    get_m_align,
+)
+from .tuning import get_qwen_ptpc_fp8_tuning
+
+_gemm1_cf_cache = {}
+_gemm2_cf_cache = {}
+
+
+def _launch_cached(cache, key, launch_fn, args, stream):
+    """AOT-compiled dispatch: first call JITs, subsequent calls use CompiledFunction (~5us vs ~60us)."""
+    cf = cache.get(key)
+    stream_arg = _FlyStream(stream)
+    if cf is None:
+        cf = flyc.compile(launch_fn, *args, stream_arg)
+        cache[key] = cf
+        return
+    cf(*args, stream_arg)
+
+
+def _needs_gfx94_bf16_atomic_workaround(dtype: torch.dtype) -> bool:
+    if dtype != torch.bfloat16:
+        return False
+    try:
+        from flydsl.runtime.device import get_rocm_arch
+    except ImportError:
+        return False
+    return str(get_rocm_arch()).startswith("gfx94")
+
+
+def _dtype_to_moe_input(dtype: torch.dtype) -> str:
+    if dtype == torch.float16:
+        return "fp16"
+    if dtype == torch.bfloat16:
+        return "bf16"
+    raise ValueError(f"fused_moe_flydsl supports fp16/bf16 hidden states, got {dtype}")
+
+
+def _dtype_to_out(dtype: torch.dtype) -> str:
+    if dtype == torch.float16:
+        return "f16"
+    if dtype == torch.bfloat16:
+        return "bf16"
+    raise ValueError(f"fused_moe_flydsl supports fp16/bf16 outputs, got {dtype}")
+
+
+def _empty_scale_like(hidden_states: torch.Tensor) -> torch.Tensor:
+    return torch.empty((0,), dtype=torch.float32, device=hidden_states.device)
+
+
+def _quantize_per_token(
+    x: torch.Tensor,
+    scale_shape,
+    *,
+    row_weights: Optional[torch.Tensor] = None,
+    input_cache_modifier: int = 0,
+    output_cache_modifier: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from .fp8_quant import fp8_quantize_per_token
+
+    return fp8_quantize_per_token(
+        x,
+        scale_shape,
+        stream=torch.cuda.current_stream(),
+        row_weights=row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+
+
+def _quantize_per_token_with_zero(
+    x: torch.Tensor,
+    scale_shape,
+    zero_tensor: torch.Tensor,
+    *,
+    row_weights: Optional[torch.Tensor] = None,
+    input_cache_modifier: int = 0,
+    output_cache_modifier: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from .fp8_quant import fp8_quantize_per_token_with_zero
+
+    return fp8_quantize_per_token_with_zero(
+        x,
+        scale_shape,
+        zero_tensor,
+        stream=torch.cuda.current_stream(),
+        row_weights=row_weights,
+        input_cache_modifier=input_cache_modifier,
+        output_cache_modifier=output_cache_modifier,
+    )
+
+
+def fused_moe_flydsl(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    expert_mask: Optional[torch.Tensor] = None,
+    activation=ActivationType.Silu,
+    quant_type=QuantType.per_Token,
+    doweight_stage1: bool = False,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None,
+    block_size_M: Optional[int] = None,
+    num_local_tokens: Optional[torch.Tensor] = None,
+    moe_sorting_dispatch_policy: int = 0,
+    dtype=None,
+    hidden_pad: int = 0,
+    intermediate_pad: int = 0,
+    bias1=None,
+    bias2=None,
+    out1_ref=None,
+    w2_bf16: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run fused MoE through FlyDSL stage1/stage2 kernels.
+
+    The supported conversion target is the same hot path as the current Gluon
+    operator: Silu activation, `QuantType.per_Token` fp8 or `QuantType.No`, and
+    preshuffled W1/W2 weights.
+    """
+    del dtype, hidden_pad, intermediate_pad, bias1, bias2, out1_ref
+    if activation != ActivationType.Silu:
+        raise NotImplementedError(f"fused_moe_flydsl only supports Silu, got {activation}")
+
+    quant_type = QuantType(int(quant_type))
+    fp8_per_token = quant_type == QuantType.per_Token
+    if not fp8_per_token:
+        raise NotImplementedError(f"fused_moe_flydsl currently supports only QuantType.per_Token, got {quant_type}")
+    if fp8_per_token and (w1_scale is None or w2_scale is None):
+        raise ValueError("QuantType.per_Token requires w1_scale and w2_scale")
+
+    B = hidden_states.shape[0]
+    E, N1, K1 = w1.shape
+    N2, K2 = w2.shape[1], w2.shape[2]
+    TOPK = topk_ids.shape[1]
+    if N1 != 2 * K2:
+        raise ValueError(f"expected w1.shape[1] == 2 * w2.shape[2], got {N1} and {K2}")
+    if N2 != K1:
+        raise ValueError(f"expected w2.shape[1] == hidden dim {K1}, got {N2}")
+
+    model_dim = K1
+    inter_dim = K2
+
+    stage1_tile_n = 128
+    stage1_tile_k = 128
+    stage2_tile_n = 128
+    stage2_tile_k = 128
+    stage2_mode_name = "atomic"
+    stage2_zero_intermediate = True
+
+    M_ALIGN = get_m_align(B, TOPK, E)
+    if block_size_M is not None:
+        BLOCK_SIZE_M = block_size_M
+    elif (E, TOPK, model_dim, inter_dim) == (128, 8, 5120, 3072):
+        # FlyDSL-tuned: block_m=32 wins at all B on 397B. The shared helper returns
+        # 64 for B>=1024 (m_per_expert_avg > 32), which is empirically slower here.
+        BLOCK_SIZE_M = 32
+    else:
+        BLOCK_SIZE_M = get_block_size_m(B, TOPK, E)
+
+    # Per-shape weight-load cache policy (SC1 = bypass L2/LLC).
+    # Small batch is memory-bound: bypassing LLC frees cache for activations and prevents
+    # weight-pollution. Large batch reuses weights across MFMA tiles → keep cached.
+    # Tuned via op_test sweep (k3a_bnt_sweep): KEEP entries are the per-B best from
+    # `s1_nt∈{0,2,4} × s2_nt∈{0,2,4}` × 50-iter rocprofv3 P50.
+    stage1_b_nt = 0
+    stage2_b_nt = 0
+    # K3b investigation: rocdl.sched_* hints in the K-loop. Isolated sweep showed B=4
+    # gain (~6.8%, sweep: /tmp/k3b_sched_sweep), but stacked on top of K3a (LLC bypass)
+    # the residual improvement drops to <1% and other batches regress.
+    stage1_hotloop_sched = False
+    stage2_hotloop_sched = False
+
+    if (E, TOPK, model_dim, inter_dim, BLOCK_SIZE_M) == (128, 8, 5120, 3072, 32):
+        if B == 1:
+            stage1_tile_n = 64
+            stage2_tile_n = 64
+            stage2_mode_name = "reduce"
+            stage2_zero_intermediate = False
+            stage2_b_nt = 2
+        elif B == 2:
+            stage1_tile_n = 64
+            stage2_tile_n = 256
+            stage2_mode_name = "reduce"
+            stage2_zero_intermediate = False
+            stage1_b_nt = 2
+        elif B == 256:
+            stage2_tile_n = 256
+            stage1_b_nt = 2
+            stage2_b_nt = 2
+        elif B in (4, 128, 512, 1024, 2048):
+            stage2_tile_n = 256
+        if B in (4, 8, 16, 32, 64):
+            stage1_b_nt = 2
+            stage2_b_nt = 2
+        elif B == 128:
+            stage1_b_nt = 2
+    elif E == 512 and TOPK == 10 and model_dim == 4096:
+        # Qwen3.5-397B-A17B PTPC-FP8 (TP=4: inter=256, TP=8: inter=128).
+        # All stages memory-bound. Per-B configs from exhaustive rocprofv3
+        # kernel-trace P50 sweep (tune_per_shape.py, 30-iter, MI308X).
+        tuning = get_qwen_ptpc_fp8_tuning(inter_dim)
+        grouped_route_min_b = tuning.grouped_route_min_b if tuning is not None else 32
+        if block_size_M is None and B >= grouped_route_min_b:
+            # Qwen grouped routing is sparse at small/medium B, but larger B
+            # benefits from wider M tiles. These cut points come from the
+            # B=1..2048 torch-correct policy probes.
+            default_grouped_tile_m = tuning.grouped_tile_m(B, BLOCK_SIZE_M) if tuning is not None else BLOCK_SIZE_M
+            if default_grouped_tile_m in (16, 32, 64):
+                BLOCK_SIZE_M = default_grouped_tile_m
+        if B <= 4 and inter_dim <= 128:
+            # Small-B TP=8 decode: direct FlyDSL routing plus single-N-tile stage1.
+            stage1_tile_n = 64
+            stage2_tile_n = 256
+            stage1_hotloop_sched = True
+        elif B <= 4 and inter_dim == 256:
+            # V27 used tile_n=32 for speed, but the TP4 direct path can emit NaN
+            # for some seeds at B<=4. Keep the stable tile_n=64 path for torch
+            # reference correctness.
+            stage1_tile_n = 64
+            stage2_tile_n = 256
+        else:
+            stage2_tile_n = 256
+            if inter_dim <= 128:
+                if 128 <= B <= 512:
+                    stage2_tile_n = 512
+                elif B == 1024:
+                    # V43: TP8 B1024 benefits slightly from a wider stage2 N
+                    # tile; B2048 regresses with wider N and stays at 128.
+                    stage2_tile_n = 512
+                elif B >= 2048:
+                    stage2_tile_n = 128
+                stage1_hotloop_sched = True
+                if 512 <= B <= 1024:
+                    # V48: with stage2 M persistence, non-atomic GEMM2 plus
+                    # direct topk reduction wins for TP8 B512/B1024. B2048
+                    # still favors the atomic path.
+                    stage2_mode_name = "reduce"
+                    stage2_zero_intermediate = False
+            elif inter_dim == 256 and B >= 8:
+                # tile_n=32 was faster for V28 TP4 B>=32, but it is not
+                # numerically stable against the torch FP8 reference. Use
+                # correctness-safe tile sizes selected from B=1..2048 probes.
+                stage1_tile_n = 64 if B >= 2048 or B < 32 else 128
+                if B >= 2048:
+                    # V47/V57: after tight route max-blocks, B1024 is faster
+                    # with tile_n=256 plus persist_m=1; B2048 keeps tile_n=512.
+                    stage2_tile_n = 512
+                if B >= 256:
+                    # Large-B TP4 is dominated by the stage2 atomic path.
+                    # SC1/bypass on W2 is consistently better in the V33
+                    # rocprofv3 probes. After tight max-blocks, K64 remains
+                    # useful only at B256; V63/V65 use K128 for B512/B1024.
+                    stage2_b_nt = 2
+                    if B >= 2048:
+                        # V74/V75: with tight route max-blocks and chunked
+                        # persistence, keeping W2 cached is faster at B2048.
+                        stage2_b_nt = 0
+                if B == 256 and BLOCK_SIZE_M != 16:
+                    stage1_tile_k = 64
+                if B >= 512:
+                    # V42: for TP4 large-B, non-atomic stage2 plus direct
+                    # topk reduction is faster than BF16 atomics after V40's
+                    # stage2 tile-M split. TP8 regresses and stays atomic.
+                    stage2_mode_name = "reduce"
+                    stage2_zero_intermediate = False
+                if B == 512 and BLOCK_SIZE_M == 16:
+                    # V198: under the restored user-facing M512 tile-M=16
+                    # policy, atomic mode avoids the reduction launch and
+                    # narrowly meets the TP4 aiter+10% gate.
+                    stage2_mode_name = "atomic"
+                    stage2_zero_intermediate = True
+            if B >= 8:
+                stage1_b_nt = 2
+    if model_dim % stage1_tile_k != 0 or inter_dim % stage2_tile_k != 0:
+        raise ValueError(
+            f"FlyDSL MoE requires model_dim divisible by stage1_tile_k={stage1_tile_k} "
+            f"and inter_dim divisible by stage2_tile_k={stage2_tile_k}, "
+            f"got model_dim={model_dim}, inter_dim={inter_dim}"
+        )
+    if inter_dim % stage1_tile_n != 0 or model_dim % stage2_tile_n != 0:
+        raise ValueError(
+            f"FlyDSL MoE requires inter_dim divisible by stage1_tile_n={stage1_tile_n} "
+            f"and model_dim divisible by stage2_tile_n={stage2_tile_n}, "
+            f"got model_dim={model_dim}, inter_dim={inter_dim}"
+        )
+    stage2_tile_m_default = BLOCK_SIZE_M
+    if E == 512 and TOPK == 10 and model_dim == 4096:
+        if inter_dim <= 128 and B >= 16:
+            # V119: tile_m=16 halves per-CTA LDS/CShuffle/MFMA overhead for the
+            # short-K (K=128) Stage2 GEMM. rocprofv3 TP=8 kernel-only:
+            # B=16 +33%, B=32 +36%, B=64 +39%, B=128 +38%, B=512 +35%.
+            # Correctness PASS all shapes (max_rel<0.012, rel_norm<0.005).
+            stage2_tile_m_default = 16
+        elif inter_dim == 256 and B >= 2048:
+            # V119's tile_m=16 was useful for isolated task66 load-only gates,
+            # but it regresses the full TP4 API-vs-aiter path at M<=512. Keep
+            # the older tile_m=32 user-facing policy except for the large-B
+            # task66/throughput path.
+            stage2_tile_m_default = 16
+    stage2_tile_m = stage2_tile_m_default
+    if BLOCK_SIZE_M % stage2_tile_m != 0:
+        raise ValueError(f"stage2_tile_m={stage2_tile_m} must divide routing BLOCK_SIZE_M={BLOCK_SIZE_M}")
+    stage2_force_f32_atomic = False
+    if _needs_gfx94_bf16_atomic_workaround(hidden_states.dtype):
+        # gfx94 bf16 CShuffle atomics can corrupt packed bf16 pairs, while the
+        # reduce fallback has shown non-finite output for real Qwen3.5 PTPC
+        # activations. Accumulate stage2 into an f32 scratch tensor with scalar
+        # atomics, then cast back to the bf16 API dtype.
+        stage2_mode_name = "atomic"
+        stage2_force_f32_atomic = True
+
+    stream = torch.cuda.current_stream()
+    use_direct_route = (
+        fp8_per_token
+        and expert_mask is None
+        and num_local_tokens is None
+        and moe_sorting_dispatch_policy == 0
+        and E == 512
+        and TOPK == 10
+        and model_dim == 4096
+    )
+    if not use_direct_route:
+        raise NotImplementedError(
+            "fused_moe_flydsl is restricted to the Qwen3.5 direct-routing path "
+            "(E=512, TOPK=10, hidden=4096, no expert_mask, no num_local_tokens) "
+            "to avoid CK/AITER operator fallbacks."
+        )
+    if use_direct_route:
+        if topk_ids.dtype != torch.int32:
+            topk_ids = topk_ids.to(torch.int32)
+        if topk_weight.dtype != torch.float32:
+            topk_weight = topk_weight.float()
+        tuning = get_qwen_ptpc_fp8_tuning(inter_dim)
+        grouped_route_min_b = tuning.grouped_route_min_b if tuning is not None else 32
+        use_grouped_route = B >= grouped_route_min_b
+        if use_grouped_route:
+            from .moe_routing import grouped_moe_route
+
+            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = grouped_moe_route(
+                topk_ids,
+                topk_weight,
+                experts=E,
+                topk=TOPK,
+                tile_m=BLOCK_SIZE_M,
+                stream=stream,
+            )
+        else:
+            from .moe_routing import direct_moe_route
+
+            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = direct_moe_route(
+                topk_ids,
+                topk_weight,
+                topk=TOPK,
+                tile_m=BLOCK_SIZE_M,
+                stream=stream,
+            )
+    del M_ALIGN
+
+    # Grouped routing may allocate inactive fixed expert slots; GEMMs skip slots
+    # whose expert id is -1 before issuing weight loads.
+    _grid_expert_blocks = sorted_expert_ids.numel()
+
+    quant_in_cache_default = 0
+    quant_out_cache_default = 0
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048:
+        quant_in_cache_default = 4
+        quant_out_cache_default = 2
+    quant_in_cache = quant_in_cache_default
+    quant_out_cache = quant_out_cache_default
+
+    if fp8_per_token:
+        a1_qt, a1_scale = _quantize_per_token(
+            hidden_states,
+            (B, 1),
+            input_cache_modifier=quant_in_cache,
+            output_cache_modifier=quant_out_cache,
+        )
+        stage_dtype = "fp8"
+    else:
+        a1_qt = hidden_states
+        a1_scale = _empty_scale_like(hidden_states)
+        w1_scale = _empty_scale_like(hidden_states)
+        stage_dtype = _dtype_to_moe_input(hidden_states.dtype)
+
+    out_dtype = _dtype_to_out(hidden_states.dtype)
+    # FlyDSL 1-stage fused kernel (opt-in). TP8 uses the original decode path;
+    # TP4 B2B can either use predequantized W2 or requantize A2 in-CTA and
+    # keep W2 on the standard FP8 path.
+    fused_1stage_fp8_w2 = False
+    _use_fused_1stage = False
+
+    if _use_fused_1stage:
+        from .moe_gemm_1stage import compile_moe_gemm_fused
+
+        stream = torch.cuda.current_stream()
+        fused_tile_k = inter_dim
+        fused_tile_n_out_default = 256 if inter_dim == 256 else 128
+        fused_tile_n_out = fused_tile_n_out_default
+        fused_out_dtype = out_dtype
+        cast_fused_output = False
+        kernel_fused = compile_moe_gemm_fused(
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=E,
+            topk=TOPK,
+            tile_m=BLOCK_SIZE_M,
+            tile_n_out=fused_tile_n_out,
+            tile_k=fused_tile_k,
+            out_dtype=fused_out_dtype,
+            b_cache_modifier_w1=stage1_b_nt,
+            b_cache_modifier_w2=0,
+            loop_n_in_block=False,
+            stage2_use_fp8_w2=fused_1stage_fp8_w2,
+            n_tiles_per_block=0,
+            cshuffle_nlane=32,
+            total_threads=256,
+            fold_route_weight_into_a2_scale=False,
+            out_tile_pair=1,
+            cshuffle_lds_xor=False,
+        )
+        w2_fused = w2 if fused_1stage_fp8_w2 else w2_bf16
+        output_dtype = torch.float16 if cast_fused_output else hidden_states.dtype
+        output = torch.zeros((B, model_dim), dtype=output_dtype, device=hidden_states.device)
+        kernel_fused(
+            output,
+            a1_qt,
+            w1,
+            w2_fused,
+            a1_scale,
+            w1_scale,
+            w2_scale,
+            sorted_ids,
+            sorted_expert_ids,
+            sorted_weights,
+            num_valid_ids,
+            B,
+            model_dim,
+            inter_dim,
+            _grid_expert_blocks,
+            stream,
+        )
+        return output.to(hidden_states.dtype) if cast_fused_output else output
+
+    from .moe_gemm_2stage import (
+        MoeGemm2Mode,
+        compile_moe_gemm1,
+        compile_moe_gemm1_m1,
+        compile_moe_gemm2_ex,
+    )
+
+    # CShuffle epilog requires tile_n divisible by (cshuffle_nlane * e_vec) = 128.
+    stage1_cshuffle = False
+    # V116/V195: iglp_opt can trigger LLVM AMDGPUIGroupLP assertions on TP4
+    # (inter_dim=256) and block_m<32. Keep it only on the validated TP8 path.
+    if (inter_dim > 128 or BLOCK_SIZE_M < 32) and stage1_hotloop_sched:
+        stage1_hotloop_sched = False
+    # V116: fast_barrier + fine_sched synergy for memory-bound shapes.
+    stage1_fast_barrier = False
+    stage1_fine_sched = False
+    use_m1_stage1 = (
+        B == 1
+        and use_direct_route
+        and fp8_per_token
+        and not stage1_cshuffle
+        and stage_dtype == "fp8"
+        and model_dim == 4096
+        and E == 512
+        and TOPK == 10
+    )
+    if use_m1_stage1:
+        stage1 = compile_moe_gemm1_m1(
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=E,
+            topk=TOPK,
+            sort_tile_m=BLOCK_SIZE_M,
+            tile_n=stage1_tile_n,
+            tile_k=stage1_tile_k,
+            doweight_stage1=doweight_stage1,
+            in_dtype=stage_dtype,
+            out_dtype=out_dtype,
+            b_cache_modifier=stage1_b_nt,
+            enable_hotloop_sched=stage1_hotloop_sched,
+            fast_barrier=stage1_fast_barrier,
+            fine_sched=stage1_fine_sched,
+        )
+    else:
+        stage1 = compile_moe_gemm1(
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=E,
+            topk=TOPK,
+            tile_m=BLOCK_SIZE_M,
+            tile_n=stage1_tile_n,
+            tile_k=stage1_tile_k,
+            doweight_stage1=doweight_stage1,
+            in_dtype=stage_dtype,
+            out_dtype=out_dtype,
+            use_cshuffle_epilog=stage1_cshuffle,
+            b_cache_modifier=stage1_b_nt,
+            enable_hotloop_sched=stage1_hotloop_sched,
+            fast_barrier=stage1_fast_barrier,
+            fine_sched=stage1_fine_sched,
+        )
+    stage1_out = torch.empty(
+        (B, TOPK, inter_dim),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    _s1_args = (
+        stage1_out,
+        a1_qt,
+        w1,
+        a1_scale,
+        w1_scale,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights,
+        num_valid_ids,
+        B,
+        inter_dim,
+        model_dim,
+        _grid_expert_blocks,
+    )
+    _launch_cached(_gemm1_cf_cache, id(stage1), stage1, _s1_args, stream)
+
+    # Decode optimization: skip intermediate fp8 quantization when w2_bf16 is provided.
+    # The caller precomputes w2_bf16 = shuffle(dequant(w2_fp8, w2_scale)) at model load.
+    # Only beneficial when inter_dim<=128 (TP=8): bf16 stage2 K=128 is single-pass.
+    # For inter_dim=256 (TP=4), bf16 stage2 has 2x K-tiles and larger W2 loads,
+    # which outweighs the quant kernel savings at small B.
+    skip_a2_quant_max_b = 4
+    _skip_a2_quant = w2_bf16 is not None and fp8_per_token and B <= skip_a2_quant_max_b and inter_dim <= 128
+
+    fold_weight_into_a2_scale = False
+    _fuse_quant2_zero = False
+    _fused_zero_output = None
+    if _skip_a2_quant:
+        # bf16 path: stage1 output (bf16) → bf16 stage2 directly (no quant)
+        a2_for_s2 = stage1_out
+        a2_scale_for_s2 = _empty_scale_like(hidden_states)
+        w2_for_s2 = w2_bf16
+        w2_scale_for_s2 = _empty_scale_like(hidden_states)
+        s2_in_dtype = "bf16"
+    elif fp8_per_token:
+        fold_weight_into_a2_scale = E == 512 and TOPK == 10 and model_dim == 4096 and B >= 512
+        a2_row_weights = topk_weight.reshape(B * TOPK) if fold_weight_into_a2_scale and not doweight_stage1 else None
+        _fuse_quant2_zero = (
+            stage2_mode_name == "atomic"
+            and not stage2_force_f32_atomic
+            and hidden_states.dtype == torch.bfloat16
+            and use_grouped_route
+            and E == 512
+            and TOPK == 10
+            and model_dim == 4096
+            and (B * model_dim) % 8 == 0
+        )
+        if _fuse_quant2_zero:
+            _output_for_zero = torch.empty((B, model_dim), dtype=hidden_states.dtype, device=hidden_states.device)
+            a2_qt, a2_scale = _quantize_per_token_with_zero(
+                stage1_out,
+                (B, TOPK, 1),
+                _output_for_zero,
+                row_weights=a2_row_weights,
+                input_cache_modifier=quant_in_cache,
+                output_cache_modifier=quant_out_cache,
+            )
+            _fused_zero_output = _output_for_zero
+        else:
+            a2_qt, a2_scale = _quantize_per_token(
+                stage1_out,
+                (B, TOPK, 1),
+                row_weights=a2_row_weights,
+                input_cache_modifier=quant_in_cache,
+                output_cache_modifier=quant_out_cache,
+            )
+            _fused_zero_output = None
+        a2_for_s2 = a2_qt
+        a2_scale_for_s2 = a2_scale
+        w2_for_s2 = w2
+        w2_scale_for_s2 = w2_scale
+        s2_in_dtype = stage_dtype
+    else:
+        a2_for_s2 = stage1_out
+        a2_scale_for_s2 = _empty_scale_like(hidden_states)
+        w2_for_s2 = w2
+        w2_scale_for_s2 = _empty_scale_like(hidden_states)
+        s2_in_dtype = stage_dtype
+
+    stage2_skip_invalid_lds_write = False
+    stage2_lds_sorted_ids = False
+    stage2_precompute_row_base = False
+    stage2_readfirst_metadata = False
+    stage2_m_fast_grid = False
+    stage2_persist_m_default = 1
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim <= 128 and 32 <= B < 512:
+        # V119: persist_m=2 amortizes single-K-tile (K=128) startup cost for TP=8.
+        # Sweep confirms pm=2 optimal for B=32-256; pm=1 for B<32 and B>=512 (already handled below).
+        stage2_persist_m_default = 2
+    if E == 512 and TOPK == 10 and model_dim == 4096 and B >= 512:
+        if inter_dim == 256:
+            if B == 512:
+                # V212: M512 is faster with full Stage2 M-tile parallelism.
+                # pm16 collapses grid_y to 50 and leaves the memory-bound
+                # Stage2 underfilled; pm1 restores grid_y to 800.
+                stage2_persist_m_default = 1
+            elif B == 1024:
+                stage2_persist_m_default = 1
+            else:
+                stage2_persist_m_default = 32
+        elif inter_dim <= 128:
+            stage2_persist_m_default = 1 if B == 1024 else 16
+    stage2_persist_m = stage2_persist_m_default
+    stage2_persistent_grid_y = 0
+    stage2_persistent_chunk_y_default = 0
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B == 2048:
+        stage2_persistent_chunk_y_default = 64
+    stage2_persistent_chunk_y = stage2_persistent_chunk_y_default
+    stage2_group_size_m_default = 1
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B == 2048:
+        stage2_group_size_m_default = 4
+    stage2_group_size_m = stage2_group_size_m_default
+    stage2_mode = MoeGemm2Mode.REDUCE if stage2_mode_name == "reduce" else MoeGemm2Mode.ATOMIC
+    reduction_in_cache_default = 0
+    reduction_out_cache_default = 0
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048:
+        reduction_in_cache_default = 2
+        reduction_out_cache_default = 2
+    stage2_out_dtype = hidden_states.dtype
+    stage2_out_dtype_name = out_dtype
+    cast_stage2_output = False
+    stage2_reduce_intermediate_dtype_name = None
+    f16_reduce_intermediate_default = E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048
+    if stage2_force_f32_atomic:
+        stage2_out_dtype = torch.float32
+        stage2_out_dtype_name = "f32"
+        cast_stage2_output = True
+    elif (
+        stage2_mode == MoeGemm2Mode.REDUCE and hidden_states.dtype == torch.bfloat16 and f16_reduce_intermediate_default
+    ):
+        # V92: keep the API output in bf16, but let non-atomic GEMM2 write the
+        # topk intermediate as f16. This removes bf16 conversion cost from the
+        # dominant TP4 B2048 stage2 kernel; the reduction converts directly to
+        # bf16 final output without an extra cast kernel.
+        stage2_reduce_intermediate_dtype_name = "f16"
+
+    if fp8_per_token and _fuse_quant2_zero and _fused_zero_output is not None:
+        output = _fused_zero_output
+    else:
+        output = torch.empty((B, model_dim), dtype=stage2_out_dtype, device=hidden_states.device)
+    if stage2_mode == MoeGemm2Mode.ATOMIC:
+        if fp8_per_token and _fuse_quant2_zero and _fused_zero_output is not None:
+            pass
+        else:
+            use_custom_zero = (
+                hidden_states.dtype == torch.bfloat16
+                and not stage2_force_f32_atomic
+                and output.is_contiguous()
+                and use_grouped_route
+                and E == 512
+                and TOPK == 10
+                and model_dim == 4096
+            )
+            zeroed = False
+            if use_custom_zero:
+                from .zero_fill import zero_fill_tensor
+
+                zeroed = zero_fill_tensor(output, stream=stream)
+            if not zeroed:
+                output.zero_()
+
+    stage2_cshuffle_nlane_default = 32
+    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048:
+        # V114: TP4 B2048 reduce-mode stage2 is faster with a narrower CShuffle
+        # lane group; other Qwen shapes keep the historical 32-lane geometry.
+        stage2_cshuffle_nlane_default = 16
+    stage2_cshuffle_nlane = stage2_cshuffle_nlane_default
+    stage2 = compile_moe_gemm2_ex(
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        experts=E,
+        topk=TOPK,
+        tile_m=stage2_tile_m,
+        tile_n=stage2_tile_n,
+        tile_k=stage2_tile_k,
+        doweight_stage2=(not doweight_stage1)
+        and not (fp8_per_token and s2_in_dtype == stage_dtype and fold_weight_into_a2_scale),
+        in_dtype=s2_in_dtype,
+        out_dtype=stage2_out_dtype_name,
+        use_cshuffle_epilog=not stage2_force_f32_atomic,
+        mode=stage2_mode,
+        zero_intermediate=stage2_zero_intermediate,
+        b_cache_modifier=stage2_b_nt,
+        enable_hotloop_sched=stage2_hotloop_sched,
+        skip_invalid_lds_write=stage2_skip_invalid_lds_write,
+        use_lds_sorted_ids=stage2_lds_sorted_ids,
+        precompute_row_base=stage2_precompute_row_base,
+        readfirst_metadata=stage2_readfirst_metadata,
+        m_fast_grid=stage2_m_fast_grid,
+        sort_block_m=BLOCK_SIZE_M,
+        persist_m=stage2_persist_m,
+        persistent_grid_y=stage2_persistent_grid_y,
+        persistent_chunk_y=stage2_persistent_chunk_y,
+        reduce_intermediate_dtype=stage2_reduce_intermediate_dtype_name,
+        group_size_m=stage2_group_size_m,
+        cshuffle_nlane=stage2_cshuffle_nlane,
+        reduction_input_cache_modifier=reduction_in_cache_default,
+        reduction_output_cache_modifier=reduction_out_cache_default,
+    )
+    _s2_args = (
+        output,
+        a2_for_s2,
+        w2_for_s2,
+        a2_scale_for_s2,
+        w2_scale_for_s2,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights,
+        num_valid_ids,
+        B,
+        model_dim,
+        inter_dim,
+        _grid_expert_blocks,
+    )
+    if hasattr(stage2, "_gemm2_exe"):
+        stage2(*_s2_args, stream)
+    else:
+        _launch_cached(_gemm2_cf_cache, id(stage2), stage2, _s2_args, stream)
+    if cast_stage2_output:
+        return output.to(hidden_states.dtype)
+    return output

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_flydsl.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_flydsl.py
@@ -11,6 +11,7 @@ Weights are expected to already be in the same preshuffled layout produced by
 
 from typing import Optional
 
+import aiter
 import torch
 
 import flydsl.compiler as flyc
@@ -89,6 +90,23 @@ def _quantize_per_token(
     )
 
 
+def _quantize_per_token_aiter(
+    x: torch.Tensor,
+    scale_shape,
+    *,
+    row_weights: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if row_weights is not None:
+        return _quantize_per_token(x, scale_shape, row_weights=row_weights)
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    out = torch.empty(x.shape, dtype=torch.float8_e4m3fnuz, device=x.device)
+    scales = torch.empty(scale_shape, dtype=torch.float32, device=x.device)
+    aiter.dynamic_per_token_scaled_quant(out, x, scales)
+    return out, scales
+
+
 def _quantize_per_token_with_zero(
     x: torch.Tensor,
     scale_shape,
@@ -144,12 +162,16 @@ def fused_moe_flydsl(
     """
     del dtype, hidden_pad, intermediate_pad, bias1, bias2, out1_ref
     if activation != ActivationType.Silu:
-        raise NotImplementedError(f"fused_moe_flydsl only supports Silu, got {activation}")
+        raise NotImplementedError(
+            f"fused_moe_flydsl only supports Silu, got {activation}"
+        )
 
     quant_type = QuantType(int(quant_type))
     fp8_per_token = quant_type == QuantType.per_Token
     if not fp8_per_token:
-        raise NotImplementedError(f"fused_moe_flydsl currently supports only QuantType.per_Token, got {quant_type}")
+        raise NotImplementedError(
+            f"fused_moe_flydsl currently supports only QuantType.per_Token, got {quant_type}"
+        )
     if fp8_per_token and (w1_scale is None or w2_scale is None):
         raise ValueError("QuantType.per_Token requires w1_scale and w2_scale")
 
@@ -229,7 +251,11 @@ def fused_moe_flydsl(
             # Qwen grouped routing is sparse at small/medium B, but larger B
             # benefits from wider M tiles. These cut points come from the
             # B=1..2048 torch-correct policy probes.
-            default_grouped_tile_m = tuning.grouped_tile_m(B, BLOCK_SIZE_M) if tuning is not None else BLOCK_SIZE_M
+            default_grouped_tile_m = (
+                tuning.grouped_tile_m(B, BLOCK_SIZE_M)
+                if tuning is not None
+                else BLOCK_SIZE_M
+            )
             if default_grouped_tile_m in (16, 32, 64):
                 BLOCK_SIZE_M = default_grouped_tile_m
         if B <= 4 and inter_dim <= 128:
@@ -324,7 +350,9 @@ def fused_moe_flydsl(
             stage2_tile_m_default = 16
     stage2_tile_m = stage2_tile_m_default
     if BLOCK_SIZE_M % stage2_tile_m != 0:
-        raise ValueError(f"stage2_tile_m={stage2_tile_m} must divide routing BLOCK_SIZE_M={BLOCK_SIZE_M}")
+        raise ValueError(
+            f"stage2_tile_m={stage2_tile_m} must divide routing BLOCK_SIZE_M={BLOCK_SIZE_M}"
+        )
     stage2_force_f32_atomic = False
     if _needs_gfx94_bf16_atomic_workaround(hidden_states.dtype):
         # gfx94 bf16 CShuffle atomics can corrupt packed bf16 pairs, while the
@@ -357,28 +385,42 @@ def fused_moe_flydsl(
             topk_weight = topk_weight.float()
         tuning = get_qwen_ptpc_fp8_tuning(inter_dim)
         grouped_route_min_b = tuning.grouped_route_min_b if tuning is not None else 32
-        use_grouped_route = B >= grouped_route_min_b
-        if use_grouped_route:
+        use_route_free = (
+            tuning.use_route_free(B) if tuning is not None else False
+        ) and not doweight_stage1
+        use_grouped_route = (not use_route_free) and B >= grouped_route_min_b
+        if use_route_free:
+            sorted_ids = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
+            sorted_weights = topk_weight.reshape(B * TOPK).contiguous()
+            sorted_expert_ids = topk_ids.reshape(B * TOPK).contiguous()
+            num_valid_ids = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
+        elif use_grouped_route:
             from .moe_routing import grouped_moe_route
 
-            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = grouped_moe_route(
-                topk_ids,
-                topk_weight,
-                experts=E,
-                topk=TOPK,
-                tile_m=BLOCK_SIZE_M,
-                stream=stream,
+            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = (
+                grouped_moe_route(
+                    topk_ids,
+                    topk_weight,
+                    experts=E,
+                    topk=TOPK,
+                    tile_m=BLOCK_SIZE_M,
+                    stream=stream,
+                )
             )
         else:
             from .moe_routing import direct_moe_route
 
-            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = direct_moe_route(
-                topk_ids,
-                topk_weight,
-                topk=TOPK,
-                tile_m=BLOCK_SIZE_M,
-                stream=stream,
+            sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids = (
+                direct_moe_route(
+                    topk_ids,
+                    topk_weight,
+                    topk=TOPK,
+                    tile_m=BLOCK_SIZE_M,
+                    stream=stream,
+                )
             )
+    else:
+        use_route_free = False
     del M_ALIGN
 
     # Grouped routing may allocate inactive fixed expert slots; GEMMs skip slots
@@ -392,14 +434,19 @@ def fused_moe_flydsl(
         quant_out_cache_default = 2
     quant_in_cache = quant_in_cache_default
     quant_out_cache = quant_out_cache_default
+    tuning = get_qwen_ptpc_fp8_tuning(inter_dim)
+    use_aiter_quant = tuning.use_aiter_quant(B) if tuning is not None else False
 
     if fp8_per_token:
-        a1_qt, a1_scale = _quantize_per_token(
-            hidden_states,
-            (B, 1),
-            input_cache_modifier=quant_in_cache,
-            output_cache_modifier=quant_out_cache,
-        )
+        if use_aiter_quant:
+            a1_qt, a1_scale = _quantize_per_token_aiter(hidden_states, (B, 1))
+        else:
+            a1_qt, a1_scale = _quantize_per_token(
+                hidden_states,
+                (B, 1),
+                input_cache_modifier=quant_in_cache,
+                output_cache_modifier=quant_out_cache,
+            )
         stage_dtype = "fp8"
     else:
         a1_qt = hidden_states
@@ -445,7 +492,9 @@ def fused_moe_flydsl(
         )
         w2_fused = w2 if fused_1stage_fp8_w2 else w2_bf16
         output_dtype = torch.float16 if cast_fused_output else hidden_states.dtype
-        output = torch.zeros((B, model_dim), dtype=output_dtype, device=hidden_states.device)
+        output = torch.zeros(
+            (B, model_dim), dtype=output_dtype, device=hidden_states.device
+        )
         kernel_fused(
             output,
             a1_qt,
@@ -469,7 +518,7 @@ def fused_moe_flydsl(
     from .moe_gemm_2stage import (
         MoeGemm2Mode,
         compile_moe_gemm1,
-        compile_moe_gemm1_m1,
+        compile_moe_gemm1_route_free,
         compile_moe_gemm2_ex,
     )
 
@@ -482,8 +531,8 @@ def fused_moe_flydsl(
     # V116: fast_barrier + fine_sched synergy for memory-bound shapes.
     stage1_fast_barrier = False
     stage1_fine_sched = False
-    use_m1_stage1 = (
-        B == 1
+    use_route_free_stage1 = (
+        use_route_free
         and use_direct_route
         and fp8_per_token
         and not stage1_cshuffle
@@ -492,8 +541,8 @@ def fused_moe_flydsl(
         and E == 512
         and TOPK == 10
     )
-    if use_m1_stage1:
-        stage1 = compile_moe_gemm1_m1(
+    if use_route_free_stage1:
+        stage1 = compile_moe_gemm1_route_free(
             model_dim=model_dim,
             inter_dim=inter_dim,
             experts=E,
@@ -555,7 +604,12 @@ def fused_moe_flydsl(
     # For inter_dim=256 (TP=4), bf16 stage2 has 2x K-tiles and larger W2 loads,
     # which outweighs the quant kernel savings at small B.
     skip_a2_quant_max_b = 4
-    _skip_a2_quant = w2_bf16 is not None and fp8_per_token and B <= skip_a2_quant_max_b and inter_dim <= 128
+    _skip_a2_quant = (
+        w2_bf16 is not None
+        and fp8_per_token
+        and B <= skip_a2_quant_max_b
+        and inter_dim <= 128
+    )
 
     fold_weight_into_a2_scale = False
     _fuse_quant2_zero = False
@@ -568,8 +622,14 @@ def fused_moe_flydsl(
         w2_scale_for_s2 = _empty_scale_like(hidden_states)
         s2_in_dtype = "bf16"
     elif fp8_per_token:
-        fold_weight_into_a2_scale = E == 512 and TOPK == 10 and model_dim == 4096 and B >= 512
-        a2_row_weights = topk_weight.reshape(B * TOPK) if fold_weight_into_a2_scale and not doweight_stage1 else None
+        fold_weight_into_a2_scale = (
+            E == 512 and TOPK == 10 and model_dim == 4096 and B >= 512
+        )
+        a2_row_weights = (
+            topk_weight.reshape(B * TOPK)
+            if fold_weight_into_a2_scale and not doweight_stage1
+            else None
+        )
         _fuse_quant2_zero = (
             stage2_mode_name == "atomic"
             and not stage2_force_f32_atomic
@@ -581,7 +641,9 @@ def fused_moe_flydsl(
             and (B * model_dim) % 8 == 0
         )
         if _fuse_quant2_zero:
-            _output_for_zero = torch.empty((B, model_dim), dtype=hidden_states.dtype, device=hidden_states.device)
+            _output_for_zero = torch.empty(
+                (B, model_dim), dtype=hidden_states.dtype, device=hidden_states.device
+            )
             a2_qt, a2_scale = _quantize_per_token_with_zero(
                 stage1_out,
                 (B, TOPK, 1),
@@ -592,13 +654,20 @@ def fused_moe_flydsl(
             )
             _fused_zero_output = _output_for_zero
         else:
-            a2_qt, a2_scale = _quantize_per_token(
-                stage1_out,
-                (B, TOPK, 1),
-                row_weights=a2_row_weights,
-                input_cache_modifier=quant_in_cache,
-                output_cache_modifier=quant_out_cache,
-            )
+            if use_aiter_quant:
+                a2_qt, a2_scale = _quantize_per_token_aiter(
+                    stage1_out,
+                    (B, TOPK, 1),
+                    row_weights=a2_row_weights,
+                )
+            else:
+                a2_qt, a2_scale = _quantize_per_token(
+                    stage1_out,
+                    (B, TOPK, 1),
+                    row_weights=a2_row_weights,
+                    input_cache_modifier=quant_in_cache,
+                    output_cache_modifier=quant_out_cache,
+                )
             _fused_zero_output = None
         a2_for_s2 = a2_qt
         a2_scale_for_s2 = a2_scale
@@ -618,7 +687,13 @@ def fused_moe_flydsl(
     stage2_readfirst_metadata = False
     stage2_m_fast_grid = False
     stage2_persist_m_default = 1
-    if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim <= 128 and 32 <= B < 512:
+    if (
+        E == 512
+        and TOPK == 10
+        and model_dim == 4096
+        and inter_dim <= 128
+        and 32 <= B < 512
+    ):
         # V119: persist_m=2 amortizes single-K-tile (K=128) startup cost for TP=8.
         # Sweep confirms pm=2 optimal for B=32-256; pm=1 for B<32 and B>=512 (already handled below).
         stage2_persist_m_default = 2
@@ -645,7 +720,9 @@ def fused_moe_flydsl(
     if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B == 2048:
         stage2_group_size_m_default = 4
     stage2_group_size_m = stage2_group_size_m_default
-    stage2_mode = MoeGemm2Mode.REDUCE if stage2_mode_name == "reduce" else MoeGemm2Mode.ATOMIC
+    stage2_mode = (
+        MoeGemm2Mode.REDUCE if stage2_mode_name == "reduce" else MoeGemm2Mode.ATOMIC
+    )
     reduction_in_cache_default = 0
     reduction_out_cache_default = 0
     if E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048:
@@ -655,13 +732,17 @@ def fused_moe_flydsl(
     stage2_out_dtype_name = out_dtype
     cast_stage2_output = False
     stage2_reduce_intermediate_dtype_name = None
-    f16_reduce_intermediate_default = E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048
+    f16_reduce_intermediate_default = (
+        E == 512 and TOPK == 10 and model_dim == 4096 and inter_dim == 256 and B >= 2048
+    )
     if stage2_force_f32_atomic:
         stage2_out_dtype = torch.float32
         stage2_out_dtype_name = "f32"
         cast_stage2_output = True
     elif (
-        stage2_mode == MoeGemm2Mode.REDUCE and hidden_states.dtype == torch.bfloat16 and f16_reduce_intermediate_default
+        stage2_mode == MoeGemm2Mode.REDUCE
+        and hidden_states.dtype == torch.bfloat16
+        and f16_reduce_intermediate_default
     ):
         # V92: keep the API output in bf16, but let non-atomic GEMM2 write the
         # topk intermediate as f16. This removes bf16 conversion cost from the
@@ -672,7 +753,9 @@ def fused_moe_flydsl(
     if fp8_per_token and _fuse_quant2_zero and _fused_zero_output is not None:
         output = _fused_zero_output
     else:
-        output = torch.empty((B, model_dim), dtype=stage2_out_dtype, device=hidden_states.device)
+        output = torch.empty(
+            (B, model_dim), dtype=stage2_out_dtype, device=hidden_states.device
+        )
     if stage2_mode == MoeGemm2Mode.ATOMIC:
         if fp8_per_token and _fuse_quant2_zero and _fused_zero_output is not None:
             pass
@@ -709,7 +792,9 @@ def fused_moe_flydsl(
         tile_n=stage2_tile_n,
         tile_k=stage2_tile_k,
         doweight_stage2=(not doweight_stage1)
-        and not (fp8_per_token and s2_in_dtype == stage_dtype and fold_weight_into_a2_scale),
+        and not (
+            fp8_per_token and s2_in_dtype == stage_dtype and fold_weight_into_a2_scale
+        ),
         in_dtype=s2_in_dtype,
         out_dtype=stage2_out_dtype_name,
         use_cshuffle_epilog=not stage2_force_f32_atomic,
@@ -731,6 +816,7 @@ def fused_moe_flydsl(
         cshuffle_nlane=stage2_cshuffle_nlane,
         reduction_input_cache_modifier=reduction_in_cache_default,
         reduction_output_cache_modifier=reduction_out_cache_default,
+        single_token_route=use_route_free,
     )
     _s2_args = (
         output,

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_helper.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/fused_moe_helper.py
@@ -1,0 +1,538 @@
+"""
+aiter_compat.py
+===============
+All aiter dependencies extracted into one file, eliminating direct aiter imports.
+All functions/classes/constants are copied from their original definitions without refactoring.
+"""
+
+import functools
+import inspect
+import logging
+import argparse
+import math
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+
+def get_m_per_expert_avg(B, TOPK, E):
+    return math.ceil(B * TOPK / E)
+
+
+def get_m_align(B, TOPK, E):
+    # NOTE: this is an experimental value and may be adjusted later
+    m_per_expert_avg = get_m_per_expert_avg(B, TOPK, E)
+    align_m_per_expert_avg = None
+    if m_per_expert_avg <= 32:
+        align_m_per_expert_avg = ((m_per_expert_avg + 31) // 32) * 32
+    else:
+        align_m_per_expert_avg = ((m_per_expert_avg + 63) // 64) * 64
+
+    # NOTE: limit bucket size to avoid long autotune time
+    MAX_BUCKET_M = 1024
+    align_m_per_expert_avg = min(align_m_per_expert_avg, MAX_BUCKET_M)
+
+    return math.ceil(align_m_per_expert_avg * E / TOPK)
+
+
+def get_block_size_m(B, TOPK, E):
+    # NOTE: this is an experimental value and may be adjusted later
+    m_per_expert_avg = get_m_per_expert_avg(B, TOPK, E)
+    return 32 if m_per_expert_avg <= 32 else 64
+
+
+# ===========================================================================
+# flush_cache (from: tensor_tools.flush_cache)
+# Falls back to no-op when tensor_tools is not available
+# ===========================================================================
+try:
+    from tensor_tools import flush_cache
+except ImportError:
+
+    def flush_cache(size_mb=512):
+        pass
+
+
+# ===========================================================================
+# profile_cuda_kernels (from: tensor_tools.profile_cuda_kernels)
+# Falls back to direct function call when tensor_tools is not available
+# ===========================================================================
+try:
+    from tensor_tools import profile_cuda_kernels
+except ImportError:
+
+    def profile_cuda_kernels(fn, enable_print=False, warmup=5, iters=30, topk=80):
+        for _ in range(warmup):
+            fn()
+        result = None
+        for _ in range(iters):
+            result = fn()
+        torch.cuda.synchronize()
+        return result, {}
+
+
+# ===========================================================================
+# logger (from: aiter.logger)
+# ===========================================================================
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+# ===========================================================================
+# ActivationType / QuantType (from: aiter.jit.module_aiter_enum, C++ pybind11)
+# Re-defined as Python IntEnum, keeping .value and .name consistent
+# ===========================================================================
+from enum import IntEnum
+
+
+class ActivationType(IntEnum):
+    No = -1
+    Silu = 0
+    Gelu = 1
+    Swiglu = 2
+
+
+class QuantType(IntEnum):
+    No = 0
+    per_Tensor = 1
+    per_Token = 2
+    per_1x32 = 3
+    per_1x128 = 4
+    per_128x128 = 5
+
+
+# ===========================================================================
+# dtypes (from: aiter.utility.dtypes)
+# ===========================================================================
+_8bit_fallback = torch.uint8
+
+i4x2 = getattr(torch, "int4", _8bit_fallback)
+fp4x2 = getattr(torch, "float4_e2m1fn_x2", _8bit_fallback)
+# fp8: gfx942 uses e4m3fnuz, gfx950 uses e4m3fn; default to gfx942
+fp8 = torch.float8_e4m3fnuz
+fp8_e8m0 = getattr(torch, "float8_e8m0fnu", _8bit_fallback)
+fp16 = torch.float16
+bf16 = torch.bfloat16
+fp32 = torch.float32
+u32 = torch.uint32
+i32 = torch.int32
+i16 = torch.int16
+i8 = torch.int8
+
+d_dtypes = {
+    "fp8": fp8,
+    "fp8_e8m0": fp8_e8m0,
+    "fp16": fp16,
+    "bf16": bf16,
+    "fp32": fp32,
+    "i4x2": i4x2,
+    "fp4x2": fp4x2,
+    "u32": u32,
+    "i32": i32,
+    "i16": i16,
+    "i8": i8,
+}
+dtypes = SimpleNamespace(**d_dtypes)
+
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("yes", "true", "t", "y", "1"):
+        return True
+    elif v.lower() in ("no", "false", "f", "n", "0"):
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def str2tuple(v):
+    try:
+        parts = v.strip("()").split(",")
+        return tuple(int(p.strip()) for p in parts)
+    except Exception as e:
+        raise argparse.ArgumentTypeError(f"invalid format of input: {v}") from e
+
+
+# ===========================================================================
+# get_torch_quant / get_torch_act (from: aiter.ops.quant)
+# ===========================================================================
+def get_torch_quant(qType):
+    def per_token_quant(x, quant_dtype=fp8):
+        amax = x.float().abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+        scale = (amax / torch.finfo(quant_dtype).max).to(torch.float32)
+        return (x.float() / scale).to(quant_dtype), scale
+
+    tmp = {
+        QuantType.No: lambda *a, **k: (a[0], None),
+        QuantType.per_Token: per_token_quant,
+    }
+
+    def raise_NotImplementedError(*a, **k):
+        raise NotImplementedError(f"unsupported quant type {qType=}")
+
+    return tmp.get(qType, raise_NotImplementedError)
+
+
+def get_torch_act(aType):
+    tmp = {
+        ActivationType.No: lambda *a, **k: a[0],
+        ActivationType.Silu: F.silu,
+        ActivationType.Gelu: F.gelu,
+    }
+    return tmp.get(aType, NotImplementedError)
+
+
+# ===========================================================================
+# get_inter_dim / quant_remap (from: aiter.fused_moe)
+# ===========================================================================
+quant_remap = {QuantType.per_128x128: QuantType.per_1x128}
+
+
+@functools.lru_cache(maxsize=2048)
+def get_inter_dim(w1_shape, w2_shape):
+    E, _, model_dim = w1_shape
+    E, model_dim, inter_dim = w2_shape
+    int4_war = model_dim // w1_shape[-1]
+    inter_dim *= int4_war
+    return E, model_dim, inter_dim
+
+
+# ===========================================================================
+# fused_topk (from: aiter.fused_moe.fused_topk)
+# Uses aiter C++ topk_softmax when available; falls back to pure torch
+# ===========================================================================
+_aiter = None
+_has_aiter = None
+
+
+def _get_aiter():
+    global _aiter, _has_aiter
+    if _has_aiter is None:
+        try:
+            import aiter as _aiter_mod
+        except ImportError:
+            _aiter = None
+            _has_aiter = False
+        else:
+            _aiter = _aiter_mod
+            _has_aiter = True
+    return _aiter if _has_aiter else None
+
+
+def fused_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    topk_ids: torch.Tensor = None,
+    topk_weights: torch.Tensor = None,
+):
+    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+    M, _ = hidden_states.shape
+
+    aiter_mod = _get_aiter()
+    if aiter_mod is not None:
+        expert = gating_output.shape[1]
+        token_expert_indicies = torch.empty(
+            M, topk, dtype=i32, device=hidden_states.device
+        )
+        if topk_weights is None:
+            topk_weights = torch.empty(M, topk, dtype=fp32, device=hidden_states.device)
+        if topk_ids is None:
+            topk_ids = torch.empty(M, topk, dtype=i32, device=hidden_states.device)
+        aiter_mod.topk_softmax(
+            topk_weights,
+            topk_ids,
+            token_expert_indicies,
+            gating_output,
+            renormalize,
+        )
+        return topk_weights, topk_ids
+
+    # Fallback: pure torch implementation
+    # NOTE: this will increase the final result error for torch.bfloat16
+    scores = torch.softmax(gating_output.float(), dim=-1)
+    topk_weights_out, topk_ids_out = torch.topk(scores, topk, dim=-1)
+
+    if renormalize:
+        topk_weights_out = topk_weights_out / topk_weights_out.sum(dim=-1, keepdim=True)
+
+    topk_weights_out = topk_weights_out.to(torch.float32)
+    topk_ids_out = topk_ids_out.to(torch.int32)
+
+    return topk_weights_out, topk_ids_out
+
+
+# ===========================================================================
+# torch_moe_stage1 (from: aiter.fused_moe.torch_moe_stage1)
+# ===========================================================================
+def torch_moe_stage1(
+    hidden_states,
+    w1,  # E, inter_dim*2, model_dim
+    w2,  # E, model_dim, inter_dim
+    topk_weight,
+    topk_ids,
+    dtype=fp16,
+    activation=ActivationType.Silu,
+    quant_type=QuantType.No,
+    # following for quant
+    a1_scale=None,  # [token, 1]
+    w1_scale=None,  # [expert, inter_dim, 1]
+    w1_bias=None,  # [expert, inter_dim, 1]
+    doweight=False,
+):
+    assert doweight is False
+    quant_type = quant_remap.get(quant_type, quant_type)
+    ctype = fp32  # compute type
+    B, D = hidden_states.shape
+    topk = topk_weight.shape[1]
+    N = w1.shape[1]
+    E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+
+    if quant_type == QuantType.No:
+        hidden_states = hidden_states.to(ctype)
+        w1 = w1.to(ctype)
+    else:
+        raise NotImplementedError(
+            f"quant_type {quant_type} not supported in compat layer"
+        )
+
+    hidden_states = hidden_states.view(B, -1, model_dim).repeat(1, topk, 1)
+
+    out = torch.zeros(
+        (B, topk, N),
+        dtype=ctype,
+        device=hidden_states.device,
+    )
+    for E_id in range(w1.shape[0]):
+        mask = topk_ids == E_id
+        if mask.sum():
+            sub_tokens = hidden_states[mask]
+            act_input = sub_tokens @ (w1[E_id].transpose(0, 1))
+            if doweight:
+                act_input = act_input * topk_weight[mask].view(-1, 1)
+            out[mask] = act_input
+            if w1_bias is not None:
+                out[mask] = out[mask] + w1_bias[E_id].view(1, -1)
+    use_g1u1 = w1.shape[1] == (2 * inter_dim)
+
+    torch_act = get_torch_act(activation)
+    if use_g1u1:
+        gate, up = out.split([inter_dim, inter_dim], dim=-1)
+        out = torch_act(gate) * up
+    else:
+        out = torch_act(out)
+    return out.to(dtype)
+
+
+# ===========================================================================
+# torch_moe_stage2 (from: aiter.fused_moe.torch_moe_stage2)
+# ===========================================================================
+def torch_moe_stage2(
+    hidden_states,
+    w1,  # E, inter_dim*2, model_dim
+    w2,  # E, model_dim, inter_dim
+    topk_weights,
+    topk_ids,
+    dtype=fp16,
+    quant_type=QuantType.No,
+    w2_scale=None,
+    a2_scale=None,
+    w2_bias=None,
+    doweight=True,
+):
+    ctype = fp32  # compute type
+    E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+
+    if quant_type == QuantType.No:
+        hidden_states = hidden_states.to(ctype)
+        w2 = w2.to(ctype)
+    else:
+        raise NotImplementedError(
+            f"quant_type {quant_type} not supported in compat layer"
+        )
+
+    token_num, topk = topk_ids.shape
+    hidden_states = hidden_states.view(token_num, topk, inter_dim)
+
+    out = torch.zeros(
+        (token_num, topk, model_dim),
+        dtype=ctype,
+        device=hidden_states.device,
+    )
+    for E_id in range(w1.shape[0]):
+        mask = topk_ids == E_id
+        if mask.sum():
+            sub_tokens = hidden_states[mask]
+            act_input = sub_tokens @ (w2[E_id].transpose(0, 1))
+            out[mask] = act_input
+            if w2_bias is not None:
+                out[mask] = out[mask] + w2_bias[E_id].view(1, -1)
+
+    if doweight:
+        out = out * topk_weights.view(token_num, -1, 1)
+    return out.sum(1).to(dtype)
+
+
+# ===========================================================================
+# shuffle_weight (from: aiter.ops.shuffle)
+# Gluon MoE kernels expect weight in (16,16) shuffled layout
+# ===========================================================================
+def shuffle_weight(x: torch.Tensor, layout=(16, 16), use_int4=False) -> torch.Tensor:
+    x_type = x.dtype
+    if hasattr(torch, "float4_e2m1fn_x2") and x_type == torch.float4_e2m1fn_x2:
+        x = x.view(torch.uint8)
+
+    IN, IK = layout
+    BK = IK * 2
+    K = 16 // x.element_size() if not use_int4 else 32
+    BN = IN
+    assert x.shape[-2] % BN == 0, f"{x.shape[-2]} % {BN} == {x.shape[-2] % BN }"
+    assert x.shape[-1] % BK == 0, f"{x.shape[-1]} % {BK} == {x.shape[-1] % BK }"
+
+    x_ = x
+    x_ = x_.view(-1, x.shape[-2] // BN, BN, x.shape[-1] // BK, BK // K, K)
+    x_ = x_.permute(0, 1, 3, 4, 2, 5)
+    x_ = x_.contiguous()
+    x_ = x_.view(*x.shape)
+    x_ = x_.view(x_type)
+    return x_
+
+
+# ===========================================================================
+# moe_sorting (calls atrex.api.moe_sorting.moe_sorting_fwd via CK JIT)
+# ===========================================================================
+def moe_sorting(
+    topk_ids,
+    topk_weights,
+    num_experts,
+    model_dim,
+    moebuf_dtype,
+    block_size=64,
+    expert_mask=None,
+    num_local_tokens=None,
+    dispatch_policy=0,
+):
+    from .moe_sorting import moe_sorting_fwd
+
+    device = topk_ids.device
+    M, topk = topk_ids.shape
+
+    max_num_tokens_padded = int(topk_ids.numel() + num_experts * block_size - topk)
+    max_num_m_blocks = int((max_num_tokens_padded + block_size - 1) // block_size)
+
+    sorted_ids = torch.empty((max_num_tokens_padded,), dtype=i32, device=device)
+    sorted_weights = torch.empty((max_num_tokens_padded,), dtype=fp32, device=device)
+    sorted_expert_ids = torch.empty((max_num_m_blocks,), dtype=i32, device=device)
+    num_valid_ids = torch.empty((2), dtype=i32, device=device)
+    moe_buf = torch.empty((M, model_dim), dtype=moebuf_dtype, device=device)
+
+    flush_cache(512)
+    moe_sorting_fwd(
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        moe_buf,
+        num_experts,
+        int(block_size),
+        expert_mask,
+        num_local_tokens,
+        dispatch_policy,
+    )
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, moe_buf
+
+
+# ===========================================================================
+# test helpers (from: aiter.test_common)
+# ===========================================================================
+def log_args(func, *args, **kwargs):
+    callargs = inspect.getcallargs(func, *args, **kwargs)
+
+    prefix = f"calling {func.__name__}("
+    blanks = " " * (len(prefix))
+
+    def getTensorInfo(el):
+        if isinstance(el, torch.Tensor):
+            return f"{el.shape} {el.dtype} {el.device} {hex(el.data_ptr())}"
+        elif isinstance(el, tuple):
+            viewNum = 5
+            if len(el) > viewNum:
+                el = list(el[:viewNum]) + ["..."]
+            return f'\n{" "*(len(prefix)+31)}'.join(
+                ["("] + [f" {getTensorInfo(e)}" for e in el] + [")"]
+            )
+        return el
+
+    info = [f"{el:<28} = {getTensorInfo(callargs[el])}" for el in callargs]
+    info = f",\n{blanks}".join(info)
+    logger.info(f"\n{prefix}{info})")
+    return callargs
+
+
+def benchmark():
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            callargs = log_args(func, *args, **kwargs)
+            ret = func(*args, **kwargs)
+            if ret is not None:
+                callargs.update(ret)
+            return callargs
+
+        return wrapper
+
+    return decorator
+
+
+def checkAllclose(
+    a, b, rtol=1e-2, atol=1e-2, tol_err_ratio=0.05, msg="", printNum=8, printLog=True
+):
+    isClose = torch.isclose(a, b, rtol=rtol, atol=atol)
+
+    if isClose.all():
+        if printLog:
+            logger.info(f"{msg}[checkAllclose {atol=} {rtol=} \033[32mpassed~\033[0m]")
+        return 0
+    else:
+        try:
+            mask = ~isClose
+            num = mask.sum()
+            printNum = min(printNum, num)
+            percent = (num / a.numel()).item()
+            if not printLog:
+                return percent
+            a_msked = a[mask]
+            b_msked = b[mask]
+            delta = (a_msked - b_msked).abs()
+        except RuntimeError:
+            mask = ~isClose.to("cpu")
+            num = mask.sum()
+            printNum = min(printNum, num)
+            percent = (num / a.numel()).item()
+            if not printLog:
+                return percent
+            a_msked = a[mask]
+            b_msked = b[mask]
+            delta = (a_msked - b_msked).abs()
+        if percent > tol_err_ratio:
+            logger.info(
+                f"""{msg}[checkAllclose {atol=} {rtol=} \033[31mfailed!\033[0m]
+    a    : {a.shape}
+           {a_msked[:printNum]}
+    b    : {b.shape}
+           {b_msked[:printNum]}
+    delta:
+           {delta[:printNum]}"""
+            )
+        else:
+            logger.info(
+                f"""{msg}[checkAllclose {atol=} {rtol=} \033[33mwarning!\033[0m] a and b results are not all close"""
+            )
+        logger.info(
+            f"-->max abs delta:{delta.max()}, delta details: {percent:.1%} ({num} of {a.numel()}) elements"
+        )
+        return percent

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/kernels/mfma_epilogues.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/kernels/mfma_epilogues.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Reusable epilogue helpers for MFMA 16x16-based kernels.
+
+This module provides:
+
+- `mfma_epilog(...)`
+  A single entrypoint that dispatches to either the default row-epilogue or the
+  LDS CShuffle epilogue based on input parameters.
+
+- `default_epilog(...)` (implementation helper)
+  A lightweight row-iterator for the common MFMA accumulator-to-output mapping
+  (mi in [0,m_repeat), ii in [0,4), row = bx_m + mi*16 + lane_div_16*4 + ii).
+  The caller supplies `body_row(...)` that performs the per-row epilogue work
+  (e.g. loads scales once, loops over ni, stores).
+
+- `c_shuffle_epilog(...)` (implementation helper)
+  A LDS CShuffle epilogue skeleton:
+    1) call `write_row_to_lds(...)` for each MFMA output row to populate `lds_out`
+       in row-major [tile_m, tile_n] order unless an optional LDS index mapper
+       is provided
+    2) barrier
+    3) remap threads into (MLane, NLane) = (8,32) and read half2 from LDS,
+       then call `store_pair(...)` to emit the final global store/atomic.
+
+  When ``lds_out_split`` is provided, the epilogue runs in split-LDS mode:
+  waves are partitioned into two groups (group A uses ``lds_out``, group B
+  uses ``lds_out_split``), each handling half of the N dimension.
+
+These helpers are intentionally *dialect-agnostic*: callers pass the dialect
+modules (`arith`, `vector`, `gpu`) and the `range_constexpr` iterator.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Callable
+
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects.arith import CmpIPredicate
+from flydsl._mlir.dialects import scf as _scf
+from flydsl.expr.typing import T
+
+
+@contextmanager
+def _if_then(if_op, scf=None):
+    scf_mod = scf if scf is not None else _scf
+    with ir.InsertionPoint(if_op.then_block):
+        try:
+            yield if_op.then_block
+        finally:
+            blk = if_op.then_block
+            if (not blk.operations) or not isinstance(blk.operations[-1], scf_mod.YieldOp):
+                scf_mod.YieldOp([])
+
+
+def default_epilog(
+    *,
+    arith,
+    range_constexpr,
+    m_repeat: int,
+    lane_div_16,
+    bx_m,
+    body_row: Callable,
+):
+    """Iterate the standard MFMA 16x16 row mapping and call `body_row(...)`.
+
+    The mapping matches the common MFMA fragment layout used across kernels in this repo.
+
+    Args:
+      arith: flydsl arith ext module.
+      range_constexpr: compile-time unrolled range helper.
+      m_repeat: tile_m // 16 (python int).
+      lane_div_16: index Value (0..3).
+      bx_m: base row (index Value). For MoE, this is the base sorted-row for the tile.
+      body_row: callback invoked as:
+        body_row(mi=<int>, ii=<int>, row_in_tile=<index>, row=<index>)
+    """
+    bx_m_v = bx_m
+    lane_div_16_mul4 = lane_div_16 * 4
+    ii_idx_list = [fx.Index(ii) for ii in range(4)]
+
+    for mi in range_constexpr(m_repeat):
+        mi_base = arith.constant(mi * 16, index=True)
+        for ii in range_constexpr(4):
+            row_off = lane_div_16_mul4 + ii_idx_list[ii]
+            row_in_tile = mi_base + row_off
+            row = bx_m_v + row_in_tile
+            body_row(mi=mi, ii=ii, row_in_tile=row_in_tile, row=row)
+
+
+def c_shuffle_epilog(
+    *,
+    arith,
+    vector,
+    gpu,
+    scf=None,
+    range_constexpr,
+    # Tile params
+    tile_m: int,
+    tile_n: int,
+    e_vec: int = 2,
+    cshuffle_nlane: int = 32,
+    block_size: int = 256,
+    m_repeat: int,
+    num_acc_n: int,
+    # Thread mapping inputs
+    tx,
+    lane_div_16,
+    lane_mod_16,
+    bx_m,
+    by_n,
+    n_tile_base,
+    # LDS buffer (f16 view, row-major [tile_m, tile_n] flattened)
+    lds_out,
+    # Element type for LDS loads (defaults to f16). Pass bf16 to support bf16 epilogues.
+    frag_elem_type: ir.Type | None = None,
+    # Callbacks
+    write_row_to_lds: Callable,
+    precompute_row: Callable | None = None,
+    store_pair: Callable,
+    lds_index_mapper: Callable | None = None,
+    # When LDS overflows, split lds_out across two buffers by wave-group.
+    # Pass the second buffer here; first buffer is `lds_out`.
+    lds_out_split=None,
+    # Row offset in lds_out for 8-wave mode (MLIR index value).
+    # Shifts both write and read LDS indices by lds_row_offset * tile_n elements.
+    lds_row_offset=None,
+):
+    """LDS CShuffle epilogue skeleton.
+
+    Call pattern:
+      - `write_row_to_lds(...)` is called once per MFMA row produced by this thread.
+        It is responsible for writing all ni columns for that row into `lds_out`.
+      - `store_pair(...)` is called for each (row_local, col_pair0) half2 after shuffle.
+
+    `store_pair` can implement either global stores or atomics.
+    """
+    if int(block_size) <= 0 or (int(block_size) % int(cshuffle_nlane)) != 0:
+        raise ValueError(f"block_size ({block_size}) must be divisible by cshuffle_nlane ({cshuffle_nlane})")
+    cshuffle_mlane = int(block_size) // int(cshuffle_nlane)
+    if (int(tile_m) % cshuffle_mlane) != 0:
+        raise ValueError(f"tile_m must be divisible by CShuffleMLane ({cshuffle_mlane}), got tile_m={tile_m}")
+    if int(e_vec) <= 0:
+        raise ValueError(f"e_vec must be positive, got {e_vec}")
+    if (int(tile_n) % (int(cshuffle_nlane) * int(e_vec))) != 0:
+        raise ValueError(
+            f"tile_n must be divisible by (CShuffleNLane*EVec) = {cshuffle_nlane*e_vec}, got tile_n={tile_n}"
+        )
+
+    # ===================== Split-LDS mode (early return) =====================
+    # When lds_out_split is provided, waves are divided into two groups:
+    #   Group A (waves 0..N/2-1) uses lds_out,  columns [0, tile_n/2)
+    #   Group B (waves N/2..N-1) uses lds_out_split, columns [tile_n/2, tile_n)
+    # Each group writes/reads independently; same barriers synchronise all waves.
+    if lds_out_split is not None:
+        if scf is None:
+            raise ValueError("scf module is required for split-LDS cshuffle")
+
+        _half_n = int(tile_n) // 2
+        _half_threads = int(block_size) // 2
+        EVec = int(e_vec)
+
+        CShuffleNLane_s = min(int(cshuffle_nlane), _half_n // EVec)
+        if _half_threads % CShuffleNLane_s != 0:
+            raise ValueError(f"half_threads={_half_threads} not divisible by CShuffleNLane_split={CShuffleNLane_s}")
+        CShuffleMLane_s = _half_threads // CShuffleNLane_s
+        if int(tile_m) % CShuffleMLane_s != 0:
+            raise ValueError(f"tile_m={tile_m} not divisible by CShuffleMLane_split={CShuffleMLane_s}")
+        m_reps_s = int(tile_m) // CShuffleMLane_s
+        n_reps_s = _half_n // (CShuffleNLane_s * EVec)
+
+        _half_n_idx = arith.constant(_half_n, index=True)
+        _half_thr_idx = arith.constant(_half_threads, index=True)
+        _zero_idx = arith.constant(0, index=True)
+
+        _is_group_b = arith.cmpi(CmpIPredicate.uge, tx, _half_thr_idx)
+
+        # -- write phase (all waves, each to its group's LDS buffer) --
+        n_tile_base_v = n_tile_base
+        col_base_local_a = n_tile_base_v + lane_mod_16
+        col_base_local_b = col_base_local_a - _half_n_idx
+
+        def _write_row_split(mi: int, ii: int, row_in_tile, row):
+            row_base_lds = row_in_tile * _half_n_idx
+            _if_g = scf.IfOp(_is_group_b)
+            with ir.InsertionPoint(_if_g.then_block):
+                write_row_to_lds(
+                    mi=mi,
+                    ii=ii,
+                    row_in_tile=row_in_tile,
+                    row=row,
+                    row_base_lds=row_base_lds,
+                    col_base_local=col_base_local_b,
+                    num_acc_n=num_acc_n,
+                    lds_out=lds_out_split,
+                )
+                scf.YieldOp([])
+            with ir.InsertionPoint(_if_g.else_block):
+                write_row_to_lds(
+                    mi=mi,
+                    ii=ii,
+                    row_in_tile=row_in_tile,
+                    row=row,
+                    row_base_lds=row_base_lds,
+                    col_base_local=col_base_local_a,
+                    num_acc_n=num_acc_n,
+                    lds_out=lds_out,
+                )
+                scf.YieldOp([])
+
+        gpu.barrier()
+        default_epilog(
+            arith=arith,
+            range_constexpr=range_constexpr,
+            m_repeat=m_repeat,
+            lane_div_16=lane_div_16,
+            bx_m=bx_m,
+            body_row=_write_row_split,
+        )
+        gpu.barrier()
+
+        # -- read phase (each group reads from its own LDS buffer) --
+        tx_local = tx - arith.select(_is_group_b, _half_thr_idx, _zero_idx)
+        c_nlane_s = arith.constant(CShuffleNLane_s, index=True)
+        m_lane_s = tx_local / c_nlane_s
+        n_lane_s = tx_local % c_nlane_s
+        c_evec = arith.constant(EVec, index=True)
+
+        if frag_elem_type is None:
+            frag_elem_type = T.f16
+        vec_frag = T.vec(EVec, frag_elem_type)
+        bx_m_v = bx_m
+        by_n_v = by_n
+
+        _precomputed_rows_s = []
+        for mr in range_constexpr(m_reps_s):
+            row_base_m = arith.constant(mr * CShuffleMLane_s, index=True)
+            row_local = row_base_m + m_lane_s
+            row = bx_m_v + row_local
+            row_ctx_raw = precompute_row(row_local=row_local, row=row) if precompute_row is not None else None
+            row_ctx = row_ctx_raw
+            row_pred = None
+            if scf is not None and row_ctx_raw is not None and isinstance(row_ctx_raw, tuple) and len(row_ctx_raw) == 2:
+                row_ctx, row_pred = row_ctx_raw
+            _precomputed_rows_s.append((row_local, row, row_ctx, row_pred))
+
+        for mr in range_constexpr(m_reps_s):
+            row_local, row, row_ctx, row_pred = _precomputed_rows_s[mr]
+
+            def _do_store_row_split():
+                row_base_lds = row_local * _half_n_idx
+                for nr in range_constexpr(n_reps_s):
+                    col_base_nr = arith.constant(nr * (CShuffleNLane_s * EVec), index=True)
+                    col_pair0_local = col_base_nr + (n_lane_s * c_evec)
+                    lds_idx = row_base_lds + col_pair0_local
+
+                    _if_ld = scf.IfOp(_is_group_b, [vec_frag])
+                    with ir.InsertionPoint(_if_ld.then_block):
+                        fb = vector.load_op(vec_frag, lds_out_split, [lds_idx])
+                        scf.YieldOp([fb])
+                    with ir.InsertionPoint(_if_ld.else_block):
+                        fa = vector.load_op(vec_frag, lds_out, [lds_idx])
+                        scf.YieldOp([fa])
+                    frag = _if_ld.results[0]
+
+                    col_pair0 = col_pair0_local + arith.select(_is_group_b, _half_n_idx, _zero_idx)
+                    store_pair(
+                        row_local=row_local,
+                        row=row,
+                        row_ctx=row_ctx,
+                        col_pair0=col_pair0,
+                        col_g0=by_n_v + col_pair0,
+                        frag=frag,
+                    )
+
+            if row_pred is not None:
+                _if_row = scf.IfOp(row_pred)
+                with _if_then(_if_row, scf):
+                    _do_store_row_split()
+            else:
+                _do_store_row_split()
+
+        return  # split path complete
+
+    # ===================== Standard (non-split) path below =====================
+
+    # ---------------- Step 1: write C tile to LDS (row-major, fp16) ----------------
+    tile_n_idx = arith.constant(int(tile_n), index=True)
+    n_tile_base_v = n_tile_base
+    col_base_local = n_tile_base_v + lane_mod_16  # index within [0,tile_n)
+
+    _lds_row_base_offset = lds_row_offset * tile_n_idx if lds_row_offset is not None else None
+
+    def _write_row(mi: int, ii: int, row_in_tile, row):
+        row_base_lds = row_in_tile * tile_n_idx
+        if _lds_row_base_offset is not None:
+            row_base_lds = row_base_lds + _lds_row_base_offset
+        write_row_to_lds(
+            mi=mi,
+            ii=ii,
+            row_in_tile=row_in_tile,
+            row=row,
+            row_base_lds=row_base_lds,
+            col_base_local=col_base_local,
+            num_acc_n=num_acc_n,
+            lds_out=lds_out,
+        )
+
+    # Ensure all LDS reads finished before the lds write.
+    gpu.barrier()
+    default_epilog(
+        arith=arith,
+        range_constexpr=range_constexpr,
+        m_repeat=m_repeat,
+        lane_div_16=lane_div_16,
+        bx_m=bx_m,
+        body_row=_write_row,
+    )
+
+    # Ensure all LDS writes are visible before the shuffle-read.
+    gpu.barrier()
+
+    # ---------------- Step 2: shuffle mapping + half2 store/atomic ----------------
+    CShuffleNLane = int(cshuffle_nlane)
+    CShuffleMLane = int(cshuffle_mlane)
+    EVec = int(e_vec)
+
+    m_reps_shuffle = int(tile_m) // CShuffleMLane
+    n_reps_shuffle = int(tile_n) // (CShuffleNLane * EVec)
+
+    c_nlane = fx.Index(CShuffleNLane)
+    m_lane = tx // c_nlane
+    n_lane = tx % c_nlane
+    c_evec = fx.Index(EVec)
+
+    if frag_elem_type is None:
+        frag_elem_type = T.f16
+    vec_frag = T.vec(EVec, frag_elem_type)
+    bx_m_v = bx_m
+    by_n_v = by_n
+
+    # Batch-precompute all row contexts (sorted_idx loads) before the store loop.
+    # This issues all buffer_load instructions upfront so the compiler can pipeline
+    # them instead of serializing each load with s_waitcnt vmcnt(0).
+    _precomputed_rows = []
+    for mr in range_constexpr(m_reps_shuffle):
+        row_base_m = arith.constant(mr * CShuffleMLane, index=True)
+        row_local = row_base_m + m_lane
+        row = bx_m_v + row_local
+
+        row_ctx_raw = precompute_row(row_local=row_local, row=row) if precompute_row is not None else None
+
+        # Optional row-level predicate: if `precompute_row` returns `(ctx, pred_i1)` and `scf`
+        # is provided, we can skip the entire N-loop for invalid rows (cheaper than per-store checks).
+        row_ctx = row_ctx_raw
+        row_pred = None
+        if scf is not None and row_ctx_raw is not None and isinstance(row_ctx_raw, tuple) and len(row_ctx_raw) == 2:
+            row_ctx, row_pred = row_ctx_raw
+
+        _precomputed_rows.append((row_local, row, row_ctx, row_pred))
+
+    # Now perform LDS reads and stores using the pre-fetched row contexts.
+    for mr in range_constexpr(m_reps_shuffle):
+        row_local, row, row_ctx, row_pred = _precomputed_rows[mr]
+
+        def _do_store_row():
+            row_base_lds = row_local * tile_n_idx
+            if _lds_row_base_offset is not None:
+                row_base_lds = row_base_lds + _lds_row_base_offset
+            for nr in range_constexpr(n_reps_shuffle):
+                col_base_nr = arith.constant(nr * (CShuffleNLane * EVec), index=True)
+                col_pair0 = col_base_nr + (n_lane * c_evec)  # even col within tile
+
+                lds_idx_pair = (
+                    lds_index_mapper(
+                        row_local=row_local,
+                        row_base_lds=row_base_lds,
+                        col_local=col_pair0,
+                    )
+                    if lds_index_mapper is not None
+                    else row_base_lds + col_pair0
+                )
+                frag = vector.load_op(vec_frag, lds_out, [lds_idx_pair])
+
+                store_pair(
+                    row_local=row_local,
+                    row=row,
+                    row_ctx=row_ctx,
+                    col_pair0=col_pair0,
+                    col_g0=by_n_v + col_pair0,
+                    frag=frag,
+                )
+
+        if row_pred is not None:
+            _if_row = scf.IfOp(row_pred)
+            with _if_then(_if_row, scf):
+                _do_store_row()
+        else:
+            _do_store_row()
+
+
+def mfma_epilog(
+    *,
+    use_cshuffle: bool,
+    # Common (always required)
+    arith,
+    range_constexpr,
+    m_repeat: int,
+    lane_div_16,
+    bx_m,
+    # Default epilog (required when use_cshuffle=False)
+    body_row: Callable | None = None,
+    # CShuffle epilog (required when use_cshuffle=True)
+    vector=None,
+    gpu=None,
+    scf=None,
+    tile_m: int | None = None,
+    tile_n: int | None = None,
+    e_vec: int = 2,
+    cshuffle_nlane: int = 32,
+    block_size: int = 256,
+    num_acc_n: int | None = None,
+    tx=None,
+    lane_mod_16=None,
+    by_n=None,
+    n_tile_base=None,
+    lds_out=None,
+    write_row_to_lds: Callable | None = None,
+    precompute_row: Callable | None = None,
+    store_pair: Callable | None = None,
+    frag_elem_type: ir.Type | None = None,
+):
+    if not use_cshuffle:
+        if body_row is None:
+            raise ValueError("mfma_epilog(use_cshuffle=False) requires `body_row`.")
+        return default_epilog(
+            arith=arith,
+            range_constexpr=range_constexpr,
+            m_repeat=m_repeat,
+            lane_div_16=lane_div_16,
+            bx_m=bx_m,
+            body_row=body_row,
+        )
+
+    return c_shuffle_epilog(
+        arith=arith,
+        vector=vector,
+        gpu=gpu,
+        scf=scf,
+        range_constexpr=range_constexpr,
+        tile_m=int(tile_m),
+        tile_n=int(tile_n),
+        e_vec=int(e_vec),
+        cshuffle_nlane=int(cshuffle_nlane),
+        block_size=int(block_size),
+        m_repeat=m_repeat,
+        num_acc_n=int(num_acc_n),
+        tx=tx,
+        lane_div_16=lane_div_16,
+        lane_mod_16=lane_mod_16,
+        bx_m=bx_m,
+        by_n=by_n,
+        n_tile_base=n_tile_base,
+        lds_out=lds_out,
+        frag_elem_type=frag_elem_type,
+        write_row_to_lds=write_row_to_lds,
+        precompute_row=precompute_row,
+        store_pair=store_pair,
+    )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/kernels/mfma_preshuffle_pipeline.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/kernels/mfma_preshuffle_pipeline.py
@@ -1,0 +1,899 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Shared MFMA preshuffle helpers for preshuffle GEMM kernels.
+
+Key primitives:
+- B preshuffle layout builder (supports byte-packed element types, incl. packed int4)
+- B pack load for MFMA K32 micro-steps (8B output pack; optional int4->int8 unpack)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects.arith import CmpIPredicate
+from flydsl.expr import arith as _arith
+from flydsl.expr.typing import T
+
+
+def crd2idx(crd, layout):
+    """crd2idx returning an index-type scalar (unwraps fly.int_tuple)."""
+    result = fx.crd2idx(crd, layout)
+    scalar = fx.get_scalar(result)
+    if isinstance(scalar, ir.Value) and not isinstance(scalar.type, ir.IndexType):
+        scalar = _arith.IndexCastOp(T.index, scalar).result
+    return scalar
+
+
+def swizzle_xor16(row, col, k_blocks16):
+    """XOR-with-row swizzle on the K dimension at 16B granularity.
+
+    Computes: col XOR ((row & (k_blocks16 - 1)) * 16)
+
+    k_blocks16 is always a power of 2 (tile_k_bytes / 16), so use
+    bitwise AND instead of remui to save ~10 VALU cycles on CDNA.
+    """
+    from flydsl.expr import arith as _swz_arith
+
+    mask = k_blocks16 - _swz_arith.index(1)
+    rem = _swz_arith.andi(row, mask)
+    return col ^ (rem * 16)
+
+
+def lds_row_major_idx(row, col, row_stride, base=None):
+    """Linearize a 2D LDS coordinate with explicit index arithmetic."""
+    idx = row * row_stride + col
+    return idx if base is None else idx + base
+
+
+def split_row_major_2d(index, minor_extent):
+    """Split a linear row-major index into (major, minor)."""
+    return index // minor_extent, index % minor_extent
+
+
+def _buffer_load_vec(
+    buffer_ops,
+    vector,
+    rsrc,
+    idx,
+    *,
+    elem_type,
+    vec_elems,
+    elem_bytes,
+    offset_in_bytes,
+    cache_modifier=0,
+):
+    """Load vec_elems elements via buffer_load dwordx[1,2,4] + bitcast."""
+    from flydsl.expr import arith as _ld_arith
+
+    elem_size = int(elem_bytes)
+    load_bytes = int(vec_elems) * elem_size
+    vec_width = load_bytes // 4
+
+    if offset_in_bytes:
+        idx_i32 = _ld_arith.shrui(idx, _ld_arith.index(2))
+    elif elem_bytes == 2:
+        idx_i32 = _ld_arith.shrui(idx, _ld_arith.index(1))
+    else:
+        idx_i32 = idx
+
+    i32_val = buffer_ops.buffer_load(
+        rsrc,
+        idx_i32,
+        vec_width=vec_width,
+        dtype=T.i32,
+        cache_modifier=cache_modifier,
+    )
+    if vec_width == 1:
+        i32_vec = vector.from_elements(T.vec(1, T.i32), [i32_val])
+    else:
+        i32_vec = i32_val
+    return vector.bitcast(T.vec(int(vec_elems), elem_type), i32_vec)
+
+
+@dataclass(frozen=True)
+class PreshuffleScaleLayout:
+    """Container returned by `make_preshuffle_scale_layout`.
+
+    The scale layout is ``(c_mn1, c_k1, 4, 16) : (stride_n0, stride_k0, stride_klane, 1)``.
+    Callers compute flat index directly with plain arith::
+
+        idx = mni * stride_n0 + ku * stride_k0 + k_lane * stride_klane + n_lane
+    """
+
+    layout_scale: object
+    stride_n0: object
+    stride_k0: object
+    stride_klane: object
+
+
+def make_preshuffle_scale_layout(
+    arith,
+    *,
+    c_mn: ir.Value,
+    c_k: ir.Value,
+    mn_pack: int = 2,
+    k_pack: int = 2,
+    elem_bytes: int = 4,
+    scale_block_size: int = 32,
+) -> PreshuffleScaleLayout:
+    """Build scale layout matching aiter/CK preshuffle for FP4/FP8 microscale.
+
+    Layout shape: ``(c_mn1, c_k1, 4, 16)`` where
+    ``c_mn1 = c_mn / 16 / mn_pack`` and ``c_k1 = (c_k / scale_block_size) / 4 / k_pack``.
+    """
+    c16 = fx.Index(16)
+    c4 = fx.Index(4)
+    c_k_scale = c_k // fx.Index(scale_block_size)
+
+    c_mn1 = (c_mn // c16) // fx.Index(mn_pack)
+    c_k1 = (c_k_scale // c4) // fx.Index(k_pack)
+    if elem_bytes != mn_pack * k_pack:
+        raise ValueError(f"elem_bytes of scale must be {mn_pack} * {k_pack}, got {elem_bytes!r}")
+
+    stride_klane = c16
+    stride_k0 = c4 * stride_klane
+    stride_n0 = c_k1 * stride_k0
+
+    c_mn1_i32 = arith.index_cast(T.i32, c_mn1)
+    c_k1_i32 = arith.index_cast(T.i32, c_k1)
+    stride_n0_i32 = arith.index_cast(T.i32, stride_n0)
+    stride_k0_i32 = arith.index_cast(T.i32, stride_k0)
+    stride_klane_i32 = arith.index_cast(T.i32, stride_klane)
+
+    layout_scale = fx.make_layout(
+        (c_mn1_i32, c_k1_i32, 4, 16),
+        stride=(stride_n0_i32, stride_k0_i32, stride_klane_i32, 1),
+    )
+
+    return PreshuffleScaleLayout(
+        layout_scale=layout_scale,
+        stride_n0=stride_n0,
+        stride_k0=stride_k0,
+        stride_klane=stride_klane,
+    )
+
+
+@dataclass(frozen=True)
+class PreshuffleBLayout:
+    """Container returned by `make_preshuffle_b_layout`."""
+
+    layout_b: object
+    kpack_bytes: int
+
+
+def make_preshuffle_b_layout(
+    arith,
+    *,
+    c_n: ir.Value,
+    c_k: ir.Value,
+    kpack_bytes: int = 16,
+    elem_bytes: int = 1,
+    k_major: bool = False,
+) -> PreshuffleBLayout:
+    """Build B layout matching aiter/CK preshuffle for A8 MFMA kernels.
+
+    When *k_major* is True the block-level order is K-major (``k_blk`` outermost),
+    matching the ``(0,3,1,4,2,5)`` shuffle permutation.  The default N-major
+    order (``k_major=False``) matches the legacy ``(0,1,3,4,2,5)`` permutation.
+    """
+    if kpack_bytes not in (8, 16):
+        raise ValueError(f"kpack_bytes must be 8 or 16, got {kpack_bytes!r}")
+
+    c16 = fx.Index(16)
+    c_kpack = fx.Index(kpack_bytes)
+
+    if elem_bytes not in (1, 2):
+        raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
+    c_k_bytes = c_k * arith.constant(int(elem_bytes), index=True)
+    n0 = c_n // c16
+
+    c_kpack_elems = c_kpack if elem_bytes == 1 else (c_kpack // arith.constant(int(elem_bytes), index=True))
+
+    stride_nlane = c_kpack_elems
+
+    if k_major:
+        c32 = fx.Index(32)
+        c2 = fx.Index(2)
+        c_k0 = c_k_bytes // c32
+        klane_dim = 2
+        stride_klane = c16 * stride_nlane
+        stride_n0 = c2 * stride_klane
+        stride_k0 = n0 * stride_n0
+    else:
+        c64 = fx.Index(64)
+        c4 = fx.Index(4)
+        c_k0 = c_k_bytes // c64
+        klane_dim = 4
+        stride_klane = c16 * stride_nlane
+        stride_k0 = c4 * stride_klane
+        stride_n0 = c_k0 * stride_k0
+
+    kpack_elems_static = kpack_bytes if elem_bytes == 1 else kpack_bytes // elem_bytes
+    n0_i32 = arith.index_cast(T.i32, n0)
+    c_k0_i32 = arith.index_cast(T.i32, c_k0)
+    stride_n0_i32 = arith.index_cast(T.i32, stride_n0)
+    stride_k0_i32 = arith.index_cast(T.i32, stride_k0)
+    stride_klane_i32 = arith.index_cast(T.i32, stride_klane)
+    stride_nlane_i32 = arith.index_cast(T.i32, stride_nlane)
+
+    stride_b = (stride_n0_i32, stride_k0_i32, stride_klane_i32, stride_nlane_i32, 1)
+    layout_b = fx.make_layout((n0_i32, c_k0_i32, klane_dim, 16, kpack_elems_static), stride_b)
+    return PreshuffleBLayout(layout_b=layout_b, kpack_bytes=kpack_bytes)
+
+
+def _unpack_int4_to_int8_pair(packed32):
+    """Split packed int4 dword into two int8 dwords (even/odd nibbles).
+
+    7-op bit manipulation shared by all int4 unpack paths (W4A8, W4A16, W4A_FP8).
+    """
+    c_08 = fx.Int32(0x08080808)
+    c_0f = fx.Int32(0x0F0F0F0F)
+    c_1e = fx.Int32(0x1E)
+    c_4 = fx.Int32(4)
+    s0 = (packed32 & c_08) * c_1e
+    even = (packed32 & c_0f) | s0
+    t = packed32 >> c_4
+    s1 = (t & c_08) * c_1e
+    odd = (t & c_0f) | s1
+    return even, odd
+
+
+def _pack_i32_pair_to_i64(lo, hi, vector):
+    """Pack two i32 values into one i64 via vector bitcast."""
+    v2 = vector.from_elements(T.vec(2, T.i32), [lo, hi])
+    v64 = vector.bitcast(T.vec(1, T.i64), v2)
+    return vector.extract(v64, static_position=[0], dynamic_position=[])
+
+
+def _i8x4_in_i32_to_bf16x4_i64(val_i32, arith, vector, scale_val=None):
+    """Convert one i32 (4 signed int8 bytes) to 4 bf16 packed as i64.
+
+    Uses shift-based f32->bf16 truncation (lshr 16) instead of arith.truncf
+    which on gfx942 expands to ~5 VALU per element. The shift is exact for
+    unscaled int8 values and introduces <0.5 ULP error for scaled values.
+    """
+    vec1_i32_t = T.vec(1, T.i32)
+    vec2_i32 = T.i32x2
+    vec4_i8 = T.i8x4
+    vec1_i64 = T.vec(1, T.i64)
+
+    v1 = vector.from_elements(vec1_i32_t, [val_i32])
+    i8x4 = vector.bitcast(vec4_i8, v1)
+
+    f32_vals = []
+    for i in range(4):
+        val_i8 = vector.extract(i8x4, static_position=[i], dynamic_position=[])
+        v = arith.sitofp(T.f32, val_i8)
+        if scale_val is not None:
+            v = v * scale_val
+        f32_vals.append(v)
+
+    c16 = fx.Int32(16)
+    c_ffff0000 = fx.Int32(0xFFFF0000)
+    bits0 = arith.bitcast(T.i32, f32_vals[0])
+    bits1 = arith.bitcast(T.i32, f32_vals[1])
+    bits2 = arith.bitcast(T.i32, f32_vals[2])
+    bits3 = arith.bitcast(T.i32, f32_vals[3])
+    i32_lo = (bits0 >> c16) | (bits1 & c_ffff0000)
+    i32_hi = (bits2 >> c16) | (bits3 & c_ffff0000)
+
+    v2 = vector.from_elements(vec2_i32, [i32_lo, i32_hi])
+    v64 = vector.bitcast(vec1_i64, v2)
+    return vector.extract(v64, static_position=[0], dynamic_position=[])
+
+
+def load_b_raw_w4a16(
+    buffer_ops,
+    arith,
+    vector,
+    *,
+    arg_b,
+    b_rsrc,
+    layout_b,
+    base_k: ir.Value,
+    ku: int,
+    n_blk: ir.Value,
+    n_intra: ir.Value,
+    lane_div_16: ir.Value,
+    elem_type: ir.Type,
+    kpack_bytes: int = 8,
+):
+    """Phase 1 of W4A16 B load: issue buffer_load_dword, return raw packed i32.
+
+    Same address calculation as the int4 unpack path in load_b_pack_k32
+    but using ku-based indexing for 2-phase latency hiding.
+    """
+    if kpack_bytes != 8:
+        raise ValueError(f"W4A16 requires kpack_bytes=8, got {kpack_bytes!r}")
+
+    c64 = fx.Index(64)
+    half_bytes = kpack_bytes // 2
+    c2_idx = fx.Index(2)
+    c4_idx = fx.Index(4)
+
+    k0_base = base_k // c64
+
+    k1_layout_offset = ku * 2
+    lane_div_32 = lane_div_16 // c2_idx
+    total_k1 = fx.Index(k1_layout_offset) + lane_div_32
+    k0 = k0_base + (total_k1 // c4_idx)
+    k1_local = total_k1 % c4_idx
+    lane_odd = lane_div_16 % c2_idx
+    k2_base = lane_odd * fx.Index(half_bytes)
+
+    coord_pack = (n_blk, k0, k1_local, n_intra, fx.Index(0))
+    idx_pack = crd2idx(coord_pack, layout_b)
+    idx_bytes = idx_pack + k2_base
+
+    b4 = _buffer_load_vec(
+        buffer_ops,
+        vector,
+        b_rsrc,
+        idx_bytes,
+        elem_type=elem_type,
+        vec_elems=4,
+        elem_bytes=1,
+        offset_in_bytes=True,
+    )
+    packed32 = vector.extract(
+        vector.bitcast(T.vec(1, T.i32), b4),
+        static_position=[0],
+        dynamic_position=[],
+    )
+    return packed32
+
+
+def _int4_to_bf16x4_i64_gfx950(packed32, nibble_offsets, arith, vector, scale_val=None, defer_scale16=False):
+    """Convert 4 int4 nibbles to 4 bf16 packed as i64 using gfx950 instructions.
+
+    Uses v_cvt_off_f32_i4_sdwa with byte_sel to avoid per-nibble shifts.
+    Even nibbles (0,2,4,6) → SDWA BYTE_0/1/2/3 on original src.
+    Odd nibbles (1,3,5,7)  → SDWA BYTE_0/1/2/3 on (src >> 4).
+    Only 1 shift total instead of 7.
+
+    When defer_scale16=True, the ×16 correction factor for v_cvt_off_f32_i4 is
+    omitted and must be applied later (e.g. in the epilogue).  This saves VALU
+    in the hot loop and uses v_cvt_pk_bf16_f32 for proper f32→bf16 conversion.
+    """
+    from flydsl._mlir.dialects._arith_ops_gen import MulFOp as _MulFOp
+    from flydsl.expr import rocdl
+
+    _uw = _arith._to_raw
+    _av = _arith.ArithValue
+
+    src_even = packed32
+    src_odd = packed32 >> fx.Int32(4)
+
+    f32_vals = []
+    for nib in nibble_offsets:
+        byte_idx = nib // 2
+        src = src_odd if (nib % 2) else src_even
+        v = rocdl.cvt_off_f32_i4(src, byte_sel=byte_idx)
+        f32_vals.append(v)
+
+    if defer_scale16:
+        # Skip ×16; multiply by scale_val only if groupwise.
+        if scale_val is not None:
+            raw_scale = _uw(scale_val)
+            f32_vals = [_MulFOp(v, raw_scale).result for v in f32_vals]
+        # Use v_cvt_pk_bf16_f32 for proper f32→bf16 (no bit-shift trick needed).
+        i32_lo = rocdl.cvt_pk_bf16_f32(f32_vals[0], f32_vals[1])
+        i32_hi = rocdl.cvt_pk_bf16_f32(f32_vals[2], f32_vals[3])
+    else:
+        c16 = fx.Float32(16.0)
+        if scale_val is not None:
+            effective_scale = scale_val * c16
+        else:
+            effective_scale = c16
+        raw_scale = _uw(effective_scale)
+        f32_vals = [_MulFOp(v, raw_scale).result for v in f32_vals]
+        # Truncate f32→bf16 via bit-shift (exact for scaled int values).
+        c16_shift = fx.Int32(16)
+        c_ffff0000 = fx.Int32(0xFFFF0000)
+        bf16_vals = [arith.bitcast(T.i32, _av(v)) for v in f32_vals]
+        i32_lo = (bf16_vals[0] >> c16_shift) | (bf16_vals[1] & c_ffff0000)
+        i32_hi = (bf16_vals[2] >> c16_shift) | (bf16_vals[3] & c_ffff0000)
+
+    v2 = vector.from_elements(T.vec(2, T.i32), [i32_lo, i32_hi])
+    v64 = vector.bitcast(T.vec(1, T.i64), v2)
+    return vector.extract(v64, static_position=[0], dynamic_position=[])
+
+
+def unpack_b_w4a16(packed32, arith, vector, scale_val=None, use_gfx950_cvt=False, defer_scale16=False):
+    """Phase 2 of W4A16 B load: unpack int4->int8 + convert int8->bf16.
+
+    Takes raw packed32 from load_b_raw_w4a16 and produces (b0, b1) --
+    two i64 values each containing 4 bf16 for one MFMA.
+
+    When use_gfx950_cvt=True, uses v_cvt_off_f32_i4 + v_cvt_pk_bf16_f32
+    for ~2x fewer VALU instructions.
+
+    When defer_scale16=True (requires use_gfx950_cvt=True), the ×16
+    correction for v_cvt_off_f32_i4 is omitted; caller must apply it
+    in the epilogue.
+    """
+    if use_gfx950_cvt:
+        b0 = _int4_to_bf16x4_i64_gfx950(packed32, [0, 2, 4, 6], arith, vector, scale_val, defer_scale16=defer_scale16)
+        b1 = _int4_to_bf16x4_i64_gfx950(packed32, [1, 3, 5, 7], arith, vector, scale_val, defer_scale16=defer_scale16)
+        return (b0, b1)
+    even, odd = _unpack_int4_to_int8_pair(packed32)
+    b0 = _i8x4_in_i32_to_bf16x4_i64(even, arith, vector, scale_val=scale_val)
+    b1 = _i8x4_in_i32_to_bf16x4_i64(odd, arith, vector, scale_val=scale_val)
+    return (b0, b1)
+
+
+def load_b_pack_k32(
+    buffer_ops,
+    arith,
+    vector,
+    *,
+    arg_b,
+    b_rsrc,
+    layout_b,
+    base_k: ir.Value,
+    ki_step: int,
+    n_blk: ir.Value,
+    n_intra: ir.Value,
+    lane_div_16: ir.Value,
+    elem_type: ir.Type,
+    kpack_bytes: int = 16,
+    elem_bytes: int = 1,
+    unpack_int4: bool = False,
+    cache_modifier: int = 0,
+) -> ir.Value:
+    """Load one B pack for one MFMA(x32) micro-step.
+
+    Returns an i64 Value containing 8 bytes consumed by MFMA.
+    """
+    if kpack_bytes not in (8, 16):
+        raise ValueError(f"kpack_bytes must be 8 or 16, got {kpack_bytes!r}")
+    if unpack_int4 and kpack_bytes != 8:
+        raise ValueError("unpack_int4 requires kpack_bytes=8 (packed int4 layout)")
+    if elem_bytes not in (1, 2):
+        raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
+
+    c64 = fx.Index(64)
+    base_k_bytes = base_k * arith.constant(int(elem_bytes), index=True)
+    k0_base = base_k_bytes // c64
+    k0 = k0_base + arith.constant(ki_step // 2, index=True)
+    k1 = lane_div_16
+    half_bytes = kpack_bytes // 2
+    k2_base = arith.constant((ki_step % 2) * half_bytes, index=True)
+
+    coord_pack = (n_blk, k0, k1, n_intra, fx.Index(0))
+    idx_pack = crd2idx(coord_pack, layout_b)
+
+    if unpack_int4:
+        idx_bytes = idx_pack + k2_base
+        b4 = _buffer_load_vec(
+            buffer_ops,
+            vector,
+            b_rsrc,
+            idx_bytes,
+            elem_type=elem_type,
+            vec_elems=4,
+            elem_bytes=1,
+            offset_in_bytes=True,
+            cache_modifier=cache_modifier,
+        )
+        packed32 = vector.extract(
+            vector.bitcast(T.vec(1, T.i32), b4),
+            static_position=[0],
+            dynamic_position=[],
+        )
+        even, odd = _unpack_int4_to_int8_pair(packed32)
+        return _pack_i32_pair_to_i64(even, odd, vector)
+
+    vec_elems = kpack_bytes // int(elem_bytes)
+    b16 = _buffer_load_vec(
+        buffer_ops,
+        vector,
+        b_rsrc,
+        idx_pack,
+        elem_type=elem_type,
+        vec_elems=vec_elems,
+        elem_bytes=elem_bytes,
+        offset_in_bytes=(elem_bytes == 1),
+        cache_modifier=cache_modifier,
+    )
+
+    b_i32x4 = vector.bitcast(T.i32x4, b16)
+
+    half = ki_step % 2
+    if half == 0:
+        d0 = vector.extract(b_i32x4, static_position=[0], dynamic_position=[])
+        d1 = vector.extract(b_i32x4, static_position=[1], dynamic_position=[])
+    else:
+        d0 = vector.extract(b_i32x4, static_position=[2], dynamic_position=[])
+        d1 = vector.extract(b_i32x4, static_position=[3], dynamic_position=[])
+
+    v2 = vector.from_elements(T.vec(2, T.i32), [d0, d1])
+    v64 = vector.bitcast(T.vec(1, T.i64), v2)
+    return vector.extract(v64, static_position=[0], dynamic_position=[])
+
+
+def tile_chunk_coord_i32(
+    arith,
+    *,
+    tx_i32_base: ir.Value,
+    i: int,
+    total_threads: int,
+    layout_tile_div4,
+    chunk_i32: int = 4,
+):
+    """Map (thread, chunk_id) -> (row_local, col_local_i32) for X/A loads."""
+    if chunk_i32 not in (1, 2, 4):
+        raise ValueError(f"chunk_i32 must be one of (1,2,4), got {chunk_i32!r}")
+    chunk_off_i32 = arith.constant(i * total_threads * chunk_i32, index=True)
+    tile_idx_i32 = tx_i32_base + chunk_off_i32
+    coord_local = fx.idx2crd(tile_idx_i32, layout_tile_div4)
+    row_local = fx.get(coord_local, 0)
+    col_local_i32 = fx.get(coord_local, 1)
+    return row_local, col_local_i32
+
+
+def buffer_copy_gmem16_dwordx4(
+    buffer_ops,
+    vector,
+    *,
+    elem_type,
+    idx_i32: ir.Value,
+    rsrc,
+    vec_elems: int = 16,
+    elem_bytes: int = 1,
+):
+    """Copy 16 bytes from global memory into regs via buffer-load dwordx4 lowering."""
+    if int(vec_elems) <= 0:
+        raise ValueError(f"vec_elems must be > 0, got {vec_elems!r}")
+    return _buffer_load_vec(
+        buffer_ops,
+        vector,
+        rsrc,
+        idx_i32,
+        elem_type=elem_type,
+        vec_elems=vec_elems,
+        elem_bytes=elem_bytes,
+        offset_in_bytes=False,
+    )
+
+
+def lds_store_16b_xor16(
+    arith,
+    vector,
+    *,
+    lds_memref,
+    vec16_ty,
+    layout_lds,
+    row_local: ir.Value,
+    col_local_i32: ir.Value,
+    tx_c4: ir.Value,
+    k_blocks16: ir.Value,
+    lds_base: ir.Value,
+    vec_part_i32x4: ir.Value,
+    elem_bytes: int = 1,
+):
+    """Store one 16B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    if elem_bytes not in (1, 2):
+        raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
+    col_local_bytes = col_local_i32 * tx_c4
+    col_swz_bytes = swizzle_xor16(row_local, col_local_bytes, k_blocks16)
+    col_swz = col_swz_bytes if elem_bytes == 1 else col_swz_bytes // 2
+    coord_store = (row_local, col_swz)
+    idx0 = crd2idx(coord_store, layout_lds) + lds_base
+    v16 = vector.bitcast(vec16_ty, vec_part_i32x4)
+    vector.store(v16, lds_memref, [idx0])
+
+
+def lds_store_8b_xor16(
+    arith,
+    vector,
+    *,
+    lds_memref,
+    vec8_ty,
+    layout_lds,
+    row_local: ir.Value,
+    col_local_i32: ir.Value,
+    tx_c4: ir.Value,
+    k_blocks16: ir.Value,
+    lds_base: ir.Value,
+    vec_part_i32x2: ir.Value,
+    elem_bytes: int = 1,
+):
+    """Store one 8B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    if elem_bytes not in (1, 2):
+        raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
+    col_local_bytes = col_local_i32 * tx_c4
+    col_swz_bytes = swizzle_xor16(row_local, col_local_bytes, k_blocks16)
+    col_swz = col_swz_bytes if elem_bytes == 1 else col_swz_bytes // 2
+    coord_store = (row_local, col_swz)
+    idx0 = crd2idx(coord_store, layout_lds) + lds_base
+    v8 = vector.bitcast(vec8_ty, vec_part_i32x2)
+    vector.store(v8, lds_memref, [idx0])
+
+
+def lds_store_4b_xor16(
+    arith,
+    vector,
+    *,
+    lds_memref,
+    vec4_ty,
+    layout_lds,
+    row_local: ir.Value,
+    col_local_i32: ir.Value,
+    tx_c4: ir.Value,
+    k_blocks16: ir.Value,
+    lds_base: ir.Value,
+    vec_part_i32x1: ir.Value,
+    elem_bytes: int = 1,
+):
+    """Store one 4B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    if elem_bytes not in (1, 2):
+        raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
+    col_local_bytes = col_local_i32 * tx_c4
+    col_swz_bytes = swizzle_xor16(row_local, col_local_bytes, k_blocks16)
+    col_swz = col_swz_bytes if elem_bytes == 1 else col_swz_bytes // 2
+    coord_store = (row_local, col_swz)
+    idx0 = crd2idx(coord_store, layout_lds) + lds_base
+    v4 = vector.bitcast(vec4_ty, vec_part_i32x1)
+    vector.store(v4, lds_memref, [idx0])
+
+
+def lds_load_pack_k32(
+    arith,
+    vector,
+    *,
+    lds_memref,
+    layout_lds,
+    k_blocks16: ir.Value,
+    curr_row_a_lds: ir.Value,
+    col_base: ir.Value,
+    half: int,
+    lds_base: ir.Value,
+    ck_lds128: bool,
+    vec16_ty,
+    vec8_ty,
+    vec2_i64_ty,
+    vec1_i64_ty,
+):
+    """Load one i64 A-pack for an MFMA K32 micro-step from LDS."""
+    col_base_swz = swizzle_xor16(curr_row_a_lds, col_base, k_blocks16)
+    if ck_lds128:
+        coord_a16 = (curr_row_a_lds, col_base_swz)
+        idx_a16 = crd2idx(coord_a16, layout_lds) + lds_base
+        loaded_a16 = vector.load_op(vec16_ty, lds_memref, [idx_a16])
+        a_vec128 = vector.bitcast(vec2_i64_ty, loaded_a16)
+        return vector.extract(a_vec128, static_position=[half], dynamic_position=[])
+    else:
+        col_swizzled = col_base_swz + (half * 8)
+        coord_a = (curr_row_a_lds, col_swizzled)
+        idx_a = crd2idx(coord_a, layout_lds) + lds_base
+        loaded_a8 = vector.load_op(vec8_ty, lds_memref, [idx_a])
+        a_vec64 = vector.bitcast(vec1_i64_ty, loaded_a8)
+        return vector.extract(a_vec64, static_position=[0], dynamic_position=[])
+
+
+def xcd_remap_bx_by(
+    bx,
+    by,
+    c_m,
+    *,
+    tile_m: int,
+    tile_n: int,
+    N: int,
+    xcd_swizzle: int,
+    num_xcds: int = 8,
+):
+    """Remap (bx, by) for L2-cache reuse via XCD swizzle.
+
+    No-op when ``xcd_swizzle <= 0``. Otherwise:
+      1. Linearize the original (bx, by) grid round-robin across ``num_xcds``
+         XCDs so that contiguous workgroup ids stay on the same XCD.
+      2. Re-tile that 1-D order with an M-major group of size ``xcd_swizzle``,
+         folding the tail group when ``gy`` does not divide evenly.
+
+    Designed to be called inside a ``@flyc.kernel`` immediately after::
+
+        bx = gpu.block_id("x")
+        by = gpu.block_id("y")
+        bx, by = xcd_remap_bx_by(bx, by, c_m, tile_m=..., tile_n=..., N=...,
+                                 xcd_swizzle=xcd_swizzle)
+
+    ``c_m`` is the dynamic ``fx.Index`` for runtime ``M``; ``tile_m``,
+    ``tile_n``, ``N`` and ``xcd_swizzle`` are compile-time Python ints.
+    """
+    if xcd_swizzle <= 0:
+        return bx, by
+
+    _c1 = fx.arith.constant(1, index=True)
+    _c_tm = fx.arith.constant(tile_m, index=True)
+    _gx = fx.arith.constant(N // tile_n, index=True)
+    _gy = (c_m + _c_tm - _c1) / _c_tm
+
+    _linear_id = bx * _gx + by
+    _num_wgs = _gx * _gy
+
+    _c_xcds = fx.arith.constant(num_xcds, index=True)
+    _wgs_per_xcd = _num_wgs / _c_xcds
+    _wgid = (_linear_id % _c_xcds) * _wgs_per_xcd + (_linear_id / _c_xcds)
+
+    _c_wgm = fx.arith.constant(xcd_swizzle, index=True)
+    _num_wgid_in_group = _c_wgm * _gx
+    _group_id = _wgid / _num_wgid_in_group
+    _first_pid_m = _group_id * _c_wgm
+    _remaining_m = _gy - _first_pid_m
+    _cmp_m = fx.arith.cmpi(CmpIPredicate.ult, _remaining_m, _c_wgm)
+    _group_size_m = fx.arith.select(_cmp_m, _remaining_m, _c_wgm)
+
+    _wgid_in_group = _wgid % _num_wgid_in_group
+    new_bx = _first_pid_m + (_wgid_in_group % _group_size_m)
+    new_by = _wgid_in_group / _group_size_m
+    return new_bx, new_by
+
+
+__all__ = [
+    "PreshuffleBLayout",
+    "PreshuffleScaleLayout",
+    "buffer_copy_gmem16_dwordx4",
+    "lds_load_pack_k32",
+    "lds_row_major_idx",
+    "lds_store_4b_xor16",
+    "lds_store_8b_xor16",
+    "lds_store_16b_xor16",
+    "make_preshuffle_b_layout",
+    "make_preshuffle_scale_layout",
+    "load_b_pack_k32",
+    "split_row_major_2d",
+    "swizzle_xor16",
+    "tile_chunk_coord_i32",
+    "unpack_b_w4a16",
+    "xcd_remap_bx_by",
+]
+
+
+# ---------------------------------------------------------------------------
+# Groupwise scale load helper (shared by W4A16 and W4A8 groupwise paths)
+# ---------------------------------------------------------------------------
+
+
+def _load_groupwise_scale(
+    buffer_ops,
+    arith,
+    *,
+    scale_rsrc,
+    expert_offset,
+    n_blk,
+    n_intra,
+    k_pos,
+    num_groups: int,
+    group_size: int,
+    n_per_expert: int,
+    scale_dtype=None,
+):
+    """Load one per-group scale value from the scale buffer.
+
+    Computes the linear index into the scale tensor from expert offset,
+    N position, and group index derived from ``k_pos``.
+
+    For bf16 scales the tensor uses ``(E, G//2, N, 2)`` layout — two
+    adjacent groups for the same N position are packed into one dword.
+    We load the raw i32 dword (no extraction) so it can be carried as
+    loop state without register copies.  Use :func:`extract_bf16_scale`
+    in the compute phase to obtain the f32 value.
+    """
+    c16 = fx.Index(16)
+    n_global = n_blk * c16 + n_intra
+    c_group_size = fx.Index(group_size)
+    c_npe = fx.Index(n_per_expert)
+    group_idx = k_pos // c_group_size
+    if scale_dtype is None:
+        scale_dtype = T.f32
+
+    if scale_dtype == T.bf16:
+        # (E, G//2, N, 2) layout: dword at [e, pair, n] holds bf16 scales
+        # for groups 2*pair and 2*pair+1.
+        pair_idx = group_idx >> fx.Index(1)  # group_idx // 2
+        # Dword index: same flat formula but with G//2 groups
+        num_pairs = num_groups // 2
+        c_npm1 = fx.Index(num_pairs - 1)
+        dword_base = expert_offset * c_npm1 + n_global
+        dword_elem = dword_base + pair_idx * c_npe
+        dword_idx = arith.index_cast(T.i32, dword_elem)
+        # Return raw i32 dword — extraction deferred to compute phase.
+        scale_val = buffer_ops.buffer_load(scale_rsrc, dword_idx, vec_width=1, dtype=T.i32)
+    else:
+        # (E, G, N) layout with f32 dtype
+        c_gm1 = fx.Index(num_groups - 1)
+        base_scale = expert_offset * c_gm1 + n_global
+        elem_idx = base_scale + group_idx * c_npe
+        scale_idx_i32 = arith.index_cast(T.i32, elem_idx)
+        scale_val = buffer_ops.buffer_load(scale_rsrc, scale_idx_i32, vec_width=1, dtype=T.f32)
+    return scale_val
+
+
+def extract_bf16_scale(arith, scale_raw_i32, ku: int):
+    """Extract f32 scale from raw i32 dword loaded by bf16 groupwise path.
+
+    In the ``(E, G//2, N, 2)`` layout two adjacent groups share one dword.
+    ``ku`` determines which half: even ku → low bf16, odd ku → high bf16.
+    """
+    if ku % 2 == 0:
+        # Low bf16: shift left by 16 to place in upper 16 bits → f32
+        return arith.bitcast(T.f32, scale_raw_i32 << fx.Int32(16))
+    else:
+        # High bf16: mask upper 16 bits → f32
+        return arith.bitcast(T.f32, scale_raw_i32 & fx.Int32(0xFFFF0000))
+
+
+# ---------------------------------------------------------------------------
+# W4A16 groupwise load / unpack helpers
+# ---------------------------------------------------------------------------
+
+
+def load_b_raw_w4a16_groupwise(
+    buffer_ops,
+    arith,
+    vector,
+    *,
+    arg_b,
+    b_rsrc,
+    layout_b,
+    base_k,
+    ku: int,
+    n_blk,
+    n_intra,
+    lane_div_16,
+    elem_type,
+    scale_rsrc,
+    expert_offset,
+    num_groups: int,
+    group_size: int,
+    n_per_expert: int,
+    kpack_bytes: int = 8,
+    scale_dtype=None,
+):
+    """Phase 1 of W4A16 groupwise B load: buffer_loads for weight + scale.
+
+    Reuses :func:`load_b_raw_w4a16` for the weight load, then issues an
+    additional ``buffer_load_dword`` for the per-group scale.
+
+    Returns ``(packed32, scale_val)``.
+    """
+    packed32 = load_b_raw_w4a16(
+        buffer_ops,
+        arith,
+        vector,
+        arg_b=arg_b,
+        b_rsrc=b_rsrc,
+        layout_b=layout_b,
+        base_k=base_k,
+        ku=ku,
+        n_blk=n_blk,
+        n_intra=n_intra,
+        lane_div_16=lane_div_16,
+        elem_type=elem_type,
+        kpack_bytes=kpack_bytes,
+    )
+    k_pos = base_k + fx.Index(ku * 32)
+    scale_val = _load_groupwise_scale(
+        buffer_ops,
+        arith,
+        scale_rsrc=scale_rsrc,
+        expert_offset=expert_offset,
+        n_blk=n_blk,
+        n_intra=n_intra,
+        k_pos=k_pos,
+        num_groups=num_groups,
+        group_size=group_size,
+        n_per_expert=n_per_expert,
+        scale_dtype=scale_dtype,
+    )
+    return (packed32, scale_val)
+
+
+def unpack_b_w4a16_groupwise(packed32, scale_val, arith, vector, use_gfx950_cvt=False):
+    """Phase 2 of W4A16 groupwise: unpack + scale + convert to bf16."""
+    return unpack_b_w4a16(packed32, arith, vector, scale_val=scale_val, use_gfx950_cvt=use_gfx950_cvt)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_1stage.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_1stage.py
@@ -1,0 +1,1534 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""1-Stage Fused MoE GEMM kernel for decode/B2B probes.
+
+Fuses stage1 (X×W1→SiLU→intermediate) and stage2 (intermediate×W2→output) into a
+single kernel launch, eliminating intermediate global memory traffic, the quant
+kernel, and the zero() kernel.
+
+Constraints:
+- FP8 input (X, W1)
+- BF16 W2 (precomputed: dequant(W2_fp8, scale_w2) → bf16, preshuffled)
+- BF16 output (atomic add)
+- inter_dim must equal tile_k (128 for TP8, 256 for TP4) — single-pass Phase 2
+- Designed for decode batch sizes (B=1-4)
+"""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, const_expr, gpu, range_constexpr, rocdl, vector
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+
+try:
+    from flydsl.runtime.device import supports_bf16_global_atomics
+except ImportError:
+    def supports_bf16_global_atomics(arch: str) -> bool:
+        return str(arch).startswith(("gfx94", "gfx95", "gfx12"))
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.expr.typing import T
+from flydsl.expr.vector import ReductionOp
+from .kernels.mfma_epilogues import c_shuffle_epilog, mfma_epilog
+from .kernels.mfma_preshuffle_pipeline import (
+    buffer_copy_gmem16_dwordx4,
+    crd2idx,
+    lds_store_16b_xor16,
+    lds_store_8b_xor16,
+    lds_store_4b_xor16,
+    load_b_pack_k32,
+    make_preshuffle_b_layout,
+    swizzle_xor16,
+    tile_chunk_coord_i32,
+)
+
+_FP32_MIN_NORMAL = 1.1754943508222875e-38
+
+from contextlib import contextmanager
+
+@contextmanager
+def _if_then(if_op):
+    with ir.InsertionPoint(if_op.then_block):
+        try:
+            yield if_op.then_block
+        finally:
+            blk = if_op.then_block
+            if (not blk.operations) or not isinstance(blk.operations[-1], scf.YieldOp):
+                scf.YieldOp([])
+
+
+@functools.lru_cache(maxsize=256)
+def compile_moe_gemm_fused(
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    tile_m: int = 32,
+    tile_n_out: int = 128,
+    tile_k: int = 128,
+    out_dtype: str = "bf16",
+    b_cache_modifier_w1: int = 0,
+    b_cache_modifier_w2: int = 0,
+    loop_n_in_block: bool = False,
+    stage2_use_fp8_w2: bool = False,
+    n_tiles_per_block: int = 0,
+    cshuffle_nlane: int = 32,
+    total_threads: int = 256,
+    fold_route_weight_into_a2_scale: bool = False,
+    out_tile_pair: int = 1,
+    cshuffle_lds_xor: bool = False,
+):
+    """Compile 1-stage fused MoE kernel for decode.
+
+    Requirements:
+    - inter_dim == tile_k (single-pass Phase 2)
+    - FP8 input (X, W1), BF16 W2 (precomputed skip-quant), BF16 output
+    """
+    if inter_dim != tile_k:
+        raise ValueError(
+            f"1-stage fused kernel requires inter_dim == tile_k, got {inter_dim} != {tile_k}"
+        )
+    if model_dim % tile_n_out != 0:
+        raise ValueError(f"model_dim ({model_dim}) must be divisible by tile_n_out ({tile_n_out})")
+    if model_dim % tile_k != 0:
+        raise ValueError(f"model_dim ({model_dim}) must be divisible by tile_k ({tile_k})")
+    if stage2_use_fp8_w2 and not loop_n_in_block:
+        raise ValueError("stage2_use_fp8_w2 is only implemented for B2B N-loop mode")
+    if stage2_use_fp8_w2 and inter_dim != 256:
+        raise ValueError("stage2_use_fp8_w2 currently requires TP4 inter_dim=256")
+    if fold_route_weight_into_a2_scale and not (
+        loop_n_in_block and stage2_use_fp8_w2 and inter_dim == 256
+    ):
+        raise ValueError(
+            "fold_route_weight_into_a2_scale is only validated for TP4 FP8-W2 B2B mode"
+        )
+    if out_tile_pair not in (1, 2):
+        raise ValueError("out_tile_pair currently supports only 1 or 2")
+    if out_tile_pair != 1 and not (loop_n_in_block and stage2_use_fp8_w2 and inter_dim == 256):
+        raise ValueError("out_tile_pair is only validated for TP4 FP8-W2 B2B mode")
+    if out_tile_pair != 1 and fold_route_weight_into_a2_scale:
+        raise ValueError("out_tile_pair is validated only with route-weight folding disabled")
+    if cshuffle_lds_xor and not (loop_n_in_block and stage2_use_fp8_w2 and inter_dim == 256):
+        raise ValueError("cshuffle_lds_xor is only validated for TP4 FP8-W2 B2B mode")
+    if cshuffle_lds_xor and (n_tiles_per_block != 0 or out_tile_pair != 1):
+        raise ValueError("cshuffle_lds_xor requires the default single-CTA output loop")
+    if cshuffle_lds_xor and (tile_n_out != 512 or cshuffle_nlane != 32 or total_threads != 256):
+        raise ValueError("cshuffle_lds_xor is validated only for tile_n_out=512, NLane32, 256 threads")
+    if total_threads not in (256, 512):
+        raise ValueError("total_threads currently supports only 256 or 512")
+    if total_threads != 256 and not (loop_n_in_block and stage2_use_fp8_w2 and inter_dim == 256):
+        raise ValueError("non-default total_threads is only validated for TP4 FP8-W2 B2B mode")
+    num_waves = total_threads // 64
+    if inter_dim % num_waves != 0:
+        raise ValueError(f"inter_dim ({inter_dim}) must be divisible by num_waves ({num_waves})")
+    if tile_n_out % num_waves != 0:
+        raise ValueError(f"tile_n_out ({tile_n_out}) must be divisible by num_waves ({num_waves})")
+    if (inter_dim // num_waves) % 16 != 0:
+        raise ValueError("stage1 n_per_wave must be divisible by 16")
+    if (tile_n_out // num_waves) % 16 != 0:
+        raise ValueError("stage2 n_per_wave must be divisible by 16")
+    if cshuffle_nlane not in (16, 32, 64):
+        raise ValueError("cshuffle_nlane currently supports only 16, 32, or 64")
+    if total_threads % cshuffle_nlane != 0:
+        raise ValueError(
+            f"total_threads ({total_threads}) must be divisible by cshuffle_nlane ({cshuffle_nlane})"
+        )
+    if tile_m % (total_threads // cshuffle_nlane) != 0:
+        raise ValueError(
+            f"tile_m ({tile_m}) must be divisible by CShuffleMLane "
+            f"({total_threads // cshuffle_nlane})"
+        )
+    if tile_n_out % (cshuffle_nlane * 2) != 0:
+        raise ValueError(
+            f"tile_n_out ({tile_n_out}) must be divisible by cshuffle_nlane*2 "
+            f"({cshuffle_nlane * 2})"
+        )
+    total_n_tiles = model_dim // tile_n_out
+    if out_tile_pair != 1:
+        if n_tiles_per_block != 0:
+            raise ValueError("out_tile_pair requires n_tiles_per_block=0")
+        if total_n_tiles % out_tile_pair != 0:
+            raise ValueError(
+                f"output N tiles ({total_n_tiles}) must be divisible by out_tile_pair "
+                f"({out_tile_pair})"
+            )
+    if n_tiles_per_block < 0:
+        raise ValueError("n_tiles_per_block must be non-negative")
+    if n_tiles_per_block != 0:
+        if not loop_n_in_block:
+            raise ValueError("n_tiles_per_block requires B2B N-loop mode")
+        if not stage2_use_fp8_w2:
+            raise ValueError("n_tiles_per_block is only validated for FP8-W2 B2B mode")
+        if n_tiles_per_block not in (2, 4):
+            raise ValueError("n_tiles_per_block currently supports only 2 or 4")
+        if total_n_tiles % n_tiles_per_block != 0:
+            raise ValueError(
+                f"output N tiles ({total_n_tiles}) must be divisible by n_tiles_per_block "
+                f"({n_tiles_per_block})"
+            )
+
+    gpu_arch = get_hip_arch()
+    allocator = SmemAllocator(None, arch=gpu_arch)
+
+    out_is_bf16 = out_dtype == "bf16"
+    out_is_f16 = out_dtype in ("f16", "fp16", "half")
+    if not (out_is_bf16 or out_is_f16):
+        raise ValueError("1-stage fused kernel only supports bf16/f16 output")
+
+    _needs_global_atomic_bf16 = out_is_bf16 and "gfx942" in gpu_arch
+
+    # Phase 1 parameters (FP8)
+    elem_bytes_fp8 = 1
+    tile_k_bytes_fp8 = tile_k * elem_bytes_fp8  # 128
+    lds_stride_stage1 = tile_k  # no padding with XOR16
+
+    # Phase 2 parameters (BF16)
+    elem_bytes_bf16 = 2
+    tile_k_bytes_bf16 = tile_k * elem_bytes_bf16  # 256
+    elem_bytes_w2 = elem_bytes_fp8 if stage2_use_fp8_w2 else elem_bytes_bf16
+    tile_k_bytes_w2 = tile_k * elem_bytes_w2
+
+    # Stage1 tile_n covers all gate+up columns
+    tile_n_stage1 = inter_dim  # 128 (each wave handles n_per_wave=32 of gate AND 32 of up)
+
+    bytes_x_per_tile = tile_m * tile_k * elem_bytes_fp8
+    if bytes_x_per_tile % total_threads != 0:
+        raise ValueError(f"tile_m*tile_k must be divisible by {total_threads}")
+    bytes_per_thread_x = bytes_x_per_tile // total_threads
+
+    # LDS sizing:
+    # Phase 1: ping-pong X tiles = 2 * tile_m * lds_stride_stage1 * 1B = 2*32*128 = 8KB
+    # Phase 1.5→2: intermediate bf16 = tile_m * inter_dim * 2B = 32*128*2 = 8KB
+    # Phase 3: CShuffle output = tile_m * tile_n_out * 2B = 32*128*2 = 8KB
+    lds_pingpong_bytes = 2 * tile_m * lds_stride_stage1 * elem_bytes_fp8
+    lds_intermediate_bytes = tile_m * inter_dim * elem_bytes_bf16
+    lds_a2_fp8_bytes = tile_m * inter_dim * elem_bytes_fp8
+    lds_cshuffle_bytes = tile_m * tile_n_out * elem_bytes_bf16
+    lds_out_offset_bytes = 0
+    lds_a2_fp8_offset_bytes = 0
+    lds_scale_offset_bytes = 0
+    lds_red_offset_bytes = 0
+    red_slots = total_threads // 64
+    if stage2_use_fp8_w2:
+        lds_a2_fp8_offset_bytes = ((lds_intermediate_bytes + 15) // 16) * 16
+        lds_scale_offset_bytes = ((lds_a2_fp8_offset_bytes + lds_a2_fp8_bytes + 15) // 16) * 16
+        lds_red_offset_bytes = ((lds_scale_offset_bytes + tile_m * 4 + 15) // 16) * 16
+        lds_out_offset_bytes = ((lds_red_offset_bytes + red_slots * 4 + 15) // 16) * 16
+        lds_total_bytes = max(
+            lds_pingpong_bytes,
+            lds_out_offset_bytes + lds_cshuffle_bytes,
+        )
+    elif loop_n_in_block:
+        lds_out_offset_bytes = ((lds_intermediate_bytes + 15) // 16) * 16
+        lds_total_bytes = max(
+            lds_pingpong_bytes,
+            lds_out_offset_bytes + lds_cshuffle_bytes,
+        )
+    else:
+        lds_total_bytes = max(lds_pingpong_bytes, lds_intermediate_bytes, lds_cshuffle_bytes)
+    lds_total_elems = lds_total_bytes  # fp8 elem_bytes=1
+
+    lds_alloc_bytes = lds_total_elems
+    lds_alloc_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_alloc_offset + lds_alloc_bytes
+
+    # CShuffle epilogue parameters
+    _cshuffle_nlane = cshuffle_nlane
+    _e_vec = 2  # atomic mode
+
+    # Module name for cache key
+    _bnt_w1_tag = f"_bntw1_{b_cache_modifier_w1}" if b_cache_modifier_w1 != 0 else ""
+    _bnt_w2_tag = f"_bntw2_{b_cache_modifier_w2}" if b_cache_modifier_w2 != 0 else ""
+    _b2b_tag = "_b2bn" if loop_n_in_block else ""
+    _fp8w2_tag = "_fp8w2" if stage2_use_fp8_w2 else ""
+    _out_tag = "_outf16" if out_dtype in ("f16", "fp16", "half") else ""
+    _ntpb_tag = f"_ntpb{n_tiles_per_block}" if n_tiles_per_block != 0 else ""
+    _csnl_tag = f"_csnl{cshuffle_nlane}" if cshuffle_nlane != 32 else ""
+    _thr_tag = f"_thr{total_threads}" if total_threads != 256 else ""
+    _wina2_tag = "_wina2" if fold_route_weight_into_a2_scale else ""
+    _opair_tag = f"_opair{out_tile_pair}" if out_tile_pair != 1 else ""
+    _csxor_tag = "_csxor" if cshuffle_lds_xor else ""
+    module_name = (
+        f"mfma_moe_fused1s_fp8_bf16"
+        f"_t{tile_m}x{tile_n_out}x{tile_k}"
+        f"_i{inter_dim}{_csnl_tag}"
+        f"{_bnt_w1_tag}{_bnt_w2_tag}{_b2b_tag}{_fp8w2_tag}{_out_tag}"
+        f"{_ntpb_tag}{_thr_tag}{_wina2_tag}{_opair_tag}{_csxor_tag}"
+        f"_abi2"
+    ).replace("-", "_")
+
+    kernel_decorator = (
+        flyc.kernel(known_block_size=[total_threads, 1, 1])
+        if total_threads > 256
+        else flyc.kernel
+    )
+
+    if True:
+
+        @kernel_decorator
+        def moe_gemm_fused(
+            arg_out: fx.Tensor,       # [tokens, model_dim] bf16
+            arg_x: fx.Tensor,         # [tokens, model_dim] fp8
+            arg_w1: fx.Tensor,        # [E, 2*inter_dim, model_dim] fp8 preshuffled
+            arg_w2: fx.Tensor,        # [E, model_dim, inter_dim] bf16 preshuffled
+            arg_scale_x: fx.Tensor,   # [tokens, 1] f32
+            arg_scale_w1: fx.Tensor,  # [E, 2*inter_dim, 1] f32
+            arg_scale_w2: fx.Tensor,  # [E, model_dim, 1] f32 for FP8 W2 path
+            arg_sorted_token_ids: fx.Tensor,
+            arg_expert_ids: fx.Tensor,
+            arg_sorted_weights: fx.Tensor,
+            arg_num_valid_ids: fx.Tensor,
+            i32_tokens_in: fx.Int32,
+            i32_model_dim_in: fx.Int32,
+            i32_inter_dim_in: fx.Int32,
+            i32_size_expert_ids_in: fx.Int32,
+        ):
+            tokens_in = arith.index_cast(T.index, i32_tokens_in)
+            model_dim_in = arith.index_cast(T.index, i32_model_dim_in)
+            size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+
+            # Element types
+            x_elem = T.f8
+            w1_elem = T.f8
+            w2_elem = T.f8 if stage2_use_fp8_w2 else T.bf16
+            out_elem = T.bf16 if out_is_bf16 else T.f16
+            vec16_elems_fp8 = 16  # 16 fp8 in 16B
+            vec8_elems_fp8 = 8
+            vec4_elems_fp8 = 4
+            vec16_x = T.vec(vec16_elems_fp8, x_elem)
+            vec8_x = T.vec(vec8_elems_fp8, x_elem)
+            vec4_x = T.vec(vec4_elems_fp8, x_elem)
+
+            acc_init = arith.constant_vector(0.0, T.f32x4)
+
+            # --- Phase 1 layouts ---
+            # W1 preshuffle: c_n = E * 2*inter_dim, c_k = model_dim
+            c_n_w1 = arith.index(experts * 2 * inter_dim)
+            k_in_stage1 = model_dim_in
+            kpack_bytes_fp8 = 16
+            b_layout_w1 = make_preshuffle_b_layout(
+                arith, c_n=c_n_w1, c_k=k_in_stage1, kpack_bytes=kpack_bytes_fp8, elem_bytes=elem_bytes_fp8
+            )
+            layout_b_w1 = b_layout_w1.layout_b
+
+            # X LDS layout
+            shape_lds_s1 = fx.make_shape(tile_m, tile_k)
+            stride_lds_s1 = fx.make_stride(lds_stride_stage1, 1)
+            layout_lds_s1 = fx.make_layout(shape_lds_s1, stride_lds_s1)
+
+            # --- Phase 2 layouts ---
+            # W2 preshuffle: c_n = E * model_dim, c_k = inter_dim
+            c_n_w2 = arith.index(experts * model_dim)
+            k_in_stage2 = arith.index(inter_dim)
+            kpack_bytes_w2 = 16
+            b_layout_w2 = make_preshuffle_b_layout(
+                arith, c_n=c_n_w2, c_k=k_in_stage2, kpack_bytes=kpack_bytes_w2, elem_bytes=elem_bytes_w2
+            )
+            layout_b_w2 = b_layout_w2.layout_b
+
+            # Intermediate LDS layout (bf16, [tile_m, inter_dim])
+            lds_stride_stage2 = inter_dim
+            shape_lds_s2 = fx.make_shape(tile_m, inter_dim)
+            stride_lds_s2 = fx.make_stride(lds_stride_stage2, 1)
+            layout_lds_s2 = fx.make_layout(shape_lds_s2, stride_lds_s2)
+            layout_lds_s2_fp8 = fx.make_layout(
+                fx.make_shape(tile_m, inter_dim), fx.make_stride(inter_dim, 1)
+            )
+
+            tx = gpu.thread_id("x")
+            by = gpu.block_id("x")  # tile along model_dim (Phase 2 output N)
+            bx = gpu.block_id("y")  # tile along sorted M (expert block)
+
+            bx_m = bx * fx.Index(tile_m)
+
+            # Early-exit: check num_valid_ids
+            numids_rsrc = buffer_ops.create_buffer_resource(
+                arg_num_valid_ids, max_size=False, num_records_bytes=fx.Index(4),
+            )
+            num_valid_i32 = buffer_ops.buffer_load(numids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+            bx_m_i32 = arith.index_cast(T.i32, bx_m)
+            blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32)
+
+            k_blocks16_s1 = arith.index(tile_k_bytes_fp8 // 16)
+            layout_tx_wave_lane = fx.make_layout((num_waves, 64), stride=(64, 1))
+            layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
+
+            _if_blk = scf.IfOp(blk_valid)
+            with _if_then(_if_blk):
+                base_ptr = allocator.get_base()
+                lds_x_ptr = SmemPtr(
+                    base_ptr, lds_alloc_offset, T.f8, shape=(lds_total_elems,),
+                )
+                lds_x = lds_x_ptr.get()
+                # In B2B-N-loop mode, CShuffle needs a separate LDS slice so
+                # each output tile can reuse the stage1 intermediate.
+                lds_intermediate = SmemPtr(
+                    base_ptr, lds_x_ptr.byte_offset, T.bf16,
+                    shape=(tile_m * inter_dim,),
+                ).get()
+                lds_out = SmemPtr(
+                    base_ptr, lds_x_ptr.byte_offset + lds_out_offset_bytes, out_elem,
+                    shape=(tile_m * tile_n_out,),
+                ).get()
+                if const_expr(stage2_use_fp8_w2):
+                    lds_a2_q_ptr = SmemPtr(
+                        base_ptr, lds_x_ptr.byte_offset + lds_a2_fp8_offset_bytes, T.f8,
+                        shape=(tile_m * inter_dim,),
+                    )
+                    lds_a2_q = lds_a2_q_ptr.get()
+                    lds_a2_q_i8 = SmemPtr(
+                        base_ptr, lds_x_ptr.byte_offset + lds_a2_fp8_offset_bytes, T.i8,
+                        shape=(tile_m * inter_dim,),
+                    )
+                    lds_a2_q_i8.get()
+                    lds_a2_scale = SmemPtr(
+                        base_ptr, lds_x_ptr.byte_offset + lds_scale_offset_bytes, T.f32,
+                        shape=(tile_m,),
+                    )
+                    lds_a2_scale.get()
+                    lds_red = SmemPtr(
+                        base_ptr, lds_x_ptr.byte_offset + lds_red_offset_bytes, T.f32,
+                        shape=(red_slots,),
+                    )
+                    lds_red.get()
+
+                # Buffer resources
+                c_topk = fx.Index(topk)
+                x_nbytes_idx = tokens_in * model_dim_in * fx.Index(elem_bytes_fp8)
+                x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_idx)
+                w1_rsrc = buffer_ops.create_buffer_resource(arg_w1, max_size=False)
+                w2_rsrc = buffer_ops.create_buffer_resource(arg_w2, max_size=False)
+
+                out_nbytes_idx = tokens_in * model_dim_in * fx.Index(2)
+                out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes_idx)
+
+                sx_nbytes_idx = tokens_in * fx.Index(4)
+                sx_rsrc = buffer_ops.create_buffer_resource(arg_scale_x, max_size=False, num_records_bytes=sx_nbytes_idx)
+                sw1_rsrc = buffer_ops.create_buffer_resource(arg_scale_w1, max_size=False)
+                sw2_rsrc = -1
+                if const_expr(stage2_use_fp8_w2):
+                    sw2_rsrc = buffer_ops.create_buffer_resource(arg_scale_w2, max_size=False)
+
+                sorted_nbytes_idx = size_expert_ids_in * fx.Index(tile_m) * fx.Index(4)
+                sorted_rsrc = buffer_ops.create_buffer_resource(
+                    arg_sorted_token_ids, max_size=False, num_records_bytes=sorted_nbytes_idx
+                )
+                sorted_w_rsrc = buffer_ops.create_buffer_resource(
+                    arg_sorted_weights, max_size=False, num_records_bytes=sorted_nbytes_idx
+                )
+                expert_rsrc = buffer_ops.create_buffer_resource(
+                    arg_expert_ids, max_size=False,
+                    num_records_bytes=(size_expert_ids_in * fx.Index(4)),
+                )
+
+                # Expert id for this M tile
+                expert_i32 = buffer_ops.buffer_load(expert_rsrc, bx, vec_width=1, dtype=T.i32)
+                expert_idx = arith.index_cast(T.index, expert_i32)
+
+                # W1 expert offset: expert * 2*inter_dim (in N dimension)
+                inter2_idx = arith.index(2 * inter_dim)
+                expert_off_w1 = expert_idx * inter2_idx
+
+                # W2 expert offset: expert * model_dim (in N dimension)
+                model_dim_idx = arith.index(model_dim)
+                expert_off_w2 = expert_idx * model_dim_idx
+
+                # ---- X gmem->reg prefetch setup ----
+                if const_expr(bytes_per_thread_x % 16 == 0):
+                    x_load_bytes = 16
+                elif const_expr(bytes_per_thread_x % 8 == 0):
+                    x_load_bytes = 8
+                elif const_expr(bytes_per_thread_x % 4 == 0):
+                    x_load_bytes = 4
+                else:
+                    raise ValueError(
+                        f"bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 4"
+                    )
+                num_x_loads = bytes_per_thread_x // x_load_bytes
+                chunk_i32 = x_load_bytes // 4
+
+                c_k_div4 = model_dim_in // fx.Index(4)  # fp8: elem_bytes=1, so k/4 = dwords
+                tile_k_dwords = tile_k // 4
+                layout_x_tile_div4 = fx.make_layout((tile_m, tile_k_dwords), stride=(tile_k_dwords, 1))
+                c_chunk_i32 = fx.Index(chunk_i32)
+                tx_i32_base = tx * c_chunk_i32
+                mask24 = fx.Int32(0xFFFFFF)
+                tokens_i32 = arith.index_cast(T.i32, tokens_in)
+                topk_i32 = fx.Int32(topk)
+
+                def x_tile_chunk_coord_i32(i: int):
+                    return tile_chunk_coord_i32(
+                        arith, tx_i32_base=tx_i32_base, i=i,
+                        total_threads=total_threads,
+                        layout_tile_div4=layout_x_tile_div4,
+                        chunk_i32=chunk_i32,
+                    )
+
+                # Decode sorted tokens once
+                x_row_base_div4 = []
+                x_col_local_i32 = []
+                x_row_local = []
+                for i in range_constexpr(num_x_loads):
+                    row_local, col_local_i32 = x_tile_chunk_coord_i32(i)
+                    x_row_local.append(row_local)
+                    x_col_local_i32.append(col_local_i32)
+
+                    sorted_row_i = bx_m + row_local
+                    fused_i = buffer_ops.buffer_load(sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32)
+                    t_raw = fused_i & mask24
+                    t_valid_i32 = arith.cmpi(arith.CmpIPredicate.ult, t_raw, tokens_i32)
+                    t_idx = arith.index_cast(T.index, t_raw)
+                    t_safe = t_valid_i32.select(t_idx, fx.Index(0))
+                    x_row_base_div4.append(t_safe * c_k_div4)
+
+                def load_x(idx_i32):
+                    if const_expr(x_load_bytes == 16):
+                        idx_elem = idx_i32  # fp8: elem_bytes=1, idx is already in element units
+                        return buffer_copy_gmem16_dwordx4(
+                            buffer_ops, vector, elem_type=x_elem,
+                            idx_i32=idx_elem, rsrc=x_rsrc,
+                            vec_elems=vec16_elems_fp8, elem_bytes=elem_bytes_fp8,
+                        )
+                    if const_expr(x_load_bytes == 8):
+                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=2, dtype=T.i32)
+                    return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=1, dtype=T.i32)
+
+                def load_x_tile(base_k):
+                    base_k_div4 = base_k // fx.Index(4)
+                    parts = []
+                    for i in range_constexpr(num_x_loads):
+                        idx_i32 = x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
+                        x_vec = load_x(idx_i32)
+                        if const_expr(x_load_bytes == 16):
+                            parts.append(vector.bitcast(T.i32x4, x_vec))
+                        elif const_expr(x_load_bytes == 8):
+                            parts.append(x_vec)
+                        else:
+                            parts.append(x_vec)
+                    return parts
+
+                # tx -> wave/lane
+                coord_wl = fx.idx2crd(tx, layout_tx_wave_lane)
+                wave_id = fx.get(coord_wl, 0)
+                lane_id = fx.get(coord_wl, 1)
+                coord_l16 = fx.idx2crd(lane_id, layout_lane16)
+                lane_div_16 = fx.get(coord_l16, 0)
+                lane_mod_16 = fx.get(coord_l16, 1)
+
+                row_a_lds = lane_mod_16
+                a_kpack_elems_fp8 = 16  # 16 bytes / 1 byte
+                col_offset_base_fp8 = lane_div_16 * arith.index(a_kpack_elems_fp8)
+                # col_offset_base_bytes for fp8 = col_offset_base (since elem=1B)
+                col_offset_base_bytes_s1 = col_offset_base_fp8
+
+                # Phase 1 N-tiling: covers ALL 2*inter_dim columns
+                # n_per_wave_s1 = tile_n_stage1 / 4 = 128/4 = 32
+                # num_acc_n_s1 = 32/16 = 2
+                n_per_wave_s1 = tile_n_stage1 // num_waves  # 32
+                num_acc_n_s1 = n_per_wave_s1 // 16  # 2
+                c_n_per_wave_s1 = fx.Index(n_per_wave_s1)
+                wave_n_id = wave_id % fx.Index(num_waves)
+                n_tile_base_s1 = wave_n_id * c_n_per_wave_s1
+
+                # Precompute n_blk/n_intra for gate and up
+                n_intra_gate = []
+                n_blk_gate = []
+                n_intra_up = []
+                n_blk_up = []
+                col_g_list_s1 = []
+                inter_idx = fx.Index(inter_dim)
+                c_n0_s1 = experts * (2 * inter_dim) // 16
+                layout_n_blk_intra_s1 = fx.make_layout((c_n0_s1, 16), stride=(16, 1))
+
+                # by_n_s1 = 0 (Phase 1 always processes full inter_dim, no grid tiling)
+                by_n_s1 = fx.Index(0)
+                for ni in range_constexpr(num_acc_n_s1):
+                    offset = arith.index(ni * 16)
+                    col_g = by_n_s1 + n_tile_base_s1 + offset + lane_mod_16
+                    col_g_list_s1.append(col_g)
+
+                    row_gate = expert_off_w1 + col_g
+                    row_up = row_gate + inter_idx
+
+                    coord_gate = fx.idx2crd(row_gate, layout_n_blk_intra_s1)
+                    n_blk_gate.append(fx.get(coord_gate, 0))
+                    n_intra_gate.append(fx.get(coord_gate, 1))
+
+                    coord_up = fx.idx2crd(row_up, layout_n_blk_intra_s1)
+                    n_blk_up.append(fx.get(coord_up, 0))
+                    n_intra_up.append(fx.get(coord_up, 1))
+
+                m_repeat = tile_m // 16
+                k_unroll_s1 = tile_k_bytes_fp8 // 64  # 128/64 = 2
+
+                # --- Phase 1 B Load ---
+                def load_b_pack_w1(base_k, ki_step, ni, blk_list, intra_list):
+                    return load_b_pack_k32(
+                        buffer_ops, arith, vector,
+                        arg_b=arg_w1, b_rsrc=w1_rsrc, layout_b=layout_b_w1,
+                        base_k=base_k, ki_step=ki_step,
+                        n_blk=blk_list[ni], n_intra=intra_list[ni],
+                        lane_div_16=lane_div_16, elem_type=w1_elem,
+                        kpack_bytes=kpack_bytes_fp8, elem_bytes=elem_bytes_fp8,
+                        unpack_int4=False,
+                        **({"cache_modifier": b_cache_modifier_w1} if b_cache_modifier_w1 != 0 else {}),
+                    )
+
+                def load_b_tile_w1(base_k, blk_list, intra_list):
+                    b_tile = []
+                    for ku in range_constexpr(k_unroll_s1):
+                        packs0 = []
+                        packs1 = []
+                        for ni in range_constexpr(num_acc_n_s1):
+                            ki0 = (ku * 2) + 0
+                            ki1 = (ku * 2) + 1
+                            b0 = load_b_pack_w1(base_k, ki0, ni, blk_list, intra_list)
+                            b1 = load_b_pack_w1(base_k, ki1, ni, blk_list, intra_list)
+                            packs0.append(b0)
+                            packs1.append(b1)
+                        b_tile.append((packs0, packs1))
+                    return b_tile
+
+                # --- LDS helpers ---
+                def store_x_tile_to_lds(vec_x_in_parts, lds_base):
+                    for i in range_constexpr(num_x_loads):
+                        row_local = x_row_local[i]
+                        col_local_i32 = x_col_local_i32[i]
+                        if const_expr(x_load_bytes == 16):
+                            lds_store_16b_xor16(
+                                arith, vector,
+                                lds_memref=lds_x,
+                                vec16_ty=vec16_x,
+                                layout_lds=layout_lds_s1,
+                                row_local=row_local,
+                                col_local_i32=col_local_i32,
+                                tx_c4=fx.Index(4),
+                                k_blocks16=k_blocks16_s1,
+                                lds_base=lds_base,
+                                vec_part_i32x4=vec_x_in_parts[i],
+                                elem_bytes=elem_bytes_fp8,
+                            )
+                        elif const_expr(x_load_bytes == 8):
+                            lds_store_8b_xor16(
+                                arith, vector,
+                                lds_memref=lds_x,
+                                vec8_ty=vec8_x,
+                                layout_lds=layout_lds_s1,
+                                row_local=row_local,
+                                col_local_i32=col_local_i32,
+                                tx_c4=fx.Index(4),
+                                k_blocks16=k_blocks16_s1,
+                                lds_base=lds_base,
+                                vec_part_i32x2=vec_x_in_parts[i],
+                                elem_bytes=elem_bytes_fp8,
+                            )
+                        else:
+                            lds_store_4b_xor16(
+                                arith, vector,
+                                lds_memref=lds_x,
+                                vec4_ty=vec4_x,
+                                layout_lds=layout_lds_s1,
+                                row_local=row_local,
+                                col_local_i32=col_local_i32,
+                                tx_c4=fx.Index(4),
+                                k_blocks16=k_blocks16_s1,
+                                lds_base=lds_base,
+                                vec_part_i32x1=vec_x_in_parts[i],
+                                elem_bytes=elem_bytes_fp8,
+                            )
+
+                def lds_load_packs_k64_s1(curr_row_a_lds, col_base_bytes, lds_base):
+                    col_base_swz_bytes = swizzle_xor16(curr_row_a_lds, col_base_bytes, k_blocks16_s1)
+                    col_base_swz = col_base_swz_bytes  # fp8: elem=1B
+                    idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds_s1)
+                    idx_a16 = idx_a16 + lds_base
+                    loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
+                    a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                    a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                    a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                    return a0, a1
+
+                # --- Phase 1 MFMA ---
+                def mfma_k64_fp8(acc0, a0, a1, b0, b1):
+                    acc1 = rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [a0, b0, acc0, 0, 0, 0])
+                    return rocdl.mfma_f32_16x16x32_fp8_fp8(T.f32x4, [a1, b1, acc1, 0, 0, 0])
+
+                def compute_tile_s1(gate_list, up_list, b_gate_tile, b_up_tile, lds_base, *, a0_prefetch=None):
+                    for ku in range_constexpr(k_unroll_s1):
+                        b_gate_packs0, b_gate_packs1 = b_gate_tile[ku]
+                        b_up_packs0, b_up_packs1 = b_up_tile[ku]
+                        ki64 = arith.index(ku * 64)
+                        col_base = col_offset_base_bytes_s1 + ki64
+
+                        for mi in range_constexpr(m_repeat):
+                            mi_val = arith.index(mi * 16)
+                            curr_row_a_lds = row_a_lds + mi_val
+
+                            if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                a0, a1 = a0_prefetch
+                            else:
+                                a0, a1 = lds_load_packs_k64_s1(curr_row_a_lds, col_base, lds_base)
+
+                            for ni in range_constexpr(num_acc_n_s1):
+                                acc_idx = mi * num_acc_n_s1 + ni
+                                gate_list[acc_idx] = mfma_k64_fp8(
+                                    gate_list[acc_idx], a0, a1,
+                                    b_gate_packs0[ni], b_gate_packs1[ni],
+                                )
+                                up_list[acc_idx] = mfma_k64_fp8(
+                                    up_list[acc_idx], a0, a1,
+                                    b_up_packs0[ni], b_up_packs1[ni],
+                                )
+                    return gate_list, up_list
+
+                # ============ PHASE 1: K-loop over model_dim ============
+                acc_gate = [acc_init] * (m_repeat * num_acc_n_s1)
+                acc_up = [acc_init] * (m_repeat * num_acc_n_s1)
+
+                lds_tile_elems_s1 = arith.index(tile_m * lds_stride_stage1)
+                lds_base_cur = fx.Index(0)
+                lds_base_nxt = lds_tile_elems_s1
+
+                rocdl.sched_barrier(0)
+
+                # Prologue: prefetch tile0
+                k0 = fx.Index(0)
+                x_regs0 = load_x_tile(k0)
+                b_gate_cur = load_b_tile_w1(k0, n_blk_gate, n_intra_gate)
+                b_up_cur = load_b_tile_w1(k0, n_blk_up, n_intra_up)
+                store_x_tile_to_lds(x_regs0, lds_base_cur)
+                gpu.barrier()
+
+                lds_base_pong = lds_base_cur
+                lds_base_ping = lds_base_nxt
+
+                a0_prefetch_pong = lds_load_packs_k64_s1(row_a_lds, col_offset_base_bytes_s1, lds_base_pong)
+
+                # Ping-pong main loop
+                c_tile_k = arith.index(tile_k)
+                total_tiles_s1 = model_dim // tile_k
+                pair_iters_s1 = max((total_tiles_s1 - 2) // 2, 0)
+
+                _n_acc_s1 = m_repeat * num_acc_n_s1
+                _vals_per_b_tile_s1 = k_unroll_s1 * 2 * num_acc_n_s1
+
+                def _flatten_b_s1(b_tile):
+                    flat = []
+                    for ku_entry in b_tile:
+                        flat.extend(ku_entry[0])
+                        flat.extend(ku_entry[1])
+                    return flat
+
+                def _unflatten_b_s1(vals):
+                    b_tile, idx = [], 0
+                    for _ in range_constexpr(k_unroll_s1):
+                        packs_even = list(vals[idx:idx + num_acc_n_s1])
+                        idx += num_acc_n_s1
+                        packs_odd = list(vals[idx:idx + num_acc_n_s1])
+                        idx += num_acc_n_s1
+                        b_tile.append((packs_even, packs_odd))
+                    return b_tile
+
+                init_state = (
+                    list(acc_gate) + list(acc_up)
+                    + _flatten_b_s1(b_gate_cur) + _flatten_b_s1(b_up_cur)
+                    + list(a0_prefetch_pong)
+                )
+
+                _p_bg = 2 * _n_acc_s1
+                _p_bu = _p_bg + _vals_per_b_tile_s1
+                _p_a0 = _p_bu + _vals_per_b_tile_s1
+
+                for pair_iv, state in range(0, pair_iters_s1, 1, init=init_state):
+                    _ag = list(state[:_n_acc_s1])
+                    _au = list(state[_n_acc_s1:_p_bg])
+                    _bg = _unflatten_b_s1(list(state[_p_bg:_p_bu]))
+                    _bu = _unflatten_b_s1(list(state[_p_bu:_p_a0]))
+                    _a0pf = (state[_p_a0], state[_p_a0 + 1])
+
+                    k_iv = pair_iv * (c_tile_k + c_tile_k)
+
+                    # Stage 0: prefetch ping, compute pong
+                    next_k1 = k_iv + c_tile_k
+                    x_regs_ping = load_x_tile(next_k1)
+                    _bg_ping = load_b_tile_w1(next_k1, n_blk_gate, n_intra_gate)
+                    _bu_ping = load_b_tile_w1(next_k1, n_blk_up, n_intra_up)
+
+                    _ag, _au = compute_tile_s1(_ag, _au, _bg, _bu, lds_base_pong, a0_prefetch=_a0pf)
+                    store_x_tile_to_lds(x_regs_ping, lds_base_ping)
+                    rocdl.sched_barrier(0)
+                    gpu.barrier()
+
+                    _a0pf_ping = lds_load_packs_k64_s1(row_a_lds, col_offset_base_bytes_s1, lds_base_ping)
+
+                    # Stage 1: prefetch pong, compute ping
+                    next_k2 = k_iv + c_tile_k + c_tile_k
+                    x_regs_pong = load_x_tile(next_k2)
+                    _bg_next = load_b_tile_w1(next_k2, n_blk_gate, n_intra_gate)
+                    _bu_next = load_b_tile_w1(next_k2, n_blk_up, n_intra_up)
+
+                    _ag, _au = compute_tile_s1(_ag, _au, _bg_ping, _bu_ping, lds_base_ping, a0_prefetch=_a0pf_ping)
+                    store_x_tile_to_lds(x_regs_pong, lds_base_pong)
+                    rocdl.sched_barrier(0)
+                    gpu.barrier()
+
+                    _a0pf_new = lds_load_packs_k64_s1(row_a_lds, col_offset_base_bytes_s1, lds_base_pong)
+
+                    loop_results = yield (
+                        list(_ag) + list(_au)
+                        + _flatten_b_s1(_bg_next) + _flatten_b_s1(_bu_next)
+                        + list(_a0pf_new)
+                    )
+
+                # After loop: extract final state
+                SmemPtr._view_cache = None
+                if const_expr(pair_iters_s1 > 0):
+                    acc_gate = list(loop_results[:_n_acc_s1])
+                    acc_up = list(loop_results[_n_acc_s1:_p_bg])
+                    b_gate_cur = _unflatten_b_s1(list(loop_results[_p_bg:_p_bu]))
+                    b_up_cur = _unflatten_b_s1(list(loop_results[_p_bu:_p_a0]))
+                    a0_prefetch_pong = (loop_results[_p_a0], loop_results[_p_a0 + 1])
+
+                # Tail: penultimate tile
+                k_tail1 = arith.index(model_dim - tile_k)
+                x_regs_ping = load_x_tile(k_tail1)
+                b_gate_ping = load_b_tile_w1(k_tail1, n_blk_gate, n_intra_gate)
+                b_up_ping = load_b_tile_w1(k_tail1, n_blk_up, n_intra_up)
+
+                acc_gate, acc_up = compute_tile_s1(
+                    acc_gate, acc_up, b_gate_cur, b_up_cur, lds_base_pong,
+                    a0_prefetch=a0_prefetch_pong,
+                )
+                store_x_tile_to_lds(x_regs_ping, lds_base_ping)
+                rocdl.sched_barrier(0)
+                gpu.barrier()
+
+                a0_prefetch_ping = lds_load_packs_k64_s1(row_a_lds, col_offset_base_bytes_s1, lds_base_ping)
+
+                # Final tile
+                acc_gate, acc_up = compute_tile_s1(
+                    acc_gate, acc_up, b_gate_ping, b_up_ping, lds_base_ping,
+                    a0_prefetch=a0_prefetch_ping,
+                )
+
+                # ============ PHASE 1.5: SiLU + Store intermediate to LDS ============
+                # intermediate[row, col] = silu(gate * sx * sw_gate) * (up * sx * sw_up)
+                # Store as bf16 to LDS with XOR16 swizzle for Phase 2 reads.
+                #
+                # MFMA 16x16 output layout (CDNA3):
+                #   Row = lane_div_16*4 + ii (ii is element index within f32x4)
+                #   Col = lane_mod_16 (within the ni-th 16-column block)
+                # So acc[mi*num_acc_n+ni][ii] corresponds to:
+                #   row_in_tile = mi*16 + lane_div_16*4 + ii
+                #   col = n_tile_base_s1 + ni*16 + lane_mod_16
+
+                def silu(x):
+                    t = x * (-1.4426950408889634)
+                    emu = rocdl.exp2(T.f32, t)
+                    den = 1.0 + emu
+                    sig = rocdl.rcp(T.f32, den)
+                    return x * sig
+
+                mask24_i32 = fx.Int32(0xFFFFFF)
+                tokens_i32_v = tokens_i32
+
+                # k_blocks16 for intermediate LDS. The stage1 result is staged
+                # as BF16 first; the FP8-W2 B2B path requantizes it into a
+                # separate FP8 LDS tile for stage2.
+                k_blocks16_s2_bf16 = arith.index(tile_k_bytes_bf16 // 16)
+                k_blocks16_s2_fp8 = arith.index(tile_k_bytes_fp8 // 16)
+                lds_stride_s2_idx = arith.index(lds_stride_stage2)
+
+                # Iterate using default_epilog pattern: for mi, for ii → row
+                lane_div_16_mul4 = lane_div_16 * fx.Index(4)
+                ii_idx_list = [fx.Index(ii) for ii in range(4)]
+
+                for mi in range_constexpr(m_repeat):
+                    mi_base = arith.index(mi * 16)
+                    for ii in range_constexpr(4):
+                        row_off = lane_div_16_mul4 + ii_idx_list[ii]
+                        row_in_tile = mi_base + row_off
+                        sorted_row = bx_m + row_in_tile
+
+                        # Decode sorted token info for scale_x
+                        fused2 = buffer_ops.buffer_load(sorted_rsrc, sorted_row, vec_width=1, dtype=T.i32)
+                        t2 = fused2 & mask24_i32
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        sx = arith.select(
+                            t_valid,
+                            buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                            fx.Float32(0.0),
+                        )
+
+                        for ni in range_constexpr(num_acc_n_s1):
+                            acc_idx = mi * num_acc_n_s1 + ni
+                            # W1 scale column: col_g = n_tile_base_s1 + ni*16 + lane_mod_16
+                            col_g = col_g_list_s1[ni]
+                            row_gate_scale = expert_off_w1 + col_g
+                            row_up_scale = row_gate_scale + inter_idx
+                            sw_gate = buffer_ops.buffer_load(sw1_rsrc, row_gate_scale, vec_width=1, dtype=T.f32)
+                            sw_up = buffer_ops.buffer_load(sw1_rsrc, row_up_scale, vec_width=1, dtype=T.f32)
+
+                            vg = vector.extract(acc_gate[acc_idx], static_position=[ii], dynamic_position=[])
+                            vu = vector.extract(acc_up[acc_idx], static_position=[ii], dynamic_position=[])
+
+                            vg = vg * sx * sw_gate
+                            vu = vu * sx * sw_up
+                            y = silu(vg) * vu
+                            y_bf16 = arith.trunc_f(T.bf16, y)
+
+                            # LDS address: intermediate[row_in_tile, col]
+                            # col = n_tile_base_s1 + ni*16 + lane_mod_16
+                            col_elem = n_tile_base_s1 + arith.index(ni * 16) + lane_mod_16
+                            col_bytes = col_elem * fx.Index(2)  # bf16 = 2 bytes
+                            # Apply XOR16 swizzle
+                            col_swz_bytes = swizzle_xor16(row_in_tile, col_bytes, k_blocks16_s2_bf16)
+                            col_swz = col_swz_bytes // fx.Index(2)  # back to element index
+                            lds_idx = crd2idx((row_in_tile, col_swz), layout_lds_s2)
+
+                            v1 = vector.from_elements(T.vec(1, T.bf16), [y_bf16])
+                            vector.store(v1, lds_intermediate, [lds_idx], alignment=2)
+
+                # Barrier before Phase 2 reads from LDS
+                gpu.barrier()
+
+                if const_expr(stage2_use_fp8_w2):
+                    tx_i32_v = arith.index_cast(T.i32, tx)
+                    lane_i32 = tx_i32_v % arith.constant(64, type=T.i32)
+                    width_i32 = arith.constant(64, type=T.i32)
+                    abs_mask_i32 = fx.Int32(0x7FFFFFFF)
+
+                    def wave_reduce_max_f32(val):
+                        w = val
+                        for shift in [32, 16, 8, 4, 2, 1]:
+                            peer = w.shuffle_xor(arith.constant(shift, type=T.i32), width_i32)
+                            w = w.maximumf(peer)
+                        return w
+
+                    abs_mask_vec4 = fx.Vector.filled(4, 0x7FFFFFFF, fx.Int32)
+                    for row_group in range_constexpr(tile_m // num_waves):
+                        row_q_idx = fx.Index(row_group * num_waves) + wave_id
+                        col_q = lane_id * fx.Index(4)
+                        col_bf16_bytes = col_q * fx.Index(2)
+                        col_bf16_swz_bytes = swizzle_xor16(
+                            row_q_idx, col_bf16_bytes, k_blocks16_s2_bf16
+                        )
+                        col_bf16_swz = col_bf16_swz_bytes // fx.Index(2)
+                        idx_bf16 = crd2idx((row_q_idx, col_bf16_swz), layout_lds_s2)
+                        loaded_bf16 = vector.load_op(
+                            T.vec(4, T.bf16), lds_intermediate, [idx_bf16]
+                        )
+                        vals_f32 = fx.Vector(loaded_bf16).to(fx.Float32)
+                        vals_abs = (vals_f32.bitcast(fx.Int32) & abs_mask_vec4).bitcast(fx.Float32)
+                        lane_max = vals_abs.reduce(ReductionOp.MAX).ir_value()
+                        row_max = wave_reduce_max_f32(lane_max)
+                        scale = row_max / arith.constant(240.0, type=T.f32)
+                        safe_nonzero_scale = scale.maximumf(
+                            arith.constant(_FP32_MIN_NORMAL, type=T.f32)
+                        )
+                        final_scale = arith.select(
+                            scale == arith.constant(0.0, type=T.f32),
+                            arith.constant(1.0, type=T.f32),
+                            safe_nonzero_scale,
+                        )
+                        if lane_i32 == fx.Int32(0):
+                            scale_out = final_scale
+                            if const_expr(fold_route_weight_into_a2_scale):
+                                sorted_row_q = bx_m + row_q_idx
+                                fused_q = buffer_ops.buffer_load(
+                                    sorted_rsrc, sorted_row_q, vec_width=1, dtype=T.i32
+                                )
+                                t_q = fused_q & mask24_i32
+                                s_q = fused_q >> 24
+                                sorted_row_q_i32 = arith.index_cast(T.i32, sorted_row_q)
+                                row_q_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, sorted_row_q_i32, num_valid_i32
+                                )
+                                t_q_ok = arith.cmpi(arith.CmpIPredicate.ult, t_q, tokens_i32_v)
+                                s_q_ok = arith.cmpi(arith.CmpIPredicate.ult, s_q, topk_i32)
+                                q_ok = row_q_ok & t_q_ok & s_q_ok
+                                tw_q = arith.select(
+                                    q_ok,
+                                    buffer_ops.buffer_load(
+                                        sorted_w_rsrc, sorted_row_q, vec_width=1, dtype=T.f32
+                                    ),
+                                    fx.Float32(0.0),
+                                )
+                                scale_out = scale_out * tw_q
+                            SmemPtr.store(lds_a2_scale, scale_out, [row_q_idx])
+                        inv_scale = arith.constant(1.0, type=T.f32) / final_scale
+                        q_vals = vals_f32 * inv_scale
+                        lo = rocdl.cvt_pk_fp8_f32(
+                            T.i32, q_vals[0], q_vals[1], fx.Int32(0), False
+                        )
+                        packed = rocdl.cvt_pk_fp8_f32(
+                            T.i32, q_vals[2], q_vals[3], lo, True
+                        )
+                        for qj in range_constexpr(4):
+                            q_shift = arith.constant(qj * 8, type=T.i32)
+                            q_byte = arith.trunci(T.i8, packed >> q_shift)
+                            col_fp8 = col_q + fx.Index(qj)
+                            col_fp8_swz = swizzle_xor16(row_q_idx, col_fp8, k_blocks16_s2_fp8)
+                            idx_fp8 = crd2idx((row_q_idx, col_fp8_swz), layout_lds_s2_fp8)
+                            SmemPtr.store(lds_a2_q_i8, q_byte, [idx_fp8])
+                    gpu.barrier()
+
+                def _emit_output_tile(by_tile):
+                    # ============ PHASE 2: intermediate × W2 (single K-pass) ============
+                    # Output N is either the grid-x tile or a CTA-local B2B loop tile.
+                    by_n_s2 = by_tile * fx.Index(tile_n_out)
+                    n_per_wave_s2 = tile_n_out // num_waves  # 128/4 = 32
+                    num_acc_n_s2 = n_per_wave_s2 // 16  # 2
+                    c_n_per_wave_s2 = fx.Index(n_per_wave_s2)
+                    n_tile_base_s2 = wave_n_id * c_n_per_wave_s2
+
+                    # Precompute W2 B-tile coordinates
+                    n_intra_list_w2 = []
+                    n_blk_list_w2 = []
+                    col_g_list_s2 = []
+                    c_n0_s2 = experts * model_dim // 16
+                    layout_n_blk_intra_s2 = fx.make_layout((c_n0_s2, 16), stride=(16, 1))
+
+                    for ni in range_constexpr(num_acc_n_s2):
+                        offset = arith.index(ni * 16)
+                        col_g = by_n_s2 + n_tile_base_s2 + offset + lane_mod_16
+                        col_g_list_s2.append(col_g)
+
+                        row_w = expert_off_w2 + col_g
+                        coord_w = fx.idx2crd(row_w, layout_n_blk_intra_s2)
+                        n_blk_list_w2.append(fx.get(coord_w, 0))
+                        n_intra_list_w2.append(fx.get(coord_w, 1))
+
+                    k_unroll_s2 = tile_k_bytes_w2 // 64
+
+                    # Load W2 tile (single K-pass, all k_unroll steps at once)
+                    def load_b_pack_w2(base_k, ki_step, ni):
+                        return load_b_pack_k32(
+                            buffer_ops, arith, vector,
+                            arg_b=arg_w2, b_rsrc=w2_rsrc, layout_b=layout_b_w2,
+                            base_k=base_k, ki_step=ki_step,
+                            n_blk=n_blk_list_w2[ni], n_intra=n_intra_list_w2[ni],
+                            lane_div_16=lane_div_16, elem_type=w2_elem,
+                            kpack_bytes=kpack_bytes_w2, elem_bytes=elem_bytes_w2,
+                            unpack_int4=False,
+                            **({"cache_modifier": b_cache_modifier_w2} if b_cache_modifier_w2 != 0 else {}),
+                        )
+
+                    # Load entire W2 B-tile
+                    b_w2_tile = []
+                    base_k_s2 = fx.Index(0)
+                    for ku in range_constexpr(k_unroll_s2):
+                        packs0 = []
+                        packs1 = []
+                        for ni in range_constexpr(num_acc_n_s2):
+                            ki0 = (ku * 2) + 0
+                            ki1 = (ku * 2) + 1
+                            b0 = load_b_pack_w2(base_k_s2, ki0, ni)
+                            b1 = load_b_pack_w2(base_k_s2, ki1, ni)
+                            packs0.append(b0)
+                            packs1.append(b1)
+                        b_w2_tile.append((packs0, packs1))
+
+                    if const_expr(stage2_use_fp8_w2):
+                        a_kpack_elems_fp8_s2 = 16
+                        col_offset_base_fp8_s2 = lane_div_16 * arith.index(a_kpack_elems_fp8_s2)
+                        vec16_a2_fp8 = T.vec(16, T.f8)
+
+                        def lds_load_packs_k64_s2(curr_row_a_lds, col_base_bytes, lds_base_s2):
+                            col_base_swz = swizzle_xor16(
+                                curr_row_a_lds, col_base_bytes, k_blocks16_s2_fp8
+                            )
+                            idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds_s2_fp8)
+                            idx_a16 = idx_a16 + lds_base_s2
+                            loaded_a16 = vector.load_op(vec16_a2_fp8, lds_a2_q, [idx_a16])
+                            a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                            a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                            a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                            return a0, a1
+
+                        def mfma_k64_s2(acc0, a0, a1, b0, b1):
+                            return mfma_k64_fp8(acc0, a0, a1, b0, b1)
+
+                        col_offset_base_bytes_s2 = col_offset_base_fp8_s2
+                    else:
+                        # Phase 2 A-load from LDS (bf16 intermediate)
+                        # a_kpack_elems for bf16 = 16/2 = 8
+                        a_kpack_elems_bf16 = 8
+                        col_offset_base_bf16 = lane_div_16 * arith.index(a_kpack_elems_bf16)
+                        col_offset_base_bytes_s2 = col_offset_base_bf16 * fx.Index(2)
+
+                        vec16_bf16 = T.vec(8, T.bf16)  # 16B = 8 bf16
+
+                        def lds_load_packs_k64_s2(curr_row_a_lds, col_base_bytes, lds_base_s2):
+                            col_base_swz_bytes = swizzle_xor16(
+                                curr_row_a_lds, col_base_bytes, k_blocks16_s2_bf16
+                            )
+                            col_base_swz = col_base_swz_bytes // fx.Index(2)
+                            idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds_s2)
+                            idx_a16 = idx_a16 + lds_base_s2
+                            loaded_a16 = vector.load_op(vec16_bf16, lds_intermediate, [idx_a16])
+                            a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                            a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                            a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                            return a0, a1
+
+                        # BF16 MFMA
+                        mfma_f32_bf16_k16 = getattr(rocdl, "mfma_f32_16x16x16bf16_1k", None) or getattr(
+                            rocdl, "mfma_f32_16x16x16_bf16_1k", None
+                        )
+
+                        def _i64_to_v4i16(x_i64):
+                            v1 = vector.from_elements(T.vec(1, T.i64), [x_i64])
+                            return vector.bitcast(T.i16x4, v1)
+
+                        def mfma_k64_s2(acc0, a0, a1, b0, b1):
+                            a0v = _i64_to_v4i16(a0)
+                            a1v = _i64_to_v4i16(a1)
+                            b0v = _i64_to_v4i16(b0)
+                            b1v = _i64_to_v4i16(b1)
+                            acc1 = mfma_f32_bf16_k16(T.f32x4, [a0v, b0v, acc0, 0, 0, 0])
+                            return mfma_f32_bf16_k16(T.f32x4, [a1v, b1v, acc1, 0, 0, 0])
+
+                    # Phase 2 MFMA compute
+                    acc_out = [acc_init] * (m_repeat * num_acc_n_s2)
+                    lds_base_s2_val = fx.Index(0)  # intermediate starts at offset 0
+
+                    for ku in range_constexpr(k_unroll_s2):
+                        b_packs0, b_packs1 = b_w2_tile[ku]
+                        ki64 = arith.index(ku * 64)
+                        col_base = col_offset_base_bytes_s2 + ki64
+
+                        for mi in range_constexpr(m_repeat):
+                            mi_val = arith.index(mi * 16)
+                            curr_row_a_lds = row_a_lds + mi_val
+                            a0, a1 = lds_load_packs_k64_s2(curr_row_a_lds, col_base, lds_base_s2_val)
+
+                            for ni in range_constexpr(num_acc_n_s2):
+                                acc_idx = mi * num_acc_n_s2 + ni
+                                acc_out[acc_idx] = mfma_k64_s2(
+                                    acc_out[acc_idx], a0, a1,
+                                    b_packs0[ni], b_packs1[ni],
+                                )
+
+                    # ============ PHASE 3: Epilog (CShuffle + atomic bf16 output) ============
+                    gpu.barrier()  # Ensure Phase 2 LDS reads complete before using CShuffle LDS.
+
+                    model_i32 = fx.Int32(model_dim)
+                    topk_i32_v = topk_i32
+                    zero_i32 = fx.Int32(0)
+                    c2_i32 = fx.Int32(2)
+                    mask_even_i32 = fx.Int32(0xFFFFFFFE)
+                    cshuffle_k_blocks16 = arith.index((tile_n_out * elem_bytes_bf16) // 16)
+
+                    out_base_idx = fx.Index(0)
+                    if const_expr(_needs_global_atomic_bf16):
+                        out_base_idx = buffer_ops.extract_base_index(arg_out)
+
+                    def cshuffle_lds_idx(row_local, row_base_lds, col_local):
+                        if const_expr(cshuffle_lds_xor):
+                            col_bytes = col_local * fx.Index(elem_bytes_bf16)
+                            col_swz_bytes = swizzle_xor16(
+                                row_local, col_bytes, cshuffle_k_blocks16
+                            )
+                            return row_base_lds + (col_swz_bytes // fx.Index(elem_bytes_bf16))
+                        return row_base_lds + col_local
+
+                    sw_vals_s2 = [fx.Float32(1.0)] * num_acc_n_s2
+                    if const_expr(stage2_use_fp8_w2):
+                        sw_vals_s2 = []
+                        for ni in range_constexpr(num_acc_n_s2):
+                            row_w_idx = expert_off_w2 + col_g_list_s2[ni]
+                            sw_vals_s2.append(
+                                buffer_ops.buffer_load(sw2_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                            )
+
+                    def write_row_to_lds_out(
+                        *, mi: int, ii: int, row_in_tile, row,
+                        row_base_lds, col_base_local, num_acc_n: int, lds_out,
+                    ):
+                        tw = fx.Float32(1.0)
+                        if const_expr(not (stage2_use_fp8_w2 and fold_route_weight_into_a2_scale)):
+                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            t2 = fused2 & mask24_i32
+                            s2 = fused2 >> 24
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
+                            ts_ok = t_ok & s_ok
+
+                            # Sorted weight (topk routing weight)
+                            tw = arith.select(
+                                ts_ok,
+                                buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32),
+                                fx.Float32(0.0),
+                            )
+
+                        for ni in range_constexpr(num_acc_n):
+                            col_local = col_base_local + (ni * 16)
+                            acc_idx = mi * num_acc_n_s2 + ni
+                            v = vector.extract(acc_out[acc_idx], static_position=[ii], dynamic_position=[])
+                            if const_expr(stage2_use_fp8_w2):
+                                sx2 = SmemPtr.load(lds_a2_scale, [row_in_tile])
+                                v = v * sx2 * sw_vals_s2[ni]
+                            # BF16 W2 path has scales already baked into W2_bf16.
+                            v = v * tw
+                            v_out = arith.trunc_f(out_elem, v)
+                            lds_idx = cshuffle_lds_idx(row_in_tile, row_base_lds, col_local)
+                            v1 = vector.from_elements(T.vec(1, out_elem), [v_out])
+                            vector.store(v1, lds_out, [lds_idx], alignment=2)
+
+                    def precompute_row_out(*, row_local, row):
+                        fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        row_i32 = arith.index_cast(T.i32, row)
+                        row_valid0 = arith.cmpi(arith.CmpIPredicate.ult, row_i32, num_valid_i32)
+                        t = fused2 & mask24_i32
+                        s = fused2 >> 24
+                        t_ok = arith.cmpi(arith.CmpIPredicate.ult, t, tokens_i32_v)
+                        s_ok = arith.cmpi(arith.CmpIPredicate.ult, s, topk_i32_v)
+                        row_valid = row_valid0 & t_ok & s_ok
+                        return (fused2, row_valid)
+
+                    def store_pair_out(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                        fused = row_ctx
+                        t = fused & mask24_i32
+                        idx0 = t * model_i32
+                        col_i32 = arith.index_cast(T.i32, col_g0)
+                        idx_elem = idx0 + col_i32
+                        idx_elem_even = idx_elem & mask_even_i32
+                        if const_expr(_needs_global_atomic_bf16):
+                            byte_off = idx_elem_even * c2_i32
+                            byte_off_idx = arith.index_cast(T.index, byte_off)
+                            ptr_addr_idx = out_base_idx + byte_off_idx
+                            out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
+                            out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                            frag_v = frag._value if hasattr(frag, "_value") else frag
+                            llvm.AtomicRMWOp(
+                                llvm.AtomicBinOp.fadd,
+                                out_ptr_v, frag_v,
+                                llvm.AtomicOrdering.monotonic,
+                                syncscope="agent", alignment=4,
+                            )
+                        else:
+                            byte_off = idx_elem_even * c2_i32
+                            rocdl.raw_ptr_buffer_atomic_fadd(
+                                frag, out_rsrc, byte_off, zero_i32, zero_i32,
+                            )
+
+                    c_shuffle_epilog(
+                        arith=arith,
+                        vector=vector,
+                        gpu=gpu,
+                        scf=scf,
+                        range_constexpr=range_constexpr,
+                        tile_m=tile_m,
+                        tile_n=tile_n_out,
+                        e_vec=_e_vec,
+                        cshuffle_nlane=_cshuffle_nlane,
+                        block_size=total_threads,
+                        m_repeat=m_repeat,
+                        num_acc_n=num_acc_n_s2,
+                        tx=tx,
+                        lane_div_16=lane_div_16,
+                        lane_mod_16=lane_mod_16,
+                        bx_m=bx_m,
+                        by_n=by_n_s2,
+                        n_tile_base=n_tile_base_s2,
+                        lds_out=lds_out,
+                        frag_elem_type=out_elem,
+                        write_row_to_lds=write_row_to_lds_out,
+                        precompute_row=precompute_row_out,
+                        store_pair=store_pair_out,
+                        lds_index_mapper=cshuffle_lds_idx if cshuffle_lds_xor else None,
+                    )
+                    if const_expr(loop_n_in_block):
+                        gpu.barrier()
+
+                def _emit_output_tile_pair(by_tile0):
+                    # Pair two adjacent B2B output tiles while reusing the same A2 LDS loads.
+                    by_tile1 = by_tile0 + fx.Index(1)
+                    by_n0_s2 = by_tile0 * fx.Index(tile_n_out)
+                    by_n1_s2 = by_tile1 * fx.Index(tile_n_out)
+                    n_per_wave_s2 = tile_n_out // num_waves
+                    num_acc_n_s2 = n_per_wave_s2 // 16
+                    c_n_per_wave_s2 = fx.Index(n_per_wave_s2)
+                    n_tile_base_s2 = wave_n_id * c_n_per_wave_s2
+                    c_n0_s2 = experts * model_dim // 16
+                    layout_n_blk_intra_s2 = fx.make_layout((c_n0_s2, 16), stride=(16, 1))
+
+                    def precompute_w2_tile(by_n_s2):
+                        n_intra_list_w2 = []
+                        n_blk_list_w2 = []
+                        col_g_list_s2 = []
+                        for ni in range_constexpr(num_acc_n_s2):
+                            offset = arith.index(ni * 16)
+                            col_g = by_n_s2 + n_tile_base_s2 + offset + lane_mod_16
+                            col_g_list_s2.append(col_g)
+                            row_w = expert_off_w2 + col_g
+                            coord_w = fx.idx2crd(row_w, layout_n_blk_intra_s2)
+                            n_blk_list_w2.append(fx.get(coord_w, 0))
+                            n_intra_list_w2.append(fx.get(coord_w, 1))
+                        return n_blk_list_w2, n_intra_list_w2, col_g_list_s2
+
+                    n_blk0_w2, n_intra0_w2, col_g0_s2 = precompute_w2_tile(by_n0_s2)
+                    n_blk1_w2, n_intra1_w2, col_g1_s2 = precompute_w2_tile(by_n1_s2)
+                    k_unroll_s2 = tile_k_bytes_w2 // 64
+                    base_k_s2 = fx.Index(0)
+
+                    def load_b_pack_w2_pair(base_k, ki_step, ni, n_blk_list, n_intra_list):
+                        return load_b_pack_k32(
+                            buffer_ops, arith, vector,
+                            arg_b=arg_w2, b_rsrc=w2_rsrc, layout_b=layout_b_w2,
+                            base_k=base_k, ki_step=ki_step,
+                            n_blk=n_blk_list[ni], n_intra=n_intra_list[ni],
+                            lane_div_16=lane_div_16, elem_type=w2_elem,
+                            kpack_bytes=kpack_bytes_w2, elem_bytes=elem_bytes_w2,
+                            unpack_int4=False,
+                            **({"cache_modifier": b_cache_modifier_w2} if b_cache_modifier_w2 != 0 else {}),
+                        )
+
+                    def load_b_packs_for_tile(ku, n_blk_list, n_intra_list):
+                        packs0 = []
+                        packs1 = []
+                        for ni in range_constexpr(num_acc_n_s2):
+                            ki0 = (ku * 2) + 0
+                            ki1 = (ku * 2) + 1
+                            packs0.append(
+                                load_b_pack_w2_pair(base_k_s2, ki0, ni, n_blk_list, n_intra_list)
+                            )
+                            packs1.append(
+                                load_b_pack_w2_pair(base_k_s2, ki1, ni, n_blk_list, n_intra_list)
+                            )
+                        return packs0, packs1
+
+                    a_kpack_elems_fp8_s2 = 16
+                    col_offset_base_fp8_s2 = lane_div_16 * arith.index(a_kpack_elems_fp8_s2)
+                    vec16_a2_fp8 = T.vec(16, T.f8)
+
+                    def lds_load_packs_k64_s2_pair(curr_row_a_lds, col_base_bytes, lds_base_s2):
+                        col_base_swz = swizzle_xor16(
+                            curr_row_a_lds, col_base_bytes, k_blocks16_s2_fp8
+                        )
+                        idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds_s2_fp8)
+                        idx_a16 = idx_a16 + lds_base_s2
+                        loaded_a16 = vector.load_op(vec16_a2_fp8, lds_a2_q, [idx_a16])
+                        a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                        a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                        a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                        return a0, a1
+
+                    def mfma_k64_s2_pair(acc0, a0, a1, b0, b1):
+                        return mfma_k64_fp8(acc0, a0, a1, b0, b1)
+
+                    acc_out0 = [acc_init] * (m_repeat * num_acc_n_s2)
+                    acc_out1 = [acc_init] * (m_repeat * num_acc_n_s2)
+                    lds_base_s2_val = fx.Index(0)
+
+                    for ku in range_constexpr(k_unroll_s2):
+                        b0_packs0, b0_packs1 = load_b_packs_for_tile(ku, n_blk0_w2, n_intra0_w2)
+                        b1_packs0, b1_packs1 = load_b_packs_for_tile(ku, n_blk1_w2, n_intra1_w2)
+                        ki64 = arith.index(ku * 64)
+                        col_base = col_offset_base_fp8_s2 + ki64
+
+                        for mi in range_constexpr(m_repeat):
+                            mi_val = arith.index(mi * 16)
+                            curr_row_a_lds = row_a_lds + mi_val
+                            a0, a1 = lds_load_packs_k64_s2_pair(
+                                curr_row_a_lds, col_base, lds_base_s2_val
+                            )
+
+                            for ni in range_constexpr(num_acc_n_s2):
+                                acc_idx = mi * num_acc_n_s2 + ni
+                                acc_out0[acc_idx] = mfma_k64_s2_pair(
+                                    acc_out0[acc_idx], a0, a1,
+                                    b0_packs0[ni], b0_packs1[ni],
+                                )
+                                acc_out1[acc_idx] = mfma_k64_s2_pair(
+                                    acc_out1[acc_idx], a0, a1,
+                                    b1_packs0[ni], b1_packs1[ni],
+                                )
+
+                    model_i32 = fx.Int32(model_dim)
+                    topk_i32_v = topk_i32
+                    zero_i32 = fx.Int32(0)
+                    c2_i32 = fx.Int32(2)
+                    mask_even_i32 = fx.Int32(0xFFFFFFFE)
+
+                    out_base_idx = fx.Index(0)
+                    if const_expr(_needs_global_atomic_bf16):
+                        out_base_idx = buffer_ops.extract_base_index(arg_out)
+
+                    def _emit_pair_epilog(acc_for_tile, by_n_s2, col_g_list_s2):
+                        sw_vals_s2 = []
+                        for ni in range_constexpr(num_acc_n_s2):
+                            row_w_idx = expert_off_w2 + col_g_list_s2[ni]
+                            sw_vals_s2.append(
+                                buffer_ops.buffer_load(sw2_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                            )
+
+                        def write_row_to_lds_out_pair(
+                            *, mi: int, ii: int, row_in_tile, row,
+                            row_base_lds, col_base_local, num_acc_n: int, lds_out,
+                        ):
+                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            t2 = fused2 & mask24_i32
+                            s2 = fused2 >> 24
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
+                            ts_ok = t_ok & s_ok
+                            tw = arith.select(
+                                ts_ok,
+                                buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32),
+                                fx.Float32(0.0),
+                            )
+
+                            for ni in range_constexpr(num_acc_n):
+                                col_local = col_base_local + (ni * 16)
+                                acc_idx = mi * num_acc_n_s2 + ni
+                                v = vector.extract(
+                                    acc_for_tile[acc_idx],
+                                    static_position=[ii],
+                                    dynamic_position=[],
+                                )
+                                sx2 = SmemPtr.load(lds_a2_scale, [row_in_tile])
+                                v = v * sx2 * sw_vals_s2[ni]
+                                v = v * tw
+                                v_out = arith.trunc_f(out_elem, v)
+                                lds_idx = row_base_lds + col_local
+                                v1 = vector.from_elements(T.vec(1, out_elem), [v_out])
+                                vector.store(v1, lds_out, [lds_idx], alignment=2)
+
+                        def precompute_row_out_pair(*, row_local, row):
+                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            row_i32 = arith.index_cast(T.i32, row)
+                            row_valid0 = arith.cmpi(arith.CmpIPredicate.ult, row_i32, num_valid_i32)
+                            t = fused2 & mask24_i32
+                            s = fused2 >> 24
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t, tokens_i32_v)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s, topk_i32_v)
+                            row_valid = row_valid0 & t_ok & s_ok
+                            return (fused2, row_valid)
+
+                        def store_pair_out_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                            fused = row_ctx
+                            t = fused & mask24_i32
+                            idx0 = t * model_i32
+                            col_i32 = arith.index_cast(T.i32, col_g0)
+                            idx_elem = idx0 + col_i32
+                            idx_elem_even = idx_elem & mask_even_i32
+                            if const_expr(_needs_global_atomic_bf16):
+                                byte_off = idx_elem_even * c2_i32
+                                byte_off_idx = arith.index_cast(T.index, byte_off)
+                                ptr_addr_idx = out_base_idx + byte_off_idx
+                                out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
+                                out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                                frag_v = frag._value if hasattr(frag, "_value") else frag
+                                llvm.AtomicRMWOp(
+                                    llvm.AtomicBinOp.fadd,
+                                    out_ptr_v, frag_v,
+                                    llvm.AtomicOrdering.monotonic,
+                                    syncscope="agent", alignment=4,
+                                )
+                            else:
+                                byte_off = idx_elem_even * c2_i32
+                                rocdl.raw_ptr_buffer_atomic_fadd(
+                                    frag, out_rsrc, byte_off, zero_i32, zero_i32,
+                                )
+
+                        c_shuffle_epilog(
+                            arith=arith,
+                            vector=vector,
+                            gpu=gpu,
+                            scf=scf,
+                            range_constexpr=range_constexpr,
+                            tile_m=tile_m,
+                            tile_n=tile_n_out,
+                            e_vec=_e_vec,
+                            cshuffle_nlane=_cshuffle_nlane,
+                            block_size=total_threads,
+                            m_repeat=m_repeat,
+                            num_acc_n=num_acc_n_s2,
+                            tx=tx,
+                            lane_div_16=lane_div_16,
+                            lane_mod_16=lane_mod_16,
+                            bx_m=bx_m,
+                            by_n=by_n_s2,
+                            n_tile_base=n_tile_base_s2,
+                            lds_out=lds_out,
+                            frag_elem_type=out_elem,
+                            write_row_to_lds=write_row_to_lds_out_pair,
+                            precompute_row=precompute_row_out_pair,
+                            store_pair=store_pair_out_pair,
+                        )
+                        gpu.barrier()
+
+                    _emit_pair_epilog(acc_out0, by_n0_s2, col_g0_s2)
+                    _emit_pair_epilog(acc_out1, by_n1_s2, col_g1_s2)
+
+                if const_expr(loop_n_in_block):
+                    if const_expr(n_tiles_per_block != 0):
+                        by_group_start = by * fx.Index(n_tiles_per_block)
+                        for by_local in range_constexpr(n_tiles_per_block):
+                            _emit_output_tile(by_group_start + fx.Index(by_local))
+                    elif const_expr(out_tile_pair == 2):
+                        for by_pair in range_constexpr(total_n_tiles // 2):
+                            _emit_output_tile_pair(fx.Index(by_pair * 2))
+                    else:
+                        for by_iter in range_constexpr(total_n_tiles):
+                            _emit_output_tile(fx.Index(by_iter))
+                else:
+                    _emit_output_tile(by)
+
+    # ── Host launcher ────────────────────────────────────────────────────────
+    @flyc.jit
+    def launch_moe_gemm_fused(
+        arg_out: fx.Tensor,
+        arg_x: fx.Tensor,
+        arg_w1: fx.Tensor,
+        arg_w2: fx.Tensor,
+        arg_scale_x: fx.Tensor,
+        arg_scale_w1: fx.Tensor,
+        arg_scale_w2: fx.Tensor,
+        arg_sorted_token_ids: fx.Tensor,
+        arg_expert_ids: fx.Tensor,
+        arg_sorted_weights: fx.Tensor,
+        arg_num_valid_ids: fx.Tensor,
+        i32_tokens_in: fx.Int32,
+        i32_model_dim_in: fx.Int32,
+        i32_inter_dim_in: fx.Int32,
+        i32_size_expert_ids_in: fx.Int32,
+        stream: fx.Stream,
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        model_dim_in = arith.index_cast(T.index, i32_model_dim_in)
+        size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+        gx = model_dim_in // fx.Index(tile_n_out)
+        if const_expr(loop_n_in_block):
+            if const_expr(n_tiles_per_block != 0):
+                gx = gx // fx.Index(n_tiles_per_block)
+            else:
+                gx = fx.Index(1)
+        gy = size_expert_ids_in
+
+        moe_gemm_fused(
+            arg_out, arg_x, arg_w1, arg_w2,
+            arg_scale_x, arg_scale_w1, arg_scale_w2,
+            arg_sorted_token_ids, arg_expert_ids, arg_sorted_weights,
+            arg_num_valid_ids,
+            i32_tokens_in, i32_model_dim_in, i32_inter_dim_in,
+            i32_size_expert_ids_in,
+        ).launch(
+            grid=(gx, gy, 1),
+            block=(total_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_moe_gemm_fused

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_2stage.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_2stage.py
@@ -1,0 +1,4294 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""MoE GEMM stage1/stage2 kernel implementations (FlyDSL MFMA FP8).
+
+This module intentionally contains the **kernel builder code** for:
+- `moe_gemm1` (stage1)
+- `moe_gemm2` (stage2)
+
+It is extracted from `tests/kernels/test_moe_gemm.py` so that:
+- `kernels/` holds the implementation
+- `tests/` holds correctness/perf harnesses
+"""
+
+import functools
+import logging
+from contextlib import contextmanager
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import (
+    arith,
+    buffer_ops,
+    const_expr,
+    gpu,
+    range_constexpr,
+    rocdl,
+    vector,
+)
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+
+try:
+    from flydsl.runtime.device import (
+        bf16_global_atomics_arch_description,
+        supports_bf16_global_atomics,
+    )
+except ImportError:
+    # Backward compatibility for runtime.device versions that only expose get_rocm_arch.
+    def supports_bf16_global_atomics(arch: str) -> bool:
+        return str(arch).startswith(("gfx94", "gfx95", "gfx12"))
+
+    def bf16_global_atomics_arch_description() -> str:
+        return "gfx94+/gfx95+/gfx12+"
+
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, memref, scf
+
+
+def _inline_barrier_impl(vmcnt=63, lgkmcnt=63):
+    """Emit a targeted waitcnt plus s_barrier without LLVM's conservative barrier wait."""
+    parts = []
+    if vmcnt < 63 or lgkmcnt < 63:
+        waits = []
+        if vmcnt < 63:
+            waits.append(f"vmcnt({vmcnt})")
+        if lgkmcnt < 63:
+            waits.append(f"lgkmcnt({lgkmcnt})")
+        parts.append("s_waitcnt " + " ".join(waits))
+    parts.append("s_barrier")
+    llvm.InlineAsmOp(
+        res=None,
+        operands_=[],
+        asm_string="\n".join(parts),
+        constraints="",
+        has_side_effects=True,
+        is_align_stack=False,
+    )
+
+
+from flydsl.expr.typing import T
+from .kernels.mfma_epilogues import c_shuffle_epilog, default_epilog, mfma_epilog
+from .kernels.mfma_preshuffle_pipeline import (
+    buffer_copy_gmem16_dwordx4,
+    crd2idx,
+    extract_bf16_scale,
+    lds_store_4b_xor16,
+    lds_store_8b_xor16,
+    lds_store_16b_xor16,
+    load_b_pack_k32,
+    load_b_raw_w4a16,
+    load_b_raw_w4a16_groupwise,
+    make_preshuffle_b_layout,
+    swizzle_xor16,
+    tile_chunk_coord_i32,
+    unpack_b_w4a16,
+)
+
+
+@contextmanager
+def _if_then(if_op):
+    """Compat helper for SCF IfOp then-region across old/new Python APIs."""
+    with ir.InsertionPoint(if_op.then_block):
+        try:
+            yield if_op.then_block
+        finally:
+            blk = if_op.then_block
+            if (not blk.operations) or not isinstance(blk.operations[-1], scf.YieldOp):
+                scf.YieldOp([])
+
+
+@contextmanager
+def _if_else(if_op):
+    """Compat helper for SCF IfOp else-region across old/new Python APIs."""
+    if getattr(if_op, "else_block", None) is None:
+        raise RuntimeError("IfOp has no else block")
+    with ir.InsertionPoint(if_op.else_block):
+        try:
+            yield if_op.else_block
+        finally:
+            blk = if_op.else_block
+            if (not blk.operations) or not isinstance(blk.operations[-1], scf.YieldOp):
+                scf.YieldOp([])
+
+
+@functools.lru_cache(maxsize=1024)
+def compile_moe_gemm1(
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    # NOTE: aiter swap passes these for API symmetry; stage1 uses dynamic memrefs so they are ignored.
+    doweight_stage1: bool,
+    in_dtype: str = "fp8",
+    group_size: int = -1,
+    out_dtype: str = "f16",
+    use_cshuffle_epilog: bool | None = None,
+    scale_is_bf16: bool = False,
+    k_batch: int = 1,
+    b_cache_modifier: int = 0,
+    enable_hotloop_sched: bool | None = None,
+    output_cache_modifier: int = 0,
+    fast_barrier: bool = False,
+    fine_sched: bool = False,
+    weight_interleaved: bool = False,
+    single_token_route: bool = False,
+    sort_tile_m: int | None = None,
+):
+    """Compile stage1 kernel (`moe_gemm1`) and return the compiled executable.
+
+    in_dtype:
+      - "fp8": X/W are fp8
+      - "fp16": X/W are fp16
+      - "bf16": X/W are bf16
+      - "int8": X/W are int8 (X is [tokens, K])
+      - "int8smooth": X/W are int8, but X is pre-expanded to [tokens*topk, K] with per-(token,slot)
+        quant scales (used to emulate MoE smoothquant behavior where each (token,slot)->expert route can
+        have a distinct input scaling before quantization).
+      - "int4": W4A8 path: X is int8, W is packed int4 (2 values per byte) unpacked to int8 in-kernel
+      - "int4_bf16": W4A16 path: X is bf16, W is packed int4 unpacked to bf16 in-kernel
+    scale_is_bf16: When True, groupwise scales are bf16 (halves scale bandwidth).
+    k_batch: Split-K factor. When >1, K is partitioned across k_batch CTAs that
+      atomically accumulate gate/up partials. Caller must pre-zero output.
+    """
+
+    gpu_arch = get_hip_arch()
+    single_token_route = bool(single_token_route)
+    sort_tile_m = int(tile_m if sort_tile_m is None else sort_tile_m)
+    if sort_tile_m <= 0:
+        raise ValueError(f"sort_tile_m must be positive, got {sort_tile_m}")
+    if single_token_route:
+        if int(tile_m) != 16:
+            raise ValueError(f"single_token_route stage1 requires tile_m=16, got {tile_m}")
+        if k_batch != 1:
+            raise ValueError("single_token_route stage1 does not support split-K")
+        if weight_interleaved:
+            raise ValueError("single_token_route stage1 does not support weight_interleaved")
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}  # legacy; kept until stage2/reduction are migrated
+
+    _valid_dtypes = ("fp8", "fp16", "bf16", "int8", "int8smooth", "int4", "int4_bf16")
+    if in_dtype not in _valid_dtypes:
+        raise ValueError(f"in_dtype must be one of {_valid_dtypes}, got {in_dtype!r}")
+    is_int4_bf16 = in_dtype == "int4_bf16"  # W4A16: bf16 activations, packed int4 weights
+    is_f16 = in_dtype == "fp16"
+    is_bf16 = is_int4_bf16 or in_dtype == "bf16"
+    is_f16_or_bf16 = is_f16 or is_bf16
+    needs_scale_w = (not is_f16_or_bf16) or is_int4_bf16
+    elem_bytes = 2 if is_f16_or_bf16 else 1
+    if out_dtype not in ("f16", "bf16"):
+        raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
+    # NOTE: don't materialize MLIR types outside an active MLIR Context.
+    out_mlir = lambda: (lambda ty: ty() if callable(ty) else ty)(T.f16 if out_dtype == "f16" else T.bf16)
+    tile_k_bytes = int(tile_k) * int(elem_bytes)
+    # K64-byte micro-step: always 64 bytes per `ku`. For fp16 this is 32 elements.
+    if (tile_k_bytes % 64) != 0:
+        raise ValueError(
+            f"tile_k_bytes must be divisible by 64, got tile_k_bytes={tile_k_bytes} "
+            f"(tile_k={tile_k}, elem_bytes={elem_bytes})"
+        )
+    is_int4 = in_dtype == "int4"
+    # INT4 here means W4A8: X is int8, W is packed int4 and unpacked to int8 in-kernel.
+    is_int8 = (in_dtype == "int8") or is_int4
+    x_is_token_slot = in_dtype == "int8smooth"
+    # "int8smooth" still uses int8 MFMA, but X/scale_x are provided per (token,slot).
+    is_int8 = is_int8 or x_is_token_slot
+
+    # w_is_int4: True for any variant where weights are packed int4.
+    w_is_int4 = is_int4 or is_int4_bf16
+
+    # Group-wise scale support for W4A16
+    # NOTE: Only group_size=32 is supported due to int4 preshuffle layout constraints.
+    use_groupwise_scale = w_is_int4 and group_size > 0
+    if use_groupwise_scale and group_size != 32:
+        raise ValueError(
+            f"FlyDSL groupwise scale only supports group_size=32, got {group_size}. "
+            f"This is due to int4 preshuffle layout constraints. "
+            f"Please use Triton kernel for other group sizes."
+        )
+    if weight_interleaved and use_groupwise_scale:
+        raise ValueError("Stage1 weight_interleaved does not support groupwise scale")
+    if weight_interleaved and (int(inter_dim) % int(tile_n)) != 0:
+        raise ValueError(
+            "Stage1 weight_interleaved requires inter_dim divisible by tile_n, "
+            f"got inter_dim={inter_dim}, tile_n={tile_n}"
+        )
+    is_int4_bf16_groupwise = is_int4_bf16 and use_groupwise_scale
+    num_groups = model_dim // group_size if use_groupwise_scale else 1
+    _scale_is_bf16 = scale_is_bf16 and use_groupwise_scale
+    experts * (2 * inter_dim) * num_groups
+    # For groupwise scale, weight scale is applied per-group in the K loop,
+    # so epilogue can skip weight scale multiplication (uses 1.0 for sw).
+
+    _is_gfx950 = "gfx95" in get_hip_arch()
+    use_gfx950_cvt = is_int4_bf16 and _is_gfx950
+
+    _use_iglp_opt = bool(enable_hotloop_sched) and not fine_sched  # iglp incompatible with fine_sched
+    _use_fine_sched = bool(fine_sched)
+    # Thread block size: 128 (2 waves) enables tile_n=32; 256 (4 waves) is default.
+    _num_waves = 2 if (tile_n < 64) else 4
+    _block_size = _num_waves * 64
+
+    # Split-K validation
+    _is_splitk = k_batch > 1
+    if _is_splitk:
+        _k_per_batch = model_dim // k_batch
+        assert model_dim % k_batch == 0, f"model_dim={model_dim} not divisible by k_batch={k_batch}"
+        assert _k_per_batch % tile_k == 0, f"K_per_batch={_k_per_batch} not divisible by tile_k={tile_k}"
+        # The ping-pong K-loop requires an even number of K tiles (>=4).
+        _k_tiles = _k_per_batch // tile_k
+        assert _k_tiles >= 4 and _k_tiles % 2 == 0, (
+            f"K_per_batch/tile_k={_k_tiles} must be even and >=4 for the ping-pong pipeline. "
+            f"Try a different k_batch (model_dim={model_dim}, tile_k={tile_k})."
+        )
+    else:
+        _k_per_batch = model_dim
+
+    mfma_i32_k32 = None
+    if is_int8:
+        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(rocdl, "mfma_i32_16x16x32_i8", None)
+        if mfma_i32_k32 is None:
+            raise AttributeError(
+                "INT8 K32 MFMA op not found: expected `rocdl.mfma_i32_16x16x32i8` (or `rocdl.mfma_i32_16x16x32_i8`)."
+            )
+
+    mfma_f32_bf16_k16 = None
+    if is_bf16:
+        mfma_f32_bf16_k16 = getattr(rocdl, "mfma_f32_16x16x16bf16_1k", None) or getattr(
+            rocdl, "mfma_f32_16x16x16_bf16_1k", None
+        )
+        if mfma_f32_bf16_k16 is None:
+            raise AttributeError(
+                "BF16 K16 MFMA op not found: expected `rocdl.mfma_f32_16x16x16bf16_1k` "
+                "(or `rocdl.mfma_f32_16x16x16_bf16_1k`)."
+            )
+
+    # gfx950: use 16x16x32 MFMA for f16/bf16 (K=32 per MFMA, vs K=16 on gfx942).
+    _use_mfma_k32 = _is_gfx950 and (is_f16 or is_bf16)
+
+    ir.ShapedType.get_dynamic_size()
+    # W is packed int4 for W4A8/W4A16/W4A_FP8: 2 values per byte.
+    ((experts * (2 * inter_dim) * model_dim) // 2 if w_is_int4 else (experts * (2 * inter_dim) * model_dim))
+
+    total_threads = 256
+    num_waves_static = total_threads // 64
+    if int(tile_n) // num_waves_static < 16:
+        raise ValueError(
+            "tile_n per wave must cover at least one MFMA N fragment: "
+            f"tile_n={tile_n}, total_threads={total_threads}, "
+            f"num_waves={num_waves_static}"
+        )
+    bytes_x_per_tile = int(tile_m) * int(tile_k) * int(elem_bytes)
+    if bytes_x_per_tile % total_threads != 0:
+        raise ValueError(
+            "tile_m*tile_k*elem_bytes must be divisible by "
+            f"{total_threads}: tile_m={tile_m}, tile_k={tile_k}, elem_bytes={elem_bytes}"
+        )
+    bytes_per_thread_x = bytes_x_per_tile // total_threads
+    _use_async_dma = False  # TODO: fix LLVM ptr<3> issue on gfx942
+    # Keep MoE stage1 X gmem->LDS pipeline consistent with the optimized GEMM kernel:
+    # split into <=16B pieces and use direct buffer_load for smaller widths.
+    # (Compute the split lens inside the kernel so the code matches GEMM structure.)
+
+    # LDS128 mode (same idea as test_preshuffle_gemm.py):
+    # - LDS stride == tile_k (no extra padding) + XOR16 swizzle
+    # - Use ds_{read,write}_b128 (16B) and extract 8B halves for MFMA steps
+    _ck_lds128 = True
+    pad_k = 0 if _ck_lds128 else 8
+    lds_stride = tile_k + pad_k
+    if use_cshuffle_epilog is None:
+        use_cshuffle_epilog = True
+    use_cshuffle_epilog = bool(use_cshuffle_epilog)
+    if single_token_route and use_cshuffle_epilog:
+        raise ValueError("single_token_route stage1 only supports the direct epilogue")
+    stage1_row_limit_x = 0
+    stage1_row_limit_epilog = 0
+    if stage1_row_limit_x < 0 or stage1_row_limit_epilog < 0:
+        raise ValueError("stage1 row limits must be non-negative")
+    if use_cshuffle_epilog:
+        stage1_row_limit_epilog = 0
+    stage1_tiny_row0_x = False
+    stage1_disable_sched = False
+    stage1_assume_valid_grid = False
+    stage1_tid_lds = False
+    stage1_prefetch_epi_tid = False
+    stage1_prefetch_epi_tid = stage1_prefetch_epi_tid and not use_cshuffle_epilog and stage1_row_limit_epilog in (1, 4)
+    if single_token_route:
+        stage1_row_limit_x = 1
+        stage1_row_limit_epilog = 1
+        stage1_tiny_row0_x = True
+        stage1_assume_valid_grid = True
+        stage1_tid_lds = False
+        stage1_prefetch_epi_tid = False
+
+    epilog_tag = "cshuffle" if use_cshuffle_epilog else "direct"
+    # IMPORTANT: module name participates in FlyDSL's compile cache key.
+    # Keep an explicit ABI tag so signature changes can't accidentally reuse an old binary.
+    _gs_tag = f"_g{group_size}" if use_groupwise_scale else ""
+    scale_tag = "_sbf16" if _scale_is_bf16 else ""
+    _split_k_tag = f"_splitk{k_batch}" if _is_splitk else ""
+    _bnt_tag = f"_bnt{int(b_cache_modifier)}" if int(b_cache_modifier) != 0 else ""
+    _wint_tag = "_wint" if bool(weight_interleaved) else ""
+    (
+        f"mfma_moe1_{in_dtype}_{out_dtype}_{epilog_tag}"
+        f"_t{tile_m}x{tile_n}x{tile_k}"
+        f"{_gs_tag}{scale_tag}{_split_k_tag}{_bnt_tag}{_wint_tag}"
+        f"_thr{total_threads}"
+        f"_tr0x{int(stage1_tiny_row0_x)}"
+        f"_rlx{stage1_row_limit_x}_rle{stage1_row_limit_epilog}"
+        f"_nosch{int(stage1_disable_sched)}"
+        f"_avg{int(stage1_assume_valid_grid)}"
+        f"_tidlds{int(stage1_tid_lds)}"
+        f"_epitid{int(stage1_prefetch_epi_tid)}"
+        f"_m1{int(single_token_route)}_stm{sort_tile_m}"
+        f"_abi7"  # also mask sentinel token ids on loads (X/scale_x) to avoid illegal address faults
+    ).replace("-", "_")
+
+    # ── LDS sizing (pure Python; no MLIR Context needed) ─────────────────────
+    # Reuse the same LDS bytes for both:
+    # - ping-pong X tiles (2 * tile_m * lds_stride bytes)
+    # - optional epilogue CShuffle tile (tile_m * tile_n f16 -> 2 * tile_m * tile_n bytes)
+    _use_cshuffle_epilog = bool(use_cshuffle_epilog)
+    # Split-K requires CShuffle epilogue (f32 atomic adds via store_pair callback)
+    if _is_splitk:
+        _use_cshuffle_epilog = True
+    _cshuffle_elem_bytes = 4 if _is_splitk else 2  # f32 for split-K, f16 otherwise
+    lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(elem_bytes)
+    lds_out_bytes = _cshuffle_elem_bytes * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    lds_total_bytes = max(lds_x_bytes, lds_out_bytes)
+    lds_total_elems = lds_total_bytes if elem_bytes == 1 else (lds_total_bytes // 2)
+
+    lds_alloc_bytes = int(lds_total_elems) * int(elem_bytes)
+    lds_alloc_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_alloc_offset + lds_alloc_bytes
+    lds_tid_offset = 0
+    if stage1_tid_lds:
+        lds_tid_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_tid_offset + int(tile_m) * 4
+
+    if True:
+
+        @flyc.kernel
+        def moe_gemm1(
+            arg_out: fx.Tensor,
+            arg_x: fx.Tensor,
+            arg_w: fx.Tensor,
+            arg_scale_x: fx.Tensor,
+            arg_scale_w: fx.Tensor,
+            arg_sorted_token_ids: fx.Tensor,
+            arg_expert_ids: fx.Tensor,
+            arg_sorted_weights: fx.Tensor,
+            arg_max_token_ids: fx.Tensor,
+            i32_tokens_in: fx.Int32,
+            i32_inter_in: fx.Int32,
+            i32_k_in: fx.Int32,
+            i32_size_expert_ids_in: fx.Int32,
+        ):
+            tokens_in = arith.index_cast(T.index, i32_tokens_in)
+            inter_in = arith.index_cast(T.index, i32_inter_in)
+            k_in = arith.index_cast(T.index, i32_k_in)
+            size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+            # i32 versions for layout construction (fly.make_shape requires i32/i64)
+            tokens_i32_v = i32_tokens_in
+            k_i32_v = i32_k_in
+            x_elem = T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            # For int4/int4_bf16, weights are stored as packed bytes (i8) and unpacked in-kernel.
+            w_elem = T.i8 if w_is_int4 else (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8)))
+            scale_dtype = T.bf16 if _scale_is_bf16 else T.f32
+            vec16_elems = 16 if elem_bytes == 1 else 8
+            vec8_elems = 8 if elem_bytes == 1 else 4
+            vec8_x = T.vec(vec8_elems, x_elem)
+            vec16_x = T.vec(vec16_elems, x_elem)
+
+            def silu(x):
+                # device fast path:
+                #   emu = exp(-x)  ~= exp2(log2e * (-x))  -> v_exp_f32
+                #   sig = rcp(1 + emu)                   -> v_rcp_f32
+                #   y = x * sig
+                #
+                # Using llvm.amdgcn intrinsics prevents lowering to the div_scale/div_fixup
+                # sequences that introduce extra compares/cndmasks.
+                t = x * (-1.4426950408889634)  # -log2(e)
+                emu = rocdl.exp2(T.f32, t)
+                den = 1.0 + emu
+                sig = rocdl.rcp(T.f32, den)
+                return x * sig
+
+            acc_init = arith.constant_vector(0, T.i32x4) if is_int8 else arith.constant_vector(0.0, T.f32x4)
+            zero_f32_acc = arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+
+            # Layouts (use i32 values; fly.make_shape requires i32/i64, not index)
+            fx.make_layout((tokens_i32_v, k_i32_v), stride=(k_i32_v, 1))
+
+            # B preshuffle layout: match GEMM test helper exactly.
+            c_n_total = arith.index(experts * (2 * inter_dim))
+            # For packed int4 (W4A8/W4A16/W4A_FP8), kpack_bytes=8.
+            kpack_bytes = 8 if w_is_int4 else 16
+            w_elem_bytes = 1 if w_is_int4 else elem_bytes
+            b_layout = make_preshuffle_b_layout(
+                arith,
+                c_n=c_n_total,
+                c_k=k_in,
+                kpack_bytes=kpack_bytes,
+                elem_bytes=w_elem_bytes,
+            )
+            layout_b = b_layout.layout_b
+            (k_in * arith.index(int(elem_bytes))) // fx.Index(64)
+
+            shape_lds = fx.make_shape(tile_m, tile_k)
+            stride_lds = fx.make_stride(lds_stride, 1)
+            layout_lds = fx.make_layout(shape_lds, stride_lds)
+
+            tx = gpu.thread_id("x")
+            # Align with Aiter launch mapping (NSwizzle==false):
+            # - blockIdx.x -> N dimension (tile along inter_dim)
+            # - blockIdx.y -> expert-block id / M dimension (tile along sorted M)
+            by = gpu.block_id("x")  # tile along inter_dim
+            bx = gpu.block_id("y")  # tile along sorted M
+
+            if const_expr(_is_splitk):
+                bz = gpu.block_id("z")  # K-batch id
+                k_base_idx = bz * arith.index(_k_per_batch)
+            else:
+                k_base_idx = arith.index(0)
+
+            # Block validity: compute as early as possible so invalid blocks skip all buffer-resource
+            # setup, LDS pointer math, and gmem prefetch work.
+            if const_expr(single_token_route):
+                bx_m = bx * fx.Index(sort_tile_m)
+            else:
+                bx_m = bx * fx.Index(tile_m)
+            if const_expr(stage1_assume_valid_grid):
+                blk_valid = arith.cmpi(arith.CmpIPredicate.eq, fx.Index(0), fx.Index(0))
+            else:
+                maxids_rsrc = buffer_ops.create_buffer_resource(
+                    arg_max_token_ids,
+                    max_size=False,
+                    num_records_bytes=fx.Index(4),
+                )
+                max_token_id_i32 = buffer_ops.buffer_load(maxids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+                bx_m_i32 = arith.index_cast(T.i32, bx_m)
+                blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, max_token_id_i32)
+                expert_rsrc_early = buffer_ops.create_buffer_resource(
+                    arg_expert_ids,
+                    max_size=False,
+                    num_records_bytes=(size_expert_ids_in * fx.Index(4)),
+                )
+                expert_i32_early = buffer_ops.buffer_load(expert_rsrc_early, bx, vec_width=1, dtype=T.i32)
+                expert_valid = arith.cmpi(
+                    arith.CmpIPredicate.sge,
+                    expert_i32_early,
+                    arith.constant(0, type=T.i32),
+                )
+                blk_valid = blk_valid & expert_valid
+            # Common constants/atoms (hoisted): keep IR small like GEMM.
+            # XOR16 swizzle parameter (in bytes; constant, power-of-two in our configs).
+            k_blocks16 = arith.index(tile_k_bytes // 16)
+            layout_tx_wave_lane = fx.make_layout((num_waves_static, 64), stride=(64, 1))
+            layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
+
+            # Everything below is gated by `blk_valid` to avoid doing buffer-resource setup and
+            # gmem work for padding blocks.
+            _if_blk = scf.IfOp(blk_valid)
+            with _if_then(_if_blk):
+                base_ptr = allocator.get_base()
+                lds_x_ptr = SmemPtr(
+                    base_ptr,
+                    lds_alloc_offset,
+                    (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))),
+                    shape=(lds_total_elems,),
+                )
+                lds_x = lds_x_ptr.get()
+                # Alias LDS bytes for optional CShuffle epilogue.
+                # Split-K uses f32 (4B) per element; f16/bf16 both use 2B.
+                _lds_out_elem_type = T.f32 if _is_splitk else out_mlir()
+                lds_out = (
+                    SmemPtr(
+                        base_ptr,
+                        lds_x_ptr.byte_offset,
+                        _lds_out_elem_type,
+                        shape=(tile_m * tile_n,),
+                    ).get()
+                    if _use_cshuffle_epilog
+                    else None
+                )
+                lds_tid = SmemPtr(base_ptr, lds_tid_offset, T.i32, shape=(tile_m,)).get() if stage1_tid_lds else None
+
+                # Buffer resources: for dynamic memrefs, provide `num_records_bytes` explicitly so
+                # hardware OOB behavior is stable (otherwise it falls back to a large max size).
+                c_topk = fx.Index(topk)
+
+                # X: [tokens, k] bytes = tokens*k*elem_bytes
+                x_rows = tokens_in * (c_topk if x_is_token_slot else fx.Index(1))
+                x_nbytes_idx = x_rows * k_in * arith.index(int(elem_bytes))
+                x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_idx)
+
+                w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
+
+                # OUT: normal=[tokens, topk, inter] f16/bf16, split-K=[tokens*topk, 2*inter] f32
+                out_elem_bytes = 4 if _is_splitk else 2
+                if const_expr(_is_splitk):
+                    out_nbytes_idx = tokens_in * c_topk * inter_in * fx.Index(2 * out_elem_bytes)
+                else:
+                    out_nbytes_idx = tokens_in * c_topk * inter_in * fx.Index(out_elem_bytes)
+                out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes_idx)
+
+                # scale_x: fp16/bf16 path ignores (implicit scale=1.0); int4_bf16 also uses 1.0.
+                x_load_bytes = 16
+                sx_rsrc = -1
+                if const_expr(not is_f16_or_bf16):
+                    sx_rows = tokens_in * (c_topk if x_is_token_slot else fx.Index(1))
+                    sx_nbytes_idx = sx_rows * fx.Index(4)
+                    sx_rsrc = buffer_ops.create_buffer_resource(
+                        arg_scale_x, max_size=False, num_records_bytes=sx_nbytes_idx
+                    )
+                # scale_w: fp16/bf16 (non-int4) path ignores; int4_bf16 needs dequant scale.
+                sw_rsrc = -1
+                if const_expr(needs_scale_w):
+                    sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False)
+
+                sorted_rsrc = buffer_ops.create_buffer_resource(arg_sorted_token_ids, max_size=False)
+                sorted_w_rsrc = buffer_ops.create_buffer_resource(arg_sorted_weights, max_size=False)
+
+                if const_expr(stage1_tid_lds):
+                    tid_in_range = arith.cmpi(arith.CmpIPredicate.ult, tx, fx.Index(tile_m))
+                    _if_tid = scf.IfOp(tid_in_range)
+                    with _if_then(_if_tid):
+                        tid_row = bx_m + tx
+                        tid_val = buffer_ops.buffer_load(sorted_rsrc, tid_row, vec_width=1, dtype=T.i32)
+                        tid_vec = vector.from_elements(T.vec(1, T.i32), [tid_val])
+                        vector.store(tid_vec, lds_tid, [tx], alignment=4)
+                    gpu.barrier()
+
+                # expert ids: [blocks] i32 -> bytes = size_expert_ids_in*4
+                expert_rsrc = buffer_ops.create_buffer_resource(
+                    arg_expert_ids,
+                    max_size=False,
+                    num_records_bytes=(size_expert_ids_in * fx.Index(4)),
+                )
+
+                # Expert id for this M tile (keep address math in `index`)
+                expert_i32 = buffer_ops.buffer_load(expert_rsrc, bx, vec_width=1, dtype=T.i32)
+                expert_idx = arith.index_cast(T.index, expert_i32)
+                route_slot_i32 = arith.index_cast(T.i32, bx)
+                inter2_idx = arith.index(2 * inter_dim)
+                if const_expr(bool(weight_interleaved)):
+                    ntile_base = by * fx.Index(experts * 2 * tile_n)
+                    expert_off_idx = ntile_base + expert_idx * fx.Index(2 * tile_n)
+                    expert_off_for_scale = expert_idx * inter2_idx
+                else:
+                    expert_off_idx = expert_idx * inter2_idx  # index
+                    expert_off_for_scale = expert_off_idx
+
+                # ---- X gmem->reg prefetch (match preshuffle GEMM mapping) ----
+                # Prefer 16B buffer-load (dwordx4). If the per-thread byte count isn't divisible by
+                # 16, fall back to 8B (dwordx2) or 4B (dword) loads. For fp16/bf16 we require 16B.
+                if const_expr(is_f16_or_bf16):
+                    if const_expr(bytes_per_thread_x % 16 != 0):
+                        raise ValueError(f"[fp16] bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 16")
+                    x_load_bytes = 16
+                else:
+                    if const_expr(bytes_per_thread_x % 16 == 0):
+                        x_load_bytes = 16
+                    elif const_expr(bytes_per_thread_x % 8 == 0):
+                        x_load_bytes = 8
+                    elif const_expr(bytes_per_thread_x % 4 == 0):
+                        x_load_bytes = 4
+                    else:
+                        raise ValueError(
+                            f"bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 4 to use the dword-indexed load mapping."
+                        )
+                num_x_loads = bytes_per_thread_x // x_load_bytes
+                chunk_i32 = x_load_bytes // 4  # dwords per chunk (1/2/4)
+
+                c_k_div4 = (k_in * arith.index(int(elem_bytes))) // fx.Index(4)
+                c_k_div4_i32 = arith.index_cast(T.i32, c_k_div4)
+                fx.make_layout((tokens_i32_v, c_k_div4_i32), stride=(c_k_div4_i32, 1))
+                tile_k_dwords = (int(tile_k) * int(elem_bytes)) // 4
+                layout_x_tile_div4 = fx.make_layout((tile_m, tile_k_dwords), stride=(tile_k_dwords, 1))
+                c_chunk_i32 = fx.Index(chunk_i32)
+                tx_i32_base = tx * c_chunk_i32
+                mask24 = fx.Int32(0xFFFFFF)
+                tokens_i32 = arith.index_cast(T.i32, tokens_in)
+                topk_i32 = fx.Int32(topk)
+
+                def x_tile_chunk_coord_i32(i: int):
+                    return tile_chunk_coord_i32(
+                        arith,
+                        tx_i32_base=tx_i32_base,
+                        i=i,
+                        total_threads=total_threads,
+                        layout_tile_div4=layout_x_tile_div4,
+                        chunk_i32=chunk_i32,
+                    )
+
+                # decode token once (per thread's M-slice) and build a base row offset.
+                x_row_base_div4 = []
+                x_col_local_i32 = []
+                x_row_local = []
+                x_row_valid = []
+                for i in range_constexpr(num_x_loads):
+                    row_local, col_local_i32 = x_tile_chunk_coord_i32(i)
+                    x_row_local.append(row_local)
+                    x_col_local_i32.append(col_local_i32)
+
+                    if const_expr(stage1_tiny_row0_x):
+                        x_row_base_div4.append(fx.Index(0))
+                        x_row_valid.append(arith.cmpi(arith.CmpIPredicate.eq, row_local, fx.Index(0)))
+                    else:
+                        sorted_row_i = bx_m + row_local
+                        # NOTE: rows beyond `num_valid_ids` can contain garbage (within the allocated
+                        # buffer). That's OK as long as we never use an out-of-range token id to index X.
+                        fused_i = (
+                            memref.load(lds_tid, [row_local])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32)
+                        )
+                        t_raw = fused_i & mask24
+                        # NOTE: aiter moe_sorting uses sentinel token_id == tokens for padding.
+                        # Do NOT rely on buffer OOB semantics for X loads; explicitly mask to a safe row.
+                        t_valid_i32 = arith.cmpi(arith.CmpIPredicate.ult, t_raw, tokens_i32)
+                        if const_expr(stage1_row_limit_x > 0):
+                            row_in_limit = arith.cmpi(
+                                arith.CmpIPredicate.ult,
+                                row_local,
+                                fx.Index(stage1_row_limit_x),
+                            )
+                            t_valid_i32 = arith.andi(t_valid_i32, row_in_limit)
+                        x_row_valid.append(t_valid_i32)
+                        if const_expr(x_is_token_slot):
+                            s_raw = fused_i >> 24
+                            # X is indexed by token-slot in **slot-major** order:
+                            #   row_ts = slot * tokens + token
+                            # This matches CK's moe_smoothquant output layout.
+                            row_ts_i32 = s_raw * tokens_i32 + t_raw
+                            row_ts_idx = arith.index_cast(T.index, row_ts_i32)
+                            # Apply bounds check to token-slot index
+                            row_ts_safe = t_valid_i32.select(row_ts_idx, fx.Index(0))
+                            x_row_base_div4.append(row_ts_safe * c_k_div4)
+                        else:
+                            t_idx = arith.index_cast(T.index, t_raw)
+                            t_safe = t_valid_i32.select(t_idx, fx.Index(0))
+                            x_row_base_div4.append(t_safe * c_k_div4)
+
+                vec4_x = T.vec(4, x_elem)
+
+                def load_x(idx_i32, x_load_bytes_v):
+                    """Load `x_load_bytes_v` bytes from X (gmem) into regs.
+
+                    For 16B, keep the fast dwordx4 path. For 8B/4B, use byte offsets.
+                    idx_i32 is in dword units; convert to element index for _buffer_load_vec.
+                    """
+                    if const_expr(x_load_bytes_v == 16):
+                        idx_elem = idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                        return buffer_copy_gmem16_dwordx4(
+                            buffer_ops,
+                            vector,
+                            elem_type=x_elem,
+                            idx_i32=idx_elem,
+                            rsrc=x_rsrc,
+                            vec_elems=vec16_elems,
+                            elem_bytes=elem_bytes,
+                        )
+                    # For 8B/4B, load raw i32 dwords directly.
+                    if const_expr(x_load_bytes_v == 8):
+                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=2, dtype=T.i32)
+                    if const_expr(x_load_bytes_v == 4):
+                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=1, dtype=T.i32)
+                    raise ValueError(f"Invalid x_load_bytes_v: {x_load_bytes_v}")
+
+                def load_x_tile(base_k, x_load_bytes_v):
+                    """Prefetch the per-thread X tile portion (gmem -> regs) for a given K base (in elements)."""
+                    base_k_div4 = (base_k * arith.index(int(elem_bytes))) // fx.Index(4)
+                    parts = []
+                    for i in range_constexpr(num_x_loads):
+                        idx_i32 = x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
+                        if const_expr(stage1_tiny_row0_x or stage1_row_limit_x > 0):
+                            if const_expr(x_load_bytes_v == 16):
+                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32x4], has_else=True)
+                                with _if_then(_if_x):
+                                    scf.YieldOp([vector.bitcast(T.i32x4, load_x(idx_i32, x_load_bytes_v))])
+                                with _if_else(_if_x):
+                                    scf.YieldOp([arith.constant_vector(0, T.i32x4)])
+                                parts.append(_if_x.results[0])
+                            elif const_expr(x_load_bytes_v == 8):
+                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32x2], has_else=True)
+                                with _if_then(_if_x):
+                                    scf.YieldOp([load_x(idx_i32, x_load_bytes_v)])
+                                with _if_else(_if_x):
+                                    scf.YieldOp([arith.constant_vector(0, T.i32x2)])
+                                parts.append(_if_x.results[0])
+                            else:
+                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32], has_else=True)
+                                with _if_then(_if_x):
+                                    scf.YieldOp([load_x(idx_i32, x_load_bytes_v)])
+                                with _if_else(_if_x):
+                                    scf.YieldOp([arith.constant(0, type=T.i32)])
+                                parts.append(_if_x.results[0])
+                        else:
+                            x_vec = load_x(idx_i32, x_load_bytes_v)
+                            if const_expr(x_load_bytes_v == 16):
+                                parts.append(vector.bitcast(T.i32x4, x_vec))
+                            elif const_expr(x_load_bytes_v == 8):
+                                parts.append(x_vec)
+                            else:
+                                parts.append(x_vec)
+                    return parts
+
+                # tx -> wave/lane (GEMM-style decomposition).
+                coord_wl = fx.idx2crd(tx, layout_tx_wave_lane)
+                wave_id = fx.get(coord_wl, 0)
+                lane_id = fx.get(coord_wl, 1)
+                coord_l16 = fx.idx2crd(lane_id, layout_lane16)
+                lane_div_16 = fx.get(coord_l16, 0)
+                lane_mod_16 = fx.get(coord_l16, 1)
+
+                # Match GEMM naming/pattern: row in LDS is lane_mod_16, and col base is lane_div_16 * a_kpack_elems.
+                # A-side kpack is always 16 bytes (activation elements); B-side kpack_bytes
+                # may differ (e.g. 8 for int4 weights), but that only affects B preshuffle.
+                row_a_lds = lane_mod_16
+                a_kpack_elems = 16 // elem_bytes
+                col_offset_base = lane_div_16 * arith.index(int(a_kpack_elems))
+                col_offset_base_bytes = (
+                    col_offset_base if elem_bytes == 1 else (col_offset_base * arith.index(int(elem_bytes)))
+                )
+
+                # Dynamic N tiling within block (same as existing kernels)
+                by_n = by * fx.Index(tile_n)
+                num_waves = num_waves_static
+                n_per_wave = tile_n // num_waves
+                num_acc_n = n_per_wave // 16
+                c_n_per_wave = fx.Index(n_per_wave)
+                wave_mod_4 = wave_id % fx.Index(4)
+                n_tile_base = wave_mod_4 * c_n_per_wave
+
+                # Precompute n_blk/n_intra for gate and up rows (GEMM-style: idx2crd/get)
+                n_intra_gate = []
+                n_blk_gate = []
+                n_intra_up = []
+                n_blk_up = []
+                col_g_list = []
+                inter_idx = fx.Index(inter_dim)
+                c_n_total // fx.Index(16)
+                c_n0_static = experts * (2 * inter_dim) // 16
+                layout_n_blk_intra = fx.make_layout((c_n0_static, 16), stride=(16, 1))
+                for ni in range_constexpr(num_acc_n):
+                    offset = arith.index(ni * 16)
+                    col_g = by_n + n_tile_base
+                    col_g = col_g + offset
+                    col_g = col_g + lane_mod_16
+                    col_g_list.append(col_g)
+
+                    if const_expr(bool(weight_interleaved)):
+                        col_w = n_tile_base + offset + lane_mod_16
+                        row_gate = expert_off_idx + col_w
+                        row_up = row_gate + fx.Index(tile_n)
+                    else:
+                        row_gate = expert_off_idx + col_g
+                        row_up = row_gate + inter_idx
+
+                    coord_gate = fx.idx2crd(row_gate, layout_n_blk_intra)
+                    n_blk_gate.append(fx.get(coord_gate, 0))
+                    n_intra_gate.append(fx.get(coord_gate, 1))
+
+                    coord_up = fx.idx2crd(row_up, layout_n_blk_intra)
+                    n_blk_up.append(fx.get(coord_up, 0))
+                    n_intra_up.append(fx.get(coord_up, 1))
+
+                m_repeat = tile_m // 16
+                k_unroll = tile_k_bytes // 64  # K64-byte micro-step (2x MFMA)
+
+                # --- B Load Logic (K64) - shared layout with preshuffle GEMM ---
+                def load_b_pack(base_k, ki_step, ni, blk_list, intra_list):
+                    return load_b_pack_k32(
+                        buffer_ops,
+                        arith,
+                        vector,
+                        arg_b=arg_w,
+                        b_rsrc=w_rsrc,
+                        layout_b=layout_b,
+                        base_k=base_k,
+                        ki_step=ki_step,
+                        n_blk=blk_list[ni],
+                        n_intra=intra_list[ni],
+                        lane_div_16=lane_div_16,  # 0..3
+                        elem_type=w_elem,
+                        kpack_bytes=kpack_bytes,
+                        elem_bytes=w_elem_bytes,
+                        unpack_int4=(is_int4 or is_int4_bf16),
+                        **({"cache_modifier": int(b_cache_modifier)} if int(b_cache_modifier) != 0 else {}),
+                    )
+
+                def load_b_tile(base_k, blk_list, intra_list):
+                    """Prefetch the entire per-thread B tile (gmem -> regs) for a given K base.
+
+                    Returns a list of length `k_unroll`, where each entry is a tuple:
+                      (packs_half0[ni], packs_half1[ni])  for the K64 micro-step.
+                    For groupwise variants, each entry also includes per-group scales:
+                      (packs0[ni], packs1[ni], scales0[ni], scales1[ni])
+                    """
+                    if const_expr(is_int4_bf16_groupwise):
+                        # W4A16 groupwise: load raw packed32 + scale; defer dequant to compute_tile.
+                        raw_data = []
+                        for ku in range_constexpr(k_unroll):
+                            raw_ku = []
+                            for ni in range_constexpr(num_acc_n):
+                                packed32, scale_val = load_b_raw_w4a16_groupwise(
+                                    buffer_ops,
+                                    arith,
+                                    vector,
+                                    arg_b=arg_w,
+                                    b_rsrc=w_rsrc,
+                                    layout_b=layout_b,
+                                    base_k=base_k,
+                                    ku=ku,
+                                    n_blk=blk_list[ni],
+                                    n_intra=intra_list[ni],
+                                    lane_div_16=lane_div_16,
+                                    elem_type=w_elem,
+                                    scale_rsrc=sw_rsrc,
+                                    expert_offset=expert_off_idx,
+                                    num_groups=num_groups,
+                                    group_size=group_size,
+                                    n_per_expert=2 * inter_dim,
+                                    kpack_bytes=kpack_bytes,
+                                    scale_dtype=scale_dtype,
+                                )
+                                raw_ku.append((packed32, scale_val))
+                            raw_data.append(raw_ku)
+                        return raw_data
+                    elif const_expr(is_int4_bf16):
+                        # W4A16 per-row: load raw packed32; defer dequant to compute_tile.
+                        raw_data = []
+                        for ku in range_constexpr(k_unroll):
+                            raw_ku = []
+                            for ni in range_constexpr(num_acc_n):
+                                raw = load_b_raw_w4a16(
+                                    buffer_ops,
+                                    arith,
+                                    vector,
+                                    arg_b=arg_w,
+                                    b_rsrc=w_rsrc,
+                                    layout_b=layout_b,
+                                    base_k=base_k,
+                                    ku=ku,
+                                    n_blk=blk_list[ni],
+                                    n_intra=intra_list[ni],
+                                    lane_div_16=lane_div_16,
+                                    elem_type=w_elem,
+                                    kpack_bytes=kpack_bytes,
+                                )
+                                raw_ku.append(raw)
+                            raw_data.append(raw_ku)
+                        return raw_data
+                    else:
+                        # fp8/int8/bf16/fp16: original code path
+                        b_tile = []
+                        for ku in range_constexpr(k_unroll):
+                            packs0 = []
+                            packs1 = []
+                            for ni in range_constexpr(num_acc_n):
+                                ki0 = (ku * 2) + 0
+                                ki1 = (ku * 2) + 1
+                                b0 = load_b_pack(base_k, ki0, ni, blk_list, intra_list)
+                                b1 = load_b_pack(base_k, ki1, ni, blk_list, intra_list)
+                                packs0.append(b0)
+                                packs1.append(b1)
+                            b_tile.append((packs0, packs1))
+                        return b_tile
+
+                acc_gate = [acc_init] * (num_acc_n * m_repeat)
+                acc_up = [acc_init] * (num_acc_n * m_repeat)
+
+                # ---- Pipeline helpers: store X tile to LDS with ping-pong base ----
+                def store_x_tile_to_lds(vec_x_in_parts, lds_base, x_load_bytes_v):
+                    for i in range_constexpr(num_x_loads):
+                        row_local = x_row_local[i]
+                        col_local_i32 = x_col_local_i32[i]
+
+                        def _store_x_part():
+                            if const_expr(x_load_bytes_v == 16):
+                                lds_store_16b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec16_ty=vec16_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x4=vec_x_in_parts[i],
+                                    elem_bytes=elem_bytes,
+                                )
+                            elif const_expr(x_load_bytes_v == 8):
+                                lds_store_8b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec8_ty=vec8_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x2=vec_x_in_parts[i],
+                                )
+                            else:
+                                lds_store_4b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec4_ty=vec4_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x1=vec_x_in_parts[i],
+                                )
+
+                        if const_expr(single_token_route):
+                            _if_store_x = scf.IfOp(x_row_valid[i])
+                            with _if_then(_if_store_x):
+                                _store_x_part()
+                        else:
+                            _store_x_part()
+
+                # --- Async DMA: global -> LDS direct (bypass VGPRs) for fp8 16B ---
+                if const_expr(_use_async_dma):
+                    _dma_bytes_s1 = 16
+                    _wave_size_s1 = 64
+
+                    def dma_x_tile_to_lds(base_k, lds_base):
+                        c4_idx = fx.Index(4)
+                        base_k_div4 = base_k // c4_idx
+                        # Use buffer_load_to_lds (simplified wrapper with proper type handling)
+                        lds_byte_addr = (
+                            memref.extract_aligned_pointer_as_index(lds_x)
+                            + lds_base * arith.index(int(elem_bytes))
+                            + wave_id * arith.index(_wave_size_s1 * _dma_bytes_s1)
+                        )
+                        lds_ptr = buffer_ops.create_llvm_ptr(lds_byte_addr, address_space=3)
+
+                        for i in range_constexpr(num_x_loads):
+                            row_local_i = x_row_local[i]
+                            col_local_i32_i = x_col_local_i32[i]
+                            col_local_sw = swizzle_xor16(row_local_i, col_local_i32_i * c4_idx, k_blocks16)
+                            row_k_dw = x_row_base_div4[i] + base_k_div4
+                            global_byte_idx = row_k_dw * c4_idx + col_local_sw
+                            global_offset = arith.index_cast(T.i32, global_byte_idx)
+                            if const_expr(i > 0):
+                                lds_ptr = buffer_ops.get_element_ptr(
+                                    lds_ptr,
+                                    static_byte_offset=total_threads * _dma_bytes_s1,
+                                )
+                            rocdl.buffer_load_to_lds(
+                                x_rsrc,
+                                lds_ptr,
+                                global_offset,
+                                size_bytes=_dma_bytes_s1,
+                            )
+
+                # --- A LDS load helper for K64 (load 16B once, extract 2x i64 halves) ---
+                def lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base):
+                    col_base_swz_bytes = swizzle_xor16(curr_row_a_lds, col_base_bytes, k_blocks16)
+                    col_base_swz = (
+                        col_base_swz_bytes if elem_bytes == 1 else (col_base_swz_bytes // arith.index(int(elem_bytes)))
+                    )
+                    idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds)
+                    idx_a16 = idx_a16 + lds_base
+                    loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
+                    a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                    a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                    a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                    return a0, a1
+
+                def compute_tile(
+                    acc_gate_in,
+                    acc_up_in,
+                    b_gate_tile_in,
+                    b_up_tile_in,
+                    lds_base,
+                    *,
+                    prefetch_epilogue: bool = False,
+                    a0_prefetch=None,
+                ):
+                    gate_list = list(acc_gate_in)
+                    up_list = list(acc_up_in)
+                    mfma_res_ty = T.i32x4 if is_int8 else T.f32x4
+                    if const_expr(_use_mfma_k32):
+                        mfma_fn = rocdl.mfma_f32_16x16x32_f16 if is_f16 else rocdl.mfma_f32_16x16x32_bf16
+                    else:
+                        mfma_fn = (
+                            mfma_i32_k32
+                            if is_int8
+                            else (
+                                mfma_f32_bf16_k16
+                                if is_bf16
+                                else (rocdl.mfma_f32_16x16x16f16 if is_f16 else rocdl.mfma_f32_16x16x32_fp8_fp8)
+                            )
+                        )
+
+                    # Optional: prefetch epilogue scales while we are about to run the last MFMA tile,
+                    # matching the preshuffle GEMM pattern of overlapping scale loads with MFMA.
+                    epilogue_pf = None
+                    if const_expr(prefetch_epilogue and not use_groupwise_scale):
+                        expert_off_pf = expert_off_for_scale
+                        sw_gate_pf = []
+                        sw_up_pf = []
+                        for ni in range_constexpr(num_acc_n):
+                            col_g = col_g_list[ni]
+                            row_gate_idx = expert_off_pf + col_g
+                            row_up_idx = row_gate_idx + inter_idx
+                            sw_gate_pf.append(
+                                fx.Float32(1.0)
+                                if not needs_scale_w
+                                else buffer_ops.buffer_load(sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32)
+                            )
+                            sw_up_pf.append(
+                                fx.Float32(1.0)
+                                if not needs_scale_w
+                                else buffer_ops.buffer_load(sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32)
+                            )
+                        epilogue_tid_pf = None
+                        if const_expr(stage1_prefetch_epi_tid):
+                            epilogue_tid_pf = []
+                            lane0_for_rows = arith.cmpi(arith.CmpIPredicate.eq, lane_div_16, fx.Index(0))
+                            for ii_pf in range_constexpr(4):
+                                if const_expr(ii_pf < stage1_row_limit_epilog):
+                                    row_pf = bx_m + fx.Index(ii_pf)
+                                    _if_tid_pf = scf.IfOp(lane0_for_rows, results_=[T.i32], has_else=True)
+                                    with _if_then(_if_tid_pf):
+                                        scf.YieldOp(
+                                            [
+                                                buffer_ops.buffer_load(
+                                                    sorted_rsrc,
+                                                    row_pf,
+                                                    vec_width=1,
+                                                    dtype=T.i32,
+                                                )
+                                            ]
+                                        )
+                                    with _if_else(_if_tid_pf):
+                                        scf.YieldOp([arith.constant(0, type=T.i32)])
+                                    epilogue_tid_pf.append(_if_tid_pf.results[0])
+                                else:
+                                    epilogue_tid_pf.append(arith.constant(0, type=T.i32))
+                        epilogue_pf = (sw_gate_pf, sw_up_pf, epilogue_tid_pf)
+
+                    def _i64_to_v4f16(x_i64):
+                        v1 = vector.from_elements(T.vec(1, T.i64), [x_i64])
+                        return vector.bitcast(T.f16x4, v1)
+
+                    def _i64_to_v4i16(x_i64):
+                        v1 = vector.from_elements(T.vec(1, T.i64), [x_i64])
+                        return vector.bitcast(T.i16x4, v1)
+
+                    def _i64x2_to_v8f16(lo, hi):
+                        v2 = vector.from_elements(T.i64x2, [lo, hi])
+                        return vector.bitcast(T.f16x8, v2)
+
+                    def _i64x2_to_v8bf16(lo, hi):
+                        v2 = vector.from_elements(T.i64x2, [lo, hi])
+                        return vector.bitcast(T.bf16x8, v2)
+
+                    def mfma_k64(acc_in, a0, a1, b0, b1):
+                        if const_expr(_use_mfma_k32):
+                            # gfx950: single 16x16x32 MFMA consuming all 128 bits (K=32 f16/bf16)
+                            if const_expr(is_f16):
+                                av = _i64x2_to_v8f16(a0, a1)
+                                bv = _i64x2_to_v8f16(b0, b1)
+                            else:
+                                av = _i64x2_to_v8bf16(a0, a1)
+                                bv = _i64x2_to_v8bf16(b0, b1)
+                            return mfma_fn(mfma_res_ty, [av, bv, acc_in, 0, 0, 0])
+                        if const_expr(is_f16):
+                            a0v = _i64_to_v4f16(a0)
+                            a1v = _i64_to_v4f16(a1)
+                            b0v = _i64_to_v4f16(b0)
+                            b1v = _i64_to_v4f16(b1)
+                            acc_mid = mfma_fn(mfma_res_ty, [a0v, b0v, acc_in, 0, 0, 0])
+                            return mfma_fn(mfma_res_ty, [a1v, b1v, acc_mid, 0, 0, 0])
+                        if const_expr(is_bf16):
+                            a0v = _i64_to_v4i16(a0)
+                            a1v = _i64_to_v4i16(a1)
+                            b0v = _i64_to_v4i16(b0)
+                            b1v = _i64_to_v4i16(b1)
+                            acc_mid = mfma_fn(mfma_res_ty, [a0v, b0v, acc_in, 0, 0, 0])
+                            return mfma_fn(mfma_res_ty, [a1v, b1v, acc_mid, 0, 0, 0])
+                        acc_mid = mfma_fn(mfma_res_ty, [a0, b0, acc_in, 0, 0, 0])
+                        return mfma_fn(mfma_res_ty, [a1, b1, acc_mid, 0, 0, 0])
+
+                    def _acc_scaled_f32(f32_acc_vec, f32_partial_vec, scale_val):
+                        """MFMA f32 partial -> scale -> add to f32 accumulator via math.fma on vector."""
+                        from flydsl._mlir.dialects._math_ops_gen import fma as _math_fma
+
+                        _uw = arith._to_raw
+                        scale_vec = _uw(vector.broadcast(T.f32x4, scale_val))
+                        return arith.ArithValue(_math_fma(scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec)))
+
+                    if const_expr(is_int4_bf16 or is_int4_bf16_groupwise):
+                        # W4A16: deferred dequant — unpack int4->bf16 right before MFMA
+                        # to minimize VGPR lifetime of dequantized bf16 values.
+                        _pending_gate_up = None
+                        for ku in range_constexpr(k_unroll):
+                            b_gate_raw = b_gate_tile_in[ku]
+                            b_up_raw = b_up_tile_in[ku]
+                            ki64 = arith.index(ku * 64)
+                            col_base = col_offset_base_bytes + ki64
+
+                            for mi in range_constexpr(m_repeat):
+                                mi_val = arith.index(mi * 16)
+                                curr_row_a_lds = row_a_lds + mi_val
+                                a0 = arith.constant(-1, type=T.i64)
+                                a1 = arith.constant(-1, type=T.i64)
+                                if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                    a0, a1 = a0_prefetch
+                                else:
+                                    a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+
+                                for ni in range_constexpr(num_acc_n):
+                                    acc_idx = mi * num_acc_n + ni
+                                    if const_expr(is_int4_bf16_groupwise):
+                                        packed_g, sc_g = b_gate_raw[ni]
+                                        packed_u, sc_u = b_up_raw[ni]
+                                        if const_expr(_scale_is_bf16):
+                                            sc_g = extract_bf16_scale(arith, sc_g, ku)
+                                            sc_u = extract_bf16_scale(arith, sc_u, ku)
+                                    else:
+                                        packed_g, sc_g = b_gate_raw[ni], None
+                                        packed_u, sc_u = b_up_raw[ni], None
+                                    if const_expr(is_int4_bf16_groupwise and use_gfx950_cvt):
+                                        # Defer group scale to post-MFMA FMA with pipeline:
+                                        # Issue current MFMA, then apply FMA for previous iteration's result.
+                                        bg0, bg1 = unpack_b_w4a16(
+                                            packed_g,
+                                            arith,
+                                            vector,
+                                            scale_val=None,
+                                            use_gfx950_cvt=True,
+                                            defer_scale16=True,
+                                        )
+                                        tmp_g = mfma_k64(zero_f32_acc, a0, a1, bg0, bg1)
+                                        bu0, bu1 = unpack_b_w4a16(
+                                            packed_u,
+                                            arith,
+                                            vector,
+                                            scale_val=None,
+                                            use_gfx950_cvt=True,
+                                            defer_scale16=True,
+                                        )
+                                        tmp_u = mfma_k64(zero_f32_acc, a0, a1, bu0, bu1)
+                                        # Apply FMA for previous pending result (MFMA already completed).
+                                        if const_expr(_pending_gate_up is not None):
+                                            p_idx, p_g, p_u, p_sc_g, p_sc_u = _pending_gate_up
+                                            gate_list[p_idx] = _acc_scaled_f32(gate_list[p_idx], p_g, p_sc_g)
+                                            up_list[p_idx] = _acc_scaled_f32(up_list[p_idx], p_u, p_sc_u)
+                                        _pending_gate_up = (
+                                            acc_idx,
+                                            tmp_g,
+                                            tmp_u,
+                                            sc_g,
+                                            sc_u,
+                                        )
+                                    else:
+                                        bg0, bg1 = unpack_b_w4a16(
+                                            packed_g,
+                                            arith,
+                                            vector,
+                                            scale_val=sc_g,
+                                            use_gfx950_cvt=use_gfx950_cvt,
+                                            defer_scale16=use_gfx950_cvt,
+                                        )
+                                        gate_list[acc_idx] = mfma_k64(gate_list[acc_idx], a0, a1, bg0, bg1)
+                                        bu0, bu1 = unpack_b_w4a16(
+                                            packed_u,
+                                            arith,
+                                            vector,
+                                            scale_val=sc_u,
+                                            use_gfx950_cvt=use_gfx950_cvt,
+                                            defer_scale16=use_gfx950_cvt,
+                                        )
+                                        up_list[acc_idx] = mfma_k64(up_list[acc_idx], a0, a1, bu0, bu1)
+                        # Drain last pending FMA.
+                        if const_expr(_pending_gate_up is not None):
+                            p_idx, p_g, p_u, p_sc_g, p_sc_u = _pending_gate_up
+                            gate_list[p_idx] = _acc_scaled_f32(gate_list[p_idx], p_g, p_sc_g)
+                            up_list[p_idx] = _acc_scaled_f32(up_list[p_idx], p_u, p_sc_u)
+                    else:
+                        for ku in range_constexpr(k_unroll):
+                            b_gate_packs0, b_gate_packs1 = b_gate_tile_in[ku]
+                            b_up_packs0, b_up_packs1 = b_up_tile_in[ku]
+                            ki64 = arith.index(ku * 64)
+                            col_base = col_offset_base_bytes + ki64
+
+                            for mi in range_constexpr(m_repeat):
+                                mi_val = arith.index(mi * 16)
+                                curr_row_a_lds = row_a_lds + mi_val
+
+                                if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                    a0, a1 = a0_prefetch
+                                else:
+                                    a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+
+                                if const_expr(_use_iglp_opt):
+                                    rocdl.s_setprio(1)
+                                for ni in range_constexpr(num_acc_n):
+                                    acc_idx = mi * num_acc_n + ni
+                                    gate_list[acc_idx] = mfma_k64(
+                                        gate_list[acc_idx],
+                                        a0,
+                                        a1,
+                                        b_gate_packs0[ni],
+                                        b_gate_packs1[ni],
+                                    )
+                                    up_list[acc_idx] = mfma_k64(
+                                        up_list[acc_idx],
+                                        a0,
+                                        a1,
+                                        b_up_packs0[ni],
+                                        b_up_packs1[ni],
+                                    )
+                                if const_expr(_use_iglp_opt):
+                                    rocdl.s_setprio(0)
+                    return gate_list, up_list, epilogue_pf
+
+                # ---------------- 2-stage pipeline (ping-pong LDS + B tile prefetch) ----------------
+                lds_tile_elems = arith.index(tile_m * lds_stride)
+                lds_base_cur = fx.Index(0)
+                lds_base_nxt = lds_tile_elems
+
+                # Optional scheduler hints copied from tuned GEMM.
+                if const_expr(not stage1_disable_sched):
+                    rocdl.sched_barrier(0)
+
+                def hot_loop_scheduler():
+                    if const_expr(stage1_disable_sched):
+                        return
+                    mfma_group = num_acc_n * 2
+                    mfma_total = (tile_k_bytes // 64 * 2) * (tile_m // 16) * mfma_group
+                    mfma_per_iter = 2 * mfma_group
+                    sche_iters = 0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                    rocdl.sched_dsrd(2)
+                    rocdl.sched_mfma(2)
+                    rocdl.sched_dsrd(1)
+                    rocdl.sched_mfma(1)
+                    rocdl.sched_dsrd(1)
+                    rocdl.sched_mfma(1)
+                    dswr_tail = num_x_loads
+                    if const_expr(dswr_tail > sche_iters):
+                        dswr_tail = sche_iters
+                    dswr_start = sche_iters - dswr_tail
+                    for sche_i in range_constexpr(sche_iters):
+                        rocdl.sched_vmem(1)
+                        rocdl.sched_mfma(mfma_group)
+                        rocdl.sched_dsrd(1)
+                        rocdl.sched_mfma(mfma_group)
+                        if const_expr(sche_i >= dswr_start - 1):
+                            rocdl.sched_dswr(1)
+                    rocdl.sched_barrier(0)
+
+                if const_expr(_use_iglp_opt):
+                    rocdl.iglp_opt(1)
+
+                # Prologue: prefetch tile0, store to LDS(cur), sync.
+                k0 = k_base_idx
+                if const_expr(_use_async_dma):
+                    dma_x_tile_to_lds(k0, lds_base_cur)
+                else:
+                    x_regs0 = load_x_tile(k0, x_load_bytes)
+                b_gate_cur = load_b_tile(k0, n_blk_gate, n_intra_gate)
+                b_up_cur = load_b_tile(k0, n_blk_up, n_intra_up)
+                if const_expr(not _use_async_dma):
+                    store_x_tile_to_lds(x_regs0, lds_base_cur, x_load_bytes)
+                if const_expr(fast_barrier):
+                    _inline_barrier_impl(vmcnt=63, lgkmcnt=0)
+                else:
+                    gpu.barrier()
+
+                # Loop-carried ping/pong state.
+                lds_base_pong = lds_base_cur  # current/compute
+                lds_base_ping = lds_base_nxt  # next/load+store
+
+                # Cross-tile A0 LDS prefetch (default-on): prefetch the first A-pack (K64) for the
+                # tile we are about to compute from LDS, to overlap with upcoming VMEM.
+                a0_prefetch_pong = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+
+                # Ping-pong main loop (2 tiles per iteration), leaving 2 tail tiles.
+                # Uses scf.for with loop-carried accumulators, B-tile prefetch, and A0 LDS prefetch.
+                arith.index(tile_k * 2)
+                c_tile_k = arith.index(tile_k)
+                total_tiles = int(_k_per_batch) // int(tile_k)
+                pair_iters = max((total_tiles - 2) // 2, 0)
+
+                # B-tile data layout per k_unroll entry (3 variants):
+                #
+                # 1) int4 + groupwise scale (is_int4_bf16_groupwise):
+                #    [(packed_w4, scale), (packed_w4, scale), ...]   per ni
+                #    Each ni has a (packed_weights, groupwise_scale) pair.
+                #    Flattened as: [packed_0..N, scale_0..N]  → 2 * num_acc_n values
+                #
+                # 2) int4_bf16 without groupwise scale (int4_bf16_single_field):
+                #    [raw_i64, raw_i64, ...]   per ni
+                #    Single packed i64 per ni, already contains both weight halves.
+                #    Flattened as: [raw_0..N]  → 1 * num_acc_n values
+                #
+                # 3) fp8/int8/bf16/fp16 (default — two register packs per ku):
+                #    (packs_even_list, packs_odd_list)
+                #    Two lists of num_acc_n regs for even/odd MFMA operands.
+                #    Flattened as: [even_0..N, odd_0..N]  → 2 * num_acc_n values
+                #
+                int4_bf16_single_field = is_int4_bf16 and not is_int4_bf16_groupwise
+                _fields_per_ku = 1 if int4_bf16_single_field else 2
+                _vals_per_b_tile = k_unroll * _fields_per_ku * num_acc_n
+
+                def _flatten_b_tile(b_tile):
+                    """Flatten B tile to a 1-D list for scf.for loop-carried state."""
+                    flat = []
+                    for ku_entry in b_tile:
+                        if const_expr(is_int4_bf16_groupwise):
+                            # [(packed, scale), ...] → [packed_0..N, scale_0..N]
+                            flat.extend(t[0] for t in ku_entry)
+                            flat.extend(t[1] for t in ku_entry)
+                        elif const_expr(int4_bf16_single_field):
+                            # [raw_i64, ...] → [raw_0..N]
+                            flat.extend(ku_entry)
+                        else:
+                            # (packs_even, packs_odd) → [even_0..N, odd_0..N]
+                            flat.extend(ku_entry[0])
+                            flat.extend(ku_entry[1])
+                    return flat
+
+                def _unflatten_b_tile(vals):
+                    """Reconstruct B tile from flattened scf.for loop-carried state."""
+                    b_tile, idx = [], 0
+                    for _ in range_constexpr(k_unroll):
+                        if const_expr(is_int4_bf16_groupwise):
+                            packed = list(vals[idx : idx + num_acc_n])
+                            idx += num_acc_n
+                            scales = list(vals[idx : idx + num_acc_n])
+                            idx += num_acc_n
+                            b_tile.append([(packed[ni], scales[ni]) for ni in range_constexpr(num_acc_n)])
+                        elif const_expr(int4_bf16_single_field):
+                            b_tile.append(list(vals[idx : idx + num_acc_n]))
+                            idx += num_acc_n
+                        else:
+                            packs_even = list(vals[idx : idx + num_acc_n])
+                            idx += num_acc_n
+                            packs_odd = list(vals[idx : idx + num_acc_n])
+                            idx += num_acc_n
+                            b_tile.append((packs_even, packs_odd))
+                    return b_tile
+
+                init_state = (
+                    list(acc_gate)
+                    + list(acc_up)
+                    + _flatten_b_tile(b_gate_cur)
+                    + _flatten_b_tile(b_up_cur)
+                    + list(a0_prefetch_pong)
+                )
+
+                _n_acc = m_repeat * num_acc_n
+                _p_bg = 2 * _n_acc
+                _p_bu = _p_bg + _vals_per_b_tile
+                _p_a0 = _p_bu + _vals_per_b_tile
+
+                for pair_iv, state in range(0, pair_iters, 1, init=init_state):
+                    _ag = list(state[:_n_acc])
+                    _au = list(state[_n_acc:_p_bg])
+                    _bg = _unflatten_b_tile(list(state[_p_bg:_p_bu]))
+                    _bu = _unflatten_b_tile(list(state[_p_bu:_p_a0]))
+                    _a0pf = (state[_p_a0], state[_p_a0 + 1])
+
+                    k_iv = k_base_idx + pair_iv * (c_tile_k + c_tile_k)
+
+                    # ---- stage 0: prefetch+store ping, compute pong ----
+                    next_k1 = k_iv + c_tile_k
+                    if const_expr(_use_async_dma):
+                        dma_x_tile_to_lds(next_k1, lds_base_ping)
+                    else:
+                        x_regs_ping = load_x_tile(next_k1, x_load_bytes)
+                    _bg_ping = load_b_tile(next_k1, n_blk_gate, n_intra_gate)
+                    _bu_ping = load_b_tile(next_k1, n_blk_up, n_intra_up)
+
+                    _ag, _au, _ = compute_tile(_ag, _au, _bg, _bu, lds_base_pong, a0_prefetch=_a0pf)
+                    if const_expr(not _use_async_dma):
+                        store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
+                    hot_loop_scheduler()
+                    if const_expr(fast_barrier):
+                        _inline_barrier_impl(vmcnt=63, lgkmcnt=0)
+                    else:
+                        gpu.barrier()
+
+                    _a0pf_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+
+                    # ---- stage 1: prefetch+store pong, compute ping ----
+                    next_k2 = k_iv + c_tile_k + c_tile_k
+                    if const_expr(_use_async_dma):
+                        dma_x_tile_to_lds(next_k2, lds_base_pong)
+                    else:
+                        x_regs_pong = load_x_tile(next_k2, x_load_bytes)
+                    _bg_next = load_b_tile(next_k2, n_blk_gate, n_intra_gate)
+                    _bu_next = load_b_tile(next_k2, n_blk_up, n_intra_up)
+
+                    _ag, _au, _ = compute_tile(
+                        _ag,
+                        _au,
+                        _bg_ping,
+                        _bu_ping,
+                        lds_base_ping,
+                        a0_prefetch=_a0pf_ping,
+                    )
+                    if const_expr(not _use_async_dma):
+                        store_x_tile_to_lds(x_regs_pong, lds_base_pong, x_load_bytes)
+                    hot_loop_scheduler()
+                    if const_expr(fast_barrier):
+                        _inline_barrier_impl(vmcnt=63, lgkmcnt=0)
+                    else:
+                        gpu.barrier()
+
+                    _a0pf_new = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+
+                    loop_results = yield (
+                        list(_ag) + list(_au) + _flatten_b_tile(_bg_next) + _flatten_b_tile(_bu_next) + list(_a0pf_new)
+                    )
+
+                # After scf.for: extract final state from yielded results.
+                SmemPtr._view_cache = None
+                if const_expr(pair_iters > 0):
+                    acc_gate = list(loop_results[:_n_acc])
+                    acc_up = list(loop_results[_n_acc:_p_bg])
+                    b_gate_cur = _unflatten_b_tile(list(loop_results[_p_bg:_p_bu]))
+                    b_up_cur = _unflatten_b_tile(list(loop_results[_p_bu:_p_a0]))
+                    a0_prefetch_pong = (loop_results[_p_a0], loop_results[_p_a0 + 1])
+                k_tail1 = k_base_idx + arith.index(_k_per_batch - tile_k)
+                if const_expr(_use_async_dma):
+                    dma_x_tile_to_lds(k_tail1, lds_base_ping)
+                else:
+                    x_regs_ping = load_x_tile(k_tail1, x_load_bytes)
+                b_gate_ping = load_b_tile(k_tail1, n_blk_gate, n_intra_gate)
+                b_up_ping = load_b_tile(k_tail1, n_blk_up, n_intra_up)
+
+                acc_gate, acc_up, _ = compute_tile(
+                    acc_gate,
+                    acc_up,
+                    b_gate_cur,
+                    b_up_cur,
+                    lds_base_pong,
+                    a0_prefetch=a0_prefetch_pong,
+                )
+                a0_prefetch_pong = None
+                if const_expr(not _use_async_dma):
+                    store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
+                hot_loop_scheduler()
+                if const_expr(fast_barrier):
+                    _inline_barrier_impl(vmcnt=63, lgkmcnt=0)
+                else:
+                    gpu.barrier()
+
+                # Cross-tile prefetch for the final ping tile.
+                a0_prefetch_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+
+                # Epilogue: compute last tile with epilogue scale prefetch to overlap loads with MFMA.
+                acc_gate, acc_up, epilogue_pf = compute_tile(
+                    acc_gate,
+                    acc_up,
+                    b_gate_ping,
+                    b_up_ping,
+                    lds_base_ping,
+                    prefetch_epilogue=True,
+                    a0_prefetch=a0_prefetch_ping,
+                )
+
+                # Store epilogue to out[t, slot, inter]
+                expert_off = expert_off_for_scale
+                tokens_i32_v = tokens_i32
+                topk_i32_v = topk_i32
+                inter_i32_v = fx.Int32(inter_dim)
+                mask24_i32 = fx.Int32(0xFFFFFF)
+                sw_gate_vals = []
+                sw_up_vals = []
+                epilogue_tid_vals = None
+
+                if const_expr(use_groupwise_scale):
+                    sw_gate_vals = [arith.constant(1.0, type=T.f32)] * num_acc_n
+                    sw_up_vals = [arith.constant(1.0, type=T.f32)] * num_acc_n
+                elif const_expr(epilogue_pf is not None):
+                    if const_expr(stage1_prefetch_epi_tid):
+                        sw_gate_vals, sw_up_vals, epilogue_tid_vals = epilogue_pf
+                    else:
+                        sw_gate_vals, sw_up_vals, _ = epilogue_pf
+                else:
+                    for ni in range_constexpr(num_acc_n):
+                        col_g = col_g_list[ni]
+                        row_gate_idx = expert_off + col_g
+                        row_up_idx = row_gate_idx + inter_idx
+                        sw_gate_vals.append(
+                            fx.Float32(1.0)
+                            if not needs_scale_w
+                            else buffer_ops.buffer_load(sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32)
+                        )
+                        sw_up_vals.append(
+                            fx.Float32(1.0)
+                            if not needs_scale_w
+                            else buffer_ops.buffer_load(sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32)
+                        )
+
+                # When defer_scale16 was used, the x16 correction for v_cvt_off_f32_i4
+                # was omitted from the hot loop.  Fold it into the epilogue scale.
+                if const_expr(use_gfx950_cvt):
+                    _c16 = fx.Float32(16.0)
+                    sw_gate_vals = [v * _c16 for v in sw_gate_vals]
+                    sw_up_vals = [v * _c16 for v in sw_up_vals]
+
+                # Epilogue hoists to keep IR + Python build time small:
+                col_i32_list = []
+                for ni in range_constexpr(num_acc_n):
+                    col_i32_list.append(arith.index_cast(T.i32, col_g_list[ni]))
+
+                lane_div_16 * fx.Index(4)
+                inter_i32_local = inter_i32_v
+
+                # Uses EVec=4 (buffer store "x4" of fp16 elements).
+                use_cshuffle_epilog_flag = _use_cshuffle_epilog
+
+                # ─── Split-K epilogue: two-pass gate/up with f32 atomic fadd ───
+                if const_expr(_is_splitk):
+                    if const_expr(lds_out is None):
+                        raise RuntimeError("Split-K epilogue requires lds_out (CShuffle)")
+
+                    out_base_idx = buffer_ops.extract_base_index(arg_out)
+                    _split_k_out_row_stride = inter_dim * 2 * out_elem_bytes  # bytes per row
+                    _split_k_e_vec = 2  # f32 vec2 for atomic fadd
+
+                    # Mutable slot: 0 for gate pass, inter_dim for up pass
+                    _split_k_n_offset = [0]
+
+                    # Mutable slots for two-pass gate/up selection
+                    _split_k_acc = [acc_gate]
+                    _split_k_sw_vals = [sw_gate_vals]
+
+                    def write_row_to_lds_splitk(
+                        *,
+                        mi: int,
+                        ii: int,
+                        row_in_tile,
+                        row,
+                        row_base_lds,
+                        col_base_local,
+                        num_acc_n: int,
+                        lds_out,
+                    ):
+                        """Write scaled f32 partial sums to LDS (no silu, no doweight)."""
+                        _acc = _split_k_acc[0]
+                        _sw = _split_k_sw_vals[0]
+                        # Load per-row scale_x (sx) — same logic as normal epilogue.
+                        fused2 = (
+                            memref.load(lds_tid, [row_local])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        )
+                        t2 = fused2 & mask24_i32
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        if const_expr(x_is_token_slot):
+                            s2 = fused2 >> 24
+                            ts2 = s2 * tokens_i32_v + t2
+                            sx = (
+                                fx.Float32(1.0)
+                                if is_f16_or_bf16
+                                else arith.select(
+                                    t_valid,
+                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    fx.Float32(0.0),
+                                )
+                            )
+                        else:
+                            sx = (
+                                fx.Float32(1.0)
+                                if is_f16_or_bf16
+                                else arith.select(
+                                    t_valid,
+                                    buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                    fx.Float32(0.0),
+                                )
+                            )
+                        for ni in range_constexpr(num_acc_n):
+                            col_local = col_base_local + (ni * 16)
+                            acc_idx = mi * num_acc_n + ni
+                            v = vector.extract(_acc[acc_idx], static_position=[ii], dynamic_position=[])
+                            if const_expr(is_int8):
+                                v = arith.sitofp(T.f32, v)
+                            v = v * sx * _sw[ni]
+                            lds_idx = row_base_lds + col_local
+                            v1 = vector.from_elements(T.vec(1, T.f32), [v])
+                            vector.store(v1, lds_out, [lds_idx], alignment=4)
+
+                    def precompute_row_splitk(*, row_local, row):
+                        fused2 = (
+                            memref.load(lds_tid, [row_in_tile])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        )
+                        t2 = fused2 & mask24_i32
+                        s2 = fused2 >> 24
+                        t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        t_idx = arith.index_cast(T.index, t2)
+                        s_idx = arith.index_cast(T.index, s2)
+                        ts_idx = t_idx * arith.index(topk) + s_idx
+                        row_byte_base = out_base_idx + ts_idx * arith.index(_split_k_out_row_stride)
+                        return (row_byte_base, t_ok)
+
+                    def store_pair_splitk(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                        row_byte_base = row_ctx
+                        col_idx = col_g0 + arith.index(_split_k_n_offset[0])
+                        byte_off_col = col_idx * arith.index(out_elem_bytes)
+                        ptr_addr_idx = row_byte_base + byte_off_col
+                        out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
+                        out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                        frag_v = frag._value if hasattr(frag, "_value") else frag
+                        llvm.AtomicRMWOp(
+                            llvm.AtomicBinOp.fadd,
+                            out_ptr_v,
+                            frag_v,
+                            llvm.AtomicOrdering.monotonic,
+                            syncscope="agent",
+                            alignment=_split_k_e_vec * out_elem_bytes,
+                        )
+
+                    _cshuffle_nlane_splitk = min(32, tile_n // _split_k_e_vec)
+                    _splitk_frag_elem = ir.F32Type.get()
+
+                    # Pass 1: gate (offset=0)
+                    _split_k_acc[0] = acc_gate
+                    _split_k_sw_vals[0] = sw_gate_vals
+                    _split_k_n_offset[0] = 0
+                    c_shuffle_epilog(
+                        arith=arith,
+                        vector=vector,
+                        gpu=gpu,
+                        scf=scf,
+                        range_constexpr=range_constexpr,
+                        tile_m=tile_m,
+                        tile_n=tile_n,
+                        e_vec=_split_k_e_vec,
+                        cshuffle_nlane=_cshuffle_nlane_splitk,
+                        block_size=total_threads,
+                        m_repeat=m_repeat,
+                        num_acc_n=num_acc_n,
+                        tx=tx,
+                        lane_div_16=lane_div_16,
+                        lane_mod_16=lane_mod_16,
+                        bx_m=bx_m,
+                        by_n=by_n,
+                        n_tile_base=n_tile_base,
+                        lds_out=lds_out,
+                        frag_elem_type=_splitk_frag_elem,
+                        write_row_to_lds=write_row_to_lds_splitk,
+                        precompute_row=precompute_row_splitk,
+                        store_pair=store_pair_splitk,
+                    )
+
+                    gpu.barrier()
+
+                    # Pass 2: up (offset=inter_dim)
+                    _split_k_acc[0] = acc_up
+                    _split_k_sw_vals[0] = sw_up_vals
+                    _split_k_n_offset[0] = inter_dim
+                    c_shuffle_epilog(
+                        arith=arith,
+                        vector=vector,
+                        gpu=gpu,
+                        scf=scf,
+                        range_constexpr=range_constexpr,
+                        tile_m=tile_m,
+                        tile_n=tile_n,
+                        e_vec=_split_k_e_vec,
+                        cshuffle_nlane=_cshuffle_nlane_splitk,
+                        block_size=total_threads,
+                        m_repeat=m_repeat,
+                        num_acc_n=num_acc_n,
+                        tx=tx,
+                        lane_div_16=lane_div_16,
+                        lane_mod_16=lane_mod_16,
+                        bx_m=bx_m,
+                        by_n=by_n,
+                        n_tile_base=n_tile_base,
+                        lds_out=lds_out,
+                        frag_elem_type=_splitk_frag_elem,
+                        write_row_to_lds=write_row_to_lds_splitk,
+                        precompute_row=precompute_row_splitk,
+                        store_pair=store_pair_splitk,
+                    )
+                    return
+
+                if const_expr(use_cshuffle_epilog_flag):
+                    if const_expr(lds_out is None):
+                        raise RuntimeError("CShuffle epilogue enabled but lds_out is not allocated/aliased.")
+
+                    def write_row_to_lds(
+                        *,
+                        mi: int,
+                        ii: int,
+                        row_in_tile,
+                        row,
+                        row_base_lds,
+                        col_base_local,
+                        num_acc_n: int,
+                        lds_out,
+                    ):
+                        # `row` is the sorted-row index (bx_m + row_in_tile).
+                        fused2 = (
+                            memref.load(lds_tid, [row_in_tile])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        )
+                        t2 = fused2 & mask24_i32
+                        s2 = fused2 >> 24
+                        # aiter moe_sorting uses sentinel token_id == tokens for padding.
+                        # Do NOT rely on buffer OOB semantics for scale loads; explicitly mask.
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        if const_expr(x_is_token_slot):
+                            # slot-major: slot*tokens + token
+                            ts2 = s2 * tokens_i32_v + t2
+                            sx = (
+                                fx.Float32(1.0)
+                                if is_f16_or_bf16
+                                else arith.select(
+                                    t_valid,
+                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    fx.Float32(0.0),
+                                )
+                            )
+                        else:
+                            sx = (
+                                fx.Float32(1.0)
+                                if is_f16_or_bf16
+                                else arith.select(
+                                    t_valid,
+                                    buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                    fx.Float32(0.0),
+                                )
+                            )
+
+                        # Sorted weight aligned with `row` (matches aiter moe_sorting output).
+                        tw = fx.Float32(1.0)
+                        if const_expr(doweight_stage1):
+                            tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+
+                        for ni in range_constexpr(num_acc_n):
+                            col_local = col_base_local + (ni * 16)
+                            sw_gate = sw_gate_vals[ni]
+                            sw_up = sw_up_vals[ni]
+
+                            acc_idx = mi * num_acc_n + ni
+                            vg = vector.extract(
+                                acc_gate[acc_idx],
+                                static_position=[ii],
+                                dynamic_position=[],
+                            )
+                            vu = vector.extract(
+                                acc_up[acc_idx],
+                                static_position=[ii],
+                                dynamic_position=[],
+                            )
+
+                            if const_expr(is_int8):
+                                vg = arith.sitofp(T.f32, vg)
+                                vu = arith.sitofp(T.f32, vu)
+                            vg = vg * sx * sw_gate
+                            vu = vu * sx * sw_up
+
+                            y = silu(vg) * vu
+                            if const_expr(doweight_stage1):
+                                y = y * tw
+                            y_out = arith.trunc_f(out_mlir(), y)
+
+                            lds_idx = row_base_lds + col_local
+                            v1 = vector.from_elements(T.vec(1, out_mlir()), [y_out])
+                            vector.store(v1, lds_out, [lds_idx], alignment=2)
+
+                    def precompute_row(*, row_local, row):
+                        fused2 = (
+                            memref.load(lds_tid, [row_local])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        )
+                        t2 = fused2 & mask24_i32
+                        s2 = fused2 >> 24
+                        return (t2 * topk_i32_v + s2) * inter_i32_local
+
+                    def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                        # Guard against sentinel token ids (t == tokens) produced by aiter moe_sorting padding.
+                        # OOB buffer stores are not guaranteed to be safe on all paths, so predicate explicitly.
+                        fused2 = (
+                            memref.load(lds_tid, [row_local])
+                            if stage1_tid_lds
+                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                        )
+                        t2 = fused2 & mask24_i32
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        _if_valid = scf.IfOp(t_valid)
+                        with _if_then(_if_valid):
+                            idx0 = row_ctx
+                            col_i32 = arith.index_cast(T.i32, col_g0)
+                            idx_out = idx0 + col_i32
+                            # Vectorized fp16 store (EVec=4).
+                            buffer_ops.buffer_store(
+                                frag,
+                                out_rsrc,
+                                idx_out,
+                                cache_modifier=int(output_cache_modifier),
+                            )
+
+                    mfma_epilog(
+                        use_cshuffle=True,
+                        arith=arith,
+                        vector=vector,
+                        gpu=gpu,
+                        scf=scf,
+                        range_constexpr=range_constexpr,
+                        tile_m=tile_m,
+                        tile_n=tile_n,
+                        e_vec=4,
+                        m_repeat=m_repeat,
+                        num_acc_n=num_acc_n,
+                        tx=tx,
+                        lane_div_16=lane_div_16,
+                        lane_mod_16=lane_mod_16,
+                        bx_m=bx_m,
+                        by_n=by_n,
+                        n_tile_base=n_tile_base,
+                        lds_out=lds_out,
+                        frag_elem_type=out_mlir(),
+                        write_row_to_lds=write_row_to_lds,
+                        precompute_row=precompute_row,
+                        store_pair=store_pair,
+                    )
+                    return
+
+                def _stage1_store_row(*, mi: int, ii: int, row_in_tile, row):
+                    # `row` is the sorted-row index (bx_m + row_in_tile).
+                    # Block-level early-exit already guards `bx_m` range.
+                    # Here we rely on buffer OOB semantics for any tail rows.
+                    if const_expr(single_token_route):
+                        t2 = arith.constant(0, type=T.i32)
+                        s2 = route_slot_i32
+                        t_valid = arith.cmpi(arith.CmpIPredicate.eq, row_in_tile, fx.Index(0))
+                    else:
+                        fused2 = (
+                            epilogue_tid_vals[ii]
+                            if stage1_prefetch_epi_tid and epilogue_tid_vals is not None
+                            else (
+                                memref.load(lds_tid, [row_in_tile])
+                                if stage1_tid_lds
+                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            )
+                        )
+                        t2_raw = fused2 & mask24_i32
+                        s2_raw = fused2 >> 24
+                        t2 = t2_raw
+                        s2 = s2_raw
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
+                        if const_expr(stage1_row_limit_epilog > 0):
+                            row_in_limit = arith.cmpi(
+                                arith.CmpIPredicate.ult,
+                                row_in_tile,
+                                fx.Index(stage1_row_limit_epilog),
+                            )
+                            t_valid = arith.andi(t_valid, row_in_limit)
+
+                    # Do NOT rely on buffer OOB semantics for scale loads; explicitly mask.
+                    sx0 = fx.Float32(1.0)
+                    if const_expr(single_token_route):
+                        sx0 = (
+                            fx.Float32(1.0)
+                            if is_f16_or_bf16
+                            else buffer_ops.buffer_load(sx_rsrc, fx.Index(0), vec_width=1, dtype=T.f32)
+                        )
+                    elif const_expr(x_is_token_slot):
+                        # slot-major: slot*tokens + token
+                        ts2 = s2 * tokens_i32_v + t2
+                        sx0 = (
+                            fx.Float32(1.0)
+                            if is_f16_or_bf16
+                            else arith.select(
+                                t_valid,
+                                buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                fx.Float32(0.0),
+                            )
+                        )
+                    else:
+                        sx0 = (
+                            fx.Float32(1.0)
+                            if is_f16_or_bf16
+                            else arith.select(
+                                t_valid,
+                                buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                fx.Float32(0.0),
+                            )
+                        )
+                    sx = sx0
+                    arith.constant(0.0, type=out_mlir())
+
+                    # out linear index base = ((t*topk + s)*inter_dim) (invariant across ni)
+                    if const_expr(single_token_route):
+                        idx0 = route_slot_i32 * inter_i32_local
+                    else:
+                        idx0 = (t2 * topk_i32_v + s2) * inter_i32_local
+
+                    # Sorted weight aligned with `row` (matches aiter moe_sorting output).
+                    tw = fx.Float32(1.0)
+                    if const_expr(doweight_stage1):
+                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+
+                    _if_valid = scf.IfOp(t_valid)
+                    with _if_then(_if_valid):
+                        for ni in range_constexpr(num_acc_n):
+                            col_i32 = col_i32_list[ni]
+                            sw_gate = sw_gate_vals[ni]
+                            sw_up = sw_up_vals[ni]
+
+                            acc_idx = mi * num_acc_n + ni
+                            vg = vector.extract(
+                                acc_gate[acc_idx],
+                                static_position=[ii],
+                                dynamic_position=[],
+                            )
+                            vu = vector.extract(
+                                acc_up[acc_idx],
+                                static_position=[ii],
+                                dynamic_position=[],
+                            )
+
+                            if const_expr(is_int8):
+                                vg = arith.sitofp(T.f32, vg)
+                                vu = arith.sitofp(T.f32, vu)
+                            vg = vg * sx * sw_gate
+                            vu = vu * sx * sw_up
+
+                            y = silu(vg) * vu
+                            if const_expr(doweight_stage1):
+                                y = y * tw
+                            y = arith.trunc_f(out_mlir(), y)
+                            idx_out0 = idx0 + col_i32
+                            buffer_ops.buffer_store(
+                                y,
+                                out_rsrc,
+                                idx_out0,
+                                cache_modifier=int(output_cache_modifier),
+                            )
+
+                mfma_epilog(
+                    use_cshuffle=False,
+                    arith=arith,
+                    range_constexpr=range_constexpr,
+                    m_repeat=m_repeat,
+                    lane_div_16=lane_div_16,
+                    bx_m=bx_m,
+                    body_row=_stage1_store_row,
+                )
+
+    # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
+    @flyc.jit
+    def launch_moe_gemm1(
+        arg_out: fx.Tensor,
+        arg_x: fx.Tensor,
+        arg_w: fx.Tensor,
+        arg_scale_x: fx.Tensor,
+        arg_scale_w: fx.Tensor,
+        arg_sorted_token_ids: fx.Tensor,
+        arg_expert_ids: fx.Tensor,
+        arg_sorted_weights: fx.Tensor,
+        arg_max_token_ids: fx.Tensor,
+        i32_tokens_in: fx.Int32,
+        i32_inter_in: fx.Int32,
+        i32_k_in: fx.Int32,
+        i32_size_expert_ids_in: fx.Int32,
+        stream: fx.Stream,
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        inter_in = arith.index_cast(T.index, i32_inter_in)
+        size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+        gx = inter_in // fx.Index(tile_n)
+        gy = size_expert_ids_in
+
+        moe_gemm1(
+            arg_out,
+            arg_x,
+            arg_w,
+            arg_scale_x,
+            arg_scale_w,
+            arg_sorted_token_ids,
+            arg_expert_ids,
+            arg_sorted_weights,
+            arg_max_token_ids,
+            i32_tokens_in,
+            i32_inter_in,
+            i32_k_in,
+            i32_size_expert_ids_in,
+        ).launch(
+            grid=(gx, gy, k_batch),
+            block=(total_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_moe_gemm1
+
+
+def compile_moe_gemm1_m1(
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    sort_tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    doweight_stage1: bool,
+    in_dtype: str = "fp8",
+    out_dtype: str = "f16",
+    b_cache_modifier: int = 0,
+    enable_hotloop_sched: bool | None = None,
+    output_cache_modifier: int = 0,
+    fast_barrier: bool = False,
+    fine_sched: bool = False,
+):
+    """Compile the decode M=1 stage1 kernel.
+
+    The direct-route layout still uses the caller's `sort_tile_m` stride for
+    stage2 compatibility, but this kernel computes only one 16-row MFMA tile
+    per route and maps `block_y` directly to slot `0..topk-1`.
+    """
+    return compile_moe_gemm1(
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        experts=experts,
+        topk=topk,
+        tile_m=16,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        doweight_stage1=doweight_stage1,
+        in_dtype=in_dtype,
+        out_dtype=out_dtype,
+        use_cshuffle_epilog=False,
+        b_cache_modifier=b_cache_modifier,
+        enable_hotloop_sched=enable_hotloop_sched,
+        output_cache_modifier=output_cache_modifier,
+        fast_barrier=fast_barrier,
+        fine_sched=fine_sched,
+        single_token_route=True,
+        sort_tile_m=sort_tile_m,
+    )
+
+
+@functools.lru_cache(maxsize=1024)
+def compile_moe_gemm2(
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    doweight_stage2: bool,
+    in_dtype: str = "fp8",
+    group_size: int = -1,
+    out_dtype: str = "f16",
+    use_cshuffle_epilog: bool | None = None,
+    accumulate: bool = True,
+    scale_is_bf16: bool = False,
+    b_cache_modifier: int = 0,
+    skip_invalid_lds_write: bool = False,
+    use_lds_sorted_ids: bool = False,
+    precompute_row_base: bool = False,
+    readfirst_metadata: bool = False,
+    m_fast_grid: bool = False,
+    sort_block_m: int = 0,
+    persist_m: int = 1,
+    persistent_grid_y: int = 0,
+    persistent_chunk_y: int = 0,
+    group_size_m: int = 1,
+    cshuffle_nlane: int = 32,
+    weight_interleaved: bool = False,
+):
+    """Compile stage2 kernel (`moe_gemm2`) and return the compiled executable.
+
+    in_dtype:
+      - "fp8": A2/W are fp8
+      - "fp16": A2/W are fp16
+      - "bf16": A2/W are bf16
+      - "int8": A2/W are int8
+      - "int4": W4A8 path: A2 is int8, W is packed int4 unpacked to int8 in-kernel
+      - "int4_bf16": W4A16 path: A2 is bf16, W is packed int4 unpacked to bf16 in-kernel
+    scale_is_bf16: When True, groupwise scales are bf16 (halves scale bandwidth).
+
+    Stage2 output supports:
+      - out_dtype="f16": fp16 half2 atomics (fast, can overflow to +/-inf for bf16 workloads)
+      - out_dtype="f32": fp32 scalar atomics (slower, but avoids fp16 atomic overflow)
+
+    `use_cshuffle_epilog` controls whether we use the LDS CShuffle epilogue before
+    global atomics (recommended for performance).
+    """
+    _use_iglp_opt = False
+    gpu_arch = get_hip_arch()
+    allocator = SmemAllocator(None, arch=gpu_arch)
+    _state = {}
+
+    _valid_dtypes = ("fp8", "fp16", "bf16", "int8", "int8smooth", "int4", "int4_bf16")
+    if in_dtype not in _valid_dtypes:
+        raise ValueError(f"in_dtype must be one of {_valid_dtypes}, got {in_dtype!r}")
+    is_int4_bf16 = in_dtype == "int4_bf16"  # W4A16: bf16 activations, packed int4 weights
+    is_f16 = in_dtype == "fp16"
+    is_bf16 = is_int4_bf16 or in_dtype == "bf16"
+    is_f16_or_bf16 = is_f16 or is_bf16
+    needs_scale_w = (not is_f16_or_bf16) or is_int4_bf16
+    elem_bytes = 2 if is_f16_or_bf16 else 1
+    out_s = str(out_dtype).strip().lower()
+    if out_s not in ("f16", "fp16", "half", "bf16", "bfloat16", "f32", "fp32", "float"):
+        raise ValueError(f"out_dtype must be 'f16', 'bf16', or 'f32', got {out_dtype!r}")
+    out_is_f32 = out_s in ("f32", "fp32", "float")
+    out_is_bf16 = out_s in ("bf16", "bfloat16")
+    if (not bool(accumulate)) and out_is_f32:
+        raise ValueError("compile_moe_gemm2(accumulate=False) only supports out_dtype in {'f16','bf16'}")
+    is_int4 = in_dtype == "int4"
+    # w_is_int4: True for any variant where weights are packed int4.
+    w_is_int4 = is_int4 or is_int4_bf16
+    # INT4 here means W4A8: A2 is int8, W is packed int4 and unpacked to int8 in-kernel.
+    is_int8 = (in_dtype in ("int8", "int8smooth")) or is_int4
+
+    # Group-wise scale support for W4A16
+    use_groupwise_scale = w_is_int4 and group_size > 0
+    if use_groupwise_scale and group_size != 32:
+        raise ValueError(
+            f"FlyDSL groupwise scale only supports group_size=32, got {group_size}. "
+            f"This is due to int4 preshuffle layout constraints. "
+            f"Please use Triton kernel for other group sizes."
+        )
+    is_int4_bf16_groupwise = is_int4_bf16 and use_groupwise_scale
+    # Stage2 K dimension is inter_dim (weight shape: [E, model_dim, inter_dim])
+    num_groups = inter_dim // group_size if use_groupwise_scale else 1
+    _scale_is_bf16 = scale_is_bf16 and use_groupwise_scale
+    _sort_block_m = int(tile_m) if int(sort_block_m) <= 0 else int(sort_block_m)
+    if _sort_block_m != int(tile_m) and (_sort_block_m % int(tile_m)) != 0:
+        raise ValueError(f"sort_block_m ({_sort_block_m}) must be a multiple of stage2 tile_m ({tile_m})")
+    _m_splits = _sort_block_m // int(tile_m)
+    _persist_m = int(persist_m)
+    if _persist_m < 1:
+        raise ValueError(f"persist_m must be >= 1, got {persist_m}")
+    _persistent_grid_y = int(persistent_grid_y)
+    if _persistent_grid_y < 0:
+        raise ValueError(f"persistent_grid_y must be >= 0, got {persistent_grid_y}")
+    _persistent_chunk_y = int(persistent_chunk_y)
+    if _persistent_chunk_y < 0:
+        raise ValueError(f"persistent_chunk_y must be >= 0, got {persistent_chunk_y}")
+    if _persistent_grid_y > 0 and _persistent_chunk_y > 0:
+        raise ValueError("persistent_grid_y and persistent_chunk_y are mutually exclusive")
+    _group_size_m = int(group_size_m)
+    if _group_size_m < 1:
+        raise ValueError(f"group_size_m must be >= 1, got {group_size_m}")
+    if _group_size_m > 1 and bool(m_fast_grid):
+        raise ValueError("group_size_m and m_fast_grid are mutually exclusive")
+    _cshuffle_nlane = int(cshuffle_nlane)
+    if _cshuffle_nlane <= 0 or (256 % _cshuffle_nlane) != 0:
+        raise ValueError(f"cshuffle_nlane must divide 256, got {cshuffle_nlane}")
+    experts * model_dim * num_groups
+
+    _is_gfx950 = "gfx95" in get_hip_arch()
+    use_gfx950_cvt = is_int4_bf16 and _is_gfx950
+
+    mfma_i32_k32 = None
+    if is_int8:
+        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(rocdl, "mfma_i32_16x16x32_i8", None)
+        if mfma_i32_k32 is None:
+            raise AttributeError(
+                "INT8 K32 MFMA op not found: expected `rocdl.mfma_i32_16x16x32i8` (or `rocdl.mfma_i32_16x16x32_i8`)."
+            )
+
+    mfma_f32_bf16_k16 = None
+    if is_bf16:
+        mfma_f32_bf16_k16 = getattr(rocdl, "mfma_f32_16x16x16bf16_1k", None) or getattr(
+            rocdl, "mfma_f32_16x16x16_bf16_1k", None
+        )
+        if mfma_f32_bf16_k16 is None:
+            raise AttributeError(
+                "BF16 K16 MFMA op not found: expected `rocdl.mfma_f32_16x16x16bf16_1k` "
+                "(or `rocdl.mfma_f32_16x16x16_bf16_1k`)."
+            )
+
+    # gfx950: use 16x16x32 MFMA for f16/bf16 (K=32 per MFMA, vs K=16 on gfx942).
+    _use_mfma_k32 = _is_gfx950 and (is_f16 or is_bf16)
+
+    ir.ShapedType.get_dynamic_size()
+    # W is packed int4 for W4A8/W4A16/W4A_FP8: 2 values per byte.
+    ((experts * model_dim * inter_dim) // 2 if w_is_int4 else (experts * model_dim * inter_dim))
+
+    total_threads = 256
+    tile_k_bytes = int(tile_k) * int(elem_bytes)
+    if (tile_k_bytes % 64) != 0:
+        raise ValueError(
+            f"tile_k_bytes must be divisible by 64, got tile_k_bytes={tile_k_bytes} "
+            f"(tile_k={tile_k}, elem_bytes={elem_bytes})"
+        )
+    bytes_x_per_tile = int(tile_m) * int(tile_k) * int(elem_bytes)
+    if bytes_x_per_tile % total_threads != 0:
+        raise ValueError(
+            "tile_m*tile_k*elem_bytes must be divisible by "
+            f"{total_threads}: tile_m={tile_m}, tile_k={tile_k}, elem_bytes={elem_bytes}"
+        )
+    bytes_per_thread_x = bytes_x_per_tile // total_threads
+
+    _ck_lds128 = True
+    pad_k = 0 if _ck_lds128 else 8
+    lds_stride = tile_k + pad_k
+    # gfx950+ has buffer_atomic_pk_add_bf16 → bf16 can use buffer atomics (same as f16).
+    # gfx942 only has global_atomic_pk_add_bf16 → must use global atomics with raw pointer.
+    _has_buffer_atomic_bf16 = str(gpu_arch).startswith(("gfx95", "gfx12"))
+    _needs_global_atomic_bf16 = out_is_bf16 and not _has_buffer_atomic_bf16
+    if out_is_bf16:
+        if not supports_bf16_global_atomics(gpu_arch):
+            raise ValueError(
+                f"out_dtype='bf16' requires bf16 global atomics ({bf16_global_atomics_arch_description()}), got arch={gpu_arch!r}"
+            )
+
+    if out_is_f32:
+        # Match origin/dev_a16w4: f32 output uses scalar atomics and does NOT use the CShuffle epilogue.
+        _use_cshuffle_epilog = False if use_cshuffle_epilog is None else bool(use_cshuffle_epilog)
+        if _use_cshuffle_epilog:
+            raise ValueError("out_dtype='f32' does not support CShuffle epilogue (set use_cshuffle_epilog=False).")
+    else:
+        if use_cshuffle_epilog is None:
+            _use_cshuffle_epilog = True
+        else:
+            _use_cshuffle_epilog = bool(use_cshuffle_epilog)
+        if not _use_cshuffle_epilog:
+            raise ValueError("stage2 f16 output currently requires CShuffle epilogue.")
+
+    # NOTE: Keep this as a callable so we don't require an MLIR Context at Python-time.
+    def out_elem():
+        ty = T.f32 if out_is_f32 else (T.bf16 if out_is_bf16 else T.f16)
+        return ty() if callable(ty) else ty
+
+    epilog_tag = "cshuffle"
+    # IMPORTANT: include tiling in the module name to avoid accidentally reusing a compiled
+    # binary for a different (tile_m, tile_n, tile_k) configuration.
+    # See stage1 note: include ABI tag to prevent binary reuse across signature changes.
+    # IMPORTANT: module name participates in FlyDSL's compile cache key.
+    # Dynamic-shape variant: safe to reuse across (tokens/sorted_size/size_expert_ids) at runtime.
+    # Keep a distinct ABI tag so the compile cache never mixes with historical signatures.
+    _gs_tag = f"_g{group_size}" if use_groupwise_scale else ""
+    scale_tag = "_sbf16" if _scale_is_bf16 else ""
+    _ldsids_tag = "_ldsid" if bool(use_lds_sorted_ids) else ""
+    _rbase_tag = "_rbase" if bool(precompute_row_base) else ""
+    _rfmeta_tag = "_rfmeta" if bool(readfirst_metadata) else ""
+    _mfast_tag = "_mfast" if bool(m_fast_grid) else ""
+    _sbm_tag = "" if _sort_block_m == int(tile_m) else f"_sbm{_sort_block_m}"
+    _pm_tag = "" if _persist_m == 1 else f"_pm{_persist_m}"
+    _pgy_tag = "" if _persistent_grid_y == 0 else f"_pgy{_persistent_grid_y}"
+    _pcy_tag = "" if _persistent_chunk_y == 0 else f"_pcy{_persistent_chunk_y}"
+    _gsm_tag = "" if _group_size_m == 1 else f"_gsm{_group_size_m}"
+    _csnl_tag = "" if _cshuffle_nlane == 32 else f"_csnl{_cshuffle_nlane}"
+    (
+        f"mfma_moe2_{in_dtype}_{out_s}_{epilog_tag}"
+        f"_t{tile_m}x{tile_n}x{tile_k}"
+        f"{_gs_tag}{scale_tag}{_ldsids_tag}{_rbase_tag}{_rfmeta_tag}{_mfast_tag}{_sbm_tag}{_pm_tag}{_pgy_tag}{_pcy_tag}{_gsm_tag}{_csnl_tag}"
+        f"_abi2"  # mask sentinel token ids on loads/stores to avoid illegal address faults
+    ).replace("-", "_")
+
+    # ── CShuffle epilogue e_vec (pure Python; must be computed before @flyc.kernel
+    # because the AST rewriter intercepts `if` statements inside kernel bodies and
+    # turns them into closure dispatches, which breaks variable reassignment) ────
+    if bool(accumulate):
+        _e_vec = 2
+    else:
+        _e_vec = 8 if int(tile_n) % (_cshuffle_nlane * 8) == 0 else 2
+        _cshuffle_stride = _cshuffle_nlane * _e_vec
+        if int(tile_n) % _cshuffle_stride != 0:
+            raise ValueError(f"tile_n={tile_n} must be divisible by {_cshuffle_stride} when accumulate=False")
+
+    # ── LDS sizing (pure Python; no MLIR Context needed) ─────────────────────
+    lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(elem_bytes)
+    lds_out_bytes = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0  # f16 bytes
+    lds_total_bytes = max(lds_x_bytes, lds_out_bytes)
+    lds_total_elems = lds_total_bytes if elem_bytes == 1 else (lds_total_bytes // 2)
+
+    lds_alloc_bytes = int(lds_total_elems) * int(elem_bytes)
+    lds_alloc_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_alloc_offset + lds_alloc_bytes
+    lds_tid_offset = 0
+    if bool(use_lds_sorted_ids):
+        lds_tid_offset = allocator._align(allocator.ptr, 4)
+        allocator.ptr = lds_tid_offset + int(tile_m) * 4
+
+    if True:
+
+        @flyc.kernel
+        def moe_gemm2(
+            arg_out: fx.Tensor,
+            arg_x: fx.Tensor,
+            arg_w: fx.Tensor,
+            arg_scale_x: fx.Tensor,
+            arg_scale_w: fx.Tensor,
+            arg_sorted_token_ids: fx.Tensor,
+            arg_expert_ids: fx.Tensor,
+            arg_sorted_weights: fx.Tensor,
+            arg_num_valid_ids: fx.Tensor,
+            i32_tokens_in: fx.Int32,
+            i32_n_in: fx.Int32,
+            i32_k_in: fx.Int32,
+            i32_size_expert_ids_in: fx.Int32,
+        ):
+            tokens_in = arith.index_cast(T.index, i32_tokens_in)
+            n_in = arith.index_cast(T.index, i32_n_in)
+            k_in = arith.index_cast(T.index, i32_k_in)
+            size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+            # i32 versions for layout construction (fly.make_shape requires i32/i64)
+            k_i32_v = i32_k_in
+            x_elem = T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            # For int4/int4_bf16, weights are stored as packed bytes (i8) and unpacked in-kernel.
+            w_elem = T.i8 if w_is_int4 else (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8)))
+            scale_dtype = T.bf16 if _scale_is_bf16 else T.f32
+            vec16_elems = 16 if elem_bytes == 1 else 8
+            vec8_elems = 8 if elem_bytes == 1 else 4
+            vec8_x = T.vec(vec8_elems, x_elem)
+            vec16_x = T.vec(vec16_elems, x_elem)
+
+            acc_init = arith.constant_vector(0, T.i32x4) if is_int8 else arith.constant_vector(0.0, T.f32x4)
+            zero_f32_acc = arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+
+            # A2 layout (flatten token-slot -> M; use i32 for fly.make_shape).
+            topk_idx = fx.Index(topk)
+            m_in = tokens_in * topk_idx
+            m_i32_v = arith.index_cast(T.i32, m_in)
+            fx.make_layout((m_i32_v, k_i32_v), stride=(k_i32_v, 1))
+
+            # B preshuffle layout: [experts*model_dim, inter_dim]
+            c_n_total = arith.index(experts * model_dim)
+            # For packed int4 (W4A8/W4A16/W4A_FP8), kpack_bytes=8.
+            kpack_bytes = 8 if w_is_int4 else 16
+            w_elem_bytes = 1 if w_is_int4 else elem_bytes
+            b_layout = make_preshuffle_b_layout(
+                arith,
+                c_n=c_n_total,
+                c_k=k_in,
+                kpack_bytes=kpack_bytes,
+                elem_bytes=w_elem_bytes,
+            )
+            layout_b = b_layout.layout_b
+            (k_in * arith.index(int(elem_bytes))) // fx.Index(64)
+
+            shape_lds = fx.make_shape(tile_m, tile_k)
+            stride_lds = fx.make_stride(lds_stride, 1)
+            layout_lds = fx.make_layout(shape_lds, stride_lds)
+
+            tx = gpu.thread_id("x")
+            # Align with Aiter launch mapping:
+            # - blockIdx.x -> N dimension (tile along model_dim)
+            # - blockIdx.y -> expert-block id / M dimension (tile along sorted M)
+            if const_expr(_group_size_m > 1):
+                tile_id = fx.Index(gpu.block_id("x"))
+                num_pid_n = n_in // fx.Index(tile_n)
+                if const_expr(_persistent_chunk_y > 0):
+                    num_pid_m = fx.Index(_persistent_chunk_y)
+                elif const_expr(_persistent_grid_y > 0):
+                    num_pid_m = fx.Index(_persistent_grid_y)
+                elif const_expr(_persist_m > 1):
+                    gy_tiles_g = size_expert_ids_in * fx.Index(_m_splits)
+                    num_pid_m = (gy_tiles_g + fx.Index(_persist_m - 1)) // fx.Index(_persist_m)
+                else:
+                    num_pid_m = size_expert_ids_in * fx.Index(_m_splits)
+                group_m = fx.Index(_group_size_m)
+                num_pid_in_group = group_m * num_pid_n
+                group_id = tile_id // num_pid_in_group
+                first_pid_m = group_id * group_m
+                remaining_m = num_pid_m - first_pid_m
+                actual_group_m = arith.select(remaining_m < group_m, remaining_m, group_m)
+                pid_in_group = tile_id % num_pid_in_group
+                bx_tile_base = pid_in_group % actual_group_m
+                bx_tile_base = bx_tile_base + first_pid_m
+                by = pid_in_group // actual_group_m
+            elif const_expr(bool(m_fast_grid)):
+                bx_tile_base = fx.Index(gpu.block_id("x"))  # compressed stage2 tile along sorted M
+                by = fx.Index(gpu.block_id("y"))  # tile along model_dim
+            else:
+                by = fx.Index(gpu.block_id("x"))  # tile along model_dim
+                bx_tile_base = fx.Index(gpu.block_id("y"))  # compressed stage2 tile along sorted M
+
+            # XOR16 swizzle parameter (in bytes; constant, power-of-two in our configs).
+            k_blocks16 = arith.index(tile_k_bytes // 16)
+            layout_tx_wave_lane = fx.make_layout((4, 64), stride=(64, 1))
+            layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
+            fx.make_layout((tile_m, tile_k), stride=(tile_k, 1))
+
+            base_ptr = allocator.get_base()
+            lds_x_ptr = SmemPtr(
+                base_ptr,
+                lds_alloc_offset,
+                (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))),
+                shape=(lds_total_elems,),
+            )
+            lds_x = lds_x_ptr.get()
+            # Alias the same underlying LDS bytes as f16/bf16 for epilogue shuffle.
+            lds_out = (
+                SmemPtr(
+                    base_ptr,
+                    lds_x_ptr.byte_offset,
+                    (T.bf16 if out_is_bf16 else T.f16),
+                    shape=(tile_m * tile_n,),
+                ).get()
+                if _use_cshuffle_epilog
+                else None
+            )
+            lds_tid = (
+                SmemPtr(base_ptr, lds_tid_offset, T.i32, shape=(tile_m,)).get()
+                if const_expr(bool(use_lds_sorted_ids))
+                else None
+            )
+
+            # Buffer resources.
+            # For dynamic memrefs, `max_size=False` cannot infer the logical size from the memref *type*,
+            # so we should pass `num_records_bytes` explicitly for stable hardware OOB behavior.
+            c_topk = fx.Index(topk)
+
+            # X(A2): [tokens*topk, inter_dim] bytes = tokens*topk*k*elem_bytes
+            x_rows = tokens_in * c_topk
+            x_nbytes_idx = x_rows * k_in * arith.index(int(elem_bytes))
+            x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_idx)
+
+            w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
+
+            # OUT: [tokens, model_dim] -> clamp to descriptor max (i32 bytes) to avoid overflow on huge tokens.
+            out_elem_bytes = 4 if out_is_f32 else 2
+            out_nbytes_idx = tokens_in * n_in * fx.Index(out_elem_bytes)
+            if const_expr(not bool(accumulate)):
+                out_nbytes_idx = tokens_in * fx.Index(topk) * n_in * fx.Index(out_elem_bytes)
+            out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes_idx)
+            # scale_x: fp16/bf16 path ignores (implicit scale=1.0); int4_bf16 also uses 1.0.
+            sx_rsrc = -1
+            if const_expr(not is_f16_or_bf16):
+                # scale_x (A2 scale): [tokens*topk] f32 -> bytes = tokens*topk*4
+                sx_nbytes_idx = x_rows * fx.Index(4)
+                sx_rsrc = buffer_ops.create_buffer_resource(
+                    arg_scale_x, max_size=False, num_records_bytes=sx_nbytes_idx
+                )
+            # scale_w: fp16/bf16 (non-int4) path ignores; int4_bf16 needs dequant scale.
+            sw_rsrc = -1
+            if const_expr(needs_scale_w):
+                # scale_w: [experts*model_dim] f32 (static shape in practice)
+                sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False)
+
+            # sorted_token_ids / sorted_weights: [sort_blocks*sort_block_m] (CK-style padded length)
+            sorted_nbytes_idx = size_expert_ids_in * fx.Index(_sort_block_m) * fx.Index(4)
+            sorted_rsrc = buffer_ops.create_buffer_resource(
+                arg_sorted_token_ids,
+                max_size=False,
+                num_records_bytes=sorted_nbytes_idx,
+            )
+            sorted_w_rsrc = buffer_ops.create_buffer_resource(
+                arg_sorted_weights, max_size=False, num_records_bytes=sorted_nbytes_idx
+            )
+
+            # expert ids: [blocks] i32 -> bytes = size_expert_ids_in*4
+            eid_nbytes_idx = size_expert_ids_in * fx.Index(4)
+            expert_rsrc = buffer_ops.create_buffer_resource(
+                arg_expert_ids, max_size=False, num_records_bytes=eid_nbytes_idx
+            )
+            # Early-exit guard (as in 2ce65fb): some routing paths can produce extra/garbage
+            # expert blocks beyond `num_valid_ids`. Skip those blocks entirely to avoid OOB.
+            numids_rsrc = buffer_ops.create_buffer_resource(
+                arg_num_valid_ids,
+                max_size=False,
+                num_records_bytes=fx.Index(4),
+            )
+            num_valid_i32 = buffer_ops.buffer_load(numids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+            if const_expr(bool(readfirst_metadata)):
+                num_valid_i32 = rocdl.readfirstlane(T.i32, num_valid_i32)
+
+            def _emit_stage2_m_tile(bx_tile):
+                if const_expr(
+                    _m_splits == 1
+                    and _persist_m == 1
+                    and _persistent_grid_y == 0
+                    and _persistent_chunk_y == 0
+                    and _group_size_m == 1
+                ):
+                    sort_blk = bx_tile
+                    bx_m = bx_tile * fx.Index(tile_m)
+                    bx_m_i32 = arith.index_cast(T.i32, bx_m)
+                    blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32)
+                else:
+                    gy_tiles = size_expert_ids_in * fx.Index(_m_splits)
+                    tile_in_range = arith.cmpi(arith.CmpIPredicate.ult, bx_tile, gy_tiles)
+                    bx_tile_safe = tile_in_range.select(bx_tile, fx.Index(0))
+                    if const_expr(_m_splits == 1):
+                        sort_blk = bx_tile_safe
+                        bx_m = bx_tile_safe * fx.Index(tile_m)
+                    else:
+                        split_idx = fx.Index(_m_splits)
+                        sort_blk = bx_tile_safe // split_idx
+                        sub_blk = bx_tile_safe % split_idx
+                        bx_m = sort_blk * fx.Index(_sort_block_m) + sub_blk * fx.Index(tile_m)
+                    bx_m_i32 = arith.index_cast(T.i32, bx_m)
+                    blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32)
+                    expert_i32_early = buffer_ops.buffer_load(expert_rsrc, sort_blk, vec_width=1, dtype=T.i32)
+                    if const_expr(bool(readfirst_metadata)):
+                        expert_i32_early = rocdl.readfirstlane(T.i32, expert_i32_early)
+                    expert_valid = arith.cmpi(
+                        arith.CmpIPredicate.sge,
+                        expert_i32_early,
+                        arith.constant(0, type=T.i32),
+                    )
+                    blk_valid = tile_in_range & blk_valid & expert_valid
+
+                def _moe_gemm2_then_body():
+                    # Expert id for this M tile.
+                    expert_i32 = buffer_ops.buffer_load(expert_rsrc, sort_blk, vec_width=1, dtype=T.i32)
+                    if const_expr(bool(readfirst_metadata)):
+                        expert_i32 = rocdl.readfirstlane(T.i32, expert_i32)
+                    expert_idx = arith.index_cast(T.index, expert_i32)
+                    if const_expr(bool(weight_interleaved)):
+                        # Interleaved layout: flat buffer [N_tiles * E * tile_n * K]
+                        # Current N-tile starts at by * (E * tile_n) in the N-dimension
+                        # Weight offset: by * (E * tile_n) + expert_id * tile_n
+                        ntile_base = by * fx.Index(experts * tile_n)
+                        expert_off_idx = ntile_base + expert_idx * fx.Index(tile_n)
+                        # Scale offset: standard layout (expert_id * model_dim)
+                        expert_off_for_scale = expert_idx * fx.Index(model_dim)
+                    else:
+                        n_idx = fx.Index(model_dim)
+                        expert_off_idx = expert_idx * n_idx  # index
+                        expert_off_for_scale = expert_off_idx
+
+                    # ---- X gmem->reg prefetch (match preshuffle GEMM mapping) ----
+                    # Prefer 16B buffer-load (dwordx4). If the per-thread byte count isn't divisible by
+                    # 16, fall back to 8B (dwordx2) or 4B (dword) loads. For fp16/bf16 we require 16B.
+                    x_load_bytes = 16
+                    if const_expr(is_f16_or_bf16):
+                        if const_expr(bytes_per_thread_x % 16 != 0):
+                            raise ValueError(
+                                f"[fp16] bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 16"
+                            )
+                        x_load_bytes = 16
+                    else:
+                        if const_expr(bytes_per_thread_x % 16 == 0):
+                            x_load_bytes = 16
+                        elif const_expr(bytes_per_thread_x % 8 == 0):
+                            x_load_bytes = 8
+                        elif const_expr(bytes_per_thread_x % 4 == 0):
+                            x_load_bytes = 4
+                        else:
+                            raise ValueError(
+                                f"bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 4 to use the dword-indexed load mapping."
+                            )
+                    num_x_loads = bytes_per_thread_x // x_load_bytes
+                    chunk_i32 = x_load_bytes // 4  # dwords per chunk (1/2/4)
+
+                    c_k_div4 = (k_in * arith.index(int(elem_bytes))) // fx.Index(4)
+                    c_k_div4_i32 = arith.index_cast(T.i32, c_k_div4)
+                    fx.make_layout((m_i32_v, c_k_div4_i32), stride=(c_k_div4_i32, 1))
+                    tile_k_dwords = (int(tile_k) * int(elem_bytes)) // 4
+                    layout_x_tile_div4 = fx.make_layout((tile_m, tile_k_dwords), stride=(tile_k_dwords, 1))
+                    c_chunk_i32 = fx.Index(chunk_i32)
+                    tx_i32_base = tx * c_chunk_i32
+
+                    topk_i32 = fx.Int32(topk)
+                    mask24 = fx.Int32(0xFFFFFF)
+                    # Sentinel clamp uses `tokens` as the upper bound: t_valid = (t < tokens).
+                    tokens_i32 = arith.index_cast(T.i32, tokens_in)
+
+                    def x_tile_chunk_coord_i32(i: int):
+                        return tile_chunk_coord_i32(
+                            arith,
+                            tx_i32_base=tx_i32_base,
+                            i=i,
+                            total_threads=total_threads,
+                            layout_tile_div4=layout_x_tile_div4,
+                            chunk_i32=chunk_i32,
+                        )
+
+                    vec4_x = T.vec(4, x_elem)
+
+                    def preload_sorted_ids_to_lds():
+                        if const_expr(bool(use_lds_sorted_ids)):
+                            tid_in_range = arith.cmpi(arith.CmpIPredicate.ult, tx, fx.Index(tile_m))
+                            tid_if = scf.IfOp(tid_in_range)
+                            with _if_then(tid_if):
+                                tid_row = bx_m + tx
+                                tid_val = buffer_ops.buffer_load(sorted_rsrc, tid_row, vec_width=1, dtype=T.i32)
+                                tid_vec1 = vector.from_elements(T.vec(1, T.i32), [tid_val])
+                                vector.store(tid_vec1, lds_tid, [tx], alignment=4)
+                            gpu.barrier()
+
+                    preload_sorted_ids_to_lds()
+
+                    def load_x(idx_i32, x_load_bytes_v):
+                        if const_expr(x_load_bytes_v == 16):
+                            idx_elem = idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                            return buffer_copy_gmem16_dwordx4(
+                                buffer_ops,
+                                vector,
+                                elem_type=x_elem,
+                                idx_i32=idx_elem,
+                                rsrc=x_rsrc,
+                                vec_elems=vec16_elems,
+                                elem_bytes=elem_bytes,
+                            )
+                        if const_expr(x_load_bytes_v == 8):
+                            return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=2, dtype=T.i32)
+                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=1, dtype=T.i32)
+
+                    # decode routed token once (per thread's M-slice) and build a base offset.
+                    x_row_base_div4 = []
+                    x_col_local_i32 = []
+                    x_row_local = []
+                    for i in range_constexpr(num_x_loads):
+                        row_local, col_local_i32 = x_tile_chunk_coord_i32(i)
+                        x_row_local.append(row_local)
+                        x_col_local_i32.append(col_local_i32)
+
+                        sorted_row_i = bx_m + row_local
+                        fused_i = (
+                            memref.load(lds_tid, [row_local])
+                            if const_expr(bool(use_lds_sorted_ids))
+                            else buffer_ops.buffer_load(sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32)
+                        )
+                        t_i32 = fused_i & mask24
+                        s_i32 = fused_i >> 24
+                        # aiter moe_sorting uses sentinel token_id == tokens for padding.
+                        # Do NOT rely on buffer OOB semantics for A2/scale loads; explicitly mask.
+                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t_i32, tokens_i32)
+                        s_valid = arith.cmpi(arith.CmpIPredicate.ult, s_i32, topk_i32)
+                        ts_valid = t_valid & s_valid
+                        t_safe = ts_valid.select(t_i32, fx.Int32(0))
+                        s_safe = ts_valid.select(s_i32, fx.Int32(0))
+                        row_ts_i32 = t_safe * topk_i32 + s_safe
+                        row_ts_idx = arith.index_cast(T.index, row_ts_i32)
+                        # Base row offset in dword units: row_ts_idx * (k_in/4)
+                        x_row_base_div4.append(row_ts_idx * c_k_div4)
+
+                    def load_x_tile(base_k, x_load_bytes_v):
+                        base_k_div4 = (base_k * arith.index(int(elem_bytes))) // fx.Index(4)
+                        parts = []
+                        for i in range_constexpr(num_x_loads):
+                            idx_i32 = x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
+                            x_vec = load_x(idx_i32, x_load_bytes_v)
+                            if const_expr(x_load_bytes_v == 16):
+                                parts.append(vector.bitcast(T.i32x4, x_vec))
+                            elif const_expr(x_load_bytes_v == 8):
+                                parts.append(vector.bitcast(T.vec(2, T.i32), x_vec))
+                            elif const_expr(x_load_bytes_v == 4):
+                                # 4B scalar load: x_vec is already i32, wrap in vector<1xi32>
+                                parts.append(vector.broadcast(T.vec(1, T.i32), x_vec))
+                            else:
+                                parts.append(vector.bitcast(T.vec(1, T.i32), x_vec))
+                        return parts
+
+                    # tx -> wave/lane (GEMM-style decomposition).
+                    coord_wl = fx.idx2crd(tx, layout_tx_wave_lane)
+                    wave_id = fx.get(coord_wl, 0)
+                    lane_id = fx.get(coord_wl, 1)
+                    coord_l16 = fx.idx2crd(lane_id, layout_lane16)
+                    lane_div_16 = fx.get(coord_l16, 0)
+                    lane_mod_16 = fx.get(coord_l16, 1)
+
+                    row_a_lds = lane_mod_16
+                    # A-side kpack is always 16 bytes; kpack_bytes is B-side (may be 8 for int4).
+                    a_kpack_elems = 16 // elem_bytes
+                    col_offset_base = lane_div_16 * arith.index(int(a_kpack_elems))
+                    col_offset_base_bytes = (
+                        col_offset_base if elem_bytes == 1 else (col_offset_base * arith.index(int(elem_bytes)))
+                    )
+
+                    # Dynamic N tiling within block.
+                    by_n = by * fx.Index(tile_n)
+                    num_waves = 4
+                    n_per_wave = tile_n // num_waves
+                    num_acc_n = n_per_wave // 16
+                    c_n_per_wave = fx.Index(n_per_wave)
+                    wave_mod_4 = wave_id % fx.Index(4)
+                    n_tile_base = wave_mod_4 * c_n_per_wave
+
+                    # Precompute (n_blk, n_intra) for B, and col indices for output.
+                    n_intra_list = []
+                    n_blk_list = []
+                    col_g_list = []
+                    c_n_total // fx.Index(16)
+                    c_n0_static = experts * model_dim // 16
+                    layout_n_blk_intra = fx.make_layout((c_n0_static, 16), stride=(16, 1))
+                    for ni in range_constexpr(num_acc_n):
+                        offset = arith.index(ni * 16)
+                        if const_expr(bool(weight_interleaved)):
+                            # In interleaved mode, col_g is local to tile_n (0..tile_n-1)
+                            col_g_local = n_tile_base + offset + lane_mod_16
+                            col_g = by_n + col_g_local  # for output addressing (full model_dim)
+                            col_g_list.append(col_g)
+                            row_w = expert_off_idx + col_g_local
+                        else:
+                            col_g = by_n + n_tile_base + offset + lane_mod_16
+                            col_g_list.append(col_g)
+                            row_w = expert_off_idx + col_g
+                        coord_w = fx.idx2crd(row_w, layout_n_blk_intra)
+                        n_blk_list.append(fx.get(coord_w, 0))
+                        n_intra_list.append(fx.get(coord_w, 1))
+
+                    m_repeat = tile_m // 16
+                    k_unroll = tile_k_bytes // 64  # K64-byte micro-step (2x MFMA)
+
+                    # --- B Load Logic (K64) ---
+                    def load_b_pack(base_k, ki_step, ni):
+                        return load_b_pack_k32(
+                            buffer_ops,
+                            arith,
+                            vector,
+                            arg_b=arg_w,
+                            b_rsrc=w_rsrc,
+                            layout_b=layout_b,
+                            base_k=base_k,
+                            ki_step=ki_step,
+                            n_blk=n_blk_list[ni],
+                            n_intra=n_intra_list[ni],
+                            lane_div_16=lane_div_16,  # 0..3
+                            elem_type=w_elem,
+                            kpack_bytes=kpack_bytes,
+                            elem_bytes=w_elem_bytes,
+                            unpack_int4=(is_int4 or is_int4_bf16),
+                            **({"cache_modifier": int(b_cache_modifier)} if int(b_cache_modifier) != 0 else {}),
+                        )
+
+                    def load_b_tile(base_k):
+                        """Prefetch the entire per-thread B tile (gmem -> regs) for a given K base.
+
+                        Returns a list of length `k_unroll`, where each entry is a tuple:
+                          (packs_half0[ni], packs_half1[ni])  for the K64 micro-step.
+                        For groupwise variants, each entry also includes per-group scales:
+                          (packs0[ni], packs1[ni], scales0[ni], scales1[ni])
+                        """
+                        if const_expr(is_int4_bf16_groupwise):
+                            # W4A16 groupwise: load raw packed32 + scale; defer dequant to compute_tile.
+                            raw_data = []
+                            for ku in range_constexpr(k_unroll):
+                                raw_ku = []
+                                for ni in range_constexpr(num_acc_n):
+                                    packed32, scale_val = load_b_raw_w4a16_groupwise(
+                                        buffer_ops,
+                                        arith,
+                                        vector,
+                                        arg_b=arg_w,
+                                        b_rsrc=w_rsrc,
+                                        layout_b=layout_b,
+                                        base_k=base_k,
+                                        ku=ku,
+                                        n_blk=n_blk_list[ni],
+                                        n_intra=n_intra_list[ni],
+                                        lane_div_16=lane_div_16,
+                                        elem_type=w_elem,
+                                        scale_rsrc=sw_rsrc,
+                                        expert_offset=expert_off_idx,
+                                        num_groups=num_groups,
+                                        group_size=group_size,
+                                        n_per_expert=model_dim,
+                                        kpack_bytes=kpack_bytes,
+                                        scale_dtype=scale_dtype,
+                                    )
+                                    raw_ku.append((packed32, scale_val))
+                                raw_data.append(raw_ku)
+                            return raw_data
+                        elif const_expr(is_int4_bf16):
+                            # W4A16 per-row: load raw packed32; defer dequant to compute_tile.
+                            raw_data = []
+                            for ku in range_constexpr(k_unroll):
+                                raw_ku = []
+                                for ni in range_constexpr(num_acc_n):
+                                    raw = load_b_raw_w4a16(
+                                        buffer_ops,
+                                        arith,
+                                        vector,
+                                        arg_b=arg_w,
+                                        b_rsrc=w_rsrc,
+                                        layout_b=layout_b,
+                                        base_k=base_k,
+                                        ku=ku,
+                                        n_blk=n_blk_list[ni],
+                                        n_intra=n_intra_list[ni],
+                                        lane_div_16=lane_div_16,
+                                        elem_type=w_elem,
+                                        kpack_bytes=kpack_bytes,
+                                    )
+                                    raw_ku.append(raw)
+                                raw_data.append(raw_ku)
+                            return raw_data
+                        else:
+                            # fp8/int8/bf16/fp16: original code path
+                            b_tile = []
+                            for ku in range_constexpr(k_unroll):
+                                packs0 = []
+                                packs1 = []
+                                for ni in range_constexpr(num_acc_n):
+                                    ki0 = (ku * 2) + 0
+                                    ki1 = (ku * 2) + 1
+                                    b0 = load_b_pack(base_k, ki0, ni)
+                                    b1 = load_b_pack(base_k, ki1, ni)
+                                    packs0.append(b0)
+                                    packs1.append(b1)
+                                b_tile.append((packs0, packs1))
+                            return b_tile
+
+                    # ---- Pipeline helpers: store X tile to LDS with ping-pong base ----
+                    def store_x_tile_to_lds(vec_x_in_parts, lds_base, x_load_bytes_v):
+                        for i in range_constexpr(num_x_loads):
+                            row_local = x_row_local[i]
+                            col_local_i32 = x_col_local_i32[i]
+                            if const_expr(x_load_bytes_v == 16):
+                                lds_store_16b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec16_ty=vec16_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x4=vec_x_in_parts[i],
+                                    elem_bytes=elem_bytes,
+                                )
+                            elif const_expr(x_load_bytes_v == 8):
+                                lds_store_8b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec8_ty=vec8_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x2=vec_x_in_parts[i],
+                                )
+                            else:
+                                lds_store_4b_xor16(
+                                    arith,
+                                    vector,
+                                    lds_memref=lds_x,
+                                    vec4_ty=vec4_x,
+                                    layout_lds=layout_lds,
+                                    row_local=row_local,
+                                    col_local_i32=col_local_i32,
+                                    tx_c4=fx.Index(4),
+                                    k_blocks16=k_blocks16,
+                                    lds_base=lds_base,
+                                    vec_part_i32x1=vec_x_in_parts[i],
+                                )
+
+                    # --- A LDS load helper for K64 (load 16B once, extract 2x i64 halves) ---
+                    def lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base):
+                        col_base_swz_bytes = swizzle_xor16(curr_row_a_lds, col_base_bytes, k_blocks16)
+                        col_base_swz = (
+                            col_base_swz_bytes
+                            if elem_bytes == 1
+                            else (col_base_swz_bytes // arith.index(int(elem_bytes)))
+                        )
+                        idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds)
+                        idx_a16 = idx_a16 + lds_base
+                        loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
+                        a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
+                        a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
+                        a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                        return a0, a1
+
+                    epilogue_pf = []
+
+                    def compute_tile(
+                        acc_in,
+                        b_tile_in,
+                        lds_base,
+                        *,
+                        prefetch_epilogue: bool = False,
+                        a0_prefetch=None,
+                    ):
+                        acc_list = list(acc_in)
+                        mfma_res_ty = T.i32x4 if is_int8 else T.f32x4
+                        if const_expr(_use_mfma_k32):
+                            mfma_fn = rocdl.mfma_f32_16x16x32_f16 if is_f16 else rocdl.mfma_f32_16x16x32_bf16
+                        else:
+                            mfma_fn = (
+                                mfma_i32_k32
+                                if is_int8
+                                else (
+                                    mfma_f32_bf16_k16
+                                    if is_bf16
+                                    else (rocdl.mfma_f32_16x16x16f16 if is_f16 else rocdl.mfma_f32_16x16x32_fp8_fp8)
+                                )
+                            )
+
+                        epilogue_pf = None
+                        if const_expr(prefetch_epilogue and not use_groupwise_scale):
+                            expert_off_pf = expert_off_for_scale
+                            sw_pf = []
+                            for ni in range_constexpr(num_acc_n):
+                                col_g = col_g_list[ni]
+                                row_w_idx = expert_off_pf + col_g
+                                sw_pf.append(
+                                    fx.Float32(1.0)
+                                    if not needs_scale_w
+                                    else buffer_ops.buffer_load(sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                                )
+                            # Also prefetch per-row routed/topk weights (sorted_weights) when enabled.
+                            tw_pf = []
+                            if const_expr(doweight_stage2):
+                                lane_div_16_mul4_pf = lane_div_16 * fx.Index(4)
+                                ii_idx_list_pf = [fx.Index(ii) for ii in range(4)]
+                                for mi in range_constexpr(m_repeat):
+                                    mi_base_pf = arith.index(mi * 16)
+                                    for ii in range_constexpr(4):
+                                        row_off_pf = lane_div_16_mul4_pf + ii_idx_list_pf[ii]
+                                        row_in_tile_pf = mi_base_pf + row_off_pf
+                                        sorted_row_pf = bx_m + row_in_tile_pf
+                                        tw_pf.append(
+                                            buffer_ops.buffer_load(
+                                                sorted_w_rsrc,
+                                                sorted_row_pf,
+                                                vec_width=1,
+                                                dtype=T.f32,
+                                            )
+                                        )
+                            epilogue_pf = (sw_pf, tw_pf)
+
+                        def _i64_to_v4f16(x_i64):
+                            v1 = vector.from_elements(T.vec(1, T.i64), [x_i64])
+                            return vector.bitcast(T.f16x4, v1)
+
+                        def _i64_to_v4i16(x_i64):
+                            v1 = vector.from_elements(T.vec(1, T.i64), [x_i64])
+                            return vector.bitcast(T.i16x4, v1)
+
+                        def _i64x2_to_v8f16(lo, hi):
+                            v2 = vector.from_elements(T.i64x2, [lo, hi])
+                            return vector.bitcast(T.f16x8, v2)
+
+                        def _i64x2_to_v8bf16(lo, hi):
+                            v2 = vector.from_elements(T.i64x2, [lo, hi])
+                            return vector.bitcast(T.bf16x8, v2)
+
+                        def mfma_k64(acc0, a0, a1, b0, b1):
+                            if const_expr(_use_mfma_k32):
+                                # gfx950: single 16x16x32 MFMA consuming all 128 bits (K=32 f16/bf16)
+                                if const_expr(is_f16):
+                                    av = _i64x2_to_v8f16(a0, a1)
+                                    bv = _i64x2_to_v8f16(b0, b1)
+                                else:
+                                    av = _i64x2_to_v8bf16(a0, a1)
+                                    bv = _i64x2_to_v8bf16(b0, b1)
+                                return mfma_fn(mfma_res_ty, [av, bv, acc0, 0, 0, 0])
+                            if const_expr(is_f16):
+                                a0v = _i64_to_v4f16(a0)
+                                a1v = _i64_to_v4f16(a1)
+                                b0v = _i64_to_v4f16(b0)
+                                b1v = _i64_to_v4f16(b1)
+                                acc1 = mfma_fn(mfma_res_ty, [a0v, b0v, acc0, 0, 0, 0])
+                                return mfma_fn(mfma_res_ty, [a1v, b1v, acc1, 0, 0, 0])
+                            if const_expr(is_bf16):
+                                a0v = _i64_to_v4i16(a0)
+                                a1v = _i64_to_v4i16(a1)
+                                b0v = _i64_to_v4i16(b0)
+                                b1v = _i64_to_v4i16(b1)
+                                acc1 = mfma_fn(mfma_res_ty, [a0v, b0v, acc0, 0, 0, 0])
+                                return mfma_fn(mfma_res_ty, [a1v, b1v, acc1, 0, 0, 0])
+                            acc1 = mfma_fn(mfma_res_ty, [a0, b0, acc0, 0, 0, 0])
+                            return mfma_fn(mfma_res_ty, [a1, b1, acc1, 0, 0, 0])
+
+                        def _acc_scaled_f32(f32_acc_vec, f32_partial_vec, scale_val):
+                            """MFMA f32 partial -> scale -> add to f32 accumulator via math.fma on vector."""
+                            from flydsl._mlir.dialects._math_ops_gen import (
+                                fma as _math_fma,
+                            )
+
+                            _uw = arith._to_raw
+                            scale_vec = _uw(vector.broadcast(T.f32x4, scale_val))
+                            return arith.ArithValue(_math_fma(scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec)))
+
+                        if const_expr(is_int4_bf16 or is_int4_bf16_groupwise):
+                            # W4A16: deferred dequant -- unpack int4->bf16 right before MFMA
+                            # to minimize VGPR lifetime of dequantized bf16 values.
+                            _pending_acc = None
+                            for ku in range_constexpr(k_unroll):
+                                b_raw = b_tile_in[ku]
+                                ki64 = arith.index(ku * 64)
+                                col_base = col_offset_base_bytes + ki64
+
+                                for mi in range_constexpr(m_repeat):
+                                    mi_val = arith.index(mi * 16)
+                                    curr_row_a_lds = row_a_lds + mi_val
+
+                                    if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                        a0, a1 = a0_prefetch
+                                    else:
+                                        a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+
+                                    for ni in range_constexpr(num_acc_n):
+                                        acc_idx = mi * num_acc_n + ni
+                                        if const_expr(is_int4_bf16_groupwise):
+                                            packed, sc = b_raw[ni]
+                                            if const_expr(_scale_is_bf16):
+                                                sc = extract_bf16_scale(arith, sc, ku)
+                                        else:
+                                            packed, sc = b_raw[ni], None
+                                        if const_expr(is_int4_bf16_groupwise and use_gfx950_cvt):
+                                            b0, b1 = unpack_b_w4a16(
+                                                packed,
+                                                arith,
+                                                vector,
+                                                scale_val=None,
+                                                use_gfx950_cvt=True,
+                                                defer_scale16=True,
+                                            )
+                                            tmp = mfma_k64(zero_f32_acc, a0, a1, b0, b1)
+                                            if const_expr(_pending_acc is not None):
+                                                p_idx, p_tmp, p_sc = _pending_acc
+                                                acc_list[p_idx] = _acc_scaled_f32(acc_list[p_idx], p_tmp, p_sc)
+                                            _pending_acc = (acc_idx, tmp, sc)
+                                        else:
+                                            b0, b1 = unpack_b_w4a16(
+                                                packed,
+                                                arith,
+                                                vector,
+                                                scale_val=sc,
+                                                use_gfx950_cvt=use_gfx950_cvt,
+                                                defer_scale16=use_gfx950_cvt,
+                                            )
+                                            acc_list[acc_idx] = mfma_k64(acc_list[acc_idx], a0, a1, b0, b1)
+                            # Drain last pending FMA.
+                            if const_expr(_pending_acc is not None):
+                                p_idx, p_tmp, p_sc = _pending_acc
+                                acc_list[p_idx] = _acc_scaled_f32(acc_list[p_idx], p_tmp, p_sc)
+                        else:
+                            for ku in range_constexpr(k_unroll):
+                                b_packs0, b_packs1 = b_tile_in[ku]
+                                ki64 = arith.index(ku * 64)
+                                col_base = col_offset_base_bytes + ki64
+
+                                for mi in range_constexpr(m_repeat):
+                                    mi_val = arith.index(mi * 16)
+                                    curr_row_a_lds = row_a_lds + mi_val
+
+                                    if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                        a0, a1 = a0_prefetch
+                                    else:
+                                        a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+
+                                    if const_expr(_use_iglp_opt):
+                                        rocdl.s_setprio(1)
+                                    for ni in range_constexpr(num_acc_n):
+                                        acc_idx = mi * num_acc_n + ni
+                                        acc_list[acc_idx] = mfma_k64(
+                                            acc_list[acc_idx],
+                                            a0,
+                                            a1,
+                                            b_packs0[ni],
+                                            b_packs1[ni],
+                                        )
+                                    if const_expr(_use_iglp_opt):
+                                        rocdl.s_setprio(0)
+                        return acc_list, epilogue_pf
+
+                    # ---------------- 2-stage pipeline (ping-pong LDS + B tile prefetch) ----------------
+                    lds_tile_elems = arith.index(tile_m * lds_stride)
+                    lds_base_cur = fx.Index(0)
+                    lds_base_nxt = lds_tile_elems
+
+                    rocdl.sched_barrier(0)
+
+                    # def hot_loop_scheduler():
+                    #     mfma_group = num_acc_n
+                    #     # K64 micro-step: 2x K32 MFMA per accumulator update.
+                    #     mfma_total = (k_unroll * 2) * m_repeat * mfma_group
+                    #     mfma_per_iter = 2 * mfma_group
+                    #     sche_iters = 0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                    #     rocdl.sched_dsrd(2)
+                    #     rocdl.sched_mfma(1)
+                    #     rocdl.sched_mfma(1)
+                    #     if num_acc_n < 4:
+                    #         rocdl.sched_dsrd(1)
+                    #         rocdl.sched_mfma(1)
+                    #         rocdl.sched_dsrd(1)
+                    #         rocdl.sched_mfma(1)
+                    #         rocdl.sched_vmem(1)
+                    #         rocdl.sched_mfma(1)
+                    #         rocdl.sched_vmem(1)
+                    #         rocdl.sched_mfma(2)
+                    #         rocdl.sched_dsrd(1)
+                    #         rocdl.sched_mfma(2)
+                    #         rocdl.sched_vmem(1)
+
+                    #     dswr_tail = num_x_loads
+                    #     if dswr_tail > sche_iters:
+                    #         dswr_tail = sche_iters
+                    #     dswr_start = sche_iters - dswr_tail
+                    #     for sche_i in range_constexpr(sche_iters):
+                    #         rocdl.sched_mfma(mfma_group // 2)
+                    #         rocdl.sched_dsrd(1)
+                    #         rocdl.sched_mfma(mfma_group // 2)
+                    #         rocdl.sched_vmem(1)
+                    #         rocdl.sched_mfma(mfma_group)
+                    #         if sche_i >= dswr_start - 1:
+                    #             rocdl.sched_dswr(1)
+                    #     rocdl.sched_barrier(0)
+
+                    def hot_loop_scheduler():
+                        rocdl.sched_barrier(0)
+                        return
+                        # - MFMA group size per "slot": num_acc_n
+                        # - Total MFMA per tile: (2*K32 per K64) * k_unroll * m_repeat * num_acc_n
+                        # - We emit (mfma_group + dsrd + mfma_group) per scheduler iteration.
+                        mfma_group = num_acc_n
+                        mfma_total = (k_unroll * 2) * m_repeat * mfma_group
+                        mfma_per_iter = 2 * mfma_group
+                        sche_iters = 0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+
+                        rocdl.sched_dsrd(2)
+                        rocdl.sched_mfma(1)
+                        if const_expr(tile_m == 16):
+                            rocdl.sched_vmem(1)
+                        rocdl.sched_mfma(1)
+                        if const_expr(tile_m == 16):
+                            rocdl.sched_vmem(1)
+                        if const_expr(num_acc_n < 4):
+                            rocdl.sched_dsrd(1)
+                            rocdl.sched_mfma(1)
+                            if const_expr(tile_m == 16):
+                                rocdl.sched_vmem(1)
+                            rocdl.sched_dsrd(1)
+                            rocdl.sched_mfma(1)
+                            if const_expr(tile_m == 16):
+                                rocdl.sched_vmem(1)
+                            rocdl.sched_mfma(1)
+
+                        # DS-write hints near the end: match total A LDS-store micro-ops per thread.
+                        dswr_tail = num_x_loads
+                        if const_expr(dswr_tail > sche_iters):
+                            dswr_tail = sche_iters
+                        dswr_start = sche_iters - dswr_tail
+
+                        for sche_i in range_constexpr(sche_iters):
+                            rocdl.sched_vmem(1)
+                            rocdl.sched_mfma(mfma_group)
+                            rocdl.sched_dsrd(1)
+                            rocdl.sched_mfma(mfma_group)
+                            if const_expr(sche_i >= dswr_start - 1):
+                                rocdl.sched_dswr(1)
+
+                        rocdl.sched_barrier(0)
+
+                    if const_expr(_use_iglp_opt):
+                        rocdl.iglp_opt(1)
+
+                    # Prologue.
+                    k0 = fx.Index(0)
+                    x_regs0 = load_x_tile(k0, x_load_bytes)
+                    b_cur = load_b_tile(k0)
+                    store_x_tile_to_lds(x_regs0, lds_base_cur, x_load_bytes)
+                    gpu.barrier()
+
+                    acc = [acc_init] * (num_acc_n * m_repeat)
+                    lds_base_pong = lds_base_cur
+                    lds_base_ping = lds_base_nxt
+
+                    # Cross-tile A0 LDS prefetch (default-on): prefetch the first A-pack (K64) for the
+                    # tile we are about to compute from LDS, to overlap with upcoming VMEM.
+                    a0_prefetch_pong = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+
+                    # Main loop: process K tiles in 2-tile ping-pong steps.
+                    #
+                    # IMPORTANT: for odd number of K tiles, leave **1** tail tile; for even, leave **2**.
+                    # Otherwise the 2-tile tail below would double-count the last tile when num_tiles is odd
+                    # (e.g. inter_dim=192, tile_k=64 -> 3 tiles).
+                    num_k_tiles_py = int(inter_dim) // int(tile_k)
+                    odd_k_tiles = (num_k_tiles_py % 2) == 1
+                    tail_tiles = 1 if odd_k_tiles else 2
+                    k_main2_py = (num_k_tiles_py - tail_tiles) * int(tile_k)
+                    if const_expr(k_main2_py < 0):
+                        k_main2_py = 0
+
+                    arith.index(tile_k * 2)
+                    c_tile_k_s2 = arith.index(tile_k)
+                    pair_iters = k_main2_py // (int(tile_k) * 2)
+
+                    # B-tile data layout per k_unroll entry (3 variants):
+                    #   See gemm1 _flatten_b_tile for full layout documentation.
+                    int4_bf16_single_field = is_int4_bf16 and not is_int4_bf16_groupwise
+                    _fields_per_ku = 1 if int4_bf16_single_field else 2
+                    _vals_per_b_tile = k_unroll * _fields_per_ku * num_acc_n
+                    _n_acc = m_repeat * num_acc_n
+                    _p_b = _n_acc
+                    _p_a0 = _p_b + _vals_per_b_tile
+
+                    def _flatten_b_tile(b_tile):
+                        """Flatten B tile to a 1-D list for scf.for loop-carried state."""
+                        flat = []
+                        for ku_entry in b_tile:
+                            if const_expr(is_int4_bf16_groupwise):
+                                flat.extend(t[0] for t in ku_entry)
+                                flat.extend(t[1] for t in ku_entry)
+                            elif const_expr(int4_bf16_single_field):
+                                flat.extend(ku_entry)
+                            else:
+                                flat.extend(ku_entry[0])
+                                flat.extend(ku_entry[1])
+                        return flat
+
+                    def _unflatten_b_tile(vals):
+                        """Reconstruct B tile from flattened scf.for loop-carried state."""
+                        b_tile, idx = [], 0
+                        for _ in range_constexpr(k_unroll):
+                            if const_expr(is_int4_bf16_groupwise):
+                                packed = list(vals[idx : idx + num_acc_n])
+                                idx += num_acc_n
+                                scales = list(vals[idx : idx + num_acc_n])
+                                idx += num_acc_n
+                                b_tile.append([(packed[ni], scales[ni]) for ni in range_constexpr(num_acc_n)])
+                            elif const_expr(int4_bf16_single_field):
+                                b_tile.append(list(vals[idx : idx + num_acc_n]))
+                                idx += num_acc_n
+                            else:
+                                packs_even = list(vals[idx : idx + num_acc_n])
+                                idx += num_acc_n
+                                packs_odd = list(vals[idx : idx + num_acc_n])
+                                idx += num_acc_n
+                                b_tile.append((packs_even, packs_odd))
+                        return b_tile
+
+                    init_state = list(acc) + _flatten_b_tile(b_cur) + list(a0_prefetch_pong)
+
+                    for pair_iv, state in range(0, pair_iters, 1, init=init_state):
+                        _ac = list(state[:_n_acc])
+                        _bc = _unflatten_b_tile(list(state[_p_b:_p_a0]))
+                        _a0 = (state[_p_a0], state[_p_a0 + 1])
+
+                        k_iv = pair_iv * (c_tile_k_s2 + c_tile_k_s2)
+
+                        next_k1 = k_iv + c_tile_k_s2
+                        x_regs_ping = load_x_tile(next_k1, x_load_bytes)
+                        _bp = load_b_tile(next_k1)
+
+                        _ac, _ = compute_tile(_ac, _bc, lds_base_pong, a0_prefetch=_a0)
+                        store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
+                        hot_loop_scheduler()
+                        gpu.barrier()
+
+                        _a0p = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+
+                        next_k2 = k_iv + c_tile_k_s2 + c_tile_k_s2
+                        x_regs_pong = load_x_tile(next_k2, x_load_bytes)
+                        _bn = load_b_tile(next_k2)
+
+                        _ac, _ = compute_tile(_ac, _bp, lds_base_ping, a0_prefetch=_a0p)
+                        store_x_tile_to_lds(x_regs_pong, lds_base_pong, x_load_bytes)
+                        hot_loop_scheduler()
+                        gpu.barrier()
+
+                        _a0n = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+
+                        loop_results = yield list(_ac) + _flatten_b_tile(_bn) + list(_a0n)
+
+                    SmemPtr._view_cache = None
+                    if const_expr(pair_iters > 0):
+                        acc = list(loop_results[:_n_acc])
+                        b_cur = _unflatten_b_tile(list(loop_results[_p_b:_p_a0]))
+                        a0_prefetch_pong = (
+                            loop_results[_p_a0],
+                            loop_results[_p_a0 + 1],
+                        )
+
+                    if const_expr(odd_k_tiles):
+                        acc, epilogue_pf = compute_tile(
+                            acc,
+                            b_cur,
+                            lds_base_pong,
+                            prefetch_epilogue=True,
+                            a0_prefetch=a0_prefetch_pong,
+                        )
+                    else:
+                        k_tail1 = k_in - tile_k
+                        x_regs_ping = load_x_tile(k_tail1, x_load_bytes)
+                        b_ping = load_b_tile(k_tail1)
+
+                        acc, _ = compute_tile(acc, b_cur, lds_base_pong, a0_prefetch=a0_prefetch_pong)
+                        store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
+                        hot_loop_scheduler()
+                        gpu.barrier()
+
+                        a0_prefetch_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+                        acc, epilogue_pf = compute_tile(
+                            acc,
+                            b_ping,
+                            lds_base_ping,
+                            prefetch_epilogue=True,
+                            a0_prefetch=a0_prefetch_ping,
+                        )
+
+                    # ---------------- Epilogue: LDS CShuffle + atomic half2 (x2) ----------------
+                    # Reuse the shared helper so GEMM / MoE kernels share the exact same CShuffle skeleton.
+                    expert_off = expert_off_for_scale
+                    mask24_i32 = fx.Int32(0xFFFFFF)
+                    model_i32 = fx.Int32(model_dim)
+                    topk_i32_v = topk_i32
+
+                    zero_i32 = fx.Int32(0)
+                    c2_i32 = fx.Int32(2)  # 2B element size for f16/bf16
+                    mask_even_i32 = fx.Int32(0xFFFFFFFE)  # align element index to even for half2 atomics
+
+                    e_vec = _e_vec
+
+                    def atomic_add_f16x2(val_f16x2, byte_off_i32):
+                        rocdl.raw_ptr_buffer_atomic_fadd(
+                            val_f16x2,
+                            out_rsrc,
+                            byte_off_i32,
+                            zero_i32,
+                            zero_i32,
+                        )
+
+                    sw_pf = None
+                    tw_pf = None
+                    if const_expr(epilogue_pf is not None):
+                        sw_pf, tw_pf = epilogue_pf
+
+                    # Weight scales for the N tile (col_g depends on lane/wave/by but not on (t,s)).
+                    sw_vals = []
+                    if const_expr(use_groupwise_scale):
+                        # Groupwise: weight scale already applied per-group in K-loop.
+                        sw_vals = [arith.constant(1.0, type=T.f32)] * num_acc_n
+                    elif const_expr(sw_pf is not None):
+                        sw_vals = sw_pf
+                    else:
+                        for ni in range_constexpr(num_acc_n):
+                            col_g = col_g_list[ni]
+                            row_w_idx = expert_off + col_g
+                            sw_vals.append(
+                                fx.Float32(1.0)
+                                if not needs_scale_w
+                                else buffer_ops.buffer_load(sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                            )
+
+                    # When defer_scale16 was used, the x16 correction for v_cvt_off_f32_i4
+                    # was omitted from the hot loop.  Fold it into the epilogue scale.
+                    if const_expr(use_gfx950_cvt):
+                        _c16 = fx.Float32(16.0)
+                        sw_vals = [v * _c16 for v in sw_vals]
+
+                    if const_expr(out_is_f32):
+                        # origin/dev_a16w4: f32 output uses scalar f32 atomics and skips CShuffle/LDS.
+                        c4_i32 = fx.Int32(4)
+
+                        def atomic_add_f32(val_f32, byte_off_i32):
+                            rocdl.raw_ptr_buffer_atomic_fadd(
+                                val_f32,
+                                out_rsrc,
+                                byte_off_i32,
+                                zero_i32,
+                                zero_i32,
+                            )
+
+                        def _stage2_row_atomic(*, mi: int, ii: int, row_in_tile, row):
+                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            t2 = fused2 & mask24_i32
+                            s2 = fused2 >> 24
+
+                            # Sentinel rows are padding from grouped routing. Do not issue
+                            # atomics for them: an invalid row can carry a NaN accumulator,
+                            # and IEEE NaN * 0 would still poison token 0.
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
+                            ts_ok = t_ok & s_ok
+                            valid_if = scf.IfOp(ts_ok)
+                            with _if_then(valid_if):
+                                ts2 = t2 * topk_i32_v + s2
+                                sx = (
+                                    fx.Float32(1.0)
+                                    if is_f16_or_bf16
+                                    else buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32)
+                                )
+
+                                tw = fx.Float32(1.0)
+                                if const_expr(doweight_stage2):
+                                    tw_idx = (mi * 4) + ii
+                                    if const_expr(tw_pf is not None):
+                                        tw = tw_pf[tw_idx]
+                                    else:
+                                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+
+                                idx0 = t2 * model_i32
+
+                                for ni in range_constexpr(num_acc_n):
+                                    col_g = col_g_list[ni]
+                                    sw = sw_vals[ni]
+                                    acc_idx = mi * num_acc_n + ni
+                                    v = vector.extract(
+                                        acc[acc_idx],
+                                        static_position=[ii],
+                                        dynamic_position=[],
+                                    )
+                                    if const_expr(is_int8):
+                                        v = arith.sitofp(T.f32, v)
+                                    v = v * sx * sw
+                                    if const_expr(doweight_stage2):
+                                        v = v * tw
+                                    col_i32 = arith.index_cast(T.i32, col_g)
+                                    idx_elem = idx0 + col_i32
+                                    byte_off = idx_elem * c4_i32
+                                    atomic_add_f32(v, byte_off)
+
+                        default_epilog(
+                            arith=arith,
+                            range_constexpr=range_constexpr,
+                            m_repeat=m_repeat,
+                            lane_div_16=lane_div_16,
+                            bx_m=bx_m,
+                            body_row=_stage2_row_atomic,
+                        )
+                    elif const_expr(not bool(accumulate) and not _use_cshuffle_epilog):
+                        # Direct bf16 scalar store for non-atomic reduce mode (no CShuffle).
+                        # Each thread writes its MFMA output values directly to the intermediate buffer.
+                        # Within a wave, 16 lanes write to 16 adjacent columns in the same row → coalesced.
+
+                        def _stage2_row_direct_store(*, mi: int, ii: int, row_in_tile, row):
+                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            t2 = fused2 & mask24_i32
+                            s2 = fused2 >> 24
+
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
+                            ts_ok = t_ok & s_ok
+                            t2_safe = ts_ok.select(t2, fx.Int32(0))
+                            s2_safe = ts_ok.select(s2, fx.Int32(0))
+                            ts2 = t2_safe * topk_i32_v + s2_safe
+
+                            sx = (
+                                fx.Float32(1.0)
+                                if is_f16_or_bf16
+                                else arith.select(
+                                    ts_ok,
+                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    fx.Float32(0.0),
+                                )
+                            )
+
+                            tw = fx.Float32(1.0)
+                            if const_expr(doweight_stage2):
+                                tw_idx = (mi * 4) + ii
+                                if const_expr(tw_pf is not None):
+                                    tw = ts_ok.select(tw_pf[tw_idx], fx.Float32(0.0))
+                                else:
+                                    tw = arith.select(
+                                        ts_ok,
+                                        buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32),
+                                        fx.Float32(0.0),
+                                    )
+
+                            idx0 = ts2 * model_i32
+
+                            for ni in range_constexpr(num_acc_n):
+                                col_g = col_g_list[ni]
+                                sw = sw_vals[ni]
+                                acc_idx = mi * num_acc_n + ni
+                                v = vector.extract(
+                                    acc[acc_idx],
+                                    static_position=[ii],
+                                    dynamic_position=[],
+                                )
+                                if const_expr(is_int8):
+                                    v = arith.sitofp(T.f32, v)
+                                v = v * sx * sw
+                                if const_expr(doweight_stage2):
+                                    v = v * tw
+                                v_out = arith.trunc_f(out_elem(), v)
+                                col_i32 = arith.index_cast(T.i32, col_g)
+                                idx_elem = idx0 + col_i32
+                                buffer_ops.buffer_store(v_out, out_rsrc, idx_elem)
+
+                        default_epilog(
+                            arith=arith,
+                            range_constexpr=range_constexpr,
+                            m_repeat=m_repeat,
+                            lane_div_16=lane_div_16,
+                            bx_m=bx_m,
+                            body_row=_stage2_row_direct_store,
+                        )
+                    else:
+                        if const_expr(lds_out is None):
+                            raise RuntimeError("stage2 CShuffle requested but lds_out is not allocated/aliased.")
+
+                        # For bf16 global atomics (gfx942 only), precompute the output base address.
+                        # gfx950+ has buffer_atomic_pk_add_bf16, so bf16 uses buffer atomics there.
+                        out_base_idx = fx.Index(0)
+                        if const_expr(_needs_global_atomic_bf16):
+                            out_base_idx = buffer_ops.extract_base_index(arg_out)
+
+                        def write_row_to_lds(
+                            *,
+                            mi: int,
+                            ii: int,
+                            row_in_tile,
+                            row,
+                            row_base_lds,
+                            col_base_local,
+                            num_acc_n: int,
+                            lds_out,
+                        ):
+                            fused2 = (
+                                memref.load(lds_tid, [row_in_tile])
+                                if const_expr(bool(use_lds_sorted_ids))
+                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            )
+                            t2 = fused2 & mask24_i32
+                            s2 = fused2 >> 24
+                            # Explicitly mask sentinel token/slot to avoid OOB scale_x loads.
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
+                            ts_ok = t_ok & s_ok
+                            t2_safe = ts_ok.select(t2, fx.Int32(0))
+                            s2_safe = ts_ok.select(s2, fx.Int32(0))
+                            ts2 = t2_safe * topk_i32_v + s2_safe
+
+                            def _write_valid_row_to_lds():
+                                sx = (
+                                    fx.Float32(1.0)
+                                    if is_f16_or_bf16
+                                    else arith.select(
+                                        ts_ok,
+                                        buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                        fx.Float32(0.0),
+                                    )
+                                )
+
+                                tw = fx.Float32(1.0)
+                                if const_expr(doweight_stage2):
+                                    tw_idx = (mi * 4) + ii
+                                    if const_expr(tw_pf is not None):
+                                        tw = tw_pf[tw_idx]
+                                    else:
+                                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+
+                                for ni in range_constexpr(num_acc_n):
+                                    col_local = col_base_local + (ni * 16)
+                                    sw = sw_vals[ni]
+                                    acc_idx = mi * num_acc_n + ni
+                                    v = vector.extract(
+                                        acc[acc_idx],
+                                        static_position=[ii],
+                                        dynamic_position=[],
+                                    )
+                                    if const_expr(is_int8):
+                                        v = arith.sitofp(T.f32, v)
+                                    v = v * sx * sw
+                                    if const_expr(doweight_stage2):
+                                        v = v * tw
+                                    v_out = arith.trunc_f(out_elem(), v)
+
+                                    lds_idx = row_base_lds + col_local
+                                    vec1_out = T.vec(1, out_elem())
+                                    v1 = vector.from_elements(vec1_out, [v_out])
+                                    vector.store(v1, lds_out, [lds_idx], alignment=2)
+
+                            if const_expr(skip_invalid_lds_write):
+                                valid_if = scf.IfOp(ts_ok)
+                                with _if_then(valid_if):
+                                    _write_valid_row_to_lds()
+                            else:
+                                _write_valid_row_to_lds()
+
+                        def precompute_row(*, row_local, row):
+                            # Precompute row context for cshuffle stores.
+                            # Return (fused_i32, row_valid_i1) so the epilogue can skip the entire row
+                            # for invalid tail rows (CK-style), avoiding per-store branching.
+                            fused2 = (
+                                memref.load(lds_tid, [row_local])
+                                if const_expr(bool(use_lds_sorted_ids))
+                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            )
+                            row_i32 = arith.index_cast(T.i32, row)
+                            row_valid0 = arith.cmpi(arith.CmpIPredicate.ult, row_i32, num_valid_i32)
+                            t = fused2 & mask24_i32
+                            s = fused2 >> 24
+                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t, tokens_i32)
+                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s, topk_i32_v)
+                            row_valid = row_valid0 & t_ok & s_ok
+                            if const_expr(bool(precompute_row_base)):
+                                idx0 = t * model_i32
+                                if const_expr(not bool(accumulate)):
+                                    ts = t * topk_i32_v + s
+                                    idx0 = ts * model_i32
+                                return ((fused2, idx0), row_valid)
+                            return (fused2, row_valid)
+
+                        def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                            if const_expr(bool(precompute_row_base)):
+                                fused, idx0 = row_ctx
+                            else:
+                                fused = row_ctx
+                                t = fused & mask24_i32
+                                s = fused >> 24
+                                idx0 = t * model_i32
+                            if const_expr(not bool(accumulate)):
+                                ts = t * topk_i32_v + s
+                                idx0 = ts * model_i32
+
+                            col_i32 = arith.index_cast(T.i32, col_g0)
+                            idx_elem = idx0 + col_i32
+                            idx_elem_even = idx_elem & mask_even_i32
+                            if const_expr(_needs_global_atomic_bf16):
+                                # gfx942: no buffer_atomic_pk_add_bf16, use global atomicrmw fadd
+                                if const_expr(bool(accumulate)):
+                                    byte_off = idx_elem_even * c2_i32
+                                    byte_off_idx = arith.index_cast(T.index, byte_off)
+                                    ptr_addr_idx = out_base_idx + byte_off_idx
+                                    out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
+                                    out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                                    frag_v = frag._value if hasattr(frag, "_value") else frag
+                                    llvm.AtomicRMWOp(
+                                        llvm.AtomicBinOp.fadd,
+                                        out_ptr_v,
+                                        frag_v,
+                                        llvm.AtomicOrdering.monotonic,
+                                        syncscope="agent",
+                                        alignment=4,
+                                    )
+                                else:
+                                    buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
+                            else:
+                                # f16, or bf16 on gfx950+ (has buffer_atomic_pk_add_bf16)
+                                byte_off = idx_elem_even * c2_i32
+                                if const_expr(bool(accumulate)):
+                                    atomic_add_f16x2(frag, byte_off)
+                                else:
+                                    buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
+
+                        c_shuffle_epilog(
+                            arith=arith,
+                            vector=vector,
+                            gpu=gpu,
+                            scf=scf,
+                            range_constexpr=range_constexpr,
+                            tile_m=tile_m,
+                            tile_n=tile_n,
+                            e_vec=e_vec,
+                            cshuffle_nlane=_cshuffle_nlane,
+                            m_repeat=m_repeat,
+                            num_acc_n=num_acc_n,
+                            tx=tx,
+                            lane_div_16=lane_div_16,
+                            lane_mod_16=lane_mod_16,
+                            bx_m=bx_m,
+                            by_n=by_n,
+                            n_tile_base=n_tile_base,
+                            lds_out=lds_out,
+                            frag_elem_type=(T.bf16 if out_is_bf16 else T.f16),
+                            write_row_to_lds=write_row_to_lds,
+                            precompute_row=precompute_row,
+                            store_pair=store_pair,
+                        )
+
+                _if_blk = scf.IfOp(blk_valid)
+                with _if_then(_if_blk):
+                    _moe_gemm2_then_body()
+
+            if const_expr(_persistent_chunk_y > 0):
+                gy_tiles = size_expert_ids_in * fx.Index(_m_splits)
+                chunk_y = fx.Index(_persistent_chunk_y)
+                tiles_per_chunk = (gy_tiles + chunk_y - fx.Index(1)) // chunk_y
+                chunk_start = bx_tile_base * tiles_per_chunk
+                for mi_chunk in range(fx.Index(0), tiles_per_chunk, fx.Index(1)):
+                    mi_chunk_idx = arith.index_cast(T.index, mi_chunk)
+                    _emit_stage2_m_tile(chunk_start + mi_chunk_idx)
+            elif const_expr(_persistent_grid_y > 0):
+                gy_tiles = size_expert_ids_in * fx.Index(_m_splits)
+                for bx_tile_loop in range(bx_tile_base, gy_tiles, fx.Index(_persistent_grid_y)):
+                    _emit_stage2_m_tile(arith.index_cast(T.index, bx_tile_loop))
+            elif const_expr(_persist_m == 1):
+                _emit_stage2_m_tile(bx_tile_base)
+            else:
+                for mi_p in range_constexpr(_persist_m):
+                    _emit_stage2_m_tile(bx_tile_base * fx.Index(_persist_m) + fx.Index(mi_p))
+
+    # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
+    @flyc.jit
+    def launch_moe_gemm2(
+        arg_out: fx.Tensor,
+        arg_x: fx.Tensor,
+        arg_w: fx.Tensor,
+        arg_scale_x: fx.Tensor,
+        arg_scale_w: fx.Tensor,
+        arg_sorted_token_ids: fx.Tensor,
+        arg_expert_ids: fx.Tensor,
+        arg_sorted_weights: fx.Tensor,
+        arg_num_valid_ids: fx.Tensor,
+        i32_tokens_in: fx.Int32,
+        i32_n_in: fx.Int32,
+        i32_k_in: fx.Int32,
+        i32_size_expert_ids_in: fx.Int32,
+        stream: fx.Stream,
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        n_in = arith.index_cast(T.index, i32_n_in)
+        size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
+        gx = n_in // fx.Index(tile_n)
+        gy = size_expert_ids_in * fx.Index(_m_splits)
+        if const_expr(_persistent_chunk_y > 0):
+            gy = fx.Index(_persistent_chunk_y)
+        elif const_expr(_persistent_grid_y > 0):
+            gy = fx.Index(_persistent_grid_y)
+        elif const_expr(_persist_m > 1):
+            gy = (gy + fx.Index(_persist_m - 1)) // fx.Index(_persist_m)
+        if const_expr(_group_size_m > 1):
+            launch_grid_x = gx * gy
+            launch_grid_y = fx.Index(1)
+        else:
+            launch_grid_x = gy if const_expr(bool(m_fast_grid)) else gx
+            launch_grid_y = gx if const_expr(bool(m_fast_grid)) else gy
+
+        moe_gemm2(
+            arg_out,
+            arg_x,
+            arg_w,
+            arg_scale_x,
+            arg_scale_w,
+            arg_sorted_token_ids,
+            arg_expert_ids,
+            arg_sorted_weights,
+            arg_num_valid_ids,
+            i32_tokens_in,
+            i32_n_in,
+            i32_k_in,
+            i32_size_expert_ids_in,
+        ).launch(
+            grid=(launch_grid_x, launch_grid_y, 1),
+            block=(256, 1, 1),
+            stream=stream,
+        )
+
+    return launch_moe_gemm2
+
+
+# MoE Reduction Kernel (reduce sum over topk dimension)
+@functools.lru_cache(maxsize=1024)
+def compile_moe_reduction(
+    *,
+    topk: int,
+    model_dim: int,
+    dtype_str: str = "f16",
+    out_dtype_str: str | None = None,
+    use_mask: bool = False,
+    input_cache_modifier: int = 0,
+    output_cache_modifier: int = 0,
+):
+    """Compile a reduction kernel that sums over the topk dimension.
+
+    Input:  X [tokens, topk, model_dim]
+            valid_mask [tokens, topk] (optional, if use_mask=True)
+    Output: Y [tokens, model_dim]
+
+    This kernel performs: Y[t, d] = sum(X[t, :, d]) for all t, d.
+    When use_mask=True, only sums slots where valid_mask[t,k]=1.
+    Used in conjunction with compile_moe_gemm2(accumulate=False) to avoid atomic contention.
+    """
+    get_hip_arch()
+    ir.ShapedType.get_dynamic_size()
+
+    # Kernel Config
+    BLOCK_SIZE = 256
+    VEC_WIDTH = 8
+
+    if out_dtype_str is None:
+        out_dtype_str = dtype_str
+    if dtype_str == "f32":
+        elem_type_tag = "f32"
+    elif dtype_str == "f16":
+        elem_type_tag = "f16"
+    elif dtype_str == "bf16":
+        elem_type_tag = "bf16"
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype_str}")
+    if out_dtype_str == "f32":
+        out_elem_type_tag = "f32"
+    elif out_dtype_str == "f16":
+        out_elem_type_tag = "f16"
+    elif out_dtype_str == "bf16":
+        out_elem_type_tag = "bf16"
+    else:
+        raise ValueError(f"Unsupported output dtype: {out_dtype_str}")
+    compute_type = lambda: T.f32
+    i8_type = lambda: T.i8
+
+    def elem_type():
+        ty = T.f32 if elem_type_tag == "f32" else (T.f16 if elem_type_tag == "f16" else T.bf16)
+        return ty() if callable(ty) else ty
+
+    def out_elem_type():
+        ty = T.f32 if out_elem_type_tag == "f32" else (T.f16 if out_elem_type_tag == "f16" else T.bf16)
+        return ty() if callable(ty) else ty
+
+    if True:
+
+        @flyc.kernel
+        def moe_reduction_kernel(
+            X: fx.Tensor,
+            Y: fx.Tensor,
+            valid_mask: fx.Tensor,
+            i32_m_tokens: fx.Int32,
+        ):
+            m_tokens = fx.Index(i32_m_tokens)
+            c_topk = fx.Index(topk)
+            c_model_dim = fx.Index(model_dim)
+            mask_nbytes_idx = m_tokens * c_topk
+            elem_bits = 32 if dtype_str == "f32" else 16
+            copy_vec_width = 128 // elem_bits  # 8 for f16/bf16, 4 for f32
+            n_sub = VEC_WIDTH // copy_vec_width  # 1 for f16/bf16, 2 for f32
+            # Buffer-backed tensors via layout API (all dtypes)
+            X_buf = fx.rocdl.make_buffer_tensor(X)
+            Y_buf = fx.rocdl.make_buffer_tensor(Y)
+            # Scalar buffer resources for tail path and mask
+            x_rsrc = buffer_ops.create_buffer_resource(X, max_size=True)
+            y_rsrc = buffer_ops.create_buffer_resource(Y, max_size=True)
+            mask_rsrc = buffer_ops.create_buffer_resource(valid_mask, max_size=False, num_records_bytes=mask_nbytes_idx)
+
+            token_idx = gpu.block_id("x")
+            tile_idx = gpu.block_id("y")
+            tid = gpu.thread_id("x")
+
+            # Guard: token in range (Index is unsigned → auto ult)
+            tok_ok = token_idx < m_tokens
+            _if_tok = scf.IfOp(tok_ok)
+            with _if_then(_if_tok):
+                tile_cols = BLOCK_SIZE * VEC_WIDTH
+                c_tile_cols = fx.Index(tile_cols)
+                c_vecw = fx.Index(VEC_WIDTH)
+
+                col_base = tile_idx * c_tile_cols + tid * c_vecw
+
+                # Guard: any work in bounds (Index < → ult)
+                col_ok = col_base < c_model_dim
+                _if_col = scf.IfOp(col_ok)
+                with _if_then(_if_col):
+                    # Fast path: full vector in-bounds (Index <= → ule)
+                    end_ok = col_base + c_vecw <= c_model_dim
+                    _if_full = scf.IfOp(end_ok, has_else=True)
+                    with _if_then(_if_full):
+                        # ── Vector path via buffer ops.
+                        # The installed FlyDSL runtime does not expose
+                        # make_rmem_tensor through flydsl.expr, so keep this
+                        # reduction kernel on the lower-level buffer API used
+                        # elsewhere in atrex.
+                        vec_type_e = T.vec(VEC_WIDTH, elem_type())
+                        out_vec_type_e = T.vec(VEC_WIDTH, out_elem_type())
+                        acc_vals = [arith.constant(0.0, type=compute_type()) for _ in range_constexpr(VEC_WIDTH)]
+                        token_base = token_idx * c_topk
+                        for k in range_constexpr(topk):
+                            x_idx_i32 = fx.Int32((token_base + fx.Index(k)) * c_model_dim + col_base)
+                            vec_e = buffer_ops.buffer_load(
+                                x_rsrc,
+                                x_idx_i32,
+                                vec_width=VEC_WIDTH,
+                                dtype=elem_type(),
+                                **(
+                                    {"cache_modifier": int(input_cache_modifier)}
+                                    if int(input_cache_modifier) != 0
+                                    else {}
+                                ),
+                            )
+                            if const_expr(use_mask):
+                                m_idx_i32 = fx.Int32(token_base + fx.Index(k))
+                                mv = buffer_ops.buffer_load(mask_rsrc, m_idx_i32, vec_width=1, dtype=i8_type())
+                                mv_ok = mv != fx.Int8(0)
+                            for lane in range_constexpr(VEC_WIDTH):
+                                v = vector.extract(vec_e, static_position=[lane], dynamic_position=[])
+                                if const_expr(use_mask):
+                                    v = mv_ok.select(v, arith.constant(0.0, type=elem_type()))
+                                if const_expr(dtype_str in ("f16", "bf16")):
+                                    v = v.extf(compute_type())
+                                acc_vals[lane] = acc_vals[lane] + v
+
+                        out_vals = []
+                        for lane in range_constexpr(VEC_WIDTH):
+                            out = acc_vals[lane]
+                            if const_expr(out_dtype_str in ("f16", "bf16")):
+                                out = out.truncf(out_elem_type())
+                            out_vals.append(out)
+                        out_vec = vector.from_elements(out_vec_type_e, out_vals)
+                        y_idx_i32 = fx.Int32(token_idx * c_model_dim + col_base)
+                        buffer_ops.buffer_store(
+                            out_vec,
+                            y_rsrc,
+                            y_idx_i32,
+                            **(
+                                {"cache_modifier": int(output_cache_modifier)}
+                                if int(output_cache_modifier) != 0
+                                else {}
+                            ),
+                        )
+
+                    with _if_else(_if_full):
+                        # Tail path: scalar load/store per lane.
+                        for lane in range_constexpr(VEC_WIDTH):
+                            col = col_base + fx.Index(lane)
+                            lane_ok = col < c_model_dim
+                            _if_lane = scf.IfOp(lane_ok)
+                            with _if_then(_if_lane):
+                                a = arith.constant(0.0, type=compute_type())
+                                token_base = token_idx * c_topk
+                                for k in range_constexpr(topk):
+                                    k_idx = fx.Index(k)
+                                    x_idx_i32 = fx.Int32((token_base + k_idx) * c_model_dim + col)
+                                    v = arith.constant(0.0, type=elem_type())
+                                    if const_expr(use_mask):
+                                        m_idx_i32 = fx.Int32(token_base + k_idx)
+                                        mv = buffer_ops.buffer_load(
+                                            mask_rsrc,
+                                            m_idx_i32,
+                                            vec_width=1,
+                                            dtype=i8_type(),
+                                        )
+                                        v = (mv != fx.Int8(0)).select(
+                                            buffer_ops.buffer_load(
+                                                x_rsrc,
+                                                x_idx_i32,
+                                                vec_width=1,
+                                                dtype=elem_type(),
+                                            ),
+                                            arith.constant(0.0, type=elem_type()),
+                                        )
+                                    else:
+                                        v = buffer_ops.buffer_load(
+                                            x_rsrc,
+                                            x_idx_i32,
+                                            vec_width=1,
+                                            dtype=elem_type(),
+                                            **(
+                                                {"cache_modifier": int(input_cache_modifier)}
+                                                if int(input_cache_modifier) != 0
+                                                else {}
+                                            ),
+                                        )
+                                    if const_expr(dtype_str in ("f16", "bf16")):
+                                        v = v.extf(compute_type())
+                                    a = a + v
+
+                                out = a
+                                if const_expr(out_dtype_str in ("f16", "bf16")):
+                                    out = out.truncf(out_elem_type())
+                                y_idx_i32 = fx.Int32(token_idx * c_model_dim + col)
+                                buffer_ops.buffer_store(
+                                    out,
+                                    y_rsrc,
+                                    y_idx_i32,
+                                    **(
+                                        {"cache_modifier": int(output_cache_modifier)}
+                                        if int(output_cache_modifier) != 0
+                                        else {}
+                                    ),
+                                )
+
+    # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
+    tile_size = BLOCK_SIZE * VEC_WIDTH
+    gy_static = (model_dim + tile_size - 1) // tile_size
+
+    @flyc.jit
+    def launch_moe_reduction(
+        X: fx.Tensor,
+        Y: fx.Tensor,
+        valid_mask: fx.Tensor,
+        i32_m_tokens: fx.Int32,
+        stream: fx.Stream,
+    ):
+        gx = fx.Index(i32_m_tokens)
+        moe_reduction_kernel(X, Y, valid_mask, i32_m_tokens).launch(
+            grid=(gx, gy_static, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    return launch_moe_reduction
+
+
+# MoE GEMM2 Execution Modes
+class MoeGemm2Mode:
+    """Execution mode for MoE GEMM2."""
+
+    ATOMIC = "atomic"  # Use atomic accumulation (default)
+    REDUCE = "reduce"  # Use non-atomic write + reduce kernel
+
+
+class _MoeGemm2ReduceWrapper:
+    """Wrapper combining GEMM2 (no atomics) with reduction kernel.
+
+    This wrapper handles the intermediate buffer allocation and orchestrates
+    the two-phase computation:
+    1. GEMM2 outputs to [tokens*topk, model_dim] without atomics
+    2. Reduce sums over topk to produce [tokens, model_dim]
+    """
+
+    def __init__(
+        self,
+        gemm2_exe,
+        reduce_exe,
+        topk: int,
+        model_dim: int,
+        out_dtype_str: str = "f16",
+        intermediate_dtype_str: str | None = None,
+        use_mask: bool = False,
+        zero_intermediate: bool = True,
+    ):
+        self._gemm2_exe = gemm2_exe
+        self._reduce_exe = reduce_exe
+        self._topk = topk
+        self._model_dim = model_dim
+        self._out_dtype_str = out_dtype_str
+        self._intermediate_dtype_str = intermediate_dtype_str or out_dtype_str
+        self._use_mask = use_mask
+        self._zero_intermediate = zero_intermediate
+
+    def _get_torch_dtype(self):
+        """Convert dtype string to torch dtype."""
+        import torch
+
+        dtype_map = {
+            "f16": torch.float16,
+            "fp16": torch.float16,
+            "bf16": torch.bfloat16,
+            "f32": torch.float32,
+        }
+        return dtype_map.get(self._intermediate_dtype_str, torch.float16)
+
+    def __call__(
+        self,
+        arg_out,
+        arg_x,
+        arg_w,
+        arg_scale_x,
+        arg_scale_w,
+        arg_sorted_token_ids,
+        arg_expert_ids,
+        arg_sorted_weights,
+        arg_num_valid_ids,
+        tokens_in,
+        n_in,
+        k_in,
+        size_expert_ids_in,
+        valid_mask=None,
+        stream=None,
+    ):
+        """Execute GEMM2 + reduce.
+
+        Args match moe_gemm2 kernel signature (see compile_moe_gemm2).
+        """
+        import torch
+
+        if stream is None:
+            stream = torch.cuda.current_stream()
+        intermediate = torch.empty(
+            tokens_in * self._topk,
+            self._model_dim,
+            device=arg_out.device,
+            dtype=self._get_torch_dtype(),
+        )
+        if self._zero_intermediate and not self._use_mask:
+            intermediate.zero_()
+        # Phase 1: GEMM2 (no atomics) -> [tokens*topk, model_dim]
+        self._gemm2_exe(
+            intermediate.view(-1),
+            arg_x,
+            arg_w,
+            arg_scale_x,
+            arg_scale_w,
+            arg_sorted_token_ids,
+            arg_expert_ids,
+            arg_sorted_weights,
+            arg_num_valid_ids,
+            tokens_in,
+            n_in,
+            k_in,
+            size_expert_ids_in,
+            stream,
+        )
+        # Phase 2: Reduce over topk -> [tokens, model_dim]
+        X = intermediate.view(tokens_in, self._topk, self._model_dim)
+        Y = arg_out.view(tokens_in, self._model_dim)
+        if not self._use_mask:
+            self._reduce_exe(X, Y, arg_num_valid_ids, tokens_in, stream)
+        else:
+            self._reduce_exe(X, Y, valid_mask, tokens_in, stream)
+
+    @property
+    def mode(self) -> str:
+        """Return the execution mode."""
+        return MoeGemm2Mode.REDUCE
+
+
+def compile_moe_gemm2_ex(
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    doweight_stage2: bool,
+    in_dtype: str = "fp8",
+    group_size: int = -1,
+    out_dtype: str = "f16",
+    use_cshuffle_epilog: bool | None = None,
+    # Extended parameters for mode control
+    mode: str = MoeGemm2Mode.ATOMIC,
+    valid_mask=None,
+    zero_intermediate: bool = True,
+    scale_is_bf16: bool = False,
+    b_cache_modifier: int = 0,
+    enable_hotloop_sched: bool | None = None,
+    skip_invalid_lds_write: bool = False,
+    use_lds_sorted_ids: bool = False,
+    precompute_row_base: bool = False,
+    readfirst_metadata: bool = False,
+    m_fast_grid: bool = False,
+    sort_block_m: int = 0,
+    persist_m: int = 1,
+    persistent_grid_y: int = 0,
+    persistent_chunk_y: int = 0,
+    reduce_intermediate_dtype: str | None = None,
+    group_size_m: int = 1,
+    cshuffle_nlane: int = 32,
+    reduction_input_cache_modifier: int = 0,
+    reduction_output_cache_modifier: int = 0,
+    weight_interleaved: bool = False,
+):
+    """Compile MoE GEMM2 kernel with optional reduction.
+
+    This is the extended interface that supports explicit mode control.
+
+    Args:
+        mode: Execution mode selection:
+            - "atomic": Use atomic accumulation (original behavior)
+            - "reduce": Use non-atomic write + reduce kernel
+
+        zero_intermediate: If all output slots are valid,
+            set False to increase performance
+
+    Returns:
+        Compiled executable (either wrapped or raw depending on mode).
+    """
+    # Compile based on mode
+    if mode == MoeGemm2Mode.REDUCE:
+        # Determine if we need masked reduction
+        use_mask = valid_mask is not None
+
+        def _normalize_out_dtype(dtype_value):
+            out_s = str(dtype_value).strip().lower()
+            if out_s in ("f16", "fp16", "half"):
+                return "f16"
+            if out_s in ("bf16", "bfloat16"):
+                return "bf16"
+            return "f32"
+
+        dtype_str = _normalize_out_dtype(out_dtype)
+        intermediate_dtype_str = (
+            _normalize_out_dtype(reduce_intermediate_dtype) if reduce_intermediate_dtype is not None else dtype_str
+        )
+
+        # Compile GEMM2 with accumulate=False
+        gemm2_exe = compile_moe_gemm2(
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=experts,
+            topk=topk,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            doweight_stage2=doweight_stage2,
+            in_dtype=in_dtype,
+            group_size=group_size,
+            out_dtype=intermediate_dtype_str,
+            use_cshuffle_epilog=use_cshuffle_epilog,
+            accumulate=False,
+            scale_is_bf16=scale_is_bf16,
+            b_cache_modifier=b_cache_modifier,
+            skip_invalid_lds_write=skip_invalid_lds_write,
+            use_lds_sorted_ids=use_lds_sorted_ids,
+            precompute_row_base=precompute_row_base,
+            readfirst_metadata=readfirst_metadata,
+            m_fast_grid=m_fast_grid,
+            sort_block_m=sort_block_m,
+            persist_m=persist_m,
+            persistent_grid_y=persistent_grid_y,
+            persistent_chunk_y=persistent_chunk_y,
+            group_size_m=group_size_m,
+            cshuffle_nlane=cshuffle_nlane,
+        )
+        reduce_exe = compile_moe_reduction(
+            topk=topk,
+            model_dim=model_dim,
+            dtype_str=intermediate_dtype_str,
+            out_dtype_str=dtype_str,
+            use_mask=use_mask,
+            input_cache_modifier=reduction_input_cache_modifier,
+            output_cache_modifier=reduction_output_cache_modifier,
+        )
+        return _MoeGemm2ReduceWrapper(
+            gemm2_exe=gemm2_exe,
+            reduce_exe=reduce_exe,
+            topk=topk,
+            model_dim=model_dim,
+            out_dtype_str=dtype_str,
+            intermediate_dtype_str=intermediate_dtype_str,
+            use_mask=use_mask,
+            zero_intermediate=zero_intermediate,
+        )
+    else:
+        # Compile GEMM2 with accumulate=True (atomic mode)
+        return compile_moe_gemm2(
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=experts,
+            topk=topk,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            tile_k=tile_k,
+            doweight_stage2=doweight_stage2,
+            in_dtype=in_dtype,
+            group_size=group_size,
+            out_dtype=out_dtype,
+            use_cshuffle_epilog=use_cshuffle_epilog,
+            accumulate=True,
+            b_cache_modifier=b_cache_modifier,
+            skip_invalid_lds_write=skip_invalid_lds_write,
+            use_lds_sorted_ids=use_lds_sorted_ids,
+            precompute_row_base=precompute_row_base,
+            readfirst_metadata=readfirst_metadata,
+            m_fast_grid=m_fast_grid,
+            sort_block_m=sort_block_m,
+            persist_m=persist_m,
+            persistent_grid_y=persistent_grid_y,
+            persistent_chunk_y=persistent_chunk_y,
+            group_size_m=group_size_m,
+            cshuffle_nlane=cshuffle_nlane,
+            weight_interleaved=weight_interleaved,
+        )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_2stage.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_gemm_2stage.py
@@ -166,18 +166,24 @@ def compile_moe_gemm1(
         raise ValueError(f"sort_tile_m must be positive, got {sort_tile_m}")
     if single_token_route:
         if int(tile_m) != 16:
-            raise ValueError(f"single_token_route stage1 requires tile_m=16, got {tile_m}")
+            raise ValueError(
+                f"single_token_route stage1 requires tile_m=16, got {tile_m}"
+            )
         if k_batch != 1:
             raise ValueError("single_token_route stage1 does not support split-K")
         if weight_interleaved:
-            raise ValueError("single_token_route stage1 does not support weight_interleaved")
+            raise ValueError(
+                "single_token_route stage1 does not support weight_interleaved"
+            )
     allocator = SmemAllocator(None, arch=gpu_arch)
     _state = {}  # legacy; kept until stage2/reduction are migrated
 
     _valid_dtypes = ("fp8", "fp16", "bf16", "int8", "int8smooth", "int4", "int4_bf16")
     if in_dtype not in _valid_dtypes:
         raise ValueError(f"in_dtype must be one of {_valid_dtypes}, got {in_dtype!r}")
-    is_int4_bf16 = in_dtype == "int4_bf16"  # W4A16: bf16 activations, packed int4 weights
+    is_int4_bf16 = (
+        in_dtype == "int4_bf16"
+    )  # W4A16: bf16 activations, packed int4 weights
     is_f16 = in_dtype == "fp16"
     is_bf16 = is_int4_bf16 or in_dtype == "bf16"
     is_f16_or_bf16 = is_f16 or is_bf16
@@ -186,7 +192,9 @@ def compile_moe_gemm1(
     if out_dtype not in ("f16", "bf16"):
         raise ValueError(f"out_dtype must be 'f16' or 'bf16', got {out_dtype!r}")
     # NOTE: don't materialize MLIR types outside an active MLIR Context.
-    out_mlir = lambda: (lambda ty: ty() if callable(ty) else ty)(T.f16 if out_dtype == "f16" else T.bf16)
+    out_mlir = lambda: (lambda ty: ty() if callable(ty) else ty)(
+        T.f16 if out_dtype == "f16" else T.bf16
+    )
     tile_k_bytes = int(tile_k) * int(elem_bytes)
     # K64-byte micro-step: always 64 bytes per `ku`. For fp16 this is 32 elements.
     if (tile_k_bytes % 64) != 0:
@@ -230,7 +238,9 @@ def compile_moe_gemm1(
     _is_gfx950 = "gfx95" in get_hip_arch()
     use_gfx950_cvt = is_int4_bf16 and _is_gfx950
 
-    _use_iglp_opt = bool(enable_hotloop_sched) and not fine_sched  # iglp incompatible with fine_sched
+    _use_iglp_opt = (
+        bool(enable_hotloop_sched) and not fine_sched
+    )  # iglp incompatible with fine_sched
     _use_fine_sched = bool(fine_sched)
     # Thread block size: 128 (2 waves) enables tile_n=32; 256 (4 waves) is default.
     _num_waves = 2 if (tile_n < 64) else 4
@@ -240,8 +250,12 @@ def compile_moe_gemm1(
     _is_splitk = k_batch > 1
     if _is_splitk:
         _k_per_batch = model_dim // k_batch
-        assert model_dim % k_batch == 0, f"model_dim={model_dim} not divisible by k_batch={k_batch}"
-        assert _k_per_batch % tile_k == 0, f"K_per_batch={_k_per_batch} not divisible by tile_k={tile_k}"
+        assert (
+            model_dim % k_batch == 0
+        ), f"model_dim={model_dim} not divisible by k_batch={k_batch}"
+        assert (
+            _k_per_batch % tile_k == 0
+        ), f"K_per_batch={_k_per_batch} not divisible by tile_k={tile_k}"
         # The ping-pong K-loop requires an even number of K tiles (>=4).
         _k_tiles = _k_per_batch // tile_k
         assert _k_tiles >= 4 and _k_tiles % 2 == 0, (
@@ -253,7 +267,9 @@ def compile_moe_gemm1(
 
     mfma_i32_k32 = None
     if is_int8:
-        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(rocdl, "mfma_i32_16x16x32_i8", None)
+        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(
+            rocdl, "mfma_i32_16x16x32_i8", None
+        )
         if mfma_i32_k32 is None:
             raise AttributeError(
                 "INT8 K32 MFMA op not found: expected `rocdl.mfma_i32_16x16x32i8` (or `rocdl.mfma_i32_16x16x32_i8`)."
@@ -275,7 +291,11 @@ def compile_moe_gemm1(
 
     ir.ShapedType.get_dynamic_size()
     # W is packed int4 for W4A8/W4A16/W4A_FP8: 2 values per byte.
-    ((experts * (2 * inter_dim) * model_dim) // 2 if w_is_int4 else (experts * (2 * inter_dim) * model_dim))
+    (
+        (experts * (2 * inter_dim) * model_dim) // 2
+        if w_is_int4
+        else (experts * (2 * inter_dim) * model_dim)
+    )
 
     total_threads = 256
     num_waves_static = total_threads // 64
@@ -319,7 +339,11 @@ def compile_moe_gemm1(
     stage1_assume_valid_grid = False
     stage1_tid_lds = False
     stage1_prefetch_epi_tid = False
-    stage1_prefetch_epi_tid = stage1_prefetch_epi_tid and not use_cshuffle_epilog and stage1_row_limit_epilog in (1, 4)
+    stage1_prefetch_epi_tid = (
+        stage1_prefetch_epi_tid
+        and not use_cshuffle_epilog
+        and stage1_row_limit_epilog in (1, 4)
+    )
     if single_token_route:
         stage1_row_limit_x = 1
         stage1_row_limit_epilog = 1
@@ -361,7 +385,9 @@ def compile_moe_gemm1(
         _use_cshuffle_epilog = True
     _cshuffle_elem_bytes = 4 if _is_splitk else 2  # f32 for split-K, f16 otherwise
     lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(elem_bytes)
-    lds_out_bytes = _cshuffle_elem_bytes * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    lds_out_bytes = (
+        _cshuffle_elem_bytes * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    )
     lds_total_bytes = max(lds_x_bytes, lds_out_bytes)
     lds_total_elems = lds_total_bytes if elem_bytes == 1 else (lds_total_bytes // 2)
 
@@ -398,9 +424,21 @@ def compile_moe_gemm1(
             # i32 versions for layout construction (fly.make_shape requires i32/i64)
             tokens_i32_v = i32_tokens_in
             k_i32_v = i32_k_in
-            x_elem = T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            x_elem = (
+                T.bf16
+                if is_bf16
+                else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            )
             # For int4/int4_bf16, weights are stored as packed bytes (i8) and unpacked in-kernel.
-            w_elem = T.i8 if w_is_int4 else (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8)))
+            w_elem = (
+                T.i8
+                if w_is_int4
+                else (
+                    T.bf16
+                    if is_bf16
+                    else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+                )
+            )
             scale_dtype = T.bf16 if _scale_is_bf16 else T.f32
             vec16_elems = 16 if elem_bytes == 1 else 8
             vec8_elems = 8 if elem_bytes == 1 else 4
@@ -421,8 +459,14 @@ def compile_moe_gemm1(
                 sig = rocdl.rcp(T.f32, den)
                 return x * sig
 
-            acc_init = arith.constant_vector(0, T.i32x4) if is_int8 else arith.constant_vector(0.0, T.f32x4)
-            zero_f32_acc = arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+            acc_init = (
+                arith.constant_vector(0, T.i32x4)
+                if is_int8
+                else arith.constant_vector(0.0, T.f32x4)
+            )
+            zero_f32_acc = (
+                arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+            )
 
             # Layouts (use i32 values; fly.make_shape requires i32/i64, not index)
             fx.make_layout((tokens_i32_v, k_i32_v), stride=(k_i32_v, 1))
@@ -473,15 +517,21 @@ def compile_moe_gemm1(
                     max_size=False,
                     num_records_bytes=fx.Index(4),
                 )
-                max_token_id_i32 = buffer_ops.buffer_load(maxids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+                max_token_id_i32 = buffer_ops.buffer_load(
+                    maxids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32
+                )
                 bx_m_i32 = arith.index_cast(T.i32, bx_m)
-                blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, max_token_id_i32)
+                blk_valid = arith.cmpi(
+                    arith.CmpIPredicate.ult, bx_m_i32, max_token_id_i32
+                )
                 expert_rsrc_early = buffer_ops.create_buffer_resource(
                     arg_expert_ids,
                     max_size=False,
                     num_records_bytes=(size_expert_ids_in * fx.Index(4)),
                 )
-                expert_i32_early = buffer_ops.buffer_load(expert_rsrc_early, bx, vec_width=1, dtype=T.i32)
+                expert_i32_early = buffer_ops.buffer_load(
+                    expert_rsrc_early, bx, vec_width=1, dtype=T.i32
+                )
                 expert_valid = arith.cmpi(
                     arith.CmpIPredicate.sge,
                     expert_i32_early,
@@ -502,7 +552,11 @@ def compile_moe_gemm1(
                 lds_x_ptr = SmemPtr(
                     base_ptr,
                     lds_alloc_offset,
-                    (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))),
+                    (
+                        T.bf16
+                        if is_bf16
+                        else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+                    ),
                     shape=(lds_total_elems,),
                 )
                 lds_x = lds_x_ptr.get()
@@ -519,7 +573,11 @@ def compile_moe_gemm1(
                     if _use_cshuffle_epilog
                     else None
                 )
-                lds_tid = SmemPtr(base_ptr, lds_tid_offset, T.i32, shape=(tile_m,)).get() if stage1_tid_lds else None
+                lds_tid = (
+                    SmemPtr(base_ptr, lds_tid_offset, T.i32, shape=(tile_m,)).get()
+                    if stage1_tid_lds
+                    else None
+                )
 
                 # Buffer resources: for dynamic memrefs, provide `num_records_bytes` explicitly so
                 # hardware OOB behavior is stable (otherwise it falls back to a large max size).
@@ -528,17 +586,25 @@ def compile_moe_gemm1(
                 # X: [tokens, k] bytes = tokens*k*elem_bytes
                 x_rows = tokens_in * (c_topk if x_is_token_slot else fx.Index(1))
                 x_nbytes_idx = x_rows * k_in * arith.index(int(elem_bytes))
-                x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_idx)
+                x_rsrc = buffer_ops.create_buffer_resource(
+                    arg_x, max_size=False, num_records_bytes=x_nbytes_idx
+                )
 
                 w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
 
                 # OUT: normal=[tokens, topk, inter] f16/bf16, split-K=[tokens*topk, 2*inter] f32
                 out_elem_bytes = 4 if _is_splitk else 2
                 if const_expr(_is_splitk):
-                    out_nbytes_idx = tokens_in * c_topk * inter_in * fx.Index(2 * out_elem_bytes)
+                    out_nbytes_idx = (
+                        tokens_in * c_topk * inter_in * fx.Index(2 * out_elem_bytes)
+                    )
                 else:
-                    out_nbytes_idx = tokens_in * c_topk * inter_in * fx.Index(out_elem_bytes)
-                out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes_idx)
+                    out_nbytes_idx = (
+                        tokens_in * c_topk * inter_in * fx.Index(out_elem_bytes)
+                    )
+                out_rsrc = buffer_ops.create_buffer_resource(
+                    arg_out, max_size=False, num_records_bytes=out_nbytes_idx
+                )
 
                 # scale_x: fp16/bf16 path ignores (implicit scale=1.0); int4_bf16 also uses 1.0.
                 x_load_bytes = 16
@@ -552,17 +618,27 @@ def compile_moe_gemm1(
                 # scale_w: fp16/bf16 (non-int4) path ignores; int4_bf16 needs dequant scale.
                 sw_rsrc = -1
                 if const_expr(needs_scale_w):
-                    sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False)
+                    sw_rsrc = buffer_ops.create_buffer_resource(
+                        arg_scale_w, max_size=False
+                    )
 
-                sorted_rsrc = buffer_ops.create_buffer_resource(arg_sorted_token_ids, max_size=False)
-                sorted_w_rsrc = buffer_ops.create_buffer_resource(arg_sorted_weights, max_size=False)
+                sorted_rsrc = buffer_ops.create_buffer_resource(
+                    arg_sorted_token_ids, max_size=False
+                )
+                sorted_w_rsrc = buffer_ops.create_buffer_resource(
+                    arg_sorted_weights, max_size=False
+                )
 
                 if const_expr(stage1_tid_lds):
-                    tid_in_range = arith.cmpi(arith.CmpIPredicate.ult, tx, fx.Index(tile_m))
+                    tid_in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult, tx, fx.Index(tile_m)
+                    )
                     _if_tid = scf.IfOp(tid_in_range)
                     with _if_then(_if_tid):
                         tid_row = bx_m + tx
-                        tid_val = buffer_ops.buffer_load(sorted_rsrc, tid_row, vec_width=1, dtype=T.i32)
+                        tid_val = buffer_ops.buffer_load(
+                            sorted_rsrc, tid_row, vec_width=1, dtype=T.i32
+                        )
                         tid_vec = vector.from_elements(T.vec(1, T.i32), [tid_val])
                         vector.store(tid_vec, lds_tid, [tx], alignment=4)
                     gpu.barrier()
@@ -575,9 +651,18 @@ def compile_moe_gemm1(
                 )
 
                 # Expert id for this M tile (keep address math in `index`)
-                expert_i32 = buffer_ops.buffer_load(expert_rsrc, bx, vec_width=1, dtype=T.i32)
+                expert_i32 = buffer_ops.buffer_load(
+                    expert_rsrc, bx, vec_width=1, dtype=T.i32
+                )
                 expert_idx = arith.index_cast(T.index, expert_i32)
-                route_slot_i32 = arith.index_cast(T.i32, bx)
+                if const_expr(single_token_route):
+                    route_token_idx = bx // fx.Index(topk)
+                    route_slot_idx = bx % fx.Index(topk)
+                else:
+                    route_token_idx = fx.Index(0)
+                    route_slot_idx = bx
+                route_token_i32 = arith.index_cast(T.i32, route_token_idx)
+                route_slot_i32 = arith.index_cast(T.i32, route_slot_idx)
                 inter2_idx = arith.index(2 * inter_dim)
                 if const_expr(bool(weight_interleaved)):
                     ntile_base = by * fx.Index(experts * 2 * tile_n)
@@ -592,7 +677,9 @@ def compile_moe_gemm1(
                 # 16, fall back to 8B (dwordx2) or 4B (dword) loads. For fp16/bf16 we require 16B.
                 if const_expr(is_f16_or_bf16):
                     if const_expr(bytes_per_thread_x % 16 != 0):
-                        raise ValueError(f"[fp16] bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 16")
+                        raise ValueError(
+                            f"[fp16] bytes_per_thread_x ({bytes_per_thread_x}) must be divisible by 16"
+                        )
                     x_load_bytes = 16
                 else:
                     if const_expr(bytes_per_thread_x % 16 == 0):
@@ -612,7 +699,9 @@ def compile_moe_gemm1(
                 c_k_div4_i32 = arith.index_cast(T.i32, c_k_div4)
                 fx.make_layout((tokens_i32_v, c_k_div4_i32), stride=(c_k_div4_i32, 1))
                 tile_k_dwords = (int(tile_k) * int(elem_bytes)) // 4
-                layout_x_tile_div4 = fx.make_layout((tile_m, tile_k_dwords), stride=(tile_k_dwords, 1))
+                layout_x_tile_div4 = fx.make_layout(
+                    (tile_m, tile_k_dwords), stride=(tile_k_dwords, 1)
+                )
                 c_chunk_i32 = fx.Index(chunk_i32)
                 tx_i32_base = tx * c_chunk_i32
                 mask24 = fx.Int32(0xFFFFFF)
@@ -640,8 +729,10 @@ def compile_moe_gemm1(
                     x_col_local_i32.append(col_local_i32)
 
                     if const_expr(stage1_tiny_row0_x):
-                        x_row_base_div4.append(fx.Index(0))
-                        x_row_valid.append(arith.cmpi(arith.CmpIPredicate.eq, row_local, fx.Index(0)))
+                        x_row_base_div4.append(route_token_idx * c_k_div4)
+                        x_row_valid.append(
+                            arith.cmpi(arith.CmpIPredicate.eq, row_local, fx.Index(0))
+                        )
                     else:
                         sorted_row_i = bx_m + row_local
                         # NOTE: rows beyond `num_valid_ids` can contain garbage (within the allocated
@@ -649,12 +740,16 @@ def compile_moe_gemm1(
                         fused_i = (
                             memref.load(lds_tid, [row_local])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32
+                            )
                         )
                         t_raw = fused_i & mask24
                         # NOTE: aiter moe_sorting uses sentinel token_id == tokens for padding.
                         # Do NOT rely on buffer OOB semantics for X loads; explicitly mask to a safe row.
-                        t_valid_i32 = arith.cmpi(arith.CmpIPredicate.ult, t_raw, tokens_i32)
+                        t_valid_i32 = arith.cmpi(
+                            arith.CmpIPredicate.ult, t_raw, tokens_i32
+                        )
                         if const_expr(stage1_row_limit_x > 0):
                             row_in_limit = arith.cmpi(
                                 arith.CmpIPredicate.ult,
@@ -687,7 +782,9 @@ def compile_moe_gemm1(
                     idx_i32 is in dword units; convert to element index for _buffer_load_vec.
                     """
                     if const_expr(x_load_bytes_v == 16):
-                        idx_elem = idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                        idx_elem = (
+                            idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                        )
                         return buffer_copy_gmem16_dwordx4(
                             buffer_ops,
                             vector,
@@ -699,9 +796,13 @@ def compile_moe_gemm1(
                         )
                     # For 8B/4B, load raw i32 dwords directly.
                     if const_expr(x_load_bytes_v == 8):
-                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=2, dtype=T.i32)
+                        return buffer_ops.buffer_load(
+                            x_rsrc, idx_i32, vec_width=2, dtype=T.i32
+                        )
                     if const_expr(x_load_bytes_v == 4):
-                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=1, dtype=T.i32)
+                        return buffer_ops.buffer_load(
+                            x_rsrc, idx_i32, vec_width=1, dtype=T.i32
+                        )
                     raise ValueError(f"Invalid x_load_bytes_v: {x_load_bytes_v}")
 
                 def load_x_tile(base_k, x_load_bytes_v):
@@ -712,21 +813,33 @@ def compile_moe_gemm1(
                         idx_i32 = x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
                         if const_expr(stage1_tiny_row0_x or stage1_row_limit_x > 0):
                             if const_expr(x_load_bytes_v == 16):
-                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32x4], has_else=True)
+                                _if_x = scf.IfOp(
+                                    x_row_valid[i], results_=[T.i32x4], has_else=True
+                                )
                                 with _if_then(_if_x):
-                                    scf.YieldOp([vector.bitcast(T.i32x4, load_x(idx_i32, x_load_bytes_v))])
+                                    scf.YieldOp(
+                                        [
+                                            vector.bitcast(
+                                                T.i32x4, load_x(idx_i32, x_load_bytes_v)
+                                            )
+                                        ]
+                                    )
                                 with _if_else(_if_x):
                                     scf.YieldOp([arith.constant_vector(0, T.i32x4)])
                                 parts.append(_if_x.results[0])
                             elif const_expr(x_load_bytes_v == 8):
-                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32x2], has_else=True)
+                                _if_x = scf.IfOp(
+                                    x_row_valid[i], results_=[T.i32x2], has_else=True
+                                )
                                 with _if_then(_if_x):
                                     scf.YieldOp([load_x(idx_i32, x_load_bytes_v)])
                                 with _if_else(_if_x):
                                     scf.YieldOp([arith.constant_vector(0, T.i32x2)])
                                 parts.append(_if_x.results[0])
                             else:
-                                _if_x = scf.IfOp(x_row_valid[i], results_=[T.i32], has_else=True)
+                                _if_x = scf.IfOp(
+                                    x_row_valid[i], results_=[T.i32], has_else=True
+                                )
                                 with _if_then(_if_x):
                                     scf.YieldOp([load_x(idx_i32, x_load_bytes_v)])
                                 with _if_else(_if_x):
@@ -757,7 +870,9 @@ def compile_moe_gemm1(
                 a_kpack_elems = 16 // elem_bytes
                 col_offset_base = lane_div_16 * arith.index(int(a_kpack_elems))
                 col_offset_base_bytes = (
-                    col_offset_base if elem_bytes == 1 else (col_offset_base * arith.index(int(elem_bytes)))
+                    col_offset_base
+                    if elem_bytes == 1
+                    else (col_offset_base * arith.index(int(elem_bytes)))
                 )
 
                 # Dynamic N tiling within block (same as existing kernels)
@@ -823,7 +938,11 @@ def compile_moe_gemm1(
                         kpack_bytes=kpack_bytes,
                         elem_bytes=w_elem_bytes,
                         unpack_int4=(is_int4 or is_int4_bf16),
-                        **({"cache_modifier": int(b_cache_modifier)} if int(b_cache_modifier) != 0 else {}),
+                        **(
+                            {"cache_modifier": int(b_cache_modifier)}
+                            if int(b_cache_modifier) != 0
+                            else {}
+                        ),
                     )
 
                 def load_b_tile(base_k, blk_list, intra_list):
@@ -979,12 +1098,16 @@ def compile_moe_gemm1(
                             + lds_base * arith.index(int(elem_bytes))
                             + wave_id * arith.index(_wave_size_s1 * _dma_bytes_s1)
                         )
-                        lds_ptr = buffer_ops.create_llvm_ptr(lds_byte_addr, address_space=3)
+                        lds_ptr = buffer_ops.create_llvm_ptr(
+                            lds_byte_addr, address_space=3
+                        )
 
                         for i in range_constexpr(num_x_loads):
                             row_local_i = x_row_local[i]
                             col_local_i32_i = x_col_local_i32[i]
-                            col_local_sw = swizzle_xor16(row_local_i, col_local_i32_i * c4_idx, k_blocks16)
+                            col_local_sw = swizzle_xor16(
+                                row_local_i, col_local_i32_i * c4_idx, k_blocks16
+                            )
                             row_k_dw = x_row_base_div4[i] + base_k_div4
                             global_byte_idx = row_k_dw * c4_idx + col_local_sw
                             global_offset = arith.index_cast(T.i32, global_byte_idx)
@@ -1002,16 +1125,24 @@ def compile_moe_gemm1(
 
                 # --- A LDS load helper for K64 (load 16B once, extract 2x i64 halves) ---
                 def lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base):
-                    col_base_swz_bytes = swizzle_xor16(curr_row_a_lds, col_base_bytes, k_blocks16)
+                    col_base_swz_bytes = swizzle_xor16(
+                        curr_row_a_lds, col_base_bytes, k_blocks16
+                    )
                     col_base_swz = (
-                        col_base_swz_bytes if elem_bytes == 1 else (col_base_swz_bytes // arith.index(int(elem_bytes)))
+                        col_base_swz_bytes
+                        if elem_bytes == 1
+                        else (col_base_swz_bytes // arith.index(int(elem_bytes)))
                     )
                     idx_a16 = crd2idx((curr_row_a_lds, col_base_swz), layout_lds)
                     idx_a16 = idx_a16 + lds_base
                     loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
                     a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
-                    a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
-                    a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                    a0 = vector.extract(
+                        a_i64x2, static_position=[0], dynamic_position=[]
+                    )
+                    a1 = vector.extract(
+                        a_i64x2, static_position=[1], dynamic_position=[]
+                    )
                     return a0, a1
 
                 def compute_tile(
@@ -1028,7 +1159,11 @@ def compile_moe_gemm1(
                     up_list = list(acc_up_in)
                     mfma_res_ty = T.i32x4 if is_int8 else T.f32x4
                     if const_expr(_use_mfma_k32):
-                        mfma_fn = rocdl.mfma_f32_16x16x32_f16 if is_f16 else rocdl.mfma_f32_16x16x32_bf16
+                        mfma_fn = (
+                            rocdl.mfma_f32_16x16x32_f16
+                            if is_f16
+                            else rocdl.mfma_f32_16x16x32_bf16
+                        )
                     else:
                         mfma_fn = (
                             mfma_i32_k32
@@ -1036,7 +1171,11 @@ def compile_moe_gemm1(
                             else (
                                 mfma_f32_bf16_k16
                                 if is_bf16
-                                else (rocdl.mfma_f32_16x16x16f16 if is_f16 else rocdl.mfma_f32_16x16x32_fp8_fp8)
+                                else (
+                                    rocdl.mfma_f32_16x16x16f16
+                                    if is_f16
+                                    else rocdl.mfma_f32_16x16x32_fp8_fp8
+                                )
                             )
                         )
 
@@ -1054,21 +1193,29 @@ def compile_moe_gemm1(
                             sw_gate_pf.append(
                                 fx.Float32(1.0)
                                 if not needs_scale_w
-                                else buffer_ops.buffer_load(sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32)
+                                else buffer_ops.buffer_load(
+                                    sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32
+                                )
                             )
                             sw_up_pf.append(
                                 fx.Float32(1.0)
                                 if not needs_scale_w
-                                else buffer_ops.buffer_load(sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32)
+                                else buffer_ops.buffer_load(
+                                    sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32
+                                )
                             )
                         epilogue_tid_pf = None
                         if const_expr(stage1_prefetch_epi_tid):
                             epilogue_tid_pf = []
-                            lane0_for_rows = arith.cmpi(arith.CmpIPredicate.eq, lane_div_16, fx.Index(0))
+                            lane0_for_rows = arith.cmpi(
+                                arith.CmpIPredicate.eq, lane_div_16, fx.Index(0)
+                            )
                             for ii_pf in range_constexpr(4):
                                 if const_expr(ii_pf < stage1_row_limit_epilog):
                                     row_pf = bx_m + fx.Index(ii_pf)
-                                    _if_tid_pf = scf.IfOp(lane0_for_rows, results_=[T.i32], has_else=True)
+                                    _if_tid_pf = scf.IfOp(
+                                        lane0_for_rows, results_=[T.i32], has_else=True
+                                    )
                                     with _if_then(_if_tid_pf):
                                         scf.YieldOp(
                                             [
@@ -1084,7 +1231,9 @@ def compile_moe_gemm1(
                                         scf.YieldOp([arith.constant(0, type=T.i32)])
                                     epilogue_tid_pf.append(_if_tid_pf.results[0])
                                 else:
-                                    epilogue_tid_pf.append(arith.constant(0, type=T.i32))
+                                    epilogue_tid_pf.append(
+                                        arith.constant(0, type=T.i32)
+                                    )
                         epilogue_pf = (sw_gate_pf, sw_up_pf, epilogue_tid_pf)
 
                     def _i64_to_v4f16(x_i64):
@@ -1136,7 +1285,9 @@ def compile_moe_gemm1(
 
                         _uw = arith._to_raw
                         scale_vec = _uw(vector.broadcast(T.f32x4, scale_val))
-                        return arith.ArithValue(_math_fma(scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec)))
+                        return arith.ArithValue(
+                            _math_fma(scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec))
+                        )
 
                     if const_expr(is_int4_bf16 or is_int4_bf16_groupwise):
                         # W4A16: deferred dequant — unpack int4->bf16 right before MFMA
@@ -1153,10 +1304,16 @@ def compile_moe_gemm1(
                                 curr_row_a_lds = row_a_lds + mi_val
                                 a0 = arith.constant(-1, type=T.i64)
                                 a1 = arith.constant(-1, type=T.i64)
-                                if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                if const_expr(
+                                    (a0_prefetch is not None)
+                                    and (ku == 0)
+                                    and (mi == 0)
+                                ):
                                     a0, a1 = a0_prefetch
                                 else:
-                                    a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+                                    a0, a1 = lds_load_packs_k64(
+                                        curr_row_a_lds, col_base, lds_base
+                                    )
 
                                 for ni in range_constexpr(num_acc_n):
                                     acc_idx = mi * num_acc_n + ni
@@ -1169,7 +1326,9 @@ def compile_moe_gemm1(
                                     else:
                                         packed_g, sc_g = b_gate_raw[ni], None
                                         packed_u, sc_u = b_up_raw[ni], None
-                                    if const_expr(is_int4_bf16_groupwise and use_gfx950_cvt):
+                                    if const_expr(
+                                        is_int4_bf16_groupwise and use_gfx950_cvt
+                                    ):
                                         # Defer group scale to post-MFMA FMA with pipeline:
                                         # Issue current MFMA, then apply FMA for previous iteration's result.
                                         bg0, bg1 = unpack_b_w4a16(
@@ -1192,9 +1351,15 @@ def compile_moe_gemm1(
                                         tmp_u = mfma_k64(zero_f32_acc, a0, a1, bu0, bu1)
                                         # Apply FMA for previous pending result (MFMA already completed).
                                         if const_expr(_pending_gate_up is not None):
-                                            p_idx, p_g, p_u, p_sc_g, p_sc_u = _pending_gate_up
-                                            gate_list[p_idx] = _acc_scaled_f32(gate_list[p_idx], p_g, p_sc_g)
-                                            up_list[p_idx] = _acc_scaled_f32(up_list[p_idx], p_u, p_sc_u)
+                                            p_idx, p_g, p_u, p_sc_g, p_sc_u = (
+                                                _pending_gate_up
+                                            )
+                                            gate_list[p_idx] = _acc_scaled_f32(
+                                                gate_list[p_idx], p_g, p_sc_g
+                                            )
+                                            up_list[p_idx] = _acc_scaled_f32(
+                                                up_list[p_idx], p_u, p_sc_u
+                                            )
                                         _pending_gate_up = (
                                             acc_idx,
                                             tmp_g,
@@ -1211,7 +1376,9 @@ def compile_moe_gemm1(
                                             use_gfx950_cvt=use_gfx950_cvt,
                                             defer_scale16=use_gfx950_cvt,
                                         )
-                                        gate_list[acc_idx] = mfma_k64(gate_list[acc_idx], a0, a1, bg0, bg1)
+                                        gate_list[acc_idx] = mfma_k64(
+                                            gate_list[acc_idx], a0, a1, bg0, bg1
+                                        )
                                         bu0, bu1 = unpack_b_w4a16(
                                             packed_u,
                                             arith,
@@ -1220,12 +1387,18 @@ def compile_moe_gemm1(
                                             use_gfx950_cvt=use_gfx950_cvt,
                                             defer_scale16=use_gfx950_cvt,
                                         )
-                                        up_list[acc_idx] = mfma_k64(up_list[acc_idx], a0, a1, bu0, bu1)
+                                        up_list[acc_idx] = mfma_k64(
+                                            up_list[acc_idx], a0, a1, bu0, bu1
+                                        )
                         # Drain last pending FMA.
                         if const_expr(_pending_gate_up is not None):
                             p_idx, p_g, p_u, p_sc_g, p_sc_u = _pending_gate_up
-                            gate_list[p_idx] = _acc_scaled_f32(gate_list[p_idx], p_g, p_sc_g)
-                            up_list[p_idx] = _acc_scaled_f32(up_list[p_idx], p_u, p_sc_u)
+                            gate_list[p_idx] = _acc_scaled_f32(
+                                gate_list[p_idx], p_g, p_sc_g
+                            )
+                            up_list[p_idx] = _acc_scaled_f32(
+                                up_list[p_idx], p_u, p_sc_u
+                            )
                     else:
                         for ku in range_constexpr(k_unroll):
                             b_gate_packs0, b_gate_packs1 = b_gate_tile_in[ku]
@@ -1237,10 +1410,16 @@ def compile_moe_gemm1(
                                 mi_val = arith.index(mi * 16)
                                 curr_row_a_lds = row_a_lds + mi_val
 
-                                if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                if const_expr(
+                                    (a0_prefetch is not None)
+                                    and (ku == 0)
+                                    and (mi == 0)
+                                ):
                                     a0, a1 = a0_prefetch
                                 else:
-                                    a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+                                    a0, a1 = lds_load_packs_k64(
+                                        curr_row_a_lds, col_base, lds_base
+                                    )
 
                                 if const_expr(_use_iglp_opt):
                                     rocdl.s_setprio(1)
@@ -1279,7 +1458,9 @@ def compile_moe_gemm1(
                     mfma_group = num_acc_n * 2
                     mfma_total = (tile_k_bytes // 64 * 2) * (tile_m // 16) * mfma_group
                     mfma_per_iter = 2 * mfma_group
-                    sche_iters = 0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                    sche_iters = (
+                        0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                    )
                     rocdl.sched_dsrd(2)
                     rocdl.sched_mfma(2)
                     rocdl.sched_dsrd(1)
@@ -1323,7 +1504,9 @@ def compile_moe_gemm1(
 
                 # Cross-tile A0 LDS prefetch (default-on): prefetch the first A-pack (K64) for the
                 # tile we are about to compute from LDS, to overlap with upcoming VMEM.
-                a0_prefetch_pong = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+                a0_prefetch_pong = lds_load_packs_k64(
+                    row_a_lds, col_offset_base_bytes, lds_base_pong
+                )
 
                 # Ping-pong main loop (2 tiles per iteration), leaving 2 tail tiles.
                 # Uses scf.for with loop-carried accumulators, B-tile prefetch, and A0 LDS prefetch.
@@ -1379,7 +1562,12 @@ def compile_moe_gemm1(
                             idx += num_acc_n
                             scales = list(vals[idx : idx + num_acc_n])
                             idx += num_acc_n
-                            b_tile.append([(packed[ni], scales[ni]) for ni in range_constexpr(num_acc_n)])
+                            b_tile.append(
+                                [
+                                    (packed[ni], scales[ni])
+                                    for ni in range_constexpr(num_acc_n)
+                                ]
+                            )
                         elif const_expr(int4_bf16_single_field):
                             b_tile.append(list(vals[idx : idx + num_acc_n]))
                             idx += num_acc_n
@@ -1422,7 +1610,9 @@ def compile_moe_gemm1(
                     _bg_ping = load_b_tile(next_k1, n_blk_gate, n_intra_gate)
                     _bu_ping = load_b_tile(next_k1, n_blk_up, n_intra_up)
 
-                    _ag, _au, _ = compute_tile(_ag, _au, _bg, _bu, lds_base_pong, a0_prefetch=_a0pf)
+                    _ag, _au, _ = compute_tile(
+                        _ag, _au, _bg, _bu, lds_base_pong, a0_prefetch=_a0pf
+                    )
                     if const_expr(not _use_async_dma):
                         store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
                     hot_loop_scheduler()
@@ -1431,7 +1621,9 @@ def compile_moe_gemm1(
                     else:
                         gpu.barrier()
 
-                    _a0pf_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+                    _a0pf_ping = lds_load_packs_k64(
+                        row_a_lds, col_offset_base_bytes, lds_base_ping
+                    )
 
                     # ---- stage 1: prefetch+store pong, compute ping ----
                     next_k2 = k_iv + c_tile_k + c_tile_k
@@ -1458,10 +1650,16 @@ def compile_moe_gemm1(
                     else:
                         gpu.barrier()
 
-                    _a0pf_new = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+                    _a0pf_new = lds_load_packs_k64(
+                        row_a_lds, col_offset_base_bytes, lds_base_pong
+                    )
 
                     loop_results = yield (
-                        list(_ag) + list(_au) + _flatten_b_tile(_bg_next) + _flatten_b_tile(_bu_next) + list(_a0pf_new)
+                        list(_ag)
+                        + list(_au)
+                        + _flatten_b_tile(_bg_next)
+                        + _flatten_b_tile(_bu_next)
+                        + list(_a0pf_new)
                     )
 
                 # After scf.for: extract final state from yielded results.
@@ -1498,7 +1696,9 @@ def compile_moe_gemm1(
                     gpu.barrier()
 
                 # Cross-tile prefetch for the final ping tile.
-                a0_prefetch_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+                a0_prefetch_ping = lds_load_packs_k64(
+                    row_a_lds, col_offset_base_bytes, lds_base_ping
+                )
 
                 # Epilogue: compute last tile with epilogue scale prefetch to overlap loads with MFMA.
                 acc_gate, acc_up, epilogue_pf = compute_tile(
@@ -1537,12 +1737,16 @@ def compile_moe_gemm1(
                         sw_gate_vals.append(
                             fx.Float32(1.0)
                             if not needs_scale_w
-                            else buffer_ops.buffer_load(sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32)
+                            else buffer_ops.buffer_load(
+                                sw_rsrc, row_gate_idx, vec_width=1, dtype=T.f32
+                            )
                         )
                         sw_up_vals.append(
                             fx.Float32(1.0)
                             if not needs_scale_w
-                            else buffer_ops.buffer_load(sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32)
+                            else buffer_ops.buffer_load(
+                                sw_rsrc, row_up_idx, vec_width=1, dtype=T.f32
+                            )
                         )
 
                 # When defer_scale16 was used, the x16 correction for v_cvt_off_f32_i4
@@ -1566,10 +1770,14 @@ def compile_moe_gemm1(
                 # ─── Split-K epilogue: two-pass gate/up with f32 atomic fadd ───
                 if const_expr(_is_splitk):
                     if const_expr(lds_out is None):
-                        raise RuntimeError("Split-K epilogue requires lds_out (CShuffle)")
+                        raise RuntimeError(
+                            "Split-K epilogue requires lds_out (CShuffle)"
+                        )
 
                     out_base_idx = buffer_ops.extract_base_index(arg_out)
-                    _split_k_out_row_stride = inter_dim * 2 * out_elem_bytes  # bytes per row
+                    _split_k_out_row_stride = (
+                        inter_dim * 2 * out_elem_bytes
+                    )  # bytes per row
                     _split_k_e_vec = 2  # f32 vec2 for atomic fadd
 
                     # Mutable slot: 0 for gate pass, inter_dim for up pass
@@ -1597,7 +1805,9 @@ def compile_moe_gemm1(
                         fused2 = (
                             memref.load(lds_tid, [row_local])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, row, vec_width=1, dtype=T.i32
+                            )
                         )
                         t2 = fused2 & mask24_i32
                         t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
@@ -1609,7 +1819,9 @@ def compile_moe_gemm1(
                                 if is_f16_or_bf16
                                 else arith.select(
                                     t_valid,
-                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    buffer_ops.buffer_load(
+                                        sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                    ),
                                     fx.Float32(0.0),
                                 )
                             )
@@ -1619,14 +1831,18 @@ def compile_moe_gemm1(
                                 if is_f16_or_bf16
                                 else arith.select(
                                     t_valid,
-                                    buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                    buffer_ops.buffer_load(
+                                        sx_rsrc, t2, vec_width=1, dtype=T.f32
+                                    ),
                                     fx.Float32(0.0),
                                 )
                             )
                         for ni in range_constexpr(num_acc_n):
                             col_local = col_base_local + (ni * 16)
                             acc_idx = mi * num_acc_n + ni
-                            v = vector.extract(_acc[acc_idx], static_position=[ii], dynamic_position=[])
+                            v = vector.extract(
+                                _acc[acc_idx], static_position=[ii], dynamic_position=[]
+                            )
                             if const_expr(is_int8):
                                 v = arith.sitofp(T.f32, v)
                             v = v * sx * _sw[ni]
@@ -1638,7 +1854,9 @@ def compile_moe_gemm1(
                         fused2 = (
                             memref.load(lds_tid, [row_in_tile])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, row, vec_width=1, dtype=T.i32
+                            )
                         )
                         t2 = fused2 & mask24_i32
                         s2 = fused2 >> 24
@@ -1646,16 +1864,24 @@ def compile_moe_gemm1(
                         t_idx = arith.index_cast(T.index, t2)
                         s_idx = arith.index_cast(T.index, s2)
                         ts_idx = t_idx * arith.index(topk) + s_idx
-                        row_byte_base = out_base_idx + ts_idx * arith.index(_split_k_out_row_stride)
+                        row_byte_base = out_base_idx + ts_idx * arith.index(
+                            _split_k_out_row_stride
+                        )
                         return (row_byte_base, t_ok)
 
-                    def store_pair_splitk(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                    def store_pair_splitk(
+                        *, row_local, row, row_ctx, col_pair0, col_g0, frag
+                    ):
                         row_byte_base = row_ctx
                         col_idx = col_g0 + arith.index(_split_k_n_offset[0])
                         byte_off_col = col_idx * arith.index(out_elem_bytes)
                         ptr_addr_idx = row_byte_base + byte_off_col
-                        out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
-                        out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                        out_ptr = buffer_ops.create_llvm_ptr(
+                            ptr_addr_idx, address_space=1
+                        )
+                        out_ptr_v = (
+                            out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
+                        )
                         frag_v = frag._value if hasattr(frag, "_value") else frag
                         llvm.AtomicRMWOp(
                             llvm.AtomicBinOp.fadd,
@@ -1734,7 +1960,9 @@ def compile_moe_gemm1(
 
                 if const_expr(use_cshuffle_epilog_flag):
                     if const_expr(lds_out is None):
-                        raise RuntimeError("CShuffle epilogue enabled but lds_out is not allocated/aliased.")
+                        raise RuntimeError(
+                            "CShuffle epilogue enabled but lds_out is not allocated/aliased."
+                        )
 
                     def write_row_to_lds(
                         *,
@@ -1751,7 +1979,9 @@ def compile_moe_gemm1(
                         fused2 = (
                             memref.load(lds_tid, [row_in_tile])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, row, vec_width=1, dtype=T.i32
+                            )
                         )
                         t2 = fused2 & mask24_i32
                         s2 = fused2 >> 24
@@ -1766,7 +1996,9 @@ def compile_moe_gemm1(
                                 if is_f16_or_bf16
                                 else arith.select(
                                     t_valid,
-                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    buffer_ops.buffer_load(
+                                        sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                    ),
                                     fx.Float32(0.0),
                                 )
                             )
@@ -1776,7 +2008,9 @@ def compile_moe_gemm1(
                                 if is_f16_or_bf16
                                 else arith.select(
                                     t_valid,
-                                    buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                    buffer_ops.buffer_load(
+                                        sx_rsrc, t2, vec_width=1, dtype=T.f32
+                                    ),
                                     fx.Float32(0.0),
                                 )
                             )
@@ -1784,7 +2018,9 @@ def compile_moe_gemm1(
                         # Sorted weight aligned with `row` (matches aiter moe_sorting output).
                         tw = fx.Float32(1.0)
                         if const_expr(doweight_stage1):
-                            tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+                            tw = buffer_ops.buffer_load(
+                                sorted_w_rsrc, row, vec_width=1, dtype=T.f32
+                            )
 
                         for ni in range_constexpr(num_acc_n):
                             col_local = col_base_local + (ni * 16)
@@ -1822,7 +2058,9 @@ def compile_moe_gemm1(
                         fused2 = (
                             memref.load(lds_tid, [row_local])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, row, vec_width=1, dtype=T.i32
+                            )
                         )
                         t2 = fused2 & mask24_i32
                         s2 = fused2 >> 24
@@ -1834,7 +2072,9 @@ def compile_moe_gemm1(
                         fused2 = (
                             memref.load(lds_tid, [row_local])
                             if stage1_tid_lds
-                            else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                            else buffer_ops.buffer_load(
+                                sorted_rsrc, row, vec_width=1, dtype=T.i32
+                            )
                         )
                         t2 = fused2 & mask24_i32
                         t_valid = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32_v)
@@ -1882,9 +2122,11 @@ def compile_moe_gemm1(
                     # Block-level early-exit already guards `bx_m` range.
                     # Here we rely on buffer OOB semantics for any tail rows.
                     if const_expr(single_token_route):
-                        t2 = arith.constant(0, type=T.i32)
+                        t2 = route_token_i32
                         s2 = route_slot_i32
-                        t_valid = arith.cmpi(arith.CmpIPredicate.eq, row_in_tile, fx.Index(0))
+                        t_valid = arith.cmpi(
+                            arith.CmpIPredicate.eq, row_in_tile, fx.Index(0)
+                        )
                     else:
                         fused2 = (
                             epilogue_tid_vals[ii]
@@ -1892,7 +2134,9 @@ def compile_moe_gemm1(
                             else (
                                 memref.load(lds_tid, [row_in_tile])
                                 if stage1_tid_lds
-                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
+                                else buffer_ops.buffer_load(
+                                    sorted_rsrc, row, vec_width=1, dtype=T.i32
+                                )
                             )
                         )
                         t2_raw = fused2 & mask24_i32
@@ -1914,7 +2158,9 @@ def compile_moe_gemm1(
                         sx0 = (
                             fx.Float32(1.0)
                             if is_f16_or_bf16
-                            else buffer_ops.buffer_load(sx_rsrc, fx.Index(0), vec_width=1, dtype=T.f32)
+                            else buffer_ops.buffer_load(
+                                sx_rsrc, route_token_idx, vec_width=1, dtype=T.f32
+                            )
                         )
                     elif const_expr(x_is_token_slot):
                         # slot-major: slot*tokens + token
@@ -1924,7 +2170,9 @@ def compile_moe_gemm1(
                             if is_f16_or_bf16
                             else arith.select(
                                 t_valid,
-                                buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                buffer_ops.buffer_load(
+                                    sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                ),
                                 fx.Float32(0.0),
                             )
                         )
@@ -1934,7 +2182,9 @@ def compile_moe_gemm1(
                             if is_f16_or_bf16
                             else arith.select(
                                 t_valid,
-                                buffer_ops.buffer_load(sx_rsrc, t2, vec_width=1, dtype=T.f32),
+                                buffer_ops.buffer_load(
+                                    sx_rsrc, t2, vec_width=1, dtype=T.f32
+                                ),
                                 fx.Float32(0.0),
                             )
                         )
@@ -1943,14 +2193,16 @@ def compile_moe_gemm1(
 
                     # out linear index base = ((t*topk + s)*inter_dim) (invariant across ni)
                     if const_expr(single_token_route):
-                        idx0 = route_slot_i32 * inter_i32_local
+                        idx0 = (t2 * topk_i32_v + s2) * inter_i32_local
                     else:
                         idx0 = (t2 * topk_i32_v + s2) * inter_i32_local
 
                     # Sorted weight aligned with `row` (matches aiter moe_sorting output).
                     tw = fx.Float32(1.0)
                     if const_expr(doweight_stage1):
-                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+                        tw = buffer_ops.buffer_load(
+                            sorted_w_rsrc, row, vec_width=1, dtype=T.f32
+                        )
 
                     _if_valid = scf.IfOp(t_valid)
                     with _if_then(_if_valid):
@@ -2050,7 +2302,7 @@ def compile_moe_gemm1(
     return launch_moe_gemm1
 
 
-def compile_moe_gemm1_m1(
+def compile_moe_gemm1_route_free(
     *,
     model_dim: int,
     inter_dim: int,
@@ -2068,11 +2320,10 @@ def compile_moe_gemm1_m1(
     fast_barrier: bool = False,
     fine_sched: bool = False,
 ):
-    """Compile the decode M=1 stage1 kernel.
+    """Compile the small-decode direct route-free stage1 kernel.
 
-    The direct-route layout still uses the caller's `sort_tile_m` stride for
-    stage2 compatibility, but this kernel computes only one 16-row MFMA tile
-    per route and maps `block_y` directly to slot `0..topk-1`.
+    This computes only row0 for each `(token, topk_slot)` route block and
+    derives token/slot from `block_y`, so no sorted route buffer is required.
     """
     return compile_moe_gemm1(
         model_dim=model_dim,
@@ -2094,6 +2345,9 @@ def compile_moe_gemm1_m1(
         single_token_route=True,
         sort_tile_m=sort_tile_m,
     )
+
+
+compile_moe_gemm1_m1 = compile_moe_gemm1_route_free
 
 
 @functools.lru_cache(maxsize=1024)
@@ -2126,6 +2380,7 @@ def compile_moe_gemm2(
     group_size_m: int = 1,
     cshuffle_nlane: int = 32,
     weight_interleaved: bool = False,
+    single_token_route: bool = False,
 ):
     """Compile stage2 kernel (`moe_gemm2`) and return the compiled executable.
 
@@ -2146,6 +2401,7 @@ def compile_moe_gemm2(
     global atomics (recommended for performance).
     """
     _use_iglp_opt = False
+    single_token_route = bool(single_token_route)
     gpu_arch = get_hip_arch()
     allocator = SmemAllocator(None, arch=gpu_arch)
     _state = {}
@@ -2153,7 +2409,9 @@ def compile_moe_gemm2(
     _valid_dtypes = ("fp8", "fp16", "bf16", "int8", "int8smooth", "int4", "int4_bf16")
     if in_dtype not in _valid_dtypes:
         raise ValueError(f"in_dtype must be one of {_valid_dtypes}, got {in_dtype!r}")
-    is_int4_bf16 = in_dtype == "int4_bf16"  # W4A16: bf16 activations, packed int4 weights
+    is_int4_bf16 = (
+        in_dtype == "int4_bf16"
+    )  # W4A16: bf16 activations, packed int4 weights
     is_f16 = in_dtype == "fp16"
     is_bf16 = is_int4_bf16 or in_dtype == "bf16"
     is_f16_or_bf16 = is_f16 or is_bf16
@@ -2161,11 +2419,15 @@ def compile_moe_gemm2(
     elem_bytes = 2 if is_f16_or_bf16 else 1
     out_s = str(out_dtype).strip().lower()
     if out_s not in ("f16", "fp16", "half", "bf16", "bfloat16", "f32", "fp32", "float"):
-        raise ValueError(f"out_dtype must be 'f16', 'bf16', or 'f32', got {out_dtype!r}")
+        raise ValueError(
+            f"out_dtype must be 'f16', 'bf16', or 'f32', got {out_dtype!r}"
+        )
     out_is_f32 = out_s in ("f32", "fp32", "float")
     out_is_bf16 = out_s in ("bf16", "bfloat16")
     if (not bool(accumulate)) and out_is_f32:
-        raise ValueError("compile_moe_gemm2(accumulate=False) only supports out_dtype in {'f16','bf16'}")
+        raise ValueError(
+            "compile_moe_gemm2(accumulate=False) only supports out_dtype in {'f16','bf16'}"
+        )
     is_int4 = in_dtype == "int4"
     # w_is_int4: True for any variant where weights are packed int4.
     w_is_int4 = is_int4 or is_int4_bf16
@@ -2186,7 +2448,9 @@ def compile_moe_gemm2(
     _scale_is_bf16 = scale_is_bf16 and use_groupwise_scale
     _sort_block_m = int(tile_m) if int(sort_block_m) <= 0 else int(sort_block_m)
     if _sort_block_m != int(tile_m) and (_sort_block_m % int(tile_m)) != 0:
-        raise ValueError(f"sort_block_m ({_sort_block_m}) must be a multiple of stage2 tile_m ({tile_m})")
+        raise ValueError(
+            f"sort_block_m ({_sort_block_m}) must be a multiple of stage2 tile_m ({tile_m})"
+        )
     _m_splits = _sort_block_m // int(tile_m)
     _persist_m = int(persist_m)
     if _persist_m < 1:
@@ -2198,12 +2462,32 @@ def compile_moe_gemm2(
     if _persistent_chunk_y < 0:
         raise ValueError(f"persistent_chunk_y must be >= 0, got {persistent_chunk_y}")
     if _persistent_grid_y > 0 and _persistent_chunk_y > 0:
-        raise ValueError("persistent_grid_y and persistent_chunk_y are mutually exclusive")
+        raise ValueError(
+            "persistent_grid_y and persistent_chunk_y are mutually exclusive"
+        )
     _group_size_m = int(group_size_m)
     if _group_size_m < 1:
         raise ValueError(f"group_size_m must be >= 1, got {group_size_m}")
     if _group_size_m > 1 and bool(m_fast_grid):
         raise ValueError("group_size_m and m_fast_grid are mutually exclusive")
+    if single_token_route:
+        if _m_splits != 1:
+            raise ValueError(
+                "single_token_route stage2 requires sort_block_m == tile_m"
+            )
+        if (
+            _persist_m != 1
+            or _persistent_grid_y != 0
+            or _persistent_chunk_y != 0
+            or _group_size_m != 1
+        ):
+            raise ValueError(
+                "single_token_route stage2 supports only the direct M grid"
+            )
+        if bool(m_fast_grid):
+            raise ValueError("single_token_route stage2 does not support m_fast_grid")
+        if bool(use_lds_sorted_ids):
+            raise ValueError("single_token_route stage2 does not use LDS sorted ids")
     _cshuffle_nlane = int(cshuffle_nlane)
     if _cshuffle_nlane <= 0 or (256 % _cshuffle_nlane) != 0:
         raise ValueError(f"cshuffle_nlane must divide 256, got {cshuffle_nlane}")
@@ -2214,7 +2498,9 @@ def compile_moe_gemm2(
 
     mfma_i32_k32 = None
     if is_int8:
-        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(rocdl, "mfma_i32_16x16x32_i8", None)
+        mfma_i32_k32 = getattr(rocdl, "mfma_i32_16x16x32i8", None) or getattr(
+            rocdl, "mfma_i32_16x16x32_i8", None
+        )
         if mfma_i32_k32 is None:
             raise AttributeError(
                 "INT8 K32 MFMA op not found: expected `rocdl.mfma_i32_16x16x32i8` (or `rocdl.mfma_i32_16x16x32_i8`)."
@@ -2236,7 +2522,11 @@ def compile_moe_gemm2(
 
     ir.ShapedType.get_dynamic_size()
     # W is packed int4 for W4A8/W4A16/W4A_FP8: 2 values per byte.
-    ((experts * model_dim * inter_dim) // 2 if w_is_int4 else (experts * model_dim * inter_dim))
+    (
+        (experts * model_dim * inter_dim) // 2
+        if w_is_int4
+        else (experts * model_dim * inter_dim)
+    )
 
     total_threads = 256
     tile_k_bytes = int(tile_k) * int(elem_bytes)
@@ -2268,9 +2558,13 @@ def compile_moe_gemm2(
 
     if out_is_f32:
         # Match origin/dev_a16w4: f32 output uses scalar atomics and does NOT use the CShuffle epilogue.
-        _use_cshuffle_epilog = False if use_cshuffle_epilog is None else bool(use_cshuffle_epilog)
+        _use_cshuffle_epilog = (
+            False if use_cshuffle_epilog is None else bool(use_cshuffle_epilog)
+        )
         if _use_cshuffle_epilog:
-            raise ValueError("out_dtype='f32' does not support CShuffle epilogue (set use_cshuffle_epilog=False).")
+            raise ValueError(
+                "out_dtype='f32' does not support CShuffle epilogue (set use_cshuffle_epilog=False)."
+            )
     else:
         if use_cshuffle_epilog is None:
             _use_cshuffle_epilog = True
@@ -2303,10 +2597,11 @@ def compile_moe_gemm2(
     _pcy_tag = "" if _persistent_chunk_y == 0 else f"_pcy{_persistent_chunk_y}"
     _gsm_tag = "" if _group_size_m == 1 else f"_gsm{_group_size_m}"
     _csnl_tag = "" if _cshuffle_nlane == 32 else f"_csnl{_cshuffle_nlane}"
+    _m1r_tag = "_m1route" if single_token_route else ""
     (
         f"mfma_moe2_{in_dtype}_{out_s}_{epilog_tag}"
         f"_t{tile_m}x{tile_n}x{tile_k}"
-        f"{_gs_tag}{scale_tag}{_ldsids_tag}{_rbase_tag}{_rfmeta_tag}{_mfast_tag}{_sbm_tag}{_pm_tag}{_pgy_tag}{_pcy_tag}{_gsm_tag}{_csnl_tag}"
+        f"{_gs_tag}{scale_tag}{_ldsids_tag}{_rbase_tag}{_rfmeta_tag}{_mfast_tag}{_sbm_tag}{_pm_tag}{_pgy_tag}{_pcy_tag}{_gsm_tag}{_csnl_tag}{_m1r_tag}"
         f"_abi2"  # mask sentinel token ids on loads/stores to avoid illegal address faults
     ).replace("-", "_")
 
@@ -2319,11 +2614,15 @@ def compile_moe_gemm2(
         _e_vec = 8 if int(tile_n) % (_cshuffle_nlane * 8) == 0 else 2
         _cshuffle_stride = _cshuffle_nlane * _e_vec
         if int(tile_n) % _cshuffle_stride != 0:
-            raise ValueError(f"tile_n={tile_n} must be divisible by {_cshuffle_stride} when accumulate=False")
+            raise ValueError(
+                f"tile_n={tile_n} must be divisible by {_cshuffle_stride} when accumulate=False"
+            )
 
     # ── LDS sizing (pure Python; no MLIR Context needed) ─────────────────────
     lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(elem_bytes)
-    lds_out_bytes = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0  # f16 bytes
+    lds_out_bytes = (
+        2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
+    )  # f16 bytes
     lds_total_bytes = max(lds_x_bytes, lds_out_bytes)
     lds_total_elems = lds_total_bytes if elem_bytes == 1 else (lds_total_bytes // 2)
 
@@ -2359,17 +2658,35 @@ def compile_moe_gemm2(
             size_expert_ids_in = arith.index_cast(T.index, i32_size_expert_ids_in)
             # i32 versions for layout construction (fly.make_shape requires i32/i64)
             k_i32_v = i32_k_in
-            x_elem = T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            x_elem = (
+                T.bf16
+                if is_bf16
+                else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+            )
             # For int4/int4_bf16, weights are stored as packed bytes (i8) and unpacked in-kernel.
-            w_elem = T.i8 if w_is_int4 else (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8)))
+            w_elem = (
+                T.i8
+                if w_is_int4
+                else (
+                    T.bf16
+                    if is_bf16
+                    else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+                )
+            )
             scale_dtype = T.bf16 if _scale_is_bf16 else T.f32
             vec16_elems = 16 if elem_bytes == 1 else 8
             vec8_elems = 8 if elem_bytes == 1 else 4
             vec8_x = T.vec(vec8_elems, x_elem)
             vec16_x = T.vec(vec16_elems, x_elem)
 
-            acc_init = arith.constant_vector(0, T.i32x4) if is_int8 else arith.constant_vector(0.0, T.f32x4)
-            zero_f32_acc = arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+            acc_init = (
+                arith.constant_vector(0, T.i32x4)
+                if is_int8
+                else arith.constant_vector(0.0, T.f32x4)
+            )
+            zero_f32_acc = (
+                arith.constant_vector(0.0, T.f32x4) if is_int4_bf16_groupwise else None
+            )
 
             # A2 layout (flatten token-slot -> M; use i32 for fly.make_shape).
             topk_idx = fx.Index(topk)
@@ -2409,7 +2726,9 @@ def compile_moe_gemm2(
                     num_pid_m = fx.Index(_persistent_grid_y)
                 elif const_expr(_persist_m > 1):
                     gy_tiles_g = size_expert_ids_in * fx.Index(_m_splits)
-                    num_pid_m = (gy_tiles_g + fx.Index(_persist_m - 1)) // fx.Index(_persist_m)
+                    num_pid_m = (gy_tiles_g + fx.Index(_persist_m - 1)) // fx.Index(
+                        _persist_m
+                    )
                 else:
                     num_pid_m = size_expert_ids_in * fx.Index(_m_splits)
                 group_m = fx.Index(_group_size_m)
@@ -2417,17 +2736,23 @@ def compile_moe_gemm2(
                 group_id = tile_id // num_pid_in_group
                 first_pid_m = group_id * group_m
                 remaining_m = num_pid_m - first_pid_m
-                actual_group_m = arith.select(remaining_m < group_m, remaining_m, group_m)
+                actual_group_m = arith.select(
+                    remaining_m < group_m, remaining_m, group_m
+                )
                 pid_in_group = tile_id % num_pid_in_group
                 bx_tile_base = pid_in_group % actual_group_m
                 bx_tile_base = bx_tile_base + first_pid_m
                 by = pid_in_group // actual_group_m
             elif const_expr(bool(m_fast_grid)):
-                bx_tile_base = fx.Index(gpu.block_id("x"))  # compressed stage2 tile along sorted M
+                bx_tile_base = fx.Index(
+                    gpu.block_id("x")
+                )  # compressed stage2 tile along sorted M
                 by = fx.Index(gpu.block_id("y"))  # tile along model_dim
             else:
                 by = fx.Index(gpu.block_id("x"))  # tile along model_dim
-                bx_tile_base = fx.Index(gpu.block_id("y"))  # compressed stage2 tile along sorted M
+                bx_tile_base = fx.Index(
+                    gpu.block_id("y")
+                )  # compressed stage2 tile along sorted M
 
             # XOR16 swizzle parameter (in bytes; constant, power-of-two in our configs).
             k_blocks16 = arith.index(tile_k_bytes // 16)
@@ -2439,7 +2764,11 @@ def compile_moe_gemm2(
             lds_x_ptr = SmemPtr(
                 base_ptr,
                 lds_alloc_offset,
-                (T.bf16 if is_bf16 else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))),
+                (
+                    T.bf16
+                    if is_bf16
+                    else (T.f16 if is_f16 else (T.i8 if is_int8 else T.f8))
+                ),
                 shape=(lds_total_elems,),
             )
             lds_x = lds_x_ptr.get()
@@ -2468,7 +2797,9 @@ def compile_moe_gemm2(
             # X(A2): [tokens*topk, inter_dim] bytes = tokens*topk*k*elem_bytes
             x_rows = tokens_in * c_topk
             x_nbytes_idx = x_rows * k_in * arith.index(int(elem_bytes))
-            x_rsrc = buffer_ops.create_buffer_resource(arg_x, max_size=False, num_records_bytes=x_nbytes_idx)
+            x_rsrc = buffer_ops.create_buffer_resource(
+                arg_x, max_size=False, num_records_bytes=x_nbytes_idx
+            )
 
             w_rsrc = buffer_ops.create_buffer_resource(arg_w, max_size=False)
 
@@ -2476,8 +2807,12 @@ def compile_moe_gemm2(
             out_elem_bytes = 4 if out_is_f32 else 2
             out_nbytes_idx = tokens_in * n_in * fx.Index(out_elem_bytes)
             if const_expr(not bool(accumulate)):
-                out_nbytes_idx = tokens_in * fx.Index(topk) * n_in * fx.Index(out_elem_bytes)
-            out_rsrc = buffer_ops.create_buffer_resource(arg_out, max_size=False, num_records_bytes=out_nbytes_idx)
+                out_nbytes_idx = (
+                    tokens_in * fx.Index(topk) * n_in * fx.Index(out_elem_bytes)
+                )
+            out_rsrc = buffer_ops.create_buffer_resource(
+                arg_out, max_size=False, num_records_bytes=out_nbytes_idx
+            )
             # scale_x: fp16/bf16 path ignores (implicit scale=1.0); int4_bf16 also uses 1.0.
             sx_rsrc = -1
             if const_expr(not is_f16_or_bf16):
@@ -2492,15 +2827,27 @@ def compile_moe_gemm2(
                 # scale_w: [experts*model_dim] f32 (static shape in practice)
                 sw_rsrc = buffer_ops.create_buffer_resource(arg_scale_w, max_size=False)
 
-            # sorted_token_ids / sorted_weights: [sort_blocks*sort_block_m] (CK-style padded length)
-            sorted_nbytes_idx = size_expert_ids_in * fx.Index(_sort_block_m) * fx.Index(4)
+            # sorted_token_ids / sorted_weights: [sort_blocks*sort_block_m] (CK-style padded length).
+            # M=1 route-free mode does not consume sorted_token_ids and stores route weights compactly.
+            sorted_ids_nbytes_idx = (
+                fx.Index(4)
+                if const_expr(single_token_route)
+                else size_expert_ids_in * fx.Index(_sort_block_m) * fx.Index(4)
+            )
+            sorted_w_nbytes_idx = (
+                size_expert_ids_in * fx.Index(4)
+                if const_expr(single_token_route)
+                else size_expert_ids_in * fx.Index(_sort_block_m) * fx.Index(4)
+            )
             sorted_rsrc = buffer_ops.create_buffer_resource(
                 arg_sorted_token_ids,
                 max_size=False,
-                num_records_bytes=sorted_nbytes_idx,
+                num_records_bytes=sorted_ids_nbytes_idx,
             )
             sorted_w_rsrc = buffer_ops.create_buffer_resource(
-                arg_sorted_weights, max_size=False, num_records_bytes=sorted_nbytes_idx
+                arg_sorted_weights,
+                max_size=False,
+                num_records_bytes=sorted_w_nbytes_idx,
             )
 
             # expert ids: [blocks] i32 -> bytes = size_expert_ids_in*4
@@ -2510,17 +2857,40 @@ def compile_moe_gemm2(
             )
             # Early-exit guard (as in 2ce65fb): some routing paths can produce extra/garbage
             # expert blocks beyond `num_valid_ids`. Skip those blocks entirely to avoid OOB.
-            numids_rsrc = buffer_ops.create_buffer_resource(
-                arg_num_valid_ids,
-                max_size=False,
-                num_records_bytes=fx.Index(4),
-            )
-            num_valid_i32 = buffer_ops.buffer_load(numids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
-            if const_expr(bool(readfirst_metadata)):
-                num_valid_i32 = rocdl.readfirstlane(T.i32, num_valid_i32)
+            if const_expr(single_token_route):
+                num_valid_i32 = arith.constant(0, type=T.i32)
+            else:
+                numids_rsrc = buffer_ops.create_buffer_resource(
+                    arg_num_valid_ids,
+                    max_size=False,
+                    num_records_bytes=fx.Index(4),
+                )
+                num_valid_i32 = buffer_ops.buffer_load(
+                    numids_rsrc, fx.Index(0), vec_width=1, dtype=T.i32
+                )
+                if const_expr(bool(readfirst_metadata)):
+                    num_valid_i32 = rocdl.readfirstlane(T.i32, num_valid_i32)
 
             def _emit_stage2_m_tile(bx_tile):
-                if const_expr(
+                if const_expr(single_token_route):
+                    tile_in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult, bx_tile, size_expert_ids_in
+                    )
+                    sort_blk = tile_in_range.select(bx_tile, fx.Index(0))
+                    bx_m = sort_blk * fx.Index(tile_m)
+                    bx_m_i32 = arith.index_cast(T.i32, bx_m)
+                    expert_i32_early = buffer_ops.buffer_load(
+                        expert_rsrc, sort_blk, vec_width=1, dtype=T.i32
+                    )
+                    if const_expr(bool(readfirst_metadata)):
+                        expert_i32_early = rocdl.readfirstlane(T.i32, expert_i32_early)
+                    expert_valid = arith.cmpi(
+                        arith.CmpIPredicate.sge,
+                        expert_i32_early,
+                        arith.constant(0, type=T.i32),
+                    )
+                    blk_valid = tile_in_range & expert_valid
+                elif const_expr(
                     _m_splits == 1
                     and _persist_m == 1
                     and _persistent_grid_y == 0
@@ -2530,10 +2900,14 @@ def compile_moe_gemm2(
                     sort_blk = bx_tile
                     bx_m = bx_tile * fx.Index(tile_m)
                     bx_m_i32 = arith.index_cast(T.i32, bx_m)
-                    blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32)
+                    blk_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32
+                    )
                 else:
                     gy_tiles = size_expert_ids_in * fx.Index(_m_splits)
-                    tile_in_range = arith.cmpi(arith.CmpIPredicate.ult, bx_tile, gy_tiles)
+                    tile_in_range = arith.cmpi(
+                        arith.CmpIPredicate.ult, bx_tile, gy_tiles
+                    )
                     bx_tile_safe = tile_in_range.select(bx_tile, fx.Index(0))
                     if const_expr(_m_splits == 1):
                         sort_blk = bx_tile_safe
@@ -2542,10 +2916,16 @@ def compile_moe_gemm2(
                         split_idx = fx.Index(_m_splits)
                         sort_blk = bx_tile_safe // split_idx
                         sub_blk = bx_tile_safe % split_idx
-                        bx_m = sort_blk * fx.Index(_sort_block_m) + sub_blk * fx.Index(tile_m)
+                        bx_m = sort_blk * fx.Index(_sort_block_m) + sub_blk * fx.Index(
+                            tile_m
+                        )
                     bx_m_i32 = arith.index_cast(T.i32, bx_m)
-                    blk_valid = arith.cmpi(arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32)
-                    expert_i32_early = buffer_ops.buffer_load(expert_rsrc, sort_blk, vec_width=1, dtype=T.i32)
+                    blk_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult, bx_m_i32, num_valid_i32
+                    )
+                    expert_i32_early = buffer_ops.buffer_load(
+                        expert_rsrc, sort_blk, vec_width=1, dtype=T.i32
+                    )
                     if const_expr(bool(readfirst_metadata)):
                         expert_i32_early = rocdl.readfirstlane(T.i32, expert_i32_early)
                     expert_valid = arith.cmpi(
@@ -2557,7 +2937,9 @@ def compile_moe_gemm2(
 
                 def _moe_gemm2_then_body():
                     # Expert id for this M tile.
-                    expert_i32 = buffer_ops.buffer_load(expert_rsrc, sort_blk, vec_width=1, dtype=T.i32)
+                    expert_i32 = buffer_ops.buffer_load(
+                        expert_rsrc, sort_blk, vec_width=1, dtype=T.i32
+                    )
                     if const_expr(bool(readfirst_metadata)):
                         expert_i32 = rocdl.readfirstlane(T.i32, expert_i32)
                     expert_idx = arith.index_cast(T.index, expert_i32)
@@ -2602,7 +2984,9 @@ def compile_moe_gemm2(
                     c_k_div4_i32 = arith.index_cast(T.i32, c_k_div4)
                     fx.make_layout((m_i32_v, c_k_div4_i32), stride=(c_k_div4_i32, 1))
                     tile_k_dwords = (int(tile_k) * int(elem_bytes)) // 4
-                    layout_x_tile_div4 = fx.make_layout((tile_m, tile_k_dwords), stride=(tile_k_dwords, 1))
+                    layout_x_tile_div4 = fx.make_layout(
+                        (tile_m, tile_k_dwords), stride=(tile_k_dwords, 1)
+                    )
                     c_chunk_i32 = fx.Index(chunk_i32)
                     tx_i32_base = tx * c_chunk_i32
 
@@ -2625,12 +3009,18 @@ def compile_moe_gemm2(
 
                     def preload_sorted_ids_to_lds():
                         if const_expr(bool(use_lds_sorted_ids)):
-                            tid_in_range = arith.cmpi(arith.CmpIPredicate.ult, tx, fx.Index(tile_m))
+                            tid_in_range = arith.cmpi(
+                                arith.CmpIPredicate.ult, tx, fx.Index(tile_m)
+                            )
                             tid_if = scf.IfOp(tid_in_range)
                             with _if_then(tid_if):
                                 tid_row = bx_m + tx
-                                tid_val = buffer_ops.buffer_load(sorted_rsrc, tid_row, vec_width=1, dtype=T.i32)
-                                tid_vec1 = vector.from_elements(T.vec(1, T.i32), [tid_val])
+                                tid_val = buffer_ops.buffer_load(
+                                    sorted_rsrc, tid_row, vec_width=1, dtype=T.i32
+                                )
+                                tid_vec1 = vector.from_elements(
+                                    T.vec(1, T.i32), [tid_val]
+                                )
                                 vector.store(tid_vec1, lds_tid, [tx], alignment=4)
                             gpu.barrier()
 
@@ -2638,7 +3028,9 @@ def compile_moe_gemm2(
 
                     def load_x(idx_i32, x_load_bytes_v):
                         if const_expr(x_load_bytes_v == 16):
-                            idx_elem = idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                            idx_elem = (
+                                idx_i32 if elem_bytes == 1 else (idx_i32 * fx.Index(2))
+                            )
                             return buffer_copy_gmem16_dwordx4(
                                 buffer_ops,
                                 vector,
@@ -2649,8 +3041,12 @@ def compile_moe_gemm2(
                                 elem_bytes=elem_bytes,
                             )
                         if const_expr(x_load_bytes_v == 8):
-                            return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=2, dtype=T.i32)
-                        return buffer_ops.buffer_load(x_rsrc, idx_i32, vec_width=1, dtype=T.i32)
+                            return buffer_ops.buffer_load(
+                                x_rsrc, idx_i32, vec_width=2, dtype=T.i32
+                            )
+                        return buffer_ops.buffer_load(
+                            x_rsrc, idx_i32, vec_width=1, dtype=T.i32
+                        )
 
                     # decode routed token once (per thread's M-slice) and build a base offset.
                     x_row_base_div4 = []
@@ -2661,31 +3057,44 @@ def compile_moe_gemm2(
                         x_row_local.append(row_local)
                         x_col_local_i32.append(col_local_i32)
 
-                        sorted_row_i = bx_m + row_local
-                        fused_i = (
-                            memref.load(lds_tid, [row_local])
-                            if const_expr(bool(use_lds_sorted_ids))
-                            else buffer_ops.buffer_load(sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32)
-                        )
-                        t_i32 = fused_i & mask24
-                        s_i32 = fused_i >> 24
-                        # aiter moe_sorting uses sentinel token_id == tokens for padding.
-                        # Do NOT rely on buffer OOB semantics for A2/scale loads; explicitly mask.
-                        t_valid = arith.cmpi(arith.CmpIPredicate.ult, t_i32, tokens_i32)
-                        s_valid = arith.cmpi(arith.CmpIPredicate.ult, s_i32, topk_i32)
-                        ts_valid = t_valid & s_valid
-                        t_safe = ts_valid.select(t_i32, fx.Int32(0))
-                        s_safe = ts_valid.select(s_i32, fx.Int32(0))
-                        row_ts_i32 = t_safe * topk_i32 + s_safe
+                        if const_expr(single_token_route):
+                            row_ts_i32 = arith.index_cast(T.i32, sort_blk)
+                        else:
+                            sorted_row_i = bx_m + row_local
+                            fused_i = (
+                                memref.load(lds_tid, [row_local])
+                                if const_expr(bool(use_lds_sorted_ids))
+                                else buffer_ops.buffer_load(
+                                    sorted_rsrc, sorted_row_i, vec_width=1, dtype=T.i32
+                                )
+                            )
+                            t_i32 = fused_i & mask24
+                            s_i32 = fused_i >> 24
+                            # aiter moe_sorting uses sentinel token_id == tokens for padding.
+                            # Do NOT rely on buffer OOB semantics for A2/scale loads; explicitly mask.
+                            t_valid = arith.cmpi(
+                                arith.CmpIPredicate.ult, t_i32, tokens_i32
+                            )
+                            s_valid = arith.cmpi(
+                                arith.CmpIPredicate.ult, s_i32, topk_i32
+                            )
+                            ts_valid = t_valid & s_valid
+                            t_safe = ts_valid.select(t_i32, fx.Int32(0))
+                            s_safe = ts_valid.select(s_i32, fx.Int32(0))
+                            row_ts_i32 = t_safe * topk_i32 + s_safe
                         row_ts_idx = arith.index_cast(T.index, row_ts_i32)
                         # Base row offset in dword units: row_ts_idx * (k_in/4)
                         x_row_base_div4.append(row_ts_idx * c_k_div4)
 
                     def load_x_tile(base_k, x_load_bytes_v):
-                        base_k_div4 = (base_k * arith.index(int(elem_bytes))) // fx.Index(4)
+                        base_k_div4 = (
+                            base_k * arith.index(int(elem_bytes))
+                        ) // fx.Index(4)
                         parts = []
                         for i in range_constexpr(num_x_loads):
-                            idx_i32 = x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
+                            idx_i32 = (
+                                x_row_base_div4[i] + base_k_div4 + x_col_local_i32[i]
+                            )
                             x_vec = load_x(idx_i32, x_load_bytes_v)
                             if const_expr(x_load_bytes_v == 16):
                                 parts.append(vector.bitcast(T.i32x4, x_vec))
@@ -2711,7 +3120,9 @@ def compile_moe_gemm2(
                     a_kpack_elems = 16 // elem_bytes
                     col_offset_base = lane_div_16 * arith.index(int(a_kpack_elems))
                     col_offset_base_bytes = (
-                        col_offset_base if elem_bytes == 1 else (col_offset_base * arith.index(int(elem_bytes)))
+                        col_offset_base
+                        if elem_bytes == 1
+                        else (col_offset_base * arith.index(int(elem_bytes)))
                     )
 
                     # Dynamic N tiling within block.
@@ -2729,13 +3140,17 @@ def compile_moe_gemm2(
                     col_g_list = []
                     c_n_total // fx.Index(16)
                     c_n0_static = experts * model_dim // 16
-                    layout_n_blk_intra = fx.make_layout((c_n0_static, 16), stride=(16, 1))
+                    layout_n_blk_intra = fx.make_layout(
+                        (c_n0_static, 16), stride=(16, 1)
+                    )
                     for ni in range_constexpr(num_acc_n):
                         offset = arith.index(ni * 16)
                         if const_expr(bool(weight_interleaved)):
                             # In interleaved mode, col_g is local to tile_n (0..tile_n-1)
                             col_g_local = n_tile_base + offset + lane_mod_16
-                            col_g = by_n + col_g_local  # for output addressing (full model_dim)
+                            col_g = (
+                                by_n + col_g_local
+                            )  # for output addressing (full model_dim)
                             col_g_list.append(col_g)
                             row_w = expert_off_idx + col_g_local
                         else:
@@ -2767,7 +3182,11 @@ def compile_moe_gemm2(
                             kpack_bytes=kpack_bytes,
                             elem_bytes=w_elem_bytes,
                             unpack_int4=(is_int4 or is_int4_bf16),
-                            **({"cache_modifier": int(b_cache_modifier)} if int(b_cache_modifier) != 0 else {}),
+                            **(
+                                {"cache_modifier": int(b_cache_modifier)}
+                                if int(b_cache_modifier) != 0
+                                else {}
+                            ),
                         )
 
                     def load_b_tile(base_k):
@@ -2899,7 +3318,9 @@ def compile_moe_gemm2(
 
                     # --- A LDS load helper for K64 (load 16B once, extract 2x i64 halves) ---
                     def lds_load_packs_k64(curr_row_a_lds, col_base_bytes, lds_base):
-                        col_base_swz_bytes = swizzle_xor16(curr_row_a_lds, col_base_bytes, k_blocks16)
+                        col_base_swz_bytes = swizzle_xor16(
+                            curr_row_a_lds, col_base_bytes, k_blocks16
+                        )
                         col_base_swz = (
                             col_base_swz_bytes
                             if elem_bytes == 1
@@ -2909,8 +3330,12 @@ def compile_moe_gemm2(
                         idx_a16 = idx_a16 + lds_base
                         loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
                         a_i64x2 = vector.bitcast(T.i64x2, loaded_a16)
-                        a0 = vector.extract(a_i64x2, static_position=[0], dynamic_position=[])
-                        a1 = vector.extract(a_i64x2, static_position=[1], dynamic_position=[])
+                        a0 = vector.extract(
+                            a_i64x2, static_position=[0], dynamic_position=[]
+                        )
+                        a1 = vector.extract(
+                            a_i64x2, static_position=[1], dynamic_position=[]
+                        )
                         return a0, a1
 
                     epilogue_pf = []
@@ -2926,7 +3351,11 @@ def compile_moe_gemm2(
                         acc_list = list(acc_in)
                         mfma_res_ty = T.i32x4 if is_int8 else T.f32x4
                         if const_expr(_use_mfma_k32):
-                            mfma_fn = rocdl.mfma_f32_16x16x32_f16 if is_f16 else rocdl.mfma_f32_16x16x32_bf16
+                            mfma_fn = (
+                                rocdl.mfma_f32_16x16x32_f16
+                                if is_f16
+                                else rocdl.mfma_f32_16x16x32_bf16
+                            )
                         else:
                             mfma_fn = (
                                 mfma_i32_k32
@@ -2934,7 +3363,11 @@ def compile_moe_gemm2(
                                 else (
                                     mfma_f32_bf16_k16
                                     if is_bf16
-                                    else (rocdl.mfma_f32_16x16x16f16 if is_f16 else rocdl.mfma_f32_16x16x32_fp8_fp8)
+                                    else (
+                                        rocdl.mfma_f32_16x16x16f16
+                                        if is_f16
+                                        else rocdl.mfma_f32_16x16x32_fp8_fp8
+                                    )
                                 )
                             )
 
@@ -2948,7 +3381,9 @@ def compile_moe_gemm2(
                                 sw_pf.append(
                                     fx.Float32(1.0)
                                     if not needs_scale_w
-                                    else buffer_ops.buffer_load(sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                                    else buffer_ops.buffer_load(
+                                        sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32
+                                    )
                                 )
                             # Also prefetch per-row routed/topk weights (sorted_weights) when enabled.
                             tw_pf = []
@@ -2958,9 +3393,15 @@ def compile_moe_gemm2(
                                 for mi in range_constexpr(m_repeat):
                                     mi_base_pf = arith.index(mi * 16)
                                     for ii in range_constexpr(4):
-                                        row_off_pf = lane_div_16_mul4_pf + ii_idx_list_pf[ii]
+                                        row_off_pf = (
+                                            lane_div_16_mul4_pf + ii_idx_list_pf[ii]
+                                        )
                                         row_in_tile_pf = mi_base_pf + row_off_pf
-                                        sorted_row_pf = bx_m + row_in_tile_pf
+                                        sorted_row_pf = (
+                                            sort_blk
+                                            if const_expr(single_token_route)
+                                            else bx_m + row_in_tile_pf
+                                        )
                                         tw_pf.append(
                                             buffer_ops.buffer_load(
                                                 sorted_w_rsrc,
@@ -3022,7 +3463,11 @@ def compile_moe_gemm2(
 
                             _uw = arith._to_raw
                             scale_vec = _uw(vector.broadcast(T.f32x4, scale_val))
-                            return arith.ArithValue(_math_fma(scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec)))
+                            return arith.ArithValue(
+                                _math_fma(
+                                    scale_vec, _uw(f32_partial_vec), _uw(f32_acc_vec)
+                                )
+                            )
 
                         if const_expr(is_int4_bf16 or is_int4_bf16_groupwise):
                             # W4A16: deferred dequant -- unpack int4->bf16 right before MFMA
@@ -3037,10 +3482,16 @@ def compile_moe_gemm2(
                                     mi_val = arith.index(mi * 16)
                                     curr_row_a_lds = row_a_lds + mi_val
 
-                                    if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                    if const_expr(
+                                        (a0_prefetch is not None)
+                                        and (ku == 0)
+                                        and (mi == 0)
+                                    ):
                                         a0, a1 = a0_prefetch
                                     else:
-                                        a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+                                        a0, a1 = lds_load_packs_k64(
+                                            curr_row_a_lds, col_base, lds_base
+                                        )
 
                                     for ni in range_constexpr(num_acc_n):
                                         acc_idx = mi * num_acc_n + ni
@@ -3050,7 +3501,9 @@ def compile_moe_gemm2(
                                                 sc = extract_bf16_scale(arith, sc, ku)
                                         else:
                                             packed, sc = b_raw[ni], None
-                                        if const_expr(is_int4_bf16_groupwise and use_gfx950_cvt):
+                                        if const_expr(
+                                            is_int4_bf16_groupwise and use_gfx950_cvt
+                                        ):
                                             b0, b1 = unpack_b_w4a16(
                                                 packed,
                                                 arith,
@@ -3062,7 +3515,9 @@ def compile_moe_gemm2(
                                             tmp = mfma_k64(zero_f32_acc, a0, a1, b0, b1)
                                             if const_expr(_pending_acc is not None):
                                                 p_idx, p_tmp, p_sc = _pending_acc
-                                                acc_list[p_idx] = _acc_scaled_f32(acc_list[p_idx], p_tmp, p_sc)
+                                                acc_list[p_idx] = _acc_scaled_f32(
+                                                    acc_list[p_idx], p_tmp, p_sc
+                                                )
                                             _pending_acc = (acc_idx, tmp, sc)
                                         else:
                                             b0, b1 = unpack_b_w4a16(
@@ -3073,11 +3528,15 @@ def compile_moe_gemm2(
                                                 use_gfx950_cvt=use_gfx950_cvt,
                                                 defer_scale16=use_gfx950_cvt,
                                             )
-                                            acc_list[acc_idx] = mfma_k64(acc_list[acc_idx], a0, a1, b0, b1)
+                                            acc_list[acc_idx] = mfma_k64(
+                                                acc_list[acc_idx], a0, a1, b0, b1
+                                            )
                             # Drain last pending FMA.
                             if const_expr(_pending_acc is not None):
                                 p_idx, p_tmp, p_sc = _pending_acc
-                                acc_list[p_idx] = _acc_scaled_f32(acc_list[p_idx], p_tmp, p_sc)
+                                acc_list[p_idx] = _acc_scaled_f32(
+                                    acc_list[p_idx], p_tmp, p_sc
+                                )
                         else:
                             for ku in range_constexpr(k_unroll):
                                 b_packs0, b_packs1 = b_tile_in[ku]
@@ -3088,10 +3547,16 @@ def compile_moe_gemm2(
                                     mi_val = arith.index(mi * 16)
                                     curr_row_a_lds = row_a_lds + mi_val
 
-                                    if const_expr((a0_prefetch is not None) and (ku == 0) and (mi == 0)):
+                                    if const_expr(
+                                        (a0_prefetch is not None)
+                                        and (ku == 0)
+                                        and (mi == 0)
+                                    ):
                                         a0, a1 = a0_prefetch
                                     else:
-                                        a0, a1 = lds_load_packs_k64(curr_row_a_lds, col_base, lds_base)
+                                        a0, a1 = lds_load_packs_k64(
+                                            curr_row_a_lds, col_base, lds_base
+                                        )
 
                                     if const_expr(_use_iglp_opt):
                                         rocdl.s_setprio(1)
@@ -3160,7 +3625,9 @@ def compile_moe_gemm2(
                         mfma_group = num_acc_n
                         mfma_total = (k_unroll * 2) * m_repeat * mfma_group
                         mfma_per_iter = 2 * mfma_group
-                        sche_iters = 0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                        sche_iters = (
+                            0 if mfma_per_iter == 0 else (mfma_total // mfma_per_iter)
+                        )
 
                         rocdl.sched_dsrd(2)
                         rocdl.sched_mfma(1)
@@ -3212,7 +3679,9 @@ def compile_moe_gemm2(
 
                     # Cross-tile A0 LDS prefetch (default-on): prefetch the first A-pack (K64) for the
                     # tile we are about to compute from LDS, to overlap with upcoming VMEM.
-                    a0_prefetch_pong = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+                    a0_prefetch_pong = lds_load_packs_k64(
+                        row_a_lds, col_offset_base_bytes, lds_base_pong
+                    )
 
                     # Main loop: process K tiles in 2-tile ping-pong steps.
                     #
@@ -3262,7 +3731,12 @@ def compile_moe_gemm2(
                                 idx += num_acc_n
                                 scales = list(vals[idx : idx + num_acc_n])
                                 idx += num_acc_n
-                                b_tile.append([(packed[ni], scales[ni]) for ni in range_constexpr(num_acc_n)])
+                                b_tile.append(
+                                    [
+                                        (packed[ni], scales[ni])
+                                        for ni in range_constexpr(num_acc_n)
+                                    ]
+                                )
                             elif const_expr(int4_bf16_single_field):
                                 b_tile.append(list(vals[idx : idx + num_acc_n]))
                                 idx += num_acc_n
@@ -3274,7 +3748,9 @@ def compile_moe_gemm2(
                                 b_tile.append((packs_even, packs_odd))
                         return b_tile
 
-                    init_state = list(acc) + _flatten_b_tile(b_cur) + list(a0_prefetch_pong)
+                    init_state = (
+                        list(acc) + _flatten_b_tile(b_cur) + list(a0_prefetch_pong)
+                    )
 
                     for pair_iv, state in range(0, pair_iters, 1, init=init_state):
                         _ac = list(state[:_n_acc])
@@ -3292,7 +3768,9 @@ def compile_moe_gemm2(
                         hot_loop_scheduler()
                         gpu.barrier()
 
-                        _a0p = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+                        _a0p = lds_load_packs_k64(
+                            row_a_lds, col_offset_base_bytes, lds_base_ping
+                        )
 
                         next_k2 = k_iv + c_tile_k_s2 + c_tile_k_s2
                         x_regs_pong = load_x_tile(next_k2, x_load_bytes)
@@ -3303,9 +3781,13 @@ def compile_moe_gemm2(
                         hot_loop_scheduler()
                         gpu.barrier()
 
-                        _a0n = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_pong)
+                        _a0n = lds_load_packs_k64(
+                            row_a_lds, col_offset_base_bytes, lds_base_pong
+                        )
 
-                        loop_results = yield list(_ac) + _flatten_b_tile(_bn) + list(_a0n)
+                        loop_results = (
+                            yield list(_ac) + _flatten_b_tile(_bn) + list(_a0n)
+                        )
 
                     SmemPtr._view_cache = None
                     if const_expr(pair_iters > 0):
@@ -3329,12 +3811,16 @@ def compile_moe_gemm2(
                         x_regs_ping = load_x_tile(k_tail1, x_load_bytes)
                         b_ping = load_b_tile(k_tail1)
 
-                        acc, _ = compute_tile(acc, b_cur, lds_base_pong, a0_prefetch=a0_prefetch_pong)
+                        acc, _ = compute_tile(
+                            acc, b_cur, lds_base_pong, a0_prefetch=a0_prefetch_pong
+                        )
                         store_x_tile_to_lds(x_regs_ping, lds_base_ping, x_load_bytes)
                         hot_loop_scheduler()
                         gpu.barrier()
 
-                        a0_prefetch_ping = lds_load_packs_k64(row_a_lds, col_offset_base_bytes, lds_base_ping)
+                        a0_prefetch_ping = lds_load_packs_k64(
+                            row_a_lds, col_offset_base_bytes, lds_base_ping
+                        )
                         acc, epilogue_pf = compute_tile(
                             acc,
                             b_ping,
@@ -3347,12 +3833,15 @@ def compile_moe_gemm2(
                     # Reuse the shared helper so GEMM / MoE kernels share the exact same CShuffle skeleton.
                     expert_off = expert_off_for_scale
                     mask24_i32 = fx.Int32(0xFFFFFF)
+                    shift24_i32 = fx.Int32(24)
                     model_i32 = fx.Int32(model_dim)
                     topk_i32_v = topk_i32
 
                     zero_i32 = fx.Int32(0)
                     c2_i32 = fx.Int32(2)  # 2B element size for f16/bf16
-                    mask_even_i32 = fx.Int32(0xFFFFFFFE)  # align element index to even for half2 atomics
+                    mask_even_i32 = fx.Int32(
+                        0xFFFFFFFE
+                    )  # align element index to even for half2 atomics
 
                     e_vec = _e_vec
 
@@ -3384,7 +3873,9 @@ def compile_moe_gemm2(
                             sw_vals.append(
                                 fx.Float32(1.0)
                                 if not needs_scale_w
-                                else buffer_ops.buffer_load(sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32)
+                                else buffer_ops.buffer_load(
+                                    sw_rsrc, row_w_idx, vec_width=1, dtype=T.f32
+                                )
                             )
 
                     # When defer_scale16 was used, the x16 correction for v_cvt_off_f32_i4
@@ -3407,23 +3898,47 @@ def compile_moe_gemm2(
                             )
 
                         def _stage2_row_atomic(*, mi: int, ii: int, row_in_tile, row):
-                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
-                            t2 = fused2 & mask24_i32
-                            s2 = fused2 >> 24
+                            if const_expr(single_token_route):
+                                route_token_idx = sort_blk // fx.Index(topk)
+                                route_slot_idx = sort_blk % fx.Index(topk)
+                                t2 = arith.index_cast(T.i32, route_token_idx)
+                                s2 = arith.index_cast(T.i32, route_slot_idx)
+                                row0_ok = arith.cmpi(
+                                    arith.CmpIPredicate.eq, row_in_tile, fx.Index(0)
+                                )
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = row0_ok & t_ok & s_ok
+                            else:
+                                fused2 = buffer_ops.buffer_load(
+                                    sorted_rsrc, row, vec_width=1, dtype=T.i32
+                                )
+                                t2 = fused2 & mask24_i32
+                                s2 = fused2 >> 24
 
-                            # Sentinel rows are padding from grouped routing. Do not issue
-                            # atomics for them: an invalid row can carry a NaN accumulator,
-                            # and IEEE NaN * 0 would still poison token 0.
-                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
-                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
-                            ts_ok = t_ok & s_ok
+                                # Sentinel rows are padding from grouped routing. Do not issue
+                                # atomics for them: an invalid row can carry a NaN accumulator,
+                                # and IEEE NaN * 0 would still poison token 0.
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = t_ok & s_ok
                             valid_if = scf.IfOp(ts_ok)
                             with _if_then(valid_if):
                                 ts2 = t2 * topk_i32_v + s2
                                 sx = (
                                     fx.Float32(1.0)
                                     if is_f16_or_bf16
-                                    else buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32)
+                                    else buffer_ops.buffer_load(
+                                        sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                    )
                                 )
 
                                 tw = fx.Float32(1.0)
@@ -3431,8 +3946,17 @@ def compile_moe_gemm2(
                                     tw_idx = (mi * 4) + ii
                                     if const_expr(tw_pf is not None):
                                         tw = tw_pf[tw_idx]
+                                    elif const_expr(single_token_route):
+                                        tw = buffer_ops.buffer_load(
+                                            sorted_w_rsrc,
+                                            sort_blk,
+                                            vec_width=1,
+                                            dtype=T.f32,
+                                        )
                                     else:
-                                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+                                        tw = buffer_ops.buffer_load(
+                                            sorted_w_rsrc, row, vec_width=1, dtype=T.f32
+                                        )
 
                                 idx0 = t2 * model_i32
 
@@ -3468,14 +3992,38 @@ def compile_moe_gemm2(
                         # Each thread writes its MFMA output values directly to the intermediate buffer.
                         # Within a wave, 16 lanes write to 16 adjacent columns in the same row → coalesced.
 
-                        def _stage2_row_direct_store(*, mi: int, ii: int, row_in_tile, row):
-                            fused2 = buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
-                            t2 = fused2 & mask24_i32
-                            s2 = fused2 >> 24
+                        def _stage2_row_direct_store(
+                            *, mi: int, ii: int, row_in_tile, row
+                        ):
+                            if const_expr(single_token_route):
+                                route_token_idx = sort_blk // fx.Index(topk)
+                                route_slot_idx = sort_blk % fx.Index(topk)
+                                t2 = arith.index_cast(T.i32, route_token_idx)
+                                s2 = arith.index_cast(T.i32, route_slot_idx)
+                                row0_ok = arith.cmpi(
+                                    arith.CmpIPredicate.eq, row_in_tile, fx.Index(0)
+                                )
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = row0_ok & t_ok & s_ok
+                            else:
+                                fused2 = buffer_ops.buffer_load(
+                                    sorted_rsrc, row, vec_width=1, dtype=T.i32
+                                )
+                                t2 = fused2 & mask24_i32
+                                s2 = fused2 >> 24
 
-                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
-                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
-                            ts_ok = t_ok & s_ok
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = t_ok & s_ok
                             t2_safe = ts_ok.select(t2, fx.Int32(0))
                             s2_safe = ts_ok.select(s2, fx.Int32(0))
                             ts2 = t2_safe * topk_i32_v + s2_safe
@@ -3485,7 +4033,9 @@ def compile_moe_gemm2(
                                 if is_f16_or_bf16
                                 else arith.select(
                                     ts_ok,
-                                    buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                    buffer_ops.buffer_load(
+                                        sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                    ),
                                     fx.Float32(0.0),
                                 )
                             )
@@ -3495,10 +4045,23 @@ def compile_moe_gemm2(
                                 tw_idx = (mi * 4) + ii
                                 if const_expr(tw_pf is not None):
                                     tw = ts_ok.select(tw_pf[tw_idx], fx.Float32(0.0))
+                                elif const_expr(single_token_route):
+                                    tw = arith.select(
+                                        ts_ok,
+                                        buffer_ops.buffer_load(
+                                            sorted_w_rsrc,
+                                            sort_blk,
+                                            vec_width=1,
+                                            dtype=T.f32,
+                                        ),
+                                        fx.Float32(0.0),
+                                    )
                                 else:
                                     tw = arith.select(
                                         ts_ok,
-                                        buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32),
+                                        buffer_ops.buffer_load(
+                                            sorted_w_rsrc, row, vec_width=1, dtype=T.f32
+                                        ),
                                         fx.Float32(0.0),
                                     )
 
@@ -3533,7 +4096,9 @@ def compile_moe_gemm2(
                         )
                     else:
                         if const_expr(lds_out is None):
-                            raise RuntimeError("stage2 CShuffle requested but lds_out is not allocated/aliased.")
+                            raise RuntimeError(
+                                "stage2 CShuffle requested but lds_out is not allocated/aliased."
+                            )
 
                         # For bf16 global atomics (gfx942 only), precompute the output base address.
                         # gfx950+ has buffer_atomic_pk_add_bf16, so bf16 uses buffer atomics there.
@@ -3552,17 +4117,39 @@ def compile_moe_gemm2(
                             num_acc_n: int,
                             lds_out,
                         ):
-                            fused2 = (
-                                memref.load(lds_tid, [row_in_tile])
-                                if const_expr(bool(use_lds_sorted_ids))
-                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
-                            )
-                            t2 = fused2 & mask24_i32
-                            s2 = fused2 >> 24
-                            # Explicitly mask sentinel token/slot to avoid OOB scale_x loads.
-                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t2, tokens_i32)
-                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s2, topk_i32_v)
-                            ts_ok = t_ok & s_ok
+                            if const_expr(single_token_route):
+                                route_token_idx = sort_blk // fx.Index(topk)
+                                route_slot_idx = sort_blk % fx.Index(topk)
+                                t2 = arith.index_cast(T.i32, route_token_idx)
+                                s2 = arith.index_cast(T.i32, route_slot_idx)
+                                row0_ok = arith.cmpi(
+                                    arith.CmpIPredicate.eq, row_in_tile, fx.Index(0)
+                                )
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = row0_ok & t_ok & s_ok
+                            else:
+                                fused2 = (
+                                    memref.load(lds_tid, [row_in_tile])
+                                    if const_expr(bool(use_lds_sorted_ids))
+                                    else buffer_ops.buffer_load(
+                                        sorted_rsrc, row, vec_width=1, dtype=T.i32
+                                    )
+                                )
+                                t2 = fused2 & mask24_i32
+                                s2 = fused2 >> 24
+                                # Explicitly mask sentinel token/slot to avoid OOB scale_x loads.
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t2, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s2, topk_i32_v
+                                )
+                                ts_ok = t_ok & s_ok
                             t2_safe = ts_ok.select(t2, fx.Int32(0))
                             s2_safe = ts_ok.select(s2, fx.Int32(0))
                             ts2 = t2_safe * topk_i32_v + s2_safe
@@ -3573,7 +4160,9 @@ def compile_moe_gemm2(
                                     if is_f16_or_bf16
                                     else arith.select(
                                         ts_ok,
-                                        buffer_ops.buffer_load(sx_rsrc, ts2, vec_width=1, dtype=T.f32),
+                                        buffer_ops.buffer_load(
+                                            sx_rsrc, ts2, vec_width=1, dtype=T.f32
+                                        ),
                                         fx.Float32(0.0),
                                     )
                                 )
@@ -3583,8 +4172,17 @@ def compile_moe_gemm2(
                                     tw_idx = (mi * 4) + ii
                                     if const_expr(tw_pf is not None):
                                         tw = tw_pf[tw_idx]
+                                    elif const_expr(single_token_route):
+                                        tw = buffer_ops.buffer_load(
+                                            sorted_w_rsrc,
+                                            sort_blk,
+                                            vec_width=1,
+                                            dtype=T.f32,
+                                        )
                                     else:
-                                        tw = buffer_ops.buffer_load(sorted_w_rsrc, row, vec_width=1, dtype=T.f32)
+                                        tw = buffer_ops.buffer_load(
+                                            sorted_w_rsrc, row, vec_width=1, dtype=T.f32
+                                        )
 
                                 for ni in range_constexpr(num_acc_n):
                                     col_local = col_base_local + (ni * 16)
@@ -3618,18 +4216,43 @@ def compile_moe_gemm2(
                             # Precompute row context for cshuffle stores.
                             # Return (fused_i32, row_valid_i1) so the epilogue can skip the entire row
                             # for invalid tail rows (CK-style), avoiding per-store branching.
-                            fused2 = (
-                                memref.load(lds_tid, [row_local])
-                                if const_expr(bool(use_lds_sorted_ids))
-                                else buffer_ops.buffer_load(sorted_rsrc, row, vec_width=1, dtype=T.i32)
-                            )
-                            row_i32 = arith.index_cast(T.i32, row)
-                            row_valid0 = arith.cmpi(arith.CmpIPredicate.ult, row_i32, num_valid_i32)
-                            t = fused2 & mask24_i32
-                            s = fused2 >> 24
-                            t_ok = arith.cmpi(arith.CmpIPredicate.ult, t, tokens_i32)
-                            s_ok = arith.cmpi(arith.CmpIPredicate.ult, s, topk_i32_v)
-                            row_valid = row_valid0 & t_ok & s_ok
+                            if const_expr(single_token_route):
+                                route_token_idx = sort_blk // fx.Index(topk)
+                                route_slot_idx = sort_blk % fx.Index(topk)
+                                t = arith.index_cast(T.i32, route_token_idx)
+                                s = arith.index_cast(T.i32, route_slot_idx)
+                                fused2 = (s << shift24_i32) | t
+                                row0_ok = arith.cmpi(
+                                    arith.CmpIPredicate.eq, row_local, fx.Index(0)
+                                )
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s, topk_i32_v
+                                )
+                                row_valid = row0_ok & t_ok & s_ok
+                            else:
+                                fused2 = (
+                                    memref.load(lds_tid, [row_local])
+                                    if const_expr(bool(use_lds_sorted_ids))
+                                    else buffer_ops.buffer_load(
+                                        sorted_rsrc, row, vec_width=1, dtype=T.i32
+                                    )
+                                )
+                                row_i32 = arith.index_cast(T.i32, row)
+                                row_valid0 = arith.cmpi(
+                                    arith.CmpIPredicate.ult, row_i32, num_valid_i32
+                                )
+                                t = fused2 & mask24_i32
+                                s = fused2 >> 24
+                                t_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, t, tokens_i32
+                                )
+                                s_ok = arith.cmpi(
+                                    arith.CmpIPredicate.ult, s, topk_i32_v
+                                )
+                                row_valid = row_valid0 & t_ok & s_ok
                             if const_expr(bool(precompute_row_base)):
                                 idx0 = t * model_i32
                                 if const_expr(not bool(accumulate)):
@@ -3638,7 +4261,9 @@ def compile_moe_gemm2(
                                 return ((fused2, idx0), row_valid)
                             return (fused2, row_valid)
 
-                        def store_pair(*, row_local, row, row_ctx, col_pair0, col_g0, frag):
+                        def store_pair(
+                            *, row_local, row, row_ctx, col_pair0, col_g0, frag
+                        ):
                             if const_expr(bool(precompute_row_base)):
                                 fused, idx0 = row_ctx
                             else:
@@ -3659,9 +4284,17 @@ def compile_moe_gemm2(
                                     byte_off = idx_elem_even * c2_i32
                                     byte_off_idx = arith.index_cast(T.index, byte_off)
                                     ptr_addr_idx = out_base_idx + byte_off_idx
-                                    out_ptr = buffer_ops.create_llvm_ptr(ptr_addr_idx, address_space=1)
-                                    out_ptr_v = out_ptr._value if hasattr(out_ptr, "_value") else out_ptr
-                                    frag_v = frag._value if hasattr(frag, "_value") else frag
+                                    out_ptr = buffer_ops.create_llvm_ptr(
+                                        ptr_addr_idx, address_space=1
+                                    )
+                                    out_ptr_v = (
+                                        out_ptr._value
+                                        if hasattr(out_ptr, "_value")
+                                        else out_ptr
+                                    )
+                                    frag_v = (
+                                        frag._value if hasattr(frag, "_value") else frag
+                                    )
                                     llvm.AtomicRMWOp(
                                         llvm.AtomicBinOp.fadd,
                                         out_ptr_v,
@@ -3671,14 +4304,18 @@ def compile_moe_gemm2(
                                         alignment=4,
                                     )
                                 else:
-                                    buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
+                                    buffer_ops.buffer_store(
+                                        frag, out_rsrc, idx_elem_even
+                                    )
                             else:
                                 # f16, or bf16 on gfx950+ (has buffer_atomic_pk_add_bf16)
                                 byte_off = idx_elem_even * c2_i32
                                 if const_expr(bool(accumulate)):
                                     atomic_add_f16x2(frag, byte_off)
                                 else:
-                                    buffer_ops.buffer_store(frag, out_rsrc, idx_elem_even)
+                                    buffer_ops.buffer_store(
+                                        frag, out_rsrc, idx_elem_even
+                                    )
 
                         c_shuffle_epilog(
                             arith=arith,
@@ -3719,13 +4356,17 @@ def compile_moe_gemm2(
                     _emit_stage2_m_tile(chunk_start + mi_chunk_idx)
             elif const_expr(_persistent_grid_y > 0):
                 gy_tiles = size_expert_ids_in * fx.Index(_m_splits)
-                for bx_tile_loop in range(bx_tile_base, gy_tiles, fx.Index(_persistent_grid_y)):
+                for bx_tile_loop in range(
+                    bx_tile_base, gy_tiles, fx.Index(_persistent_grid_y)
+                ):
                     _emit_stage2_m_tile(arith.index_cast(T.index, bx_tile_loop))
             elif const_expr(_persist_m == 1):
                 _emit_stage2_m_tile(bx_tile_base)
             else:
                 for mi_p in range_constexpr(_persist_m):
-                    _emit_stage2_m_tile(bx_tile_base * fx.Index(_persist_m) + fx.Index(mi_p))
+                    _emit_stage2_m_tile(
+                        bx_tile_base * fx.Index(_persist_m) + fx.Index(mi_p)
+                    )
 
     # ── Host launcher (flyc.jit + .launch) ────────────────────────────────
     @flyc.jit
@@ -3841,11 +4482,19 @@ def compile_moe_reduction(
     i8_type = lambda: T.i8
 
     def elem_type():
-        ty = T.f32 if elem_type_tag == "f32" else (T.f16 if elem_type_tag == "f16" else T.bf16)
+        ty = (
+            T.f32
+            if elem_type_tag == "f32"
+            else (T.f16 if elem_type_tag == "f16" else T.bf16)
+        )
         return ty() if callable(ty) else ty
 
     def out_elem_type():
-        ty = T.f32 if out_elem_type_tag == "f32" else (T.f16 if out_elem_type_tag == "f16" else T.bf16)
+        ty = (
+            T.f32
+            if out_elem_type_tag == "f32"
+            else (T.f16 if out_elem_type_tag == "f16" else T.bf16)
+        )
         return ty() if callable(ty) else ty
 
     if True:
@@ -3870,7 +4519,9 @@ def compile_moe_reduction(
             # Scalar buffer resources for tail path and mask
             x_rsrc = buffer_ops.create_buffer_resource(X, max_size=True)
             y_rsrc = buffer_ops.create_buffer_resource(Y, max_size=True)
-            mask_rsrc = buffer_ops.create_buffer_resource(valid_mask, max_size=False, num_records_bytes=mask_nbytes_idx)
+            mask_rsrc = buffer_ops.create_buffer_resource(
+                valid_mask, max_size=False, num_records_bytes=mask_nbytes_idx
+            )
 
             token_idx = gpu.block_id("x")
             tile_idx = gpu.block_id("y")
@@ -3901,10 +4552,15 @@ def compile_moe_reduction(
                         # elsewhere in atrex.
                         vec_type_e = T.vec(VEC_WIDTH, elem_type())
                         out_vec_type_e = T.vec(VEC_WIDTH, out_elem_type())
-                        acc_vals = [arith.constant(0.0, type=compute_type()) for _ in range_constexpr(VEC_WIDTH)]
+                        acc_vals = [
+                            arith.constant(0.0, type=compute_type())
+                            for _ in range_constexpr(VEC_WIDTH)
+                        ]
                         token_base = token_idx * c_topk
                         for k in range_constexpr(topk):
-                            x_idx_i32 = fx.Int32((token_base + fx.Index(k)) * c_model_dim + col_base)
+                            x_idx_i32 = fx.Int32(
+                                (token_base + fx.Index(k)) * c_model_dim + col_base
+                            )
                             vec_e = buffer_ops.buffer_load(
                                 x_rsrc,
                                 x_idx_i32,
@@ -3918,12 +4574,18 @@ def compile_moe_reduction(
                             )
                             if const_expr(use_mask):
                                 m_idx_i32 = fx.Int32(token_base + fx.Index(k))
-                                mv = buffer_ops.buffer_load(mask_rsrc, m_idx_i32, vec_width=1, dtype=i8_type())
+                                mv = buffer_ops.buffer_load(
+                                    mask_rsrc, m_idx_i32, vec_width=1, dtype=i8_type()
+                                )
                                 mv_ok = mv != fx.Int8(0)
                             for lane in range_constexpr(VEC_WIDTH):
-                                v = vector.extract(vec_e, static_position=[lane], dynamic_position=[])
+                                v = vector.extract(
+                                    vec_e, static_position=[lane], dynamic_position=[]
+                                )
                                 if const_expr(use_mask):
-                                    v = mv_ok.select(v, arith.constant(0.0, type=elem_type()))
+                                    v = mv_ok.select(
+                                        v, arith.constant(0.0, type=elem_type())
+                                    )
                                 if const_expr(dtype_str in ("f16", "bf16")):
                                     v = v.extf(compute_type())
                                 acc_vals[lane] = acc_vals[lane] + v
@@ -3958,7 +4620,9 @@ def compile_moe_reduction(
                                 token_base = token_idx * c_topk
                                 for k in range_constexpr(topk):
                                     k_idx = fx.Index(k)
-                                    x_idx_i32 = fx.Int32((token_base + k_idx) * c_model_dim + col)
+                                    x_idx_i32 = fx.Int32(
+                                        (token_base + k_idx) * c_model_dim + col
+                                    )
                                     v = arith.constant(0.0, type=elem_type())
                                     if const_expr(use_mask):
                                         m_idx_i32 = fx.Int32(token_base + k_idx)
@@ -3984,7 +4648,11 @@ def compile_moe_reduction(
                                             vec_width=1,
                                             dtype=elem_type(),
                                             **(
-                                                {"cache_modifier": int(input_cache_modifier)}
+                                                {
+                                                    "cache_modifier": int(
+                                                        input_cache_modifier
+                                                    )
+                                                }
                                                 if int(input_cache_modifier) != 0
                                                 else {}
                                             ),
@@ -4180,6 +4848,7 @@ def compile_moe_gemm2_ex(
     reduction_input_cache_modifier: int = 0,
     reduction_output_cache_modifier: int = 0,
     weight_interleaved: bool = False,
+    single_token_route: bool = False,
 ):
     """Compile MoE GEMM2 kernel with optional reduction.
 
@@ -4211,7 +4880,9 @@ def compile_moe_gemm2_ex(
 
         dtype_str = _normalize_out_dtype(out_dtype)
         intermediate_dtype_str = (
-            _normalize_out_dtype(reduce_intermediate_dtype) if reduce_intermediate_dtype is not None else dtype_str
+            _normalize_out_dtype(reduce_intermediate_dtype)
+            if reduce_intermediate_dtype is not None
+            else dtype_str
         )
 
         # Compile GEMM2 with accumulate=False
@@ -4242,6 +4913,7 @@ def compile_moe_gemm2_ex(
             persistent_chunk_y=persistent_chunk_y,
             group_size_m=group_size_m,
             cshuffle_nlane=cshuffle_nlane,
+            single_token_route=single_token_route,
         )
         reduce_exe = compile_moe_reduction(
             topk=topk,
@@ -4291,4 +4963,5 @@ def compile_moe_gemm2_ex(
             group_size_m=group_size_m,
             cshuffle_nlane=cshuffle_nlane,
             weight_interleaved=weight_interleaved,
+            single_token_route=single_token_route,
         )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_routing.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/moe_routing.py
@@ -1,0 +1,966 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Small-batch MoE routing helpers implemented in FlyDSL."""
+
+import functools
+from contextlib import contextmanager
+
+import torch
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm, scf
+from flydsl.expr import arith, buffer_ops, gpu
+from flydsl.expr import Stream as _FlyStream
+from flydsl.expr.typing import T
+
+_route_cf_cache = {}
+
+
+def _launch_cached(cache, key, launch_fn, args, stream):
+    cf = cache.get(key)
+    stream_arg = _FlyStream(stream)
+    if cf is None:
+        cf = flyc.compile(launch_fn, *args, stream_arg)
+        cache[key] = cf
+        return
+    cf(*args, stream_arg)
+
+
+@contextmanager
+def _if_then(if_op):
+    with ir.InsertionPoint(if_op.then_block):
+        try:
+            yield if_op.then_block
+        finally:
+            blk = if_op.then_block
+            if (not blk.operations) or not isinstance(blk.operations[-1], scf.YieldOp):
+                scf.YieldOp([])
+
+
+@functools.lru_cache(maxsize=32)
+def compile_direct_moe_route(*, topk: int, tile_m: int):
+    """Compile a direct route metadata kernel for very small MoE batches.
+
+    The kernel emits one padded GEMM tile for every `(token, topk_slot)` route:
+    row 0 contains the real packed route id, rows 1..tile_m-1 contain the
+    sentinel `(topk << 24) | tokens`. This matches the existing stage1/stage2
+    sorted-buffer contract without invoking CK `moe_sorting`.
+    """
+
+    @flyc.kernel
+    def direct_moe_route_kernel(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        route = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        route_i32 = arith.index_cast(T.i32, route)
+        tid_i32 = arith.index_cast(T.i32, tid)
+        tokens_idx = arith.index_cast(T.index, i32_tokens)
+        routes_idx = tokens_idx * fx.Index(topk)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        weights_rsrc = buffer_ops.create_buffer_resource(
+            topk_weights, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(tile_m * 4),
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(tile_m * 4),
+        )
+        expert_rsrc = buffer_ops.create_buffer_resource(
+            sorted_expert_ids,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(4),
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+
+        token = route // fx.Index(topk)
+        slot = route % fx.Index(topk)
+        token_i32 = arith.index_cast(T.i32, token)
+        slot_i32 = arith.index_cast(T.i32, slot)
+        topk_i32 = arith.constant(topk, type=T.i32)
+        shift24 = arith.constant(24, type=T.i32)
+
+        expert = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+        route_weight = buffer_ops.buffer_load(weights_rsrc, route, vec_width=1, dtype=T.f32)
+        valid_fused = (slot_i32 << shift24) | token_i32
+        sentinel = (topk_i32 << shift24) | i32_tokens
+
+        is_first_row = arith.cmpi(arith.CmpIPredicate.eq, tid_i32, arith.constant(0, type=T.i32))
+        fused = arith.select(is_first_row, valid_fused, sentinel)
+        weight = arith.select(is_first_row, route_weight, arith.constant(0.0, type=T.f32))
+        out_row = route * fx.Index(tile_m) + tid
+        buffer_ops.buffer_store(fused, sorted_rsrc, out_row)
+        buffer_ops.buffer_store(weight, sorted_w_rsrc, out_row)
+
+        first_row_if = scf.IfOp(is_first_row)
+        with _if_then(first_row_if):
+            buffer_ops.buffer_store(expert, expert_rsrc, route)
+
+        route_zero = arith.cmpi(arith.CmpIPredicate.eq, route_i32, arith.constant(0, type=T.i32))
+        first_route = is_first_row & route_zero
+        first_route_if = scf.IfOp(first_route)
+        with _if_then(first_route_if):
+            padded = i32_tokens * topk_i32 * arith.constant(tile_m, type=T.i32)
+            buffer_ops.buffer_store(padded, num_valid_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(i32_tokens * topk_i32, num_valid_rsrc, fx.Index(1))
+
+    @flyc.jit
+    def launch_direct_moe_route(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+        stream: fx.Stream,
+    ):
+        routes = fx.Index(i32_tokens) * fx.Index(topk)
+        direct_moe_route_kernel(
+            topk_ids,
+            topk_weights,
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            num_valid_ids,
+            i32_tokens,
+        ).launch(grid=(routes, 1, 1), block=(tile_m, 1, 1), stream=stream)
+
+    return launch_direct_moe_route
+
+
+def direct_moe_route(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    topk: int,
+    tile_m: int,
+    stream,
+):
+    tokens = int(topk_ids.shape[0])
+    routes = tokens * int(topk)
+    sorted_ids = torch.empty((routes * tile_m,), dtype=torch.int32, device=topk_ids.device)
+    sorted_weights = torch.empty((routes * tile_m,), dtype=torch.float32, device=topk_ids.device)
+    sorted_expert_ids = torch.empty((routes,), dtype=torch.int32, device=topk_ids.device)
+    num_valid_ids = torch.empty((2,), dtype=torch.int32, device=topk_ids.device)
+    launcher = compile_direct_moe_route(topk=int(topk), tile_m=int(tile_m))
+    _r_args = (
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        tokens,
+    )
+    _launch_cached(_route_cf_cache, id(launcher), launcher, _r_args, stream)
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids
+
+
+@functools.lru_cache(maxsize=32)
+def compile_grouped_moe_route(*, experts: int, topk: int, tile_m: int):
+    """Compile a pure FlyDSL expert-grouped route metadata path.
+
+    This emits the same sorted-buffer contract consumed by the existing MoE
+    GEMMs, but compacts rows by expert instead of emitting one M tile per
+    token-slot route. It is intentionally simple: one workgroup owns one expert
+    and serially scans all routes, reserving compact output tiles with one
+    global atomic per active expert.
+    """
+
+    @flyc.kernel
+    def grouped_route_init_kernel(
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+    ):
+        counter_rsrc = buffer_ops.create_buffer_resource(
+            route_tile_count, max_size=False, num_records_bytes=fx.Index(4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+        zero = arith.constant(0, type=T.i32)
+        buffer_ops.buffer_store(zero, counter_rsrc, fx.Index(0))
+        buffer_ops.buffer_store(zero, num_valid_rsrc, fx.Index(0))
+        buffer_ops.buffer_store(zero, num_valid_rsrc, fx.Index(1))
+
+    @flyc.kernel
+    def grouped_moe_route_kernel(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        expert = gpu.block_id("x")
+        expert_i32 = arith.index_cast(T.i32, expert)
+        tokens_idx = arith.index_cast(T.index, i32_tokens)
+        routes_idx = tokens_idx * fx.Index(topk)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        weights_rsrc = buffer_ops.create_buffer_resource(
+            topk_weights, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(tile_m * 4),
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(tile_m * 4),
+        )
+        expert_rsrc = buffer_ops.create_buffer_resource(
+            sorted_expert_ids,
+            max_size=False,
+            num_records_bytes=routes_idx * fx.Index(4),
+        )
+
+        zero_i32 = arith.constant(0, type=T.i32)
+        one_i32 = arith.constant(1, type=T.i32)
+        topk_i32 = arith.constant(topk, type=T.i32)
+        tile_m_i32 = arith.constant(tile_m, type=T.i32)
+        shift24 = arith.constant(24, type=T.i32)
+
+        # Count routes for this expert.
+        for route, state in range(fx.Index(0), routes_idx, fx.Index(1), init=[zero_i32]):
+            count = state[0]
+            route_expert = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+            is_match = arith.cmpi(arith.CmpIPredicate.eq, route_expert, expert_i32)
+            inc = arith.select(is_match, one_i32, zero_i32)
+            results = yield [count + inc]
+        count = results
+
+        has_routes = arith.cmpi(arith.CmpIPredicate.ugt, count, zero_i32)
+        count_if = scf.IfOp(has_routes)
+        with _if_then(count_if):
+            tiles_i32 = (count + tile_m_i32 - one_i32) // tile_m_i32
+            counter_base = buffer_ops.extract_base_index(route_tile_count)
+            counter_ptr = buffer_ops.create_llvm_ptr(counter_base, address_space=1)
+            counter_ptr_v = counter_ptr._value if hasattr(counter_ptr, "_value") else counter_ptr
+            base_i32 = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                counter_ptr_v,
+                tiles_i32,
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            ).result
+
+            base_idx = arith.index_cast(T.index, base_i32)
+            tiles_idx = arith.index_cast(T.index, tiles_i32)
+            count_idx = arith.index_cast(T.index, count)
+
+            # Per-output-tile expert ids.
+            for tile in range(fx.Index(0), tiles_idx, fx.Index(1)):
+                tile_idx = arith.index_cast(T.index, tile)
+                buffer_ops.buffer_store(expert_i32, expert_rsrc, base_idx + tile_idx)
+
+            # Scatter matching routes into compact expert-contiguous rows.
+            for route, state in range(fx.Index(0), routes_idx, fx.Index(1), init=[zero_i32]):
+                rank = state[0]
+                route_expert = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+                is_match = arith.cmpi(arith.CmpIPredicate.eq, route_expert, expert_i32)
+                match_if = scf.IfOp(is_match)
+                with _if_then(match_if):
+                    token = route // fx.Index(topk)
+                    slot = route % fx.Index(topk)
+                    token_i32 = arith.index_cast(T.i32, token)
+                    slot_i32 = arith.index_cast(T.i32, slot)
+                    fused = arith.ori(arith.shli(slot_i32, shift24), token_i32)
+                    route_weight = buffer_ops.buffer_load(weights_rsrc, route, vec_width=1, dtype=T.f32)
+                    rank_idx = arith.index_cast(T.index, rank)
+                    out_row = base_idx * fx.Index(tile_m) + rank_idx
+                    buffer_ops.buffer_store(fused, sorted_rsrc, out_row)
+                    buffer_ops.buffer_store(route_weight, sorted_w_rsrc, out_row)
+                inc = arith.select(is_match, one_i32, zero_i32)
+                results_scatter = yield [rank + inc]
+
+            # Pad the tail of the final tile with the CK-style sentinel.
+            del results_scatter
+            sentinel = arith.ori(arith.shli(topk_i32, shift24), arith.unwrap(i32_tokens))
+            padded_rows_idx = tiles_idx * fx.Index(tile_m)
+            for pad in range(count_idx, padded_rows_idx, fx.Index(1)):
+                pad_idx = arith.index_cast(T.index, pad)
+                out_row = base_idx * fx.Index(tile_m) + pad_idx
+                buffer_ops.buffer_store(sentinel, sorted_rsrc, out_row)
+                buffer_ops.buffer_store(arith.constant(0.0, type=T.f32), sorted_w_rsrc, out_row)
+
+    @flyc.kernel
+    def grouped_route_finalize_kernel(
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        counter_rsrc = buffer_ops.create_buffer_resource(
+            route_tile_count, max_size=False, num_records_bytes=fx.Index(4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+        tiles = buffer_ops.buffer_load(counter_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+        tile_m_i32 = arith.constant(tile_m, type=T.i32)
+        topk_i32 = arith.constant(topk, type=T.i32)
+        buffer_ops.buffer_store(tiles * tile_m_i32, num_valid_rsrc, fx.Index(0))
+        buffer_ops.buffer_store(i32_tokens * topk_i32, num_valid_rsrc, fx.Index(1))
+
+    @flyc.jit
+    def launch_grouped_moe_route(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        i32_tokens: fx.Int32,
+        stream: fx.Stream,
+    ):
+        grouped_route_init_kernel(route_tile_count, num_valid_ids).launch(
+            grid=(1, 1, 1), block=(1, 1, 1), stream=stream
+        )
+        grouped_moe_route_kernel(
+            topk_ids,
+            topk_weights,
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            route_tile_count,
+            i32_tokens,
+        ).launch(grid=(experts, 1, 1), block=(1, 1, 1), stream=stream)
+        grouped_route_finalize_kernel(route_tile_count, num_valid_ids, i32_tokens).launch(
+            grid=(1, 1, 1), block=(1, 1, 1), stream=stream
+        )
+
+    return launch_grouped_moe_route
+
+
+@functools.lru_cache(maxsize=32)
+def compile_atomic_grouped_moe_route(
+    *,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    tiles_per_expert: int,
+    block_threads: int = 256,
+):
+    """Compile a parallel fixed-slot grouped route path.
+
+    The output uses `experts * tiles_per_expert` metadata blocks. Inactive blocks
+    are marked with expert id -1 and skipped by the GEMMs before any weight
+    loads. This avoids the serial all-expert scan in `compile_grouped_moe_route`.
+    """
+
+    max_blocks = int(experts) * int(tiles_per_expert)
+    max_rows = max_blocks * int(tile_m)
+
+    @flyc.kernel
+    def atomic_grouped_route_init_kernel(
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        linear = bid * fx.Index(block_threads) + tid
+        linear_i32 = arith.index_cast(T.i32, linear)
+
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        expert_rsrc = buffer_ops.create_buffer_resource(
+            sorted_expert_ids,
+            max_size=False,
+            num_records_bytes=fx.Index(max_blocks * 4),
+        )
+        counts_rsrc = buffer_ops.create_buffer_resource(
+            expert_counts, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+
+        topk_i32 = arith.constant(topk, type=T.i32)
+        shift24 = arith.constant(24, type=T.i32)
+        sentinel = arith.ori(arith.shli(topk_i32, shift24), arith.unwrap(i32_tokens))
+
+        row_ok = arith.cmpi(arith.CmpIPredicate.ult, linear_i32, arith.constant(max_rows, type=T.i32))
+        row_if = scf.IfOp(row_ok)
+        with _if_then(row_if):
+            buffer_ops.buffer_store(sentinel, sorted_rsrc, linear)
+            buffer_ops.buffer_store(arith.constant(0.0, type=T.f32), sorted_w_rsrc, linear)
+
+        block_ok = arith.cmpi(arith.CmpIPredicate.ult, linear_i32, arith.constant(max_blocks, type=T.i32))
+        block_if = scf.IfOp(block_ok)
+        with _if_then(block_if):
+            buffer_ops.buffer_store(arith.constant(-1, type=T.i32), expert_rsrc, linear)
+
+        expert_ok = arith.cmpi(arith.CmpIPredicate.ult, linear_i32, arith.constant(experts, type=T.i32))
+        expert_if = scf.IfOp(expert_ok)
+        with _if_then(expert_if):
+            buffer_ops.buffer_store(arith.constant(0, type=T.i32), counts_rsrc, linear)
+
+        first = arith.cmpi(arith.CmpIPredicate.eq, linear_i32, arith.constant(0, type=T.i32))
+        first_if = scf.IfOp(first)
+        with _if_then(first_if):
+            buffer_ops.buffer_store(arith.constant(max_rows, type=T.i32), num_valid_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(i32_tokens * topk_i32, num_valid_rsrc, fx.Index(1))
+
+    @flyc.kernel
+    def atomic_grouped_moe_route_kernel(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        route = bid * fx.Index(block_threads) + tid
+        route_i32 = arith.index_cast(T.i32, route)
+        tokens_idx = arith.index_cast(T.index, i32_tokens)
+        routes_idx = tokens_idx * fx.Index(topk)
+        routes_i32 = arith.index_cast(T.i32, routes_idx)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        weights_rsrc = buffer_ops.create_buffer_resource(
+            topk_weights, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        expert_rsrc = buffer_ops.create_buffer_resource(
+            sorted_expert_ids,
+            max_size=False,
+            num_records_bytes=fx.Index(max_blocks * 4),
+        )
+
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, route_i32, routes_i32)
+        range_if = scf.IfOp(in_range)
+        with _if_then(range_if):
+            expert_i32 = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+            expert_idx = arith.index_cast(T.index, expert_i32)
+            counts_base = buffer_ops.extract_base_index(expert_counts)
+            count_ptr = buffer_ops.create_llvm_ptr(counts_base + expert_idx * fx.Index(4), address_space=1)
+            count_ptr_v = count_ptr._value if hasattr(count_ptr, "_value") else count_ptr
+            rank_i32 = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                count_ptr_v,
+                arith.constant(1, type=T.i32),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            ).result
+            rank_idx = arith.index_cast(T.index, rank_i32)
+
+            block_local = rank_idx // fx.Index(tile_m)
+            row_local = rank_idx % fx.Index(tile_m)
+            block = expert_idx * fx.Index(tiles_per_expert) + block_local
+            out_row = block * fx.Index(tile_m) + row_local
+
+            token = route // fx.Index(topk)
+            slot = route % fx.Index(topk)
+            token_i32 = arith.index_cast(T.i32, token)
+            slot_i32 = arith.index_cast(T.i32, slot)
+            shift24 = arith.constant(24, type=T.i32)
+            fused = arith.ori(arith.shli(slot_i32, shift24), token_i32)
+            route_weight = buffer_ops.buffer_load(weights_rsrc, route, vec_width=1, dtype=T.f32)
+
+            buffer_ops.buffer_store(fused, sorted_rsrc, out_row)
+            buffer_ops.buffer_store(route_weight, sorted_w_rsrc, out_row)
+            buffer_ops.buffer_store(expert_i32, expert_rsrc, block)
+
+    @flyc.jit
+    def launch_atomic_grouped_moe_route(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        i32_tokens: fx.Int32,
+        stream: fx.Stream,
+    ):
+        init_elems = fx.Index(max(max_rows, max_blocks, experts))
+        init_blocks = (init_elems + fx.Index(block_threads - 1)) // fx.Index(block_threads)
+        atomic_grouped_route_init_kernel(
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            expert_counts,
+            num_valid_ids,
+            i32_tokens,
+        ).launch(grid=(init_blocks, 1, 1), block=(block_threads, 1, 1), stream=stream)
+
+        routes = fx.Index(i32_tokens) * fx.Index(topk)
+        route_blocks = (routes + fx.Index(block_threads - 1)) // fx.Index(block_threads)
+        atomic_grouped_moe_route_kernel(
+            topk_ids,
+            topk_weights,
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            expert_counts,
+            i32_tokens,
+        ).launch(grid=(route_blocks, 1, 1), block=(block_threads, 1, 1), stream=stream)
+
+    return launch_atomic_grouped_moe_route
+
+
+@functools.lru_cache(maxsize=32)
+def compile_compact_atomic_grouped_moe_route(
+    *,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    tiles_per_expert: int,
+    max_blocks: int | None = None,
+    block_threads: int = 256,
+):
+    """Compile a parallel compact grouped route path.
+
+    This uses route-parallel atomics for count/scatter and a small per-expert
+    prefix/fill kernel to emit compact GEMM metadata blocks.
+    """
+
+    max_blocks = int(max_blocks) if max_blocks is not None else int(experts) * int(tiles_per_expert)
+    max_rows = max_blocks * int(tile_m)
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def compact_route_init_count_kernel(
+        topk_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        expert_bases: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        tid = gpu.thread_id("x")
+        tid_i32 = arith.index_cast(T.i32, tid)
+        routes_idx = arith.index_cast(T.index, i32_tokens) * fx.Index(topk)
+        routes_i32 = arith.index_cast(T.i32, routes_idx)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        counts_rsrc = buffer_ops.create_buffer_resource(
+            expert_counts, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        bases_rsrc = buffer_ops.create_buffer_resource(
+            expert_bases, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        tile_count_rsrc = buffer_ops.create_buffer_resource(
+            route_tile_count, max_size=False, num_records_bytes=fx.Index(4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+
+        expert_ok = arith.cmpi(arith.CmpIPredicate.ult, tid_i32, arith.constant(experts, type=T.i32))
+        expert_if = scf.IfOp(expert_ok)
+        with _if_then(expert_if):
+            buffer_ops.buffer_store(arith.constant(0, type=T.i32), counts_rsrc, tid)
+            buffer_ops.buffer_store(arith.constant(-1, type=T.i32), bases_rsrc, tid)
+
+        first = arith.cmpi(arith.CmpIPredicate.eq, tid_i32, arith.constant(0, type=T.i32))
+        first_if = scf.IfOp(first)
+        with _if_then(first_if):
+            zero = arith.constant(0, type=T.i32)
+            buffer_ops.buffer_store(zero, tile_count_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(zero, num_valid_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(
+                i32_tokens * arith.constant(topk, type=T.i32),
+                num_valid_rsrc,
+                fx.Index(1),
+            )
+
+        gpu.barrier()
+
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, tid_i32, routes_i32)
+        range_if = scf.IfOp(in_range)
+        with _if_then(range_if):
+            expert_i32 = buffer_ops.buffer_load(ids_rsrc, tid, vec_width=1, dtype=T.i32)
+            expert_idx = arith.index_cast(T.index, expert_i32)
+            counts_base = buffer_ops.extract_base_index(expert_counts)
+            count_ptr = buffer_ops.create_llvm_ptr(counts_base + expert_idx * fx.Index(4), address_space=1)
+            count_ptr_v = count_ptr._value if hasattr(count_ptr, "_value") else count_ptr
+            llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                count_ptr_v,
+                arith.constant(1, type=T.i32),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            )
+
+    @flyc.kernel
+    def compact_route_init_kernel(
+        expert_counts: fx.Tensor,
+        expert_bases: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        linear = bid * fx.Index(block_threads) + tid
+        linear_i32 = arith.index_cast(T.i32, linear)
+
+        counts_rsrc = buffer_ops.create_buffer_resource(
+            expert_counts, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        bases_rsrc = buffer_ops.create_buffer_resource(
+            expert_bases, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        tile_count_rsrc = buffer_ops.create_buffer_resource(
+            route_tile_count, max_size=False, num_records_bytes=fx.Index(4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+
+        expert_ok = arith.cmpi(arith.CmpIPredicate.ult, linear_i32, arith.constant(experts, type=T.i32))
+        expert_if = scf.IfOp(expert_ok)
+        with _if_then(expert_if):
+            buffer_ops.buffer_store(arith.constant(0, type=T.i32), counts_rsrc, linear)
+            buffer_ops.buffer_store(arith.constant(-1, type=T.i32), bases_rsrc, linear)
+
+        first = arith.cmpi(arith.CmpIPredicate.eq, linear_i32, arith.constant(0, type=T.i32))
+        first_if = scf.IfOp(first)
+        with _if_then(first_if):
+            zero = arith.constant(0, type=T.i32)
+            buffer_ops.buffer_store(zero, tile_count_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(zero, num_valid_rsrc, fx.Index(0))
+            buffer_ops.buffer_store(
+                i32_tokens * arith.constant(topk, type=T.i32),
+                num_valid_rsrc,
+                fx.Index(1),
+            )
+
+    @flyc.kernel
+    def compact_route_count_kernel(
+        topk_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        route = bid * fx.Index(block_threads) + tid
+        route_i32 = arith.index_cast(T.i32, route)
+        routes_idx = arith.index_cast(T.index, i32_tokens) * fx.Index(topk)
+        routes_i32 = arith.index_cast(T.i32, routes_idx)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, route_i32, routes_i32)
+        range_if = scf.IfOp(in_range)
+        with _if_then(range_if):
+            expert_i32 = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+            expert_idx = arith.index_cast(T.index, expert_i32)
+            counts_base = buffer_ops.extract_base_index(expert_counts)
+            count_ptr = buffer_ops.create_llvm_ptr(counts_base + expert_idx * fx.Index(4), address_space=1)
+            count_ptr_v = count_ptr._value if hasattr(count_ptr, "_value") else count_ptr
+            llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                count_ptr_v,
+                arith.constant(1, type=T.i32),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            )
+
+    @flyc.kernel
+    def compact_route_prefix_fill_kernel(
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        expert_bases: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        expert = gpu.block_id("x")
+        expert_i32 = arith.index_cast(T.i32, expert)
+
+        counts_rsrc = buffer_ops.create_buffer_resource(
+            expert_counts, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        bases_rsrc = buffer_ops.create_buffer_resource(
+            expert_bases, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        expert_rsrc = buffer_ops.create_buffer_resource(
+            sorted_expert_ids,
+            max_size=False,
+            num_records_bytes=fx.Index(max_blocks * 4),
+        )
+
+        count = buffer_ops.buffer_load(counts_rsrc, expert, vec_width=1, dtype=T.i32)
+        has_routes = arith.cmpi(arith.CmpIPredicate.ugt, count, arith.constant(0, type=T.i32))
+        count_if = scf.IfOp(has_routes)
+        with _if_then(count_if):
+            tile_m_i32 = arith.constant(tile_m, type=T.i32)
+            one_i32 = arith.constant(1, type=T.i32)
+            tiles_i32 = (count + tile_m_i32 - one_i32) // tile_m_i32
+            tile_count_base = buffer_ops.extract_base_index(route_tile_count)
+            tile_count_ptr = buffer_ops.create_llvm_ptr(tile_count_base, address_space=1)
+            tile_count_ptr_v = tile_count_ptr._value if hasattr(tile_count_ptr, "_value") else tile_count_ptr
+            base_i32 = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                tile_count_ptr_v,
+                tiles_i32,
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            ).result
+            end_rows_i32 = (base_i32 + tiles_i32) * arith.constant(tile_m, type=T.i32)
+            num_valid_base = buffer_ops.extract_base_index(num_valid_ids)
+            num_valid_ptr = buffer_ops.create_llvm_ptr(num_valid_base, address_space=1)
+            num_valid_ptr_v = num_valid_ptr._value if hasattr(num_valid_ptr, "_value") else num_valid_ptr
+            llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.max,
+                num_valid_ptr_v,
+                end_rows_i32,
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            )
+            buffer_ops.buffer_store(base_i32, bases_rsrc, expert)
+
+            base_idx = arith.index_cast(T.index, base_i32)
+            tiles_idx = arith.index_cast(T.index, tiles_i32)
+            topk_i32 = arith.constant(topk, type=T.i32)
+            shift24 = arith.constant(24, type=T.i32)
+            sentinel = arith.ori(arith.shli(topk_i32, shift24), arith.unwrap(i32_tokens))
+
+            for tile in range(fx.Index(0), tiles_idx, fx.Index(1)):
+                tile_idx = arith.index_cast(T.index, tile)
+                buffer_ops.buffer_store(expert_i32, expert_rsrc, base_idx + tile_idx)
+
+            padded_rows = tiles_idx * fx.Index(tile_m)
+            for row in range(fx.Index(0), padded_rows, fx.Index(1)):
+                row_idx = arith.index_cast(T.index, row)
+                out_row = base_idx * fx.Index(tile_m) + row_idx
+                buffer_ops.buffer_store(sentinel, sorted_rsrc, out_row)
+                buffer_ops.buffer_store(arith.constant(0.0, type=T.f32), sorted_w_rsrc, out_row)
+
+            buffer_ops.buffer_store(arith.constant(0, type=T.i32), counts_rsrc, expert)
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def compact_route_scatter_kernel(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        expert_counts: fx.Tensor,
+        expert_bases: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        route = bid * fx.Index(block_threads) + tid
+        route_i32 = arith.index_cast(T.i32, route)
+        routes_idx = arith.index_cast(T.index, i32_tokens) * fx.Index(topk)
+        routes_i32 = arith.index_cast(T.i32, routes_idx)
+
+        ids_rsrc = buffer_ops.create_buffer_resource(
+            topk_ids, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        weights_rsrc = buffer_ops.create_buffer_resource(
+            topk_weights, max_size=False, num_records_bytes=routes_idx * fx.Index(4)
+        )
+        sorted_rsrc = buffer_ops.create_buffer_resource(
+            sorted_ids, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        sorted_w_rsrc = buffer_ops.create_buffer_resource(
+            sorted_weights, max_size=False, num_records_bytes=fx.Index(max_rows * 4)
+        )
+        bases_rsrc = buffer_ops.create_buffer_resource(
+            expert_bases, max_size=False, num_records_bytes=fx.Index(experts * 4)
+        )
+
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, route_i32, routes_i32)
+        range_if = scf.IfOp(in_range)
+        with _if_then(range_if):
+            expert_i32 = buffer_ops.buffer_load(ids_rsrc, route, vec_width=1, dtype=T.i32)
+            expert_idx = arith.index_cast(T.index, expert_i32)
+            counts_base = buffer_ops.extract_base_index(expert_counts)
+            count_ptr = buffer_ops.create_llvm_ptr(counts_base + expert_idx * fx.Index(4), address_space=1)
+            count_ptr_v = count_ptr._value if hasattr(count_ptr, "_value") else count_ptr
+            rank_i32 = llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                count_ptr_v,
+                arith.constant(1, type=T.i32),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="agent",
+                alignment=4,
+            ).result
+            rank_idx = arith.index_cast(T.index, rank_i32)
+            base_i32 = buffer_ops.buffer_load(bases_rsrc, expert_idx, vec_width=1, dtype=T.i32)
+            base_idx = arith.index_cast(T.index, base_i32)
+            out_row = base_idx * fx.Index(tile_m) + rank_idx
+
+            token = route // fx.Index(topk)
+            slot = route % fx.Index(topk)
+            token_i32 = arith.index_cast(T.i32, token)
+            slot_i32 = arith.index_cast(T.i32, slot)
+            shift24 = arith.constant(24, type=T.i32)
+            fused = arith.ori(arith.shli(slot_i32, shift24), token_i32)
+            route_weight = buffer_ops.buffer_load(weights_rsrc, route, vec_width=1, dtype=T.f32)
+
+            buffer_ops.buffer_store(fused, sorted_rsrc, out_row)
+            buffer_ops.buffer_store(route_weight, sorted_w_rsrc, out_row)
+
+    @flyc.kernel
+    def compact_route_finalize_kernel(
+        route_tile_count: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        i32_tokens: fx.Int32,
+    ):
+        tile_count_rsrc = buffer_ops.create_buffer_resource(
+            route_tile_count, max_size=False, num_records_bytes=fx.Index(4)
+        )
+        num_valid_rsrc = buffer_ops.create_buffer_resource(num_valid_ids, max_size=False, num_records_bytes=fx.Index(8))
+        tiles = buffer_ops.buffer_load(tile_count_rsrc, fx.Index(0), vec_width=1, dtype=T.i32)
+        buffer_ops.buffer_store(tiles * arith.constant(tile_m, type=T.i32), num_valid_rsrc, fx.Index(0))
+        buffer_ops.buffer_store(i32_tokens * arith.constant(topk, type=T.i32), num_valid_rsrc, fx.Index(1))
+
+    @flyc.jit
+    def launch_compact_atomic_grouped_moe_route(
+        topk_ids: fx.Tensor,
+        topk_weights: fx.Tensor,
+        sorted_ids: fx.Tensor,
+        sorted_weights: fx.Tensor,
+        sorted_expert_ids: fx.Tensor,
+        num_valid_ids: fx.Tensor,
+        expert_counts: fx.Tensor,
+        expert_bases: fx.Tensor,
+        route_tile_count: fx.Tensor,
+        i32_tokens: fx.Int32,
+        stream: fx.Stream,
+    ):
+        routes = fx.Index(i32_tokens) * fx.Index(topk)
+        route_blocks = (routes + fx.Index(block_threads - 1)) // fx.Index(block_threads)
+        if const_expr(block_threads >= experts):
+            compact_route_init_count_kernel(
+                topk_ids,
+                expert_counts,
+                expert_bases,
+                route_tile_count,
+                num_valid_ids,
+                i32_tokens,
+            ).launch(grid=(1, 1, 1), block=(block_threads, 1, 1), stream=stream)
+        else:
+            expert_blocks = (fx.Index(experts) + fx.Index(block_threads - 1)) // fx.Index(block_threads)
+            compact_route_init_kernel(expert_counts, expert_bases, route_tile_count, num_valid_ids, i32_tokens).launch(
+                grid=(expert_blocks, 1, 1), block=(block_threads, 1, 1), stream=stream
+            )
+            compact_route_count_kernel(topk_ids, expert_counts, i32_tokens).launch(
+                grid=(route_blocks, 1, 1), block=(block_threads, 1, 1), stream=stream
+            )
+        compact_route_prefix_fill_kernel(
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            expert_counts,
+            expert_bases,
+            route_tile_count,
+            num_valid_ids,
+            i32_tokens,
+        ).launch(grid=(experts, 1, 1), block=(1, 1, 1), stream=stream)
+        compact_route_scatter_kernel(
+            topk_ids,
+            topk_weights,
+            sorted_ids,
+            sorted_weights,
+            expert_counts,
+            expert_bases,
+            i32_tokens,
+        ).launch(grid=(route_blocks, 1, 1), block=(block_threads, 1, 1), stream=stream)
+
+    return launch_compact_atomic_grouped_moe_route
+
+
+def grouped_moe_route(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    experts: int,
+    topk: int,
+    tile_m: int,
+    stream,
+):
+    tokens = int(topk_ids.shape[0])
+    routes = tokens * int(topk)
+    tiles_per_expert = (tokens + int(tile_m) - 1) // int(tile_m)
+    dense_max_blocks = int(experts) * int(tiles_per_expert)
+    if routes <= int(experts):
+        tight_max_blocks = routes
+    else:
+        tight_max_blocks = int(experts) + ((routes - int(experts)) // int(tile_m))
+    tight_max_blocks = max(1, int(tight_max_blocks))
+    max_blocks = min(dense_max_blocks, tight_max_blocks)
+    max_rows = max_blocks * int(tile_m)
+    sorted_ids = torch.empty((max_rows,), dtype=torch.int32, device=topk_ids.device)
+    sorted_weights = torch.empty((max_rows,), dtype=torch.float32, device=topk_ids.device)
+    sorted_expert_ids = torch.empty((max_blocks,), dtype=torch.int32, device=topk_ids.device)
+    num_valid_ids = torch.empty((2,), dtype=torch.int32, device=topk_ids.device)
+    expert_counts = torch.empty((int(experts),), dtype=torch.int32, device=topk_ids.device)
+    expert_bases = torch.empty((int(experts),), dtype=torch.int32, device=topk_ids.device)
+    route_tile_count = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
+    block_threads = 512 if routes <= 512 and int(experts) <= 512 else 256
+    launcher = compile_compact_atomic_grouped_moe_route(
+        experts=int(experts),
+        topk=int(topk),
+        tile_m=int(tile_m),
+        tiles_per_expert=int(tiles_per_expert),
+        max_blocks=int(max_blocks),
+        block_threads=int(block_threads),
+    )
+    _gr_args = (
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        expert_counts,
+        expert_bases,
+        route_tile_count,
+        tokens,
+    )
+    _launch_cached(_route_cf_cache, id(launcher), launcher, _gr_args, stream)
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/tuning.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/tuning.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class FlydslMoeBatchRangeTuning:
+    min_m: int
+    max_m: Optional[int]
+    grouped_tile_m: int
+
+    def matches(self, batch_m: int) -> bool:
+        return batch_m >= self.min_m and (self.max_m is None or batch_m <= self.max_m)
+
+
+@dataclass(frozen=True)
+class FlydslMoeShapeTuning:
+    max_m: int
+    grouped_route_min_b: int
+    grouped_tile_m_ranges: tuple[FlydslMoeBatchRangeTuning, ...] = ()
+
+    def grouped_tile_m(self, batch_m: int, default: int) -> int:
+        for batch_tuning in self.grouped_tile_m_ranges:
+            if batch_tuning.matches(batch_m):
+                return batch_tuning.grouped_tile_m
+        return default
+
+
+# Qwen3.5-397B-A17B PTPC-FP8 direct-routing tuning table.
+# Key is per-rank inter_dim after TP sharding.
+_QWEN_PTPC_FP8_TUNING_BY_INTER_DIM = {
+    # TP=4. Op tests show FlyDSL wins through M=512 and regresses at M=513.
+    256: FlydslMoeShapeTuning(
+        max_m=512,
+        grouped_route_min_b=8,
+        grouped_tile_m_ranges=(
+            FlydslMoeBatchRangeTuning(min_m=8, max_m=2047, grouped_tile_m=16),
+            FlydslMoeBatchRangeTuning(min_m=2048, max_m=None, grouped_tile_m=64),
+        ),
+    ),
+    # TP=8. No negative boundary was found in the measured range.
+    128: FlydslMoeShapeTuning(
+        max_m=0,
+        grouped_route_min_b=32,
+        grouped_tile_m_ranges=(
+            FlydslMoeBatchRangeTuning(min_m=128, max_m=1023, grouped_tile_m=16),
+            FlydslMoeBatchRangeTuning(min_m=1024, max_m=2047, grouped_tile_m=32),
+            FlydslMoeBatchRangeTuning(min_m=2048, max_m=None, grouped_tile_m=64),
+        ),
+    ),
+}
+
+
+def get_qwen_ptpc_fp8_tuning(inter_dim: int) -> Optional[FlydslMoeShapeTuning]:
+    return _QWEN_PTPC_FP8_TUNING_BY_INTER_DIM.get(inter_dim)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/tuning.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/tuning.py
@@ -16,6 +16,8 @@ class FlydslMoeBatchRangeTuning:
 class FlydslMoeShapeTuning:
     max_m: int
     grouped_route_min_b: int
+    aiter_quant_max_m: int = 0
+    route_free_max_m: int = 0
     grouped_tile_m_ranges: tuple[FlydslMoeBatchRangeTuning, ...] = ()
 
     def grouped_tile_m(self, batch_m: int, default: int) -> int:
@@ -23,6 +25,12 @@ class FlydslMoeShapeTuning:
             if batch_tuning.matches(batch_m):
                 return batch_tuning.grouped_tile_m
         return default
+
+    def use_aiter_quant(self, batch_m: int) -> bool:
+        return self.aiter_quant_max_m > 0 and batch_m <= self.aiter_quant_max_m
+
+    def use_route_free(self, batch_m: int) -> bool:
+        return self.route_free_max_m > 0 and batch_m <= self.route_free_max_m
 
 
 # Qwen3.5-397B-A17B PTPC-FP8 direct-routing tuning table.
@@ -32,19 +40,20 @@ _QWEN_PTPC_FP8_TUNING_BY_INTER_DIM = {
     256: FlydslMoeShapeTuning(
         max_m=512,
         grouped_route_min_b=8,
+        aiter_quant_max_m=1,
+        route_free_max_m=15,
         grouped_tile_m_ranges=(
             FlydslMoeBatchRangeTuning(min_m=8, max_m=2047, grouped_tile_m=16),
             FlydslMoeBatchRangeTuning(min_m=2048, max_m=None, grouped_tile_m=64),
         ),
     ),
-    # TP=8. No negative boundary was found in the measured range.
+    # TP=8. Op tests show FlyDSL wins through M=512 and regresses at M>=1024.
     128: FlydslMoeShapeTuning(
-        max_m=0,
+        max_m=512,
         grouped_route_min_b=32,
+        route_free_max_m=15,
         grouped_tile_m_ranges=(
-            FlydslMoeBatchRangeTuning(min_m=128, max_m=1023, grouped_tile_m=16),
-            FlydslMoeBatchRangeTuning(min_m=1024, max_m=2047, grouped_tile_m=32),
-            FlydslMoeBatchRangeTuning(min_m=2048, max_m=None, grouped_tile_m=64),
+            FlydslMoeBatchRangeTuning(min_m=128, max_m=512, grouped_tile_m=16),
         ),
     ),
 }

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/zero_fill.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/flydsl/zero_fill.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Small tensor fill helpers implemented in FlyDSL."""
+
+import functools
+
+import torch
+
+import flydsl.compiler as flyc
+from flydsl.expr import Stream as _FlyStream
+
+_zero_cf_cache = {}
+
+
+def _launch_cached(cache, key, launch_fn, args, stream):
+    cf = cache.get(key)
+    stream_arg = _FlyStream(stream)
+    if cf is not None:
+        cf(*args, stream_arg)
+    else:
+        launch_fn(*args, stream=stream)
+        cf = flyc.compile(launch_fn, *args, stream_arg)
+        cache[key] = cf
+import flydsl.expr as fx
+from flydsl.expr import arith, buffer_ops, gpu, vector
+from flydsl.expr.typing import T
+
+
+@functools.lru_cache(maxsize=16)
+def compile_zero_fill(*, dtype: str, vec_width: int = 8, block_threads: int = 256):
+    if dtype not in ("bf16", "f16"):
+        raise ValueError(f"zero fill supports bf16/f16 outputs, got {dtype!r}")
+    if int(vec_width) <= 0 or int(block_threads) <= 0:
+        raise ValueError("vec_width and block_threads must be positive")
+
+    is_bf16 = dtype == "bf16"
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def zero_fill_kernel(out: fx.Tensor, i32_numel: fx.Int32):
+        bid = gpu.block_id("x")
+        tid = gpu.thread_id("x")
+        vec_id = bid * fx.Index(block_threads) + tid
+        elem_base = vec_id * fx.Index(vec_width)
+        numel_idx = arith.index_cast(T.index, i32_numel)
+        vec_count = numel_idx // fx.Index(vec_width)
+
+        out_rsrc = buffer_ops.create_buffer_resource(
+            out, max_size=False, num_records_bytes=numel_idx * fx.Index(2)
+        )
+        in_range = arith.cmpi(arith.CmpIPredicate.ult, vec_id, vec_count)
+        elem_type = T.bf16 if is_bf16 else T.f16
+        zero_scalar = arith.constant(0.0, type=elem_type)
+        zero_vec = vector.broadcast(T.vec(vec_width, elem_type), zero_scalar)
+        buffer_ops.buffer_store(zero_vec, out_rsrc, elem_base, mask=in_range)
+
+    @flyc.jit
+    def launch_zero_fill(out: fx.Tensor, i32_numel: fx.Int32, stream: fx.Stream):
+        numel_idx = fx.Index(i32_numel)
+        vec_count = numel_idx // fx.Index(vec_width)
+        blocks = (vec_count + fx.Index(block_threads - 1)) // fx.Index(block_threads)
+        zero_fill_kernel(out, i32_numel).launch(
+            grid=(blocks, 1, 1),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_zero_fill
+
+
+def zero_fill_tensor(x: torch.Tensor, *, stream) -> bool:
+    """Zero a contiguous fp16/bf16 CUDA tensor.
+
+    Returns True when the FlyDSL fast path launched. Unsupported shapes return
+    False so callers can keep their existing fallback.
+    """
+    if x.dtype == torch.bfloat16:
+        dtype = "bf16"
+    elif x.dtype == torch.float16:
+        dtype = "f16"
+    else:
+        return False
+    if (not x.is_cuda) or (not x.is_contiguous()):
+        return False
+
+    numel = int(x.numel())
+    vec_width = 8
+    if numel == 0 or numel % vec_width != 0:
+        return False
+
+    launcher = compile_zero_fill(dtype=dtype, vec_width=vec_width, block_threads=256)
+    _launch_cached(_zero_cf_cache, id(launcher), launcher, (x, numel), stream)
+    return True

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
@@ -67,6 +67,17 @@ py_test (
     exec_properties = {'gpu':'MI355X-ROCM7'},
 )
 
+py_test (
+    name = "rocm_moe_flydsl_gate_test",
+    srcs = ["rocm_moe_flydsl_gate_test.py"],
+    deps = [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+        "//rtp_llm:testlib",
+    ],
+    tags = ["rocm"],
+)
+
 # CPU-only regression test for torch_moe_ref (PR #882 review #4):
 # the apply_router_weight_on_input=True path used to raise UnboundLocalError.
 # Pure PyTorch CPU - intentionally no rocm tag / gpu exec_properties so it

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_moe_flydsl_gate_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_moe_flydsl_gate_test.py
@@ -1,0 +1,110 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+
+try:
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
+        _flydsl_fused_moe_enabled,
+        _flydsl_fused_moe_unsupported_reason,
+    )
+    from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.flydsl.tuning import (
+        get_qwen_ptpc_fp8_tuning,
+    )
+
+    _IMPORT_ERROR = None
+except ImportError as exc:
+    _IMPORT_ERROR = exc
+
+
+class RocmMoeFlydslGateTest(unittest.TestCase):
+    def setUp(self):
+        if _IMPORT_ERROR is not None:
+            raise unittest.SkipTest(f"ROCm fused_moe deps unavailable: {_IMPORT_ERROR}")
+
+    def _reason(
+        self,
+        m: int,
+        *,
+        activation: str = "silu",
+        experts: int = 512,
+        topk: int = 10,
+        model_dim: int = 4096,
+        inter_dim: int = 256,
+        effective_expert_mask=None,
+        expert_ids_are_local: bool = False,
+        ep_size: int = 1,
+    ):
+        hidden_states = torch.empty((m, model_dim), dtype=torch.bfloat16, device="meta")
+        w1 = torch.empty(
+            (experts, 2 * inter_dim, model_dim),
+            dtype=torch.float8_e4m3fnuz,
+            device="meta",
+        )
+        w2 = torch.empty((experts, model_dim, inter_dim), dtype=torch.float8_e4m3fnuz, device="meta")
+        topk_ids = torch.empty((m, topk), dtype=torch.int32, device="meta")
+        return _flydsl_fused_moe_unsupported_reason(
+            hidden_states,
+            w1,
+            w2,
+            topk_ids,
+            activation=activation,
+            effective_expert_mask=effective_expert_mask,
+            expert_ids_are_local=expert_ids_are_local,
+            num_experts=experts,
+            local_num_experts=experts,
+            ep_size=ep_size,
+        )
+
+    def test_tp4_m512_is_supported(self):
+        self.assertIsNone(self._reason(512))
+
+    def test_tp4_m513_falls_back_by_default(self):
+        reason = self._reason(513)
+        self.assertIn("M=513", reason)
+
+    def test_tp8_m513_is_supported_by_table(self):
+        self.assertIsNone(self._reason(513, inter_dim=128))
+
+    def test_flydsl_moe_env_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(_flydsl_fused_moe_enabled())
+
+    def test_flydsl_moe_env_requires_global_flydsl(self):
+        with patch.dict(os.environ, {"USE_FLYDSL_MOE": "1"}):
+            self.assertFalse(_flydsl_fused_moe_enabled())
+
+    def test_global_flydsl_env_does_not_enable_moe_by_itself(self):
+        with patch.dict(os.environ, {"USE_FLYDSL": "1"}):
+            self.assertFalse(_flydsl_fused_moe_enabled())
+
+    def test_flydsl_moe_env_enables_experiment_with_global_flydsl(self):
+        with patch.dict(os.environ, {"USE_FLYDSL": "1", "USE_FLYDSL_MOE": "1"}):
+            self.assertTrue(_flydsl_fused_moe_enabled())
+
+    def test_grouped_tile_m_comes_from_table(self):
+        tp4_tuning = get_qwen_ptpc_fp8_tuning(256)
+        tp8_tuning = get_qwen_ptpc_fp8_tuning(128)
+        self.assertIsNotNone(tp4_tuning)
+        self.assertIsNotNone(tp8_tuning)
+        self.assertEqual(16, tp4_tuning.grouped_tile_m(512, default=32))
+        self.assertEqual(64, tp4_tuning.grouped_tile_m(2048, default=32))
+        self.assertEqual(32, tp8_tuning.grouped_tile_m(1024, default=16))
+
+    def test_unsupported_activation_falls_back(self):
+        reason = self._reason(16, activation="gelu")
+        self.assertIn("activation", reason)
+
+    def test_expert_mask_falls_back(self):
+        mask = torch.empty((512,), dtype=torch.int32, device="meta")
+        reason = self._reason(16, effective_expert_mask=mask)
+        self.assertIn("expert_mask", reason)
+
+    def test_non_qwen_shape_falls_back(self):
+        reason = self._reason(16, experts=4, topk=2, model_dim=256, inter_dim=128)
+        self.assertIn("shape", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_moe_flydsl_gate_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_moe_flydsl_gate_test.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -8,9 +9,13 @@ try:
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
         _flydsl_fused_moe_enabled,
         _flydsl_fused_moe_unsupported_reason,
+        _should_use_flydsl_fused_moe,
     )
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.flydsl.tuning import (
         get_qwen_ptpc_fp8_tuning,
+    )
+    from rtp_llm.models_py.model_desc.qwen3_next import (
+        _use_qwen35_flydsl_moe_phase_hint,
     )
 
     _IMPORT_ERROR = None
@@ -27,6 +32,7 @@ class RocmMoeFlydslGateTest(unittest.TestCase):
         self,
         m: int,
         *,
+        is_gfx942_device: bool = True,
         activation: str = "silu",
         experts: int = 512,
         topk: int = 10,
@@ -35,6 +41,7 @@ class RocmMoeFlydslGateTest(unittest.TestCase):
         effective_expert_mask=None,
         expert_ids_are_local: bool = False,
         ep_size: int = 1,
+        is_prefill: bool = False,
     ):
         hidden_states = torch.empty((m, model_dim), dtype=torch.bfloat16, device="meta")
         w1 = torch.empty(
@@ -42,30 +49,65 @@ class RocmMoeFlydslGateTest(unittest.TestCase):
             dtype=torch.float8_e4m3fnuz,
             device="meta",
         )
-        w2 = torch.empty((experts, model_dim, inter_dim), dtype=torch.float8_e4m3fnuz, device="meta")
-        topk_ids = torch.empty((m, topk), dtype=torch.int32, device="meta")
-        return _flydsl_fused_moe_unsupported_reason(
-            hidden_states,
-            w1,
-            w2,
-            topk_ids,
-            activation=activation,
-            effective_expert_mask=effective_expert_mask,
-            expert_ids_are_local=expert_ids_are_local,
-            num_experts=experts,
-            local_num_experts=experts,
-            ep_size=ep_size,
+        w2 = torch.empty(
+            (experts, model_dim, inter_dim), dtype=torch.float8_e4m3fnuz, device="meta"
         )
+        topk_ids = torch.empty((m, topk), dtype=torch.int32, device="meta")
+        with patch(
+            "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe.is_gfx942",
+            return_value=is_gfx942_device,
+        ):
+            return _flydsl_fused_moe_unsupported_reason(
+                hidden_states,
+                w1,
+                w2,
+                topk_ids,
+                activation=activation,
+                is_prefill=is_prefill,
+                effective_expert_mask=effective_expert_mask,
+                expert_ids_are_local=expert_ids_are_local,
+                num_experts=experts,
+                local_num_experts=experts,
+                ep_size=ep_size,
+            )
 
     def test_tp4_m512_is_supported(self):
         self.assertIsNone(self._reason(512))
+
+    def test_prefill_falls_back_to_aiter(self):
+        reason = self._reason(1, is_prefill=True)
+        self.assertIn("prefill", reason)
+
+    def test_non_mi308_device_falls_back(self):
+        reason = self._reason(1, is_gfx942_device=False)
+        self.assertIn("MI308X/gfx942", reason)
+
+    def test_qwen35_next_shape_passes_phase_hint(self):
+        qwen35_cfg = SimpleNamespace(
+            moe_style=2,
+            expert_num=512,
+            moe_k=10,
+            hidden_size=4096,
+        )
+        other_cfg = SimpleNamespace(
+            moe_style=2,
+            expert_num=512,
+            moe_k=10,
+            hidden_size=8192,
+        )
+        self.assertTrue(_use_qwen35_flydsl_moe_phase_hint(qwen35_cfg))
+        self.assertFalse(_use_qwen35_flydsl_moe_phase_hint(other_cfg))
 
     def test_tp4_m513_falls_back_by_default(self):
         reason = self._reason(513)
         self.assertIn("M=513", reason)
 
-    def test_tp8_m513_is_supported_by_table(self):
-        self.assertIsNone(self._reason(513, inter_dim=128))
+    def test_tp8_m512_is_supported(self):
+        self.assertIsNone(self._reason(512, inter_dim=128))
+
+    def test_tp8_m513_falls_back_by_default(self):
+        reason = self._reason(513, inter_dim=128)
+        self.assertIn("M=513", reason)
 
     def test_flydsl_moe_env_disabled_by_default(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -83,6 +125,41 @@ class RocmMoeFlydslGateTest(unittest.TestCase):
         with patch.dict(os.environ, {"USE_FLYDSL": "1", "USE_FLYDSL_MOE": "1"}):
             self.assertTrue(_flydsl_fused_moe_enabled())
 
+    def test_should_use_flydsl_only_checks_gate(self):
+        hidden_states = torch.empty((1, 4096), dtype=torch.bfloat16, device="meta")
+        w1 = torch.empty(
+            (512, 512, 4096), dtype=torch.float8_e4m3fnuz, device="meta"
+        )
+        w2 = torch.empty(
+            (512, 4096, 256), dtype=torch.float8_e4m3fnuz, device="meta"
+        )
+        topk_ids = torch.empty((1, 10), dtype=torch.int32, device="meta")
+        with patch.dict(os.environ, {"USE_FLYDSL": "1", "USE_FLYDSL_MOE": "1"}):
+            with patch(
+                "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe.is_gfx942",
+                return_value=True,
+            ):
+                with patch(
+                    "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe._load_flydsl_fused_moe",
+                    side_effect=AssertionError("load should happen only on execution"),
+                ) as load_flydsl:
+                    self.assertTrue(
+                        _should_use_flydsl_fused_moe(
+                            hidden_states,
+                            w1,
+                            w2,
+                            topk_ids,
+                            activation="silu",
+                            is_prefill=False,
+                            effective_expert_mask=None,
+                            expert_ids_are_local=False,
+                            num_experts=512,
+                            local_num_experts=512,
+                            ep_size=1,
+                        )
+                    )
+                    load_flydsl.assert_not_called()
+
     def test_grouped_tile_m_comes_from_table(self):
         tp4_tuning = get_qwen_ptpc_fp8_tuning(256)
         tp8_tuning = get_qwen_ptpc_fp8_tuning(128)
@@ -90,7 +167,28 @@ class RocmMoeFlydslGateTest(unittest.TestCase):
         self.assertIsNotNone(tp8_tuning)
         self.assertEqual(16, tp4_tuning.grouped_tile_m(512, default=32))
         self.assertEqual(64, tp4_tuning.grouped_tile_m(2048, default=32))
-        self.assertEqual(32, tp8_tuning.grouped_tile_m(1024, default=16))
+        self.assertEqual(16, tp8_tuning.grouped_tile_m(512, default=32))
+
+    def test_m1_aiter_quant_comes_from_table(self):
+        tp4_tuning = get_qwen_ptpc_fp8_tuning(256)
+        tp8_tuning = get_qwen_ptpc_fp8_tuning(128)
+        self.assertIsNotNone(tp4_tuning)
+        self.assertIsNotNone(tp8_tuning)
+        self.assertTrue(tp4_tuning.use_aiter_quant(1))
+        self.assertFalse(tp4_tuning.use_aiter_quant(2))
+        self.assertFalse(tp8_tuning.use_aiter_quant(1))
+
+    def test_small_m_route_free_comes_from_table(self):
+        tp4_tuning = get_qwen_ptpc_fp8_tuning(256)
+        tp8_tuning = get_qwen_ptpc_fp8_tuning(128)
+        self.assertIsNotNone(tp4_tuning)
+        self.assertIsNotNone(tp8_tuning)
+        self.assertTrue(tp4_tuning.use_route_free(1))
+        self.assertTrue(tp4_tuning.use_route_free(15))
+        self.assertFalse(tp4_tuning.use_route_free(16))
+        self.assertTrue(tp8_tuning.use_route_free(1))
+        self.assertTrue(tp8_tuning.use_route_free(15))
+        self.assertFalse(tp8_tuning.use_route_free(16))
 
     def test_unsupported_activation_falls_back(self):
         reason = self._reason(16, activation="gelu")


### PR DESCRIPTION
## Summary

  - Add env-gated FlyDSL fused MoE path for Qwen3.5 397B PTPC FP8 decode on ROCm.
  - Restrict FlyDSL fused MoE to MI308/gfx942 and validated TP4/TP8 decode shapes.
  - Keep prefill on AITER fused MoE; unsupported decode shapes also fallback to AITER.
  - Align FlyDSL fused MoE fallback behavior with FlyDSL GDN: gate before dispatch, and surface FlyDSL execution failures instead of silently falling back.
  - Enable Qwen3Next ROCm path by removing the CUDA-only guard and MRoPE reject in ROCm RoPE binding.