### PR TITLE
refactor(cache): DSV4 spec tag 集中化声明与 compress_ratio 动态读取

### DIFF
--- a/rtp_llm/cpp/cache/CacheConfigCreator.cc
+++ b/rtp_llm/cpp/cache/CacheConfigCreator.cc
@@ -7,37 +7,13 @@
 #include "rtp_llm/cpp/cache/HybridConfigCreator.h"
 #include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
 #include "rtp_llm/cpp/cache/SingleConfigCreator.h"
+#include "rtp_llm/cpp/cache/DSV4CacheConfigHelper.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 
 namespace rtp_llm {
 
 namespace {
-
-bool hasDsv4KvCacheSpecs(const ModelConfig& model_config) {
-    constexpr const char* kExpectedTags[] = {
-        "csa_kv", "hca_kv", "indexer_kv", "indexer_state", "csa_state", "hca_state", "swa_kv"};
-    for (const auto& layer_specs : model_config.kv_cache_specs) {
-        for (const auto& spec : layer_specs.second) {
-            if (spec == nullptr) {
-                continue;
-            }
-            for (const char* expected_tag : kExpectedTags) {
-                if (spec->tag == expected_tag) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-bool hasTypedHybridPoolLayout(const ModelConfig& model_config) {
-    RTP_LLM_CHECK_WITH_INFO(model_config.attn_config.layer_compress_ratios.empty() || hasDsv4KvCacheSpecs(model_config),
-                            "DSV4 cache config requires model_config.kv_cache_specs; "
-                            "layer_compress_ratios fallback is disabled");
-    return hasDsv4KvCacheSpecs(model_config);
-}
 
 size_t steppedBytes(size_t bytes, int step) {
     return (bytes > 0 && step > 1) ? bytes / static_cast<size_t>(step) : bytes;

--- a/rtp_llm/cpp/cache/DSV4CacheConfigHelper.cc
+++ b/rtp_llm/cpp/cache/DSV4CacheConfigHelper.cc
@@ -47,12 +47,9 @@ struct DSV4PoolDesc {
 
 using DSV4SpecMap = std::map<std::string, KVCacheSpecPtr>;
 
-constexpr int kCsaCompressRatio     = 4;
-constexpr int kHcaCompressRatio     = 128;
-constexpr int kIndexerCompressRatio = 4;
-constexpr int kCsaOverlap           = 1;
-constexpr int kHcaOverlap           = 0;
-constexpr int kIndexerOverlap       = 1;
+constexpr int kCsaOverlap     = 1;
+constexpr int kHcaOverlap     = 0;
+constexpr int kIndexerOverlap = 1;
 
 inline uint32_t alignUpToMultiple(uint32_t value, uint32_t multiple) {
     RTP_LLM_CHECK_WITH_INFO(multiple > 0, "DSV4 align multiple must be > 0");
@@ -337,16 +334,26 @@ std::vector<DSV4PoolDesc> buildDSV4PoolDescs(const DSV4LayerSets&     sets,
                                              uint32_t                 physical_tokens_per_block,
                                              const ParallelismConfig& parallelism_config,
                                              int                      gen_num_per_cycle) {
+    // Read compress_ratio from the spec declaration instead of hardcoded
+    // constants so missing paged specs (e.g. MTP SWA-only model) default to
+    // ratio=1 and produce empty placeholder pools downstream.
+    auto try_compress_ratio = [&](const char* tag) -> int {
+        const auto it = spec_decls.find(tag);
+        return (it != spec_decls.end()) ? static_cast<int>(dsv4SpecCompressionRatio(*it->second)) : 1;
+    };
+    const auto  csa_compress_ratio     = try_compress_ratio("csa_kv");
+    const auto  hca_compress_ratio     = try_compress_ratio("hca_kv");
+    const auto  indexer_compress_ratio = try_compress_ratio("indexer_kv");
     const uint32_t csa_state_eb =
-        maybeAdjustFixedEntriesForCpSharding(computeStateRing(kCsaCompressRatio, kCsaOverlap, gen_num_per_cycle),
+        maybeAdjustFixedEntriesForCpSharding(computeStateRing(csa_compress_ratio, kCsaOverlap, gen_num_per_cycle),
                                              parallelism_config,
                                              KVCacheRegionName::CSA_STATE);
     const uint32_t hca_state_eb =
-        maybeAdjustFixedEntriesForCpSharding(computeStateRing(kHcaCompressRatio, kHcaOverlap, gen_num_per_cycle),
+        maybeAdjustFixedEntriesForCpSharding(computeStateRing(hca_compress_ratio, kHcaOverlap, gen_num_per_cycle),
                                              parallelism_config,
                                              KVCacheRegionName::HCA_STATE);
     const uint32_t indexer_state_eb = maybeAdjustFixedEntriesForCpSharding(
-        computeStateRing(kIndexerCompressRatio, kIndexerOverlap, gen_num_per_cycle),
+        computeStateRing(indexer_compress_ratio, kIndexerOverlap, gen_num_per_cycle),
         parallelism_config,
         KVCacheRegionName::INDEXER_STATE);
     // SWA_KV ring = window + MTP draft slack, sized like the HCA state ring.

--- a/rtp_llm/cpp/cache/DSV4CacheConfigHelper.cc
+++ b/rtp_llm/cpp/cache/DSV4CacheConfigHelper.cc
@@ -21,7 +21,7 @@ constexpr uint32_t kDsv4KernelTokensPerBlock    = 256;
 constexpr uint32_t kDsv4MinKernelTokensPerBlock = 128;
 // SWA sliding-window length in tokens (SWA_KV ring base size; see swa_kv_eb).
 constexpr uint32_t kDsv4SwaWindowEntries = 128;
-constexpr size_t   kDsv4PoolNum               = 7;
+// kDsv4PoolNum, ExpectedDSV4Spec, kExpectedDsv4Specs are defined in DSV4KVCacheSpec.h
 
 struct DSV4LayerSets {
     std::vector<int> csa_layers;
@@ -43,22 +43,6 @@ struct DSV4PoolDesc {
     size_t                  block_size_bytes_override       = 0;
     size_t                  block_size_bytes_alignment      = 0;
     uint32_t                block_alignment_min_entries     = 0;
-};
-
-struct ExpectedDSV4Spec {
-    const char*       tag;
-    KVCacheRegionName region_name;
-    bool              is_paged;
-};
-
-constexpr std::array<ExpectedDSV4Spec, kDsv4PoolNum> kExpectedDsv4Specs = {
-    ExpectedDSV4Spec{"csa_kv", KVCacheRegionName::CSA_KV, true},
-    ExpectedDSV4Spec{"hca_kv", KVCacheRegionName::HCA_KV, true},
-    ExpectedDSV4Spec{"indexer_kv", KVCacheRegionName::INDEXER_KV, true},
-    ExpectedDSV4Spec{"indexer_state", KVCacheRegionName::INDEXER_STATE, false},
-    ExpectedDSV4Spec{"csa_state", KVCacheRegionName::CSA_STATE, false},
-    ExpectedDSV4Spec{"hca_state", KVCacheRegionName::HCA_STATE, false},
-    ExpectedDSV4Spec{"swa_kv", KVCacheRegionName::SWA_KV, false},
 };
 
 using DSV4SpecMap = std::map<std::string, KVCacheSpecPtr>;
@@ -156,12 +140,6 @@ bool sameLayers(const std::vector<int>& lhs, const std::vector<int>& rhs) {
     return lhs == rhs;
 }
 
-const KVCacheSpec& specForTag(const DSV4SpecMap& specs, const char* tag) {
-    const auto it = specs.find(tag);
-    RTP_LLM_CHECK_WITH_INFO(it != specs.end() && it->second != nullptr, "missing DSV4 kv_cache spec tag=%s", tag);
-    return *it->second;
-}
-
 bool isDsv4PagedSpec(const KVCacheSpec& spec) {
     return dynamic_cast<const DSV4KVSpec*>(&spec) != nullptr;
 }
@@ -216,39 +194,6 @@ uint32_t dsv4SpecBlockAlignmentMinEntries(const KVCacheSpec& spec) {
     }
     RTP_LLM_CHECK_WITH_INFO(false, "DSV4 kv_cache spec tag=%s has unsupported concrete type", spec.tag.c_str());
     return 0;
-}
-
-KVCacheSpecPtr makeFallbackDsv4Decl(const char* tag, const ExpectedDSV4Spec& expected, const ModelConfig& model_config) {
-    const bool     fp8_kv              = model_config.attn_config.kv_cache_dtype == KvCacheDataType::FP8;
-    const uint32_t head_dim            = static_cast<uint32_t>(model_config.attn_config.size_per_head);
-    const uint32_t indexer_head_dim    = static_cast<uint32_t>(model_config.attn_config.indexer_head_dim);
-    const uint32_t kv_entry_elems      = fp8_kv ? DSV4_FP8_KV_ENTRY_BYTES : head_dim * 2;
-    const uint32_t indexer_entry_elems = fp8_kv ? DSV4_FP8_INDEXER_ENTRY_BYTES : indexer_head_dim * 2;
-
-    KVCacheSpecPtr spec;
-    if (expected.is_paged) {
-        auto kv_spec               = std::make_shared<DSV4KVSpec>();
-        kv_spec->entry_elems       = std::string(tag) == "indexer_kv" ? indexer_entry_elems : kv_entry_elems;
-        kv_spec->compression_ratio = std::string(tag) == "hca_kv" ? kHcaCompressRatio : kCsaCompressRatio;
-        kv_spec->store_dtype       = DataType::TYPE_UINT8;
-        spec                       = kv_spec;
-    } else {
-        auto state_spec        = std::make_shared<DSV4StateSpec>();
-        state_spec->store_dtype = std::string(tag) == "swa_kv" ? DataType::TYPE_UINT8 : DataType::TYPE_FP32;
-        if (std::string(tag) == "indexer_state") {
-            state_spec->state_dim = 4 * indexer_head_dim;
-        } else if (std::string(tag) == "csa_state") {
-            state_spec->state_dim = 4 * head_dim;
-        } else if (std::string(tag) == "hca_state") {
-            state_spec->state_dim = 2 * head_dim;
-        } else {
-            state_spec->state_dim = kv_entry_elems;
-        }
-        spec = state_spec;
-    }
-    spec->tag   = tag;
-    spec->dtype = expected.is_paged || std::string(tag) == "swa_kv" ? DataType::TYPE_UINT8 : DataType::TYPE_FP32;
-    return spec;
 }
 
 std::pair<DSV4LayerSets, DSV4SpecMap> parseDSV4Specs(const ModelConfig& model_config) {
@@ -313,11 +258,10 @@ std::pair<DSV4LayerSets, DSV4SpecMap> parseDSV4Specs(const ModelConfig& model_co
             layers_by_tag[decl.tag].push_back(layer_id);
         }
     }
-    for (const auto& expected : kExpectedDsv4Specs) {
-        if (specs.count(expected.tag) == 0) {
-            specs.emplace(expected.tag, makeFallbackDsv4Decl(expected.tag, expected, model_config));
-        }
-    }
+    // No mandatory all-tags check: MTP propose layers only register "swa_kv",
+    // so tags like csa_kv/hca_kv are legitimately absent.  Missing tags
+    // simply yield empty layer lists and placeholder pools downstream.
+    // Python-side UT validates spec completeness for non-MTP models.
 
     DSV4LayerSets sets;
     sets.csa_layers = layers_by_tag["csa_kv"];
@@ -327,14 +271,23 @@ std::pair<DSV4LayerSets, DSV4SpecMap> parseDSV4Specs(const ModelConfig& model_co
     const auto& hca = sets.hca_layers;
     const auto& all = sets.all_layers;
 
-    RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["indexer_kv"], csa),
-                            "DSV4 indexer_kv layers must match csa_kv layers");
-    RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["indexer_state"], csa),
-                            "DSV4 indexer_state layers must match csa_kv layers");
-    RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["csa_state"], csa),
-                            "DSV4 csa_state layers must match csa_kv layers");
-    RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["hca_state"], hca),
-                            "DSV4 hca_state layers must match hca_kv layers");
+    // Cross-validation only applies when the corresponding specs exist.
+    if (specs.count("indexer_kv")) {
+        RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["indexer_kv"], csa),
+                                "DSV4 indexer_kv layers must match csa_kv layers");
+    }
+    if (specs.count("indexer_state")) {
+        RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["indexer_state"], csa),
+                                "DSV4 indexer_state layers must match csa_kv layers");
+    }
+    if (specs.count("csa_state")) {
+        RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["csa_state"], csa),
+                                "DSV4 csa_state layers must match csa_kv layers");
+    }
+    if (specs.count("hca_state")) {
+        RTP_LLM_CHECK_WITH_INFO(sameLayers(layers_by_tag["hca_state"], hca),
+                                "DSV4 hca_state layers must match hca_kv layers");
+    }
 
     std::set<int> compressed_layers;
     for (int layer_id : csa) {
@@ -412,7 +365,13 @@ std::vector<DSV4PoolDesc> buildDSV4PoolDescs(const DSV4LayerSets&     sets,
     auto paged_desc = [&](const char* tag,
                            KVCacheRegionName region,
                            const std::vector<int>* layers) -> DSV4PoolDesc {
-        const auto& decl             = specForTag(spec_decls, tag);
+        const auto it = spec_decls.find(tag);
+        // Missing spec (e.g. MTP SWA-only model): empty placeholder pool.
+        if (it == spec_decls.end()) {
+            return {tag, region, layers, 0, 0, physical_tokens_per_block, 1,
+                    DataType::TYPE_UINT8, true, 0, 0, 0};
+        }
+        const auto& decl             = *it->second;
         const auto  compression_ratio = dsv4SpecCompressionRatio(decl);
         const auto  entry_elems       = dsv4SpecEntryElems(decl);
         const auto  alignment         = dsv4SpecBlockSizeBytesAlignment(decl);
@@ -441,7 +400,14 @@ std::vector<DSV4PoolDesc> buildDSV4PoolDescs(const DSV4LayerSets&     sets,
                           uint32_t entries_per_block,
                           uint32_t tokens_per_block,
                           size_t block_size_bytes_override = 0) -> DSV4PoolDesc {
-        const auto& decl        = specForTag(spec_decls, tag);
+        const auto it = spec_decls.find(tag);
+        // Missing spec (e.g. MTP SWA-only model): empty placeholder pool.
+        if (it == spec_decls.end()) {
+            return {tag, region, layers, 0, entries_per_block, tokens_per_block, 1,
+                    DataType::TYPE_FP32, false, block_size_bytes_override, 0,
+                    DSV4_SWA_WINDOW_ENTRIES};
+        }
+        const auto& decl        = *it->second;
         const auto  entry_elems = dsv4SpecEntryElems(decl);
         const auto  alignment   = dsv4SpecBlockSizeBytesAlignment(decl);
         const auto  min_entries = dsv4SpecBlockAlignmentMinEntries(decl);

--- a/rtp_llm/cpp/cache/DSV4CacheConfigHelper.h
+++ b/rtp_llm/cpp/cache/DSV4CacheConfigHelper.h
@@ -1,10 +1,70 @@
 #pragma once
 
+#include <array>
+#include <string>
+
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
 #include "rtp_llm/cpp/config/ModelConfig.h"
 
 namespace rtp_llm {
+
+// DSV4 expected spec tags and their metadata. Single source of truth for
+// all DSV4 cache config validation. Co-located with DSV4CacheConfigHelper
+// because both are transitional and will be removed once the declarative
+// spec pipeline fully replaces this helper.
+constexpr size_t kDsv4PoolNum = 7;
+
+struct ExpectedDSV4Spec {
+    const char*       tag;
+    KVCacheRegionName region_name;
+    bool              is_paged;
+};
+
+constexpr std::array<ExpectedDSV4Spec, kDsv4PoolNum> kExpectedDsv4Specs = {
+    ExpectedDSV4Spec{"csa_kv",        KVCacheRegionName::CSA_KV,        true},
+    ExpectedDSV4Spec{"hca_kv",        KVCacheRegionName::HCA_KV,        true},
+    ExpectedDSV4Spec{"indexer_kv",    KVCacheRegionName::INDEXER_KV,    true},
+    ExpectedDSV4Spec{"indexer_state", KVCacheRegionName::INDEXER_STATE, false},
+    ExpectedDSV4Spec{"csa_state",     KVCacheRegionName::CSA_STATE,     false},
+    ExpectedDSV4Spec{"hca_state",     KVCacheRegionName::HCA_STATE,     false},
+    ExpectedDSV4Spec{"swa_kv",        KVCacheRegionName::SWA_KV,        false},
+};
+
+inline bool isDsv4SpecTag(const std::string& tag) {
+    for (const auto& expected : kExpectedDsv4Specs) {
+        if (tag == expected.tag) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Whether the model uses a DSV4 typed hybrid-pool layout (i.e. declares any
+// DSV4 KV cache spec by tag). Single source of truth — callers must use this
+// instead of re-implementing tag checks in .cc anonymous namespaces. Performs
+// the transitional fail-fast: when layer_compress_ratios is set the model must
+// also declare DSV4 kv_cache_specs (the ratios-only fallback is disabled).
+// Co-located here so every DSV4 transitional predicate is removed together
+// once the declarative spec pipeline fully replaces this helper.
+inline bool hasTypedHybridPoolLayout(const ModelConfig& model_config) {
+    bool has_dsv4 = false;
+    for (const auto& layer_specs : model_config.kv_cache_specs) {
+        for (const auto& spec : layer_specs.second) {
+            if (spec != nullptr && isDsv4SpecTag(spec->tag)) {
+                has_dsv4 = true;
+                break;
+            }
+        }
+        if (has_dsv4) {
+            break;
+        }
+    }
+    RTP_LLM_CHECK_WITH_INFO(model_config.attn_config.layer_compress_ratios.empty() || has_dsv4,
+                            "DSV4 cache config requires model_config.kv_cache_specs; "
+                            "layer_compress_ratios fallback is disabled");
+    return has_dsv4;
+}
 
 class DSV4CacheConfigHelper {
 public:

--- a/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
+++ b/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
@@ -13,24 +13,6 @@ namespace rtp_llm {
 
 namespace {
 
-bool hasDsv4KvCacheSpecs(const ModelConfig& model_config) {
-    constexpr const char* kExpectedTags[] = {
-        "csa_kv", "hca_kv", "indexer_kv", "indexer_state", "csa_state", "hca_state", "swa_kv"};
-    for (const auto& layer_specs : model_config.kv_cache_specs) {
-        for (const auto& spec : layer_specs.second) {
-            if (spec == nullptr) {
-                continue;
-            }
-            for (const char* expected_tag : kExpectedTags) {
-                if (spec->tag == expected_tag) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 struct HybridPoolLayers {
     std::vector<int> full_layers;
     std::vector<int> linear_layers;
@@ -320,11 +302,8 @@ CacheConfig createHybridAttentionPoolConfig(const ModelConfig&       model_confi
     config.linear_step        = 1;
     config.is_sparse          = model_config.attn_config.is_sparse;
 
-    RTP_LLM_CHECK_WITH_INFO(model_config.attn_config.layer_compress_ratios.empty() || hasDsv4KvCacheSpecs(model_config),
-                            "DSV4 cache config requires model_config.kv_cache_specs; "
-                            "layer_compress_ratios fallback is disabled");
-
-    if (hasDsv4KvCacheSpecs(model_config)) {
+    const bool is_dsv4_config = hasTypedHybridPoolLayout(model_config);
+    if (is_dsv4_config) {
         DSV4CacheConfigHelper::applyConfig(
             config, model_config, parallelism_config, kv_cache_config, gen_num_per_cycle);
     } else {
@@ -334,7 +313,6 @@ CacheConfig createHybridAttentionPoolConfig(const ModelConfig&       model_confi
     }
 
     RTP_LLM_CHECK_WITH_INFO(!config.cache_specs.empty(), "hybrid-pool config produced no cache specs");
-    const bool is_dsv4_config = hasDsv4KvCacheSpecs(model_config);
     setupGroupCounts(config);
     auto specs          = config.cache_specs;
     auto layers_by_group = config.layer_ids;


### PR DESCRIPTION
This PR refactors the DSV4 KV cache configuration layer with three changes: (1) centralize duplicated DSV4 spec tag declarations and detection predicates into a single header as the single source of truth, (2) fix MTP SWA-only model startup failure by removing the mandatory all-7-tags check, and (3) replace hardcoded compress_ratio constants with dynamic reads from spec declarations. All changes are behaviour-equivalent for existing full-config DSV4 models.