### PR TITLE
Feature/opt fifo scheduler

### DIFF
--- a/rtp_llm/cpp/cache/FullKVCacheGroup.cc
+++ b/rtp_llm/cpp/cache/FullKVCacheGroup.cc
@@ -7,6 +7,30 @@ int FullKVCacheGroup::needBlocksNum(int seq_len, int current_blocks, int reserve
     return std::max((seq_len + reserve_step + seq_size_per_block_ - 1) / seq_size_per_block_ - current_blocks, 0);
 }
 
+int FullKVCacheGroup::estimatePeakNeedBlocks(int                     seq_len,
+                                             const BlockIndicesType& current_block_indices,
+                                             int                     remaining_tokens,
+                                             int                     reserve_step,
+                                             bool                    enable_reuse_cache) const {
+    (void)enable_reuse_cache;
+    const int current_blocks = static_cast<int>(current_block_indices.size());
+    return std::max((seq_len + remaining_tokens + reserve_step + seq_size_per_block_ - 1) / seq_size_per_block_ - current_blocks, 0);
+}
+
+int FullKVCacheGroup::estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                         int  common_seq_len,
+                                                         int  remaining_tokens,
+                                                         int  reserve_step,
+                                                         bool enable_reuse_cache,
+                                                         int  target_batch_size) const {
+    (void)enable_reuse_cache;
+    const int batch_size    = std::max(target_batch_size, 1);
+    const int common_blocks = (common_seq_len + seq_size_per_block_ - 1) / seq_size_per_block_;
+    const int peak_blocks =
+        (seq_len + remaining_tokens + reserve_step + seq_size_per_block_ - 1) / seq_size_per_block_;
+    return common_blocks + batch_size * std::max(peak_blocks - common_blocks, 0);
+}
+
 NeedBlocksInfo FullKVCacheGroup::getNeedBlocks(
     int common_seq_len, int seq_len, int reserve_step, int reuse_blocks_len, bool reuse_enabled) const {
     (void)reuse_blocks_len;

--- a/rtp_llm/cpp/cache/FullKVCacheGroup.h
+++ b/rtp_llm/cpp/cache/FullKVCacheGroup.h
@@ -21,6 +21,17 @@ public:
     insertIntoCache(const CacheKeysType& cache_keys, const BlockIndicesType& block_indices, bool is_resident) override;
     void removeSkippedBlocks(BlockIds& block_ids, bool enable_reuse_cache = false, int reserve_step = 0) override;
     int  needBlocksNum(int seq_len, int current_blocks = 0, int reserve_step = 0) const override;
+    int estimatePeakNeedBlocks(int                     seq_len,
+                               const BlockIndicesType& current_block_indices,
+                               int                     remaining_tokens,
+                               int                     reserve_step,
+                               bool                    enable_reuse_cache) const override;
+    int estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                           int  common_seq_len,
+                                           int  remaining_tokens,
+                                           int  reserve_step,
+                                           bool enable_reuse_cache,
+                                           int  target_batch_size) const override;
     NeedBlocksInfo getNeedBlocks(int  common_seq_len,
                                  int  seq_len,
                                  int  reserve_step,

--- a/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.cc
@@ -233,7 +233,7 @@ MallocResult HybridTypeKVCacheAllocator::initMallocForCommonLen(const MallocInfo
 
     const auto&  cache_keys         = kv_resource->cacheKeys(0);
     int64_t      match_cost_time_us = 0;
-    const size_t reserve_blocks     = reserveBlockNum();
+    const size_t reserve_blocks     = reserveBlocksNum();
     int          reuse_blocks       = 0;
 
     if (malloc_info.enable_device_cache) {
@@ -570,6 +570,41 @@ int HybridTypeKVCacheAllocator::singleBatchNeedBlocks(const BatchKVCacheResource
     }
 
     return need_blocks;
+}
+
+int HybridTypeKVCacheAllocator::estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                                                       int                    seq_len,
+                                                       int                    remaining_tokens,
+                                                       int                    reserve_step,
+                                                       bool                   enable_reuse_cache) const {
+    int need_blocks = 0;
+    for (int gid = 0; gid < kv_cache_resource.groupNums(); ++gid) {
+        need_blocks += kv_cache_groups_[static_cast<size_t>(gid)]->estimatePeakNeedBlocks(
+            seq_len,
+            kv_cache_resource.blocks(gid),
+            remaining_tokens,
+            reserve_step,
+            enable_reuse_cache);
+    }
+    return need_blocks;
+}
+
+int HybridTypeKVCacheAllocator::estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                                   int  common_seq_len,
+                                                                   int  remaining_tokens,
+                                                                   int  reserve_step,
+                                                                   bool enable_reuse_cache,
+                                                                   int  target_batch_size) const {
+    int peak_blocks = 0;
+    for (const auto& group : kv_cache_groups_) {
+        peak_blocks += group->estimateInitialBatchPeakNeedBlocks(seq_len,
+                                                                 common_seq_len,
+                                                                 remaining_tokens,
+                                                                 reserve_step,
+                                                                 enable_reuse_cache,
+                                                                 target_batch_size);
+    }
+    return peak_blocks;
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/HybridTypeKVCacheAllocator.h
@@ -40,11 +40,24 @@ public:
                               int                            seq_len,
                               int                            reserve_step) const override;
 
+protected:
+    int estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                               int                    seq_len,
+                               int                    remaining_tokens,
+                               int                    reserve_step,
+                               bool                   enable_reuse_cache) const override;
+
 private:
     bool         doInit() override;
     MallocResult incrMalloc(const MallocInfo& malloc_info) override;
     MallocResult initMallocForCommonLen(const MallocInfo& malloc_info) override;
     int          getNeedBlocks(const MallocInfo& malloc_info) const override;
+    int          estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                    int  common_seq_len,
+                                                    int  remaining_tokens,
+                                                    int  reserve_step,
+                                                    bool enable_reuse_cache,
+                                                    int  target_batch_size) const override;
     void         decrKVCacheRef(const KVCacheResource& kvcache_resource, bool is_connector = false) override;
 
     // Joint match across groups. Returns reuse_blocks decided by full groups + linear groups.

--- a/rtp_llm/cpp/cache/KVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <unordered_set>
@@ -85,6 +86,48 @@ MallocResult KVCacheAllocator::malloc(const MallocInfo& malloc_info) {
     } else {
         return incrMalloc(malloc_info);
     }
+}
+
+int KVCacheAllocator::estimateBatchPeakNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource,
+                                                  int                            seq_len,
+                                                  int                            common_seq_len,
+                                                  int                            remaining_tokens,
+                                                  int                            reserve_step,
+                                                  bool                           enable_reuse_cache,
+                                                  int                            target_batch_size) const {
+    if (!batch_kv_cache_resource || batch_kv_cache_resource->batchSize() == 0) {
+        return 0;
+    }
+
+    const int current_batch_size = batch_kv_cache_resource->batchSize();
+    const int target_width       = std::max(current_batch_size, target_batch_size);
+    const int clamped_common_len = std::clamp(common_seq_len, 0, seq_len);
+
+    // A fresh resource follows initMalloc's two phases. Each group estimates that exact sequence so Linear groups can
+    // distinguish the shared common tail from every sequence's private suffix tail.
+    if (batch_kv_cache_resource->curBlocksNum() == 0) {
+        return estimateInitialBatchPeakNeedBlocks(seq_len,
+                                                  clamped_common_len,
+                                                  remaining_tokens,
+                                                  reserve_step,
+                                                  enable_reuse_cache,
+                                                  target_width);
+    }
+
+    // Initialized sequences have the same layout, and all subsequent growth is private per sequence.
+    const int per_sequence_growth =
+        estimatePeakNeedBlocks(batch_kv_cache_resource->cacheResource(0),
+                               seq_len,
+                               remaining_tokens,
+                               reserve_step,
+                               enable_reuse_cache);
+
+    // Full blocks remain shared when the batch expands, but every additional sequence needs a physical copy of the
+    // current partial tail before it can diverge.
+    const int expanded_sequences = target_width - current_batch_size;
+    const int tail_copy_blocks =
+        expanded_sequences > 0 && seq_len % seqSizePerBlock() != 0 ? expanded_sequences : 0;
+    return target_width * per_sequence_growth + tail_copy_blocks;
 }
 
 uint32_t KVCacheAllocator::convertToGlobalLayerId(size_t model_id, int local_layer_id) const {

--- a/rtp_llm/cpp/cache/KVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.h
@@ -46,6 +46,14 @@ public:
     virtual int              singleBatchNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource,
                                                    int                            seq_len,
                                                    int                            reserve_step) const                 = 0;
+    // Common-prefix growth is charged once; non-common growth is charged once per target sequence.
+    int estimateBatchPeakNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource,
+                                    int                            seq_len,
+                                    int                            common_seq_len,
+                                    int                            remaining_tokens,
+                                    int                            reserve_step,
+                                    bool                           enable_reuse_cache,
+                                    int                            target_batch_size) const;
 
     MallocResult malloc(const MallocInfo& malloc_info);
     void         blockCopy(int src_block_index, int dest_block_index);
@@ -59,10 +67,10 @@ public:
 
     // Reserve some blocks for already-running streams' future allocations.
     // Only applied to "init malloc" requests where batch_kv_cache_resource has no blocks yet.
-    void setReserveBlockNum(size_t reserve_block_num) {
+    void setReserveBlocksNum(size_t reserve_block_num) {
         reserve_block_num_ = reserve_block_num;
     }
-    size_t reserveBlockNum() const {
+    size_t reserveBlocksNum() const {
         return reserve_block_num_;
     }
 
@@ -88,6 +96,18 @@ protected:
     virtual MallocResult incrMalloc(const MallocInfo& malloc_info)                                          = 0;
     virtual MallocResult initMallocForCommonLen(const MallocInfo& malloc_info)                              = 0;
     virtual int          getNeedBlocks(const MallocInfo& malloc_info) const                                 = 0;
+    // Estimate peak additional blocks for one sequence resource.
+    virtual int          estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                                                int                    seq_len,
+                                                int                    remaining_tokens,
+                                                int                    reserve_step,
+                                                bool                   enable_reuse_cache) const = 0;
+    virtual int          estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                            int  common_seq_len,
+                                                            int  remaining_tokens,
+                                                            int  reserve_step,
+                                                            bool enable_reuse_cache,
+                                                            int  target_batch_size) const = 0;
     virtual void         decrKVCacheRef(const KVCacheResource& kvcache_resource, bool is_connector = false) = 0;
 
     CacheConfig                        config_;

--- a/rtp_llm/cpp/cache/KVCacheGroup.h
+++ b/rtp_llm/cpp/cache/KVCacheGroup.h
@@ -43,6 +43,20 @@ public:
     insertIntoCache(const CacheKeysType& cache_keys, const BlockIndicesType& block_indices, bool is_resident)    = 0;
     virtual void removeSkippedBlocks(BlockIds& block_ids, bool enable_reuse_cache = false, int reserve_step = 0) = 0;
     virtual int  needBlocksNum(int seq_len, int current_blocks, int reserve_step = 0) const                      = 0;
+    // Estimate peak additional blocks needed when generating remaining_tokens more tokens.
+    virtual int estimatePeakNeedBlocks(int                     seq_len,
+                                       const BlockIndicesType& current_block_indices,
+                                       int                     remaining_tokens,
+                                       int                     reserve_step,
+                                       bool                    enable_reuse_cache) const = 0;
+    // Estimate the physical-block peak of a fresh batch by following initMalloc's real order:
+    // allocate the common prefix once, reference it from every sequence, then allocate each private suffix.
+    virtual int estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                   int  common_seq_len,
+                                                   int  remaining_tokens,
+                                                   int  reserve_step,
+                                                   bool enable_reuse_cache,
+                                                   int  target_batch_size) const = 0;
     virtual NeedBlocksInfo getNeedBlocks(
         int common_seq_len, int seq_len, int reserve_step, int reuse_blocks_len, bool reuse_enabled = false) const = 0;
     virtual void reference(BlockIds& block_ids, const BlockIndicesType& new_block_indices)                         = 0;

--- a/rtp_llm/cpp/cache/KVCacheManager.cc
+++ b/rtp_llm/cpp/cache/KVCacheManager.cc
@@ -123,6 +123,22 @@ int KVCacheManager::singleBatchNeedBlocks(const BatchKVCacheResourcePtr& batch_k
     return allocator_->singleBatchNeedBlocks(batch_kv_cache_resource, seq_len, reserve_step);
 }
 
+int KVCacheManager::estimatePeakNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource,
+                                           int                            seq_len,
+                                           int                            common_seq_len,
+                                           int                            remaining_tokens,
+                                           int                            reserve_step,
+                                           bool                           enable_reuse_cache,
+                                           int                            target_batch_size) const {
+    return allocator_->estimateBatchPeakNeedBlocks(batch_kv_cache_resource,
+                                                   seq_len,
+                                                   common_seq_len,
+                                                   remaining_tokens,
+                                                   reserve_step,
+                                                   enable_reuse_cache,
+                                                   target_batch_size);
+}
+
 // 块操作相关
 
 void KVCacheManager::blockCopy(int src_block_index, int dest_block_index) {
@@ -396,6 +412,10 @@ size_t KVCacheManager::freeBlocksNum() const {
 
 size_t KVCacheManager::availableBlocksNum() const {
     return allocator_->availableBlocksNum();
+}
+
+size_t KVCacheManager::reserveBlocksNum() const {
+    return allocator_->reserveBlocksNum();
 }
 
 size_t KVCacheManager::notInUseBlocksNum() const {

--- a/rtp_llm/cpp/cache/KVCacheManager.h
+++ b/rtp_llm/cpp/cache/KVCacheManager.h
@@ -49,6 +49,14 @@ public:
     int
     singleBatchNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource, int seq_len, int reserve_step) const;
 
+    int estimatePeakNeedBlocks(const BatchKVCacheResourcePtr& batch_kv_cache_resource,
+                               int                            seq_len,
+                               int                            common_seq_len,
+                               int                            remaining_tokens,
+                               int                            reserve_step,
+                               bool                           enable_reuse_cache,
+                               int                            target_batch_size) const;
+
     // 块操作相关
     void blockCopy(int src_block_index, int dest_block_index);
     void blockBatchCopy(const std::vector<BlockIdPair>& copy_mapping);
@@ -81,6 +89,7 @@ public:
     // 资源统计和信息查询
     size_t                  freeBlocksNum() const;
     size_t                  availableBlocksNum() const;
+    size_t                  reserveBlocksNum() const;
     size_t                  notInUseBlocksNum() const;
     BatchKVCacheResourcePtr popBlocksFromCache(size_t min_blocks_to_free);
     void                    blockCacheFree(const BatchKVCacheResourcePtr& batch_kv_cache_resource);

--- a/rtp_llm/cpp/cache/LinearKVCacheGroup.cc
+++ b/rtp_llm/cpp/cache/LinearKVCacheGroup.cc
@@ -1,11 +1,51 @@
 #include "rtp_llm/cpp/cache/LinearKVCacheGroup.h"
 
 #include <algorithm>
+#include <numeric>
 #include <unordered_set>
 
 #include "rtp_llm/cpp/utils/Logger.h"
 
 namespace rtp_llm {
+namespace {
+
+bool shouldAllocateSlot(int slot, int seq_slots, int reserve_step, bool enable_reuse_cache, int linear_step) {
+    const bool is_seq_tail = seq_slots > 0 && slot == seq_slots - 1;
+    const bool is_reserve  = reserve_step > 0 && slot >= seq_slots;
+    const bool step_hit    = (slot + 1) % linear_step == 0;
+    return is_reserve || (enable_reuse_cache ? (step_hit || is_seq_tail) : is_seq_tail);
+}
+
+int estimatePeakFromSlotCosts(std::vector<int> block_costs,
+                              int              final_slots,
+                              int              new_slot_cost,
+                              int              reserve_step,
+                              bool             enable_reuse_cache,
+                              int              linear_step) {
+    int physical_blocks = std::accumulate(block_costs.begin(), block_costs.end(), 0);
+    int peak_blocks     = physical_blocks;
+
+    while (static_cast<int>(block_costs.size()) < final_slots) {
+        block_costs.push_back(new_slot_cost);
+        physical_blocks += new_slot_cost;
+        peak_blocks = std::max(peak_blocks, physical_blocks);
+
+        for (int slot = static_cast<int>(block_costs.size()) - 3 - reserve_step; slot >= 0; --slot) {
+            auto& cost = block_costs[static_cast<size_t>(slot)];
+            if (cost == 0) {
+                break;
+            }
+            if (enable_reuse_cache && (slot + 1) % linear_step == 0) {
+                continue;
+            }
+            physical_blocks -= cost;
+            cost = 0;
+        }
+    }
+    return peak_blocks;
+}
+
+}  // namespace
 
 void LinearKVCacheGroup::filterValidBlocks(const BlockIndicesType& in, BlockIndicesType& out) const {
     out.clear();
@@ -20,6 +60,74 @@ void LinearKVCacheGroup::filterValidBlocks(const BlockIndicesType& in, BlockIndi
 int LinearKVCacheGroup::needBlocksNum(int seq_len, int current_blocks, int reserve_step) const {
     int extra_blocks = reserve_step ? reserve_step - 1 : 0;
     return std::max((seq_len + seq_size_per_block_ - 1) / seq_size_per_block_ + extra_blocks - current_blocks, 0);
+}
+
+int LinearKVCacheGroup::estimatePeakNeedBlocks(int                     seq_len,
+                                               const BlockIndicesType& current_block_indices,
+                                               int                     remaining_tokens,
+                                               int                     reserve_step,
+                                               bool                    enable_reuse_cache) const {
+    const int step              = std::max(1, linear_step_);
+    const int current_seq_slots = (seq_len + seq_size_per_block_ - 1) / seq_size_per_block_;
+    const int final_seq_slots =
+        (seq_len + remaining_tokens + seq_size_per_block_ - 1) / seq_size_per_block_;
+    const int extra_blocks = reserve_step ? reserve_step - 1 : 0;
+    const int total_slots  = final_seq_slots + extra_blocks;
+
+    std::vector<int> block_costs;
+    block_costs.reserve(std::max(total_slots, static_cast<int>(current_block_indices.size())));
+
+    int current_physical_blocks = 0;
+    if (!current_block_indices.empty()) {
+        for (const auto block_index : current_block_indices) {
+            const bool allocated = !isNullBlockIdx(block_index);
+            block_costs.push_back(allocated ? 1 : 0);
+            current_physical_blocks += allocated;
+        }
+    } else {
+        const int initial_slots = current_seq_slots + extra_blocks;
+        for (int i = 0; i < initial_slots; ++i) {
+            block_costs.push_back(
+                shouldAllocateSlot(i, current_seq_slots, reserve_step, enable_reuse_cache, step) ? 1 : 0);
+        }
+    }
+
+    const int peak_blocks =
+        estimatePeakFromSlotCosts(std::move(block_costs), total_slots, 1, reserve_step, enable_reuse_cache, step);
+    return std::max(peak_blocks - current_physical_blocks, 0);
+}
+
+int LinearKVCacheGroup::estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                           int  common_seq_len,
+                                                           int  remaining_tokens,
+                                                           int  reserve_step,
+                                                           bool enable_reuse_cache,
+                                                           int  target_batch_size) const {
+    const int step       = std::max(1, linear_step_);
+    const int batch_size = std::max(target_batch_size, 1);
+    const auto seq_slots = [&](int length) { return (length + seq_size_per_block_ - 1) / seq_size_per_block_; };
+
+    const int common_slots     = seq_slots(common_seq_len);
+    const int initial_slots    = seq_slots(seq_len);
+    const int reserve_blocks   = reserve_step > 0 ? reserve_step - 1 : 0;
+    const int initial_total    = initial_slots + reserve_blocks;
+    const int final_total      = seq_slots(seq_len + remaining_tokens) + reserve_blocks;
+    std::vector<int> block_costs;
+    block_costs.reserve(static_cast<size_t>(std::max(initial_total, final_total)));
+
+    for (int slot = 0; slot < common_slots; ++slot) {
+        block_costs.push_back(
+            shouldAllocateSlot(slot, common_slots, 0, enable_reuse_cache, step) ? 1 : 0);
+    }
+
+    // initMalloc's incrMalloc phase appends the whole prompt suffix without sparse cleanup.
+    for (int slot = common_slots; slot < initial_total; ++slot) {
+        block_costs.push_back(
+            shouldAllocateSlot(slot, initial_slots, reserve_step, enable_reuse_cache, step) ? batch_size : 0);
+    }
+
+    return estimatePeakFromSlotCosts(
+        std::move(block_costs), final_total, batch_size, reserve_step, enable_reuse_cache, step);
 }
 
 NeedBlocksInfo LinearKVCacheGroup::getNeedBlocks(

--- a/rtp_llm/cpp/cache/LinearKVCacheGroup.h
+++ b/rtp_llm/cpp/cache/LinearKVCacheGroup.h
@@ -28,6 +28,17 @@ public:
     void free(const BlockIndicesType& block_indices) override;
     void reference(BlockIds& block_ids, const BlockIndicesType& new_block_indices) override;
     int  needBlocksNum(int seq_len, int current_blocks, int reserve_step = 0) const override;
+    int estimatePeakNeedBlocks(int                     seq_len,
+                               const BlockIndicesType& current_block_indices,
+                               int                     remaining_tokens,
+                               int                     reserve_step,
+                               bool                    enable_reuse_cache) const override;
+    int estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                           int  common_seq_len,
+                                           int  remaining_tokens,
+                                           int  reserve_step,
+                                           bool enable_reuse_cache,
+                                           int  target_batch_size) const override;
     NeedBlocksInfo getNeedBlocks(int  common_seq_len,
                                  int  seq_len,
                                  int  reserve_step,

--- a/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.cc
@@ -75,7 +75,7 @@ MallocResult SingleTypeKVCacheAllocator::initMallocForCommonLen(const MallocInfo
     auto&       block_ids_0        = kv_resource->mutableBlockIds(0);
     int64_t     match_cost_time_us = 0;
 
-    const size_t reserve_blocks   = reserveBlockNum();
+    const size_t reserve_blocks   = reserveBlocksNum();
     const int    estimated_blocks = (reserve_blocks > 0) ? getNeedBlocks(malloc_info) : 0;
     int          reuse_blocks     = 0;
 
@@ -455,6 +455,29 @@ int SingleTypeKVCacheAllocator::singleBatchNeedBlocks(const BatchKVCacheResource
                                                       int                            seq_len,
                                                       int                            reserve_step) const {
     return full_kv_cache_group_->needBlocksNum(seq_len, 0, reserve_step);
+}
+
+int SingleTypeKVCacheAllocator::estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                                                       int                    seq_len,
+                                                       int                    remaining_tokens,
+                                                       int                    reserve_step,
+                                                       bool                   enable_reuse_cache) const {
+    return full_kv_cache_group_->estimatePeakNeedBlocks(
+        seq_len, kv_cache_resource.blocks(0), remaining_tokens, reserve_step, enable_reuse_cache);
+}
+
+int SingleTypeKVCacheAllocator::estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                                   int  common_seq_len,
+                                                                   int  remaining_tokens,
+                                                                   int  reserve_step,
+                                                                   bool enable_reuse_cache,
+                                                                   int  target_batch_size) const {
+    return full_kv_cache_group_->estimateInitialBatchPeakNeedBlocks(seq_len,
+                                                                    common_seq_len,
+                                                                    remaining_tokens,
+                                                                    reserve_step,
+                                                                    enable_reuse_cache,
+                                                                    target_batch_size);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.h
@@ -37,11 +37,24 @@ public:
                               int                            seq_len,
                               int                            reserve_step) const override;
 
+protected:
+    int estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                               int                    seq_len,
+                               int                    remaining_tokens,
+                               int                    reserve_step,
+                               bool                   enable_reuse_cache) const override;
+
 private:
     bool         doInit() override;
     MallocResult incrMalloc(const MallocInfo& malloc_info) override;
     MallocResult initMallocForCommonLen(const MallocInfo& malloc_info) override;
     int          getNeedBlocks(const MallocInfo& malloc_info) const override;
+    int          estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                                    int  common_seq_len,
+                                                    int  remaining_tokens,
+                                                    int  reserve_step,
+                                                    bool enable_reuse_cache,
+                                                    int  target_batch_size) const override;
     void         decrKVCacheRef(const KVCacheResource& kvcache_resource, bool is_connector = false) override;
 
 private:

--- a/rtp_llm/cpp/cache/connector/remote_connector/test/GroupPolicyTest.cc
+++ b/rtp_llm/cpp/cache/connector/remote_connector/test/GroupPolicyTest.cc
@@ -66,7 +66,22 @@ public:
                               int                            reserve_step) const override {
         return 0;
     }
+    int estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                               int                    seq_len,
+                               int                    remaining_tokens,
+                               int                    reserve_step,
+                               bool                   enable_reuse_cache) const override {
+        return 0;
+    }
     int getNeedBlocks(const MallocInfo& malloc_info) const override {
+        return 0;
+    }
+    int estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                           int  common_seq_len,
+                                           int  remaining_tokens,
+                                           int  reserve_step,
+                                           bool enable_reuse_cache,
+                                           int  target_batch_size) const override {
         return 0;
     }
 

--- a/rtp_llm/cpp/cache/connector/remote_connector/test/RemoteConnectorInternalTest.cc
+++ b/rtp_llm/cpp/cache/connector/remote_connector/test/RemoteConnectorInternalTest.cc
@@ -114,7 +114,22 @@ public:
                               int                            reserve_step) const override {
         return 0;
     }
