### PR TITLE
Add KVS cache connector for KV cache reuse

### DIFF
--- a/rtp_llm/cpp/cache/connector/BUILD
+++ b/rtp_llm/cpp/cache/connector/BUILD
@@ -17,6 +17,7 @@ cc_library(
     deps = [
         "//rtp_llm/cpp/cache:cache_core",
         "//rtp_llm/cpp/cache:cache_types",
+        "//rtp_llm/cpp/cache/connector/kvs_connector",
         "//rtp_llm/cpp/cache/connector/memory:memory_connector",
         "//rtp_llm/cpp/cache/connector/p2p:connector",
         "//rtp_llm/cpp/cache/connector/p2p:layer_block_converter",

--- a/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.cc
+++ b/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.cc
@@ -8,6 +8,7 @@
 #include "rtp_llm/cpp/utils/ProfilingScope.h"
 #include "rtp_llm/cpp/cache/connector/KVCacheConnectorReadWriteContext.h"
 #include "rtp_llm/cpp/cache/connector/memory/KVCacheMemoryConnector.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.h"
 #include "rtp_llm/cpp/cache/connector/p2p/P2PConnector.h"
 #include "rtp_llm/cpp/cache/connector/p2p/LayerBlockConverterImpl.h"
 #ifdef USE_REMOTE_KV_CACHE
@@ -198,11 +199,15 @@ bool KVCacheConnectorCoordinator::init() {
         connectors_.emplace_back(memory_connector_);
     }
 #ifdef USE_REMOTE_KV_CACHE
-    if (kv_cache_config_.reuse_cache && kv_cache_config_.enable_remote_cache) {
+    if (kv_cache_config_.reuse_cache && kv_cache_config_.enable_remote_cache && !kv_cache_config_.enable_kvs_cache) {
         remote_connector_ = initRemoteConnector();
         connectors_.emplace_back(remote_connector_);
     }
 #endif
+    if (kv_cache_config_.reuse_cache && kv_cache_config_.enable_kvs_cache) {
+        kvs_connector_ = initKVSConnector();
+        connectors_.emplace_back(kvs_connector_);
+    }
     if (!initP2PConnectorInternal()) {
         RTP_LLM_LOG_WARNING("init P2P connector failed, P2P path disabled — engine continues without it");
     }
@@ -369,6 +374,17 @@ std::shared_ptr<RemoteConnector> KVCacheConnectorCoordinator::initRemoteConnecto
 #endif
 }
 
+std::shared_ptr<kvs::KVSConnector> KVCacheConnectorCoordinator::initKVSConnector() {
+    auto kvs_connector = std::make_shared<kvs::KVSConnector>(cache_config_,
+                                                             kv_cache_config_,
+                                                             runtime_config_,
+                                                             parallelism_config_,
+                                                             allocator_,
+                                                             metrics_reporter_);
+    RTP_LLM_CHECK_WITH_INFO(kvs_connector->init(), "KVS connector init failed");
+    return kvs_connector;
+}
+
 int KVCacheConnectorCoordinator::cpSize() const {
     const auto& cp_cfg = parallelism_config_.prefill_cp_config;
     if (!cp_cfg.kv_cache_sharded) {
@@ -475,10 +491,13 @@ bool KVCacheConnectorCoordinator::executeFunction(const FunctionRequestPB& reque
         return memory_connector_->copyCache(request.mem_request(), *(response.mutable_mem_response()));
     } else if (request.has_remote_request()) {
 #ifdef USE_REMOTE_KV_CACHE
-        RTP_LLM_CHECK(remote_connector_ != nullptr);
+        if (!remote_connector_) {
+            RTP_LLM_LOG_WARNING("executeFunction: remote_request received but remote connector not initialized");
+            return false;
+        }
         return remote_connector_->copyCache(request.remote_request(), *(response.mutable_remote_response()));
 #endif
-        RTP_LLM_CHECK(false);
+        RTP_LLM_LOG_WARNING("executeFunction: remote_request received but remote cache support is disabled");
         return false;
     } else if (request.has_p2p_request()) {
         if (!p2p_connector_) {

--- a/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.h
+++ b/rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.h
@@ -22,6 +22,9 @@ class KVCacheAllocator;
 class KVCacheMemoryConnector;
 class RemoteConnector;
 class P2PConnector;
+namespace kvs {
+class KVSConnector;
+}
 class KVCacheConnectorReadWriteContext;
 
 class KVCacheConnectorCoordinator: public IKVCacheConnectorCoordinator {
@@ -66,6 +69,7 @@ public:
 private:
     std::shared_ptr<KVCacheMemoryConnector> initMemoryConnector();
     std::shared_ptr<RemoteConnector>        initRemoteConnector();
+    std::shared_ptr<kvs::KVSConnector>      initKVSConnector();
     bool                                    initP2PConnectorInternal();
     // Returns CP size when page-level RR sharding is active; 1 otherwise.
     int  cpSize() const;
@@ -91,6 +95,7 @@ private:
     std::vector<std::shared_ptr<KVCacheConnector>>    connectors_;
     std::shared_ptr<KVCacheMemoryConnector>           memory_connector_;
     std::shared_ptr<RemoteConnector>                  remote_connector_;
+    std::shared_ptr<kvs::KVSConnector>                kvs_connector_;
     std::shared_ptr<P2PConnector>                     p2p_connector_;
     mutable std::mutex                                update_mutex_;
     std::list<std::shared_ptr<FusedAsyncReadContext>> fused_async_read_context_list_;

--- a/rtp_llm/cpp/cache/connector/kvs_connector/BUILD
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/BUILD
@@ -1,0 +1,37 @@
+load("//:def.bzl", "copts")
+load("//bazel:arch_select.bzl", "torch_deps")
+
+cc_library(
+    name = "kvs_connector",
+    srcs = [
+        "KVSCacheStore.cc",
+        "KVSClient.cc",
+        "KVSConnector.cc",
+    ],
+    hdrs = [
+        "KVSCacheStore.h",
+        "KVSClient.h",
+        "KVSConnector.h",
+    ],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//rtp_llm/cpp/cache:batch_kv_cache_resource",
+        "//rtp_llm/cpp/cache:block_info",
+        "//rtp_llm/cpp/cache:cache_types",
+        "//rtp_llm/cpp/cache:kv_cache_allocator",
+        "//rtp_llm/cpp/cache/connector:connector_base",
+        "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/utils:core_utils",
+        "@curl//:curl",
+        "@havenask//aios/autil:env_util",
+        "@havenask//aios/autil:thread",
+        "@rapidjson//:rapidjson",
+    ] + torch_deps() + select({
+        "@//:using_cuda": [
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.cc
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.cc
@@ -1,0 +1,321 @@
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <unordered_set>
+
+#include "autil/EnvUtil.h"
+#include "rtp_llm/cpp/cache/allocator/KVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/connector/Meta.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+
+namespace rtp_llm::kvs {
+namespace {
+
+std::string sanitizeKeyPart(std::string value) {
+    for (char& ch : value) {
+        if (ch == '/' || ch == ' ' || ch == '\t' || ch == '\n') {
+            ch = '_';
+        }
+    }
+    return value;
+}
+
+std::string hashString(const std::string& value) {
+    uint64_t hash = 1469598103934665603ULL;
+    for (unsigned char ch : value) {
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+    std::ostringstream oss;
+    oss << std::hex << hash;
+    return oss.str();
+}
+
+size_t totalBytes(const std::vector<BlockInfo>& iovs) {
+    size_t bytes = 0;
+    for (const auto& iov : iovs) {
+        bytes += iov.size_bytes;
+    }
+    return bytes;
+}
+
+bool isValidBlockInfo(const BlockInfo& block_info) {
+    return block_info.addr != nullptr && block_info.size_bytes > 0;
+}
+
+}  // namespace
+
+KVSCacheStore::KVSCacheStore(KVSCacheStoreConfig                config,
+                             std::shared_ptr<KVCacheAllocator> allocator,
+                             std::shared_ptr<KVSClient>        client,
+                             kmonitor::MetricsReporterPtr      metrics_reporter):
+    config_(std::move(config)),
+    allocator_(std::move(allocator)),
+    client_(std::move(client)),
+    metrics_reporter_(std::move(metrics_reporter)) {}
+
+bool KVSCacheStore::init() {
+    if (!client_) {
+        client_ = std::make_shared<KVSClient>();
+    }
+    if (config_.deployment_id.empty()) {
+        config_.deployment_id = buildDeploymentId();
+    }
+
+    KVSClientConfig client_config;
+    client_config.v6d_url         = config_.kv_cache_config.kvs_v6d_url;
+    client_config.v6d_socket_path = config_.kv_cache_config.kvs_v6d_socket_path;
+    client_config.timeout_ms      = config_.kv_cache_config.kvs_timeout_ms;
+    client_config.lease_term_sec  = config_.kv_cache_config.kvs_lease_term_sec;
+    if (!client_->init(client_config)) {
+        RTP_LLM_LOG_ERROR("KVSCacheStore init failed: KVSClient init failed");
+        return false;
+    }
+    RTP_LLM_LOG_INFO("KVSCacheStore initialized, deployment_id[%s]", config_.deployment_id.c_str());
+    return true;
+}
+
+std::optional<KVSMatchSession> KVSCacheStore::match(const std::shared_ptr<KVCacheResource>& resource,
+                                                    const std::shared_ptr<Meta>&            meta) {
+    if (!resource || !meta) {
+        return std::nullopt;
+    }
+
+    KVSMatchSession session;
+    session.prev_reuse_blocks = resource->reuseBlockNum();
+    session.matched_blocks    = session.prev_reuse_blocks;
+
+    auto keys = resource->cacheKeys();
+    if (!keys.empty()) {
+        keys.pop_back();
+    }
+    if (session.prev_reuse_blocks >= keys.size()) {
+        return session;
+    }
+
+    auto                     block_objects = buildBlockObjects(resource, keys);
+    std::vector<std::string> object_keys;
+    for (size_t i = session.prev_reuse_blocks; i < block_objects.size(); ++i) {
+        for (const auto& object : block_objects[i].objects) {
+            object_keys.push_back(object.object_key);
+        }
+    }
+    if (object_keys.empty()) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore match has no readable objects, prev_reuse[%zu], candidate_blocks[%zu]",
+                            session.prev_reuse_blocks,
+                            keys.size());
+        return session;
+    }
+    std::sort(object_keys.begin(), object_keys.end());
+    object_keys.erase(std::unique(object_keys.begin(), object_keys.end()), object_keys.end());
+
+    RTP_LLM_LOG_INFO("KVSCacheStore match start, trace_id[%s], prev_reuse[%zu], candidate_blocks[%zu], object_count[%zu]",
+                     meta->trace_id().c_str(),
+                     session.prev_reuse_blocks,
+                     block_objects.size(),
+                     object_keys.size());
+    auto read_session = client_->acquireForRead(object_keys, "kvs_match_" + meta->trace_id());
+    if (!read_session) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore match failed, degrade to miss, trace_id[%s]", meta->trace_id().c_str());
+        return session;
+    }
+
+    size_t matched = session.prev_reuse_blocks;
+    for (size_t i = session.prev_reuse_blocks; i < block_objects.size(); ++i) {
+        bool hit = true;
+        for (const auto& object : block_objects[i].objects) {
+            if (read_session->handles.find(object.object_key) == read_session->handles.end()) {
+                hit = false;
+                break;
+            }
+        }
+        if (!hit) {
+            break;
+        }
+        matched++;
+        session.matched_block_objects.push_back(block_objects[i]);
+    }
+
+    session.matched_blocks = matched;
+    session.read_session   = std::move(read_session);
+    if (session.matched_blocks <= session.prev_reuse_blocks) {
+        close(session);
+    }
+
+    RTP_LLM_LOG_INFO("KVSCacheStore match done, trace_id[%s], matched_blocks[%zu], prev_reuse[%zu], lease[%s]",
+                     meta->trace_id().c_str(),
+                     session.matched_blocks,
+                     session.prev_reuse_blocks,
+                     session.read_session ? session.read_session->lease_id.c_str() : "");
+    return session;
+}
+
+bool KVSCacheStore::read(KVSMatchSession&                         session,
+                         const std::shared_ptr<KVCacheResource>& resource,
+                         int                                      start_read_block_index,
+                         int                                      read_block_num) {
+    if (!resource || !session.read_session || read_block_num <= 0) {
+        return false;
+    }
+
+    std::vector<KVSObjectBuffer> dst_buffers;
+    const int                    end_block_index = start_read_block_index + read_block_num;
+    for (const auto& block : session.matched_block_objects) {
+        if (static_cast<int>(block.block_index) < start_read_block_index
+            || static_cast<int>(block.block_index) >= end_block_index) {
+            continue;
+        }
+        for (const auto& object : block.objects) {
+            dst_buffers.push_back(KVSObjectBuffer{object.object_key, object.iovs});
+        }
+    }
+    if (dst_buffers.empty()) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore read has no destination buffers, start_block[%d], block_num[%d]",
+                            start_read_block_index,
+                            read_block_num);
+        return false;
+    }
+    std::vector<std::string> object_keys;
+    object_keys.reserve(dst_buffers.size());
+    for (const auto& dst : dst_buffers) {
+        object_keys.push_back(dst.object_key);
+    }
+    const auto trace_id = "kvs_read_" + session.read_session->lease_id;
+
+    RTP_LLM_LOG_INFO("KVSCacheStore read start, start_block[%d], block_num[%d], object_count[%zu]",
+                     start_read_block_index,
+                     read_block_num,
+                     dst_buffers.size());
+    if (!client_->fetch(*session.read_session, object_keys, trace_id)) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore fetch failed, start_block[%d], block_num[%d], object_count[%zu]",
+                            start_read_block_index,
+                            read_block_num,
+                            object_keys.size());
+        return false;
+    }
+    if (!client_->load(*session.read_session, dst_buffers)) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore read failed, start_block[%d], block_num[%d], object_count[%zu]",
+                            start_read_block_index,
+                            read_block_num,
+                            dst_buffers.size());
+        return false;
+    }
+    if (!client_->complete(*session.read_session, object_keys, trace_id)) {
+        RTP_LLM_LOG_WARNING("KVSCacheStore complete failed, start_block[%d], block_num[%d], object_count[%zu]",
+                            start_read_block_index,
+                            read_block_num,
+                            object_keys.size());
+        return false;
+    }
+    resource->setRemoteReuseBlockNum(start_read_block_index + read_block_num);
+    RTP_LLM_LOG_INFO("KVSCacheStore read done, remote_reuse_blocks[%d]", start_read_block_index + read_block_num);
+    return true;
+}
+
+bool KVSCacheStore::write(const std::shared_ptr<KVCacheResource>& resource, const std::shared_ptr<Meta>& meta) {
+    if (!resource || !meta) {
+        return false;
+    }
+    auto keys = resource->cacheKeys();
+    if (!keys.empty() && !resource->lastBlockAligned()) {
+        keys.pop_back();
+    }
+    if (keys.empty()) {
+        return true;
+    }
+
+    auto                         block_objects = buildBlockObjects(resource, keys);
+    std::vector<KVSObjectBuffer> src_buffers;
+    for (const auto& block : block_objects) {
+        for (const auto& object : block.objects) {
+            if (!object.iovs.empty() && totalBytes(object.iovs) > 0) {
+                src_buffers.push_back(KVSObjectBuffer{object.object_key, object.iovs});
+            }
+        }
+    }
+    RTP_LLM_LOG_INFO("KVSCacheStore write start, trace_id[%s], blocks[%zu], object_count[%zu]",
+                     meta->trace_id().c_str(),
+                     block_objects.size(),
+                     src_buffers.size());
+    if (!client_->store(src_buffers, "kvs_store_" + meta->trace_id())) {
+        RTP_LLM_LOG_WARNING(
+            "KVSCacheStore write failed, trace_id[%s], object_count[%zu]", meta->trace_id().c_str(), src_buffers.size());
+        return false;
+    }
+    RTP_LLM_LOG_INFO(
+        "KVSCacheStore write done, trace_id[%s], object_count[%zu]", meta->trace_id().c_str(), src_buffers.size());
+    return true;
+}
+
+void KVSCacheStore::close(KVSMatchSession& session) {
+    if (session.read_session && !session.read_session->lease_id.empty() && client_) {
+        client_->release(session.read_session->lease_id);
+        session.read_session->lease_id.clear();
+    }
+    session.read_session.reset();
+}
+
+std::vector<KVSBlockObjects>
+KVSCacheStore::buildBlockObjects(const std::shared_ptr<KVCacheResource>& resource,
+                                 const std::vector<CacheKeyType>&        keys) const {
+    std::vector<KVSBlockObjects> result;
+    if (!resource || !allocator_) {
+        return result;
+    }
+    result.reserve(keys.size());
+    for (size_t block_index = 0; block_index < keys.size(); ++block_index) {
+        KVSBlockObjects block_objects;
+        block_objects.block_index = block_index;
+        for (int group_id = 0; group_id < resource->groupNums(); ++group_id) {
+            const auto& block_ids = resource->groupBlocks().at(group_id)->blocks();
+            if (block_index >= block_ids.size() || isNullBlockIdx(block_ids[block_index])) {
+                continue;
+            }
+            std::vector<BlockInfo> iovs;
+            for (int layer_id : config_.cache_config.layerIdsForGroup(static_cast<size_t>(group_id))) {
+                auto block_infos = allocator_->convertIndexToBuffer(layer_id, group_id, block_ids[block_index]);
+                for (const auto& block_info : block_infos) {
+                    if (!isValidBlockInfo(block_info)) {
+                        iovs.clear();
+                        break;
+                    }
+                    iovs.push_back(block_info);
+                }
+                if (iovs.empty()) {
+                    break;
+                }
+            }
+            if (!iovs.empty()) {
+                block_objects.objects.push_back(KVSBlockObject{
+                    block_index, group_id, buildObjectKey(keys[block_index], group_id), std::move(iovs)});
+            }
+        }
+        result.push_back(std::move(block_objects));
+    }
+    return result;
+}
+
+std::string KVSCacheStore::buildObjectKey(CacheKeyType cache_key, int32_t group_id) const {
+    std::ostringstream oss;
+    oss << sanitizeKeyPart(config_.kv_cache_config.kvs_object_namespace) << "/v"
+        << sanitizeKeyPart(config_.kv_cache_config.kvs_cache_key_version) << "/" << config_.deployment_id << "/tp-"
+        << config_.parallelism_config.tp_rank << "/group-" << group_id << "/block-" << cache_key;
+    return oss.str();
+}
+
+std::string KVSCacheStore::buildDeploymentId() const {
+    const auto         checkpoint_path = autil::EnvUtil::getEnv("CHECKPOINT_PATH", std::string(""));
+    std::ostringstream raw;
+    raw << "model=" << config_.runtime_config.model_name << ";ckpt=" << checkpoint_path
+        << ";dtype=" << getDataTypeStr(config_.cache_config.dtype) << ";seq=" << config_.cache_config.seq_size_per_block
+        << ";kernel_seq=" << config_.cache_config.kernel_seq_size_per_block
+        << ";tp=" << config_.parallelism_config.tp_size << ";fp8=" << config_.kv_cache_config.fp8_kv_cache
+        << ";int8=" << config_.kv_cache_config.int8_kv_cache << ";mla=" << config_.cache_config.use_mla
+        << ";groups=" << config_.cache_config.groupNums() << ";typed=" << config_.cache_config.use_typed_cache_regions;
+    return sanitizeKeyPart(config_.runtime_config.model_name.empty() ? "model" : config_.runtime_config.model_name)
+           + "-" + hashString(raw.str());
+}
+
+}  // namespace rtp_llm::kvs

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.h
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "kmonitor/client/MetricsReporter.h"
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/KVCacheResource.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h"
+#include "rtp_llm/cpp/config/ConfigModules.h"
+
+namespace rtp_llm {
+
+class KVCacheAllocator;
+class Meta;
+
+namespace kvs {
+
+struct KVSBlockObject {
+    size_t                 block_index = 0;
+    int32_t                group_id    = 0;
+    std::string            object_key;
+    std::vector<BlockInfo> iovs;
+};
+
+struct KVSBlockObjects {
+    size_t                      block_index = 0;
+    std::vector<KVSBlockObject> objects;
+};
+
+struct KVSMatchSession {
+    size_t prev_reuse_blocks = 0;
+    size_t matched_blocks    = 0;
+
+    std::vector<KVSBlockObjects>  matched_block_objects;
+    std::optional<KVSReadSession> read_session;
+};
+
+struct KVSCacheStoreConfig {
+    CacheConfig       cache_config;
+    KVCacheConfig     kv_cache_config;
+    RuntimeConfig     runtime_config;
+    ParallelismConfig parallelism_config;
+    std::string       deployment_id;
+};
+
+class KVSCacheStore {
+public:
+    KVSCacheStore(KVSCacheStoreConfig                 config,
+                  std::shared_ptr<KVCacheAllocator>  allocator,
+                  std::shared_ptr<KVSClient>         client,
+                  kmonitor::MetricsReporterPtr       metrics_reporter);
+
+    bool init();
+
+    std::optional<KVSMatchSession> match(const std::shared_ptr<KVCacheResource>& resource,
+                                         const std::shared_ptr<Meta>&            meta);
+
+    bool read(KVSMatchSession&                         session,
+              const std::shared_ptr<KVCacheResource>& resource,
+              int                                      start_read_block_index,
+              int                                      read_block_num);
+
+    bool write(const std::shared_ptr<KVCacheResource>& resource, const std::shared_ptr<Meta>& meta);
+
+    void close(KVSMatchSession& session);
+
+private:
+    std::vector<KVSBlockObjects>
+    buildBlockObjects(const std::shared_ptr<KVCacheResource>& resource, const std::vector<CacheKeyType>& keys) const;
+
+    std::string buildObjectKey(CacheKeyType cache_key, int32_t group_id) const;
+    std::string buildDeploymentId() const;
+
+private:
+    KVSCacheStoreConfig                config_;
+    std::shared_ptr<KVCacheAllocator>  allocator_;
+    std::shared_ptr<KVSClient>         client_;
+    kmonitor::MetricsReporterPtr       metrics_reporter_;
+};
+
+}  // namespace kvs
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.cc
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.cc
@@ -1,0 +1,721 @@
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h"
+
+#include <algorithm>
+#include <cstring>
+#include <cstdio>
+#include <limits>
+#include <mutex>
+#include <sstream>
+#include <unordered_set>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "curl/curl.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+
+#if USING_CUDA
+#include <cuda_runtime.h>
+#elif USING_ROCM
+#include "rtp_llm/models_py/bindings/rocm/cuda_shims.h"
+#endif
+
+namespace rtp_llm::kvs {
+namespace {
+
+constexpr uint64_t kMaxJsonMessageBytes = 16ULL * 1024ULL * 1024ULL;
+
+void curlGlobalInitOnce() {
+    static std::once_flag once;
+    std::call_once(once, []() { curl_global_init(CURL_GLOBAL_ALL); });
+}
+
+size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* output = static_cast<std::string*>(userdata);
+    output->append(ptr, size * nmemb);
+    return size * nmemb;
+}
+
+std::string joinUrl(std::string base, const std::string& endpoint) {
+    while (!base.empty() && base.back() == '/') {
+        base.pop_back();
+    }
+    if (!endpoint.empty() && endpoint.front() == '/') {
+        return base + endpoint;
+    }
+    return base + "/" + endpoint;
+}
+
+bool sendAll(int fd, const void* data, size_t bytes) {
+    const char* ptr = static_cast<const char*>(data);
+    while (bytes > 0) {
+        ssize_t sent = ::send(fd, ptr, bytes, 0);
+        if (sent <= 0) {
+            return false;
+        }
+        ptr += sent;
+        bytes -= static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+bool recvAll(int fd, void* data, size_t bytes) {
+    char* ptr = static_cast<char*>(data);
+    while (bytes > 0) {
+        ssize_t got = ::recv(fd, ptr, bytes, 0);
+        if (got <= 0) {
+            return false;
+        }
+        ptr += got;
+        bytes -= static_cast<size_t>(got);
+    }
+    return true;
+}
+
+bool sendJsonMessage(int fd, const std::string& message) {
+    uint64_t len = message.size();
+    return sendAll(fd, &len, sizeof(len)) && sendAll(fd, message.data(), message.size());
+}
+
+std::optional<std::string> recvJsonMessage(int fd) {
+    uint64_t len = 0;
+    if (!recvAll(fd, &len, sizeof(len))) {
+        return std::nullopt;
+    }
+    if (len > kMaxJsonMessageBytes) {
+        RTP_LLM_LOG_WARNING("KVSClient recv message too large: %llu", static_cast<unsigned long long>(len));
+        return std::nullopt;
+    }
+    std::string message;
+    message.resize(static_cast<size_t>(len));
+    if (message.empty()) {
+        return message;
+    }
+    if (!recvAll(fd, &message[0], message.size())) {
+        return std::nullopt;
+    }
+    return message;
+}
+
+size_t totalBytes(const std::vector<BlockInfo>& iovs) {
+    size_t bytes = 0;
+    for (const auto& iov : iovs) {
+        bytes += iov.size_bytes;
+    }
+    return bytes;
+}
+
+bool copyHostAndDevice(void* dst, const void* src, size_t bytes, bool dst_cuda, bool src_cuda) {
+    if (bytes == 0) {
+        return true;
+    }
+    if (!dst || !src) {
+        return false;
+    }
+    if (!dst_cuda && !src_cuda) {
+        std::memcpy(dst, src, bytes);
+        return true;
+    }
+#if USING_CUDA || USING_ROCM
+    cudaMemcpyKind kind = cudaMemcpyDefault;
+    if (dst_cuda && src_cuda) {
+        kind = cudaMemcpyDeviceToDevice;
+    } else if (dst_cuda) {
+        kind = cudaMemcpyHostToDevice;
+    } else if (src_cuda) {
+        kind = cudaMemcpyDeviceToHost;
+    }
+    auto err = cudaMemcpy(dst, src, bytes, kind);
+    if (err != cudaSuccess) {
+        RTP_LLM_LOG_WARNING("KVSClient cudaMemcpy failed: %s", cudaGetErrorString(err));
+        return false;
+    }
+    return true;
+#else
+    RTP_LLM_LOG_WARNING("KVSClient copy requires GPU runtime, dst_cuda[%d], src_cuda[%d]", dst_cuda, src_cuda);
+    return false;
+#endif
+}
+
+std::optional<uint64_t> getJsonUint64(const rapidjson::Value& value) {
+    if (value.IsUint64()) {
+        return value.GetUint64();
+    }
+    if (value.IsInt64() && value.GetInt64() >= 0) {
+        return static_cast<uint64_t>(value.GetInt64());
+    }
+    if (value.IsUint()) {
+        return value.GetUint();
+    }
+    if (value.IsInt() && value.GetInt() >= 0) {
+        return static_cast<uint64_t>(value.GetInt());
+    }
+    return std::nullopt;
+}
+
+void writeStringArray(rapidjson::Writer<rapidjson::StringBuffer>& writer,
+                      const char*                                 name,
+                      const std::vector<std::string>&             values) {
+    writer.Key(name);
+    writer.StartArray();
+    for (const auto& value : values) {
+        writer.String(value.c_str());
+    }
+    writer.EndArray();
+}
+
+}  // namespace
+
+KVSClient::KVSClient() = default;
+
+KVSClient::~KVSClient() {
+    if (mmap_base_ && mmap_size_ > 0) {
+        ::munmap(mmap_base_, mmap_size_);
+    }
+    if (mmap_fd_ >= 0) {
+        ::close(mmap_fd_);
+    }
+    if (socket_fd_ >= 0) {
+        ::close(socket_fd_);
+    }
+}
+
+bool KVSClient::init(const KVSClientConfig& config) {
+    config_ = config;
+    if (config_.v6d_url.empty()) {
+        RTP_LLM_LOG_WARNING("KVSClient init failed, v6d url is empty");
+        return false;
+    }
+    auto health = httpGet("health");
+    if (!health || health->status_code != 200) {
+        RTP_LLM_LOG_WARNING("KVSClient health check failed, url[%s], status[%ld]",
+                            config_.v6d_url.c_str(),
+                            health ? health->status_code : -1);
+        return false;
+    }
+    if (!initMmap()) {
+        return false;
+    }
+    inited_ = true;
+    RTP_LLM_LOG_INFO("KVSClient initialized, v6d_url[%s], socket_path[%s], mmap_base[%p], mmap_size[%zu]",
+                     config_.v6d_url.c_str(),
+                     config_.v6d_socket_path.c_str(),
+                     mmap_base_,
+                     mmap_size_);
+    return true;
+}
+
+std::optional<KVSClient::HttpResponse> KVSClient::httpGet(const std::string& endpoint) {
+    curlGlobalInitOnce();
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        return std::nullopt;
+    }
+    std::string response;
+    std::string url = joinUrl(config_.v6d_url, endpoint);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, config_.timeout_ms);
+    CURLcode rc     = curl_easy_perform(curl);
+    long     status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(curl);
+    if (rc != CURLE_OK) {
+        RTP_LLM_LOG_WARNING("KVSClient GET [%s] failed: %s", url.c_str(), curl_easy_strerror(rc));
+        return std::nullopt;
+    }
+    return HttpResponse{status, std::move(response)};
+}
+
+std::optional<KVSClient::HttpResponse> KVSClient::httpPost(const std::string& endpoint, const std::string& payload) {
+    curlGlobalInitOnce();
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        return std::nullopt;
+    }
+    std::string        response;
+    std::string        url     = joinUrl(config_.v6d_url, endpoint);
+    struct curl_slist* headers = nullptr;
+    headers                    = curl_slist_append(headers, "Content-Type: application/json");
+    headers                    = curl_slist_append(headers, "Accept: application/json");
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.size());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, config_.timeout_ms);
+    CURLcode rc     = curl_easy_perform(curl);
+    long     status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    if (rc != CURLE_OK) {
+        RTP_LLM_LOG_WARNING("KVSClient POST [%s] failed: %s", url.c_str(), curl_easy_strerror(rc));
+        return std::nullopt;
+    }
+    return HttpResponse{status, std::move(response)};
+}
+
+bool KVSClient::initMmap() {
+    if (config_.v6d_socket_path.empty()) {
+        RTP_LLM_LOG_WARNING("KVSClient init mmap failed, v6d socket path is empty");
+        return false;
+    }
+    socket_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (socket_fd_ < 0) {
+        RTP_LLM_LOG_WARNING("KVSClient create unix socket failed");
+        return false;
+    }
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", config_.v6d_socket_path.c_str());
+    if (::connect(socket_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        RTP_LLM_LOG_WARNING("KVSClient connect vineyard socket [%s] failed", config_.v6d_socket_path.c_str());
+        return false;
+    }
+
+    const std::string register_request =
+        R"({"type":"register_request","version":"0.0.0","store_type":0,"session_id":0,"username":"","password":""})";
+    if (!sendJsonMessage(socket_fd_, register_request)) {
+        RTP_LLM_LOG_WARNING("KVSClient send register_request failed");
+        return false;
+    }
+    auto register_reply = recvJsonMessage(socket_fd_);
+    if (!register_reply || register_reply->find("register_reply") == std::string::npos) {
+        RTP_LLM_LOG_WARNING("KVSClient bad register_reply [%s]", register_reply ? register_reply->c_str() : "");
+        return false;
+    }
+    if (!sendJsonMessage(socket_fd_, R"({"type":"get_vineyard_mmap_fd_request"})")) {
+        RTP_LLM_LOG_WARNING("KVSClient send get_vineyard_mmap_fd_request failed");
+        return false;
+    }
+    auto fd_reply = recvJsonMessage(socket_fd_);
+    if (!fd_reply) {
+        RTP_LLM_LOG_WARNING("KVSClient receive get_vineyard_mmap_fd_reply failed");
+        return false;
+    }
+    rapidjson::Document doc;
+    doc.Parse(fd_reply->c_str());
+    if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("size")) {
+        RTP_LLM_LOG_WARNING("KVSClient invalid mmap reply [%s]", fd_reply->c_str());
+        return false;
+    }
+    auto mmap_size = getJsonUint64(doc["size"]);
+    if (!mmap_size) {
+        RTP_LLM_LOG_WARNING("KVSClient invalid mmap size reply [%s]", fd_reply->c_str());
+        return false;
+    }
+    mmap_size_ = static_cast<size_t>(*mmap_size);
+
+    char   control_buffer[CMSG_SPACE(sizeof(int))] = {};
+    char   data_buffer[1]                          = {};
+    iovec  iov{data_buffer, sizeof(data_buffer)};
+    msghdr msg{};
+    msg.msg_iov        = &iov;
+    msg.msg_iovlen     = 1;
+    msg.msg_control    = control_buffer;
+    msg.msg_controllen = sizeof(control_buffer);
+    if (::recvmsg(socket_fd_, &msg, 0) < 0) {
+        RTP_LLM_LOG_WARNING("KVSClient receive mmap fd failed");
+        return false;
+    }
+    for (cmsghdr* cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+        if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+            std::memcpy(&mmap_fd_, CMSG_DATA(cmsg), sizeof(int));
+            break;
+        }
+    }
+    if (mmap_fd_ < 0) {
+        RTP_LLM_LOG_WARNING("KVSClient no mmap fd in SCM_RIGHTS");
+        return false;
+    }
+    mmap_base_ = ::mmap(nullptr, mmap_size_, PROT_READ | PROT_WRITE, MAP_SHARED, mmap_fd_, 0);
+    if (mmap_base_ == MAP_FAILED) {
+        mmap_base_ = nullptr;
+        RTP_LLM_LOG_WARNING("KVSClient mmap failed, size[%zu]", mmap_size_);
+        return false;
+    }
+    return true;
+}
+
+std::optional<KVSObjectHandle> KVSClient::parseObjectHandle(const rapidjson::Value& object_value) const {
+    if (!object_value.IsObject() || !object_value.HasMember("key") || !object_value["key"].IsString()
+        || !object_value.HasMember("blobs") || !object_value["blobs"].IsArray() || object_value["blobs"].Empty()) {
+        return std::nullopt;
+    }
+    const auto& blob = object_value["blobs"][0];
+    if (!blob.IsObject() || !blob.HasMember("type") || !blob["type"].IsString()
+        || std::string(blob["type"].GetString()) != "vineyard" || !blob.HasMember("handle")
+        || !blob["handle"].IsObject()) {
+        return std::nullopt;
+    }
+    const auto& handle = blob["handle"];
+    if (!handle.HasMember("data_offset") || !handle.HasMember("data_size")) {
+        return std::nullopt;
+    }
+    auto data_offset = getJsonUint64(handle["data_offset"]);
+    auto data_size   = getJsonUint64(handle["data_size"]);
+    if (!data_offset || !data_size) {
+        return std::nullopt;
+    }
+    if (handle.HasMember("object_id")) {
+        auto object_id = getJsonUint64(handle["object_id"]);
+        if (!object_id || *object_id == std::numeric_limits<uint64_t>::max()) {
+            return std::nullopt;
+        }
+    }
+    KVSObjectHandle result;
+    result.object_key  = object_value["key"].GetString();
+    result.data_offset = *data_offset;
+    result.bytes       = static_cast<size_t>(*data_size);
+    if (object_value.HasMember("meta") && object_value["meta"].IsObject()) {
+        const auto& meta = object_value["meta"];
+        if (meta.HasMember("size")) {
+            auto meta_size = getJsonUint64(meta["size"]);
+            if (meta_size && *meta_size > 0) {
+                result.bytes = static_cast<size_t>(*meta_size);
+            }
+        }
+    }
+    if (result.data_offset > mmap_size_ || result.bytes > mmap_size_ - result.data_offset) {
+        RTP_LLM_LOG_WARNING("KVSClient object [%s] out of mmap range, offset[%llu], bytes[%zu], mmap_size[%zu]",
+                            result.object_key.c_str(),
+                            static_cast<unsigned long long>(result.data_offset),
+                            result.bytes,
+                            mmap_size_);
+        return std::nullopt;
+    }
+    return result;
+}
+
+std::optional<KVSReadSession> KVSClient::acquireForRead(const std::vector<std::string>& object_keys,
+                                                        const std::string&              trace_id) {
+    if (!inited_ || object_keys.empty()) {
+        return KVSReadSession{};
+    }
+    RTP_LLM_LOG_INFO(
+        "KVSClient acquire READ start, trace_id[%s], object_count[%zu]", trace_id.c_str(), object_keys.size());
+    rapidjson::StringBuffer                    buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("scope");
+    writer.String("read");
+    writeStringArray(writer, "object_keys", object_keys);
+    writer.Key("term");
+    writer.Int(config_.lease_term_sec);
+    writer.Key("peer");
+    writer.String("local");
+    writer.Key("wait_timeout");
+    writer.Int(0);
+    writer.Key("request_id");
+    writer.String(trace_id.c_str());
+    writer.Key("best_effort");
+    writer.Bool(true);
+    writer.EndObject();
+
+    auto response = httpPost("acquire", buffer.GetString());
+    if (!response || response->status_code != 200) {
+        if (response) {
+            RTP_LLM_LOG_WARNING(
+                "KVSClient acquire READ failed, status[%ld], body[%s]", response->status_code, response->body.c_str());
+        }
+        return std::nullopt;
+    }
+    rapidjson::Document doc;
+    doc.Parse(response->body.c_str());
+    if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("lease") || !doc.HasMember("objects")) {
+        RTP_LLM_LOG_WARNING("KVSClient parse acquire READ response failed, body[%s]", response->body.c_str());
+        return std::nullopt;
+    }
+    KVSReadSession session;
+    if (doc["lease"].IsObject() && doc["lease"].HasMember("lease_id") && doc["lease"]["lease_id"].IsString()) {
+        session.lease_id = doc["lease"]["lease_id"].GetString();
+    }
+    const auto& objects = doc["objects"];
+    if (!objects.IsArray()) {
+        return std::nullopt;
+    }
+    for (auto it = objects.Begin(); it != objects.End(); ++it) {
+        if (it->IsNull()) {
+            continue;
+        }
+        auto handle = parseObjectHandle(*it);
+        if (handle) {
+            session.handles.emplace(handle->object_key, *handle);
+        }
+    }
+    RTP_LLM_LOG_INFO("KVSClient acquire READ done, trace_id[%s], requested[%zu], handles[%zu], lease[%s]",
+                     trace_id.c_str(),
+                     object_keys.size(),
+                     session.handles.size(),
+                     session.lease_id.c_str());
+    return session;
+}
+
+bool KVSClient::copyFromObject(const KVSObjectHandle& handle, const std::vector<BlockInfo>& dst_iovs) {
+    const char* src    = static_cast<const char*>(mmap_base_) + handle.data_offset;
+    size_t      offset = 0;
+    for (const auto& dst : dst_iovs) {
+        if (offset + dst.size_bytes > handle.bytes) {
+            return false;
+        }
+        if (!copyHostAndDevice(dst.addr, src + offset, dst.size_bytes, dst.is_cuda, false)) {
+            return false;
+        }
+        offset += dst.size_bytes;
+    }
+    return offset == handle.bytes;
+}
+
+bool KVSClient::copyToObject(const KVSObjectHandle& handle, const std::vector<BlockInfo>& src_iovs) {
+    char*  dst    = static_cast<char*>(mmap_base_) + handle.data_offset;
+    size_t offset = 0;
+    for (const auto& src : src_iovs) {
+        if (offset + src.size_bytes > handle.bytes) {
+            return false;
+        }
+        if (!copyHostAndDevice(dst + offset, src.addr, src.size_bytes, false, src.is_cuda)) {
+            return false;
+        }
+        offset += src.size_bytes;
+    }
+    return offset == handle.bytes;
+}
+
+bool KVSClient::fetch(KVSReadSession&                 session,
+                      const std::vector<std::string>& object_keys,
+                      const std::string&              trace_id) {
+    RTP_LLM_LOG_INFO("KVSClient fetch start, trace_id[%s], object_count[%zu], lease[%s]",
+                     trace_id.c_str(),
+                     object_keys.size(),
+                     session.lease_id.c_str());
+    for (const auto& object_key : object_keys) {
+        if (session.handles.find(object_key) == session.handles.end()) {
+            RTP_LLM_LOG_WARNING("KVSClient fetch miss handle, trace_id[%s], object_key[%s]",
+                                trace_id.c_str(),
+                                object_key.c_str());
+            return false;
+        }
+        session.fetched_keys.insert(object_key);
+    }
+    RTP_LLM_LOG_INFO("KVSClient fetch done, trace_id[%s], object_count[%zu]", trace_id.c_str(), object_keys.size());
+    return true;
+}
+
+bool KVSClient::load(const KVSReadSession& session, const std::vector<KVSObjectBuffer>& dst_buffers) {
+    RTP_LLM_LOG_INFO(
+        "KVSClient load start, object_count[%zu], lease[%s]", dst_buffers.size(), session.lease_id.c_str());
+    for (const auto& dst : dst_buffers) {
+        if (session.fetched_keys.find(dst.object_key) == session.fetched_keys.end()) {
+            RTP_LLM_LOG_WARNING("KVSClient load before fetch, object_key[%s]", dst.object_key.c_str());
+            return false;
+        }
+        const auto handle_it = session.handles.find(dst.object_key);
+        if (handle_it == session.handles.end()) {
+            RTP_LLM_LOG_WARNING("KVSClient load miss handle, object_key[%s]", dst.object_key.c_str());
+            return false;
+        }
+        const auto expected = totalBytes(dst.iovs);
+        auto       handle   = handle_it->second;
+        if (handle.data_offset > mmap_size_ || expected > mmap_size_ - handle.data_offset) {
+            RTP_LLM_LOG_WARNING("KVSClient load out of mmap range, object_key[%s], offset[%llu], dst[%zu], mmap[%zu]",
+                                dst.object_key.c_str(),
+                                static_cast<unsigned long long>(handle.data_offset),
+                                expected,
+                                mmap_size_);
+            return false;
+        }
+        handle.bytes = expected;
+        if (!copyFromObject(handle, dst.iovs)) {
+            RTP_LLM_LOG_WARNING("KVSClient load copy failed, object_key[%s]", dst.object_key.c_str());
+            return false;
+        }
+    }
+    RTP_LLM_LOG_INFO("KVSClient load done, object_count[%zu]", dst_buffers.size());
+    return true;
+}
+
+bool KVSClient::complete(KVSReadSession& session,
+                         const std::vector<std::string>& object_keys,
+                         const std::string&              trace_id) {
+    RTP_LLM_LOG_INFO("KVSClient complete start, trace_id[%s], object_count[%zu], lease[%s]",
+                     trace_id.c_str(),
+                     object_keys.size(),
+                     session.lease_id.c_str());
+    for (const auto& object_key : object_keys) {
+        if (session.fetched_keys.find(object_key) == session.fetched_keys.end()) {
+            RTP_LLM_LOG_WARNING("KVSClient complete before fetch, trace_id[%s], object_key[%s]",
+                                trace_id.c_str(),
+                                object_key.c_str());
+            return false;
+        }
+    }
+    RTP_LLM_LOG_INFO("KVSClient complete done, trace_id[%s], object_count[%zu]", trace_id.c_str(), object_keys.size());
+    return true;
+}
+
+bool KVSClient::store(const std::vector<KVSObjectBuffer>& src_buffers, const std::string& trace_id) {
+    if (!inited_ || src_buffers.empty()) {
+        return true;
+    }
+    RTP_LLM_LOG_INFO("KVSClient store start, trace_id[%s], object_count[%zu]", trace_id.c_str(), src_buffers.size());
+    rapidjson::StringBuffer                    buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("scope");
+    writer.String("create");
+    writer.Key("object_keys");
+    writer.StartArray();
+    for (const auto& src : src_buffers) {
+        writer.String(src.object_key.c_str());
+    }
+    writer.EndArray();
+    writer.Key("object_metas");
+    writer.StartArray();
+    for (const auto& src : src_buffers) {
+        writer.StartObject();
+        writer.Key("size");
+        writer.Uint64(totalBytes(src.iovs));
+        writer.Key("layout");
+        writer.String("rtp_llm_group_block_v1");
+        writer.EndObject();
+    }
+    writer.EndArray();
+    writer.Key("term");
+    writer.Int(config_.lease_term_sec);
+    writer.Key("request_id");
+    writer.String(trace_id.c_str());
+    // When ignore_existing is true, KVS may omit already sealed objects from the
+    // create lease response. Only returned objects need data copy and seal.
+    writer.Key("ignore_existing");
+    writer.Bool(true);
+    writer.EndObject();
+
+    auto response = httpPost("acquire", buffer.GetString());
+    if (!response || response->status_code != 200) {
+        if (response) {
+            RTP_LLM_LOG_WARNING("KVSClient acquire CREATE failed, status[%ld], body[%s]",
+                                response->status_code,
+                                response->body.c_str());
+        }
+        return false;
+    }
+    rapidjson::Document doc;
+    doc.Parse(response->body.c_str());
+    if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("lease") || !doc.HasMember("objects")) {
+        RTP_LLM_LOG_WARNING("KVSClient parse acquire CREATE response failed, body[%s]", response->body.c_str());
+        return false;
+    }
+    std::string lease_id;
+    if (doc["lease"].IsObject() && doc["lease"].HasMember("lease_id") && doc["lease"]["lease_id"].IsString()) {
+        lease_id = doc["lease"]["lease_id"].GetString();
+    }
+    if (lease_id.empty()) {
+        RTP_LLM_LOG_INFO("KVSClient store no-op, trace_id[%s], empty lease", trace_id.c_str());
+        return true;
+    }
+    std::unordered_map<std::string, const KVSObjectBuffer*> src_by_key;
+    for (const auto& src : src_buffers) {
+        src_by_key.emplace(src.object_key, &src);
+    }
+    bool        ok      = true;
+    const auto& objects = doc["objects"];
+    if (!objects.IsArray()) {
+        RTP_LLM_LOG_WARNING("KVSClient acquire CREATE response objects is not array, body[%s]", response->body.c_str());
+        discard(lease_id);
+        return false;
+    }
+    std::unordered_set<std::string> copied_keys;
+    for (auto it = objects.Begin(); it != objects.End(); ++it) {
+        auto handle = parseObjectHandle(*it);
+        if (!handle) {
+            ok = false;
+            break;
+        }
+        const auto src_it = src_by_key.find(handle->object_key);
+        if (src_it == src_by_key.end()) {
+            ok = false;
+            break;
+        }
+        const auto expected = totalBytes(src_it->second->iovs);
+        if (handle->data_offset > mmap_size_ || expected > mmap_size_ - handle->data_offset) {
+            RTP_LLM_LOG_WARNING("KVSClient store out of mmap range, object_key[%s], offset[%llu], src[%zu], mmap[%zu]",
+                                handle->object_key.c_str(),
+                                static_cast<unsigned long long>(handle->data_offset),
+                                expected,
+                                mmap_size_);
+            ok = false;
+            break;
+        }
+        handle->bytes = expected;
+        if (!copyToObject(*handle, src_it->second->iovs)) {
+            ok = false;
+            break;
+        }
+        copied_keys.insert(handle->object_key);
+    }
+    if (ok && copied_keys.empty() && !src_buffers.empty()) {
+        RTP_LLM_LOG_INFO("KVSClient store no new objects to copy, trace_id[%s]", trace_id.c_str());
+    }
+    if (ok) {
+        rapidjson::StringBuffer                    seal_buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> seal_writer(seal_buffer);
+        seal_writer.StartObject();
+        seal_writer.Key("lease_id");
+        seal_writer.String(lease_id.c_str());
+        seal_writer.Key("request_id");
+        seal_writer.String(trace_id.c_str());
+        seal_writer.EndObject();
+        auto seal_response = httpPost("seal", seal_buffer.GetString());
+        ok                 = seal_response && seal_response->status_code == 204;
+    }
+    if (ok) {
+        release(lease_id);
+    } else {
+        discard(lease_id);
+    }
+    RTP_LLM_LOG_INFO(
+        "KVSClient store done, trace_id[%s], object_count[%zu], ok[%d]", trace_id.c_str(), src_buffers.size(), ok);
+    return ok;
+}
+
+void KVSClient::release(const std::string& lease_id) {
+    if (lease_id.empty()) {
+        return;
+    }
+    rapidjson::StringBuffer                    buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("lease_id");
+    writer.String(lease_id.c_str());
+    writer.EndObject();
+    auto response = httpPost("release", buffer.GetString());
+    if (!response || response->status_code != 204) {
+        RTP_LLM_LOG_WARNING("KVSClient release failed, lease_id[%s]", lease_id.c_str());
+    }
+}
+
+void KVSClient::discard(const std::string& lease_id) {
+    if (lease_id.empty()) {
+        return;
+    }
+    rapidjson::StringBuffer                    buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("lease_id");
+    writer.String(lease_id.c_str());
+    writer.EndObject();
+    auto response = httpPost("discard", buffer.GetString());
+    if (!response || response->status_code != 204) {
+        RTP_LLM_LOG_WARNING("KVSClient discard failed, lease_id[%s]", lease_id.c_str());
+    }
+}
+
+}  // namespace rtp_llm::kvs

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "rapidjson/document.h"
+#include "rtp_llm/cpp/cache/BlockInfo.h"
+
+namespace rtp_llm {
+namespace kvs {
+
+struct KVSClientConfig {
+    KVSClientConfig() = default;
+    KVSClientConfig(std::string url, std::string socket_path, int timeout_ms, int lease_term_sec):
+        v6d_url(std::move(url)),
+        v6d_socket_path(std::move(socket_path)),
+        timeout_ms(timeout_ms),
+        lease_term_sec(lease_term_sec) {}
+
+    std::string v6d_url;
+    std::string v6d_socket_path;
+    int         timeout_ms     = 12000;
+    int         lease_term_sec = 60;
+};
+
+struct KVSObjectHandle {
+    std::string object_key;
+    size_t      bytes       = 0;
+    uint64_t    data_offset = 0;
+};
+
+struct KVSReadSession {
+    std::string                                      lease_id;
+    std::unordered_map<std::string, KVSObjectHandle> handles;
+    std::unordered_set<std::string>                  fetched_keys;
+};
+
+struct KVSObjectBuffer {
+    std::string            object_key;
+    std::vector<BlockInfo> iovs;
+};
+
+class KVSClient {
+public:
+    KVSClient();
+    virtual ~KVSClient();
+
+    virtual bool init(const KVSClientConfig& config);
+
+    virtual std::optional<KVSReadSession> acquireForRead(const std::vector<std::string>& object_keys,
+                                                         const std::string&              trace_id);
+
+    virtual bool fetch(KVSReadSession&                 session,
+                       const std::vector<std::string>& object_keys,
+                       const std::string&              trace_id);
+
+    virtual bool load(const KVSReadSession& session, const std::vector<KVSObjectBuffer>& dst_buffers);
+
+    virtual bool complete(KVSReadSession&                 session,
+                          const std::vector<std::string>& object_keys,
+                          const std::string&              trace_id);
+
+    virtual bool store(const std::vector<KVSObjectBuffer>& src_buffers, const std::string& trace_id);
+
+    virtual void release(const std::string& lease_id);
+    virtual void discard(const std::string& lease_id);
+
+private:
+    struct HttpResponse {
+        long        status_code = 0;
+        std::string body;
+    };
+
+    std::optional<HttpResponse> httpGet(const std::string& endpoint);
+    std::optional<HttpResponse> httpPost(const std::string& endpoint, const std::string& payload);
+    bool                        initMmap();
+    bool                        copyFromObject(const KVSObjectHandle& handle, const std::vector<BlockInfo>& dst_iovs);
+    bool                        copyToObject(const KVSObjectHandle& handle, const std::vector<BlockInfo>& src_iovs);
+    std::optional<KVSObjectHandle> parseObjectHandle(const rapidjson::Value& object_value) const;
+
+private:
+    KVSClientConfig config_;
+    void*           mmap_base_ = nullptr;
+    size_t          mmap_size_ = 0;
+    int             mmap_fd_   = -1;
+    int             socket_fd_ = -1;
+    bool            inited_    = false;
+};
+
+}  // namespace kvs
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.cc
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.cc
@@ -1,0 +1,467 @@
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <unordered_set>
+
+#include "autil/EnvUtil.h"
+#include "rtp_llm/cpp/cache/KVCacheResource.h"
+#include "rtp_llm/cpp/cache/allocator/KVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/connector/Meta.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+
+namespace rtp_llm::kvs {
+namespace {
+
+std::string sanitizeKeyPart(std::string value) {
+    for (char& ch : value) {
+        if (ch == '/' || ch == ' ' || ch == '\t' || ch == '\n') {
+            ch = '_';
+        }
+    }
+    return value;
+}
+
+std::string hashString(const std::string& value) {
+    uint64_t hash = 1469598103934665603ULL;
+    for (unsigned char ch : value) {
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+    std::ostringstream oss;
+    oss << std::hex << hash;
+    return oss.str();
+}
+
+size_t totalBytes(const std::vector<BlockInfo>& iovs) {
+    size_t bytes = 0;
+    for (const auto& iov : iovs) {
+        bytes += iov.size_bytes;
+    }
+    return bytes;
+}
+
+bool isValidBlockInfo(const BlockInfo& block_info) {
+    return block_info.addr != nullptr && block_info.size_bytes > 0;
+}
+
+}  // namespace
+
+bool KVSConnectorState::done() const {
+    auto cur = state();
+    return cur == State::SUCCESS || cur == State::ERROR || cur == State::THREADPOOL_FULL || cur == State::CLIENT_ERROR;
+}
+
+bool KVSConnectorState::success() const {
+    return state() == State::SUCCESS;
+}
+
+void KVSConnectorState::set(State state) {
+    state_.store(state, std::memory_order_release);
+}
+
+KVSConnectorState::State KVSConnectorState::state() const {
+    return state_.load(std::memory_order_acquire);
+}
+
+bool KVSAsyncMatchContext::done() const {
+    return state_.done();
+}
+
+KVSAsyncMatchContext::~KVSAsyncMatchContext() {
+    if (read_session_ && !read_session_->lease_id.empty() && client_) {
+        client_->release(read_session_->lease_id);
+    }
+}
+
+bool KVSAsyncMatchContext::success() const {
+    return state_.success();
+}
+
+size_t KVSAsyncMatchContext::matchedBlockCount() const {
+    return matched_block_count_;
+}
+
+bool KVSAsyncContext::done() const {
+    return state_.done();
+}
+
+bool KVSAsyncContext::success() const {
+    return state_.success();
+}
+
+KVSConnector::KVSConnector(const CacheConfig&                 cache_config,
+                           const KVCacheConfig&               kv_cache_config,
+                           const RuntimeConfig&               runtime_config,
+                           const ParallelismConfig&           parallelism_config,
+                           std::shared_ptr<KVCacheAllocator>  allocator,
+                           const kmonitor::MetricsReporterPtr metrics_reporter,
+                           std::shared_ptr<KVSClient>         client):
+    state_(std::make_shared<KVSConnectorSharedState>()) {
+    state_->cache_config       = cache_config;
+    state_->kv_cache_config    = kv_cache_config;
+    state_->runtime_config     = runtime_config;
+    state_->parallelism_config = parallelism_config;
+    state_->allocator          = std::move(allocator);
+    state_->metrics_reporter   = metrics_reporter;
+    state_->client             = client ? std::move(client) : std::make_shared<KVSClient>();
+}
+
+KVSConnector::~KVSConnector() {
+    if (thread_pool_) {
+        // Async tasks capture shared state instead of this, so queued/running tasks do
+        // not depend on KVSConnector object lifetime during shutdown.
+        thread_pool_->stop();
+        thread_pool_->waitFinish();
+        thread_pool_.reset();
+    }
+}
+
+bool KVSConnector::init() {
+    state_->deployment_id = buildDeploymentId(state_);
+    KVSClientConfig config;
+    config.v6d_url         = state_->kv_cache_config.kvs_v6d_url;
+    config.v6d_socket_path = state_->kv_cache_config.kvs_v6d_socket_path;
+    config.timeout_ms      = state_->kv_cache_config.kvs_timeout_ms;
+    config.lease_term_sec  = state_->kv_cache_config.kvs_lease_term_sec;
+    if (!state_->client->init(config)) {
+        RTP_LLM_LOG_ERROR("KVSConnector init failed: KVSClient init failed");
+        return false;
+    }
+    thread_pool_ = std::make_unique<autil::ThreadPool>(state_->kv_cache_config.reco_asyncwrapper_thread_num,
+                                                       state_->kv_cache_config.reco_asyncwrapper_queue_size,
+                                                       nullptr,
+                                                       "KVSThreadPool",
+                                                       /*stopIfHasException=*/true);
+    if (!thread_pool_->start("")) {
+        RTP_LLM_LOG_ERROR("KVSConnector init failed: start thread pool failed");
+        return false;
+    }
+    RTP_LLM_LOG_INFO("KVSConnector initialized, deployment_id[%s]", state_->deployment_id.c_str());
+    return true;
+}
+
+std::shared_ptr<AsyncMatchContext> KVSConnector::asyncMatch(const std::shared_ptr<KVCacheResource>& resource,
+                                                            const std::shared_ptr<Meta>&            meta) {
+    if (!meta || !meta->enableRemoteCache() || !resource || !thread_pool_) {
+        return nullptr;
+    }
+    auto async_context = std::make_shared<KVSAsyncMatchContext>(resource->reuseBlockNum(), state_->client);
+    auto ec            = thread_pool_->pushTask(
+        [state = state_, resource, meta, async_context]() {
+            async_context->state_.set(KVSConnectorState::State::START);
+            asyncMatchTask(state, resource, meta, async_context);
+        },
+        false);
+    if (ec != autil::ThreadPoolBase::ERROR_TYPE::ERROR_NONE) {
+        async_context->state_.set(KVSConnectorState::State::THREADPOOL_FULL);
+        return nullptr;
+    }
+    return async_context;
+}
+
+std::shared_ptr<AsyncContext> KVSConnector::asyncRead(const std::shared_ptr<KVCacheResource>&   resource,
+                                                      const std::shared_ptr<Meta>&              meta,
+                                                      const std::shared_ptr<AsyncMatchContext>& match_context,
+                                                      int                                       start_read_block_index,
+                                                      int                                       read_block_num) {
+    if (!resource || read_block_num <= 0) {
+        return nullptr;
+    }
+    auto kvs_match_context = std::dynamic_pointer_cast<KVSAsyncMatchContext>(match_context);
+    if (!kvs_match_context) {
+        return nullptr;
+    }
+    auto async_context = std::make_shared<KVSAsyncContext>();
+    auto ec            = thread_pool_->pushTask(
+        [state = state_,
+         resource,
+         meta,
+         start_read_block_index,
+         read_block_num,
+         async_context,
+         kvs_match_context]() {
+            async_context->state_.set(KVSConnectorState::State::START);
+            asyncReadTask(
+                state, resource, meta, start_read_block_index, read_block_num, async_context, kvs_match_context);
+        },
+        false);
+    if (ec != autil::ThreadPoolBase::ERROR_TYPE::ERROR_NONE) {
+        async_context->state_.set(KVSConnectorState::State::THREADPOOL_FULL);
+        return nullptr;
+    }
+    return async_context;
+}
+
+std::shared_ptr<AsyncContext> KVSConnector::asyncWrite(const std::shared_ptr<KVCacheResource>& resource,
+                                                       const std::shared_ptr<Meta>&            meta) {
+    if (!meta || !meta->enableRemoteCache() || !resource || !thread_pool_) {
+        return nullptr;
+    }
+    auto async_context = std::make_shared<KVSAsyncContext>();
+    auto ec            = thread_pool_->pushTask(
+        [state = state_, resource, meta, async_context]() {
+            async_context->state_.set(KVSConnectorState::State::START);
+            asyncWriteTask(state, resource, meta, async_context);
+        },
+        false);
+    if (ec != autil::ThreadPoolBase::ERROR_TYPE::ERROR_NONE) {
+        async_context->state_.set(KVSConnectorState::State::THREADPOOL_FULL);
+        return nullptr;
+    }
+    return async_context;
+}
+
+std::shared_ptr<AsyncContext>
+KVSConnector::asyncWriteByLayer(int layer_id, const std::shared_ptr<KVCacheConnectorLayerContext>& layer_context) {
+    (void)layer_context;
+    RTP_LLM_LOG_DEBUG("KVSConnector asyncWriteByLayer is disabled in v1, layer_id[%d]", layer_id);
+    return nullptr;
+}
+
+void KVSConnector::asyncMatchTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                  const std::shared_ptr<KVCacheResource>&         resource,
+                                  const std::shared_ptr<Meta>&                    meta,
+                                  const std::shared_ptr<KVSAsyncMatchContext>&    async_context) {
+    auto keys = resource->cacheKeys();
+    // Match only sealed/full blocks. The current tail can still be growing, so it
+    // is intentionally excluded from remote reuse candidates.
+    if (!keys.empty()) {
+        keys.pop_back();
+    }
+    const size_t prev_reuse = async_context->prev_reuse_blocks_num_;
+    if (prev_reuse >= keys.size()) {
+        async_context->matched_block_count_ = prev_reuse;
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        return;
+    }
+
+    auto                     block_objects = buildBlockObjects(state, resource, keys);
+    std::vector<std::string> object_keys;
+    for (size_t i = prev_reuse; i < block_objects.size(); ++i) {
+        for (const auto& object : block_objects[i].objects) {
+            object_keys.push_back(object.object_key);
+        }
+    }
+    if (object_keys.empty()) {
+        RTP_LLM_LOG_WARNING("KVSConnector match has no readable objects, prev_reuse[%zu], candidate_blocks[%zu]",
+                            prev_reuse,
+                            keys.size());
+        async_context->matched_block_count_ = prev_reuse;
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        return;
+    }
+    std::sort(object_keys.begin(), object_keys.end());
+    object_keys.erase(std::unique(object_keys.begin(), object_keys.end()), object_keys.end());
+
+    RTP_LLM_LOG_INFO(
+        "KVSConnector match start, trace_id[%s], prev_reuse[%zu], candidate_blocks[%zu], object_count[%zu]",
+        meta->trace_id().c_str(),
+        prev_reuse,
+        block_objects.size(),
+        object_keys.size());
+    auto session = state->client->acquireForRead(object_keys, "kvs_match_" + meta->trace_id());
+    if (!session) {
+        RTP_LLM_LOG_WARNING("KVSConnector match failed, degrade to miss, trace_id[%s]", meta->trace_id().c_str());
+        async_context->matched_block_count_ = prev_reuse;
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        return;
+    }
+
+    size_t                       matched = prev_reuse;
+    std::vector<KVSBlockObjects> matched_blocks;
+    for (size_t i = prev_reuse; i < block_objects.size(); ++i) {
+        bool hit = true;
+        for (const auto& object : block_objects[i].objects) {
+            if (session->handles.find(object.object_key) == session->handles.end()) {
+                hit = false;
+                break;
+            }
+        }
+        if (!hit) {
+            break;
+        }
+        matched++;
+        matched_blocks.push_back(block_objects[i]);
+    }
+
+    if (matched <= prev_reuse && !session->lease_id.empty()) {
+        state->client->release(session->lease_id);
+        session->lease_id.clear();
+    }
+    async_context->matched_block_count_ = matched;
+    async_context->matched_blocks_      = std::move(matched_blocks);
+    async_context->read_session_        = std::move(session);
+    RTP_LLM_LOG_INFO("KVSConnector match done, trace_id[%s], matched_blocks[%zu], prev_reuse[%zu], lease[%s]",
+                     meta->trace_id().c_str(),
+                     matched,
+                     prev_reuse,
+                     async_context->read_session_ ? async_context->read_session_->lease_id.c_str() : "");
+    async_context->state_.set(KVSConnectorState::State::SUCCESS);
+}
+
+void KVSConnector::asyncReadTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                 const std::shared_ptr<KVCacheResource>&         resource,
+                                 const std::shared_ptr<Meta>&                    meta,
+                                 int                                             start_read_block_index,
+                                 int                                             read_block_num,
+                                 const std::shared_ptr<KVSAsyncContext>&         async_context,
+                                 const std::shared_ptr<KVSAsyncMatchContext>&    match_context) {
+    if (!match_context->read_session_) {
+        async_context->state_.set(KVSConnectorState::State::ERROR);
+        return;
+    }
+    std::vector<KVSObjectBuffer> dst_buffers;
+    const int                    end_block_index = start_read_block_index + read_block_num;
+    for (const auto& block : match_context->matched_blocks_) {
+        if (static_cast<int>(block.block_index) < start_read_block_index
+            || static_cast<int>(block.block_index) >= end_block_index) {
+            continue;
+        }
+        for (const auto& object : block.objects) {
+            dst_buffers.push_back(KVSObjectBuffer{object.object_key, object.iovs});
+        }
+    }
+    if (dst_buffers.empty()) {
+        RTP_LLM_LOG_WARNING("KVSConnector read has no destination buffers, start_block[%d], block_num[%d]",
+                            start_read_block_index,
+                            read_block_num);
+        state->client->release(match_context->read_session_->lease_id);
+        match_context->read_session_.reset();
+        async_context->state_.set(KVSConnectorState::State::CLIENT_ERROR);
+        return;
+    }
+    std::vector<std::string> object_keys;
+    object_keys.reserve(dst_buffers.size());
+    for (const auto& dst : dst_buffers) {
+        object_keys.push_back(dst.object_key);
+    }
+    const auto trace_id =
+        meta ? "kvs_read_" + meta->trace_id() : "kvs_read_" + match_context->read_session_->lease_id;
+    RTP_LLM_LOG_INFO("KVSConnector read start, start_block[%d], block_num[%d], object_count[%zu]",
+                     start_read_block_index,
+                     read_block_num,
+                     dst_buffers.size());
+    bool ok = state->client->fetch(*match_context->read_session_, object_keys, trace_id);
+    if (ok) {
+        ok = state->client->load(*match_context->read_session_, dst_buffers);
+    }
+    if (ok) {
+        ok = state->client->complete(*match_context->read_session_, object_keys, trace_id);
+    }
+    state->client->release(match_context->read_session_->lease_id);
+    match_context->read_session_.reset();
+    if (ok) {
+        resource->setRemoteReuseBlockNum(start_read_block_index + read_block_num);
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        RTP_LLM_LOG_INFO("KVSConnector read done, remote_reuse_blocks[%d]", start_read_block_index + read_block_num);
+    } else {
+        RTP_LLM_LOG_WARNING("KVSConnector read failed, start_block[%d], block_num[%d], object_count[%zu]",
+                            start_read_block_index,
+                            read_block_num,
+                            dst_buffers.size());
+        async_context->state_.set(KVSConnectorState::State::CLIENT_ERROR);
+    }
+}
+
+void KVSConnector::asyncWriteTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                  const std::shared_ptr<KVCacheResource>&         resource,
+                                  const std::shared_ptr<Meta>&                    meta,
+                                  const std::shared_ptr<KVSAsyncContext>&         async_context) {
+    auto keys = resource->cacheKeys();
+    if (!keys.empty() && !resource->lastBlockAligned()) {
+        keys.pop_back();
+    }
+    if (keys.empty()) {
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        return;
+    }
+    auto                         block_objects = buildBlockObjects(state, resource, keys);
+    std::vector<KVSObjectBuffer> src_buffers;
+    for (const auto& block : block_objects) {
+        for (const auto& object : block.objects) {
+            if (!object.iovs.empty() && totalBytes(object.iovs) > 0) {
+                src_buffers.push_back(KVSObjectBuffer{object.object_key, object.iovs});
+            }
+        }
+    }
+    RTP_LLM_LOG_INFO("KVSConnector write start, trace_id[%s], blocks[%zu], object_count[%zu]",
+                     meta->trace_id().c_str(),
+                     block_objects.size(),
+                     src_buffers.size());
+    if (state->client->store(src_buffers, "kvs_store_" + meta->trace_id())) {
+        async_context->state_.set(KVSConnectorState::State::SUCCESS);
+        RTP_LLM_LOG_INFO(
+            "KVSConnector write done, trace_id[%s], object_count[%zu]", meta->trace_id().c_str(), src_buffers.size());
+    } else {
+        RTP_LLM_LOG_WARNING(
+            "KVSConnector write failed, trace_id[%s], object_count[%zu]", meta->trace_id().c_str(), src_buffers.size());
+        async_context->state_.set(KVSConnectorState::State::CLIENT_ERROR);
+    }
+}
+
+std::vector<KVSBlockObjects> KVSConnector::buildBlockObjects(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                                             const std::shared_ptr<KVCacheResource>&         resource,
+                                                             const std::vector<CacheKeyType>&                keys) {
+    std::vector<KVSBlockObjects> result;
+    result.reserve(keys.size());
+    for (size_t block_index = 0; block_index < keys.size(); ++block_index) {
+        KVSBlockObjects block_objects;
+        block_objects.block_index = block_index;
+        for (int group_id = 0; group_id < resource->groupNums(); ++group_id) {
+            const auto& block_ids = resource->groupBlocks().at(group_id)->blocks();
+            if (block_index >= block_ids.size() || isNullBlockIdx(block_ids[block_index])) {
+                continue;
+            }
+            std::vector<BlockInfo> iovs;
+            for (int layer_id : state->cache_config.layerIdsForGroup(static_cast<size_t>(group_id))) {
+                auto block_infos = state->allocator->convertIndexToBuffer(layer_id, group_id, block_ids[block_index]);
+                for (const auto& block_info : block_infos) {
+                    if (!isValidBlockInfo(block_info)) {
+                        iovs.clear();
+                        break;
+                    }
+                    iovs.push_back(block_info);
+                }
+                if (iovs.empty()) {
+                    break;
+                }
+            }
+            if (!iovs.empty()) {
+                block_objects.objects.push_back(KVSBlockObject{
+                    block_index, group_id, buildObjectKey(state, keys[block_index], group_id), std::move(iovs)});
+            }
+        }
+        result.push_back(std::move(block_objects));
+    }
+    return result;
+}
+
+std::string KVSConnector::buildObjectKey(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                         CacheKeyType                                    cache_key,
+                                         int32_t                                         group_id) {
+    std::ostringstream oss;
+    oss << sanitizeKeyPart(state->kv_cache_config.kvs_object_namespace) << "/v"
+        << sanitizeKeyPart(state->kv_cache_config.kvs_cache_key_version) << "/" << state->deployment_id << "/tp-"
+        << state->parallelism_config.tp_rank << "/group-" << group_id << "/block-" << cache_key;
+    return oss.str();
+}
+
+std::string KVSConnector::buildDeploymentId(const std::shared_ptr<KVSConnectorSharedState>& state) {
+    // The deployment id is intentionally model-layout scoped. CHECKPOINT_PATH is
+    // included when available to avoid cross-model collisions for identical names;
+    // operators can override namespace/version to widen or narrow reuse scope.
+    const auto         checkpoint_path = autil::EnvUtil::getEnv("CHECKPOINT_PATH", std::string(""));
+    std::ostringstream raw;
+    raw << "model=" << state->runtime_config.model_name << ";ckpt=" << checkpoint_path
+        << ";dtype=" << getDataTypeStr(state->cache_config.dtype) << ";seq=" << state->cache_config.seq_size_per_block
+        << ";kernel_seq=" << state->cache_config.kernel_seq_size_per_block
+        << ";tp=" << state->parallelism_config.tp_size << ";fp8=" << state->kv_cache_config.fp8_kv_cache
+        << ";int8=" << state->kv_cache_config.int8_kv_cache << ";mla=" << state->cache_config.use_mla
+        << ";groups=" << state->cache_config.groupNums() << ";typed=" << state->cache_config.use_typed_cache_regions;
+    return sanitizeKeyPart(state->runtime_config.model_name.empty() ? "model" : state->runtime_config.model_name) + "-"
+           + hashString(raw.str());
+}
+
+}  // namespace rtp_llm::kvs

