### PR TITLE
feat(recommendation): cross-sequence combo dedup with primary-protect…

### DIFF
--- a/rtp_llm/config/generate_config.py
+++ b/rtp_llm/config/generate_config.py
@@ -1,8 +1,10 @@
 import copy
 import hashlib
+import logging
+import time
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, PrivateAttr, field_serializer, field_validator, model_validator
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from rtp_llm.config.exceptions import ExceptionType, FtRuntimeException
@@ -48,8 +50,31 @@ class RoleAddr(BaseModel):
         """Serialize RoleType enum to its name string for JSON serialization."""
         return role.name
 
+# === 跨序列去重共享常量（SYNC: 必须与 RecommendationLogitsProcessor.cc 保持一致） ===
+# 对应 C++ kDivergeStartComboWarnThreshold，更改时两侧同步 + test_generate_config_validators.py 会断言一致。
+_DIVERGE_START_COMBO_WARN_THRESHOLD = 100
+# 对应 C++ kMaxDivergeDepth，超过此值的 num_return_sequences 可能导致采样质量退化。
+_MAX_DIVERGE_DEPTH = 8
+# 警告限流状态：与 C++ INTERVAL_LOG(300) 对齐，每 300 秒最多输出一次。
+# NOTE: 模块级全局无锁读改写，多线程下可能偶发多输出/少输出一次告警，
+# 仅影响告警频率不影响正确性，可接受。
+_SANITIZE_WARN_INTERVAL = 300  # seconds
+_last_sanitize_warn_time: float = 0.0
+_last_downgrade_warn_time: float = 0.0
+
+
+def _reset_sanitize_warn_state():
+    """Reset rate-limiting state for testing. NOT for production use."""
+    global _last_sanitize_warn_time, _last_downgrade_warn_time
+    _last_sanitize_warn_time = 0.0
+    _last_downgrade_warn_time = 0.0
+
 
 class GenerateConfig(BaseModel):
+    # --- private attrs（不参与序列化/schema，生命周期与实例绑定） ---
+    _diverge_depth_warned: bool = PrivateAttr(default=False)
+    _ban_auto_downgraded: bool = PrivateAttr(default=False)
+
     max_new_tokens: int = 32000
     # only for qwen agent fncall check max input tokens
     max_input_tokens: int = 32000
@@ -81,6 +106,18 @@ class GenerateConfig(BaseModel):
     combo_token_size: int = 0
     banned_combo_token_ids: List[List[int]] = []
     auto_parse_banned_combo: bool = False
+    # 跨序列 combo 去重：当 num_return_sequences > 1 时，任一序列生成完整 combo 后自动广播到
+    # 其他序列的 banned_combos，确保多条序列输出互不重复。默认关闭。
+    # 跨序列去重开关（primary-protected 非对称模式）：开启后，主序列（序列 0）仅保留自身 ban、
+    # 不受其他序列影响；补充序列接收所有序列 banned_combos 并集，保证彼此不重复。
+    # 注意：enable_cross_sequence_ban 必须与 num_return_sequences(>1)、combo_token_size(>=2)
+    # 在同一次 GenerateConfig 构造中给出。若条件不满足会被自动降级；
+    # 后续 update()/update_and_pop() 补齐条件后会自动重新启用（仅限曾被自动降级的情况）。
+    enable_cross_sequence_ban: bool = False
+    # 跨序列分叉起始商品位置：前 N 个商品所有序列保持 greedy 一致，
+    # 从第 N+1 个商品开始对非主序列施加 top-K 遮蔽制造分叉。默认 0（立即分叉）。
+    cross_seq_diverge_start_combo: int = 0
+
     random_seed: Optional[Union[List[int], int]] = None
     top_p_decay: Optional[Union[List[float], float]] = None
     top_p_min: Optional[Union[List[float], float]] = None
@@ -170,6 +207,131 @@ class GenerateConfig(BaseModel):
 
     unique_key: str = ""
 
+    # --- validators（统一放在所有 field 声明之后） ---
+
+    @staticmethod
+    def _sanitize_diverge_start_combo(v: "int | str | None") -> int:
+        """将 cross_seq_diverge_start_combo 规范化为非负 int32 范围内的整数。
+
+        供 field_validator（构造路径）和 update()/update_and_pop()（请求路径）共同复用，
+        确保任何入口的值都经过相同的 clamp/类型兜底。
+
+        上下界钳制：
+          - 下界：负值 clamp 到 0
+          - 上界：超过 INT32_MAX 的值 clamp 到 INT32_MAX，避免 trans_input protobuf 序列化时
+            触发 ValueError（C++ 侧 int32_t 对应）。超大值的实际语义等价于“永不分叉”。
+
+        NOTE on rate-limiting: 与 C++ INTERVAL_LOG(300) 对齐，非法值告警每 300 秒最多输出一次，
+        避免畸形客户端高 QPS 下无界日志刷屏。
+        """
+        global _last_sanitize_warn_time
+        _INT32_MAX = 2**31 - 1
+        if v is None:
+            return 0
+        try:
+            val = int(v)
+        except (TypeError, ValueError) as e:
+            now = time.monotonic()
+            if now - _last_sanitize_warn_time >= _SANITIZE_WARN_INTERVAL:
+                logging.getLogger(__name__).warning(
+                    "cross_seq_diverge_start_combo received non-integer value %r, defaulting to 0: %s", v, e)
+                _last_sanitize_warn_time = now
+            return 0
+        if val < 0:
+            now = time.monotonic()
+            if now - _last_sanitize_warn_time >= _SANITIZE_WARN_INTERVAL:
+                logging.getLogger(__name__).warning(
+                    "cross_seq_diverge_start_combo is negative (%d), clamped to 0", val)
+                _last_sanitize_warn_time = now
+            return 0
+        if val > _INT32_MAX:
+            now = time.monotonic()
+            if now - _last_sanitize_warn_time >= _SANITIZE_WARN_INTERVAL:
+                logging.getLogger(__name__).warning(
+                    "cross_seq_diverge_start_combo exceeds int32 max (%d), clamped to %d", val, _INT32_MAX)
+                _last_sanitize_warn_time = now
+            return _INT32_MAX
+        # "过大" 告警已移至 _check_cross_seq_ban_compatibility，仅在特性启用时触发，
+        # 与 C++ 侧 (enable_cross_seq_ban && diverge_start_combo > threshold) 行为一致。
+        return val
+
+    @field_validator("cross_seq_diverge_start_combo", mode="before")
+    @classmethod
+    def _clamp_diverge_start_combo(cls, v):
+        """构造路径入口：委托给 _sanitize_diverge_start_combo。"""
+        return cls._sanitize_diverge_start_combo(v)
+
+    @model_validator(mode='after')
+    def _check_cross_seq_ban_compatibility(self):
+        """cross_sequence_ban 与多项配置不兼容时直接禁用，一次性报告所有不兼容原因。
+
+        NOTE on rate-limiting:
+          - 不兼容降级 WARNING：每次调用无条件触发（保证即时性）。
+          - 采样质量软告警（超 depth）：通过 _diverge_depth_warned (PrivateAttr) 标志去重，
+            同一 GenerateConfig 实例生命周期内最多输出一次。若 update() 修改了
+            num_return_sequences 使其重新超 depth，标志会被重置以允许再次告警。
+          - C++ 侧使用 INTERVAL_LOG(300) 是因为 fromGenerateInput 在高 QPS 下可能
+            对同一配置反复调用，属不同场景。
+        """
+        if not self.enable_cross_sequence_ban:
+            # “先建后补”场景补救：若特性曾被自动降级且当前条件已全部满足，重新启用并继续校验。
+            # 解决 request_extractor 两次 update_and_pop 分步合并导致的误降级问题。
+            if (self._ban_auto_downgraded
+                    and not self.has_num_beams()
+                    and self.combo_token_size >= 2
+                    and self.num_return_sequences > 1):
+                self.enable_cross_sequence_ban = True
+                self._ban_auto_downgraded = False
+                logging.getLogger(__name__).info(
+                    "enable_cross_sequence_ban re-enabled: conditions now satisfied after incremental update")
+                # 不 return，继续执行下方 depth/过大 告警校验
+            else:
+                return self
+        # SYNC: 以下判定条件必须与 C++ RecommendationLogitsProcessor.cc::fromGenerateInput
+        # 中 enable_cross_seq_ban 的计算逻辑保持一致（取反关系）。
+        # 同步保障机制：
+        #   - 常量：static_assert 钉住 kMaxDivergeDepth / kDivergeStartComboWarnThreshold
+        #   - 启用条件逻辑：人工维护双份真值表测试，无运行期交叉校验
+        #   - 生产映射：C++ 测试中断言 batchSize(0)==max(num,1) 等价性
+        # ━━ 新增/修改启用条件时的 CHECKLIST ━━
+        #   1. 同步修改另一侧的判定逻辑
+        #   2. 更新双侧真值表测试：
+        #      Python: TestCrossLanguageConstantSync::test_enable_conditions_sync
+        #      C++:    RecommendationLogitsProcessorTest::testEnableConditionsTruthTable
+        #   3. 确认新条件在双侧真值表中均有覆盖（正反例）
+        #   未来演进：若条件进一步增多，应将真值表落为共享 JSON 数据文件（单一真源）。
+        reasons: list = []
+        if self.has_num_beams():
+            reasons.append(f"incompatible with beam search (max_num_beams={self.max_num_beams()})")
+        if self.combo_token_size < 2:
+            reasons.append(f"combo_token_size must be >=2, got {self.combo_token_size}")
+        if self.num_return_sequences <= 1:
+            reasons.append(f"num_return_sequences must be >1, got {self.num_return_sequences}")
+        if reasons:
+            global _last_downgrade_warn_time
+            now = time.monotonic()
+            if now - _last_downgrade_warn_time >= _SANITIZE_WARN_INTERVAL:
+                logging.getLogger(__name__).warning(
+                    "enable_cross_sequence_ban disabled: %s", "; ".join(reasons))
+                _last_downgrade_warn_time = now
+            self.enable_cross_sequence_ban = False
+            self._ban_auto_downgraded = True
+        elif self.num_return_sequences - 1 > _MAX_DIVERGE_DEPTH:
+            # 软告警去重：同一实例生命周期内最多输出一次，避免 update() 多次调用时形成日志噪声。
+            if not self._diverge_depth_warned:
+                logging.getLogger(__name__).warning(
+                    "num_return_sequences=%d exceeds recommended max diverge depth %d, "
+                    "sampling quality may degrade for higher-indexed sequences",
+                    self.num_return_sequences, _MAX_DIVERGE_DEPTH)
+                self._diverge_depth_warned = True
+        # 「过大」告警：仅在特性最终仍然启用时触发（reasons 为空），与 C++ 侧行为一致
+        # （SYNC: C++ else if (enable_cross_seq_ban && diverge_start_combo > kDivergeStartComboWarnThreshold)）
+        if not reasons and self.cross_seq_diverge_start_combo > _DIVERGE_START_COMBO_WARN_THRESHOLD:
+            logging.getLogger(__name__).warning(
+                "cross_seq_diverge_start_combo=%d is very large, top-K diverge masking may never activate",
+                self.cross_seq_diverge_start_combo)
+        return self
+
     @field_validator("return_all_probs", mode="before")
     @classmethod
     def _coerce_return_all_probs(cls, v):
@@ -206,16 +368,48 @@ class GenerateConfig(BaseModel):
         return self.md5_value == config.md5_value
 
     def update(self, new: Dict[str, Any]):
+        """批量更新字段。
+
+        降级/重启用语义：
+          - 当条件不满足时，enable_cross_sequence_ban 会被自动降级为 False。
+          - 若后续 update 补齐了条件，且开关是因自动降级而关闭的（而非用户从未开启），
+            则会自动重新启用。这确保 request_extractor 两阶段合并不会导致误降级。
+          - 若用户在同一次 update 中显式传入 enable_cross_sequence_ban，视为用户重新表态，
+            自动重启用启发式不会覆盖其显式意图。
+        """
         for key, value in new.items():
             if hasattr(self, key):
                 setattr(self, key, value)
+        # setattr 不会触发 field_validator / model_validator，手动补偿：
+        # 1) cross_seq_diverge_start_combo 的 clamp/类型兜底
+        if "cross_seq_diverge_start_combo" in new:
+            self.cross_seq_diverge_start_combo = self._sanitize_diverge_start_combo(
+                self.cross_seq_diverge_start_combo)
+        # 2) 若 num_return_sequences 变化，重置深度告警标志以允许重新检测
+        if "num_return_sequences" in new:
+            self._diverge_depth_warned = False
+        # 3) 用户显式传入 enable_cross_sequence_ban 时，视为重新表态，清除自动降级标志
+        if "enable_cross_sequence_ban" in new:
+            self._ban_auto_downgraded = False
+        # 4) 跨序列去重兼容性
+        self._check_cross_seq_ban_compatibility()
 
     def update_and_pop(self, new: Dict[str, Any]):
+        """批量更新字段并返回未被消费的 key。校验策略同 update()。"""
         to_remove: List[str] = []
         for key, value in new.items():
             if hasattr(self, key):
                 setattr(self, key, value)
                 to_remove.append(key)
+        # setattr 不会触发 field_validator / model_validator，手动补偿：
+        if "cross_seq_diverge_start_combo" in new:
+            self.cross_seq_diverge_start_combo = self._sanitize_diverge_start_combo(
+                self.cross_seq_diverge_start_combo)
+        if "num_return_sequences" in new:
+            self._diverge_depth_warned = False
+        if "enable_cross_sequence_ban" in new:
+            self._ban_auto_downgraded = False
+        self._check_cross_seq_ban_compatibility()
         return {k: v for k, v in new.items() if k not in to_remove}
 
     @staticmethod