+    int estimatePeakNeedBlocks(const KVCacheResource& kv_cache_resource,
+                               int                    seq_len,
+                               int                    remaining_tokens,
+                               int                    reserve_step,
+                               bool                   enable_reuse_cache) const override {
+        return 0;
+    }
     int getNeedBlocks(const MallocInfo& malloc_info) const override {
+        return 0;
+    }
+    int estimateInitialBatchPeakNeedBlocks(int  seq_len,
+                                           int  common_seq_len,
+                                           int  remaining_tokens,
+                                           int  reserve_step,
+                                           bool enable_reuse_cache,
+                                           int  target_batch_size) const override {
         return 0;
     }
     std::shared_ptr<KVCacheResource> incrKVCacheRef(const KVCacheResource& kvcache_resource,

--- a/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
@@ -167,6 +167,21 @@ static BatchKVCacheResourcePtr makeBatchResource(int                            
     return res;
 }
 
+static int estimateBatchPeakForSingleSequence(const KVCacheAllocator&          allocator,
+                                              const BatchKVCacheResourcePtr& batch_resource,
+                                              int                            seq_len,
+                                              int                            remaining_tokens,
+                                              int                            reserve_step,
+                                              bool                           enable_reuse_cache) {
+    return allocator.estimateBatchPeakNeedBlocks(batch_resource,
+                                                 seq_len,
+                                                 /*common_seq_len=*/seq_len,
+                                                 remaining_tokens,
+                                                 reserve_step,
+                                                 enable_reuse_cache,
+                                                 /*target_batch_size=*/1);
+}
+
 static std::vector<BlockIdxType> allocateAndCache(BlockPoolPtr         block_pool,
                                                   BlockCachePtr        block_cache,
                                                   int                  group_id,
@@ -1006,6 +1021,273 @@ TEST_F(HybridTypeKVCacheAllocatorTest, DecodeIncrMallocAppliesSparseCleanupOnLin
     for (size_t i = 0; i < full_out.size(); ++i) {
         EXPECT_EQ(full_out[i], full_alloc[i]);
     }
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, EstimatePeakNeedBlocks) {
+    // Config: [0,1]=linear group (gid=0), [2,3]=full group (gid=1). seq_size_per_block=4.
+    auto config    = makeTinyHybridConfig();
+    auto allocator = std::make_shared<HybridTypeKVCacheAllocator>(config, AllocationType::DEVICE);
+    ASSERT_TRUE(allocator->init());
+
+    const int group_nums = 2;
+    const int blk = config.seq_size_per_block;  // 4
+
+    // New resource (cur_slots=0 for both groups):
+    // reuse disabled: full=ceil(108/4)=27, linear tail peak=3 => total=30.
+    auto new_res = makeBatchResource(1, group_nums, config.layer_num, config.layerGroupIdsSnapshot(), {});
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 100, 0, /*enable_reuse_cache=*/false),
+              30);
+
+    // reuse enabled: linear keeps 14 blocks after cleanup and transiently holds a fifteenth tail block.
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 100, 0, /*enable_reuse_cache=*/true),
+              42);
+
+    // With reserve_step=3: full=ceil(111/4)=28. linear: total_slots=29, tail=5,
+    // step-hits before tail=24/2=12 => linear=17. total=45.
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 100, 3, /*enable_reuse_cache=*/true),
+              45);
+
+    // Allocate blocks to simulate running decode (seqLen=8 → 2 slots per group)
+    auto token_ids = makeCompleteTokenIds(1, /*seq_length=*/8, config.seq_size_per_block);
+    MallocInfo mi{new_res, token_ids};
+    auto result = allocator->malloc(mi);
+    ASSERT_TRUE(result.success);
+
+    const int full_slots   = new_res->blocksNum(0, 1);   // full group slots after malloc
+    const int linear_slots = new_res->blocksNum(0, 0);   // linear group slots after malloc
+
+    // remaining=0: no more slots needed for either group
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 0, 0, /*enable_reuse_cache=*/false),
+              0);
+
+    // remaining=4: ceil((8+4)/4)=3 per group, minus cur_slots
+    int expect_per_group = (8 + 4 + blk - 1) / blk;
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 4, 0, /*enable_reuse_cache=*/false),
+              std::max(expect_per_group - full_slots, 0) + std::max(expect_per_group - linear_slots, 0));
+
+    // Large remaining from current_slots=2:
+    // reuse disabled: the initial null slot stops the first cleanup scan. At the second boundary the running
+    // resource therefore holds three physical linear blocks before cleanup, two more than its current tail.
+    int expect_full_large = (8 + 100 + blk - 1) / blk;  // 27
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 100, 0, /*enable_reuse_cache=*/false),
+              std::max(expect_full_large - full_slots, 0) + 2);
+
+    // reuse enabled: target linear keeps tail 2 + step-hit slots before tail 12;
+    // The fresh seq_len=8 allocation owns one physical linear block. Decode later peaks at 15 physical blocks.
+    int expect_linear_large = 14;
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator, new_res, 8, 100, 0, /*enable_reuse_cache=*/true),
+              std::max(expect_full_large - full_slots, 0) + expect_linear_large);
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, EstimateBatchPeakNeedBlocksAccountsForNonEmptyTargetWidth) {
+    auto config    = makeTinyHybridConfig();
+    auto allocator = std::make_shared<HybridTypeKVCacheAllocator>(config, AllocationType::DEVICE);
+    ASSERT_TRUE(allocator->init());
+
+    auto resource = makeBatchResource(/*batch_size=*/2,
+                                      /*group_nums=*/2,
+                                      /*layer_num=*/config.layer_num,
+                                      /*layer_group_ids=*/config.layerGroupIdsSnapshot(),
+                                      /*keys=*/{});
+
+    // common_seq_len=8 means the first two slots are shared. The NULL slot in the linear group consumes no block.
+    resource->setBatchBlocks(/*batch_id=*/0, /*group_id=*/0, {NULL_BLOCK_IDX, 10, 11});
+    resource->setBatchBlocks(/*batch_id=*/1, /*group_id=*/0, {NULL_BLOCK_IDX, 10, 12});
+    resource->setBatchBlocks(/*batch_id=*/0, /*group_id=*/1, {20, 21, 22});
+    resource->setBatchBlocks(/*batch_id=*/1, /*group_id=*/1, {20, 21, 23});
+
+    // No growth is needed at the current batch width.
+    EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                     /*seq_len=*/12,
+                                                     /*common_seq_len=*/8,
+                                                     /*remaining_tokens=*/0,
+                                                     /*reserve_step=*/0,
+                                                     /*enable_reuse_cache=*/false,
+                                                     /*target_batch_size=*/2),
+              0);
+
+    // No future growth is needed, regardless of the target width.
+    EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                     /*seq_len=*/12,
+                                                     /*common_seq_len=*/8,
+                                                     /*remaining_tokens=*/0,
+                                                     /*reserve_step=*/0,
+                                                     /*enable_reuse_cache=*/false,
+                                                     /*target_batch_size=*/3),
+              0);
+
+    // Four more tokens add one block in each group for each current batch.
+    EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                     /*seq_len=*/12,
+                                                     /*common_seq_len=*/8,
+                                                     /*remaining_tokens=*/4,
+                                                     /*reserve_step=*/0,
+                                                     /*enable_reuse_cache=*/false,
+                                                     /*target_batch_size=*/2),
+              4);
+
+    // One future block in each group is charged at the requested target width.
+    EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                     /*seq_len=*/12,
+                                                     /*common_seq_len=*/8,
+                                                     /*remaining_tokens=*/4,
+                                                     /*reserve_step=*/0,
+                                                     /*enable_reuse_cache=*/false,
+                                                     /*target_batch_size=*/3),
+              6);
+
+    resource->setBatchBlocks(/*batch_id=*/0, /*group_id=*/0, {NULL_BLOCK_IDX, 10, 11, NULL_BLOCK_IDX});
+    resource->setBatchBlocks(/*batch_id=*/1, /*group_id=*/0, {NULL_BLOCK_IDX, 10, 12, NULL_BLOCK_IDX});
+    resource->setBatchBlocks(/*batch_id=*/0, /*group_id=*/1, {20, 21, 22, 24});
+    resource->setBatchBlocks(/*batch_id=*/1, /*group_id=*/1, {20, 21, 23, 25});
+
+    // Existing blocks already cover this unaligned sequence length.
+    EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                     /*seq_len=*/13,
+                                                     /*common_seq_len=*/8,
+                                                     /*remaining_tokens=*/0,
+                                                     /*reserve_step=*/0,
+                                                     /*enable_reuse_cache=*/false,
+                                                     /*target_batch_size=*/2),
+              0);
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, FreshUnalignedMultiSequencePeakMatchesExactCapacity) {
+    for (const bool reuse_cache : {false, true}) {
+        SCOPED_TRACE(reuse_cache ? "reuse enabled" : "reuse disabled");
+
+        auto config      = makeTinyHybridConfig();
+        config.block_num = 7;  // Six usable blocks: exactly the two-stage initialization peak below.
+        auto allocator   = std::make_shared<HybridTypeKVCacheAllocator>(config, AllocationType::DEVICE);
+        ASSERT_TRUE(allocator->init());
+
+        auto resource = makeBatchResource(/*batch_size=*/2,
+                                          /*group_nums=*/2,
+                                          /*layer_num=*/config.layer_num,
+                                          /*layer_group_ids=*/config.layerGroupIdsSnapshot(),
+                                          /*keys=*/{});
+
+        // block_size=4, seq_len=5: initMallocForCommonLen shares one Linear and one Full block for the first four
+        // tokens. incrMalloc then allocates one private tail in each group for each sequence: 2 + 2 * 2 = 6.
+        EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                         /*seq_len=*/5,
+                                                         /*common_seq_len=*/4,
+                                                         /*remaining_tokens=*/0,
+                                                         /*reserve_step=*/0,
+                                                         reuse_cache,
+                                                         /*target_batch_size=*/2),
+                  6);
+        EXPECT_EQ(allocator->freeBlocksNum(), 6);
+
+        // At the next block boundary both groups allocate one more private block per sequence. Linear cleanup only
+        // happens after that allocation, so the lifecycle peak is ten blocks.
+        EXPECT_EQ(allocator->estimateBatchPeakNeedBlocks(resource,
+                                                         /*seq_len=*/5,
+                                                         /*common_seq_len=*/4,
+                                                         /*remaining_tokens=*/4,
+                                                         /*reserve_step=*/0,
+                                                         reuse_cache,
+                                                         /*target_batch_size=*/2),
+                  10);
+
+        auto token_ids = makeCompleteTokenIds(
+            /*batch_size=*/2, /*seq_length=*/5, /*seq_size_per_block=*/config.seq_size_per_block);
+        MallocInfo info{resource, token_ids};
+        info.enable_device_cache          = false;
+        info.reuse_cache                  = reuse_cache;
+        info.enable_remove_skipped_blocks = false;
+        ASSERT_TRUE(allocator->malloc(info).success);
+        EXPECT_EQ(allocator->freeBlocksNum(), 0);
+
+        allocator->free(FreeInfo{resource, token_ids});
+        EXPECT_EQ(allocator->freeBlocksNum(), 6);
+    }
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, EstimatedPeakCoversDecodeMallocAndSparseCleanup) {
+    auto config      = makeTinyHybridConfig();
+    config.block_num = 28;  // 27 usable blocks.
+    auto allocator   = std::make_shared<HybridTypeKVCacheAllocator>(config, AllocationType::DEVICE);
+    ASSERT_TRUE(allocator->init());
+
+    auto batch_res = makeBatchResource(/*batch_size=*/1,
+                                       /*group_nums=*/2,
+                                       /*layer_num=*/static_cast<int>(config.layer_all_num),
+                                       /*layer_group_ids=*/config.layerGroupIdsSnapshot(),
+                                       CacheKeysType{});
+    auto token_ids = makeCompleteTokenIds(/*batch_size=*/1,
+                                          /*seq_length=*/8,
+                                          /*seq_size_per_block=*/config.seq_size_per_block);
+
+    MallocInfo info{batch_res, token_ids};
+    info.enable_device_cache          = false;
+    info.reuse_cache                  = true;
+    info.enable_remove_skipped_blocks = false;
+    ASSERT_TRUE(allocator->malloc(info).success);
+    ASSERT_EQ(allocator->freeBlocksNum(), 24);
+
+    // From seq_len=8 to 68: full needs 15 more blocks; linear grows from one physical block to a transient peak of 10.
+    ASSERT_EQ(estimateBatchPeakForSingleSequence(*allocator,
+                                                batch_res,
+                                                /*seq_len=*/8,
+                                                /*remaining_tokens=*/60,
+                                                /*reserve_step=*/0,
+                                                /*reuse_cache=*/true),
+              24);
+
+    info.enable_remove_skipped_blocks = true;
+    size_t min_free_blocks            = allocator->freeBlocksNum();
+    for (int seq_len = 9; seq_len <= 68; ++seq_len) {
+        token_ids->setSeqLength(seq_len);
+        ASSERT_TRUE(allocator->malloc(info).success) << "seq_len=" << seq_len;
+        min_free_blocks = std::min(min_free_blocks, allocator->freeBlocksNum());
+    }
+
+    EXPECT_EQ(countValidBlocks(batch_res->blocks(0, /*gid=*/0)), 9);
+    EXPECT_EQ(countValidBlocks(batch_res->blocks(0, /*gid=*/1)), 17);
+    EXPECT_EQ(min_free_blocks, 1);
+    EXPECT_EQ(allocator->freeBlocksNum(), 1);
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, FreshReusePeakCoversThreeBoundaryDecodeAtExactCapacity) {
+    auto config    = makeTinyHybridConfig();  // 9 usable blocks, seq_size_per_block=4, linear_step=2.
+    auto allocator = std::make_shared<HybridTypeKVCacheAllocator>(config, AllocationType::DEVICE);
+    ASSERT_TRUE(allocator->init());
+
+    auto batch_res = makeBatchResource(/*batch_size=*/1,
+                                       /*group_nums=*/2,
+                                       /*layer_num=*/static_cast<int>(config.layer_all_num),
+                                       /*layer_group_ids=*/config.layerGroupIdsSnapshot(),
+                                       CacheKeysType{});
+    auto token_ids = makeCompleteTokenIds(/*batch_size=*/1,
+                                          /*seq_length=*/8,
+                                          /*seq_size_per_block=*/config.seq_size_per_block);
+
+    // seq_len 8 -> 17 crosses the slot boundaries at 9, 13 and 17. Full peaks at 5 blocks and linear peaks at 4.
+    ASSERT_EQ(allocator->freeBlocksNum(), 9);
+    ASSERT_EQ(estimateBatchPeakForSingleSequence(*allocator,
+                                                batch_res,
+                                                /*seq_len=*/8,
+                                                /*remaining_tokens=*/9,
+                                                /*reserve_step=*/0,
+                                                /*reuse_cache=*/true),
+              9);
+
+    MallocInfo info{batch_res, token_ids};
+    info.enable_device_cache          = false;
+    info.reuse_cache                  = true;
+    info.enable_remove_skipped_blocks = false;
+    ASSERT_TRUE(allocator->malloc(info).success);
+
+    info.enable_remove_skipped_blocks = true;
+    for (int seq_len = 9; seq_len <= 17; ++seq_len) {
+        token_ids->setSeqLength(seq_len);
+        ASSERT_TRUE(allocator->malloc(info).success) << "seq_len=" << seq_len;
+    }
+
+    EXPECT_EQ(countValidBlocks(batch_res->blocks(0, /*gid=*/0)), 3);
+    EXPECT_EQ(countValidBlocks(batch_res->blocks(0, /*gid=*/1)), 5);
+    EXPECT_EQ(allocator->freeBlocksNum(), 1);
 }
 
 }  // namespace test

--- a/rtp_llm/cpp/cache/test/LinearKVCacheGroupTest.cc
+++ b/rtp_llm/cpp/cache/test/LinearKVCacheGroupTest.cc
@@ -118,6 +118,94 @@ TEST_F(LinearKVCacheGroupTest, MallocAllocatesReserveTailBlocksWhenReuseDisabled
     EXPECT_EQ(block_pool->freeBlocksNum(), 7u);
 }
 
+TEST_F(LinearKVCacheGroupTest, EstimatePeakNeedBlocksIncludesTransientTailAllocation) {
+    auto block_pool = createBlockPool();
+    ASSERT_TRUE(block_pool->init());
+
+    auto               spec = makeTestLinearSpec(/*seq_size_per_block=*/4);
+    LinearKVCacheGroup group(/*layer_ids=*/{}, spec, block_pool, /*group_id=*/0, /*linear_step=*/2);
+    ASSERT_TRUE(group.init());
+
+    const BlockIndicesType current_blocks = {NULL_BLOCK_IDX, 0, 1};
+
+    // Three logical slots currently contain two physical tail blocks.
+    // Decoding across the next block still allocates the new tail before sparse cleanup releases the old one.
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/12, current_blocks, /*remaining_tokens=*/4, /*reserve_step=*/0, false),
+              1);
+}
+
+TEST_F(LinearKVCacheGroupTest, EstimateInitialBatchPeakKeepsSharedAndPrivateTailsDistinct) {
+    auto block_pool = createBlockPool();
+    ASSERT_TRUE(block_pool->init());
+
+    auto               spec = makeTestLinearSpec(/*seq_size_per_block=*/4);
+    LinearKVCacheGroup group(/*layer_ids=*/{}, spec, block_pool, /*group_id=*/0, /*linear_step=*/2);
+    ASSERT_TRUE(group.init());
+
+    // The aligned common prefix owns one shared tail. The unaligned prompt then owns one private tail per sequence.
+    EXPECT_EQ(group.estimateInitialBatchPeakNeedBlocks(/*seq_len=*/5,
+                                                       /*common_seq_len=*/4,
+                                                       /*remaining_tokens=*/0,
+                                                       /*reserve_step=*/0,
+                                                       /*enable_reuse_cache=*/false,
+                                                       /*target_batch_size=*/2),
+              3);
+
+    // Crossing the next boundary allocates another private tail per sequence before the shared tail is cleaned up.
+    EXPECT_EQ(group.estimateInitialBatchPeakNeedBlocks(/*seq_len=*/5,
+                                                       /*common_seq_len=*/4,
+                                                       /*remaining_tokens=*/4,
+                                                       /*reserve_step=*/0,
+                                                       /*enable_reuse_cache=*/false,
+                                                       /*target_batch_size=*/2),
+              5);
+}
+
+TEST_F(LinearKVCacheGroupTest, EstimatePeakNeedBlocksAddsTransientWhenFreshResourceCrossesTwoBoundaries) {
+    auto block_pool = createBlockPool();
+    ASSERT_TRUE(block_pool->init());
+
+    auto               spec = makeTestLinearSpec(/*seq_size_per_block=*/4);
+    LinearKVCacheGroup group(/*layer_ids=*/{}, spec, block_pool, /*group_id=*/0, /*linear_step=*/2);
+    ASSERT_TRUE(group.init());
+
+    // From seq_len=8, remaining=4 crosses only the boundary at seq_len=9, so two tail blocks are sufficient.
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/8, {}, /*remaining_tokens=*/4, /*reserve_step=*/0, false),
+              2);
+
+    // remaining=5 also crosses the boundary at seq_len=13. The new tail is allocated before sparse cleanup releases
+    // the oldest tail, so the fresh resource transiently needs three physical blocks.
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/8, {}, /*remaining_tokens=*/5, /*reserve_step=*/0, false),
+              3);
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/8, {}, /*remaining_tokens=*/100, /*reserve_step=*/0, false),
+              3);
+
+    // With reuse enabled and linear_step=2, the third later boundary allocates a non-step tail before cleanup.
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/8, {}, /*remaining_tokens=*/9, /*reserve_step=*/0, true),
+              4);
+}
+
+TEST_F(LinearKVCacheGroupTest, EstimatePeakNeedBlocksIncludesTransientReserveAllocation) {
+    auto block_pool = createBlockPool();
+    ASSERT_TRUE(block_pool->init());
+
+    auto               spec = makeTestLinearSpec(/*seq_size_per_block=*/4);
+    LinearKVCacheGroup group(/*layer_ids=*/{}, spec, block_pool, /*group_id=*/0, /*linear_step=*/2);
+    ASSERT_TRUE(group.init());
+
+    const BlockIndicesType current_blocks = {NULL_BLOCK_IDX, NULL_BLOCK_IDX, NULL_BLOCK_IDX, 0, 1};
+
+    // With reserve_step=2, only the new reserve tail is allocated before cleanup.
+    EXPECT_EQ(group.estimatePeakNeedBlocks(
+                  /*seq_len=*/16, current_blocks, /*remaining_tokens=*/4, /*reserve_step=*/2, false),
+              1);
+}
+
 TEST_F(LinearKVCacheGroupTest, RemoveSkippedBlocksFreesNonStepBlocksButKeepsLastTwo) {
     auto block_pool = createBlockPool();
     ASSERT_TRUE(block_pool->init());

--- a/rtp_llm/cpp/cache/test/SingleTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/SingleTypeKVCacheAllocatorTest.cc
@@ -112,6 +112,21 @@ BatchKVCacheResourcePtr createBatchKVCacheResource(int batch_size, int layer_num
     return resource;
 }
 
+static int estimateBatchPeakForSingleSequence(const KVCacheAllocator&          allocator,
+                                              const BatchKVCacheResourcePtr& batch_resource,
+                                              int                            seq_len,
+                                              int                            remaining_tokens,
+                                              int                            reserve_step,
+                                              bool                           enable_reuse_cache) {
+    return allocator.estimateBatchPeakNeedBlocks(batch_resource,
+                                                 seq_len,
+                                                 /*common_seq_len=*/seq_len,
+                                                 remaining_tokens,
+                                                 reserve_step,
+                                                 enable_reuse_cache,
+                                                 /*target_batch_size=*/1);
+}
+
 class SingleTypeKVCacheAllocatorTest: public ::testing::Test {
 protected:
     void SetUp() override {
@@ -203,7 +218,7 @@ TEST_F(SingleTypeKVCacheAllocatorTest, ReserveBlocksOnlyAppliedToInitMalloc) {
     allocator_  = std::make_shared<SingleTypeKVCacheAllocator>(config);
     ASSERT_TRUE(allocator_->init());
 
-    allocator_->setReserveBlockNum(2);
+    allocator_->setReserveBlocksNum(2);
 
     const size_t available_before = allocator_->availableBlocksNum();
     ASSERT_EQ(available_before, 9u);
@@ -241,7 +256,7 @@ TEST_F(SingleTypeKVCacheAllocatorTest, ReserveBlocksCheckHappensAfterReuseRefere
     allocator_  = std::make_shared<SingleTypeKVCacheAllocator>(config);
     ASSERT_TRUE(allocator_->init());
 
-    allocator_->setReserveBlockNum(2);
+    allocator_->setReserveBlocksNum(2);
     ASSERT_EQ(allocator_->availableBlocksNum(), 9);
     ASSERT_EQ(allocator_->freeBlocksNum(), 9);
 
@@ -1221,6 +1236,141 @@ TEST_F(SingleTypeKVCacheAllocatorTest, MixedOperations) {
     }
 
     EXPECT_GT(allocator_->freeBlocksNum(), 0);
+}
+
+
+TEST_F(SingleTypeKVCacheAllocatorTest, EstimatePeakNeedBlocks) {
+    // seq_size_per_block=4, block_num=10
+    auto config = createSingleTypeTestConfig(/*layer_num=*/1, /*block_num=*/10, /*seq_size_per_block=*/4);
+    allocator_  = std::make_shared<SingleTypeKVCacheAllocator>(config);
+    ASSERT_TRUE(allocator_->init());
+
+    // New resource (no blocks allocated): ceil((8+100)/4) - 0 = 27
+    auto new_res = createBatchKVCacheResource(1, config.layer_num);
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator_, new_res, 8, 100, 0, /*enable_reuse_cache=*/false),
+              27);
+
+    // With reserve_step=3: ceil((8+100+3)/4) - 0 = 28
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator_, new_res, 8, 100, 3, /*enable_reuse_cache=*/false),
+              28);
+
+    // Allocate blocks for seq_len=8 (2 blocks)
+    auto token_ids = createCompleteTokenIds(1, /*seq_length=*/8, /*seq_size_per_block=*/4);
+    MallocInfo mi{new_res, token_ids};
+    auto result = allocator_->malloc(mi);
+    ASSERT_TRUE(result.success);
+    ASSERT_EQ(new_res->blocksNum(0, 0), 2);
+
+    // After malloc: ceil((8+0)/4) - 2 = 0
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator_, new_res, 8, 0, 0, /*enable_reuse_cache=*/false),
+              0);
+
+    // remaining=4: ceil((8+4)/4) - 2 = 1
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator_, new_res, 8, 4, 0, /*enable_reuse_cache=*/false),
+              1);
+
+    // remaining=4, reserve=4: ceil((8+4+4)/4) - 2 = 2
+    EXPECT_EQ(estimateBatchPeakForSingleSequence(*allocator_, new_res, 8, 4, 4, /*enable_reuse_cache=*/false),
+              2);
+}
+
+TEST_F(SingleTypeKVCacheAllocatorTest, EstimateBatchPeakNeedBlocksAccountsForNonEmptyTargetWidth) {
+    auto config = createSingleTypeTestConfig(/*layer_num=*/1, /*block_num=*/16, /*seq_size_per_block=*/4);
+    allocator_  = std::make_shared<SingleTypeKVCacheAllocator>(config);
+    ASSERT_TRUE(allocator_->init());
+
+    auto resource = createBatchKVCacheResource(/*batch_size=*/2, config.layer_num);
+    resource->setBatchBlocks(/*batch_id=*/0, /*group_id=*/0, {1, 2, 3});
+    resource->setBatchBlocks(/*batch_id=*/1, /*group_id=*/0, {1, 2, 4});
+
+    // Two common blocks are shared. Each current batch owns one private tail block.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/9,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/0,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/2),
+              0);
+
+    // Expanding the partial tail from two sequences to four needs two physical copies.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/9,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/0,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/4),
+              2);
+
+    // Existing resources need one additional block for each current batch.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/9,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/4,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/2),
+              2);
+
+    // Charge four future blocks plus two copies of the current partial tail.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/9,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/4,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/4),
+              6);
+
+    // An aligned tail remains shared while the batch expands.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/12,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/0,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/4),
+              0);
+
+    auto empty_resource = createBatchKVCacheResource(/*batch_size=*/1, config.layer_num);
+    // Empty resource: two prompt blocks are shared and one future block is private per target batch.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(empty_resource,
+                                                      /*seq_len=*/8,
+                                                      /*common_seq_len=*/8,
+                                                      /*remaining_tokens=*/3,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/4),
+              6);
+}
+
+TEST_F(SingleTypeKVCacheAllocatorTest, EstimateBatchPeakCoversPartialTailCopiesAtExactCapacity) {
+    auto config = createSingleTypeTestConfig(/*layer_num=*/1, /*block_num=*/6, /*seq_size_per_block=*/4);
+    allocator_  = std::make_shared<SingleTypeKVCacheAllocator>(config);
+    ASSERT_TRUE(allocator_->init());
+
+    auto resource  = createBatchKVCacheResource(/*batch_size=*/1, config.layer_num);
+    auto token_ids = createCompleteTokenIds(/*batch_size=*/1, /*seq_length=*/5, /*seq_size_per_block=*/4);
+    ASSERT_TRUE(allocator_->malloc(MallocInfo{resource, token_ids}).success);
+    ASSERT_EQ(allocator_->freeBlocksNum(), 3);
+
+    // The two future KV steps fit in the current tail, but a delayed 1-to-4 beam expansion copies it three times.
+    EXPECT_EQ(allocator_->estimateBatchPeakNeedBlocks(resource,
+                                                      /*seq_len=*/5,
+                                                      /*common_seq_len=*/4,
+                                                      /*remaining_tokens=*/2,
+                                                      /*reserve_step=*/0,
+                                                      /*enable_reuse_cache=*/false,
+                                                      /*target_batch_size=*/4),
+              3);
+
+    std::vector<BlockIdPair> block_update_mapping;
+    ASSERT_TRUE(allocator_->updateKVBlock(
+        resource, /*block_src_batch=*/{0, 0, 0, 0}, /*copy_last_block=*/true, block_update_mapping));
+    EXPECT_EQ(resource->batchSize(), 4);
+    EXPECT_EQ(block_update_mapping.size(), 3);
+    EXPECT_EQ(allocator_->freeBlocksNum(), 0);
 }
 
 }  // namespace test

--- a/rtp_llm/cpp/cache/test/mock/MockKVCacheAllocator.h
+++ b/rtp_llm/cpp/cache/test/mock/MockKVCacheAllocator.h
@@ -39,12 +39,29 @@ public:
                 singleBatchNeedBlocks,
                 (const BatchKVCacheResourcePtr& batch_kv_cache_resource, int seq_len, int reserve_step),
                 (const, override));
+    MOCK_METHOD(int,
+                estimatePeakNeedBlocks,
+                (const KVCacheResource& kv_cache_resource,
+                 int                    seq_len,
+                 int                    remaining_tokens,
+                 int                    reserve_step,
+                 bool                   enable_reuse_cache),
+                (const, override));
 
 protected:
     MOCK_METHOD(bool, doInit, (), (override));
     MOCK_METHOD(MallocResult, incrMalloc, (const MallocInfo&), (override));
     MOCK_METHOD(MallocResult, initMallocForCommonLen, (const MallocInfo&), (override));
     MOCK_METHOD(int, getNeedBlocks, (const MallocInfo&), (const, override));
