### PR TITLE
feat: add rejection sampling kernel

### DIFF
--- a/rtp_llm/cpp/testing/BUILD
+++ b/rtp_llm/cpp/testing/BUILD
@@ -67,3 +67,18 @@ cc_library(
     visibility = ["//visibility:public"],
     copts = test_copts,
 )
+
+cc_library(
+    name = "rejection_sampling_test_utils",
+    hdrs = [
+        "RejectionSamplingOpTest.hpp",
+    ],
+    deps = [
+        "//rtp_llm/models_py/bindings/core:op_data",
+        "//rtp_llm/models_py/bindings/core:rejection_sampling_ops_test_lib",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps(),
+    visibility = ["//visibility:public"],
+    copts = test_copts,
+)

--- a/rtp_llm/cpp/testing/RejectionSamplingOpTest.hpp
+++ b/rtp_llm/cpp/testing/RejectionSamplingOpTest.hpp
@@ -1,0 +1,414 @@
+#pragma once
+
+#include "rtp_llm/models_py/bindings/core/OpData.h"
+
+#include <algorithm>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <torch/torch.h>
+#include <vector>
+
+using namespace rtp_llm;
+
+namespace rtp_llm {
+void rejectionSampling(const RejectionSamplingParams& params);
+}
+
+class RejectionSamplingOpTest: public ::testing::Test {
+protected:
+    struct ReferenceOutput {
+        std::vector<int32_t> token_ids;
+        std::vector<int32_t> accepted_token_num;
+    };
+
+    void SetUp() override {
+        torch::manual_seed(114514);
+    }
+
+    torch::Tensor cudaFloatTensor(const std::vector<int64_t>& shape, const std::vector<float>& data) {
+        return cudaTensorFromVector<float>(shape, data, torch::kFloat32);
+    }
+
+    torch::Tensor cudaIntTensor(const std::vector<int64_t>& shape, const std::vector<int32_t>& data) {
+        return cudaTensorFromVector<int32_t>(shape, data, torch::kInt32);
+    }
+
+    torch::Tensor cudaBoolTensor(const std::vector<bool>& data) {
+        auto cpu = torch::empty({static_cast<int64_t>(data.size())}, torch::TensorOptions().dtype(torch::kBool));
+        auto ptr = cpu.data_ptr<bool>();
+        for (size_t i = 0; i < data.size(); ++i) {
+            ptr[i] = data[i];
+        }
+        return cpu.to(torch::kCUDA);
+    }
+
+    void runReferenceCases() {
+        constexpr int batch_size             = 4;
+        constexpr int num_speculative_tokens = 3;
+        constexpr int vocab_size             = 5;
+        constexpr int target_token_stride    = 2;
+
+        std::vector<float>   draft_probs(batch_size * num_speculative_tokens * vocab_size, 0.2f);
+        std::vector<float>   target_probs(batch_size * (num_speculative_tokens + 1) * vocab_size, 0.2f);
+        std::vector<int32_t> draft_token_ids{
+            1,
+            2,
+            3,
+            0,
+            4,
+            2,
+            3,
+            1,
+            0,
+            2,
+            4,
+            1,
+        };
+        std::vector<int32_t> target_token_ids(batch_size * (num_speculative_tokens + 1) * target_token_stride, -100);
+        std::vector<float>   uniform_samples(batch_size * (num_speculative_tokens + 1), 0.5f);
+        std::vector<bool>    do_sample{true, false, true, true};
+
+        setTargetTokenIds(target_token_ids, batch_size, num_speculative_tokens, target_token_stride, 0, {1, 2, 3, 4});
+        setTargetTokenIds(target_token_ids, batch_size, num_speculative_tokens, target_token_stride, 1, {0, 2, 3, 4});
+        setTargetTokenIds(target_token_ids, batch_size, num_speculative_tokens, target_token_stride, 2, {4, 2, 0, 1});
+        setTargetTokenIds(target_token_ids, batch_size, num_speculative_tokens, target_token_stride, 3, {0, 4, 3, 4});
+
+        setProbRow(draft_probs, num_speculative_tokens, vocab_size, 2, 0, {0.05f, 0.05f, 0.05f, 0.20f, 0.65f});
+        setProbRow(target_probs, num_speculative_tokens + 1, vocab_size, 2, 0, {0.05f, 0.05f, 0.05f, 0.80f, 0.05f});
+        setProbRow(draft_probs, num_speculative_tokens, vocab_size, 2, 1, {0.10f, 0.70f, 0.10f, 0.05f, 0.05f});
+        setProbRow(target_probs, num_speculative_tokens + 1, vocab_size, 2, 1, {0.05f, 0.10f, 0.60f, 0.20f, 0.05f});
+        uniform_samples[2 * (num_speculative_tokens + 1) + 2] = 0.90f;
+
+        setProbRow(draft_probs, num_speculative_tokens, vocab_size, 3, 0, {0.10f, 0.10f, 0.50f, 0.20f, 0.10f});
+        setProbRow(target_probs, num_speculative_tokens + 1, vocab_size, 3, 0, {0.05f, 0.05f, 0.80f, 0.05f, 0.05f});
+        setProbRow(draft_probs, num_speculative_tokens, vocab_size, 3, 2, {0.10f, 0.50f, 0.10f, 0.20f, 0.10f});
+        setProbRow(target_probs, num_speculative_tokens + 1, vocab_size, 3, 2, {0.025f, 0.90f, 0.025f, 0.025f, 0.025f});
+        setProbRow(target_probs, num_speculative_tokens + 1, vocab_size, 3, 3, {0.10f, 0.20f, 0.30f, 0.25f, 0.15f});
+        uniform_samples[3 * (num_speculative_tokens + 1) + 0] = 0.20f;
+        uniform_samples[3 * (num_speculative_tokens + 1) + 2] = 0.10f;
+        uniform_samples[3 * (num_speculative_tokens + 1) + 3] = 0.55f;
+
+        auto expected = referenceRejectionSampling(batch_size,
+                                                   num_speculative_tokens,
+                                                   vocab_size,
+                                                   target_token_stride,
+                                                   draft_probs,
+                                                   draft_token_ids,
+                                                   uniform_samples,
+                                                   target_probs,
+                                                   target_token_ids,
+                                                   do_sample);
+
+        RejectionSamplingParams params{
+            cudaFloatTensor({batch_size, num_speculative_tokens, vocab_size}, draft_probs),
+            cudaIntTensor({batch_size, num_speculative_tokens}, draft_token_ids),
+            cudaFloatTensor({batch_size, num_speculative_tokens + 1}, uniform_samples),
+            cudaFloatTensor({batch_size, num_speculative_tokens + 1, vocab_size}, target_probs),
+            cudaIntTensor({batch_size * (num_speculative_tokens + 1), target_token_stride}, target_token_ids),
+            torch::full({batch_size, num_speculative_tokens + 1},
+                        -7,
+                        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+            torch::zeros({batch_size}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+            cudaBoolTensor(do_sample),
+        };
+
+        rejectionSampling(params);
+
+        assertVectorEqual(getTensorValues<int32_t>(params.output_token_ids_d), expected.token_ids);
+        assertVectorEqual(getTensorValues<int32_t>(params.output_accepted_token_num_d), expected.accepted_token_num);
+    }
+
+    void runZeroAndOneSpeculativeTokenCases() {
+        {
+            constexpr int batch_size             = 2;
+            constexpr int num_speculative_tokens = 0;
+            constexpr int vocab_size             = 4;
+            constexpr int target_token_stride    = 2;
+
+            std::vector<float>   draft_probs;
+            std::vector<float>   target_probs(batch_size * (num_speculative_tokens + 1) * vocab_size, 0.25f);
+            std::vector<int32_t> draft_token_ids;
+            std::vector<float>   uniform_samples(batch_size * (num_speculative_tokens + 1), 0.0f);
+            std::vector<int32_t> target_token_ids{10, 2, 11, 3};
+            std::vector<bool>    do_sample{false, true};
+
+            auto expected = referenceRejectionSampling(batch_size,
+                                                       num_speculative_tokens,
+                                                       vocab_size,
+                                                       target_token_stride,
+                                                       draft_probs,
+                                                       draft_token_ids,
+                                                       uniform_samples,
+                                                       target_probs,
+                                                       target_token_ids,
+                                                       do_sample);
+
+            RejectionSamplingParams params{
+                cudaFloatTensor({batch_size, num_speculative_tokens, vocab_size}, draft_probs),
+                cudaIntTensor({batch_size, num_speculative_tokens}, draft_token_ids),
+                cudaFloatTensor({batch_size, num_speculative_tokens + 1}, uniform_samples),
+                cudaFloatTensor({batch_size, num_speculative_tokens + 1, vocab_size}, target_probs),
+                cudaIntTensor({batch_size * (num_speculative_tokens + 1), target_token_stride}, target_token_ids),
+                torch::full({batch_size, num_speculative_tokens + 1},
+                            -7,
+                            torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+                torch::zeros({batch_size}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+                cudaBoolTensor(do_sample),
+            };
+
+            rejectionSampling(params);
+
+            assertVectorEqual(getTensorValues<int32_t>(params.output_token_ids_d), expected.token_ids);
+            assertVectorEqual(getTensorValues<int32_t>(params.output_accepted_token_num_d),
+                              expected.accepted_token_num);
+        }
+
+        {
+            constexpr int batch_size             = 2;
+            constexpr int num_speculative_tokens = 1;
+            constexpr int vocab_size             = 4;
+            constexpr int target_token_stride    = 1;
+
+            std::vector<float>   draft_probs(batch_size * num_speculative_tokens * vocab_size, 0.25f);
+            std::vector<float>   target_probs(batch_size * (num_speculative_tokens + 1) * vocab_size, 0.25f);
+            std::vector<int32_t> draft_token_ids{1, 0};
+            std::vector<float>   uniform_samples(batch_size * (num_speculative_tokens + 1), 0.5f);
+            std::vector<int32_t> target_token_ids{1, 3, 2, 0};
+            std::vector<bool>    do_sample{true, false};
+
+            auto expected = referenceRejectionSampling(batch_size,
+                                                       num_speculative_tokens,
+                                                       vocab_size,
+                                                       target_token_stride,
+                                                       draft_probs,
+                                                       draft_token_ids,
+                                                       uniform_samples,
+                                                       target_probs,
+                                                       target_token_ids,
+                                                       do_sample);
+
+            RejectionSamplingParams params{
+                cudaFloatTensor({batch_size, num_speculative_tokens, vocab_size}, draft_probs),
+                cudaIntTensor({batch_size, num_speculative_tokens}, draft_token_ids),
+                cudaFloatTensor({batch_size, num_speculative_tokens + 1}, uniform_samples),
+                cudaFloatTensor({batch_size, num_speculative_tokens + 1, vocab_size}, target_probs),
+                cudaIntTensor({batch_size * (num_speculative_tokens + 1), target_token_stride}, target_token_ids),
+                torch::full({batch_size, num_speculative_tokens + 1},
+                            -7,
+                            torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+                torch::zeros({batch_size}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA)),
+                cudaBoolTensor(do_sample),
+            };
+
+            rejectionSampling(params);
+
+            assertVectorEqual(getTensorValues<int32_t>(params.output_token_ids_d), expected.token_ids);
+            assertVectorEqual(getTensorValues<int32_t>(params.output_accepted_token_num_d),
+                              expected.accepted_token_num);
+        }
+    }
+
+    void runRejectsInvalidTensorMetadata() {
+        constexpr int batch_size             = 2;
+        constexpr int num_speculative_tokens = 1;
+        constexpr int vocab_size             = 4;
+        constexpr int target_token_stride    = 1;
+
+        auto float_options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+        auto int_options   = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+        auto bool_options  = torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA);
+
+        auto draft_probs =
+            torch::full({batch_size, num_speculative_tokens, vocab_size}, 0.25f, float_options).contiguous();
+        auto draft_token_ids = torch::zeros({batch_size, num_speculative_tokens}, int_options);
+        auto uniform_samples = torch::zeros({batch_size, num_speculative_tokens + 1}, float_options);
+        auto target_probs =
+            torch::full({batch_size, num_speculative_tokens + 1, vocab_size}, 0.25f, float_options).contiguous();
+        auto target_token_ids =
+            torch::zeros({batch_size * (num_speculative_tokens + 1), target_token_stride}, int_options);
+        auto output_token_ids          = torch::zeros({batch_size, num_speculative_tokens + 1}, int_options);
+        auto output_accepted_token_num = torch::zeros({batch_size}, int_options);
+        auto do_sample                 = torch::ones({batch_size}, bool_options);
+
+        auto makeParams = [&]() {
+            return RejectionSamplingParams{draft_probs,
+                                           draft_token_ids,
+                                           uniform_samples,
+                                           target_probs,
+                                           target_token_ids,
+                                           output_token_ids,
+                                           output_accepted_token_num,
+                                           do_sample};
+        };
+
+        auto bad_uniform = torch::zeros({num_speculative_tokens + 1, batch_size}, float_options).transpose(0, 1);
+        auto params      = makeParams();
+        params.uniform_samples_d = bad_uniform;
+        EXPECT_ANY_THROW(rejectionSampling(params));
+
+        params = makeParams();
+        params.target_token_ids_d =
+            torch::zeros({batch_size * (num_speculative_tokens + 1) - 1, target_token_stride}, int_options);
+        EXPECT_ANY_THROW(rejectionSampling(params));
+
+        params                    = makeParams();
+        params.output_token_ids_d = torch::zeros({batch_size, num_speculative_tokens}, int_options);
+        EXPECT_ANY_THROW(rejectionSampling(params));
+
+        params             = makeParams();
+        params.do_sample_d = torch::ones({batch_size + 1}, bool_options);
+        EXPECT_ANY_THROW(rejectionSampling(params));
+
+        params                    = makeParams();
+        params.target_token_ids_d = target_token_ids.cpu();
+        EXPECT_ANY_THROW(rejectionSampling(params));
+
+        params             = makeParams();
+        params.do_sample_d = torch::ones({batch_size}, int_options);
+        EXPECT_ANY_THROW(rejectionSampling(params));
+    }
+
+private:
+    template<typename T>
+    torch::Tensor
+    cudaTensorFromVector(const std::vector<int64_t>& shape, const std::vector<T>& data, c10::ScalarType dtype) {
+        auto cpu = torch::empty(shape, torch::TensorOptions().dtype(dtype));
+        if (!data.empty()) {
+            std::memcpy(cpu.data_ptr<T>(), data.data(), data.size() * sizeof(T));
+        }
+        return cpu.to(torch::kCUDA);
+    }
+
+    template<typename T>
+    std::vector<T> getTensorValues(const torch::Tensor& tensor) {
+        auto           cpu_tensor = tensor.cpu().contiguous();
+        std::vector<T> values(cpu_tensor.numel());
+        std::memcpy(values.data(), cpu_tensor.data_ptr<T>(), sizeof(T) * cpu_tensor.numel());
+        return values;
+    }
+
+    template<typename T>
+    void assertVectorEqual(const std::vector<T>& actual, const std::vector<T>& expected) {
+        ASSERT_EQ(actual.size(), expected.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            ASSERT_EQ(actual[i], expected[i]) << "vectors differ at index " << i;
+        }
+    }
+
+    void setProbRow(std::vector<float>&          probs,
+                    int                          rows_per_batch,
+                    int                          vocab_size,
+                    int                          batch_idx,
+                    int                          row_idx,
+                    std::initializer_list<float> values) {
+        ASSERT_EQ(static_cast<int>(values.size()), vocab_size);
+        auto offset = (batch_idx * rows_per_batch + row_idx) * vocab_size;
+        std::copy(values.begin(), values.end(), probs.begin() + offset);
+    }
+
+    void setTargetTokenIds(std::vector<int32_t>&          target_token_ids,
+                           int                            batch_size,
+                           int                            num_speculative_tokens,
+                           int                            target_token_stride,
+                           int                            batch_idx,
+                           std::initializer_list<int32_t> ids) {
+        (void)batch_size;
+        ASSERT_EQ(static_cast<int>(ids.size()), num_speculative_tokens + 1);
+        int row = 0;
+        for (auto id : ids) {
+            target_token_ids[((batch_idx * (num_speculative_tokens + 1) + row) * target_token_stride)
+                             + target_token_stride - 1] = id;
+            ++row;
+        }
+    }
+
+    ReferenceOutput referenceRejectionSampling(int                         batch_size,
+                                               int                         num_speculative_tokens,
+                                               int                         vocab_size,
+                                               int                         target_token_stride,
+                                               const std::vector<float>&   draft_probs,
+                                               const std::vector<int32_t>& draft_token_ids,
+                                               const std::vector<float>&   uniform_samples,
+                                               const std::vector<float>&   target_probs,
+                                               const std::vector<int32_t>& target_token_ids,
+                                               const std::vector<bool>&    do_sample) {
+        ReferenceOutput output;
+        output.token_ids.assign(batch_size * (num_speculative_tokens + 1), -1);
+        output.accepted_token_num.assign(batch_size, 0);
+
+        for (int batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
+            bool all_same_token = true;
+            int  pos            = num_speculative_tokens;
+            for (int i = 0; i < num_speculative_tokens; ++i) {
+                auto draft_id = draft_token_ids[batch_idx * num_speculative_tokens + i];
+                auto target_id =
+                    targetTokenId(target_token_ids, num_speculative_tokens, target_token_stride, batch_idx, i);
+                auto q = target_probs[((batch_idx * (num_speculative_tokens + 1) + i) * vocab_size) + draft_id];
+                auto p = draft_probs[((batch_idx * num_speculative_tokens + i) * vocab_size) + draft_id];
+                auto u = uniform_samples[batch_idx * (num_speculative_tokens + 1) + i];
+
+                bool same_token = target_id == draft_id;
+                if (same_token || (do_sample[batch_idx] && u * p < q)) {
+                    output.token_ids[batch_idx * (num_speculative_tokens + 1) + i] = draft_id;
+                    all_same_token                                                 = all_same_token && same_token;
+                } else {
+                    pos = i;
+                    break;
+                }
+            }
+
+            output.accepted_token_num[batch_idx] = pos + 1;
+
+            if (all_same_token) {
+                output.token_ids[batch_idx * (num_speculative_tokens + 1) + pos] =
+                    targetTokenId(target_token_ids, num_speculative_tokens, target_token_stride, batch_idx, pos);
+                continue;
+            }
+
+            output.token_ids[batch_idx * (num_speculative_tokens + 1) + pos] = sampleFromReluDiff(
+                batch_idx, pos, num_speculative_tokens, vocab_size, draft_probs, uniform_samples, target_probs);
+        }
+
+        return output;
+    }
+
+    int32_t targetTokenId(const std::vector<int32_t>& target_token_ids,
+                          int                         num_speculative_tokens,
+                          int                         target_token_stride,
+                          int                         batch_idx,
+                          int                         row_idx) {
+        return target_token_ids[((batch_idx * (num_speculative_tokens + 1) + row_idx) * target_token_stride)
+                                + target_token_stride - 1];
+    }
+
+    int32_t sampleFromReluDiff(int                       batch_idx,
+                               int                       pos,
+                               int                       num_speculative_tokens,
+                               int                       vocab_size,
+                               const std::vector<float>& draft_probs,
+                               const std::vector<float>& uniform_samples,
+                               const std::vector<float>& target_probs) {
+        std::vector<float> relu_q_minus_p(vocab_size, 0.0f);
+        float              sum = 0.0f;
+        for (int token_id = 0; token_id < vocab_size; ++token_id) {
+            auto q = target_probs[((batch_idx * (num_speculative_tokens + 1) + pos) * vocab_size) + token_id];
+            auto p = pos == num_speculative_tokens ?
+                         0.0f :
+                         draft_probs[((batch_idx * num_speculative_tokens + pos) * vocab_size) + token_id];
+            relu_q_minus_p[token_id] = std::max(q - p, 0.0f);
+            sum += relu_q_minus_p[token_id];
+        }
+
+        auto uniform_idx = batch_idx * (num_speculative_tokens + 1) + std::min(pos + 1, num_speculative_tokens);
+        auto threshold   = uniform_samples[uniform_idx] * sum;
+        auto aggregate   = 0.0f;
+        for (int token_id = 0; token_id < vocab_size; ++token_id) {
+            aggregate += relu_q_minus_p[token_id];
+            if (relu_q_minus_p[token_id] > 0.0f && aggregate > threshold) {
+                return token_id;
+            }
+        }
+        return vocab_size - 1;
+    }
+};

--- a/rtp_llm/models_py/bindings/core/BUILD
+++ b/rtp_llm/models_py/bindings/core/BUILD
@@ -275,6 +275,38 @@ cc_library(
         ],
         "@//:using_cuda": [
             "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
+            "//rtp_llm/models_py/bindings/cuda/kernels:kernels_speculative_sampling",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "rejection_sampling_ops_test_lib",
+    srcs = [
+        "CudaSampleOp.cc",
+    ],
+    deps = [
+        ":common_defines",
+        ":op_data",
+        "//rtp_llm/cpp/utils:debug_utils",
+        "//rtp_llm/models_py/bindings/common/kernels:kernels_sampling",
+    ] + torch_deps() + select({
+        "@//:using_rocm": [
+            "//rtp_llm/models_py/bindings/rocm/kernels/sampling:sampling",
+            "//rtp_llm/models_py/bindings/rocm:speculative_sampling",
+            "//rtp_llm/models_py/bindings/rocm:rocm_host_utils",
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:rocm",
+        ],
+        "@//:using_cuda": [
+            "//rtp_llm/models_py/bindings/cuda:cuda_host_utils",
+            "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
+            "//rtp_llm/models_py/bindings/cuda/kernels:kernels_speculative_sampling",
+            "//3rdparty/flashinfer:flashinfer",
         ],
         "//conditions:default": [],
     }),
@@ -308,4 +340,3 @@ cc_library(
     visibility = ["//visibility:public"],
     copts = copts(),
 )
-

--- a/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
+++ b/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
@@ -1,11 +1,14 @@
 #include "rtp_llm/models_py/bindings/core/OpData.h"
 #include "rtp_llm/models_py/bindings/core/CommonDefines.h"
 
+#include <limits>
+
 #if USING_CUDA
 #include <ATen/cuda/CUDAContext.h>
 #include "rtp_llm/models_py/bindings/cuda/cuda_host_utils.h"
 #include "rtp_llm/models_py/bindings/common/kernels/sampling_penalty_kernels.h"
 #include "rtp_llm/models_py/bindings/common/kernels/banRepeatNgram.h"
+#include "rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.h"
 #include "rtp_llm/cpp/utils/DebugUtils.h"
 #include "rtp_llm/models_py/bindings/cuda/kernels/sampling/sampling.h"
 #include "3rdparty/flashinfer/flashinfer.h"
@@ -17,6 +20,93 @@
 using namespace std;
 
 namespace rtp_llm {
+
+namespace {
+
+struct RejectionSamplingLaunchConfig {
+    int batch_size;
+    int num_speculative_tokens;
+    int target_vocab_size;
+    int target_token_stride;
+};
+
+void checkRejectionSamplingTensor(const torch::Tensor& tensor, const char* name, c10::ScalarType dtype, int64_t dim) {
+    RTP_LLM_CHECK_WITH_INFO(tensor.defined(), "%s must be defined", name);
+    RTP_LLM_CHECK_WITH_INFO(tensor.is_cuda(), "%s must be on CUDA/HIP device", name);
+    RTP_LLM_CHECK_WITH_INFO(tensor.scalar_type() == dtype, "%s dtype mismatch", name);
+    RTP_LLM_CHECK_WITH_INFO(tensor.dim() == dim,
+                            "%s must be %ld-D, got %ld-D",
+                            name,
+                            static_cast<long>(dim),
+                            static_cast<long>(tensor.dim()));
+    RTP_LLM_CHECK_WITH_INFO(tensor.is_contiguous(), "%s must be contiguous", name);
+}
+
+void checkSameDevice(const torch::Tensor& tensor, const char* name, const c10::Device& device) {
+    RTP_LLM_CHECK_WITH_INFO(tensor.device() == device, "%s must be on the same device as draft_probs_d", name);
+}
+
+RejectionSamplingLaunchConfig validateRejectionSamplingParams(const RejectionSamplingParams& params) {
+    checkRejectionSamplingTensor(params.draft_probs_d, "draft_probs_d", torch::kFloat32, 3);
+    const auto device = params.draft_probs_d.device();
+
+    checkRejectionSamplingTensor(params.draft_token_ids_d, "draft_token_ids_d", torch::kInt32, 2);
+    checkRejectionSamplingTensor(params.uniform_samples_d, "uniform_samples_d", torch::kFloat32, 2);
+    checkRejectionSamplingTensor(params.target_probs_d, "target_probs_d", torch::kFloat32, 3);
+    checkRejectionSamplingTensor(params.target_token_ids_d, "target_token_ids_d", torch::kInt32, 2);
+    checkRejectionSamplingTensor(params.output_token_ids_d, "output_token_ids_d", torch::kInt32, 2);
+    checkRejectionSamplingTensor(params.output_accepted_token_num_d, "output_accepted_token_num_d", torch::kInt32, 1);
+    checkRejectionSamplingTensor(params.do_sample_d, "do_sample_d", torch::kBool, 1);
+
+    checkSameDevice(params.draft_token_ids_d, "draft_token_ids_d", device);
+    checkSameDevice(params.uniform_samples_d, "uniform_samples_d", device);
+    checkSameDevice(params.target_probs_d, "target_probs_d", device);
+    checkSameDevice(params.target_token_ids_d, "target_token_ids_d", device);
+    checkSameDevice(params.output_token_ids_d, "output_token_ids_d", device);
+    checkSameDevice(params.output_accepted_token_num_d, "output_accepted_token_num_d", device);
+    checkSameDevice(params.do_sample_d, "do_sample_d", device);
+
+    const int64_t batch_size             = params.draft_probs_d.size(0);
+    const int64_t num_speculative_tokens = params.draft_probs_d.size(1);
+    const int64_t target_vocab_size      = params.draft_probs_d.size(2);
+    const int64_t target_token_stride    = params.target_token_ids_d.size(1);
+
+    RTP_LLM_CHECK_WITH_INFO(target_vocab_size > 0, "target_vocab_size must be positive");
+    RTP_LLM_CHECK_WITH_INFO(target_token_stride > 0, "target_token_ids_d stride dimension must be positive");
+    RTP_LLM_CHECK_WITH_INFO(batch_size <= std::numeric_limits<int>::max(), "batch_size too large");
+    RTP_LLM_CHECK_WITH_INFO(num_speculative_tokens <= std::numeric_limits<int>::max(),
+                            "num_speculative_tokens too large");
+    RTP_LLM_CHECK_WITH_INFO(target_vocab_size <= std::numeric_limits<int>::max(), "target_vocab_size too large");
+    RTP_LLM_CHECK_WITH_INFO(target_token_stride <= std::numeric_limits<int>::max(), "target_token_stride too large");
+
+    const int64_t target_token_rows = batch_size * (num_speculative_tokens + 1);
+
+    RTP_LLM_CHECK_WITH_INFO(params.draft_token_ids_d.size(0) == batch_size, "draft_token_ids_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.draft_token_ids_d.size(1) == num_speculative_tokens,
+                            "draft_token_ids_d shape[1] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.uniform_samples_d.size(0) == batch_size, "uniform_samples_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.uniform_samples_d.size(1) == num_speculative_tokens + 1,
+                            "uniform_samples_d shape[1] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.target_probs_d.size(0) == batch_size, "target_probs_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.target_probs_d.size(1) == num_speculative_tokens + 1,
+                            "target_probs_d shape[1] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.target_probs_d.size(2) == target_vocab_size, "target_probs_d shape[2] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.target_token_ids_d.size(0) == target_token_rows,
+                            "target_token_ids_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.output_token_ids_d.size(0) == batch_size, "output_token_ids_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.output_token_ids_d.size(1) == num_speculative_tokens + 1,
+                            "output_token_ids_d shape[1] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.output_accepted_token_num_d.size(0) == batch_size,
+                            "output_accepted_token_num_d shape[0] mismatch");
+    RTP_LLM_CHECK_WITH_INFO(params.do_sample_d.size(0) == batch_size, "do_sample_d shape[0] mismatch");
+
+    return {static_cast<int>(batch_size),
+            static_cast<int>(num_speculative_tokens),
+            static_cast<int>(target_vocab_size),
+            static_cast<int>(target_token_stride)};
+}
+
+}  // anonymous namespace
 
 #if USING_CUDA
 
@@ -287,6 +377,25 @@ void chainSpeculativeSampling(const SpeculativeSamplingParams& params) {
                                int64_t(stream));
 }
 
+void rejectionSampling(const RejectionSamplingParams& params) {
+    auto config = validateRejectionSamplingParams(params);
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+
+    check_cuda_value(invokeRejectionSampling(params.draft_probs_d.data_ptr<float>(),
+                                             params.draft_token_ids_d.data_ptr<int32_t>(),
+                                             params.uniform_samples_d.data_ptr<float>(),
+                                             params.target_probs_d.data_ptr<float>(),
+                                             params.target_token_ids_d.data_ptr<int32_t>(),
+                                             config.target_token_stride,
+                                             params.output_token_ids_d.data_ptr<int32_t>(),
+                                             params.output_accepted_token_num_d.data_ptr<int32_t>(),
+                                             params.do_sample_d.data_ptr<bool>(),
+                                             config.batch_size,
+                                             config.num_speculative_tokens,
+                                             config.target_vocab_size,
+                                             stream));
+}
+
 #else  // !USING_CUDA — ROCm platform
 
 }  // namespace rtp_llm — temporarily close for includes
@@ -523,6 +632,21 @@ void chain_speculative_sampling(at::Tensor draft_probs,
                                 bool       deterministic,
                                 int64_t    hip_stream);
 
+template<typename DType, typename IdType>
+hipError_t invokeRejectionSampling(DType*      draft_probs,
+                                   IdType*     draft_token_ids,
+                                   DType*      uniform_samples,
+                                   DType*      target_probs,
+                                   IdType*     target_token_ids,
+                                   int         target_token_stride,
+                                   IdType*     output_token_ids,
+                                   IdType*     output_accepted_token_num,
+                                   bool*       do_sample,
+                                   int         batch_size,
+                                   int         num_speculative_tokens,
+                                   int         target_vocab_size,
+                                   hipStream_t stream);
+
 namespace rtp_llm {
 
 void chainSpeculativeSampling(const SpeculativeSamplingParams& params) {
@@ -536,6 +660,26 @@ void chainSpeculativeSampling(const SpeculativeSamplingParams& params) {
                                  params.output_emitted_token_num_d,
                                  true,
                                  int64_t(stream));
+}
+
+void rejectionSampling(const RejectionSamplingParams& params) {
+    auto config = validateRejectionSamplingParams(params);
+    auto stream = at::hip::getCurrentHIPStream().stream();
+
+    hipError_t err = ::invokeRejectionSampling(params.draft_probs_d.data_ptr<float>(),
+                                               params.draft_token_ids_d.data_ptr<int32_t>(),
+                                               params.uniform_samples_d.data_ptr<float>(),
+                                               params.target_probs_d.data_ptr<float>(),
+                                               params.target_token_ids_d.data_ptr<int32_t>(),
+                                               config.target_token_stride,
+                                               params.output_token_ids_d.data_ptr<int32_t>(),
+                                               params.output_accepted_token_num_d.data_ptr<int32_t>(),
+                                               params.do_sample_d.data_ptr<bool>(),
+                                               config.batch_size,
+                                               config.num_speculative_tokens,
+                                               config.target_vocab_size,
+                                               stream);
+    RTP_LLM_CHECK_WITH_INFO(err == hipSuccess, "invokeRejectionSampling failed: %s", hipGetErrorString(err));
 }
 
 #endif  // USING_CUDA

--- a/rtp_llm/models_py/bindings/core/ExecOps.cc
+++ b/rtp_llm/models_py/bindings/core/ExecOps.cc
@@ -33,6 +33,7 @@ namespace rtp_llm {
 GreedyOutput     sampleGreedy(const GreedyParams& params);
 BeamSearchOutput sampleBeamSearch(BeamSearchParams params);
 void             chainSpeculativeSampling(const SpeculativeSamplingParams& params);
+void             rejectionSampling(const RejectionSamplingParams& params);
 void             multiMergeCopy(const MultiMergeCopyParams& params);
 }  // namespace rtp_llm
 
@@ -425,6 +426,10 @@ BeamSearchOutput execSampleBeamSearch(BeamSearchParams params) {
 
 void execChainSpeculativeSampling(const SpeculativeSamplingParams& params) {
     chainSpeculativeSampling(params);
+}
+
+void execRejectionSampling(const RejectionSamplingParams& params) {
+    rejectionSampling(params);
 }
 
 // === Communication ops (Python callbacks via pybind11) ===

--- a/rtp_llm/models_py/bindings/core/ExecOps.h
+++ b/rtp_llm/models_py/bindings/core/ExecOps.h
@@ -83,6 +83,7 @@ void fusedStridedCopy(const FusedStridedCopyParams& params);
 GreedyOutput     execSampleGreedy(const GreedyParams& params);
 BeamSearchOutput execSampleBeamSearch(BeamSearchParams params);
 void             execChainSpeculativeSampling(const SpeculativeSamplingParams& params);
+void             execRejectionSampling(const RejectionSamplingParams& params);
 
 // ===================================================================
 // Communication ops (backed by c10d ProcessGroup)

--- a/rtp_llm/models_py/bindings/core/OpData.h
+++ b/rtp_llm/models_py/bindings/core/OpData.h
@@ -387,4 +387,15 @@ struct SpeculativeSamplingParams {
         output_emitted_token_num_d(output_emitted_token_num_d) {}
 };
 
+struct RejectionSamplingParams {
+    torch::Tensor draft_probs_d;
+    torch::Tensor draft_token_ids_d;
+    torch::Tensor uniform_samples_d;
+    torch::Tensor target_probs_d;
+    torch::Tensor target_token_ids_d;
+    torch::Tensor output_token_ids_d;
+    torch::Tensor output_accepted_token_num_d;
+    torch::Tensor do_sample_d;
+};
+
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/BUILD
@@ -164,6 +164,22 @@ cc_library(
 )
 
 cc_library(
+    name = "kernels_speculative_sampling",
+    srcs = glob(["speculative_sampling/*.cu"]),
+    hdrs = glob([
+        "speculative_sampling/*.h",
+        "speculative_sampling/*.cuh",
+    ]),
+    deps = cuda_deps + [
+        "//rtp_llm/cpp/utils:core_utils",
+        "//rtp_llm/models_py/bindings/cuda:launch_utils",
+    ],
+    copts = any_cuda_copts(),
+    include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "kernels_mla",
     srcs = glob(["mla_kernels/*.cu"]),
     hdrs = glob([

--- a/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/exception.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/exception.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_EXCEPTION_H_
+#define FLASHINFER_EXCEPTION_H_
+
+#include <exception>
+#include <sstream>
+
+namespace flashinfer {
+
+class Error: public std::exception {
+private:
+    std::string message_;
+
+public:
+    Error(const std::string& func, const std::string& file, int line, const std::string& message) {
+        std::ostringstream oss;
+        oss << "Error in function '" << func << "' "
+            << "at " << file << ":" << line << ": " << message;
+        message_ = oss.str();
+    }
+
+    virtual const char* what() const noexcept override {
+        return message_.c_str();
+    }
+};
+
+#define FLASHINFER_ERROR(message) throw flashinfer::Error(__FUNCTION__, __FILE__, __LINE__, message)
+
+#define FLASHINFER_CHECK(condition, message)                                                                           \
+    if (!(condition)) {                                                                                                \
+        FLASHINFER_ERROR(message);                                                                                     \
+    }
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_EXCEPTION_H_

--- a/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.cu
@@ -1,0 +1,441 @@
+#include "rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.h"
+#include "rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/vec_dtypes.cuh"
+#include "rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/util.cuh"
+
+#include <cstdint>
+#include <numeric>
+#include <cuda/std/limits>
+#include <cub/block/block_adjacent_difference.cuh>
+#include <cub/block/block_reduce.cuh>
+#include <cub/block/block_scan.cuh>
+#include <cuda_runtime.h>
+
+namespace rtp_llm {
+using namespace cub;
+
+constexpr BlockScanAlgorithm   SCAN_ALGO   = BLOCK_SCAN_WARP_SCANS;
+constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
+
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
+#define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+#endif
+
+template<typename T>
+struct Pair {
+    T   value;
+    int count;
+
+    __device__ Pair operator+(const Pair& other) const {
+        return {value + other.value, count + other.count};
+    }
+    __device__ Pair& operator+=(const Pair& other) {
+        value += other.value;
+        count += other.count;
+        return *this;
+    }
+};
+
+struct BoolDiffOp {
+    __device__ __forceinline__ bool operator()(const bool& lhs, const bool& rhs) const {
+        return lhs != rhs;
+    }
+};
+
+template<typename T, uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM, BlockReduceAlgorithm REDUCE_ALGORITHM>
+struct SamplingTempStorage {
+    union {
+        T                                                                     deterministic_scan[BLOCK_THREADS / 32];
+        typename BlockScan<T, BLOCK_THREADS, SCAN_ALGORITHM>::TempStorage     scan;
+        typename BlockReduce<T, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce;
+        typename BlockReduce<Pair<T>, BLOCK_THREADS, REDUCE_ALGORITHM>::TempStorage reduce_pair;
+        typename BlockAdjacentDifference<bool, BLOCK_THREADS>::TempStorage          adj_diff;
+    } block_prim;
+    struct {
+        int32_t sampled_id;
+        union {
+            T       value;
+            Pair<T> pair;
+            T       max_p;
+        } block_aggregate;
+    };
+};
+
+/*!
+ * \brief Deterministic inclusive scan implementation, use Belloch scan algorithm.
+ * \note This implementation is slower than the cub::BlockScan, but it is deterministic.
+ */
+template<uint32_t             VEC_SIZE,
+         uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         typename T>
+__device__ __forceinline__ void
+DeterministicInclusiveSum(const T*                                                                 in_data,
+                          T*                                                                       out_data,
+                          SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+    T* smem_prefix_sum = temp_storage->block_prim.deterministic_scan;
+    T  thread_data[VEC_SIZE];
+    T  thread_sum = 0;
+#pragma unroll
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+        thread_sum += in_data[i];
+        thread_data[i] = thread_sum;
+    }
+
+    T thread_exclusive_prefix_sum = thread_sum;
+
+#pragma unroll
+    for (uint32_t offset = 1; offset < 32; offset *= 2) {
+        T tmp = __shfl_up_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+        if ((threadIdx.x + 1) % (offset * 2) == 0) {
+            thread_exclusive_prefix_sum += tmp;
+        }
+    }
+
+    T warp_sum = __shfl_sync(0xffffffff, thread_exclusive_prefix_sum, threadIdx.x | 0xffffffff);
+    if (threadIdx.x % 32 == 31) {
+        thread_exclusive_prefix_sum = 0;
+    }
+
+#pragma unroll
+    for (uint32_t offset = 16; offset >= 1; offset /= 2) {
+        T tmp = __shfl_xor_sync(0xffffffff, thread_exclusive_prefix_sum, offset);
+        if ((threadIdx.x + 1) % (offset * 2) == 0) {
+            thread_exclusive_prefix_sum = tmp + thread_exclusive_prefix_sum;
+        }
+        if ((threadIdx.x + 1) % (offset * 2) == offset) {
+            thread_exclusive_prefix_sum = tmp;
+        }
+    }
+
+    smem_prefix_sum[threadIdx.x / 32] = warp_sum;
+    __syncthreads();
+
+    if (threadIdx.x < 32) {
+        T warp_exclusive_prefix_sum = (threadIdx.x < BLOCK_THREADS / 32) ? smem_prefix_sum[threadIdx.x] : 0;
+
+#pragma unroll
+        for (uint32_t offset = 1; offset < 32; offset *= 2) {
+            T tmp = __shfl_up_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+            if ((threadIdx.x + 1) % (offset * 2) == 0) {
+                warp_exclusive_prefix_sum += tmp;
+            }
+        }
+
+        if (threadIdx.x % 32 == 31) {
+            warp_exclusive_prefix_sum = 0;
+        }
+
+#pragma unroll
+        for (uint32_t offset = 16; offset >= 1; offset /= 2) {
+            T tmp = __shfl_xor_sync(0xffffffff, warp_exclusive_prefix_sum, offset);
+            if ((threadIdx.x + 1) % (offset * 2) == 0) {
+                warp_exclusive_prefix_sum = tmp + warp_exclusive_prefix_sum;
+            }
+            if ((threadIdx.x + 1) % (offset * 2) == offset) {
+                warp_exclusive_prefix_sum = tmp;
+            }
+        }
+        if (threadIdx.x < BLOCK_THREADS / 32) {
+            smem_prefix_sum[threadIdx.x] = warp_exclusive_prefix_sum;
+        }
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (uint32_t i = 0; i < VEC_SIZE; ++i) {
+        out_data[i] = smem_prefix_sum[threadIdx.x / 32] + thread_exclusive_prefix_sum + thread_data[i];
+    }
+}
+
+template<uint32_t             VEC_SIZE,
+         uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         bool                 DETERMINISTIC,
+         typename T,
+         typename Predicate>
+__device__ __forceinline__ void
+DeviceSamplingFromProb(uint32_t                                                                 i,
+                       uint32_t                                                                 d,
+                       Predicate                                                                pred,
+                       T                                                                        u,
+                       flashinfer::vec_t<T, VEC_SIZE>                                           prob_vec,
+                       T&                                                                       aggregate,
+                       SamplingTempStorage<T, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>* temp_storage) {
+    const uint32_t tx = threadIdx.x;
+    T              prob_greater_than_threshold[VEC_SIZE];
+    T              inclusive_cdf[VEC_SIZE];
+    bool           greater_than_u[VEC_SIZE], valid[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+        prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : T(0);
+        valid[j]                       = pred(prob_vec[j]) && (i * BLOCK_THREADS + tx) * VEC_SIZE < d;
+    }
+    T aggregate_local = BlockReduce<T, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
+                            .template Sum<VEC_SIZE>(prob_greater_than_threshold);
+    if (tx == 0) {
+        temp_storage->block_aggregate.value = aggregate_local;
+    }
+    __syncthreads();
+    aggregate_local = temp_storage->block_aggregate.value;
+
+    if (aggregate + aggregate_local > u) {
+        if constexpr (DETERMINISTIC) {
+            DeterministicInclusiveSum<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, T>(
+                prob_greater_than_threshold, inclusive_cdf, temp_storage);
+        } else {
+            BlockScan<T, BLOCK_THREADS, SCAN_ALGORITHM>(temp_storage->block_prim.scan)
+                .template InclusiveSum<VEC_SIZE>(prob_greater_than_threshold, inclusive_cdf);
+
+            __syncthreads();
+        }
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            greater_than_u[j] = (inclusive_cdf[j] + aggregate > u) && valid[j];
+        }
+
+        bool greater_than_u_diff[VEC_SIZE];
+#ifdef FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
+        BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+            .template SubtractLeft<VEC_SIZE>(greater_than_u, greater_than_u_diff, BoolDiffOp());
+#else
+        BlockAdjacentDifference<bool, BLOCK_THREADS>(temp_storage->block_prim.adj_diff)
+            .template FlagHeads<VEC_SIZE>(greater_than_u_diff, greater_than_u, BoolDiffOp(), 0);
+#endif
+        __syncthreads();
+
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            if (greater_than_u_diff[j]) {
+                atomicMin(&(temp_storage->sampled_id), (i * BLOCK_THREADS + tx) * VEC_SIZE + j);
+            }
+        }
+        __syncthreads();
+    }
+    aggregate += aggregate_local;
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
+__global__ void rejection_sampling_kernel(DType*  draft_probs,
+                                          IdType* draft_token_ids,
+                                          DType*  uniform_samples,
+                                          DType*  target_probs,
+                                          IdType* target_token_ids,
+                                          int     target_token_stride,
+                                          IdType* output_token_ids,
+                                          IdType* output_accepted_token_num,
+                                          bool*   do_sample,
+                                          int     batch_size,
+                                          int     num_speculative_tokens,
+                                          int     target_vocab_size) {
+    const uint32_t bx = blockIdx.x, tx = threadIdx.x;
+    const uint32_t row_idx = bx;
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    if (row_idx >= batch_size) {
+        return;
+    }
+
+    // Accept loop is serial — only thread 0 performs it and broadcasts results via shared memory.
+    __shared__ int  s_pos;
+    __shared__ bool s_all_same_token;
+
+    if (tx == 0) {
+        bool all_same_token = true;
+        int  pos            = num_speculative_tokens;
+        for (int i = 0; i < num_speculative_tokens; ++i) {
+            IdType draft_id  = draft_token_ids[row_idx * num_speculative_tokens + i];
+            IdType target_id = target_token_ids[(row_idx * (num_speculative_tokens + 1) + i) * target_token_stride
+                                                + target_token_stride - 1];
+
+            float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * target_vocab_size + draft_id],
+                  p = draft_probs[(row_idx * num_speculative_tokens + i) * target_vocab_size + draft_id];
+            DType u = uniform_samples[row_idx * (num_speculative_tokens + 1) + i];
+
+            bool same_token = target_id == draft_id;
+            if (same_token || (do_sample[row_idx] && u * p < q)) {
+                output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
+                all_same_token                                               = all_same_token && same_token;
+            } else {
+                // Keep all_same_token as-is. If every previous accepted token was an exact target/draft match,
+                // the verifier token at this rejected position is already target-distributed and can be emitted.
+                pos = i;
+                break;
+            }
+        }
+
+        output_accepted_token_num[row_idx] = pos + 1;
+
+        if (all_same_token) {
+            IdType bonus_token_id =
+                target_token_ids[(row_idx * (num_speculative_tokens + 1) + pos) * target_token_stride
+                                 + target_token_stride - 1];
+            output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = bonus_token_id;
+            for (int p = pos + 1; p < num_speculative_tokens + 1; ++p) {
+                output_token_ids[row_idx * (num_speculative_tokens + 1) + p] = -1;
+            }
+        }
+
+        s_pos            = pos;
+        s_all_same_token = all_same_token;
+    }
+    __syncthreads();
+
+    if (s_all_same_token) {
+        return;
+    }
+    int pos = s_pos;
+
+    // sample from relu(target_probs - draft_probs)
+    DType                              sum_relu_q_minus_p(0);
+    flashinfer::vec_t<DType, VEC_SIZE> q_vec, p_vec;
+    DType                              relu_q_minus_p[VEC_SIZE];
+    for (uint32_t i = 0; i < flashinfer::ceil_div(target_vocab_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(DType(0));
+        p_vec.fill(DType(0));
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < target_vocab_size) {
+            q_vec.load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * target_vocab_size
+                       + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.load(draft_probs + (row_idx * num_speculative_tokens + pos) * target_vocab_size
+                           + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], DType(0));
+        }
+        sum_relu_q_minus_p += BlockReduce<DType, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                                  .template Sum<VEC_SIZE>(relu_q_minus_p);
+        __syncthreads();
+    }
+    if (tx == 0) {
+        temp_storage.block_aggregate.value = sum_relu_q_minus_p;
+    }
+    // init the first rejected token to (d - 1)
+    temp_storage.sampled_id = target_vocab_size - 1;
+    __syncthreads();
+    sum_relu_q_minus_p = temp_storage.block_aggregate.value;
+    DType u            = uniform_samples[row_idx * (num_speculative_tokens + 1) + min(pos + 1, num_speculative_tokens)]
+              * sum_relu_q_minus_p;
+
+    DType aggregate_relu_q_minus_p(0);
+    for (uint32_t i = 0; i < flashinfer::ceil_div(target_vocab_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(DType(0));
+        p_vec.fill(DType(0));
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < target_vocab_size) {
+            q_vec.load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * target_vocab_size
+                       + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.load(draft_probs + (row_idx * num_speculative_tokens + pos) * target_vocab_size
+                           + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+
+        flashinfer::vec_t<DType, VEC_SIZE> relu_q_minus_p_vec;
+#pragma unroll
+        for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], DType(0));
+        }
+
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC, DType>(
+            i,
+            target_vocab_size,
+            [&](DType x) { return x > 0; },
+            u,
+            relu_q_minus_p_vec,
+            aggregate_relu_q_minus_p,
+            &temp_storage);
+        if (aggregate_relu_q_minus_p > u) {
+            break;
+        }
+    }
+    __syncthreads();
+    if (tx == 0) {
+        // set the first rejected token
+        output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = temp_storage.sampled_id;
+        // pad remaining tokens with -1
+        for (int p = pos + 1; p < num_speculative_tokens + 1; ++p) {
+            output_token_ids[row_idx * (num_speculative_tokens + 1) + p] = -1;
+        }
+    }
+}
+
+template<typename DType, typename IdType>
+cudaError_t invokeRejectionSampling(DType*       draft_probs,
+                                    IdType*      draft_token_ids,
+                                    DType*       uniform_samples,
+                                    DType*       target_probs,
+                                    IdType*      target_token_ids,
+                                    int          target_token_stride,
+                                    IdType*      output_token_ids,
+                                    IdType*      output_accepted_token_num,
+                                    bool*        do_sample,
+                                    int          batch_size,
+                                    int          num_speculative_tokens,
+                                    int          target_vocab_size,
+                                    cudaStream_t stream) {
+    if (batch_size == 0) {
+        return cudaSuccess;
+    }
+
+    constexpr uint32_t BLOCK_THREADS = 1024;
+    const uint32_t     vec_size      = std::gcd(16 / sizeof(DType), target_vocab_size);
+
+    const uint32_t smem_size = sizeof(SamplingTempStorage<DType, BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3           nblks(batch_size);
+    dim3           nthrs(BLOCK_THREADS);
+
+    void* args[] = {&draft_probs,
+                    &draft_token_ids,
+                    &uniform_samples,
+                    &target_probs,
+                    &target_token_ids,
+                    &target_token_stride,
+                    &output_token_ids,
+                    &output_accepted_token_num,
+                    &do_sample,
+                    &batch_size,
+                    &num_speculative_tokens,
+                    &target_vocab_size};
+
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        auto kernel = rejection_sampling_kernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE, false, DType, IdType>;
+        FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+        FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+    });
+
+    return cudaSuccess;
+}
+
+#define INSTANTIATE_REJECTION_SAMPLING(DType, IdType)                                                                  \
+    template cudaError_t invokeRejectionSampling(DType*       draft_probs,                                             \
+                                                 IdType*      draft_token_ids,                                         \
+                                                 DType*       uniform_samples,                                         \
+                                                 DType*       target_probs,                                            \
+                                                 IdType*      target_token_ids,                                        \
+                                                 int          target_token_stride,                                     \
+                                                 IdType*      output_token_ids,                                        \
+                                                 IdType*      output_accepted_token_num,                               \
+                                                 bool*        do_sample,                                               \
+                                                 int          batch_size,                                              \
+                                                 int          num_speculative_tokens,                                  \
+                                                 int          target_vocab_size,                                       \
+                                                 cudaStream_t stream);
+
+INSTANTIATE_REJECTION_SAMPLING(float, int);
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/sampling.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+#ifdef USING_ROCM
+#include "rtp_llm/models_py/bindings/rocm/cuda_shims.h"
+#endif
+
+#if USING_CUDA
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#endif
+
+namespace rtp_llm {
+
+template<typename DType, typename IdType>
+cudaError_t invokeRejectionSampling(DType*       draft_probs,
+                                    IdType*      draft_token_ids,
+                                    DType*       uniform_samples,
+                                    DType*       target_probs,
+                                    IdType*      target_token_ids,
+                                    int          target_token_stride,
+                                    IdType*      output_token_ids,
+                                    IdType*      output_accepted_token_num,
+                                    bool*        do_sample,
+                                    int          batch_size,
+                                    int          num_speculative_tokens,
+                                    int          target_vocab_size,
+                                    cudaStream_t stream);
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/util.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/util.cuh
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_UTILS_CUH_
+#define FLASHINFER_UTILS_CUH_
+#include <cuda_bf16.h>
+#include <cuda_device_runtime_api.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+#include "rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/exception.h"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+// macro to turn off fp16 qk reduction to reduce binary
+#ifndef FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION
+#define FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION 0
+#endif
+
+#ifndef NDEBUG
+#define FLASHINFER_CUDA_CALL(func, ...)                                                                                \
+    {                                                                                                                  \
+        cudaError_t e = (func);                                                                                        \
+        if (e != cudaSuccess) {                                                                                        \
+            std::cerr << "CUDA Error: " << cudaGetErrorString(e) << " (" << e << ") " << __FILE__ << ": line "         \
+                      << __LINE__ << " at function " << STR(func) << std::endl;                                        \
+            return e;                                                                                                  \
+        }                                                                                                              \
+    }
+#else
+#define FLASHINFER_CUDA_CALL(func, ...)                                                                                \
+    {                                                                                                                  \
+        cudaError_t e = (func);                                                                                        \
+        if (e != cudaSuccess) {                                                                                        \
+            return e;                                                                                                  \
+        }                                                                                                              \
+    }
+#endif
+
+#define DISPATCH_ALIGNED_VEC_SIZE(aligned_vec_size, ALIGNED_VEC_SIZE, ...)                                             \
+    switch (aligned_vec_size) {                                                                                        \
+        case 16: {                                                                                                     \
+            constexpr size_t ALIGNED_VEC_SIZE = 16;                                                                    \
+            __VA_ARGS__                                                                                                \
+            break;                                                                                                     \
+        }                                                                                                              \
+        case 8: {                                                                                                      \
+            constexpr size_t ALIGNED_VEC_SIZE = 8;                                                                     \
+            __VA_ARGS__                                                                                                \
+            break;                                                                                                     \
+        }                                                                                                              \
+        case 4: {                                                                                                      \
+            constexpr size_t ALIGNED_VEC_SIZE = 4;                                                                     \
+            __VA_ARGS__                                                                                                \
+            break;                                                                                                     \
+        }                                                                                                              \
+        case 2: {                                                                                                      \
+            constexpr size_t ALIGNED_VEC_SIZE = 2;                                                                     \
+            __VA_ARGS__                                                                                                \
+            break;                                                                                                     \
+        }                                                                                                              \
+        case 1: {                                                                                                      \
+            constexpr size_t ALIGNED_VEC_SIZE = 1;                                                                     \
+            __VA_ARGS__                                                                                                \
+            break;                                                                                                     \
+        }                                                                                                              \
+        default: {                                                                                                     \
+            std::ostringstream err_msg;                                                                                \
+            err_msg << "Unsupported aligned_vec_size: " << aligned_vec_size;                                           \
+            FLASHINFER_ERROR(err_msg.str());                                                                           \
+        }                                                                                                              \
+    }
+
+namespace flashinfer {
+
+template<typename T1, typename T2>
+__forceinline__ __device__ __host__ T1 ceil_div(const T1 x, const T2 y) {
+    return (x + y - 1) / y;
+}
+
+inline std::pair<int, int> GetCudaComputeCapability() {
+    int device_id = 0;
+    cudaGetDevice(&device_id);
+    int major = 0, minor = 0;
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id);
+    cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id);
+    return std::make_pair(major, minor);
+}
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_UTILS_CUH_

--- a/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/vec_dtypes.cuh
+++ b/rtp_llm/models_py/bindings/cuda/kernels/speculative_sampling/vec_dtypes.cuh
@@ -1,0 +1,1522 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef VEC_DTYPES_CUH_
+#define VEC_DTYPES_CUH_
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <type_traits>
+
+namespace flashinfer {
+
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
+#define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+#endif
+
+#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
+
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 < 120400)                                               \
+    && (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+// CUDA version < 12.4 and GPU architecture < 80
+FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y) {
+    __nv_bfloat162 t;
+    t.x = x;
+    t.y = y;
+    return t;
+}
+
+FLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
+    __nv_bfloat16 val;
+    const float   fa = __bfloat162float(a);
+    const float   fb = __bfloat162float(b);
+    // avoid ftz in device code
+    val = __float2bfloat16(__fmaf_ieee_rn(fa, fb, -0.0f));
+    return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+    __nv_bfloat162 val;
+    val.x = __hmul(a.x, b.x);
+    val.y = __hmul(a.y, b.y);
+    return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __floats2bfloat162_rn(const float a, const float b) {
+    __nv_bfloat162 val;
+    val = __nv_bfloat162(__float2bfloat16_rn(a), __float2bfloat16_rn(b));
+    return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __float22bfloat162_rn(const float2 a) {
+    __nv_bfloat162 val = __floats2bfloat162_rn(a.x, a.y);
+    return val;
+}
+FLASHINFER_INLINE float2 __bfloat1622float2(const __nv_bfloat162 a) {
+    float hi_float;
+    float lo_float;
+    lo_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).x);
+    hi_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).y);
+    return make_float2(lo_float, hi_float);
+}
+#endif
+
+/******************* vec_t type cast *******************/
+
+template<typename dst_t, typename src_t>
+struct vec_cast {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(dst_t* dst, const src_t* src) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size; ++i) {
+            dst[i] = (dst_t)src[i];
+        }
+    }
+};
+
+template<>
+struct vec_cast<float, half> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(float* dst, const half* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = (float)src[0];
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                ((float2*)dst)[i] = __half22float2(((half2*)src)[i]);
+            }
+        }
+    }
+};
+
+template<>
+struct vec_cast<half, float> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(half* dst, const float* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = __float2half(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                ((half2*)dst)[i] = __float22half2_rn(((float2*)src)[i]);
+            }
+        }
+    }
+};
+
+template<typename T>
+constexpr FLASHINFER_INLINE int get_exponent_bits() {
+    if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+        return 4;
+    } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+        return 5;
+    } else if constexpr (std::is_same_v<T, half>) {
+        return 5;
+    } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+        return 8;
+    }
+}
+
+template<typename T>
+constexpr FLASHINFER_INLINE int get_mantissa_bits() {
+    if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+        return 3;
+    } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+        return 2;
+    } else if constexpr (std::is_same_v<T, half>) {
+        return 11;
+    } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+        return 7;
+    }
+}
+
+/*!
+ * \brief Fallback to software fast dequant implementation if hardware dequantization is not
+ * available.
+ * \note Inspired by Marlin's fast dequantization, but here we don't have to permute
+ * weights order.
+ * \ref
+ * https://github.com/vllm-project/vllm/blob/6dffa4b0a6120159ef2fe44d695a46817aff65bc/csrc/quantization/fp8/fp8_marlin.cu#L120
+ */
+template<typename fp8_dtype, typename fp16_dtype>
+__device__ void fast_dequant_f8f16x4(uint32_t* input, uint2* output) {
+    uint32_t q = *input;
+    if constexpr (std::is_same_v<fp8_dtype, __nv_fp8_e5m2> && std::is_same_v<fp16_dtype, half>) {
+        output->x = __byte_perm(0U, q, 0x5140);
+        output->y = __byte_perm(0U, q, 0x7362);
+    } else {
+        constexpr int FP8_EXPONENT  = get_exponent_bits<fp8_dtype>();
+        constexpr int FP8_MANTISSA  = get_mantissa_bits<fp8_dtype>();
+        constexpr int FP16_EXPONENT = get_exponent_bits<fp16_dtype>();
+
+        constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
+        // Calculate MASK for extracting mantissa and exponent
+        constexpr int MASK1 = 0x80000000;
+        constexpr int MASK2 = MASK1 >> (FP8_EXPONENT + FP8_MANTISSA);
+        constexpr int MASK3 = MASK2 & 0x7fffffff;
+        constexpr int MASK  = MASK3 | (MASK3 >> 16);
+        q                   = __byte_perm(q, q, 0x1302);
+
+        // Extract and shift FP8 values to FP16 format
+        uint32_t Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+        uint32_t Out2 = ((q << 8) & 0x80008000) | (((q << 8) & MASK) >> RIGHT_SHIFT);
+
+        constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+        // Construct and apply exponent bias
+        if constexpr (std::is_same_v<fp16_dtype, half>) {
+            const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+            // Convert to half2 and apply bias
+            *(half2*)&(output->x) = __hmul2(*reinterpret_cast<const half2*>(&Out1), bias_reg);
+            *(half2*)&(output->y) = __hmul2(*reinterpret_cast<const half2*>(&Out2), bias_reg);
+        } else {
+            constexpr uint32_t BIAS     = (BIAS_OFFSET + 127) << 23;
+            const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+            // Convert to bfloat162 and apply bias
+            *(nv_bfloat162*)&(output->x) = __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out1), bias_reg);
+            *(nv_bfloat162*)&(output->y) = __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out2), bias_reg);
+        }
+    }
+}
+
+template<>
+struct vec_cast<nv_bfloat16, __nv_fp8_e4m3> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e4m3* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = nv_bfloat16(src[0]);
+        } else if constexpr (vec_size == 2) {
+            dst[0] = nv_bfloat16(src[0]);
+            dst[1] = nv_bfloat16(src[1]);
+        } else {
+            static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+            for (uint32_t i = 0; i < vec_size / 4; ++i) {
+                fast_dequant_f8f16x4<__nv_fp8_e4m3, nv_bfloat16>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+            }
+        }
+    }
+};
+
+template<>
+struct vec_cast<nv_bfloat16, __nv_fp8_e5m2> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e5m2* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = nv_bfloat16(src[0]);
+        } else if constexpr (vec_size == 2) {
+            dst[0] = nv_bfloat16(src[0]);
+            dst[1] = nv_bfloat16(src[1]);
+        } else {
+            static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+            for (uint32_t i = 0; i < vec_size / 4; ++i) {
+                fast_dequant_f8f16x4<__nv_fp8_e5m2, nv_bfloat16>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+            }
+        }
+    }
+};
+
+template<>
+struct vec_cast<__nv_fp8_e4m3, half> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(__nv_fp8_e4m3* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+        if constexpr (vec_size == 1) {
+            dst[0] = __nv_fp8_e4m3(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                uint16_t y;
+                uint32_t x = *(uint32_t*)&src[i * 2];
+                asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+                *(uint16_t*)&dst[i * 2] = y;
+            }
+        }
+#else
+#pragma unroll
+        for (size_t i = 0; i < vec_size; ++i) {
+            dst[i] = __nv_fp8_e4m3(src[i]);
+        }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    }
+};
+
+template<>
+struct vec_cast<__nv_fp8_e5m2, half> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(__nv_fp8_e5m2* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+        if constexpr (vec_size == 1) {
+            dst[0] = __nv_fp8_e5m2(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                uint16_t y;
+                uint32_t x = *(uint32_t*)&src[i * 2];
+                asm volatile("cvt.rn.satfinite.e5m2x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+                *(uint16_t*)&dst[i * 2] = y;
+            }
+        }
+#else
+#pragma unroll
+        for (size_t i = 0; i < vec_size; ++i) {
+            dst[i] = __nv_fp8_e5m2(src[i]);
+        }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    }
+};
+
+template<>
+struct vec_cast<half, __nv_fp8_e4m3> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e4m3* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+        if constexpr (vec_size == 1) {
+            dst[0] = half(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                uint32_t y;
+                uint16_t x = *(uint16_t*)&src[i * 2];
+                asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;" : "=r"(y) : "h"(x));
+                *(uint32_t*)&dst[i * 2] = y;
+            }
+        }
+#else
+        if constexpr (vec_size == 1) {
+            dst[0] = half(src[0]);
+        } else if constexpr (vec_size == 2) {
+            dst[0] = half(src[0]);
+            dst[1] = half(src[1]);
+        } else {
+            static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+            for (uint32_t i = 0; i < vec_size / 4; ++i) {
+                fast_dequant_f8f16x4<__nv_fp8_e4m3, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+            }
+        }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    }
+};
+
+template<>
+struct vec_cast<half, __nv_fp8_e5m2> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e5m2* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+        if constexpr (vec_size == 1) {
+            dst[0] = half(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                uint32_t y;
+                uint16_t x = *(uint16_t*)&src[i * 2];
+                asm volatile("cvt.rn.f16x2.e5m2x2 %0, %1;" : "=r"(y) : "h"(x));
+                *(uint32_t*)&dst[i * 2] = y;
+            }
+        }
+#else
+        if constexpr (vec_size == 1) {
+            dst[0] = half(src[0]);
+        } else if constexpr (vec_size == 2) {
+            dst[0] = half(src[0]);
+            dst[1] = half(src[1]);
+        } else {
+            static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+            for (uint32_t i = 0; i < vec_size / 4; ++i) {
+                fast_dequant_f8f16x4<__nv_fp8_e5m2, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+            }
+        }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    }
+};
+
+template<>
+struct vec_cast<float, nv_bfloat16> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(float* dst, const nv_bfloat16* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = (float)src[0];
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                ((float2*)dst)[i] = __bfloat1622float2(((nv_bfloat162*)src)[i]);
+            }
+        }
+    }
+};
+
+template<>
+struct vec_cast<nv_bfloat16, float> {
+    template<size_t vec_size>
+    FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const float* src) {
+        if constexpr (vec_size == 1) {
+            dst[0] = nv_bfloat16(src[0]);
+        } else {
+#pragma unroll
+            for (size_t i = 0; i < vec_size / 2; ++i) {
+                ((nv_bfloat162*)dst)[i] = __float22bfloat162_rn(((float2*)src)[i]);
+            }
+        }
+    }
+};
+
+template<typename float_t, size_t vec_size>
+struct vec_t {
+    FLASHINFER_INLINE float_t&       operator[](size_t i);
+    FLASHINFER_INLINE const float_t& operator[](size_t i) const;
+    FLASHINFER_INLINE void           fill(float_t val);
+    FLASHINFER_INLINE void           load(const float_t* ptr);
+    FLASHINFER_INLINE void           store(float_t* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src);
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr);
+    template<typename T>
+    FLASHINFER_INLINE void        cast_store(T* ptr) const;
+    FLASHINFER_INLINE static void memcpy(float_t* dst, const float_t* src);
+    FLASHINFER_INLINE float_t*    ptr();
+};
+
+template<typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_from_impl(vec_t<tgt_float_t, vec_size>& dst, const vec_t<src_float_t, vec_size>& src) {
+    vec_cast<tgt_float_t, src_float_t>::cast<vec_size>(dst.ptr(),
+                                                       const_cast<vec_t<src_float_t, vec_size>*>(&src)->ptr());
+}
+
+template<typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_load_impl(vec_t<tgt_float_t, vec_size>& dst, const src_float_t* src_ptr) {
+    if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+        dst.load(src_ptr);
+    } else {
+        vec_t<src_float_t, vec_size> tmp;
+        tmp.load(src_ptr);
+        dst.cast_from(tmp);
+    }
+}
+
+template<typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_store_impl(tgt_float_t* dst_ptr, const vec_t<src_float_t, vec_size>& src) {
+    if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+        src.store(dst_ptr);
+    } else {
+        vec_t<tgt_float_t, vec_size> tmp;
+        tmp.cast_from(src);
+        tmp.store(dst_ptr);
+    }
+}
+
+/******************* vec_t<__nv_fp8_e4m3> *******************/
+
+// __nv_fp8_e4m3 x 1
+template<>
+struct vec_t<__nv_fp8_e4m3, 1> {
+    __nv_fp8_e4m3 data;
+
+    FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) {
+        return ((__nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+        return ((const __nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e4m3* ptr() {
+        return reinterpret_cast<__nv_fp8_e4m3*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::fill(__nv_fp8_e4m3 val) {
+    data = val;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::load(const __nv_fp8_e4m3* ptr) {
+    data = *ptr;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::store(__nv_fp8_e4m3* ptr) const {
+    *ptr = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+    *dst = *src;
+}
+
+// __nv_fp8_e4m3 x 2
+template<>
+struct vec_t<__nv_fp8_e4m3, 2> {
+    __nv_fp8x2_e4m3 data;
+
+    FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) {
+        return ((__nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+        return ((const __nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e4m3* ptr() {
+        return reinterpret_cast<__nv_fp8_e4m3*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::fill(__nv_fp8_e4m3 val) {
+    data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::load(const __nv_fp8_e4m3* ptr) {
+    data = *((__nv_fp8x2_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::store(__nv_fp8_e4m3* ptr) const {
+    *((__nv_fp8x2_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+    *((__nv_fp8x2_e4m3*)dst) = *((__nv_fp8x2_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 4
+
+template<>
+struct vec_t<__nv_fp8_e4m3, 4> {
+    __nv_fp8x4_e4m3 data;
+
+    FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) {
+        return ((__nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+        return ((const __nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e4m3* ptr() {
+        return reinterpret_cast<__nv_fp8_e4m3*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::fill(__nv_fp8_e4m3 val) {
+    data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+               | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::load(const __nv_fp8_e4m3* ptr) {
+    data = *((__nv_fp8x4_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::store(__nv_fp8_e4m3* ptr) const {
+    *((__nv_fp8x4_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+    *((__nv_fp8x4_e4m3*)dst) = *((__nv_fp8x4_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 8
+
+template<>
+struct vec_t<__nv_fp8_e4m3, 8> {
+    uint2 data;
+
+    FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) {
+        return ((__nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+        return ((const __nv_fp8_e4m3*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e4m3* ptr() {
+        return reinterpret_cast<__nv_fp8_e4m3*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::fill(__nv_fp8_e4m3 val) {
+    ((__nv_fp8x4_e4m3*)(&data.x))->__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                                         | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    ((__nv_fp8x4_e4m3*)(&data.y))->__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                                         | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::load(const __nv_fp8_e4m3* ptr) {
+    data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::store(__nv_fp8_e4m3* ptr) const {
+    *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+    *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e4m3 x 16 or more
+template<size_t vec_size>
+struct vec_t<__nv_fp8_e4m3, vec_size> {
+    uint4 data[vec_size / 16];
+
+    FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) {
+        return ((__nv_fp8_e4m3*)data)[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+        return ((const __nv_fp8_e4m3*)data)[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e4m3* ptr() {
+        return reinterpret_cast<__nv_fp8_e4m3*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((__nv_fp8x4_e4m3*)(&(data[i].x)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e4m3*)(&(data[i].y)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e4m3*)(&(data[i].z)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e4m3*)(&(data[i].w)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+        }
+    }
+    FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            data[i] = ((uint4*)ptr)[i];
+        }
+    }
+    FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((uint4*)ptr)[i] = data[i];
+        }
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((uint4*)dst)[i] = ((uint4*)src)[i];
+        }
+    }
+};
+
+/******************* vec_t<__nv_fp8_e5m2> *******************/
+
+// __nv_fp8_e5m2 x 1
+template<>
+struct vec_t<__nv_fp8_e5m2, 1> {
+    __nv_fp8_e5m2 data;
+
+    FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) {
+        return ((__nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+        return ((const __nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e5m2* ptr() {
+        return reinterpret_cast<__nv_fp8_e5m2*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::fill(__nv_fp8_e5m2 val) {
+    data = val;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::load(const __nv_fp8_e5m2* ptr) {
+    data = *ptr;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::store(__nv_fp8_e5m2* ptr) const {
+    *ptr = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+    *dst = *src;
+}
+
+// __nv_fp8_e5m2 x 2
+template<>
+struct vec_t<__nv_fp8_e5m2, 2> {
+    __nv_fp8x2_e5m2 data;
+
+    FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) {
+        return ((__nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+        return ((const __nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e5m2* ptr() {
+        return reinterpret_cast<__nv_fp8_e5m2*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::fill(__nv_fp8_e5m2 val) {
+    data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::load(const __nv_fp8_e5m2* ptr) {
+    data = *((__nv_fp8x2_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::store(__nv_fp8_e5m2* ptr) const {
+    *((__nv_fp8x2_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+    *((__nv_fp8x2_e5m2*)dst) = *((__nv_fp8x2_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 4
+
+template<>
+struct vec_t<__nv_fp8_e5m2, 4> {
+    __nv_fp8x4_e5m2 data;
+
+    FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) {
+        return ((__nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+        return ((const __nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e5m2* ptr() {
+        return reinterpret_cast<__nv_fp8_e5m2*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::fill(__nv_fp8_e5m2 val) {
+    data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+               | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::load(const __nv_fp8_e5m2* ptr) {
+    data = *((__nv_fp8x4_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::store(__nv_fp8_e5m2* ptr) const {
+    *((__nv_fp8x4_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+    *((__nv_fp8x4_e5m2*)dst) = *((__nv_fp8x4_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 8
+
+template<>
+struct vec_t<__nv_fp8_e5m2, 8> {
+    uint2 data;
+
+    FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) {
+        return ((__nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+        return ((const __nv_fp8_e5m2*)(&data))[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e5m2* ptr() {
+        return reinterpret_cast<__nv_fp8_e5m2*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+    FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+    FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::fill(__nv_fp8_e5m2 val) {
+    ((__nv_fp8x4_e5m2*)(&data.x))->__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                                         | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    ((__nv_fp8x4_e5m2*)(&data.y))->__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                                         | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::load(const __nv_fp8_e5m2* ptr) {
+    data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::store(__nv_fp8_e5m2* ptr) const {
+    *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+    *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e5m2 x 16 or more
+
+template<size_t vec_size>
+struct vec_t<__nv_fp8_e5m2, vec_size> {
+    uint4 data[vec_size / 16];
+
+    FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) {
+        return ((__nv_fp8_e5m2*)data)[i];
+    }
+    FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+        return ((const __nv_fp8_e5m2*)data)[i];
+    }
+    FLASHINFER_INLINE __nv_fp8_e5m2* ptr() {
+        return reinterpret_cast<__nv_fp8_e5m2*>(&data);
+    }
+    FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((__nv_fp8x4_e5m2*)(&(data[i].x)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e5m2*)(&(data[i].y)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e5m2*)(&(data[i].z)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+            ((__nv_fp8x4_e5m2*)(&(data[i].w)))->__x =
+                (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16)
+                | (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+        }
+    }
+    FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            data[i] = ((uint4*)ptr)[i];
+        }
+    }
+    FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((uint4*)ptr)[i] = data[i];
+        }
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 16; ++i) {
+            ((uint4*)dst)[i] = ((uint4*)src)[i];
+        }
+    }
+};
+
+/******************* vec_t<half> *******************/
+
+// half x 1
+template<>
+struct vec_t<half, 1> {
+    half data;
+
+    FLASHINFER_INLINE half& operator[](size_t i) {
+        return ((half*)(&data))[i];
+    }
+    FLASHINFER_INLINE const half& operator[](size_t i) const {
+        return ((const half*)(&data))[i];
+    }
+    FLASHINFER_INLINE half* ptr() {
+        return reinterpret_cast<half*>(&data);
+    }
+    FLASHINFER_INLINE void fill(half val);
+    FLASHINFER_INLINE void load(const half* ptr);
+    FLASHINFER_INLINE void store(half* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 1>::fill(half val) {
+    data = val;
+}
+
+FLASHINFER_INLINE void vec_t<half, 1>::load(const half* ptr) {
+    data = *ptr;
+}
+
+FLASHINFER_INLINE void vec_t<half, 1>::store(half* ptr) const {
+    *ptr = data;
+}
+
+FLASHINFER_INLINE void vec_t<half, 1>::memcpy(half* dst, const half* src) {
+    *dst = *src;
+}
+
+// half x 2
+template<>
+struct vec_t<half, 2> {
+    half2 data;
+
+    FLASHINFER_INLINE half& operator[](size_t i) {
+        return ((half*)(&data))[i];
+    }
+    FLASHINFER_INLINE const half& operator[](size_t i) const {
+        return ((const half*)(&data))[i];
+    }
+    FLASHINFER_INLINE half* ptr() {
+        return reinterpret_cast<half*>(&data);
+    }
+    FLASHINFER_INLINE void fill(half val);
+    FLASHINFER_INLINE void load(const half* ptr);
+    FLASHINFER_INLINE void store(half* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+
+    FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 2>::fill(half val) {
+    data = make_half2(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<half, 2>::load(const half* ptr) {
+    data = *((half2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<half, 2>::store(half* ptr) const {
+    *((half2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<half, 2>::memcpy(half* dst, const half* src) {
+    *((half2*)dst) = *((half2*)src);
+}
+
+// half x 4
+
+template<>
+struct vec_t<half, 4> {
+    uint2 data;
+
+    FLASHINFER_INLINE half& operator[](size_t i) {
+        return ((half*)(&data))[i];
+    }
+    FLASHINFER_INLINE const half& operator[](size_t i) const {
+        return ((const half*)(&data))[i];
+    }
+    FLASHINFER_INLINE half* ptr() {
+        return reinterpret_cast<half*>(&data);
+    }
+    FLASHINFER_INLINE void fill(half val);
+    FLASHINFER_INLINE void load(const half* ptr);
+    FLASHINFER_INLINE void store(half* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 4>::fill(half val) {
+    *(half2*)(&data.x) = make_half2(val, val);
+    *(half2*)(&data.y) = make_half2(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<half, 4>::load(const half* ptr) {
+    data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<half, 4>::store(half* ptr) const {
+    *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<half, 4>::memcpy(half* dst, const half* src) {
+    *((uint2*)dst) = *((uint2*)src);
+}
+
+// half x 8 or more
+
+template<size_t vec_size>
+struct vec_t<half, vec_size> {
+    uint4                   data[vec_size / 8];
+    FLASHINFER_INLINE half& operator[](size_t i) {
+        return ((half*)data)[i];
+    }
+    FLASHINFER_INLINE const half& operator[](size_t i) const {
+        return ((const half*)data)[i];
+    }
+    FLASHINFER_INLINE half* ptr() {
+        return reinterpret_cast<half*>(&data);
+    }
+    FLASHINFER_INLINE void fill(half val) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            *(half2*)(&(data[i].x)) = make_half2(val, val);
+            *(half2*)(&(data[i].y)) = make_half2(val, val);
+            *(half2*)(&(data[i].z)) = make_half2(val, val);
+            *(half2*)(&(data[i].w)) = make_half2(val, val);
+        }
+    }
+    FLASHINFER_INLINE void load(const half* ptr) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            data[i] = ((uint4*)ptr)[i];
+        }
+    }
+    FLASHINFER_INLINE void store(half* ptr) const {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            ((uint4*)ptr)[i] = data[i];
+        }
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(half* dst, const half* src) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            ((uint4*)dst)[i] = ((uint4*)src)[i];
+        }
+    }
+};
+
+/******************* vec_t<nv_bfloat16> *******************/
+
+// nv_bfloat16 x 1
+template<>
+struct vec_t<nv_bfloat16, 1> {
+    nv_bfloat16                    data;
+    FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) {
+        return ((nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+        return ((const nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE nv_bfloat16* ptr() {
+        return reinterpret_cast<nv_bfloat16*>(&data);
+    }
+    FLASHINFER_INLINE void fill(nv_bfloat16 val);
+    FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+    FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::fill(nv_bfloat16 val) {
+    data = val;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::load(const nv_bfloat16* ptr) {
+    data = *ptr;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::store(nv_bfloat16* ptr) const {
+    *ptr = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+    *dst = *src;
+}
+
+// nv_bfloat16 x 2
+template<>
+struct vec_t<nv_bfloat16, 2> {
+    nv_bfloat162 data;
+
+    FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) {
+        return ((nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+        return ((const nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE nv_bfloat16* ptr() {
+        return reinterpret_cast<nv_bfloat16*>(&data);
+    }
+    FLASHINFER_INLINE void fill(nv_bfloat16 val);
+    FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+    FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::fill(nv_bfloat16 val) {
+    data = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::load(const nv_bfloat16* ptr) {
+    data = *((nv_bfloat162*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::store(nv_bfloat16* ptr) const {
+    *((nv_bfloat162*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+    *((nv_bfloat162*)dst) = *((nv_bfloat162*)src);
+}
+
+// nv_bfloat16 x 4
+
+template<>
+struct vec_t<nv_bfloat16, 4> {
+    uint2 data;
+
+    FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) {
+        return ((nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+        return ((const nv_bfloat16*)(&data))[i];
+    }
+    FLASHINFER_INLINE nv_bfloat16* ptr() {
+        return reinterpret_cast<nv_bfloat16*>(&data);
+    }
+    FLASHINFER_INLINE void fill(nv_bfloat16 val);
+    FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+    FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::fill(nv_bfloat16 val) {
+    *(nv_bfloat162*)(&data.x) = make_bfloat162(val, val);
+    *(nv_bfloat162*)(&data.y) = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::load(const nv_bfloat16* ptr) {
+    data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::store(nv_bfloat16* ptr) const {
+    *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+    *((uint2*)dst) = *((uint2*)src);
+}
+
+// nv_bfloat16 x 8 or more
+
+template<size_t vec_size>
+struct vec_t<nv_bfloat16, vec_size> {
+    uint4 data[vec_size / 8];
+
+    FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) {
+        return ((nv_bfloat16*)data)[i];
+    }
+    FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+        return ((const nv_bfloat16*)data)[i];
+    }
+    FLASHINFER_INLINE nv_bfloat16* ptr() {
+        return reinterpret_cast<nv_bfloat16*>(&data);
+    }
+    FLASHINFER_INLINE void fill(nv_bfloat16 val) {
+#pragma unoll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            *(nv_bfloat162*)(&(data[i].x)) = make_bfloat162(val, val);
+            *(nv_bfloat162*)(&(data[i].y)) = make_bfloat162(val, val);
+            *(nv_bfloat162*)(&(data[i].z)) = make_bfloat162(val, val);
+            *(nv_bfloat162*)(&(data[i].w)) = make_bfloat162(val, val);
+        }
+    }
+    FLASHINFER_INLINE void load(const nv_bfloat16* ptr) {
+#pragma unoll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            data[i] = ((uint4*)ptr)[i];
+        }
+    }
+    FLASHINFER_INLINE void store(nv_bfloat16* ptr) const {
+#pragma unoll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            ((uint4*)ptr)[i] = data[i];
+        }
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+#pragma unoll
+        for (size_t i = 0; i < vec_size / 8; ++i) {
+            ((uint4*)dst)[i] = ((uint4*)src)[i];
+        }
+    }
+};
+
+/******************* vec_t<float> *******************/
+
+// float x 1
+
+template<>
+struct vec_t<float, 1> {
+    float data;
+
+    FLASHINFER_INLINE float& operator[](size_t i) {
+        return ((float*)(&data))[i];
+    }
+    FLASHINFER_INLINE const float& operator[](size_t i) const {
+        return ((const float*)(&data))[i];
+    }
+    FLASHINFER_INLINE float* ptr() {
+        return reinterpret_cast<float*>(&data);
+    }
+    FLASHINFER_INLINE void fill(float val);
+    FLASHINFER_INLINE void load(const float* ptr);
+    FLASHINFER_INLINE void store(float* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 1>::fill(float val) {
+    data = val;
+}
+
+FLASHINFER_INLINE void vec_t<float, 1>::load(const float* ptr) {
+    data = *ptr;
+}
+
+FLASHINFER_INLINE void vec_t<float, 1>::store(float* ptr) const {
+    *ptr = data;
+}
+
+FLASHINFER_INLINE void vec_t<float, 1>::memcpy(float* dst, const float* src) {
+    *dst = *src;
+}
+
+// float x 2
+
+template<>
+struct vec_t<float, 2> {
+    float2 data;
+
+    FLASHINFER_INLINE float& operator[](size_t i) {
+        return ((float*)(&data))[i];
+    }
+    FLASHINFER_INLINE const float& operator[](size_t i) const {
+        return ((const float*)(&data))[i];
+    }
+    FLASHINFER_INLINE float* ptr() {
+        return reinterpret_cast<float*>(&data);
+    }
+    FLASHINFER_INLINE void fill(float val);
+    FLASHINFER_INLINE void load(const float* ptr);
+    FLASHINFER_INLINE void store(float* ptr) const;
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 2>::fill(float val) {
+    data = make_float2(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<float, 2>::load(const float* ptr) {
+    data = *((float2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<float, 2>::store(float* ptr) const {
+    *((float2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<float, 2>::memcpy(float* dst, const float* src) {
+    *((float2*)dst) = *((float2*)src);
+}
+
+// float x 4 or more
+template<size_t vec_size>
+struct vec_t<float, vec_size> {
+    float4 data[vec_size / 4];
+
+    FLASHINFER_INLINE float& operator[](size_t i) {
+        return ((float*)(data))[i];
+    }
+    FLASHINFER_INLINE const float& operator[](size_t i) const {
+        return ((const float*)(data))[i];
+    }
+    FLASHINFER_INLINE float* ptr() {
+        return reinterpret_cast<float*>(&data);
+    }
+    FLASHINFER_INLINE void fill(float val) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 4; ++i) {
+            data[i] = make_float4(val, val, val, val);
+        }
+    }
+    FLASHINFER_INLINE void load(const float* ptr) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 4; ++i) {
+            data[i] = ((float4*)ptr)[i];
+        }
+    }
+    FLASHINFER_INLINE void store(float* ptr) const {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 4; ++i) {
+            ((float4*)ptr)[i] = data[i];
+        }
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+        cast_from_impl(*this, src);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_load(const T* ptr) {
+        cast_load_impl(*this, ptr);
+    }
+    template<typename T>
+    FLASHINFER_INLINE void cast_store(T* ptr) const {
+        cast_store_impl(ptr, *this);
+    }
+    FLASHINFER_INLINE static void memcpy(float* dst, const float* src) {
+#pragma unroll
+        for (size_t i = 0; i < vec_size / 4; ++i) {
+            ((float4*)dst)[i] = ((float4*)src)[i];
+        }
+    }
+};
+
+}  // namespace flashinfer
+
+#endif  // VEC_DTYPES_CUH_

--- a/rtp_llm/models_py/bindings/cuda/ops/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/ops/BUILD
@@ -106,6 +106,7 @@ cc_library(
         "//rtp_llm/models_py/bindings/core/ops:torch_beam_search_op_impl",
         "//rtp_llm/models_py/bindings/cuda/kernels/sampling:sampling",
         "//rtp_llm/models_py/bindings/cuda/kernels:scaled_fp8_quant",
+        "//rtp_llm/models_py/bindings/cuda/kernels:kernels_speculative_sampling",
         "//rtp_llm/cpp/utils:debug_utils",
         ":flashinfer",
         "//3rdparty/flashinfer:flashinfer",

--- a/rtp_llm/models_py/bindings/cuda/ops/tests/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/ops/tests/BUILD
@@ -50,6 +50,19 @@ cc_test(
 )
 
 cc_test(
+    name = "rejection_sampling_op_test",
+    srcs = [
+        "CudaRejectionSamplingOpTest.cc",
+    ],
+    data = [],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/cpp/testing:rejection_sampling_test_utils",
+    ] + torch_deps(),
+    exec_properties = {'gpu':'H20'},
+)
+
+cc_test(
     name = "beam_search_op_test",
     srcs = [
         "CudaBeamSearchOpTest.cc",

--- a/rtp_llm/models_py/bindings/cuda/ops/tests/CudaRejectionSamplingOpTest.cc
+++ b/rtp_llm/models_py/bindings/cuda/ops/tests/CudaRejectionSamplingOpTest.cc
@@ -1,0 +1,15 @@
+#include "rtp_llm/cpp/testing/RejectionSamplingOpTest.hpp"
+
+class CudaRejectionSamplingOpTest: public RejectionSamplingOpTest {};
+
+TEST_F(CudaRejectionSamplingOpTest, referenceCases) {
+    runReferenceCases();
+}
+
+TEST_F(CudaRejectionSamplingOpTest, zeroAndOneSpeculativeTokenCases) {
+    runZeroAndOneSpeculativeTokenCases();
+}
+
+TEST_F(CudaRejectionSamplingOpTest, rejectsInvalidTensorMetadata) {
+    runRejectsInvalidTensorMetadata();
+}

--- a/rtp_llm/models_py/bindings/rocm/speculative_sampling/sampling.cu
+++ b/rtp_llm/models_py/bindings/rocm/speculative_sampling/sampling.cu
@@ -293,6 +293,166 @@ template<uint32_t             BLOCK_THREADS,
          bool                 DETERMINISTIC,
          typename DType,
          typename IdType>
+__global__ void rejection_sampling_kernel(DType*  draft_probs,
+                                          IdType* draft_token_ids,
+                                          DType*  uniform_samples,
+                                          DType*  target_probs,
+                                          IdType* target_token_ids,
+                                          int     target_token_stride,
+                                          IdType* output_token_ids,
+                                          IdType* output_accepted_token_num,
+                                          bool*   do_sample,
+                                          int     batch_size,
+                                          int     num_speculative_tokens,
+                                          int     target_vocab_size) {
+    const int bx = blockIdx.x, tx = threadIdx.x;
+    const int row_idx = bx;
+
+    extern __shared__ __align__(alignof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>))
+        uint8_t       smem_sampling[];
+    auto&             temp_storage =
+        reinterpret_cast<SamplingTempStorage<BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM>&>(smem_sampling);
+
+    if (row_idx >= batch_size) {
+        return;
+    }
+
+    __shared__ int  s_pos;
+    __shared__ bool s_all_same_token;
+
+    if (tx == 0) {
+        bool all_same_token = true;
+        int  pos            = num_speculative_tokens;
+        for (int i = 0; i < num_speculative_tokens; ++i) {
+            IdType draft_id  = draft_token_ids[row_idx * num_speculative_tokens + i];
+            IdType target_id = target_token_ids[(row_idx * (num_speculative_tokens + 1) + i) * target_token_stride
+                                                + target_token_stride - 1];
+
+            float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * target_vocab_size + draft_id],
+                  p = draft_probs[(row_idx * num_speculative_tokens + i) * target_vocab_size + draft_id];
+            DType u = uniform_samples[row_idx * (num_speculative_tokens + 1) + i];
+
+            bool same_token = target_id == draft_id;
+            if (same_token || (do_sample[row_idx] && u * p < q)) {
+                output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
+                all_same_token                                               = all_same_token && same_token;
+            } else {
+                // Keep all_same_token as-is. If every previous accepted token was an exact target/draft match,
+                // the verifier token at this rejected position is already target-distributed and can be emitted.
+                pos = i;
+                break;
+            }
+        }
+
+        output_accepted_token_num[row_idx] = pos + 1;
+
+        if (all_same_token) {
+            IdType bonus_token_id =
+                target_token_ids[(row_idx * (num_speculative_tokens + 1) + pos) * target_token_stride
+                                 + target_token_stride - 1];
+            output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = bonus_token_id;
+            for (int p = pos + 1; p < num_speculative_tokens + 1; ++p) {
+                output_token_ids[row_idx * (num_speculative_tokens + 1) + p] = -1;
+            }
+        }
+
+        s_pos            = pos;
+        s_all_same_token = all_same_token;
+    }
+    __syncthreads();
+
+    if (s_all_same_token) {
+        return;
+    }
+    int pos = s_pos;
+
+    // sample from relu(target_probs - draft_probs)
+    float                  sum_relu_q_minus_p = 0;
+    vec_t<float, VEC_SIZE> q_vec, p_vec;
+    float                  relu_q_minus_p[VEC_SIZE];
+#pragma unroll 2
+    for (int i = 0; i < ceil_div(target_vocab_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(0);
+        p_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < target_vocab_size) {
+            q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * target_vocab_size
+                            + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * target_vocab_size
+                                + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+#pragma unroll
+        for (int j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p[j] = max(q_vec[j] - p_vec[j], 0);
+        }
+        sum_relu_q_minus_p += BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage.block_prim.reduce)
+                                  .template Sum<VEC_SIZE>(relu_q_minus_p);
+        __syncthreads();
+    }
+    if (tx == 0) {
+        temp_storage.block_aggregate.value = sum_relu_q_minus_p;
+    }
+    // init the first rejected token to target_vocab_size
+    temp_storage.sampled_id = target_vocab_size - 1;
+    __syncthreads();
+    sum_relu_q_minus_p = temp_storage.block_aggregate.value;
+    DType u            = uniform_samples[row_idx * (num_speculative_tokens + 1) + min(pos + 1, num_speculative_tokens)]
+              * sum_relu_q_minus_p;
+
+    float aggregate_relu_q_minus_p(0);
+#pragma unroll 2
+    for (int i = 0; i < ceil_div(target_vocab_size, BLOCK_THREADS * VEC_SIZE); ++i) {
+        q_vec.fill(0);
+        p_vec.fill(0);
+        if ((i * BLOCK_THREADS + tx) * VEC_SIZE < target_vocab_size) {
+            q_vec.cast_load(target_probs + (row_idx * (num_speculative_tokens + 1) + pos) * target_vocab_size
+                            + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            if (pos != num_speculative_tokens) {
+                // there is no draft_probs for the bonus token
+                p_vec.cast_load(draft_probs + (row_idx * num_speculative_tokens + pos) * target_vocab_size
+                                + i * BLOCK_THREADS * VEC_SIZE + tx * VEC_SIZE);
+            }
+        }
+
+        vec_t<float, VEC_SIZE> relu_q_minus_p_vec;
+#pragma unroll
+        for (int j = 0; j < VEC_SIZE; ++j) {
+            relu_q_minus_p_vec[j] = max(q_vec[j] - p_vec[j], 0);
+        }
+
+        DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM, DETERMINISTIC>(
+            i,
+            target_vocab_size,
+            [&](float x) { return x > 0; },
+            u,
+            relu_q_minus_p_vec,
+            aggregate_relu_q_minus_p,
+            &temp_storage);
+        if (aggregate_relu_q_minus_p > u) {
+            break;
+        }
+    }
+    __syncthreads();
+    if (tx == 0) {
+        int sampled_id = temp_storage.sampled_id;
+        // set the first rejected token
+        output_token_ids[row_idx * (num_speculative_tokens + 1) + pos] = sampled_id;
+        // pad remaining tokens with -1
+        for (int p = pos + 1; p < num_speculative_tokens + 1; ++p) {
+            output_token_ids[row_idx * (num_speculative_tokens + 1) + p] = -1;
+        }
+    }
+}
+
+template<uint32_t             BLOCK_THREADS,
+         BlockScanAlgorithm   SCAN_ALGORITHM,
+         BlockReduceAlgorithm REDUCE_ALGORITHM,
+         uint32_t             VEC_SIZE,
+         bool                 DETERMINISTIC,
+         typename DType,
+         typename IdType>
 __global__ void ChainSpeculativeSampling(DType*   draft_probs,
                                          IdType*  draft_token_ids,
                                          DType*   uniform_samples,
@@ -450,6 +610,48 @@ hipError_t ChainSpeculativeSampling(DType*      draft_probs,
     return hipSuccess;
 }
 
+template<typename DType, typename IdType>
+hipError_t invokeRejectionSampling(DType*      draft_probs,
+                                   IdType*     draft_token_ids,
+                                   DType*      uniform_samples,
+                                   DType*      target_probs,
+                                   IdType*     target_token_ids,
+                                   int         target_token_stride,
+                                   IdType*     output_token_ids,
+                                   IdType*     output_accepted_token_num,
+                                   bool*       do_sample,
+                                   int         batch_size,
+                                   int         num_speculative_tokens,
+                                   int         target_vocab_size,
+                                   hipStream_t stream) {
+    if (batch_size == 0) {
+        return hipSuccess;
+    }
+    constexpr uint32_t BLOCK_THREADS = 1024;
+    const uint32_t     vec_size      = std::gcd(16 / sizeof(DType), target_vocab_size);
+
+    const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
+    dim3           nblks(batch_size);
+    dim3           nthrs(BLOCK_THREADS);
+
+    DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
+        rejection_sampling_kernel<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE, false, DType, IdType>
+            <<<nblks, nthrs, smem_size, stream>>>(draft_probs,
+                                                  draft_token_ids,
+                                                  uniform_samples,
+                                                  target_probs,
+                                                  target_token_ids,
+                                                  target_token_stride,
+                                                  output_token_ids,
+                                                  output_accepted_token_num,
+                                                  do_sample,
+                                                  batch_size,
+                                                  num_speculative_tokens,
+                                                  target_vocab_size);
+    });
+    return hipSuccess;
+}
+
 void chain_speculative_sampling(at::Tensor draft_probs,
                                 at::Tensor draft_token_ids,
                                 at::Tensor uniform_samples,
@@ -482,3 +684,20 @@ void chain_speculative_sampling(at::Tensor draft_probs,
     TORCH_CHECK(status == hipSuccess,
                 "ChainSpeculativeSampling failed with error code " + std::string(hipGetErrorString(status)));
 }
+
+#define INSTANTIATE_REJECTION_SAMPLING(DType, IdType)                                                                  \
+    template hipError_t invokeRejectionSampling(DType*      draft_probs,                                               \
+                                                IdType*     draft_token_ids,                                           \
+                                                DType*      uniform_samples,                                           \
+                                                DType*      target_probs,                                              \
+                                                IdType*     target_token_ids,                                          \
+                                                int         target_token_stride,                                       \
+                                                IdType*     output_token_ids,                                          \
+                                                IdType*     output_accepted_token_num,                                 \
+                                                bool*       do_sample,                                                 \
+                                                int         batch_size,                                                \
+                                                int         num_speculative_tokens,                                    \
+                                                int         target_vocab_size,                                         \
+                                                hipStream_t stream);
+
+INSTANTIATE_REJECTION_SAMPLING(float, int);


### PR DESCRIPTION
## Summary

Add standalone rejection sampling kernel support for speculative decoding.

This PR only extracts the kernel-side implementation and minimal API/BUILD glue:
- add CUDA rejection sampling kernel under `models_py/bindings/cuda/kernels/speculative_sampling`
- add ROCm-side `invokeRejectionSampling` support
- expose `execRejectionSampling` through C++ exec ops
- wire Bazel dependencies for CUDA kernel linkage

This PR intentionally does not change MTP/speculative sampler call logic.

## Design Notes

The new rejection kernel supports a fast path when all previously accepted draft tokens exactly match verifier tokens. If a later draft token is rejected in that state, the verifier token at that position is already target-distributed, so the kernel can emit it as the bonus token instead of running recovery sampling. This is documented in both CUDA and ROCm implementations.


## Tests

- `git diff --check origin/main..HEAD` passed
- pre-commit hooks passed: conflict, line ending, whitespace, clang-format where applicable