### PR TITLE
refactor: extract DecodeAttnImplBase template for decode attention backends

### DIFF
--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -158,54 +158,70 @@ struct PyContextParallelParams {
 };
 
 struct PyAttentionInputs {
-    bool          is_prefill{false};
-    bool          is_target_verify{false};
-    torch::Tensor prefix_lengths;
-    torch::Tensor sequence_lengths;
-    torch::Tensor input_lengths;
-    // Kernel-granularity block IDs for attention compute.
+    // ── Phase-affinity legend ────────────────────────────────────────────────
+    // Tags below mark which phase's attention kernels actually CONSUME each field
+    // on the standard MHA/MLA path:
+    //   [S] shared   - meaningful in both prefill and decode
+    //   [P] prefill  - decode leaves it empty/zero (built but unused there)
+    //   [D] decode   - prefill leaves it empty/zero (built but unused there)
+    // buildPyAttentionInputs() in PyWrappedModel.cc is the source of truth for how
+    // each field is populated per phase. NOTE: a few special paths populate some
+    // fields differently from these tags — speculative-decode target-verify
+    // (is_target_verify), linear-attention/mamba models (model_desc/qwen3_next.py),
+    // and CUDA-graph capture (cuda_graph_*.cc). See those sites for the exceptions.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    bool          is_prefill{false};        // [S] phase selector (true = prefill)
+    bool          is_target_verify{false};  // [S] spec-decode: this batch verifies draft tokens
+    torch::Tensor prefix_lengths;           // [P] reused-context length per seq (empty in decode)
+    torch::Tensor sequence_lengths;         // [D] past KV length per seq (empty in prefill)
+    torch::Tensor input_lengths;            // [S] tokens per seq (real in prefill, all-1 in decode)
+    // [S] Kernel-granularity block IDs for attention compute.
     // Shape: [group, batch, max_kernel_blocks] or [batch, max_kernel_blocks].
     torch::Tensor kv_cache_kernel_block_id_host;
     torch::Tensor kv_cache_kernel_block_id_device;
-    // Physical block IDs dedicated for cache store.
+    // [S] Physical block IDs dedicated for cache store.
     // Shape: [group, batch, max_blocks] or [batch, max_blocks].
     torch::Tensor kv_cache_block_id_host;
     torch::Tensor kv_cache_block_id_device;
-    // Hybrid cache support:
+    // [S] Hybrid cache support:
     // - kv_cache_kernel_block_id_*_by_group: vector of 2-D kernel block tables, each [batch, max_kernel_blocks].
     std::vector<torch::Tensor> kv_cache_kernel_block_id_host_by_group;
     std::vector<torch::Tensor> kv_cache_kernel_block_id_device_by_group;
     torch::Tensor              kv_cache_layer_to_group;
-    caffe2::TypeMeta           dtype;
-    // Cumulative sequence lengths for attention kernels (e.g. FusedRopeKVCacheDecodeOp).
+    caffe2::TypeMeta           dtype;  // [S] KV cache element type
+    // [P] Cumulative sequence lengths for variable-length packing in PREFILL
+    // (cu_seqlens = input_lengths.cumsum; consumed by FusedRopeKVCachePrefillOp / context FMHA).
+    // In decode these are zero placeholders — decode uses decode_cu_seqlens_* instead.
     // cu_seqlens lives on CUDA device; cu_seqlens_host is its pinned-memory CPU mirror
     // used for CUDA graph replay (write host → async copy to device, avoiding GPU-side fills).
     torch::Tensor cu_seqlens;
     torch::Tensor cu_seqlens_host;
     torch::Tensor cu_kv_seqlens;
-    torch::Tensor decode_cu_seqlens_host;
-    int           context_total_kv_length = 0;
-    int           total_tokens            = 0;
-    torch::Tensor padding_offset;
-    torch::Tensor combo_position_ids;
+    torch::Tensor decode_cu_seqlens_host;  // [D] arange(0..batch); diff() yields uniform decode q-len (XQA geometry)
+    int           context_total_kv_length = 0;  // [P] context KV token count (TRT context FMHA)
+    int           total_tokens            = 0;  // [P] total prefill tokens (cu_seqlens[batch])
+    torch::Tensor padding_offset;               // [P] per-token padding offset for prefill RoPE
+    torch::Tensor combo_position_ids;           // [S] RoPE position ids (both phases)
 
-    // for write cache store
+    // [P] for write cache store (PD-separation): write path is gated on is_prefill
+    // (see attention/common.py create_write_cache_store_impl / apply_write_cache_store).
     std::optional<PyCacheStoreInputs> cache_store_inputs;
 
-    std::optional<PyPrefillCudaGaphCopyParams> prefill_cuda_graph_copy_params;
-    bool                                       is_s_padded = false;
+    std::optional<PyPrefillCudaGaphCopyParams> prefill_cuda_graph_copy_params;  // [P] prefill cuda-graph copy params
+    bool is_s_padded = false;  // [P] TRT context FMHA s-padded (set on cuda-graph path)
     // Device-side mirrors of host tensors, managed by C++ for fused D2D copy in CUDA graph.
-    torch::Tensor prefix_lengths_d;
-    torch::Tensor sequence_lengths_plus_1_d;
-    torch::Tensor input_lengths_d;
-    torch::Tensor decode_cu_seqlens_d;
+    torch::Tensor prefix_lengths_d;           // [P] device mirror of prefix_lengths (also read by mamba/linear models)
+    torch::Tensor sequence_lengths_plus_1_d;  // [D] decode KV-len+1 (trtllm-gen / aiter / mamba decode)
+    torch::Tensor input_lengths_d;            // [S] device mirror of input_lengths
+    torch::Tensor decode_cu_seqlens_d;        // [D] device mirror of decode_cu_seqlens_host
 
-    // CUDA Graph mode flags
+    // [S] CUDA Graph mode flag
     bool is_cuda_graph = false;  // True when running in CUDA graph mode (capture or replay)
 
-    std::optional<PyContextParallelParams> context_parallel_info;
+    std::optional<PyContextParallelParams> context_parallel_info;  // [P] prefill context-parallel info
 
-    // Headwise attention config (Python dict or None).
+    // [S] Headwise attention config (Python dict or None).
     py::object headwise_config{py::none()};
 };
 

