### PR TITLE
fix: dynamically detect qwen35 visual checkpoint prefix

### DIFF
--- a/rtp_llm/models/qwen3_next/qwen3_next_weight.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_weight.py
@@ -550,7 +550,7 @@ class Qwen3NextWeight(Qwen3NextBaseWeight):
 
 
 class Qwen35MoeWeight(Qwen3NextBaseWeight):
-    """Qwen3.5 MoE weight loading (model.language_model. prefix, separate weight format, stackwd support)."""
+    """Qwen3.5 MoE weight loading (dynamic prefix detection, separate weight format, stacked support)."""
 
     def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]):
         super().__init__(*args, **kwargs)
@@ -650,7 +650,7 @@ class Qwen35MoeWeight(Qwen3NextBaseWeight):
 
 
 class Qwen35DenseWeight(Qwen35MoeWeight):
-    """Qwen3.5 Dense weight loading (model.language_model. prefix, separate weight format, stackwd support)."""
+    """Qwen3.5 Dense weight loading (dynamic prefix detection, separate weight format, stacked support)."""
 
     def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]):
         super().__init__(*args, **kwargs)

--- a/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
@@ -121,6 +121,7 @@ class BaseMultiModalMixin:
 
     def create_mm_mixin_loader(self) -> MultimodalMixinLoader:
         database = CkptDatabase(self.ckpt_path)
+        self._prepare_vit_weights(database)
 
         weights_info: ModelDeployWeightInfo = self.get_multimodal_mixin_weight_info()(
             vit_weights=self.mm_related_params.vit_weights,
@@ -132,6 +133,9 @@ class BaseMultiModalMixin:
             database,
             load_method=self.load_method,
         )
+
+    def _prepare_vit_weights(self, database: CkptDatabase) -> None:
+        pass
 
     @classmethod
     def get_multimodal_mixin_weight_info(cls) -> ModelDeployWeightInfo:

--- a/rtp_llm/multimodal/multimodal_mixins/qwen3_5_moe/qwen3_5_moe_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen3_5_moe/qwen3_5_moe_mixin.py
@@ -26,6 +26,8 @@ from rtp_llm.multimodal.multimodal_util import get_bytes_io_from_url
 from rtp_llm.ops import MMPreprocessConfig, MultimodalInput
 from rtp_llm.utils.base_model_datatypes import MMUrlType
 from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+from rtp_llm.utils.database import CkptDatabase
+
 
 default_attn_impl = "sdpa"
 try:
@@ -149,6 +151,20 @@ class Qwen3_5MoeVitWeight(BaseVitWeights):
         self._ckpt_prefix = "model.visual."
         self._ft_prefix = "self.mm_part.visual."
 
+    def detect_ckpt_prefix(self, tensor_names: List[str]):
+        suffix = "blocks.0.norm1.weight"
+        suffix_with_visual = "visual." + suffix
+        for name in tensor_names:
+            if name.endswith(suffix_with_visual):
+                # Extract the prefix ending at the visual module closest to the anchor.
+                self._ckpt_prefix = name[: -len(suffix)]
+                break
+        else:
+            raise ValueError(
+                f"Qwen3_5MoeVitWeight: cannot determine visual prefix, no key ending "
+                f"with {suffix_with_visual!r} in {len(tensor_names)} ckpt keys"
+            )
+
 
 class Qwen3_5MoeMixin(Qwen3_VLMixin):
     def _init_multimodal(self):
@@ -156,6 +172,11 @@ class Qwen3_5MoeMixin(Qwen3_VLMixin):
         self.mm_related_params.vit_weights = Qwen3_5MoeVitWeight(
             {"vit": self.mm_part.visual}
         )
+
+    def _prepare_vit_weights(self, database: CkptDatabase) -> None:
+        vit_weights = self.mm_related_params.vit_weights
+        if isinstance(vit_weights, Qwen3_5MoeVitWeight):
+            vit_weights.detect_ckpt_prefix(database.get_pretrain_tensor_names())
 
     @classmethod
     def _get_mm_module(cls, mm_related_params: VitParameters, vit_config: VitConfig):

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -67,3 +67,13 @@ py_test(
         "//rtp_llm:testlib",
     ],
 )
+
+py_test(
+    name = "qwen35_prefix_detection_test",
+    srcs = [
+        "qwen35_prefix_detection_test.py",
+    ],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+)

