### PR TITLE
fix(moe): avoid cross-warp stale read in ep_scatter_1 prefix sum

### DIFF
--- a/rtp_llm/models_py/triton_kernels/moe/ep_kernels.py
+++ b/rtp_llm/models_py/triton_kernels/moe/ep_kernels.py
@@ -30,8 +30,9 @@ def _fwd_kernel_ep_scatter_1(
     )
     cumsum = tl.cumsum(tokens_per_expert) - tokens_per_expert
     tl.store(expert_start_loc + offset_cumsum, cumsum, mask=offset_cumsum < num_experts)
-    cur_expert_start = tl.load(expert_start_loc + cur_expert)
-    cur_expert_token_num = tl.load(num_recv_tokens_per_expert + cur_expert)
+    expert_mask = offset_cumsum == cur_expert
+    cur_expert_start = tl.sum(tl.where(expert_mask, cumsum, tl.zeros_like(cumsum)))
+    cur_expert_token_num = tl.sum(tl.where(expert_mask, tokens_per_expert, tl.zeros_like(tokens_per_expert)))
     m_indices_start_ptr = m_indices + cur_expert_start
     off_expert = tl.arange(0, BLOCK_E)
     for start_m in tl.range(0, cur_expert_token_num, BLOCK_E, num_stages=4):

--- a/rtp_llm/models_py/triton_kernels/moe/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/moe/test/BUILD
@@ -22,3 +22,13 @@ py_test(
     visibility = ["//visibility:public"],
     exec_properties = {"gpu": "H20"},
 )
+
+py_test(
+    name = "test_ep_scatter",
+    srcs = ["test_ep_scatter.py"],
+    deps = [
+        "//rtp_llm/models_py/triton_kernels:moe",
+    ] + [":triton", ":torch"],
+    visibility = ["//visibility:public"],
+    exec_properties = {"gpu": "H20"},
+)

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
@@ -64,7 +64,8 @@ def _old_kernel_output_start(
     offset = tl.arange(0, BLOCK_EXPERT_NUM)
     tokens = tl.load(
         num_recv_tokens_per_expert + offset,
-        mask=offset < num_experts, other=0,
+        mask=offset < num_experts,
+        other=0,
     )
     cumsum = tl.cumsum(tokens) - tokens
     tl.store(expert_start_loc + offset, cumsum, mask=offset < num_experts)
@@ -88,9 +89,7 @@ class TestEpScatter1Correctness(unittest.TestCase):
         expert_start_loc = torch.empty(
             num_experts, dtype=torch.int32, device=self.device
         )
-        m_indices = torch.full(
-            (all_tokens,), -1, dtype=torch.int32, device=self.device
-        )
+        m_indices = torch.full((all_tokens,), -1, dtype=torch.int32, device=self.device)
         BLOCK_E = 128
         _fwd_kernel_ep_scatter_1[(num_experts,)](
             num_recv_tokens_per_expert,
@@ -110,20 +109,27 @@ class TestEpScatter1Correctness(unittest.TestCase):
         token_counts: list[int],
         label: str = "",
     ) -> None:
-        counts_gpu = torch.tensor(
-            token_counts, dtype=torch.int32, device=self.device
-        )
+        counts_gpu = torch.tensor(token_counts, dtype=torch.int32, device=self.device)
         ref_start, ref_m = reference_scatter_1(counts_gpu)
 
         got_start, got_m = self._run_kernel(counts_gpu)
 
+        got_start_cpu = got_start.cpu()
         self.assertTrue(
-            torch.equal(got_start.cpu(), ref_start),
-            f"[{label}] expert_start_loc mismatch:\n  got={got_start.cpu().tolist()[:16]}...\n  ref={ref_start.tolist()[:16]}...",
+            torch.equal(got_start_cpu, ref_start),
+            f"[{label}] expert_start_loc mismatch:\n"
+            f"  got={got_start_cpu.tolist()[:16]}...\n"
+            f"  ref={ref_start.tolist()[:16]}...",
         )
+        got_m_cpu = got_m.cpu()
+        m_equal = torch.equal(got_m_cpu, ref_m)
+        if not m_equal:
+            diff_idx = (got_m_cpu != ref_m).nonzero(as_tuple=True)[0][0].item()
+        else:
+            diff_idx = "N/A"
         self.assertTrue(
-            torch.equal(got_m.cpu(), ref_m),
-            f"[{label}] m_indices mismatch (first diff at {(got_m.cpu() != ref_m).nonzero(as_tuple=True)[0][0].item() if not torch.equal(got_m.cpu(), ref_m) else 'N/A'})",
+            m_equal,
+            f"[{label}] m_indices mismatch (first diff at {diff_idx})",
         )
 
     def test_small_4_experts(self) -> None:
@@ -152,17 +158,13 @@ class TestEpScatter1Correctness(unittest.TestCase):
 
     def test_256_experts_stress(self) -> None:
         """Repeat 256-expert scatter 200 times to probe race window."""
-        counts_gpu = torch.tensor(
-            [128] * 256, dtype=torch.int32, device=self.device
-        )
+        counts_gpu = torch.tensor([128] * 256, dtype=torch.int32, device=self.device)
         ref_start, ref_m = reference_scatter_1(counts_gpu)
 
         for iteration in range(200):
             got_start, got_m = self._run_kernel(counts_gpu)
             if not torch.equal(got_start.cpu(), ref_start):
-                self.fail(
-                    f"expert_start_loc mismatch at iteration {iteration}"
-                )
+                self.fail(f"expert_start_loc mismatch at iteration {iteration}")
             if not torch.equal(got_m.cpu(), ref_m):
                 self.fail(f"m_indices mismatch at iteration {iteration}")
 
@@ -208,15 +210,20 @@ class TestEpScatter1PoisonRegression(unittest.TestCase):
                 (num_experts,), -1, dtype=torch.int32, device=self.device
             )
             _old_kernel_output_start[(num_experts,)](
-                counts_gpu, expert_start_loc, result_buf,
-                num_experts=num_experts, num_warps=8,
+                counts_gpu,
+                expert_start_loc,
+                result_buf,
+                num_experts=num_experts,
+                num_warps=8,
                 BLOCK_EXPERT_NUM=triton.next_power_of_2(num_experts),
             )
             torch.cuda.synchronize()
             got = result_buf.cpu()
             total_mismatches += int((got != ref_start).sum().item())
 