--- a/rtp_llm/cpp/engine_base/stream/GenerateConfig.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateConfig.h
@@ -102,6 +102,15 @@ public:
     int combo_token_size = 0;
     // banned_combo_token_ids 是禁止生成的商品 token 组合列表，每项长度应等于 combo_token_size
     std::vector<std::vector<int>> banned_combo_token_ids;
+    // 跨序列 combo 去重：当 num_return_sequences > 1 时，任一序列生成完整 combo 后
+    // 自动广播到其他序列的 banned_combos，尽力降低多条序列输出重复（best-effort）。默认关闭。
+    // 启用后采用主序列保护模式：序列 0 不接收其他序列的 ban，补充序列接收所有。
+    // 限制：同一 decode step 内并发生成的相同 combo、以及 diverge_start 之前的 greedy
+    // 一致前缀，不在去重保证范围内。
+    bool enable_cross_sequence_ban = false;
+    // 跨序列分叉起始商品位置：前 N 个商品所有序列保持 greedy 一致，
+    // 从第 N+1 个商品开始对非主序列施加 top-K 遮蔽制造分叉。默认 0（立即分叉）。
+    int cross_seq_diverge_start_combo = 0;
 
     bool top1() {
         return top_k == 1;
@@ -158,7 +167,9 @@ public:
                      << ", enable_memory_cache: " << enable_memory_cache
                      << ", enable_remote_cache: " << enable_remote_cache << ", force_batch: " << force_batch
                      << ", unique_key: " << unique_key << ", combo_token_size: " << combo_token_size
-                     << ", banned_combo_token_ids_size: " << banned_combo_token_ids.size() << "}";
+                     << ", banned_combo_token_ids_size: " << banned_combo_token_ids.size()
+                     << ", enable_cross_sequence_ban: " << enable_cross_sequence_ban
+                     << ", cross_seq_diverge_start_combo: " << cross_seq_diverge_start_combo << "}";
         return debug_string.str();
     }
 
@@ -268,6 +279,8 @@ public:
         JSONIZE(unique_key);
         JSONIZE(combo_token_size);
         JSONIZE(banned_combo_token_ids);
+        JSONIZE(enable_cross_sequence_ban);
+        JSONIZE(cross_seq_diverge_start_combo);
 #undef JSONIZE
 #undef JSONIZE_OPTIONAL
     }

