### PR TITLE
Feature/kvcm online optmizer

### DIFF
--- a/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/HttpLoadBalanceServer.java
+++ b/rtp_llm/flexlb/flexlb-api/src/main/java/org/flexlb/httpserver/HttpLoadBalanceServer.java
@@ -17,6 +17,8 @@ import org.flexlb.domain.consistency.SyncLBStatusResp;
 import org.flexlb.service.RouteService;
 import org.flexlb.service.grace.ActiveRequestCounter;
 import org.flexlb.service.monitor.EngineHealthReporter;
+import org.flexlb.service.optimizer.OnlineOptimizerClient;
+import org.flexlb.service.optimizer.OnlineOptimizerHooker;
 import org.flexlb.transport.GeneralHttpNettyService;
 import org.flexlb.util.JsonUtils;
 import org.flexlb.util.Logger;
@@ -46,19 +48,22 @@ public class HttpLoadBalanceServer {
     private final EngineHealthReporter engineHealthReporter;
     private final QueueManager queueManager;
     private final ActiveRequestCounter activeRequestCounter;
+    private final OnlineOptimizerHooker onlineOptimizerHooker;
 
     public HttpLoadBalanceServer(GeneralHttpNettyService generalHttpNettyService,
                                  RouteService routeService,
                                  LBStatusConsistencyService lbStatusConsistencyService,
                                  EngineHealthReporter engineHealthReporter,
                                  QueueManager queueManager,
-                                 ActiveRequestCounter activeRequestCounter) {
+                                 ActiveRequestCounter activeRequestCounter,
+                                 OnlineOptimizerHooker onlineOptimizerHooker) {
         this.generalHttpNettyService = generalHttpNettyService;
         this.routeService = routeService;
         this.lbStatusConsistencyService = lbStatusConsistencyService;
         this.engineHealthReporter = engineHealthReporter;
         this.queueManager = queueManager;
         this.activeRequestCounter = activeRequestCounter;
+        this.onlineOptimizerHooker = onlineOptimizerHooker;
     }
 
     @Bean
@@ -256,12 +261,29 @@ public class HttpLoadBalanceServer {
         response.setRealMasterHost(lbStatusConsistencyService.getMasterHostIpPort());
 
         if (response.isSuccess()) {
+            fireTraceQuery(ctx);
             return buildSuccessResponse(response);
         } else {
             Logger.error("Routing failed with error code: {}", response.getErrorMessage());
             ctx.setSuccess(false);
             ctx.setErrorMessage("error_code:" + response.getErrorMessage());
             return buildErrorResponse(response);
+        }
+    }
+
+    private void fireTraceQuery(BalanceContext ctx) {
+        // Best-effort fire-and-forget. Any failure here MUST NOT propagate to the request path.
+        try {
+            OnlineOptimizerClient client = onlineOptimizerHooker.getClient();
+            if (client == null) {
+                return;
+            }
+            Request req = ctx.getRequest();
+            if (req != null && req.getBlockCacheKeys() != null && !req.getBlockCacheKeys().isEmpty()) {
+                client.traceQuery(req.getRequestId(), req.getBlockCacheKeys());
+            }
+        } catch (Throwable t) {
+            Logger.warn("fireTraceQuery skipped due to error: {}", t.getMessage());
         }
     }
 

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/CommonResponseHeader.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/CommonResponseHeader.java
@@ -12,7 +12,14 @@ public class CommonResponseHeader {
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Status {
-        private int code;
+        // Object type to accept both protobuf enum string ("OK") and integer (1)
+        private Object code;
         private String message;
+
+        public boolean isOk() {
+            if (code == null) return false;
+            if (code instanceof Number) return ((Number) code).intValue() == 1;
+            return "OK".equals(code);
+        }
     }
 }

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/CommonResponseHeader.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/CommonResponseHeader.java
@@ -1,0 +1,18 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommonResponseHeader {
+
+    private Status status;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Status {
+        private int code;
+        private String message;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerGetInstanceRequest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerGetInstanceRequest.java
@@ -1,0 +1,14 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class OptimizerGetInstanceRequest {
+
+    @JsonProperty("trace_id")
+    private String traceId;
+
+    @JsonProperty("instance_id")
+    private String instanceId;
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerGetInstanceResponse.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerGetInstanceResponse.java
@@ -1,0 +1,51 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OptimizerGetInstanceResponse {
+
+    private CommonResponseHeader header;
+
+    @JsonProperty("instance_group")
+    private String instanceGroup;
+
+    @JsonProperty("instance_id")
+    private String instanceId;
+
+    @JsonProperty("block_size")
+    private int blockSize;
+
+    @JsonProperty("location_spec_infos")
+    private List<LocationSpecInfo> locationSpecInfos;
+
+    @JsonProperty("location_spec_groups")
+    private List<LocationSpecGroup> locationSpecGroups;
+
+    @JsonProperty("linear_step")
+    private int linearStep;
+
+    @JsonProperty("full_group_name")
+    private String fullGroupName;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LocationSpecInfo {
+        private String name;
+        private int size;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LocationSpecGroup {
+        private String name;
+
+        @JsonProperty("spec_names")
+        private List<String> specNames;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerInstanceParams.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerInstanceParams.java
@@ -1,0 +1,119 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Encapsulates all optimizer instance registration params and provides remote consistency check.
+ */
+@Data
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OptimizerInstanceParams {
+
+    @JsonProperty("block_size")
+    private int blockSize;
+
+    @JsonProperty("location_spec_infos")
+    private List<OptimizerRegisterRequest.LocationSpecInfo> locationSpecInfos;
+
+    @JsonProperty("location_spec_groups")
+    private List<OptimizerRegisterRequest.LocationSpecGroup> locationSpecGroups;
+
+    @JsonProperty("linear_step")
+    private int linearStep;
+
+    @JsonProperty("full_group_name")
+    private String fullGroupName;
+
+    @JsonProperty("instance_group")
+    private String instanceGroup;
+
+    /**
+     * Check whether local params match the remote getInstance response (including instanceGroup).
+     */
+    public boolean matchesRemote(OptimizerGetInstanceResponse remote) {
+        if (remote == null) return false;
+
+        if (!Objects.equals(nullToEmpty(this.instanceGroup), nullToEmpty(remote.getInstanceGroup()))) return false;
+        if (this.blockSize != remote.getBlockSize()) return false;
+        if (this.linearStep != remote.getLinearStep()) return false;
+        if (!Objects.equals(nullToEmpty(this.fullGroupName), nullToEmpty(remote.getFullGroupName()))) return false;
+        if (!matchLocationSpecInfos(remote.getLocationSpecInfos())) return false;
+        if (!matchLocationSpecGroups(remote.getLocationSpecGroups())) return false;
+
+        return true;
+    }
+
+    private boolean matchLocationSpecInfos(List<OptimizerGetInstanceResponse.LocationSpecInfo> remoteInfos) {
+        List<OptimizerRegisterRequest.LocationSpecInfo> localInfos = this.locationSpecInfos;
+        if (localInfos == null || localInfos.isEmpty()) {
+            return remoteInfos == null || remoteInfos.isEmpty();
+        }
+        if (remoteInfos == null || remoteInfos.size() != localInfos.size()) return false;
+
+        // null-safe sort to prevent NPE when name is null
+        Comparator<String> nameCmp = Comparator.nullsFirst(String::compareTo);
+        List<OptimizerRegisterRequest.LocationSpecInfo> sortedLocal = new ArrayList<>(localInfos);
+        sortedLocal.sort(Comparator.comparing(OptimizerRegisterRequest.LocationSpecInfo::getName, nameCmp));
+        List<OptimizerGetInstanceResponse.LocationSpecInfo> sortedRemote = new ArrayList<>(remoteInfos);
+        sortedRemote.sort(Comparator.comparing(OptimizerGetInstanceResponse.LocationSpecInfo::getName, nameCmp));
+
+        for (int i = 0; i < sortedLocal.size(); i++) {
+            OptimizerRegisterRequest.LocationSpecInfo local = sortedLocal.get(i);
+            OptimizerGetInstanceResponse.LocationSpecInfo remote = sortedRemote.get(i);
+            if (!Objects.equals(local.getName(), remote.getName()) || local.getSize() != remote.getSize()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matchLocationSpecGroups(List<OptimizerGetInstanceResponse.LocationSpecGroup> remoteGroups) {
+        List<OptimizerRegisterRequest.LocationSpecGroup> localGroups = this.locationSpecGroups;
+        if (localGroups == null || localGroups.isEmpty()) {
+            return remoteGroups == null || remoteGroups.isEmpty();
+        }
+        if (remoteGroups == null || remoteGroups.size() != localGroups.size()) return false;
+
+        // null-safe sort to prevent NPE when name is null
+        Comparator<String> nameCmp = Comparator.nullsFirst(String::compareTo);
+        List<OptimizerRegisterRequest.LocationSpecGroup> sortedLocal = new ArrayList<>(localGroups);
+        sortedLocal.sort(Comparator.comparing(OptimizerRegisterRequest.LocationSpecGroup::getName, nameCmp));
+        List<OptimizerGetInstanceResponse.LocationSpecGroup> sortedRemote = new ArrayList<>(remoteGroups);
+        sortedRemote.sort(Comparator.comparing(OptimizerGetInstanceResponse.LocationSpecGroup::getName, nameCmp));
+
+        for (int i = 0; i < sortedLocal.size(); i++) {
+            OptimizerRegisterRequest.LocationSpecGroup local = sortedLocal.get(i);
+            OptimizerGetInstanceResponse.LocationSpecGroup remote = sortedRemote.get(i);
+            if (!Objects.equals(local.getName(), remote.getName())) return false;
+            List<String> localSpecs = local.getSpecNames();
+            List<String> remoteSpecs = remote.getSpecNames();
+            if (localSpecs == null || localSpecs.isEmpty()) {
+                if (remoteSpecs != null && !remoteSpecs.isEmpty()) return false;
+            } else if (remoteSpecs == null || localSpecs.size() != remoteSpecs.size()) {
+                return false;
+            } else {
+                // null-safe sort to prevent NPE when specName is null
+                Comparator<String> specCmp = Comparator.nullsFirst(String::compareTo);
+                List<String> sortedLocalSpecs = new ArrayList<>(localSpecs);
+                sortedLocalSpecs.sort(specCmp);
+                List<String> sortedRemoteSpecs = new ArrayList<>(remoteSpecs);
+                sortedRemoteSpecs.sort(specCmp);
+                if (!Objects.equals(sortedLocalSpecs, sortedRemoteSpecs)) return false;
+            }
+        }
+        return true;
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRegisterRequest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRegisterRequest.java
@@ -1,0 +1,62 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class OptimizerRegisterRequest {
+
+    @JsonProperty("trace_id")
+    private String traceId;
+
+    @JsonProperty("instance_group")
+    private String instanceGroup;
+
+    @JsonProperty("instance_id")
+    private String instanceId;
+
+    @JsonProperty("block_size")
+    private int blockSize;
+
+    @JsonProperty("location_spec_infos")
+    private List<LocationSpecInfo> locationSpecInfos;
+
+    @JsonProperty("location_spec_groups")
+    private List<LocationSpecGroup> locationSpecGroups;
+
+    @JsonProperty("linear_step")
+    private int linearStep;
+
+    @JsonProperty("full_group_name")
+    private String fullGroupName;
+
+    @Data
+    public static class LocationSpecInfo {
+        private String name;
+        private int size;
+
+        public LocationSpecInfo() {}
+
+        public LocationSpecInfo(String name, int size) {
+            this.name = name;
+            this.size = size;
+        }
+    }
+
+    @Data
+    public static class LocationSpecGroup {
+        private String name;
+
+        @JsonProperty("spec_names")
+        private List<String> specNames;
+
+        public LocationSpecGroup() {}
+
+        public LocationSpecGroup(String name, List<String> specNames) {
+            this.name = name;
+            this.specNames = specNames;
+        }
+    }
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRegisterResponse.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRegisterResponse.java
@@ -1,0 +1,20 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OptimizerRegisterResponse {
+
+    private CommonResponseHeader header;
+
+    @JsonProperty("capacity_blocks")
+    private List<Long> capacityBlocks;
+
+    @JsonProperty("avg_bytes_per_block")
+    private long avgBytesPerBlock;
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRemoveInstanceRequest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRemoveInstanceRequest.java
@@ -1,0 +1,14 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class OptimizerRemoveInstanceRequest {
+
+    @JsonProperty("trace_id")
+    private String traceId;
+
+    @JsonProperty("instance_id")
+    private String instanceId;
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRemoveInstanceResponse.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerRemoveInstanceResponse.java
@@ -1,0 +1,11 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OptimizerRemoveInstanceResponse {
+
+    private CommonResponseHeader header;
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerTraceQueryRequest.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerTraceQueryRequest.java
@@ -1,0 +1,19 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class OptimizerTraceQueryRequest {
+
+    @JsonProperty("trace_id")
+    private String traceId;
+
+    @JsonProperty("instance_id")
+    private String instanceId;
+
+    @JsonProperty("block_keys")
+    private List<Long> blockKeys;
+}

--- a/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerTraceQueryResponse.java
+++ b/rtp_llm/flexlb/flexlb-common/src/main/java/org/flexlb/dao/optimizer/OptimizerTraceQueryResponse.java
@@ -1,0 +1,11 @@
+package org.flexlb.dao.optimizer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OptimizerTraceQueryResponse {
+
+    private CommonResponseHeader header;
+}

--- a/rtp_llm/flexlb/flexlb-sync/pom.xml
+++ b/rtp_llm/flexlb/flexlb-sync/pom.xml
@@ -66,6 +66,11 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/grace/GracefulOnlineService.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/grace/GracefulOnlineService.java
@@ -3,6 +3,7 @@ package org.flexlb.service.grace;
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.service.grace.strategy.LbConsistencyHooker;
 import org.flexlb.service.grace.strategy.QueryWarmerHooker;
+import org.flexlb.service.optimizer.OnlineOptimizerHooker;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ import java.util.Arrays;
  * Executes online hooks in a fixed order:
  * 1. LB consistency — register with service discovery (ZK)
  * 2. Query warmer — warm up service before accepting traffic
+ * 3. OnlineOptimizer — async register with KV cache optimizer
  */
 @Slf4j
 @Component
@@ -22,12 +24,15 @@ public class GracefulOnlineService implements EnvironmentAware {
 
     private final LbConsistencyHooker lbConsistencyHooker;
     private final QueryWarmerHooker queryWarmerHooker;
+    private final OnlineOptimizerHooker onlineOptimizerHooker;
     private Environment environment;
 
     public GracefulOnlineService(LbConsistencyHooker lbConsistencyHooker,
-                                 QueryWarmerHooker queryWarmerHooker) {
+                                 QueryWarmerHooker queryWarmerHooker,
+                                 OnlineOptimizerHooker onlineOptimizerHooker) {
         this.lbConsistencyHooker = lbConsistencyHooker;
         this.queryWarmerHooker = queryWarmerHooker;
+        this.onlineOptimizerHooker = onlineOptimizerHooker;
     }
 
     @Override
@@ -48,5 +53,8 @@ public class GracefulOnlineService implements EnvironmentAware {
 
         log.info("Graceful online: step 2 — warm up service");
         queryWarmerHooker.afterStartUp();
+
+        log.info("Graceful online: step 3 — register with OnlineOptimizer");
+        onlineOptimizerHooker.afterStartUp();
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/grace/GracefulShutdownService.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/grace/GracefulShutdownService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.flexlb.service.grace.strategy.ActiveRequestShutdownHooker;
 import org.flexlb.service.grace.strategy.HealthCheckHooker;
 import org.flexlb.service.grace.strategy.LbConsistencyHooker;
+import org.flexlb.service.optimizer.OnlineOptimizerHooker;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
  * 1. HealthCheck offline  — stop accepting new requests
  * 2. ZK / LB consistency offline — deregister from service discovery
  * 3. Active request drain — wait for in-flight requests to complete
+ * 4. OnlineOptimizer shutdown — stop optimizer refresh and retry threads
  */
 @Slf4j
 @Component
@@ -21,13 +23,16 @@ public class GracefulShutdownService {
     private final HealthCheckHooker healthCheckHooker;
     private final LbConsistencyHooker lbConsistencyHooker;
     private final ActiveRequestShutdownHooker activeRequestShutdownHooker;
+    private final OnlineOptimizerHooker onlineOptimizerHooker;
 
     public GracefulShutdownService(HealthCheckHooker healthCheckHooker,
                                    LbConsistencyHooker lbConsistencyHooker,
-                                   ActiveRequestShutdownHooker activeRequestShutdownHooker) {
+                                   ActiveRequestShutdownHooker activeRequestShutdownHooker,
+                                   OnlineOptimizerHooker onlineOptimizerHooker) {
         this.healthCheckHooker = healthCheckHooker;
         this.lbConsistencyHooker = lbConsistencyHooker;
         this.activeRequestShutdownHooker = activeRequestShutdownHooker;
+        this.onlineOptimizerHooker = onlineOptimizerHooker;
     }
 
     public void offline() {
@@ -39,5 +44,8 @@ public class GracefulShutdownService {
 
         log.info("Graceful shutdown: step 3 — drain active requests");
         activeRequestShutdownHooker.beforeShutdown();
+
+        log.info("Graceful shutdown: step 4 — shutdown OnlineOptimizer");
+        onlineOptimizerHooker.beforeShutdown();
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/DirectAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/DirectAddressResolver.java
@@ -1,0 +1,21 @@
+package org.flexlb.service.optimizer;
+
+import java.util.List;
+
+public class DirectAddressResolver implements OptimizerAddressResolver {
+
+    private final List<String> addresses;
+
+    public DirectAddressResolver(String address) {
+        this.addresses = List.of(address);
+    }
+
+    @Override
+    public List<String> getAddresses() {
+        return addresses;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/DirectAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/DirectAddressResolver.java
@@ -15,6 +15,12 @@ public class DirectAddressResolver implements OptimizerAddressResolver {
         return addresses;
     }
 
+    /** Static address is always available; no initialization needed. */
+    @Override
+    public boolean start() {
+        return true;
+    }
+
     @Override
     public void shutdown() {
     }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
@@ -1,6 +1,7 @@
 package org.flexlb.service.optimizer;
 
 import lombok.extern.slf4j.Slf4j;
+import org.flexlb.dao.optimizer.CommonResponseHeader;
 import org.flexlb.dao.optimizer.OptimizerGetInstanceRequest;
 import org.flexlb.dao.optimizer.OptimizerGetInstanceResponse;
 import org.flexlb.dao.optimizer.OptimizerInstanceParams;
@@ -100,6 +101,12 @@ public class OnlineOptimizerClient {
         if (registered) return;
 
         try {
+            // Defer resolver start to async retry so listen failures do not block startup.
+            if (!addressResolver.start()) {
+                log.info("OnlineOptimizer address resolver not yet started, will retry");
+                scheduleRetry(instanceId, params, currentDelayMs);
+                return;
+            }
             refreshUri();
             if (optimizerUri == null) {
                 log.info("OnlineOptimizer address not yet resolved, will retry");
@@ -163,11 +170,10 @@ public class OnlineOptimizerClient {
             log.warn("OnlineOptimizer getInstance returned null, instanceId={}", instanceId);
             return null;
         }
-        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
-                && resp.getHeader().getStatus().getCode() != 1) {
-            // instance not found or other non-OK status
-            log.info("OnlineOptimizer getInstance returned status={}, instanceId={}",
-                    resp.getHeader().getStatus().getCode(), instanceId);
+        if (!isOkHeader(resp.getHeader())) {
+            // Non-OK or malformed response: treat as not found, register flow will retry on its own check.
+            log.info("OnlineOptimizer getInstance returned non-OK status code={}, instanceId={}",
+                    extractStatusCode(resp.getHeader()), instanceId);
             return null;
         }
         return resp;
@@ -187,11 +193,10 @@ public class OnlineOptimizerClient {
             log.warn("OnlineOptimizer removeInstance returned null, instanceId={}", instanceId);
             return false;
         }
-        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
-                && resp.getHeader().getStatus().getCode() != 1) {
+        if (!isOkHeader(resp.getHeader())) {
             log.warn("OnlineOptimizer removeInstance failed, status={}, message={}, instanceId={}",
-                    resp.getHeader().getStatus().getCode(),
-                    resp.getHeader().getStatus().getMessage(), instanceId);
+                    extractStatusCode(resp.getHeader()),
+                    extractStatusMessage(resp.getHeader()), instanceId);
             return false;
         }
         log.info("OnlineOptimizer removeInstance success, instanceId={}", instanceId);
@@ -218,11 +223,11 @@ public class OnlineOptimizerClient {
             log.warn("OnlineOptimizer registerInstance returned null, instanceId={}", instanceId);
             return false;
         }
-        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
-                && resp.getHeader().getStatus().getCode() != 1) {
+        if (!isOkHeader(resp.getHeader())) {
+            // Strict: only code == 1 means success; malformed counts as failure to keep retrying.
             log.warn("OnlineOptimizer registerInstance failed, status={}, message={}, instanceId={}",
-                    resp.getHeader().getStatus().getCode(),
-                    resp.getHeader().getStatus().getMessage(), instanceId);
+                    extractStatusCode(resp.getHeader()),
+                    extractStatusMessage(resp.getHeader()), instanceId);
             return false;
         }
         log.info("OnlineOptimizer registerInstance success: instanceId={}", instanceId);
@@ -235,7 +240,10 @@ public class OnlineOptimizerClient {
         }
         try {
             refreshUri();
-            if (optimizerUri == null) {
+            // Snapshot to local to avoid TOCTOU: another thread could clear optimizerUri
+            // between the null check and the HTTP call.
+            URI uri = optimizerUri;
+            if (uri == null) {
                 return;
             }
 
@@ -244,7 +252,7 @@ public class OnlineOptimizerClient {
             req.setInstanceId(instanceId);
             req.setBlockKeys(blockCacheKeys);
 
-            httpService.request(req, optimizerUri, basePath + "/traceQuery",
+            httpService.request(req, uri, basePath + "/traceQuery",
                             OptimizerTraceQueryResponse.class)
                     .subscribe(
                             resp -> {},
@@ -271,14 +279,39 @@ public class OnlineOptimizerClient {
         addressResolver.shutdown();
     }
 
-    private void refreshUri() {
+    private synchronized void refreshUri() {
         List<String> addresses = addressResolver.getAddresses();
-        if (addresses.isEmpty()) return;
+        if (addresses.isEmpty()) {
+            // Resolver reports zero hosts: drop cached URI to avoid hitting a dead address.
+            if (optimizerUri != null) {
+                log.info("OnlineOptimizer addresses empty, clearing cached URI: {}", addressSnapshot);
+                this.optimizerUri = null;
+                this.addressSnapshot = "";
+            }
+            return;
+        }
         String first = addresses.get(0);
         if (!first.equals(addressSnapshot)) {
             this.optimizerUri = URI.create("http://" + first);
             this.addressSnapshot = first;
             log.info("OnlineOptimizer address updated: {}", first);
         }
+    }
+
+    private static boolean isOkHeader(CommonResponseHeader header) {
+        return header != null
+                && header.getStatus() != null
+                && header.getStatus().getCode() == 1;
+    }
+
+    private static Integer extractStatusCode(CommonResponseHeader header) {
+        // null means header/status absent; avoids colliding with a real -1 from server.
+        if (header == null || header.getStatus() == null) return null;
+        return header.getStatus().getCode();
+    }
+
+    private static String extractStatusMessage(CommonResponseHeader header) {
+        if (header == null || header.getStatus() == null) return null;
+        return header.getStatus().getMessage();
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
@@ -1,0 +1,284 @@
+package org.flexlb.service.optimizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.flexlb.dao.optimizer.OptimizerGetInstanceRequest;
+import org.flexlb.dao.optimizer.OptimizerGetInstanceResponse;
+import org.flexlb.dao.optimizer.OptimizerInstanceParams;
+import org.flexlb.dao.optimizer.OptimizerRegisterRequest;
+import org.flexlb.dao.optimizer.OptimizerRegisterResponse;
+import org.flexlb.dao.optimizer.OptimizerRemoveInstanceRequest;
+import org.flexlb.dao.optimizer.OptimizerRemoveInstanceResponse;
+import org.flexlb.dao.optimizer.OptimizerTraceQueryRequest;
+import org.flexlb.dao.optimizer.OptimizerTraceQueryResponse;
+import org.flexlb.transport.GeneralHttpNettyService;
+import org.flexlb.util.IdUtils;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public class OnlineOptimizerClient {
+
+    private final GeneralHttpNettyService httpService;
+    private final OptimizerAddressResolver addressResolver;
+    private final String instanceGroup;
+    private final String basePath;
+    private final int registerTimeoutMs;
+
+    private volatile URI optimizerUri;
+    private volatile String addressSnapshot = "";
+    private volatile String instanceId;
+    private volatile boolean registered = false;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    private final ScheduledExecutorService retryScheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "optimizer-register-retry");
+                t.setDaemon(true);
+                return t;
+            });
+
+    private static final long INITIAL_RETRY_DELAY_MS = 1000;
+    private static final long MAX_RETRY_DELAY_MS = 30_000;
+    private static final double BACKOFF_MULTIPLIER = 2.0;
+    private static final long JITTER_BOUND_MS = 2000;
+
+    public OnlineOptimizerClient(GeneralHttpNettyService httpService,
+                                 OptimizerAddressResolver addressResolver,
+                                 String instanceGroup,
+                                 String basePath,
+                                 int registerTimeoutMs) {
+        this.httpService = httpService;
+        this.addressResolver = addressResolver;
+        this.instanceGroup = instanceGroup;
+        this.basePath = stripTrailingSlash(basePath);
+        this.registerTimeoutMs = registerTimeoutMs;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        if (s == null) return "";
+        String r = s;
+        while (r.endsWith("/")) {
+            r = r.substring(0, r.length() - 1);
+        }
+        return r;
+    }
+
+    public void startRegistrationAsync(String instanceId, OptimizerInstanceParams params) {
+        if (!started.compareAndSet(false, true)) {
+            log.info("OnlineOptimizer registration already started, skip duplicate call");
+            return;
+        }
+        this.instanceId = instanceId;
+        safeSubmit(() -> attemptRegistration(instanceId, params, INITIAL_RETRY_DELAY_MS));
+    }
+
+    private void safeSubmit(Runnable task) {
+        try {
+            retryScheduler.submit(task);
+        } catch (RejectedExecutionException e) {
+            log.warn("OnlineOptimizer scheduler rejected task: {}", e.getMessage());
+        }
+    }
+
+    private void safeSchedule(Runnable task, long delayMs) {
+        try {
+            retryScheduler.schedule(task, delayMs, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            log.warn("OnlineOptimizer scheduler rejected scheduled task: {}", e.getMessage());
+        }
+    }
+
+    private void attemptRegistration(String instanceId, OptimizerInstanceParams params, long currentDelayMs) {
+        if (registered) return;
+
+        try {
+            refreshUri();
+            if (optimizerUri == null) {
+                log.info("OnlineOptimizer address not yet resolved, will retry");
+                scheduleRetry(instanceId, params, currentDelayMs);
+                return;
+            }
+
+            boolean success = registerWithCheck(instanceId, params);
+            if (success) {
+                this.registered = true;
+                log.info("OnlineOptimizer registration completed, traceQuery enabled");
+                return;
+            }
+        } catch (Exception e) {
+            log.warn("OnlineOptimizer registration attempt failed: {}", e.getMessage());
+        }
+
+        scheduleRetry(instanceId, params, currentDelayMs);
+    }
+
+    private void scheduleRetry(String instanceId, OptimizerInstanceParams params, long currentDelayMs) {
+        long jitter = ThreadLocalRandom.current().nextLong(0, JITTER_BOUND_MS);
+        long nextDelay = Math.min((long) (currentDelayMs * BACKOFF_MULTIPLIER), MAX_RETRY_DELAY_MS);
+        long actualDelay = currentDelayMs + jitter;
+        log.info("OnlineOptimizer will retry registration in {}ms", actualDelay);
+
+        safeSchedule(
+                () -> attemptRegistration(instanceId, params, nextDelay),
+                actualDelay);
+    }
+
+    private boolean registerWithCheck(String instanceId, OptimizerInstanceParams params) {
+        OptimizerGetInstanceResponse existing = findExistingInstance(instanceId);
+
+        if (existing != null) {
+            if (params.matchesRemote(existing)) {
+                log.info("OnlineOptimizer instance already registered with matching params, skip");
+                return true;
+            }
+            log.info("OnlineOptimizer instance exists but params differ, removing first");
+            if (!removeInstance(instanceId)) {
+                log.warn("OnlineOptimizer removeInstance failed, instanceId={}", instanceId);
+                return false;
+            }
+        }
+
+        return doRegister(instanceId, params);
+    }
+
+    private OptimizerGetInstanceResponse findExistingInstance(String instanceId) {
+        OptimizerGetInstanceRequest req = new OptimizerGetInstanceRequest();
+        req.setTraceId(IdUtils.fastUuid());
+        req.setInstanceId(instanceId);
+
+        OptimizerGetInstanceResponse resp = httpService.request(
+                req, optimizerUri, basePath + "/getInstance",
+                OptimizerGetInstanceResponse.class
+        ).block(Duration.ofMillis(registerTimeoutMs));
+
+        if (resp == null) {
+            log.warn("OnlineOptimizer getInstance returned null, instanceId={}", instanceId);
+            return null;
+        }
+        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
+                && resp.getHeader().getStatus().getCode() != 1) {
+            // instance not found or other non-OK status
+            log.info("OnlineOptimizer getInstance returned status={}, instanceId={}",
+                    resp.getHeader().getStatus().getCode(), instanceId);
+            return null;
+        }
+        return resp;
+    }
+
+    private boolean removeInstance(String instanceId) {
+        OptimizerRemoveInstanceRequest req = new OptimizerRemoveInstanceRequest();
+        req.setTraceId(IdUtils.fastUuid());
+        req.setInstanceId(instanceId);
+
+        OptimizerRemoveInstanceResponse resp = httpService.request(
+                req, optimizerUri, basePath + "/removeInstance",
+                OptimizerRemoveInstanceResponse.class
+        ).block(Duration.ofMillis(registerTimeoutMs));
+
+        if (resp == null) {
+            log.warn("OnlineOptimizer removeInstance returned null, instanceId={}", instanceId);
+            return false;
+        }
+        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
+                && resp.getHeader().getStatus().getCode() != 1) {
+            log.warn("OnlineOptimizer removeInstance failed, status={}, message={}, instanceId={}",
+                    resp.getHeader().getStatus().getCode(),
+                    resp.getHeader().getStatus().getMessage(), instanceId);
+            return false;
+        }
+        log.info("OnlineOptimizer removeInstance success, instanceId={}", instanceId);
+        return true;
+    }
+
+    private boolean doRegister(String instanceId, OptimizerInstanceParams params) {
+        OptimizerRegisterRequest req = new OptimizerRegisterRequest();
+        req.setTraceId(IdUtils.fastUuid());
+        req.setInstanceGroup(instanceGroup);
+        req.setInstanceId(instanceId);
+        req.setBlockSize(params.getBlockSize());
+        req.setLocationSpecInfos(params.getLocationSpecInfos());
+        req.setLocationSpecGroups(params.getLocationSpecGroups());
+        req.setLinearStep(params.getLinearStep());
+        req.setFullGroupName(params.getFullGroupName());
+
+        OptimizerRegisterResponse resp = httpService.request(
+                req, optimizerUri, basePath + "/registerInstance",
+                OptimizerRegisterResponse.class
+        ).block(Duration.ofMillis(registerTimeoutMs));
+
+        if (resp == null) {
+            log.warn("OnlineOptimizer registerInstance returned null, instanceId={}", instanceId);
+            return false;
+        }
+        if (resp.getHeader() != null && resp.getHeader().getStatus() != null
+                && resp.getHeader().getStatus().getCode() != 1) {
+            log.warn("OnlineOptimizer registerInstance failed, status={}, message={}, instanceId={}",
+                    resp.getHeader().getStatus().getCode(),
+                    resp.getHeader().getStatus().getMessage(), instanceId);
+            return false;
+        }
+        log.info("OnlineOptimizer registerInstance success: instanceId={}", instanceId);
+        return true;
+    }
+
+    public void traceQuery(long requestId, List<Long> blockCacheKeys) {
+        if (!registered || blockCacheKeys == null || blockCacheKeys.isEmpty()) {
+            return;
+        }
+        try {
+            refreshUri();
+            if (optimizerUri == null) {
+                return;
+            }
+
+            OptimizerTraceQueryRequest req = new OptimizerTraceQueryRequest();
+            req.setTraceId(String.valueOf(requestId));
+            req.setInstanceId(instanceId);
+            req.setBlockKeys(blockCacheKeys);
+
+            httpService.request(req, optimizerUri, basePath + "/traceQuery",
+                            OptimizerTraceQueryResponse.class)
+                    .subscribe(
+                            resp -> {},
+                            err -> log.debug("OnlineOptimizer traceQuery error: {}", err.getMessage()));
+        } catch (Throwable t) {
+            log.debug("OnlineOptimizer traceQuery dispatch failed: {}", t.getMessage());
+        }
+    }
+
+    public boolean isRegistered() {
+        return registered;
+    }
+
+    public void shutdown() {
+        retryScheduler.shutdown();
+        try {
+            if (!retryScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
+                retryScheduler.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            retryScheduler.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        addressResolver.shutdown();
+    }
+
+    private void refreshUri() {
+        List<String> addresses = addressResolver.getAddresses();
+        if (addresses.isEmpty()) return;
+        String first = addresses.get(0);
+        if (!first.equals(addressSnapshot)) {
+            this.optimizerUri = URI.create("http://" + first);
+            this.addressSnapshot = first;
+            log.info("OnlineOptimizer address updated: {}", first);
+        }
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerClient.java
@@ -11,6 +11,7 @@ import org.flexlb.dao.optimizer.OptimizerRemoveInstanceRequest;
 import org.flexlb.dao.optimizer.OptimizerRemoveInstanceResponse;
 import org.flexlb.dao.optimizer.OptimizerTraceQueryRequest;
 import org.flexlb.dao.optimizer.OptimizerTraceQueryResponse;
+import org.flexlb.exception.FlexLBException;
 import org.flexlb.transport.GeneralHttpNettyService;
 import org.flexlb.util.IdUtils;
 
@@ -50,6 +51,11 @@ public class OnlineOptimizerClient {
     private static final long MAX_RETRY_DELAY_MS = 30_000;
     private static final double BACKOFF_MULTIPLIER = 2.0;
     private static final long JITTER_BOUND_MS = 2000;
+
+    private static final String PATH_GET_INSTANCE = "/getInstance";
+    private static final String PATH_REGISTER_INSTANCE = "/registerInstance";
+    private static final String PATH_REMOVE_INSTANCE = "/removeInstance";
+    private static final String PATH_TRACE_QUERY = "/traceQuery";
 
     public OnlineOptimizerClient(GeneralHttpNettyService httpService,
                                  OptimizerAddressResolver addressResolver,
@@ -161,17 +167,31 @@ public class OnlineOptimizerClient {
         req.setTraceId(IdUtils.fastUuid());
         req.setInstanceId(instanceId);
 
-        OptimizerGetInstanceResponse resp = httpService.request(
-                req, optimizerUri, basePath + "/getInstance",
-                OptimizerGetInstanceResponse.class
-        ).block(Duration.ofMillis(registerTimeoutMs));
+        OptimizerGetInstanceResponse resp;
+        try {
+            resp = httpService.request(
+                    req, optimizerUri, basePath + PATH_GET_INSTANCE,
+                    OptimizerGetInstanceResponse.class
+            ).block(Duration.ofMillis(registerTimeoutMs));
+        } catch (FlexLBException e) {
+            // Transport/infrastructure failure (connection error, read timeout, netty error).
+            // Instance may still exist; propagate to trigger retry.
+            throw e;
+        } catch (IllegalStateException e) {
+            // Reactor block() timeout — request did not complete in time, trigger retry.
+            throw e;
+        } catch (Exception e) {
+            // HTTP non-200 response (e.g. 404 instance not found) from server.
+            // Treat as "instance does not exist" so registration can proceed.
+            log.info("OnlineOptimizer getInstance returned HTTP error (treat as not found): {}", e.getMessage());
+            return null;
+        }
 
         if (resp == null) {
             log.warn("OnlineOptimizer getInstance returned null, instanceId={}", instanceId);
             return null;
         }
         if (!isOkHeader(resp.getHeader())) {
-            // Non-OK or malformed response: treat as not found, register flow will retry on its own check.
             log.info("OnlineOptimizer getInstance returned non-OK status code={}, instanceId={}",
                     extractStatusCode(resp.getHeader()), instanceId);
             return null;
@@ -185,7 +205,7 @@ public class OnlineOptimizerClient {
         req.setInstanceId(instanceId);
 
         OptimizerRemoveInstanceResponse resp = httpService.request(
-                req, optimizerUri, basePath + "/removeInstance",
+                req, optimizerUri, basePath + PATH_REMOVE_INSTANCE,
                 OptimizerRemoveInstanceResponse.class
         ).block(Duration.ofMillis(registerTimeoutMs));
 
@@ -215,7 +235,7 @@ public class OnlineOptimizerClient {
         req.setFullGroupName(params.getFullGroupName());
 
         OptimizerRegisterResponse resp = httpService.request(
-                req, optimizerUri, basePath + "/registerInstance",
+                req, optimizerUri, basePath + PATH_REGISTER_INSTANCE,
                 OptimizerRegisterResponse.class
         ).block(Duration.ofMillis(registerTimeoutMs));
 
@@ -252,7 +272,7 @@ public class OnlineOptimizerClient {
             req.setInstanceId(instanceId);
             req.setBlockKeys(blockCacheKeys);
 
-            httpService.request(req, uri, basePath + "/traceQuery",
+            httpService.request(req, uri, basePath + PATH_TRACE_QUERY,
                             OptimizerTraceQueryResponse.class)
                     .subscribe(
                             resp -> {},
@@ -267,6 +287,10 @@ public class OnlineOptimizerClient {
     }
 
     public void shutdown() {
+        // Intentionally NOT calling removeInstance: keep the registration alive on the
+        // optimizer server so that a restarted instance can reuse the same slot without
+        // re-registration overhead (the server will match by instanceId on next startup).
+        registered = false;
         retryScheduler.shutdown();
         try {
             if (!retryScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
@@ -279,7 +303,10 @@ public class OnlineOptimizerClient {
         addressResolver.shutdown();
     }
 
-    private synchronized void refreshUri() {
+    // No synchronization needed: both optimizerUri and addressSnapshot are volatile,
+    // and all updates are idempotent. Concurrent callers may redundantly compute the
+    // same URI, which is harmless.
+    private void refreshUri() {
         List<String> addresses = addressResolver.getAddresses();
         if (addresses.isEmpty()) {
             // Resolver reports zero hosts: drop cached URI to avoid hitting a dead address.
@@ -290,6 +317,9 @@ public class OnlineOptimizerClient {
             }
             return;
         }
+        // Only use the first address: optimizer is stateful, cross-replica failover may
+        // cause inconsistent registration. Host failures are handled by ServiceDiscovery
+        // removing dead hosts, so the next retry naturally picks the new first address.
         String first = addresses.get(0);
         if (!first.equals(addressSnapshot)) {
             this.optimizerUri = URI.create("http://" + first);
@@ -301,11 +331,10 @@ public class OnlineOptimizerClient {
     private static boolean isOkHeader(CommonResponseHeader header) {
         return header != null
                 && header.getStatus() != null
-                && header.getStatus().getCode() == 1;
+                && header.getStatus().isOk();
     }
 
-    private static Integer extractStatusCode(CommonResponseHeader header) {
-        // null means header/status absent; avoids colliding with a real -1 from server.
+    private static Object extractStatusCode(CommonResponseHeader header) {
         if (header == null || header.getStatus() == null) return null;
         return header.getStatus().getCode();
     }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
@@ -1,0 +1,224 @@
+package org.flexlb.service.optimizer;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.flexlb.dao.optimizer.OptimizerInstanceParams;
+import org.flexlb.dao.optimizer.OptimizerRegisterRequest;
+import org.flexlb.dao.route.ServiceRoute;
+import org.flexlb.discovery.ServiceDiscovery;
+import org.flexlb.listener.AppOnlineHooker;
+import org.flexlb.listener.AppShutDownHooker;
+import org.flexlb.transport.GeneralHttpNettyService;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Component
+public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker {
+
+    private final GeneralHttpNettyService httpService;
+    private final ServiceDiscovery serviceDiscovery;
+
+    private final String instanceGroup;
+    private final String basePath;
+    private final int registerTimeoutMs;
+    private final String instanceId;
+    private final String vipserverDomain;
+    private final String directAddress;
+
+    @Getter
+    private final boolean enabled;
+
+    @Getter
+    private volatile OnlineOptimizerClient client;
+
+    // Guard against duplicate afterStartUp invocations (e.g. sidecar retry on /hook/after_start)
+    // to prevent ServiceDiscovery listener leaks and duplicate retry schedulers.
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    public OnlineOptimizerHooker(GeneralHttpNettyService httpService, ServiceDiscovery serviceDiscovery) {
+
+        this.httpService = httpService;
+        this.serviceDiscovery = serviceDiscovery;
+        this.instanceGroup = envOrDefault("ONLINE_OPTIMIZER_INSTANCE_GROUP", "");
+        this.basePath = envOrDefault("ONLINE_OPTIMIZER_BASE_PATH", "/api/optimizer");
+        this.registerTimeoutMs = intEnvOrDefault("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS", 5000);
+        this.vipserverDomain = envOrDefault("OPTIMIZER_VIPSERVER_DOMAIN", "");
+        this.directAddress = envOrDefault("OPTIMIZER_DIRECT_ADDRESS", "");
+        this.instanceId = !instanceGroup.isEmpty() ? resolveInstanceId() : "";
+
+        boolean addressConfigured = !vipserverDomain.isEmpty() || !directAddress.isEmpty();
+        boolean serviceDiscoveryReady = vipserverDomain.isEmpty() || serviceDiscovery != null;
+
+        if (instanceGroup.isEmpty()) {
+            log.info("OnlineOptimizer disabled");
+            this.enabled = false;
+        } else if (instanceId.isEmpty()) {
+            log.warn("OnlineOptimizer disabled: instanceId is empty, please set ONLINE_OPTIMIZER_INSTANCE_ID " +
+                    "or ensure MODEL_SERVICE_CONFIG contains a valid serviceId");
+            this.enabled = false;
+        } else if (!addressConfigured) {
+            log.warn("OnlineOptimizer disabled: address resolver could not be created, " +
+                    "check OPTIMIZER_VIPSERVER_DOMAIN / OPTIMIZER_DIRECT_ADDRESS / ServiceDiscovery bean");
+            this.enabled = false;
+        } else if (!serviceDiscoveryReady) {
+            log.warn("OnlineOptimizer disabled: ServiceDiscovery bean required for vipserver domain={}", vipserverDomain);
+            this.enabled = false;
+        } else {
+            this.enabled = true;
+        }
+    }
+
+    @Override
+    public void afterStartUp() {
+        if (!enabled) return;
+        if (!started.compareAndSet(false, true)) {
+            log.info("OnlineOptimizer afterStartUp already executed, skip duplicate invocation");
+            return;
+        }
+
+        // afterStartUp runs after Spring has fully started (GracefulOnlineService.online),
+        // so blocking IO from getHosts/listen does not affect container startup.
+        OptimizerAddressResolver resolver = createAddressResolver();
+        if (resolver == null) {
+            log.warn("OnlineOptimizer afterStartUp: address resolver could not be created, skip registration");
+            return;
+        }
+        OnlineOptimizerClient newClient =
+                new OnlineOptimizerClient(httpService, resolver, instanceGroup, basePath, registerTimeoutMs);
+        this.client = newClient;
+
+        int blockSize = intEnvOrDefault("ONLINE_OPTIMIZER_BLOCK_SIZE", 0);
+        int blockBytes = intEnvOrDefault("ONLINE_OPTIMIZER_BLOCK_BYTES", 0);
+        int linearStep = intEnvOrDefault("ONLINE_OPTIMIZER_LINEAR_STEP", 0);
+        String fullGroupName = envOrDefault("ONLINE_OPTIMIZER_FULL_GROUP_NAME", "");
+
+        List<OptimizerRegisterRequest.LocationSpecInfo> locationSpecInfos = parseLocationSpecInfos();
+        if (locationSpecInfos == null && blockBytes > 0) {
+            locationSpecInfos = List.of(new OptimizerRegisterRequest.LocationSpecInfo("full", blockBytes));
+        }
+
+        List<OptimizerRegisterRequest.LocationSpecGroup> locationSpecGroups = parseLocationSpecGroups();
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .instanceGroup(instanceGroup)
+                .blockSize(blockSize)
+                .locationSpecInfos(locationSpecInfos)
+                .locationSpecGroups(locationSpecGroups)
+                .linearStep(linearStep)
+                .fullGroupName(fullGroupName)
+                .build();
+
+        newClient.startRegistrationAsync(instanceId, params);
+        log.info("OnlineOptimizer registration submitted (async): instanceId={}", instanceId);
+    }
+
+    @Override
+    public void beforeShutdown() {
+        if (client != null) {
+            client.shutdown();
+            log.info("OnlineOptimizer shutdown completed");
+        }
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    private String resolveInstanceId() {
+        String explicit = System.getenv("ONLINE_OPTIMIZER_INSTANCE_ID");
+        if (explicit != null && !explicit.isEmpty()) return explicit;
+
+        String modelConfig = System.getenv("MODEL_SERVICE_CONFIG");
+        if (modelConfig != null && !modelConfig.isEmpty()) {
+            try {
+                ServiceRoute route = org.flexlb.util.JsonUtils.toObject(modelConfig, ServiceRoute.class);
+                if (route != null && route.getServiceId() != null && !route.getServiceId().isEmpty()) {
+                    return route.getServiceId() + "-master";
+                }
+            } catch (Exception e) {
+                log.warn("Failed to parse MODEL_SERVICE_CONFIG for instanceId: {}", e.getMessage());
+            }
+        }
+
+        return "";
+    }
+
+    private OptimizerAddressResolver createAddressResolver() {
+        if (!vipserverDomain.isEmpty()) {
+            ServiceDiscoveryAddressResolver resolver =
+                    new ServiceDiscoveryAddressResolver(serviceDiscovery, vipserverDomain);
+            resolver.start();
+            log.info("OnlineOptimizer using ServiceDiscoveryAddressResolver, domain={}", vipserverDomain);
+            return resolver;
+        }
+        if (!directAddress.isEmpty()) {
+            return new DirectAddressResolver(directAddress);
+        }
+        return null;
+    }
+
+    private static String envOrDefault(String key, String defaultValue) {
+        String val = System.getenv(key);
+        return (val != null && !val.isEmpty()) ? val : defaultValue;
+    }
+
+    private static int intEnvOrDefault(String key, int defaultValue) {
+        String val = System.getenv(key);
+        if (val != null && !val.isEmpty()) {
+            try {
+                return Integer.parseInt(val);
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Parse ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS, format: "name1:size1,name2:size2"
+     * e.g. "full:131072,linear:65536"
+     */
+    private static List<OptimizerRegisterRequest.LocationSpecInfo> parseLocationSpecInfos() {
+        String val = System.getenv("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS");
+        if (val == null || val.isEmpty()) return null;
+
+        List<OptimizerRegisterRequest.LocationSpecInfo> result = new ArrayList<>();
+        for (String part : val.split(",")) {
+            String[] kv = part.trim().split(":");
+            if (kv.length == 2) {
+                try {
+                    result.add(new OptimizerRegisterRequest.LocationSpecInfo(kv[0].trim(), Integer.parseInt(kv[1].trim())));
+                } catch (NumberFormatException e) {
+                    log.warn("Invalid location_spec_info entry: {}", part);
+                }
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    /**
+     * Parse ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS, format: "groupName:spec1|spec2,groupName2:spec3|spec4"
+     * e.g. "full_group:full|linear"
+     */
+    private static List<OptimizerRegisterRequest.LocationSpecGroup> parseLocationSpecGroups() {
+        String val = System.getenv("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS");
+        if (val == null || val.isEmpty()) return null;
+
+        List<OptimizerRegisterRequest.LocationSpecGroup> result = new ArrayList<>();
+        for (String part : val.split(",")) {
+            String[] kv = part.trim().split(":");
+            if (kv.length == 2) {
+                String groupName = kv[0].trim();
+                List<String> specNames = Arrays.asList(kv[1].trim().split("\\|"));
+                result.add(new OptimizerRegisterRequest.LocationSpecGroup(groupName, specNames));
+            }
+        }
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
@@ -4,13 +4,15 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.flexlb.dao.optimizer.OptimizerInstanceParams;
 import org.flexlb.dao.optimizer.OptimizerRegisterRequest;
-import org.flexlb.dao.route.ServiceRoute;
 import org.flexlb.discovery.ServiceDiscovery;
 import org.flexlb.listener.AppOnlineHooker;
 import org.flexlb.listener.AppShutDownHooker;
 import org.flexlb.transport.GeneralHttpNettyService;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +48,12 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
         this.serviceDiscovery = serviceDiscovery;
         this.instanceGroup = envOrDefault("ONLINE_OPTIMIZER_INSTANCE_GROUP", "");
         this.basePath = envOrDefault("ONLINE_OPTIMIZER_BASE_PATH", "/api/optimizer");
-        this.registerTimeoutMs = intEnvOrDefault("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS", 5000);
+        int rawTimeoutMs = intEnvOrDefault("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS", 5000);
+        if (rawTimeoutMs <= 0) {
+            log.warn("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS must be positive, got {}, using default 5000", rawTimeoutMs);
+            rawTimeoutMs = 5000;
+        }
+        this.registerTimeoutMs = rawTimeoutMs;
         this.vipserverDomain = envOrDefault("OPTIMIZER_VIPSERVER_DOMAIN", "");
         this.directAddress = envOrDefault("OPTIMIZER_DIRECT_ADDRESS", "");
         this.instanceId = !instanceGroup.isEmpty() ? resolveInstanceId() : "";
@@ -55,11 +62,11 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
         boolean serviceDiscoveryReady = vipserverDomain.isEmpty() || serviceDiscovery != null;
 
         if (instanceGroup.isEmpty()) {
-            log.info("OnlineOptimizer disabled");
+            log.info("OnlineOptimizer disabled: ONLINE_OPTIMIZER_INSTANCE_GROUP not set");
             this.enabled = false;
         } else if (instanceId.isEmpty()) {
             log.warn("OnlineOptimizer disabled: instanceId is empty, please set ONLINE_OPTIMIZER_INSTANCE_ID " +
-                    "or ensure MODEL_SERVICE_CONFIG contains a valid serviceId");
+                    "or ensure MODEL_SERVICE_CONFIG is configured");
             this.enabled = false;
         } else if (!addressConfigured) {
             log.warn("OnlineOptimizer disabled: address resolver could not be created, " +
@@ -69,6 +76,9 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
             log.warn("OnlineOptimizer disabled: ServiceDiscovery bean required for vipserver domain={}", vipserverDomain);
             this.enabled = false;
         } else {
+            log.info("OnlineOptimizer enabled: instanceGroup={}, instanceId={}, address={}",
+                    instanceGroup, instanceId,
+                    !vipserverDomain.isEmpty() ? "vipserver:" + vipserverDomain : "direct:" + directAddress);
             this.enabled = true;
         }
     }
@@ -81,6 +91,42 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
             return;
         }
 
+        // Validate params before allocating any thread resources.
+        int blockSize = intEnvOrDefault("ONLINE_OPTIMIZER_BLOCK_SIZE", 0);
+        if (blockSize <= 0) {
+            log.error("OnlineOptimizer registration aborted: ONLINE_OPTIMIZER_BLOCK_SIZE must be positive, got {}", blockSize);
+            return;
+        }
+
+        int linearStep = intEnvOrDefault("ONLINE_OPTIMIZER_LINEAR_STEP", 0);
+        if (linearStep < 0) {
+            log.error("OnlineOptimizer registration aborted: ONLINE_OPTIMIZER_LINEAR_STEP must be non-negative, got {}", linearStep);
+            return;
+        }
+
+        String fullGroupName = envOrDefault("ONLINE_OPTIMIZER_FULL_GROUP_NAME", "");
+
+        List<OptimizerRegisterRequest.LocationSpecInfo> locationSpecInfos = parseLocationSpecInfos();
+        if (locationSpecInfos == null) {
+            log.error("OnlineOptimizer registration aborted: locationSpecInfos parse failed");
+            return;
+        }
+
+        List<OptimizerRegisterRequest.LocationSpecGroup> locationSpecGroups = parseLocationSpecGroups();
+        if (locationSpecGroups == null) {
+            log.error("OnlineOptimizer registration aborted: locationSpecGroups parse failed");
+            return;
+        }
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .instanceGroup(instanceGroup)
+                .blockSize(blockSize)
+                .locationSpecInfos(locationSpecInfos)
+                .locationSpecGroups(locationSpecGroups)
+                .linearStep(linearStep)
+                .fullGroupName(fullGroupName)
+                .build();
+
         // afterStartUp runs after Spring has fully started (GracefulOnlineService.online),
         // so blocking IO from getHosts/listen does not affect container startup.
         OptimizerAddressResolver resolver = createAddressResolver();
@@ -92,37 +138,22 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
                 new OnlineOptimizerClient(httpService, resolver, instanceGroup, basePath, registerTimeoutMs);
         this.client = newClient;
 
-        int blockSize = intEnvOrDefault("ONLINE_OPTIMIZER_BLOCK_SIZE", 0);
-        int blockBytes = intEnvOrDefault("ONLINE_OPTIMIZER_BLOCK_BYTES", 0);
-        int linearStep = intEnvOrDefault("ONLINE_OPTIMIZER_LINEAR_STEP", 0);
-        String fullGroupName = envOrDefault("ONLINE_OPTIMIZER_FULL_GROUP_NAME", "");
-
-        List<OptimizerRegisterRequest.LocationSpecInfo> locationSpecInfos = parseLocationSpecInfos();
-        if (locationSpecInfos == null && blockBytes > 0) {
-            locationSpecInfos = List.of(new OptimizerRegisterRequest.LocationSpecInfo("full", blockBytes));
-        }
-
-        List<OptimizerRegisterRequest.LocationSpecGroup> locationSpecGroups = parseLocationSpecGroups();
-
-        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
-                .instanceGroup(instanceGroup)
-                .blockSize(blockSize)
-                .locationSpecInfos(locationSpecInfos)
-                .locationSpecGroups(locationSpecGroups)
-                .linearStep(linearStep)
-                .fullGroupName(fullGroupName)
-                .build();
-
+        log.info("OnlineOptimizer registration params: blockSize={}, linearStep={}, " +
+                "fullGroupName={}, locationSpecInfos={}, locationSpecGroups={}",
+                blockSize, linearStep, fullGroupName, locationSpecInfos, locationSpecGroups);
         newClient.startRegistrationAsync(instanceId, params);
         log.info("OnlineOptimizer registration submitted (async): instanceId={}", instanceId);
     }
 
     @Override
     public void beforeShutdown() {
-        if (client != null) {
-            client.shutdown();
-            log.info("OnlineOptimizer shutdown completed");
+        if (client == null) {
+            log.info("OnlineOptimizer beforeShutdown: client not initialized, nothing to shutdown");
+            return;
         }
+        log.info("OnlineOptimizer shutting down: instanceId={}", instanceId);
+        client.shutdown();
+        log.info("OnlineOptimizer shutdown completed");
     }
 
     @Override
@@ -132,21 +163,36 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
 
     private String resolveInstanceId() {
         String explicit = System.getenv("ONLINE_OPTIMIZER_INSTANCE_ID");
-        if (explicit != null && !explicit.isEmpty()) return explicit;
+        if (explicit != null && !explicit.isEmpty()) {
+            log.info("OnlineOptimizer using explicit instanceId from env");
+            return explicit;
+        }
 
         String modelConfig = System.getenv("MODEL_SERVICE_CONFIG");
         if (modelConfig != null && !modelConfig.isEmpty()) {
-            try {
-                ServiceRoute route = org.flexlb.util.JsonUtils.toObject(modelConfig, ServiceRoute.class);
-                if (route != null && route.getServiceId() != null && !route.getServiceId().isEmpty()) {
-                    return route.getServiceId() + "-master";
-                }
-            } catch (Exception e) {
-                log.warn("Failed to parse MODEL_SERVICE_CONFIG for instanceId: {}", e.getMessage());
+            String hashId = computeHashId(modelConfig);
+            if (!hashId.isEmpty()) {
+                log.info("OnlineOptimizer instanceId derived from MODEL_SERVICE_CONFIG hash: {}", hashId);
+                return hashId;
             }
         }
 
         return "";
+    }
+
+    private static String computeHashId(String modelConfig) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(modelConfig.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 8; i++) {
+                sb.append(String.format("%02x", hash[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            log.error("SHA-256 algorithm not available, cannot compute instanceId", e);
+            return "";
+        }
     }
 
     private OptimizerAddressResolver createAddressResolver() {
@@ -156,6 +202,7 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
             return new ServiceDiscoveryAddressResolver(serviceDiscovery, vipserverDomain);
         }
         if (!directAddress.isEmpty()) {
+            log.info("OnlineOptimizer using DirectAddressResolver, address={}", directAddress);
             return new DirectAddressResolver(directAddress);
         }
         return null;
@@ -172,6 +219,7 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
             try {
                 return Integer.parseInt(val);
             } catch (NumberFormatException e) {
+                log.warn("Invalid integer value for env {}: '{}', using default={}", key, val, defaultValue);
                 return defaultValue;
             }
         }
@@ -184,20 +232,27 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
      */
     private static List<OptimizerRegisterRequest.LocationSpecInfo> parseLocationSpecInfos() {
         String val = System.getenv("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS");
-        if (val == null || val.isEmpty()) return null;
+        if (val == null || val.isEmpty()) {
+            log.info("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS not set, skip");
+            return null;
+        }
 
         List<OptimizerRegisterRequest.LocationSpecInfo> result = new ArrayList<>();
         for (String part : val.split(",")) {
             String[] kv = part.trim().split(":");
-            if (kv.length == 2) {
-                try {
-                    result.add(new OptimizerRegisterRequest.LocationSpecInfo(kv[0].trim(), Integer.parseInt(kv[1].trim())));
-                } catch (NumberFormatException e) {
-                    log.warn("Invalid location_spec_info entry: {}", part);
-                }
+            if (kv.length != 2) {
+                log.error("Invalid location_spec_info entry, expected 'name:size' format: '{}'", part);
+                return null;
+            }
+            try {
+                result.add(new OptimizerRegisterRequest.LocationSpecInfo(kv[0].trim(), Integer.parseInt(kv[1].trim())));
+            } catch (NumberFormatException e) {
+                log.error("Invalid location_spec_info entry, non-integer size: '{}'", part);
+                return null;
             }
         }
-        return result.isEmpty() ? null : result;
+        log.info("Parsed locationSpecInfos: count={}, entries={}", result.size(), result);
+        return result;
     }
 
     /**
@@ -206,17 +261,23 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
      */
     private static List<OptimizerRegisterRequest.LocationSpecGroup> parseLocationSpecGroups() {
         String val = System.getenv("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS");
-        if (val == null || val.isEmpty()) return null;
+        if (val == null || val.isEmpty()) {
+            log.info("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS not set, skip");
+            return null;
+        }
 
         List<OptimizerRegisterRequest.LocationSpecGroup> result = new ArrayList<>();
         for (String part : val.split(",")) {
             String[] kv = part.trim().split(":");
-            if (kv.length == 2) {
-                String groupName = kv[0].trim();
-                List<String> specNames = Arrays.asList(kv[1].trim().split("\\|"));
-                result.add(new OptimizerRegisterRequest.LocationSpecGroup(groupName, specNames));
+            if (kv.length != 2) {
+                log.error("Invalid location_spec_group entry, expected 'groupName:spec1|spec2' format: '{}'", part);
+                return null;
             }
+            String groupName = kv[0].trim();
+            List<String> specNames = Arrays.asList(kv[1].trim().split("\\|"));
+            result.add(new OptimizerRegisterRequest.LocationSpecGroup(groupName, specNames));
         }
-        return result.isEmpty() ? null : result;
+        log.info("Parsed locationSpecGroups: count={}, groups={}", result.size(), result);
+        return result;
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OnlineOptimizerHooker.java
@@ -151,11 +151,9 @@ public class OnlineOptimizerHooker implements AppOnlineHooker, AppShutDownHooker
 
     private OptimizerAddressResolver createAddressResolver() {
         if (!vipserverDomain.isEmpty()) {
-            ServiceDiscoveryAddressResolver resolver =
-                    new ServiceDiscoveryAddressResolver(serviceDiscovery, vipserverDomain);
-            resolver.start();
+            // Defer start() to client's async retry; never block afterStartUp on listen failure.
             log.info("OnlineOptimizer using ServiceDiscoveryAddressResolver, domain={}", vipserverDomain);
-            return resolver;
+            return new ServiceDiscoveryAddressResolver(serviceDiscovery, vipserverDomain);
         }
         if (!directAddress.isEmpty()) {
             return new DirectAddressResolver(directAddress);

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OptimizerAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OptimizerAddressResolver.java
@@ -7,4 +7,12 @@ public interface OptimizerAddressResolver {
     List<String> getAddresses();
 
     void shutdown();
+
+    /**
+     * Idempotent + retryable start. Returns true if started or already started;
+     * returns false on transient failure (state rolled back, caller should retry).
+     */
+    default boolean start() {
+        return true;
+    }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OptimizerAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/OptimizerAddressResolver.java
@@ -1,0 +1,10 @@
+package org.flexlb.service.optimizer;
+
+import java.util.List;
+
+public interface OptimizerAddressResolver {
+
+    List<String> getAddresses();
+
+    void shutdown();
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
@@ -12,13 +12,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Optimizer address resolver backed by a shared {@link ServiceDiscovery} bean.
  *
- * <p>Behavior aligned with {@code EngineAddressNameResolver}/{@code WorkerAddressService}:
- * a null or empty host list clears the resolved addresses. Caller decides whether to
- * invoke {@link #start()} synchronously or on a background thread.</p>
- *
- * <p>If {@code listen} fails, {@code started} is rolled back so the next {@link #start()} can retry.
- * {@link #shutdown()} only sets a flag (the underlying {@link ServiceDiscovery} is a shared bean
- * with no {@code unlisten} API), preventing late listener callbacks from mutating state.</p>
+ * <p>Empty/null host list clears resolved addresses. {@link #start()} is idempotent
+ * and rolls back on listen failure so callers can retry. {@link #shutdown()} only
+ * sets a flag (ServiceDiscovery is shared, has no unlisten API) to block late callbacks.</p>
  */
 @Slf4j
 public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver {
@@ -35,14 +31,15 @@ public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver
         this.domain = domain;
     }
 
-    public void start() {
+    /** Idempotent + retryable. See {@link OptimizerAddressResolver#start()}. */
+    @Override
+    public boolean start() {
         if (shutdown.get()) {
             log.info("ServiceDiscoveryAddressResolver already shutdown, skip start, domain={}", domain);
-            return;
+            return false;
         }
         if (!started.compareAndSet(false, true)) {
-            log.info("ServiceDiscoveryAddressResolver already started, skip duplicate start, domain={}", domain);
-            return;
+            return true;
         }
         // Initial pull so getAddresses() is non-empty before listener fires
         try {
@@ -50,26 +47,21 @@ public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver
         } catch (Throwable t) {
             log.warn("ServiceDiscovery.getHosts failed on start, domain={}, msg={}", domain, t.getMessage());
         }
-        // Register push listener; roll back started on failure to allow retry
-        boolean listenOk = false;
         try {
             serviceDiscovery.listen(domain, this::updateFromHosts);
-            listenOk = true;
         } catch (Throwable t) {
-            log.warn("ServiceDiscovery.listen failed, domain={}, msg={}", domain, t.getMessage());
-        }
-        if (!listenOk) {
-            // Roll back so next start() can re-attempt initial pull + listen
+            // Roll back so the next start() can re-attempt
             started.set(false);
-            log.warn("ServiceDiscoveryAddressResolver listen registration failed, started rollback, domain={}", domain);
-            return;
+            log.warn("ServiceDiscovery.listen failed, domain={}, msg={}", domain, t.getMessage());
+            return false;
         }
         log.info("ServiceDiscoveryAddressResolver started: domain={}, initialCount={}",
                 domain, resolvedAddresses.size());
+        return true;
     }
 
     private void updateFromHosts(List<WorkerHost> hosts) {
-        // Ignore callbacks after shutdown to prevent stale listener mutations
+        // Drop callbacks after shutdown to avoid stale mutations
         if (shutdown.get()) {
             return;
         }
@@ -93,8 +85,7 @@ public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver
 
     @Override
     public void shutdown() {
-        // ServiceDiscovery is a shared Spring bean; only set a flag here
-        // to block subsequent listener callbacks from mutating state.
+        // ServiceDiscovery is a shared bean; only flag here to block late callbacks.
         shutdown.set(true);
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
@@ -1,0 +1,100 @@
+package org.flexlb.service.optimizer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.flexlb.dao.master.WorkerHost;
+import org.flexlb.discovery.ServiceDiscovery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Optimizer address resolver backed by a shared {@link ServiceDiscovery} bean.
+ *
+ * <p>Behavior aligned with {@code EngineAddressNameResolver}/{@code WorkerAddressService}:
+ * a null or empty host list clears the resolved addresses. Caller decides whether to
+ * invoke {@link #start()} synchronously or on a background thread.</p>
+ *
+ * <p>If {@code listen} fails, {@code started} is rolled back so the next {@link #start()} can retry.
+ * {@link #shutdown()} only sets a flag (the underlying {@link ServiceDiscovery} is a shared bean
+ * with no {@code unlisten} API), preventing late listener callbacks from mutating state.</p>
+ */
+@Slf4j
+public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver {
+
+    private final ServiceDiscovery serviceDiscovery;
+    private final String domain;
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
+    private volatile List<String> resolvedAddresses = Collections.emptyList();
+
+    public ServiceDiscoveryAddressResolver(ServiceDiscovery serviceDiscovery, String domain) {
+        this.serviceDiscovery = serviceDiscovery;
+        this.domain = domain;
+    }
+
+    public void start() {
+        if (shutdown.get()) {
+            log.info("ServiceDiscoveryAddressResolver already shutdown, skip start, domain={}", domain);
+            return;
+        }
+        if (!started.compareAndSet(false, true)) {
+            log.info("ServiceDiscoveryAddressResolver already started, skip duplicate start, domain={}", domain);
+            return;
+        }
+        // Initial pull so getAddresses() is non-empty before listener fires
+        try {
+            updateFromHosts(serviceDiscovery.getHosts(domain));
+        } catch (Throwable t) {
+            log.warn("ServiceDiscovery.getHosts failed on start, domain={}, msg={}", domain, t.getMessage());
+        }
+        // Register push listener; roll back started on failure to allow retry
+        boolean listenOk = false;
+        try {
+            serviceDiscovery.listen(domain, this::updateFromHosts);
+            listenOk = true;
+        } catch (Throwable t) {
+            log.warn("ServiceDiscovery.listen failed, domain={}, msg={}", domain, t.getMessage());
+        }
+        if (!listenOk) {
+            // Roll back so next start() can re-attempt initial pull + listen
+            started.set(false);
+            log.warn("ServiceDiscoveryAddressResolver listen registration failed, started rollback, domain={}", domain);
+            return;
+        }
+        log.info("ServiceDiscoveryAddressResolver started: domain={}, initialCount={}",
+                domain, resolvedAddresses.size());
+    }
+
+    private void updateFromHosts(List<WorkerHost> hosts) {
+        // Ignore callbacks after shutdown to prevent stale listener mutations
+        if (shutdown.get()) {
+            return;
+        }
+        if (hosts == null || hosts.isEmpty()) {
+            this.resolvedAddresses = Collections.emptyList();
+            log.info("ServiceDiscoveryAddressResolver cleared, domain={}", domain);
+            return;
+        }
+        List<String> addresses = new ArrayList<>(hosts.size());
+        for (WorkerHost host : hosts) {
+            addresses.add(host.getIp() + ":" + host.getPort());
+        }
+        this.resolvedAddresses = addresses;
+        log.info("ServiceDiscoveryAddressResolver updated, domain={}, count={}", domain, addresses.size());
+    }
+
+    @Override
+    public List<String> getAddresses() {
+        return resolvedAddresses;
+    }
+
+    @Override
+    public void shutdown() {
+        // ServiceDiscovery is a shared Spring bean; only set a flag here
+        // to block subsequent listener callbacks from mutating state.
+        shutdown.set(true);
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/main/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolver.java
@@ -74,7 +74,7 @@ public class ServiceDiscoveryAddressResolver implements OptimizerAddressResolver
         for (WorkerHost host : hosts) {
             addresses.add(host.getIp() + ":" + host.getPort());
         }
-        this.resolvedAddresses = addresses;
+        this.resolvedAddresses = Collections.unmodifiableList(addresses);
         log.info("ServiceDiscoveryAddressResolver updated, domain={}, count={}", domain, addresses.size());
     }
 

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/DirectAddressResolverTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/DirectAddressResolverTest.java
@@ -1,0 +1,29 @@
+package org.flexlb.service.optimizer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DirectAddressResolverTest {
+
+    @Test
+    void should_return_configured_address() {
+        DirectAddressResolver resolver = new DirectAddressResolver("10.0.0.1:8082");
+
+        List<String> addresses = resolver.getAddresses();
+
+        assertEquals(1, addresses.size());
+        assertEquals("10.0.0.1:8082", addresses.get(0));
+    }
+
+    @Test
+    void should_shutdown_without_error() {
+        DirectAddressResolver resolver = new DirectAddressResolver("10.0.0.1:8082");
+
+        resolver.shutdown();
+
+        assertEquals(List.of("10.0.0.1:8082"), resolver.getAddresses());
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
@@ -1,0 +1,450 @@
+package org.flexlb.service.optimizer;
+
+import org.flexlb.dao.optimizer.CommonResponseHeader;
+import org.flexlb.dao.optimizer.OptimizerGetInstanceResponse;
+import org.flexlb.dao.optimizer.OptimizerInstanceParams;
+import org.flexlb.dao.optimizer.OptimizerRegisterRequest;
+import org.flexlb.dao.optimizer.OptimizerRegisterResponse;
+import org.flexlb.dao.optimizer.OptimizerRemoveInstanceResponse;
+import org.flexlb.dao.optimizer.OptimizerTraceQueryResponse;
+import org.flexlb.transport.GeneralHttpNettyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnlineOptimizerClientTest {
+
+    @Mock
+    private GeneralHttpNettyService httpService;
+
+    @Mock
+    private OptimizerAddressResolver addressResolver;
+
+    private OnlineOptimizerClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new OnlineOptimizerClient(httpService, addressResolver, "test-group", "/api/optimizer", 5000);
+    }
+
+    @Test
+    void should_skip_traceQuery_when_not_registered() {
+        client.traceQuery(123L, List.of(1L, 2L, 3L));
+
+        verify(httpService, never()).request(any(), any(URI.class), any(), any());
+    }
+
+    @Test
+    void should_skip_traceQuery_when_blockKeys_empty() {
+        client.traceQuery(123L, List.of());
+
+        verify(httpService, never()).request(any(), any(URI.class), any(), any());
+    }
+
+    @Test
+    void should_skip_traceQuery_when_blockKeys_null() {
+        client.traceQuery(123L, null);
+
+        verify(httpService, never()).request(any(), any(URI.class), any(), any());
+    }
+
+    @Test
+    void should_register_successfully_when_instance_not_exists() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .blockSize(64)
+                .locationSpecInfos(List.of(new OptimizerRegisterRequest.LocationSpecInfo("full", 131072)))
+                .build();
+        client.startRegistrationAsync("test-instance", params);
+
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+
+        Thread.sleep(100);
+        assertTrue(client.isRegistered());
+    }
+
+    @Test
+    void should_skip_registration_when_instance_exists_with_matching_params() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(okHeader());
+        getResp.setInstanceId("test-instance");
+        getResp.setBlockSize(64);
+        getResp.setLocationSpecInfos(List.of(createRemoteSpecInfo("full", 131072)));
+        getResp.setLinearStep(0);
+        getResp.setFullGroupName("");
+
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .blockSize(64)
+                .locationSpecInfos(List.of(new OptimizerRegisterRequest.LocationSpecInfo("full", 131072)))
+                .build();
+        client.startRegistrationAsync("test-instance", params);
+
+        Thread.sleep(500);
+        assertTrue(client.isRegistered());
+        verify(httpService, never()).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+    }
+
+    @Test
+    void should_remove_and_reregister_when_params_differ() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(okHeader());
+        getResp.setInstanceId("test-instance");
+        getResp.setBlockSize(32);
+        getResp.setLocationSpecInfos(List.of(createRemoteSpecInfo("full", 65536)));
+
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRemoveInstanceResponse removeResp = new OptimizerRemoveInstanceResponse();
+        removeResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/removeInstance"),
+                eq(OptimizerRemoveInstanceResponse.class)))
+                .thenReturn(Mono.just(removeResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .blockSize(64)
+                .locationSpecInfos(List.of(new OptimizerRegisterRequest.LocationSpecInfo("full", 131072)))
+                .build();
+        client.startRegistrationAsync("test-instance", params);
+
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/removeInstance"), eq(OptimizerRemoveInstanceResponse.class));
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+
+        Thread.sleep(100);
+        assertTrue(client.isRegistered());
+    }
+
+    @Test
+    void should_retry_when_address_not_resolved() throws Exception {
+        when(addressResolver.getAddresses())
+                .thenReturn(List.of())
+                .thenReturn(List.of())
+                .thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        client.startRegistrationAsync("test-instance", params);
+
+        verify(httpService, timeout(10000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+
+        Thread.sleep(100);
+        assertTrue(client.isRegistered());
+    }
+
+    @Test
+    void should_retry_when_registration_fails() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.error(new RuntimeException("connection refused")))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        client.startRegistrationAsync("test-instance", params);
+
+        verify(httpService, timeout(10000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+
+        Thread.sleep(100);
+        assertTrue(client.isRegistered());
+    }
+
+    @Test
+    void should_fire_traceQuery_when_registered() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        client.startRegistrationAsync("test-instance", params);
+        Thread.sleep(500);
+        assertTrue(client.isRegistered());
+
+        OptimizerTraceQueryResponse traceResp = new OptimizerTraceQueryResponse();
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/traceQuery"),
+                eq(OptimizerTraceQueryResponse.class)))
+                .thenReturn(Mono.just(traceResp));
+
+        client.traceQuery(999L, List.of(10L, 20L, 30L));
+
+        verify(httpService, timeout(1000)).request(any(), any(URI.class),
+                eq("/api/optimizer/traceQuery"), eq(OptimizerTraceQueryResponse.class));
+    }
+
+    private static CommonResponseHeader okHeader() {
+        CommonResponseHeader header = new CommonResponseHeader();
+        CommonResponseHeader.Status status = new CommonResponseHeader.Status();
+        status.setCode(1);
+        header.setStatus(status);
+        return header;
+    }
+
+    private static OptimizerGetInstanceResponse.LocationSpecInfo createRemoteSpecInfo(String name, int size) {
+        OptimizerGetInstanceResponse.LocationSpecInfo info = new OptimizerGetInstanceResponse.LocationSpecInfo();
+        info.setName(name);
+        info.setSize(size);
+        return info;
+    }
+
+    private static OptimizerGetInstanceResponse.LocationSpecGroup createRemoteSpecGroup(String name, List<String> specNames) {
+        OptimizerGetInstanceResponse.LocationSpecGroup group = new OptimizerGetInstanceResponse.LocationSpecGroup();
+        group.setName(name);
+        group.setSpecNames(specNames);
+        return group;
+    }
+
+    @Test
+    void should_skip_duplicate_startRegistrationAsync() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        client.startRegistrationAsync("test-instance", params);
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        Thread.sleep(100);
+
+        // 重复调用应被 AtomicBoolean started 拦截，不应产生额外 register 请求
+        client.startRegistrationAsync("test-instance", params);
+        Thread.sleep(200);
+        verify(httpService, times(1)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+    }
+
+    @Test
+    void should_normalize_basePath_with_trailing_slash() {
+        OnlineOptimizerClient c = new OnlineOptimizerClient(
+                httpService, addressResolver, "g", "/api/optimizer///", 5000);
+        try {
+            when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+            OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+            CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+            CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+            notFoundStatus.setCode(0);
+            notFoundHeader.setStatus(notFoundStatus);
+            getResp.setHeader(notFoundHeader);
+            when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                    eq(OptimizerGetInstanceResponse.class)))
+                    .thenReturn(Mono.just(getResp));
+
+            OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+            registerResp.setHeader(okHeader());
+            when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                    eq(OptimizerRegisterResponse.class)))
+                    .thenReturn(Mono.just(registerResp));
+
+            c.startRegistrationAsync("id", OptimizerInstanceParams.builder().blockSize(64).build());
+
+            // 拼出的路径应为 /api/optimizer/getInstance 与 /api/optimizer/registerInstance，而非双斜杠
+            verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                    eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        } finally {
+            c.shutdown();
+        }
+    }
+
+    @Test
+    void should_swallow_exception_in_traceQuery() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        CommonResponseHeader notFoundHeader = new CommonResponseHeader();
+        CommonResponseHeader.Status notFoundStatus = new CommonResponseHeader.Status();
+        notFoundStatus.setCode(0);
+        notFoundHeader.setStatus(notFoundStatus);
+        getResp.setHeader(notFoundHeader);
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+        Thread.sleep(500);
+        assertTrue(client.isRegistered());
+
+        // httpService.request 同步抛出（非 Mono.error），traceQuery 外层需咽住不要外传
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/traceQuery"),
+                eq(OptimizerTraceQueryResponse.class)))
+                .thenThrow(new RuntimeException("boom"));
+
+        client.traceQuery(999L, List.of(10L, 20L));
+        // 未抛异常即表示 try/catch Throwable 生效
+    }
+
+    @Test
+    void should_shutdown_invoke_addressResolver() {
+        client.shutdown();
+        verify(addressResolver).shutdown();
+        // 重复 shutdown 不应抛异常
+        client.shutdown();
+    }
+
+    @Test
+    void should_not_register_after_shutdown() throws Exception {
+        client.shutdown();
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        // RejectedExecutionException 应被 safeSubmit 咽住，不会传出
+        client.startRegistrationAsync("test-instance", params);
+        Thread.sleep(200);
+        assertFalse(client.isRegistered());
+    }
+
+    @Test
+    void should_match_params_regardless_of_order() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(okHeader());
+        getResp.setInstanceId("test-instance");
+        getResp.setBlockSize(64);
+        // Remote returns specs in REVERSED order compared to local
+        getResp.setLocationSpecInfos(List.of(
+                createRemoteSpecInfo("linear", 65536),
+                createRemoteSpecInfo("full", 131072)));
+        getResp.setLocationSpecGroups(List.of(createRemoteSpecGroup("group_b", List.of("linear")),
+                createRemoteSpecGroup("group_a", List.of("full"))));
+        getResp.setLinearStep(0);
+        getResp.setFullGroupName("");
+
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        // Local params have specs/groups in different order than remote
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder()
+                .blockSize(64)
+                .locationSpecInfos(List.of(
+                        new OptimizerRegisterRequest.LocationSpecInfo("full", 131072),
+                        new OptimizerRegisterRequest.LocationSpecInfo("linear", 65536)))
+                .locationSpecGroups(List.of(
+                        new OptimizerRegisterRequest.LocationSpecGroup("group_a", List.of("full")),
+                        new OptimizerRegisterRequest.LocationSpecGroup("group_b", List.of("linear"))))
+                .build();
+        client.startRegistrationAsync("test-instance", params);
+
+        Thread.sleep(500);
+        assertTrue(client.isRegistered());
+        // Should NOT re-register since params match (order-independent)
+        verify(httpService, never()).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
@@ -7,6 +7,8 @@ import org.flexlb.dao.optimizer.OptimizerRegisterRequest;
 import org.flexlb.dao.optimizer.OptimizerRegisterResponse;
 import org.flexlb.dao.optimizer.OptimizerRemoveInstanceResponse;
 import org.flexlb.dao.optimizer.OptimizerTraceQueryResponse;
+import org.flexlb.enums.StatusEnum;
+import org.flexlb.exception.FlexLBException;
 import org.flexlb.transport.GeneralHttpNettyService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,8 +122,7 @@ class OnlineOptimizerClientTest {
         verify(httpService, timeout(3000)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
 
-        Thread.sleep(100);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
     }
 
     @Test
@@ -146,8 +147,7 @@ class OnlineOptimizerClientTest {
                 .build();
         client.startRegistrationAsync("test-instance", params);
 
-        Thread.sleep(500);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
         verify(httpService, never()).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
     }
@@ -189,8 +189,7 @@ class OnlineOptimizerClientTest {
         verify(httpService, timeout(3000)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
 
-        Thread.sleep(100);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
     }
 
     @Test
@@ -222,8 +221,7 @@ class OnlineOptimizerClientTest {
         verify(httpService, timeout(10000)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
 
-        Thread.sleep(100);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
     }
 
     @Test
@@ -238,7 +236,7 @@ class OnlineOptimizerClientTest {
         getResp.setHeader(notFoundHeader);
         when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
                 eq(OptimizerGetInstanceResponse.class)))
-                .thenReturn(Mono.error(new RuntimeException("connection refused")))
+                .thenReturn(Mono.error(StatusEnum.INTERNAL_ERROR.toException("connection refused")))
                 .thenReturn(Mono.just(getResp));
 
         OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
@@ -253,8 +251,32 @@ class OnlineOptimizerClientTest {
         verify(httpService, timeout(10000)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
 
-        Thread.sleep(100);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
+    }
+
+    @Test
+    void should_treat_http_error_as_not_found_and_proceed_to_register() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        // Plain RuntimeException (HTTP non-200) should be treated as "instance not found"
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.error(new RuntimeException("http error, httpStatusCode=404, body=not found")));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
+        client.startRegistrationAsync("test-instance", params);
+
+        // Should proceed directly to registration without retry
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+
+        awaitRegistered(3000);
     }
 
     @Test
@@ -279,8 +301,7 @@ class OnlineOptimizerClientTest {
 
         OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
         client.startRegistrationAsync("test-instance", params);
-        Thread.sleep(500);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
 
         OptimizerTraceQueryResponse traceResp = new OptimizerTraceQueryResponse();
         when(httpService.request(any(), any(URI.class), eq("/api/optimizer/traceQuery"),
@@ -339,11 +360,11 @@ class OnlineOptimizerClientTest {
         client.startRegistrationAsync("test-instance", params);
         verify(httpService, timeout(3000)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
-        Thread.sleep(100);
+        awaitRegistered(3000);
 
         // Duplicate call must be blocked by AtomicBoolean started; no extra register request.
         client.startRegistrationAsync("test-instance", params);
-        Thread.sleep(200);
+        // startRegistrationAsync rejects synchronously via AtomicBoolean; no async delay needed.
         verify(httpService, times(1)).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
     }
@@ -403,8 +424,7 @@ class OnlineOptimizerClientTest {
 
         client.startRegistrationAsync("test-instance",
                 OptimizerInstanceParams.builder().blockSize(64).build());
-        Thread.sleep(500);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
 
         // httpService.request throws synchronously (not Mono.error); traceQuery must swallow it.
         when(httpService.request(any(), any(URI.class), eq("/api/optimizer/traceQuery"),
@@ -430,7 +450,8 @@ class OnlineOptimizerClientTest {
         OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
         // RejectedExecutionException should be swallowed by safeSubmit and not propagate.
         client.startRegistrationAsync("test-instance", params);
-        Thread.sleep(200);
+
+        // RejectedExecutionException is swallowed synchronously by safeSubmit; no async delay.
         assertFalse(client.isRegistered());
     }
 
@@ -467,8 +488,7 @@ class OnlineOptimizerClientTest {
                 .build();
         client.startRegistrationAsync("test-instance", params);
 
-        Thread.sleep(500);
-        assertTrue(client.isRegistered());
+        awaitRegistered(3000);
         // Should NOT re-register since params match (order-independent)
         verify(httpService, never()).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
@@ -497,7 +517,6 @@ class OnlineOptimizerClientTest {
 
         verify(httpService, timeout(3000).atLeastOnce()).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
-        Thread.sleep(200);
 
         // Strict isOkHeader: missing header must NOT be treated as success
         assertFalse(client.isRegistered());
@@ -525,7 +544,6 @@ class OnlineOptimizerClientTest {
 
         verify(httpService, timeout(3000).atLeastOnce()).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
-        Thread.sleep(200);
 
         assertFalse(client.isRegistered());
     }
@@ -558,11 +576,9 @@ class OnlineOptimizerClientTest {
         // Now resolver reports zero hosts (e.g. all instances down).
         when(addressResolver.getAddresses()).thenReturn(List.of());
 
+        // traceQuery is synchronous; refreshUri clears optimizerUri so the call short-circuits.
         client.traceQuery(999L, List.of(10L, 20L));
-        Thread.sleep(100);
 
-        // refreshUri must clear optimizerUri so traceQuery short-circuits and never
-        // hits the dead address.
         verify(httpService, never()).request(any(), any(URI.class),
                 eq("/api/optimizer/traceQuery"), eq(OptimizerTraceQueryResponse.class));
     }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerClientTest.java
@@ -8,6 +8,7 @@ import org.flexlb.dao.optimizer.OptimizerRegisterResponse;
 import org.flexlb.dao.optimizer.OptimizerRemoveInstanceResponse;
 import org.flexlb.dao.optimizer.OptimizerTraceQueryResponse;
 import org.flexlb.transport.GeneralHttpNettyService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +21,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -42,6 +46,28 @@ class OnlineOptimizerClientTest {
     @BeforeEach
     void setUp() {
         client = new OnlineOptimizerClient(httpService, addressResolver, "test-group", "/api/optimizer", 5000);
+        // Default resolver to "started". Tests that exercise listen-fail retry override this.
+        lenient().when(addressResolver.start()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Stop async retry thread; shutdown is idempotent.
+        if (client != null) {
+            client.shutdown();
+        }
+    }
+
+    /** Poll until registered or timeout, instead of a fixed Thread.sleep. */
+    private void awaitRegistered(long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (client.isRegistered()) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        fail("client did not become registered within " + timeoutMs + "ms");
     }
 
     @Test
@@ -315,7 +341,7 @@ class OnlineOptimizerClientTest {
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
         Thread.sleep(100);
 
-        // 重复调用应被 AtomicBoolean started 拦截，不应产生额外 register 请求
+        // Duplicate call must be blocked by AtomicBoolean started; no extra register request.
         client.startRegistrationAsync("test-instance", params);
         Thread.sleep(200);
         verify(httpService, times(1)).request(any(), any(URI.class),
@@ -347,7 +373,7 @@ class OnlineOptimizerClientTest {
 
             c.startRegistrationAsync("id", OptimizerInstanceParams.builder().blockSize(64).build());
 
-            // 拼出的路径应为 /api/optimizer/getInstance 与 /api/optimizer/registerInstance，而非双斜杠
+            // Resolved path should be /api/optimizer/{getInstance,registerInstance}, not doubled slashes.
             verify(httpService, timeout(3000)).request(any(), any(URI.class),
                     eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
         } finally {
@@ -380,20 +406,20 @@ class OnlineOptimizerClientTest {
         Thread.sleep(500);
         assertTrue(client.isRegistered());
 
-        // httpService.request 同步抛出（非 Mono.error），traceQuery 外层需咽住不要外传
+        // httpService.request throws synchronously (not Mono.error); traceQuery must swallow it.
         when(httpService.request(any(), any(URI.class), eq("/api/optimizer/traceQuery"),
                 eq(OptimizerTraceQueryResponse.class)))
                 .thenThrow(new RuntimeException("boom"));
 
         client.traceQuery(999L, List.of(10L, 20L));
-        // 未抛异常即表示 try/catch Throwable 生效
+        // No exception thrown means the try/catch Throwable guard works.
     }
 
     @Test
     void should_shutdown_invoke_addressResolver() {
         client.shutdown();
         verify(addressResolver).shutdown();
-        // 重复 shutdown 不应抛异常
+        // Repeated shutdown must not throw.
         client.shutdown();
     }
 
@@ -402,7 +428,7 @@ class OnlineOptimizerClientTest {
         client.shutdown();
 
         OptimizerInstanceParams params = OptimizerInstanceParams.builder().blockSize(64).build();
-        // RejectedExecutionException 应被 safeSubmit 咽住，不会传出
+        // RejectedExecutionException should be swallowed by safeSubmit and not propagate.
         client.startRegistrationAsync("test-instance", params);
         Thread.sleep(200);
         assertFalse(client.isRegistered());
@@ -446,5 +472,160 @@ class OnlineOptimizerClientTest {
         // Should NOT re-register since params match (order-independent)
         verify(httpService, never()).request(any(), any(URI.class),
                 eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+    }
+
+    // ===== malformed response =====
+
+    @Test
+    void should_treat_missing_header_as_register_failure() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(notFoundHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        // Malformed: response object exists but header is null
+        OptimizerRegisterResponse malformed = new OptimizerRegisterResponse();
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(malformed));
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+
+        verify(httpService, timeout(3000).atLeastOnce()).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        Thread.sleep(200);
+
+        // Strict isOkHeader: missing header must NOT be treated as success
+        assertFalse(client.isRegistered());
+    }
+
+    @Test
+    void should_treat_missing_status_as_register_failure() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(notFoundHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        // Malformed: header present but status is null
+        OptimizerRegisterResponse malformed = new OptimizerRegisterResponse();
+        malformed.setHeader(new CommonResponseHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(malformed));
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+
+        verify(httpService, timeout(3000).atLeastOnce()).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        Thread.sleep(200);
+
+        assertFalse(client.isRegistered());
+    }
+
+    // ===== empty addresses clears cached URI =====
+
+    @Test
+    void should_clear_cached_uri_when_addresses_become_empty() throws Exception {
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(notFoundHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+        // Wait for async registration to actually complete instead of a fixed sleep.
+        verify(httpService, timeout(3000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        awaitRegistered(3000);
+
+        // Now resolver reports zero hosts (e.g. all instances down).
+        when(addressResolver.getAddresses()).thenReturn(List.of());
+
+        client.traceQuery(999L, List.of(10L, 20L));
+        Thread.sleep(100);
+
+        // refreshUri must clear optimizerUri so traceQuery short-circuits and never
+        // hits the dead address.
+        verify(httpService, never()).request(any(), any(URI.class),
+                eq("/api/optimizer/traceQuery"), eq(OptimizerTraceQueryResponse.class));
+    }
+
+    // ===== resolver listen-fail async retry =====
+
+    @Test
+    void should_retry_when_resolver_start_fails_then_recovers() throws Exception {
+        // Override default lenient stub: first two start() calls fail (listen broken),
+        // then recover. The retry chain inside attemptRegistration must keep calling start().
+        when(addressResolver.start())
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true);
+        when(addressResolver.getAddresses()).thenReturn(List.of("10.0.0.1:8082"));
+
+        OptimizerGetInstanceResponse getResp = new OptimizerGetInstanceResponse();
+        getResp.setHeader(notFoundHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/getInstance"),
+                eq(OptimizerGetInstanceResponse.class)))
+                .thenReturn(Mono.just(getResp));
+
+        OptimizerRegisterResponse registerResp = new OptimizerRegisterResponse();
+        registerResp.setHeader(okHeader());
+        when(httpService.request(any(), any(URI.class), eq("/api/optimizer/registerInstance"),
+                eq(OptimizerRegisterResponse.class)))
+                .thenReturn(Mono.just(registerResp));
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+
+        // Backoff: 1s + jitter, then 2s + jitter — give it up to 15s
+        verify(httpService, timeout(15000)).request(any(), any(URI.class),
+                eq("/api/optimizer/registerInstance"), eq(OptimizerRegisterResponse.class));
+        awaitRegistered(3000);
+
+        // start() must be called at least 3 times: first two return false to trigger retry,
+        // third one finally succeeds.
+        verify(addressResolver, atLeast(3)).start();
+    }
+
+    @Test
+    void should_not_call_httpService_when_resolver_start_keeps_failing() throws Exception {
+        // Override default: start() always returns false (listen permanently broken).
+        when(addressResolver.start()).thenReturn(false);
+
+        client.startRegistrationAsync("test-instance",
+                OptimizerInstanceParams.builder().blockSize(64).build());
+
+        // Wait until the retry chain ran at least twice (initial attempt + first retry)
+        // to avoid jitter-boundary flakiness from a fixed sleep.
+        verify(addressResolver, timeout(5000).atLeast(2)).start();
+
+        // No HTTP traffic should have been issued because resolver never started.
+        verify(httpService, never()).request(any(), any(URI.class), any(), any());
+        assertFalse(client.isRegistered());
+    }
+
+    private static CommonResponseHeader notFoundHeader() {
+        CommonResponseHeader header = new CommonResponseHeader();
+        CommonResponseHeader.Status status = new CommonResponseHeader.Status();
+        status.setCode(0);
+        header.setStatus(status);
+        return header;
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -135,9 +136,9 @@ class OnlineOptimizerHookerTest {
 
         hooker.afterStartUp();
         assertNotNull(hooker.getClient());
-        // ServiceDiscovery is touched only after afterStartUp
-        verify(serviceDiscovery).getHosts("optimizer.test.domain.com");
-        verify(serviceDiscovery).listen(any(), any());
+        // ServiceDiscovery is touched only after afterStartUp, via async retry
+        verify(serviceDiscovery, timeout(3000)).getHosts("optimizer.test.domain.com");
+        verify(serviceDiscovery, timeout(3000)).listen(any(), any());
     }
 
     @Test

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
@@ -61,6 +61,9 @@ class OnlineOptimizerHookerTest {
         env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
         env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
         env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
 
         OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
 
@@ -84,6 +87,9 @@ class OnlineOptimizerHookerTest {
         env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
         env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
         env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
 
         OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
         assertTrue(hooker.isEnabled());
@@ -99,6 +105,9 @@ class OnlineOptimizerHookerTest {
         env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
         env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
         env.set("MODEL_SERVICE_CONFIG", "{\"service_id\":\"function.qwen-72b\",\"role_endpoints\":[]}");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
 
         OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
         assertTrue(hooker.isEnabled());
@@ -112,6 +121,9 @@ class OnlineOptimizerHookerTest {
         env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
         env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
         env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "my-custom-id");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
 
         OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
         assertTrue(hooker.isEnabled());
@@ -125,6 +137,9 @@ class OnlineOptimizerHookerTest {
         env.set("OPTIMIZER_VIPSERVER_DOMAIN", "optimizer.test.domain.com");
         env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
         env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
         when(serviceDiscovery.getHosts(anyString())).thenReturn(Collections.emptyList());
 
         OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
@@ -182,5 +197,182 @@ class OnlineOptimizerHookerTest {
         verify(serviceDiscovery, never()).getHosts(any());
         verify(serviceDiscovery, never()).listen(any(), any());
         assertNull(hooker.getClient());
+    }
+
+    // ===== Parameter validation boundary tests =====
+
+    /**
+     * Verifies that illegal numeric params (blockSize, linearStep) abort registration.
+     * Covers: missing, negative, non-integer values.
+     */
+    @Test
+    void should_abort_registration_when_numeric_params_illegal() {
+        // blockSize not set (defaults to 0) -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // blockSize negative -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "-1");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // blockSize non-integer -> falls back to 0 -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "abc");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // linearStep negative -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LINEAR_STEP", "-5");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+    }
+
+    /**
+     * Verifies that invalid locationSpecInfos / locationSpecGroups abort registration.
+     * Covers: not set, wrong format, non-integer size.
+     */
+    @Test
+    void should_abort_registration_when_location_spec_params_illegal() {
+        // locationSpecInfos not set -> null -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // locationSpecInfos invalid format (no colon) -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "invalid_no_colon");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // locationSpecInfos non-integer size -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:not_a_number");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // locationSpecGroups not set -> null -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        });
+
+        // locationSpecGroups invalid format (no colon) -> abort
+        assertAborts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "no_colon_here");
+        });
+    }
+
+    /**
+     * Verifies that valid params (multi-entry, single-entry, max value) all proceed to registration.
+     */
+    @Test
+    void should_start_registration_when_params_valid() {
+        // Multi-entry valid config
+        assertStarts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+            env.set("ONLINE_OPTIMIZER_LINEAR_STEP", "0");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072,linear:65536");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full|linear");
+        });
+
+        // Max blockSize boundary
+        assertStarts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", String.valueOf(Integer.MAX_VALUE));
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        });
+
+        // Single-entry minimal valid config (blockSize=1)
+        assertStarts(env -> {
+            env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "1");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:1");
+            env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "g:full");
+        });
+    }
+
+    /**
+     * Verifies that ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS <= 0 falls back to default (5000).
+     * The hooker should still be enabled and start registration normally.
+     */
+    @Test
+    void should_fallback_to_default_timeout_when_register_timeout_ms_not_positive() {
+        // Zero value -> falls back to default
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        env.set("ONLINE_OPTIMIZER_BLOCK_SIZE", "64");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS", "full:131072");
+        env.set("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS", "group_a:full");
+        env.set("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS", "0");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+        hooker.beforeShutdown();
+
+        // Negative value -> falls back to default
+        env.set("ONLINE_OPTIMIZER_REGISTER_TIMEOUT_MS", "-1000");
+
+        OnlineOptimizerHooker hooker2 = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker2.isEnabled());
+        hooker2.afterStartUp();
+        assertNotNull(hooker2.getClient());
+        hooker2.beforeShutdown();
+    }
+
+    // ===== helpers =====
+
+    private void assertAborts(java.util.function.Consumer<EnvironmentVariables> extraEnv) {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        extraEnv.accept(env);
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+        hooker.afterStartUp();
+        // Client is only created after param validation passes; invalid params means no client.
+        assertNull(hooker.getClient());
+        hooker.beforeShutdown();
+
+        // Reset env for next sub-case
+        env.remove("ONLINE_OPTIMIZER_BLOCK_SIZE");
+        env.remove("ONLINE_OPTIMIZER_LINEAR_STEP");
+        env.remove("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS");
+        env.remove("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS");
+    }
+
+    private void assertStarts(java.util.function.Consumer<EnvironmentVariables> extraEnv) {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        extraEnv.accept(env);
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+        hooker.beforeShutdown();
+
+        // Reset env for next sub-case
+        env.remove("ONLINE_OPTIMIZER_BLOCK_SIZE");
+        env.remove("ONLINE_OPTIMIZER_LINEAR_STEP");
+        env.remove("ONLINE_OPTIMIZER_LOCATION_SPEC_INFOS");
+        env.remove("ONLINE_OPTIMIZER_LOCATION_SPEC_GROUPS");
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/OnlineOptimizerHookerTest.java
@@ -1,0 +1,185 @@
+package org.flexlb.service.optimizer;
+
+import org.flexlb.discovery.ServiceDiscovery;
+import org.flexlb.transport.GeneralHttpNettyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class OnlineOptimizerHookerTest {
+
+    @Mock
+    private GeneralHttpNettyService httpService;
+
+    @Mock
+    private ServiceDiscovery serviceDiscovery;
+
+    @SystemStub
+    private EnvironmentVariables env = new EnvironmentVariables();
+
+    @Test
+    void should_be_disabled_when_no_env_vars_configured() {
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+
+        assertFalse(hooker.isEnabled());
+        assertNull(hooker.getClient());
+        hooker.afterStartUp();
+        assertNull(hooker.getClient());
+    }
+
+    @Test
+    void should_be_disabled_when_only_address_configured() {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+
+        assertFalse(hooker.isEnabled());
+        assertNull(hooker.getClient());
+    }
+
+    @Test
+    void should_be_enabled_when_address_and_group_configured() {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+
+        assertTrue(hooker.isEnabled());
+        // client is created lazily in afterStartUp
+        assertNull(hooker.getClient());
+
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+    }
+
+    @Test
+    void should_shutdown_safely_when_disabled() {
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+
+        hooker.beforeShutdown();
+    }
+
+    @Test
+    void should_shutdown_client_when_enabled() {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+
+        hooker.beforeShutdown();
+    }
+
+    @Test
+    void should_resolve_instanceId_from_model_service_config() {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("MODEL_SERVICE_CONFIG", "{\"service_id\":\"function.qwen-72b\",\"role_endpoints\":[]}");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+    }
+
+    @Test
+    void should_use_explicit_instanceId_when_configured() {
+        env.set("OPTIMIZER_DIRECT_ADDRESS", "10.0.0.1:8082");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "my-custom-id");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertTrue(hooker.isEnabled());
+
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+    }
+
+    @Test
+    void should_be_enabled_when_vipserver_domain_configured() {
+        env.set("OPTIMIZER_VIPSERVER_DOMAIN", "optimizer.test.domain.com");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+        when(serviceDiscovery.getHosts(anyString())).thenReturn(Collections.emptyList());
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+
+        assertTrue(hooker.isEnabled());
+        // No service-discovery interaction at construction time
+        verify(serviceDiscovery, never()).getHosts(any());
+        verify(serviceDiscovery, never()).listen(any(), any());
+
+        hooker.afterStartUp();
+        assertNotNull(hooker.getClient());
+        // ServiceDiscovery is touched only after afterStartUp
+        verify(serviceDiscovery).getHosts("optimizer.test.domain.com");
+        verify(serviceDiscovery).listen(any(), any());
+    }
+
+    @Test
+    void should_be_disabled_when_vipserver_domain_set_but_no_service_discovery() {
+        env.set("OPTIMIZER_VIPSERVER_DOMAIN", "optimizer.test.domain.com");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_ID", "test-instance");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, null);
+
+        assertFalse(hooker.isEnabled());
+        assertNull(hooker.getClient());
+    }
+
+    @Test
+    void should_not_touch_service_discovery_when_disabled_due_to_missing_instanceGroup() throws Exception {
+        // Only domain set; instanceGroup missing -> disabled, must not touch ServiceDiscovery
+        env.set("OPTIMIZER_VIPSERVER_DOMAIN", "optimizer.test.domain.com");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertFalse(hooker.isEnabled());
+
+        hooker.afterStartUp();
+        Thread.sleep(50);
+        verify(serviceDiscovery, never()).getHosts(any());
+        verify(serviceDiscovery, never()).listen(any(), any());
+        assertNull(hooker.getClient());
+    }
+
+    @Test
+    void should_not_touch_service_discovery_when_disabled_due_to_missing_instanceId() throws Exception {
+        // domain + instanceGroup set, instanceId missing -> disabled, must not touch ServiceDiscovery
+        env.set("OPTIMIZER_VIPSERVER_DOMAIN", "optimizer.test.domain.com");
+        env.set("ONLINE_OPTIMIZER_INSTANCE_GROUP", "test-group");
+
+        OnlineOptimizerHooker hooker = new OnlineOptimizerHooker(httpService, serviceDiscovery);
+        assertFalse(hooker.isEnabled());
+
+        hooker.afterStartUp();
+        Thread.sleep(50);
+        verify(serviceDiscovery, never()).getHosts(any());
+        verify(serviceDiscovery, never()).listen(any(), any());
+        assertNull(hooker.getClient());
+    }
+}

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolverTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolverTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -154,13 +155,15 @@ class ServiceDiscoveryAddressResolverTest {
                 .when(sd).listen(eq(DOMAIN), any(ServiceHostListener.class));
 
         ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
-        r.start();
+        // start() returns false on listen failure
+        assertFalse(r.start());
         verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
 
         // After fixing listen, start() again should re-invoke getHosts and listen
         reset(sd);
         when(sd.getHosts(DOMAIN)).thenReturn(List.of(WorkerHost.of("4.4.4.4", 7000)));
-        r.start();
+        // start() returns true after recovery
+        assertTrue(r.start());
 
         verify(sd, times(1)).getHosts(DOMAIN);
         verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
@@ -178,5 +181,49 @@ class ServiceDiscoveryAddressResolverTest {
         // After shutdown, no service-discovery calls should be issued
         verify(sd, never()).getHosts(any());
         verify(sd, never()).listen(any(), any());
+    }
+
+    // ===== start() return-value contract =====
+
+    @Test
+    void start_should_return_true_on_success() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        assertTrue(r.start());
+    }
+
+    @Test
+    void start_should_return_true_when_already_started() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        assertTrue(r.start());
+        // Idempotent: subsequent calls also return true without re-issuing IO
+        assertTrue(r.start());
+        verify(sd, times(1)).getHosts(DOMAIN);
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+    }
+
+    @Test
+    void start_should_return_false_when_listen_fails() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+        doThrow(new RuntimeException("listen boom"))
+                .when(sd).listen(eq(DOMAIN), any(ServiceHostListener.class));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        assertFalse(r.start());
+    }
+
+    @Test
+    void start_should_return_false_after_shutdown() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.shutdown();
+        assertFalse(r.start());
     }
 }

--- a/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolverTest.java
+++ b/rtp_llm/flexlb/flexlb-sync/src/test/java/org/flexlb/service/optimizer/ServiceDiscoveryAddressResolverTest.java
@@ -1,0 +1,182 @@
+package org.flexlb.service.optimizer;
+
+import org.flexlb.dao.master.WorkerHost;
+import org.flexlb.discovery.ServiceDiscovery;
+import org.flexlb.discovery.ServiceHostListener;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceDiscoveryAddressResolverTest {
+
+    private static final String DOMAIN = "optimizer.test.domain.com";
+
+    @Test
+    void should_return_empty_before_start() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+
+        assertTrue(r.getAddresses().isEmpty());
+    }
+
+    @Test
+    void should_seed_initial_hosts_and_register_listener_on_start() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(List.of(WorkerHost.of("1.1.1.1", 8000, "site-a")));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+
+        assertEquals(List.of("1.1.1.1:8000"), r.getAddresses());
+        verify(sd, times(1)).getHosts(DOMAIN);
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+    }
+
+    @Test
+    void should_update_addresses_on_listener_callback() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+
+        ArgumentCaptor<ServiceHostListener> captor = ArgumentCaptor.forClass(ServiceHostListener.class);
+        verify(sd).listen(eq(DOMAIN), captor.capture());
+        ServiceHostListener listener = captor.getValue();
+
+        listener.onHostsChanged(List.of(
+                WorkerHost.of("2.2.2.2", 9000),
+                WorkerHost.of("3.3.3.3", 9001)
+        ));
+
+        assertEquals(List.of("2.2.2.2:9000", "3.3.3.3:9001"), r.getAddresses());
+    }
+
+    @Test
+    void should_clear_addresses_when_listener_pushes_empty_or_null() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(List.of(WorkerHost.of("1.1.1.1", 8000)));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+        assertEquals(List.of("1.1.1.1:8000"), r.getAddresses());
+
+        ArgumentCaptor<ServiceHostListener> captor = ArgumentCaptor.forClass(ServiceHostListener.class);
+        verify(sd).listen(eq(DOMAIN), captor.capture());
+
+        // Empty hosts clear the snapshot (aligned with EngineAddressNameResolver)
+        captor.getValue().onHostsChanged(Collections.emptyList());
+        assertTrue(r.getAddresses().isEmpty());
+
+        // null also clears
+        captor.getValue().onHostsChanged(List.of(WorkerHost.of("2.2.2.2", 9000)));
+        assertEquals(List.of("2.2.2.2:9000"), r.getAddresses());
+        captor.getValue().onHostsChanged(null);
+        assertTrue(r.getAddresses().isEmpty());
+    }
+
+    @Test
+    void should_skip_duplicate_start() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+        r.start();
+
+        verify(sd, times(1)).getHosts(DOMAIN);
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+    }
+
+    @Test
+    void shutdown_should_not_propagate_to_shared_service_discovery() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+        r.shutdown();
+
+        // ServiceDiscovery is a shared Spring bean; shutdown() must not propagate
+        verify(sd, never()).shutdown();
+    }
+
+    @Test
+    void should_tolerate_getHosts_failure_and_still_register_listener() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenThrow(new RuntimeException("boom"));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+
+        assertTrue(r.getAddresses().isEmpty());
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+    }
+
+    @Test
+    void should_ignore_listener_callbacks_after_shutdown() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(List.of(WorkerHost.of("1.1.1.1", 8000)));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+        assertEquals(List.of("1.1.1.1:8000"), r.getAddresses());
+
+        ArgumentCaptor<ServiceHostListener> captor = ArgumentCaptor.forClass(ServiceHostListener.class);
+        verify(sd).listen(eq(DOMAIN), captor.capture());
+
+        r.shutdown();
+        // After shutdown, late listener callbacks must not mutate state
+        captor.getValue().onHostsChanged(List.of(WorkerHost.of("9.9.9.9", 8888)));
+        assertEquals(List.of("1.1.1.1:8000"), r.getAddresses());
+    }
+
+    @Test
+    void should_rollback_started_and_allow_retry_when_listen_fails() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+        when(sd.getHosts(DOMAIN)).thenReturn(Collections.emptyList());
+        // First listen() throws -> started should roll back so a retry is possible
+        doThrow(new RuntimeException("listen boom"))
+                .when(sd).listen(eq(DOMAIN), any(ServiceHostListener.class));
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.start();
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+
+        // After fixing listen, start() again should re-invoke getHosts and listen
+        reset(sd);
+        when(sd.getHosts(DOMAIN)).thenReturn(List.of(WorkerHost.of("4.4.4.4", 7000)));
+        r.start();
+
+        verify(sd, times(1)).getHosts(DOMAIN);
+        verify(sd, times(1)).listen(eq(DOMAIN), any(ServiceHostListener.class));
+        assertEquals(List.of("4.4.4.4:7000"), r.getAddresses());
+    }
+
+    @Test
+    void should_not_start_after_shutdown() {
+        ServiceDiscovery sd = mock(ServiceDiscovery.class);
+
+        ServiceDiscoveryAddressResolver r = new ServiceDiscoveryAddressResolver(sd, DOMAIN);
+        r.shutdown();
+        r.start();
+
+        // After shutdown, no service-discovery calls should be issued
+        verify(sd, never()).getHosts(any());
+        verify(sd, never()).listen(any(), any());
+    }
+}


### PR DESCRIPTION
flexlb 新增 Online Optimizer 客户端，支持 KV Cache 理论命中率统计
1. 启动时异步注册实例至远程 optimizer，带指数退避重试
2. 注册前校验远程参数一致性，不一致则先删再注册
3. 路由成功后 fire-and-forget 上报 block cache keys（traceQuery）
4. 支持 VIPServer 服务发现与直连两种寻址方式
5. 集成至优雅上下线生命周期（GracefulOnlineService / GracefulShutdownService）
6. 幂等保护防止重复初始化导致监听器泄漏