### PR TITLE
临时ci测试: defer CUDA graph capture to support dynamic attention backend selectio

### DIFF
--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -82,6 +82,10 @@ public:
         return false;
     }
 
+    // Trigger any deferred CUDA graph capture held by the underlying model(s).
+    // Default no-op for executors that capture eagerly during construction.
+    virtual void triggerInitCapture() {}
+
 public:
 };
 

--- a/rtp_llm/cpp/models/ModelTypes.h
+++ b/rtp_llm/cpp/models/ModelTypes.h
@@ -125,6 +125,10 @@ public:
     virtual ~ModelBase()                                          = default;
     virtual GptModelOutputs forward(const GptModelInputs& inputs) = 0;
     virtual void            releaseBuffers() {}
+    // Trigger any deferred CUDA graph capture. No-op for models that capture
+    // eagerly in their constructor; PyWrappedModel overrides this when capture
+    // is deferred (e.g. so an accuracy gate can run before the graph is frozen).
+    virtual void triggerInitCapture() {}
 
     rtp_llm::Weights            weights_;
     rtp_llm::OverallExpertStats overall_expert_stats_;

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -48,6 +48,29 @@ torch::Tensor PyWrappedModel::tensorHoldHostAndToCuda(const torch::Tensor& tenso
     return cuda_tensor;
 }
 
+void PyWrappedModel::triggerInitCapture() {
+    if (!enable_cuda_graph_ || graph_runner_ == nullptr) {
+        // CUDA graph disabled / skipped (e.g. warmup, no kv layout): nothing to do.
+        return;
+    }
+    if (capture_done_) {
+        RTP_LLM_LOG_WARNING("PyWrappedModel::triggerInitCapture called but capture already done, skip");
+        return;
+    }
+#if USING_CUDA || USING_ROCM
+    // Mirror the guards the constructor held when it would have captured:
+    // InferenceMode for the capture forwards, GIL for the Python model calls.
+    c10::InferenceMode     inference_guard(true);
+    py::gil_scoped_acquire gil;
+    RTP_LLM_LOG_INFO("PyWrappedModel: triggering deferred CUDA graph capture");
+    graph_runner_->initCapture();
+    capture_done_ = true;
+    RTP_LLM_LOG_INFO("PyWrappedModel: deferred CUDA graph capture done");
+#else
+    RTP_LLM_CHECK_WITH_INFO(false, "CUDA/HIP Graph is only supported on CUDA/ROCm platform");
+#endif
+}
+
 void PyWrappedModel::releaseBuffers() {
     if (held_attn_pyobj_.ptr()) {
         py::gil_scoped_acquire gil;

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -35,12 +35,17 @@ public:
                    py::object                py_instance,
                    bool                      is_prefill_cuda_graph_mode = false,
                    bool                      use_spec_decoding          = false,
-                   const std::vector<int>&   kv_cache_layer_to_group    = {});
+                   const std::vector<int>&   kv_cache_layer_to_group    = {},
+                   bool                      defer_capture              = false);
     ~PyWrappedModel();
 
     GptModelOutputs forward(const GptModelInputs& inputs) override;
     GptModelOutputs forwardMicroBatched(const GptModelInputs& inputs);
     void            releaseBuffers() override;
+    // Run the CUDA graph capture that was skipped in the constructor when
+    // defer_capture was set. Idempotent and safe to call when capture is not
+    // deferred / CUDA graph is disabled (then it is a no-op).
+    void            triggerInitCapture() override;
 
 private:
     std::optional<PyCacheStoreInputs> prepareWriteCacheParams(const GptModelInputs& inputs);
@@ -93,6 +98,11 @@ private:
     bool       use_spec_decoding_{false};
     bool       enable_device_perf_{false};
     bool       check_nan_{false};
+    // When true, the constructor skips graph_runner_->initCapture() and leaves it
+    // for an explicit triggerInitCapture() call. capture_done_ guards against
+    // double capture (whether done eagerly in ctor or later via trigger).
+    bool       defer_capture_{false};
+    bool       capture_done_{false};
 
     std::unique_ptr<IContextParallelProcessor> context_parallel_processor_{nullptr};
     std::unique_ptr<CacheStoreAsyncWriter>     cache_store_async_writer_;
@@ -110,7 +120,8 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
                                       py::object                py_instance,
                                       bool                      is_prefill_cuda_graph_mode,
                                       bool                      use_spec_decoding,
-                                      const std::vector<int>&   kv_cache_layer_to_group):
+                                      const std::vector<int>&   kv_cache_layer_to_group,
+                                      bool                      defer_capture):
     device_props_(buildExecProperties(params.parallelism_config, params.device_resource_config)),
     mla_ops_type_(params.mla_ops_type),
     layer_num_(params.weights.layers.size()),
@@ -120,7 +131,8 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
     is_prefill_cuda_graph_mode_(is_prefill_cuda_graph_mode),
     use_spec_decoding_(use_spec_decoding),
     enable_device_perf_(params.profile_debug_logging_config.enable_device_perf),