--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -108,6 +108,8 @@ std::shared_ptr<GenerateConfig> QueryConverter::transGenerateConfig(const Genera
 
     // 生成式推荐：组合 token 约束
     generate_config->combo_token_size = config_proto->combo_token_size();
+    generate_config->enable_cross_sequence_ban = config_proto->enable_cross_sequence_ban();
+    generate_config->cross_seq_diverge_start_combo = config_proto->cross_seq_diverge_start_combo();
     for (const auto& combo_proto : config_proto->banned_combo_token_ids().rows()) {
         std::vector<int> combo;
         combo.reserve(combo_proto.values_size());

--- a/rtp_llm/cpp/model_rpc/model_rpc_client.py
+++ b/rtp_llm/cpp/model_rpc/model_rpc_client.py
@@ -168,6 +168,8 @@ def trans_input(input_py: GenerateInput):
 
     # 生成式推荐：组合 token 约束
     generate_config_pb.combo_token_size = input_py.generate_config.combo_token_size
+    generate_config_pb.enable_cross_sequence_ban = input_py.generate_config.enable_cross_sequence_ban
+    generate_config_pb.cross_seq_diverge_start_combo = input_py.generate_config.cross_seq_diverge_start_combo
     for i in range(len(input_py.generate_config.banned_combo_token_ids)):
         banned_combo = generate_config_pb.banned_combo_token_ids.rows.add()
         banned_combo.values.extend(

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -105,6 +105,10 @@ message GenerateConfigPB {
     IntMatrix banned_combo_token_ids = 59;
     // 0=unset(fallback to bool return_all_probs), 1=NONE, 2=DEFAULT, 3=ORIGINAL
     int32 return_all_probs_mode = 60;
+    // 跨序列 combo 去重开关
+    bool enable_cross_sequence_ban = 61;
+    // 跨序列分叉起始商品位置
+    int32 cross_seq_diverge_start_combo = 62;
 }
 
 message MMPreprocessConfigPB {

--- a/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.cc
+++ b/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.cc
@@ -1,11 +1,29 @@
 #include "rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.h"
 
+#include <algorithm>
 #include <limits>
+#include <string>
 #include <vector>
 
 #include "rtp_llm/cpp/utils/AssertUtils.h"
+#include "rtp_llm/cpp/utils/Logger.h"
 
 namespace rtp_llm {
+
+// 遮蔽深度上界：防止 num_return_sequences 过大时采样退化为随机噪声。
+// 实际场景推荐 N=2~4，设为 8 提供安全余量。
+static constexpr int kMaxDivergeDepth = 8;
+// SYNC: 若修改此值，必须同步更新 Python generate_config.py::_MAX_DIVERGE_DEPTH
+// 以及 test_generate_config_validators.py::test_max_diverge_depth_sync 中的硬编码期望值。
+static_assert(kMaxDivergeDepth == 8,
+    "SYNC: update Python _MAX_DIVERGE_DEPTH and test_max_diverge_depth_sync expected value");
+
+// cross_seq_diverge_start_combo "过大" 告警阈值，Python 侧 generate_config.py 使用相同值。
+static constexpr int kDivergeStartComboWarnThreshold = 100;
+// SYNC: 若修改此值，必须同步更新 Python generate_config.py::_DIVERGE_START_COMBO_WARN_THRESHOLD
+// 以及 test_generate_config_validators.py::test_diverge_start_combo_warn_threshold_sync 中的硬编码期望值。
+static_assert(kDivergeStartComboWarnThreshold == 100,
+    "SYNC: update Python _DIVERGE_START_COMBO_WARN_THRESHOLD and test expected value");
 
 RecommendationLogitsProcessor::RecommendationLogitsProcessor(std::vector<StreamRecommendationInfo> infos):
     infos_(std::move(infos)) {}
@@ -25,7 +43,54 @@ RecommendationLogitsProcessor::fromGenerateInput(std::shared_ptr<GenerateInput> 
         }
     }
 
-    const bool is_beam_search = config->hasNumBeams() || config->num_return_sequences > 1;
+    const bool needs_token_offset = config->hasNumBeams() || config->num_return_sequences > 1;
+    // beam search 与跨序列去重互斥：updateMultiSeqStatus 会重排序列身份，破坏主序列不变量
+    // combo_token_size == 1 时 diverge 与 ban 在同一步叠加，易导致采样退化，仅 combo_token_size >= 2 时启用
+    // C++ 自校验：num<=1 时 diverge 逻辑天然 no-op（i>0 分支不可达），但仍显式禁用以避免布尔开关处于「已置位但部分配置」状态
+    // SYNC: 以下判定条件必须与 Python generate_config.py::_check_cross_seq_ban_compatibility
+    // 中的判定逻辑保持一致（取反关系）。
+    // ━━ 新增/修改启用条件时的 CHECKLIST ━━
+    //   1. 同步修改另一侧的判定逻辑
+    //   2. 更新双侧真值表测试：
+    //      Python: TestCrossLanguageConstantSync::test_enable_conditions_sync
+    //      C++:    RecommendationLogitsProcessorTest::testEnableConditionsTruthTable
+    //   3. 确认新条件在双侧真值表中均有覆盖（正反例）
+    //   未来演进：若条件进一步增多，应将真值表落为共享 JSON 数据文件（单一真源）。
+    const bool enable_cross_seq_ban = config->enable_cross_sequence_ban
+                                      && !config->hasNumBeams()
+                                      && config->combo_token_size >= 2
+                                      && num > 1;
+    // 可观测性：当用户显式开启但被降级禁用时，一次性输出所有不兼容原因
+    // 使用 INTERVAL_LOG 避免高 QPS 下同一配置重复告警形成日志风暴
+    if (config->enable_cross_sequence_ban && !enable_cross_seq_ban) {
+        std::string reasons;
+        if (config->hasNumBeams()) {
+            reasons += "incompatible with beam search; ";
+        }
+        if (config->combo_token_size < 2) {
+            reasons += "combo_token_size must be >= 2 (got " + std::to_string(config->combo_token_size) + "); ";
+        }
+        if (num <= 1) {
+            reasons += "num_return_sequences must be > 1 (got " + std::to_string(num) + "); ";
+        }
+        RTP_LLM_INTERVAL_LOG(300, WARN, "cross_sequence_ban disabled: %s", reasons.c_str());
+    }
+    // 遮蔽深度上界校验：最大遮蔽 k = num-1，若超过 kMaxDivergeDepth 则警告采样可能退化
+    if (enable_cross_seq_ban && num - 1 > kMaxDivergeDepth) {
+        RTP_LLM_INTERVAL_LOG(300, WARN,
+            "cross_sequence_ban: num_return_sequences=%d exceeds recommended max diverge depth %d, "
+            "sampling quality may degrade for higher-indexed sequences",
+            num, kMaxDivergeDepth);
+    }
+    const int32_t diverge_start_combo = std::max(0, config->cross_seq_diverge_start_combo);
+    if (config->cross_seq_diverge_start_combo < 0) {
+        RTP_LLM_INTERVAL_LOG(300, WARN, "cross_seq_diverge_start_combo is negative (%d), clamped to 0",
+                            config->cross_seq_diverge_start_combo);
+    } else if (enable_cross_seq_ban && diverge_start_combo > kDivergeStartComboWarnThreshold) {
+        RTP_LLM_INTERVAL_LOG(300, WARN,
+            "cross_seq_diverge_start_combo=%d is very large, top-K diverge masking may never activate",
+            diverge_start_combo);
+    }
     // 若为空,think_done 初始为 true,Processor 行为等同历史版本(从首个 token 起累 combo)。
     const std::vector<int>& end_think_token_ids = config->end_think_token_ids;
 
@@ -34,9 +99,11 @@ RecommendationLogitsProcessor::fromGenerateInput(std::shared_ptr<GenerateInput> 
         StreamRecommendationInfo info(config->combo_token_size,
                                       generate_input->inputLength(),
                                       /*current_output_length=*/0,
-                                      is_beam_search,
+                                      needs_token_offset,
                                       banned_combos,
-                                      end_think_token_ids);
+                                      end_think_token_ids,
+                                      enable_cross_seq_ban,
+                                      diverge_start_combo);
         processor_ptr->infos_.push_back(std::move(info));
     }
     return processor_ptr;
@@ -46,77 +113,154 @@ void RecommendationLogitsProcessor::process(const SamplerInputs& inputs, size_t 
     const size_t batch_size = finish_idx - start_idx;
     RTP_LLM_CHECK(batch_size == size());
 
-    // 仅在位于 combo 最后一位时需要施加掩码
-    bool need_process = false;
-    for (const auto& info : infos_) {
+    // 位置不变量（primary-index-0）：
+    // cross-seq ban 的 primary-protected 语义依赖 infos_[0] 恒为主序列、且 size() 在整个
+    // decode 生命周期内不变（无 stream 内子序列早停压缩或重排）。
+    // 保证条件：updateMultiSeqStatus 已断言与 cross-seq ban 互斥，此处 batch_size==size()
+    // 确认无压缩。若未来引入 intra-stream 子序列管理，需增加显式重排检测。
+
+    // 判断是否需要进行 banned combo 屏蔽或 top-K 分叉遮蔽
+    bool need_ban_process = false;
+    bool need_diverge_process = false;
+    for (size_t i = 0; i < batch_size; ++i) {
+        const auto& info = infos_[i];
         if (info.combo_token_size <= 0) {
             continue;
         }
         if (info.pos_in_combo == info.combo_token_size - 1 && !info.banned_combos.empty()) {
-            need_process = true;
-            break;
+            need_ban_process = true;
+        }
+        // top-K 分叉：非主序列(i>0) + think完成 + 在 combo 起始位置 + 已达到分叉起始商品 + 开关开启
+        if (i > 0 && info.enable_cross_sequence_ban && info.think_done
+            && info.pos_in_combo == 0
+            && info.completed_combo_count >= info.cross_seq_diverge_start_combo) {
+            need_diverge_process = true;
         }
     }
-    if (!need_process) {
+    if (!need_ban_process && !need_diverge_process) {
         return;
     }
 
     auto         logits     = inputs.logits.narrow(0, start_idx, batch_size);
     const size_t vocab_size = logits.size(1);
+    RTP_LLM_CHECK_WITH_INFO(vocab_size > 0, "process called with vocab_size=0");
 
-    // 只收集要屏蔽的 (row, col) 坐标,避开按 batch*vocab 分配 mask 张量与 H2D 拷贝的热路径开销。
-    std::vector<int64_t> rows;
-    std::vector<int64_t> cols;
-    for (size_t i = 0; i < batch_size; ++i) {
-        auto& info = infos_[i];
-        if (info.combo_token_size <= 0 || info.pos_in_combo != info.combo_token_size - 1) {
-            continue;
-        }
-        const int combo_last_idx = info.combo_token_size - 1;
-        // 对所有前 n-1 个 token 等于 current_prefix 的 banned combo,屏蔽其最后一位
-        for (const auto& combo : info.banned_combos) {
-            RTP_LLM_CHECK((int32_t)combo.size() == info.combo_token_size);
-            bool prefix_match = true;
-            for (int32_t k = 0; k < combo_last_idx; ++k) {
-                if (combo[k] != info.current_prefix[k]) {
-                    prefix_match = false;
-                    break;
-                }
-            }
-            if (!prefix_match) {
+    // --- top-K 分叉遮蔽：对非主序列在 combo 起始位置遮蔽前 i 个最大 logit ---
+    // 设计权衡（deliberate trade-off）：达到 diverge_start_combo 后，每个 combo 起点无条件遮蔽，
+    // 不判断序列是否已与主序列分叉。原因：
+    //   1) "已分叉" 难以定义 —— temperature/top_p 采样下 logits 不同不等于输出不同，
+    //      反之 logits 相同也可能采出不同 token，判断开销高且不可靠；
+    //   2) 遮蔽仅影响 combo 第一位（占生成 token 的 1/combo_token_size），且只剥夺 top-i
+    //      （i 为行号，通常 1~3），对整体质量影响有限；
+    //   3) 三层保护已约束风险：kMaxDivergeDepth 上界、diverge_start_combo 延迟启动、默认关闭。
+    // 若未来观察到高索引序列质量明显下降，可引入基于 banned_combos 差异度的自适应退出。
+    //
+    // 可观测性演进方向（生产侧质量验证）：
+    //   - 每序列平均被遮蔽 token 数（per-step masked_count / active_steps）
+    //   - 分叉命中率（diverge 遮蔽后实际采样到非 top-i 的比例）
+    //   - 高索引序列 combo 完成率 vs 主序列 combo 完成率
+    //   上述指标可通过 kmonitor counter 暴露，为自适应退出策略提供数据支撑。
+    //
+    // 批量化设计决策：对所有非主行做一次 batch topk(max_k)，而非逐行筛选后再 gather/topk/scatter。
+    // 原因：1) 单次 kernel launch 比多次显著更快；2) N=2-4 时几乎所有非主行都符合条件，
+    // 不符合条件的行其 topk 结果不会被使用（下方 for 循环中 skip），无副作用。
+    // trade-off 记录：对不需要 diverge 的行仍做了 topk，但避免了更复杂的条件筛选 + scatter 逻辑，
+    // 在 N<=8 的场景下，多余 topk 计算的开销远小于额外 kernel launch 的开销。
+    if (need_diverge_process) {
+        int max_k = 0;
+        for (size_t i = 1; i < batch_size; ++i) {
+            auto& info = infos_[i];
+            if (info.combo_token_size <= 0 || !info.enable_cross_sequence_ban || !info.think_done) continue;
+            if (info.pos_in_combo != 0
+                || info.completed_combo_count < info.cross_seq_diverge_start_combo) {
                 continue;
             }
-            const int banned_token = combo[combo_last_idx];
-            if (banned_token >= 0 && (size_t)banned_token < vocab_size) {
-                rows.push_back(static_cast<int64_t>(i));
-                cols.push_back(static_cast<int64_t>(banned_token));
+            int k = std::min({static_cast<int>(i), static_cast<int>(vocab_size) - 1, kMaxDivergeDepth});
+            if (k > max_k) max_k = k;
+        }
+        if (max_k > 0) {
+            // 防御：确保 topk 的 k 不超过 vocab_size（torch::topk 要求 k <= dim_size）
+            max_k = std::min(max_k, static_cast<int>(vocab_size));
+            // 仅对非主序列(row 1~N-1)做 topk，避免对 row 0 的无效计算
+            auto non_primary_logits = logits.narrow(0, 1, batch_size - 1);
+            auto topk_indices = std::get<1>(non_primary_logits.topk(max_k, /*dim=*/1));
+            for (size_t i = 1; i < batch_size; ++i) {
+                auto& info = infos_[i];
+                if (info.combo_token_size <= 0 || !info.enable_cross_sequence_ban || !info.think_done) continue;
+                if (info.pos_in_combo != 0
+                    || info.completed_combo_count < info.cross_seq_diverge_start_combo) {
+                    continue;
+                }
+                // 防御：确保至少保留 1 个可选 token，同时不超过 kMaxDivergeDepth 避免采样退化
+                const int k = std::min({static_cast<int>(i), static_cast<int>(vocab_size) - 1, kMaxDivergeDepth});
+                if (k <= 0) continue;
+                // 从预计算的 batch topk indices 中裁剪前 k 个位置进行遮蔽
+                // topk_indices 行号 = i-1（因为 narrow 排除了 row 0）
+                logits[i].index_put_({topk_indices[i - 1].slice(0, 0, k)},
+                                     -std::numeric_limits<float>::infinity());
             }
         }
     }
 
-    if (rows.empty()) {
-        return;
+    // --- banned combo 屏蔽 ---
+    if (need_ban_process) {
+        // 只收集要屏蔽的 (row, col) 坐标,避开按 batch*vocab 分配 mask 张量与 H2D 拷贝的热路径开销。
+        std::vector<int64_t> rows;
+        std::vector<int64_t> cols;
+        for (size_t i = 0; i < batch_size; ++i) {
+            auto& info = infos_[i];
+            if (info.combo_token_size <= 0 || info.pos_in_combo != info.combo_token_size - 1) {
+                continue;
+            }
+            const int combo_last_idx = info.combo_token_size - 1;
+            for (const auto& combo : info.banned_combos) {
+                RTP_LLM_CHECK((int32_t)combo.size() == info.combo_token_size);
+                bool prefix_match = true;
+                for (int32_t k = 0; k < combo_last_idx; ++k) {
+                    if (combo[k] != info.current_prefix[k]) {
+                        prefix_match = false;
+                        break;
+                    }
+                }
+                if (!prefix_match) {
+                    continue;
+                }
+                const int banned_token = combo[combo_last_idx];
+                if (banned_token >= 0 && (size_t)banned_token < vocab_size) {
+                    rows.push_back(static_cast<int64_t>(i));
+                    cols.push_back(static_cast<int64_t>(banned_token));
+                }
+            }
+        }
+        if (!rows.empty()) {
+            auto rows_t = torch::tensor(rows, torch::kLong).to(logits.device());
+            auto cols_t = torch::tensor(cols, torch::kLong).to(logits.device());
+            logits.index_put_({rows_t, cols_t}, -std::numeric_limits<float>::infinity());
+        }
     }
-
-    // 直接在 logits 上按坐标批量写 -inf,按命中数量分摊 H2D 拷贝,体积 O(K) 远小于 O(B*V)。
-    auto rows_t = torch::tensor(rows, torch::kLong).to(logits.device());
-    auto cols_t = torch::tensor(cols, torch::kLong).to(logits.device());
-    logits.index_put_({rows_t, cols_t}, -std::numeric_limits<float>::infinity());
 }
 
 void RecommendationLogitsProcessor::updateMultiSeqStatus(const std::vector<int>& src_batch_indices) {
+    RTP_LLM_CHECK_WITH_INFO(!infos_.empty(),
+        "updateMultiSeqStatus called on empty processor");
+    // 业务不变量：updateMultiSeqStatus 用于 beam search 重排序列，与 cross-sequence ban 互斥
+    RTP_LLM_CHECK_WITH_INFO(
+        std::none_of(infos_.begin(), infos_.end(),
+                     [](const StreamRecommendationInfo& info) { return info.enable_cross_sequence_ban; }),
+        "updateMultiSeqStatus must not be called when cross_sequence_ban is enabled");
     std::vector<StreamRecommendationInfo> new_infos;
     new_infos.reserve(src_batch_indices.size());
     for (const auto src_idx : src_batch_indices) {
         RTP_LLM_CHECK((size_t)src_idx < infos_.size());
-        new_infos.push_back(infos_[src_idx].copy());
+        new_infos.push_back(infos_[src_idx]);
     }
     infos_ = std::move(new_infos);
 }
 
-void RecommendationLogitsProcessor::advanceOneToken(StreamRecommendationInfo& info, int token_id) {
+bool RecommendationLogitsProcessor::advanceOneToken(StreamRecommendationInfo& info, int token_id,
+                                                    std::vector<std::vector<int>>* new_combos) {
     if (info.combo_token_size <= 0) {
-        return;
+        return false;
     }
 
     // 未完成 think prelude 跳过时,本 token 只用于推进 DFA,不进 combo 前缀。
@@ -131,20 +275,24 @@ void RecommendationLogitsProcessor::advanceOneToken(StreamRecommendationInfo& in
         } else {
             info.end_think_match_pos = 0;
         }
-        return;
+        return false;
     }
 
     if (info.pos_in_combo < info.combo_token_size - 1) {
         // combo 未结束:追加到前缀
         info.current_prefix.push_back(token_id);
         info.pos_in_combo += 1;
+        return false;
     } else {
         // 本次 token 即 combo 的最后一位:形成完整 combo 并加入去重集合
         std::vector<int> full_combo = info.current_prefix;
         full_combo.push_back(token_id);
+        if (new_combos) new_combos->push_back(full_combo);
         info.banned_combos.insert(std::move(full_combo));
         info.current_prefix.clear();
         info.pos_in_combo = 0;
+        info.completed_combo_count += 1;
+        return true;
     }
 }
 
@@ -153,26 +301,64 @@ void RecommendationLogitsProcessor::updateStatus(const torch::Tensor& new_tokens
     // 明确 sampler 输出契约:仅接受 int32,避免 dtype 变动后 data_ptr<int>() 静默读错字节。
     RTP_LLM_CHECK(new_tokens.scalar_type() == torch::kInt32);
     RTP_LLM_CHECK(size() == (size_t)new_tokens.size(0));
+    // 位置不变量（primary-index-0）：广播逻辑 i>=1 接收、i==0 保护，依赖 infos_ 顺序
+    // 在 decode 生命周期内不被重排。此不变量由 size()==new_tokens.size(0)(无压缩)
+    // + updateMultiSeqStatus 与 cross-seq ban 互斥（无重排）共同保证。
 
+    bool any_combo_completed = false;
+    // 仅在跨序列 ban 开启时分配 combo 收集容器，避免未启用功能时的无效内存分配
+    const bool need_broadcast = size() > 1 && infos_[0].enable_cross_sequence_ban;
+    // 强不变量断言：同 Processor 内所有 infos 的 enable_cross_sequence_ban 必须一致
+    // 仅在跨序列 ban 开启时执行 O(N) 扫描，避免未启用时在采样热路径上引入无谓开销
+    if (need_broadcast) {
+        RTP_LLM_CHECK_WITH_INFO(
+            std::all_of(infos_.begin(), infos_.end(),
+                        [&](const StreamRecommendationInfo& info) {
+                            return info.enable_cross_sequence_ban == infos_[0].enable_cross_sequence_ban;
+                        }),
+            "updateStatus: enable_cross_sequence_ban flag inconsistent across infos");
+    }
+    std::vector<std::vector<std::vector<int>>> new_combos_per_seq;
+    if (need_broadcast) {
+        new_combos_per_seq.resize(size());
+    }
     for (size_t i = 0; i < size(); ++i) {
         auto& info = infos_[i];
         if (info.combo_token_size <= 0) {
             continue;
         }
 
-        const int64_t offset = info.is_beam_search ? (info.current_output_length + info.input_length) : 0;
+        const int64_t offset = info.needs_token_offset ? (info.current_output_length + info.input_length) : 0;
 
-        if (!info.is_beam_search) {
+        if (!info.needs_token_offset) {
             RTP_LLM_CHECK(num_new_tokens == new_tokens.size(1));
         }
 
         const int64_t stride = new_tokens.size(1);
         for (int32_t j = 0; j < num_new_tokens; ++j) {
             const int token_id = new_tokens.data_ptr<int>()[i * stride + j + offset];
-            advanceOneToken(info, token_id);
+            if (advanceOneToken(info, token_id, need_broadcast ? &new_combos_per_seq[i] : nullptr)) {
+                any_combo_completed = true;
+            }
         }
 
         info.current_output_length += num_new_tokens;
+    }
+
+    // 跨序列增量广播（非对称模式）：将其他序列本步新完成的 combo 插入非主序列
+    // 设计意图（primary-protected）：序列 0（主序列）仅保留自身产生的 banned_combos，不接收其他
+    // 序列的 ban。补充序列接收所有其他序列的新增 combo，确保彼此不重复。
+    // 复杂度：O((N-1) * N * new_combos_per_step)，生产场景 N=2~4、每步最多 1 个 combo 完成，
+    // 实际开销可忽略。若未来 N 增大，可将序列 0 的 combo 批量插入后再处理交叉插入，或改用 shared 视图。
+    if (any_combo_completed && need_broadcast) {
+        for (size_t i = 1; i < size(); ++i) {
+            for (size_t j = 0; j < size(); ++j) {
+                if (j == i) continue;
+                for (const auto& combo : new_combos_per_seq[j]) {
+                    infos_[i].banned_combos.insert(combo);
+                }
+            }
+        }
     }
 }
 

--- a/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.h
+++ b/rtp_llm/cpp/models/logits_processor/RecommendationLogitsProcessor.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "rtp_llm/cpp/models/logits_processor/BaseLogitsProcessor.h"
+#include "rtp_llm/cpp/utils/AssertUtils.h"
 
 namespace rtp_llm {
 
@@ -16,13 +17,19 @@ namespace rtp_llm {
 // 对 qwen3 等会默认输出 <think>\n\n</think>\n\n 占位的模型,若 end_think_token_ids
 // 非空,则先按该序列跳过 think prelude,跳过完成前的 token 不进入 combo 前缀。
 struct StreamRecommendationInfo {
-    int32_t combo_token_size      = 0;
-    int32_t input_length          = 0;
-    int32_t current_output_length = 0;
-    bool    is_beam_search        = false;
+    int32_t combo_token_size          = 0;
+    int32_t input_length              = 0;
+    int32_t current_output_length     = 0;
+    // 实际语义：hasNumBeams() || num_return_sequences > 1，控制 token 读取是否需要 full-position offset。
+    // 与 enable_cross_sequence_ban 不互斥（互斥的是 hasNumBeams()，见 fromGenerateInput）。
+    bool    needs_token_offset        = false;
+    bool    enable_cross_sequence_ban = false;
+    int32_t cross_seq_diverge_start_combo = 0;
 
     // 当前正在生成 combo 内的位置,取值 [0, combo_token_size-1]
     int32_t pos_in_combo = 0;
+    // 已完成的 combo 数量（用于判断是否达到分叉起始位置）
+    int32_t completed_combo_count = 0;
     // 当前 combo 已生成的前缀(长度 = pos_in_combo)
     std::vector<int> current_prefix;
     // 被禁止生成的 combo 集合;初始由 config 填充,每产生一个完整 combo 自动加入
@@ -39,31 +46,26 @@ struct StreamRecommendationInfo {
     StreamRecommendationInfo(int32_t                           combo_token_size,
                              int32_t                           input_length,
                              int32_t                           current_output_length,
-                             bool                              is_beam_search,
+                             bool                              needs_token_offset,
                              const std::set<std::vector<int>>& banned_combos,
-                             const std::vector<int>&           end_think_token_ids = {}):
+                             const std::vector<int>&           end_think_token_ids = {},
+                             bool                              enable_cross_sequence_ban = false,
+                             int32_t                           cross_seq_diverge_start_combo = 0):
         combo_token_size(combo_token_size),
         input_length(input_length),
         current_output_length(current_output_length),
-        is_beam_search(is_beam_search),
+        needs_token_offset(needs_token_offset),
+        enable_cross_sequence_ban(enable_cross_sequence_ban),
+        cross_seq_diverge_start_combo(cross_seq_diverge_start_combo),
         banned_combos(banned_combos),
         end_think_token_ids(end_think_token_ids),
         think_done(end_think_token_ids.empty()) {}
 
-    StreamRecommendationInfo copy() const {
-        StreamRecommendationInfo info;
-        info.combo_token_size      = combo_token_size;
-        info.input_length          = input_length;
-        info.current_output_length = current_output_length;
-        info.is_beam_search        = is_beam_search;
-        info.pos_in_combo          = pos_in_combo;
-        info.current_prefix        = current_prefix;
-        info.banned_combos         = banned_combos;
-        info.end_think_token_ids   = end_think_token_ids;
-        info.think_done            = think_done;
-        info.end_think_match_pos   = end_think_match_pos;
-        return info;
-    }
+    // 默认拷贝构造/赋值即为深拷贝（std::set、std::vector 均值语义），无需手动 copy()。
+    StreamRecommendationInfo(const StreamRecommendationInfo&) = default;
+    StreamRecommendationInfo& operator=(const StreamRecommendationInfo&) = default;
+    StreamRecommendationInfo(StreamRecommendationInfo&&) = default;
+    StreamRecommendationInfo& operator=(StreamRecommendationInfo&&) = default;
 };
 
 class RecommendationLogitsProcessor: public BaseLogitsProcessor {
@@ -90,15 +92,36 @@ public:
         return infos_;
     }
     void insert(std::shared_ptr<RecommendationLogitsProcessor> others) {
-        if (others != nullptr) {
+        if (others != nullptr && !others->infos_.empty()) {
+            // 接口契约：合并后关键配置字段必须一致，否则广播/分叉判断失效
+            if (!infos_.empty()) {
+                const auto& existing = infos_[0];
+                const auto& incoming = others->infos_[0];
+                RTP_LLM_CHECK_WITH_INFO(
+                    existing.enable_cross_sequence_ban == incoming.enable_cross_sequence_ban,
+                    "insert: enable_cross_sequence_ban flag mismatch");
+                RTP_LLM_CHECK_WITH_INFO(
+                    existing.combo_token_size == incoming.combo_token_size,
+                    "insert: combo_token_size mismatch");
+                RTP_LLM_CHECK_WITH_INFO(
+                    existing.cross_seq_diverge_start_combo == incoming.cross_seq_diverge_start_combo,
+                    "insert: cross_seq_diverge_start_combo mismatch");
+                RTP_LLM_CHECK_WITH_INFO(
+                    existing.needs_token_offset == incoming.needs_token_offset,
+                    "insert: needs_token_offset mismatch");
+                RTP_LLM_CHECK_WITH_INFO(
+                    existing.end_think_token_ids == incoming.end_think_token_ids,
+                    "insert: end_think_token_ids mismatch");
+            }
             infos_.insert(infos_.end(), others->infos_.begin(), others->infos_.end());
         }
     }
 
 private:
-    // 将单个 token 推进到状态机;若形成完整 combo 则自动加入 banned_combos。
-    // 若 think prelude 未跳过完毕,则本 token 仅用于推进 think DFA,不进入 combo 前缀。
-    void advanceOneToken(StreamRecommendationInfo& info, int token_id);
+    // 将单个 token 推进到状态机;若形成完整 combo 则加入 banned_combos 并返回 true。
+    // 若 new_combos 非空，新完成的 combo 会同时被 push 到该向量（用于增量广播）。
+    bool advanceOneToken(StreamRecommendationInfo& info, int token_id,
+                         std::vector<std::vector<int>>* new_combos = nullptr);
 
 private:
     std::vector<StreamRecommendationInfo> infos_;

--- a/rtp_llm/cpp/models/logits_processor/test/RecommendationLogitsProcessorTest.cc
+++ b/rtp_llm/cpp/models/logits_processor/test/RecommendationLogitsProcessorTest.cc
@@ -11,10 +11,10 @@ namespace rtp_llm {
 // 构造一个 StreamRecommendationInfo 便捷方法
 static StreamRecommendationInfo makeInfo(int32_t                                  combo_token_size,
                                          const std::vector<std::vector<int>>&     banned,
-                                         bool                                     is_beam_search = false,
+                                         bool                                     needs_token_offset = false,
                                          int32_t                                  input_length   = 0) {
     std::set<std::vector<int>> banned_set(banned.begin(), banned.end());
-    return StreamRecommendationInfo(combo_token_size, input_length, 0, is_beam_search, banned_set);
+    return StreamRecommendationInfo(combo_token_size, input_length, 0, needs_token_offset, banned_set);
 }
 
 // 分配一个仅装载 logits 的 SamplerInputs（vocab_size 可控）
@@ -195,6 +195,852 @@ TEST_F(RecommendationLogitsProcessorTest, testFromGenerateInputEnabled) {
         EXPECT_EQ(3, info.combo_token_size);
         EXPECT_EQ(2u, info.banned_combos.size());  // (7,8) 已被过滤
         EXPECT_EQ(5, info.input_length);
+    }
+}
+
+// 场景 8：跨序列去重（非对称模式）—— 序列 0 不接收其他序列的 ban，补充序列接收所有
+TEST_F(RecommendationLogitsProcessorTest, testCrossSequenceBanAsymmetric) {
+    // 模拟 2 条序列，combo_token_size=3，开启跨序列去重
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 序列 0 生成 combo (1,2,3)，序列 1 生成 combo (4,5,6)
+    auto step = [&](int tok0, int tok1) {
+        auto t = torch::tensor({{tok0}, {tok1}}, torch::kInt32);
+        processor->updateStatus(t, 1);
+    };
+    step(1, 4);  // pos_in_combo: 0 → 1
+    step(2, 5);  // pos_in_combo: 1 → 2
+    step(3, 6);  // pos_in_combo: 2 → 0 (combo 完成)
+
+    // 非对称广播：序列 0 只有自己的，序列 1 有所有的
+    ASSERT_EQ(1u, processor->infos()[0].banned_combos.size());
+    ASSERT_EQ(2u, processor->infos()[1].banned_combos.size());
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({1, 2, 3}));
+    EXPECT_FALSE(processor->infos()[0].banned_combos.count({4, 5, 6}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({1, 2, 3}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({4, 5, 6}));
+
+    // 验证 completed_combo_count
+    EXPECT_EQ(1, processor->infos()[0].completed_combo_count);
+    EXPECT_EQ(1, processor->infos()[1].completed_combo_count);
+}
+
+// 场景 9：关闭跨序列去重时，各序列独立维护 banned_combos
+TEST_F(RecommendationLogitsProcessorTest, testCrossSequenceBanDisabled) {
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    // enable_cross_sequence_ban = false
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, false));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, false));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    auto step = [&](int tok0, int tok1) {
+        auto t = torch::tensor({{tok0}, {tok1}}, torch::kInt32);
+        processor->updateStatus(t, 1);
+    };
+    step(1, 4);
+    step(2, 5);
+    step(3, 6);
+
+    // 关闭跨序列去重时，各序列只有自己的 combo
+    ASSERT_EQ(1u, processor->infos()[0].banned_combos.size());
+    ASSERT_EQ(1u, processor->infos()[1].banned_combos.size());
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({1, 2, 3}));
+    EXPECT_FALSE(processor->infos()[0].banned_combos.count({4, 5, 6}));
+    EXPECT_TRUE(processor->infos()[1].banned_combos.count({4, 5, 6}));
+    EXPECT_FALSE(processor->infos()[1].banned_combos.count({1, 2, 3}));
+}
+
+// 场景 10：top-K 分叉遮蔽——非主序列在 combo 起始位置被遮蔽 top-i
+TEST_F(RecommendationLogitsProcessorTest, testTopKDivergeMasking) {
+    // 3 条序列，combo_token_size=3，开启跨序列去重，diverge_start_combo=0
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 通过 allocateSamplerInputs 在 CUDA 上分配 logits，与生产环境一致
+    const size_t vocab_size = 5;
+    auto sampler_inputs = allocateSamplerInputs(3, vocab_size, processor);
+    // 填充 logits: 每行 = [1.0, 5.0, 3.0, 4.0, 2.0]
+    // top-1=col1(5.0), top-2=col3(4.0)
+    auto logits_cpu = torch::tensor({{1.0f, 5.0f, 3.0f, 4.0f, 2.0f},
+                                      {1.0f, 5.0f, 3.0f, 4.0f, 2.0f},
+                                      {1.0f, 5.0f, 3.0f, 4.0f, 2.0f}});
+    sampler_inputs.logits.copy_(logits_cpu);
+
+    // 所有序列 pos_in_combo=0 且 completed_combo_count=0 >= diverge_start=0
+    processor->process(sampler_inputs, 0, 3);
+
+    auto result = sampler_inputs.logits.cpu();
+    // 序列 0（主）：不受影响，top-1 仍然是 col1
+    EXPECT_FLOAT_EQ(5.0f, result[0][1].item<float>());
+    EXPECT_FLOAT_EQ(4.0f, result[0][3].item<float>());
+
+    // 序列 1：遮蔽 top-1 (col1)，col1 应为 -inf
+    EXPECT_TRUE(std::isinf(result[1][1].item<float>()) && result[1][1].item<float>() < 0);
+    EXPECT_FLOAT_EQ(4.0f, result[1][3].item<float>());  // top-2 不受影响
+
+    // 序列 2：遮蔽 top-1,2 (col1, col3)，两者应为 -inf
+    EXPECT_TRUE(std::isinf(result[2][1].item<float>()) && result[2][1].item<float>() < 0);
+    EXPECT_TRUE(std::isinf(result[2][3].item<float>()) && result[2][3].item<float>() < 0);
+}
+
+// 场景 11：diverge_start_combo 延迟分叉——前 N 个商品不遮蔽
+TEST_F(RecommendationLogitsProcessorTest, testDivergeStartComboDelay) {
+    // 2 条序列，combo_token_size=3，diverge_start_combo=1（前 1 个商品不分叉）
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 1));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 1));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 第 1 个 combo 开始时 completed_combo_count=0 < diverge_start=1，不应遮蔽
+    const size_t vocab_size = 3;
+    auto sampler_inputs1 = allocateSamplerInputs(2, vocab_size, processor);
+    auto init_vals1 = torch::tensor({{1.0f, 5.0f, 3.0f}, {1.0f, 5.0f, 3.0f}});
+    sampler_inputs1.logits.copy_(init_vals1);
+    processor->process(sampler_inputs1, 0, 2);
+
+    auto result1 = sampler_inputs1.logits.cpu();
+    // 序列 1 的 top-1 不应被遮蔽（因为还没达到 diverge_start_combo）
+    EXPECT_FLOAT_EQ(5.0f, result1[1][1].item<float>());
+
+    // 生成完成第 1 个 combo
+    auto step = [&](int tok0, int tok1) {
+        auto t = torch::tensor({{tok0}, {tok1}}, torch::kInt32);
+        processor->updateStatus(t, 1);
+    };
+    step(1, 1);
+    step(2, 2);
+    step(3, 3);
+    // 现在 completed_combo_count=1 >= diverge_start=1
+
+    // 第 2 个 combo 开始时，应该对序列 1 遮蔽
+    auto sampler_inputs2 = allocateSamplerInputs(2, vocab_size, processor);
+    auto init_vals2 = torch::tensor({{1.0f, 5.0f, 3.0f}, {1.0f, 5.0f, 3.0f}});
+    sampler_inputs2.logits.copy_(init_vals2);
+    processor->process(sampler_inputs2, 0, 2);
+
+    auto result2 = sampler_inputs2.logits.cpu();
+    // 序列 1 的 top-1 (col1) 现在应被遮蔽
+    EXPECT_TRUE(std::isinf(result2[1][1].item<float>()) && result2[1][1].item<float>() < 0);
+    // 序列 0 不受影响
+    EXPECT_FLOAT_EQ(5.0f, result2[0][1].item<float>());
+}
+
+// 场景 12：combo_token_size==1 时跨序列去重被降级禁用（前置校验）
+TEST_F(RecommendationLogitsProcessorTest, testCrossSeqBanDisabledWhenComboSize1) {
+    auto generate_input             = std::make_shared<GenerateInput>();
+    generate_input->generate_config = std::make_shared<GenerateConfig>();
+    generate_input->generate_config->combo_token_size            = 1;
+    generate_input->generate_config->enable_cross_sequence_ban   = true;
+    generate_input->generate_config->num_return_sequences        = 4;
+    generate_input->generate_config->banned_combo_token_ids      = {{5}};
+    generate_input->input_ids                                    = torch::zeros({3}, torch::kInt32);
+
+    auto p = RecommendationLogitsProcessor::fromGenerateInput(generate_input, 4);
+    ASSERT_NE(nullptr, p);
+    // combo_token_size==1 时 enable_cross_sequence_ban 应被降级为 false
+    for (const auto& info : p->infos()) {
+        EXPECT_FALSE(info.enable_cross_sequence_ban);
+    }
+}
+
+// 场景 13：diverge 遮蔽与 banned combo 屏蔽在同一次 process() 中同时生效
+TEST_F(RecommendationLogitsProcessorTest, testDivergeAndBanSimultaneous) {
+    // 3 条序列，combo_token_size=3，开启跨序列去重
+    // 序列 0: pos_in_combo=0 —— 主序列，不受 diverge 影响
+    // 序列 1: pos_in_combo=0 —— 触发 diverge 遮蔽 (top-1)
+    // 序列 2: pos_in_combo=2 且前缀匹配 banned combo —— 触发 ban 屏蔽
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> banned_with_match({{10, 20, 30}});
+    std::set<std::vector<int>> empty_set;
+
+    // 序列 0: pos=0, 主序列
+    auto info0 = StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0);
+    infos.push_back(info0);
+
+    // 序列 1: pos=0, 待 diverge
+    auto info1 = StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0);
+    infos.push_back(info1);
+
+    // 序列 2: pos=2, prefix={10,20}, banned={(10,20,30)} —— 待 ban
+    auto info2 = StreamRecommendationInfo(3, 0, 0, false, banned_with_match, {}, true, 0);
+    info2.pos_in_combo = 2;
+    info2.current_prefix = {10, 20};
+    infos.push_back(info2);
+
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // vocab_size=50，在 CUDA 上分配
+    const size_t vocab_size = 50;
+    auto sampler_inputs = allocateSamplerInputs(3, vocab_size, processor);
+    // 每行填充为 1.0，方便观察哪些位置被置为 -inf
+    sampler_inputs.logits.fill_(1.0f);
+
+    processor->process(sampler_inputs, 0, 3);
+
+    auto result = sampler_inputs.logits.cpu();
+    auto data0 = result[0].data_ptr<float>();
+    auto data1 = result[1].data_ptr<float>();
+    auto data2 = result[2].data_ptr<float>();
+
+    // 序列 0：主序列，所有位置仍为 1.0（无 diverge，无 ban）
+    for (size_t j = 0; j < vocab_size; ++j) {
+        EXPECT_FLOAT_EQ(1.0f, data0[j]);
+    }
+
+    // 序列 1：diverge 遮蔽 top-1（所有值都是 1.0，topk 选出第一个），应有恰好 1 个位置被置为 -inf
+    int inf_count_seq1 = 0;
+    for (size_t j = 0; j < vocab_size; ++j) {
+        if (std::isinf(data1[j]) && data1[j] < 0) inf_count_seq1++;
+    }
+    EXPECT_EQ(1, inf_count_seq1);  // top-1 遮蔽
+
+    // 序列 2：ban 屏蔽 token 30（前缀 {10,20} 匹配 banned combo {10,20,30}）
+    // 序列 2 在 pos=2 不触发 diverge（diverge 仅在 pos=0），仅触发 ban
+    EXPECT_TRUE(std::isinf(data2[30]) && data2[30] < 0);
+    // 其他位置不受影响
+    EXPECT_FLOAT_EQ(1.0f, data2[29]);
+    EXPECT_FLOAT_EQ(1.0f, data2[31]);
+}
+
+// 场景 14：updateMultiSeqStatus 与 cross-sequence ban 互斥——启用时调用应触发 assert
+TEST_F(RecommendationLogitsProcessorTest, testUpdateMultiSeqStatusRejectsWhenCrossSeqBanEnabled) {
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    // enable_cross_sequence_ban = true
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // updateMultiSeqStatus 在 cross_sequence_ban 启用时应触发断言失败
+    EXPECT_ANY_THROW(processor->updateMultiSeqStatus({0, 1}));
+}
+
+// 场景 15：updateMultiSeqStatus 在关闭 cross-sequence ban 时正常工作
+TEST_F(RecommendationLogitsProcessorTest, testUpdateMultiSeqStatusWorksWhenCrossSeqBanDisabled) {
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    // enable_cross_sequence_ban = false
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, false, 0));
+    infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, false, 0));
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 关闭时正常重排，不抛异常
+    EXPECT_NO_THROW(processor->updateMultiSeqStatus({1, 0}));
+    // 验证重排生效（序列交换）
+    EXPECT_EQ(processor->infos().size(), 2u);
+}
+
+// 场景 16：通过 fromGenerateInput 走生产路径（needs_token_offset=true, enable_cross_seq_ban=true）
+// 验证 updateStatus 在 offset = current_output_length + input_length 路径下正确工作
+TEST_F(RecommendationLogitsProcessorTest, testFromGenerateInputProductionPath) {
+    // 配置：combo_token_size=3, num_return_sequences=3, enable_cross_sequence_ban=true
+    // 生产中 needs_token_offset = hasNumBeams() || num_return_sequences > 1 = true
+    // 注意：needs_token_offset 与 enable_cross_sequence_ban 不互斥，
+    // 互斥的是 hasNumBeams()（即真正的 beam search），这里 num_return_sequences>1 触发 offset 但不是 beam search。
+    auto generate_input             = std::make_shared<GenerateInput>();
+    generate_input->generate_config = std::make_shared<GenerateConfig>();
+    generate_input->generate_config->combo_token_size          = 3;
+    generate_input->generate_config->num_return_sequences      = 3;
+    generate_input->generate_config->enable_cross_sequence_ban = true;
+    generate_input->generate_config->cross_seq_diverge_start_combo = 0;
+    generate_input->generate_config->banned_combo_token_ids    = {};
+    generate_input->input_ids = torch::zeros({4}, torch::kInt32);  // input_length=4
+
+    auto p = RecommendationLogitsProcessor::fromGenerateInput(generate_input, 3);
+    ASSERT_NE(nullptr, p);
+    ASSERT_EQ(3u, p->size());
+
+    // 验证 needs_token_offset=true 和 enable_cross_sequence_ban=true
+    for (const auto& info : p->infos()) {
+        EXPECT_TRUE(info.needs_token_offset);
+        EXPECT_TRUE(info.enable_cross_sequence_ban);
+        EXPECT_EQ(4, info.input_length);
+    }
+
+    // 模拟 updateStatus （needs_token_offset=true 路径）
+    // tensor 形状 [N, input_length + total_output_length]
+    // 第一步：output_length=0，offset=0+4=4，张量的第 4 列是新 token
+    int input_len = 4;
+    auto tokens_step1 = torch::zeros({3, input_len + 1}, torch::kInt32);
+    // 序列 0 生成 token 10，序列 1 生成 token 20，序列 2 生成 token 30
+    tokens_step1[0][input_len] = 10;
+    tokens_step1[1][input_len] = 20;
+    tokens_step1[2][input_len] = 30;
+    p->updateStatus(tokens_step1, 1);
+
+    // 每个序列 pos_in_combo 应该前进到 1
+    for (const auto& info : p->infos()) {
+        EXPECT_EQ(1, info.pos_in_combo);
+    }
+
+    // 第二步：output_length=1，offset=1+4=5
+    auto tokens_step2 = torch::zeros({3, input_len + 2}, torch::kInt32);
+    tokens_step2[0][input_len + 1] = 11;
+    tokens_step2[1][input_len + 1] = 21;
+    tokens_step2[2][input_len + 1] = 31;
+    p->updateStatus(tokens_step2, 1);
+
+    for (const auto& info : p->infos()) {
+        EXPECT_EQ(2, info.pos_in_combo);
+    }
+
+    // 第三步：output_length=2，offset=2+4=6，combo 完成
+    auto tokens_step3 = torch::zeros({3, input_len + 3}, torch::kInt32);
+    tokens_step3[0][input_len + 2] = 12;
+    tokens_step3[1][input_len + 2] = 22;
+    tokens_step3[2][input_len + 2] = 32;
+    p->updateStatus(tokens_step3, 1);
+
+    // combo 完成，非对称广播：序列 0 仅有自己的，序列 1/2 有所有的
+    EXPECT_EQ(1u, p->infos()[0].banned_combos.size());
+    EXPECT_EQ(3u, p->infos()[1].banned_combos.size());
+    EXPECT_EQ(3u, p->infos()[2].banned_combos.size());
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({10, 11, 12}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({10, 11, 12}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({20, 21, 22}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({30, 31, 32}));
+}
+
+// 场景 17：needs_token_offset=true + num_new_tokens>1 组合路径
+// 验证 updateStatus 在 offset>0 且 j>0 时索引算术 [i*stride + j + offset] 正确
+TEST_F(RecommendationLogitsProcessorTest, testOffsetWithMultiTokenAdvance) {
+    // 配置：combo_token_size=2, num_return_sequences=2, enable_cross_sequence_ban=true
+    // needs_token_offset=true (num_return_sequences > 1)
+    auto generate_input             = std::make_shared<GenerateInput>();
+    generate_input->generate_config = std::make_shared<GenerateConfig>();
+    generate_input->generate_config->combo_token_size          = 2;
+    generate_input->generate_config->num_return_sequences      = 2;
+    generate_input->generate_config->enable_cross_sequence_ban = true;
+    generate_input->generate_config->cross_seq_diverge_start_combo = 0;
+    generate_input->generate_config->banned_combo_token_ids    = {};
+    generate_input->input_ids = torch::zeros({3}, torch::kInt32);  // input_length=3
+
+    auto p = RecommendationLogitsProcessor::fromGenerateInput(generate_input, 2);
+    ASSERT_NE(nullptr, p);
+    ASSERT_EQ(2u, p->size());
+    for (const auto& info : p->infos()) {
+        EXPECT_TRUE(info.needs_token_offset);
+        EXPECT_EQ(3, info.input_length);
+    }
+
+    // 一次推进 2 个 token (num_new_tokens=2)
+    // 当前状态：current_output_length=0，offset = 0 + 3 = 3
+    // tensor 形状 [2, input_length + num_new_tokens] = [2, 5]
+    // 序列 i 的 token 在 row i，列 offset+j = 3+0, 3+1
+    const int input_len = 3;
+    const int num_new = 2;
+    auto tokens = torch::zeros({2, input_len + num_new}, torch::kInt32);
+    // 序列 0: token at col 3 = 10, col 4 = 11 → combo [10,11] 完成
+    tokens[0][input_len + 0] = 10;
+    tokens[0][input_len + 1] = 11;
+    // 序列 1: token at col 3 = 20, col 4 = 21 → combo [20,21] 完成
+    tokens[1][input_len + 0] = 20;
+    tokens[1][input_len + 1] = 21;
+
+    p->updateStatus(tokens, num_new);
+
+    // 两个序列各完成 1 个 combo
+    EXPECT_EQ(0, p->infos()[0].pos_in_combo);  // combo 完成后重置为 0
+    EXPECT_EQ(1, p->infos()[0].completed_combo_count);
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({10, 11}));
+
+    EXPECT_EQ(0, p->infos()[1].pos_in_combo);
+    EXPECT_EQ(1, p->infos()[1].completed_combo_count);
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({20, 21}));
+
+    // 跨序列广播：序列 1 收到序列 0 的 combo，序列 0（主序列）不收
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({10, 11}));
+    EXPECT_FALSE(p->infos()[0].banned_combos.count({20, 21}));
+
+    // 第二步：current_output_length=2，offset = 2 + 3 = 5
+    // tensor 形状 [2, input_length + total_output_length] = [2, 7]
+    // 新 token 在列 5, 6
+    auto tokens2 = torch::zeros({2, input_len + num_new + num_new}, torch::kInt32);
+    tokens2[0][input_len + num_new + 0] = 30;
+    tokens2[0][input_len + num_new + 1] = 31;
+    tokens2[1][input_len + num_new + 0] = 40;
+    tokens2[1][input_len + num_new + 1] = 41;
+
+    p->updateStatus(tokens2, num_new);
+
+    // 序列 0: 第 2 个 combo [30,31] 完成
+    EXPECT_EQ(2, p->infos()[0].completed_combo_count);
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({30, 31}));
+    // 序列 1: 第 2 个 combo [40,41] 完成
+    EXPECT_EQ(2, p->infos()[1].completed_combo_count);
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({40, 41}));
+    // 序列 1 收到序列 0 的 [30,31]
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({30, 31}));
+}
+
+// 场景 18：top-K 遮蔽深度上界保护 —— num_return_sequences=12 时，序列 11 的遮蔽深度
+// 应被 kMaxDivergeDepth(=8) 钳制，至少保留足够可选 token
+TEST_F(RecommendationLogitsProcessorTest, testDivergeDepthCappedByMaxLimit) {
+    const int N = 12;  // 超过 kMaxDivergeDepth=8
+    const int combo_size = 2;
+    const int vocab = 20;
+
+    std::vector<StreamRecommendationInfo> infos;
+    for (int i = 0; i < N; ++i) {
+        StreamRecommendationInfo info(combo_size, 0, 0, false, {}, {},
+                                      /*enable_cross_sequence_ban=*/true,
+                                      /*cross_seq_diverge_start_combo=*/0);
+        infos.push_back(std::move(info));
+    }
+    auto p = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+
+    // 通过 allocateSamplerInputs 在 CUDA 上分配，与其他测试保持一致
+    auto sampler_inputs = allocateSamplerInputs(N, vocab, p);
+    // 填充 logits: 让 token 0~11 有高分，方便观察遮蔽
+    sampler_inputs.logits.fill_(1.0f);
+    for (int i = 0; i < N; ++i) {
+        for (int j = 0; j < N; ++j) {
+            sampler_inputs.logits[i][j] = 100.0f - j;
+        }
+    }
+
+    p->process(sampler_inputs, 0, N);
+
+    auto logits_cpu = sampler_inputs.logits.cpu();
+    // 序列 0 不应被遮蔽
+    for (int j = 0; j < vocab; ++j) {
+        EXPECT_GT(logits_cpu[0][j].item<float>(), -1e30);
+    }
+    // 序列 11(i=11)：k = min(11, vocab-1=19, kMaxDivergeDepth=8) = 8
+    // 应恰好有 8 个 token 被遮蔽为 -inf
+    int masked_count = 0;
+    for (int j = 0; j < vocab; ++j) {
+        if (logits_cpu[11][j].item<float>() < -1e30) {
+            masked_count++;
+        }
+    }
+    EXPECT_EQ(8, masked_count);  // 受 kMaxDivergeDepth 钳制，而非 11
+
+    // 序列 5(i=5)：k = min(5, 19, 8) = 5，正常不受 cap 影响
+    int masked_count_5 = 0;
+    for (int j = 0; j < vocab; ++j) {
+        if (logits_cpu[5][j].item<float>() < -1e30) {
+            masked_count_5++;
+        }
+    }
+    EXPECT_EQ(5, masked_count_5);
+}
+
+// 场景 19：num_new_tokens > 1 批量推进（speculative decoding 场景）
+// 一次推 3 个 token，combo_size=2，同一序列在一次 updateStatus 中完成 1 个 combo 并开始下一个
+TEST_F(RecommendationLogitsProcessorTest, testBatchTokenAdvance) {
+    const int N = 2;
+    const int combo_size = 2;
+    std::set<std::vector<int>> empty_set;
+
+    std::vector<StreamRecommendationInfo> infos;
+    for (int i = 0; i < N; ++i) {
+        StreamRecommendationInfo info(combo_size, 0, 0, false, empty_set, {},
+                                      /*enable_cross_sequence_ban=*/true,
+                                      /*cross_seq_diverge_start_combo=*/0);
+        infos.push_back(std::move(info));
+    }
+    auto p = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+
+    // 一次推 3 个 token: [A, B, C]
+    // combo_size=2: token A+B 组成第 1 个 combo，token C 是第 2 个 combo 的第 1 位
+    auto tokens = torch::zeros({N, 3}, torch::kInt32);
+    tokens[0][0] = 10; tokens[0][1] = 11; tokens[0][2] = 20;
+    tokens[1][0] = 30; tokens[1][1] = 31; tokens[1][2] = 40;
+
+    p->updateStatus(tokens, 3);  // num_new_tokens=3
+
+    // 序列 0: combo [10,11] 完成，然后 token 20 开始新 combo→pos_in_combo=1
+    EXPECT_EQ(1, p->infos()[0].pos_in_combo);
+    EXPECT_EQ(1, p->infos()[0].completed_combo_count);
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({10, 11}));
+
+    // 序列 1: combo [30,31] 完成，然后 token 40 开始新 combo→pos_in_combo=1
+    EXPECT_EQ(1, p->infos()[1].pos_in_combo);
+    EXPECT_EQ(1, p->infos()[1].completed_combo_count);
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({30, 31}));
+
+    // 跨序列广播验证：序列 1 应收到序列 0 的 combo [10,11]
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({10, 11}));
+    // 序列 0 不接收序列 1 的 combo（primary-protected）
+    EXPECT_FALSE(p->infos()[0].banned_combos.count({30, 31}));
+}
+
+// 场景 20：num_new_tokens=4，combo_size=2，同一序列一次 updateStatus 完成 2 个完整 combo
+TEST_F(RecommendationLogitsProcessorTest, testBatchTokenMultipleCombos) {
+    const int N = 2;
+    const int combo_size = 2;
+    std::set<std::vector<int>> empty_set;
+
+    std::vector<StreamRecommendationInfo> infos;
+    for (int i = 0; i < N; ++i) {
+        StreamRecommendationInfo info(combo_size, 0, 0, false, empty_set, {},
+                                      /*enable_cross_sequence_ban=*/true,
+                                      /*cross_seq_diverge_start_combo=*/0);
+        infos.push_back(std::move(info));
+    }
+    auto p = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+
+    // 一次推 4 个 token: combo_size=2 → 完成 2 个 combo
+    // 序列 0: [A,B,C,D] → combo1=[A,B], combo2=[C,D]
+    auto tokens = torch::zeros({N, 4}, torch::kInt32);
+    tokens[0][0] = 1; tokens[0][1] = 2; tokens[0][2] = 3; tokens[0][3] = 4;
+    tokens[1][0] = 5; tokens[1][1] = 6; tokens[1][2] = 7; tokens[1][3] = 8;
+
+    p->updateStatus(tokens, 4);
+
+    // 序列 0: 2 个 combo 完成，pos_in_combo=0 (刚好在边界上)
+    EXPECT_EQ(0, p->infos()[0].pos_in_combo);
+    EXPECT_EQ(2, p->infos()[0].completed_combo_count);
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({1, 2}));
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({3, 4}));
+
+    // 序列 1: 同样 2 个 combo
+    EXPECT_EQ(0, p->infos()[1].pos_in_combo);
+    EXPECT_EQ(2, p->infos()[1].completed_combo_count);
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({5, 6}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({7, 8}));
+
+    // 跨序列广播：序列 1 应收到序列 0 的两个 combo
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({1, 2}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({3, 4}));
+    // 序列 0 不接收序列 1 的
+    EXPECT_FALSE(p->infos()[0].banned_combos.count({5, 6}));
+}
+
+// 场景 21：think prelude 未完成时不进 combo，完成后正常进 combo + 跨序列广播
+TEST_F(RecommendationLogitsProcessorTest, testThinkPreludeWithCrossSeqBan) {
+    const int N = 2;
+    const int combo_size = 2;
+    std::set<std::vector<int>> empty_set;
+    // end_think_token_ids = {99, 100}
+    std::vector<int> end_think_ids = {99, 100};
+
+    std::vector<StreamRecommendationInfo> infos;
+    for (int i = 0; i < N; ++i) {
+        StreamRecommendationInfo info(combo_size, 0, 0, false, empty_set, end_think_ids,
+                                      /*enable_cross_sequence_ban=*/true,
+                                      /*cross_seq_diverge_start_combo=*/0);
+        infos.push_back(std::move(info));
+    }
+    auto p = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+
+    // 第 1 步：推送非 end_think token，think 未完成，combo 不应推进
+    auto tokens1 = torch::zeros({N, 1}, torch::kInt32);
+    tokens1[0][0] = 50;  tokens1[1][0] = 50;
+    p->updateStatus(tokens1, 1);
+    EXPECT_EQ(0, p->infos()[0].pos_in_combo);  // combo 未推进
+    EXPECT_EQ(0, p->infos()[0].completed_combo_count);
+    EXPECT_FALSE(p->infos()[0].think_done);
+
+    // 第 2 步：推送 end_think 序列的第一个 token (99)
+    auto tokens2 = torch::zeros({N, 1}, torch::kInt32);
+    tokens2[0][0] = 99;  tokens2[1][0] = 99;
+    p->updateStatus(tokens2, 1);
+    EXPECT_FALSE(p->infos()[0].think_done);  // 仅匹配一半
+
+    // 第 3 步：推送 end_think 序列的第二个 token (100)，think 完成
+    auto tokens3 = torch::zeros({N, 1}, torch::kInt32);
+    tokens3[0][0] = 100;  tokens3[1][0] = 100;
+    p->updateStatus(tokens3, 1);
+    EXPECT_TRUE(p->infos()[0].think_done);
+    EXPECT_EQ(0, p->infos()[0].pos_in_combo);  // combo 仍未开始
+
+    // 第 4-5 步：think 完成后推送 combo token，应形成完整 combo 并广播
+    auto tokens4 = torch::zeros({N, 1}, torch::kInt32);
+    tokens4[0][0] = 10;  tokens4[1][0] = 30;
+    p->updateStatus(tokens4, 1);
+    EXPECT_EQ(1, p->infos()[0].pos_in_combo);  // combo 推进到第 1 位
+
+    auto tokens5 = torch::zeros({N, 1}, torch::kInt32);
+    tokens5[0][0] = 11;  tokens5[1][0] = 31;
+    p->updateStatus(tokens5, 1);
+    EXPECT_EQ(0, p->infos()[0].pos_in_combo);  // combo 完成，复位
+    EXPECT_EQ(1, p->infos()[0].completed_combo_count);
+    EXPECT_TRUE(p->infos()[0].banned_combos.count({10, 11}));
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({30, 31}));
+    // 跨序列广播
+    EXPECT_TRUE(p->infos()[1].banned_combos.count({10, 11}));
+    // primary-protected: 序列 0 不接收序列 1
+    EXPECT_FALSE(p->infos()[0].banned_combos.count({30, 31}));
+}
+
+// 场景 21：num_return_sequences=1 + enable_cross_sequence_ban=true 的 no-op 边界
+TEST_F(RecommendationLogitsProcessorTest, testSingleSequenceCrossSeqBanNoOp) {
+    // N=1 时 updateStatus 跳过广播(size()>1 不满足)，process 跳过 diverge(i>0 不满足)
+    const int N = 1;
+    const size_t vocab_size = 10;
+    const int combo_size = 2;
+    std::set<std::vector<int>> banned = {{1, 2}};
+
+    std::vector<StreamRecommendationInfo> infos;
+    StreamRecommendationInfo info(combo_size, 0, 0, false, banned, {},
+                                   /*enable_cross_sequence_ban=*/true,
+                                   /*cross_seq_diverge_start_combo=*/0);
+    info.pos_in_combo = 1;
+    info.current_prefix = {1};
+    info.completed_combo_count = 1;
+    infos.push_back(std::move(info));
+
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+    auto inputs = allocateSamplerInputs(N, vocab_size, processor);
+    inputs.logits.fill_(1.0f);
+
+    processor->process(inputs, 0, N);
+
+    // ban 应该正常工作：token 2 被封锁
+    auto logits_cpu = inputs.logits.cpu();
+    auto acc = logits_cpu.accessor<float, 2>();
+    EXPECT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), acc[0][2]);
+    // 其他 token 不受影响
+    EXPECT_FLOAT_EQ(1.0f, acc[0][0]);
+    EXPECT_FLOAT_EQ(1.0f, acc[0][1]);
+    EXPECT_FLOAT_EQ(1.0f, acc[0][3]);
+
+    // updateStatus 不应崩溃，且无广播发生
+    auto tokens = torch::zeros({N, 1}, torch::kInt32);
+    tokens[0][0] = 2;  // 完成 combo [1,2]
+    processor->updateStatus(tokens, 1);
+    EXPECT_EQ(2, processor->infos()[0].completed_combo_count);
+    EXPECT_TRUE(processor->infos()[0].banned_combos.count({1, 2}));
+}
+
+// 场景 22：insert() flag 一致性校验
+TEST_F(RecommendationLogitsProcessorTest, testInsertFlagConsistencyCheck) {
+    const int combo_size = 3;
+    std::set<std::vector<int>> empty_set;
+    std::vector<int> no_think;
+
+    // 正向：flag 一致时 insert 成功
+    {
+        std::vector<StreamRecommendationInfo> infos_a;
+        infos_a.emplace_back(combo_size, 0, 0, false, empty_set, no_think,
+                             /*enable_cross_sequence_ban=*/true, 0);
+        auto proc_a = std::make_shared<RecommendationLogitsProcessor>(std::move(infos_a));
+
+        std::vector<StreamRecommendationInfo> infos_b;
+        infos_b.emplace_back(combo_size, 0, 0, false, empty_set, no_think,
+                             /*enable_cross_sequence_ban=*/true, 0);
+        auto proc_b = std::make_shared<RecommendationLogitsProcessor>(std::move(infos_b));
+
+        proc_a->insert(proc_b);
+        EXPECT_EQ(2u, proc_a->size());
+    }
+
+    // 反向：flag 不一致时触发 CHECK 失败
+    {
+        std::vector<StreamRecommendationInfo> infos_a;
+        infos_a.emplace_back(combo_size, 0, 0, false, empty_set, no_think,
+                             /*enable_cross_sequence_ban=*/true, 0);
+        auto proc_a = std::make_shared<RecommendationLogitsProcessor>(std::move(infos_a));
+
+        std::vector<StreamRecommendationInfo> infos_b;
+        infos_b.emplace_back(combo_size, 0, 0, false, empty_set, no_think,
+                             /*enable_cross_sequence_ban=*/false, 0);
+        auto proc_b = std::make_shared<RecommendationLogitsProcessor>(std::move(infos_b));
+
+        EXPECT_THROW(proc_a->insert(proc_b), std::exception);
+    }
+
+    // 边界：insert nullptr 和空 processor 不崩溃
+    {
+        std::vector<StreamRecommendationInfo> infos_a;
+        infos_a.emplace_back(combo_size, 0, 0, false, empty_set, no_think,
+                             /*enable_cross_sequence_ban=*/true, 0);
+        auto proc_a = std::make_shared<RecommendationLogitsProcessor>(std::move(infos_a));
+
+        proc_a->insert(nullptr);
+        EXPECT_EQ(1u, proc_a->size());
+
+        auto proc_empty = std::make_shared<RecommendationLogitsProcessor>(std::vector<StreamRecommendationInfo>{});
+        proc_a->insert(proc_empty);
+        EXPECT_EQ(1u, proc_a->size());
+    }
+}
+
+// 场景 23：think 模型 + 跨序列去重，think 前缀未完成时不应触发 diverge 遮蔽
+TEST_F(RecommendationLogitsProcessorTest, testThinkModeSkipsDiverge) {
+    const int N = 2;
+    const size_t vocab_size = 10;
+    const int combo_size = 2;
+    std::set<std::vector<int>> banned = {};
+    // end_think_token_ids = {7, 8}，think 完成前不应遮蔽 topk
+    std::vector<int> end_think = {7, 8};
+
+    std::vector<StreamRecommendationInfo> infos;
+    for (int i = 0; i < N; ++i) {
+        infos.emplace_back(combo_size, 0, 0, false, banned, end_think,
+                           /*enable_cross_sequence_ban=*/true,
+                           /*cross_seq_diverge_start_combo=*/0);
+    }
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(std::move(infos));
+    auto inputs = allocateSamplerInputs(N, vocab_size, processor);
+    inputs.logits.fill_(1.0f);
+    // 给序列 1 的 token 0 一个较高的 logit，如果 diverge 触发则会被遮蔽
+    inputs.logits[1][0] = 10.0f;
+
+    // think_done = false，不应触发 diverge
+    processor->process(inputs, 0, N);
+
+    auto logits_cpu = inputs.logits.cpu();
+    auto acc = logits_cpu.accessor<float, 2>();
+    // 序列 1 的 token 0 应该不被遮蔽（think 未完成，diverge 跳过）
+    EXPECT_FLOAT_EQ(10.0f, acc[1][0]);
+
+    // 现在完成 think：喂入 token 7, 8
+    auto tokens = torch::zeros({N, 1}, torch::kInt32);
+    tokens[0][0] = 7;
+    tokens[1][0] = 7;
+    processor->updateStatus(tokens, 1);
+    tokens[0][0] = 8;
+    tokens[1][0] = 8;
+    processor->updateStatus(tokens, 1);
+
+    // think_done = true，pos_in_combo=0，现在应该触发 diverge
+    EXPECT_TRUE(processor->infos()[1].think_done);
+    inputs.logits.fill_(1.0f);
+    inputs.logits[1][0] = 10.0f;
+    processor->process(inputs, 0, N);
+
+    logits_cpu = inputs.logits.cpu();
+    acc = logits_cpu.accessor<float, 2>();
+    // 序列 1 的 token 0 应被遮蔽（diverge k=1）
+    EXPECT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), acc[1][0]);
+}
+
+// 场景 24：多流合批路径——start_idx > 0 时 diverge 和 ban 都正确工作
+TEST_F(RecommendationLogitsProcessorTest, testProcessWithNonZeroStartIdx) {
+    // 模拟生产链路：全局 logits 张量有 5 行，本 Processor 占 row 2~4 (start_idx=2, finish_idx=5)
+    const size_t global_batch = 5;
+    const size_t vocab_size   = 6;
+    const size_t proc_batch   = 3;  // 本 processor 的 batch
+    const size_t start_idx    = 2;
+
+    // 3 条序列，combo_token_size=3，开启 cross_seq_ban，diverge_start=0
+    std::vector<StreamRecommendationInfo> infos;
+    std::set<std::vector<int>> empty_set;
+    for (size_t i = 0; i < proc_batch; ++i) {
+        infos.push_back(StreamRecommendationInfo(3, 0, 0, false, empty_set, {}, true, 0));
+    }
+    // 设置序列 0 处于 combo 末位，有 banned combo [10,20,X] —— 测试 ban 逻辑
+    infos[0].pos_in_combo = 2;
+    infos[0].current_prefix = {1, 2};
+    infos[0].banned_combos.insert({1, 2, 3});
+
+    auto processor = std::make_shared<RecommendationLogitsProcessor>(infos);
+
+    // 分配全局 logits 张量
+    SamplerInputs sampler_inputs;
+    sampler_inputs.batch_size     = global_batch;
+    sampler_inputs.batch_size_out = global_batch;
+    sampler_inputs.vocab_size     = vocab_size;
+    sampler_inputs.logits = torch::ones({(int64_t)global_batch, (int64_t)vocab_size},
+                                         torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    // 为所有行设置相同的 logit 值，使 top-1 为 col 0
+    sampler_inputs.logits.index({torch::indexing::Slice(), 0}) = 10.0f;
+
+    LogitsProcessorStatesPtr state_ptr = std::make_shared<LogitsProcessorStates>();
+    state_ptr->insert(processor, start_idx, start_idx + proc_batch);
+    sampler_inputs.logits_processor_states_ptr = state_ptr;
+
+    // 通过 batchProcess 模拟生产调用路径
+    state_ptr->batchProcess(sampler_inputs);
+
+    auto result = sampler_inputs.logits.cpu();
+    auto acc = result.accessor<float, 2>();
+
+    // row 0~1 (start_idx 前) 不属于本 processor，应完全不受影响
+    EXPECT_FLOAT_EQ(10.0f, acc[0][0]);
+    EXPECT_FLOAT_EQ(10.0f, acc[1][0]);
+
+    // row 2 (本 processor 的序列 0，主序列): banned combo [1,2,3] 匹配前缀 [1,2]，应将 col 3 置为 -inf
+    EXPECT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), acc[2][3]);
+    // col 0 不受 diverge 影响（主序列不遮蔽）
+    EXPECT_FLOAT_EQ(10.0f, acc[2][0]);
+
+    // row 3 (本 processor 的序列 1): diverge 应遮蔽 top-1 (col 0)
+    EXPECT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), acc[3][0]);
+
+    // row 4 (本 processor 的序列 2): diverge 应遮蔽 top-1,2 (col 0 和次高)
+    EXPECT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), acc[4][0]);
+}
+
+// 场景 25：启用条件真值表 —— SYNC with Python TestCrossLanguageConstantSync::test_enable_conditions_sync
+// SYNC: 修改这里的真值表时必须同时更新 Python 侧的 test_enable_conditions_sync
+// NOTE: 生产路径中 fromGenerateInput 收到的 num 等于 batchSize(0) = max(num_return_sequences, 1)
+// （调用链：GenerateStream.cc:58 → LogitsProcessorFactory.cc:32）。
+// 本测试直接传 num_return_sequences 作为 num，等价性由下方断言保证。
+TEST_F(RecommendationLogitsProcessorTest, testEnableConditionsTruthTable) {
+    // 静态确认：当 hasNumBeams()=false 时，batchSize(0) = max(num_return_sequences, 1).
+    // 真值表中所有 num_return_sequences >= 1，因此 max(n,1)==n，直接传入等价于生产路径。
+    // 若 batchSize 映射逻辑变化，此处需同步更新。
+    // 真值表：(num_beams, combo_token_size, num_return_sequences, expected_enabled)
+    struct Case {
+        int  num_beams;
+        int  combo_token_size;
+        int  num_return_sequences;
+        bool expected_enabled;
+    };
+    std::vector<Case> truth_table = {
+        // 全部满足 → 启用
+        {1, 3, 4, true},
+        {1, 2, 2, true},
+        // beam search 不兼容 → 禁用
+        {2, 3, 4, false},
+        {4, 3, 4, false},
+        // combo_token_size < 2 → 禁用
+        {1, 1, 4, false},
+        // num_return_sequences <= 1 → 禁用
+        {1, 3, 1, false},
+        // 多条件同时不满足 → 禁用
+        {2, 1, 1, false},
+    };
+
+    // 断言 batchSize(0) 映射等价性：对于所有 num>=1 且 hasNumBeams=false，
+    // batchSize(0) == max(num_return_sequences, 1) == num_return_sequences。
+    for (const auto& c : truth_table) {
+        if (c.num_beams <= 1 && c.num_return_sequences >= 1) {
+            ASSERT_EQ(c.num_return_sequences, std::max(c.num_return_sequences, 1))
+                << "batchSize(0) equivalence broken for num=" << c.num_return_sequences;
+        }
+    }
+
+    for (const auto& c : truth_table) {
+        auto generate_input             = std::make_shared<GenerateInput>();
+        generate_input->generate_config = std::make_shared<GenerateConfig>();
+        generate_input->generate_config->num_beams                  = c.num_beams;
+        generate_input->generate_config->combo_token_size            = c.combo_token_size;
+        generate_input->generate_config->enable_cross_sequence_ban  = true;
+        generate_input->generate_config->banned_combo_token_ids     = {};
+        generate_input->input_ids = torch::zeros({1}, torch::kInt32);
+
+        auto p = RecommendationLogitsProcessor::fromGenerateInput(
+            generate_input, c.num_return_sequences);
+
+        if (c.combo_token_size <= 0) {
+            // combo_token_size <= 0 时 fromGenerateInput 返回 nullptr
+            ASSERT_EQ(nullptr, p) << "num_beams=" << c.num_beams
+                << ", combo=" << c.combo_token_size << ", num=" << c.num_return_sequences;
+        } else {
+            ASSERT_NE(nullptr, p) << "num_beams=" << c.num_beams
+                << ", combo=" << c.combo_token_size << ", num=" << c.num_return_sequences;
+            for (const auto& info : p->infos()) {
+                EXPECT_EQ(c.expected_enabled, info.enable_cross_sequence_ban)
+                    << "num_beams=" << c.num_beams
+                    << ", combo=" << c.combo_token_size
+                    << ", num=" << c.num_return_sequences;
+            }
+        }
     }
 }
 

