### PR TITLE
fix: avoid num_return_sequences prefill batch fanout

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -62,7 +62,7 @@ GenerateStream::GenerateStream(const shared_ptr<GenerateInput>& input,
         loss_ = torch::zeros({(int64_t)inputLength() - 1}, torch::kFloat32);
     }
     if (generate_input_->generate_config->return_softmax_probs) {
-        softmax_probs_ = torch::zeros({(int64_t)init_batch_size, (int64_t)max_seq_len_}, torch::kFloat32);
+        softmax_probs_ = torch::zeros({(int64_t)maxBatchSize(), (int64_t)max_seq_len_}, torch::kFloat32);
     }
     if (generate_input_->generate_config->return_all_hidden_states) {
         setReturnLastHiddenStates(true);
@@ -175,9 +175,12 @@ rtp_llm::SpecialTokens GenerateStream::specialTokens() const {
 int GenerateStream::batchSize(int output_len) const {
     if (generate_input_->generate_config->hasNumBeams()) {
         return numBeams(output_len);
-    } else {
-        return std::max(numReturnSequences(), 1);
     }
+    // The prompt is executed once; num_return_sequences fans out from the first sampling step.
+    if (output_len == 0 && !perf_test_) {
+        return 1;
+    }
+    return std::max(numReturnSequences(), 1);
 }
 
 int GenerateStream::currentBatchSize() const {
@@ -860,7 +863,7 @@ bool GenerateStream::updateKvCacheBlocks(const torch::Tensor& src_batch_indices)
 
 void GenerateStream::updateLogitProcessorMultiSeqStatus(const torch::Tensor& src_batch_indices) {
     RTP_LLM_PROFILE_FUNCTION();
-    if (!src_batch_indices.defined() || !hasNumBeams()) {
+    if (!src_batch_indices.defined()) {
         return;
     }
 

--- a/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
@@ -5,6 +5,7 @@
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 #include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
 #include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
+#include "rtp_llm/cpp/engine_base/stream/StreamGroups.h"
 #include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
 #include "rtp_llm/cpp/testing/TestBase.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
@@ -91,6 +92,36 @@ TEST_F(GenerateStreamTest, testConstruct) {
     auto builder = GenerateStreamBuilder();
     auto stream1 = builder.createContextStream({{1, 2, 3, 4, 5}, {}});
     auto stream2 = builder.createDecoderStream({1, 2, 3, 4, 5}, {1, 2, 3});
+}
+
+TEST_F(GenerateStreamTest, testNumReturnSequencesTileAfterContextBatch) {
+    std::shared_ptr<GenerateInput> query         = make_shared<GenerateInput>();
+    query->input_ids                             = torch::tensor({1, 2, 3, 4, 5}, torch::kInt32);
+    query->generate_config                       = make_shared<GenerateConfig>();
+    query->generate_config->num_return_sequences = 20;
+    query->generate_config->return_softmax_probs = true;
+
+    ModelConfig model_config;
+    model_config.max_seq_len = 2048;
+    RuntimeConfig   runtime_config;
+    ResourceContext resource_context;
+    auto stream = make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
+
+    ASSERT_TRUE(stream->isContextStream());
+    EXPECT_EQ(1, stream->currentBatchSize());
+    EXPECT_EQ(20, stream->nextBatchSize());
+    EXPECT_EQ(20, stream->maxBatchSize());
+    EXPECT_TRUE(stream->needTilingForSampling());
+    EXPECT_EQ(5, stream->currentExecuteTokenSize());
+    EXPECT_EQ(20 * 2048, stream->getSoftmaxProbs().numel());
+
+    std::list<GenerateStreamPtr> streams{stream};
+    StreamGroups                 stream_groups(streams);
+    EXPECT_EQ(1, stream_groups.totalContextBatchSize());
+    EXPECT_EQ(1, stream_groups.totalModelBatchSize());
+    EXPECT_EQ(5, stream_groups.modelExecuteTokenSize());
+    EXPECT_EQ(20, stream_groups.totalSamplerBatchSizeIn());
+    EXPECT_EQ(20, stream_groups.totalSamplerBatchSizeOut());
 }
 
 TEST_F(GenerateStreamTest, testGenerateStreamReuseCacheMethod) {

--- a/rtp_llm/cpp/models/logits_processor/LogitsProcessorFactory.cc
+++ b/rtp_llm/cpp/models/logits_processor/LogitsProcessorFactory.cc
@@ -23,13 +23,17 @@ LogitsProcessorFactory::createLogitsProcessors(std::shared_ptr<GenerateInput> ge
         result.push_back(std::static_pointer_cast<BaseLogitsProcessor>(think_processor));
     }
 
-    auto tree_processor = TreeLogitsProcessor::fromGenerateInput(generate_input, init_batch_size);
+    const bool need_return_sequence_tiling =
+        !generate_input->generate_config->hasNumBeams() && max_batch_size > init_batch_size;
+    const int32_t state_batch_size = need_return_sequence_tiling ? max_batch_size : init_batch_size;
+
+    auto tree_processor = TreeLogitsProcessor::fromGenerateInput(generate_input, state_batch_size);
     if (tree_processor != nullptr) {
         result.push_back(std::static_pointer_cast<BaseLogitsProcessor>(tree_processor));
     }
 
     // 生成式推荐：combo 粒度去重 + 曝光过滤
-    auto rec_processor = RecommendationLogitsProcessor::fromGenerateInput(generate_input, init_batch_size);
+    auto rec_processor = RecommendationLogitsProcessor::fromGenerateInput(generate_input, state_batch_size);
     if (rec_processor != nullptr) {
         result.push_back(std::static_pointer_cast<BaseLogitsProcessor>(rec_processor));
     }

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -169,7 +169,8 @@ absl::StatusOr<GenerateStreamPtr> NormalEngine::preRun(const std::shared_ptr<Gen
                                                          resource_context_,
                                                          nullptr,
                                                          0,
-                                                         mode == preRunMode::prefill_warm_up);
+                                                         mode == preRunMode::prefill_warm_up
+                                                             || mode == preRunMode::decode_warm_up);
     if (mode == preRunMode::decode_warm_up) {
         stream->setIsContextStream(false);
         size_t seq_size_per_block = model_config_.attn_config.tokens_per_block;

--- a/rtp_llm/cpp/normal_engine/NormalOutputDispatcher.cc
+++ b/rtp_llm/cpp/normal_engine/NormalOutputDispatcher.cc
@@ -16,26 +16,32 @@ absl::Status NormalOutputDispatcher::dispatch(const StreamGroups& stream_groups,
     const auto&  sampler_output       = merge_outputs.sampler_output;
     const size_t total_batch_size_out = stream_groups.totalSamplerBatchSizeOut();
     RTP_LLM_CHECK(total_batch_size_out == (size_t)sampler_output.token_ids.size(0));
+    if (sampler_output.success.defined()) {
+        RTP_LLM_CHECK(stream_groups.totalSamplerBatchSizeIn() == (size_t)sampler_output.success.size(0));
+    }
     // token_ids and success may be CUDA tensors (Sampler keeps them on GPU to avoid D2H sync during sampling).
     // Move to CPU once here so dispatchSingleStream can use data_ptr safely.
     const torch::Tensor token_ids_cpu =
         sampler_output.token_ids.defined() ? sampler_output.token_ids.cpu() : torch::Tensor();
     RTP_LLM_LOG_DEBUG("new_all_token_ids = [%s]", tensorDebugStringWithData<int32_t>(token_ids_cpu).c_str());
     const torch::Tensor success_cpu = sampler_output.success.defined() ? sampler_output.success.cpu() : torch::Tensor();
-    int                 batch_idx_in     = 0;
-    int                 batch_idx_out    = 0;
-    int                 token_offset     = 0;
-    bool                return_all_probs = stream_groups.needReturnAllProbs() != ReturnAllProbsMode::NONE;
-    auto                new_tokens_all   = torch::empty({(int64_t)total_batch_size_out, 1}, torch::kInt32);
+    int                 batch_idx_in         = 0;
+    int                 sampler_batch_idx_in = 0;
+    int                 batch_idx_out        = 0;
+    int                 token_offset         = 0;
+    bool                return_all_probs     = stream_groups.needReturnAllProbs() != ReturnAllProbsMode::NONE;
+    auto                new_tokens_all       = torch::empty({(int64_t)total_batch_size_out, 1}, torch::kInt32);
 
     for (auto& stream : stream_groups.allStreams()) {
-        auto cur_batch_size  = stream->currentBatchSize();
-        auto next_batch_size = stream->nextBatchSize();
-        auto token_size      = stream->currentExecuteTokenSize();
+        auto cur_batch_size     = stream->currentBatchSize();
+        auto sampler_batch_size = stream->needTilingForSampling() ? stream->nextBatchSize() : cur_batch_size;
+        auto next_batch_size    = stream->nextBatchSize();
+        auto token_size         = stream->currentExecuteTokenSize();
 
         dispatchSingleStream(stream,
                              merge_outputs,
                              batch_idx_in,
+                             sampler_batch_idx_in,
                              batch_idx_out,
                              token_offset,
                              return_all_probs,
@@ -44,6 +50,7 @@ absl::Status NormalOutputDispatcher::dispatch(const StreamGroups& stream_groups,
                              success_cpu);
 
         batch_idx_in += cur_batch_size;
+        sampler_batch_idx_in += sampler_batch_size;
         batch_idx_out += next_batch_size;
         token_offset += token_size;
     }
@@ -55,6 +62,7 @@ absl::Status NormalOutputDispatcher::dispatch(const StreamGroups& stream_groups,
 void NormalOutputDispatcher::dispatchSingleStream(GenerateStreamPtr    stream,
                                                   const MergedOutput&  merge_outputs,
                                                   int                  batch_idx_in,
+                                                  int                  sampler_batch_idx_in,
                                                   int                  batch_idx_out,
                                                   int                  token_offset,
                                                   bool                 return_all_probs,
@@ -67,9 +75,10 @@ void NormalOutputDispatcher::dispatchSingleStream(GenerateStreamPtr    stream,
     const auto&  new_all_token_ids = token_ids_cpu;
     const size_t token_stride      = new_all_token_ids.size(1);
 
-    auto cur_batch_size  = stream->currentBatchSize();
-    auto next_batch_size = stream->nextBatchSize();
-    auto token_size      = stream->currentExecuteTokenSize();
+    auto cur_batch_size     = stream->currentBatchSize();
+    auto sampler_batch_size = stream->needTilingForSampling() ? stream->nextBatchSize() : cur_batch_size;
+    auto next_batch_size    = stream->nextBatchSize();
+    auto token_size         = stream->currentExecuteTokenSize();
 
     auto batch_new_all_token_ids = new_all_token_ids.narrow(0, batch_idx_out, next_batch_size);
 
@@ -148,8 +157,8 @@ void NormalOutputDispatcher::dispatchSingleStream(GenerateStreamPtr    stream,
         }
     }
 
-    for (int i = 0; i < cur_batch_size; ++i) {
-        if (success_cpu.defined() && !(success_cpu.data_ptr<bool>()[batch_idx_in + i])) {
+    for (int i = 0; i < sampler_batch_size; ++i) {
+        if (success_cpu.defined() && !(success_cpu.data_ptr<bool>()[sampler_batch_idx_in + i])) {
             stream->reportError(ErrorCode::UNKNOWN_ERROR, "sampler generate token id failed");
         }
     }

--- a/rtp_llm/cpp/normal_engine/NormalOutputDispatcher.h
+++ b/rtp_llm/cpp/normal_engine/NormalOutputDispatcher.h
@@ -17,6 +17,7 @@ private:
     void dispatchSingleStream(GenerateStreamPtr    stream,
                               const MergedOutput&  merge_outputs,
                               int                  batch_idx_in,
+                              int                  sampler_batch_idx_in,
                               int                  batch_idx_out,
                               int                  token_offset,
                               bool                 return_all_probs,

--- a/rtp_llm/cpp/normal_engine/NormalSamplerInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalSamplerInputGatherer.cc
@@ -14,10 +14,10 @@ absl::StatusOr<SamplerInputs> NormalSamplerInputGatherer::gather(const StreamGro
     (void)model_inputs;
     RTP_LLM_LOG_DEBUG(__PRETTY_FUNCTION__);
     RTP_LLM_CHECK(!stream_groups.empty());
-    auto all_streams          = stream_groups.allStreams();
-    auto total_batch_size_in  = stream_groups.totalSamplerBatchSizeIn();
-    auto total_batch_size_out = stream_groups.totalSamplerBatchSizeOut();
-    ReturnAllProbsMode return_all_probs = stream_groups.needReturnAllProbs();
+    auto               all_streams          = stream_groups.allStreams();
+    auto               total_batch_size_in  = stream_groups.totalSamplerBatchSizeIn();
+    auto               total_batch_size_out = stream_groups.totalSamplerBatchSizeOut();
+    ReturnAllProbsMode return_all_probs     = stream_groups.needReturnAllProbs();
 
     SamplerInputs sampler_inputs = allocateSamplerInputs(stream_groups, total_batch_size_in, total_batch_size_out);
     fillSamplerCommonInputs(sampler_inputs, all_streams);
@@ -43,7 +43,7 @@ absl::StatusOr<SamplerInputs> NormalSamplerInputGatherer::gather(const StreamGro
                    complete_token_ids.data_ptr<int32_t>() + cur_batch * complete_seq_len,
                    seq_len * sizeof(int));
             reinterpret_cast<bool*>(sampler_inputs.finished_mask.data_ptr())[batch_idx] =
-                stream->isSubGenerateDoneWithoutLock(i);
+                stream->isSubGenerateDoneWithoutLock(cur_batch);
             batch_idx += 1;
         }
         need_tiling |= stream->needTilingForSampling();
@@ -167,13 +167,19 @@ void NormalSamplerInputGatherer::fillSamplerCommonInputs(SamplerInputs&         
         } else {
             sampler_batch_size = stream->currentBatchSize();
         }
-        if (sampler_inputs.cum_log_probs.defined()) {
-            const auto& cum_log_probs = stream->cumLogProbs();
-            memcpy(sampler_inputs.cum_log_probs.data_ptr<float>() + batch_idx,
-                   cum_log_probs.data_ptr<float>(),
-                   cum_log_probs.numel() * sizeof(float));
+        const auto& cum_log_probs = stream->cumLogProbs();
+        auto*       cum_log_probs_out =
+            sampler_inputs.cum_log_probs.defined() ? sampler_inputs.cum_log_probs.data_ptr<float>() : nullptr;
+        auto* cum_log_probs_in  = sampler_inputs.cum_log_probs.defined() ? cum_log_probs.data_ptr<float>() : nullptr;
+        auto  cum_log_probs_num = sampler_inputs.cum_log_probs.defined() ? cum_log_probs.numel() : 0;
+        if (cum_log_probs_out != nullptr) {
+            RTP_LLM_CHECK(cum_log_probs_num > 0);
         }
         for (int i = 0; i < sampler_batch_size; ++i) {
+            if (cum_log_probs_out != nullptr) {
+                auto cur_batch               = std::min<int64_t>(i, cum_log_probs_num - 1);
+                cum_log_probs_out[batch_idx] = cum_log_probs_in[cur_batch];
+            }
             input_lengths[batch_idx]      = stream->inputLength();
             sequence_lengths[batch_idx]   = stream->seqLength() + propose_step;
             num_beams_in[batch_idx]       = stream->currentNumBeams();
@@ -201,11 +207,19 @@ void NormalSamplerInputGatherer::setLogitsProcessorInputs(SamplerInputs&        
                                                           std::list<GenerateStreamPtr>& all_streams,
                                                           bool                          score_batch) const {
     LogitsProcessorStatesPtr state_ptr = std::make_shared<LogitsProcessorStates>();
-    std::for_each(all_streams.begin(), all_streams.end(), [&state_ptr, idx = 0](auto& stream) mutable {
-        for (const auto& processor : stream->getAllLogitsProcessorPtr()) {
-            state_ptr->insert(processor, idx, idx + stream->currentBatchSize());
+    std::for_each(all_streams.begin(), all_streams.end(), [&state_ptr, score_batch, idx = 0](auto& stream) mutable {
+        int sampler_batch_size;
+        if (score_batch) {
+            sampler_batch_size = stream->scoreLen();
+        } else if (stream->needTilingForSampling()) {
+            sampler_batch_size = stream->nextBatchSize();
+        } else {
+            sampler_batch_size = stream->currentBatchSize();
         }
-        idx += stream->currentBatchSize();
+        for (const auto& processor : stream->getAllLogitsProcessorPtr()) {
+            state_ptr->insert(processor, idx, idx + sampler_batch_size);
+        }
+        idx += sampler_batch_size;
     });
     sampler_inputs.logits_processor_states_ptr = state_ptr;
 }

--- a/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
@@ -133,6 +133,55 @@ TEST_F(NormalBatchStreamProcessorTest, testSimpleAssemble) {
     }
 }
 
+TEST_F(NormalBatchStreamProcessorTest, testNumReturnSequencesTilesSamplerInputOnly) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len = 2048;
+    model_config.vocab_size  = 8;
+    model_config.num_layers  = 2;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    cache_config.group_types = {CacheGroupType::FULL};
+    RuntimeConfig runtime_config;
+
+    NormalBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+
+    std::shared_ptr<GenerateInput> query         = make_shared<GenerateInput>();
+    query->input_ids                             = hostIntBuffer({1, 2, 3});
+    query->generate_config                       = make_shared<GenerateConfig>();
+    query->generate_config->num_return_sequences = 3;
+    query->generate_config->return_cum_log_probs = true;
+    GenerateStreamPtr stream =
+        make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
+    stream->generate_status_->status = StreamState::RUNNING;
+
+    std::list<GenerateStreamPtr> streams{stream};
+    StreamGroups                 stream_groups(streams);
+    ASSERT_EQ(1, stream_groups.totalModelBatchSize());
+    ASSERT_EQ(3, stream_groups.totalSamplerBatchSizeIn());
+    ASSERT_EQ(3, stream_groups.totalSamplerBatchSizeOut());
+
+    auto merge_input_status = processor.gatherModelInput(stream_groups);
+    ASSERT_TRUE(merge_input_status.ok());
+    EXPECT_EQ(std::vector<int>({1, 2, 3}), toVec<int>(merge_input_status.value().combo_tokens));
+
+    GptModelOutputs model_output;
+    model_output.logits       = torch::tensor({0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f}).reshape({1, 8});
+    auto sampler_input_status = processor.gatherSamplerInput(stream_groups, merge_input_status.value(), model_output);
+    ASSERT_TRUE(sampler_input_status.ok());
+    const auto& sampler_inputs = sampler_input_status.value();
+    EXPECT_EQ(3, sampler_inputs.batch_size);
+    EXPECT_EQ(3, sampler_inputs.batch_size_out);
+    EXPECT_EQ(std::vector<float>({0.0f, 0.0f, 0.0f}), toVec<float>(sampler_inputs.cum_log_probs));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(std::vector<int>({1, 2, 3}), toVec<int>(sampler_inputs.token_ids[i].narrow(0, 0, 3)));
+        EXPECT_EQ(std::vector<float>({0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f}),
+                  toVec<float>(sampler_inputs.logits[i]));
+    }
+}
+
 TEST_F(NormalBatchStreamProcessorTest, testSoftmaxProbs) {
     ResourceContext resource_context;
     ModelConfig     model_config;


### PR DESCRIPTION
## Summary

- Keep non-beam `num_return_sequences` streams at batch size 1 for the prompt/context execution step, then fan out to `num_return_sequences` at the first sampling step.
- Preserve sampler fan-out by tiling sampler token/logit inputs, cum log probs, finished masks, logits processor intervals, and dispatcher success offsets by sampler batch size.
- Keep warmup behavior intact by treating decode warmup as perf-test mode, and size `return_softmax_probs` storage by max batch.

## Why

For FIFO scheduling, `num_return_sequences` should not inflate the context/model batch size before the request has produced its first sampled token. The previous `GenerateStream::batchSize(0)` returned `num_return_sequences` for non-beam requests, so StreamGroups and model input assembly treated the prompt step as a larger batch even though the prompt only needs one model execution.
