### PR TITLE
fix: sync mtp position ids with spec tokens

### DIFF
--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -163,15 +163,13 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
             if (!py_model_inputs_.combo_position_ids.defined()) {
                 RTP_LLM_LOG_WARNING("combo_position_ids not defined in graph but present in input, skipping copy");
             } else {
-                size_t copy_size = inputs.combo_position_ids.numel() * sizeof(int);
-                if (py_model_inputs_.combo_position_ids.numel() * sizeof(int) >= copy_size) {
-                    optimizedCopyAsync(inputs.combo_position_ids, py_model_inputs_.combo_position_ids, copy_size);
-                } else {
-                    RTP_LLM_LOG_WARNING(
-                        "combo_position_ids target tensor size (%zu) is smaller than needed (%zu), skipping copy",
-                        py_model_inputs_.combo_position_ids.numel() * sizeof(int),
-                        copy_size);
-                }
+                const size_t copy_size   = inputs.combo_position_ids.numel() * sizeof(int);
+                const size_t target_size = py_model_inputs_.combo_position_ids.numel() * sizeof(int);
+                RTP_LLM_CHECK_WITH_INFO(target_size >= copy_size,
+                                        "combo_position_ids target tensor size (%zu) is smaller than needed (%zu)",
+                                        target_size,
+                                        copy_size);
+                optimizedCopyAsync(inputs.combo_position_ids, py_model_inputs_.combo_position_ids, copy_size);
             }
         }
     } else {

--- a/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.cc
@@ -8,6 +8,44 @@
 
 namespace rtp_llm {
 
+void MtpBatchStreamProcessor::expandTargetVerifyPositionIds(const StreamGroups& stream_groups,
+                                                            GptModelInputs&     model_input) const {
+    if (!model_input.combo_position_ids.defined()) {
+        return;
+    }
+
+    const size_t position_id_len_factor = model_input_gatherer_config_.position_id_len_factor;
+    const size_t batch_size = model_input.combo_position_ids.numel() / position_id_len_factor;
+    auto target_combo_position_ids =
+        torch::empty({(int64_t)(batch_size * (propose_step_ + 1) * position_id_len_factor)}, torch::kInt32)
+            .pin_memory();
+
+    int* dst_position_ids = target_combo_position_ids.data_ptr<int>();
+    if (stream_groups.empty()) {
+        // Non-driver TP ranks only need a correctly shaped placeholder here; draftModelDecode broadcasts rank0's
+        // stream-derived combo_position_ids into this storage before target verify.
+        target_combo_position_ids.zero_();
+        model_input.combo_position_ids = std::move(target_combo_position_ids);
+        return;
+    }
+
+    size_t batch_idx = 0;
+    // Speculative decoding rejects num_return_sequences > 1 and beam search before this path.
+    for (const auto& stream : stream_groups.allStreams()) {
+        int* base_position_ids = dst_position_ids + batch_idx * (propose_step_ + 1) * position_id_len_factor;
+        stream->generateNextPositionId(base_position_ids);
+        for (int step = 0; step < propose_step_ + 1; ++step) {
+            int* step_position_ids = base_position_ids + step * position_id_len_factor;
+            for (size_t dim = 0; dim < position_id_len_factor; ++dim) {
+                step_position_ids[dim] = base_position_ids[dim] + step;
+            }
+        }
+        batch_idx++;
+    }
+
+    model_input.combo_position_ids = std::move(target_combo_position_ids);
+}
+
 absl::Status MtpBatchStreamProcessor::dispatchPrefill(const StreamGroups& stream_groups,
                                                       const MergedOutput& prefill_output,
                                                       const MergedOutput& propose_output) const {
@@ -190,6 +228,8 @@ void MtpBatchStreamProcessor::prepareOneStepSpecDecodeModelInput(const StreamGro
         batch_idx++;
     }
 
+    expandTargetVerifyPositionIds(stream_groups, model_input);
+
     // update model_input
     model_input.combo_tokens       = std::move(target_combo_tokens);
     model_input.prefix_lengths     = target_prefix_lengths;
@@ -217,13 +257,27 @@ void MtpBatchStreamProcessor::updateDecodeDraftModelInput(GptModelInputs&       
     // here combo_tokens is a device buffer
     model_input.combo_tokens = draft_token_ids.reshape({batch_size});
 
+    if (model_input.combo_position_ids.defined()) {
+        const size_t position_id_len_factor = model_input_gatherer_config_.position_id_len_factor;
+        auto         next_position_ids =
+            torch::empty({(int64_t)(batch_size * position_id_len_factor)}, torch::kInt32).pin_memory();
+        int* dst_position_ids = next_position_ids.data_ptr<int>();
+        const auto src_position_ids = model_input.combo_position_ids.cpu().contiguous();
+        const int* src              = src_position_ids.data_ptr<int>();
+        for (int64_t i = 0; i < next_position_ids.numel(); ++i) {
+            dst_position_ids[i] = src[i] + 1;
+        }
+        model_input.combo_position_ids = std::move(next_position_ids);
+    }
+
     model_input.sequence_lengths = model_input.sequence_lengths.cpu().clone().pin_memory();
     for (int i = 0; i < batch_size; i++) {
         model_input.sequence_lengths.data_ptr<int>()[i]++;
     }
 }
 
-void MtpBatchStreamProcessor::updatePrefillPostDraftModelInput(GptModelInputs&        model_input,
+void MtpBatchStreamProcessor::updatePrefillPostDraftModelInput(const StreamGroups&    stream_groups,
+                                                               GptModelInputs&        model_input,
                                                                const GptModelOutputs& model_output,
                                                                const SamplerOutput&   sampler_output) {
     model_input.last_hidden_states = model_output.all_hidden_states;
@@ -240,17 +294,58 @@ void MtpBatchStreamProcessor::updatePrefillPostDraftModelInput(GptModelInputs&  
     int* combo_tokens  = model_input.combo_tokens.data_ptr<int>();
 
     int offset = 0;
+    int* combo_position_ids =
+        model_input.combo_position_ids.defined() ? model_input.combo_position_ids.data_ptr<int>() : nullptr;
+    const size_t position_id_len_factor = model_input_gatherer_config_.position_id_len_factor;
+    auto all_streams = stream_groups.allStreams();
+    auto stream_it = all_streams.begin();
+    // Speculative decoding rejects num_return_sequences > 1 and beam search before this path.
     for (int i = 0; i < batch_size; i++) {
         // should shift one token for combo_tokens
         int input_length = input_lengths[i];
-        memcpy(combo_tokens + offset, combo_tokens + offset + 1, (input_length - 1) * sizeof(int));
+        memmove(combo_tokens + offset, combo_tokens + offset + 1, (input_length - 1) * sizeof(int));
 
         // set new token id
         int new_token_id = new_all_token_ids_cpu.data_ptr<int>()[i * token_stride + token_stride - 1];
         combo_tokens[offset + input_length - 1] = new_token_id;
 
+        if (combo_position_ids != nullptr) {
+            int* stream_position_ids = combo_position_ids + offset * position_id_len_factor;
+            memmove(stream_position_ids,
+                    stream_position_ids + position_id_len_factor,
+                    (input_length - 1) * position_id_len_factor * sizeof(int));
+            int* new_position_ids = stream_position_ids + (input_length - 1) * position_id_len_factor;
+            (*stream_it)->generateNextPositionId(new_position_ids);
+        }
         offset += input_length;
+        ++stream_it;
     }
+}
+
+torch::Tensor MtpBatchStreamProcessor::compactAcceptedPositionIds(const torch::Tensor&    combo_position_ids,
+                                                                  const std::vector<int>& accept_lens,
+                                                                  size_t total_accept_len) const {
+    if (!combo_position_ids.defined()) {
+        return torch::Tensor();
+    }
+
+    const size_t position_id_len_factor = model_input_gatherer_config_.position_id_len_factor;
+    auto         compact_position_ids =
+        torch::empty({(int64_t)(total_accept_len * position_id_len_factor)}, torch::kInt32).pin_memory();
+    const int* src_position_ids = combo_position_ids.data_ptr<int>();
+    int*       dst_position_ids = compact_position_ids.data_ptr<int>();
+
+    int token_offset = 0;
+    for (size_t i = 0; i < accept_lens.size(); ++i) {
+        for (int step = 0; step < accept_lens[i]; ++step) {
+            memcpy(dst_position_ids + (token_offset + step) * position_id_len_factor,
+                   src_position_ids + (i * (propose_step_ + 1) + step) * position_id_len_factor,
+                   position_id_len_factor * sizeof(int));
+        }
+        token_offset += accept_lens[i];
+    }
+
+    return compact_position_ids;
 }
 
 void MtpBatchStreamProcessor::updateDecodePostDraftModelInput(
@@ -292,6 +387,10 @@ void MtpBatchStreamProcessor::updateDecodePostDraftModelInput(
     hidden_states_d_t              = torch::cat(hidden_states_list).contiguous();
     model_input.last_hidden_states = hidden_states_d_t;
     model_input.lm_output_indexes  = std::move(lm_output_indexes);
+    auto compact_position_ids = compactAcceptedPositionIds(model_input.combo_position_ids, accept_lens, total_accept_len);
+    if (compact_position_ids.defined()) {
+        model_input.combo_position_ids = std::move(compact_position_ids);
+    }
 }
 
 void MtpBatchStreamProcessor::updateOneStepDraftSamplerOutput(const StreamGroups& stream_groups,

--- a/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.h
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.h
@@ -35,11 +35,14 @@ public:
 
     void prepareOneStepSpecDecodeModelInput(const StreamGroups& stream_groups, GptModelInputs& model_input);
 
+    void expandTargetVerifyPositionIds(const StreamGroups& stream_groups, GptModelInputs& model_input) const;
+
     void updateDecodeDraftModelInput(GptModelInputs&        model_input,
                                      const GptModelOutputs& model_output,
                                      const torch::Tensor&   draft_token_ids);
 
-    void updatePrefillPostDraftModelInput(GptModelInputs&        model_input,
+    void updatePrefillPostDraftModelInput(const StreamGroups&    stream_groups,
+                                          GptModelInputs&        model_input,
                                           const GptModelOutputs& model_output,
                                           const SamplerOutput&   sampler_output);
 
@@ -76,6 +79,10 @@ protected:
                                      const speculative::SpeculativeSamplerOutput& spec_decode_output,
                                      const MergedOutput&                          draft_prefill_output,
                                      std::vector<StreamSpecUpdateInfo>&           spec_update_infos) const;
+
+    torch::Tensor compactAcceptedPositionIds(const torch::Tensor&    combo_position_ids,
+                                             const std::vector<int>& accept_lens,
+                                             size_t                  total_accept_len) const;
 
     void gatherHiddenStates(const StreamGroups& stream_groups, GptModelInputs& model_input) const;
 

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -383,7 +383,8 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
             CHECK_AND_RETURN_REF(sampler_input,
                                  batch_stream_processor_->gatherSamplerInput(stream_groups, model_input, model_output));
             sampler_output = std::move(sampler_->forward(sampler_input));
-            batch_stream_processor_->updatePrefillPostDraftModelInput(model_input, model_output, sampler_output);
+            batch_stream_processor_->updatePrefillPostDraftModelInput(
+                stream_groups, model_input, model_output, sampler_output);
         }
     }
 
@@ -685,6 +686,8 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
         RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(draft_model_forward)");
         // Use sp_prefill_draft_model_ if CUDA graph is enabled, otherwise use draft_model_
         if (sp_prefill_draft_model_) {
+            // All currently supported draft models are non-MRoPE and do not use
+            // model_input.combo_position_ids, so the draft prefill CUDA graph does not need to copy it.
             draft_prefill_model_output = std::move(sp_prefill_draft_model_->forward(model_input));
         } else {
             draft_prefill_model_output = std::move(draft_model_->forward(model_input));
@@ -913,6 +916,7 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
         model_input.lm_output_indexes = std::move(lm_output_indexes);
         model_input.prefix_lengths    = spec_prefix_lengths;
         model_input.combo_tokens      = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
+        batch_stream_processor_->expandTargetVerifyPositionIds(stream_groups, model_input);
         model_input.sequence_lengths =
             torch::empty({0}, torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
         model_input.last_hidden_states = torch::Tensor();
@@ -920,7 +924,11 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
         // Since other tp ranks don't have streams, its combo_tokens' first token is not correct.
         // Thus, we need to broadcast the combo_tokens to other tp ranks.
         if (parallelism_config_.tp_size > 1) {
-            execBroadcast({{model_input.combo_tokens}, 0});
+            std::vector<torch::Tensor> broadcast_tensors{model_input.combo_tokens};
+            if (model_input.combo_position_ids.defined()) {
+                broadcast_tensors.push_back(model_input.combo_position_ids);
+            }
+            execBroadcast({broadcast_tensors, 0});
         }
 
         const auto& cache_cfg             = cache_manager_->cacheConfig();

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpBatchStreamProcessorTest.cc
@@ -462,11 +462,78 @@ TEST_F(MtpBatchStreamProcessorTest, testUpdatePrefillPostDraftModelInput) {
     SamplerOutput sampler_output;
     sampler_output.token_ids = torch::tensor({1, -2, 2, 1, 2, 3}, torch::kInt32).reshape({2, 3});
 
-    processor.updatePrefillPostDraftModelInput(model_input, model_output, sampler_output);
+    processor.updatePrefillPostDraftModelInput(stream_groups, model_input, model_output, sampler_output);
 
     auto        combo_tokens        = model_input.combo_tokens;
     vector<int> expect_combo_tokens = {2, 2, 3};
     EXPECT_EQ(expect_combo_tokens, toVec<int>(combo_tokens));
+}
+TEST_F(MtpBatchStreamProcessorTest, testUpdatePrefillPostDraftModelInputShiftsComboPositionIds) {
+    ModelConfig                 model_config;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    SpeculativeExecutionConfig  sp_config;
+    model_config.max_seq_len                          = 2048;
+    model_config.vocab_size                           = 4;
+    model_config.num_layers                           = 1;
+    model_config.mm_model_config.mm_position_ids_style = MROPE;
+    model_config.attn_config.rope_config.index_factor  = 3;
+    sp_config.gen_num_per_cycle                       = 2;
+    cache_config.group_types                          = {CacheGroupType::FULL};
+    MtpBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+    RuntimeConfig   runtime_config;
+    ResourceContext resource_context;
+    auto            stream1 = createContextStream(model_config, runtime_config, resource_context, {1, 2}, 1);
+    auto            stream2 = createContextStream(model_config, runtime_config, resource_context, {1, 2, 3}, 2);
+    stream1->setContextPositionIds(torch::tensor({100, 101, 102, 110, 111, 112}, torch::kInt32));
+    stream2->setContextPositionIds(
+        torch::tensor({200, 201, 202, 210, 211, 212, 220, 221, 222}, torch::kInt32));
+    auto stream_groups = StreamGroups({stream1, stream2});
+    GptModelInputs model_input;
+    model_input.input_lengths      = torch::tensor({2, 3}, torch::kInt32);
+    model_input.combo_tokens       = torch::tensor({10, 11, 20, 21, 22}, torch::kInt32);
+    model_input.combo_position_ids = torch::tensor({100,
+                                                    101,
+                                                    102,
+                                                    110,
+                                                    111,
+                                                    112,
+                                                    200,
+                                                    201,
+                                                    202,
+                                                    210,
+                                                    211,
+                                                    212,
+                                                    220,
+                                                    221,
+                                                    222},
+                                                   torch::kInt32);
+    GptModelOutputs model_output;
+    model_output.all_hidden_states =
+        torch::tensor({0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f}, torch::kFloat32)
+            .reshape({5, 2});
+    SamplerOutput sampler_output;
+    sampler_output.token_ids = torch::tensor({1, -2, 12, 1, 2, 23}, torch::kInt32).reshape({2, 3});
+    processor.updatePrefillPostDraftModelInput(stream_groups, model_input, model_output, sampler_output);
+    EXPECT_EQ((vector<int>{11, 12, 21, 22, 23}), toVec<int>(model_input.combo_tokens));
+    EXPECT_EQ((vector<int>{110,
+                           111,
+                           112,
+                           112,
+                           112,
+                           112,
+                           210,
+                           211,
+                           212,
+                           220,
+                           221,
+                           222,
+                           222,
+                           222,
+                           222}),
+              toVec<int>(model_input.combo_position_ids));
 }
 
 TEST_F(MtpBatchStreamProcessorTest, testUpdateDecodePostDraftModelInput) {
@@ -542,6 +609,160 @@ TEST_F(MtpBatchStreamProcessorTest, testUpdateDecodePostDraftModelInput) {
     auto          last_hidden_states        = model_input.last_hidden_states;
     vector<float> expect_last_hidden_states = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 1.1, 1.2};
     EXPECT_EQ(expect_last_hidden_states, toVec<float>(last_hidden_states));
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testUpdateDecodePostDraftModelInputCompactsComboPositionIds) {
+    ModelConfig                 model_config;
+    RuntimeConfig               runtime_config;
+    SpeculativeExecutionConfig  sp_config;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+
+    model_config.max_seq_len                          = 2048;
+    model_config.vocab_size                           = 4;
+    model_config.num_layers                           = 1;
+    model_config.mm_model_config.mm_position_ids_style = MROPE;
+    model_config.attn_config.rope_config.index_factor  = 3;
+    sp_config.gen_num_per_cycle                       = 2;
+
+    auto kv_cache_config = test::makeSimpleMhaCacheConfig(/*layer_num=*/1,
+                                                          /*block_num=*/10,
+                                                          /*tokens_per_block=*/2,
+                                                          rtp_llm::TYPE_INT8,
+                                                          /*local_head_num_kv=*/128,
+                                                          /*size_per_head=*/256);
+    auto cache_manager   = std::make_shared<KVCacheManager>(kv_cache_config,
+
+                                                          /*warmup=*/false,
+                                                          /*metrics_reporter=*/nullptr,
+                                                          KVCacheConfig{},
+                                                          ParallelismConfig{},
+                                                          runtime_config);
+    ASSERT_TRUE(cache_manager->init());
+    ResourceContext resource_context;
+    resource_context.cache_manager = cache_manager;
+
+    GenerateStreamPtr stream1 = createContextStream(model_config, runtime_config, resource_context, {1}, 1);
+    GenerateStreamPtr stream2 = createContextStream(model_config, runtime_config, resource_context, {1, 2}, 2);
+    GenerateStreamPtr stream3 = createContextStream(model_config, runtime_config, resource_context, {1, 2, 3}, 3);
+
+    auto stream_groups = StreamGroups({stream1, stream2, stream3});
+
+    cache_config.group_types = {CacheGroupType::FULL};
+    auto processor           = MtpBatchStreamProcessor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+    auto model_input_status = processor.gatherModelInput(stream_groups);
+    EXPECT_TRUE(model_input_status.ok());
+
+    auto& model_input = model_input_status.value();
+    model_input.combo_position_ids =
+        torch::tensor({10,  11,  12,  20,  21,  22,  30,  31,  32,  40,  41,  42,  50,  51,
+                       52,  60,  61,  62,  70,  71,  72,  80,  81,  82,  90,  91,  92},
+                      torch::kInt32);
+
+    speculative::SpeculativeSamplerOutput spec_decode_output;
+    spec_decode_output.accept_len    = {3, 2, 1};
+    spec_decode_output.accept_tokens = {torch::tensor({{2, 3, 1}}, torch::kInt32),
+                                        torch::tensor({{2, 3}}, torch::kInt32),
+                                        torch::tensor({{2}}, torch::kInt32)};
+
+    torch::Tensor hidden_states_d_t;
+    size_t        total_accept_len;
+
+    GptModelOutputs model_output;
+    model_output.all_hidden_states = torch::tensor({0.1f,
+                                                    0.2f,
+                                                    0.3f,
+                                                    0.4f,
+                                                    0.5f,
+                                                    0.6f,
+                                                    1.1f,
+                                                    1.2f,
+                                                    1.3f,
+                                                    1.4f,
+                                                    1.5f,
+                                                    1.6f,
+                                                    2.1f,
+                                                    2.2f,
+                                                    2.3f,
+                                                    2.4f,
+                                                    2.5f,
+                                                    2.6f},
+                                                   torch::kFloat32)
+                                        .reshape({9, 2});
+
+    processor.updateDecodePostDraftModelInput(
+        model_input, model_output, spec_decode_output, 3, hidden_states_d_t, total_accept_len);
+
+    auto        combo_position_ids        = model_input.combo_position_ids;
+    vector<int> expect_combo_position_ids = {10, 11, 12, 20, 21, 22, 30, 31, 32,
+                                             40, 41, 42, 50, 51, 52, 70, 71, 72};
+    EXPECT_EQ(expect_combo_position_ids, toVec<int>(combo_position_ids));
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testUpdateDecodeDraftModelInputAdvancesComboPositionIds) {
+    ModelConfig                 model_config;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    SpeculativeExecutionConfig  sp_config;
+
+    model_config.max_seq_len                          = 2048;
+    model_config.vocab_size                           = 4;
+    model_config.num_layers                           = 1;
+    model_config.mm_model_config.mm_position_ids_style = MROPE;
+    model_config.attn_config.rope_config.index_factor  = 3;
+    sp_config.gen_num_per_cycle                       = 2;
+    cache_config.group_types                          = {CacheGroupType::FULL};
+
+    MtpBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+
+    GptModelInputs model_input;
+    model_input.combo_tokens       = torch::tensor({11, 21}, torch::kInt32);
+    model_input.sequence_lengths   = torch::tensor({5, 7}, torch::kInt32);
+    model_input.combo_position_ids = torch::tensor({5, 6, 7, 10, 11, 12}, torch::kInt32);
+
+    GptModelOutputs model_output;
+    model_output.all_hidden_states = torch::tensor({0.1f, 0.2f, 1.1f, 1.2f}, torch::kFloat32).reshape({2, 2});
+    auto draft_token_ids           = torch::tensor({12, 22}, torch::kInt32).reshape({2, 1});
+
+    processor.updateDecodeDraftModelInput(model_input, model_output, draft_token_ids);
+
+    EXPECT_EQ((vector<int>{12, 22}), toVec<int>(model_input.combo_tokens));
+    EXPECT_EQ((vector<int>{6, 8}), toVec<int>(model_input.sequence_lengths));
+    EXPECT_EQ((vector<float>{0.1, 0.2, 1.1, 1.2}), toVec<float>(model_input.last_hidden_states));
+    EXPECT_EQ((vector<int>{6, 7, 8, 11, 12, 13}), toVec<int>(model_input.combo_position_ids));
+}
+
+TEST_F(MtpBatchStreamProcessorTest, testExpandTargetVerifyPositionIdsInitializesNonDriverPlaceholder) {
+    ModelConfig                 model_config;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    SpeculativeExecutionConfig  sp_config;
+
+    model_config.max_seq_len                          = 2048;
+    model_config.vocab_size                           = 4;
+    model_config.num_layers                           = 1;
+    model_config.mm_model_config.mm_position_ids_style = MROPE;
+    model_config.attn_config.rope_config.index_factor  = 3;
+    sp_config.gen_num_per_cycle                       = 2;
+    cache_config.group_types                          = {CacheGroupType::FULL};
+
+    MtpBatchStreamProcessor processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, sp_config, false);
+
+    GptModelInputs model_input;
+    model_input.combo_position_ids = torch::tensor({5, 6, 7, 10, 11, 12}, torch::kInt32);
+    auto empty_stream_groups       = StreamGroups(std::list<GenerateStreamPtr>{});
+
+    processor.expandTargetVerifyPositionIds(empty_stream_groups, model_input);
+
+    EXPECT_EQ(18, model_input.combo_position_ids.numel());
+    EXPECT_EQ((vector<int>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+              toVec<int>(model_input.combo_position_ids));
 }
 
 TEST_F(MtpBatchStreamProcessorTest, testUpdateOneStepDraftSamplerOutput) {

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
@@ -29,6 +29,8 @@ struct MtpExecutorTestConfig {
     size_t num_layers          = 1;
     size_t gen_num_per_cycle   = 4;
     size_t vocab_size_override = 0;  // 0 means use vocab_size
+    int64_t mm_position_ids_style = 0;
+    int     position_id_len_factor = 1;
 };
 
 template<typename T>
@@ -135,6 +137,7 @@ public:
         checkTensorField("prefix_lengths", inputs.prefix_lengths, expected_inputs.prefix_lengths);
         checkTensorField("lm_output_indexes", inputs.lm_output_indexes, expected_inputs.lm_output_indexes);
         checkTensorField("last_hidden_states", inputs.last_hidden_states, expected_inputs.last_hidden_states);
+        checkTensorField("combo_position_ids", inputs.combo_position_ids, expected_inputs.combo_position_ids);
     }
 
     void setOutputs(const vector<GptModelOutputs>& outputs) {
@@ -319,6 +322,8 @@ public:
         model_config.max_seq_len    = test_config.max_seq_len;
         model_config.vocab_size     = test_config.vocab_size;
         model_config.num_layers     = test_config.num_layers;
+        model_config.mm_model_config.mm_position_ids_style = test_config.mm_position_ids_style;
+        model_config.attn_config.rope_config.index_factor  = test_config.position_id_len_factor;
         sp_config.gen_num_per_cycle = test_config.gen_num_per_cycle;
 
         resource_context.cache_manager =
@@ -899,6 +904,143 @@ TEST_F(MtpExecutorTest, testMultiBatchDecode) {
     // check stream result
     checkOutput(stream1, {0, 1, 2, 3, 3}, {3, 1}, {0, 1, 0, 0}, {0.1, 0.11});
     checkOutput(stream2, {3, 2, 1, 3, 0, 2, 2, 1}, {1, 2}, {0.0, 1.0, 0.0, 0.0}, {1.5, 1.55});
+}
+
+TEST_F(MtpExecutorTest, testDraftModelDecodeExpandsTargetVerifyPositionIds) {
+    size_t propose_step = 4;
+    size_t batch_size   = 2;
+    size_t vocab_size   = 4;
+
+    MtpExecutorTestConfig test_config;
+    test_config.gen_num_per_cycle      = propose_step;
+    test_config.vocab_size_override    = vocab_size;
+    test_config.mm_position_ids_style  = MROPE;
+    test_config.position_id_len_factor = 3;
+    auto components                    = createMtpExecutorComponents(test_config);
+
+    auto stream_model_config = components.model_config;
+    stream_model_config.mm_model_config.mm_position_ids_style = MROPE;
+    stream_model_config.attn_config.rope_config.index_factor  = 3;
+    auto stream1 =
+        createContextStream(stream_model_config, components.runtime_config, components.resource_context, {0, 1, 2, 3, 0, 1});
+    auto stream2 = createContextStream(
+        stream_model_config, components.runtime_config, components.resource_context, {1, 2, 3, 0, 1, 2, 3, 0});
+    stream1->setContextPositionIds(torch::tensor({0, 0, 0}, torch::kInt32));
+    stream2->setContextPositionIds(torch::tensor({0, 0, 0}, torch::kInt32));
+
+    auto sp_output_buffer1    = std::make_shared<SpeculativeExecutorStreamOutput>();
+    sp_output_buffer1->tokens = torch::tensor({10, 11}, torch::kInt32).reshape({1, 2});
+    stream1->setSPOutputBuffer(sp_output_buffer1);
+
+    auto sp_output_buffer2    = std::make_shared<SpeculativeExecutorStreamOutput>();
+    sp_output_buffer2->tokens = torch::tensor({20, 21}, torch::kInt32).reshape({1, 2});
+    stream2->setSPOutputBuffer(sp_output_buffer2);
+
+    StreamGroups stream_groups({stream1, stream2});
+
+    GptModelInputs model_input;
+    model_input.combo_tokens       = torch::tensor({11, 21}, torch::kInt32);
+    model_input.input_lengths      = torch::tensor({5, 6}, torch::kInt32);
+    model_input.sequence_lengths   = torch::tensor({5, 7}, torch::kInt32);
+    model_input.lm_output_indexes  = torch::tensor({0, 1}, torch::kInt32);
+    model_input.last_hidden_states = torch::tensor({0.1f, 0.2f, 1.1f, 1.2f}, torch::kFloat32).reshape({2, 2});
+    model_input.combo_position_ids = torch::tensor({5, 5, 5, 7, 7, 7}, torch::kInt32);
+
+    auto makeDraftInput = [](std::vector<int> combo_tokens,
+                             std::vector<int> sequence_lengths,
+                             torch::Tensor    last_hidden_states,
+                             std::vector<int> combo_position_ids = {}) {
+        GptModelInputs input;
+        input.combo_tokens       = torch::tensor(combo_tokens, torch::kInt32);
+        input.input_lengths      = torch::tensor({5, 6}, torch::kInt32);
+        input.sequence_lengths   = torch::tensor(sequence_lengths, torch::kInt32);
+        input.lm_output_indexes  = torch::tensor({0, 1}, torch::kInt32);
+        input.last_hidden_states = std::move(last_hidden_states);
+        if (!combo_position_ids.empty()) {
+            input.combo_position_ids = torch::tensor(combo_position_ids, torch::kInt32);
+        }
+        return input;
+    };
+
+    auto draft_output_1 = createRandomGptModelOutputs(batch_size, vocab_size, 2);
+    auto draft_output_2 = createRandomGptModelOutputs(batch_size, vocab_size, 2);
+    auto draft_output_3 = createRandomGptModelOutputs(batch_size, vocab_size, 2);
+
+    components.fake_draft_model->setInputs({
+        makeDraftInput({11, 21}, {5, 7}, model_input.last_hidden_states, {5, 5, 5, 7, 7, 7}),
+        makeDraftInput({12, 22}, {6, 8}, draft_output_1.all_hidden_states, {6, 6, 6, 8, 8, 8}),
+        makeDraftInput({13, 23}, {7, 9}, draft_output_2.all_hidden_states, {7, 7, 7, 9, 9, 9}),
+    });
+    components.fake_draft_model->setOutputs({draft_output_1, draft_output_2, draft_output_3});
+
+    spec::FastTopKSamplerOutput draft_sampler_output_1;
+    draft_sampler_output_1.token_ids = torch::tensor({12, 22}, torch::kInt32).reshape({(int64_t)batch_size, 1});
+    draft_sampler_output_1.all_probs =
+        torch::tensor({0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f}, torch::kFloat32)
+            .reshape({(int64_t)batch_size, (int64_t)vocab_size});
+
+    spec::FastTopKSamplerOutput draft_sampler_output_2;
+    draft_sampler_output_2.token_ids = torch::tensor({13, 23}, torch::kInt32).reshape({(int64_t)batch_size, 1});
+    draft_sampler_output_2.all_probs =
+        torch::tensor({0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}, torch::kFloat32)
+            .reshape({(int64_t)batch_size, (int64_t)vocab_size});
+
+    spec::FastTopKSamplerOutput draft_sampler_output_3;
+    draft_sampler_output_3.token_ids = torch::tensor({14, 24}, torch::kInt32).reshape({(int64_t)batch_size, 1});
+    draft_sampler_output_3.all_probs =
+        torch::tensor({0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f}, torch::kFloat32)
+            .reshape({(int64_t)batch_size, (int64_t)vocab_size});
+
+    components.fake_fast_topk_sampler->setInputs(
+        {draft_output_1.logits, draft_output_2.logits, draft_output_3.logits});
+    components.fake_fast_topk_sampler->setOutputs(
+        {draft_sampler_output_1, draft_sampler_output_2, draft_sampler_output_3});
+
+    components.executor->setDraftModel(std::move(components.fake_draft_model));
+    components.executor->setFastTopKSampler(std::move(components.fake_fast_topk_sampler));
+
+    std::vector<torch::Tensor> draft_probs_list;
+    torch::Tensor              draft_token_ids_t;
+    components.executor->draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t);
+
+    EXPECT_EQ((std::vector<int>{10, 11, 12, 13, 14, 20, 21, 22, 23, 24}),
+              toVec<int>(model_input.combo_tokens));
+    EXPECT_EQ((std::vector<int>{5, 5}), toVec<int>(model_input.input_lengths));
+    EXPECT_EQ((std::vector<int>{5, 7}), toVec<int>(model_input.prefix_lengths));
+    EXPECT_EQ(0, model_input.sequence_lengths.numel());
+    EXPECT_EQ((std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}), toVec<int>(model_input.lm_output_indexes));
+
+    EXPECT_EQ((std::vector<int>{5,
+                                5,
+                                5,
+                                6,
+                                6,
+                                6,
+                                7,
+                                7,
+                                7,
+                                8,
+                                8,
+                                8,
+                                9,
+                                9,
+                                9,
+                                7,
+                                7,
+                                7,
+                                8,
+                                8,
+                                8,
+                                9,
+                                9,
+                                9,
+                                10,
+                                10,
+                                10,
+                                11,
+                                11,
+                                11}),
+              toVec<int>(model_input.combo_position_ids));
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
@@ -27,7 +27,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** Create thought-provoking, practical",
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** The questions should be thought-prov",
                             "reasoning_content": null,
                             "function_call": null,
                             "tool_calls": null,
@@ -48,7 +48,7 @@
                 "debug_info": null,
                 "aux_info": {
                     "cost_time": 3143.197,
-                    "iter_count": 26,
+                    "iter_count": 25,
                     "prefix_len": 0,
                     "input_len": 18,
                     "output_len": 100,

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
@@ -23,7 +23,8 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate for clarity).\n    *   **Goal:** To generate thought-provoking,"
+                            "content": "Here's a thinking process that leads to the suggested questions about English listening methods:\n\n1.  **Analyze the Request:**\n    *   **Topic:** English Listening Methods (英语听力方法).\n    *   **Task:** Propose several questions (提出几个问题).\n    *   **Language:** The user asked in Chinese, so the output should be in Chinese (with English terms where appropriate).\n    *   **Goal:** The questions should be thought-provoking,",
+                            "partial": false
                         },
                         "finish_reason": "length"
                     }


### PR DESCRIPTION
# Fix MTP Position IDs for Speculative Decoding

### Summary

This PR fixes an MTP speculative decoding crash caused by inconsistent token and position-id shapes during target verification.

MTP target verification expands `combo_tokens` to:

```text
batch_size * (propose_step + 1)
```

However, `combo_position_ids` previously remained sized for only one token per stream:

```text
batch_size * position_id_len_factor
```

For MRoPE models, the fused RoPE/KV-cache prefill kernel reads position ids using:

```cpp
position_ids[token_idx * rope_config.index_factor + now_dim]
```

Because target verification processes the expanded token batch, the undersized position-id buffer causes an out-of-bounds GPU read and can result in `cudaErrorIllegalAddress`.

### Root Cause

During MTP decode:

- The draft model produces multiple speculative tokens for each stream.
- Target verification packs the target token and speculative tokens into a sequence of `propose_step + 1` tokens per stream.
- `combo_position_ids` was not expanded or updated together with `combo_tokens`.
- Subsequent draft-prefill and accepted-token compaction paths also updated tokens without applying the corresponding position-id transformation.

For MRoPE, where `position_id_len_factor = 3`, this produced:

```text
actual:   batch_size * 3
required: batch_size * (propose_step + 1) * 3
```

One captured failure showed the following values:

```text
batch_size=66
propose_step=4
combo_tokens=330
position_ids.numel()=198
required_position_ids=990
```

The relationship is deterministic:

```text
198 = 66 * 3
330 = 66 * (4 + 1)
990 = 330 * 3
```

The fused RoPE/KV-cache kernel therefore processed 330 tokens while receiving position ids for only 66 MRoPE tokens.

### Reproduction

Run an MTP smoke test (for example `//rtp_llm/test/smoke:next_mtp_basic`) against the pre-fix implementation with PyTorch CUDA memory caching disabled and the server process wrapped by Compute Sanitizer. Disabling the caching allocator (PYTORCH_NO_CUDA_MEMORY_CACHING=1) is important because an out-of-bounds read may otherwise remain inside a larger cached allocation and not be reported as crossing an allocation boundary.

With the old input construction, Compute Sanitizer reports the first relevant error in the fused RoPE/KV-cache prefill kernel:

```text
Invalid __global__ read of size 4 bytes
    at rtp_kernel::prefill_add_fusedQKV_bias_transpose_kernel<..., RopeStyle)7>
    Access at ... is out of bounds
    and is 37 bytes after the nearest allocation ... of size 12 bytes
```

The 12-byte allocation contains exactly three `int32` values: one MRoPE position-id triplet for a single token. Target verification continues reading position ids for the expanded speculative token sequence and crosses that allocation boundary. In the captured run, Compute Sanitizer summarized the failure as:

```text
Invalid __global__ read of size 4 bytes: 8192
Access at ... is out of bounds: 8192
ERROR SUMMARY: 8204 errors
```

### Fix

- Expand target-verification `combo_position_ids` to match `batch_size * (propose_step + 1) * position_id_len_factor`.
- Use each stream's existing `generateNextPositionId()` result as the first verify position and advance every position-id dimension for subsequent speculative steps.
- Advance `combo_position_ids` together with `combo_tokens` during each draft-model iteration.
- Shift and append position ids together with tokens when preparing post-draft prefill input.
- Compact accepted position ids using the same per-stream accept lengths used to compact accepted tokens.
- Broadcast both `combo_tokens` and `combo_position_ids` from TP rank 0 so every rank receives the same stream-derived target-verification input.
- Refresh `combo_position_ids` for both decode and prefill CUDA Graph replay.
- Fail fast when the captured CUDA Graph position-id buffer is smaller than the runtime input instead of silently skipping the copy.