--- a/rtp_llm/test/BUILD
+++ b/rtp_llm/test/BUILD
@@ -322,3 +322,16 @@ py_test(
     imports=[],
     exec_properties={"gpu": "H20"},
 )
+
+# NOTE: 纯配置校验测试，但 generate_config.py 导入链拉起 rtp_llm.ops (CUDA .so)，import 阶段需 GPU 在场。
+# TODO(panyang): 拆分 rtp_llm.ops lazy-import 后移除 GPU 约束。
+py_test(
+    name = "test_generate_config_validators",
+    srcs = [
+        "test_generate_config_validators.py",
+    ],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+    exec_properties = {'gpu':'H20'},
+)

--- a/rtp_llm/test/test_generate_config_validators.py
+++ b/rtp_llm/test/test_generate_config_validators.py
@@ -1,0 +1,393 @@
+"""cross_seq_diverge_start_combo validator 单元测试。
+
+覆盖 _clamp_diverge_start_combo 的 4 条分支：
+1. None → 返回 0
+2. 非整数类型(TypeError/ValueError) → warning + 返回 0
+3. 负值 → warning + clamp 到 0
+4. 超大值(>100) → 保留原值（告警仅在特性启用时触发，与 C++ 侧一致）
+
+覆盖 _check_cross_seq_ban_compatibility 的分支：
+1. 多重不兼容 → 一次性报告所有原因 + 禁用
+2. 合法配置 → 无 warning，保持启用
+3. num_return_sequences 超 depth → 采样质量告警
+4. update() 路径也触发校验
+5. fail-safe 降级后 update 补齐条件 → WARNING 诊断日志
+
+跨语言常量同步测试：
+确保 Python _DIVERGE_START_COMBO_WARN_THRESHOLD / _MAX_DIVERGE_DEPTH
+与 C++ kDivergeStartComboWarnThreshold / kMaxDivergeDepth 一致。
+策略：Python 侧硬编码期望值 + C++ 侧 static_assert，无需解析源码。
+"""
+
+import logging
+import unittest
+
+from rtp_llm.config.generate_config import (
+    GenerateConfig,
+    _DIVERGE_START_COMBO_WARN_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
+    _MAX_DIVERGE_DEPTH,  # pyright: ignore[reportPrivateUsage]
+    _reset_sanitize_warn_state,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+class TestClampDivergeStartCombo(unittest.TestCase):
+
+    def setUp(self):
+        # 每个用例前复位限流状态，确保用例间独立不受全局时间戳影响。
+        _reset_sanitize_warn_state()
+
+    def test_none_returns_zero(self):
+        """None 输入应返回 0。"""
+        cfg = GenerateConfig(cross_seq_diverge_start_combo=None)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+
+    def test_non_integer_string_returns_zero(self):
+        """非整数字符串应触发 warning 并返回 0。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(cross_seq_diverge_start_combo="abc")
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+        self.assertTrue(any("non-integer" in msg for msg in cm.output))
+
+    def test_negative_clamped_to_zero(self):
+        """负值应 clamp 到 0 并触发 warning。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=-5)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+        self.assertTrue(any("negative" in msg for msg in cm.output))
+
+    def test_exceeds_int32_clamped(self):
+        """超过 INT32_MAX 的值应 clamp 到 2**31-1 并触发 warning。"""
+        huge = 2**31 + 100
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=huge)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 2**31 - 1)
+        self.assertTrue(any("int32" in msg for msg in cm.output))
+
+    def test_large_value_warns_but_keeps(self):
+        """超大值(>100)且特性启用时应触发 warning 但保留原值。
+
+        NOTE: 「过大」告警仅在 enable_cross_sequence_ban=True 且特性未被降级时触发，
+        与 C++ 侧 (enable_cross_seq_ban && diverge_start_combo > threshold) 行为一致。
+        """
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                cross_seq_diverge_start_combo=999,
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=2,
+            )
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 999)
+        self.assertTrue(any("very large" in msg for msg in cm.output))
+
+    def test_large_value_no_warn_when_disabled(self):
+        """超大值但特性未启用时不产生告警噪声。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=999)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 999)
+
+    def test_normal_value_no_warning(self):
+        """正常值(0-100)无 warning，原值返回。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=5)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 5)
+
+    def test_zero_value(self):
+        """​0 是合法值，应原样返回。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=0)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+
+    def test_boundary_100_no_warning(self):
+        """恰好 100 不触发 warning。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(cross_seq_diverge_start_combo=100)
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 100)
+
+
+class TestCrossSeqBanCompatibility(unittest.TestCase):
+    """测试 enable_cross_sequence_ban 与 beam search / combo_token_size 的互斥校验。"""
+
+    def setUp(self):
+        _reset_sanitize_warn_state()
+
+    def test_beam_search_incompatible_disables(self):
+        """开启 cross_seq_ban + num_beams>1 应触发 warning 并禁用。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                num_beams=4,
+                combo_token_size=3,
+            )
+        self.assertTrue(any("incompatible with beam search" in msg for msg in cm.output))
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_variable_num_beams_incompatible_disables(self):
+        """开启 cross_seq_ban + variable_num_beams 包含>1 应触发 warning 并禁用。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                num_beams=1,
+                variable_num_beams=[1, 4],
+                combo_token_size=3,
+            )
+        self.assertTrue(any("incompatible with beam search" in msg for msg in cm.output))
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_combo_token_size_lt2_disables(self):
+        """开启 cross_seq_ban + combo_token_size<2 应触发 warning 并禁用。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=1,
+            )
+        self.assertTrue(any("combo_token_size" in msg for msg in cm.output))
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_num_return_sequences_le1_disables(self):
+        """开启 cross_seq_ban + num_return_sequences<=1 应触发 warning 并禁用。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=1,
+            )
+        self.assertTrue(any("num_return_sequences" in msg for msg in cm.output))
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_multiple_incompatible_reports_all(self):
+        """同时命中多条不兼容时，一次性报告所有原因。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                num_beams=4,
+                combo_token_size=1,
+                num_return_sequences=1,
+            )
+        # 单条 warning 中同时包含所有不兼容原因
+        combined = " ".join(cm.output)
+        self.assertIn("beam search", combined)
+        self.assertIn("combo_token_size", combined)
+        self.assertIn("num_return_sequences", combined)
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_exceeds_max_diverge_depth_warns(self):
+        """合法配置但 num_return_sequences 超过 max_diverge_depth 应告警采样质量。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=10,  # 10-1=9 > _MAX_DIVERGE_DEPTH=8
+            )
+        self.assertTrue(any("diverge depth" in msg for msg in cm.output))
+        # 不禁用，只警告
+        self.assertTrue(cfg.enable_cross_sequence_ban)
+
+    def test_update_triggers_revalidation(self):
+        """通过 update() 修改字段后应重新校验兼容性。"""
+        cfg = GenerateConfig(
+            enable_cross_sequence_ban=True,
+            combo_token_size=3,
+            num_beams=1,
+            num_return_sequences=2,
+        )
+        self.assertTrue(cfg.enable_cross_sequence_ban)
+        # update 为不兼容配置后应自动禁用
+        with self.assertLogs(level=logging.WARNING):
+            cfg.update({"num_beams": 4})
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_update_clamps_diverge_start_combo_negative(self):
+        """通过 update() 传入负值应 clamp 到 0。"""
+        cfg = GenerateConfig()
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg.update({"cross_seq_diverge_start_combo": -10})
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+        self.assertTrue(any("negative" in msg for msg in cm.output))
+
+    def test_update_clamps_diverge_start_combo_non_integer(self):
+        """通过 update() 传入非整数应 fallback 到 0。"""
+        cfg = GenerateConfig()
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg.update({"cross_seq_diverge_start_combo": "abc"})
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+        self.assertTrue(any("non-integer" in msg for msg in cm.output))
+
+    def test_update_and_pop_clamps_diverge_start_combo(self):
+        """通过 update_and_pop() 传入负值应 clamp 到 0。"""
+        cfg = GenerateConfig()
+        with self.assertLogs(level=logging.WARNING):
+            remaining = cfg.update_and_pop({"cross_seq_diverge_start_combo": -5})
+        self.assertEqual(cfg.cross_seq_diverge_start_combo, 0)
+        # cross_seq_diverge_start_combo 是已知字段，应被 pop 掉
+        self.assertNotIn("cross_seq_diverge_start_combo", remaining)
+
+    def test_valid_config_no_warning(self):
+        """合法配置不触发 warning，开关保持启用。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=2,
+            )
+        self.assertTrue(cfg.enable_cross_sequence_ban)
+
+    def test_diverge_depth_warning_dedup(self):
+        """采样质量软告警同一实例不重复输出；修改 num_return_sequences 后可重新告警。"""
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=10,  # 9 > 8
+            )
+        depth_warnings = [m for m in cm.output if "diverge depth" in m]
+        self.assertEqual(len(depth_warnings), 1)
+        # 第二次 update 不改变 num_return_sequences → 不应再次告警
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg.update({"combo_token_size": 4})
+        # 修改 num_return_sequences 到新的超 depth 值 → 标志重置，应再次告警
+        with self.assertLogs(level=logging.WARNING) as cm:
+            cfg.update({"num_return_sequences": 12})
+        self.assertTrue(any("diverge depth" in m for m in cm.output))
+
+    def test_reenable_after_incremental_update(self):
+        """先建后 update 场景：enable 因条件不足被降级，update 补齐条件后应自动重新启用。"""
+        # 构造时 num_return_sequences=0 → 不满足条件 → enable 被降级为 False
+        with self.assertLogs(level=logging.WARNING):
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=0,  # 不满足 >1
+            )
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+        # update 补齐条件 → 自动重新启用
+        cfg.update({"num_return_sequences": 4})
+        self.assertTrue(cfg.enable_cross_sequence_ban)
+
+    def test_two_phase_update_and_pop_reenable(self):
+        """模拟 request_extractor 两次 update_and_pop：第一次缺条件降级，第二次补齐后重新启用。"""
+        # 第一阶段：config_json 包含 enable + combo_token_size，但缺 num_return_sequences
+        with self.assertLogs(level=logging.WARNING):
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+            )
+        self.assertFalse(cfg.enable_cross_sequence_ban)  # 被降级
+        # 第二阶段：顶层 kwargs 提供 num_return_sequences
+        leftover = cfg.update_and_pop({"num_return_sequences": 4})
+        self.assertTrue(cfg.enable_cross_sequence_ban)  # 重新启用
+        self.assertEqual(leftover, {})  # num_return_sequences 被消费
+
+    def test_no_failsafe_misfire_when_never_enabled(self):
+        """用户从未开启 enable_cross_sequence_ban 时，即使其他条件满足也不应误报。"""
+        with self.assertNoLogs(level=logging.WARNING):
+            cfg = GenerateConfig(
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=2,
+                # enable_cross_sequence_ban 默认 False，用户从未开启
+            )
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+    def test_explicit_disable_in_update_not_overridden(self):
+        """用户在 update 中显式传 enable=False 时，自动重启用不应覆盖其意图。"""
+        # 构造：enable=True 但 num_return_sequences 不足 → 降级
+        with self.assertLogs(level=logging.WARNING):
+            cfg = GenerateConfig(
+                enable_cross_sequence_ban=True,
+                combo_token_size=3,
+                num_beams=1,
+                num_return_sequences=1,
+            )
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+        # 用户显式关闭 + 补齐条件 → 不应被重新启用
+        cfg.update({"enable_cross_sequence_ban": False, "num_return_sequences": 4})
+        self.assertFalse(cfg.enable_cross_sequence_ban)
+
+
+class TestCrossLanguageConstantSync(unittest.TestCase):
+    """Python/C++ 共享常量 + 启用条件同步断言，防止单侧修改导致漂移。
+
+    常量同步策略（无源码解析）：
+      Python 侧：本测试硬编码期望值，直接与 Python 常量比对。
+      C++ 侧：RecommendationLogitsProcessor.cc 中 static_assert 钉住常量值。
+      任一侧改值 → 对应断言编译/运行失败 → 错误信息明确指向需同步的另一侧。
+    启用条件同步：通过真值表比对——直接构造 GenerateConfig 并验证
+    enable_cross_sequence_ban 的最终值。C++ 侧必须对相同输入产生相同结论。
+    """
+
+    def test_diverge_start_combo_warn_threshold_sync(self):
+        """确保 Python _DIVERGE_START_COMBO_WARN_THRESHOLD == C++ kDivergeStartComboWarnThreshold(=100)。
+
+        C++ 侧通过 static_assert(kDivergeStartComboWarnThreshold == 100) 保证编译期不变。
+        若 C++ 侧修改了值，需同步更新此处期望值和 Python 常量。
+        """
+        EXPECTED_CPP_VALUE = 100  # mirrors C++ kDivergeStartComboWarnThreshold
+        self.assertEqual(
+            _DIVERGE_START_COMBO_WARN_THRESHOLD, EXPECTED_CPP_VALUE,
+            f"Python({_DIVERGE_START_COMBO_WARN_THRESHOLD}) != C++ expected({EXPECTED_CPP_VALUE}), "
+            f"constants drifted! Check RecommendationLogitsProcessor.cc static_assert.")
+
+    def test_max_diverge_depth_sync(self):
+        """确保 Python _MAX_DIVERGE_DEPTH == C++ kMaxDivergeDepth(=8)。
+
+        C++ 侧通过 static_assert(kMaxDivergeDepth == 8) 保证编译期不变。
+        若 C++ 侧修改了值，需同步更新此处期望值和 Python 常量。
+        """
+        EXPECTED_CPP_VALUE = 8  # mirrors C++ kMaxDivergeDepth
+        self.assertEqual(
+            _MAX_DIVERGE_DEPTH, EXPECTED_CPP_VALUE,
+            f"Python({_MAX_DIVERGE_DEPTH}) != C++ expected({EXPECTED_CPP_VALUE}), "
+            f"constants drifted! Check RecommendationLogitsProcessor.cc static_assert.")
+
+    def test_enable_conditions_sync(self):
+        """SYNC 真值表比对：验证 Python 侧启用条件的行为语义。
+
+        C++ RecommendationLogitsProcessor.cc::fromGenerateInput 中 enable_cross_seq_ban 的
+        计算逻辑必须与以下真值表一致（取反关系）。
+        修改任一侧条件时，此测试将失败（Python 侧），同时 C++ 侧的
+        RecommendationLogitsProcessorTest::testEnableConditionsTruthTable 也应失败。
+
+        三项禁用条件：
+        1. has_num_beams()  ↔  C++: hasNumBeams()
+        2. combo_token_size < 2  ↔  C++: combo_token_size >= 2 (取反)
+        3. num_return_sequences <= 1  ↔  C++: num > 1 (取反)
+        """
+        # 真值表：(num_beams, combo_token_size, num_return_sequences) -> expected_enabled
+        truth_table = [
+            # 全部满足 → 启用
+            (1, 3, 4, True),
+            (1, 2, 2, True),
+            # beam search 不兼容 → 禁用
+            (2, 3, 4, False),
+            (4, 3, 4, False),
+            # combo_token_size < 2 → 禁用
+            (1, 1, 4, False),
+            (1, 0, 4, False),
+            # num_return_sequences <= 1 → 禁用
+            (1, 3, 1, False),
+            # 多条件同时不满足 → 禁用
+            (2, 1, 1, False),
+        ]
+        for num_beams, combo_size, num_ret, expected in truth_table:
+            with self.subTest(num_beams=num_beams, combo_size=combo_size, num_ret=num_ret):
+                cfg = GenerateConfig(
+                    enable_cross_sequence_ban=True,
+                    num_beams=num_beams,
+                    combo_token_size=combo_size,
+                    num_return_sequences=num_ret,
+                )
+                self.assertEqual(
+                    cfg.enable_cross_sequence_ban, expected,
+                    f"Input({num_beams}, {combo_size}, {num_ret}): "
+                    f"expected enabled={expected}, got {cfg.enable_cross_sequence_ban}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…ed asymmetric broadcast

- Add enable_cross_sequence_ban (default: false) and cross_seq_diverge_start_combo (default: 0) to GenerateConfig
- Full parameter passing chain: Python -> Proto (fields 61,62) -> C++ deserialization -> JSONIZE
- Asymmetric broadcast: sequence 0 keeps only its own bans; sequences 1+ receive merged bans from all
- Top-K diverge masking: sequence i masks top-i logits at combo start position for deterministic divergence
- Configurable diverge start: first N combos stay greedy-consistent across all sequences
- No impact on existing logic when switch is off (all new paths guarded by enable_cross_sequence_ban)