--- a/rtp_llm/multimodal/test/qwen35_prefix_detection_test.py
+++ b/rtp_llm/multimodal/test/qwen35_prefix_detection_test.py
@@ -1,0 +1,72 @@
+import unittest
+
+from rtp_llm.models.qwen3_next.qwen3_next_weight import Qwen35MoeWeight
+from rtp_llm.multimodal.multimodal_mixins.qwen3_5_moe.qwen3_5_moe_mixin import (
+    Qwen3_5MoeVitWeight,
+)
+
+
+class Qwen35PrefixDetectionTest(unittest.TestCase):
+    def test_detects_legacy_checkpoint_prefixes(self):
+        llm_weight = object.__new__(Qwen35MoeWeight)
+        llm_weight._has_stacked_ckpt = False
+        llm_weight._process_meta(
+            {},
+            {
+                "mtp.layers.0.input_layernorm.weight",
+                "model.language_model.layers.0.input_layernorm.weight",
+            },
+        )
+        self.assertEqual("model.language_model.", llm_weight.prefix)
+
+        vit_weight = object.__new__(Qwen3_5MoeVitWeight)
+        vit_weight.detect_ckpt_prefix(
+            ["model.visual.blocks.0.norm1.weight"],
+        )
+        self.assertEqual("model.visual.", vit_weight._ckpt_prefix)
+
+    def test_detects_transformers_540_converted_checkpoint_prefixes(self):
+        llm_weight = object.__new__(Qwen35MoeWeight)
+        llm_weight._has_stacked_ckpt = False
+        llm_weight._process_meta(
+            {},
+            {
+                "model.language_model.language_model.language_model.layers.0.input_layernorm.weight",
+                "model.language_model.language_model.language_model.layers.0.mlp.experts.gate_up_proj",
+            },
+        )
+        self.assertEqual(
+            "model.language_model.language_model.language_model.",
+            llm_weight.prefix,
+        )
+        self.assertTrue(llm_weight._has_stacked_ckpt)
+
+        vit_weight = object.__new__(Qwen3_5MoeVitWeight)
+        vit_weight.detect_ckpt_prefix(
+            ["model.language_model.visual.blocks.0.norm1.weight"],
+        )
+        self.assertEqual("model.language_model.visual.", vit_weight._ckpt_prefix)
+
+    def test_detects_visual_prefix_from_nearest_visual_anchor(self):
+        vit_weight = object.__new__(Qwen3_5MoeVitWeight)
+        vit_weight.detect_ckpt_prefix(
+            ["model.visual.language_model.visual.blocks.0.norm1.weight"],
+        )
+        self.assertEqual(
+            "model.visual.language_model.visual.",
+            vit_weight._ckpt_prefix,
+        )
+
+    def test_raises_when_required_prefix_anchor_is_missing(self):
+        llm_weight = object.__new__(Qwen35MoeWeight)
+        llm_weight._has_stacked_ckpt = False
+        with self.assertRaisesRegex(ValueError, "cannot determine prefix"):
+            llm_weight._process_meta({}, {"mtp.layers.0.input_layernorm.weight"})
+
+        vit_weight = object.__new__(Qwen3_5MoeVitWeight)
+        with self.assertRaisesRegex(ValueError, "cannot determine visual prefix"):
+            vit_weight.detect_ckpt_prefix(["model.text.blocks.0.norm1.weight"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  Fix Qwen3.5 VL checkpoint loading for checkpoints converted by transformers 5.4.0.

  Compared with the existing checkpoint layout, transformers 5.4.0 changes the visual parameter prefix:

  - Legacy visual model: `model.visual.*`
  - transformers 5.4.0 visual model: `model.language_model.visual.*`

  The previous multimodal loader used a fixed `model.visual.` prefix, so it could not locate visual weights from the converted checkpoint.

  ## Changes

  - Detect the Qwen3.5 visual checkpoint prefix from the actual checkpoint tensor names.
  - Apply the detected visual prefix before creating the multimodal mixin loader.
  - Add unit coverage for both legacy and transformers 5.4.0 converted visual checkpoint layouts.

  ## Test

  ```bash
  bazelisk --output_user_root=/data0/zhanghuidong.zhd/.cache/bazel_cuda129_cache test //rtp_llm/multimodal/ test:qwen35_prefix_detection_test --config=cuda12_9 --jobs=200 --config=daily_aone_bazel_cache --remote_header=x-aone-bazel-api-key=ai-infra-cicd --test_timeout=3000

  Result: PASSED