--- a/rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.h
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "autil/ThreadPool.h"
+#include "kmonitor/client/MetricsReporter.h"
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/KVCacheResource.h"
+#include "rtp_llm/cpp/cache/connector/KVCacheConnector.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h"
+#include "rtp_llm/cpp/config/ConfigModules.h"
+
+namespace rtp_llm {
+
+class KVCacheAllocator;
+
+namespace kvs {
+
+struct KVSConnectorSharedState {
+    CacheConfig                       cache_config;
+    KVCacheConfig                     kv_cache_config;
+    RuntimeConfig                     runtime_config;
+    ParallelismConfig                 parallelism_config;
+    std::shared_ptr<KVCacheAllocator> allocator;
+    kmonitor::MetricsReporterPtr      metrics_reporter;
+    std::shared_ptr<KVSClient>        client;
+    std::string                       deployment_id;
+};
+
+class KVSConnectorState {
+public:
+    enum class State {
+        INIT            = 0,
+        START           = 1,
+        SUCCESS         = 2,
+        ERROR           = 3,
+        THREADPOOL_FULL = 4,
+        CLIENT_ERROR    = 5,
+    };
+
+    bool  done() const;
+    bool  success() const;
+    void  set(State state);
+    State state() const;
+
+private:
+    std::atomic<State> state_{State::INIT};
+};
+
+class KVSAsyncMatchContext: public AsyncMatchContext {
+public:
+    KVSAsyncMatchContext(size_t prev_reuse_blocks_num, std::shared_ptr<KVSClient> client):
+        prev_reuse_blocks_num_(prev_reuse_blocks_num), client_(std::move(client)) {}
+    ~KVSAsyncMatchContext() override;
+
+    bool   done() const override;
+    bool   success() const override;
+    void   waitDone() override {}
+    size_t matchedBlockCount() const override;
+
+private:
+    friend class KVSConnector;
+
+    size_t                        prev_reuse_blocks_num_ = 0;
+    size_t                        matched_block_count_   = 0;
+    std::vector<KVSBlockObjects>  matched_blocks_;
+    std::optional<KVSReadSession> read_session_;
+    std::shared_ptr<KVSClient>    client_;
+    KVSConnectorState             state_;
+};
+
+class KVSAsyncContext: public AsyncContext {
+public:
+    bool done() const override;
+    bool success() const override;
+    void waitDone() override {}
+
+private:
+    friend class KVSConnector;
+    KVSConnectorState state_;
+};
+
+class KVSConnector: public KVCacheConnector {
+public:
+    KVSConnector(const CacheConfig&                 cache_config,
+                 const KVCacheConfig&               kv_cache_config,
+                 const RuntimeConfig&               runtime_config,
+                 const ParallelismConfig&           parallelism_config,
+                 std::shared_ptr<KVCacheAllocator>  allocator,
+                 const kmonitor::MetricsReporterPtr metrics_reporter = nullptr,
+                 std::shared_ptr<KVSClient>         client           = nullptr);
+    ~KVSConnector() override;
+
+    bool init();
+
+    std::shared_ptr<AsyncMatchContext> asyncMatch(const std::shared_ptr<KVCacheResource>& resource,
+                                                  const std::shared_ptr<Meta>&            meta) override;
+    std::shared_ptr<AsyncContext>      asyncRead(const std::shared_ptr<KVCacheResource>&   resource,
+                                                 const std::shared_ptr<Meta>&              meta,
+                                                 const std::shared_ptr<AsyncMatchContext>& match_context,
+                                                 int                                       start_read_block_index,
+                                                 int                                       read_block_num) override;
+    std::shared_ptr<AsyncContext>      asyncWrite(const std::shared_ptr<KVCacheResource>& resource,
+                                                  const std::shared_ptr<Meta>&            meta) override;
+    std::shared_ptr<AsyncContext>
+    asyncWriteByLayer(int layer_id, const std::shared_ptr<KVCacheConnectorLayerContext>& layer_context) override;
+
+private:
+    static void asyncMatchTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                               const std::shared_ptr<KVCacheResource>&         resource,
+                               const std::shared_ptr<Meta>&                    meta,
+                               const std::shared_ptr<KVSAsyncMatchContext>&    async_context);
+    static void asyncReadTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                              const std::shared_ptr<KVCacheResource>&         resource,
+                              const std::shared_ptr<Meta>&                    meta,
+                              int                                             start_read_block_index,
+                              int                                             read_block_num,
+                              const std::shared_ptr<KVSAsyncContext>&         async_context,
+                              const std::shared_ptr<KVSAsyncMatchContext>&    match_context);
+    static void asyncWriteTask(const std::shared_ptr<KVSConnectorSharedState>& state,
+                               const std::shared_ptr<KVCacheResource>&         resource,
+                               const std::shared_ptr<Meta>&                    meta,
+                               const std::shared_ptr<KVSAsyncContext>&         async_context);
+
+    static std::vector<KVSBlockObjects> buildBlockObjects(const std::shared_ptr<KVSConnectorSharedState>& state,
+                                                          const std::shared_ptr<KVCacheResource>&         resource,
+                                                          const std::vector<CacheKeyType>&                keys);
+    static std::string
+    buildObjectKey(const std::shared_ptr<KVSConnectorSharedState>& state, CacheKeyType cache_key, int32_t group_id);
+    static std::string buildDeploymentId(const std::shared_ptr<KVSConnectorSharedState>& state);
+
+private:
+    std::shared_ptr<KVSConnectorSharedState> state_;
+    std::unique_ptr<autil::ThreadPool>       thread_pool_;
+};
+
+}  // namespace kvs
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/connector/kvs_connector/test/BUILD
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/test/BUILD
@@ -1,0 +1,50 @@
+load("//:def.bzl", "cc_test_wrapper", "copts")
+load("//bazel:arch_select.bzl", "torch_deps")
+
+cc_test = cc_test_wrapper
+
+cc_import(
+    name = "cuda13_torch_nvshmem",
+    shared_library = "@pip_gpu_cuda13_torch_torch//:site-packages/torch/lib/libtorch_nvshmem.so",
+)
+
+cuda13_torch_link_deps = select({
+    "@//:using_cuda13_x86": [
+        ":cuda13_torch_nvshmem",
+    ],
+    "//conditions:default": [],
+})
+
+cc_test(
+    name = "kvs_connector_test",
+    srcs = [
+        "KVSConnectorTest.cc",
+    ],
+    copts = [
+        "-fno-access-control",
+    ] + copts(),
+    deps = [
+        "//rtp_llm/cpp/cache:batch_kv_cache_resource",
+        "//rtp_llm/cpp/cache:cache_types",
+        "//rtp_llm/cpp/cache:kv_cache_allocator",
+        "//rtp_llm/cpp/cache/connector:connector_base",
+        "//rtp_llm/cpp/cache/connector/kvs_connector",
+        "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/utils:core_utils",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps() + cuda13_torch_link_deps,
+)
+
+cc_test(
+    name = "kvs_client_integration_test",
+    srcs = [
+        "KVSClientIntegrationTest.cc",
+    ],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/cpp/cache/connector/kvs_connector",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ] + cuda13_torch_link_deps,
+)

--- a/rtp_llm/cpp/cache/connector/kvs_connector/test/KVSClientIntegrationTest.cc
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/test/KVSClientIntegrationTest.cc
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSClient.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+
+namespace rtp_llm::kvs {
+namespace {
+
+const char* envOrNull(const char* name) {
+    const char* value = std::getenv(name);
+    return value && value[0] != '\0' ? value : nullptr;
+}
+
+BlockInfo cpuBlock(void* addr, size_t bytes) {
+    BlockInfo info;
+    info.is_cuda    = false;
+    info.addr       = addr;
+    info.size_bytes = bytes;
+    return info;
+}
+
+TEST(KVSClientIntegrationTest, StoreAcquireLoadRelease) {
+    const char* url    = envOrNull("KVS_INTEGRATION_URL");
+    const char* socket = envOrNull("KVS_INTEGRATION_SOCKET");
+    if (!url || !socket) {
+        GTEST_SKIP() << "set KVS_INTEGRATION_URL and KVS_INTEGRATION_SOCKET to run real KVS integration";
+    }
+
+    KVSClientConfig config(url, socket, 5000, 20);
+
+    KVSClient client;
+    initLogger();
+    ASSERT_TRUE(client.init(config));
+
+    std::vector<char> src_a(32);
+    std::vector<char> src_b(17);
+    for (size_t i = 0; i < src_a.size(); ++i) {
+        src_a[i] = static_cast<char>('a' + (i % 26));
+    }
+    for (size_t i = 0; i < src_b.size(); ++i) {
+        src_b[i] = static_cast<char>('A' + (i % 26));
+    }
+
+    const std::string object_key = "rtp_llm/test/kvs_client/" + std::to_string(getpid()) + "/object";
+    std::cerr << "object_key=" << object_key << std::endl;
+    KVSObjectBuffer src;
+    src.object_key = object_key;
+    src.iovs       = {cpuBlock(src_a.data(), src_a.size()), cpuBlock(src_b.data(), src_b.size())};
+
+    ASSERT_TRUE(client.store({src}, "kvs-client-integration-store"));
+
+    auto session = client.acquireForRead({object_key}, "kvs-client-integration-read");
+    ASSERT_TRUE(session.has_value());
+    ASSERT_EQ(session->handles.size(), 1);
+    ASSERT_NE(session->handles.find(object_key), session->handles.end());
+
+    std::vector<char> dst_a(src_a.size(), 0);
+    std::vector<char> dst_b(src_b.size(), 0);
+    KVSObjectBuffer   dst;
+    dst.object_key = object_key;
+    dst.iovs       = {cpuBlock(dst_a.data(), dst_a.size()), cpuBlock(dst_b.data(), dst_b.size())};
+
+    ASSERT_TRUE(client.fetch(*session, {object_key}, "kvs-client-integration-read"));
+    EXPECT_TRUE(client.load(*session, {dst}));
+    EXPECT_TRUE(client.complete(*session, {object_key}, "kvs-client-integration-read"));
+    EXPECT_EQ(dst_a, src_a);
+    EXPECT_EQ(dst_b, src_b);
+    client.release(session->lease_id);
+}
+
+TEST(KVSClientIntegrationTest, StoreThenReloadWithNewClient) {
+    const char* url    = envOrNull("KVS_INTEGRATION_URL");
+    const char* socket = envOrNull("KVS_INTEGRATION_SOCKET");
+    if (!url || !socket) {
+        GTEST_SKIP() << "set KVS_INTEGRATION_URL and KVS_INTEGRATION_SOCKET to run real KVS integration";
+    }
+
+    KVSClientConfig config(url, socket, 5000, 300);
+
+    initLogger();
+
+    std::vector<char> src(64);
+    for (size_t i = 0; i < src.size(); ++i) {
+        src[i] = static_cast<char>((i * 17) & 0xff);
+    }
+
+    const std::string object_key = "rtp_llm/test/kvs_client/reload/" + std::to_string(getpid()) + "/object";
+    std::cerr << "reload_object_key=" << object_key << std::endl;
+
+    {
+        KVSClient client;
+        ASSERT_TRUE(client.init(config));
+
+        KVSObjectBuffer src_buffer;
+        src_buffer.object_key = object_key;
+        src_buffer.iovs       = {cpuBlock(src.data(), src.size())};
+        ASSERT_TRUE(client.store({src_buffer}, "kvs-client-integration-store-reload"));
+        ASSERT_TRUE(client.store({src_buffer}, "kvs-client-integration-store-reload-duplicate"));
+    }
+
+    KVSClient reload_client;
+    ASSERT_TRUE(reload_client.init(config));
+    auto session = reload_client.acquireForRead({object_key}, "kvs-client-integration-read-reload");
+    ASSERT_TRUE(session.has_value());
+    ASSERT_EQ(session->handles.size(), 1);
+
+    std::vector<char> dst(src.size(), 0);
+    KVSObjectBuffer   dst_buffer;
+    dst_buffer.object_key = object_key;
+    dst_buffer.iovs       = {cpuBlock(dst.data(), dst.size())};
+
+    ASSERT_TRUE(reload_client.fetch(*session, {object_key}, "kvs-client-integration-read-reload"));
+    EXPECT_TRUE(reload_client.load(*session, {dst_buffer}));
+    EXPECT_TRUE(reload_client.complete(*session, {object_key}, "kvs-client-integration-read-reload"));
+    EXPECT_EQ(dst, src);
+    reload_client.release(session->lease_id);
+}
+
+TEST(KVSClientIntegrationTest, MissingObjectReturnsEmptyHandles) {
+    const char* url    = envOrNull("KVS_INTEGRATION_URL");
+    const char* socket = envOrNull("KVS_INTEGRATION_SOCKET");
+    if (!url || !socket) {
+        GTEST_SKIP() << "set KVS_INTEGRATION_URL and KVS_INTEGRATION_SOCKET to run real KVS integration";
+    }
+
+    KVSClientConfig config(url, socket, 5000, 20);
+
+    KVSClient client;
+    initLogger();
+    ASSERT_TRUE(client.init(config));
+
+    const std::string object_key = "rtp_llm/test/kvs_client/missing/" + std::to_string(getpid()) + "/object";
+    auto              session    = client.acquireForRead({object_key}, "kvs-client-integration-missing");
+
+    ASSERT_TRUE(session.has_value());
+    EXPECT_TRUE(session->handles.empty());
+    client.release(session->lease_id);
+}
+
+}  // namespace
+}  // namespace rtp_llm::kvs

--- a/rtp_llm/cpp/cache/connector/kvs_connector/test/KVSConnectorTest.cc
+++ b/rtp_llm/cpp/cache/connector/kvs_connector/test/KVSConnectorTest.cc
@@ -1,0 +1,474 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/allocator/KVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/connector/Meta.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSCacheStore.h"
+#include "rtp_llm/cpp/cache/connector/kvs_connector/KVSConnector.h"
+#include "rtp_llm/cpp/cache/spec/MHAKVCacheSpec.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+#include "rtp_llm/models_py/bindings/core/OpData.h"
+
+namespace rtp_llm {
+
+void execBatchCopy(const BatchCopyParams&) {}
+
+}  // namespace rtp_llm
+
+namespace rtp_llm::kvs {
+namespace {
+
+class TestMeta final: public Meta {
+public:
+    TestMeta(bool enable_remote_cache, std::string trace_id):
+        enable_remote_cache_(enable_remote_cache), trace_id_(std::move(trace_id)) {}
+
+    bool enableMemoryCache() const override {
+        return false;
+    }
+
+    bool enableRemoteCache() const override {
+        return enable_remote_cache_;
+    }
+
+    const std::string& trace_id() const override {
+        return trace_id_;
+    }
+
+    const std::string& unique_id() const override {
+        return unique_id_;
+    }
+
+    const std::vector<int64_t>& tokens() const override {
+        return tokens_;
+    }
+
+private:
+    bool                 enable_remote_cache_;
+    std::string          trace_id_;
+    std::string          unique_id_ = "test_unique_id";
+    std::vector<int64_t> tokens_;
+};
+
+class FakeKVCacheAllocator final: public KVCacheAllocator {
+public:
+    explicit FakeKVCacheAllocator(const CacheConfig& config): KVCacheAllocator(config), data_(4096, 0) {}
+
+    void free(const FreeInfo&) override {}
+    void insertIntoCache(const InsertInfo&) override {}
+
+    BlockAddrInfo convertIndexToAddr(int, int) const override {
+        return {};
+    }
+
+    std::vector<BlockInfo> convertIndexToBuffer(int layer_id, int block_id) const override {
+        return convertIndexToBuffer(layer_id, 0, block_id);
+    }
+
+    std::vector<BlockInfo> convertIndexToBuffer(int layer_id, int block_id, int, int) const override {
+        return convertIndexToBuffer(layer_id, block_id);
+    }
+
+    std::vector<BlockInfo> convertIndexToBuffer(int layer_id, int group_id, int block_id) const override {
+        if (return_empty_buffers) {
+            return {};
+        }
+        if (return_null_buffers) {
+            return {BlockInfo{
+                false,
+                0,
+                0,
+                nullptr,
+                kBlockBytes,
+            }};
+        }
+        const size_t offset = static_cast<size_t>((layer_id * 128) + (group_id * 32) + block_id);
+        return {BlockInfo{
+            false,
+            0,
+            0,
+            const_cast<char*>(data_.data()) + (offset % (data_.size() - kBlockBytes)),
+            kBlockBytes,
+        }};
+    }
+
+    std::shared_ptr<KVCacheResource> incrKVCacheRef(const KVCacheResource&, const CacheKeysType&, bool) override {
+        return nullptr;
+    }
+
+    CacheLayerLayout allLayerCacheBase() const override {
+        return {};
+    }
+
+    bool
+    updateKVBlock(const BatchKVCacheResourcePtr&, const std::vector<int>&, bool, std::vector<BlockIdPair>&) override {
+        return false;
+    }
+
+    int seqSizePerBlock() const override {
+        return 1;
+    }
+
+    int singleBatchNeedBlocks(const BatchKVCacheResourcePtr&, int, int) const override {
+        return 0;
+    }
+
+    bool return_empty_buffers = false;
+    bool return_null_buffers  = false;
+
+protected:
+    bool doInit() override {
+        return true;
+    }
+
+    MallocResult incrMalloc(const MallocInfo&) override {
+        return {};
+    }
+
+    MallocResult initMallocForCommonLen(const MallocInfo&) override {
+        return {};
+    }
+
+    int getNeedBlocks(const MallocInfo&) const override {
+        return 0;
+    }
+
+    void decrKVCacheRef(const KVCacheResource&, bool) override {}
+
+private:
+    static constexpr size_t kBlockBytes = 16;
+    std::vector<char>       data_;
+};
+
+class FakeKVSClient final: public KVSClient {
+public:
+    bool init(const KVSClientConfig& config) override {
+        init_config = config;
+        return init_ok;
+    }
+
+    std::optional<KVSReadSession> acquireForRead(const std::vector<std::string>& object_keys,
+                                                 const std::string&              trace_id) override {
+        acquired_keys = object_keys;
+        acquire_trace = trace_id;
+        if (!acquire_ok) {
+            return std::nullopt;
+        }
+        KVSReadSession session;
+        session.lease_id = lease_id;
+        for (const auto& object_key : object_keys) {
+            if (std::find(missing_keys.begin(), missing_keys.end(), object_key) != missing_keys.end()) {
+                continue;
+            }
+            session.handles.emplace(object_key, KVSObjectHandle{object_key, 16, 0});
+        }
+        return session;
+    }
+
+    bool load(const KVSReadSession& session, const std::vector<KVSObjectBuffer>& dst_buffers) override {
+        load_lease_id = session.lease_id;
+        loaded_keys.clear();
+        for (const auto& dst : dst_buffers) {
+            loaded_keys.push_back(dst.object_key);
+            if (session.fetched_keys.find(dst.object_key) == session.fetched_keys.end()) {
+                return false;
+            }
+        }
+        return load_ok;
+    }
+
+    bool fetch(KVSReadSession&                 session,
+               const std::vector<std::string>& object_keys,
+               const std::string&              trace_id) override {
+        fetch_lease_id = session.lease_id;
+        fetch_trace    = trace_id;
+        fetched_keys   = object_keys;
+        if (!fetch_ok) {
+            return false;
+        }
+        for (const auto& object_key : object_keys) {
+            session.fetched_keys.insert(object_key);
+        }
+        return true;
+    }
+
+    bool complete(KVSReadSession&                 session,
+                  const std::vector<std::string>& object_keys,
+                  const std::string&              trace_id) override {
+        complete_lease_id = session.lease_id;
+        complete_trace    = trace_id;
+        completed_keys    = object_keys;
+        if (!complete_ok) {
+            return false;
+        }
+        for (const auto& object_key : object_keys) {
+            if (session.fetched_keys.find(object_key) == session.fetched_keys.end()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool store(const std::vector<KVSObjectBuffer>& src_buffers, const std::string& trace_id) override {
+        store_trace = trace_id;
+        stored_keys.clear();
+        stored_iov_counts.clear();
+        for (const auto& src : src_buffers) {
+            stored_keys.push_back(src.object_key);
+            stored_iov_counts.push_back(src.iovs.size());
+        }
+        return store_ok;
+    }
+
+    void release(const std::string& lease) override {
+        released_leases.push_back(lease);
+    }
+
+    bool                     init_ok     = true;
+    bool                     acquire_ok  = true;
+    bool                     fetch_ok    = true;
+    bool                     load_ok     = true;
+    bool                     complete_ok = true;
+    bool                     store_ok    = true;
+    std::string              lease_id    = "lease-1";
+    KVSClientConfig          init_config;
+    std::vector<std::string> acquired_keys;
+    std::vector<std::string> missing_keys;
+    std::vector<std::string> fetched_keys;
+    std::vector<std::string> loaded_keys;
+    std::vector<std::string> completed_keys;
+    std::vector<std::string> stored_keys;
+    std::vector<size_t>      stored_iov_counts;
+    std::vector<std::string> released_leases;
+    std::string              acquire_trace;
+    std::string              fetch_trace;
+    std::string              load_lease_id;
+    std::string              complete_trace;
+    std::string              fetch_lease_id;
+    std::string              complete_lease_id;
+    std::string              store_trace;
+};
+
+CacheConfig makeCacheConfig() {
+    CacheConfig config;
+    config.dtype                     = DataType::TYPE_FP16;
+    config.layer_num                 = 2;
+    config.layer_all_num             = 2;
+    config.block_num                 = 8;
+    config.seq_size_per_block        = 1;
+    config.kernel_seq_size_per_block = 1;
+
+    auto spec                = std::make_shared<MHAKVCacheSpec>();
+    spec->type               = KVCacheSpecType::MultiHeadAttention;
+    spec->dtype              = config.dtype;
+    spec->local_head_num_kv  = 1;
+    spec->size_per_head      = 1;
+    spec->seq_size_per_block = 1;
+    config.fromGroupedSpecs({spec}, {{0, 1}}, {CacheGroupType::FULL}, {"default"});
+    return config;
+}
+
+KVCacheConfig makeKVCacheConfig() {
+    KVCacheConfig config;
+    config.reuse_cache                  = true;
+    config.enable_kvs_cache             = true;
+    config.kvs_object_namespace         = "rtp llm/test";
+    config.kvs_cache_key_version        = "test/v";
+    config.reco_asyncwrapper_thread_num = 1;
+    config.reco_asyncwrapper_queue_size = 8;
+    return config;
+}
+
+std::shared_ptr<KVCacheResource> makeResource(bool last_block_aligned = true) {
+    auto resource = std::make_shared<KVCacheResource>();
+    resource->initGroups(1, 2, {{0}, {0}}, 1, {CacheGroupType::FULL});
+    resource->mutableBlockIds(0).assign({10, 11, 12});
+    resource->setCacheKeys({100, 101, 102});
+    resource->setLastBlockAligned(last_block_aligned);
+    return resource;
+}
+
+template<typename ContextPtr>
+void waitDone(const ContextPtr& context) {
+    ASSERT_NE(context, nullptr);
+    for (int i = 0; i < 200 && !context->done(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(context->done());
+}
+
+bool containsSuffix(const std::string& value, const std::string& suffix) {
+    return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+}  // namespace
+
+class KVSConnectorTest: public ::testing::Test {
+public:
+    void SetUp() override {
+        initLogger();
+        cache_config_               = makeCacheConfig();
+        kv_config_                  = makeKVCacheConfig();
+        runtime_config_.model_name  = "test/model";
+        parallelism_config_.tp_size = 1;
+        parallelism_config_.tp_rank = 0;
+        allocator_                  = std::make_shared<FakeKVCacheAllocator>(cache_config_);
+        client_                     = std::make_shared<FakeKVSClient>();
+    }
+
+    std::unique_ptr<KVSConnector> makeConnector() {
+        auto connector = std::make_unique<KVSConnector>(
+            cache_config_, kv_config_, runtime_config_, parallelism_config_, allocator_, nullptr, client_);
+        EXPECT_TRUE(connector->init());
+        return connector;
+    }
+
+protected:
+    CacheConfig                           cache_config_;
+    KVCacheConfig                         kv_config_;
+    RuntimeConfig                         runtime_config_;
+    ParallelismConfig                     parallelism_config_;
+    std::shared_ptr<FakeKVCacheAllocator> allocator_;
+    std::shared_ptr<FakeKVSClient>        client_;
+};
+
+TEST_F(KVSConnectorTest, AsyncWriteUsesStableCacheKeysAndSkipsUnalignedTail) {
+    auto connector = makeConnector();
+    auto resource  = makeResource(false);
+    auto meta      = std::make_shared<TestMeta>(true, "trace-write");
+
+    auto context = connector->asyncWrite(resource, meta);
+    waitDone(context);
+
+    ASSERT_TRUE(context->success());
+    ASSERT_EQ(client_->stored_keys.size(), 2);
+    EXPECT_TRUE(containsSuffix(client_->stored_keys[0], "/tp-0/group-0/block-100"));
+    EXPECT_TRUE(containsSuffix(client_->stored_keys[1], "/tp-0/group-0/block-101"));
+    EXPECT_FALSE(containsSuffix(client_->stored_keys[0], "/tp-0/group-0/block-10"));
+    EXPECT_FALSE(containsSuffix(client_->stored_keys[1], "/tp-0/group-0/block-11"));
+    EXPECT_EQ(client_->stored_iov_counts, std::vector<size_t>({2, 2}));
+    EXPECT_EQ(client_->store_trace, "kvs_store_trace-write");
+}
+
+TEST_F(KVSConnectorTest, CacheStoreWriteUsesStableCacheKeysAndSkipsUnalignedTail) {
+    KVSCacheStoreConfig store_config;
+    store_config.cache_config       = cache_config_;
+    store_config.kv_cache_config    = kv_config_;
+    store_config.runtime_config     = runtime_config_;
+    store_config.parallelism_config = parallelism_config_;
+
+    KVSCacheStore store(store_config, allocator_, client_, nullptr);
+    ASSERT_TRUE(store.init());
+
+    auto resource = makeResource(false);
+    auto meta     = std::make_shared<TestMeta>(true, "trace-store-write");
+
+    ASSERT_TRUE(store.write(resource, meta));
+    ASSERT_EQ(client_->stored_keys.size(), 2);
+    EXPECT_TRUE(containsSuffix(client_->stored_keys[0], "/tp-0/group-0/block-100"));
+    EXPECT_TRUE(containsSuffix(client_->stored_keys[1], "/tp-0/group-0/block-101"));
+    EXPECT_EQ(client_->stored_iov_counts, std::vector<size_t>({2, 2}));
+    EXPECT_EQ(client_->store_trace, "kvs_store_trace-store-write");
+}
+
+TEST_F(KVSConnectorTest, AsyncMatchDegradesAcquireFailureToMiss) {
+    client_->acquire_ok = false;
+    auto connector      = makeConnector();
+    auto resource       = makeResource();
+    auto meta           = std::make_shared<TestMeta>(true, "trace-miss");
+
+    auto match_context = connector->asyncMatch(resource, meta);
+    waitDone(match_context);
+
+    EXPECT_TRUE(match_context->success());
+    EXPECT_EQ(match_context->matchedBlockCount(), 0);
+    ASSERT_EQ(client_->acquired_keys.size(), 2);
+    EXPECT_TRUE(containsSuffix(client_->acquired_keys[0], "/tp-0/group-0/block-100"));
+    EXPECT_TRUE(containsSuffix(client_->acquired_keys[1], "/tp-0/group-0/block-101"));
+}
+
+TEST_F(KVSConnectorTest, AsyncMatchDoesNotReportHitWhenBlockObjectsAreEmpty) {
+    allocator_->return_empty_buffers = true;
+    auto connector                   = makeConnector();
+    auto resource                    = makeResource();
+    auto meta                        = std::make_shared<TestMeta>(true, "trace-empty");
+
+    auto match_context = connector->asyncMatch(resource, meta);
+    waitDone(match_context);
+
+    EXPECT_TRUE(match_context->success());
+    EXPECT_EQ(match_context->matchedBlockCount(), 0);
+    EXPECT_TRUE(client_->acquired_keys.empty());
+}
+
+TEST_F(KVSConnectorTest, AsyncMatchDoesNotReportHitWhenBlockObjectsAreInvalid) {
+    allocator_->return_null_buffers = true;
+    auto connector                  = makeConnector();
+    auto resource                   = makeResource();
+    auto meta                       = std::make_shared<TestMeta>(true, "trace-invalid");
+
+    auto match_context = connector->asyncMatch(resource, meta);
+    waitDone(match_context);
+
+    EXPECT_TRUE(match_context->success());
+    EXPECT_EQ(match_context->matchedBlockCount(), 0);
+    EXPECT_TRUE(client_->acquired_keys.empty());
+}
+
+TEST_F(KVSConnectorTest, AsyncReadLoadsMatchedBlocksAndReleasesLease) {
+    auto connector = makeConnector();
+    auto resource  = makeResource();
+    auto meta      = std::make_shared<TestMeta>(true, "trace-hit");
+
+    auto match_context = connector->asyncMatch(resource, meta);
+    waitDone(match_context);
+    ASSERT_TRUE(match_context->success());
+    ASSERT_EQ(match_context->matchedBlockCount(), 2);
+
+    auto read_context = connector->asyncRead(resource, meta, match_context, 0, 2);
+    waitDone(read_context);
+
+    EXPECT_TRUE(read_context->success());
+    EXPECT_EQ(resource->remoteReuseBlockNum(), 2);
+    EXPECT_EQ(client_->fetch_lease_id, "lease-1");
+    EXPECT_EQ(client_->load_lease_id, "lease-1");
+    EXPECT_EQ(client_->complete_lease_id, "lease-1");
+    EXPECT_EQ(client_->fetched_keys.size(), 2);
+    EXPECT_EQ(client_->loaded_keys.size(), 2);
+    EXPECT_EQ(client_->completed_keys, client_->fetched_keys);
+    EXPECT_EQ(client_->fetch_trace, "kvs_read_trace-hit");
+    EXPECT_EQ(client_->complete_trace, "kvs_read_trace-hit");
+    EXPECT_EQ(client_->released_leases, std::vector<std::string>({"lease-1"}));
+}
+
+TEST_F(KVSConnectorTest, AsyncReadFailsWithoutPromotingRemoteReuseWhenFetchFails) {
+    client_->fetch_ok = false;
+    auto connector    = makeConnector();
+    auto resource     = makeResource();
+    auto meta         = std::make_shared<TestMeta>(true, "trace-fetch-fail");
+
+    auto match_context = connector->asyncMatch(resource, meta);
+    waitDone(match_context);
+    ASSERT_TRUE(match_context->success());
+    ASSERT_EQ(match_context->matchedBlockCount(), 2);
+
+    auto read_context = connector->asyncRead(resource, meta, match_context, 0, 2);
+    waitDone(read_context);
+
+    EXPECT_FALSE(read_context->success());
+    EXPECT_EQ(resource->remoteReuseBlockNum(), 0);
+    EXPECT_EQ(client_->fetched_keys.size(), 2);
+    EXPECT_TRUE(client_->loaded_keys.empty());
+    EXPECT_TRUE(client_->completed_keys.empty());
+    EXPECT_EQ(client_->released_leases, std::vector<std::string>({"lease-1"}));
+}
+
+}  // namespace rtp_llm::kvs

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -145,7 +145,14 @@ std::string KVCacheConfig::to_string() const {
         << "prefix_tree_memory_state_swa_pool_ratio: " << prefix_tree_memory_state_swa_pool_ratio << "\n"
         << "enable_independent_group_eviction: " << enable_independent_group_eviction << "\n"
         << "device_cache_min_free_blocks: " << device_cache_min_free_blocks << "\n"
-        << "load_cache_retry_times: " << load_cache_retry_times << "\n";
+        << "load_cache_retry_times: " << load_cache_retry_times << "\n"
+        << "enable_kvs_cache: " << enable_kvs_cache << "\n"
+        << "kvs_v6d_url: " << kvs_v6d_url << "\n"
+        << "kvs_v6d_socket_path: " << (kvs_v6d_socket_path.empty() ? "" : "[set]") << "\n"
+        << "kvs_timeout_ms: " << kvs_timeout_ms << "\n"
+        << "kvs_lease_term_sec: " << kvs_lease_term_sec << "\n"
+        << "kvs_object_namespace: " << kvs_object_namespace << "\n"
+        << "kvs_cache_key_version: " << kvs_cache_key_version << "\n";
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -208,6 +208,15 @@ struct KVCacheConfig {
     int         reco_get_broadcast_timeout           = 15000;
     int         reco_put_broadcast_timeout           = 15000;
     std::string reco_client_config                   = "";
+
+    // KVS/v6d connector configuration fields
+    bool        enable_kvs_cache        = false;
+    std::string kvs_v6d_url             = "http://127.0.0.1:8080";
+    std::string kvs_v6d_socket_path     = "";
+    int         kvs_timeout_ms          = 12000;
+    int         kvs_lease_term_sec      = 60;
+    std::string kvs_object_namespace    = "rtp_llm";
+    std::string kvs_cache_key_version   = "1";
     void        insertMultiTaskPromptTokens(std::string task_id, std::vector<int64_t> tokens_id);
     std::string to_string() const;
 };

--- a/rtp_llm/cpp/engine_base/stream/ResourceContext.cc
+++ b/rtp_llm/cpp/engine_base/stream/ResourceContext.cc
@@ -8,7 +8,7 @@ void ResourceContext::initCacheConfig(const KVCacheConfig&       kv_cache_config
                                       int64_t                    max_seq_len) {
     reuse_cache                = kv_cache_config.reuse_cache;
     enable_memory_cache        = kv_cache_config.enable_memory_cache;
-    enable_remote_cache        = kv_cache_config.enable_remote_cache;
+    enable_remote_cache        = kv_cache_config.enable_remote_cache || kv_cache_config.enable_kvs_cache;
     enable_device_cache        = kv_cache_config.enable_device_cache;
     write_cache_sync           = kv_cache_config.write_cache_sync;
     enable_tiered_memory_cache = kv_cache_config.enable_tiered_memory_cache;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -416,6 +416,13 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("reco_get_broadcast_timeout", &KVCacheConfig::reco_get_broadcast_timeout)
         .def_readwrite("reco_put_broadcast_timeout", &KVCacheConfig::reco_put_broadcast_timeout)
         .def_readwrite("reco_client_config", &KVCacheConfig::reco_client_config)
+        .def_readwrite("enable_kvs_cache", &KVCacheConfig::enable_kvs_cache)
+        .def_readwrite("kvs_v6d_url", &KVCacheConfig::kvs_v6d_url)
+        .def_readwrite("kvs_v6d_socket_path", &KVCacheConfig::kvs_v6d_socket_path)
+        .def_readwrite("kvs_timeout_ms", &KVCacheConfig::kvs_timeout_ms)
+        .def_readwrite("kvs_lease_term_sec", &KVCacheConfig::kvs_lease_term_sec)
+        .def_readwrite("kvs_object_namespace", &KVCacheConfig::kvs_object_namespace)
+        .def_readwrite("kvs_cache_key_version", &KVCacheConfig::kvs_cache_key_version)
         .def("insertMultiTaskPromptTokens", &KVCacheConfig::insertMultiTaskPromptTokens)
         .def("to_string", &KVCacheConfig::to_string)
         .def(py::pickle(
@@ -473,13 +480,20 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.enable_prefix_tree_memory_cache,
                                       self.enable_legacy_memory_connector_fallback,
                                       self.prefix_tree_memory_state_swa_pool_ratio,
-                                      self.enable_independent_group_eviction);
+                                      self.enable_independent_group_eviction,
+                                      self.enable_kvs_cache,
+                                      self.kvs_v6d_url,
+                                      self.kvs_v6d_socket_path,
+                                      self.kvs_timeout_ms,
+                                      self.kvs_lease_term_sec,
+                                      self.kvs_object_namespace,
+                                      self.kvs_cache_key_version);
             },
             [](py::tuple t) {
                 const bool has_disk_fields =
                     t.size() >= 50 && py::isinstance<py::str>(t[9]);
                 const size_t min_size = has_disk_fields ? 54u : 49u;
-                const size_t max_size = has_disk_fields ? 56u : 51u;
+                const size_t max_size = has_disk_fields ? 63u : 58u;
                 if (t.size() < min_size || t.size() > max_size) {
                     throw std::runtime_error("Invalid state!");
                 }
@@ -547,8 +561,30 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.enable_legacy_memory_connector_fallback = t[extra_idx++].cast<bool>();
                     c.prefix_tree_memory_state_swa_pool_ratio = t[extra_idx++].cast<int64_t>();
                     c.enable_independent_group_eviction       = t[extra_idx++].cast<bool>();
-                    if (t.size() > extra_idx) {
+                    if (t.size() > extra_idx && py::isinstance<py::dict>(t[extra_idx])) {
                         (void)t[extra_idx].cast<std::map<std::string, uint32_t>>();
+                        extra_idx++;
+                    }
+                    if (t.size() > extra_idx) {
+                        c.enable_kvs_cache = t[extra_idx++].cast<bool>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_v6d_url = t[extra_idx++].cast<std::string>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_v6d_socket_path = t[extra_idx++].cast<std::string>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_timeout_ms = t[extra_idx++].cast<int>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_lease_term_sec = t[extra_idx++].cast<int>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_object_namespace = t[extra_idx++].cast<std::string>();
+                    }
+                    if (t.size() > extra_idx) {
+                        c.kvs_cache_key_version = t[extra_idx++].cast<std::string>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("KVCacheConfig unpickle error: ") + e.what());

--- a/rtp_llm/server/server_args/kv_cache_group_args.py
+++ b/rtp_llm/server/server_args/kv_cache_group_args.py
@@ -400,6 +400,62 @@ def init_kv_cache_group_args(parser, kv_cache_config):
         default="",
     )
     kv_cache_group.add_argument(
+        "--enable_kvs_cache",
+        env_name="ENABLE_KVS_CACHE",
+        bind_to=(kv_cache_config, "enable_kvs_cache"),
+        type=str2bool,
+        default=False,
+        help="是否启用 KVS KV cache connector。开启后优先使用 KVSConnector。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_v6d_url",
+        env_name="KVS_V6D_URL",
+        bind_to=(kv_cache_config, "kvs_v6d_url"),
+        type=str,
+        default="http://127.0.0.1:8080",
+        help="KVS 服务 HTTP 地址。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_v6d_socket_path",
+        env_name="KVS_V6D_SOCKET_PATH",
+        bind_to=(kv_cache_config, "kvs_v6d_socket_path"),
+        type=str,
+        default="",
+        help="KVS 数据面 Unix socket 路径。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_timeout_ms",
+        env_name="KVS_TIMEOUT_MS",
+        bind_to=(kv_cache_config, "kvs_timeout_ms"),
+        type=int,
+        default=12000,
+        help="KVS 控制面请求超时时间，单位毫秒。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_lease_term_sec",
+        env_name="KVS_LEASE_TERM_SEC",
+        bind_to=(kv_cache_config, "kvs_lease_term_sec"),
+        type=int,
+        default=60,
+        help="KVS acquire lease TTL，单位秒。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_object_namespace",
+        env_name="KVS_OBJECT_NAMESPACE",
+        bind_to=(kv_cache_config, "kvs_object_namespace"),
+        type=str,
+        default="rtp_llm",
+        help="KVS object key namespace。",
+    )
+    kv_cache_group.add_argument(
+        "--kvs_cache_key_version",
+        env_name="KVS_CACHE_KEY_VERSION",
+        bind_to=(kv_cache_config, "kvs_cache_key_version"),
+        type=str,
+        default="1",
+        help="KVS object key version，用于 key/layout 规则升级隔离。",
+    )
+    kv_cache_group.add_argument(
         "--enable_tiered_memory_cache",
         env_name="ENABLE_TIERED_MEMORY_CACHE",
         bind_to=(kv_cache_config, "enable_tiered_memory_cache"),


### PR DESCRIPTION
## Summary
- Add KVS cache connector for KV cache reuse.
- Wire KVS connector into cache connector coordinator and resource context.
- Add KVS cache configuration and server args.
- Build stable KVS cache object keys with namespace and version.