--- a/rtp_llm/models_py/kernels/cuda/test/test_xqa_batch_decode.py
+++ b/rtp_llm/models_py/kernels/cuda/test/test_xqa_batch_decode.py
@@ -15,7 +15,6 @@ except ImportError:
     _FLASHINFER_AVAILABLE = False
 
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.xqa import XQADecodeImpl
-from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ModelConfig
 
 # RTP-LLM imports
@@ -405,39 +404,15 @@ class TestXQABatchDecode(unittest.TestCase):
         kv_cache = LayerKVCache()
         kv_cache.kv_cache_base = kv_cache_tensor
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            result = original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, attn_inputs)
+        if kv_dtype == "fp8":
+            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(
+                attn_inputs,
+                q_scale=q_scale * k_scale * sm_scale,
+                kv_scale=v_scale / o_scale,
+                o_scale=o_scale,
             )
-            self.rope_kvcache_impl = rope_kvcache_impl
-            return result
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, attn_inputs)
-            # Prepare fmha_params with scale parameters
-            if kv_dtype == "fp8":
-                xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(
-                    attn_inputs,
-                    q_scale=q_scale * k_scale * sm_scale,
-                    kv_scale=v_scale / o_scale,
-                    o_scale=o_scale,
-                )
-            else:
-                xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(attn_inputs)
-            xqa_impl.attn_inputs = attn_inputs
-
-            class DummyRopeParams:
-                pass
-
-            xqa_impl.rope_params = DummyRopeParams()
-        finally:
-            FMHAImplBase.__init__ = original_init
 
         output_4d = xqa_impl.forward(q, kv_cache).squeeze(1)
         output = output_4d.reshape(-1, output_4d.shape[2], output_4d.shape[3])
@@ -518,25 +493,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = DTYPE_MAP["bf16"]
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(cap_inputs)
-            xqa_impl.attn_inputs = cap_inputs
-            xqa_impl.rope_params = xqa_impl.rope_kvcache_impl.prepare(cap_inputs)
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
 
         replay_kv_len = capture_kv_len + 5
         q_lens_rep, in_kv_lens_rep, seq_lens_rep = generate_seq_lens_decode(
@@ -663,25 +621,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = DTYPE_MAP["bf16"]
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(cap_inputs)
-            xqa_impl.attn_inputs = cap_inputs
-            xqa_impl.rope_params = xqa_impl.rope_kvcache_impl.prepare(cap_inputs)
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
 
         # --- Replay phase: actual_batch < capture_batch ---
         for actual_batch_size in [1, 2, 5]:
@@ -871,25 +812,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = DTYPE_MAP["bf16"]
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(cap_inputs)
-            xqa_impl.attn_inputs = cap_inputs
-            xqa_impl.rope_params = xqa_impl.rope_kvcache_impl.prepare(cap_inputs)
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
 
         # Pre-allocate fixed input/output buffers for graph capture
         q_cap, _, _ = create_query_tensor(q_lens_cap, num_qo_heads, head_dim, "bf16")
@@ -1064,25 +988,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = DTYPE_MAP["bf16"]
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(cap_inputs)
-            xqa_impl.attn_inputs = cap_inputs
-            xqa_impl.rope_params = xqa_impl.rope_kvcache_impl.prepare(cap_inputs)
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
 
         q_cap, _, _ = create_query_tensor(q_lens_cap, num_qo_heads, head_dim, "bf16")
         kv_cache_layer = LayerKVCache()
@@ -1228,25 +1135,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = DTYPE_MAP["bf16"]
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(cap_inputs)
-            xqa_impl.attn_inputs = cap_inputs
-            xqa_impl.rope_params = xqa_impl.rope_kvcache_impl.prepare(cap_inputs)
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, cap_inputs)
 
         # Pre-allocate fixed input/output buffers for graph capture
         q_cap, _, _ = create_query_tensor(q_lens_cap, num_qo_heads, head_dim, "bf16")
@@ -1462,29 +1352,8 @@ class TestXQABatchDecode(unittest.TestCase):
         attn_configs.kv_cache_dtype = KvCacheDataType.BASE
         attn_configs.dtype = q.dtype
 