+    MOCK_METHOD(int,
+                estimateInitialBatchPeakNeedBlocks,
+                (int seq_len,
+                 int common_seq_len,
+                 int remaining_tokens,
+                 int reserve_step,
+                 bool enable_reuse_cache,
+                 int target_batch_size),
+                (const, override));
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -349,6 +349,7 @@ struct FIFOSchedulerConfig {
     //   "ratio" -> PDFusionRatioScheduler with decode_prefill_ratio
     std::string pdfusion_scheduler_mode = "";
     // PDFusionRatioScheduler cadence knob, as a decode:prefill round ratio string.
+    //   "0"   -> always try PREFILL first when a waiting stream exists.
     //   "N"   -> 1 prefill : N decode (decode-heavy); "1" = strict alternation.
     //   "1/X" -> X prefill : 1 decode (prefill-heavy).
     //   invalid input falls back to "1".

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.cc
@@ -34,7 +34,7 @@ FIFOScheduler::~FIFOScheduler() {
 }
 
 bool FIFOScheduler::evaluateRunningMemory(const list<GenerateStreamPtr>& streams,
-                                          const GenerateStreamPtr&       new_stream) const {
+                                          const GenerateStreamPtr&       new_stream) {
     RTP_LLM_PROFILE_FUNCTION();
     if (pd_sep_config_.role_type == RoleType::DECODE) {
         if (running_streams_.size() + streams.size() + 1 < max_generate_batch_size_) {

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h
@@ -33,7 +33,7 @@ private:
         return "FIFOScheduler";
     }
     bool evaluateRunningMemory(const std::list<GenerateStreamPtr>& streams,
-                               const GenerateStreamPtr&            new_stream) const override;
+                               const GenerateStreamPtr&            new_stream) override;
     void accountBatchMetrics(const GenerateStreamPtr& new_stream);
     bool waitPredicate() override;
     void onRunningStream(const GenerateStreamPtr& stream) override;

--- a/rtp_llm/cpp/engine_base/schedulers/FIFOSchedulerBase.h
+++ b/rtp_llm/cpp/engine_base/schedulers/FIFOSchedulerBase.h
@@ -49,7 +49,7 @@ public:
 protected:
     virtual const char* schedulerName() const                                            = 0;
     virtual bool        evaluateRunningMemory(const std::list<GenerateStreamPtr>& streams,
-                                              const GenerateStreamPtr&            new_stream) const = 0;
+                                              const GenerateStreamPtr&            new_stream) = 0;
     virtual bool        waitPredicate()                                                  = 0;
     virtual void        onRunningStream(const GenerateStreamPtr& stream) {}
     virtual void        cancelExtraStreams() {}

--- a/rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
 #include "rtp_llm/cpp/utils/Logger.h"
@@ -15,7 +16,25 @@ namespace rtp_llm {
 namespace {
 constexpr auto kNoProgressScheduleGap = std::chrono::milliseconds(1);
 
+int remainingKVAllocationSteps(const GenerateStreamPtr& stream) {
+    // The final generated token is never used as input to another forward, so it does not get a KV entry.
+    return std::max(0, static_cast<int>(stream->maxTokenNum()) - stream->seqLength() - 1);
+}
+
+int64_t estimateNeedBlocks(const GenerateStreamPtr& stream, int decode_step) {
+    return std::max(stream->estimatePeakNeedBlocks(decode_step), 0);
+}
+
+int64_t estimateInitialNeedBlocks(const GenerateStreamPtr& stream) {
+    return std::max(stream->estimateInitialNeedBlocks(), 0);
+}
+
+bool isAdmittedWaitingStream(const GenerateStreamPtr& stream) {
+    return stream->hasEvent(StreamEvents::CanRun) && stream->hasEvent(StreamEvents::LoadInitiated);
+}
+
 // Parse the decode_prefill_ratio string into the internal signed cadence step.
+//   "0"   (prefill-first) -> 0
 //   "N"   (N>=1) -> N    (1 prefill : N decode)
 //   "1/X" (X>=1) -> -X   (X prefill : 1 decode)
 //   invalid      -> 1    (alternation), with a warning
@@ -25,7 +44,7 @@ int64_t parseDecodePrefillRatio(const std::string& ratio) {
         if (slash == std::string::npos) {
             size_t  pos = 0;
             int64_t n   = std::stoll(ratio, &pos);
-            if (pos == ratio.size() && n >= 1) {
+            if (pos == ratio.size() && n >= 0) {
                 return n;
             }
         } else if (ratio.substr(0, slash) == "1") {
@@ -43,6 +62,76 @@ int64_t parseDecodePrefillRatio(const std::string& ratio) {
     return 1;
 }
 }  // namespace
+
+namespace {
+
+struct AdmissionStreamInfo {
+    GenerateStreamPtr stream;
+    int               remaining_kv_steps;
+};
+
+struct AdmissionPeak {
+    int     decode_step = 0;
+    int64_t need_blocks = 0;
+};
+
+bool longerLifetimeFirst(const AdmissionStreamInfo& lhs, const AdmissionStreamInfo& rhs) {
+    return lhs.remaining_kv_steps > rhs.remaining_kv_steps;
+}
+
+AdmissionPeak estimateApproximatePeak(const std::vector<AdmissionStreamInfo>& streams) {
+    AdmissionPeak peak;
+    int64_t       peak_tokens        = -1;
+    int64_t       active_base_tokens = 0;
+    int64_t       active_batch_size  = 0;
+
+    // Streams are ordered by lifetime. At each distinct lifetime, the prefix visited so far is exactly
+    // the set still alive at that decode step, so the aggregate logical-token peak is found in one sweep.
+    for (size_t begin = 0; begin < streams.size();) {
+        const int decode_step = streams[begin].remaining_kv_steps;
+        size_t    end         = begin;
+        while (end < streams.size() && streams[end].remaining_kv_steps == decode_step) {
+            const auto&   stream     = streams[end].stream;
+            const int64_t batch_size = std::max(stream->maxBatchSize(), 1);
+            active_base_tokens += batch_size * stream->seqLength();
+            active_batch_size += batch_size;
+            ++end;
+        }
+        const int64_t active_tokens = active_base_tokens + active_batch_size * decode_step;
+        if (active_tokens > peak_tokens) {
+            peak_tokens      = active_tokens;
+            peak.decode_step = decode_step;
+        }
+        begin = end;
+    }
+
+    // This is deliberately a best-effort KV admission filter, not a lifecycle capacity guarantee. Before this
+    // optimization, PDFusion admitted every candidate that passed the existing batch/token limits, and an
+    // allocator-side MALLOC_FAILED was an allowed product outcome. This heuristic only rejects a subset of those
+    // candidates, reducing allocation failures without changing the existing failure semantics; it may still
+    // underestimate the actual physical-block peak and over-admit work.
+    //
+    // Summing each stream's independent peak is O(N) to compute, but treats non-coincident peaks as simultaneous and
+    // substantially under-admits work, reducing batching concurrency and throughput. Tracking every stream lifetime
+    // and KV-group allocation/release boundary would avoid that conservatism, but adds disproportionate implementation
+    // complexity and scheduler-lock latency. This performance-oriented scheduler therefore evaluates physical blocks
+    // only at the logical-token peak.
+    for (const auto& stream : streams) {
+        if (stream.remaining_kv_steps < peak.decode_step) {
+            break;
+        }
+        peak.need_blocks += estimateNeedBlocks(stream.stream, peak.decode_step);
+    }
+    return peak;
+}
+
+}  // namespace
+
+struct PDFusionRatioScheduler::AdmissionPeakState {
+    std::vector<AdmissionStreamInfo> streams;
+    AdmissionPeak                    peak;
+    int64_t                          initial_need_blocks = 0;
+};
 
 PDFusionRatioScheduler::PDFusionRatioScheduler(const RuntimeConfig&                   runtime_config,
                                                const ModelConfig&                     model_config,
@@ -77,22 +166,30 @@ PDFusionRatioScheduler::~PDFusionRatioScheduler() {
 }
 
 bool PDFusionRatioScheduler::evaluateRunningMemory(const list<GenerateStreamPtr>& streams,
-                                                   const GenerateStreamPtr&       new_stream) const {
+                                                   const GenerateStreamPtr&       new_stream) {
     RTP_LLM_PROFILE_FUNCTION();
-    const auto in_flight_streams =
-        loading_cache_streams_.size() + running_streams_.size() + pending_decode_streams_.size() + streams.size();
+    if (!new_stream->isContextStream()) {
+        return false;
+    }
+    // The peak state is built once per prefill round and updated after every successful admission,
+    // so its stream count covers both existing in-flight work and candidates admitted in this round.
+    if (!admission_peak_state_) {
+        buildAdmissionPeakState();
+    }
+    const auto in_flight_streams = admission_peak_state_->streams.size();
     if (in_flight_streams + 1 > max_generate_batch_size_) {
         return false;
     }
 
     size_t max_token_size = static_cast<size_t>(new_stream->contextLength());
     if (streams.empty() && max_token_size < max_seq_len_) {
-        return true;
+        return tryAdmitKVForPrefill(new_stream);
     }
     for (auto& stream : streams) {
         max_token_size = std::max(max_token_size, static_cast<size_t>(stream->contextLength()));
     }
-    return max_token_size * (streams.size() + 1) < max_batch_tokens_size_;
+    return max_token_size * (streams.size() + 1) < max_batch_tokens_size_
+           && tryAdmitKVForPrefill(new_stream);
 }
 
 bool PDFusionRatioScheduler::waitPredicate() {
@@ -120,7 +217,10 @@ absl::StatusOr<list<GenerateStreamPtr>> PDFusionRatioScheduler::schedule() {
 
     if (round == RoundType::PREFILL) {
         const size_t prev_waiting_size = waiting_streams_.size();
+        // Build once for this in-flight snapshot, then update for accepted candidates.
+        admission_peak_state_.reset();
         evaluateWaitingStreams(waiting_streams_);
+        admission_peak_state_.reset();
         made_progress |= evaluateAndUpdateStreams(waiting_streams_) > 0;
         if (!new_streams_.empty()) {
             list<GenerateStreamPtr> prefill_batch(new_streams_.begin(), new_streams_.end());
@@ -165,11 +265,95 @@ PDFusionRatioScheduler::RoundType PDFusionRatioScheduler::chooseRound() {
     if (running_streams_.empty() && pending_decode_streams_.empty()) {
         return RoundType::PREFILL;
     }
+    if (decode_prefill_step_ == 0) {
+        return RoundType::PREFILL;
+    }
     if (decode_prefill_step_ >= 1) {
         return decode_since_prefill_ >= decode_prefill_step_ ? RoundType::PREFILL : RoundType::DECODE;
     }
     const int64_t m = -decode_prefill_step_;
     return prefill_since_decode_ < m ? RoundType::PREFILL : RoundType::DECODE;
+}
+
+void PDFusionRatioScheduler::buildAdmissionPeakState() {
+    auto state = std::make_unique<AdmissionPeakState>();
+    state->streams.reserve(loading_cache_streams_.size() + running_streams_.size() + pending_decode_streams_.size()
+                           + waiting_streams_.size());
+    auto append_stream = [&](const GenerateStreamPtr& s) {
+        state->streams.push_back({s, remainingKVAllocationSteps(s)});
+        state->initial_need_blocks += estimateInitialNeedBlocks(s);
+    };
+    for (const auto& s : loading_cache_streams_) {
+        append_stream(s);
+    }
+    for (const auto& s : running_streams_) {
+        append_stream(s);
+    }
+    for (const auto& s : pending_decode_streams_) {
+        append_stream(s);
+    }
+    for (const auto& s : waiting_streams_) {
+        if (isAdmittedWaitingStream(s)) {
+            append_stream(s);
+        }
+    }
+    std::sort(state->streams.begin(), state->streams.end(), longerLifetimeFirst);
+    state->peak           = estimateApproximatePeak(state->streams);
+    admission_peak_state_ = std::move(state);
+}
+
+bool PDFusionRatioScheduler::tryAddToAdmissionPeakState(const GenerateStreamPtr& new_stream,
+                                                        int64_t                  initial_capacity,
+                                                        int64_t                  lifecycle_capacity) {
+    auto&     state              = *admission_peak_state_;
+    const int remaining_kv_steps = remainingKVAllocationSteps(new_stream);
+    // Preserve the idle fast path, where the allocator reports an impossible standalone request.
+    const bool    enforce_capacity = !state.streams.empty();
+    // Device KV-cache matching happens later in the allocator. At scheduler admission time the actual prefix hit is
+    // unknown, so use the conservative no-hit estimate here.
+    const int64_t initial_delta    = estimateInitialNeedBlocks(new_stream);
+
+    if (enforce_capacity
+        && (state.initial_need_blocks + initial_delta > initial_capacity
+            || state.peak.need_blocks > lifecycle_capacity)) {
+        return false;
+    }
+
+    const auto insert_it = std::lower_bound(state.streams.begin(),
+                                            state.streams.end(),
+                                            AdmissionStreamInfo{new_stream, remaining_kv_steps},
+                                            longerLifetimeFirst);
+    const auto candidate_it   = state.streams.insert(insert_it, {new_stream, remaining_kv_steps});
+    auto       candidate_peak = estimateApproximatePeak(state.streams);
+    // Adding work cannot invalidate a block requirement already sampled before this candidate.
+    candidate_peak.need_blocks = std::max(candidate_peak.need_blocks, state.peak.need_blocks);
+    if (enforce_capacity && candidate_peak.need_blocks > lifecycle_capacity) {
+        state.streams.erase(candidate_it);
+        return false;
+    }
+
+    state.initial_need_blocks += initial_delta;
+    state.peak = candidate_peak;
+    return true;
+}
+
+bool PDFusionRatioScheduler::tryAdmitKVForPrefill(const GenerateStreamPtr& new_stream) {
+    if (!cache_manager_) {
+        return false;
+    }
+
+    if (!admission_peak_state_) {
+        buildAdmissionPeakState();
+    }
+
+    const size_t available        = cache_manager_->availableBlocksNum();
+    const size_t reserved         = cache_manager_->reserveBlocksNum();
+    const size_t initial_capacity = (available > reserved) ? (available - reserved) : 0;
+    // force_batch is best-effort grouping, not all-or-nothing admission. Its members were already
+    // checked individually against batch-size and prefill-token limits before KV admission was added;
+    // KV gating intentionally preserves that behavior.
+    return tryAddToAdmissionPeakState(
+        new_stream, static_cast<int64_t>(initial_capacity), static_cast<int64_t>(available));
 }
 
 size_t PDFusionRatioScheduler::reapErroredWaitingStreams() {

--- a/rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.h
+++ b/rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.h
@@ -3,7 +3,6 @@
 #include <list>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "kmonitor/client/MetricsReporter.h"
 #include "rtp_llm/cpp/cache/KVCacheManager.h"
@@ -45,7 +44,7 @@ private:
         return "PDFusionRatioScheduler";
     }
     bool      evaluateRunningMemory(const std::list<GenerateStreamPtr>& streams,
-                                    const GenerateStreamPtr&            new_stream) const override;
+                                    const GenerateStreamPtr&            new_stream) override;
     bool      waitPredicate() override;
     void      cancelExtraStreams() override;
     bool      hasExtraStreams() const override;
@@ -55,12 +54,21 @@ private:
     size_t    reapFinished(std::list<GenerateStreamPtr>& streams);
     size_t    promotePendingDecodeStreams();
     RoundType chooseRound();
+    bool      tryAdmitKVForPrefill(const GenerateStreamPtr& new_stream);
+
+    struct AdmissionPeakState;
+    void buildAdmissionPeakState();
+    bool tryAddToAdmissionPeakState(const GenerateStreamPtr& new_stream,
+                                    int64_t                  initial_capacity,
+                                    int64_t                  lifecycle_capacity);
 
 private:
     std::list<GenerateStreamPtr> pending_decode_streams_;
-    int64_t                      decode_prefill_step_  = 1;
-    int64_t                      decode_since_prefill_ = 0;
-    int64_t                      prefill_since_decode_ = 0;
+    // Per-prefill-round scratch state, guarded by the scheduler lock.
+    std::unique_ptr<AdmissionPeakState> admission_peak_state_;
+    int64_t                             decode_prefill_step_  = 1;
+    int64_t                             decode_since_prefill_ = 0;
+    int64_t                             prefill_since_decode_ = 0;
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/engine_base/schedulers/test/BUILD
+++ b/rtp_llm/cpp/engine_base/schedulers/test/BUILD
@@ -29,7 +29,9 @@ cc_test(
     ],
     data = [],
     copts = copts() + ["-fno-access-control"],
-    deps = test_deps,
+    deps = test_deps + [
+        "//rtp_llm/cpp/cache/test:cache_config_test_utils",
+    ],
     env = {
         "TEST_USING_DEVICE": "CUDA",
     },

--- a/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerAsyncCacheTest.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerAsyncCacheTest.cc
@@ -81,7 +81,9 @@ protected:
 
     GenerateStreamPtr createStream(const std::vector<int>& input_tokens        = {1, 2, 3},
                                    bool                    reuse_cache         = false,
-                                   bool                    enable_memory_cache = false) {
+                                   bool                    enable_memory_cache = false,
+                                   int                     max_new_tokens      = 1,
+                                   const std::vector<int>& variable_num_beams  = {}) {
         ResourceContext resource_context;
         resource_context.cache_manager       = cache_manager_;
         resource_context.reuse_cache         = reuse_cache;
@@ -95,6 +97,8 @@ protected:
         std::shared_ptr<GenerateConfig> generate_config(new GenerateConfig());
         generate_config->reuse_cache         = reuse_cache;
         generate_config->enable_memory_cache = enable_memory_cache;
+        generate_config->max_new_tokens      = max_new_tokens;
+        generate_config->variable_num_beams  = variable_num_beams;
         query->input_ids                     = torch::tensor(input_tokens, torch::kInt32);
         query->generate_config               = generate_config;
         return std::make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -240,6 +244,94 @@ TEST_F(FIFOSchedulerAsyncCacheTest, testPDFusionLoadingCacheLifecyclePromotesToD
     ASSERT_EQ(decode.value().front().get(), stream.get());
     ASSERT_EQ(scheduler->runningStreamsSize(), 1);
     ASSERT_EQ(scheduler->pendingDecodeStreamsSize(), 0);
+}
+
+TEST_F(FIFOSchedulerAsyncCacheTest, testPDFusionCompletedAsyncLoadStaysInAdmissionPeak) {
+    cache_config_ = test::makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/3, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_INT8);
+    cache_manager_ = std::make_shared<KVCacheManager>(cache_config_);
+    ASSERT_TRUE(cache_manager_->init());
+    ASSERT_EQ(cache_manager_->freeBlocksNum(), 2);
+
+    setupMockCoordinator();
+    auto done_ctx = createDoneAsyncContext();
+    EXPECT_CALL(*mock_coord_, asyncRead(_)).WillOnce(Return(std::static_pointer_cast<AsyncContext>(done_ctx)));
+
+    auto scheduler = createPDFusionRatioScheduler();
+    auto loaded    = createStream({1, 2}, /*reuse_cache=*/true, /*enable_memory_cache=*/true);
+    loaded->generateConfig()->max_new_tokens = 2;
+    ASSERT_TRUE(scheduler->enqueue(loaded).ok());
+
+    auto loading = scheduler->schedule();
+    ASSERT_TRUE(loading.ok());
+    ASSERT_TRUE(loading.value().empty());
+    ASSERT_EQ(loaded->getStatus(), StreamState::LOADING_CACHE);
+    ASSERT_EQ(cache_manager_->freeBlocksNum(), 1);
+    ASSERT_EQ(loaded->estimatePeakNeedBlocks(/*remaining_tokens=*/1), 1);
+
+    auto candidate = createStream({3});
+    candidate->generateConfig()->max_new_tokens = 2;
+    ASSERT_EQ(candidate->estimatePeakNeedBlocks(/*remaining_tokens=*/1), 1);
+    ASSERT_TRUE(scheduler->enqueue(candidate).ok());
+
+    // The completed load returns to WAITING after the candidate was enqueued. Their combined
+    // one-block future peaks exceed the one remaining block, so only the pre-admitted load may run.
+    auto prefill = scheduler->schedule();
+    ASSERT_TRUE(prefill.ok());
+    ASSERT_EQ(prefill.value().size(), 1);
+    ASSERT_EQ(prefill.value().front().get(), loaded.get());
+    ASSERT_EQ(scheduler->pendingDecodeStreamsSize(), 1);
+    ASSERT_EQ(scheduler->waitingStreamsSize(), 1);
+    ASSERT_EQ(scheduler->waiting_streams_.front().get(), candidate.get());
+    ASSERT_FALSE(candidate->hasEvent(StreamEvents::CanRun));
+}
+
+TEST_F(FIFOSchedulerAsyncCacheTest, testPDFusionLoadingCacheReservesDelayedBeamTailCopies) {
+    cache_config_ = test::makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/6, /*tokens_per_block=*/4, rtp_llm::DataType::TYPE_INT8);
+    cache_manager_ = std::make_shared<KVCacheManager>(cache_config_);
+    ASSERT_TRUE(cache_manager_->init());
+    ASSERT_EQ(cache_manager_->freeBlocksNum(), 5);
+
+    setupMockCoordinator();
+    auto done_ctx = createDoneAsyncContext();
+    EXPECT_CALL(*mock_coord_, asyncRead(_)).WillOnce(Return(std::static_pointer_cast<AsyncContext>(done_ctx)));
+
+    auto scheduler = createPDFusionRatioScheduler();
+    auto loaded    = createStream({1, 2, 3, 4, 5},
+                                  /*reuse_cache=*/true,
+                                  /*enable_memory_cache=*/true,
+                                  /*max_new_tokens=*/3,
+                                  /*variable_num_beams=*/{1, 4});
+    ASSERT_EQ(loaded->currentBatchSize(), 1);
+    ASSERT_EQ(loaded->maxBatchSize(), 4);
+    ASSERT_TRUE(scheduler->enqueue(loaded).ok());
+
+    auto loading = scheduler->schedule();
+    ASSERT_TRUE(loading.ok());
+    ASSERT_TRUE(loading.value().empty());
+    ASSERT_EQ(loaded->getStatus(), StreamState::LOADING_CACHE);
+    ASSERT_EQ(cache_manager_->freeBlocksNum(), 3);
+    ASSERT_EQ(loaded->estimatePeakNeedBlocks(/*remaining_tokens=*/2), 3);
+
+    auto candidate = createStream({6},
+                                  /*reuse_cache=*/false,
+                                  /*enable_memory_cache=*/false,
+                                  /*max_new_tokens=*/3);
+    ASSERT_EQ(candidate->estimatePeakNeedBlocks(/*remaining_tokens=*/2), 1);
+    ASSERT_TRUE(scheduler->enqueue(candidate).ok());
+
+    // The three free blocks exactly cover the loaded stream's delayed 1-to-4 partial-tail fork. The concurrent
+    // candidate must remain waiting so the later beam expansion cannot fail after admission.
+    auto prefill = scheduler->schedule();
+    ASSERT_TRUE(prefill.ok());
+    ASSERT_EQ(prefill.value().size(), 1);
+    ASSERT_EQ(prefill.value().front().get(), loaded.get());
+    ASSERT_EQ(scheduler->pendingDecodeStreamsSize(), 1);
+    ASSERT_EQ(scheduler->waitingStreamsSize(), 1);
+    ASSERT_EQ(scheduler->waiting_streams_.front().get(), candidate.get());
+    ASSERT_FALSE(candidate->hasEvent(StreamEvents::CanRun));
+    ASSERT_EQ(cache_manager_->freeBlocksNum(), 3);
 }
 
 // ============================================================================

--- a/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerCancelTest.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerCancelTest.cc
@@ -59,6 +59,7 @@ protected:
 
         auto query             = std::make_shared<GenerateInput>();
         auto generate_config   = std::make_shared<GenerateConfig>();
+        generate_config->max_new_tokens = 1;
         query->input_ids       = torch::tensor(input_tokens, torch::kInt32);
         query->generate_config = generate_config;
         return std::make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);

--- a/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerTest.cc
+++ b/rtp_llm/cpp/engine_base/schedulers/test/FIFOSchedulerTest.cc
@@ -1,5 +1,8 @@
-#include <memory>
 #include <chrono>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
 #include "torch/all.h"
 #include "gmock/gmock-actions.h"
 #include "gmock/gmock-function-mocker.h"
@@ -9,6 +12,7 @@
 #define protected public
 #include "rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h"
 #include "rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.h"
+#include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
 #include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
 #include "rtp_llm/models_py/bindings/core/Types.h"
 #include "rtp_llm/cpp/testing/TestBase.h"
@@ -22,6 +26,12 @@ class FIFOSchedulerTest: public DeviceTestBase {
 public:
     FIFOSchedulerTest() {}
 };
+
+static std::shared_ptr<GenerateConfig> makeTestGenerateConfig(int max_new_tokens = 1) {
+    auto generate_config            = make_shared<GenerateConfig>();
+    generate_config->max_new_tokens = max_new_tokens;
+    return generate_config;
+}
 
 static PDSepConfig makePDFusionPDSepConfig() {
     PDSepConfig pd_sep_config;
@@ -49,7 +59,7 @@ TEST_F(FIFOSchedulerTest, testSimple) {
         runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig();
     shared_ptr<GenerateStream> stream =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
     ASSERT_TRUE(scheduler.enqueue(stream).ok());
@@ -93,10 +103,10 @@ TEST_F(FIFOSchedulerTest, testInitKVCacheLackMem) {
         runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1, 2, 3}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig();
     shared_ptr<GenerateStream> stream =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
-    // In the new code, checkInputLength rejects at enqueue time
+    // checkInputLength rejects the oversized input at enqueue time.
     ASSERT_FALSE(scheduler.enqueue(stream).ok());
     ASSERT_TRUE(stream->hasError());
     ASSERT_EQ(stream->stopReason(), "input len 3 is greater than kv cache max available tokens num 2");
@@ -124,7 +134,7 @@ TEST_F(FIFOSchedulerTest, testIncrKVCacheLackMem) {
         runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1, 2, 3, 4}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig(0);
     shared_ptr<GenerateStream> stream =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
     ASSERT_TRUE(scheduler.enqueue(stream).ok());
@@ -181,7 +191,7 @@ TEST_F(FIFOSchedulerTest, testInitKVCacheRejectedByReserveBlocks) {
     // Need 6 blocks. With reserve=5 blocks and available=10 blocks, init malloc should be rejected.
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1, 2, 3, 4, 5, 6}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig();
 
     shared_ptr<GenerateStream> stream =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -230,7 +240,7 @@ TEST_F(FIFOSchedulerTest, testReserveBlocksOnlyAffectInitMallocNotIncrMalloc) {
     // Init need 4 blocks, should pass: 10 >= 4 + 5.
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1, 2, 3, 4}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig();
 
     shared_ptr<GenerateStream> stream =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -273,7 +283,7 @@ TEST_F(FIFOSchedulerTest, testReuseCache) {
 
     std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
     query->input_ids                     = torch::tensor({1, 2, 3, 4, 5}, torch::kInt32);
-    query->generate_config               = make_shared<GenerateConfig>();
+    query->generate_config               = makeTestGenerateConfig();
     shared_ptr<GenerateStream> stream1 =
         make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
     ASSERT_TRUE(scheduler.enqueue(stream1).ok());
@@ -302,7 +312,7 @@ TEST_F(FIFOSchedulerTest, testReuseCache) {
 
     std::shared_ptr<GenerateInput> query2 = make_shared<GenerateInput>();
     query2->input_ids                     = torch::tensor({1, 2, 3, 4, 5, 6, 7}, torch::kInt32);
-    query2->generate_config               = make_shared<GenerateConfig>();
+    query2->generate_config               = makeTestGenerateConfig();
     shared_ptr<GenerateStream> stream2 =
         make_shared<NormalGenerateStream>(query2, model_config, runtime_config, resource_context, nullptr);
     ASSERT_TRUE(scheduler.enqueue(stream2).ok());
@@ -347,7 +357,7 @@ TEST_F(FIFOSchedulerTest, testMaxContextBatchSize) {
         // test normalcase
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1, 2, 3, 4, 5}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         shared_ptr<GenerateStream> stream1 =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
         ASSERT_TRUE(scheduler.enqueue(stream1).ok());
@@ -371,7 +381,7 @@ TEST_F(FIFOSchedulerTest, testMaxContextBatchSize) {
         // test normal case with tile num
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1, 2, 3, 4, 5}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         query->generate_config->num_beams    = 2;
         shared_ptr<GenerateStream> stream1 =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -401,7 +411,7 @@ TEST_F(FIFOSchedulerTest, testMaxContextBatchSize) {
 
         std::shared_ptr<GenerateInput> query2         = make_shared<GenerateInput>();
         query2->input_ids                             = torch::tensor({1, 2, 3, 4, 5, 6, 7}, torch::kInt32);
-        query2->generate_config                       = make_shared<GenerateConfig>();
+        query2->generate_config                       = makeTestGenerateConfig();
         query2->generate_config->num_return_sequences = 20;
         shared_ptr<GenerateStream> stream2 =
             make_shared<NormalGenerateStream>(query2, model_config, runtime_config, resource_context, nullptr);
@@ -442,7 +452,7 @@ TEST_F(FIFOSchedulerTest, testCheckInputLengthIgnoresBatchSizeFanOut) {
         // num_return_sequences fan-out: input_len 7 * batch 20 = 140 > 100, but accepted.
         std::shared_ptr<GenerateInput> query         = make_shared<GenerateInput>();
         query->input_ids                             = torch::tensor({1, 2, 3, 4, 5, 6, 7}, torch::kInt32);
-        query->generate_config                       = make_shared<GenerateConfig>();
+        query->generate_config                       = makeTestGenerateConfig();
         query->generate_config->num_return_sequences = 20;
         shared_ptr<GenerateStream> stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -454,7 +464,7 @@ TEST_F(FIFOSchedulerTest, testCheckInputLengthIgnoresBatchSizeFanOut) {
         // num_beams fan-out: input_len 10 * batch 16 = 160 > 100, but accepted.
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         query->generate_config->num_beams    = 16;
         shared_ptr<GenerateStream> stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -468,7 +478,7 @@ TEST_F(FIFOSchedulerTest, testCheckInputLengthIgnoresBatchSizeFanOut) {
         // Cache has 20 blocks * 8 tokens/block - 1 reserved tail = 159 max available; pick a length above it.
         std::vector<int32_t> ids(int(cache_manager->maxAvailableTokensNum()) + 1, 1);
         query->input_ids       = torch::tensor(ids, torch::kInt32);
-        query->generate_config = make_shared<GenerateConfig>();
+        query->generate_config = makeTestGenerateConfig();
         shared_ptr<GenerateStream> stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
         ASSERT_FALSE(scheduler.enqueue(stream).ok());
@@ -498,7 +508,7 @@ TEST_F(FIFOSchedulerTest, testBatchEnqueue) {
     {
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         shared_ptr<GenerateStream> stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
         streams.push_back(stream);
@@ -506,7 +516,7 @@ TEST_F(FIFOSchedulerTest, testBatchEnqueue) {
     {
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         shared_ptr<GenerateStream> stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
         streams.push_back(stream);
@@ -549,7 +559,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchGroupComplete) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id;
@@ -562,7 +572,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchGroupComplete) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id;
@@ -583,7 +593,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchGroupComplete) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id;
@@ -629,7 +639,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchTimeout) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = timeout_ms;
         query->batch_group_id                       = group_id;
@@ -642,7 +652,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchTimeout) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = timeout_ms;
         query->batch_group_id                       = group_id;
@@ -686,7 +696,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchIsolation) {
     {
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids                     = torch::tensor({1}, torch::kInt32);
-        query->generate_config               = make_shared<GenerateConfig>();
+        query->generate_config               = makeTestGenerateConfig();
         query->begin_time_us                 = autil::TimeUtility::currentTimeInMicroSeconds();
         normal_stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
@@ -695,7 +705,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchIsolation) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id;
@@ -708,7 +718,7 @@ TEST_F(FIFOSchedulerTest, testForceBatchIsolation) {
     {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id;
@@ -765,7 +775,7 @@ TEST_F(FIFOSchedulerTest, testTwoForceBatchGroupsIsolation) {
     for (int i = 0; i < group_size; i++) {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id_a;
@@ -778,7 +788,7 @@ TEST_F(FIFOSchedulerTest, testTwoForceBatchGroupsIsolation) {
     for (int i = 0; i < group_size; i++) {
         std::shared_ptr<GenerateInput> query        = make_shared<GenerateInput>();
         query->input_ids                            = torch::tensor({1}, torch::kInt32);
-        query->generate_config                      = make_shared<GenerateConfig>();
+        query->generate_config                      = makeTestGenerateConfig();
         query->generate_config->force_batch         = true;
         query->generate_config->batch_group_timeout = 10;
         query->batch_group_id                       = group_id_b;
@@ -815,10 +825,16 @@ TEST_F(FIFOSchedulerTest, testTwoForceBatchGroupsIsolation) {
 static std::shared_ptr<GenerateStream> makeStream(const std::vector<int>& ids,
                                                   const ModelConfig&      model_config,
                                                   const RuntimeConfig&    runtime_config,
-                                                  const ResourceContext&  resource_context) {
+                                                  const ResourceContext&  resource_context,
+                                                  int                     max_new_tokens      = 1,
+                                                  int                     num_return_sequences = 1,
+                                                  const std::vector<int>&  variable_num_beams   = {}) {
     auto query             = std::make_shared<GenerateInput>();
     query->input_ids       = torch::tensor(ids, torch::kInt32);
-    query->generate_config = std::make_shared<GenerateConfig>();
+    query->generate_config = makeTestGenerateConfig();
+    query->generate_config->max_new_tokens      = max_new_tokens;
+    query->generate_config->num_return_sequences = num_return_sequences;
+    query->generate_config->variable_num_beams   = variable_num_beams;
     return std::make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
 }
 
@@ -830,7 +846,8 @@ static std::shared_ptr<GenerateStream> makeForceBatchStream(const std::vector<in
                                                             const ResourceContext&  resource_context) {
     auto query                                  = std::make_shared<GenerateInput>();
     query->input_ids                            = torch::tensor(ids, torch::kInt32);
-    query->generate_config                      = std::make_shared<GenerateConfig>();
+    query->generate_config                      = makeTestGenerateConfig();
+    query->generate_config->max_new_tokens      = 1;
     query->generate_config->force_batch         = true;
     query->generate_config->batch_group_timeout = 1000;
     query->batch_group_id                       = group_id;
@@ -987,7 +1004,7 @@ TEST_F(FIFOSchedulerTest, testDecodeRoundReapsErroredWaitingStream) {
 }
 
 TEST_F(FIFOSchedulerTest, testInvalidDecodePrefillRatioFallsBackToAlternation) {
-    const std::vector<std::string> invalid_ratios = {"", "0", "1/0", "-1", "abc", "2/3"};
+    const std::vector<std::string> invalid_ratios = {"", "1/0", "-1", "abc", "2/3"};
     for (const auto& ratio : invalid_ratios) {
         CacheConfig cache_config  = makeMhaCacheConfig(1, 64, 1, 4, 8, rtp_llm::DataType::TYPE_FP16);
         auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
@@ -1172,6 +1189,45 @@ TEST_F(FIFOSchedulerTest, testLargeStepDecodeFirst) {
     ASSERT_EQ(scheduler.waitingStreamsSize(), 0);  // s2 finally admitted
 }
 
+TEST_F(FIFOSchedulerTest, testZeroRatioTriesPrefillBeforeDecode) {
+    CacheConfig cache_config  = makeMhaCacheConfig(1, 64, 1, 4, 8, rtp_llm::DataType::TYPE_FP16);
+    auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len = 8192;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto s1 = makeStream({1, 2}, model_config, runtime_config, resource_context);
+    ASSERT_TRUE(scheduler.enqueue(s1).ok());
+    auto r1 = scheduler.schedule();  // seed PREFILL s1
+    ASSERT_TRUE(r1.ok());
+    ASSERT_EQ(r1.value().size(), 1);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
+    s1->setSeqLength(s1->seqLength() + 1);
+
+    auto s2 = makeStream({3, 4}, model_config, runtime_config, resource_context);
+    ASSERT_TRUE(scheduler.enqueue(s2).ok());
+
+    // decode_prefill_ratio=0 means any waiting stream gets a PREFILL attempt before decode.
+    auto r2 = scheduler.schedule();
+    ASSERT_TRUE(r2.ok());
+    ASSERT_EQ(r2.value().size(), 1);
+    ASSERT_EQ(r2.value().front().get(), s2.get());
+    ASSERT_EQ(scheduler.runningStreamsSize(), 0);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 2);
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
+}
+
 TEST_F(FIFOSchedulerTest, testConcurrencyCapCountsPending) {
     CacheConfig cache_config  = makeMhaCacheConfig(1, 64, 1, 4, 8, rtp_llm::DataType::TYPE_FP16);
     auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
@@ -1214,6 +1270,48 @@ TEST_F(FIFOSchedulerTest, testConcurrencyCapCountsPending) {
     ASSERT_EQ(scheduler.waitingStreamsSize(), 2);
 }
 
+TEST_F(FIFOSchedulerTest, testZeroRatioFallsBackToDecodeWhenKvAdmissionRejectsAllWaiting) {
+    CacheConfig cache_config  = makeMhaCacheConfig(1, 5, 1, 4, 2, rtp_llm::DataType::TYPE_FP16);
+    auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 4);
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len = 8192;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto running = makeStream({1}, model_config, runtime_config, resource_context);
+    ASSERT_TRUE(scheduler.enqueue(running).ok());
+    auto r1 = scheduler.schedule();  // seed PREFILL running
+    ASSERT_TRUE(r1.ok());
+    ASSERT_EQ(r1.value().size(), 1);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
+    running->setSeqLength(running->seqLength() + 1);
+
+    auto blocked = makeStream({2, 3, 4, 5, 6, 7, 8}, model_config, runtime_config, resource_context);
+    ASSERT_TRUE(scheduler.enqueue(blocked).ok());
+
+    // decode_prefill_ratio=0 selects a PREFILL round, but the KV admission check rejects the only
+    // waiting stream. The scheduler must then fall back to DECODE and promote the pending stream.
+    auto r2 = scheduler.schedule();
+    ASSERT_TRUE(r2.ok());
+    ASSERT_EQ(r2.value().size(), 1);
+    ASSERT_EQ(r2.value().front().get(), running.get());
+    ASSERT_EQ(scheduler.runningStreamsSize(), 1);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 0);
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 1);
+    ASSERT_FALSE(blocked->hasError());
+}
+
 TEST_F(FIFOSchedulerTest, testEmptyDegradedPrefillDoesNotAdvanceDecodeCounter) {
     CacheConfig cache_config  = makeMhaCacheConfig(1, 64, 1, 4, 8, rtp_llm::DataType::TYPE_FP16);
     auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
@@ -1250,8 +1348,8 @@ TEST_F(FIFOSchedulerTest, testEmptyDegradedPrefillDoesNotAdvanceDecodeCounter) {
 // ---------------------------------------------------------------------------
 
 TEST_F(FIFOSchedulerTest, testKvGatedAdmission) {
-    // Only 2 free KV blocks: two one-block prompts can both prefill. The ratio scheduler should
-    // not hold back the second stream with a scheduler-side first-decode headroom estimate.
+    // Only 2 free KV blocks: with max_new_tokens=1, two 1-token prompts can both prefill and
+    // still satisfy the estimated peak check.
     CacheConfig cache_config  = makeMhaCacheConfig(1, 3, 1, 4, 2, rtp_llm::DataType::TYPE_FP16);
     auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
     ASSERT_TRUE(cache_manager->init());
@@ -1270,12 +1368,12 @@ TEST_F(FIFOSchedulerTest, testKvGatedAdmission) {
     PDFusionRatioScheduler scheduler(
         runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
 
-    auto s1 = makeStream({1, 2}, model_config, runtime_config, resource_context);
-    auto s2 = makeStream({3, 4}, model_config, runtime_config, resource_context);
+    auto s1 = makeStream({1}, model_config, runtime_config, resource_context);
+    auto s2 = makeStream({3}, model_config, runtime_config, resource_context);
     ASSERT_TRUE(scheduler.enqueue(s1).ok());
     ASSERT_TRUE(scheduler.enqueue(s2).ok());
 
-    auto r1 = scheduler.schedule();  // seed PREFILL: real initKVBlock admits both prompts
+    auto r1 = scheduler.schedule();  // seed PREFILL: KV admission admits both prompts
     ASSERT_TRUE(r1.ok());
     ASSERT_EQ(r1.value().size(), 2);
     ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 2);
@@ -1326,9 +1424,8 @@ TEST_F(FIFOSchedulerTest, testMultiBlockPromptPromotesWithIncrementalKv) {
 }
 
 TEST_F(FIFOSchedulerTest, testPrefillAdmissionAccountsPromptBlocksAcrossRound) {
-    // Two 8-token prompts need 4 blocks each. With 7 free blocks, scheduler-side admission no
-    // longer predicts KV. Both streams are tried in the prefill round; real initKVBlock admits the
-    // first and fails the second.
+    // Two block-aligned 8-token prompts need 4 blocks each. With 7
+    // free blocks, scheduler-side admission admits only the first and leaves the second waiting.
     CacheConfig cache_config  = makeMhaCacheConfig(1, 8, 1, 4, 2, rtp_llm::DataType::TYPE_FP16);
     auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
     ASSERT_TRUE(cache_manager->init());
@@ -1356,19 +1453,546 @@ TEST_F(FIFOSchedulerTest, testPrefillAdmissionAccountsPromptBlocksAcrossRound) {
     ASSERT_TRUE(prefill.ok());
     ASSERT_EQ(prefill.value().size(), 1);
     ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
-    ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 1);
     ASSERT_FALSE(s1->hasError());
-    ASSERT_TRUE(s2->hasError());
+    ASSERT_FALSE(s2->hasError());
 }
 
-TEST_F(FIFOSchedulerTest, testPrefillAdmissionUsesRealInitKvBlockWithoutDecodeHeadroom) {
-    // A single 8-token prompt needs 4 prompt blocks. With exactly 4 free blocks and no extra
-    // first-decode headroom, prefill should still run; decode allocation is decided later by the
-    // real state machine.
-    CacheConfig cache_config  = makeMhaCacheConfig(1, 5, 1, 4, 2, rtp_llm::DataType::TYPE_FP16);
+TEST_F(FIFOSchedulerTest, testPrefillAdmissionAccountsFanOutAtShortLifetimePeak) {
+    // The first stream has a short lifetime but high num_return_sequences fan-out. Its 7-token
+    // prompt is a partial block, so prefill allocates one physical block per return sequence. Its
+    // second generated token is cached by the final decode step in the next block, where fan-out
+    // needs another block per sequence. A long single-output stream must not be admitted when that
+    // peak exceeds the remaining KV capacity.
+    constexpr int kTokensPerBlock = 8;
+    CacheConfig   cache_config    = makeMhaCacheConfig(1, 81, 1, 4, kTokensPerBlock, rtp_llm::DataType::TYPE_FP16);
+    auto          cache_manager   = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 80);
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = kTokensPerBlock;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto high_fanout = makeStream({1, 2, 3, 4, 5, 6, 7},
+                                  model_config,
+                                  runtime_config,
+                                  resource_context,
+                                  /*max_new_tokens=*/3,
+                                  /*num_return_sequences=*/40);
+    ASSERT_TRUE(scheduler.enqueue(high_fanout).ok());
+
+    auto seed = scheduler.schedule();
+    ASSERT_TRUE(seed.ok());
+    ASSERT_EQ(seed.value().size(), 1);
+    ASSERT_EQ(seed.value().front().get(), high_fanout.get());
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 40);
+
+    auto long_remaining = makeStream({2},
+                                     model_config,
+                                     runtime_config,
+                                     resource_context,
+                                     /*max_new_tokens=*/20,
+                                     /*num_return_sequences=*/1);
+    ASSERT_TRUE(scheduler.enqueue(long_remaining).ok());
+
+    auto decode = scheduler.schedule();
+    ASSERT_TRUE(decode.ok());
+    ASSERT_EQ(decode.value().size(), 1);
+    ASSERT_EQ(decode.value().front().get(), high_fanout.get());
+    ASSERT_EQ(scheduler.runningStreamsSize(), 1);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 0);
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 1);
+    ASSERT_FALSE(long_remaining->hasError());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 40);
+}
+
+TEST_F(FIFOSchedulerTest, testPeakEstimateSharesAlignedPromptAcrossMaximumBatchWidth) {
+    CacheConfig cache_config = makeMhaCacheConfig(1, 64, 1, 4, 4, rtp_llm::DataType::TYPE_FP16);
     auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
     ASSERT_TRUE(cache_manager->init());
-    ASSERT_EQ(cache_manager->freeBlocksNum(), 4);
+
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = 4;
+    RuntimeConfig runtime_config;
+
+    const std::vector<int> aligned_prompt{1, 2, 3, 4, 5, 6, 7, 8};
+    auto single_beam = makeStream(aligned_prompt,
+                                  model_config,
+                                  runtime_config,
+                                  resource_context,
+                                  /*max_new_tokens=*/3,
+                                  /*num_return_sequences=*/1,
+                                  /*variable_num_beams=*/{1});
+    auto multi_return = makeStream(aligned_prompt,
+                                   model_config,
+                                   runtime_config,
+                                   resource_context,
+                                   /*max_new_tokens=*/3,
+                                   /*num_return_sequences=*/4);
+    auto dynamic_beam = makeStream(aligned_prompt,
+                                   model_config,
+                                   runtime_config,
+                                   resource_context,
+                                   /*max_new_tokens=*/3,
+                                   /*num_return_sequences=*/1,
+                                   /*variable_num_beams=*/{1, 4, 2});
+
+    ASSERT_EQ(dynamic_beam->nextBatchSize(), 1);
+    ASSERT_EQ(dynamic_beam->maxBatchSize(), 4);
+    ASSERT_EQ(single_beam->estimatePeakNeedBlocks(/*remaining_tokens=*/3), 3);
+    // Two prompt blocks stay shared; the one independent future block is charged four times.
+    ASSERT_EQ(dynamic_beam->estimateInitialNeedBlocks(), 2);
+    ASSERT_EQ(multi_return->estimatePeakNeedBlocks(/*remaining_tokens=*/3), 6);
+    ASSERT_EQ(dynamic_beam->estimatePeakNeedBlocks(/*remaining_tokens=*/3), 6);
+
+    // Prefill has allocated the two shared blocks at width one. The non-empty estimate must retain
+    // those blocks and reserve four private future blocks for the maximum beam width.
+    ASSERT_TRUE(dynamic_beam->initKVBlock().ok());
+    ASSERT_EQ(dynamic_beam->estimateInitialNeedBlocks(), 0);
+    ASSERT_EQ(dynamic_beam->estimatePeakNeedBlocks(/*remaining_tokens=*/3), 4);
+    dynamic_beam->releaseResource();
+}
+
+TEST_F(FIFOSchedulerTest, testMultiSequenceAdmissionMatchesPhysicalFreeBlockWatermark) {
+    constexpr int kTokensPerBlock = 4;
+    CacheConfig   cache_config    = makeMhaCacheConfig(1, 8, 1, 4, kTokensPerBlock, rtp_llm::DataType::TYPE_FP16);
+    auto          cache_manager   = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 7);
+
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = kTokensPerBlock;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto in_flight = makeStream({0},
+                                model_config,
+                                runtime_config,
+                                resource_context,
+                                /*max_new_tokens=*/0);
+    ASSERT_TRUE(scheduler.enqueue(in_flight).ok());
+    auto first_prefill = scheduler.schedule();
+    ASSERT_TRUE(first_prefill.ok());
+    ASSERT_EQ(first_prefill.value().size(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 6);
+
+    auto candidate = makeStream({1, 2, 3, 4, 5, 6, 7, 8},
+                                model_config,
+                                runtime_config,
+                                resource_context,
+                                /*max_new_tokens=*/4,
+                                /*num_return_sequences=*/4);
+    const size_t free_before_admission = cache_manager->freeBlocksNum();
+    const int    estimated_peak        = candidate->estimatePeakNeedBlocks(/*remaining_tokens=*/4);
+    ASSERT_EQ(estimated_peak, 6);
+    ASSERT_EQ(free_before_admission, static_cast<size_t>(estimated_peak));
+    ASSERT_TRUE(scheduler.enqueue(candidate).ok());
+
+    auto candidate_prefill = scheduler.schedule();
+    ASSERT_TRUE(candidate_prefill.ok());
+    ASSERT_EQ(candidate_prefill.value().size(), 1);
+    ASSERT_EQ(candidate_prefill.value().front().get(), candidate.get());
+    ASSERT_FALSE(candidate->hasError());
+
+    size_t min_free_blocks = cache_manager->freeBlocksNum();
+    ASSERT_EQ(min_free_blocks, 4);  // two aligned prompt blocks are physically shared
+
+    auto promote = scheduler.schedule();
+    ASSERT_TRUE(promote.ok());
+    ASSERT_EQ(promote.value().size(), 2);
+
+    candidate->setSeqLength(candidate->seqLength() + 1);
+    auto cross_boundary = scheduler.schedule();
+    ASSERT_TRUE(cross_boundary.ok());
+    ASSERT_EQ(cross_boundary.value().size(), 2);
+    ASSERT_FALSE(candidate->hasError());
+    min_free_blocks = std::min(min_free_blocks, cache_manager->freeBlocksNum());
+
+    ASSERT_EQ(min_free_blocks, free_before_admission - static_cast<size_t>(estimated_peak));
+}
+
+TEST_F(FIFOSchedulerTest, testHybridAdmissionAllowsUnderestimateAtDifferentBlockPeak) {
+    // The logical-token peak is at t=0, where the block estimate is 13. The short stream's physical
+    // block peak is 16 at t=9 because Hybrid block boundaries do not necessarily follow token volume.
+    // Admission intentionally accepts this underestimate instead of scanning every endpoint.
+    auto cache_config = test::makeSimpleHybridMhaCacheConfig(
+        /*layer_num=*/4, /*block_num=*/64, /*tokens_per_block=*/1, rtp_llm::DataType::TYPE_FP16);
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+
+    ResourceContext no_reuse_context;
+    no_reuse_context.cache_manager = cache_manager;
+    no_reuse_context.reuse_cache   = false;
+    ResourceContext reuse_context  = no_reuse_context;
+    reuse_context.reuse_cache      = true;
+
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = 1;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto long_context_short_lifetime = makeStream({1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                                                  model_config,
+                                                  runtime_config,
+                                                  no_reuse_context,
+                                                  /*max_new_tokens=*/1);
+    auto short_context_long_lifetime = makeStream({11},
+                                                  model_config,
+                                                  runtime_config,
+                                                  reuse_context,
+                                                  /*max_new_tokens=*/10);
+
+    ASSERT_EQ(long_context_short_lifetime->estimatePeakNeedBlocks(/*remaining_tokens=*/0), 11);
+    ASSERT_EQ(short_context_long_lifetime->estimatePeakNeedBlocks(/*remaining_tokens=*/0), 2);
+    ASSERT_EQ(short_context_long_lifetime->estimatePeakNeedBlocks(/*remaining_tokens=*/9), 16);
+
+    scheduler.buildAdmissionPeakState();
+    ASSERT_TRUE(scheduler.tryAddToAdmissionPeakState(
+        long_context_short_lifetime, /*initial_capacity=*/13, /*lifecycle_capacity=*/13));
+    ASSERT_FALSE(scheduler.tryAddToAdmissionPeakState(
+        short_context_long_lifetime, /*initial_capacity=*/13, /*lifecycle_capacity=*/12));
+    // The rejected attempt must not mutate the committed state.
+    ASSERT_TRUE(scheduler.tryAddToAdmissionPeakState(
+        short_context_long_lifetime, /*initial_capacity=*/13, /*lifecycle_capacity=*/13));
+}
+
+TEST_F(FIFOSchedulerTest, testKVAdmissionCostAcrossStreamCounts) {
+    constexpr int kTokensPerBlock = 8;
+    auto          cache_config    = test::makeSimpleHybridMhaCacheConfig(
+        /*layer_num=*/4, /*block_num=*/64, kTokensPerBlock, rtp_llm::DataType::TYPE_FP16);
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    resource_context.reuse_cache   = true;
+
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = kTokensPerBlock;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 1024;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 1 << 20;
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    std::vector<int> prompt(1024);
+    std::iota(prompt.begin(), prompt.end(), 1);
+    constexpr int kRepeats = 3;
+
+    for (const int stream_count : {8, 32, 64, 128, 256, 512}) {
+        scheduler.running_streams_.clear();
+
+        for (int i = 0; i < stream_count; ++i) {
+            auto stream = makeStream(prompt,
+                                     model_config,
+                                     runtime_config,
+                                     resource_context,
+                                     /*max_new_tokens=*/i + 2);
+            scheduler.running_streams_.push_back(stream);
+        }
+        auto candidate = makeStream(prompt,
+                                    model_config,
+                                    runtime_config,
+                                    resource_context,
+                                    /*max_new_tokens=*/stream_count + 128);
+
+        // Warm caches. Distinct max_new_tokens exercise one unique lifetime per stream.
+        scheduler.buildAdmissionPeakState();
+        ASSERT_TRUE(scheduler.tryAddToAdmissionPeakState(
+            candidate, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()));
+
+        int64_t build_total_us     = 0;
+        int64_t admission_total_us = 0;
+        for (int repeat = 0; repeat < kRepeats; ++repeat) {
+            auto begin = std::chrono::steady_clock::now();
+            scheduler.buildAdmissionPeakState();
+            build_total_us +=
+                std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - begin).count();
+
+            begin               = std::chrono::steady_clock::now();
+            const bool admitted = scheduler.tryAddToAdmissionPeakState(
+                candidate, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max());
+            const auto admission_elapsed = std::chrono::steady_clock::now() - begin;
+            ASSERT_TRUE(admitted);
+            admission_total_us += std::chrono::duration_cast<std::chrono::microseconds>(admission_elapsed).count();
+        }
+
+        const int64_t build_avg_us     = build_total_us / kRepeats;
+        const int64_t admission_avg_us = admission_total_us / kRepeats;
+        std::cout << "[KV_ADMISSION_COST] streams=" << stream_count << " sampled_endpoints=1"
+                  << " build_avg_us=" << build_avg_us << " candidate_avg_us=" << admission_avg_us << std::endl;
+        RecordProperty("streams_" + std::to_string(stream_count) + "_build_avg_us", build_avg_us);
+        RecordProperty("streams_" + std::to_string(stream_count) + "_candidate_avg_us", admission_avg_us);
+        if (stream_count == 512) {
+            // Keep ample headroom for loaded CI hosts while preventing a regression to the previous ~50 ms rebuild.
+            EXPECT_LT(build_avg_us, 10000);
+            EXPECT_LT(admission_avg_us, 10000);
+        }
+    }
+}
+
+TEST_F(FIFOSchedulerTest, testScheduleBatchKVAdmissionCostAcrossWaitingCounts) {
+    constexpr int kTokensPerBlock = 8;
+
+    for (const int stream_count : {256, 512}) {
+        // Block zero is unavailable for allocation, leaving exactly one physical block per stream.
+        auto cache_config = makeMhaCacheConfig(/*layer_num=*/1,
+                                               /*block_num=*/stream_count + 1,
+                                               /*local_head_num_kv=*/1,
+                                               /*size_per_head=*/4,
+                                               kTokensPerBlock,
+                                               rtp_llm::DataType::TYPE_FP16);
+        KVCacheConfig kv_cache_config;
+        kv_cache_config.reserve_block_ratio = 0;
+        auto cache_manager =
+            std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false, nullptr, kv_cache_config);
+        ASSERT_TRUE(cache_manager->init());
+        ASSERT_EQ(cache_manager->availableBlocksNum(), stream_count);
+        ASSERT_EQ(cache_manager->reserveBlocksNum(), 0);
+
+        ResourceContext resource_context;
+        resource_context.cache_manager = cache_manager;
+        resource_context.reuse_cache   = false;
+
+        ModelConfig model_config;
+        model_config.max_seq_len                  = 8192;
+        model_config.attn_config.tokens_per_block = kTokensPerBlock;
+        RuntimeConfig runtime_config;
+        runtime_config.max_generate_batch_size                     = 1024;
+        runtime_config.fifo_scheduler_config.max_batch_tokens_size = 1 << 20;
+        PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+        ParallelismConfig      parallelism_config;
+        ModelSpecificConfig    model_specific_config;
+        PDFusionRatioScheduler scheduler(
+            runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+        for (int i = 0; i < stream_count; ++i) {
+            auto stream = makeStream({i + 1},
+                                     model_config,
+                                     runtime_config,
+                                     resource_context,
+                                     /*max_new_tokens=*/1);
+            ASSERT_TRUE(scheduler.enqueue(stream).ok());
+        }
+        ASSERT_EQ(scheduler.waitingStreamsSize(), stream_count);
+
+        // Measure the public, lock-holding path: the whole waiting batch is admitted in this schedule call.
+        const auto begin     = std::chrono::steady_clock::now();
+        auto       scheduled = scheduler.schedule();
+        const auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - begin).count();
+
+        ASSERT_TRUE(scheduled.ok());
+        ASSERT_EQ(scheduled.value().size(), stream_count);
+        ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
+        ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), stream_count);
+        ASSERT_EQ(cache_manager->freeBlocksNum(), 0);
+
+        std::cout << "[KV_BATCH_ADMISSION_COST] waiting_streams=" << stream_count
+                  << " schedule_total_ms=" << elapsed_ms << std::endl;
+        RecordProperty("waiting_streams_" + std::to_string(stream_count) + "_schedule_total_ms", elapsed_ms);
+        // Keep ample headroom for loaded CI hosts while bounding scheduler-lock latency for the largest batch.
+        EXPECT_LT(elapsed_ms, 100);
+    }
+}
+
+TEST_F(FIFOSchedulerTest, testReserveOnlyLimitsInitialAllocationNotLifecycleGrowth) {
+    CacheConfig cache_config = makeMhaCacheConfig(/*layer_num=*/1,
+                                                  /*block_num=*/11,
+                                                  /*local_head_num_kv=*/1,
+                                                  /*size_per_head=*/4,
+                                                  /*tokens_per_block=*/1,
+                                                  rtp_llm::DataType::TYPE_FP16);
+    KVCacheConfig kv_cache_config;
+    kv_cache_config.reserve_block_ratio = 20;
+    auto cache_manager = std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false, nullptr, kv_cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->availableBlocksNum(), 10);
+    ASSERT_EQ(cache_manager->reserveBlocksNum(), 2);
+
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = 1;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto long_running = makeStream({1, 2},
+                                   model_config,
+                                   runtime_config,
+                                   resource_context,
+                                   /*max_new_tokens=*/4);
+    ASSERT_TRUE(scheduler.enqueue(long_running).ok());
+    auto first_prefill = scheduler.schedule();
+    ASSERT_TRUE(first_prefill.ok());
+    ASSERT_EQ(first_prefill.value().size(), 1);
+    ASSERT_EQ(cache_manager->availableBlocksNum(), 8);
+
+    auto candidate = makeStream({3, 4, 5},
+                                model_config,
+                                runtime_config,
+                                resource_context,
+                                /*max_new_tokens=*/3);
+    ASSERT_EQ(candidate->estimatePeakNeedBlocks(/*remaining_tokens=*/0), 3);
+    ASSERT_LE(3 + cache_manager->reserveBlocksNum(), cache_manager->availableBlocksNum());
+    // At the candidate endpoint: existing growth(2) + candidate lifecycle(5) = 7.
+    // It exceeds available-reserve(6), but fits the full available capacity(8).
+    ASSERT_EQ(long_running->estimatePeakNeedBlocks(/*remaining_tokens=*/2)
+                  + candidate->estimatePeakNeedBlocks(/*remaining_tokens=*/2),
+              7);
+    ASSERT_TRUE(scheduler.enqueue(candidate).ok());
+
+    auto second_prefill = scheduler.schedule();
+    ASSERT_TRUE(second_prefill.ok());
+    ASSERT_EQ(second_prefill.value().size(), 1);
+    ASSERT_EQ(second_prefill.value().front().get(), candidate.get());
+    ASSERT_FALSE(candidate->hasError());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 5);
+
+    auto promote = scheduler.schedule();
+    ASSERT_TRUE(promote.ok());
+    ASSERT_EQ(promote.value().size(), 2);
+    for (int step = 0; step < 2; ++step) {
+        long_running->setSeqLength(long_running->seqLength() + 1);
+        candidate->setSeqLength(candidate->seqLength() + 1);
+        auto decode = scheduler.schedule();
+        ASSERT_TRUE(decode.ok());
+        ASSERT_EQ(decode.value().size(), 2);
+        ASSERT_FALSE(long_running->hasError());
+        ASSERT_FALSE(candidate->hasError());
+    }
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 1);
+}
+
+TEST_F(FIFOSchedulerTest, testMaxNewTokensOneDoesNotReserveFinalTokenKVBlock) {
+    // Keep one stream running so KV admission is enforced. The aligned candidate prompt needs two
+    // blocks; its only generated token completes the request and is never written into KV cache.
+    CacheConfig cache_config  = makeMhaCacheConfig(1, 4, 1, 4, 4, rtp_llm::DataType::TYPE_FP16);
+    auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 3);
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len                  = 8192;
+    model_config.attn_config.tokens_per_block = 4;
+    model_config.vocab_size                   = 32;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto running = makeStream({0}, model_config, runtime_config, resource_context, /*max_new_tokens=*/2);
+    ASSERT_TRUE(scheduler.enqueue(running).ok());
+    auto running_prefill = scheduler.schedule();
+    ASSERT_TRUE(running_prefill.ok());
+    ASSERT_EQ(running_prefill.value().size(), 1);
+    auto promote = scheduler.schedule();
+    ASSERT_TRUE(promote.ok());
+    ASSERT_EQ(promote.value().size(), 1);
+    ASSERT_EQ(scheduler.runningStreamsSize(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 2);
+
+    auto candidate =
+        makeStream({1, 2, 3, 4, 5, 6, 7, 8}, model_config, runtime_config, resource_context, /*max_new_tokens=*/1);
+    ASSERT_TRUE(scheduler.enqueue(candidate).ok());
+    auto prefill = scheduler.schedule();
+    ASSERT_TRUE(prefill.ok());
+    ASSERT_EQ(prefill.value().size(), 1);
+    ASSERT_EQ(prefill.value().front().get(), candidate.get());
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 0);
+
+    auto final_token = torch::tensor({9}, torch::kInt32).reshape({1, 1});
+    candidate->update({final_token,
+                       /*num_new_tokens=*/1,
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       torch::Tensor(),
+                       /*update_remote_generate=*/false,
+                       /*force_update_info=*/false});
+    ASSERT_TRUE(candidate->hasEvent(StreamEvents::GenerateDone));
+
+    auto decode = scheduler.schedule();
+    ASSERT_TRUE(decode.ok());
+    ASSERT_EQ(decode.value().size(), 1);
+    ASSERT_EQ(decode.value().front().get(), running.get());
+    ASSERT_FALSE(candidate->hasError());
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 0);
+    ASSERT_EQ(scheduler.runningStreamsSize(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 2);
+}
+
+TEST_F(FIFOSchedulerTest, testSinglePrefillDefersReserveCapacityFailureToAllocator) {
+    CacheConfig cache_config = makeMhaCacheConfig(/*layer_num=*/1,
+                                                  /*block_num=*/11,
+                                                  /*local_head_num_kv=*/1,
+                                                  /*size_per_head=*/4,
+                                                  /*tokens_per_block=*/1,
+                                                  rtp_llm::DataType::TYPE_FP16);
+    KVCacheConfig kv_cache_config;
+    kv_cache_config.reserve_block_ratio = 50;
+    auto cache_manager =
+        std::make_shared<KVCacheManager>(cache_config, /*warmup=*/false, nullptr, kv_cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->totalBlocksNum(), 10);
+    ASSERT_EQ(cache_manager->reserveBlocksNum(), 5);
+
     ResourceContext resource_context;
     resource_context.cache_manager = cache_manager;
     ModelConfig model_config;
@@ -1383,7 +2007,64 @@ TEST_F(FIFOSchedulerTest, testPrefillAdmissionUsesRealInitKvBlockWithoutDecodeHe
     PDFusionRatioScheduler scheduler(
         runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
 
-    auto stream = makeStream({1, 2, 3, 4, 5, 6, 7, 8}, model_config, runtime_config, resource_context);
+    // The input fits the 10-block physical cache but violates the 5-block reserve watermark.
+    // The idle scheduler admits it, then the allocator reports the reserve-capacity failure.
+    auto stream = makeStream({1, 2, 3, 4, 5, 6},
+                             model_config,
+                             runtime_config,
+                             resource_context,
+                             /*max_new_tokens=*/0);
+    ASSERT_TRUE(scheduler.enqueue(stream).ok());
+    ASSERT_FALSE(stream->hasError());
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 1);
+
+    auto prefill = scheduler.schedule();
+    ASSERT_TRUE(prefill.ok());
+    ASSERT_EQ(prefill.value().size(), 0);
+    ASSERT_TRUE(stream->hasError());
+    ASSERT_EQ(stream->statusInfo().code(), ErrorCode::MALLOC_FAILED);
+    ASSERT_EQ(stream->stopReason(), "LACK MEM");
+    ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 0);
+    ASSERT_EQ(scheduler.runningStreamsSize(), 0);
+    ASSERT_EQ(cache_manager->availableBlocksNum(), 10);
+}
+
+TEST_F(FIFOSchedulerTest, testPrefillAdmissionUsesMaxTokenNumRemainingTokens) {
+    // Keep one stream in flight so the single-request fast path does not apply. The candidate asks
+    // for far more tokens than model max_seq_len allows; admission should use GenerateStream::maxTokenNum(),
+    // not the raw max_new_tokens request value.
+    CacheConfig cache_config  = makeMhaCacheConfig(1, 5, 1, 4, 4, rtp_llm::DataType::TYPE_FP16);
+    auto        cache_manager = std::make_shared<KVCacheManager>(cache_config);
+    ASSERT_TRUE(cache_manager->init());
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 4);
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+    ModelConfig model_config;
+    model_config.max_seq_len = 10;
+    RuntimeConfig runtime_config;
+    runtime_config.max_generate_batch_size                     = 100;
+    runtime_config.fifo_scheduler_config.max_batch_tokens_size = 8192;
+    runtime_config.fifo_scheduler_config.decode_prefill_ratio  = "0";
+    PDSepConfig            pd_sep_config                       = makePDFusionPDSepConfig();
+    ParallelismConfig      parallelism_config;
+    ModelSpecificConfig    model_specific_config;
+    PDFusionRatioScheduler scheduler(
+        runtime_config, model_config, pd_sep_config, parallelism_config, model_specific_config, cache_manager);
+
+    auto seed = makeStream({0}, model_config, runtime_config, resource_context, /*max_new_tokens=*/0);
+    ASSERT_TRUE(scheduler.enqueue(seed).ok());
+    auto seed_prefill = scheduler.schedule();
+    ASSERT_TRUE(seed_prefill.ok());
+    ASSERT_EQ(seed_prefill.value().size(), 1);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
+    ASSERT_EQ(cache_manager->freeBlocksNum(), 3);
+
+    auto stream = makeStream({1, 2, 3, 4, 5, 6, 7, 8},
+                             model_config,
+                             runtime_config,
+                             resource_context,
+                             /*max_new_tokens=*/1000);
     ASSERT_TRUE(scheduler.enqueue(stream).ok());
 
     auto prefill = scheduler.schedule();
@@ -1392,8 +2073,7 @@ TEST_F(FIFOSchedulerTest, testPrefillAdmissionUsesRealInitKvBlockWithoutDecodeHe
     ASSERT_EQ(prefill.value().front().get(), stream.get());
     ASSERT_FALSE(stream->hasError());
     ASSERT_EQ(scheduler.waitingStreamsSize(), 0);
-    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 1);
-    ASSERT_EQ(scheduler.runningStreamsSize(), 0);
+    ASSERT_EQ(scheduler.pendingDecodeStreamsSize(), 2);
 }
 
 TEST_F(FIFOSchedulerTest, testPendingDecodePromotionMallocFailureFinishes) {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.cc
@@ -47,7 +47,7 @@ void GenerateStateMachine::handleWaiting() {
     }
     // LoadInitiated 未设置时，必须先执行 initKVBlock 和 asyncLoadCache
     if (!events_.has(StreamEvents::LoadInitiated)) {
-        auto result = stream_cache_resource_->initKVBlock(reserve_step_);
+        auto result = stream_cache_resource_->initKVBlock();
         if (!result.ok()) {
             error_info = ErrorInfo(ErrorCode::MALLOC_FAILED, "LACK MEM");
             status.store(StreamState::FINISHED, std::memory_order_release);
@@ -77,7 +77,7 @@ void GenerateStateMachine::handleWaiting() {
     }
 
     // 绕过incrKVBlock at prefill
-    auto result = stream_cache_resource_->incrKVBlock(reserve_step_);
+    auto result = stream_cache_resource_->incrKVBlock();
     if (!result.ok()) {
         error_info = ErrorInfo(ErrorCode::MALLOC_FAILED, "LACK MEM");
         status.store(StreamState::FINISHED, std::memory_order_release);
@@ -104,7 +104,7 @@ void GenerateStateMachine::handleRunning() {
     if (stream_cache_resource_->resourceContext().role_type == RoleType::PREFILL) {
         return;
     }
-    auto result = stream_cache_resource_->incrKVBlock(reserve_step_);
+    auto result = stream_cache_resource_->incrKVBlock();
     if (!result.ok()) {
         // Report Error event so moveToNext() won't be called again on this stream
         reportEvent(StreamEvents::Error, ErrorCode::MALLOC_FAILED, "incrKVBlock failed: LACK MEM");

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -114,7 +114,7 @@ const CacheKeysType& GenerateStream::cacheKeys(int32_t batch_id) const {
 absl::Status GenerateStream::initKVBlock() {
     RTP_LLM_PROFILE_FUNCTION();
     std::lock_guard<std::mutex> lock(*mutex_);
-    auto                        ret = stream_cache_resource_->initKVBlock(reserve_step_);
+    auto                        ret = stream_cache_resource_->initKVBlock();
     if (!ret.ok()) {
         RTP_LLM_LOG_WARNING("GenerateStream::initKVBlock: initKVBlock failed, stream_id: %lld", streamId());
     }
@@ -129,7 +129,7 @@ void GenerateStream::fakeInitKVBlock(size_t reserved_blocks) {
 absl::Status GenerateStream::incrKVBlock() {
     RTP_LLM_PROFILE_FUNCTION();
     std::lock_guard<std::mutex> lock(*mutex_);
-    return stream_cache_resource_->incrKVBlock(reserve_step_);
+    return stream_cache_resource_->incrKVBlock();
 }
 
 void GenerateStream::releaseResource() {
@@ -146,6 +146,24 @@ void GenerateStream::setNeedReleaseResource(bool need_release_resource) {
 int GenerateStream::nextNeedBlockNums(int reserve_step) const {
     // TODO: maybe need fix when context and reuse
     return stream_cache_resource_->singleBatchNeedBlocks(seqLength(), reserve_step) * nextBatchSize();
+}
+
+int GenerateStream::estimateKVNeedBlocks(int remaining_tokens, int target_batch_size) const {
+    const int reserve_step   = complete_token_ids_->getReserveStep();
+    int common_seq_len = std::min(complete_token_ids_->commonSeqLength(), seqLength());
+    if (target_batch_size > 1) {
+        common_seq_len = common_seq_len / seqSizePerBlock() * seqSizePerBlock();
+    }
+    return stream_cache_resource_->estimatePeakNeedBlocks(
+        seqLength(), common_seq_len, remaining_tokens, reserve_step, target_batch_size);
+}
+
+int GenerateStream::estimateInitialNeedBlocks() const {
+    return estimateKVNeedBlocks(/*remaining_tokens=*/0, currentBatchSize());
+}
+
+int GenerateStream::estimatePeakNeedBlocks(int remaining_tokens) const {
+    return estimateKVNeedBlocks(remaining_tokens, maxBatchSize());
 }
 
 std::shared_ptr<GenerateInput> GenerateStream::generateInput() const {
@@ -532,8 +550,10 @@ bool GenerateStream::isActive() const {
 }
 
 void GenerateStream::setReserveStep(size_t reserve_step) {
+    // Keep GenerateStream as the only entry point for setting reserve_step.
     reserve_step_ = reserve_step;
     generate_status_->setReserveStep(reserve_step);
+    complete_token_ids_->setReserveStep(static_cast<int>(reserve_step));
 }
 
 StreamState GenerateStream::moveToNext() {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -144,6 +144,8 @@ public:
     virtual absl::Status incrKVBlock();
     virtual void         releaseResource();
     int                  nextNeedBlockNums(int reserve_step) const;
+    int                  estimateInitialNeedBlocks() const;
+    int                  estimatePeakNeedBlocks(int remaining_tokens) const;
     void                 setNeedReleaseResource(bool need_release_resource);
     bool                 hasCacheKeys() const;
     const CacheKeysType& cacheKeys(int32_t batch_id = 0) const;
@@ -537,6 +539,7 @@ public:
     bool     queryPdSep() const;
 
 protected:
+    int  estimateKVNeedBlocks(int remaining_tokens, int target_batch_size) const;
     void updateLogitProcessorMultiSeqStatus(const torch::Tensor& src_batch_indices);
     void updateLogitProcessorStatus(const StreamUpdateInfo& update_info);
     void fillSubGenerateStatus(StreamState state);

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -313,8 +313,19 @@ int StreamCacheResource::singleBatchNeedBlocks(int seq_len, int reserve_step) co
     return resource_context_.cache_manager->singleBatchNeedBlocks(batch_kv_cache_resource_, seq_len, reserve_step);
 }
 
+int StreamCacheResource::estimatePeakNeedBlocks(
+    int seq_len, int common_seq_len, int remaining_tokens, int reserve_step, int target_batch_size) const {
+    return resource_context_.cache_manager->estimatePeakNeedBlocks(batch_kv_cache_resource_,
+                                                                   seq_len,
+                                                                   common_seq_len,
+                                                                   remaining_tokens,
+                                                                   reserve_step,
+                                                                   reuseCache(),
+                                                                   target_batch_size);
+}
+
 // TODO(xinfei.sxf) 保证这个函数的原子性
-absl::Status StreamCacheResource::initKVBlock(size_t reserve_step) {
+absl::Status StreamCacheResource::initKVBlock() {
     RTP_LLM_PROFILE_FUNCTION();
     // Decode side: first malloc should NOT use device cache, regardless of runtime config.
     // Follow-up allocations (incrKVBlock) will respect reuseCache() && enableDeviceCache().
@@ -341,7 +352,6 @@ absl::Status StreamCacheResource::initKVBlock(size_t reserve_step) {
     }
     malloc_info.enable_remove_skipped_blocks = false;
 
-    malloc_info.complete_token_ids->setReserveStep(reserve_step);
     auto result = resource_context_.cache_manager->malloc(malloc_info);
     if (!result.success) {
         malloc_failed_times_++;
@@ -357,7 +367,7 @@ absl::Status StreamCacheResource::initKVBlock(size_t reserve_step) {
     return absl::OkStatus();
 }
 
-absl::Status StreamCacheResource::incrKVBlock(size_t reserve_step) {
+absl::Status StreamCacheResource::incrKVBlock() {
     RTP_LLM_PROFILE_FUNCTION();
     // TODO(xinfei.sxf) add reserver_blocks
     if (fake_inited_) {
@@ -373,7 +383,6 @@ absl::Status StreamCacheResource::incrKVBlock(size_t reserve_step) {
     malloc_info.enable_device_cache          = reuseCache() && enableDeviceCache();
     malloc_info.enable_remove_skipped_blocks = true;
 
-    malloc_info.complete_token_ids->setReserveStep(reserve_step);
     auto result = resource_context_.cache_manager->malloc(malloc_info);
     if (!result.success) {
         malloc_failed_times_++;

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
@@ -28,8 +28,8 @@ public:
     void                 init(int batch_size);
     bool                 hasCacheKeys() const;
     const CacheKeysType& cacheKeys(int32_t batch_id) const;
-    absl::Status         initKVBlock(size_t reserve_step = 0);
-    absl::Status         incrKVBlock(size_t reserve_step = 0);
+    absl::Status         initKVBlock();
+    absl::Status         incrKVBlock();
     void                 fakeInitKVBlock(size_t reserved_blocks = 0);
     int                  tryReleaseKVBlock(size_t nums);
     void                 freeBatchBlocks(size_t batch_id, std::vector<int>& blocks);
@@ -42,6 +42,8 @@ public:
 
     // TODO, remove this after remove fallback
     int singleBatchNeedBlocks(int seq_len, int reserve_step) const;
+    int estimatePeakNeedBlocks(
+        int seq_len, int common_seq_len, int remaining_tokens, int reserve_step, int target_batch_size) const;
 
     int curBlocksNum() const;
     int mallocFailedTimes() const;

--- a/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/StreamCacheResourceTest.cc
@@ -146,8 +146,7 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 //     stream_->enable_fast_gen_ = true;
 
 //     // first chunk: 分块场景下 current_chunk_len 会被设置为 >0
-//     int token_capacity = 4;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 6);
 //     ASSERT_GT(stream_->currentChunkLen(), 0);
 
@@ -165,14 +164,13 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 //     prepareResource();
 //     auto& resource = stream_->streamCacheResource();
 
-//     int token_capacity = 1000;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 5);
 //     ASSERT_EQ(resource.maxBlockSize(), 3);
 
 //     stream_->setSeqLength(7);
 //     stream_->setIsContextStream(false);
-//     ASSERT_TRUE(resource.incrKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.incrKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 3);
 //     ASSERT_EQ(resource.maxBlockSize(), 4);
 
@@ -188,8 +186,7 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 
 //     // Test with query-level reuse_cache = true
 //     stream_->generate_input_->generate_config->reuse_cache = true;
-//     int token_capacity                                     = 1000;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 5);
 //     ASSERT_EQ(resource.maxBlockSize(), 3);
 
@@ -199,7 +196,7 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 //     resource.init(stream_->currentBatchSize());
 //     size_t baseline_free_blocks                            = cache_manager_->freeBlocksNum();
 //     stream_->generate_input_->generate_config->reuse_cache = false;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(),
 //               baseline_free_blocks >= 3 ? baseline_free_blocks - 3 : baseline_free_blocks);
 //     ASSERT_EQ(resource.maxBlockSize(), 3);
@@ -214,8 +211,7 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 
 //     // Test with query-level reuse_cache = true, but should be ignored
 //     stream_->generate_input_->generate_config->reuse_cache = true;
-//     int token_capacity                                     = 1000;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 5);
 //     ASSERT_EQ(resource.maxBlockSize(), 3);
 
@@ -224,7 +220,7 @@ TEST_F(StreamCacheResourceTest, testAllocateResource) {
 //     // Re-initialize batch resource after release
 //     resource.init(stream_->currentBatchSize());
 //     stream_->generate_input_->generate_config->reuse_cache = false;
-//     ASSERT_TRUE(resource.initKVBlock(token_capacity).ok());
+//     ASSERT_TRUE(resource.initKVBlock().ok());
 //     ASSERT_EQ(cache_manager_->freeBlocksNum(), 5);
 //     ASSERT_EQ(resource.maxBlockSize(), 3);
 
@@ -292,7 +288,7 @@ TEST_F(StreamCacheResourceTest, testInitKVBlock_TriggersLoadCacheSync_AndUpdates
             return std::static_pointer_cast<AsyncContext>(load_ctx);
         }));
 
-    ASSERT_TRUE(resource.initKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.initKVBlock().ok());
     ASSERT_TRUE(resource.asyncLoadCache());
     ASSERT_TRUE(resource.loadCacheDone());
     ASSERT_NE(captured_ctx, nullptr);
@@ -360,10 +356,10 @@ TEST_F(StreamCacheResourceTest, testDecodeInitKVBlock_DisablesDeviceCacheOnlyFor
             return {true, 0};
         }));
 
-    ASSERT_TRUE(resource.initKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.initKVBlock().ok());
     resource.asyncLoadCache();
     resource.loadCacheDone();
-    ASSERT_TRUE(resource.incrKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.incrKVBlock().ok());
 }
 
 TEST_F(StreamCacheResourceTest, testTryReleaseKVBlock_TriggersStoreCacheAsync_WhenFinishedAndReuseCache) {
@@ -397,7 +393,7 @@ TEST_F(StreamCacheResourceTest, testTryReleaseKVBlock_TriggersStoreCacheAsync_Wh
             return store_ctx;
         }));
 
-    ASSERT_TRUE(resource.incrKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.incrKVBlock().ok());
     ASSERT_GT(resource.curBlocksNum(), 0);
 
     stream_->generate_status_->status = StreamState::FINISHED;
@@ -428,7 +424,7 @@ TEST_F(StreamCacheResourceTest, testTryReleaseKVBlock_DoesNotStoreCacheAsync_Whe
 
     EXPECT_CALL(*mock_coord, asyncWrite(testing::_)).Times(0);
 
-    ASSERT_TRUE(resource.incrKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.incrKVBlock().ok());
     const int blocks = resource.curBlocksNum();
     ASSERT_GT(blocks, 0);
 
@@ -466,7 +462,7 @@ TEST_F(StreamCacheResourceTest, testTryReleaseKVBlock_TieredMemoryCache_EvictsDe
                 return store_ctx;
             }));
 
-    ASSERT_TRUE(resource.incrKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.incrKVBlock().ok());
     ASSERT_GT(resource.curBlocksNum(), 0);
 
     stream_->generate_status_->status = StreamState::FINISHED;
@@ -724,7 +720,7 @@ TEST_F(StreamCacheResourceTest, testInitKVBlock_SecondCallDoesNotOverwriteReuseL
         .WillOnce(testing::Return(std::static_pointer_cast<AsyncContext>(load_ctx1)));
 
     // First initKVBlock + asyncLoadCache + loadCacheDone: sets reuse lengths
-    ASSERT_TRUE(resource.initKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.initKVBlock().ok());
     ASSERT_GT(resource.curBlocksNum(), 0);
     ASSERT_TRUE(resource.asyncLoadCache());
     ASSERT_TRUE(resource.loadCacheDone());
@@ -737,7 +733,7 @@ TEST_F(StreamCacheResourceTest, testInitKVBlock_SecondCallDoesNotOverwriteReuseL
     // Second initKVBlock + asyncLoadCache + loadCacheDone: load_cache_once_ prevents re-issue.
     // The once-per-lifecycle guard means the second asyncLoadCache() returns false (skipped),
     // which inherently preserves the reuse lengths set by the first load.
-    ASSERT_TRUE(resource.initKVBlock(/*reserve_step=*/0).ok());
+    ASSERT_TRUE(resource.initKVBlock().ok());
     ASSERT_TRUE(resource.asyncLoadCache());
     ASSERT_TRUE(resource.loadCacheDone());
 

--- a/rtp_llm/server/server_args/fifo_scheduler_group_args.py
+++ b/rtp_llm/server/server_args/fifo_scheduler_group_args.py
@@ -40,6 +40,6 @@ def init_fifo_scheduler_group_args(parser, fifo_scheduler_config):
         type=str,
         default="1",
         help="PDFusionRatioScheduler 的 decode:prefill 轮数比字符串。仅当 pdfusion_scheduler_mode='ratio' 生效；"
-        "默认 '1' 严格交替；'N' = 1 轮 prefill 后 N 轮 decode；"
+        "'0' = 有 waiting stream 时优先尝试 prefill；默认 '1' 严格交替；'N' = 1 轮 prefill 后 N 轮 decode；"
         "'1/X' = X 轮 prefill 后 1 轮 decode。非法值回退为 '1'。",
     )

--- a/rtp_llm/server/server_args/server_args.py
+++ b/rtp_llm/server/server_args/server_args.py
@@ -481,7 +481,14 @@ def init_all_group_args(
     init_grpc_group_args(parser, py_env_configs.grpc_config)
 
 
-def setup_args() -> PyEnvConfigs:
+def setup_args(args: Optional[Sequence[str]] = None) -> PyEnvConfigs:
+    """Parse engine arguments into the canonical ``PyEnvConfigs`` object.
+
+    ``args=None`` preserves the server entry point behavior (parse ``sys.argv``).
+    Supplying an explicit sequence lets in-process tools, such as the offline
+    capacity estimator, reuse the exact same parser and config bindings without
+    temporarily replacing global process arguments.
+    """
     parser = EnvArgumentParser(description="RTP LLM")
 
     # 先创建配置对象
@@ -494,6 +501,6 @@ def setup_args() -> PyEnvConfigs:
     init_all_group_args(parser, py_env_configs)
 
     # 解析参数（会自动应用所有配置绑定）
-    parsed_args = parser.parse_args()
+    parser.parse_args(args)
 
     return py_env_configs

--- a/rtp_llm/server/server_args/test/server_args_test.py
+++ b/rtp_llm/server/server_args/test/server_args_test.py
@@ -287,6 +287,24 @@ class ServerArgsSetTest(TestCase):
             "1/3",
         )
 
+        sys.argv = [
+            "prog",
+            "--pdfusion_scheduler_mode",
+            "ratio",
+            "--decode_prefill_ratio",
+            "0",
+        ]
+        importlib.reload(rtp_llm.server.server_args.server_args)
+        py_env_configs = rtp_llm.server.server_args.server_args.setup_args()
+        self.assertEqual(
+            py_env_configs.runtime_config.fifo_scheduler_config.pdfusion_scheduler_mode,
+            "ratio",
+        )
+        self.assertEqual(
+            py_env_configs.runtime_config.fifo_scheduler_config.decode_prefill_ratio,
+            "0",
+        )
+
     def test_pdfusion_scheduler_mode_rejects_unknown_value(self):
         """Test that pdfusion_scheduler_mode only accepts fixed scheduler patterns."""
         sys.argv = ["prog", "--pdfusion_scheduler_mode", "ratioo"]

--- a/rtp_llm/test/perf_test/BUILD
+++ b/rtp_llm/test/perf_test/BUILD
@@ -17,6 +17,8 @@ py_library(
         "distribution_runner.py",
         "grid_runner.py",
         "hub_download.py",
+        "offline_bench_test.py",
+        "offline_runner.py",
         "perf_config.py",
         "perf_utils.py",
         "tps_runner.py",
@@ -36,10 +38,42 @@ py_library(
 py_test(
     name = "test_perf_config_and_runners",
     srcs = ["test_perf_config_and_runners.py"],
+    data = [
+        "//rtp_llm/test/tokenizer_test:testdata",
+    ],
     deps = [
         "//rtp_llm/test/perf_test:perf_test_lib",
     ],
 )
+
+# Offline throughput benchmark (new entry point).
+# Manual target: Qwen3.5 weights must be available locally or resolvable by perf path resolution.
+py_test(
+    name = "offline_bench_test",
+    main = "offline_bench_test.py",
+    srcs = ["offline_bench_test.py"],
+    timeout = "eternal",
+    deps = [
+        "//rtp_llm:pyodps",
+        "//rtp_llm:testlib",
+        "//rtp_llm/test/perf_test:perf_test_lib",
+    ],
+    data = [
+        "//rtp_llm:sdk",
+    ],
+    args = [
+        "--checkpoint_path", "Qwen/Qwen3.5-35B-A3B",
+        "--model_type", "qwen35_moe",
+        "--input_len_min", "128",
+        "--input_len_max", "512",
+        "--output_len_min", "64",
+        "--output_len_max", "256",
+        "--concurrency_limit", "256",
+        "--seq_size_per_block", "1024",
+    ],
+    tags = ["manual"],
+)
+
 
 # Distribution mode: sampling from dataset using model's parameters.
 py_test(

--- a/rtp_llm/test/perf_test/batch_decode_test.py
+++ b/rtp_llm/test/perf_test/batch_decode_test.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 from rtp_llm.test.perf_test.dataclass import PerfTestConfig
 from rtp_llm.test.perf_test.distribution_runner import DistributionRunner
 from rtp_llm.test.perf_test.grid_runner import GridRunner
+from rtp_llm.test.perf_test.dataset import extract_arg
 from rtp_llm.test.perf_test.perf_config import (
     parse_args,
     prepare_config,
@@ -165,6 +166,9 @@ def main() -> str:
 
     args, remaining = parse_args()
     remaining = resolve_perf_engine_paths(remaining)
+    # batch_decode_test always needs BatchDecodeScheduler
+    if extract_arg(remaining, "use_batch_decode_scheduler") is None:
+        remaining.extend(["--use_batch_decode_scheduler", "1"])
     generate_config = json.loads(args.generate_config)
     os.makedirs(args.result_dir, exist_ok=True)
     EngineServer.propagate_engine_env(remaining)
@@ -179,7 +183,9 @@ def main() -> str:
     server = EngineServer(args, remaining)
     try:
         server.start(
-            max_seq_len=config.max_seq_len, max_concurrency=config.max_concurrency
+            max_seq_len=config.max_seq_len,
+            max_concurrency=config.max_concurrency,
+            use_batch_decode_scheduler=True,
         )
         engine_status = query_engine_status(server.port)
         print_config_table(args, config, engine_status, remaining)

--- a/rtp_llm/test/perf_test/offline_bench_test.py
+++ b/rtp_llm/test/perf_test/offline_bench_test.py
@@ -1,0 +1,210 @@
+"""Offline throughput benchmark — standalone entry point.
+
+Flow:
+  1. Parse benchmark and engine arguments
+  2. Start engine server
+  3. Run benchmark and collect metrics
+"""
+
+import logging
+import os
+
+from rtp_llm.test.perf_test.dataset import extract_arg
+from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig, OfflineRunner
+from rtp_llm.test.perf_test.perf_config import resolve_perf_engine_paths
+from rtp_llm.test.perf_test.server import EngineServer
+from rtp_llm.test.utils.coredump_util import summarize_and_cleanup_coredumps
+
+
+def parse_offline_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="RTP-LLM offline throughput benchmark. "
+        "Unrecognized arguments are forwarded to the engine server.",
+    )
+
+    bench = parser.add_argument_group("benchmark")
+    bench.add_argument(
+        "--duration",
+        type=int,
+        default=300,
+        help="Duration in seconds to dispatch requests (duration mode)",
+    )
+    bench.add_argument(
+        "--total_requests",
+        type=int,
+        default=-1,
+        help="Fixed-workload mode: submit exactly N requests then drain. "
+        "-1 = 2 * manually configured concurrency_limit, "
+        "0 = duration mode.",
+    )
+    bench.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for workload generation (default 42)",
+    )
+    bench.add_argument(
+        "--drain_timeout",
+        type=int,
+        default=0,
+        help="Max seconds to wait for in-flight requests after dispatch ends. "
+        "0 = wait forever (default). "
+        "When exceeded, remaining requests are cancelled and report is generated.",
+    )
+    bench.add_argument("--input_len_min", type=int, default=512)
+    bench.add_argument("--input_len_max", type=int, default=2048)
+    bench.add_argument("--output_len_min", type=int, default=64)
+    bench.add_argument("--output_len_max", type=int, default=512)
+    bench.add_argument("--prefix_groups", type=int, default=1)
+    bench.add_argument("--prefix_len", type=int, default=0)
+    bench.add_argument("--num_return_sequences", type=int, default=1)
+    bench.add_argument("--dump_workload", type=str, default="")
+    bench.add_argument(
+        "--result_dir",
+        type=str,
+        default=os.environ.get(
+            "TEST_UNDECLARED_OUTPUTS_DIR", "./offline_bench_results"
+        ),
+    )
+    bench.add_argument(
+        "--max_seq_len",
+        type=int,
+        default=32768,
+        help="Max sequence length (context + output). Defaults to 32768.",
+    )
+    bench.add_argument(
+        "--concurrency_limit",
+        type=int,
+        required=True,
+        help="Manually configured engine concurrency limit",
+    )
+    bench.add_argument(
+        "--profile",
+        action="store_true",
+        default=False,
+        help="Enable GPU timeline profiling during steady state",
+    )
+    bench.add_argument(
+        "--profile_steps",
+        type=int,
+        default=50,
+        help="Number of steps to profile (default 50)",
+    )
+    bench.add_argument("--dp_size", type=int, default=1)
+    bench.add_argument("--partial", type=int, default=1)
+    bench.add_argument(
+        "--checkpoint_path", type=str, default="", help="Model checkpoint path"
+    )
+    bench.add_argument(
+        "--tokenizer_path",
+        type=str,
+        default="",
+        help="Tokenizer path (defaults to checkpoint_path)",
+    )
+    bench.add_argument("--tp_size", type=int, default=1)
+    bench.add_argument(
+        "--server_start_timeout",
+        type=int,
+        default=1600,
+        help="Max seconds to wait for engine server health check during startup",
+    )
+
+    args, remaining = parser.parse_known_args()
+    return args, remaining
+
+
+def main() -> str:
+    from rtp_llm.config.log_config import setup_logging
+
+    setup_logging()
+
+    args, remaining = parse_offline_args()
+    os.makedirs(args.result_dir, exist_ok=True)
+
+    checkpoint_path = args.checkpoint_path or os.environ.get("CHECKPOINT_PATH", "")
+    tokenizer_path = (
+        args.tokenizer_path or os.environ.get("TOKENIZER_PATH", "") or checkpoint_path
+    )
+    tp_size = args.tp_size or 1
+
+    if checkpoint_path and not extract_arg(remaining, "checkpoint_path"):
+        remaining.extend(["--checkpoint_path", checkpoint_path])
+    if tokenizer_path and not extract_arg(remaining, "tokenizer_path"):
+        remaining.extend(["--tokenizer_path", tokenizer_path])
+    if args.tp_size and not extract_arg(remaining, "tp_size"):
+        remaining.extend(["--tp_size", str(tp_size)])
+
+    # Resolve Hub IDs (e.g. "Qwen/Qwen3.5-35B-A3B") to local paths
+    remaining = resolve_perf_engine_paths(remaining)
+    checkpoint_path = extract_arg(remaining, "checkpoint_path") or checkpoint_path
+    tokenizer_path = extract_arg(remaining, "tokenizer_path") or tokenizer_path
+    model_type = extract_arg(remaining, "model_type", "") or os.environ.get(
+        "MODEL_TYPE", ""
+    )
+
+    EngineServer.propagate_engine_env(remaining)
+
+    dump_workload = args.dump_workload
+    if dump_workload and not os.path.isabs(dump_workload):
+        dump_workload = os.path.join(args.result_dir, dump_workload)
+
+    total_requests = args.total_requests
+    if total_requests == -1:
+        total_requests = args.concurrency_limit * 2
+        logging.info(
+            f"Default total_requests: {total_requests} "
+            f"(2 * concurrency_limit={args.concurrency_limit})"
+        )
+
+    config = OfflineBenchConfig(
+        input_len_min=args.input_len_min,
+        input_len_max=args.input_len_max,
+        output_len_min=args.output_len_min,
+        output_len_max=args.output_len_max,
+        prefix_groups=args.prefix_groups,
+        prefix_len=args.prefix_len,
+        num_return_sequences=args.num_return_sequences,
+        duration_s=args.duration,
+        drain_timeout_s=args.drain_timeout,
+        concurrency_limit=args.concurrency_limit,
+        total_requests=total_requests,
+        seed=args.seed,
+        dump_workload=dump_workload,
+    )
+    config.validate()
+
+    # Start engine and run benchmark
+    server = EngineServer(args, remaining)
+    try:
+        server.start(
+            max_seq_len=args.max_seq_len,
+            max_concurrency=args.concurrency_limit,
+            server_start_timeout=args.server_start_timeout,
+            use_batch_decode_scheduler=False,
+        )
+
+        runner = OfflineRunner(
+            port=server.port,
+            config=config,
+            tokenizer_path=tokenizer_path,
+            checkpoint_path=checkpoint_path,
+            model_type=model_type,
+            result_dir=args.result_dir,
+            profile=args.profile,
+            profile_steps=args.profile_steps,
+        )
+
+        runner.run()
+    finally:
+        try:
+            server.stop()
+        finally:
+            summarize_and_cleanup_coredumps(args.result_dir)
+
+    return args.result_dir
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/test/perf_test/offline_runner.py
+++ b/rtp_llm/test/perf_test/offline_runner.py
@@ -1,0 +1,1414 @@
+"""Offline throughput benchmark runner.
+
+Closed-loop dispatch: maintains concurrency_limit requests in flight for a
+configurable duration, then drains all in-flight requests.
+
+Statistics cover ALL completed requests (no warmup/cooldown exclusion).
+TPS = total_success_tokens / wall_time (first submit → last completion).
+"""
+
+import asyncio
+import concurrent.futures
+import json
+import logging
+import os
+import random
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, NamedTuple, Optional, Set, TextIO, Tuple
+
+import aiohttp
+import requests
+
+BASE_TEXTS = [
+    "The quick brown fox jumps over the lazy dog near the river bank. ",
+    "In a galaxy far far away there existed a civilization of extraordinary beings. ",
+    "Once upon a time in a land of endless mountains and deep valleys lived a wise old sage. ",
+    "The fundamental principles of quantum mechanics govern the behavior of particles at atomic scales. ",
+    "Throughout history great empires have risen and fallen leaving behind monuments and legends. ",
+    "Modern artificial intelligence systems leverage vast amounts of data to learn complex patterns. ",
+    "The ocean depths remain one of the least explored frontiers on our planet today. ",
+    "Classical music compositions from the baroque era continue to influence contemporary artists worldwide. ",
+    "Advances in biotechnology have enabled unprecedented precision in genetic engineering applications. ",
+    "The philosophy of consciousness explores the nature of subjective experience and awareness. ",
+]
+
+
+@dataclass
+class OfflineBenchConfig:
+    input_len_min: int = 512
+    input_len_max: int = 2048
+    output_len_min: int = 64
+    output_len_max: int = 512
+    prefix_groups: int = 1
+    prefix_len: int = 0
+    num_return_sequences: int = 1
+
+    duration_s: int = 300
+    drain_timeout_s: int = 0  # 0 = wait forever
+    concurrency_limit: int = 0
+    total_requests: int = (
+        -1
+    )  # -1 = auto (2*concurrency_limit), 0 = duration mode, >0 = fixed
+    seed: int = 42
+    dump_workload: str = ""
+
+    def validate(self):
+        if self.input_len_min <= 0:
+            raise ValueError("input_len_min must be > 0")
+        if self.input_len_min > self.input_len_max:
+            raise ValueError(
+                f"input_len_min ({self.input_len_min}) must be <= input_len_max ({self.input_len_max})"
+            )
+        if self.output_len_min <= 0:
+            raise ValueError("output_len_min must be > 0")
+        if self.output_len_min > self.output_len_max:
+            raise ValueError(
+                f"output_len_min ({self.output_len_min}) must be <= output_len_max ({self.output_len_max})"
+            )
+        if self.prefix_groups < 1:
+            raise ValueError("prefix_groups must be >= 1")
+        if self.prefix_len < 0:
+            raise ValueError("prefix_len must be >= 0")
+        if self.prefix_len > self.input_len_min:
+            raise ValueError(
+                f"prefix_len ({self.prefix_len}) must be <= input_len_min ({self.input_len_min})"
+            )
+        if self.num_return_sequences < 1:
+            raise ValueError("num_return_sequences must be >= 1")
+        if self.total_requests <= 0 and self.duration_s <= 0:
+            raise ValueError("duration_s must be > 0 in duration mode")
+        if self.concurrency_limit <= 0:
+            raise ValueError("concurrency_limit must be > 0")
+
+
+@dataclass
+class OfflineMetrics:
+    total_wall_time_s: float = 0.0
+    output_tps: float = 0.0
+    input_tps: float = 0.0
+    total_tps: float = 0.0
+
+    total_submitted: int = 0
+    success_requests: int = 0
+    fail_requests: int = 0
+    cancelled_requests: int = 0
+    avg_request_latency_s: float = 0.0
+    p50_request_latency_s: float = 0.0
+    p99_request_latency_s: float = 0.0
+    avg_wait_time_ms: float = 0.0
+    max_wait_time_ms: float = 0.0
+
+    avg_ttft_ms: float = 0.0
+    p50_ttft_ms: float = 0.0
+    p99_ttft_ms: float = 0.0
+    avg_tpot_ms: float = 0.0
+    p50_tpot_ms: float = 0.0
+    p99_tpot_ms: float = 0.0
+
+    avg_input_len: float = 0.0
+    avg_output_len: float = 0.0
+    input_len_range: Tuple[int, int] = (0, 0)
+    output_len_range: Tuple[int, int] = (0, 0)
+
+    avg_reuse_len: float = 0.0
+    avg_reuse_ratio: float = 0.0
+    total_reuse_tokens: int = 0
+    total_compute_tokens: int = 0
+
+    kv_cache_total_tokens: int = 0
+    kv_cache_total_blocks: int = 0
+    kv_cache_block_size: int = 0
+    kv_cache_avg_utilization: float = 0.0
+    kv_cache_max_utilization: float = 0.0
+    kv_cache_min_utilization: float = 0.0
+    kv_cache_max_dp_utilization: float = 0.0
+    concurrency_avg_utilization: float = 0.0
+    concurrency_max_utilization: float = 0.0
+
+    def raise_if_all_requests_failed(self):
+        if self.total_submitted == 0:
+            raise RuntimeError("Offline benchmark failed: no requests were submitted")
+        if self.success_requests == 0:
+            raise RuntimeError(
+                "Offline benchmark failed: no requests succeeded "
+                f"({self.total_submitted} submitted, {self.fail_requests} failed, "
+                f"{self.cancelled_requests} cancelled)"
+            )
+
+    def print_table(self):
+        lines = [
+            "================== Offline Throughput Benchmark ==================",
+            f"Submitted:             {self.total_submitted}",
+            f"Success / Fail / Cancelled: "
+            f"{self.success_requests} / {self.fail_requests} / {self.cancelled_requests}",
+            f"Wall Time:             {self.total_wall_time_s:.1f} s",
+            "--- Throughput ---",
+            f"Output TPS:            {self.output_tps:,.1f} tokens/s",
+            f"Input TPS:             {self.input_tps:,.1f} tokens/s",
+            f"Total TPS:             {self.total_tps:,.1f} tokens/s",
+            "--- Request Latency ---",
+            f"Avg / P50 / P99:       {self.avg_request_latency_s:.2f} / "
+            f"{self.p50_request_latency_s:.2f} / {self.p99_request_latency_s:.2f} s",
+            f"Avg Wait Time:         {self.avg_wait_time_ms:.1f} ms "
+            f"(max: {self.max_wait_time_ms:.1f} ms)",
+            f"TTFT (avg/p50/p99):    {self.avg_ttft_ms:.1f} / "
+            f"{self.p50_ttft_ms:.1f} / {self.p99_ttft_ms:.1f} ms",
+            f"TPOT (avg/p50/p99):    {self.avg_tpot_ms:.2f} / "
+            f"{self.p50_tpot_ms:.2f} / {self.p99_tpot_ms:.2f} ms",
+            "--- Input / Output Distribution ---",
+            f"Input  Len:            avg={self.avg_input_len:.0f}  "
+            f"range=[{self.input_len_range[0]}, {self.input_len_range[1]}]",
+            f"Output Len:            avg={self.avg_output_len:.0f}  "
+            f"range=[{self.output_len_range[0]}, {self.output_len_range[1]}]",
+            "--- Prefix Cache ---",
+            f"Avg Reuse Len:         {self.avg_reuse_len:.0f} tokens "
+            f"({self.avg_reuse_ratio * 100:.1f}% of input)",
+            f"Total Reuse:           {self.total_reuse_tokens:,} tokens",
+            f"Actual Prefill:        {self.total_compute_tokens:,} tokens",
+            "--- KV Cache ---",
+            f"Total Tokens:          {self.kv_cache_total_tokens:,}",
+            f"Total Blocks:          {self.kv_cache_total_blocks:,} "
+            f"(block_size={self.kv_cache_block_size})",
+        ]
+        if self.kv_cache_max_utilization > 0:
+            lines += [
+                "--- Runtime Utilization ---",
+                f"KV Cache:              avg={self.kv_cache_avg_utilization * 100:.1f}%  "
+                f"max={self.kv_cache_max_utilization * 100:.1f}%  "
+                f"min={self.kv_cache_min_utilization * 100:.1f}%",
+                f"Max DP KV Cache:       {self.kv_cache_max_dp_utilization * 100:.1f}%",
+                f"Concurrency:           avg={self.concurrency_avg_utilization * 100:.1f}%  "
+                f"max={self.concurrency_max_utilization * 100:.1f}%",
+            ]
+        lines += [
+            "==================================================================",
+        ]
+        print("\n".join(lines))
+
+    def save_json(self, result_dir: str):
+        os.makedirs(result_dir, exist_ok=True)
+        path = os.path.join(result_dir, "offline_benchmark_result.json")
+        data = asdict(self)
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        logging.info(f"Saved offline benchmark result to {path}")
+
+
+# ---------------------------------------------------------------------------
+# WorkloadGenerator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PrefixGroup:
+    group_id: int
+    prefix_text: str
+    prefix_token_ids: Tuple[int, ...]
+    rng: random.Random
+
+
+@dataclass(frozen=True)
+class _WorkloadSpec:
+    request_id: int
+    group: _PrefixGroup
+    input_len: int
+    output_len: int
+
+
+@dataclass(frozen=True)
+class _PreparedPrompt:
+    request_id: Optional[int]
+    prompt: str
+    output_len: int
+    dump_record: Optional[str] = None
+
+
+class _PromptGenerationExpired(Exception):
+    """Prompt generation was cancelled or crossed its dispatch deadline."""
+
+
+class WorkloadGenerator:
+    """On-demand request generator with independent per-prefix-group RNGs.
+
+    Prompt generation starts from token-id slices for speed, then validates the
+    final text with the real tokenizer. Decode/concatenation is not assumed to
+    preserve token boundaries: candidates are repaired until they have the
+    requested exact length and the group's canonical token prefix.
+    """
+
+    _MAX_TOKEN_REPAIR_ATTEMPTS = 64
+
+    def __init__(
+        self,
+        config: OfflineBenchConfig,
+        tokenizer: Any,
+        seed: int = 42,
+        dump_file: Optional[TextIO] = None,
+    ):
+        self._config = config
+        self._tokenizer = tokenizer
+        self._seed = seed
+        self._dump_file = dump_file
+        self._counter = 0
+        self._state_lock = threading.Lock()
+        self._dump_lock = threading.Lock()
+        self._pending_dump_records: Dict[int, str] = {}
+        self._next_dump_id = 0
+
+        # Pre-compute a token buffer large enough for all configured prompt and prefix slices.
+        big_text = " ".join(BASE_TEXTS) * 50
+        base_tokens = self._tokenizer.encode(big_text)
+        if not base_tokens:
+            raise ValueError("tokenizer produced an empty token buffer")
+        min_buffer_tokens = max(
+            config.input_len_max,
+            config.prefix_groups * config.prefix_len,
+            1,
+        )
+        repeats = (min_buffer_tokens + len(base_tokens) - 1) // len(base_tokens)
+        self._big_tokens = base_tokens * repeats
+        self._big_text = big_text
+
+        self._groups: List[_PrefixGroup] = []
+        for g in range(config.prefix_groups):
+            prefix_text = ""
+            prefix_token_ids: Tuple[int, ...] = ()
+            if config.prefix_len > 0:
+                prefix_text, encoded_prefix = self._find_exact_text(
+                    offset=g * config.prefix_len,
+                    target_len=config.prefix_len,
+                )
+                prefix_token_ids = tuple(encoded_prefix)
+                if any(
+                    prefix_token_ids == group.prefix_token_ids for group in self._groups
+                ):
+                    # Very small/fake tokenizers can map multiple source slices to
+                    # the same text. Search farther in the reservoir so configured
+                    # groups still represent distinct cache-prefix populations.
+                    for shift in range(1, self._MAX_TOKEN_REPAIR_ATTEMPTS + 1):
+                        candidate_text, candidate_ids = self._find_exact_text(
+                            offset=(g + shift) * config.prefix_len,
+                            target_len=config.prefix_len,
+                        )
+                        candidate_tuple = tuple(candidate_ids)
+                        if all(
+                            candidate_tuple != group.prefix_token_ids
+                            for group in self._groups
+                        ):
+                            prefix_text = candidate_text
+                            prefix_token_ids = candidate_tuple
+                            break
+            self._groups.append(
+                _PrefixGroup(
+                    group_id=g,
+                    prefix_text=prefix_text,
+                    prefix_token_ids=prefix_token_ids,
+                    rng=random.Random(seed + g),
+                )
+            )
+
+    def _token_slice(self, offset: int, length: int) -> List[int]:
+        if length <= 0:
+            return []
+        buf = self._big_tokens
+        start = offset % len(buf)
+        end = start + length
+        if end <= len(buf):
+            return buf[start:end]
+
+        result = buf[start:]
+        remaining = length - len(result)
+        full_repeats, tail = divmod(remaining, len(buf))
+        if full_repeats:
+            result.extend(buf * full_repeats)
+        if tail:
+            result.extend(buf[:tail])
+        return result
+
+    def _find_exact_text(
+        self,
+        offset: int,
+        target_len: int,
+        prefix_text: str = "",
+        prefix_token_ids: Tuple[int, ...] = (),
+        cancel_event: Optional[threading.Event] = None,
+        deadline: Optional[float] = None,
+    ) -> Tuple[str, List[int]]:
+        """Decode a reservoir slice and repair it to an exact token length.
+
+        The tokenizer is authoritative. Each candidate is encoded after the
+        final string concatenation, so boundary merges/splits are observed.
+        ``prefix_token_ids`` makes the first ``prefix_len`` tokens an invariant
+        rather than an assumption about string concatenation.
+        """
+        self._check_generation_active(cancel_event, deadline)
+        if target_len < len(prefix_token_ids):
+            raise ValueError(
+                f"target_len ({target_len}) is shorter than required prefix "
+                f"({len(prefix_token_ids)})"
+            )
+        if target_len == len(prefix_token_ids):
+            self._check_generation_active(cancel_event, deadline)
+            encoded = list(self._tokenizer.encode(prefix_text))
+            self._check_generation_active(cancel_event, deadline)
+            if len(encoded) == target_len and tuple(encoded) == prefix_token_ids:
+                return prefix_text, encoded
+
+        suffix_len = max(target_len - len(prefix_token_ids), 0)
+        last_error = ""
+        for shift in range(self._MAX_TOKEN_REPAIR_ATTEMPTS):
+            self._check_generation_active(cancel_event, deadline)
+            candidate_suffix_len = suffix_len
+            shifted_offset = offset + shift
+            for _ in range(self._MAX_TOKEN_REPAIR_ATTEMPTS):
+                self._check_generation_active(cancel_event, deadline)
+                suffix_ids = self._token_slice(shifted_offset, candidate_suffix_len)
+                candidate = prefix_text + self._tokenizer.decode(suffix_ids)
+                self._check_generation_active(cancel_event, deadline)
+                encoded = list(self._tokenizer.encode(candidate))
+                self._check_generation_active(cancel_event, deadline)
+                prefix_matches = (
+                    tuple(encoded[: len(prefix_token_ids)]) == prefix_token_ids
+                )
+                if len(encoded) == target_len and prefix_matches:
+                    return candidate, encoded
+
+                last_error = (
+                    f"encoded_len={len(encoded)}, target_len={target_len}, "
+                    f"prefix_matches={prefix_matches}"
+                )
+                length_delta = target_len - len(encoded)
+                if length_delta == 0:
+                    # The length is right but this suffix re-tokenizes the prefix
+                    # boundary. Try a different reservoir offset.
+                    break
+                repaired_len = candidate_suffix_len + length_delta
+                if repaired_len < 0 or repaired_len == candidate_suffix_len:
+                    break
+                candidate_suffix_len = repaired_len
+
+        raise ValueError(
+            "Unable to construct an exact tokenizer-validated prompt after "
+            f"{self._MAX_TOKEN_REPAIR_ATTEMPTS} attempts: {last_error}"
+        )
+
+    @staticmethod
+    def _check_generation_active(
+        cancel_event: Optional[threading.Event], deadline: Optional[float]
+    ) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise _PromptGenerationExpired("prompt generation cancelled")
+        if deadline is not None and time.perf_counter() >= deadline:
+            raise _PromptGenerationExpired("prompt generation deadline exceeded")
+
+    def _reserve_next(self) -> _WorkloadSpec:
+        """Reserve deterministic RNG state before parallel prompt construction."""
+        with self._state_lock:
+            idx = self._counter
+            self._counter += 1
+            group = self._groups[idx % len(self._groups)]
+            cfg = self._config
+            input_len = group.rng.randint(cfg.input_len_min, cfg.input_len_max)
+            output_len = group.rng.randint(cfg.output_len_min, cfg.output_len_max)
+        return _WorkloadSpec(idx, group, input_len, output_len)
+
+    def _generate(
+        self,
+        spec: _WorkloadSpec,
+        cancel_event: Optional[threading.Event] = None,
+        deadline: Optional[float] = None,
+    ) -> _PreparedPrompt:
+        idx = spec.request_id
+        group = spec.group
+        input_len = spec.input_len
+        output_len = spec.output_len
+        cfg = self._config
+
+        self._check_generation_active(cancel_event, deadline)
+        # Start from a pre-tokenized slice, but treat encode(final_prompt) as the
+        # source of truth because decode and string concatenation can merge tokens.
+        buf = self._big_tokens
+        offset = (idx * 37) % max(1, len(buf) - input_len + 1)
+        prompt, prompt_token_ids = self._find_exact_text(
+            offset=offset + cfg.prefix_len,
+            target_len=input_len,
+            prefix_text=group.prefix_text,
+            prefix_token_ids=group.prefix_token_ids,
+            cancel_event=cancel_event,
+            deadline=deadline,
+        )
+        self._check_generation_active(cancel_event, deadline)
+        if len(prompt_token_ids) != input_len:
+            raise AssertionError(
+                f"prompt token length mismatch: {len(prompt_token_ids)} != {input_len}"
+            )
+        if tuple(prompt_token_ids[: cfg.prefix_len]) != group.prefix_token_ids:
+            raise AssertionError(f"prompt prefix mismatch for group {group.group_id}")
+
+        encoded_record = None
+        if self._dump_file is not None:
+            record = {
+                "id": idx,
+                "group_id": group.group_id,
+                "input_len": input_len,
+                "output_len": output_len,
+                "prompt_preview": prompt[:200],
+            }
+            encoded_record = json.dumps(record, ensure_ascii=False) + "\n"
+
+        return _PreparedPrompt(idx, prompt, output_len, encoded_record)
+
+    def commit(self, prepared: _PreparedPrompt) -> None:
+        """Record a generated prompt only once the dispatcher will submit it."""
+        if (
+            self._dump_file is None
+            or prepared.request_id is None
+            or prepared.dump_record is None
+        ):
+            return
+
+        with self._dump_lock:
+            self._pending_dump_records[prepared.request_id] = prepared.dump_record
+            while self._next_dump_id in self._pending_dump_records:
+                self._dump_file.write(
+                    self._pending_dump_records.pop(self._next_dump_id)
+                )
+                self._next_dump_id += 1
+
+    def next(self) -> Tuple[str, int]:
+        """Generate one (prompt, output_len) pair."""
+        prepared = self._generate(self._reserve_next())
+        self.commit(prepared)
+        return prepared.prompt, prepared.output_len
+
+
+class _PromptPrefetcher:
+    """Bounded, ordered prompt prefetch backed by a small thread pool."""
+
+    def __init__(
+        self,
+        gen: WorkloadGenerator,
+        concurrency_limit: int,
+        total_requests: Optional[int] = None,
+        deadline: Optional[float] = None,
+    ):
+        worker_count = min(4, concurrency_limit, total_requests or concurrency_limit)
+        self._gen = gen
+        self._total_requests = total_requests
+        self._deadline = deadline
+        self._cancel_event = threading.Event()
+        self._loop = asyncio.get_running_loop()
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(worker_count, 1), thread_name_prefix="prompt_gen"
+        )
+        self._queue: asyncio.Queue[asyncio.Future] = asyncio.Queue(
+            maxsize=max(concurrency_limit, 1)
+        )
+        self._native_futures: Set[concurrent.futures.Future] = set()
+        self._native_futures_lock = threading.Lock()
+        self._async_futures: Set[asyncio.Future] = set()
+        self._closed = False
+        self._scheduler_task = asyncio.create_task(self._schedule())
+
+    async def __aenter__(self) -> "_PromptPrefetcher":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def _schedule(self) -> None:
+        scheduled = 0
+        while True:
+            if self._total_requests is not None and scheduled >= self._total_requests:
+                return
+            if self._deadline is not None and time.perf_counter() >= self._deadline:
+                return
+
+            future = self._submit_next()
+            try:
+                await self._queue.put(future)
+            except asyncio.CancelledError:
+                future.cancel()
+                raise
+            scheduled += 1
+
+    def _submit_next(self) -> asyncio.Future:
+        if isinstance(self._gen, WorkloadGenerator):
+            # Reserve request IDs and RNG draws on the event-loop thread so executor
+            # worker start order cannot change a seeded workload's request order.
+            spec = self._gen._reserve_next()
+            native_future = self._executor.submit(
+                self._gen._generate,
+                spec,
+                self._cancel_event,
+                self._deadline,
+            )
+        else:
+            native_future = self._executor.submit(self._generate_generic_prompt)
+
+        with self._native_futures_lock:
+            self._native_futures.add(native_future)
+        native_future.add_done_callback(self._discard_native_future)
+
+        future = asyncio.wrap_future(native_future, loop=self._loop)
+        self._async_futures.add(future)
+        future.add_done_callback(self._discard_async_future)
+        return future
+
+    def _generate_generic_prompt(self) -> _PreparedPrompt:
+        self._check_generation_active()
+        prompt, output_len = self._gen.next()
+        self._check_generation_active()
+        return _PreparedPrompt(None, prompt, output_len)
+
+    def _check_generation_active(self) -> None:
+        if self._cancel_event.is_set():
+            raise _PromptGenerationExpired("prompt generation cancelled")
+        if self._deadline is not None and time.perf_counter() >= self._deadline:
+            raise _PromptGenerationExpired("prompt generation deadline exceeded")
+
+    def _discard_native_future(self, future: concurrent.futures.Future) -> None:
+        with self._native_futures_lock:
+            self._native_futures.discard(future)
+
+    def _discard_async_future(self, future: asyncio.Future) -> None:
+        self._async_futures.discard(future)
+        if not future.cancelled():
+            future.exception()
+
+    async def get(self, timeout: Optional[float] = None) -> _PreparedPrompt:
+        async def _get() -> _PreparedPrompt:
+            future = await self._queue.get()
+            return await future
+
+        if timeout is None:
+            return await _get()
+        return await asyncio.wait_for(_get(), timeout=timeout)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._cancel_event.set()
+        self._scheduler_task.cancel()
+        await asyncio.gather(self._scheduler_task, return_exceptions=True)
+
+        while not self._queue.empty():
+            self._queue.get_nowait()
+        async_futures = list(self._async_futures)
+        for future in async_futures:
+            future.cancel()
+        if async_futures:
+            await asyncio.gather(*async_futures, return_exceptions=True)
+        with self._native_futures_lock:
+            native_futures = list(self._native_futures)
+        for future in native_futures:
+            future.cancel()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+
+# ---------------------------------------------------------------------------
+# OfflineRunner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RequestRecord:
+    submit_time: float
+    finish_time: float
+    response: Dict[str, Any]
+
+
+class _DispatchResult(NamedTuple):
+    records: List[_RequestRecord]
+    cancelled_count: int
+    submitted_count: int
+    first_submit_time: Optional[float]
+    terminal_time: float
+
+
+class OfflineRunner:
+    def __init__(
+        self,
+        port: int,
+        config: OfflineBenchConfig,
+        tokenizer_path: str,
+        checkpoint_path: str = "",
+        model_type: str = "",
+        result_dir: str = ".",
+        seed: int = 42,
+        profile: bool = False,
+        profile_steps: int = 50,
+    ):
+        self._port = port
+        self._config = config
+        self._tokenizer_path = tokenizer_path
+        self._checkpoint_path = checkpoint_path
+        self._model_type = model_type
+        self._result_dir = result_dir
+        self._seed = seed
+        self._profile = profile
+        self._profile_steps = profile_steps
+        self._tokenizer = None
+        self._status_samples: List[Dict[str, Any]] = []
+        self._status_sample_errors: int = 0
+
+    def run(self) -> OfflineMetrics:
+        self._config.validate()
+        self._load_tokenizer()
+
+        dump_file: Optional[TextIO] = None
+        try:
+            if self._config.dump_workload:
+                dump_path = self._config.dump_workload
+                os.makedirs(os.path.dirname(dump_path) or ".", exist_ok=True)
+                dump_file = open(dump_path, "w")
+                logging.info(f"Dumping workload to {dump_path}")
+
+            gen = WorkloadGenerator(
+                self._config,
+                self._tokenizer,
+                seed=self._config.seed,
+                dump_file=dump_file,
+            )
+
+            metrics = self._run(gen)
+        finally:
+            if dump_file is not None:
+                dump_file.close()
+
+        metrics.print_table()
+        metrics.save_json(self._result_dir)
+        self._save_status_samples()
+        metrics.raise_if_all_requests_failed()
+        return metrics
+
+    def _run(self, gen: WorkloadGenerator) -> OfflineMetrics:
+        cfg = self._config
+
+        engine_status = self._query_status()
+        logging.info(f"Engine status before: {engine_status}")
+
+        concurrency_limit = cfg.concurrency_limit
+
+        if cfg.total_requests > 0:
+            logging.info(
+                f"Fixed-workload mode: {cfg.total_requests} requests, "
+                f"concurrency_limit={concurrency_limit}, seed={cfg.seed}, "
+                f"input_len=[{cfg.input_len_min}, {cfg.input_len_max}], "
+                f"output_len=[{cfg.output_len_min}, {cfg.output_len_max}]"
+            )
+        else:
+            logging.info(
+                f"Duration mode: {cfg.duration_s}s, concurrency_limit={concurrency_limit}, "
+                f"input_len=[{cfg.input_len_min}, {cfg.input_len_max}], "
+                f"output_len=[{cfg.output_len_min}, {cfg.output_len_max}], "
+                f"prefix_groups={cfg.prefix_groups}, prefix_len={cfg.prefix_len}"
+            )
+
+        if cfg.total_requests > 0:
+            dispatch_result = asyncio.run(
+                self._dispatch_fixed(
+                    gen, concurrency_limit, cfg.total_requests, cfg.drain_timeout_s
+                )
+            )
+        else:
+            dispatch_result = asyncio.run(
+                self._dispatch(
+                    gen, concurrency_limit, cfg.duration_s, cfg.drain_timeout_s
+                )
+            )
+
+        records = dispatch_result.records
+        cancelled_count = dispatch_result.cancelled_count
+        submitted_count = dispatch_result.submitted_count
+
+        # Include cancelled requests in the throughput window. Their request records do not have a
+        # finish time, so dispatch reports the complete request lifecycle explicitly.
+        if dispatch_result.first_submit_time is not None:
+            wall_time = max(
+                dispatch_result.terminal_time - dispatch_result.first_submit_time, 0.0
+            )
+        else:
+            wall_time = 0.0
+
+        logging.info(
+            f"Finished: {len(records)} completed, {cancelled_count} cancelled, "
+            f"wall_time={wall_time:.1f}s"
+        )
+
+        metrics = self._analyze(
+            records,
+            wall_time,
+            engine_status,
+            submitted_count,
+            cancelled_count,
+        )
+        return metrics
+
+    async def _dispatch(
+        self,
+        gen: WorkloadGenerator,
+        concurrency_limit: int,
+        duration_s: float,
+        drain_timeout_s: int = 0,
+    ) -> _DispatchResult:
+        """Dispatch requests for duration_s, then drain all in-flight.
+
+        If drain_timeout_s > 0, cancel remaining requests after that many
+        seconds and report based on whatever has completed so far.
+
+        Returns completed records, counts, the first actual submit time, and the time when every
+        submitted request has completed or been cancelled.
+        """
+        sem = asyncio.Semaphore(concurrency_limit)
+        records: List[_RequestRecord] = []
+        lock = asyncio.Lock()
+        submitted = 0
+        first_submit_time: Optional[float] = None
+        loop = asyncio.get_running_loop()
+
+        timeout = aiohttp.ClientTimeout(total=3 * 3600)
+        connector = aiohttp.TCPConnector(limit=0)
+        t_start = time.perf_counter()
+        deadline = t_start + duration_s
+        prefetcher = _PromptPrefetcher(gen, concurrency_limit, deadline=deadline)
+        async with prefetcher, aiohttp.ClientSession(
+            timeout=timeout, connector=connector
+        ) as session:
+            pending_tasks: Set[asyncio.Task] = set()
+            profile_futures: Set[asyncio.Future] = set()
+
+            sampler_task = asyncio.create_task(
+                self._status_sampler(
+                    interval=5.0, t_start=t_start, duration=duration_s + 600
+                )
+            )
+
+            while time.perf_counter() < deadline:
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    break
+                try:
+                    prepared = await prefetcher.get(timeout=remaining)
+                except (asyncio.TimeoutError, _PromptGenerationExpired):
+                    break
+
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    break
+                try:
+                    await asyncio.wait_for(sem.acquire(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    break
+
+                if isinstance(gen, WorkloadGenerator):
+                    gen.commit(prepared)
+                submit_time = time.perf_counter()
+                if first_submit_time is None:
+                    first_submit_time = submit_time
+                submitted += 1
+
+                task = asyncio.create_task(
+                    self._send_and_release(
+                        session,
+                        sem,
+                        prepared.prompt,
+                        prepared.output_len,
+                        submit_time,
+                        records,
+                        lock,
+                    )
+                )
+                pending_tasks.add(task)
+                task.add_done_callback(pending_tasks.discard)
+
+                if self._profile and submitted == concurrency_limit:
+                    self._schedule_profile_trigger(loop, profile_futures)
+
+                if submitted % 100 == 0:
+                    elapsed = time.perf_counter() - t_start
+                    inflight = len(pending_tasks)
+                    logging.info(
+                        f"Submitted {submitted}, elapsed={elapsed:.1f}s/{duration_s:.0f}s, "
+                        f"inflight={inflight}/{concurrency_limit}"
+                    )
+
+            drain_count = len(pending_tasks)
+            drain_deadline_desc = (
+                f"{drain_timeout_s}s" if drain_timeout_s > 0 else "unlimited"
+            )
+            logging.info(
+                f"Dispatch done: {submitted} submitted. "
+                f"Draining {drain_count} in-flight requests "
+                f"(timeout={drain_deadline_desc})..."
+            )
+
+            cancelled_count = await self._drain_pending(pending_tasks, drain_timeout_s)
+            terminal_time = time.perf_counter()
+
+            sampler_task.cancel()
+            try:
+                await sampler_task
+            except asyncio.CancelledError:
+                pass
+
+        if cancelled_count > 0:
+            logging.info(
+                f"Drain finished: {len(records)} completed, "
+                f"{cancelled_count} cancelled"
+            )
+        else:
+            logging.info(f"All requests drained. Total records: {len(records)}")
+        return _DispatchResult(
+            records, cancelled_count, submitted, first_submit_time, terminal_time
+        )
+
+    async def _drain_pending(
+        self, pending_tasks: Set[asyncio.Task], drain_timeout_s: int
+    ) -> int:
+        cancelled_count = 0
+        if pending_tasks:
+            remaining = set(pending_tasks)
+            drain_start = time.perf_counter()
+            drain_deadline = (
+                drain_start + drain_timeout_s if drain_timeout_s > 0 else float("inf")
+            )
+            last_log_time = drain_start
+            while remaining:
+                wait_timeout = 10.0
+                if drain_timeout_s > 0:
+                    time_left = drain_deadline - time.perf_counter()
+                    if time_left <= 0:
+                        break
+                    wait_timeout = min(wait_timeout, time_left)
+                _, remaining = await asyncio.wait(
+                    remaining, timeout=wait_timeout, return_when=asyncio.FIRST_COMPLETED
+                )
+                now = time.perf_counter()
+                if now - last_log_time >= 10.0 or not remaining:
+                    elapsed_drain = now - drain_start
+                    logging.info(
+                        f"Draining: {len(remaining)} requests remaining, "
+                        f"drain elapsed={elapsed_drain:.1f}s"
+                    )
+                    last_log_time = now
+
+            if remaining:
+                cancelled_count = len(remaining)
+                logging.warning(
+                    f"Drain timeout ({drain_timeout_s}s) reached, "
+                    f"cancelling {cancelled_count} in-flight requests"
+                )
+                for task in remaining:
+                    task.cancel()
+                await asyncio.gather(*remaining, return_exceptions=True)
+        return cancelled_count
+
+    async def _dispatch_fixed(
+        self,
+        gen: WorkloadGenerator,
+        concurrency_limit: int,
+        total_requests: int,
+        drain_timeout_s: int = 0,
+    ) -> _DispatchResult:
+        """Submit exactly total_requests, then drain all in-flight.
+
+        Returns completed records, counts, the first actual submit time, and the time when every
+        submitted request has completed or been cancelled.
+        """
+        sem = asyncio.Semaphore(concurrency_limit)
+        records: List[_RequestRecord] = []
+        lock = asyncio.Lock()
+        submitted = 0
+        first_submit_time: Optional[float] = None
+        loop = asyncio.get_running_loop()
+
+        timeout = aiohttp.ClientTimeout(total=3 * 3600)
+        connector = aiohttp.TCPConnector(limit=0)
+        t_start = time.perf_counter()
+        prefetcher = _PromptPrefetcher(
+            gen, concurrency_limit, total_requests=total_requests
+        )
+        async with prefetcher, aiohttp.ClientSession(
+            timeout=timeout, connector=connector
+        ) as session:
+            pending_tasks: Set[asyncio.Task] = set()
+            profile_futures: Set[asyncio.Future] = set()
+
+            sampler_task = asyncio.create_task(
+                self._status_sampler(interval=5.0, t_start=t_start, duration=3 * 3600)
+            )
+
+            while submitted < total_requests:
+                prepared = await prefetcher.get()
+
+                # drain_timeout starts only after the fixed workload has been fully submitted.
+                await sem.acquire()
+                if isinstance(gen, WorkloadGenerator):
+                    gen.commit(prepared)
+                submit_time = time.perf_counter()
+                if first_submit_time is None:
+                    first_submit_time = submit_time
+                submitted += 1
+
+                task = asyncio.create_task(
+                    self._send_and_release(
+                        session,
+                        sem,
+                        prepared.prompt,
+                        prepared.output_len,
+                        submit_time,
+                        records,
+                        lock,
+                    )
+                )
+                pending_tasks.add(task)
+                task.add_done_callback(pending_tasks.discard)
+
+                if self._profile and submitted == concurrency_limit:
+                    self._schedule_profile_trigger(loop, profile_futures)
+
+                if submitted % 100 == 0:
+                    elapsed = time.perf_counter() - t_start
+                    inflight = len(pending_tasks)
+                    logging.info(
+                        f"Submitted {submitted}/{total_requests}, elapsed={elapsed:.1f}s, "
+                        f"inflight={inflight}/{concurrency_limit}"
+                    )
+
+            logging.info(
+                f"Submission complete: {submitted}/{total_requests} requests submitted. "
+                f"Draining in-flight requests..."
+            )
+
+            cancelled_count = await self._drain_pending(pending_tasks, drain_timeout_s)
+            terminal_time = time.perf_counter()
+
+            sampler_task.cancel()
+            try:
+                await sampler_task
+            except asyncio.CancelledError:
+                pass
+
+        if cancelled_count > 0:
+            logging.info(
+                f"Fixed-workload done: {len(records)} completed, "
+                f"{cancelled_count} cancelled"
+            )
+        else:
+            logging.info(f"Fixed-workload done: all {len(records)} completed")
+        return _DispatchResult(
+            records, cancelled_count, submitted, first_submit_time, terminal_time
+        )
+
+    def _schedule_profile_trigger(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        profile_futures: Set[asyncio.Future],
+    ) -> None:
+        future = loop.run_in_executor(None, self._trigger_profile)
+        profile_futures.add(future)
+
+        def _cleanup(done: asyncio.Future) -> None:
+            profile_futures.discard(done)
+            try:
+                done.result()
+            except Exception as e:
+                logging.warning(f"Profile trigger executor failed: {e}")
+
+        future.add_done_callback(_cleanup)
+
+    def _trigger_profile(self) -> None:
+        try:
+            resp = requests.post(
+                f"http://127.0.0.1:{self._port}/start_profile",
+                json={
+                    "trace_name": "offline_bench",
+                    "start_step": 0,
+                    "num_steps": self._profile_steps,
+                },
+                timeout=60,
+            )
+            logging.info(
+                f"Profile triggered: num_steps={self._profile_steps}, response={resp.status_code}"
+            )
+        except Exception as e:
+            logging.warning(f"Failed to trigger profile: {e}")
+
+    async def _send_and_release(
+        self,
+        session: aiohttp.ClientSession,
+        sem: asyncio.Semaphore,
+        prompt: str,
+        output_len: int,
+        submit_time: float,
+        records: List[_RequestRecord],
+        lock: asyncio.Lock,
+    ) -> None:
+        try:
+            resp = await self._send_one(session, prompt, output_len)
+            finish_time = time.perf_counter()
+            async with lock:
+                records.append(
+                    _RequestRecord(
+                        submit_time=submit_time, finish_time=finish_time, response=resp
+                    )
+                )
+        finally:
+            sem.release()
+
+    # ---- status sampling ----
+
+    async def _status_sampler(
+        self, interval: float, t_start: float, duration: float
+    ) -> None:
+        deadline = t_start + duration
+        while time.perf_counter() < deadline:
+            try:
+                status = await asyncio.get_running_loop().run_in_executor(
+                    None, self._query_status
+                )
+                status["timestamp"] = time.time()
+                status["elapsed_s"] = time.perf_counter() - t_start
+                total_kv = status.get("total_kv_cache", 0)
+                avail_kv = status.get("available_kv_cache", 0)
+                conc_limit = status.get("concurrency_limit", 0)
+                avail_conc = status.get("available_concurrency", 0)
+                if total_kv > 0:
+                    status["kv_utilization"] = 1.0 - avail_kv / total_kv
+                if conc_limit > 0:
+                    status["concurrency_utilization"] = 1.0 - avail_conc / conc_limit
+                self._status_samples.append(status)
+            except Exception as e:
+                self._status_sample_errors += 1
+                if self._status_sample_errors <= 3:
+                    logging.warning(
+                        f"Status sample failed ({self._status_sample_errors}): {e}"
+                    )
+            await asyncio.sleep(interval)
+
+    def _save_status_samples(self) -> None:
+        if not self._status_samples:
+            return
+        path = os.path.join(self._result_dir, "status_samples.jsonl")
+        with open(path, "w") as f:
+            for s in self._status_samples:
+                f.write(json.dumps(s) + "\n")
+        logging.info(f"Saved {len(self._status_samples)} status samples to {path}")
+
+    # ---- shared HTTP request ----
+
+    async def _send_one(
+        self, session: aiohttp.ClientSession, prompt: str, output_len: int
+    ) -> Dict[str, Any]:
+        generate_config: Dict[str, Any] = {
+            "max_new_tokens": output_len,
+            "min_new_tokens": output_len,
+            "top_k": 1,
+        }
+        if self._config.num_return_sequences > 1:
+            generate_config.update(
+                {
+                    "num_beams": 1,
+                    "num_return_sequences": self._config.num_return_sequences,
+                    "do_sample": True,
+                }
+            )
+        pload = {
+            "prompt": prompt,
+            "generate_config": generate_config,
+            "aux_info": True,
+        }
+        try:
+            async with session.post(
+                f"http://127.0.0.1:{self._port}", json=pload
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    # ---- engine status ----
+
+    def _query_status(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        try:
+            cache = requests.get(
+                f"http://127.0.0.1:{self._port}/cache_status", timeout=60
+            ).json()
+            worker = requests.get(
+                f"http://127.0.0.1:{self._port}/worker_status", timeout=60
+            ).json()
+
+            cache_results = cache.get("results") or [cache]
+            if cache_results:
+                per_dp_kv_cache = []
+                for dp_id, shard in enumerate(cache_results):
+                    total_kv = int(shard.get("total_kv_cache", 0))
+                    available_kv = int(shard.get("available_kv_cache", 0))
+                    block_size = max(int(shard.get("block_size", 1)), 1)
+                    utilization = 1.0 - available_kv / total_kv if total_kv > 0 else 0.0
+                    per_dp_kv_cache.append(
+                        {
+                            "dp_id": dp_id,
+                            "total_kv_cache": total_kv,
+                            "available_kv_cache": available_kv,
+                            "block_size": block_size,
+                            "utilization": utilization,
+                        }
+                    )
+
+                result["per_dp_kv_cache"] = per_dp_kv_cache
+                result["total_kv_cache"] = sum(
+                    s["total_kv_cache"] for s in per_dp_kv_cache
+                )
+                result["available_kv_cache"] = sum(
+                    s["available_kv_cache"] for s in per_dp_kv_cache
+                )
+                result["total_kv_cache_blocks"] = sum(
+                    s["total_kv_cache"] // s["block_size"] for s in per_dp_kv_cache
+                )
+                result["kv_cache_max_dp_utilization"] = max(
+                    s["utilization"] for s in per_dp_kv_cache
+                )
+                block_sizes = {s["block_size"] for s in per_dp_kv_cache}
+                result["block_size"] = (
+                    next(iter(block_sizes)) if len(block_sizes) == 1 else 0
+                )
+
+            result["concurrency_limit"] = int(
+                worker.get("frontend_concurrency_limit", 0)
+            )
+            result["available_concurrency"] = int(
+                worker.get("frontend_available_concurrency", 0)
+            )
+
+            task_list = worker.get("running_task_info", [])
+            result["running_streams"] = sum(
+                1 for t in task_list if not t.get("is_waiting", False)
+            )
+            result["waiting_streams"] = sum(
+                1 for t in task_list if t.get("is_waiting", False)
+            )
+        except Exception as e:
+            logging.warning(f"Failed to query engine status: {e}")
+        return result
+
+    # ---- tokenizer ----
+
+    def _load_tokenizer(self):
+        from rtp_llm.test.perf_test.test_util import _load_tokenizer
+
+        self._tokenizer = _load_tokenizer(
+            self._tokenizer_path,
+            checkpoint_path=self._checkpoint_path,
+            model_type=self._model_type,
+        )
+
+    # ---- analysis ----
+
+    def _analyze(
+        self,
+        records: List[_RequestRecord],
+        wall_time: float,
+        engine_status: Dict[str, Any],
+        submitted_count: int,
+        cancelled_count: int,
+    ) -> OfflineMetrics:
+        metrics = OfflineMetrics()
+        metrics.total_wall_time_s = wall_time
+        metrics.total_submitted = submitted_count
+        metrics.cancelled_requests = cancelled_count
+
+        responses = [r.response for r in records]
+
+        success_aux: List[Dict[str, Any]] = []
+        success_sequence_aux: List[Dict[str, Any]] = []
+        fail_reasons: Dict[str, int] = {}
+        for resp in responses:
+            if isinstance(resp, Exception):
+                reason = f"exception:{type(resp).__name__}"
+                fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+                continue
+            if (
+                isinstance(resp, dict)
+                and "error" not in resp
+                and "error_code" not in resp
+            ):
+                raw_aux = resp.get("aux_info", {})
+                aux_list = raw_aux if isinstance(raw_aux, list) else [raw_aux]
+                aux_list = [aux for aux in aux_list if isinstance(aux, dict) and aux]
+                if len(aux_list) != self._config.num_return_sequences:
+                    reason = (
+                        "aux_info_count_mismatch: "
+                        f"expected={self._config.num_return_sequences}, actual={len(aux_list)}"
+                    )
+                    fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+                    continue
+
+                # Request-level input is counted once, while every returned sequence
+                # contributes generated tokens. This keeps TPS correct for n>1 without
+                # multiplying the shared prompt tokens.
+                request_aux = dict(aux_list[0])
+                request_aux["output_len"] = sum(
+                    aux.get("output_len", 0) for aux in aux_list
+                )
+                for field in (
+                    "cost_time",
+                    "wait_time",
+                    "first_token_cost_time",
+                    "first_token_cost_time_us",
+                ):
+                    request_aux[field] = max(
+                        (aux.get(field, 0) for aux in aux_list), default=0
+                    )
+                success_aux.append(request_aux)
+                success_sequence_aux.extend(aux_list)
+            else:
+                error_code = (
+                    resp.get("error_code", "unknown")
+                    if isinstance(resp, dict)
+                    else "unknown"
+                )
+                error_msg = (
+                    (
+                        resp.get("message")
+                        or resp.get("error_message")
+                        or resp.get("error")
+                        or ""
+                    )
+                    if isinstance(resp, dict)
+                    else str(resp)
+                )
+                reason = f"error_code={error_code}: {str(error_msg)[:120]}"
+                fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+
+        metrics.success_requests = len(success_aux)
+        metrics.fail_requests = max(
+            submitted_count - metrics.success_requests - cancelled_count, 0
+        )
+        if cancelled_count > 0:
+            if self._config.drain_timeout_s > 0:
+                reason = f"cancelled: drain_timeout={self._config.drain_timeout_s}s"
+            else:
+                reason = "cancelled"
+            fail_reasons[reason] = fail_reasons.get(reason, 0) + cancelled_count
+
+        if fail_reasons:
+            print(f"\n--- Failed Requests ({metrics.fail_requests} total) ---")
+            for reason, count in sorted(fail_reasons.items(), key=lambda x: -x[1]):
+                print(f"  [{count:4d}] {reason}")
+
+        if not success_aux:
+            return metrics
+
+        input_lens = [a.get("input_len", 0) for a in success_aux]
+        output_lens = [a.get("output_len", 0) for a in success_aux]
+        cost_times = [a.get("cost_time", 0.0) for a in success_aux]
+        wait_times = [a.get("wait_time", 0.0) for a in success_aux]
+        reuse_lens = [a.get("reuse_len", 0) for a in success_aux]
+
+        total_input = sum(input_lens)
+        total_output = sum(output_lens)
+
+        metrics.output_tps = total_output / wall_time if wall_time > 0 else 0
+        metrics.input_tps = total_input / wall_time if wall_time > 0 else 0
+        metrics.total_tps = (
+            (total_input + total_output) / wall_time if wall_time > 0 else 0
+        )
+
+        latencies_s = [t / 1000.0 for t in cost_times]
+        latencies_s.sort()
+        n = len(latencies_s)
+        metrics.avg_request_latency_s = sum(latencies_s) / n
+        metrics.p50_request_latency_s = latencies_s[n // 2]
+        metrics.p99_request_latency_s = latencies_s[min(int(n * 0.99), n - 1)]
+
+        metrics.avg_wait_time_ms = sum(wait_times) / n
+        metrics.max_wait_time_ms = max(wait_times)
+
+        first_token_times = [
+            a.get(
+                "first_token_cost_time", a.get("first_token_cost_time_us", 0) / 1000.0
+            )
+            for a in success_aux
+        ]
+        ttft_ms_list = [t for t in first_token_times if t > 0]
+        if ttft_ms_list:
+            ttft_ms_list.sort()
+            nt = len(ttft_ms_list)
+            metrics.avg_ttft_ms = sum(ttft_ms_list) / nt
+            metrics.p50_ttft_ms = ttft_ms_list[nt // 2]
+            metrics.p99_ttft_ms = ttft_ms_list[min(int(nt * 0.99), nt - 1)]
+
+        tpot_ms_list = []
+        for a in success_sequence_aux:
+            ct = a.get("cost_time", 0.0)
+            ft = a.get(
+                "first_token_cost_time", a.get("first_token_cost_time_us", 0) / 1000.0
+            )
+            ol = a.get("output_len", 0)
+            if ol > 1 and ct > ft:
+                tpot_ms_list.append((ct - ft) / (ol - 1))
+        if tpot_ms_list:
+            tpot_ms_list.sort()
+            nt = len(tpot_ms_list)
+            metrics.avg_tpot_ms = sum(tpot_ms_list) / nt
+            metrics.p50_tpot_ms = tpot_ms_list[nt // 2]
+            metrics.p99_tpot_ms = tpot_ms_list[min(int(nt * 0.99), nt - 1)]
+
+        metrics.avg_input_len = total_input / n
+        metrics.avg_output_len = total_output / n
+        metrics.input_len_range = (min(input_lens), max(input_lens))
+        metrics.output_len_range = (min(output_lens), max(output_lens))
+
+        metrics.total_reuse_tokens = sum(reuse_lens)
+        metrics.total_compute_tokens = sum(
+            il - rl for il, rl in zip(input_lens, reuse_lens)
+        )
+        metrics.avg_reuse_len = metrics.total_reuse_tokens / n
+        metrics.avg_reuse_ratio = (
+            metrics.avg_reuse_len / metrics.avg_input_len
+            if metrics.avg_input_len > 0
+            else 0
+        )
+
+        # /cache_status reports total_kv_cache in tokens. Convert to blocks only
+        # for the block-count field; keeping both fields makes the units explicit.
+        metrics.kv_cache_total_tokens = int(engine_status.get("total_kv_cache", 0))
+        metrics.kv_cache_block_size = max(int(engine_status.get("block_size", 1)), 1)
+        metrics.kv_cache_total_blocks = int(
+            engine_status.get(
+                "total_kv_cache_blocks",
+                metrics.kv_cache_total_tokens // metrics.kv_cache_block_size,
+            )
+        )
+        if self._status_samples:
+            kv_utils = [
+                s["kv_utilization"]
+                for s in self._status_samples
+                if "kv_utilization" in s
+            ]
+            dp_kv_utils = [
+                s["kv_cache_max_dp_utilization"]
+                for s in self._status_samples
+                if "kv_cache_max_dp_utilization" in s
+            ]
+            conc_utils = [
+                s["concurrency_utilization"]
+                for s in self._status_samples
+                if "concurrency_utilization" in s
+            ]
+            if kv_utils:
+                metrics.kv_cache_avg_utilization = sum(kv_utils) / len(kv_utils)
+                metrics.kv_cache_max_utilization = max(kv_utils)
+                metrics.kv_cache_min_utilization = min(kv_utils)
+            if dp_kv_utils:
+                metrics.kv_cache_max_dp_utilization = max(dp_kv_utils)
+            if conc_utils:
+                metrics.concurrency_avg_utilization = sum(conc_utils) / len(conc_utils)
+                metrics.concurrency_max_utilization = max(conc_utils)
+
+        return metrics

--- a/rtp_llm/test/perf_test/server.py
+++ b/rtp_llm/test/perf_test/server.py
@@ -15,18 +15,27 @@ class EngineServer:
         self._remaining_args = remaining_args
         self._server: Optional[MagaServerManager] = None
 
-    def start(self, max_seq_len: int, max_concurrency: int) -> None:
+    def start(
+        self,
+        max_seq_len: int,
+        max_concurrency: int,
+        server_start_timeout: int = 1600,
+        use_batch_decode_scheduler: Optional[bool] = True,
+    ) -> None:
         """Assemble CLI args and start MagaServerManager."""
         engine_cli = self._build_engine_cli(max_seq_len, max_concurrency)
 
         env: Dict[str, str] = {
-            "USE_BATCH_DECODE_SCHEDULER": "1",
             "FAKE_BALANCE_EXPERT": "1",
             "BATCH_DECODE_SCHEDULER_WARMUP_TYPE": (
                 "0" if self._args.partial in (0, 1) else "1"
             ),
             "TORCH_CUDA_PROFILER_DIR": self._args.result_dir,
         }
+        if use_batch_decode_scheduler is not None:
+            env["USE_BATCH_DECODE_SCHEDULER"] = (
+                "1" if use_batch_decode_scheduler else "0"
+            )
 
         logging.info(f"Starting server with engine CLI: {engine_cli}")
         logging.info(f"remaining_args (raw list): {self._remaining_args}")
@@ -35,15 +44,21 @@ class EngineServer:
             process_file_name="process.log",
             smoke_args_str=engine_cli,
         )
-        if not self._server.start_server():
-            self._server.print_process_log()
-            raise RuntimeError(
-                "Engine server failed to start. Check process.log above for details."
-            )
+        try:
+            if not self._server.start_server(timeout=server_start_timeout):
+                self._server.print_process_log()
+                raise RuntimeError(
+                    "Engine server failed to start. Check process.log above for details."
+                )
+        except Exception:
+            self.stop()
+            raise
 
     def stop(self) -> None:
-        if self._server is not None:
-            self._server.stop_server()
+        server = self._server
+        self._server = None
+        if server is not None:
+            server.stop_server()
 
     @property
     def port(self) -> int:

--- a/rtp_llm/test/perf_test/test_perf_config_and_runners.py
+++ b/rtp_llm/test/perf_test/test_perf_config_and_runners.py
@@ -8,7 +8,10 @@ Tests:
 """
 
 import argparse
+import asyncio
+import os
 import sys
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -363,6 +366,1330 @@ class TestTpsBsCandidates(unittest.TestCase):
     def test_max_bs_4(self):
         candidates = TpsBinarySearchRunner._make_bs_candidates(4)
         self.assertEqual(candidates, [1, 4])
+
+
+class TestOfflineBenchConfig(unittest.TestCase):
+    """Lightweight tests for OfflineBenchConfig.validate."""
+
+    def test_validate_ok(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        config = OfflineBenchConfig(
+            input_len_min=128,
+            input_len_max=512,
+            output_len_min=32,
+            output_len_max=128,
+            concurrency_limit=1,
+        )
+        config.validate()
+
+    def test_validate_requires_concurrency_limit(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        with self.assertRaisesRegex(ValueError, "concurrency_limit must be > 0"):
+            OfflineBenchConfig().validate()
+
+    def test_validate_input_len_inverted(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        config = OfflineBenchConfig(input_len_min=512, input_len_max=128)
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_output_len_zero(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        config = OfflineBenchConfig(output_len_min=0)
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_prefix_len_exceeds_input(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        config = OfflineBenchConfig(input_len_min=64, prefix_len=128)
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_num_return_sequences(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineBenchConfig
+
+        with self.assertRaisesRegex(
+            ValueError, "num_return_sequences must be >= 1"
+        ):
+            OfflineBenchConfig(num_return_sequences=0).validate()
+
+
+class TestOfflineFailurePolicy(unittest.TestCase):
+    def test_rejects_zero_submitted_requests(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineMetrics
+
+        with self.assertRaisesRegex(RuntimeError, "no requests were submitted"):
+            OfflineMetrics().raise_if_all_requests_failed()
+
+    def test_rejects_zero_successful_requests(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineMetrics
+
+        metrics = OfflineMetrics(
+            total_submitted=2, success_requests=0, fail_requests=2
+        )
+        with self.assertRaisesRegex(RuntimeError, "no requests succeeded"):
+            metrics.raise_if_all_requests_failed()
+
+    def test_accepts_partial_failures(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineMetrics
+
+        metrics = OfflineMetrics(
+            total_submitted=10,
+            success_requests=7,
+            fail_requests=2,
+            cancelled_requests=1,
+        )
+        metrics.raise_if_all_requests_failed()
+
+
+class TestWorkloadGenerator(unittest.TestCase):
+    """Test WorkloadGenerator prompt generation with a fake tokenizer."""
+
+    def _make_fake_tokenizer(self):
+        tok = MagicMock()
+        tok.encode = lambda text: list(range(len(text.split())))
+        tok.decode = lambda ids: " ".join(str(i) for i in ids)
+        return tok
+
+    def test_basic_generation(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        tokenizer = self._make_fake_tokenizer()
+        config = OfflineBenchConfig(
+            input_len_min=6,
+            input_len_max=6,
+            output_len_min=2,
+            output_len_max=4,
+            prefix_len=0,
+        )
+        gen = WorkloadGenerator(config, tokenizer, seed=0)
+        prompt, out_len = gen.next()
+        self.assertIsInstance(prompt, str)
+        self.assertEqual(len(tokenizer.encode(prompt)), 6)
+        self.assertGreaterEqual(out_len, 2)
+        self.assertLessEqual(out_len, 4)
+
+    def test_prefix_groups_have_different_prefixes(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        config = OfflineBenchConfig(
+            input_len_min=16,
+            input_len_max=32,
+            output_len_min=2,
+            output_len_max=4,
+            prefix_groups=3,
+            prefix_len=4,
+        )
+        gen = WorkloadGenerator(config, self._make_fake_tokenizer(), seed=0)
+        prefixes = [g.prefix_text for g in gen._groups]
+        self.assertEqual(len(prefixes), 3)
+        self.assertEqual(len(set(prefixes)), 3)
+
+    def test_unrepresentable_exact_length_fails(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        tok = MagicMock()
+        tok.encode = lambda text: [0, 1, 2]
+        tok.decode = lambda ids: " ".join(str(i) for i in ids)
+        config = OfflineBenchConfig(
+            input_len_min=5,
+            input_len_max=8,
+            output_len_min=1,
+            output_len_max=1,
+            prefix_groups=4,
+            prefix_len=5,
+        )
+        with patch.object(WorkloadGenerator, "_MAX_TOKEN_REPAIR_ATTEMPTS", 2):
+            with self.assertRaisesRegex(ValueError, "exact tokenizer-validated"):
+                WorkloadGenerator(config, tok, seed=0)
+
+    def test_long_prompt_generation_does_not_resize_token_buffer(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        tok = self._make_fake_tokenizer()
+        config = OfflineBenchConfig(
+            input_len_min=20, input_len_max=20, output_len_min=1, output_len_max=1
+        )
+        gen = WorkloadGenerator(config, tok, seed=0)
+        initial_len = len(gen._big_tokens)
+
+        for _ in range(5):
+            prompt, output_len = gen.next()
+            self.assertEqual(output_len, 1)
+            self.assertTrue(prompt)
+            self.assertEqual(len(tok.encode(prompt)), 20)
+            self.assertEqual(len(gen._big_tokens), initial_len)
+
+    def test_group_requests_share_exact_token_prefix(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        tokenizer = self._make_fake_tokenizer()
+        config = OfflineBenchConfig(
+            input_len_min=12,
+            input_len_max=12,
+            output_len_min=1,
+            output_len_max=1,
+            prefix_groups=3,
+            prefix_len=4,
+        )
+        gen = WorkloadGenerator(config, tokenizer, seed=0)
+
+        for request_id in range(9):
+            prompt, _ = gen.next()
+            token_ids = tokenizer.encode(prompt)
+            group = gen._groups[request_id % config.prefix_groups]
+            self.assertEqual(len(token_ids), config.input_len_min)
+            self.assertEqual(
+                tuple(token_ids[: config.prefix_len]),
+                group.prefix_token_ids,
+            )
+
+    def test_boundary_retokenization_is_repaired(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        class BoundaryMergingTokenizer:
+            def __init__(self):
+                self.boundary_merge_count = 0
+
+            def encode(self, text):
+                result = []
+                index = 0
+                while index < len(text):
+                    if text[index : index + 2] == "xy":
+                        result.append(1000)
+                        self.boundary_merge_count += 1
+                        index += 2
+                    else:
+                        result.append(ord(text[index]))
+                        index += 1
+                return result
+
+            def decode(self, token_ids):
+                decoded = []
+                for token_id in token_ids:
+                    if token_id == ord("T"):
+                        decoded.append("x")
+                    elif token_id == ord("h"):
+                        decoded.append("y")
+                    elif token_id == 1000:
+                        decoded.append("xy")
+                    else:
+                        decoded.append(chr(token_id))
+                return "".join(decoded)
+
+        tokenizer = BoundaryMergingTokenizer()
+        config = OfflineBenchConfig(
+            input_len_min=6,
+            input_len_max=6,
+            output_len_min=1,
+            output_len_max=1,
+            prefix_len=1,
+        )
+        gen = WorkloadGenerator(config, tokenizer, seed=0)
+        prompt, _ = gen.next()
+        token_ids = tokenizer.encode(prompt)
+
+        self.assertGreater(tokenizer.boundary_merge_count, 0)
+        self.assertEqual(len(token_ids), 6)
+        self.assertEqual(tuple(token_ids[:1]), gen._groups[0].prefix_token_ids)
+
+    def test_qwen2_tokenizer_prompts_have_exact_length_and_prefix(self):
+        from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            WorkloadGenerator,
+        )
+
+        tokenizer = Qwen2Tokenizer.from_pretrained(
+            "rtp_llm/test/tokenizer_test/testdata/qwen2_tokenizer"
+        )
+        config = OfflineBenchConfig(
+            input_len_min=32,
+            input_len_max=32,
+            output_len_min=1,
+            output_len_max=1,
+            prefix_groups=2,
+            prefix_len=8,
+        )
+        gen = WorkloadGenerator(config, tokenizer, seed=0)
+
+        for request_id in range(6):
+            prompt, _ = gen.next()
+            token_ids = tokenizer.encode(prompt)
+            group = gen._groups[request_id % config.prefix_groups]
+            self.assertEqual(len(token_ids), 32)
+            self.assertEqual(tuple(token_ids[:8]), group.prefix_token_ids)
+
+
+class TestOfflineAnalyze(unittest.TestCase):
+    """Test OfflineRunner._analyze with synthetic records."""
+
+    def test_analyze_basic(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            _RequestRecord,
+        )
+
+        config = OfflineBenchConfig(
+            input_len_min=4, input_len_max=8, output_len_min=2, output_len_max=4
+        )
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._config = config
+        runner._result_dir = "/tmp"
+        total_kv_tokens = 2_247_680
+        available_kv_tokens = 2_231_296
+        expected_kv_utilization = 1.0 - available_kv_tokens / total_kv_tokens
+        runner._status_samples = [
+            {
+                "kv_utilization": expected_kv_utilization,
+                "kv_cache_max_dp_utilization": expected_kv_utilization,
+            }
+        ]
+
+        records = [
+            _RequestRecord(
+                submit_time=0.0,
+                finish_time=1.0,
+                response={
+                    "aux_info": [
+                        {
+                            "input_len": 100,
+                            "output_len": 50,
+                            "cost_time": 500.0,
+                            "wait_time": 10.0,
+                            "first_token_cost_time": 100.0,
+                        }
+                    ]
+                },
+            ),
+            _RequestRecord(
+                submit_time=0.5,
+                finish_time=1.5,
+                response={
+                    "aux_info": [
+                        {
+                            "input_len": 200,
+                            "output_len": 80,
+                            "cost_time": 800.0,
+                            "wait_time": 20.0,
+                            "first_token_cost_time": 150.0,
+                        }
+                    ]
+                },
+            ),
+        ]
+
+        metrics = runner._analyze(
+            records,
+            wall_time=2.0,
+            engine_status={
+                "total_kv_cache": total_kv_tokens,
+                "available_kv_cache": available_kv_tokens,
+                "block_size": 1024,
+            },
+            submitted_count=2,
+            cancelled_count=0,
+        )
+        self.assertEqual(metrics.success_requests, 2)
+        self.assertEqual(metrics.fail_requests, 0)
+        self.assertAlmostEqual(metrics.output_tps, (50 + 80) / 2.0)
+        self.assertAlmostEqual(metrics.input_tps, (100 + 200) / 2.0)
+        self.assertEqual(metrics.kv_cache_total_tokens, total_kv_tokens)
+        self.assertEqual(metrics.kv_cache_total_blocks, 2_195)
+        self.assertEqual(metrics.kv_cache_block_size, 1024)
+        self.assertAlmostEqual(
+            metrics.kv_cache_avg_utilization, expected_kv_utilization
+        )
+        self.assertAlmostEqual(
+            metrics.kv_cache_max_dp_utilization, expected_kv_utilization
+        )
+
+    def test_analyze_multi_return_counts_input_once(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            _RequestRecord,
+        )
+
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._config = OfflineBenchConfig(num_return_sequences=2)
+        runner._status_samples = []
+        records = [
+            _RequestRecord(
+                submit_time=0.0,
+                finish_time=2.0,
+                response={
+                    "aux_info": [
+                        {
+                            "input_len": 100,
+                            "output_len": 50,
+                            "cost_time": 500.0,
+                            "wait_time": 10.0,
+                            "first_token_cost_time": 100.0,
+                        },
+                        {
+                            "input_len": 100,
+                            "output_len": 60,
+                            "cost_time": 600.0,
+                            "wait_time": 20.0,
+                            "first_token_cost_time": 120.0,
+                        },
+                    ]
+                },
+            )
+        ]
+
+        metrics = runner._analyze(
+            records,
+            wall_time=2.0,
+            engine_status={},
+            submitted_count=1,
+            cancelled_count=0,
+        )
+
+        self.assertEqual(metrics.success_requests, 1)
+        self.assertEqual(metrics.fail_requests, 0)
+        self.assertAlmostEqual(metrics.input_tps, 100 / 2.0)
+        self.assertAlmostEqual(metrics.output_tps, (50 + 60) / 2.0)
+        self.assertEqual(metrics.avg_input_len, 100)
+        self.assertEqual(metrics.avg_output_len, 110)
+        self.assertAlmostEqual(
+            metrics.avg_tpot_ms,
+            ((500.0 - 100.0) / 49 + (600.0 - 120.0) / 59) / 2,
+        )
+
+    def test_query_status_preserves_cache_status_token_units(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineRunner
+
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._port = 12345
+        cache_response = MagicMock()
+        cache_response.json.return_value = {
+            "total_kv_cache": "2247680",
+            "available_kv_cache": "2231296",
+            "block_size": "1024",
+            "results": [
+                {
+                    "total_kv_cache": "2247680",
+                    "available_kv_cache": "2231296",
+                    "block_size": "1024",
+                }
+            ],
+        }
+        worker_response = MagicMock()
+        worker_response.json.return_value = {
+            "frontend_concurrency_limit": 4,
+            "frontend_available_concurrency": 3,
+            "running_task_info": [],
+        }
+
+        with patch(
+            "rtp_llm.test.perf_test.offline_runner.requests.get",
+            side_effect=[cache_response, worker_response],
+        ):
+            status = runner._query_status()
+
+        self.assertEqual(status["total_kv_cache"], 2_247_680)
+        self.assertEqual(status["available_kv_cache"], 2_231_296)
+        self.assertEqual(status["block_size"], 1024)
+        self.assertEqual(len(status["per_dp_kv_cache"]), 1)
+
+    def test_query_status_aggregates_all_dp_cache_shards(self):
+        from rtp_llm.test.perf_test.offline_runner import OfflineRunner
+
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._port = 12345
+        cache_response = MagicMock()
+        cache_response.json.return_value = {
+            "results": [
+                {
+                    "total_kv_cache": "100",
+                    "available_kv_cache": "20",
+                    "block_size": "10",
+                },
+                {
+                    "total_kv_cache": "300",
+                    "available_kv_cache": "240",
+                    "block_size": "10",
+                },
+            ],
+        }
+        worker_response = MagicMock()
+        worker_response.json.return_value = {
+            "frontend_concurrency_limit": 4,
+            "frontend_available_concurrency": 3,
+            "running_task_info": [],
+        }
+
+        with patch(
+            "rtp_llm.test.perf_test.offline_runner.requests.get",
+            side_effect=[cache_response, worker_response],
+        ):
+            status = runner._query_status()
+
+        self.assertEqual(status["total_kv_cache"], 400)
+        self.assertEqual(status["available_kv_cache"], 260)
+        self.assertEqual(status["total_kv_cache_blocks"], 40)
+        self.assertAlmostEqual(status["kv_cache_max_dp_utilization"], 0.8)
+        self.assertAlmostEqual(status["per_dp_kv_cache"][0]["utilization"], 0.8)
+        self.assertAlmostEqual(status["per_dp_kv_cache"][1]["utilization"], 0.2)
+
+    def test_analyze_with_failures(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            _RequestRecord,
+        )
+
+        config = OfflineBenchConfig()
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._config = config
+        runner._result_dir = "/tmp"
+        runner._status_samples = []
+
+        records = [
+            _RequestRecord(
+                submit_time=0.0,
+                finish_time=1.0,
+                response={"error_code": "MALLOC_FAILED", "message": "OOM"},
+            ),
+        ]
+        metrics = runner._analyze(
+            records,
+            wall_time=1.0,
+            engine_status={},
+            submitted_count=1,
+            cancelled_count=0,
+        )
+        self.assertEqual(metrics.success_requests, 0)
+        self.assertEqual(metrics.fail_requests, 1)
+
+    def test_dispatch_drains_only_inflight_fast_tasks(self):
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+        )
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeGenerator:
+            def __init__(self):
+                self.count = 0
+
+            def next(self):
+                self.count += 1
+                return "prompt", 1
+
+        async def run_dispatch():
+            config = OfflineBenchConfig(
+                input_len_min=1, input_len_max=1, output_len_min=1, output_len_max=1
+            )
+            runner = OfflineRunner.__new__(OfflineRunner)
+            runner._config = config
+            runner._port = 0
+            runner._profile = False
+            runner._profile_steps = 1
+            runner._status_samples = []
+            runner._status_sample_errors = 0
+
+            async def fake_status_sampler(*args, **kwargs):
+                try:
+                    while True:
+                        await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    raise
+
+            async def fake_send_one(session, prompt, output_len):
+                await asyncio.sleep(0)
+                return {"aux_info": [{"input_len": 1, "output_len": output_len}]}
+
+            runner._status_sampler = fake_status_sampler
+            runner._send_one = fake_send_one
+
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ):
+                return await runner._dispatch(
+                    FakeGenerator(),
+                    concurrency_limit=2,
+                    duration_s=0.01,
+                    drain_timeout_s=1,
+                )
+
+        loop = asyncio.new_event_loop()
+        try:
+            dispatch_result = loop.run_until_complete(run_dispatch())
+        finally:
+            loop.close()
+        self.assertEqual(dispatch_result.cancelled_count, 0)
+        self.assertEqual(len(dispatch_result.records), dispatch_result.submitted_count)
+        self.assertGreater(dispatch_result.submitted_count, 2)
+        self.assertIsNotNone(dispatch_result.first_submit_time)
+        self.assertGreaterEqual(
+            dispatch_result.terminal_time, dispatch_result.records[-1].finish_time
+        )
+
+    def test_duration_report_does_not_wait_for_slow_tokenizer_thread(self):
+        import threading
+
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            WorkloadGenerator,
+        )
+
+        tokenizer_started = threading.Event()
+        release_tokenizer = threading.Event()
+        tokenizer_finished = threading.Event()
+
+        class SlowTokenizer:
+            def encode(self, text):
+                return list(range(len(text.split())))
+
+            def decode(self, token_ids):
+                tokenizer_started.set()
+                release_tokenizer.wait(timeout=1.0)
+                tokenizer_finished.set()
+                return " ".join(str(token_id) for token_id in token_ids)
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        config = OfflineBenchConfig(
+            input_len_min=1,
+            input_len_max=1,
+            output_len_min=1,
+            output_len_max=1,
+            duration_s=0.05,
+            concurrency_limit=1,
+            total_requests=0,
+        )
+        gen = WorkloadGenerator(config, SlowTokenizer(), seed=0)
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._config = config
+        runner._port = 0
+        runner._profile = False
+        runner._profile_steps = 1
+        runner._status_samples = []
+        runner._status_sample_errors = 0
+
+        async def fake_status_sampler(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        runner._status_sampler = fake_status_sampler
+
+        start = time.perf_counter()
+        try:
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ), patch.object(runner, "_query_status", return_value={}):
+                metrics = runner._run(gen)
+            elapsed = time.perf_counter() - start
+        finally:
+            release_tokenizer.set()
+            self.assertTrue(tokenizer_finished.wait(timeout=1.0))
+
+        self.assertTrue(tokenizer_started.is_set())
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(metrics.total_submitted, 0)
+        self.assertEqual(metrics.success_requests, 0)
+
+    def test_duration_workload_dump_contains_only_submitted_requests(self):
+        import io
+        import json
+        import threading
+
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            WorkloadGenerator,
+        )
+
+        second_prompt_generated = threading.Event()
+
+        class RecordingWorkloadGenerator(WorkloadGenerator):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.generated_ids = []
+
+            def _generate(self, spec, *args, **kwargs):
+                prepared = super()._generate(spec, *args, **kwargs)
+                self.generated_ids.append(spec.request_id)
+                if spec.request_id == 1:
+                    second_prompt_generated.set()
+                return prepared
+
+        class FastTokenizer:
+            def encode(self, text):
+                return list(range(len(text.split())))
+
+            def decode(self, token_ids):
+                return " ".join(str(token_id) for token_id in token_ids)
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def run_dispatch():
+            config = OfflineBenchConfig(
+                input_len_min=1,
+                input_len_max=1,
+                output_len_min=1,
+                output_len_max=1,
+            )
+            dump_file = io.StringIO()
+            gen = RecordingWorkloadGenerator(
+                config, FastTokenizer(), seed=0, dump_file=dump_file
+            )
+            runner = OfflineRunner.__new__(OfflineRunner)
+            runner._config = config
+            runner._port = 0
+            runner._profile = False
+            runner._profile_steps = 1
+            runner._status_samples = []
+            runner._status_sample_errors = 0
+
+            async def fake_status_sampler(*args, **kwargs):
+                await asyncio.Event().wait()
+
+            async def hold_first_request(session, prompt, output_len):
+                while not second_prompt_generated.is_set():
+                    await asyncio.sleep(0)
+                await asyncio.sleep(0.05)
+                return {"aux_info": [{"input_len": 1, "output_len": output_len}]}
+
+            runner._status_sampler = fake_status_sampler
+            runner._send_one = hold_first_request
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ):
+                result = await runner._dispatch(
+                    gen, concurrency_limit=1, duration_s=0.02, drain_timeout_s=1
+                )
+            dumped_ids = [
+                json.loads(line)["id"] for line in dump_file.getvalue().splitlines()
+            ]
+            return result, gen.generated_ids, dumped_ids
+
+        result, generated_ids, dumped_ids = asyncio.run(run_dispatch())
+
+        self.assertIn(1, generated_ids)
+        self.assertEqual(result.submitted_count, 1)
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(dumped_ids, [0])
+
+    def test_fixed_dispatch_starts_drain_timeout_after_all_requests_submitted(self):
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+        )
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeGenerator:
+            def next(self):
+                return "prompt", 1
+
+        async def run_dispatch():
+            runner = OfflineRunner.__new__(OfflineRunner)
+            runner._config = OfflineBenchConfig(
+                input_len_min=1, input_len_max=1, output_len_min=1, output_len_max=1
+            )
+            runner._port = 0
+            runner._profile = False
+            runner._profile_steps = 1
+            runner._status_samples = []
+            runner._status_sample_errors = 0
+
+            async def fake_status_sampler(*args, **kwargs):
+                await asyncio.Event().wait()
+
+            async def slow_send_one(session, prompt, output_len):
+                await asyncio.sleep(0.01)
+                return {"aux_info": [{"input_len": 1, "output_len": output_len}]}
+
+            runner._status_sampler = fake_status_sampler
+            runner._send_one = slow_send_one
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ):
+                return await runner._dispatch_fixed(
+                    FakeGenerator(),
+                    concurrency_limit=1,
+                    total_requests=3,
+                    drain_timeout_s=0.005,
+                )
+
+        loop = asyncio.new_event_loop()
+        try:
+            dispatch_result = loop.run_until_complete(run_dispatch())
+        finally:
+            loop.close()
+
+        self.assertEqual(dispatch_result.submitted_count, 3)
+        self.assertEqual(len(dispatch_result.records), 2)
+        self.assertEqual(dispatch_result.cancelled_count, 1)
+
+    def test_fixed_dispatch_prefetch_maintains_concurrency_with_slow_generator(self):
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+        )
+
+        concurrency_limit = 3
+        replacement_count = 3
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class SlowGenerator:
+            def next(self):
+                time.sleep(0.2)
+                return "prompt", 1
+
+        async def run_dispatch():
+            runner = OfflineRunner.__new__(OfflineRunner)
+            runner._config = OfflineBenchConfig(
+                input_len_min=1, input_len_max=1, output_len_min=1, output_len_max=1
+            )
+            runner._port = 0
+            runner._profile = False
+            runner._profile_steps = 1
+            runner._status_samples = []
+            runner._status_sample_errors = 0
+
+            inflight = 0
+            full_event = asyncio.Event()
+            release_queue = asyncio.Queue()
+            request_start_levels = []
+
+            async def fake_status_sampler(*args, **kwargs):
+                await asyncio.Event().wait()
+
+            async def controlled_send_one(session, prompt, output_len):
+                nonlocal inflight
+                inflight += 1
+                request_start_levels.append(inflight)
+                if inflight == concurrency_limit:
+                    full_event.set()
+                await release_queue.get()
+                inflight -= 1
+                return {"aux_info": [{"input_len": 1, "output_len": output_len}]}
+
+            runner._status_sampler = fake_status_sampler
+            runner._send_one = controlled_send_one
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ):
+                dispatch_task = asyncio.create_task(
+                    runner._dispatch_fixed(
+                        SlowGenerator(),
+                        concurrency_limit=concurrency_limit,
+                        total_requests=concurrency_limit + replacement_count,
+                        drain_timeout_s=1,
+                    )
+                )
+
+                await asyncio.wait_for(full_event.wait(), timeout=2)
+                # Give the bounded queue time to prepare one replacement per active request.
+                await asyncio.sleep(0.3)
+
+                for _ in range(replacement_count):
+                    full_event.clear()
+                    release_queue.put_nowait(None)
+                    await asyncio.wait_for(full_event.wait(), timeout=0.1)
+
+                for _ in range(concurrency_limit):
+                    release_queue.put_nowait(None)
+                dispatch_result = await dispatch_task
+
+            return dispatch_result, request_start_levels
+
+        loop = asyncio.new_event_loop()
+        try:
+            dispatch_result, request_start_levels = loop.run_until_complete(
+                run_dispatch()
+            )
+        finally:
+            loop.close()
+
+        self.assertEqual(dispatch_result.submitted_count, 6)
+        self.assertEqual(dispatch_result.cancelled_count, 0)
+        self.assertEqual(len(dispatch_result.records), 6)
+        self.assertEqual(
+            request_start_levels[-replacement_count:],
+            [concurrency_limit] * replacement_count,
+        )
+
+    def test_fixed_dispatch_window_starts_with_cancelled_first_request(self):
+        import rtp_llm.test.perf_test.offline_runner as offline_runner
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+        )
+
+        class FakeClientSession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeGenerator:
+            def __init__(self):
+                self.count = 0
+
+            def next(self):
+                self.count += 1
+                return f"prompt-{self.count}", 1
+
+        async def run_dispatch():
+            runner = OfflineRunner.__new__(OfflineRunner)
+            runner._config = OfflineBenchConfig(
+                input_len_min=1, input_len_max=1, output_len_min=1, output_len_max=1
+            )
+            runner._port = 0
+            runner._profile = False
+            runner._profile_steps = 1
+            runner._status_samples = []
+            runner._status_sample_errors = 0
+
+            async def fake_status_sampler(*args, **kwargs):
+                await asyncio.Event().wait()
+
+            async def send_first_slow(session, prompt, output_len):
+                if prompt == "prompt-1":
+                    await asyncio.Event().wait()
+                return {"aux_info": [{"input_len": 1, "output_len": output_len}]}
+
+            runner._status_sampler = fake_status_sampler
+            runner._send_one = send_first_slow
+            with patch.object(
+                offline_runner.aiohttp, "ClientSession", FakeClientSession
+            ):
+                return await runner._dispatch_fixed(
+                    FakeGenerator(),
+                    concurrency_limit=2,
+                    total_requests=2,
+                    drain_timeout_s=0.005,
+                )
+
+        loop = asyncio.new_event_loop()
+        try:
+            dispatch_result = loop.run_until_complete(run_dispatch())
+        finally:
+            loop.close()
+
+        self.assertEqual(dispatch_result.submitted_count, 2)
+        self.assertEqual(dispatch_result.cancelled_count, 1)
+        self.assertEqual(len(dispatch_result.records), 1)
+        self.assertIsNotNone(dispatch_result.first_submit_time)
+        self.assertLess(
+            dispatch_result.first_submit_time, dispatch_result.records[0].submit_time
+        )
+        self.assertGreaterEqual(
+            dispatch_result.terminal_time, dispatch_result.records[0].finish_time
+        )
+
+    def test_run_uses_full_dispatch_window_for_tps_after_cancellation(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+            _DispatchResult,
+            _RequestRecord,
+        )
+
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._config = OfflineBenchConfig(
+            input_len_min=1,
+            input_len_max=1,
+            output_len_min=1,
+            output_len_max=1,
+            concurrency_limit=2,
+            total_requests=2,
+        )
+        runner._status_samples = []
+        dispatch_result = _DispatchResult(
+            records=[
+                _RequestRecord(
+                    submit_time=20.0,
+                    finish_time=30.0,
+                    response={"aux_info": [{"input_len": 100, "output_len": 50}]},
+                )
+            ],
+            cancelled_count=1,
+            submitted_count=2,
+            first_submit_time=10.0,
+            terminal_time=30.0,
+        )
+
+        with patch.object(runner, "_query_status", return_value={}), patch.object(
+            runner, "_dispatch_fixed", return_value=dispatch_result
+        ):
+            metrics = runner._run(MagicMock())
+
+        self.assertEqual(metrics.cancelled_requests, 1)
+        self.assertAlmostEqual(metrics.total_wall_time_s, 20.0)
+        self.assertAlmostEqual(metrics.output_tps, 2.5)
+
+
+class TestParseOfflineArgs(unittest.TestCase):
+    """Test parse_offline_args from offline_bench_test."""
+
+    def test_default_args(self):
+        from rtp_llm.test.perf_test.offline_bench_test import parse_offline_args
+
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--checkpoint_path",
+                "/tmp/model",
+                "--concurrency_limit",
+                "32",
+            ],
+        ):
+            args, remaining = parse_offline_args()
+            self.assertEqual(args.checkpoint_path, "/tmp/model")
+            self.assertEqual(args.input_len_min, 512)
+            self.assertEqual(args.server_start_timeout, 1600)
+            self.assertEqual(args.concurrency_limit, 32)
+
+    def test_concurrency_limit_is_required(self):
+        from rtp_llm.test.perf_test.offline_bench_test import parse_offline_args
+
+        with patch("sys.argv", ["prog", "--checkpoint_path", "/tmp/model"]):
+            with self.assertRaises(SystemExit):
+                parse_offline_args()
+
+    def test_custom_args(self):
+        from rtp_llm.test.perf_test.offline_bench_test import parse_offline_args
+
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--checkpoint_path",
+                "/tmp/m",
+                "--concurrency_limit",
+                "48",
+                "--input_len_min",
+                "1024",
+                "--duration",
+                "60",
+                "--server_start_timeout",
+                "3600",
+                "--num_return_sequences",
+                "4",
+            ],
+        ):
+            args, remaining = parse_offline_args()
+            self.assertEqual(args.input_len_min, 1024)
+            self.assertEqual(args.duration, 60)
+            self.assertEqual(args.server_start_timeout, 3600)
+            self.assertEqual(args.concurrency_limit, 48)
+            self.assertEqual(args.num_return_sequences, 4)
+
+    def test_num_return_sequences_request_payload(self):
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineBenchConfig,
+            OfflineRunner,
+        )
+
+        class FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def json(self):
+                return {"ok": True}
+
+        class FakeSession:
+            def post(self, url, json):
+                self.url = url
+                self.payload = json
+                return FakeResponse()
+
+        runner = OfflineRunner.__new__(OfflineRunner)
+        runner._port = 12345
+        runner._config = OfflineBenchConfig(num_return_sequences=4)
+        session = FakeSession()
+
+        result = asyncio.run(runner._send_one(session, "prompt", 32))
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(
+            session.payload["generate_config"],
+            {
+                "max_new_tokens": 32,
+                "min_new_tokens": 32,
+                "top_k": 1,
+                "num_beams": 1,
+                "num_return_sequences": 4,
+                "do_sample": True,
+            },
+        )
+
+
+class TestOfflineBenchMain(unittest.TestCase):
+    def test_all_failed_requests_raise_from_entry_point_and_stop_server(self):
+        import rtp_llm.test.perf_test.offline_bench_test as offline_bench
+        import rtp_llm.test.perf_test.offline_runner as offline_runner_module
+        from rtp_llm.test.perf_test.offline_runner import (
+            OfflineMetrics,
+            OfflineRunner,
+        )
+
+        server = MagicMock(port=12345)
+        failed_metrics = OfflineMetrics(
+            total_submitted=2, success_requests=0, fail_requests=2
+        )
+        argv = [
+            "prog",
+            "--checkpoint_path",
+            "/tmp/model",
+            "--concurrency_limit",
+            "2",
+        ]
+        with patch.object(sys, "argv", argv), patch.object(
+            offline_bench, "resolve_perf_engine_paths", side_effect=lambda args: args
+        ), patch.object(offline_bench, "EngineServer") as engine_server, patch.object(
+            OfflineRunner, "_load_tokenizer"
+        ), patch.object(
+            OfflineRunner, "_run", return_value=failed_metrics
+        ), patch.object(
+            offline_runner_module, "WorkloadGenerator"
+        ), patch.object(
+            OfflineMetrics, "print_table"
+        ), patch.object(
+            OfflineMetrics, "save_json"
+        ), patch.object(
+            OfflineRunner, "_save_status_samples"
+        ), patch.object(
+            offline_bench, "summarize_and_cleanup_coredumps"
+        ), patch.object(
+            offline_bench.os, "makedirs"
+        ), patch(
+            "rtp_llm.config.log_config.setup_logging"
+        ):
+            engine_server.return_value = server
+            with self.assertRaisesRegex(RuntimeError, "no requests succeeded"):
+                offline_bench.main()
+
+        server.stop.assert_called_once()
+
+    def test_manual_concurrency_is_forwarded_to_server_and_runner(self):
+        import rtp_llm.test.perf_test.offline_bench_test as offline_bench
+
+        server = MagicMock(port=12345)
+        argv = [
+            "prog",
+            "--checkpoint_path",
+            "/tmp/model",
+            "--concurrency_limit",
+            "37",
+            "--duration",
+            "0",
+            "--test_block_num",
+            "17",
+        ]
+        with patch.object(sys, "argv", argv), patch.object(
+            offline_bench, "resolve_perf_engine_paths", side_effect=lambda args: args
+        ), patch.object(offline_bench, "EngineServer") as engine_server, patch.object(
+            offline_bench, "OfflineRunner"
+        ) as offline_runner, patch.object(
+            offline_bench, "summarize_and_cleanup_coredumps"
+        ), patch.object(
+            offline_bench.os, "makedirs"
+        ), patch(
+            "rtp_llm.config.log_config.setup_logging"
+        ):
+            engine_server.return_value = server
+            offline_bench.main()
+
+        parsed_args, engine_args = engine_server.call_args.args
+        self.assertEqual(parsed_args.concurrency_limit, 37)
+        self.assertEqual(engine_args[engine_args.index("--test_block_num") + 1], "17")
+        self.assertEqual(server.start.call_args.kwargs["max_concurrency"], 37)
+
+        runner_config = offline_runner.call_args.kwargs["config"]
+        self.assertEqual(runner_config.concurrency_limit, 37)
+        self.assertEqual(runner_config.total_requests, 74)
+
+    def test_tokenizer_and_model_type_fall_back_to_environment(self):
+        import rtp_llm.test.perf_test.offline_bench_test as offline_bench
+
+        server = MagicMock(port=12345)
+        argv = [
+            "prog",
+            "--checkpoint_path",
+            "/tmp/checkpoint",
+            "--concurrency_limit",
+            "2",
+        ]
+        env = {
+            "TOKENIZER_PATH": "/tmp/tokenizer",
+            "MODEL_TYPE": "factory_model",
+        }
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            sys, "argv", argv
+        ), patch.object(
+            offline_bench, "resolve_perf_engine_paths", side_effect=lambda args: args
+        ), patch.object(
+            offline_bench, "EngineServer"
+        ) as engine_server, patch.object(
+            offline_bench, "OfflineRunner"
+        ) as offline_runner, patch.object(
+            offline_bench, "summarize_and_cleanup_coredumps"
+        ), patch.object(
+            offline_bench.os, "makedirs"
+        ), patch(
+            "rtp_llm.config.log_config.setup_logging"
+        ):
+            engine_server.return_value = server
+            offline_bench.main()
+
+        _, engine_args = engine_server.call_args.args
+        self.assertEqual(
+            engine_args[engine_args.index("--tokenizer_path") + 1],
+            "/tmp/tokenizer",
+        )
+        self.assertEqual(
+            offline_runner.call_args.kwargs["checkpoint_path"], "/tmp/checkpoint"
+        )
+        self.assertEqual(
+            offline_runner.call_args.kwargs["tokenizer_path"], "/tmp/tokenizer"
+        )
+        self.assertEqual(offline_runner.call_args.kwargs["model_type"], "factory_model")
+
+    def test_cli_tokenizer_overrides_environment(self):
+        import rtp_llm.test.perf_test.offline_bench_test as offline_bench
+
+        server = MagicMock(port=12345)
+        argv = [
+            "prog",
+            "--checkpoint_path",
+            "/tmp/checkpoint",
+            "--tokenizer_path",
+            "/tmp/cli-tokenizer",
+            "--concurrency_limit",
+            "2",
+        ]
+        with patch.dict(
+            os.environ, {"TOKENIZER_PATH": "/tmp/env-tokenizer"}, clear=True
+        ), patch.object(sys, "argv", argv), patch.object(
+            offline_bench, "resolve_perf_engine_paths", side_effect=lambda args: args
+        ), patch.object(
+            offline_bench, "EngineServer"
+        ) as engine_server, patch.object(
+            offline_bench, "OfflineRunner"
+        ) as offline_runner, patch.object(
+            offline_bench, "summarize_and_cleanup_coredumps"
+        ), patch.object(
+            offline_bench.os, "makedirs"
+        ), patch(
+            "rtp_llm.config.log_config.setup_logging"
+        ):
+            engine_server.return_value = server
+            offline_bench.main()
+
+        self.assertEqual(
+            offline_runner.call_args.kwargs["tokenizer_path"], "/tmp/cli-tokenizer"
+        )
+
+
+class TestEngineServerLifecycle(unittest.TestCase):
+    @patch("rtp_llm.test.perf_test.server.MagaServerManager")
+    def test_failed_start_stops_partial_server(self, MockMagaServerManager):
+        from rtp_llm.test.perf_test.server import EngineServer
+
+        manager = MockMagaServerManager.return_value
+        manager.start_server.return_value = False
+        server = EngineServer(_make_args(), [])
+
+        with self.assertRaisesRegex(RuntimeError, "Engine server failed to start"):
+            server.start(
+                max_seq_len=8192,
+                max_concurrency=8,
+                server_start_timeout=1,
+                use_batch_decode_scheduler=False,
+            )
+
+        manager.print_process_log.assert_called_once()
+        manager.stop_server.assert_called_once()
+        server.stop()
+        manager.stop_server.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/rtp_llm/test/perf_test/test_util.py
+++ b/rtp_llm/test/perf_test/test_util.py
@@ -3,13 +3,27 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, Dict, List, Optional, Tuple
 
-from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from transformers import AutoTokenizer
 
 from rtp_llm.utils.fuser import fetch_remote_file_to_local
 
 
-def _load_tokenizer(tokenizer_path: str) -> PreTrainedTokenizerBase:
+def _load_tokenizer(
+    tokenizer_path: str,
+    checkpoint_path: str = "",
+    model_type: str = "",
+) -> Any:
     local_path = fetch_remote_file_to_local(os.path.expanduser(tokenizer_path.strip()))
+    if model_type:
+        from rtp_llm.frontend.tokenizer_factory.tokenizer_factory import (
+            TokenizerFactory,
+        )
+
+        local_checkpoint_path = checkpoint_path or local_path
+        local_checkpoint_path = fetch_remote_file_to_local(
+            os.path.expanduser(local_checkpoint_path.strip())
+        )
+        return TokenizerFactory.create(local_checkpoint_path, local_path, model_type)
     return AutoTokenizer.from_pretrained(local_path, trust_remote_code=True)
 
 


### PR DESCRIPTION
 Summary

  This PR improves offline inference scheduling for PDFusion-style burst traffic and adds an offline benchmark
  runner to validate throughput under high-concurrency workloads.

  Design

  1. Prefill-first scheduling for PDFusionRatioScheduler

  This PR implements a prefill-first scheduling strategy in `PDFusionRatioScheduler`.

  When `pdfusion_scheduler_mode=ratio` is enabled, `decode_prefill_ratio=0` makes the scheduler try a PREFILL round whenever waiting streams exist. If no prefill request can pass admission, the scheduler falls back to a DECODE round in the same scheduling cycle.

  The goal is to admit queued prefill requests earlier, expose more active streams to later decode phases, and increase decode batch size under bursty offline workloads. This is generally favorable for throughput and TTFT, while TPOT may be weaker because decode-only progress is no longer always prioritized.

  2. KV-cache-aware prefill admission

  Prefill admission is guarded by approximately upper bound of future KV-cache block usage.

  For each candidate prefill request, the scheduler considers all in-flight decode-capable streams across their remaining lifetime, including loading-cache streams, running streams, pending decode streams, streams already selected in the current prefill round, and the new candidate stream.

  It estimates the maximum number of additional KV blocks these streams may still need over their lifetime, then compares that requirement with the pool's currently allocatable KV blocks. A prefill request is admitted only when this strict upper-bound check passes, preventing later decode growth from exceeding KV-cache capacity.

  3. Offline throughput benchmark runner

  This PR adds a standalone offline throughput benchmark entry point and runner.

  The benchmark simulates instantaneous high-concurrency load instead of steady low-rate online traffic. It starts the engine, generates synthetic token-length workloads, keeps requests in flight up to a configured concurrency limit, drains outstanding requests, and reports throughput, latency, and KV-cache metrics.