### PR TITLE
feat(recommendation): add cross-sequence combo dedup for multi-return…

### DIFF
--- a/rtp_llm/config/generate_config.py
+++ b/rtp_llm/config/generate_config.py
@@ -81,6 +81,9 @@ class GenerateConfig(BaseModel):
     combo_token_size: int = 0
     banned_combo_token_ids: List[List[int]] = []
     auto_parse_banned_combo: bool = False
+    # 跨序列 combo 去重：当 num_return_sequences > 1 时，任一序列生成完整 combo 后自动广播到
+    # 其他序列的 banned_combos，确保多条序列输出互不重复。默认关闭。
+    enable_cross_sequence_ban: bool = False
     random_seed: Optional[Union[List[int], int]] = None
     top_p_decay: Optional[Union[List[float], float]] = None
     top_p_min: Optional[Union[List[float], float]] = None

--- a/rtp_llm/cpp/engine_base/stream/GenerateConfig.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateConfig.h
@@ -102,6 +102,9 @@ public:
     int combo_token_size = 0;
     // banned_combo_token_ids 是禁止生成的商品 token 组合列表，每项长度应等于 combo_token_size
     std::vector<std::vector<int>> banned_combo_token_ids;
+    // 跨序列 combo 去重：当 num_return_sequences > 1 时，任一序列生成完整 combo 后
+    // 自动广播到其他序列的 banned_combos，确保多条序列输出互不重复。默认关闭。
+    bool enable_cross_sequence_ban = false;
 
     bool top1() {
         return top_k == 1;
@@ -158,7 +161,8 @@ public:
                      << ", enable_memory_cache: " << enable_memory_cache
                      << ", enable_remote_cache: " << enable_remote_cache << ", force_batch: " << force_batch
                      << ", unique_key: " << unique_key << ", combo_token_size: " << combo_token_size
-                     << ", banned_combo_token_ids_size: " << banned_combo_token_ids.size() << "}";
+                     << ", banned_combo_token_ids_size: " << banned_combo_token_ids.size()
+                     << ", enable_cross_sequence_ban: " << enable_cross_sequence_ban << "}";
         return debug_string.str();
     }
 
@@ -268,6 +272,7 @@ public:
         JSONIZE(unique_key);
         JSONIZE(combo_token_size);
         JSONIZE(banned_combo_token_ids);
+        JSONIZE(enable_cross_sequence_ban);
 #undef JSONIZE
 #undef JSONIZE_OPTIONAL
     }