-        original_init = FMHAImplBase.__init__
-
-        def patched_init(
-            self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=True
-        ):
-            original_init(
-                self, fmha_impl, rope_kvcache_impl, attn_inputs, init_params=False
-            )
-            self.rope_kvcache_impl = rope_kvcache_impl
-
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl = XQADecodeImpl(attn_configs, attn_inputs)
-            xqa_impl.fmha_params = xqa_impl.fmha_impl.prepare(attn_inputs)
-            xqa_impl.attn_inputs = attn_inputs
-
-            class DummyRopeParams:
-                pass
-
-            xqa_impl.rope_params = DummyRopeParams()
-        finally:
-            FMHAImplBase.__init__ = original_init
+        attn_configs.need_rope_kv_cache = False
+        xqa_impl = XQADecodeImpl(attn_configs, attn_inputs)
 
         # Forward with 2D packed KV cache
         kv_cache_packed = LayerKVCache()
@@ -1497,16 +1366,7 @@ class TestXQABatchDecode(unittest.TestCase):
         kv_cache_normal = LayerKVCache()
         kv_cache_normal.kv_cache_base = kv_cache_5d
 
-        xqa_impl2 = XQADecodeImpl.__new__(XQADecodeImpl)
-        FMHAImplBase.__init__ = patched_init
-        try:
-            attn_configs.need_rope_kv_cache = False
-            xqa_impl2 = XQADecodeImpl(attn_configs, attn_inputs)
-            xqa_impl2.fmha_params = xqa_impl2.fmha_impl.prepare(attn_inputs)
-            xqa_impl2.attn_inputs = attn_inputs
-            xqa_impl2.rope_params = DummyRopeParams()
-        finally:
-            FMHAImplBase.__init__ = original_init
+        xqa_impl2 = XQADecodeImpl(attn_configs, attn_inputs)
 
         output_5d = xqa_impl2.forward(q, kv_cache_normal).squeeze(1)
         output_5d = output_5d.reshape(-1, output_5d.shape[2], output_5d.shape[3])

--- a/rtp_llm/models_py/modules/factory/attention/common.py
+++ b/rtp_llm/models_py/modules/factory/attention/common.py
@@ -1,17 +1,44 @@
 """Common utilities for attention implementations.
 
 This module contains helper functions for FMHA implementations including:
+- Workspace buffer pooling
 - Cache store operations
 - Parameter updates for CUDA graph
 - KV cache offset management
 """
 
+import threading
 from typing import Any, Optional
 
 import torch
 
 from rtp_llm.models_py.modules.base.common.kvcache_store import WriteCacheStoreOp
 from rtp_llm.ops.compute_ops import LayerKVCache, PyAttentionInputs