-    check_nan_(params.profile_debug_logging_config.check_nan) {
+    check_nan_(params.profile_debug_logging_config.check_nan),
+    defer_capture_(defer_capture) {
 
     c10::InferenceMode inference_guard(true);
 
@@ -264,7 +276,15 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         RTP_LLM_CHECK_WITH_INFO(graph_runner_ != nullptr, "graph_runner_ can't be null");
         auto py_initialize_method = py_instance.attr("initialize");
         py_init_result            = py_initialize_method(init_resources);
-        graph_runner_->initCapture();
+        if (defer_capture_) {
+            // Capture is deferred: leave graph_runner_ created-but-not-captured.
+            // The owner must call triggerInitCapture() later (e.g. after the
+            // accuracy gate / backend selection) before the graph is used.
+            RTP_LLM_LOG_INFO("PyWrappedModel: CUDA graph capture deferred, awaiting triggerInitCapture()");
+        } else {
+            graph_runner_->initCapture();
+            capture_done_ = true;
+        }
     }
 
     auto py_init_success = py_init_result.cast<bool>();

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -107,6 +107,13 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
 
     RTP_LLM_LOG_INFO("create normal executor done");
 
+    // CUDA graph capture is deferred out of the model constructor (see PyWrappedModel
+    // defer_capture). This is the window where the decode accuracy gate / backend
+    // selection will run in the future; for now we immediately trigger capture here so
+    // behavior is unchanged except that capture happens slightly later in startup.
+    executor_->triggerInitCapture();
+    RTP_LLM_LOG_INFO("trigger deferred cuda graph capture done");
+
     // 释放模型加载过程中使用的临时host内存
     // 此时checkpoint已加载完成，可以将glibc缓存的内存归还给操作系统
     releaseHostMemoryCache();

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.cc
@@ -96,7 +96,16 @@ NormalExecutor::NormalExecutor(const EngineInitParams&                params,
     }
     if (!params.py_model.is_none()) {
         RTP_LLM_LOG_INFO("init executor with python model");
-        model_.reset(new PyWrappedModel(model_init_params, params.py_model));
+        // Defer CUDA graph capture for the serving model so the engine can run the
+        // accuracy gate / backend selection before the graph is frozen; capture is
+        // then triggered via NormalEngine -> Executor::triggerInitCapture(). Warmup
+        // executors never capture (no kv layout), so deferral there is a harmless no-op.
+        model_.reset(new PyWrappedModel(model_init_params,
+                                        params.py_model,
+                                        /*is_prefill_cuda_graph_mode=*/false,
+                                        /*use_spec_decoding=*/false,
+                                        /*kv_cache_layer_to_group=*/{},
+                                        /*defer_capture=*/!warm_up_));
     } else if (test_model_factory) {
         RTP_LLM_LOG_INFO("init executor with test model factory");
         model_ = test_model_factory(model_init_params);

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.h
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.h
@@ -48,6 +48,12 @@ public:
 
     bool updateEplbConfig(const EPLBConfig& config) override;
 
+    void triggerInitCapture() override {
+        if (model_) {
+            model_->triggerInitCapture();
+        }
+    }
+
 private:
     std::unique_ptr<ModelBase>                                               model_;
     std::unique_ptr<Sampler>                                                 sampler_;

--- a/rtp_llm/models_py/modules/configs/attention_backend_plan/PLAN_FORMAT.md
+++ b/rtp_llm/models_py/modules/configs/attention_backend_plan/PLAN_FORMAT.md
@@ -1,0 +1,41 @@
+# attention_backend_plan —— decode attention 后端选择 plan
+
+存放 **decode attention 后端调度 plan**(`{capture bs 桶 → 后端名}`)的 autotune 结果。
+与同级 `../cutlass_groupgemm/`、`../../triton_kernels/autotune_cache/configs/` 同类:
+per-GPU 的 kernel / 后端选择调优产物,**入仓版本管理**(决策配置,非数据)。
+
+## 命名约定
+
+```
+<device_name>/plan_<modelsig>_tp<tp>[_<workload>].json
+例: NVIDIA_H20/plan_h32kv8d128p64_tp4_mooncake.json
+```
+
+- **device_name**:`torch.cuda.get_device_name()` 规范化(空格→`_`)。后端相对延迟随 GPU
+  型号变(H20 的 plan 不能给 H800),**必按 device 分目录**——与 triton autotune_cache 一致。
+- **modelsig**:`h<num_heads>kv<kv_heads>d<head_dim>p<page_size>`(per-rank,TP 切分后的 head 数)。
+- **tp**:tensor parallel 度。
+- **workload**:可选,业务分布标签(mooncake / azure / …);动态调度按各桶 kvlen 分布选后端时区分。
+
+## 内容格式
+
+```json
+{
+  "assignments": { "1": "XQAImpl", "8": "PyFlashinferDecodeImpl", "16": "PyFlashinferDecodeImpl" },
+  "note": "..."
+}
+```
+
+key = capture bs 桶(int,json 里为 str);value = 后端类名(`XQAImpl` / `XQADecodeImpl` /
+`PyFlashinferDecodeImpl`)。
+
+## 谁产 / 谁读
+
+- **产**:动态 attention 调度器 warmup 时 profiling → `cached_plan(model, tp, device, build_fn, workload=…)`
+  覆盖写到此(命中即跳过重测)。
+- **读**:生产引擎按 plan 决定每个 cudagraph 桶 capture 哪个后端;离线评估器经 `Plan.load` 喂入做对比。
+- **工具**:`Plan` 契约 + `cache_path` / `cached_plan`（即将随评估器代码提交到本仓）。
+
+## 覆盖写,不累积
+
+同 `(device, model, tp, workload)` 永远同一文件,覆盖写;要历史靠 git，不靠时间戳堆文件。


### PR DESCRIPTION
…ackend selection

- Add defer_capture parameter to PyWrappedModel constructor; when set, the model skips graph_runner_->initCapture() during construction.
- Add triggerInitCapture() virtual method to ModelBase, Executor, and NormalExecutor so the engine can explicitly trigger capture later.
- NormalEngine calls triggerInitCapture() after executor construction, providing a future hook for the accuracy gate / backend dispatch to run before the graph is frozen.
- Add attention_backend_plan directory with PLAN_FORMAT.md documenting the per-GPU decode backend selection plan file convention.