-        print(f"Old kernel poison diagnostic: {total_mismatches} mismatches in 100 rounds")
+        print(
+            f"Old kernel poison diagnostic: {total_mismatches} mismatches in 100 rounds"
+        )
 
     def test_new_kernel_immune_to_poison(self) -> None:
         """Production kernel (fixed) + poison fill: expert_start_loc and
@@ -235,8 +242,11 @@ class TestEpScatter1PoisonRegression(unittest.TestCase):
                 (all_tokens,), -1, dtype=torch.int32, device=self.device
             )
             _fwd_kernel_ep_scatter_1[(num_experts,)](
-                counts_gpu, expert_start_loc, m_indices,
-                num_experts=num_experts, num_warps=8,
+                counts_gpu,
+                expert_start_loc,
+                m_indices,
+                num_experts=num_experts,
+                num_warps=8,
                 BLOCK_E=128,
                 BLOCK_EXPERT_NUM=triton.next_power_of_2(num_experts),
             )

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
@@ -191,7 +191,9 @@ class TestEpScatter1PoisonRegression(unittest.TestCase):
         return ref
 
     def test_old_kernel_reads_poison(self) -> None:
-        """Old kernel + poison fill: cur_expert_start should read stale values."""
+        """Diagnostic: check if old kernel (global memory load) reads stale
+        poison values. This is NOT a CI gate — if Triton compiler is updated
+        to insert bar.sync, 0 mismatches is expected and acceptable."""
         num_experts = 256
         counts = [128] * num_experts
         counts_gpu = torch.tensor(counts, dtype=torch.int32, device=self.device)
@@ -214,12 +216,7 @@ class TestEpScatter1PoisonRegression(unittest.TestCase):
             got = result_buf.cpu()
             total_mismatches += int((got != ref_start).sum().item())
 
-        self.assertGreater(
-            total_mismatches, 0,
-            "Old kernel should read stale poison values for cur_expert_start, "
-            "but all 100 rounds were correct. "
-            "Triton compiler may have been updated to insert bar.sync.",
-        )
+        print(f"Old kernel poison diagnostic: {total_mismatches} mismatches in 100 rounds")
 
     def test_new_kernel_immune_to_poison(self) -> None:
         """Production kernel (fixed) + poison fill: expert_start_loc and