+
+
+class WorkspaceBufferPool:
+    """Thread-safe pool of reusable GPU workspace buffers.
+
+    Each attention backend (XQA / TRT-LLM gen / FlashInfer) keeps its own pool
+    sized for that backend. Buffers are uint8 scratch space handed to kernels;
+    `get` reuses a pooled buffer or allocates one (outside the lock to minimize
+    contention), `release` returns it to the pool for the next instance.
+    """
+
+    def __init__(self, size_mb: int) -> None:
+        self._size_bytes = size_mb * 1024 * 1024
+        self._pool: list[torch.Tensor] = []
+        self._lock = threading.Lock()
+
+    def get(self, device: str = "cuda") -> torch.Tensor:
+        with self._lock:
+            if self._pool:
+                return self._pool.pop()
+        return torch.zeros(self._size_bytes, dtype=torch.uint8, device=device)
+
+    def release(self, buffer: torch.Tensor) -> None:
+        with self._lock:
+            self._pool.append(buffer)
 
 
 def reshape_paged_kv_cache(

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -18,6 +18,9 @@ from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_sm_10
 from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla import (
     check_attention_inputs,
 )
+from rtp_llm.models_py.modules.factory.attention.decode_attn_base import (
+    DecodeAttnImplBase,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import (
     AttentionConfigs,
@@ -39,30 +42,18 @@ from rtp_llm.ops.compute_ops import (
 # Constants
 DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB = 128
 
-# Global workspace buffer pool
-_g_py_flashinfer_workspace_pool: list[torch.Tensor] = []
-_g_py_flashinfer_pool_lock = __import__("threading").Lock()
+# Global workspace buffer pool (shared by decode + CP prefill impls that import these)
+_g_py_flashinfer_workspace_pool = common.WorkspaceBufferPool(
+    DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB
+)
 
 
 def get_py_flashinfer_workspace_buffer(device: str = "cuda") -> torch.Tensor:
-    """Get a PyFlashInfer workspace buffer from the pool.
-
-    This function manages workspace buffers to support multiple concurrent instances.
-    """
-    with _g_py_flashinfer_pool_lock:
-        if _g_py_flashinfer_workspace_pool:
-            return _g_py_flashinfer_workspace_pool.pop()
-    return torch.zeros(
-        DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
-        dtype=torch.uint8,
-        device=device,
-    )
+    return _g_py_flashinfer_workspace_pool.get(device)
 
 
 def release_py_flashinfer_workspace_buffer(buffer: torch.Tensor) -> None:
-    """Release a PyFlashInfer workspace buffer back to the pool."""
-    with _g_py_flashinfer_pool_lock:
-        _g_py_flashinfer_workspace_pool.append(buffer)
+    _g_py_flashinfer_workspace_pool.release(buffer)
 
 
 class PyFlashinferPrefillPagedAttnOp(object):
@@ -777,36 +768,7 @@ class PyFlashinferDecodeAttnOp(object):
         return self.decode_wrapper.run(q, paged_kv_cache)
 
 
-class PyFlashinferDecodeImpl(FMHAImplBase):
-    def __init__(
-        self,
-        attn_configs: AttentionConfigs,
-        attn_inputs: PyAttentionInputs,
-        parallelism_config: Optional[ParallelismConfig] = None,
-    ) -> None:
-        # Create implementations
-        self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = PyFlashinferDecodeAttnOp(attn_configs, attn_inputs)
-        self.rope_impl = FusedRopeKVCacheDecodeOp(attn_configs)
-        self.attn_configs = attn_configs
-
-        # Store input info
-        self.attn_inputs = attn_inputs
-
-        self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
-        self.fmha_impl.set_params(self.fmha_params)
-        self.fmha_impl.prepare(attn_inputs)
-        self.rope_params = self.rope_impl.prepare(attn_inputs)
-        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
-
-    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
-        """Prepare FlashInfer/RoPE buffers and metadata for CUDA graph replay."""
-        self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
-        # Update rope params for correct position encoding during cuda graph replay
-        new_rope_params = self.rope_impl.prepare(attn_inputs)
-        common.copy_kv_cache_offset(
-            self.rope_params.kv_cache_offset, new_rope_params.kv_cache_offset
-        )
+class PyFlashinferDecodeImpl(DecodeAttnImplBase):
 
     def support_cuda_graph(self) -> bool:
         return True
@@ -817,20 +779,16 @@ class PyFlashinferDecodeImpl(FMHAImplBase):
     ) -> bool:
         return not attn_configs.use_mla
 
-    def forward(
-        self,
-        qkv: torch.Tensor,
-        kv_cache: Optional[LayerKVCache],
-        layer_idx: int = 0,
-    ) -> torch.Tensor:
-        # Apply RoPE and KV Cache processing
-        if self.need_rope_kv_cache:
-            qkv = self.rope_impl.forward(qkv, kv_cache, self.rope_params)
+    # ─── DecodeAttnImplBase hooks ────────────────────────────────────────
 
-        # Apply write cache store if needed
-        common.apply_write_cache_store(
-            self.write_cache_store_impl, self.attn_inputs, kv_cache
-        )
+    def _create_fmha_impl(self, attn_configs, attn_inputs):
+        return PyFlashinferDecodeAttnOp(attn_configs, attn_inputs)
 
-        # Execute FMHA forward
-        return self.fmha_impl.forward(qkv, kv_cache, self.fmha_params)
+    def _init_fmha_params(self, attn_inputs):
+        params = rtp_llm_ops.FlashInferMlaAttnParams()
+        self.fmha_impl.set_params(params)
+        self.fmha_impl.prepare(attn_inputs)
+        return params
+
+    def _prepare_cuda_graph_impl(self, attn_inputs):
+        self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -7,10 +7,12 @@ import triton.language as tl
 
 from rtp_llm.models_py.modules.factory.attention import common
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_sm_100
+from rtp_llm.models_py.modules.factory.attention.decode_attn_base import (
+    DecodeAttnImplBase,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import AttentionConfigs, FMHAType, ParallelismConfig
 from rtp_llm.ops.compute_ops import (
-    FusedRopeKVCacheDecodeOp,
     FusedRopeKVCachePrefillOpQOut,
     LayerKVCache,
     PyAttentionInputs,
@@ -22,42 +24,15 @@ DEFAULT_TRT_WORKSPACE_SIZE_MB = (
 )
 
 # Global workspace buffer pool
-_g_trt_workspace_pool: list[torch.Tensor] = []
-_g_trt_pool_lock = __import__("threading").Lock()
+_g_trt_workspace_pool = common.WorkspaceBufferPool(DEFAULT_TRT_WORKSPACE_SIZE_MB)
 
 
 def get_trt_workspace_buffer(device: str = "cuda") -> torch.Tensor:
-    """Get a TRT workspace buffer from the pool.
-
-    This function manages a pool of workspace buffers to support multiple
-    concurrent instances while avoiding excessive memory allocation.
-
-    Args:
-        device: CUDA device to allocate buffer on (default: "cuda")
-
-    Returns:
-        Workspace buffer tensor of size DEFAULT_TRT_WORKSPACE_SIZE_MB
-    """
-    with _g_trt_pool_lock:
-        if _g_trt_workspace_pool:
-            return _g_trt_workspace_pool.pop()
-        else:
-            # No available buffer in pool, create a new one
-            return torch.zeros(
-                DEFAULT_TRT_WORKSPACE_SIZE_MB * 1024 * 1024,
-                dtype=torch.uint8,
-                device=device,
-            )
+    return _g_trt_workspace_pool.get(device)
 
 
 def release_trt_workspace_buffer(buffer: torch.Tensor) -> None:
-    """Release a TRT workspace buffer back to the pool.
-
-    Args:
-        buffer: The workspace buffer to release
-    """
-    with _g_trt_pool_lock:
-        _g_trt_workspace_pool.append(buffer)
+    _g_trt_workspace_pool.release(buffer)
 
 
 class FlashInferTRTLLMParams(object):
@@ -678,29 +653,7 @@ class FlashInferTRTLLMSpecDecodeImpl(FMHAImplBase):
             )
 
 
-class FlashInferTRTLLMDecodeImpl(FMHAImplBase):
-
-    def __init__(
-        self,
-        attn_configs: AttentionConfigs,
-        attn_inputs: PyAttentionInputs,
-        parallelism_config: Optional[ParallelismConfig] = None,
-    ) -> None:
-        self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = FlashInferTRTLLMDecodeOp(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOp(attn_configs)
-        self.attn_configs = attn_configs
-        self.attn_inputs = attn_inputs
-        self.fmha_params = self.fmha_impl.prepare(attn_inputs)
-        self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
-        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
-
-        self._cg = _init_decode_cg_params(
-            self.fmha_params.batch_size,
-            attn_inputs.kv_cache_kernel_block_id_device,
-            self.fmha_params.seq_lens,
-            self.rope_params.kv_cache_offset,
-        )
+class FlashInferTRTLLMDecodeImpl(DecodeAttnImplBase):
 
     @classmethod
     def support(
@@ -711,23 +664,22 @@ class FlashInferTRTLLMDecodeImpl(FMHAImplBase):
         fmha_impl = FlashInferTRTLLMDecodeOp(attn_configs)
         return fmha_impl.support(attn_inputs)
 
-    def forward(
-        self,
-        qkv: torch.Tensor,
-        kv_cache: Optional[LayerKVCache],
-        layer_idx: int,
-    ) -> torch.Tensor:
-        if self.need_rope_kv_cache:
-            fmha_input = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
-        else:
-            fmha_input = qkv
+    # ─── DecodeAttnImplBase hooks ────────────────────────────────────────
 
-        common.apply_write_cache_store(
-            self.write_cache_store_impl, self.attn_inputs, kv_cache
+    def _create_fmha_impl(self, attn_configs, attn_inputs):
+        return FlashInferTRTLLMDecodeOp(attn_configs)
+
+    def _init_fmha_params(self, attn_inputs):
+        params = self.fmha_impl.prepare(attn_inputs)
+        self._cg = _init_decode_cg_params(
+            params.batch_size,
+            attn_inputs.kv_cache_kernel_block_id_device,
+            params.seq_lens,
+            self.rope_params.kv_cache_offset,
         )
-        return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
+        return params
 
-    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
+    def _prepare_cuda_graph_impl(self, attn_inputs):
         p = self._cg
         _prepare_cg_decode_kernel[p.grid](
             attn_inputs.sequence_lengths_plus_1_d,
@@ -739,3 +691,7 @@ class FlashInferTRTLLMDecodeImpl(FMHAImplBase):
             p.total_bm,
             BLOCK_SIZE=p.BLOCK_SIZE,
         )
+
+    def _update_rope_offset(self, attn_inputs):
+        # kv_cache_offset is updated by the Triton kernel above; no extra copy needed.
+        pass

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
@@ -1,49 +1,31 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional, Type
+from typing import Optional, Type
 
 import torch
 
 from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.decode_attn_base import (
+    DecodeAttnImplBase,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.models_py.utils.arch import get_num_device_sms
-from rtp_llm.ops import (
-    AttentionConfigs,
-    FMHAConfig,
-    FMHAType,
-    KvCacheDataType,
-    ParallelismConfig,
-)
-from rtp_llm.ops.compute_ops import (
-    FusedRopeKVCacheDecodeOp,
-    LayerKVCache,
-    PyAttentionInputs,
-    XQAAttnOp,
-)
+from rtp_llm.ops import AttentionConfigs, FMHAConfig, FMHAType, KvCacheDataType
+from rtp_llm.ops.compute_ops import LayerKVCache, PyAttentionInputs, XQAAttnOp
 
 # Constants
 DEFAULT_XQA_WORKSPACE_SIZE_MB = 248
 
 # Global workspace buffer pool
-_g_xqa_workspace_pool: list[torch.Tensor] = []
-_g_xqa_pool_lock = __import__("threading").Lock()
+_g_xqa_workspace_pool = common.WorkspaceBufferPool(DEFAULT_XQA_WORKSPACE_SIZE_MB)
 
 
 def get_xqa_workspace_buffer(device: str = "cuda") -> torch.Tensor:
-    with _g_xqa_pool_lock:
-        if _g_xqa_workspace_pool:
-            return _g_xqa_workspace_pool.pop()
-        else:
-            return torch.zeros(
-                DEFAULT_XQA_WORKSPACE_SIZE_MB * 1024 * 1024,
-                dtype=torch.uint8,
-                device=device,
-            )
+    return _g_xqa_workspace_pool.get(device)
 
 
 def release_xqa_workspace_buffer(buffer: torch.Tensor) -> None:
-    with _g_xqa_pool_lock:
-        _g_xqa_workspace_pool.append(buffer)
+    _g_xqa_workspace_pool.release(buffer)
 
 
 @dataclass
@@ -59,26 +41,7 @@ class XQAParams:
     o_scale: float = 1.0
 
 
-class XQAImpl(FMHAImplBase):
-
-    def __init__(
-        self,
-        attn_configs: AttentionConfigs,
-        attn_inputs: PyAttentionInputs,
-        parallelism_config: Optional[ParallelismConfig] = None,
-    ) -> None:
-        self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = XQAAttnOp(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOp(attn_configs)
-
-        self.attn_inputs = attn_inputs
-
-        self.fmha_params = self.fmha_impl.prepare(attn_inputs)
-        self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
-        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
-        # C++ XQAParams.sequence_lengths shares storage with this tensor.
-        # Keep a reference so prepare_cuda_graph can update it in-place.
-        self._captured_seq_lens = attn_inputs.sequence_lengths
+class XQAImpl(DecodeAttnImplBase):
 
     @classmethod
     def support(
@@ -87,56 +50,33 @@ class XQAImpl(FMHAImplBase):
         fmha_impl = XQAAttnOp(attn_configs)
         return fmha_impl.support(attn_inputs)
 
-    def forward(
-        self,
-        qkv: torch.Tensor,
-        kv_cache: Optional[LayerKVCache],
-        layer_idx: int = 0,
-    ) -> torch.Tensor:
-        if self.need_rope_kv_cache:
-            fmha_input = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
-        else:
-            fmha_input = qkv
+    # ─── DecodeAttnImplBase hooks ────────────────────────────────────────
 
-        common.apply_write_cache_store(
-            self.write_cache_store_impl, self.attn_inputs, kv_cache
-        )
+    def _create_fmha_impl(self, attn_configs, attn_inputs):
+        return XQAAttnOp(attn_configs)
 
-        return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
+    def _init_fmha_params(self, attn_inputs):
+        params = self.fmha_impl.prepare(attn_inputs)
+        # C++ XQAParams.sequence_lengths shares storage with this tensor.
+        # Keep a reference so _prepare_cuda_graph_impl can update it in-place.
+        self._captured_seq_lens = attn_inputs.sequence_lengths
+        return params
 
-    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
-        common.update_trt_params(
-            self.fmha_impl,
-            self.rope_kvcache_impl,
-            self.fmha_params,
-            self.rope_params,
-            attn_inputs,
-        )
-        # update_trt_params only copies kv_cache_offset. The TRT XQA kernel also
-        # reads sequence_lengths via the captured data_ptr(), so we must update
-        # the data in-place at the address recorded during CUDA graph capture.
+    def _prepare_cuda_graph_impl(self, attn_inputs):
+        # Update fmha kv_cache_offset in-place
+        new_fmha_params = self.fmha_impl.prepare(attn_inputs)
+        old_offset = self.fmha_params.kv_cache_offset
+        new_offset = new_fmha_params.kv_cache_offset
+        common.copy_kv_cache_offset(old_offset, new_offset)
+
+        # The TRT XQA kernel reads sequence_lengths via the captured data_ptr(),
+        # so we must update the data in-place at the address recorded during capture.
         new_seq_lens = attn_inputs.sequence_lengths
         n = min(self._captured_seq_lens.numel(), new_seq_lens.numel())
         self._captured_seq_lens[:n].copy_(new_seq_lens[:n], non_blocking=True)
 
 
-class XQADecodeImpl(FMHAImplBase):
-
-    def __init__(
-        self,
-        attn_configs: AttentionConfigs,
-        attn_inputs: PyAttentionInputs,
-        parallelism_config: Optional[ParallelismConfig] = None,
-    ) -> None:
-        self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = XQAWrapper(attn_configs, attn_inputs)
-        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOp(attn_configs)
-
-        self.attn_inputs = attn_inputs
-
-        self.fmha_params = self.fmha_impl.prepare(attn_inputs)
-        self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
-        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+class XQADecodeImpl(DecodeAttnImplBase):
 
     @classmethod
     def support(
@@ -156,24 +96,15 @@ class XQADecodeImpl(FMHAImplBase):
             and attn_configs.kernel_tokens_per_block in [16, 32, 64, 128]
         )
 
-    def forward(
-        self,
-        qkv: torch.Tensor,
-        kv_cache: Optional[LayerKVCache],
-        layer_idx: int = 0,
-    ) -> torch.Tensor:
-        if self.need_rope_kv_cache:
-            fmha_input = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
-        else:
-            fmha_input = qkv
+    # ─── DecodeAttnImplBase hooks ────────────────────────────────────────
 
-        common.apply_write_cache_store(
-            self.write_cache_store_impl, self.attn_inputs, kv_cache
-        )
+    def _create_fmha_impl(self, attn_configs, attn_inputs):
+        return XQAWrapper(attn_configs, attn_inputs)
 
-        return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
+    def _init_fmha_params(self, attn_inputs):
+        return self.fmha_impl.prepare(attn_inputs)
 
-    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
+    def _prepare_cuda_graph_impl(self, attn_inputs):
         self.fmha_impl.prepare_for_cuda_graph_replay(attn_inputs)
 
         new_fmha_params = self.fmha_impl.make_params(attn_inputs)
@@ -184,11 +115,6 @@ class XQADecodeImpl(FMHAImplBase):
         self.fmha_params.seq_lens = new_fmha_params.seq_lens
         self.fmha_params.batch_size = new_fmha_params.batch_size
         self.fmha_params.max_seq_len = new_fmha_params.max_seq_len
-
-        new_rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
-        new_offset = new_rope_params.kv_cache_offset
-        old_offset = self.rope_params.kv_cache_offset
-        common.copy_kv_cache_offset(old_offset, new_offset)
 
 
 def _load_xqa_fn():
@@ -223,7 +149,9 @@ class XQAWrapper:
     ):
         self.config = config
         self.attn_inputs = attn_inputs
-        self.cu_qseqlens = attn_inputs.cu_seqlens
+        # NOTE: decode does NOT use attn_inputs.cu_seqlens (it is a zero placeholder in
+        # the decode branch of buildPyAttentionInputs); the real per-seq q geometry comes
+        # from attn_inputs.decode_cu_seqlens_host (see _compute_batch_geometry below).
         assert not self.attn_inputs.is_prefill, "XQA is not supported"
         self.workspace_buffer = get_xqa_workspace_buffer()
         self.semaphores = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device="cuda")
@@ -250,33 +178,14 @@ class XQAWrapper:
     def __del__(self):
         release_xqa_workspace_buffer(self.workspace_buffer)
 
-    def support(self, attn_inputs: Any) -> bool:
-        group_size = self.config.head_num // self.config.kv_head_num
-        input_type_supported = self.config.dtype in [torch.bfloat16, torch.float16]
-        output_type_supported = self.config.dtype in [
-            torch.bfloat16,
-            torch.float16,
-            torch.float8_e4m3fn,
-        ]
-        group_size_supported = 1 <= group_size <= 16
-        head_dim_supported = self.config.size_per_head in [64, 128, 256]
-        page_size_supported = self.config.kernel_tokens_per_block in [16, 32, 64, 128]
-        return (
-            input_type_supported
-            and output_type_supported
-            and group_size_supported
-            and head_dim_supported
-            and page_size_supported
-        )
-
     def _compute_batch_geometry(self, attn_inputs: PyAttentionInputs) -> None:
-        cu_seqlens = attn_inputs.decode_cu_seqlens_host
-        seqlens = torch.diff(cu_seqlens).tolist()
+        cu_q_seqlens = attn_inputs.decode_cu_seqlens_host
+        q_lens = torch.diff(cu_q_seqlens).tolist()
         assert (
-            len(set(seqlens)) == 1
-        ), f"All sequences must have the same length for XQA, got lengths: {seqlens}"
-        self._q_len_per_req = seqlens[0]
-        self._batch_size = len(seqlens)
+            len(set(q_lens)) == 1
+        ), f"All sequences must have the same q_len for XQA, got lengths: {q_lens}"
+        self._q_len_per_req = q_lens[0]
+        self._batch_size = len(q_lens)
 
     def _compute_spec_mask(self, device: str = "cuda") -> None:
         q_len = self._q_len_per_req

--- a/rtp_llm/models_py/modules/factory/attention/decode_attn_base.py
+++ b/rtp_llm/models_py/modules/factory/attention/decode_attn_base.py
@@ -1,0 +1,124 @@
+"""Decode Attention 后端统一模板基类。
+
+所有 decode attention 实现共享相同的 forward 流程：
+1. 若需要 RoPE，调用 rope_impl 处理 qkv
+2. 若需要 cache store，写入 kv_cache
+3. 调用 fmha_impl 执行 attention forward
+
+子类只需实现差异化的 hook 方法，无需重复 forward/init 逻辑。
+"""
+
+from abc import abstractmethod
+from typing import Any, Optional
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
+from rtp_llm.ops import AttentionConfigs, ParallelismConfig
+from rtp_llm.ops.compute_ops import (
+    FusedRopeKVCacheDecodeOp,
+    LayerKVCache,
+    PyAttentionInputs,
+)
+
+
+class DecodeAttnImplBase(FMHAImplBase):
+    """Decode attention 后端统一模板基类。
+
+    Template Method 模式：forward 和 prepare_cuda_graph 由基类驱动，
+    子类通过以下 hook 方法注入差异化逻辑：
+
+    必须实现：
+        _create_fmha_impl(attn_configs, attn_inputs) -> fmha算子实例
+        _init_fmha_params(attn_inputs) -> fmha参数对象
+        _prepare_cuda_graph_impl(attn_inputs) -> None
+
+    可选覆写：
+        _create_rope_impl(attn_configs) -> rope算子实例
+        _update_rope_offset(attn_inputs) -> None
+        support_cuda_graph() -> bool
+    """
+
+    def __init__(
+        self,
+        attn_configs: AttentionConfigs,
+        attn_inputs: PyAttentionInputs,
+        parallelism_config: Optional[ParallelismConfig] = None,
+    ) -> None:
+        self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
+        self.attn_inputs = attn_inputs
+
+        # 子类 hook：创建底层算子
+        self.fmha_impl = self._create_fmha_impl(attn_configs, attn_inputs)
+        self.rope_impl = self._create_rope_impl(attn_configs)
+
+        # 统一的参数初始化（rope_params 先于 fmha_params，因为部分后端的
+        # _init_fmha_params 需要引用 rope_params.kv_cache_offset）
+        self.rope_params = (
+            self.rope_impl.prepare(attn_inputs) if self.rope_impl is not None else None
+        )
+        self.fmha_params = self._init_fmha_params(attn_inputs)
+        self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+
+    # ─── Template Methods (不要覆写) ────────────────────────────────────────
+
+    def forward(
+        self,
+        qkv: torch.Tensor,
+        kv_cache: Optional[LayerKVCache],
+        layer_idx: int = 0,
+    ) -> torch.Tensor:
+        """统一的 forward 模板 - 所有 decode 后端共享。"""
+        if self.need_rope_kv_cache and self.rope_impl is not None:
+            qkv = self.rope_impl.forward(qkv, kv_cache, self.rope_params)
+
+        common.apply_write_cache_store(
+            self.write_cache_store_impl, self.attn_inputs, kv_cache
+        )
+
+        return self.fmha_impl.forward(qkv, kv_cache, self.fmha_params)
+
+    def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs) -> None:
+        """统一的 CUDA graph 准备入口。"""
+        self._prepare_cuda_graph_impl(attn_inputs)
+        self._update_rope_offset(attn_inputs)
+
+    # ─── 子类必须实现的 Hook ─────────────────────────────────────────────────
+
+    @abstractmethod
+    def _create_fmha_impl(
+        self, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
+    ) -> Any:
+        """创建底层 FMHA 算子实例。"""
+        ...
+
+    @abstractmethod
+    def _init_fmha_params(self, attn_inputs: PyAttentionInputs) -> Any:
+        """初始化 FMHA 参数对象。在 __init__ 中被调用。"""
+        ...
+
+    @abstractmethod
+    def _prepare_cuda_graph_impl(self, attn_inputs: PyAttentionInputs) -> None:
+        """CUDA graph 重放时的参数更新逻辑（不含 rope offset 更新）。"""
+        ...
+
+    # ─── 可选覆写的 Hook ─────────────────────────────────────────────────────
+
+    def _create_rope_impl(self, attn_configs: AttentionConfigs) -> Any:
+        """创建 RoPE 算子实例。默认使用 FusedRopeKVCacheDecodeOp。"""
+        return FusedRopeKVCacheDecodeOp(attn_configs)
+
+    def _update_rope_offset(self, attn_inputs: PyAttentionInputs) -> None:
+        """更新 RoPE 的 kv_cache_offset。默认通过 in-place copy 实现。
+
+        某些后端（如 FlashInferTRTLLMDecodeImpl）的 kv_cache_offset 由 Triton
+        kernel 在 _prepare_cuda_graph_impl 中统一更新，无需再单独 copy，
+        可覆写此方法为空操作。
+        """
+        if self.rope_impl is None:
+            return
+        new_rope_params = self.rope_impl.prepare(attn_inputs)
+        common.copy_kv_cache_offset(
+            self.rope_params.kv_cache_offset, new_rope_params.kv_cache_offset
+        )

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -174,14 +174,21 @@ class FusedRopeKVCacheDecodeOp:
         self._dummy_scale: Optional[torch.Tensor] = None
 
     def _get_kv_scale(self, kv_cache: LayerKVCache) -> Optional[torch.Tensor]:
-        # FP8 KV cache uses direct cast (no dynamic scaling), so the kernel always writes
-        # scale = 1.0. The buffer here is an output target for the kernel, not a real scale.
+        # FP8 KV cache uses direct cast (no dynamic scaling): the RoPE kernel
+        # hardcodes s_max=128 in fused_rope_kvcache_kernel.cu, so the stored
+        # per-block scale is always 1.0 (see xqa.py XQAParams.kv_scale comment).
+        # Attention kernels treat the scale as 1.0 unconditionally —
+        # FlashInfer's k_scale/v_scale default to 1.0 and PyFlashinferDecodeImpl
+        # never passes them; TRTAttn only consumes the buffer pointer. So this
+        # buffer is a kernel pointer-arg / write-target, not a value-carrying scale.
         #
         # `is not None` is sufficient here: pybind11 maps an undefined C++ torch::Tensor to
         # Python None, and the cache allocator only stores defined tensors with numel > 0
-        # (see SingleTypeKVCacheAllocator::allLayerCacheBase). MHAKVCacheSpec guarantees
-        # FP8 dtype always has a scale buffer, so the dummy-scale branch below is purely
-        # defensive and unreachable under normal operation.
+        # (see SingleTypeKVCacheAllocator::allLayerCacheBase). In production
+        # MHAKVCacheSpec always allocates this buffer; the dummy-scale branch
+        # below is a functionally equivalent fallback for callers that build
+        # LayerKVCache by hand (e.g. bench scripts / unit tests) — values are
+        # 1.0 either way, so the two paths are numerically identical.
         if kv_cache.kv_scale_base is not None:
             return kv_cache.kv_scale_base
         if kv_cache.kv_cache_base.dtype == torch.float8_e4m3fn:


### PR DESCRIPTION
## Summary

- Introduce `DecodeAttnImplBase` (Template Method pattern) as a common base class for
  XQAImpl, XQADecodeImpl, PyFlashinferDecodeImpl, and FlashInferTRTLLMDecodeImpl,
  eliminating ~140 lines of duplicated forward/init/cuda-graph code
- Extract `WorkspaceBufferPool` into `common.py`, replacing three identical thread-safe
  pool implementations
- Annotate `PyAttentionInputs` fields with phase-affinity tags ([S]hared / [P]refill / [D]ecode)