--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -108,6 +108,7 @@ std::shared_ptr<GenerateConfig> QueryConverter::transGenerateConfig(const Genera
 
     // 生成式推荐：组合 token 约束
     generate_config->combo_token_size = config_proto->combo_token_size();
+    generate_config->enable_cross_sequence_ban = config_proto->enable_cross_sequence_ban();
     for (const auto& combo_proto : config_proto->banned_combo_token_ids().rows()) {
         std::vector<int> combo;
         combo.reserve(combo_proto.values_size());

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -168,6 +168,7 @@ def trans_input(input_py: GenerateInput):
 
     # 生成式推荐：组合 token 约束
     generate_config_pb.combo_token_size = input_py.generate_config.combo_token_size
+    generate_config_pb.enable_cross_sequence_ban = input_py.generate_config.enable_cross_sequence_ban
     for i in range(len(input_py.generate_config.banned_combo_token_ids)):
         banned_combo = generate_config_pb.banned_combo_token_ids.rows.add()
         banned_combo.values.extend(

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -105,6 +105,8 @@ message GenerateConfigPB {
     IntMatrix banned_combo_token_ids = 59;
     // 0=unset(fallback to bool return_all_probs), 1=NONE, 2=DEFAULT, 3=ORIGINAL
     int32 return_all_probs_mode = 60;
+    // 跨序列 combo 去重开关
+    bool enable_cross_sequence_ban = 61;
 }
 
 message MMPreprocessConfigPB {

--- a/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.cc
+++ b/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.cc
@@ -26,6 +26,7 @@ RecommendationLogitsProcessor::fromGenerateInput(std::shared_ptr<GenerateInput> 
     }
 
     const bool is_beam_search = config->hasNumBeams() || config->num_return_sequences > 1;
+    const bool enable_cross_seq_ban = config->enable_cross_sequence_ban;
     // 若为空,think_done 初始为 true,Processor 行为等同历史版本(从首个 token 起累 combo)。
     const std::vector<int>& end_think_token_ids = config->end_think_token_ids;
 
@@ -36,7 +37,8 @@ RecommendationLogitsProcessor::fromGenerateInput(std::shared_ptr<GenerateInput> 
                                       /*current_output_length=*/0,
                                       is_beam_search,
                                       banned_combos,
-                                      end_think_token_ids);
+                                      end_think_token_ids,
+                                      enable_cross_seq_ban);
         processor_ptr->infos_.push_back(std::move(info));
     }
     return processor_ptr;
@@ -142,7 +144,7 @@ void RecommendationLogitsProcessor::advanceOneToken(StreamRecommendationInfo& in
         // 本次 token 即 combo 的最后一位:形成完整 combo 并加入去重集合
         std::vector<int> full_combo = info.current_prefix;
         full_combo.push_back(token_id);
-        info.banned_combos.insert(std::move(full_combo));
+        info.banned_combos.insert(full_combo);
         info.current_prefix.clear();
         info.pos_in_combo = 0;
     }
@@ -173,6 +175,17 @@ void RecommendationLogitsProcessor::updateStatus(const torch::Tensor& new_tokens
         }
 
         info.current_output_length += num_new_tokens;
+    }
+
+    // 跨序列广播:将所有序列的 banned_combos 合并为统一集合,确保多序列输出互不重复
+    if (size() > 1 && infos_[0].enable_cross_sequence_ban) {
+        std::set<std::vector<int>> merged;
+        for (size_t i = 0; i < size(); ++i) {
+            merged.insert(infos_[i].banned_combos.begin(), infos_[i].banned_combos.end());
+        }
+        for (size_t i = 0; i < size(); ++i) {
+            infos_[i].banned_combos = merged;
+        }
     }
 }
 

--- a/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.h
+++ b/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.h
@@ -16,10 +16,11 @@ namespace rtp_llm {
 // 对 qwen3 等会默认输出 <think>\n\n</think>\n\n 占位的模型,若 end_think_token_ids
 // 非空,则先按该序列跳过 think prelude,跳过完成前的 token 不进入 combo 前缀。
 struct StreamRecommendationInfo {
-    int32_t combo_token_size      = 0;
-    int32_t input_length          = 0;
-    int32_t current_output_length = 0;
-    bool    is_beam_search        = false;
+    int32_t combo_token_size          = 0;
+    int32_t input_length              = 0;
+    int32_t current_output_length     = 0;
+    bool    is_beam_search            = false;
+    bool    enable_cross_sequence_ban = false;
 
     // 当前正在生成 combo 内的位置,取值 [0, combo_token_size-1]
     int32_t pos_in_combo = 0;
@@ -41,27 +42,30 @@ struct StreamRecommendationInfo {
                              int32_t                           current_output_length,
                              bool                              is_beam_search,
                              const std::set<std::vector<int>>& banned_combos,
-                             const std::vector<int>&           end_think_token_ids = {}):
+                             const std::vector<int>&           end_think_token_ids = {},
+                             bool                              enable_cross_sequence_ban = false):
         combo_token_size(combo_token_size),
         input_length(input_length),
         current_output_length(current_output_length),
         is_beam_search(is_beam_search),
+        enable_cross_sequence_ban(enable_cross_sequence_ban),
         banned_combos(banned_combos),
         end_think_token_ids(end_think_token_ids),
         think_done(end_think_token_ids.empty()) {}
 
     StreamRecommendationInfo copy() const {
         StreamRecommendationInfo info;
-        info.combo_token_size      = combo_token_size;
-        info.input_length          = input_length;
-        info.current_output_length = current_output_length;
-        info.is_beam_search        = is_beam_search;
-        info.pos_in_combo          = pos_in_combo;
-        info.current_prefix        = current_prefix;
-        info.banned_combos         = banned_combos;
-        info.end_think_token_ids   = end_think_token_ids;
-        info.think_done            = think_done;
-        info.end_think_match_pos   = end_think_match_pos;
+        info.combo_token_size          = combo_token_size;
+        info.input_length              = input_length;
+        info.current_output_length     = current_output_length;
+        info.is_beam_search            = is_beam_search;
+        info.enable_cross_sequence_ban = enable_cross_sequence_ban;
+        info.pos_in_combo              = pos_in_combo;
+        info.current_prefix            = current_prefix;
+        info.banned_combos             = banned_combos;
+        info.end_think_token_ids       = end_think_token_ids;
+        info.think_done                = think_done;
+        info.end_think_match_pos       = end_think_match_pos;
         return info;
     }
 };