--- a/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
+++ b/rtp_llm/models_py/triton_kernels/moe/test/test_ep_scatter.py
@@ -1,0 +1,260 @@
+"""Unit tests for ep_scatter / _fwd_kernel_ep_scatter_1 correctness.
+
+Targets the fix for a cross-warp synchronization bug in _fwd_kernel_ep_scatter_1
+where a vector store to expert_start_loc followed by a scalar load could read
+stale data when Triton omits the inter-warp barrier (num_experts=256, num_warps=8).
+
+The test verifies:
+  1. m_indices is filled with correct expert ids at correct positions
+  2. expert_start_loc holds the correct exclusive prefix sum
+  3. Runs in a tight loop (stress) to increase race-window hit probability
+
+Run with bazel:
+    bazel test //rtp_llm/models_py/triton_kernels/moe/test:test_ep_scatter --config=cuda12
+"""
+
+import math
+import unittest
+
+import torch
+import triton
+import triton.language as tl
+
+from rtp_llm.models_py.triton_kernels.moe.ep_kernels import (
+    _fwd_kernel_ep_scatter_1,
+)
+
+
+def align_up(n: int, alignment: int = 128) -> int:
+    return int(math.ceil(n / alignment)) * alignment
+
+
+def reference_scatter_1(
+    num_recv_tokens_per_expert: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """CPU reference for _fwd_kernel_ep_scatter_1 outputs."""
+    counts = num_recv_tokens_per_expert.cpu().tolist()
+    num_experts = len(counts)
+    all_tokens = sum(counts)
+
+    expert_start_loc = torch.zeros(num_experts, dtype=torch.int32)
+    running = 0
+    for i in range(num_experts):
+        expert_start_loc[i] = running
+        running += counts[i]
+
+    m_indices = torch.full((all_tokens,), -1, dtype=torch.int32)
+    for i in range(num_experts):
+        start = expert_start_loc[i].item()
+        end = start + counts[i]
+        m_indices[start:end] = i
+
+    return expert_start_loc, m_indices
+
+
+@triton.jit
+def _old_kernel_output_start(
+    num_recv_tokens_per_expert,
+    expert_start_loc,
+    result_buf,
+    num_experts: tl.constexpr,
+    BLOCK_EXPERT_NUM: tl.constexpr,
+):
+    cur_expert = tl.program_id(0)
+    offset = tl.arange(0, BLOCK_EXPERT_NUM)
+    tokens = tl.load(
+        num_recv_tokens_per_expert + offset,
+        mask=offset < num_experts, other=0,
+    )
+    cumsum = tl.cumsum(tokens) - tokens
+    tl.store(expert_start_loc + offset, cumsum, mask=offset < num_experts)
+    cur_expert_start = tl.load(expert_start_loc + cur_expert)
+    tl.store(result_buf + cur_expert, cur_expert_start)
+
+
+class TestEpScatter1Correctness(unittest.TestCase):
+    """Verify _fwd_kernel_ep_scatter_1 produces correct m_indices and expert_start_loc."""
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA required")
+        self.device = torch.device("cuda")
+
+    def _run_kernel(
+        self, num_recv_tokens_per_expert: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_experts = num_recv_tokens_per_expert.shape[0]
+        all_tokens = int(num_recv_tokens_per_expert.sum().item())
+        expert_start_loc = torch.empty(
+            num_experts, dtype=torch.int32, device=self.device
+        )
+        m_indices = torch.full(
+            (all_tokens,), -1, dtype=torch.int32, device=self.device
+        )
+        BLOCK_E = 128
+        _fwd_kernel_ep_scatter_1[(num_experts,)](
+            num_recv_tokens_per_expert,
+            expert_start_loc,
+            m_indices,
+            num_experts=num_experts,
+            num_warps=8,
+            BLOCK_E=BLOCK_E,
+            BLOCK_EXPERT_NUM=triton.next_power_of_2(num_experts),
+        )
+        torch.cuda.synchronize()
+        return expert_start_loc, m_indices
+
+    def _check(
+        self,
+        num_experts: int,
+        token_counts: list[int],
+        label: str = "",
+    ) -> None:
+        counts_gpu = torch.tensor(
+            token_counts, dtype=torch.int32, device=self.device
+        )
+        ref_start, ref_m = reference_scatter_1(counts_gpu)
+
+        got_start, got_m = self._run_kernel(counts_gpu)
+
+        self.assertTrue(
+            torch.equal(got_start.cpu(), ref_start),
+            f"[{label}] expert_start_loc mismatch:\n  got={got_start.cpu().tolist()[:16]}...\n  ref={ref_start.tolist()[:16]}...",
+        )
+        self.assertTrue(
+            torch.equal(got_m.cpu(), ref_m),
+            f"[{label}] m_indices mismatch (first diff at {(got_m.cpu() != ref_m).nonzero(as_tuple=True)[0][0].item() if not torch.equal(got_m.cpu(), ref_m) else 'N/A'})",
+        )
+
+    def test_small_4_experts(self) -> None:
+        self._check(4, [128, 256, 128, 0], "4experts")
+
+    def test_64_experts_uniform(self) -> None:
+        self._check(64, [128] * 64, "64experts_uniform")
+
+    def test_256_experts_uniform(self) -> None:
+        """Exact config from the crash: 256 experts, 8 warps, BLOCK_EXPERT_NUM=256."""
+        self._check(256, [128] * 256, "256experts_uniform")
+
+    def test_256_experts_mixed(self) -> None:
+        """256 experts with varying token counts (some zero)."""
+        torch.manual_seed(42)
+        raw = torch.randint(0, 20, (256,)).tolist()
+        aligned = [align_up(x, 128) for x in raw]
+        self._check(256, aligned, "256experts_mixed")
+
+    def test_256_experts_sparse(self) -> None:
+        """256 experts, most with 0 tokens, a few with large counts."""
+        counts = [0] * 256
+        for i in [0, 7, 42, 100, 200, 255]:
+            counts[i] = 128 * (i % 5 + 1)
+        self._check(256, counts, "256experts_sparse")
+
+    def test_256_experts_stress(self) -> None:
+        """Repeat 256-expert scatter 200 times to probe race window."""
+        counts_gpu = torch.tensor(
+            [128] * 256, dtype=torch.int32, device=self.device
+        )
+        ref_start, ref_m = reference_scatter_1(counts_gpu)
+
+        for iteration in range(200):
+            got_start, got_m = self._run_kernel(counts_gpu)
+            if not torch.equal(got_start.cpu(), ref_start):
+                self.fail(
+                    f"expert_start_loc mismatch at iteration {iteration}"
+                )
+            if not torch.equal(got_m.cpu(), ref_m):
+                self.fail(f"m_indices mismatch at iteration {iteration}")
+
+
+class TestEpScatter1PoisonRegression(unittest.TestCase):
+    """Poison-fill regression test for the cross-warp store-load race.
+
+    Pre-fills expert_start_loc with poison, then checks whether the kernel
+    reads the correct prefix sum or the stale poison value.
+
+    Old kernel (global memory load): reads poison cross-warp -> mismatch.
+    Fixed kernel (register-local read): immune to poison -> always correct.
+    """
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA required")
+        self.device = torch.device("cuda")
+
+    def _compute_reference(self, counts: list[int]) -> torch.Tensor:
+        ref = torch.zeros(len(counts), dtype=torch.int32)
+        running = 0
+        for i, c in enumerate(counts):
+            ref[i] = running
+            running += c
+        return ref
+
+    def test_old_kernel_reads_poison(self) -> None:
+        """Old kernel + poison fill: cur_expert_start should read stale values."""
+        num_experts = 256
+        counts = [128] * num_experts
+        counts_gpu = torch.tensor(counts, dtype=torch.int32, device=self.device)
+        ref_start = self._compute_reference(counts)
+
+        total_mismatches = 0
+        for _ in range(100):
+            expert_start_loc = torch.full(
+                (num_experts,), 0x7FFFFFFF, dtype=torch.int32, device=self.device
+            )
+            result_buf = torch.full(
+                (num_experts,), -1, dtype=torch.int32, device=self.device
+            )
+            _old_kernel_output_start[(num_experts,)](
+                counts_gpu, expert_start_loc, result_buf,
+                num_experts=num_experts, num_warps=8,
+                BLOCK_EXPERT_NUM=triton.next_power_of_2(num_experts),
+            )
+            torch.cuda.synchronize()
+            got = result_buf.cpu()
+            total_mismatches += int((got != ref_start).sum().item())
+
+        self.assertGreater(
+            total_mismatches, 0,
+            "Old kernel should read stale poison values for cur_expert_start, "
+            "but all 100 rounds were correct. "
+            "Triton compiler may have been updated to insert bar.sync.",
+        )
+
+    def test_new_kernel_immune_to_poison(self) -> None:
+        """Production kernel (fixed) + poison fill: expert_start_loc and
+        m_indices must always match the golden reference."""
+        num_experts = 256
+        counts = [128] * num_experts
+        counts_gpu = torch.tensor(counts, dtype=torch.int32, device=self.device)
+        ref_start, ref_m = reference_scatter_1(counts_gpu)
+        all_tokens = sum(counts)
+
+        for round_i in range(100):
+            expert_start_loc = torch.full(
+                (num_experts,), 0x7FFFFFFF, dtype=torch.int32, device=self.device
+            )
+            m_indices = torch.full(
+                (all_tokens,), -1, dtype=torch.int32, device=self.device
+            )
+            _fwd_kernel_ep_scatter_1[(num_experts,)](
+                counts_gpu, expert_start_loc, m_indices,
+                num_experts=num_experts, num_warps=8,
+                BLOCK_E=128,
+                BLOCK_EXPERT_NUM=triton.next_power_of_2(num_experts),
+            )
+            torch.cuda.synchronize()
+            self.assertTrue(
+                torch.equal(expert_start_loc.cpu(), ref_start),
+                f"Round {round_i}: expert_start_loc mismatch with golden",
+            )
+            self.assertTrue(
+                torch.equal(m_indices.cpu(), ref_m),
+                f"Round {round_i}: m_indices mismatch with golden. "
+                f"Production kernel may have been reverted to the buggy "
+                f"global-memory-load pattern.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

MoE 模型（Qwen3.5-35B-A3B-FP8, 256 experts）压测下间歇性崩溃，堆栈指向 `ep_scatter` →
`_fwd_kernel_ep_scatter_1`（开启了`CUDA_LAUNCH_BLOCKING=1` ）。

## 压测环境

- **模型**：Qwen3.5-35B-A3B-FP8（MoE，expert_num=256，moe_k=8）
- **平台**：H20 GPU，CUDA 12.9，单卡PDFUSION部署

## 崩溃堆栈

ep_kernels.py:142 ep_scatter → _fwd_kernel_ep_scatter_1
  CUDA 非法内存访问 cudaErrorIllegalAddress → SIGABRT

## 崩溃原因

kernel 将 prefix sum 写入 global memory（`expert_start_loc`）后立即读回，但 Triton 编译器未在 `st.global`
 和 `ld.global` 之间插入 `bar.sync`。导出 PTX 确认：

```ptx
@%p1 st.global.b32 [ %rd4 + 0 ], { %r11 };   # store cumsum → expert_start_loc
                                                # ← 无 bar.sync / membar.cta
mov.u32 %r12, 0x0;
ld.global.b32 { %r12 }, [ %rd5 + 0 ];          # load expert_start_loc[cur_expert]

256 experts 对应 8 个 warp 各写 32 个 slot，但所有 warp 都读同一个 slot。根据 CUDA 弱内存模型，跨 warp 的
 st.global 不保证对同 block 内其他 warp 的 ld.global 可见，导致部分 warp 读到残留旧值，m_indices
写入越界。
```

## 复现验证

- test_old_kernel_reads_poison：旧 kernel + poison 预填 → 100 轮检测到 12 次 cur_expert_start 读错（证明
bug 存在）
- test_new_kernel_immune_to_poison：生产 kernel + poison 预填 → 100 轮 expert_start_loc 和 m_indices 均与
 golden 一致
- kernel benchmark：最差场景 +6ns（纳秒级，对端到端推理无影响）
<img width="836" height="364" alt="image" src="https://github.com/user-attachments/assets/3c1bc183-df17-45ac-a014-13ffd5a47bfe" />

## TODO
kernel代码来自LightLLM，后续和开源社区沟通修复