--- a/rtp_llm/cpp/models/logits_processor/test/RecommendationLogitsProcessorTest.cc
+++ b/rtp_llm/cpp/models/logits_processor/test/RecommendationLogitsProcessorTest.cc
@@ -198,4 +198,57 @@ TEST_F(RecommendationLogitsProcessorTest, testFromGenerateInputEnabled) {
     }
 }
 
+// 场景 8：跨序列去重 —— 多序列生成时广播 banned_combos
+TEST_F(RecommendationLogitsProcessorTest, testCrossSequenceBanBroadcast) {
+    // 模拟 2 条序列，combo_token_size=3，开启跨序列去重
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, true, empty_set, {}, true));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, true, empty_set, {}, true));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 序列 0 生成 combo (1,2,3)，序列 1 生成 combo (4,5,6)
+    auto step = [&](int tok0, int tok1) {
+        auto t = torch::tensor({{tok0}, {tok1}}, torch::kInt32);
+        processor->updateStatus(t, 1);
+    };
+    step(1, 4);  // pos_in_combo: 0 → 1
+    step(2, 5);  // pos_in_combo: 1 → 2
+    step(3, 6);  // pos_in_combo: 2 → 0 (combo 完成)
+
+    // 跨序列广播后，两条序列都应有 {(1,2,3), (4,5,6)}
+    ASSERT_EQ(2u, processor->infos()[0].banned_combos.size());
+    ASSERT_EQ(2u, processor->infos()[1].banned_combos.size());
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({1, 2, 3}));
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({4, 5, 6}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({1, 2, 3}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({4, 5, 6}));
+}
+
+// 场景 9：关闭跨序列去重时，各序列独立维护 banned_combos
+TEST_F(RecommendationLogitsProcessorTest, testCrossSequenceBanDisabled) {
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    // enable_cross_sequence_ban = false
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, true, empty_set, {}, false));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, true, empty_set, {}, false));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    auto step = [&](int tok0, int tok1) {
+        auto t = torch::tensor({{tok0}, {tok1}}, torch::kInt32);
+        processor->updateStatus(t, 1);
+    };
+    step(1, 4);
+    step(2, 5);
+    step(3, 6);
+
+    // 关闭跨序列去重时，各序列只有自己的 combo
+    ASSERT_EQ(1u, processor->infos()[0].banned_combos.size());
+    ASSERT_EQ(1u, processor->infos()[1].banned_combos.size());
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({1, 2, 3}));
+    EXPECT_FALSE(processor->infos()[0].banned_combos.count({4, 5, 6}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({4, 5, 6}));
+    EXPECT_FALSE(processor->infos()[1].banned_combos.count({1, 2, 3}));
+}
+
 }  // namespace rtp_llm


### PR DESCRIPTION
…-sequences

When num_return_sequences > 1 and enable_cross_sequence_ban is true, completed combos are broadcast across all sequences' banned_combos, ensuring N parallel greedy sequences produce fully non-overlapping items.

This enables generating 4x10=40 unique high-quality candidates for category diversification in a single inference pass with ~1x latency.

Default: disabled (enable_cross_sequence_ban = false).