### PR TITLE
Add newloader core framework

### DIFF
--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -113,6 +113,22 @@ py_library(
 )
 
 py_library(
+    name = "new_weight_loader",
+    srcs = glob([
+        "__init__.py",
+        "module_base.py",
+        "weight_mapper.py",
+        "registry.py",
+        "model_loader.py",
+        "quant_methods/*.py",
+        "layers/*.py",
+        "new_models/*.py",
+        "new_models/**/*.py",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "models",
     srcs = glob([
         "model_desc/*.py",
@@ -123,6 +139,7 @@ py_library(
         ":modules",
         ":kernels",
         ":configs",
+        ":new_weight_loader",
         "//rtp_llm/model_loader:loader",
     ] + select({
         "@//:using_cuda12": [

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -125,6 +125,21 @@ py_library(
         "new_models/*.py",
         "new_models/**/*.py",
     ]),
+    deps = [
+        ":kernels",
+        ":modules",
+        ":utils",
+        "//rtp_llm:_ft_pickler",
+        "//rtp_llm:config",
+        "//rtp_llm:device",
+        "//rtp_llm:lora",
+        "//rtp_llm:ops",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm:triton",
+        "//rtp_llm/model_loader:loader",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -113,6 +113,24 @@ py_library(
 )
 
 py_library(
+    name = "bert_model_desc",
+    srcs = [
+        "model_desc/bert.py",
+        "model_desc/module_base.py",
+    ],
+    deps = [
+        ":modules",
+        "//rtp_llm:config",
+        "//rtp_llm:device",
+        "//rtp_llm:ops",
+        "//rtp_llm:torch",
+        "//rtp_llm:utils",
+        "//rtp_llm/model_loader:loader",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "new_weight_loader",
     srcs = glob([
         "__init__.py",
@@ -126,6 +144,7 @@ py_library(
         "new_models/**/*.py",
     ]),
     deps = [
+        ":bert_model_desc",
         ":kernels",
         ":modules",
         ":utils",
@@ -148,9 +167,13 @@ py_library(
     name = "models",
     srcs = glob([
         "model_desc/*.py",
-        "model_desc/cuda_graph/*.py"
+        "model_desc/cuda_graph/*.py",
+    ], exclude = [
+        "model_desc/bert.py",
+        "model_desc/module_base.py",
     ]),
     deps = [
+        ":bert_model_desc",
         ":utils",
         ":modules",
         ":kernels",

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -137,6 +137,7 @@ py_library(
         "//rtp_llm:safetensors",
         "//rtp_llm:torch",
         "//rtp_llm:triton",
+        "//rtp_llm:utils",
         "//rtp_llm/model_loader:loader",
         "//rtp_llm/models_py/distributed:collective_torch",
     ],

--- a/rtp_llm/models_py/__init__.py
+++ b/rtp_llm/models_py/__init__.py
@@ -1,0 +1,43 @@
+import logging
+
+from rtp_llm.models_py.model_loader import LoadConfig, NewModelLoader
+from rtp_llm.models_py.module_base import RtpModule, rtp_module
+from rtp_llm.models_py.registry import MODEL_REGISTRY, get_model_class, register_model, _LAZY_MODEL_REGISTRY
+
+_logger = logging.getLogger(__name__)
+
+# Dynamically gather all unique model class names declared in registry to avoid double-registration.
+_DYNAMIC_CLASSES = list(set(class_name for _, class_name in _LAZY_MODEL_REGISTRY.values()))
+
+
+def __getattr__(name: str):
+    # Lookup model class by its name dynamically inside the central registry map.
+    for _, (module_path, class_name) in _LAZY_MODEL_REGISTRY.items():
+        if class_name == name:
+            import importlib
+            try:
+                mod = importlib.import_module(module_path)
+                return getattr(mod, class_name)
+            except Exception as e:
+                _logger.warning(
+                    "Failed to dynamic-import '%s' (from %s.%s): %s",
+                    name,
+                    module_path,
+                    class_name,
+                    e,
+                )
+                raise ImportError(
+                    f"Failed to dynamically import {name} from {module_path}: {e}"
+                ) from e
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "MODEL_REGISTRY",
+    "register_model",
+    "get_model_class",
+    "NewModelLoader",
+    "LoadConfig",
+    "RtpModule",
+    "rtp_module",
+] + _DYNAMIC_CLASSES

--- a/rtp_llm/models_py/layers/__init__.py
+++ b/rtp_llm/models_py/layers/__init__.py
@@ -1,0 +1,25 @@
+from rtp_llm.models_py.layers.attention import MMEncoderAttention
+from rtp_llm.models_py.layers.conv import Conv3dLayer
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    LinearBase,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.norm import LayerNorm, RMSNorm
+
+__all__ = [
+    "LinearBase",
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "MergedColumnParallelLinear",
+    "QKVParallelLinear",
+    "RMSNorm",
+    "LayerNorm",
+    "VocabParallelEmbedding",
+    "ParallelLMHead",
+    "Conv3dLayer",
+    "MMEncoderAttention",
+]

--- a/rtp_llm/models_py/layers/activation.py
+++ b/rtp_llm/models_py/layers/activation.py
@@ -1,0 +1,71 @@
+"""共享激活算子。
+
+新 loader 的原则:推理 forward 与旧 loader 用同一套 rtp 融合 kernel(保证效率 + 数值
+一致),只在加载权重的方式上不同。这里把激活算子默认接到 rtp 融合 kernel,非 CUDA /
+kernel 不可用时回退到 fp32 eager(可移植兜底)。
+"""
+
+import torch
+
+_SILU_FALLBACK_WARNED = False
+
+
+def swigluoai_and_mul(
+    gate_up: torch.Tensor,
+    alpha: float = 1.702,
+    limit: float = 7.0,
+) -> torch.Tensor:
+    """OpenAI SwiGLU variant used by MiniMax-M3.
+
+    ``gate_up`` is laid out as [gate, up]. The activation is
+    ``gate * sigmoid(alpha * gate) * (up + 1)`` with the same clipping used by
+    the GPT-OSS/MiniMax config family.
+    """
+    d = gate_up.shape[-1] // 2
+    gate, up = gate_up[..., :d].float(), gate_up[..., d:].float()
+    gate = torch.clamp(gate, max=limit)
+    up = torch.clamp(up, min=-limit, max=limit)
+    return (gate * torch.sigmoid(alpha * gate) * (up + 1.0)).to(gate_up.dtype)
+
+
+def silu_and_mul(gate_up: torch.Tensor) -> torch.Tensor:
+    """SiLU(gate) * up。
+
+    Args:
+        gate_up: [..., 2d] 融合张量(前半为 gate,后半为 up)。
+    Returns:
+        [..., d] 张量。
+    CUDA/ROCm 走 rtp 融合 ``silu_and_mul``(内部 fp32,与旧 loader 一致);
+    其它后端 eager 但上采 fp32,贴近融合 kernel 精度。
+    """
+    if gate_up.is_cuda:
+        try:
+            d = gate_up.shape[-1] // 2
+            out = torch.empty(
+                gate_up.shape[:-1] + (d,),
+                dtype=gate_up.dtype,
+                device=gate_up.device,
+            )
+            if getattr(torch.version, "hip", None) is not None:
+                import aiter
+
+                aiter.silu_and_mul(out, gate_up)
+                return out
+
+            from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+            stream_id = torch.cuda.current_stream().cuda_stream
+            rtp_llm_ops.silu_and_mul(out, gate_up, stream_id)
+            return out
+        except Exception as e:
+            global _SILU_FALLBACK_WARNED
+            if not _SILU_FALLBACK_WARNED:
+                _SILU_FALLBACK_WARNED = True
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "[silu_and_mul] 融合 kernel 不可用,回退 fp32 eager: %s", e
+                )
+    d = gate_up.shape[-1] // 2
+    gate, up = gate_up[..., :d], gate_up[..., d:]
+    return (torch.nn.functional.silu(gate.float()) * up.float()).to(gate_up.dtype)

--- a/rtp_llm/models_py/layers/attention.py
+++ b/rtp_llm/models_py/layers/attention.py
@@ -1,0 +1,152 @@
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+
+
+class _FusedQKVColumnParallelLinear(ColumnParallelLinear):
+    def __init__(self, hidden_size: int, *args, **kwargs):
+        self.hidden_size = hidden_size
+        super().__init__(*args, **kwargs)
+
+    def _split_fused_qkv_rows(
+        self, tensor: torch.Tensor, local_rows: int
+    ) -> Optional[torch.Tensor]:
+        full_rows = local_rows * self.tp_size
+        if tensor.shape[0] != full_rows:
+            return None
+        if full_rows % 3 != 0 or local_rows % 3 != 0:
+            raise ValueError(
+                f"fused qkv rows must split evenly across Q/K/V and TP, got "
+                f"full_rows={full_rows}, local_rows={local_rows}, tp_size={self.tp_size}"
+            )
+        full_rows_per_proj = full_rows // 3
+        local_rows_per_proj = local_rows // 3
+        chunks = []
+        for offset in (0, full_rows_per_proj, 2 * full_rows_per_proj):
+            start = offset + self.tp_rank * local_rows_per_proj
+            chunks.append(tensor.narrow(0, start, local_rows_per_proj))
+        return torch.cat(chunks, dim=0).contiguous()
+
+    def _split_weight(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        if self.tp_size <= 1 or dim != 0:
+            return super()._split_weight(tensor, dim)
+
+        if (
+            tensor.dim() == 2
+            and tensor.shape[0] == self.hidden_size
+            and tensor.shape[1] == 3 * self.hidden_size
+        ):
+            tensor = tensor.t().contiguous()
+
+        split = self._split_fused_qkv_rows(tensor, self.output_size_per_partition)
+        if split is not None:
+            return split
+
+        weight_scale_inv = getattr(self, "weight_scale_inv", None)
+        if weight_scale_inv is not None:
+            split = self._split_fused_qkv_rows(tensor, weight_scale_inv.shape[0])
+            if split is not None:
+                return split
+
+        return super()._split_weight(tensor, dim)
+
+
+class MMEncoderAttention(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = True,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        if num_heads <= 0:
+            raise ValueError(f"num_heads must be positive, got {num_heads}")
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        if tp_rank < 0 or tp_rank >= tp_size:
+            raise ValueError(
+                f"tp_rank must satisfy 0 <= tp_rank < tp_size, got "
+                f"tp_rank={tp_rank}, tp_size={tp_size}"
+            )
+        if hidden_size % num_heads != 0:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by num_heads ({num_heads})"
+            )
+        if num_heads % tp_size != 0:
+            raise ValueError(
+                f"num_heads ({num_heads}) must be divisible by tp_size ({tp_size})"
+            )
+
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.qkv = _FusedQKVColumnParallelLinear(
+            hidden_size=hidden_size,
+            input_size=hidden_size,
+            output_size=3 * hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv" if prefix else "qkv",
+            bias=bias,
+            params_dtype=params_dtype,
+        )
+
+        self.proj = RowParallelLinear(
+            input_size=hidden_size,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj" if prefix else "proj",
+            bias=bias,
+            params_dtype=params_dtype,
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        qkv_weights: Dict[str, torch.Tensor] = {}
+        proj_weights: Dict[str, torch.Tensor] = {}
+
+        for name, tensor in weights.items():
+            if name.startswith("qkv."):
+                qkv_weights[name[4:]] = tensor
+            elif name.startswith("proj."):
+                proj_weights[name[5:]] = tensor
+            elif "qkv" in name:
+                qkv_weights[name] = tensor
+            elif "proj" in name or "out" in name:
+                proj_weights[name] = tensor
+
+        if qkv_weights:
+            self.qkv.load_weights(qkv_weights)
+        if proj_weights:
+            self.proj.load_weights(proj_weights)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, N, C = x.shape
+        qkv = self.qkv(x)
+
+        head_dim = self.head_dim
+        num_heads_per_partition = self.qkv.output_size // (3 * head_dim)
+        qkv = qkv.reshape(B, N, 3, num_heads_per_partition, head_dim)
+        qkv = qkv.permute(2, 0, 3, 1, 4)
+        q, k, v = qkv.unbind(0)
+
+        scale = head_dim**-0.5
+        attn = (q @ k.transpose(-2, -1)) * scale
+        attn = attn.softmax(dim=-1)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, -1)
+
+        output = self.proj(x)
+        return output

--- a/rtp_llm/models_py/layers/conv.py
+++ b/rtp_llm/models_py/layers/conv.py
@@ -1,0 +1,58 @@
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+
+class Conv3dLayer(nn.Module):
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Tuple[int, int, int],
+        stride: Optional[Tuple[int, int, int]] = None,
+        padding: Optional[Tuple[int, int, int]] = None,
+        bias: bool = True,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        if stride is None:
+            stride = kernel_size
+        if padding is None:
+            padding = (0, 0, 0)
+
+        self.conv = nn.Conv3d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=bias,
+        )
+        self.conv = self.conv.to(dtype=params_dtype)
+        self._loaded_param_names = set()
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name and "bias" not in name:
+                self.conv.weight.data.copy_(tensor)
+                self._loaded_param_names.add("weight")
+            elif "bias" in name:
+                if self.conv.bias is not None:
+                    self.conv.bias.data.copy_(tensor)
+                    self._loaded_param_names.add("bias")
+
+    def process_weights_after_loading(self):
+        required = {"weight"}
+        if self.conv.bias is not None:
+            required.add("bias")
+        missing = sorted(required - self._loaded_param_names)
+        if missing:
+            raise RuntimeError(f"Conv3dLayer missing required checkpoint tensors: {missing}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)

--- a/rtp_llm/models_py/layers/embedding.py
+++ b/rtp_llm/models_py/layers/embedding.py
@@ -1,0 +1,229 @@
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, all_reduce
+
+
+class VocabParallelEmbedding(nn.Module):
+
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        # Floor-division shards below would silently lose tail vocab rows.
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        if tp_rank < 0 or tp_rank >= tp_size:
+            raise ValueError(
+                f"tp_rank must satisfy 0 <= tp_rank < tp_size, got "
+                f"tp_rank={tp_rank}, tp_size={tp_size}"
+            )
+        if vocab_size % tp_size != 0:
+            raise ValueError(
+                f"vocab_size ({vocab_size}) must be divisible by tp_size ({tp_size}); "
+                f"pad vocab_size up to a multiple of tp_size before constructing "
+                f"VocabParallelEmbedding."
+            )
+
+        self.vocab_size = vocab_size
+        self.embedding_dim = embedding_dim
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+
+        self.vocab_size_per_partition = vocab_size // tp_size
+        self.vocab_start_idx = tp_rank * self.vocab_size_per_partition
+        self.vocab_end_idx = self.vocab_start_idx + self.vocab_size_per_partition
+
+        self.weight = nn.Parameter(
+            torch.empty(
+                self.vocab_size_per_partition, embedding_dim, dtype=params_dtype
+            ),
+            requires_grad=False,
+        )
+        self._weight_loaded = False
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name:
+                if self.tp_size > 1:
+                    tensor = tensor[self.vocab_start_idx : self.vocab_end_idx, :]
+                self.weight.data.copy_(tensor)
+                self._weight_loaded = True
+
+    def process_weights_after_loading(self):
+        if not self._weight_loaded:
+            raise RuntimeError("VocabParallelEmbedding missing required checkpoint tensor: weight")
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+        token_types: Optional[torch.Tensor] = None,
+        text_tokens_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.tp_size > 1:
+            mask = (input_ids >= self.vocab_start_idx) & (
+                input_ids < self.vocab_end_idx
+            )
+            masked_ids = (input_ids - self.vocab_start_idx) * mask
+            output = torch.nn.functional.embedding(masked_ids, self.weight)
+            output = output * mask.unsqueeze(-1)
+            output = all_reduce(output, group=Group.TP)
+        else:
+            output = torch.nn.functional.embedding(input_ids, self.weight)
+        return output
+
+
+class HiddenParallelEmbedding(nn.Module):
+    """Embedding whose hidden dimension is tensor-parallel sharded.
+
+    This mirrors the legacy PyModel Embedding path: each rank stores
+    [vocab_size, hidden_size / tp_size], looks up its local hidden shard, then
+    all-gathers hidden shards back into the full hidden state.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        if tp_rank < 0 or tp_rank >= tp_size:
+            raise ValueError(
+                f"tp_rank must satisfy 0 <= tp_rank < tp_size, got "
+                f"tp_rank={tp_rank}, tp_size={tp_size}"
+            )
+        if embedding_dim % tp_size != 0:
+            raise ValueError(
+                f"embedding_dim ({embedding_dim}) must be divisible by tp_size "
+                f"({tp_size}) for HiddenParallelEmbedding."
+            )
+
+        self.vocab_size = vocab_size
+        self.embedding_dim = embedding_dim
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.embedding_dim_per_partition = embedding_dim // tp_size
+        self.hidden_start_idx = tp_rank * self.embedding_dim_per_partition
+        self.hidden_end_idx = self.hidden_start_idx + self.embedding_dim_per_partition
+
+        self.weight = nn.Parameter(
+            torch.empty(
+                vocab_size, self.embedding_dim_per_partition, dtype=params_dtype
+            ),
+            requires_grad=False,
+        )
+        self._weight_loaded = False
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name:
+                if self.tp_size > 1:
+                    tensor = tensor[:, self.hidden_start_idx : self.hidden_end_idx]
+                self.weight.data.copy_(tensor)
+                self._weight_loaded = True
+
+    def process_weights_after_loading(self):
+        if not self._weight_loaded:
+            raise RuntimeError("HiddenParallelEmbedding missing required checkpoint tensor: weight")
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+        token_types: Optional[torch.Tensor] = None,
+        text_tokens_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        tokens = input_ids.size(0)
+        local_hidden_size = self.weight.size(-1)
+        output = torch.empty(
+            (tokens, local_hidden_size),
+            dtype=self.weight.dtype,
+            device=input_ids.device,
+        )
+        from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+        rtp_llm_ops.embedding(
+            output,
+            input_ids,
+            self.weight.data,
+            position_ids,
+            token_types,
+            text_tokens_mask,
+        )
+        if self.tp_size > 1:
+            m, n = output.shape
+            output = all_gather(output, group=Group.TP)
+            output = (
+                output.reshape(self.tp_size, m, n)
+                .transpose(0, 1)
+                .contiguous()
+                .reshape(m, -1)
+            )
+        return output
+
+
+class ParallelLMHead(nn.Module):
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        if tp_rank < 0 or tp_rank >= tp_size:
+            raise ValueError(
+                f"tp_rank must satisfy 0 <= tp_rank < tp_size, got "
+                f"tp_rank={tp_rank}, tp_size={tp_size}"
+            )
+        if vocab_size % tp_size != 0:
+            raise ValueError(
+                f"vocab_size ({vocab_size}) must be divisible by tp_size ({tp_size}); "
+                f"pad vocab_size up to a multiple of tp_size before constructing "
+                f"ParallelLMHead."
+            )
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+
+        self.vocab_size_per_partition = vocab_size // tp_size
+        self.weight = nn.Parameter(
+            torch.empty(self.vocab_size_per_partition, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        self._weight_loaded = False
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name:
+                if self.tp_size > 1:
+                    start = self.tp_rank * self.vocab_size_per_partition
+                    tensor = tensor[start : start + self.vocab_size_per_partition, :]
+                self.weight.data.copy_(tensor)
+                self._weight_loaded = True
+
+    def process_weights_after_loading(self):
+        if not self._weight_loaded:
+            raise RuntimeError("ParallelLMHead missing required checkpoint tensor: weight")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.linear(x, self.weight)

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -713,6 +713,12 @@ class QKVParallelLinear(ColumnParallelLinear):
                 f"QKVParallelLinear requires num_heads ({num_heads}) to be "
                 f"divisible by tp_size ({tp_size}) for prefix={prefix!r}"
             )
+        if num_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"QKVParallelLinear requires num_heads ({num_heads}) to be "
+                f"divisible by num_kv_heads ({num_kv_heads}) for GQA, "
+                f"prefix={prefix!r}"
+            )
 
         self.kv_tp_size = math.gcd(num_kv_heads, tp_size)
         if self.kv_tp_size <= 0 or num_kv_heads % self.kv_tp_size != 0:
@@ -725,6 +731,12 @@ class QKVParallelLinear(ColumnParallelLinear):
 
         self.num_heads_per_partition = num_heads // tp_size
         self.num_kv_heads_per_partition = num_kv_heads // self.kv_tp_size
+        if self.num_heads_per_partition % self.num_kv_heads_per_partition != 0:
+            raise ValueError(
+                f"QKVParallelLinear requires local Q heads "
+                f"({self.num_heads_per_partition}) to be divisible by local KV "
+                f"heads ({self.num_kv_heads_per_partition}) for prefix={prefix!r}"
+            )
 
         self.q_size = self.num_heads_per_partition * head_dim
         self.kv_size = self.num_kv_heads_per_partition * head_dim

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -120,6 +120,16 @@ class LinearBase(nn.Module):
         return [block_n, block_k]
 
     @staticmethod
+    def _check_fp8_block_aligned(start: int, size: int, block: int, what: str):
+        if start % block != 0 or size % block != 0:
+            raise ValueError(
+                f"{what} requires block-aligned shard boundaries, got "
+                f"start={start}, size={size}, block={block}. Non-aligned "
+                f"FP8 block scales would overlap checkpoint blocks and cannot "
+                f"be copied safely without requantization."
+            )
+
+    @staticmethod
     def _ceil_div(x: int, y: int) -> int:
         return (x + y - 1) // y
 
@@ -478,18 +488,32 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     continue
 
                 if param_name == "weight_scale_inv":
-                    # FP8 per-block scale grid [out_blocks, in_blocks]. Each
-                    # shard (gate/up) ships its own grid; place this shard's
-                    # block-rows at its block offset. shard_size is in weight
-                    # rows, so convert through the quant config's N block.
+                    # FP8 per-block scale grid [out_blocks, in_blocks]. Copying
+                    # a gate/up shard is only valid when the shard boundary is
+                    # aligned to the source block grid. Otherwise one source
+                    # scale block overlaps two local shards and must be
+                    # reconstructed by dequant+requant, which this path does not do.
                     block_n, _ = self._fp8_scale_block_size()
-                    blocks_per_shard = self._ceil_div(shard_size, block_n)
+                    shard_row_start = shard_id * shard_size
+                    self._check_fp8_block_aligned(
+                        shard_row_start,
+                        shard_size,
+                        block_n,
+                        f"FP8 block merged scale {self.prefix}.{self.shard_names[shard_id]}",
+                    )
+                    blocks_per_shard = shard_size // block_n
                     if (
                         self.tp_size > 1
                         and tensor.shape[0] == blocks_per_shard * self.tp_size
                     ):
                         start = self.tp_rank * blocks_per_shard
                         tensor = tensor.narrow(0, start, blocks_per_shard).contiguous()
+                    if tensor.shape[0] != blocks_per_shard:
+                        raise ValueError(
+                            f"Shape mismatch for merged {self.prefix}.{param_name} "
+                            f"shard={shard_id}: got block rows={tensor.shape[0]}, "
+                            f"expected {blocks_per_shard}"
+                        )
                     offset = shard_id * blocks_per_shard
                     param.data[offset : offset + blocks_per_shard].copy_(tensor)
                     self._mark_loaded((param_name, shard_id))
@@ -813,10 +837,18 @@ class QKVParallelLinear(ColumnParallelLinear):
         if param_name == "weight_scale_inv":
             # FP8 per-block grid for this q/k/v shard: TP-slice along the
             # output(head)-block dim, then place at the shard's block offset
-            # in the merged [total_blocks, in_blocks] grid. For GQA/MQA with
-            # fewer KV heads than TP ranks, mirror _split_qkv(): replicate the
-            # selected KV head's block instead of slicing past the ckpt tensor.
+            # in the merged [total_blocks, in_blocks] grid. Copying is only
+            # correct when both q/k/v boundaries and TP sub-shard boundaries
+            # align to block_n; otherwise a single source scale block would be
+            # shared by two local regions and must be rebuilt by requantization.
             block_n, _ = self._fp8_scale_block_size()
+            self._check_fp8_block_aligned(
+                offset,
+                size,
+                block_n,
+                f"FP8 block QKV scale {self.prefix}.{qkv_key}",
+            )
+            expected_blocks = size // block_n
             if self.tp_size > 1:
                 if num_heads < self.tp_size:
                     start_row = (self.tp_rank % num_heads) * self.head_dim
@@ -825,9 +857,21 @@ class QKVParallelLinear(ColumnParallelLinear):
                     heads_pp = num_heads // self.tp_size
                     rows = heads_pp * self.head_dim
                     start_row = self.tp_rank * rows
+                self._check_fp8_block_aligned(
+                    start_row,
+                    rows,
+                    block_n,
+                    f"FP8 block QKV TP scale {self.prefix}.{qkv_key}",
+                )
                 start_blk = start_row // block_n
-                block_count = max(1, self._ceil_div(rows, block_n))
+                block_count = rows // block_n
                 tensor = tensor.narrow(0, start_blk, block_count).contiguous()
+                expected_blocks = block_count
+            if tensor.shape[0] != expected_blocks:
+                raise ValueError(
+                    f"Shape mismatch for QKV {self.prefix}.{param_name}/{qkv_key}: "
+                    f"got block rows={tensor.shape[0]}, expected {expected_blocks}"
+                )
             off_blk = offset // block_n
             param.data[off_blk : off_blk + tensor.shape[0]].copy_(tensor)
             self._mark_loaded((param_name, qkv_key))

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -1,0 +1,934 @@
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, all_reduce
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig, QuantizeMethodBase
+
+
+class LinearBase(nn.Module):
+
+    # FP8 per-block (DeepSeek-style) quantization block size, used when
+    # TP-slicing / shard-merging `weight_scale_inv` block grids.
+    _FP8_BLOCK = 128
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+        **kwargs,
+    ):
+        super().__init__()
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        if tp_rank < 0 or tp_rank >= tp_size:
+            raise ValueError(
+                f"tp_rank must satisfy 0 <= tp_rank < tp_size, got "
+                f"tp_rank={tp_rank}, tp_size={tp_size}, prefix={prefix!r}"
+            )
+        self.input_size = input_size
+        self.output_size = output_size
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.prefix = prefix
+        self.params_dtype = params_dtype
+        self._loaded_weight_keys = set()
+
+        if quant_config is None:
+            quant_config = QuantizationConfig(quant_type="none")
+        self.quant_config = quant_config
+        self.quant_method = quant_config.get_quant_method(self, prefix)
+
+        if bias:
+            self.bias = nn.Parameter(
+                torch.zeros(output_size, dtype=params_dtype), requires_grad=False
+            )
+        else:
+            self.bias = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output = self.quant_method.apply(self, x, self.bias)
+        return output
+
+    def process_weights_after_loading(self):
+        # Called once by NewModelLoader._run_post_load_hooks after model.to(device)
+        # and after every weight shard is in place. Doing the work here (rather
+        # than at the end of load_weights) is required for streaming dispatch:
+        # MergedColumnParallelLinear / QKVParallelLinear receive their shards on
+        # separate RtpModule.load_weights ticks, so a per-tick call would quantize
+        # before all shards arrived (corrupt scale) and then re-quantize an
+        # already-fp8 weight on the next tick (kernel dispatch failure).
+        if getattr(self, "_post_load_done", False):
+            return
+        self._check_load_complete()
+        self.quant_method.process_weights_after_loading(self)
+        self._post_load_done = True
+
+    def _mark_loaded(self, key):
+        self._loaded_weight_keys.add(key)
+
+    def _required_load_keys(self):
+        keys = set()
+        # Online quant methods create runtime scales during post-load; already
+        # quantized methods must receive their ckpt scales explicitly.
+        quant_type = getattr(self.quant_config, "quant_type", "none")
+        online = quant_type in (
+            "fp8_online",
+            "fp8_per_channel_online",
+            "fp8_block_online",
+        )
+        if isinstance(getattr(self, "weight", None), nn.Parameter):
+            keys.add("weight")
+        if isinstance(getattr(self, "bias", None), nn.Parameter):
+            keys.add("bias")
+        for name in ("qweight", "qzeros", "scales"):
+            if isinstance(getattr(self, name, None), nn.Parameter):
+                keys.add(name)
+        if not online and isinstance(getattr(self, "weight_scale", None), nn.Parameter):
+            keys.add("weight_scale")
+        if isinstance(getattr(self, "weight_scale_inv", None), nn.Parameter):
+            keys.add("weight_scale_inv")
+        return keys
+
+    def _check_load_complete(self):
+        required = self._required_load_keys()
+        missing = sorted(required - self._loaded_weight_keys)
+        if missing:
+            raise RuntimeError(
+                f"{type(self).__name__} {self.prefix!r} missing required "
+                f"checkpoint tensors: {missing}; loaded={sorted(self._loaded_weight_keys)}"
+            )
+
+    def _fp8_scale_block_size(self):
+        block_size = getattr(self.quant_config, "weight_block_size", None)
+        if block_size is None:
+            block_size = [self._FP8_BLOCK, self._FP8_BLOCK]
+        if len(block_size) != 2:
+            raise ValueError(f"weight_block_size must have 2 values, got {block_size}")
+        block_n, block_k = int(block_size[0]), int(block_size[1])
+        if block_n <= 0 or block_k <= 0:
+            raise ValueError(
+                f"weight_block_size values must be positive, got {block_size}"
+            )
+        return [block_n, block_k]
+
+    @staticmethod
+    def _ceil_div(x: int, y: int) -> int:
+        return (x + y - 1) // y
+
+    @staticmethod
+    def _check_divisible(value: int, divisor: int, what: str, prefix: str):
+        if divisor <= 0:
+            raise ValueError(f"{what} requires positive tp_size, got {divisor}")
+        if value % divisor != 0:
+            raise ValueError(
+                f"{what} ({value}) must be divisible by tp_size ({divisor}) "
+                f"for prefix={prefix!r}; non-divisible TP sharding would drop weights"
+            )
+
+
+class ColumnParallelLinear(LinearBase):
+
+    shard_names: List[str] = []
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        gather_output: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+        **kwargs,
+    ):
+        self._check_divisible(output_size, tp_size, "ColumnParallelLinear output_size", prefix)
+        self.output_size_per_partition = output_size // tp_size
+        self.gather_output = gather_output
+
+        super().__init__(
+            input_size=input_size,
+            output_size=self.output_size_per_partition,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=prefix,
+            bias=bias,
+            params_dtype=params_dtype,
+            **kwargs,
+        )
+
+        self.quant_method.create_weights(
+            layer=self,
+            input_size=input_size,
+            output_size=self.output_size_per_partition,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output = super().forward(x)
+        if self.gather_output and self.tp_size > 1:
+            original_shape = output.shape
+            output_2d = output.reshape(-1, original_shape[-1])
+            m, n = output_2d.shape
+            gathered = all_gather(output_2d, group=Group.TP)
+            output = (
+                gathered.reshape(self.tp_size, m, n)
+                .transpose(0, 1)
+                .contiguous()
+                .reshape(*original_shape[:-1], n * self.tp_size)
+            )
+        return output
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            param_name = self._get_param_name(name)
+            if param_name is None:
+                continue
+
+            param = getattr(self, param_name, None)
+            if param is None or not isinstance(param, nn.Parameter):
+                continue
+
+            if param_name == "weight":
+                tensor = self._split_weight(tensor, dim=0)
+            elif param_name == "bias":
+                tensor = self._split_weight(tensor, dim=0)
+            elif param_name in ("weight_scale", "input_scale"):
+                if (
+                    tensor.numel() > 1
+                    and tensor.shape[0] == self.output_size_per_partition * self.tp_size
+                ):
+                    tensor = self._split_weight(tensor, dim=0)
+            elif param_name == "weight_scale_inv":
+                if self.tp_size > 1:
+                    tensor = self._split_weight(tensor, dim=0)
+            elif param_name in ("scales", "zeros"):
+                if (
+                    tensor.dim() == 1
+                    and tensor.shape[0] == self.output_size_per_partition * self.tp_size
+                ):
+                    if self.tp_size > 1:
+                        tensor = self._split_weight(tensor, dim=0)
+                elif (
+                    tensor.dim() > 1
+                    and tensor.shape[-1]
+                    == self.output_size_per_partition * self.tp_size
+                ):
+                    if self.tp_size > 1:
+                        tensor = self._split_weight(tensor, dim=-1)
+            elif param_name in ("qweight", "qzeros"):
+                # AWQ(w4a16):qweight[in, out//8] / qzeros[g, out//8] / scales[g, out]
+                # —— 输出维都是 dim1,ColumnParallel 切输出 → 切 dim1。
+                if self.tp_size > 1:
+                    tensor = self._split_weight(tensor, dim=1)
+
+            if tensor.shape != param.shape:
+                if tensor.dim() == 1 and param.dim() == 2 and tensor.numel() == param.numel():
+                    tensor = tensor.view_as(param)
+                elif (
+                    param_name == "weight"
+                    and tensor.dim() == 2
+                    and tensor.shape[0] != tensor.shape[1]
+                    and tensor.t().shape == param.shape
+                ):
+                    tensor = tensor.t().contiguous()
+                else:
+                    raise ValueError(
+                        f"Shape mismatch for {self.prefix}.{param_name}: "
+                        f"weight {tensor.shape} vs param {param.shape}"
+                    )
+            param.data.copy_(tensor)
+            self._mark_loaded(param_name)
+
+        # process_weights_after_loading is invoked by NewModelLoader's
+        # post-load hook after every shard has landed; see LinearBase.
+
+    def _split_weight(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        if self.tp_size <= 1:
+            return tensor
+        self._check_divisible(
+            tensor.shape[dim],
+            self.tp_size,
+            f"{type(self).__name__} tensor dim {dim}",
+            self.prefix,
+        )
+        size_per_partition = tensor.shape[dim] // self.tp_size
+        start = self.tp_rank * size_per_partition
+        return tensor.narrow(dim, start, size_per_partition).contiguous()
+
+    def _get_param_name(self, weight_name: str) -> Optional[str]:
+        parts = weight_name.rsplit(".", 1)
+        name = parts[-1] if len(parts) > 1 else weight_name
+        return name
+
+
+class RowParallelLinear(LinearBase):
+
+    shard_names: List[str] = []
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        reduce_output: bool = True,
+        params_dtype: torch.dtype = torch.float16,
+        **kwargs,
+    ):
+        self._check_divisible(input_size, tp_size, "RowParallelLinear input_size", prefix)
+        self.input_size_per_partition = input_size // tp_size
+        self.reduce_output = reduce_output
+
+        super().__init__(
+            input_size=self.input_size_per_partition,
+            output_size=output_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=prefix,
+            bias=bias,
+            params_dtype=params_dtype,
+            **kwargs,
+        )
+
+        self.quant_method.create_weights(
+            layer=self,
+            input_size=self.input_size_per_partition,
+            output_size=output_size,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.reduce_output and self.tp_size > 1:
+            output = self.quant_method.apply(self, x, bias=None)
+            output = all_reduce(output, group=Group.TP)
+            if self.bias is not None:
+                output = output + self.bias
+            return output
+        return super().forward(x)
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            param_name = self._get_param_name(name)
+            if param_name is None:
+                continue
+
+            param = getattr(self, param_name, None)
+            if param is None or not isinstance(param, nn.Parameter):
+                continue
+
+            if param_name == "weight":
+                tensor = self._split_weight(tensor, dim=1)
+            elif param_name in ("weight_scale", "input_scale"):
+                if (
+                    tensor.numel() > 1
+                    and tensor.shape[-1] == self.input_size_per_partition * self.tp_size
+                ):
+                    tensor = self._split_weight(tensor, dim=-1)
+            elif param_name == "weight_scale_inv":
+                if self.tp_size > 1:
+                    tensor = self._split_weight(tensor, dim=1)
+            elif param_name == "g_idx":
+                if self.tp_size > 1:
+                    tensor = self._split_weight(tensor, dim=0)
+            elif param_name in ("scales", "zeros"):
+                if tensor.dim() > 1 and tensor.shape[0] > 1:
+                    if self.tp_size > 1:
+                        tensor = self._split_weight(tensor, dim=0)
+            elif param_name in ("qweight", "qzeros"):
+                # AWQ(w4a16):qweight[in, out//8] / qzeros[g, out//8] / scales[g, out]
+                # —— 输入维都是 dim0,RowParallel 切输入 → 切 dim0。
+                if self.tp_size > 1:
+                    tensor = self._split_weight(tensor, dim=0)
+
+            if tensor.shape != param.shape:
+                if tensor.dim() == 1 and param.dim() == 2 and tensor.numel() == param.numel():
+                    tensor = tensor.view_as(param)
+                elif (
+                    param_name == "weight"
+                    and tensor.dim() == 2
+                    and tensor.shape[0] != tensor.shape[1]
+                    and tensor.t().shape == param.shape
+                ):
+                    tensor = tensor.t().contiguous()
+                else:
+                    raise ValueError(
+                        f"Shape mismatch for {self.prefix}.{param_name}: "
+                        f"weight {tensor.shape} vs param {param.shape}"
+                    )
+            param.data.copy_(tensor)
+            self._mark_loaded(param_name)
+
+        # process_weights_after_loading is invoked by NewModelLoader's
+        # post-load hook after every shard has landed; see LinearBase.
+
+    def _split_weight(self, tensor: torch.Tensor, dim: int = 1) -> torch.Tensor:
+        if self.tp_size <= 1:
+            return tensor
+        self._check_divisible(
+            tensor.shape[dim],
+            self.tp_size,
+            f"{type(self).__name__} tensor dim {dim}",
+            self.prefix,
+        )
+        size_per_partition = tensor.shape[dim] // self.tp_size
+        start = self.tp_rank * size_per_partition
+        return tensor.narrow(dim, start, size_per_partition).contiguous()
+
+    def _get_param_name(self, weight_name: str) -> Optional[str]:
+        parts = weight_name.rsplit(".", 1)
+        return parts[-1] if len(parts) > 1 else weight_name
+
+
+class MergedColumnParallelLinear(ColumnParallelLinear):
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        shard_names: Optional[List[str]] = None,
+        params_dtype: torch.dtype = torch.float16,
+        **kwargs,
+    ):
+        if shard_names:
+            self.shard_names = shard_names
+        num_shards = len(self.shard_names) if self.shard_names else 1
+        if num_shards <= 0:
+            raise ValueError("MergedColumnParallelLinear requires at least one shard")
+        partition = output_size // tp_size
+        if partition % num_shards != 0:
+            raise ValueError(
+                f"MergedColumnParallelLinear output partition ({partition}) "
+                f"must be divisible by num_shards ({num_shards}) for prefix={prefix!r}"
+            )
+
+        super().__init__(
+            input_size=input_size,
+            output_size=output_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=prefix,
+            bias=bias,
+            params_dtype=params_dtype,
+            **kwargs,
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        num_shards = len(self.shard_names) if self.shard_names else 1
+        shard_size = self.output_size_per_partition // num_shards
+
+        for full_name, tensor in weights.items():
+            param_name = self._get_param_name(full_name)
+            shard_id = self._get_shard_id(full_name)
+
+            if param_name != "weight" and param_name != "bias":
+                param = getattr(self, param_name, None)
+                if param is None or not isinstance(param, nn.Parameter):
+                    continue
+
+                if shard_id < 0:
+                    # Un-sharded param (e.g. already-merged ckpt) — full copy.
+                    param.data.copy_(tensor)
+                    self._mark_loaded(param_name)
+                    continue
+
+                if param_name in ("qweight", "qzeros", "scales"):
+                    # AWQ(w4a16):输出维是 dim1;qweight/qzeros 以 pack_factor 压缩,
+                    # scales 不压缩。每个 shard(gate/up)沿 dim1 TP 切 + 按 shard 偏移拼入。
+                    pf = (
+                        1
+                        if param_name == "scales"
+                        else getattr(self.quant_method, "PACK_FACTOR", 8)
+                    )
+                    shard_cols = shard_size // pf
+                    if (
+                        self.tp_size > 1
+                        and tensor.shape[1] == shard_cols * self.tp_size
+                    ):
+                        start = self.tp_rank * shard_cols
+                        tensor = tensor.narrow(1, start, shard_cols).contiguous()
+                    if tensor.shape[1] != shard_cols:
+                        raise ValueError(
+                            f"[AWQ merged] {self.prefix}.{param_name} shard={shard_id}: "
+                            f"dim1={tensor.shape[1]} != expected {shard_cols}"
+                        )
+                    off = shard_id * shard_cols
+                    param.data[:, off : off + shard_cols].copy_(tensor)
+                    self._mark_loaded((param_name, shard_id))
+                    continue
+
+                if param_name == "weight_scale_inv":
+                    # FP8 per-block scale grid [out_blocks, in_blocks]. Each
+                    # shard (gate/up) ships its own grid; place this shard's
+                    # block-rows at its block offset. shard_size is in weight
+                    # rows, so convert through the quant config's N block.
+                    block_n, _ = self._fp8_scale_block_size()
+                    blocks_per_shard = self._ceil_div(shard_size, block_n)
+                    if (
+                        self.tp_size > 1
+                        and tensor.shape[0] == blocks_per_shard * self.tp_size
+                    ):
+                        start = self.tp_rank * blocks_per_shard
+                        tensor = tensor.narrow(0, start, blocks_per_shard).contiguous()
+                    offset = shard_id * blocks_per_shard
+                    param.data[offset : offset + blocks_per_shard].copy_(tensor)
+                    self._mark_loaded((param_name, shard_id))
+                    continue
+
+                # Per-shard non-weight param (e.g. per-channel weight_scale).
+                if param.numel() == 1:
+                    # Streaming dispatch calls load_weights once per tensor, so
+                    # per-shard scalar scales must be accumulated on the instance
+                    # and merged only after every shard has landed.
+                    val = float(tensor.flatten()[0].item())
+                    if not hasattr(self, "_merged_per_tensor_scales"):
+                        self._merged_per_tensor_scales = {}
+                    self._merged_per_tensor_scales.setdefault(param_name, {})[
+                        shard_id
+                    ] = val
+                    self._mark_loaded((param_name, shard_id))
+                    continue
+
+                # Per-channel/per-shard tensor: TP-slice + offset copy along dim 0.
+                # Convention: ckpt tensor's dim-0 covers one shard's full output
+                # (= shard_size * tp_size).
+                if self.tp_size > 1 and tensor.shape[0] == shard_size * self.tp_size:
+                    start = self.tp_rank * shard_size
+                    tensor = tensor.narrow(0, start, shard_size).contiguous()
+                offset = shard_id * shard_size
+                if tensor.shape[0] != shard_size:
+                    raise ValueError(
+                        f"Shape mismatch for merged {self.prefix}.{param_name} "
+                        f"shard={shard_id}: got dim-0={tensor.shape[0]}, "
+                        f"expected {shard_size}"
+                    )
+                if tensor.dim() == 1 and param.dim() == 2:
+                    tensor = tensor.view(-1, 1)
+                param.data[offset : offset + shard_size].copy_(tensor)
+                self._mark_loaded((param_name, shard_id))
+                continue
+
+            if shard_id < 0:
+                if param_name == "weight":
+                    split_tensor = self._split_weight(tensor, dim=0)
+                    if (
+                        split_tensor.shape != self.weight.shape
+                        and split_tensor.dim() == 2
+                        and split_tensor.shape[0] != split_tensor.shape[1]
+                        and split_tensor.t().shape == self.weight.shape
+                    ):
+                        split_tensor = split_tensor.t().contiguous()
+                    self.weight.data.copy_(split_tensor)
+                    self._mark_loaded("weight")
+                continue
+
+            if self.tp_size > 1:
+                self._check_divisible(
+                    tensor.shape[0],
+                    self.tp_size,
+                    f"{type(self).__name__} shard tensor dim 0",
+                    self.prefix,
+                )
+                shard_output_size = tensor.shape[0] // self.tp_size
+                start = self.tp_rank * shard_output_size
+                tensor = tensor.narrow(0, start, shard_output_size).contiguous()
+
+            if param_name == "weight":
+                offset = shard_id * shard_size
+                if (
+                    tensor.dim() == 2
+                    and self.weight.shape[0] == tensor.shape[1]
+                    and self.weight.shape[1] >= offset + shard_size
+                ):
+                    self.weight.data[:, offset : offset + shard_size].copy_(
+                        tensor.t().contiguous()
+                    )
+                else:
+                    self.weight.data[offset : offset + shard_size, :].copy_(tensor)
+                self._mark_loaded(("weight", shard_id))
+            elif param_name == "bias" and self.bias is not None:
+                offset = shard_id * shard_size
+                self.bias.data[offset : offset + shard_size].copy_(tensor)
+                self._mark_loaded(("bias", shard_id))
+
+        # process_weights_after_loading is invoked by NewModelLoader's
+        # post-load hook after every shard has landed; see LinearBase.
+
+    def _required_load_keys(self):
+        base = super()._required_load_keys()
+        if not self.shard_names:
+            return base
+        shard_ids = range(len(self.shard_names))
+        required = set()
+        for key in base:
+            direct_loaded = key in self._loaded_weight_keys
+            shard_keys = {(key, shard_id) for shard_id in shard_ids}
+            if direct_loaded or shard_keys.issubset(self._loaded_weight_keys):
+                continue
+            required.update(shard_keys)
+        return required
+
+    def process_weights_after_loading(self):
+        # Merge per-tensor gate/up scales and rescale fp8 weight shards so both
+        # shards share the same final scale. This must run before quant_method
+        # post-load hooks, matching QKVParallelLinear's streaming-safe behavior.
+        if getattr(self, "_post_load_done", False):
+            return
+        self._check_load_complete()
+        self._merge_merged_per_tensor_scales()
+        self.quant_method.process_weights_after_loading(self)
+        self._post_load_done = True
+
+    def _merge_merged_per_tensor_scales(self):
+        scales_by_param = getattr(self, "_merged_per_tensor_scales", None)
+        if not scales_by_param:
+            return
+
+        num_shards = len(self.shard_names) if self.shard_names else 1
+        shard_size = self.output_size_per_partition // num_shards
+        for param_name, scales in scales_by_param.items():
+            param = getattr(self, param_name, None)
+            if param is None or param.numel() != 1:
+                continue
+            max_scale = max(scales.values())
+            param.data.fill_(max_scale)
+            if param_name != "weight_scale":
+                continue
+            for shard_id, scale_val in scales.items():
+                if scale_val == max_scale:
+                    continue
+                weight_slice = self._merged_shard_weight_slice(shard_id, shard_size)
+                ratio = scale_val / max_scale
+                rescaled = (weight_slice.float() * ratio).to(weight_slice.dtype)
+                weight_slice.copy_(rescaled)
+
+    def _get_shard_id(self, weight_name: str) -> int:
+        for idx, shard_name in enumerate(self.shard_names):
+            if shard_name in weight_name:
+                return idx
+        return -1
+
+    def _merged_shard_weight_slice(self, shard_id: int, shard_size: int) -> torch.Tensor:
+        offset = shard_id * shard_size
+        if self.weight.shape[0] >= offset + shard_size:
+            return self.weight.data[offset : offset + shard_size, :]
+        if self.weight.dim() == 2 and self.weight.shape[1] >= offset + shard_size:
+            return self.weight.data[:, offset : offset + shard_size]
+        raise ValueError(
+            f"Cannot locate merged shard {shard_id} for {self.prefix}.weight: "
+            f"weight shape={tuple(self.weight.shape)}, shard_size={shard_size}"
+        )
+
+
+
+class QKVParallelLinear(ColumnParallelLinear):
+
+    shard_names: List[str] = ["q_proj", "k_proj", "v_proj"]
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+
+        if num_heads % tp_size != 0:
+            raise ValueError(
+                f"QKVParallelLinear requires num_heads ({num_heads}) to be "
+                f"divisible by tp_size ({tp_size}) for prefix={prefix!r}"
+            )
+        if num_kv_heads >= tp_size and num_kv_heads % tp_size != 0:
+            raise ValueError(
+                f"QKVParallelLinear requires num_kv_heads ({num_kv_heads}) to be "
+                f"divisible by tp_size ({tp_size}) when num_kv_heads >= tp_size "
+                f"for prefix={prefix!r}; non-divisible grouped KV sharding is not "
+                "implemented in newloader yet"
+            )
+
+        self.num_heads_per_partition = num_heads // tp_size
+        self.num_kv_heads_per_partition = max(1, num_kv_heads // tp_size)
+
+        self.q_size = self.num_heads_per_partition * head_dim
+        self.kv_size = self.num_kv_heads_per_partition * head_dim
+
+        total_output = self.q_size + 2 * self.kv_size
+
+        LinearBase.__init__(
+            self,
+            input_size=hidden_size,
+            output_size=total_output,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=prefix,
+            bias=bias,
+            params_dtype=params_dtype,
+            **kwargs,
+        )
+        self.output_size_per_partition = total_output
+        self.gather_output = False
+
+        self.quant_method.create_weights(
+            layer=self,
+            input_size=hidden_size,
+            output_size=total_output,
+            params_dtype=params_dtype,
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        # Streaming-dispatch contract: this method may be called many times
+        # with a single q/k/v shard at a time. Each call writes the shard
+        # into its own offset slice in self.weight (and self.bias, etc.) so
+        # that partial calls are safe — there's no "wait for all three" gate.
+        # NewModelLoader._run_post_load_hooks invokes
+        # process_weights_after_loading after every shard has landed; see
+        # LinearBase.
+        for full_name, tensor in weights.items():
+            param_name = self._get_param_name(full_name)
+            if param_name is None:
+                continue
+
+            qkv_key = None
+            if "q_proj" in full_name:
+                qkv_key = "q"
+            elif "k_proj" in full_name:
+                qkv_key = "k"
+            elif "v_proj" in full_name:
+                qkv_key = "v"
+
+            if qkv_key is None:
+                # Non-q/k/v param (e.g. an already-merged ckpt or auxiliary
+                # tensor that maps directly onto a self.* param).
+                if param_name == "weight":
+                    self.weight.data.copy_(self._split_weight(tensor, dim=0))
+                    self._mark_loaded("weight")
+                else:
+                    param = getattr(self, param_name, None)
+                    if isinstance(param, nn.Parameter) and tensor.shape == param.shape:
+                        param.data.copy_(tensor)
+                        self._mark_loaded(param_name)
+                continue
+
+            self._dispatch_qkv_shard(qkv_key, param_name, tensor)
+
+    def _dispatch_qkv_shard(self, qkv_key: str, param_name: str, tensor: torch.Tensor):
+        """Write a single q/k/v shard into the merged parameter at its offset."""
+        # Resolve per-shard size and offset in the merged QKV layout.
+        if qkv_key == "q":
+            num_heads, size, offset = self.num_heads, self.q_size, 0
+        elif qkv_key == "k":
+            num_heads, size, offset = self.num_kv_heads, self.kv_size, self.q_size
+        else:  # "v"
+            num_heads, size, offset = (
+                self.num_kv_heads,
+                self.kv_size,
+                self.q_size + self.kv_size,
+            )
+
+        if param_name in ("qweight", "qzeros", "scales"):
+            # AWQ(w4a16):输出维是 dim1;qweight/qzeros 以 pack_factor 压缩。
+            # q/k/v 各自的 size、offset 在 dim1 上换算(压缩参数 //pf)。
+            param = getattr(self, param_name, None)
+            if param is None or not isinstance(param, nn.Parameter):
+                return
+            pf = (
+                1
+                if param_name == "scales"
+                else getattr(self.quant_method, "PACK_FACTOR", 8)
+            )
+            cols = size // pf
+            off_cols = offset // pf
+            if self.tp_size > 1 and tensor.shape[1] == cols * self.tp_size:
+                start = self.tp_rank * cols
+                tensor = tensor.narrow(1, start, cols).contiguous()
+            if tensor.shape[1] != cols:
+                raise ValueError(
+                    f"[AWQ QKV] {self.prefix}.{param_name}/{qkv_key}: "
+                    f"dim1={tensor.shape[1]} != expected {cols}"
+                )
+            param.data[:, off_cols : off_cols + cols].copy_(tensor)
+            self._mark_loaded((param_name, qkv_key))
+            return
+
+        if param_name == "weight":
+            split = self._split_qkv(tensor, num_heads, self.head_dim)
+            if (
+                split.dim() == 2
+                and self.weight.shape[0] == split.shape[1]
+                and self.weight.shape[1] >= offset + size
+            ):
+                self.weight.data[:, offset : offset + size].copy_(
+                    split.t().contiguous()
+                )
+            else:
+                self.weight.data[offset : offset + size].copy_(split)
+            self._mark_loaded(("weight", qkv_key))
+            return
+
+        if param_name == "bias":
+            if self.bias is None:
+                return
+            split = self._split_qkv(tensor, num_heads, self.head_dim)
+            self.bias.data[offset : offset + size].copy_(split)
+            self._mark_loaded(("bias", qkv_key))
+            return
+
+        # Auxiliary per-shard params (per-channel weight_scale, input_scale, ...).
+        param = getattr(self, param_name, None)
+        if param is None or not isinstance(param, nn.Parameter):
+            return
+
+        if param_name == "weight_scale_inv":
+            # FP8 per-block grid for this q/k/v shard: TP-slice along the
+            # output(head)-block dim, then place at the shard's block offset
+            # in the merged [total_blocks, in_blocks] grid. For GQA/MQA with
+            # fewer KV heads than TP ranks, mirror _split_qkv(): replicate the
+            # selected KV head's block instead of slicing past the ckpt tensor.
+            block_n, _ = self._fp8_scale_block_size()
+            if self.tp_size > 1:
+                if num_heads < self.tp_size:
+                    start_row = (self.tp_rank % num_heads) * self.head_dim
+                    rows = self.head_dim
+                else:
+                    heads_pp = num_heads // self.tp_size
+                    rows = heads_pp * self.head_dim
+                    start_row = self.tp_rank * rows
+                start_blk = start_row // block_n
+                block_count = max(1, self._ceil_div(rows, block_n))
+                tensor = tensor.narrow(0, start_blk, block_count).contiguous()
+            off_blk = offset // block_n
+            param.data[off_blk : off_blk + tensor.shape[0]].copy_(tensor)
+            self._mark_loaded((param_name, qkv_key))
+            return
+
+        if param.numel() == 1:
+            # Per-tensor scalar: collect per-shard scales now and merge in
+            # process_weights_after_loading. Naive max-merge here is wrong for
+            # `weight_scale` because each q/k/v shard's fp8 weights are stored
+            # in the representation of its OWN ckpt scale; if the merged scale
+            # is the max across shards, the smaller-scale shards' fp8 values
+            # decode to magnitudes inflated by max/own — silently corrupt.
+            # The original loader's `merge_qkv_hf_fp8_with_scale` rescales each
+            # shard's weight to share max_scale; we mirror that in post-load.
+            val = float(tensor.flatten()[0].item())
+            if not hasattr(self, "_qkv_per_tensor_scales"):
+                self._qkv_per_tensor_scales = {}
+            self._qkv_per_tensor_scales.setdefault(param_name, {})[qkv_key] = val
+            self._mark_loaded((param_name, qkv_key))
+            return
+
+        # Per-channel along output dim: TP-slice and write into [offset:offset+size).
+        split = self._split_qkv(tensor, num_heads, self.head_dim)
+        if split.shape[0] != size:
+            raise ValueError(
+                f"Shape mismatch for QKV shard {self.prefix}.{param_name}/{qkv_key}: "
+                f"got dim-0={split.shape[0]}, expected {size}"
+            )
+        if split.dim() == 1 and param.dim() == 2:
+            split = split.view(-1, 1)
+        param.data[offset : offset + size].copy_(split)
+        self._mark_loaded((param_name, qkv_key))
+
+    def _required_load_keys(self):
+        base = LinearBase._required_load_keys(self)
+        shard_keys = ("q", "k", "v")
+        required = set()
+        for key in base:
+            direct_loaded = key in self._loaded_weight_keys
+            qkv_required = {(key, shard) for shard in shard_keys}
+            if direct_loaded or qkv_required.issubset(self._loaded_weight_keys):
+                continue
+            required.update(qkv_required)
+        return required
+
+    def process_weights_after_loading(self):
+        # Merge per-tensor q/k/v scales and rescale fp8 weights so all three
+        # shards share the same final scale. Must run BEFORE the quant_method
+        # post-load hook (which may rebind weight/scale Parameters and freeze
+        # dtypes), so we override here instead of letting LinearBase handle it.
+        if getattr(self, "_post_load_done", False):
+            return
+        self._check_load_complete()
+        self._merge_qkv_per_tensor_scales()
+        self.quant_method.process_weights_after_loading(self)
+        self._post_load_done = True
+
+    def _merge_qkv_per_tensor_scales(self):
+        scales_by_param = getattr(self, "_qkv_per_tensor_scales", None)
+        if not scales_by_param:
+            return
+
+        for param_name, scales in scales_by_param.items():
+            param = getattr(self, param_name, None)
+            if param is None or param.numel() != 1:
+                continue
+            max_scale = max(scales.values())
+            param.data.fill_(max_scale)
+            # input_scale doesn't index into self.weight; only weight_scale
+            # requires per-shard fp8 rescale.
+            if param_name != "weight_scale":
+                continue
+            for qkv_key, scale_val in scales.items():
+                if scale_val == max_scale:
+                    continue
+                offset, size = self._qkv_shard_offset_size(qkv_key)
+                weight_slice = self.weight.data[offset : offset + size]
+                ratio = scale_val / max_scale
+                rescaled = (weight_slice.float() * ratio).to(weight_slice.dtype)
+                self.weight.data[offset : offset + size].copy_(rescaled)
+
+        del self._qkv_per_tensor_scales
+
+    def _qkv_shard_offset_size(self, qkv_key: str):
+        if qkv_key == "q":
+            return 0, self.q_size
+        if qkv_key == "k":
+            return self.q_size, self.kv_size
+        return self.q_size + self.kv_size, self.kv_size
+
+    def _split_qkv(
+        self, tensor: torch.Tensor, num_heads: int, head_dim: int
+    ) -> torch.Tensor:
+        if self.tp_size <= 1:
+            return tensor
+        if num_heads < self.tp_size:
+            # GQA/MQA: there are fewer KV heads than TP ranks. Replicate heads
+            # across ranks by cycling instead of slicing past the checkpoint tensor.
+            start = (self.tp_rank % num_heads) * head_dim
+            return tensor.narrow(0, start, head_dim).contiguous()
+        heads_per_partition = num_heads // self.tp_size
+        size_per_partition = heads_per_partition * head_dim
+        start = self.tp_rank * size_per_partition
+        return tensor.narrow(0, start, size_per_partition).contiguous()

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -238,6 +238,14 @@ class ColumnParallelLinear(LinearBase):
                     tensor = self._split_weight(tensor, dim=0)
             elif param_name == "weight_scale_inv":
                 if self.tp_size > 1:
+                    block_n, _ = self._fp8_scale_block_size()
+                    start = self.tp_rank * self.output_size_per_partition
+                    self._check_fp8_block_aligned(
+                        start,
+                        self.output_size_per_partition,
+                        block_n,
+                        f"FP8 block ColumnParallel scale {self.prefix}",
+                    )
                     tensor = self._split_weight(tensor, dim=0)
             elif param_name in ("scales", "zeros"):
                 if (
@@ -368,6 +376,14 @@ class RowParallelLinear(LinearBase):
                     tensor = self._split_weight(tensor, dim=-1)
             elif param_name == "weight_scale_inv":
                 if self.tp_size > 1:
+                    _, block_k = self._fp8_scale_block_size()
+                    start = self.tp_rank * self.input_size_per_partition
+                    self._check_fp8_block_aligned(
+                        start,
+                        self.input_size_per_partition,
+                        block_k,
+                        f"FP8 block RowParallel scale {self.prefix}",
+                    )
                     tensor = self._split_weight(tensor, dim=1)
             elif param_name == "g_idx":
                 if self.tp_size > 1:

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -7,6 +7,22 @@ from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, al
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig, QuantizeMethodBase
 
 
+def _weight_name_segments(weight_name: str, prefix: str) -> List[str]:
+    segments = [segment for segment in weight_name.split(".") if segment]
+    prefix_segments = [segment for segment in prefix.split(".") if segment]
+    if prefix_segments and segments[: len(prefix_segments)] == prefix_segments:
+        return segments[len(prefix_segments) :]
+    return segments
+
+
+def _find_shard_segment(weight_name: str, prefix: str, shard_names: List[str]) -> int:
+    segments = _weight_name_segments(weight_name, prefix)
+    for idx, shard_name in enumerate(shard_names):
+        if shard_name in segments:
+            return idx
+    return -1
+
+
 class LinearBase(nn.Module):
 
     # FP8 per-block (DeepSeek-style) quantization block size, used when
@@ -647,10 +663,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 weight_slice.copy_(rescaled)
 
     def _get_shard_id(self, weight_name: str) -> int:
-        for idx, shard_name in enumerate(self.shard_names):
-            if shard_name in weight_name:
-                return idx
-        return -1
+        return _find_shard_segment(weight_name, self.prefix, self.shard_names)
 
     def _merged_shard_weight_slice(self, shard_id: int, shard_size: int) -> torch.Tensor:
         offset = shard_id * shard_size
@@ -745,11 +758,12 @@ class QKVParallelLinear(ColumnParallelLinear):
                 continue
 
             qkv_key = None
-            if "q_proj" in full_name:
+            qkv_shard_id = _find_shard_segment(full_name, self.prefix, self.shard_names)
+            if qkv_shard_id == 0:
                 qkv_key = "q"
-            elif "k_proj" in full_name:
+            elif qkv_shard_id == 1:
                 qkv_key = "k"
-            elif "v_proj" in full_name:
+            elif qkv_shard_id == 2:
                 qkv_key = "v"
 
             if qkv_key is None:

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -368,7 +368,19 @@ class RowParallelLinear(LinearBase):
 
             if param_name == "weight":
                 tensor = self._split_weight(tensor, dim=1)
-            elif param_name in ("weight_scale", "input_scale"):
+            elif param_name == "weight_scale":
+                # RowParallel splits the input/K axis. Per-output-channel weight
+                # scales ([N] or [N, 1]) are tied to the output axis and must be
+                # replicated on every rank, even when N happens to equal global K.
+                if tensor.dim() == 1:
+                    tensor = tensor.reshape(-1, 1).contiguous()
+                elif (
+                    tensor.dim() > 1
+                    and tensor.shape[-1] == self.input_size_per_partition * self.tp_size
+                    and tensor.shape[0] != self.output_size
+                ):
+                    tensor = self._split_weight(tensor, dim=-1)
+            elif param_name == "input_scale":
                 if (
                     tensor.numel() > 1
                     and tensor.shape[-1] == self.input_size_per_partition * self.tp_size

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -701,21 +702,29 @@ class QKVParallelLinear(ColumnParallelLinear):
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
 
+        if num_heads <= 0 or num_kv_heads <= 0 or head_dim <= 0:
+            raise ValueError(
+                f"QKVParallelLinear requires positive head counts and head_dim, got "
+                f"num_heads={num_heads}, num_kv_heads={num_kv_heads}, "
+                f"head_dim={head_dim}, prefix={prefix!r}"
+            )
         if num_heads % tp_size != 0:
             raise ValueError(
                 f"QKVParallelLinear requires num_heads ({num_heads}) to be "
                 f"divisible by tp_size ({tp_size}) for prefix={prefix!r}"
             )
-        if num_kv_heads >= tp_size and num_kv_heads % tp_size != 0:
+
+        self.kv_tp_size = math.gcd(num_kv_heads, tp_size)
+        if self.kv_tp_size <= 0 or num_kv_heads % self.kv_tp_size != 0:
             raise ValueError(
-                f"QKVParallelLinear requires num_kv_heads ({num_kv_heads}) to be "
-                f"divisible by tp_size ({tp_size}) when num_kv_heads >= tp_size "
-                f"for prefix={prefix!r}; non-divisible grouped KV sharding is not "
-                "implemented in newloader yet"
+                f"QKVParallelLinear cannot form a valid KV TP group for "
+                f"num_kv_heads={num_kv_heads}, tp_size={tp_size}, prefix={prefix!r}"
             )
+        self.kv_replication_group_size = tp_size // self.kv_tp_size
+        self.kv_tp_rank = tp_rank // self.kv_replication_group_size
 
         self.num_heads_per_partition = num_heads // tp_size
-        self.num_kv_heads_per_partition = max(1, num_kv_heads // tp_size)
+        self.num_kv_heads_per_partition = num_kv_heads // self.kv_tp_size
 
         self.q_size = self.num_heads_per_partition * head_dim
         self.kv_size = self.num_kv_heads_per_partition * head_dim
@@ -767,33 +776,110 @@ class QKVParallelLinear(ColumnParallelLinear):
                 qkv_key = "v"
 
             if qkv_key is None:
-                # Non-q/k/v param (e.g. an already-merged ckpt or auxiliary
-                # tensor that maps directly onto a self.* param).
-                if param_name == "weight":
-                    self.weight.data.copy_(self._split_weight(tensor, dim=0))
-                    self._mark_loaded("weight")
-                else:
-                    param = getattr(self, param_name, None)
-                    if isinstance(param, nn.Parameter) and tensor.shape == param.shape:
-                        param.data.copy_(tensor)
-                        self._mark_loaded(param_name)
+                if self._dispatch_fused_qkv_param(param_name, tensor):
+                    continue
+                param = getattr(self, param_name, None)
+                if isinstance(param, nn.Parameter) and tensor.shape == param.shape:
+                    param.data.copy_(tensor)
+                    self._mark_loaded(param_name)
                 continue
 
             self._dispatch_qkv_shard(qkv_key, param_name, tensor)
 
-    def _dispatch_qkv_shard(self, qkv_key: str, param_name: str, tensor: torch.Tensor):
-        """Write a single q/k/v shard into the merged parameter at its offset."""
-        # Resolve per-shard size and offset in the merged QKV layout.
+    def _qkv_partition(self, qkv_key: str):
         if qkv_key == "q":
-            num_heads, size, offset = self.num_heads, self.q_size, 0
-        elif qkv_key == "k":
-            num_heads, size, offset = self.num_kv_heads, self.kv_size, self.q_size
-        else:  # "v"
-            num_heads, size, offset = (
+            return self.num_heads, self.q_size, 0, self.tp_size, self.tp_rank
+        if qkv_key == "k":
+            return (
+                self.num_kv_heads,
+                self.kv_size,
+                self.q_size,
+                self.kv_tp_size,
+                self.kv_tp_rank,
+            )
+        if qkv_key == "v":
+            return (
                 self.num_kv_heads,
                 self.kv_size,
                 self.q_size + self.kv_size,
+                self.kv_tp_size,
+                self.kv_tp_rank,
             )
+        raise ValueError(f"Unknown QKV shard key {qkv_key!r}")
+
+    def _split_fused_qkv_tensor(self, param_name: str, tensor: torch.Tensor):
+        q_rows = self.num_heads * self.head_dim
+        kv_rows = self.num_kv_heads * self.head_dim
+        if param_name in ("qweight", "qzeros", "scales"):
+            pf = 1 if param_name == "scales" else getattr(self.quant_method, "PACK_FACTOR", 8)
+            q_cols = q_rows // pf
+            kv_cols = kv_rows // pf
+            if tensor.dim() < 2 or tensor.shape[1] != q_cols + 2 * kv_cols:
+                return None
+            q = tensor.narrow(1, 0, q_cols)
+            k = tensor.narrow(1, q_cols, kv_cols)
+            v = tensor.narrow(1, q_cols + kv_cols, kv_cols)
+            return {"q": q, "k": k, "v": v}
+        if param_name == "weight_scale_inv":
+            block_n, _ = self._fp8_scale_block_size()
+            self._check_fp8_block_aligned(0, q_rows, block_n, f"FP8 block fused QKV scale {self.prefix}.q")
+            self._check_fp8_block_aligned(q_rows, kv_rows, block_n, f"FP8 block fused QKV scale {self.prefix}.k")
+            self._check_fp8_block_aligned(q_rows + kv_rows, kv_rows, block_n, f"FP8 block fused QKV scale {self.prefix}.v")
+            q_blocks = q_rows // block_n
+            kv_blocks = kv_rows // block_n
+            if tensor.shape[0] != q_blocks + 2 * kv_blocks:
+                return None
+            q = tensor.narrow(0, 0, q_blocks)
+            k = tensor.narrow(0, q_blocks, kv_blocks)
+            v = tensor.narrow(0, q_blocks + kv_blocks, kv_blocks)
+            return {"q": q, "k": k, "v": v}
+        total_rows = q_rows + 2 * kv_rows
+        if tensor.shape[0] != total_rows:
+            return None
+        q = tensor.narrow(0, 0, q_rows)
+        k = tensor.narrow(0, q_rows, kv_rows)
+        v = tensor.narrow(0, q_rows + kv_rows, kv_rows)
+        return {"q": q, "k": k, "v": v}
+
+    def _dispatch_fused_qkv_param(self, param_name: str, tensor: torch.Tensor) -> bool:
+        if param_name in ("weight_scale", "input_scale") and tensor.numel() == 1:
+            param = getattr(self, param_name, None)
+            if isinstance(param, nn.Parameter) and param.numel() == 1:
+                param.data.copy_(tensor.view_as(param))
+                self._mark_loaded(param_name)
+                return True
+
+        param = getattr(self, param_name, None)
+        if (
+            param_name == "weight_scale_inv"
+            and isinstance(param, nn.Parameter)
+            and tensor.shape == param.shape
+            and self.tp_size == 1
+        ):
+            param.data.copy_(tensor)
+            self._mark_loaded(param_name)
+            return True
+
+        if param_name not in (
+            "weight",
+            "bias",
+            "weight_scale",
+            "weight_scale_inv",
+            "qweight",
+            "qzeros",
+            "scales",
+        ):
+            return False
+        parts = self._split_fused_qkv_tensor(param_name, tensor)
+        if parts is None:
+            return False
+        for qkv_key, part in parts.items():
+            self._dispatch_qkv_shard(qkv_key, param_name, part.contiguous())
+        return True
+
+    def _dispatch_qkv_shard(self, qkv_key: str, param_name: str, tensor: torch.Tensor):
+        """Write a single q/k/v shard into the merged parameter at its offset."""
+        num_heads, size, offset, partition_world, partition_rank = self._qkv_partition(qkv_key)
 
         if param_name in ("qweight", "qzeros", "scales"):
             # AWQ(w4a16):输出维是 dim1;qweight/qzeros 以 pack_factor 压缩。
@@ -808,8 +894,8 @@ class QKVParallelLinear(ColumnParallelLinear):
             )
             cols = size // pf
             off_cols = offset // pf
-            if self.tp_size > 1 and tensor.shape[1] == cols * self.tp_size:
-                start = self.tp_rank * cols
+            if partition_world > 1 and tensor.shape[1] == cols * partition_world:
+                start = partition_rank * cols
                 tensor = tensor.narrow(1, start, cols).contiguous()
             if tensor.shape[1] != cols:
                 raise ValueError(
@@ -821,8 +907,14 @@ class QKVParallelLinear(ColumnParallelLinear):
             return
 
         if param_name == "weight":
-            split = self._split_qkv(tensor, num_heads, self.head_dim)
+            split = self._split_qkv(tensor, qkv_key)
             if (
+                split.dim() == 2
+                and self.weight.shape[0] >= offset + size
+                and self.weight.shape[1] == split.shape[1]
+            ):
+                self.weight.data[offset : offset + size].copy_(split)
+            elif (
                 split.dim() == 2
                 and self.weight.shape[0] == split.shape[1]
                 and self.weight.shape[1] >= offset + size
@@ -831,14 +923,18 @@ class QKVParallelLinear(ColumnParallelLinear):
                     split.t().contiguous()
                 )
             else:
-                self.weight.data[offset : offset + size].copy_(split)
+                raise ValueError(
+                    f"Shape mismatch for QKV {self.prefix}.weight/{qkv_key}: "
+                    f"weight shape={tuple(self.weight.shape)}, split shape={tuple(split.shape)}, "
+                    f"offset={offset}, size={size}"
+                )
             self._mark_loaded(("weight", qkv_key))
             return
 
         if param_name == "bias":
             if self.bias is None:
                 return
-            split = self._split_qkv(tensor, num_heads, self.head_dim)
+            split = self._split_qkv(tensor, qkv_key)
             self.bias.data[offset : offset + size].copy_(split)
             self._mark_loaded(("bias", qkv_key))
             return
@@ -863,14 +959,9 @@ class QKVParallelLinear(ColumnParallelLinear):
                 f"FP8 block QKV scale {self.prefix}.{qkv_key}",
             )
             expected_blocks = size // block_n
-            if self.tp_size > 1:
-                if num_heads < self.tp_size:
-                    start_row = (self.tp_rank % num_heads) * self.head_dim
-                    rows = self.head_dim
-                else:
-                    heads_pp = num_heads // self.tp_size
-                    rows = heads_pp * self.head_dim
-                    start_row = self.tp_rank * rows
+            if partition_world > 1:
+                rows = size
+                start_row = partition_rank * rows
                 self._check_fp8_block_aligned(
                     start_row,
                     rows,
@@ -908,7 +999,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             return
 
         # Per-channel along output dim: TP-slice and write into [offset:offset+size).
-        split = self._split_qkv(tensor, num_heads, self.head_dim)
+        split = self._split_qkv(tensor, qkv_key)
         if split.shape[0] != size:
             raise ValueError(
                 f"Shape mismatch for QKV shard {self.prefix}.{param_name}/{qkv_key}: "
@@ -976,17 +1067,18 @@ class QKVParallelLinear(ColumnParallelLinear):
             return self.q_size, self.kv_size
         return self.q_size + self.kv_size, self.kv_size
 
-    def _split_qkv(
-        self, tensor: torch.Tensor, num_heads: int, head_dim: int
-    ) -> torch.Tensor:
-        if self.tp_size <= 1:
+    def _split_qkv(self, tensor: torch.Tensor, qkv_key: str) -> torch.Tensor:
+        num_heads, size_per_partition, _, partition_world, partition_rank = self._qkv_partition(qkv_key)
+        if partition_world <= 1:
             return tensor
-        if num_heads < self.tp_size:
-            # GQA/MQA: there are fewer KV heads than TP ranks. Replicate heads
-            # across ranks by cycling instead of slicing past the checkpoint tensor.
-            start = (self.tp_rank % num_heads) * head_dim
-            return tensor.narrow(0, start, head_dim).contiguous()
-        heads_per_partition = num_heads // self.tp_size
-        size_per_partition = heads_per_partition * head_dim
-        start = self.tp_rank * size_per_partition
+        if tensor.shape[0] == size_per_partition:
+            return tensor
+        full_size = num_heads * self.head_dim
+        if tensor.shape[0] != full_size:
+            raise ValueError(
+                f"Shape mismatch for QKV shard {self.prefix}.{qkv_key}: "
+                f"got dim-0={tensor.shape[0]}, expected local {size_per_partition} "
+                f"or full {full_size}"
+            )
+        start = partition_rank * size_per_partition
         return tensor.narrow(0, start, size_per_partition).contiguous()

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -88,14 +88,24 @@ class BaseMoEExperts(nn.Module):
         moe_config: Any,
         quant_config: Optional[QuantizationConfig],
         layer_idx: int,
+        prefix: Optional[str] = None,
     ):
         super().__init__()
+        self.prefix = prefix or f"model.layers.{layer_idx}.mlp.experts"
 
-        # Resolve quant family from quant_config.
+        # Resolve quant family from quant_config. Ignored layers must use the
+        # unquantized method and must not require quantization auxiliary tensors.
+        ignored_by_quant_config = bool(
+            quant_config is not None and quant_config.is_layer_ignored(self.prefix)
+        )
         raw_qt = (
-            getattr(quant_config, "quant_type", "none")
-            if quant_config is not None
-            else "none"
+            "none"
+            if ignored_by_quant_config
+            else (
+                getattr(quant_config, "quant_type", "none")
+                if quant_config is not None
+                else "none"
+            )
         )
         full_map = {**self._BASE_QUANT_MAP, **self._EXTRA_QUANT_MAP}
         self._quant_family = full_map.get(raw_qt, "none")
@@ -170,7 +180,9 @@ class BaseMoEExperts(nn.Module):
         # methods own quantized loading. The built-in fallback is kept only for
         # unquantized weights when no method is registered.
         self.quant_method = (
-            quant_config.get_quant_method(self) if quant_config is not None else None
+            quant_config.get_quant_method(self, self.prefix)
+            if quant_config is not None
+            else None
         )
         if self.quant_method is None and self._quant_family != "none":
             raise ValueError(

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -277,10 +277,10 @@ class BaseMoEExperts(nn.Module):
             parts = name.split(".")
             base = parts[0]
             if base in ("gate_up_proj", "down_proj") and hasattr(tensor, "dim"):
-                if tensor.dim() == 3 and len(parts) == 1:
+                if tensor.dim() == 3 and (len(parts) == 1 or (len(parts) == 2 and parts[1] == "weight")):
                     self._load_stacked_experts(base, tensor)
                     continue
-                if len(parts) == 2 and tensor.shape[0] == self.num_experts:
+                if len(parts) == 2 and parts[1] != "weight" and tensor.shape[0] == self.num_experts:
                     self._load_stacked_expert_aux(base, parts[1], tensor)
                     continue
             if len(parts) < 3:

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -482,8 +482,16 @@ class BaseMoEExperts(nn.Module):
 
         if param_name == "weight_scale_inv" and self._quant_family == "fp8_per_block":
             nb = getattr(self, "_n_scale_blocks_per_proj", None)
-            if nb is not None and tensor.shape[0] == 2 * nb:
-                return tensor[:nb].contiguous(), tensor[nb:].contiguous()
+            if nb is not None:
+                if tensor.shape[0] == 2 * nb:
+                    return tensor[:nb].contiguous(), tensor[nb:].contiguous()
+                if tensor.dim() >= 2 and tensor.shape[-1] == 2 * nb:
+                    gate = tensor.narrow(-1, 0, nb).contiguous()
+                    up = tensor.narrow(-1, nb, nb).contiguous()
+                    if gate.dim() == 2:
+                        gate = gate.t().contiguous()
+                        up = up.t().contiguous()
+                    return gate, up
 
         raise ValueError(
             f"gate_up_proj.{param_name} shape "

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -1,0 +1,718 @@
+"""Base class for stacked-expert MoE modules with EP/TP support.
+
+Provides common logic for:
+  - EP parameter computation (num_local_experts, expert id remapping)
+  - TP slicing of per-expert projections
+  - Buffer allocation for w13 (up+gate fused) and w2 (down)
+  - Streaming weight dispatch from per-expert HF checkpoint tensors
+  - Delegation to registered MoE quantization methods
+  - FusedMoe construction via FusedMoeFactory
+
+Quantized MoE families are implemented by registered QuantizeMethodBase
+instances; this base class keeps only the unquantized fallback.
+"""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.device import get_current_device
+from rtp_llm.models_py.modules import FusedMoeFactory
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.utils.model_weight import W
+
+logger = logging.getLogger(__name__)
+
+
+class BaseMoEExperts(nn.Module):
+    """Stacked-expert MLP backed by FusedMoeFactory.
+
+    w13 layout: [E, 2*M_tp, H]
+        first half ([:M_tp])  = up_proj
+        second half ([M_tp:]) = gate_proj
+    w2 layout:  [E, H, M_tp]
+        down_proj
+
+    This matches Qwen3.5 old loader's stack_moe_w1 input order:
+    CkptWeightInfo lists up_proj first and gate_proj second, so the fused
+    tensor is concat([up, gate], dim=1).
+
+    Quantized MoE loading is delegated to registered methods (for example
+    Fp8MoEMethod and W4A8Int4MoEMethod). This class owns the shared EP/TP
+    routing and the unquantized fallback only.
+    """
+
+    # Subclasses should list the HF projection names they expect.
+    PROJ_NAMES: Tuple[str, ...] = ("gate_proj", "up_proj", "down_proj")
+
+    # Quant type string -> family. Registered MoE quant methods own the actual
+    # quantized buffer allocation/dispatch/postprocess; this map is used for
+    # diagnostics and for fail-fast if a quant family is not registered.
+    _BASE_QUANT_MAP = {
+        # already-quantized FP8 ckpts (weight is fp8 + ckpt has weight_scale)
+        "FP8_PER_TENSOR_COMPRESSED": "fp8_per_tensor",
+        "FP8_DYNAMIC_PER_TENSOR": "fp8_per_tensor",
+        "fp8": "fp8_per_tensor",
+        "FP8_PER_BLOCK": "fp8_per_block",
+        "fp8_block": "fp8_per_block",
+        "FP8_PER_CHANNEL_COMPRESSED": "fp8_per_channel",
+        "fp8_per_channel": "fp8_per_channel",
+        "FP8_PER_CHANNEL_QUARK": "fp8_per_channel",
+        # BF16/FP16 ckpts that get quantized at load time
+        "fp8_online": "fp8_per_tensor_online",
+        "fp8_block_online": "fp8_per_block_online",
+        "fp8_per_channel_online": "fp8_per_channel_online",
+        "W4A8_INT4_PER_CHANNEL": "w4a8_int4_per_channel_online",
+        "W4A8_INT4_PER_CHANNEL_COMPRESSED": "w4a8_int4_per_channel_compressed",
+    }
+    _EXTRA_QUANT_MAP: Dict[str, str] = {}
+    _FP8_BLOCK_SIZE = 128
+
+    def __init__(
+        self,
+        num_experts: int,
+        hidden_size: int,
+        moe_intermediate_size: int,
+        tp_size: int,
+        tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        params_dtype: torch.dtype,
+        model_config: Any,
+        parallelism_config: Any,
+        moe_config: Any,
+        quant_config: Optional[QuantizationConfig],
+        layer_idx: int,
+    ):
+        super().__init__()
+
+        # Resolve quant family from quant_config.
+        raw_qt = (
+            getattr(quant_config, "quant_type", "none")
+            if quant_config is not None
+            else "none"
+        )
+        full_map = {**self._BASE_QUANT_MAP, **self._EXTRA_QUANT_MAP}
+        self._quant_family = full_map.get(raw_qt, "none")
+        if layer_idx == 0:
+            logger.info(
+                "[BaseMoEExperts] layer_idx=%d resolved raw_qt=%r -> "
+                "_quant_family=%r (num_experts=%d, hidden=%d, "
+                "moe_inter=%d, tp=%d, ep=%d)",
+                layer_idx,
+                raw_qt,
+                self._quant_family,
+                num_experts,
+                hidden_size,
+                moe_intermediate_size,
+                tp_size,
+                ep_size,
+            )
+
+        if ep_size <= 0:
+            raise ValueError(f"ep_size must be positive, got {ep_size}")
+        if ep_rank < 0 or ep_rank >= ep_size:
+            raise ValueError(
+                f"ep_rank must satisfy 0 <= ep_rank < ep_size, got "
+                f"ep_rank={ep_rank}, ep_size={ep_size}"
+            )
+        if num_experts < 0:
+            raise ValueError(f"num_experts must be non-negative, got {num_experts}")
+        if num_experts != 0 and num_experts % ep_size != 0:
+            raise ValueError(
+                f"num_experts ({num_experts}) must be divisible by ep_size ({ep_size}) "
+                "to avoid silently dropping experts during EP loading."
+            )
+
+        # Match old loader's moe_pure_tp_mode: only shard expert intermediate
+        # dimensions when there is no EP/DP split. In EP all-gather topologies
+        # each rank owns a local expert subset and must keep those experts full.
+        dp_size = getattr(parallelism_config, "dp_size", 1)
+        self.moe_expert_tp_size = tp_size if ep_size == 1 and dp_size == 1 else 1
+        self.moe_expert_tp_rank = tp_rank if self.moe_expert_tp_size > 1 else 0
+        if moe_intermediate_size % self.moe_expert_tp_size != 0:
+            raise ValueError(
+                f"moe_intermediate_size {moe_intermediate_size} not divisible "
+                f"by moe_expert_tp_size {self.moe_expert_tp_size}"
+            )
+
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.moe_inter = moe_intermediate_size
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.layer_idx = layer_idx
+
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.moe_inter_tp = moe_intermediate_size // self.moe_expert_tp_size
+
+        # EP: compute local expert range
+        if ep_size > 1:
+            experts_per_rank = num_experts // ep_size
+            self._ep_start_expert = ep_rank * experts_per_rank
+            self.num_local_experts = experts_per_rank
+        else:
+            self._ep_start_expert = 0
+            self.num_local_experts = num_experts
+
+        self._model_config = model_config
+        self._parallelism_config = parallelism_config
+        self._moe_config = moe_config
+        self._quant_config = quant_config
+
+        # Unified dispatch (symmetric with LinearBase): registered MoE quant
+        # methods own quantized loading. The built-in fallback is kept only for
+        # unquantized weights when no method is registered.
+        self.quant_method = (
+            quant_config.get_quant_method(self) if quant_config is not None else None
+        )
+        if self.quant_method is None and self._quant_family != "none":
+            raise ValueError(
+                f"MoE quant family {self._quant_family!r} is not registered in "
+                "the newloader MoE quant-method registry; refusing to use the "
+                "legacy built-in FP8 fallback path."
+            )
+        if layer_idx == 0:
+            logger.info(
+                "[BaseMoEExperts] layer_idx=0 quant_method=%s "
+                "(None=unquantized fallback; otherwise method delegation)",
+                type(self.quant_method).__name__ if self.quant_method else None,
+            )
+
+        self._init_buffers(params_dtype)
+
+        self.fused_moe: Optional[nn.Module] = None
+        self._loaded_count = 0
+        self._expected_count = self.num_local_experts * len(self.PROJ_NAMES)
+        self._loaded_keys = set()
+        self._loaded_aux_keys = set()
+
+    # ------------------------------------------------------------------ #
+    #  Buffer allocation — override in subclass for quantization
+    # ------------------------------------------------------------------ #
+
+    def _init_buffers(self, params_dtype: torch.dtype):
+        """Allocate w13/w2 parameter buffers based on quantization family."""
+        if self.quant_method is not None:
+            # 委托给统一派发拿到的 MoE 量化方法（Step B 起 fp8 走这条）。
+            self.quant_method.create_weights(
+                self,
+                self.num_local_experts,
+                self.hidden_size,
+                self.moe_inter_tp,
+                params_dtype,
+            )
+            return
+        E = self.num_local_experts
+        M_tp = self.moe_inter_tp
+        H = self.hidden_size
+        qf = self._quant_family
+        if qf != "none":
+            raise ValueError(
+                f"MoE quant family {qf!r} must be handled by a registered "
+                "QuantizeMethodBase implementation."
+            )
+
+        # Unquantized BF16/FP16 fallback. Quantized MoE families are handled by
+        # registered methods such as Fp8MoEMethod/W4A8Int4MoEMethod; keeping a
+        # second built-in quantized implementation here would make the two paths
+        # drift silently.
+        self.w13 = nn.Parameter(
+            torch.empty(E, 2 * M_tp, H, dtype=params_dtype),
+            requires_grad=False,
+        )
+        self.w2 = nn.Parameter(
+            torch.empty(E, H, M_tp, dtype=params_dtype),
+            requires_grad=False,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  EP: expert id remapping
+    # ------------------------------------------------------------------ #
+
+    def _remap_expert_id(self, global_expert_id: int) -> Optional[int]:
+        """Map global expert id to local buffer index.  Returns None if out of range."""
+        local_id = global_expert_id - self._ep_start_expert
+        if 0 <= local_id < self.num_local_experts:
+            return local_id
+        return None
+
+    # ------------------------------------------------------------------ #
+    #  Weight loading: streaming dispatch
+    # ------------------------------------------------------------------ #
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        """Parse per-expert HF weight names and dispatch to copy helpers.
+
+        Expected name format: ``{expert_id}.{proj_name}.{param_name}``
+        e.g. ``65.gate_proj.weight``, ``65.gate_proj.weight_scale``.
+        """
+        for name, tensor in weights.items():
+            # Stacked (fused-experts) ckpt format: a single 3D tensor holds all
+            # experts, e.g. Qwen3-VL-MoE ships ``experts.gate_up_proj`` [E,H,2M]
+            # and ``experts.down_proj`` [E,M,H]. Split per-expert and reuse the
+            # per-expert copy helpers (which do TP-slice + EP remap).
+            parts = name.split(".")
+            base = parts[0]
+            if base in ("gate_up_proj", "down_proj") and hasattr(tensor, "dim"):
+                if tensor.dim() == 3 and len(parts) == 1:
+                    self._load_stacked_experts(base, tensor)
+                    continue
+                if len(parts) == 2 and tensor.shape[0] == self.num_experts:
+                    self._load_stacked_expert_aux(base, parts[1], tensor)
+                    continue
+            if len(parts) < 3:
+                continue
+            try:
+                global_expert_id = int(parts[0])
+            except ValueError:
+                continue
+
+            local_expert_id = self._remap_expert_id(global_expert_id)
+            if local_expert_id is None:
+                continue
+
+            proj = parts[1]
+            param_name = parts[2]
+
+            if self.quant_method is not None and self.quant_method.dispatch_weight(
+                self, local_expert_id, proj, param_name, tensor
+            ):
+                self._loaded_count += 1
+                if proj in self.PROJ_NAMES:
+                    self._loaded_keys.add((local_expert_id, proj))
+                continue
+
+            if param_name == "weight":
+                if proj == "gate_up_proj":
+                    self._dispatch_gate_up_weight(local_expert_id, tensor)
+                    continue
+                # Log first weight tensor we see, for diagnostics.
+                if self.layer_idx == 0 and not getattr(
+                    self, "_logged_first_weight", False
+                ):
+                    logger.info(
+                        "[BaseMoEExperts] layer_idx=0 first weight: "
+                        "name=%r proj=%r dtype=%s shape=%s buf_dtype=%s "
+                        "buf_shape=%s _quant_family=%r",
+                        name,
+                        proj,
+                        tensor.dtype,
+                        tuple(tensor.shape),
+                        self.w13.dtype if proj != "down_proj" else self.w2.dtype,
+                        tuple(self.w13.shape if proj != "down_proj" else self.w2.shape),
+                        self._quant_family,
+                    )
+                    self._logged_first_weight = True
+                self._dispatch_weight(local_expert_id, proj, tensor)
+            else:
+                if proj == "gate_up_proj":
+                    if param_name == "weight_packed":
+                        self._dispatch_gate_up_quant_weight(
+                            local_expert_id, param_name, tensor
+                        )
+                    elif param_name in ("weight_scale", "weight_scale_inv"):
+                        self._dispatch_gate_up_scale(local_expert_id, param_name, tensor)
+                    else:
+                        raise RuntimeError(
+                            f"Unexpected gate_up_proj auxiliary tensor: "
+                            f"expert={local_expert_id} param={param_name!r}"
+                        )
+                    continue
+                # Log first scale tensor we see, for diagnostics.
+                if self.layer_idx == 0 and not getattr(
+                    self, "_logged_first_scale", False
+                ):
+                    logger.info(
+                        "[BaseMoEExperts] layer_idx=0 first non-weight tensor: "
+                        "name=%r proj=%r param=%r dtype=%s shape=%s "
+                        "_quant_family=%r",
+                        name,
+                        proj,
+                        param_name,
+                        tensor.dtype,
+                        tuple(tensor.shape),
+                        self._quant_family,
+                    )
+                    self._logged_first_scale = True
+                self._dispatch_scale(local_expert_id, proj, param_name, tensor)
+
+    def _load_stacked_expert_aux(self, base: str, param_name: str, tensor: torch.Tensor):
+        for g in range(tensor.shape[0]):
+            local_id = self._remap_expert_id(g)
+            if local_id is None:
+                continue
+            if base == "gate_up_proj":
+                self._dispatch_gate_up_scale(local_id, param_name, tensor[g])
+            else:
+                self._dispatch_scale(local_id, "down_proj", param_name, tensor[g])
+
+    def _load_stacked_experts(self, base: str, tensor: torch.Tensor):
+        """Load a stacked fused-experts tensor (one 3D tensor for all experts).
+
+        Layouts (HF Qwen3-VL-MoE, [E, in, out]):
+          * ``gate_up_proj``: [E, H, 2M]，最后一维 2M = [gate(M) | up(M)]。
+            每个专家转置 + 切 gate/up，得到 per-expert [M, H]，复用 ``_copy_gate_or_up``
+            (Qwen3.5 split expert 旧 loader 的 w13 顺序是 up 在前、gate 在后)。
+          * ``down_proj``: [E, M, H]，转置成 [H, M] 复用 ``_copy_down``。
+        ``_copy_*`` 内部负责 TP 切分；``_remap_expert_id`` 负责 EP 选本地专家。
+        """
+        E = tensor.shape[0]
+        if base == "gate_up_proj":
+            M = self.moe_inter
+            for g in range(E):
+                local_id = self._remap_expert_id(g)
+                if local_id is None:
+                    continue
+                e = tensor[g]  # [H, 2M]
+                if e.shape == (self.hidden_size, 2 * M):
+                    # Qwen3-VL-MoE layout: [H, 2M] = [gate | up].
+                    gate_e = e[:, :M].t().contiguous()  # [M, H]
+                    up_e = e[:, M:].t().contiguous()  # [M, H]
+                elif e.shape == (2 * M, self.hidden_size):
+                    # Qwen3.5 BF16 layout: [2M, H] = [gate | up].
+                    gate_e = e[:M, :].contiguous()
+                    up_e = e[M:, :].contiguous()
+                else:
+                    raise ValueError(
+                        f"stacked gate_up_proj expert {g} shape {tuple(e.shape)} "
+                        f"does not match [H,2M]=({self.hidden_size},{2 * M}) "
+                        f"or [2M,H]=({2 * M},{self.hidden_size})"
+                    )
+                self._copy_gate_or_up(local_id, gate_e, gate=True)
+                self._copy_gate_or_up(local_id, up_e, gate=False)
+                self._loaded_count += 2
+                self._loaded_keys.add((local_id, "gate_proj"))
+                self._loaded_keys.add((local_id, "up_proj"))
+        else:  # down_proj
+            for g in range(E):
+                local_id = self._remap_expert_id(g)
+                if local_id is None:
+                    continue
+                e = tensor[g]
+                if e.shape == (self.moe_inter, self.hidden_size):
+                    d = e.t().contiguous()  # [M, H] -> [H, M]
+                elif e.shape == (self.hidden_size, self.moe_inter):
+                    d = e.contiguous()
+                else:
+                    raise ValueError(
+                        f"stacked down_proj expert {g} shape {tuple(e.shape)} "
+                        f"does not match [M,H]=({self.moe_inter},{self.hidden_size}) "
+                        f"or [H,M]=({self.hidden_size},{self.moe_inter})"
+                    )
+                self._copy_down(local_id, d)
+                self._loaded_count += 1
+                self._loaded_keys.add((local_id, "down_proj"))
+
+    def _split_gate_up_rows(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        M = self.moe_inter
+        if tensor.shape[0] == 2 * M:
+            return tensor[:M].contiguous(), tensor[M:].contiguous()
+        if tensor.dim() >= 2 and tensor.shape[-2] == 2 * M:
+            return (
+                tensor.narrow(-2, 0, M).contiguous(),
+                tensor.narrow(-2, M, M).contiguous(),
+            )
+        raise ValueError(
+            f"gate_up_proj.{param_name} shape {tuple(tensor.shape)} cannot be "
+            f"split into gate/up rows with moe_intermediate_size={M}"
+        )
+
+    def _dispatch_gate_up_quant_weight(
+        self, local_id: int, param_name: str, tensor: torch.Tensor
+    ):
+        gate, up = self._split_gate_up_rows(param_name, tensor)
+        if self.quant_method is None:
+            raise RuntimeError(
+                f"Unexpected gate_up_proj.{param_name} without a MoE quant method"
+            )
+        gate_done = self.quant_method.dispatch_weight(
+            self, local_id, "gate_proj", param_name, gate
+        )
+        up_done = self.quant_method.dispatch_weight(
+            self, local_id, "up_proj", param_name, up
+        )
+        if not gate_done or not up_done:
+            raise RuntimeError(
+                f"MoE quant method did not handle gate_up_proj.{param_name}"
+            )
+        self._loaded_count += 2
+        self._loaded_keys.add((local_id, "gate_proj"))
+        self._loaded_keys.add((local_id, "up_proj"))
+
+    def _split_gate_up_aux_tensor(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if param_name == "weight_scale" and self._quant_family == "fp8_per_tensor":
+            flat = tensor.float().reshape(-1)
+            if flat.numel() == 1:
+                return flat[0:1], flat[0:1]
+            if flat.numel() == 2:
+                return flat[0:1], flat[1:2]
+
+        if param_name != "weight_scale_inv":
+            try:
+                return self._split_gate_up_rows(param_name, tensor)
+            except ValueError:
+                pass
+
+        if param_name == "weight_scale_inv" and self._quant_family == "fp8_per_block":
+            nb = getattr(self, "_n_scale_blocks_per_proj", None)
+            if nb is not None and tensor.shape[0] == 2 * nb:
+                return tensor[:nb].contiguous(), tensor[nb:].contiguous()
+
+        raise ValueError(
+            f"gate_up_proj.{param_name} shape "
+            f"{tuple(tensor.shape)} cannot be split into gate/up scales for "
+            f"quant family {self._quant_family!r}"
+        )
+
+    def _dispatch_gate_up_scale(
+        self, local_id: int, param_name: str, tensor: torch.Tensor
+    ):
+        gate, up = self._split_gate_up_aux_tensor(param_name, tensor)
+        self._dispatch_scale(local_id, "gate_proj", param_name, gate)
+        self._dispatch_scale(local_id, "up_proj", param_name, up)
+
+    def _dispatch_gate_up_weight(self, local_id: int, tensor: torch.Tensor):
+        M = self.moe_inter
+        if tensor.shape == (self.hidden_size, 2 * M):
+            gate = tensor[:, :M].t().contiguous()
+            up = tensor[:, M:].t().contiguous()
+        elif tensor.shape == (2 * M, self.hidden_size):
+            gate = tensor[:M, :].contiguous()
+            up = tensor[M:, :].contiguous()
+        else:
+            raise ValueError(
+                f"expert {local_id} gate_up_proj.weight shape {tuple(tensor.shape)} "
+                f"does not match [H,2M]=({self.hidden_size},{2 * M}) "
+                f"or [2M,H]=({2 * M},{self.hidden_size})"
+            )
+        self._copy_gate_or_up(local_id, gate, gate=True)
+        self._copy_gate_or_up(local_id, up, gate=False)
+        self._loaded_count += 2
+        self._loaded_keys.add((local_id, "gate_proj"))
+        self._loaded_keys.add((local_id, "up_proj"))
+
+    def _dispatch_weight(self, local_id: int, proj: str, tensor: torch.Tensor):
+        """Route a weight tensor to the correct buffer position."""
+        if proj == "gate_proj":
+            self._copy_gate_or_up(local_id, tensor, gate=True)
+            self._loaded_count += 1
+            self._loaded_keys.add((local_id, "gate_proj"))
+        elif proj == "up_proj":
+            self._copy_gate_or_up(local_id, tensor, gate=False)
+            self._loaded_count += 1
+            self._loaded_keys.add((local_id, "up_proj"))
+        elif proj == "down_proj":
+            if tensor.shape == (self.moe_inter, self.hidden_size):
+                tensor = tensor.t().contiguous()
+            self._copy_down(local_id, tensor)
+            self._loaded_count += 1
+            self._loaded_keys.add((local_id, "down_proj"))
+
+    def _dispatch_scale(
+        self, local_id: int, proj: str, param_name: str, tensor: torch.Tensor
+    ):
+        """Route a scale/meta tensor through the registered quant method."""
+        if self.quant_method is not None:
+            self.quant_method.dispatch_scale(self, local_id, proj, param_name, tensor)
+            if proj in self.PROJ_NAMES and self._is_required_aux_param(proj, param_name):
+                self._loaded_aux_keys.add((local_id, proj, param_name))
+            return
+        raise RuntimeError(
+            f"Unexpected MoE auxiliary tensor for unquantized fallback: "
+            f"expert={local_id} proj={proj!r} param={param_name!r}. Quantized "
+            "MoE checkpoints must be handled by a registered quant method."
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Weight copy helpers (TP slicing + buffer write)
+    # ------------------------------------------------------------------ #
+
+    def _copy_gate_or_up(self, expert_id: int, tensor: torch.Tensor, gate: bool):
+        """TP-slice a gate/up projection and write into w13 buffer.
+
+        up_proj   → first  half of w13 (rows [0:M_tp])
+        gate_proj → second half of w13 (rows [M_tp:2*M_tp])
+        """
+        tp_rows = self.w13.shape[1] // 2
+        full_rows = tp_rows * self.moe_expert_tp_size
+        if tensor.shape[0] != full_rows:
+            raise ValueError(
+                f"expert {expert_id} {'gate' if gate else 'up'}_proj.weight "
+                f"dim-0 {tensor.shape[0]} != expected {full_rows}"
+            )
+        start = self.moe_expert_tp_rank * tp_rows
+        sliced = tensor.narrow(0, start, tp_rows).contiguous()
+        row_start = tp_rows if gate else 0
+        self.w13.data[expert_id, row_start : row_start + tp_rows].copy_(sliced)
+
+    def _copy_down(self, expert_id: int, tensor: torch.Tensor):
+        """TP-slice a down projection and write into w2 buffer."""
+        tp_cols = self.w2.shape[2]
+        full_cols = tp_cols * self.moe_expert_tp_size
+        if tensor.shape[1] != full_cols:
+            raise ValueError(
+                f"expert {expert_id} down_proj.weight dim-1 {tensor.shape[1]} "
+                f"!= expected {full_cols}"
+            )
+        start = self.moe_expert_tp_rank * tp_cols
+        sliced = tensor.narrow(1, start, tp_cols).contiguous()
+        self.w2.data[expert_id].copy_(sliced)
+
+
+    def _required_aux_param_names(self):
+        qf = self._quant_family
+        if qf in ("fp8_per_tensor", "fp8_per_channel"):
+            return ("weight_scale",)
+        if qf == "fp8_per_block":
+            return ("weight_scale_inv",)
+        if qf == "w4a8_int4_per_channel_compressed":
+            return ("weight_scale",)
+        # Online quantization creates scales during post-load; unquantized has no aux tensors.
+        return ()
+
+    def _is_required_aux_param(self, proj: str, param_name: str) -> bool:
+        return param_name in self._required_aux_param_names()
+
+    def _check_load_complete(self):
+        expected = {
+            (expert_id, proj)
+            for expert_id in range(self.num_local_experts)
+            for proj in self.PROJ_NAMES
+        }
+        missing = sorted(expected - self._loaded_keys)
+        if missing:
+            sample = missing[:10]
+            more = f" (+{len(missing) - len(sample)} more)" if len(missing) > len(sample) else ""
+            raise RuntimeError(
+                f"BaseMoEExperts layer {self.layer_idx} loaded {self._loaded_count}/"
+                f"{self._expected_count} expert projection weights; missing {sample}{more}. "
+                "Refusing to build fused MoE with uninitialized torch.empty buffers."
+            )
+
+        aux_names = self._required_aux_param_names()
+        if not aux_names:
+            return
+        expected_aux = {
+            (expert_id, proj, aux_name)
+            for expert_id in range(self.num_local_experts)
+            for proj in self.PROJ_NAMES
+            for aux_name in aux_names
+        }
+        missing_aux = sorted(expected_aux - self._loaded_aux_keys)
+        if missing_aux:
+            sample = missing_aux[:10]
+            more = (
+                f" (+{len(missing_aux) - len(sample)} more)"
+                if len(missing_aux) > len(sample)
+                else ""
+            )
+            raise RuntimeError(
+                f"BaseMoEExperts layer {self.layer_idx} missing required MoE "
+                f"auxiliary tensors {sample}{more}; loaded={sorted(self._loaded_aux_keys)[:10]}. "
+                "Refusing to build fused MoE with incomplete quantization scales."
+            )
+
+    # ------------------------------------------------------------------ #
+    #  Post-load processing
+    # ------------------------------------------------------------------ #
+
+    def process_weights_after_loading(self):
+        """Called after all weights are loaded.
+
+        Runs registered quant-method post-load work after verifying all expert
+        projection weights were loaded.
+        """
+        self._check_load_complete()
+        if self.quant_method is not None:
+            self.quant_method.process_weights_after_loading(self)
+            self._maybe_build_fused_moe()
+            return
+        self._maybe_build_fused_moe()
+
+    def _build_weights_dict(self) -> Dict[str, torch.Tensor]:
+        """Build the weight dict for FusedMoeFactory.
+
+        Registered quant methods add any extra runtime tensors such as FP8 or
+        W4A8 scales.
+        """
+        weights_dict: Dict[str, torch.Tensor] = {
+            W.moe_w1: self.w13.data,
+            W.moe_w2: self.w2.data,
+        }
+        if self.quant_method is not None:
+            self.quant_method.add_weight_tensors(self, weights_dict)
+        runtime_device = getattr(self._model_config, "exported_device", None)
+        if runtime_device is None:
+            runtime_device = get_current_device()
+        if self.layer_idx == 0 and not getattr(self, "_logged_moe_runtime_device", False):
+            logger.info(
+                "[BaseMoEExperts] layer_idx=0 using runtime_device=%s for newloader MoE postprocess",
+                type(runtime_device).__name__ if runtime_device is not None else None,
+            )
+            self._logged_moe_runtime_device = True
+        if runtime_device is not None:
+            for name in (W.moe_w1, W.moe_w2, W.moe_s1, W.moe_s2):
+                tensor = weights_dict.get(name)
+                if tensor is None:
+                    continue
+                # Newloader builds executor weights directly from PyModel tensors.
+                # Apply the runtime MoE layout transform here so ROCm AITER gets
+                # gate/up order and preshuffled weights without using the legacy
+                # loader's AtomicWeight path. Per-tensor FP8 scales are 1D and
+                # do not encode gate/up rows.
+                if tensor.dim() == 1:
+                    continue
+                weights_dict[name] = runtime_device.shuffle_moe_weight(
+                    tensor, self._model_config.data_type, name
+                )
+        return weights_dict
+
+    def _maybe_build_fused_moe(self):
+        if self.fused_moe is not None:
+            return
+        # MoEConfigAdapter.quant_config must be the CONFIG-side QuantizationConfig
+        # (rtp_llm.config.quant_config, exposing is_quanted()/get_method()), which
+        # the strategy resolver and the DeepEP wrapper rely on. self._quant_config
+        # is the models_py runtime QuantizationConfig (only quant_type) used to
+        # pick the expert quant family — passing it here makes the DeepEP
+        # low-latency path crash on quant_config.is_quanted(). Use the model's
+        # config-side quant_config instead.
+        adapter = MoEConfigAdapter(
+            model_config=self._model_config,
+            parallelism_config=self._parallelism_config,
+            moe_config=self._moe_config,
+            quant_config=getattr(self._model_config, "quant_config", None),
+            enable_cuda_graph=False,
+        )
+        weights_dict = self._build_weights_dict()
+        self.fused_moe = FusedMoeFactory().create_fused_moe(adapter, weights_dict)
+
+    # ------------------------------------------------------------------ #
+    #  Forward
+    # ------------------------------------------------------------------ #
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.fused_moe is None:
+            self._maybe_build_fused_moe()
+        return self.fused_moe(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation="SiGLU",
+        )

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -652,7 +652,8 @@ class BaseMoEExperts(nn.Module):
         self._check_load_complete()
         if self.quant_method is not None:
             self.quant_method.process_weights_after_loading(self)
-            self._maybe_build_fused_moe()
+        if bool(getattr(self, "_new_loader_defer_moe_executor_build", False)):
+            self._new_loader_deferred_moe_executor = True
             return
         self._maybe_build_fused_moe()
 

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -175,6 +175,10 @@ class BaseMoEExperts(nn.Module):
         self._parallelism_config = parallelism_config
         self._moe_config = moe_config
         self._quant_config = quant_config
+        self._ignored_by_quant_config = ignored_by_quant_config
+        self._effective_model_quant_config = (
+            None if ignored_by_quant_config else getattr(model_config, "quant_config", None)
+        )
 
         # Unified dispatch (symmetric with LinearBase): registered MoE quant
         # methods own quantized loading. The built-in fallback is kept only for
@@ -704,7 +708,7 @@ class BaseMoEExperts(nn.Module):
             model_config=self._model_config,
             parallelism_config=self._parallelism_config,
             moe_config=self._moe_config,
-            quant_config=getattr(self._model_config, "quant_config", None),
+            quant_config=self._effective_model_quant_config,
             enable_cuda_graph=False,
         )
         weights_dict = self._build_weights_dict()

--- a/rtp_llm/models_py/layers/norm.py
+++ b/rtp_llm/models_py/layers/norm.py
@@ -1,0 +1,184 @@
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+_RMSNORM_FALLBACK_WARNED = False
+
+
+class RMSNorm(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype), requires_grad=False
+        )
+        self._weight_loaded = False
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name:
+                self.weight.data.copy_(tensor)
+                self._weight_loaded = True
+
+    def process_weights_after_loading(self):
+        if not self._weight_loaded:
+            raise RuntimeError(f"{type(self).__name__} missing required checkpoint tensor: weight")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # 默认走 rtp 融合 rmsnorm（与旧 loader modules.RMSNorm 一致）；
+        # CUDA/ROCm 上 is_cuda 均为 True，rtp_llm_ops 按 arch 编译为对应后端 kernel。
+        # 非 CUDA / kernel 不可用时回退 eager fp32（可移植）。
+        if x.is_cuda:
+            try:
+                if getattr(torch.version, "hip", None) is not None:
+                    from aiter import rms_norm
+
+                    return rms_norm(x, self.weight.data, self.eps)
+
+                from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+                orig_shape = x.shape
+                # 融合 kernel 按最后一维归一；reshape 成 2D 以兼容 q_norm/k_norm 的
+                # [tokens, heads, head_dim] 三维输入。
+                x2d = x.reshape(-1, orig_shape[-1]).contiguous()
+                out = torch.empty_like(x2d)
+                stream_id = torch.cuda.current_stream().cuda_stream
+                rtp_llm_ops.rmsnorm(out, x2d, self.weight.data, self.eps, stream_id)
+                return out.reshape(orig_shape)
+            except Exception as e:  # 失败回退 eager，且告警一次
+                global _RMSNORM_FALLBACK_WARNED
+                if not _RMSNORM_FALLBACK_WARNED:
+                    _RMSNORM_FALLBACK_WARNED = True
+                    import logging
+
+                    logging.getLogger(__name__).warning(
+                        "[RMSNorm] 融合 rmsnorm 不可用，回退 eager fp32: %s", e
+                    )
+        input_dtype = x.dtype
+        x = x.to(torch.float32)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        return (self.weight * x).to(input_dtype)
+
+
+class RMSResNorm(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype), requires_grad=False
+        )
+        self._weight_loaded = False
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name:
+                self.weight.data.copy_(tensor)
+                self._weight_loaded = True
+
+    def process_weights_after_loading(self):
+        if not self._weight_loaded:
+            raise RuntimeError(f"{type(self).__name__} missing required checkpoint tensor: weight")
+
+    def forward(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if hidden_states.is_cuda:
+            try:
+                if getattr(torch.version, "hip", None) is not None:
+                    from aiter import rmsnorm2d_fwd_with_add as fused_add_rmsnorm
+
+                    output = torch.empty_like(hidden_states)
+                    residual_out = torch.empty_like(hidden_states)
+                    fused_add_rmsnorm(
+                        output,
+                        hidden_states,
+                        residual,
+                        residual_out,
+                        self.weight.data,
+                        self.eps,
+                        0,
+                    )
+                    return output, residual_out
+
+                from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+                orig_shape = hidden_states.shape
+                hidden_2d = hidden_states.reshape(-1, orig_shape[-1]).contiguous()
+                residual_2d = residual.reshape(-1, orig_shape[-1]).contiguous()
+                stream_id = torch.cuda.current_stream().cuda_stream
+                rtp_llm_ops.fused_add_rmsnorm(
+                    hidden_2d, residual_2d, self.weight.data, self.eps, stream_id
+                )
+                return hidden_2d.reshape(orig_shape), residual_2d.reshape(orig_shape)
+            except Exception as e:
+                global _RMSNORM_FALLBACK_WARNED
+                if not _RMSNORM_FALLBACK_WARNED:
+                    _RMSNORM_FALLBACK_WARNED = True
+                    import logging
+
+                    logging.getLogger(__name__).warning(
+                        "[RMSResNorm] 融合 fused_add_rmsnorm 不可用，回退 eager fp32: %s",
+                        e,
+                    )
+
+        residual = hidden_states + residual
+        input_dtype = residual.dtype
+        x = residual.to(torch.float32)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.eps)
+        return (self.weight * x).to(input_dtype), residual
+
+
+class LayerNorm(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-5,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype), requires_grad=False
+        )
+        self.bias = nn.Parameter(
+            torch.zeros(hidden_size, dtype=params_dtype), requires_grad=False
+        )
+        self._loaded_param_names = set()
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        for name, tensor in weights.items():
+            if "weight" in name or "gamma" in name:
+                self.weight.data.copy_(tensor)
+                self._loaded_param_names.add("weight")
+            elif "bias" in name or "beta" in name:
+                self.bias.data.copy_(tensor)
+                self._loaded_param_names.add("bias")
+
+    def process_weights_after_loading(self):
+        missing = sorted({"weight", "bias"} - self._loaded_param_names)
+        if missing:
+            raise RuntimeError(f"LayerNorm missing required checkpoint tensors: {missing}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.layer_norm(
+            x, [self.hidden_size], self.weight, self.bias, self.eps
+        )

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -499,6 +499,13 @@ class NewModelLoader:
         try:
             return self._load_via_fastsafetensors()
         except Exception as e:
+            if self._distributed_world_size() > 1:
+                logger.error(
+                    "fastsafetensors load failed under distributed loading; "
+                    "refusing per-rank fallback to avoid collective mismatch: %s",
+                    e,
+                )
+                raise
             if explicit:
                 logger.error(
                     "fastsafetensors load failed and fallback is disabled "
@@ -539,11 +546,12 @@ class NewModelLoader:
                 "before moving final weights to %s",
                 self.device,
             )
-            self._run_post_load_hooks(model)
+            self._run_post_load_hooks(model, defer_moe_executor_build=True)
             t1 = time.time()
             logger.info(f"Moving post-load model to device: {self.device}")
             model.to(self.device)
             logger.info(f"model.to({self.device}) took {time.time() - t1:.2f}s")
+            self._build_deferred_moe_executors(model)
         else:
             t1 = time.time()
             logger.info(f"Moving model to device: {self.device}")
@@ -593,7 +601,7 @@ class NewModelLoader:
         self._log_peak_gpu_memory()
         return model
 
-    def _run_post_load_hooks(self, model: nn.Module):
+    def _run_post_load_hooks(self, model: nn.Module, defer_moe_executor_build: bool = False):
         import time
 
         t0 = time.time()
@@ -604,12 +612,24 @@ class NewModelLoader:
                 "_new_loader_force_cpu_load_weights",
                 bool(self.load_config.force_cpu_load_weights),
             )
+            setattr(module, "_new_loader_defer_moe_executor_build", defer_moe_executor_build)
             if hasattr(module, "process_weights_after_loading"):
                 module.process_weights_after_loading()
                 count += 1
         logger.info(
             f"Post-load hooks ran on {count} modules in {time.time() - t0:.2f}s"
         )
+
+    def _build_deferred_moe_executors(self, model: nn.Module):
+        count = 0
+        for module in model.modules():
+            if bool(getattr(module, "_new_loader_deferred_moe_executor", False)):
+                setattr(module, "_new_loader_defer_moe_executor_build", False)
+                module._maybe_build_fused_moe()
+                module._new_loader_deferred_moe_executor = False
+                count += 1
+        if count:
+            logger.info("Built %d deferred MoE executor(s) after device migration", count)
 
     def _log_peak_gpu_memory(self):
         if not torch.cuda.is_available():
@@ -642,6 +662,20 @@ class NewModelLoader:
             with torch.cuda.device(target_device):
                 return torch.cuda.mem_get_info()
 
+    def _distributed_world_size(self) -> int:
+        if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+            return 1
+        return torch.distributed.get_world_size(torch.distributed.group.WORLD)
+
+    def _all_gather_load_decision(self, ok: bool, reason: str):
+        if self._distributed_world_size() <= 1:
+            return [(ok, reason)]
+        gathered = [None for _ in range(self._distributed_world_size())]
+        torch.distributed.all_gather_object(
+            gathered, (bool(ok), str(reason)), group=torch.distributed.group.WORLD
+        )
+        return gathered
+
     def _resolve_load_method(self) -> Tuple[str, bool]:
         configured = getattr(self.load_config, "load_method", LoadMethod.AUTO)
         load_method = (configured or LoadMethod.AUTO).lower()
@@ -660,10 +694,12 @@ class NewModelLoader:
                 logger.info(f"LOAD_METHOD env: {load_method}")
             else:
                 ok, reason = self._fastsafetensors_eligible()
-                if ok:
+                decisions = self._all_gather_load_decision(ok, reason)
+                if all(item[0] for item in decisions):
                     return LoadMethod.FASTSAFETENSORS, False
                 logger.info(
-                    "auto fastsafetensors unavailable: %s; using scratch", reason
+                    "auto fastsafetensors unavailable on at least one rank: %s; using scratch",
+                    decisions,
                 )
                 return LoadMethod.SCRATCH, False
 
@@ -676,6 +712,15 @@ class NewModelLoader:
 
         if load_method == LoadMethod.FASTSAFETENSORS:
             ok, reason = self._fastsafetensors_eligible()
+            decisions = self._all_gather_load_decision(ok, reason)
+            if not all(item[0] for item in decisions):
+                if len(decisions) > 1:
+                    reason = "; ".join(
+                        f"rank{idx}: {item[1]}"
+                        for idx, item in enumerate(decisions)
+                        if not item[0]
+                    )
+                ok = False
             if not ok:
                 if reason == "insufficient GPU free memory":
                     ckpt_files = self._discover_ckpt_files_cached()
@@ -887,9 +932,9 @@ class NewModelLoader:
                 logger.warning(f"LoRA: unmapped module '{hf_module}', skipping")
                 continue
 
-            tensor = tensor.to(compute_dtype)
+            tensor = tensor.to(compute_dtype).t().contiguous()
 
-            # TP slicing
+            # TP slicing uses the engine-internal transposed layout.
             if tp_size > 1:
                 split_rule = _LORA_TP_RULES.get((hf_module, ab_suffix))
                 if split_rule is not None:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -237,128 +237,6 @@ def _get_all_weights(
     logger.info("Finished streaming %d weights (skipped=%d)", count, skipped)
 
 
-def _get_fastsafetensors_weights(
-    ckpt_files: List[str], device: str
-) -> Iterator[Tuple[str, torch.Tensor]]:
-    # Apply monkey patch to bypass KeyError: 'data_offsets' for non-tensor metadata keys.
-    # Guard it so repeated model loads do not stack wrappers around the global class.
-    try:
-        import fastsafetensors.common
-
-        metadata_cls = fastsafetensors.common.SafeTensorsMetadata
-        if not getattr(metadata_cls, "_rtp_patched", False):
-            orig_init = metadata_cls.__init__
-
-            def patched_init(self, *args, **kwargs):
-                new_args = list(args)
-
-                def _clean_and_replace(obj):
-                    if hasattr(obj, "items"):
-                        has_bad = False
-                        cleaned = {}
-                        for k, v in obj.items():
-                            try:
-                                if hasattr(v, "__getitem__") and "data_offsets" in v:
-                                    cleaned[k] = v
-                                else:
-                                    has_bad = True
-                            except Exception:
-                                has_bad = True
-                        if has_bad:
-                            return cleaned
-                    return obj
-
-                for i in range(len(new_args)):
-                    new_args[i] = _clean_and_replace(new_args[i])
-                for k in list(kwargs.keys()):
-                    kwargs[k] = _clean_and_replace(kwargs[k])
-
-                return orig_init(self, *new_args, **kwargs)
-
-            metadata_cls.__init__ = patched_init
-            metadata_cls._rtp_patched = True
-    except Exception as patch_err:
-        logging.warning(f"Failed to apply MonkeyPatch to fastsafetensors: {patch_err}")
-
-
-    from fastsafetensors import ParallelLoader, SingleGroup
-    from safetensors import safe_open
-
-    from rtp_llm.model_loader.per_expert_parallel_loader import PerExpertParallelLoader
-
-    if torch.distributed.is_available() and torch.distributed.is_initialized():
-        pg = torch.distributed.group.WORLD
-    else:
-        pg = SingleGroup()
-
-    stacked_key_config = {}
-    if ckpt_files:
-        try:
-            with safe_open(ckpt_files[0], framework="pt") as f:
-                for key in f.keys():
-                    if (
-                        "mlp.experts.gate_up_proj" in key
-                        or "mlp.experts.down_proj" in key
-                    ) and "experts.weight" not in key:
-                        slice_ = f.get_slice(key)
-                        if len(slice_.shape) == 3:
-                            template = key.replace(
-                                "experts.gate_up_proj",
-                                "experts.{expert_id}.gate_up_proj",
-                            ).replace(
-                                "experts.down_proj", "experts.{expert_id}.down_proj"
-                            )
-                            stacked_key_config[key] = template
-        except Exception as e:
-            logging.warning(
-                f"Failed to auto-detect stacked keys for PerExpertParallelLoader: {e}"
-            )
-
-    loader_kwargs = dict(
-        pg=pg,
-        hf_weights_files=sorted(ckpt_files),
-        use_tqdm_on_load=True,
-        device=device,
-        bbuf_size_kb=1024
-        * 256,  # Optimized from 2GB to 256MB to save GPU memory headroom
-        use_shm=True,
-    )
-
-    if stacked_key_config:
-        logging.info(
-            f"FST per-expert parallel loader enabled for {len(stacked_key_config)} stacked keys: {list(stacked_key_config.keys())}"
-        )
-        loader = PerExpertParallelLoader(stacked_key_config, **loader_kwargs)
-    else:
-        loader = ParallelLoader(**loader_kwargs)
-
-    try:
-        yield from loader.iterate_weights()
-    finally:
-        inner = getattr(loader, "loader", None)
-        if inner is not None and hasattr(inner, "close"):
-            inner.close()
-
-
-_STACKED_EXPERT_RE = re.compile(
-    r"^(?P<prefix>.*\.experts)\.(?P<expert_id>\d+)\.(?P<proj>gate_up_proj|down_proj)$"
-)
-
-
-def _normalize_fastsafetensors_stacked_moe_weights(
-    weights_iter: Iterator[Tuple[str, torch.Tensor]]
-) -> Iterator[Tuple[str, torch.Tensor]]:
-    for name, tensor in weights_iter:
-        m = _STACKED_EXPERT_RE.match(name)
-        if m is None:
-            yield name, tensor
-            continue
-        prefix = m.group("prefix")
-        expert_id = m.group("expert_id")
-        proj = m.group("proj")
-        yield f"{prefix}.{expert_id}.{proj}.weight", tensor
-
-
 _EP_EXPERT_RE = re.compile(r"experts\.(\d+)\.")
 _STACKED_EP_RE = re.compile(
     r"^(?P<prefix>.*\.experts)\.(?P<proj>gate_up_proj|down_proj)"
@@ -491,40 +369,10 @@ class NewModelLoader:
         self._ckpt_files_cache: Optional[List[str]] = None
 
     def load(self) -> nn.Module:
-        method, explicit = self._resolve_load_method()
+        method, _ = self._resolve_load_method()
         logger.info(f"NewModelLoader using load method: {method}")
-        if method != LoadMethod.FASTSAFETENSORS:
-            return self._load_via_scratch()
-
-        try:
-            return self._load_via_fastsafetensors()
-        except Exception as e:
-            if self._distributed_world_size() > 1:
-                logger.error(
-                    "fastsafetensors load failed under distributed loading; "
-                    "refusing per-rank fallback to avoid collective mismatch: %s",
-                    e,
-                )
-                raise
-            if explicit:
-                logger.error(
-                    "fastsafetensors load failed and fallback is disabled "
-                    "because the load method was explicitly requested: %s",
-                    e,
-                )
-                raise
-            error_msg = str(e)
-
-        logger.warning(
-            "fastsafetensors load failed (%s), automatically falling back to "
-            "scratch load path after releasing failed fast-path resources...",
-            error_msg,
-        )
-        import gc
-
-        gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        if method != LoadMethod.SCRATCH:
+            raise RuntimeError(f"Unsupported newloader load method after resolution: {method}")
         return self._load_via_scratch()
 
     def _load_via_scratch(self) -> nn.Module:
@@ -566,38 +414,6 @@ class NewModelLoader:
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-        self._log_peak_gpu_memory()
-        return model
-
-    def _load_via_fastsafetensors(self) -> nn.Module:
-        import time
-
-        logger.info("Starting model loading (fastsafetensors path)...")
-
-        target_device = self._resolve_target_device()
-
-        t0 = time.time()
-        with torch.device("meta"):
-            model = self._create_model()
-        model.to_empty(device=target_device)
-        logger.info(
-            f"meta create + to_empty({target_device}) " f"took {time.time() - t0:.2f}s"
-        )
-
-        weights_iter = _get_fastsafetensors_weights(
-            self._discover_ckpt_files_cached(), device=target_device
-        )
-        weights_iter = _normalize_fastsafetensors_stacked_moe_weights(weights_iter)
-        weights_iter = self._apply_ep_filter(weights_iter)
-
-        t1 = time.time()
-        model.load_weights(weights_iter)
-        logger.info(f"model.load_weights() took {time.time() - t1:.2f}s")
-
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-
-        self._run_post_load_hooks(model)
         self._log_peak_gpu_memory()
         return model
 
@@ -654,27 +470,10 @@ class NewModelLoader:
             return device
         return f"cuda:{torch.cuda.current_device()}"
 
-    def _target_cuda_mem_get_info(self) -> Tuple[int, int]:
-        target_device = self._resolve_target_device()
-        try:
-            return torch.cuda.mem_get_info(target_device)
-        except TypeError:
-            with torch.cuda.device(target_device):
-                return torch.cuda.mem_get_info()
-
     def _distributed_world_size(self) -> int:
         if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
             return 1
         return torch.distributed.get_world_size(torch.distributed.group.WORLD)
-
-    def _all_gather_load_decision(self, ok: bool, reason: str):
-        if self._distributed_world_size() <= 1:
-            return [(ok, reason)]
-        gathered = [None for _ in range(self._distributed_world_size())]
-        torch.distributed.all_gather_object(
-            gathered, (bool(ok), str(reason)), group=torch.distributed.group.WORLD
-        )
-        return gathered
 
     def _resolve_load_method(self) -> Tuple[str, bool]:
         configured = getattr(self.load_config, "load_method", LoadMethod.AUTO)
@@ -693,14 +492,9 @@ class NewModelLoader:
                 explicit = True
                 logger.info(f"LOAD_METHOD env: {load_method}")
             else:
-                ok, reason = self._fastsafetensors_eligible()
-                decisions = self._all_gather_load_decision(ok, reason)
-                if all(item[0] for item in decisions):
-                    return LoadMethod.FASTSAFETENSORS, False
-                logger.info(
-                    "auto fastsafetensors unavailable on at least one rank: %s; using scratch",
-                    decisions,
-                )
+                # Keep the core newloader PR on the scratch path. The
+                # fastsafetensors path needs a separate distributed failure/abort
+                # protocol before it can be safely enabled in auto mode.
                 return LoadMethod.SCRATCH, False
 
         if load_method not in (LoadMethod.SCRATCH, LoadMethod.FASTSAFETENSORS):
@@ -711,90 +505,11 @@ class NewModelLoader:
             )
 
         if load_method == LoadMethod.FASTSAFETENSORS:
-            ok, reason = self._fastsafetensors_eligible()
-            decisions = self._all_gather_load_decision(ok, reason)
-            if not all(item[0] for item in decisions):
-                if len(decisions) > 1:
-                    reason = "; ".join(
-                        f"rank{idx}: {item[1]}"
-                        for idx, item in enumerate(decisions)
-                        if not item[0]
-                    )
-                ok = False
-            if not ok:
-                if reason == "insufficient GPU free memory":
-                    ckpt_files = self._discover_ckpt_files_cached()
-                    sizes = [os.path.getsize(f) for f in ckpt_files]
-                    total = sum(sizes)
-                    tp_size = max(getattr(self.load_config, "tp_size", 1), 1)
-                    ep_size = max(getattr(self.load_config, "ep_size", 1), 1)
-                    rank_share = total / max(tp_size, ep_size)
-
-                    if _is_quantized_load(self.model_config, self.load_config):
-                        rank_share /= 2.0
-
-                    free_bytes, _ = self._target_cuda_mem_get_info()
-                    if free_bytes < rank_share:
-                        raise RuntimeError(
-                            f"fastsafetensors load requested but unavailable: {reason} "
-                            f"(free={free_bytes/1024**3:.1f}GiB < rank_share={rank_share/1024**3:.1f}GiB)"
-                        )
-                    else:
-                        logger.warning(
-                            f"fastsafetensors headroom is negative, but free memory ({free_bytes/1024**3:.1f}GiB) "
-                            f"is sufficient to hold rank_share ({rank_share/1024**3:.1f}GiB). Proceeding anyway."
-                        )
-                else:
-                    raise RuntimeError(
-                        f"fastsafetensors load requested but unavailable: {reason}"
-                    )
-            return LoadMethod.FASTSAFETENSORS, explicit
+            raise RuntimeError(
+                "fastsafetensors load_method is not enabled in the newloader core PR; "
+                "use scratch and submit fastsafetensors as a separate distributed-load PR."
+            )
         return LoadMethod.SCRATCH, explicit
-
-    def _fastsafetensors_eligible(self) -> Tuple[bool, str]:
-        if self.load_config.force_cpu_load_weights:
-            return False, "force_cpu_load_weights requires scratch CPU staging"
-        try:
-            import fastsafetensors  # noqa: F401
-        except ImportError:
-            return False, "fastsafetensors module not installed"
-        if not torch.cuda.is_available():
-            return False, "cuda not available"
-        if not str(self.device).startswith("cuda"):
-            return False, f"device {self.device} is not cuda"
-
-        ckpt_files = self._discover_ckpt_files_cached()
-        if not ckpt_files:
-            return False, "no checkpoint files discovered"
-        if not all(f.endswith(".safetensors") for f in ckpt_files):
-            return False, "not all checkpoint files are safetensors"
-
-        sizes = [os.path.getsize(f) for f in ckpt_files]
-        max_file = max(sizes)
-        total = sum(sizes)
-        tp_size = max(getattr(self.load_config, "tp_size", 1), 1)
-        ep_size = max(getattr(self.load_config, "ep_size", 1), 1)
-        rank_share = total / max(tp_size, ep_size)
-
-        if _is_quantized_load(self.model_config, self.load_config):
-            rank_share /= 2.0
-
-        try:
-            free_bytes, _ = self._target_cuda_mem_get_info()
-        except Exception as e:
-            return False, f"cuda mem_get_info failed: {e}"
-
-        headroom = free_bytes - rank_share - 3 * max_file
-        gib = 1024**3
-        logger.info(
-            f"fastsafetensors capacity: free={free_bytes/gib:.1f}GiB, "
-            f"rank_share={rank_share/gib:.1f}GiB, "
-            f"max_file={max_file/gib:.1f}GiB, "
-            f"headroom={headroom/gib:.1f}GiB"
-        )
-        if headroom <= 0:
-            return False, "insufficient GPU free memory"
-        return True, "ok"
 
     def _discover_ckpt_files_cached(self) -> List[str]:
         if self._ckpt_files_cache is not None:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -443,24 +443,32 @@ class NewModelLoader:
     def load(self) -> nn.Module:
         method, explicit = self._resolve_load_method()
         logger.info(f"NewModelLoader using load method: {method}")
-        if method == LoadMethod.FASTSAFETENSORS:
-            try:
-                model = self._load_via_fastsafetensors()
-            except Exception as e:
-                if explicit:
-                    logger.error(
-                        "fastsafetensors load failed and fallback is disabled "
-                        "because the load method was explicitly requested: %s",
-                        e,
-                    )
-                    raise
-                logger.warning(
-                    f"fastsafetensors load failed ({e}), automatically falling back to scratch load path..."
+        if method != LoadMethod.FASTSAFETENSORS:
+            return self._load_via_scratch()
+
+        try:
+            return self._load_via_fastsafetensors()
+        except Exception as e:
+            if explicit:
+                logger.error(
+                    "fastsafetensors load failed and fallback is disabled "
+                    "because the load method was explicitly requested: %s",
+                    e,
                 )
-                model = self._load_via_scratch()
-        else:
-            model = self._load_via_scratch()
-        return model
+                raise
+            error_msg = str(e)
+
+        logger.warning(
+            "fastsafetensors load failed (%s), automatically falling back to "
+            "scratch load path after releasing failed fast-path resources...",
+            error_msg,
+        )
+        import gc
+
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        return self._load_via_scratch()
 
     def _load_via_scratch(self) -> nn.Module:
         import time
@@ -475,15 +483,31 @@ class NewModelLoader:
         model.load_weights(weights_iter)
         logger.info(f"model.load_weights() took {time.time() - t0:.2f}s")
 
-        t1 = time.time()
-        logger.info(f"Moving model to device: {self.device}")
-        model.to(self.device)
-        logger.info(f"model.to({self.device}) took {time.time() - t1:.2f}s")
+        if self.load_config.force_cpu_load_weights:
+            logger.warning(
+                "force_cpu_load_weights is enabled; running post-load hooks on CPU "
+                "before moving final weights to %s",
+                self.device,
+            )
+            self._run_post_load_hooks(model)
+            t1 = time.time()
+            logger.info(f"Moving post-load model to device: {self.device}")
+            model.to(self.device)
+            logger.info(f"model.to({self.device}) took {time.time() - t1:.2f}s")
+        else:
+            t1 = time.time()
+            logger.info(f"Moving model to device: {self.device}")
+            model.to(self.device)
+            logger.info(f"model.to({self.device}) took {time.time() - t1:.2f}s")
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+            self._run_post_load_hooks(model)
 
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
 
-        self._run_post_load_hooks(model)
         self._log_peak_gpu_memory()
         return model
 
@@ -633,6 +657,8 @@ class NewModelLoader:
         return LoadMethod.SCRATCH, explicit
 
     def _fastsafetensors_eligible(self) -> Tuple[bool, str]:
+        if self.load_config.force_cpu_load_weights:
+            return False, "force_cpu_load_weights requires scratch CPU staging"
         try:
             import fastsafetensors  # noqa: F401
         except ImportError:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -619,14 +619,18 @@ class NewModelLoader:
         compute_dtype = getattr(self.load_config, "compute_dtype", torch.float16)
 
         state_dict = self._load_lora_state_dict(lora_path, device)
+        loaded_pairs = set()
+        skipped = []
 
         for hf_name, tensor in state_dict.items():
             parsed = _parse_hf_lora_name(hf_name)
             if parsed is None:
+                skipped.append((hf_name, "unrecognized name"))
                 continue
             layer_id, hf_module, ab_suffix = parsed
 
             if layer_id >= num_layers:
+                skipped.append((hf_name, f"layer {layer_id} out of range"))
                 continue
 
             if hf_module in (
@@ -644,7 +648,7 @@ class NewModelLoader:
 
             engine_name = _HF_TO_ENGINE_LORA.get(hf_module)
             if engine_name is None:
-                logger.warning(f"LoRA: unmapped module '{hf_module}', skipping")
+                skipped.append((hf_name, f"unmapped module {hf_module!r}"))
                 continue
 
             tensor = tensor.to(compute_dtype).t().contiguous()
@@ -657,6 +661,25 @@ class NewModelLoader:
 
             full_name = f"{engine_name}.{ab_suffix}"
             lora_weights.set_layer_weight(False, layer_id, full_name, tensor)
+            loaded_pairs.add((layer_id, engine_name, ab_suffix))
+
+        if not loaded_pairs:
+            sample = skipped[:5]
+            raise RuntimeError(
+                f"LoRA adapter '{adapter_name}' did not contain any mappable "
+                f"newloader tensors; skipped={sample}"
+            )
+
+        missing_pairs = []
+        for layer_id, engine_name, _ in loaded_pairs:
+            for suffix in ("lora_A", "lora_B"):
+                if (layer_id, engine_name, suffix) not in loaded_pairs:
+                    missing_pairs.append((layer_id, engine_name, suffix))
+        if missing_pairs:
+            raise RuntimeError(
+                f"LoRA adapter '{adapter_name}' has incomplete A/B tensor pairs: "
+                f"missing={missing_pairs[:10]}"
+            )
 
         lora_weights.apply_scale(lora_alpha / rank)
         logger.info(

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -466,7 +466,13 @@ def _is_quanted_config(source_config: Any) -> bool:
 def _is_quantized_load(model_config: Any, load_config: LoadConfig) -> bool:
     if _is_quanted_config(getattr(load_config, "quant_source_config", None)):
         return True
-    return getattr(model_config, "quantization", None) is not None
+    quant_config = getattr(model_config, "quant_config", None)
+    if _is_quanted_config(quant_config):
+        return True
+    quantization = getattr(model_config, "quantization", None)
+    if isinstance(quantization, str):
+        return quantization.strip().lower() not in ("", "none", "null")
+    return bool(quantization)
 
 
 class NewModelLoader:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -1,0 +1,927 @@
+import inspect
+import logging
+import os
+import re
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+class LoadMethod:
+    AUTO = "auto"
+    SCRATCH = "scratch"
+    FASTSAFETENSORS = "fastsafetensors"
+
+
+class LoadConfig:
+
+    def __init__(
+        self,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        ep_size: int = 1,
+        ep_rank: int = 0,
+        quant_type: str = "none",
+        compute_dtype: torch.dtype = torch.float16,
+        device: str = "cuda",
+        load_method: str = LoadMethod.AUTO,
+        quant_source_config: Any = None,
+        force_cpu_load_weights: bool = False,
+    ):
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.quant_type = quant_type
+        self.compute_dtype = compute_dtype
+        self.device = device
+        self.load_method = load_method
+        self.quant_source_config = quant_source_config
+        self.force_cpu_load_weights = force_cpu_load_weights
+
+    @property
+    def quant_config(self):
+        try:
+            from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+
+            # 走法1:把旧 config/quant_config.py 解析出的富对象透传为 source_config，
+            # 供新 loader 的 method 读取 dynamic / ignore / group_size 等结构化字段，
+            # 而不在新 loader 重复解析 ckpt。base_model 经 quant_source_config 注入。
+            return QuantizationConfig(
+                quant_type=self.quant_type,
+                source_config=self.quant_source_config,
+            )
+        except ImportError:
+            return None
+
+
+class _WeightsFilter:
+
+    def __init__(self, exclude_patterns: Optional[List[str]] = None):
+        self._exclude_patterns = exclude_patterns or []
+        self._compiled = None
+        if self._exclude_patterns:
+            import re
+
+            self._compiled = re.compile("|".join(self._exclude_patterns))
+
+    def apply(
+        self, weights_iter: Iterator[Tuple[str, torch.Tensor]]
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        if not self._exclude_patterns or self._compiled is None:
+            yield from weights_iter
+            return
+        for name, tensor in weights_iter:
+            if self.should_load(name):
+                yield name, tensor
+
+    def should_load(self, name: str) -> bool:
+        if not self._exclude_patterns or self._compiled is None:
+            return True
+        return self._compiled.search(name) is None
+
+
+def _discover_ckpt_files(model_path: str) -> List[str]:
+    try:
+        from rtp_llm.models_py import weight_mapper
+
+        if hasattr(weight_mapper, "discover_ckpt_files"):
+            return weight_mapper.discover_ckpt_files(model_path)
+    except ImportError:
+        pass
+    import glob
+
+    # Match weight_mapper.discover_ckpt_files priority: prefer safetensors,
+    # then bin, then pt — and return the first non-empty group rather than
+    # mixing formats. Mixing co-located safetensors and bin would double-load
+    # the same weights through two paths.
+    for ext in ("*.safetensors", "*.bin", "*.pt"):
+        found = sorted(glob.glob(os.path.join(model_path, ext)))
+        if ext == "*.bin":
+            found = [f for f in found if "optimizer" not in os.path.basename(f)]
+        if found:
+            return found
+    return []
+
+
+def _evict_page_cache(ckpt_files: List[str]):
+    total = 0
+    for path in ckpt_files:
+        try:
+            size = os.path.getsize(path)
+            fd = os.open(path, os.O_RDONLY)
+            try:
+                os.posix_fadvise(fd, 0, size, os.POSIX_FADV_DONTNEED)
+                total += size
+            finally:
+                os.close(fd)
+        except (OSError, AttributeError):
+            pass
+    logger.info(
+        f"Evicted page cache for {len(ckpt_files)} files " f"({total / 1024**3:.2f} GB)"
+    )
+
+
+def _get_all_weights(
+    ckpt_files: List[str], device: str = "cpu", name_filter: Optional[Any] = None
+) -> Iterator[Tuple[str, torch.Tensor]]:
+    if name_filter is None:
+        try:
+            from rtp_llm.models_py import weight_mapper
+
+            if hasattr(weight_mapper, "get_all_weights"):
+                count = 0
+                logger.info(
+                    "Begin streaming weights via weight_mapper: files=%d device=%s",
+                    len(ckpt_files),
+                    device,
+                )
+                for name, tensor in weight_mapper.get_all_weights(
+                    ckpt_files, device=device
+                ):
+                    count += 1
+                    if count == 1 or count % 500 == 0:
+                        logger.info(
+                            "Streaming weight #%d: %s shape=%s dtype=%s",
+                            count,
+                            name,
+                            tuple(tensor.shape),
+                            tensor.dtype,
+                        )
+                    yield name, tensor
+                logger.info("Finished streaming %d weights via weight_mapper", count)
+                return
+        except ImportError:
+            pass
+    else:
+        logger.info(
+            "Begin streaming weights with name filter: files=%d device=%s",
+            len(ckpt_files),
+            device,
+        )
+
+    def _should_load(name: str) -> bool:
+        return name_filter is None or name_filter.should_load(name)
+
+    count = 0
+    skipped = 0
+    for ckpt_file in ckpt_files:
+        logger.info("Loading checkpoint file: %s", ckpt_file)
+        if ckpt_file.endswith(".safetensors"):
+            from safetensors import safe_open
+
+            with safe_open(ckpt_file, framework="pt", device=device) as f:
+                keys = list(f.keys())
+                for name in keys:
+                    if not _should_load(name):
+                        skipped += 1
+                        continue
+                    tensor = f.get_tensor(name)
+                    count += 1
+                    if count == 1 or count % 500 == 0:
+                        logger.info(
+                            "Streaming weight #%d: %s shape=%s dtype=%s (skipped=%d)",
+                            count,
+                            name,
+                            tuple(tensor.shape),
+                            tensor.dtype,
+                            skipped,
+                        )
+                    yield name, tensor
+            logger.info(
+                "Scanned checkpoint file: %s yielded=%d skipped=%d",
+                ckpt_file,
+                count,
+                skipped,
+            )
+        else:
+            # weights_only=True forbids arbitrary pickle payloads — torch.load
+            # otherwise allows arbitrary code execution on untrusted .pt/.bin
+            # files. Modern HF ckpts and the {state_dict, model} containers
+            # below are pure tensor dicts and load fine under this flag.
+            from rtp_llm.models_py.weight_mapper import _unwrap_pytorch_state_dict
+
+            state_dict = _unwrap_pytorch_state_dict(
+                torch.load(ckpt_file, map_location=device, weights_only=True)
+            )
+            logger.info(
+                "Loaded checkpoint file: %s tensors=%d", ckpt_file, len(state_dict)
+            )
+            for name, tensor in state_dict.items():
+                if not _should_load(name):
+                    skipped += 1
+                    continue
+                count += 1
+                if count == 1 or count % 500 == 0:
+                    logger.info(
+                        "Streaming filtered weight #%d: %s shape=%s dtype=%s "
+                        "(skipped=%d)",
+                        count,
+                        name,
+                        tuple(tensor.shape),
+                        tensor.dtype,
+                        skipped,
+                    )
+                yield name, tensor
+    logger.info("Finished streaming %d weights (skipped=%d)", count, skipped)
+
+
+def _get_fastsafetensors_weights(
+    ckpt_files: List[str], device: str
+) -> Iterator[Tuple[str, torch.Tensor]]:
+    # Apply monkey patch to bypass KeyError: 'data_offsets' for non-tensor metadata keys.
+    # Guard it so repeated model loads do not stack wrappers around the global class.
+    try:
+        import fastsafetensors.common
+
+        metadata_cls = fastsafetensors.common.SafeTensorsMetadata
+        if not getattr(metadata_cls, "_rtp_patched", False):
+            orig_init = metadata_cls.__init__
+
+            def patched_init(self, *args, **kwargs):
+                new_args = list(args)
+
+                def _clean_and_replace(obj):
+                    if hasattr(obj, "items"):
+                        has_bad = False
+                        cleaned = {}
+                        for k, v in obj.items():
+                            try:
+                                if hasattr(v, "__getitem__") and "data_offsets" in v:
+                                    cleaned[k] = v
+                                else:
+                                    has_bad = True
+                            except Exception:
+                                has_bad = True
+                        if has_bad:
+                            return cleaned
+                    return obj
+
+                for i in range(len(new_args)):
+                    new_args[i] = _clean_and_replace(new_args[i])
+                for k in list(kwargs.keys()):
+                    kwargs[k] = _clean_and_replace(kwargs[k])
+
+                return orig_init(self, *new_args, **kwargs)
+
+            metadata_cls.__init__ = patched_init
+            metadata_cls._rtp_patched = True
+    except Exception as patch_err:
+        logging.warning(f"Failed to apply MonkeyPatch to fastsafetensors: {patch_err}")
+
+
+    from fastsafetensors import ParallelLoader, SingleGroup
+    from safetensors import safe_open
+
+    from rtp_llm.model_loader.per_expert_parallel_loader import PerExpertParallelLoader
+
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        pg = torch.distributed.group.WORLD
+    else:
+        pg = SingleGroup()
+
+    stacked_key_config = {}
+    if ckpt_files:
+        try:
+            with safe_open(ckpt_files[0], framework="pt") as f:
+                for key in f.keys():
+                    if (
+                        "mlp.experts.gate_up_proj" in key
+                        or "mlp.experts.down_proj" in key
+                    ) and "experts.weight" not in key:
+                        slice_ = f.get_slice(key)
+                        if len(slice_.shape) == 3:
+                            template = key.replace(
+                                "experts.gate_up_proj",
+                                "experts.{expert_id}.gate_up_proj",
+                            ).replace(
+                                "experts.down_proj", "experts.{expert_id}.down_proj"
+                            )
+                            stacked_key_config[key] = template
+        except Exception as e:
+            logging.warning(
+                f"Failed to auto-detect stacked keys for PerExpertParallelLoader: {e}"
+            )
+
+    loader_kwargs = dict(
+        pg=pg,
+        hf_weights_files=sorted(ckpt_files),
+        use_tqdm_on_load=True,
+        device=device,
+        bbuf_size_kb=1024
+        * 256,  # Optimized from 2GB to 256MB to save GPU memory headroom
+        use_shm=True,
+    )
+
+    if stacked_key_config:
+        logging.info(
+            f"FST per-expert parallel loader enabled for {len(stacked_key_config)} stacked keys: {list(stacked_key_config.keys())}"
+        )
+        loader = PerExpertParallelLoader(stacked_key_config, **loader_kwargs)
+    else:
+        loader = ParallelLoader(**loader_kwargs)
+
+    try:
+        yield from loader.iterate_weights()
+    finally:
+        inner = getattr(loader, "loader", None)
+        if inner is not None and hasattr(inner, "close"):
+            inner.close()
+
+
+_STACKED_EXPERT_RE = re.compile(
+    r"^(?P<prefix>.*\.experts)\.(?P<expert_id>\d+)\.(?P<proj>gate_up_proj|down_proj)$"
+)
+
+
+def _normalize_fastsafetensors_stacked_moe_weights(
+    weights_iter: Iterator[Tuple[str, torch.Tensor]]
+) -> Iterator[Tuple[str, torch.Tensor]]:
+    for name, tensor in weights_iter:
+        m = _STACKED_EXPERT_RE.match(name)
+        if m is None:
+            yield name, tensor
+            continue
+        prefix = m.group("prefix")
+        expert_id = m.group("expert_id")
+        proj = m.group("proj")
+        yield f"{prefix}.{expert_id}.{proj}.weight", tensor
+
+
+_EP_EXPERT_RE = re.compile(r"experts\.(\d+)\.")
+
+
+class _ExpertRangeFilter:
+    """Drop weights for experts outside [start_expert, end_expert).
+
+    Replaces the previous N-alternation regex (one branch per excluded expert),
+    which compiled and matched in O(num_experts) per weight — costly for
+    256/512-expert MoE ckpts. Here we run one O(1) re.search per weight name
+    against a single fixed pattern and bound-check the captured expert id.
+    """
+
+    def __init__(self, start_expert: int, end_expert: int):
+        self.start_expert = start_expert
+        self.end_expert = end_expert
+
+    def apply(
+        self, weights_iter: Iterator[Tuple[str, torch.Tensor]]
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        for name, tensor in weights_iter:
+            if self.should_load(name):
+                yield name, tensor
+
+    def should_load(self, name: str) -> bool:
+        m = _EP_EXPERT_RE.search(name)
+        if m is None:
+            # Not an expert-scoped weight (e.g. shared attn / norm); keep.
+            return True
+        expert_id = int(m.group(1))
+        return self.start_expert <= expert_id < self.end_expert
+
+
+def _validate_ep_partition(ep_size: int, ep_rank: int, num_experts: int):
+    if ep_size <= 0:
+        raise ValueError(f"ep_size must be positive, got {ep_size}")
+    if ep_rank < 0 or ep_rank >= ep_size:
+        raise ValueError(
+            f"ep_rank must satisfy 0 <= ep_rank < ep_size, got "
+            f"ep_rank={ep_rank}, ep_size={ep_size}"
+        )
+    if num_experts < 0:
+        raise ValueError(f"num_experts must be non-negative, got {num_experts}")
+    if num_experts != 0 and num_experts % ep_size != 0:
+        raise ValueError(
+            f"num_experts ({num_experts}) must be divisible by ep_size ({ep_size}) "
+            "to avoid silently dropping experts during EP loading."
+        )
+
+
+def _create_ep_filter(ep_size: int, ep_rank: int, num_experts: int):
+    _validate_ep_partition(ep_size, ep_rank, num_experts)
+    if num_experts == 0:
+        return _WeightsFilter()
+    experts_per_rank = num_experts // ep_size
+    start_expert = ep_rank * experts_per_rank
+    end_expert = start_expert + experts_per_rank
+    return _ExpertRangeFilter(start_expert, end_expert)
+
+
+def _is_quanted_config(source_config: Any) -> bool:
+    if source_config is None:
+        return False
+    value = getattr(source_config, "is_quanted", False)
+    if callable(value):
+        return bool(value())
+    return bool(value)
+
+
+def _is_quantized_load(model_config: Any, load_config: LoadConfig) -> bool:
+    if _is_quanted_config(getattr(load_config, "quant_source_config", None)):
+        return True
+    return getattr(model_config, "quantization", None) is not None
+
+
+class NewModelLoader:
+
+    def __init__(
+        self,
+        model_config: Any,
+        load_config: Optional[LoadConfig] = None,
+        model_path: Optional[str] = None,
+        device: Optional[str] = None,
+    ):
+        self.model_config = model_config
+        self.load_config = load_config if load_config is not None else LoadConfig()
+        self.model_path = model_path
+        self.device = device if device is not None else self.load_config.device
+        self._ckpt_files_cache: Optional[List[str]] = None
+
+    def load(self) -> nn.Module:
+        method, explicit = self._resolve_load_method()
+        logger.info(f"NewModelLoader using load method: {method}")
+        if method == LoadMethod.FASTSAFETENSORS:
+            try:
+                model = self._load_via_fastsafetensors()
+            except Exception as e:
+                if explicit:
+                    logger.error(
+                        "fastsafetensors load failed and fallback is disabled "
+                        "because the load method was explicitly requested: %s",
+                        e,
+                    )
+                    raise
+                logger.warning(
+                    f"fastsafetensors load failed ({e}), automatically falling back to scratch load path..."
+                )
+                model = self._load_via_scratch()
+        else:
+            model = self._load_via_scratch()
+        return model
+
+    def _load_via_scratch(self) -> nn.Module:
+        import time
+
+        logger.info("Starting model loading (scratch path)...")
+        model = self._create_model()
+        ep_filter = self._create_ep_filter()
+        weights_iter = _get_all_weights(
+            self._discover_ckpt_files_cached(), device="cpu", name_filter=ep_filter
+        )
+        t0 = time.time()
+        model.load_weights(weights_iter)
+        logger.info(f"model.load_weights() took {time.time() - t0:.2f}s")
+
+        t1 = time.time()
+        logger.info(f"Moving model to device: {self.device}")
+        model.to(self.device)
+        logger.info(f"model.to({self.device}) took {time.time() - t1:.2f}s")
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        self._run_post_load_hooks(model)
+        self._log_peak_gpu_memory()
+        return model
+
+    def _load_via_fastsafetensors(self) -> nn.Module:
+        import time
+
+        logger.info("Starting model loading (fastsafetensors path)...")
+
+        target_device = self._resolve_target_device()
+
+        t0 = time.time()
+        with torch.device("meta"):
+            model = self._create_model()
+        model.to_empty(device=target_device)
+        logger.info(
+            f"meta create + to_empty({target_device}) " f"took {time.time() - t0:.2f}s"
+        )
+
+        weights_iter = _get_fastsafetensors_weights(
+            self._discover_ckpt_files_cached(), device=target_device
+        )
+        weights_iter = _normalize_fastsafetensors_stacked_moe_weights(weights_iter)
+        weights_iter = self._apply_ep_filter(weights_iter)
+
+        t1 = time.time()
+        model.load_weights(weights_iter)
+        logger.info(f"model.load_weights() took {time.time() - t1:.2f}s")
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        self._run_post_load_hooks(model)
+        self._log_peak_gpu_memory()
+        return model
+
+    def _run_post_load_hooks(self, model: nn.Module):
+        import time
+
+        t0 = time.time()
+        count = 0
+        for module in model.modules():
+            setattr(
+                module,
+                "_new_loader_force_cpu_load_weights",
+                bool(self.load_config.force_cpu_load_weights),
+            )
+            if hasattr(module, "process_weights_after_loading"):
+                module.process_weights_after_loading()
+                count += 1
+        logger.info(
+            f"Post-load hooks ran on {count} modules in {time.time() - t0:.2f}s"
+        )
+
+    def _log_peak_gpu_memory(self):
+        if not torch.cuda.is_available():
+            return
+        try:
+            allocated = torch.cuda.max_memory_allocated()
+            reserved = torch.cuda.max_memory_reserved()
+            gib = 1024**3
+            logger.info(
+                f"Peak GPU memory after loading: "
+                f"allocated={allocated / gib:.2f} GiB, "
+                f"reserved={reserved / gib:.2f} GiB"
+            )
+        except Exception as e:
+            logger.debug("Failed to query peak GPU memory after loading: %s", e)
+
+    def _resolve_target_device(self) -> str:
+        device = str(self.device)
+        if not device.startswith("cuda"):
+            return device
+        if ":" in device:
+            return device
+        return f"cuda:{torch.cuda.current_device()}"
+
+    def _target_cuda_mem_get_info(self) -> Tuple[int, int]:
+        target_device = self._resolve_target_device()
+        try:
+            return torch.cuda.mem_get_info(target_device)
+        except TypeError:
+            with torch.cuda.device(target_device):
+                return torch.cuda.mem_get_info()
+
+    def _resolve_load_method(self) -> Tuple[str, bool]:
+        configured = getattr(self.load_config, "load_method", LoadMethod.AUTO)
+        load_method = (configured or LoadMethod.AUTO).lower()
+        explicit = load_method != LoadMethod.AUTO
+        if load_method == LoadMethod.AUTO:
+            env = os.environ.get("LOAD_METHOD", "").strip().lower()
+            if env and env != LoadMethod.AUTO:
+                if env not in (LoadMethod.SCRATCH, LoadMethod.FASTSAFETENSORS):
+                    raise ValueError(
+                        f"Unsupported LOAD_METHOD {env!r}; expected one of "
+                        f"{LoadMethod.AUTO!r}, {LoadMethod.SCRATCH!r}, "
+                        f"{LoadMethod.FASTSAFETENSORS!r}"
+                    )
+                load_method = env
+                explicit = True
+                logger.info(f"LOAD_METHOD env: {load_method}")
+            else:
+                ok, reason = self._fastsafetensors_eligible()
+                if ok:
+                    return LoadMethod.FASTSAFETENSORS, False
+                logger.info(
+                    "auto fastsafetensors unavailable: %s; using scratch", reason
+                )
+                return LoadMethod.SCRATCH, False
+
+        if load_method not in (LoadMethod.SCRATCH, LoadMethod.FASTSAFETENSORS):
+            raise ValueError(
+                f"Unsupported load_method {load_method!r}; expected one of "
+                f"{LoadMethod.AUTO!r}, {LoadMethod.SCRATCH!r}, "
+                f"{LoadMethod.FASTSAFETENSORS!r}"
+            )
+
+        if load_method == LoadMethod.FASTSAFETENSORS:
+            ok, reason = self._fastsafetensors_eligible()
+            if not ok:
+                if reason == "insufficient GPU free memory":
+                    ckpt_files = self._discover_ckpt_files_cached()
+                    sizes = [os.path.getsize(f) for f in ckpt_files]
+                    total = sum(sizes)
+                    tp_size = max(getattr(self.load_config, "tp_size", 1), 1)
+                    ep_size = max(getattr(self.load_config, "ep_size", 1), 1)
+                    rank_share = total / max(tp_size, ep_size)
+
+                    if _is_quantized_load(self.model_config, self.load_config):
+                        rank_share /= 2.0
+
+                    free_bytes, _ = self._target_cuda_mem_get_info()
+                    if free_bytes < rank_share:
+                        raise RuntimeError(
+                            f"fastsafetensors load requested but unavailable: {reason} "
+                            f"(free={free_bytes/1024**3:.1f}GiB < rank_share={rank_share/1024**3:.1f}GiB)"
+                        )
+                    else:
+                        logger.warning(
+                            f"fastsafetensors headroom is negative, but free memory ({free_bytes/1024**3:.1f}GiB) "
+                            f"is sufficient to hold rank_share ({rank_share/1024**3:.1f}GiB). Proceeding anyway."
+                        )
+                else:
+                    raise RuntimeError(
+                        f"fastsafetensors load requested but unavailable: {reason}"
+                    )
+            return LoadMethod.FASTSAFETENSORS, explicit
+        return LoadMethod.SCRATCH, explicit
+
+    def _fastsafetensors_eligible(self) -> Tuple[bool, str]:
+        try:
+            import fastsafetensors  # noqa: F401
+        except ImportError:
+            return False, "fastsafetensors module not installed"
+        if not torch.cuda.is_available():
+            return False, "cuda not available"
+        if not str(self.device).startswith("cuda"):
+            return False, f"device {self.device} is not cuda"
+
+        ckpt_files = self._discover_ckpt_files_cached()
+        if not ckpt_files:
+            return False, "no checkpoint files discovered"
+        if not all(f.endswith(".safetensors") for f in ckpt_files):
+            return False, "not all checkpoint files are safetensors"
+
+        sizes = [os.path.getsize(f) for f in ckpt_files]
+        max_file = max(sizes)
+        total = sum(sizes)
+        tp_size = max(getattr(self.load_config, "tp_size", 1), 1)
+        ep_size = max(getattr(self.load_config, "ep_size", 1), 1)
+        rank_share = total / max(tp_size, ep_size)
+
+        if _is_quantized_load(self.model_config, self.load_config):
+            rank_share /= 2.0
+
+        try:
+            free_bytes, _ = self._target_cuda_mem_get_info()
+        except Exception as e:
+            return False, f"cuda mem_get_info failed: {e}"
+
+        headroom = free_bytes - rank_share - 3 * max_file
+        gib = 1024**3
+        logger.info(
+            f"fastsafetensors capacity: free={free_bytes/gib:.1f}GiB, "
+            f"rank_share={rank_share/gib:.1f}GiB, "
+            f"max_file={max_file/gib:.1f}GiB, "
+            f"headroom={headroom/gib:.1f}GiB"
+        )
+        if headroom <= 0:
+            return False, "insufficient GPU free memory"
+        return True, "ok"
+
+    def _discover_ckpt_files_cached(self) -> List[str]:
+        if self._ckpt_files_cache is not None:
+            return self._ckpt_files_cache
+        model_path = self._resolve_model_path()
+        if not os.path.isdir(model_path):
+            raise NotADirectoryError(f"model_path is not a directory: {model_path}")
+        ckpt_files = _discover_ckpt_files(model_path)
+        if not ckpt_files:
+            raise FileNotFoundError(f"No checkpoint files found in: {model_path}")
+        logger.info(f"Found {len(ckpt_files)} checkpoint file(s) in {model_path}")
+        if os.environ.get("DROP_PAGE_CACHE", "0") == "1":
+            _evict_page_cache(ckpt_files)
+        self._ckpt_files_cache = ckpt_files
+        return ckpt_files
+
+    def _create_model(self) -> nn.Module:
+        from rtp_llm.models_py.registry import MODEL_REGISTRY
+
+        model_type = self._get_model_type()
+        if model_type not in MODEL_REGISTRY:
+            raise ValueError(
+                f"Model type '{model_type}' not found in registry. "
+                f"Available: {list(MODEL_REGISTRY.keys())}."
+            )
+        model_cls = MODEL_REGISTRY[model_type]
+        logger.info(
+            "NewModelLoader registry hit: model_type=%s cls=%s module=%s file=%s",
+            model_type,
+            model_cls.__qualname__,
+            model_cls.__module__,
+            inspect.getfile(model_cls),
+        )
+        model = model_cls(self.model_config, self.load_config)
+        logger.info(f"Created model: {model_cls.__name__} (type={model_type})")
+        return model
+
+    def _get_model_type(self) -> str:
+        if hasattr(self.model_config, "model_type"):
+            return self.model_config.model_type
+        elif isinstance(self.model_config, dict):
+            return self.model_config.get("model_type", "")
+        raise ValueError("Cannot determine model_type from model_config.")
+
+    def _resolve_model_path(self) -> str:
+        if self.model_path:
+            return self.model_path
+        if hasattr(self.model_config, "model_path"):
+            if self.model_config.model_path:
+                return self.model_config.model_path
+        if isinstance(self.model_config, dict):
+            path = self.model_config.get("model_path", "")
+            if path:
+                return path
+        raise ValueError("model_path is required for weight loading.")
+
+    def _apply_ep_filter(self, weights_iter):
+        ep_filter = self._create_ep_filter()
+        if ep_filter is None:
+            return weights_iter
+        return ep_filter.apply(weights_iter)
+
+    def _create_ep_filter(self):
+        ep_size = getattr(self.load_config, "ep_size", 1)
+        ep_rank = getattr(self.load_config, "ep_rank", 0)
+        if ep_size <= 1:
+            return None
+        # Single source of truth: model_config.expert_num. Same convention as
+        # the legacy loader (model_loader/ffn_weight.py) and every MoE executor
+        # under models_py/modules/factory/fused_moe/. dense models lack this
+        # attr, getattr default 0 short-circuits _create_ep_filter to a no-op.
+        num_experts = getattr(self.model_config, "expert_num", 0)
+        if num_experts == 0:
+            return None
+        return _create_ep_filter(ep_size, ep_rank, num_experts)
+
+    # ------------------------------------------------------------------ #
+    #  LoRA support
+    # ------------------------------------------------------------------ #
+
+    def load_lora_weights(self, adapter_name: str, lora_path: str, device: str = "cpu"):
+        """Load HF-format LoRA adapter weights independently of the legacy loader.
+
+        Reads adapter_config.json for rank/alpha, then loads adapter_model
+        checkpoint, maps HF module names to engine-internal W.* names, applies
+        TP slicing, and returns a LoRAWeights object ready for the C++ runtime.
+        """
+        from rtp_llm.lora.lora_weights import LoRAWeights
+        from rtp_llm.utils.model_weight import W
+
+        lora_config = self._read_lora_config(lora_path)
+        rank = lora_config["rank"]
+        lora_alpha = lora_config["lora_alpha"]
+
+        num_layers = getattr(self.model_config, "num_layers", 0)
+        if num_layers == 0:
+            num_layers = getattr(self.model_config, "num_hidden_layers", 0)
+        lora_weights = LoRAWeights(num_layers)
+        lora_weights.set_lora_rank(rank)
+
+        tp_size = getattr(self.load_config, "tp_size", 1)
+        tp_rank = getattr(self.load_config, "tp_rank", 0)
+        compute_dtype = getattr(self.load_config, "compute_dtype", torch.float16)
+
+        state_dict = self._load_lora_state_dict(lora_path, device)
+
+        for hf_name, tensor in state_dict.items():
+            parsed = _parse_hf_lora_name(hf_name)
+            if parsed is None:
+                continue
+            layer_id, hf_module, ab_suffix = parsed
+
+            if layer_id >= num_layers:
+                continue
+
+            if hf_module in (
+                "self_attn.q_proj",
+                "self_attn.k_proj",
+                "self_attn.v_proj",
+            ):
+                raise NotImplementedError(
+                    "NewModelLoader LoRA does not yet support split q/k/v adapters. "
+                    "They must be packed into the engine fused qkv LoRA tensor before "
+                    "being passed to LoRAWeights; refusing to map them all to "
+                    "self_attention_weights.query_weight.kernel because that would "
+                    "overwrite q/k/v adapters silently."
+                )
+
+            engine_name = _HF_TO_ENGINE_LORA.get(hf_module)
+            if engine_name is None:
+                logger.warning(f"LoRA: unmapped module '{hf_module}', skipping")
+                continue
+
+            tensor = tensor.to(compute_dtype)
+
+            # TP slicing
+            if tp_size > 1:
+                split_rule = _LORA_TP_RULES.get((hf_module, ab_suffix))
+                if split_rule is not None:
+                    tensor = _tp_slice(tensor, tp_size, tp_rank, split_rule)
+
+            full_name = f"{engine_name}.{ab_suffix}"
+            lora_weights.set_layer_weight(False, layer_id, full_name, tensor)
+
+        lora_weights.apply_scale(lora_alpha / rank)
+        logger.info(
+            f"Loaded LoRA '{adapter_name}' from {lora_path}: "
+            f"rank={rank}, alpha={lora_alpha}, layers={num_layers}"
+        )
+        return lora_weights
+
+    @staticmethod
+    def _read_lora_config(lora_path: str) -> dict:
+        import json
+
+        config_path = os.path.join(lora_path, "adapter_config.json")
+        if not os.path.exists(config_path):
+            raise FileNotFoundError(
+                f"LoRA adapter_config.json not found: {config_path}"
+            )
+        with open(config_path) as f:
+            cfg = json.load(f)
+        return {
+            "rank": cfg["r"],
+            "lora_alpha": cfg["lora_alpha"],
+        }
+
+    @staticmethod
+    def _load_lora_state_dict(lora_path: str, device: str) -> dict:
+        for filename in (
+            "adapter_model.safetensors",
+            "adapter_model.bin",
+            "adapter_model.pt",
+        ):
+            filepath = os.path.join(lora_path, filename)
+            if os.path.exists(filepath):
+                if filepath.endswith(".safetensors"):
+                    from safetensors.torch import load_file
+
+                    return load_file(filepath, device=device)
+                else:
+                    return torch.load(filepath, map_location=device, weights_only=True)
+        raise FileNotFoundError(f"No adapter model file found in {lora_path}")
+
+
+# ------------------------------------------------------------------ #
+#  LoRA name mapping and TP slicing helpers
+# ------------------------------------------------------------------ #
+
+_HF_LORA_PATTERN = re.compile(
+    r"base_model\.model\.model\.layers\.(\d+)\.(.*)\.(lora_A|lora_B)\.weight"
+)
+
+
+def _parse_hf_lora_name(name: str):
+    """Parse HF LoRA tensor name -> (layer_id, hf_module, 'lora_A'|'lora_B')."""
+    m = _HF_LORA_PATTERN.match(name)
+    if m is None:
+        return None
+    return int(m.group(1)), m.group(2), m.group(3)
+
+
+# HF module path -> engine internal W.* name
+_HF_TO_ENGINE_LORA = {
+    "self_attn.o_proj": "self_attention_weights.attention_output_weight.kernel",
+    "mlp.gate_proj": "ffn_weights.intermediate_weight.kernel",
+    "mlp.up_proj": "ffn_weights.intermediate_weight3.kernel",
+    "mlp.down_proj": "ffn_weights.intermediate_weight2.kernel",
+}
+
+
+# TP slicing rules: (hf_module, ab_suffix) -> (dim, "split"|"identity")
+# Column-parallel projections (q/k/v/gate/up): lora_B sliced on dim=-1
+# Row-parallel projections (o/down): lora_A sliced on dim=0
+_LORA_TP_RULES: Dict[tuple, tuple] = {
+    # q/k/v: lora_B output-dim split
+    ("self_attn.q_proj", "lora_B"): (-1, "split"),
+    ("self_attn.k_proj", "lora_B"): (-1, "split"),
+    ("self_attn.v_proj", "lora_B"): (-1, "split"),
+    # o_proj: lora_A input-dim split
+    ("self_attn.o_proj", "lora_A"): (0, "split"),
+    # gate/up: lora_B output-dim split
+    ("mlp.gate_proj", "lora_B"): (-1, "split"),
+    ("mlp.up_proj", "lora_B"): (-1, "split"),
+    # down: lora_A input-dim split
+    ("mlp.down_proj", "lora_A"): (0, "split"),
+}
+
+
+def _tp_slice(
+    tensor: torch.Tensor, tp_size: int, tp_rank: int, rule: tuple
+) -> torch.Tensor:
+    dim, action = rule
+    if action != "split":
+        return tensor
+    size = tensor.shape[dim]
+    if tp_size <= 0:
+        raise ValueError(f"LoRA TP slice requires positive tp_size, got {tp_size}")
+    if tp_rank < 0 or tp_rank >= tp_size:
+        raise ValueError(
+            f"LoRA TP slice requires 0 <= tp_rank < tp_size, got "
+            f"tp_rank={tp_rank}, tp_size={tp_size}"
+        )
+    if size % tp_size != 0:
+        raise ValueError(
+            f"LoRA TP slice dimension {dim} size ({size}) must be divisible "
+            f"by tp_size ({tp_size}); non-divisible sharding would drop weights"
+        )
+    chunk_size = size // tp_size
+    start = tp_rank * chunk_size
+    return tensor.narrow(dim, start, chunk_size).contiguous()

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -166,6 +166,14 @@ def _get_all_weights(
     def _should_load(name: str) -> bool:
         return name_filter is None or name_filter.should_load(name)
 
+    def _emit_filtered_item(
+        name: str, tensor: torch.Tensor
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        if name_filter is not None and hasattr(name_filter, "filter_item"):
+            yield from name_filter.filter_item(name, tensor)
+        else:
+            yield name, tensor
+
     count = 0
     skipped = 0
     for ckpt_file in ckpt_files:
@@ -190,7 +198,7 @@ def _get_all_weights(
                             tensor.dtype,
                             skipped,
                         )
-                    yield name, tensor
+                    yield from _emit_filtered_item(name, tensor)
             logger.info(
                 "Scanned checkpoint file: %s yielded=%d skipped=%d",
                 ckpt_file,
@@ -225,7 +233,7 @@ def _get_all_weights(
                         tensor.dtype,
                         skipped,
                     )
-                yield name, tensor
+                yield from _emit_filtered_item(name, tensor)
     logger.info("Finished streaming %d weights (skipped=%d)", count, skipped)
 
 
@@ -352,6 +360,10 @@ def _normalize_fastsafetensors_stacked_moe_weights(
 
 
 _EP_EXPERT_RE = re.compile(r"experts\.(\d+)\.")
+_STACKED_EP_RE = re.compile(
+    r"^(?P<prefix>.*\.experts)\.(?P<proj>gate_up_proj|down_proj)"
+    r"(?:\.(?P<param>[^.]+))?$"
+)
 
 
 class _ExpertRangeFilter:
@@ -371,10 +383,42 @@ class _ExpertRangeFilter:
         self, weights_iter: Iterator[Tuple[str, torch.Tensor]]
     ) -> Iterator[Tuple[str, torch.Tensor]]:
         for name, tensor in weights_iter:
-            if self.should_load(name):
-                yield name, tensor
+            yield from self.filter_item(name, tensor)
+
+    def filter_item(
+        self, name: str, tensor: torch.Tensor
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        stacked = _STACKED_EP_RE.match(name)
+        if stacked is not None:
+            yield from self._split_stacked_experts(stacked, name, tensor)
+            return
+        if self.should_load(name):
+            yield name, tensor
+
+    def _split_stacked_experts(
+        self, match: re.Match, name: str, tensor: torch.Tensor
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        if not hasattr(tensor, "dim") or tensor.dim() == 0:
+            raise ValueError(
+                f"EP stacked MoE tensor {name!r} must have expert dimension at dim 0"
+            )
+        if tensor.shape[0] < self.end_expert:
+            raise ValueError(
+                f"EP stacked MoE tensor {name!r} has only {tensor.shape[0]} experts, "
+                f"but this rank needs [{self.start_expert}, {self.end_expert})"
+            )
+        prefix = match.group("prefix")
+        proj = match.group("proj")
+        param = match.group("param") or "weight"
+        for expert_id in range(self.start_expert, self.end_expert):
+            yield (
+                f"{prefix}.{expert_id}.{proj}.{param}",
+                tensor.select(0, expert_id).contiguous(),
+            )
 
     def should_load(self, name: str) -> bool:
+        if _STACKED_EP_RE.match(name) is not None:
+            return True
         m = _EP_EXPERT_RE.search(name)
         if m is None:
             # Not an expert-scoped weight (e.g. shared attn / norm); keep.
@@ -767,11 +811,15 @@ class NewModelLoader:
         ep_rank = getattr(self.load_config, "ep_rank", 0)
         if ep_size <= 1:
             return None
-        # Single source of truth: model_config.expert_num. Same convention as
-        # the legacy loader (model_loader/ffn_weight.py) and every MoE executor
-        # under models_py/modules/factory/fused_moe/. dense models lack this
-        # attr, getattr default 0 short-circuits _create_ep_filter to a no-op.
-        num_experts = getattr(self.model_config, "expert_num", 0)
+        # Prefer model_config.expert_num, matching the legacy loader and MoE
+        # executors. Accept num_experts as a compatibility alias for lightweight
+        # configs/tests that use HF-style naming. Dense models lack both attrs
+        # and short-circuit to a no-op filter.
+        num_experts = getattr(
+            self.model_config,
+            "expert_num",
+            getattr(self.model_config, "num_experts", 0),
+        )
         if num_experts == 0:
             return None
         return _create_ep_filter(ep_size, ep_rank, num_experts)

--- a/rtp_llm/models_py/module_base.py
+++ b/rtp_llm/models_py/module_base.py
@@ -1,0 +1,207 @@
+import logging
+from collections import defaultdict
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+_ALLOWED_DROPPED_WEIGHT_SUFFIXES = (
+    "rotary_emb.inv_freq",
+    "rotary_emb.cos_cached",
+    "rotary_emb.sin_cached",
+    "rope.inv_freq",
+    "inv_freq",
+)
+
+
+def _is_allowed_dropped_weight(name: str) -> bool:
+    return any(name == suffix or name.endswith(f".{suffix}") for suffix in _ALLOWED_DROPPED_WEIGHT_SUFFIXES)
+
+
+class RtpModule(nn.Module):
+    """Base class for RTP-LLM new-loader modules.
+
+    Provides per-tensor streaming weight loading via ``load_weights``. Each
+    incoming tensor immediately walks the module tree to its leaf and copies
+    directly, so peak memory stays at model-params + one ckpt tensor (no
+    intermediate dict buffering).
+
+    Subclasses choose one of two roles:
+      * **Container** modules inherit ``load_weights`` unchanged and act as
+        recursive dispatchers into their children.
+      * **Leaf** modules (e.g. ``MergedColumnParallelLinear``,
+        ``BaseMoEExperts``) override ``load_weights`` to handle TP sharding,
+        FP8/INT4 quantization fusion, or expert-parallel slicing themselves.
+        Their override wins via normal MRO; the parent's recursion stops at
+        them via ``hasattr(child, "load_weights")``.
+    """
+
+    def _build_redirect(self) -> Dict[str, Tuple[Any, int, str]]:
+        redirect: Dict[str, Tuple[Any, int, str]] = {}
+        for name, child in self.named_children():
+            if hasattr(child, "shard_names") and child.shard_names:
+                for idx, shard_name in enumerate(child.shard_names):
+                    redirect[shard_name] = (child, idx, name)
+        return redirect
+
+    def _is_fused_target(self, child: nn.Module) -> bool:
+        return (
+            hasattr(child, "shard_names")
+            and child.shard_names
+            and hasattr(child, "load_weights")
+        )
+
+    def _get_child_module(self, name: str) -> Optional[nn.Module]:
+        if hasattr(self, name):
+            return getattr(self, name)
+        try:
+            idx = int(name)
+            for attr_name, attr in self.named_children():
+                if isinstance(attr, nn.ModuleList) and idx < len(attr):
+                    return attr[idx]
+        except (ValueError, IndexError):
+            pass
+        return None
+
+    def _assign_weight(self, module: nn.Module, name: str, tensor: torch.Tensor) -> bool:
+        if "." in name:
+            prefix, rest = name.split(".", 1)
+            child = getattr(module, prefix, None)
+            if child is None:
+                return False
+            return self._assign_weight(child, rest, tensor)
+
+        if not hasattr(module, name):
+            return False
+        param = getattr(module, name)
+        if not isinstance(param, nn.Parameter):
+            return False
+        try:
+            param.data.copy_(tensor)
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"Error copying weight to parameter '{name}' in module '{module.__class__.__name__}': "
+                f"target shape is {list(param.shape)}, source shape is {list(tensor.shape)}. Original error: {e}"
+            ) from e
+        return True
+
+    def _groupby_prefix(
+        self, weights: Iterator[Tuple[str, torch.Tensor]]
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        grouped: Dict[str, Dict[str, torch.Tensor]] = defaultdict(dict)
+        for full_name, tensor in weights:
+            if "." in full_name:
+                prefix, rest = full_name.split(".", 1)
+                grouped[prefix][rest] = tensor
+            else:
+                grouped["_self_"][full_name] = tensor
+        return dict(grouped)
+
+    def load_weights(self, weights: Any):
+        """Per-tensor streaming dispatch: each tensor immediately walks the
+        module tree to its leaf and copies directly. No intermediate dict
+        buffering, so peak memory stays at model-params + one ckpt tensor.
+        """
+        if isinstance(weights, dict):
+            weights_iter = iter(weights.items())
+        else:
+            weights_iter = weights
+
+        redirect = self._build_redirect()
+        dropped: List[str] = []
+
+        for full_name, tensor in weights_iter:
+            if "." not in full_name:
+                if hasattr(self, full_name):
+                    param = getattr(self, full_name)
+                    if isinstance(param, nn.Parameter):
+                        param.data.copy_(tensor)
+                    else:
+                        dropped.append(full_name)
+                else:
+                    dropped.append(full_name)
+                continue
+
+            prefix, rest = full_name.split(".", 1)
+
+            if prefix in redirect:
+                layer, _shard_id, _target_name = redirect[prefix]
+                layer.load_weights({f"{prefix}.{rest}": tensor})
+            else:
+                child = self._get_child_module(prefix)
+                if child is None:
+                    dropped.append(full_name)
+                    continue
+
+                if isinstance(child, nn.ModuleList):
+                    if not _dispatch_single_to_module_list(self, child, rest, tensor):
+                        dropped.append(full_name)
+                elif hasattr(child, "load_weights"):
+                    child.load_weights({rest: tensor})
+                elif not self._assign_weight(child, rest, tensor):
+                    dropped.append(full_name)
+
+        if dropped:
+            cls_name = self.__class__.__name__
+            allowed = [name for name in dropped if _is_allowed_dropped_weight(name)]
+            unexpected = [name for name in dropped if not _is_allowed_dropped_weight(name)]
+            if unexpected:
+                sample = unexpected[:10]
+                more = (
+                    f" (+{len(unexpected) - len(sample)} more)"
+                    if len(unexpected) > len(sample)
+                    else ""
+                )
+                raise RuntimeError(
+                    f"[{cls_name}] {len(unexpected)} weight(s) had no matching "
+                    f"submodule: {sample}{more}. Refusing to continue with "
+                    "possibly uninitialized parameters. Add an explicit allowlist "
+                    "entry only for known non-persistent checkpoint tensors."
+                )
+            if allowed:
+                sample = allowed[:10]
+                more = (
+                    f" (+{len(allowed) - len(sample)} more)"
+                    if len(allowed) > len(sample)
+                    else ""
+                )
+                logger.info(
+                    "[%s] ignored %d known non-persistent checkpoint tensor(s): %s%s",
+                    cls_name,
+                    len(allowed),
+                    sample,
+                    more,
+                )
+
+
+def _dispatch_single_to_module_list(
+    parent: nn.Module, module_list: nn.ModuleList, name: str, tensor: torch.Tensor
+) -> bool:
+    if "." not in name:
+        return False
+    idx_str, rest = name.split(".", 1)
+    try:
+        idx = int(idx_str)
+    except ValueError:
+        return False
+    if idx < 0 or idx >= len(module_list):
+        return False
+    child = module_list[idx]
+    if hasattr(child, "load_weights"):
+        child.load_weights({rest: tensor})
+        return True
+    if isinstance(parent, RtpModule):
+        return parent._assign_weight(child, rest, tensor)
+    return False
+
+
+def rtp_module(cls):
+    """Deprecated. Use ``class Foo(RtpModule)`` instead.
+
+    Kept as a no-op alias so any external/legacy code still importing the
+    decorator does not break.
+    """
+    return cls

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/config_adapter.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/config_adapter.py
@@ -5,6 +5,8 @@ This allows Router and Executor classes to work with specific config objects.
 
 from typing import Optional
 
+_UNSET_QUANT_CONFIG = object()
+
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.config.quant_config import QuantizationConfig
 from rtp_llm.ops import MoeConfig, ParallelismConfig
@@ -21,13 +23,17 @@ class MoEConfigAdapter:
         model_config: ModelConfig,
         parallelism_config: ParallelismConfig,
         moe_config: Optional[MoeConfig] = None,
-        quant_config: Optional[QuantizationConfig] = None,
+        quant_config: Optional[QuantizationConfig] = _UNSET_QUANT_CONFIG,
         enable_cuda_graph: bool = False,
     ):
         self.model_config = model_config
         self.parallelism_config = parallelism_config
         self.moe_config = moe_config or MoeConfig()
-        self.quant_config = quant_config
+        self.quant_config = (
+            getattr(model_config, "quant_config", None)
+            if quant_config is _UNSET_QUANT_CONFIG
+            else quant_config
+        )
 
         # Provide shortcut access to commonly used attributes
         self.ep_size = parallelism_config.ep_size

--- a/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
@@ -73,7 +73,7 @@ class StrategyRegistry:
         if not candidates:
             logger.error(
                 f"No suitable MOE strategy found. Config details: "
-                f"quant_config={config.model_config.quant_config}, "
+                f"quant_config={config.quant_config}, "
                 f"ep_size={config.ep_size}, "
                 f"world_size={config.world_size}, "
                 f"tp_size={config.tp_size}, "

--- a/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/utils/config_resolver.py
@@ -35,7 +35,7 @@ class MoeConfigResolver:
         Returns:
             Whether quantization is enabled
         """
-        return config.model_config.quant_config is not None
+        return config.quant_config is not None
 
     @staticmethod
     def is_bf16(config: MoEConfigAdapter) -> bool:
@@ -59,9 +59,9 @@ class MoeConfigResolver:
         Returns:
             Quantization method name, or None if quantization is not enabled
         """
-        if config.model_config.quant_config is None:
+        if config.quant_config is None:
             return None
-        return config.model_config.quant_config.get_method()
+        return config.quant_config.get_method()
 
     @staticmethod
     def is_ep_enabled(config: MoEConfigAdapter) -> bool:

--- a/rtp_llm/models_py/new_models/__init__.py
+++ b/rtp_llm/models_py/new_models/__init__.py
@@ -1,0 +1,6 @@
+"""Lazy new-loader model package.
+
+Model classes are imported by rtp_llm.models_py.registry on demand.
+"""
+
+__all__ = []

--- a/rtp_llm/models_py/new_models/bert/__init__.py
+++ b/rtp_llm/models_py/new_models/bert/__init__.py
@@ -1,0 +1,3 @@
+from rtp_llm.models_py.new_models.bert.language import BertForEmbedding, RobertaForEmbedding
+
+__all__ = ["BertForEmbedding", "RobertaForEmbedding"]

--- a/rtp_llm/models_py/new_models/bert/language.py
+++ b/rtp_llm/models_py/new_models/bert/language.py
@@ -160,6 +160,12 @@ class _BertNewLoaderBase(nn.Module):
             self.parallelism_config.ep_rank = getattr(load_config, "ep_rank", 0)
             self.parallelism_config.world_size = max(self.parallelism_config.tp_size, 1)
             self.parallelism_config.local_world_size = self.parallelism_config.world_size
+        if int(getattr(self.parallelism_config, "tp_size", 1) or 1) != 1:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} newloader does not support tensor parallel "
+                "loading yet; tp_size > 1 would require rank-local BERT weight "
+                "partitioning before rebuilding ModelWeights"
+            )
         self.model = None
         self.weights = None
         self.embeddings = _BertEmbeddingParams()

--- a/rtp_llm/models_py/new_models/bert/language.py
+++ b/rtp_llm/models_py/new_models/bert/language.py
@@ -1,0 +1,424 @@
+import hashlib
+import logging
+from typing import Any, Dict, Iterator, Tuple
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.model_loader.model_weight_info import ModelWeights
+from rtp_llm.model_loader.weight_module import CustomAtomicWeight
+from rtp_llm.ops import ParallelismConfig
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+from rtp_llm.utils.model_weight import W
+
+logger = logging.getLogger(__name__)
+
+
+def _as_iter(weights: Any) -> Iterator[Tuple[str, torch.Tensor]]:
+    if isinstance(weights, dict):
+        return iter(weights.items())
+    return iter(weights)
+
+
+def _strip_known_prefix(name: str, model_prefix: str) -> str:
+    for prefix in (model_prefix + ".", "bert.", "roberta."):
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+    return name
+
+
+def _float_to_dtype(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    if tensor.is_floating_point():
+        return tensor.to(dtype)
+    return tensor
+
+
+def _set_param(module: nn.Module, attr: str, tensor: torch.Tensor, dtype: torch.dtype):
+    value = _float_to_dtype(tensor.detach().contiguous(), dtype)
+    current = getattr(module, attr, None)
+    if isinstance(current, nn.Parameter):
+        if current.shape != value.shape:
+            raise ValueError(f"Shape mismatch for {attr}: {value.shape} vs {current.shape}")
+        current.data.copy_(value)
+    else:
+        module.register_parameter(attr, nn.Parameter(value, requires_grad=False))
+
+
+def _required_param(module: nn.Module, attr: str) -> nn.Parameter:
+    value = getattr(module, attr, None)
+    if not isinstance(value, nn.Parameter):
+        raise KeyError(attr)
+    return value
+
+
+def _optional_param(module: nn.Module, attr: str):
+    value = getattr(module, attr, None)
+    return value if isinstance(value, nn.Parameter) else None
+
+
+def _weight_data(param: nn.Parameter, dtype: torch.dtype) -> torch.Tensor:
+    return _float_to_dtype(param.data, dtype)
+
+
+_ALLOWED_DROPPED_SUFFIXES = (
+    "position_ids",
+    "token_type_ids",
+)
+
+
+def _is_allowed_dropped_weight(name: str) -> bool:
+    return any(name == suffix or name.endswith(f".{suffix}") for suffix in _ALLOWED_DROPPED_SUFFIXES)
+
+
+class _BertEmbeddingParams(nn.Module):
+    def load_weight(self, name: str, tensor: torch.Tensor, dtype: torch.dtype) -> bool:
+        mapping = {
+            "word_embeddings.weight": "word_embeddings_weight",
+            "position_embeddings.weight": "position_embeddings_weight",
+            "token_type_embeddings.weight": "token_type_embeddings_weight",
+            "LayerNorm.weight": "layernorm_weight",
+            "LayerNorm.bias": "layernorm_bias",
+            "LayerNorm.gamma": "layernorm_weight",
+            "LayerNorm.beta": "layernorm_bias",
+        }
+        attr = mapping.get(name)
+        if attr is None:
+            return False
+        _set_param(self, attr, tensor, dtype)
+        return True
+
+
+class _BertLayerParams(nn.Module):
+    _MAPPING = {
+        "attention.self.query.weight": "attention_query_weight",
+        "attention.self.query.bias": "attention_query_bias",
+        "attention.self.key.weight": "attention_key_weight",
+        "attention.self.key.bias": "attention_key_bias",
+        "attention.self.value.weight": "attention_value_weight",
+        "attention.self.value.bias": "attention_value_bias",
+        "attention.output.dense.weight": "attention_output_dense_weight",
+        "attention.output.dense.bias": "attention_output_dense_bias",
+        "attention.output.LayerNorm.weight": "attention_output_layernorm_weight",
+        "attention.output.LayerNorm.bias": "attention_output_layernorm_bias",
+        "attention.output.LayerNorm.gamma": "attention_output_layernorm_weight",
+        "attention.output.LayerNorm.beta": "attention_output_layernorm_bias",
+        "intermediate.dense.weight": "intermediate_dense_weight",
+        "intermediate.dense.bias": "intermediate_dense_bias",
+        "output.dense.weight": "output_dense_weight",
+        "output.dense.bias": "output_dense_bias",
+        "output.LayerNorm.weight": "output_layernorm_weight",
+        "output.LayerNorm.bias": "output_layernorm_bias",
+        "output.LayerNorm.gamma": "output_layernorm_weight",
+        "output.LayerNorm.beta": "output_layernorm_bias",
+    }
+
+    def load_weight(self, name: str, tensor: torch.Tensor, dtype: torch.dtype) -> bool:
+        attr = self._MAPPING.get(name)
+        if attr is None:
+            return False
+        _set_param(self, attr, tensor, dtype)
+        return True
+
+
+class _BertCustomParams(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.names: Dict[str, str] = {}
+
+    @staticmethod
+    def _attr(name: str) -> str:
+        return "custom_" + hashlib.sha256(name.encode("utf-8")).hexdigest()[:24]
+
+    def load_weight(self, name: str, tensor: torch.Tensor, dtype: torch.dtype):
+        attr = self._attr(name)
+        self.names[attr] = name
+        _set_param(self, attr, tensor, dtype)
+
+
+class _BertNewLoaderBase(nn.Module):
+    """New-loader wrapper for legacy BERT/Roberta PyModel.
+
+    The new loader creates this object first, then calls load_weights(weights_iter).
+    load_weights stores checkpoint tensors as parameters on this PyModel.  The
+    legacy BertModel still needs W.* layout for kernels, so we rebuild a small
+    ModelWeights view from the PyModel parameters after loading.
+    """
+
+    model_prefix = "bert"
+
+    def __init__(self, model_config, load_config):
+        super().__init__()
+        self.config = model_config
+        self.load_config = load_config
+        self.compute_dtype = getattr(load_config, "compute_dtype", torch.float16)
+        self.parallelism_config = getattr(load_config, "parallelism_config", None)
+        if self.parallelism_config is None:
+            self.parallelism_config = ParallelismConfig()
+            self.parallelism_config.tp_size = getattr(load_config, "tp_size", 1)
+            self.parallelism_config.tp_rank = getattr(load_config, "tp_rank", 0)
+            self.parallelism_config.ep_size = getattr(load_config, "ep_size", 1)
+            self.parallelism_config.ep_rank = getattr(load_config, "ep_rank", 0)
+            self.parallelism_config.world_size = max(self.parallelism_config.tp_size, 1)
+            self.parallelism_config.local_world_size = self.parallelism_config.world_size
+        self.model = None
+        self.weights = None
+        self.embeddings = _BertEmbeddingParams()
+        self.layers = nn.ModuleList(
+            [_BertLayerParams() for _ in range(int(getattr(self.config, "num_layers")))]
+        )
+        self.custom_params = _BertCustomParams()
+
+    def _embedding_param(self, attr: str) -> nn.Parameter:
+        return _required_param(self.embeddings, attr)
+
+    def _optional_embedding_param(self, attr: str):
+        return _optional_param(self.embeddings, attr)
+
+    def _layer_param(self, layer_idx: int, attr: str) -> nn.Parameter:
+        return _required_param(self.layers[layer_idx], attr)
+
+    def _create_model_weights(self) -> ModelWeights:
+        num_layers = int(getattr(self.config, "num_layers"))
+        weights = ModelWeights(num_layers, "cpu", self.compute_dtype)
+
+        def put_global(w_name: str, attr: str, *, optional: bool = False):
+            param = self._optional_embedding_param(attr) if optional else self._embedding_param(attr)
+            if param is not None:
+                weights.set_global_weight(w_name, _weight_data(param, self.compute_dtype).contiguous())
+
+        put_global(W.embedding, "word_embeddings_weight")
+        put_global(W.positional_embedding, "position_embeddings_weight")
+        put_global(W.token_type_embedding, "token_type_embeddings_weight", optional=True)
+        if W.token_type_embedding not in weights.global_weights:
+            type_vocab_size = int(getattr(self.config, "type_vocab_size", 0) or 0)
+            if type_vocab_size > 0:
+                hidden_size = int(getattr(self.config, "hidden_size"))
+                weights.set_global_weight(
+                    W.token_type_embedding,
+                    torch.zeros(type_vocab_size, hidden_size, dtype=self.compute_dtype),
+                )
+        put_global(W.pre_decoder_ln_gamma, "layernorm_weight")
+        put_global(W.pre_decoder_ln_beta, "layernorm_bias")
+
+        for i in range(num_layers):
+            q_w = _weight_data(self._layer_param(i, "attention_query_weight"), self.compute_dtype)
+            k_w = _weight_data(self._layer_param(i, "attention_key_weight"), self.compute_dtype)
+            v_w = _weight_data(self._layer_param(i, "attention_value_weight"), self.compute_dtype)
+            q_b = _weight_data(self._layer_param(i, "attention_query_bias"), self.compute_dtype)
+            k_b = _weight_data(self._layer_param(i, "attention_key_bias"), self.compute_dtype)
+            v_b = _weight_data(self._layer_param(i, "attention_value_bias"), self.compute_dtype)
+
+            weights.set_layer_weight(
+                i,
+                W.attn_qkv_w,
+                torch.cat([q_w.t(), k_w.t(), v_w.t()], dim=1)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.attn_qkv_b,
+                torch.cat([q_b, k_b, v_b], dim=0).contiguous().to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.attn_o_w,
+                _weight_data(self._layer_param(i, "attention_output_dense_weight"), self.compute_dtype)
+                .t()
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.attn_o_b,
+                _weight_data(self._layer_param(i, "attention_output_dense_bias"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.post_ln_gamma,
+                _weight_data(self._layer_param(i, "attention_output_layernorm_weight"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.post_ln_beta,
+                _weight_data(self._layer_param(i, "attention_output_layernorm_bias"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.ffn_w3,
+                _weight_data(self._layer_param(i, "intermediate_dense_weight"), self.compute_dtype)
+                .t()
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.ffn_b3,
+                _weight_data(self._layer_param(i, "intermediate_dense_bias"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.ffn_w2,
+                _weight_data(self._layer_param(i, "output_dense_weight"), self.compute_dtype)
+                .t()
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.ffn_b2,
+                _weight_data(self._layer_param(i, "output_dense_bias"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.post_ffn_ln_gamma,
+                _weight_data(self._layer_param(i, "output_layernorm_weight"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+            weights.set_layer_weight(
+                i,
+                W.post_ffn_ln_beta,
+                _weight_data(self._layer_param(i, "output_layernorm_bias"), self.compute_dtype)
+                .contiguous()
+                .to(self.compute_dtype),
+            )
+
+        return weights
+
+    def _add_custom_weights(self, model_weights: ModelWeights):
+        for attr, name in self.custom_params.names.items():
+            param = _required_param(self.custom_params, attr)
+            model_weights.set_global_weight(
+                CustomAtomicWeight.prefix + name,
+                _weight_data(param, self.compute_dtype).contiguous(),
+            )
+
+    def _build_inner_model(self):
+        from rtp_llm.models_py.model_desc.bert import BertModel
+
+        self.model = BertModel(
+            self.config,
+            self.parallelism_config,
+            self.weights,
+            max_generate_batch_size=int(getattr(self.config, "max_generate_batch_size", 0) or 0),
+            quant_config=getattr(self.config, "quant_config", None),
+            fmha_config=getattr(self.load_config, "fmha_config", None),
+            py_hw_kernel_config=getattr(self.load_config, "hw_kernel_config", None),
+            device_resource_config=getattr(self.load_config, "device_resource_config", None),
+        )
+
+    def load_weights(self, weights):
+        loaded = 0
+        custom_loaded = 0
+        dropped = []
+        self.custom_params.names.clear()
+        for name, tensor in _as_iter(weights):
+            stripped = _strip_known_prefix(name, self.model_prefix)
+            if stripped.startswith("embeddings."):
+                if self.embeddings.load_weight(stripped[len("embeddings.") :], tensor, self.compute_dtype):
+                    loaded += 1
+                else:
+                    dropped.append(name)
+                continue
+            if stripped.startswith("encoder.layer."):
+                parts = stripped.split(".", 3)
+                if len(parts) == 4 and parts[2].isdigit():
+                    layer_idx = int(parts[2])
+                    if 0 <= layer_idx < len(self.layers) and self.layers[layer_idx].load_weight(
+                        parts[3], tensor, self.compute_dtype
+                    ):
+                        loaded += 1
+                    else:
+                        dropped.append(name)
+                else:
+                    dropped.append(name)
+                continue
+            if isinstance(tensor, torch.Tensor) and tensor.is_floating_point():
+                custom_name = name if name.startswith("bert.pooler.") else stripped
+                self.custom_params.load_weight(custom_name, tensor, self.compute_dtype)
+                custom_loaded += 1
+            else:
+                dropped.append(name)
+        unexpected = [name for name in dropped if not _is_allowed_dropped_weight(name)]
+        if unexpected:
+            sample = unexpected[:10]
+            more = f" (+{len(unexpected) - len(sample)} more)" if len(unexpected) > len(sample) else ""
+            raise RuntimeError(
+                f"{self.__class__.__name__} dropped unexpected checkpoint tensors: {sample}{more}"
+            )
+        if dropped:
+            logger.info(
+                "%s ignored %d known non-persistent BERT tensor(s): %s",
+                self.__class__.__name__,
+                len(dropped),
+                dropped[:10],
+            )
+        self.weights = self._create_model_weights()
+        self._add_custom_weights(self.weights)
+        self._build_inner_model()
+        logger.info(
+            "%s newloader streamed BERT-style weights into PyModel params: tensors=%d custom_tensors=%d dropped=%d",
+            self.__class__.__name__,
+            loaded,
+            custom_loaded,
+            len(dropped),
+        )
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        if self.weights is not None:
+            self.weights = self._create_model_weights()
+            self._add_custom_weights(self.weights)
+            if self.model is not None:
+                self._build_inner_model()
+        return self
+
+    def initialize(self, init_resource):
+        if self.model is None:
+            raise RuntimeError("BERT newloader model is not loaded")
+        return self.model.initialize(init_resource)
+
+    def fill_params(self, *args, **kwargs):
+        return self.model.fill_params(*args, **kwargs)
+
+    def prepare_fmha_impl(self, *args, **kwargs):
+        if self.model is None:
+            raise RuntimeError("BERT newloader model is not loaded")
+        return self.model.prepare_fmha_impl(*args, **kwargs)
+
+    @staticmethod
+    def _is_missing_tensor(tensor) -> bool:
+        return tensor is None or (hasattr(tensor, "numel") and tensor.numel() == 0)
+
+    def _fill_bert_embedding_inputs(self, inputs: PyModelInputs):
+        bert_inputs = inputs.bert_embedding_inputs
+        if self._is_missing_tensor(bert_inputs.position_encoding):
+            bert_inputs.position_encoding = self.weights.get_global_weight(W.positional_embedding)
+        if self._is_missing_tensor(bert_inputs.token_type_embedding):
+            bert_inputs.token_type_embedding = self.weights.get_global_weight(W.token_type_embedding)
+        return bert_inputs
+
+    def forward(self, inputs: PyModelInputs, fmha_impl=None) -> PyModelOutputs:
+        if self.model is None:
+            raise RuntimeError("BERT newloader model is not loaded")
+        self._fill_bert_embedding_inputs(inputs)
+        return self.model(inputs, fmha_impl)
+
+
+class BertForEmbedding(_BertNewLoaderBase):
+    model_prefix = "bert"
+
+
+class RobertaForEmbedding(_BertNewLoaderBase):
+    model_prefix = "roberta"

--- a/rtp_llm/models_py/new_models/bert/language.py
+++ b/rtp_llm/models_py/new_models/bert/language.py
@@ -371,9 +371,11 @@ class _BertNewLoaderBase(nn.Module):
                 len(dropped),
                 dropped[:10],
             )
-        self.weights = self._create_model_weights()
-        self._add_custom_weights(self.weights)
-        self._build_inner_model()
+        self._loaded_tensor_count = loaded
+        self._custom_tensor_count = custom_loaded
+        self._dropped_tensor_count = len(dropped)
+        self.weights = None
+        self.model = None
         logger.info(
             "%s newloader streamed BERT-style weights into PyModel params: tensors=%d custom_tensors=%d dropped=%d",
             self.__class__.__name__,
@@ -381,6 +383,11 @@ class _BertNewLoaderBase(nn.Module):
             custom_loaded,
             len(dropped),
         )
+
+    def process_weights_after_loading(self):
+        self.weights = self._create_model_weights()
+        self._add_custom_weights(self.weights)
+        self._build_inner_model()
 
     def _apply(self, fn):
         super()._apply(fn)

--- a/rtp_llm/models_py/new_models/bert/language.py
+++ b/rtp_llm/models_py/new_models/bert/language.py
@@ -193,9 +193,10 @@ class _BertNewLoaderBase(nn.Module):
             type_vocab_size = int(getattr(self.config, "type_vocab_size", 0) or 0)
             if type_vocab_size > 0:
                 hidden_size = int(getattr(self.config, "hidden_size"))
+                embedding_weight = weights.get_global_weight(W.embedding)
                 weights.set_global_weight(
                     W.token_type_embedding,
-                    torch.zeros(type_vocab_size, hidden_size, dtype=self.compute_dtype),
+                    embedding_weight.new_zeros((type_vocab_size, hidden_size)),
                 )
         put_global(W.pre_decoder_ln_gamma, "layernorm_weight")
         put_global(W.pre_decoder_ln_beta, "layernorm_bias")

--- a/rtp_llm/models_py/quant_methods/__init__.py
+++ b/rtp_llm/models_py/quant_methods/__init__.py
@@ -1,0 +1,33 @@
+# 导入即触发 @register_quant_method / @register_moe_quant_method 注册。
+from rtp_llm.models_py.quant_methods.awq import AWQLinearMethod
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig, QuantizeMethodBase
+from rtp_llm.models_py.quant_methods.fp8 import (
+    Fp8BlockDequantLinearMethod,
+    Fp8BlockLinearMethod,
+    Fp8BlockOnlineLinearMethod,
+    Fp8LinearMethod,
+    Fp8OnlineLinearMethod,
+    Fp8PerChannelOnlineLinearMethod,
+)
+from rtp_llm.models_py.quant_methods.fp8_moe import Fp8MoEMethod
+from rtp_llm.models_py.quant_methods.unquantized import (
+    UnquantizedFusedMoEMethod,
+    UnquantizedLinearMethod,
+)
+from rtp_llm.models_py.quant_methods.w4a8_moe import W4A8Int4MoEMethod
+
+__all__ = [
+    "QuantizeMethodBase",
+    "QuantizationConfig",
+    "Fp8LinearMethod",
+    "Fp8OnlineLinearMethod",
+    "Fp8PerChannelOnlineLinearMethod",
+    "Fp8BlockOnlineLinearMethod",
+    "Fp8BlockLinearMethod",
+    "Fp8BlockDequantLinearMethod",
+    "Fp8MoEMethod",
+    "AWQLinearMethod",
+    "W4A8Int4MoEMethod",
+    "UnquantizedLinearMethod",
+    "UnquantizedFusedMoEMethod",
+]

--- a/rtp_llm/models_py/quant_methods/awq.py
+++ b/rtp_llm/models_py/quant_methods/awq.py
@@ -1,0 +1,111 @@
+"""AWQ (w4a16) Linear 量化方法（新 loader），参照 vLLM ``AWQLinearMethod`` 移植。
+
+权重布局(AutoAWQ/vLLM 约定,注意 qweight 是 ``[in, out]`` 而非标准 ``[out, in]``):
+  - ``qweight``: [input_size, output_size // 8]  int32（8 个 4-bit 打包进一个 int32）
+  - ``qzeros`` : [input_size // group_size, output_size // 8]  int32
+  - ``scales`` : [input_size // group_size, output_size]  fp16/bf16
+
+前向:``awq_dequantize_triton`` 反量化成 [input, output] 权重 → ``torch.matmul(x, w)``。
+group_size 来自上游 ``config/quant_config.AWQConfig``（经 QuantizationConfig.source_config
+透传,见 [[newloader-quant-dispatch-refactor]] 走法1）。
+TP 切分在 ``ColumnParallelLinear/RowParallelLinear.load_weights`` 里对 qweight/qzeros/scales
+处理（Column 切 dim1=输出、Row 切 dim0=输入）。
+
+注意：本 reference 实现不注册为生产 quant method。它每次 forward 都会全量反量化，
+只能用于后续 fused/cache-backed AWQ GEMM 接入前的格式参考，不能进入 decode 热路径。
+"""
+
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.quant_methods.base import LinearMethodBase
+
+
+class AWQLinearMethod(LinearMethodBase):
+    PACK_FACTOR = 8  # 32 // 4-bit
+
+    def __init__(self, quant_config: Any = None):
+        self.quant_config = quant_config
+        # 上游旧 AWQConfig（带 group_size/bits），经 source_config 透传。
+        self.source_config = getattr(quant_config, "source_config", None)
+
+    def _group_size(self, input_size: int) -> int:
+        src = self.source_config
+        if src is None:
+            return input_size
+        # 旧 QuantizationConfig 的 group_size 是「方法」(返回 self._group_size),
+        # 也兼容当作属性的情况。
+        gs = getattr(src, "group_size", None)
+        if callable(gs):
+            gs = gs()
+        if gs in (-1, 0, None):
+            return input_size  # 整个输入维一个 group
+        return int(gs)
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        pf = self.PACK_FACTOR
+        gs = self._group_size(input_size)
+        if input_size % gs != 0:
+            raise ValueError(
+                f"[AWQ] input_size {input_size} 不能被 group_size {gs} 整除"
+                f"（可能 TP 切分过大）。"
+            )
+        if output_size % pf != 0:
+            raise ValueError(
+                f"[AWQ] output_size {output_size} 不能被 pack_factor {pf} 整除"
+                f"（可能 TP 切分过大）。"
+            )
+        num_groups = input_size // gs
+
+        layer.register_parameter(
+            "qweight",
+            nn.Parameter(
+                torch.empty(input_size, output_size // pf, dtype=torch.int32),
+                requires_grad=False,
+            ),
+        )
+        layer.register_parameter(
+            "qzeros",
+            nn.Parameter(
+                torch.empty(num_groups, output_size // pf, dtype=torch.int32),
+                requires_grad=False,
+            ),
+        )
+        layer.register_parameter(
+            "scales",
+            nn.Parameter(
+                torch.empty(num_groups, output_size, dtype=params_dtype),
+                requires_grad=False,
+            ),
+        )
+        layer._awq_group_size = gs
+
+    def process_weights_after_loading(self, layer):
+        # 权重已是目标布局,无需后处理（反量化在 apply 里按需做）。
+        return None
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
+
+        # Reference path: dequantize to [input, output] on every forward, then
+        # run a standard matmul. This keeps first-phase weight loading correct;
+        # a fused/cache-backed w4a16 GEMM should replace it before this AWQ path
+        # is used on decode hot paths.
+        weight = awq_dequantize_triton(layer.qweight, layer.scales, layer.qzeros)
+        out_dim = weight.shape[1]
+        reshaped_x = x.reshape(-1, x.shape[-1])
+        out = torch.matmul(reshaped_x, weight)
+        if bias is not None:
+            out = out + bias
+        return out.reshape(*x.shape[:-1], out_dim)

--- a/rtp_llm/models_py/quant_methods/awq_triton.py
+++ b/rtp_llm/models_py/quant_methods/awq_triton.py
@@ -1,0 +1,160 @@
+"""AWQ (w4a16) 反量化 Triton kernel —— 移植自 vLLM
+``vllm/model_executor/layers/quantization/awq_triton.py``（仅取 dequantize 部分）。
+
+新 loader 的 Linear forward 在 Python 跑,没有可调的 w4a16 C++ gemm,故用 Triton:
+``awq_dequantize_triton`` 把 [K, N//8] 的 int32 packed 4-bit 权重反量化成 [K, N] 的
+fp16/bf16 权重(应用 per-group scales/zeros + AWQ 的 reverse-order 解包),再由调用方
+``torch.matmul(x, weight)`` 完成 gemm。
+
+与 vLLM 唯一差异:把 ``from vllm.triton_utils import tl, triton`` 换成标准 triton 导入。
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+AWQ_TRITON_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
+
+
+@triton.jit
+def awq_dequantize_kernel(
+    qweight_ptr,  # quantized matrix
+    scales_ptr,  # scales, per group
+    zeros_ptr,  # zeros, per group
+    group_size,  # Should always be one of the supported group sizes
+    result_ptr,  # Output matrix
+    num_cols,  # input num cols in qweight
+    num_rows,  # input num rows in qweight
+    BLOCK_SIZE_X: tl.constexpr,
+    BLOCK_SIZE_Y: tl.constexpr,
+):
+    # Set up the pids.
+    pid_x = tl.program_id(axis=0)
+    pid_y = tl.program_id(axis=1)
+
+    # Compute offsets and masks for qweight_ptr.
+    offsets_y = pid_y * BLOCK_SIZE_Y + tl.arange(0, BLOCK_SIZE_Y)
+    offsets_x = pid_x * BLOCK_SIZE_X + tl.arange(0, BLOCK_SIZE_X)
+    offsets = num_cols * offsets_y[:, None] + offsets_x[None, :]
+
+    masks_y = offsets_y < num_rows
+    masks_x = offsets_x < num_cols
+
+    masks = masks_y[:, None] & masks_x[None, :]
+
+    # Compute offsets and masks for result output ptr.
+    result_offsets_y = pid_y * BLOCK_SIZE_Y + tl.arange(0, BLOCK_SIZE_Y)
+    result_offsets_x = pid_x * BLOCK_SIZE_X * 8 + tl.arange(0, BLOCK_SIZE_X * 8)
+    result_offsets = (
+        8 * num_cols * result_offsets_y[:, None] + result_offsets_x[None, :]
+    )
+
+    result_masks_y = result_offsets_y < num_rows
+    result_masks_x = result_offsets_x < num_cols * 8
+    result_masks = result_masks_y[:, None] & result_masks_x[None, :]
+
+    # Load the weights.
+    iweights = tl.load(qweight_ptr + offsets, masks, 0.0)
+    iweights = tl.interleave(iweights, iweights)
+    iweights = tl.interleave(iweights, iweights)
+    iweights = tl.interleave(iweights, iweights)
+
+    # Create reverse AWQ order as tensor: [0, 4, 1, 5, 2, 6, 3, 7]
+    # that will map given indices to the correct order.
+    reverse_awq_order_tensor = (
+        (tl.arange(0, 2) * 4)[None, :] + tl.arange(0, 4)[:, None]
+    ).reshape(8)
+
+    # Use this to compute a set of shifts that can be used to unpack and
+    # reorder the values in iweights and zeros.
+    shifts = reverse_awq_order_tensor * 4
+    shifts = tl.broadcast_to(shifts[None, :], (BLOCK_SIZE_Y * BLOCK_SIZE_X, 8))
+    shifts = tl.reshape(shifts, (BLOCK_SIZE_Y, BLOCK_SIZE_X * 8))
+
+    # Unpack and reorder: shift out the correct 4-bit value and mask.
+    iweights = (iweights >> shifts) & 0xF
+
+    # Compute zero offsets and masks.
+    zero_offsets_y = pid_y * BLOCK_SIZE_Y // group_size + tl.arange(0, 1)
+    zero_offsets_x = pid_x * BLOCK_SIZE_X + tl.arange(0, BLOCK_SIZE_X)
+    zero_offsets = num_cols * zero_offsets_y[:, None] + zero_offsets_x[None, :]
+
+    zero_masks_y = zero_offsets_y < num_rows // group_size
+    zero_masks_x = zero_offsets_x < num_cols
+    zero_masks = zero_masks_y[:, None] & zero_masks_x[None, :]
+
+    # Load the zeros.
+    zeros = tl.load(zeros_ptr + zero_offsets, zero_masks, 0.0)
+    zeros = tl.interleave(zeros, zeros)
+    zeros = tl.interleave(zeros, zeros)
+    zeros = tl.interleave(zeros, zeros)
+    zeros = tl.broadcast_to(zeros, (BLOCK_SIZE_Y, BLOCK_SIZE_X * 8))
+
+    # Unpack and reorder: shift out the correct 4-bit value and mask.
+    zeros = (zeros >> shifts) & 0xF
+
+    # Compute scale offsets and masks.
+    scale_offsets_y = pid_y * BLOCK_SIZE_Y // group_size + tl.arange(0, 1)
+    scale_offsets_x = pid_x * BLOCK_SIZE_X * 8 + tl.arange(0, BLOCK_SIZE_X * 8)
+    scale_offsets = num_cols * 8 * scale_offsets_y[:, None] + scale_offsets_x[None, :]
+    scale_masks_y = scale_offsets_y < num_rows // group_size
+    scale_masks_x = scale_offsets_x < num_cols * 8
+    scale_masks = scale_masks_y[:, None] & scale_masks_x[None, :]
+
+    # Load the scales.
+    scales = tl.load(scales_ptr + scale_offsets, scale_masks, 0.0)
+    scales = tl.broadcast_to(scales, (BLOCK_SIZE_Y, BLOCK_SIZE_X * 8))
+
+    # Dequantize.
+    iweights = (iweights - zeros) * scales
+    iweights = iweights.to(result_ptr.type.element_ty)
+
+    # Finally, store.
+    tl.store(result_ptr + result_offsets, iweights, result_masks)
+
+
+def awq_dequantize_triton(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    block_size_x: int = 32,
+    block_size_y: int = 32,
+) -> torch.Tensor:
+    """qweight [K, N//8] int32 → 反量化权重 [K, N]（dtype 同 scales）。"""
+    K = qweight.shape[0]
+    M = scales.shape[1]
+    group_size = qweight.shape[0] // scales.shape[0]
+
+    assert K > 0 and M > 0
+    assert scales.shape[0] == K // group_size and scales.shape[1] == M
+    assert zeros.shape[0] == K // group_size and zeros.shape[1] == M // 8
+    assert group_size <= K
+    assert group_size in AWQ_TRITON_SUPPORTED_GROUP_SIZES or group_size == K
+
+    result = torch.empty(
+        qweight.shape[0],
+        qweight.shape[1] * 8,
+        device=qweight.device,
+        dtype=scales.dtype,
+    )
+
+    Y = qweight.shape[0]  # num rows
+    X = qweight.shape[1]  # num cols
+
+    grid = lambda META: (
+        triton.cdiv(X, META["BLOCK_SIZE_X"]),
+        triton.cdiv(Y, META["BLOCK_SIZE_Y"]),
+    )
+    awq_dequantize_kernel[grid](
+        qweight,
+        scales,
+        zeros,
+        group_size,
+        result,
+        X,
+        Y,
+        BLOCK_SIZE_X=block_size_x,
+        BLOCK_SIZE_Y=block_size_y,
+    )
+
+    return result

--- a/rtp_llm/models_py/quant_methods/awq_triton.py
+++ b/rtp_llm/models_py/quant_methods/awq_triton.py
@@ -123,13 +123,35 @@ def awq_dequantize_triton(
     """qweight [K, N//8] int32 → 反量化权重 [K, N]（dtype 同 scales）。"""
     K = qweight.shape[0]
     M = scales.shape[1]
-    group_size = qweight.shape[0] // scales.shape[0]
 
-    assert K > 0 and M > 0
-    assert scales.shape[0] == K // group_size and scales.shape[1] == M
-    assert zeros.shape[0] == K // group_size and zeros.shape[1] == M // 8
-    assert group_size <= K
-    assert group_size in AWQ_TRITON_SUPPORTED_GROUP_SIZES or group_size == K
+    if K <= 0 or M <= 0:
+        raise ValueError(
+            f"AWQ dequant expects non-empty qweight/scales, got K={K}, M={M}"
+        )
+    if scales.shape[0] == 0:
+        raise ValueError(
+            f"AWQ scales must have at least one group, got {tuple(scales.shape)}"
+        )
+    group_size = qweight.shape[0] // scales.shape[0]
+    if group_size <= 0:
+        raise ValueError(
+            f"AWQ group_size computed as {group_size} from qweight "
+            f"{tuple(qweight.shape)} and scales {tuple(scales.shape)}"
+        )
+    if scales.shape[0] != K // group_size or scales.shape[1] != M:
+        raise ValueError(
+            f"AWQ scales shape {tuple(scales.shape)} is incompatible "
+            f"with qweight {tuple(qweight.shape)}"
+        )
+    if zeros.shape[0] != K // group_size or zeros.shape[1] != M // 8:
+        raise ValueError(
+            f"AWQ zeros shape {tuple(zeros.shape)} is incompatible "
+            f"with qweight {tuple(qweight.shape)}"
+        )
+    if group_size > K:
+        raise ValueError(f"AWQ group_size {group_size} exceeds K={K}")
+    if group_size not in AWQ_TRITON_SUPPORTED_GROUP_SIZES and group_size != K:
+        raise ValueError(f"AWQ group_size {group_size} is not supported")
 
     result = torch.empty(
         qweight.shape[0],

--- a/rtp_llm/models_py/quant_methods/base.py
+++ b/rtp_llm/models_py/quant_methods/base.py
@@ -1,0 +1,292 @@
+"""新 loader 的量化抽象（vLLM 风格）。
+
+双层抽象：
+- ``QuantizationConfig``：描述「用什么量化方案」（fp8/awq/gptq...），由上游
+  ``config/quant_config.py`` 的 ``load_from_ckpt`` 解析 ckpt 得到（走法1：本类只
+  *携带* 那个富对象 ``source_config``，不在此重复解析）。
+- ``QuantizeMethodBase``：描述「具体怎么建权重、怎么算」，三段式钩子
+  ``create_weights`` / ``apply`` / ``process_weights_after_loading``。
+
+按层类型分流（对齐 vLLM 的 ``isinstance(layer)`` 派发）：
+- Linear 层 → ``LinearMethodBase`` 子类（二维权重，按 input/output 切分）；
+- MoE 层   → ``FusedMoEMethodBase`` 子类（带 expert 维三维权重 + 路由信息）。
+两者共享三个钩子名，但签名不同，所以是两条独立子树、两套注册表。
+
+``get_quant_method(layer, prefix)`` 据此派发，并支持 ``prefix`` 命中 ignore 列表
+（混合精度 / compressed-tensors 的 ignore / lm_head 不量化）时回退未量化。
+"""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+import re
+
+import torch
+
+if TYPE_CHECKING:
+    from rtp_llm.models_py.layers.linear import LinearBase
+
+
+class QuantizeMethodBase(ABC):
+    """量化方法三段式契约的顶层基类。
+
+    Linear 与 MoE 共享这三个钩子名;具体签名见 ``LinearMethodBase`` /
+    ``FusedMoEMethodBase``。
+    """
+
+    def __init__(self, quant_config: "Any" = None):
+        # 统一持有 QuantizationConfig（携带 source_config:group_size/ignore 等）。
+        # 现有 fp8 方法不重写 __init__、也不读它,行为不变;AWQ 等需要 group_size 的
+        # 方法从这里取（见 AWQLinearMethod）。
+        self.quant_config = quant_config
+
+    @abstractmethod
+    def create_weights(
+        self,
+        layer: "LinearBase",
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply(
+        self, layer: "LinearBase", x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: "LinearBase"):
+        raise NotImplementedError
+
+
+class LinearMethodBase(QuantizeMethodBase):
+    """Linear（二维权重，按 input/output_partition 切分）量化方法基类。
+
+    现有 ``Fp8*LinearMethod`` / ``UnquantizedLinearMethod`` 语义上都属于本类;
+    新增的 Linear 量化方法应继承本类并用 ``@register_quant_method`` 注册。
+    签名沿用 ``QuantizeMethodBase``（``create_weights(layer, input_size,
+    output_size, params_dtype)`` / ``apply(layer, x, bias)``）。
+    """
+
+    pass
+
+
+class FusedMoEMethodBase(QuantizeMethodBase):
+    """MoE（带 expert 维三维权重 + 路由）量化方法基类。
+
+    与 Linear 的关键区别:``create_weights`` 按 ``num_experts/hidden_size/
+    intermediate_size`` 建三维（含 expert 维 + per-expert scale）权重。
+
+    rtp-llm 结构下 MoE 的前向计算由层（``BaseMoEExperts.forward`` → ``fused_moe``）
+    负责,量化在「建权重 / 加载 scale / 加载后融合·在线量化 / 把 scale 喂给
+    fused_moe」这几步,因此本类的契约是:
+      - ``create_weights(layer, num_experts, hidden_size, intermediate_size, params_dtype)``
+        建 w13/w2 + scale buffer;
+      - ``process_weights_after_loading(layer)`` 做融合 / 在线量化;
+      - 可选 ``dispatch_scale(layer, local_id, proj, param_name, tensor)`` 流式加载
+        期路由 scale 张量;
+      - 可选 ``add_weight_tensors(layer, weights_dict)`` 把 scale 加进喂给
+        FusedMoeFactory 的权重字典。
+    ``apply`` 在 MoE 路径不使用（前向由层调 fused_moe）,给个默认实现避免强制重写。
+    新增的 MoE 量化方法继承本类并用 ``@register_moe_quant_method`` 注册。
+    """
+
+    @abstractmethod
+    def create_weights(
+        self,
+        layer,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer):
+        raise NotImplementedError
+
+    # --- 可选钩子（默认 no-op），具体方法按需重写 ---
+
+    def dispatch_scale(self, layer, local_id: int, proj: str, param_name: str, tensor):
+        """流式加载期:把一个 scale/meta 张量路由到对应 buffer。默认忽略。"""
+        return None
+
+    def dispatch_weight(self, layer, local_id: int, proj: str, param_name: str, tensor):
+        """流式加载期:让量化方法接管非标准权重张量。返回 True 表示已处理。"""
+        return False
+
+    def add_weight_tensors(self, layer, weights_dict: Dict[str, Any]) -> None:
+        """把量化 scale 等加进喂给 FusedMoeFactory 的权重字典。默认不加。"""
+        return None
+
+    # MoE 前向由层（fused_moe）负责,本钩子不用;给默认实现避免强制重写。
+    def apply(self, layer, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError(
+            "FusedMoEMethodBase.apply 不应被调用:MoE 前向由 BaseMoEExperts.forward "
+            "经 fused_moe 完成。"
+        )
+
+
+# 两套注册表:同一 quant_type 字符串可分别注册 Linear 与 MoE 两种实现，
+# get_quant_method 按层类型选其一。
+_LINEAR_METHOD_REGISTRY: Dict[str, Type[QuantizeMethodBase]] = {}
+_MOE_METHOD_REGISTRY: Dict[str, Type[FusedMoEMethodBase]] = {}
+
+# 向后兼容别名:历史代码里的 _RUNTIME_METHOD_REGISTRY 即 Linear 注册表。
+_RUNTIME_METHOD_REGISTRY = _LINEAR_METHOD_REGISTRY
+
+
+def _register(registry: Dict[str, Type], keys, cls):
+    for k in keys:
+        existing = registry.get(k)
+        if existing is not None and existing is not cls:
+            raise ValueError(
+                f"quant method key '{k}' already registered to "
+                f"{existing.__name__}, cannot re-register to {cls.__name__}"
+            )
+        registry[k] = cls
+    return cls
+
+
+def register_quant_method(*keys: str):
+    """注册 Linear 量化方法（名字保持向后兼容）。"""
+
+    def deco(cls: Type[QuantizeMethodBase]) -> Type[QuantizeMethodBase]:
+        return _register(_LINEAR_METHOD_REGISTRY, keys, cls)
+
+    return deco
+
+
+def register_moe_quant_method(*keys: str):
+    """注册 MoE 量化方法。"""
+
+    def deco(cls: Type[FusedMoEMethodBase]) -> Type[FusedMoEMethodBase]:
+        return _register(_MOE_METHOD_REGISTRY, keys, cls)
+
+    return deco
+
+
+class QuantizationConfig:
+    """量化配置载体（走法1:携带旧 loader 解析出的富对象，不重复解析 ckpt）。"""
+
+    def __init__(
+        self,
+        quant_type: str = "none",
+        source_config: Any = None,
+        ignored_layers: Optional[List[str]] = None,
+    ):
+        self.quant_type = quant_type
+        # 旧 config/quant_config.py 的 load_from_ckpt 已把 ckpt 解析成富对象
+        # （带 dynamic / scale_suffix / group_size / ignore 等结构化字段）。
+        # 这里只携带它，供各 method 读取，避免在新 loader 重复解析。
+        self.source_config = source_config
+        # 混合精度 / compressed-tensors 的 ignore 列表:命中的模块走未量化。
+        self.ignored_layers = (
+            ignored_layers
+            if ignored_layers is not None
+            else self._extract_ignored(source_config)
+        )
+        self.weight_block_size = getattr(source_config, "weight_block_size", None)
+        if self.weight_block_size is None:
+            self.weight_block_size = [128, 128]
+
+    @staticmethod
+    def _extract_ignored(source_config: Any) -> List[str]:
+        if source_config is None:
+            return []
+        for attr in ("ignore_patterns", "ignored_layers", "ignore"):
+            v = getattr(source_config, attr, None)
+            if v:
+                return list(v)
+        return []
+
+    def is_layer_ignored(self, prefix: str) -> bool:
+        """模块名（prefix）是否在 ignore 列表里 → 该模块不量化。
+
+        采用点边界（.）分段前缀匹配与 fnmatch 通配符支持，避免子串包含匹配（如 gate 误伤 gate_proj）。
+        """
+        if not prefix or not self.ignored_layers:
+            return False
+
+        for pat in self.ignored_layers:
+            if not pat:
+                continue
+            if pat.startswith("re:"):
+                if re.fullmatch(pat[3:], prefix):
+                    return True
+                continue
+            # 1. 通配符模式匹配
+            if "*" in pat or "?" in pat:
+                import fnmatch
+
+                if fnmatch.fnmatch(prefix, pat) or fnmatch.fnmatch(prefix, f"{pat}.*"):
+                    return True
+                continue
+            # 2. 精确点分割路径匹配。单段模式（如 "lm_head"）按
+            # path segment 命中，避免子串误伤（vision 不应命中 visionxxx）；
+            # 多段模式保持从根开始的前缀匹配。
+            prefix_parts = prefix.split(".")
+            pat_parts = pat.split(".")
+            if len(pat_parts) == 1:
+                if pat_parts[0] in prefix_parts:
+                    return True
+            elif len(pat_parts) <= len(prefix_parts):
+                if prefix_parts[: len(pat_parts)] == pat_parts:
+                    return True
+        return False
+
+    @staticmethod
+    def _is_moe_layer(layer) -> bool:
+        # 惰性 import 避免环依赖（moe_experts 反过来 import 本模块）。
+        try:
+            from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
+        except Exception:
+            return False
+        return isinstance(layer, BaseMoEExperts)
+
+    def get_quant_method(self, layer, prefix: str = "") -> Optional[QuantizeMethodBase]:
+        """按层类型 + prefix 派发量化方法。
+
+        - prefix 命中 ignore → 未量化;
+        - MoE 层 → MoE 注册表（无对应实现则返回 None，交回 MoE 模块自身处理）;
+        - 其余（Linear 层）→ Linear 注册表（无对应实现则未量化）。
+        """
+        from rtp_llm.models_py.quant_methods.unquantized import (
+            UnquantizedFusedMoEMethod,
+            UnquantizedLinearMethod,
+        )
+
+        is_moe = self._is_moe_layer(layer)
+
+        # prefix 命中 ignore → 未量化（按层类型选对应的未量化方法）。
+        if self.is_layer_ignored(prefix):
+            return (
+                UnquantizedFusedMoEMethod(self) if is_moe else UnquantizedLinearMethod()
+            )
+
+        quant_type = self.quant_type or ""
+        if is_moe:
+            cls = _MOE_METHOD_REGISTRY.get(quant_type)
+            if cls is not None:
+                return cls(self)
+            if quant_type in ("", "none"):
+                return None
+            raise ValueError(
+                f"Unsupported MoE quant_type {quant_type!r}; registered keys: "
+                f"{sorted(_MOE_METHOD_REGISTRY.keys())}"
+            )
+
+        cls = _LINEAR_METHOD_REGISTRY.get(quant_type)
+        if cls is not None:
+            # 传入 config（AWQ 等需要 group_size 等;fp8/unquantized 继承基类 __init__ 接收后忽略）。
+            return cls(self)
+        if quant_type in ("", "none"):
+            return UnquantizedLinearMethod()
+        raise ValueError(
+            f"Unsupported linear quant_type {quant_type!r}; registered keys: "
+            f"{sorted(_LINEAR_METHOD_REGISTRY.keys())}"
+        )

--- a/rtp_llm/models_py/quant_methods/fp8.py
+++ b/rtp_llm/models_py/quant_methods/fp8.py
@@ -1,0 +1,1046 @@
+import logging
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn
+
+from rtp_llm.models_py.quant_methods.base import (
+    QuantizeMethodBase,
+    register_quant_method,
+)
+
+logger = logging.getLogger(__name__)
+
+_FP8_MIN_SCALE = 1e-12
+
+
+def _runtime_fp8_dtype() -> torch.dtype:
+    if getattr(torch.version, "hip", None) is None:
+        return torch.float8_e4m3fn
+    try:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
+            get_rocm_fp8_dtype,
+        )
+
+        return get_rocm_fp8_dtype()
+    except Exception:
+        return torch.float8_e4m3fn
+
+
+def _requant_per_tensor_to_runtime_fp8(
+    weight: torch.Tensor, scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    runtime_dtype = _runtime_fp8_dtype()
+    if weight.dtype == runtime_dtype:
+        return weight.contiguous(), scale.view(1).contiguous()
+
+    scale_scalar = scale.float().view(-1)[0]
+    deq = weight.float() * scale_scalar
+    fp8_max = float(torch.finfo(runtime_dtype).max)
+    new_scale = deq.abs().amax().clamp_min(_FP8_MIN_SCALE) / fp8_max
+    requant = (deq / new_scale).to(runtime_dtype)
+    return requant.contiguous(), new_scale.reshape(1).to(torch.float32).contiguous()
+
+
+def _requant_per_channel_to_runtime_fp8(
+    weight: torch.Tensor, scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    runtime_dtype = _runtime_fp8_dtype()
+    scale_rows = scale.float().view(-1, 1)
+    if weight.dtype == runtime_dtype:
+        return weight.contiguous(), scale_rows.view(1, -1).contiguous()
+
+    if scale_rows.shape[0] != weight.shape[0]:
+        raise ValueError(
+            f"FP8 per-channel scale/weight mismatch: "
+            f"weight={tuple(weight.shape)} scale={tuple(scale.shape)}"
+        )
+    deq = weight.float() * scale_rows
+    fp8_max = float(torch.finfo(runtime_dtype).max)
+    new_scale = (
+        deq.abs().amax(dim=1, keepdim=True).clamp_min(_FP8_MIN_SCALE) / fp8_max
+    )
+    requant = (deq / new_scale).to(runtime_dtype)
+    return requant.contiguous(), new_scale.view(1, -1).to(torch.float32).contiguous()
+
+# Hoist kernel imports to module scope. apply() is on the per-token decode hot
+# path: doing the import inside apply() (even though sys.modules caches it)
+# still costs a sys.modules lookup + LOAD_ATTR on every call. Importing once at
+# module load amortizes that cost across the lifetime of the process.
+#
+# Each method that uses a kernel still falls back to a lazy `_resolve_*()` helper
+# below when the module-level symbol is None, since `fp8.py` is loaded eagerly
+# from `quant_methods/__init__.py` and may resolve before the kernel package
+# finishes initialization (the kernel package's __init__ calls load_all_configs()
+# which can take long enough for an interleaving import to observe a partially
+# initialized module — that is reported with a logger.warning here so the
+# fallback isn't silent).
+try:
+    from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+        per_block_cast_to_fp8,
+        requant_weight_ue8m0,
+        scaled_fp8_per_tensor_quant,
+        scaled_fp8_per_token_quant,
+        sgl_per_token_group_quant_fp8,
+    )
+except (
+    ImportError
+) as e:  # pragma: no cover - kernel package may be absent on CPU-only setups
+    logger.warning(
+        "fp8 kernel imports unavailable: %s (will fall back to lazy import)", e
+    )
+    per_block_cast_to_fp8 = None
+    requant_weight_ue8m0 = None
+    scaled_fp8_per_tensor_quant = None
+    scaled_fp8_per_token_quant = None
+    sgl_per_token_group_quant_fp8 = None
+
+try:
+    from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
+        fp8_gemm_nt,
+        has_deep_gemm,
+    )
+except ImportError as e:  # pragma: no cover
+    logger.warning(
+        "deepgemm_wrapper imports unavailable: %s (will fall back to lazy import)", e
+    )
+    fp8_gemm_nt = None
+
+    def has_deep_gemm() -> bool:  # type: ignore[no-redef]
+        return False
+
+
+def _resolve_per_tensor_quant():
+    """Return scaled_fp8_per_tensor_quant, lazy-importing on a hoist miss."""
+    global scaled_fp8_per_tensor_quant
+    if scaled_fp8_per_tensor_quant is None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+                scaled_fp8_per_tensor_quant as _fn,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "fp8 kernel not available: scaled_fp8_per_tensor_quant is required"
+            ) from e
+        if _fn is None:
+            raise ImportError(
+                "fp8 kernel not available: scaled_fp8_per_tensor_quant is None"
+            )
+        scaled_fp8_per_tensor_quant = _fn
+    return scaled_fp8_per_tensor_quant
+
+
+def cpu_per_tensor_quant_like_legacy(
+    input: torch.Tensor, output: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """CPU fallback matching old loader's dynamic FP8 per-tensor quantization."""
+    device = input.device
+    from rtp_llm.model_loader.dynamic_fp8_quant_weight import (
+        quantize_weight_to_fp8 as legacy_quantize_weight_to_fp8,
+    )
+
+    quant, scale = legacy_quantize_weight_to_fp8(input.detach().to("cpu"))
+    quant = quant.to(device)
+    scale = scale.reshape(1).to(device)
+    if output is not None:
+        output.copy_(quant)
+        quant = output
+    return quant, scale
+
+
+def _resolve_per_token_quant():
+    """Return scaled_fp8_per_token_quant, lazy-importing on a hoist miss."""
+    global scaled_fp8_per_token_quant
+    if scaled_fp8_per_token_quant is None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+                scaled_fp8_per_token_quant as _fn,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "fp8 kernel not available: scaled_fp8_per_token_quant is required"
+            ) from e
+        if _fn is None:
+            raise ImportError(
+                "fp8 kernel not available: scaled_fp8_per_token_quant is None"
+            )
+        scaled_fp8_per_token_quant = _fn
+    return scaled_fp8_per_token_quant
+
+
+def _resolve_per_block_cast():
+    """Return per_block_cast_to_fp8, lazy-importing on a hoist miss."""
+    global per_block_cast_to_fp8
+    if per_block_cast_to_fp8 is None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+                per_block_cast_to_fp8 as _fn,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "fp8 kernel not available: per_block_cast_to_fp8 is required"
+            ) from e
+        if _fn is None:
+            raise ImportError("fp8 kernel not available: per_block_cast_to_fp8 is None")
+        per_block_cast_to_fp8 = _fn
+    return per_block_cast_to_fp8
+
+
+def _normalize_weight_block_size(layer, default_block: int) -> List[int]:
+    block_size = getattr(
+        getattr(layer, "quant_config", None), "weight_block_size", None
+    )
+    if block_size is None:
+        block_size = [default_block, default_block]
+    if len(block_size) != 2:
+        raise ValueError(f"weight_block_size must have 2 values, got {block_size}")
+    block_n, block_k = int(block_size[0]), int(block_size[1])
+    if block_n <= 0 or block_k <= 0:
+        raise ValueError(f"weight_block_size values must be positive, got {block_size}")
+    return [block_n, block_k]
+
+
+def _require_cuda_weight_for_online_quant(layer, weight: torch.Tensor, method: str):
+    if weight.is_cuda:
+        return weight
+    raise RuntimeError(
+        f"{method} requires weights to be on CUDA/ROCm before post-load "
+        f"quantization, got device={weight.device} for prefix="
+        f"{getattr(layer, 'prefix', '?')!r}. Set LoadConfig.device to a CUDA "
+        "device or use an already-quantized/non-online quant method for CPU load."
+    )
+
+
+def _resolve_requant_weight_ue8m0():
+    """Return requant_weight_ue8m0, lazy-importing on a hoist miss."""
+    global requant_weight_ue8m0
+    if requant_weight_ue8m0 is None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+                requant_weight_ue8m0 as _fn,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "fp8 kernel not available: requant_weight_ue8m0 is required"
+            ) from e
+        if _fn is None:
+            raise ImportError("fp8 kernel not available: requant_weight_ue8m0 is None")
+        requant_weight_ue8m0 = _fn
+    return requant_weight_ue8m0
+
+
+def _resolve_sgl_per_token_group_quant():
+    """Return sgl_per_token_group_quant_fp8, lazy-importing on a hoist miss."""
+    global sgl_per_token_group_quant_fp8
+    if sgl_per_token_group_quant_fp8 is None:
+        try:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
+                sgl_per_token_group_quant_fp8 as _fn,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "fp8 kernel not available: sgl_per_token_group_quant_fp8 is required"
+            ) from e
+        if _fn is None:
+            raise ImportError(
+                "fp8 kernel not available: sgl_per_token_group_quant_fp8 is None"
+            )
+        sgl_per_token_group_quant_fp8 = _fn
+    return sgl_per_token_group_quant_fp8
+
+
+def _resolve_fp8_gemm_nt():
+    """Return fp8_gemm_nt, lazy-importing on a hoist miss."""
+    global fp8_gemm_nt
+    if fp8_gemm_nt is None:
+        from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import fp8_gemm_nt as _fn
+
+        fp8_gemm_nt = _fn
+    return fp8_gemm_nt
+
+
+@register_quant_method(
+    "fp8",
+    "FP8_PER_TENSOR_COMPRESSED",
+    "FP8_DYNAMIC_PER_TENSOR",
+)
+class Fp8LinearMethod(QuantizeMethodBase):
+    """Already-quantized FP8 per-tensor (e.g. compressed-tensors) ckpt loader.
+
+    ckpt provides:
+      - weight: float8_e4m3fn [N, K]
+      - weight_scale: fp32 scalar (per-tensor)
+      - input_scale: fp32 scalar (optional; static activation scale)
+
+    Forward: torch._scaled_mm with online dynamic per-tensor activation quant.
+    The ckpt's static input_scale is intentionally unused — using runtime-
+    computed activation scale gives equivalent numerical accuracy without
+    needing to plumb static-vs-dynamic through the LinearMethod construction.
+    """
+
+    # Class-level flag: the diagnostic log fires at most once across ALL
+    # instances in a process. See Fp8OnlineLinearMethod for the assumption.
+    _apply_logged: bool = False
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=_runtime_fp8_dtype()),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        weight_scale = nn.Parameter(
+            torch.ones(1, dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+        input_scale = nn.Parameter(
+            torch.ones(1, dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.register_parameter("input_scale", input_scale)
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        out_dtype = x.dtype
+        input_2d = x.reshape(-1, x.shape[-1])
+        out_features = layer.weight.shape[0]
+        output_shape = list(x.shape[:-1]) + [out_features]
+
+        qinput, x_scale = _resolve_per_tensor_quant()(input_2d)
+
+        if not Fp8LinearMethod._apply_logged:
+            logger.info(
+                "[Fp8LinearMethod] FIRST forward via torch._scaled_mm: "
+                "prefix=%r, x.shape=%s, weight.shape=%s, weight_scale=%.6f, "
+                "x_scale=%.6f",
+                getattr(layer, "prefix", "?"),
+                tuple(x.shape),
+                tuple(layer.weight.shape),
+                float(layer.weight_scale.view(1)[0].item()),
+                float(x_scale.view(1)[0].item()),
+            )
+            Fp8LinearMethod._apply_logged = True
+
+        output = torch._scaled_mm(
+            qinput,
+            layer.weight.t(),
+            scale_a=x_scale,
+            scale_b=layer.weight_scale,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+        if isinstance(output, tuple):
+            output = output[0]
+        return output.view(*output_shape)
+
+    def process_weights_after_loading(self, layer):
+        fp8_weight, scale = _requant_per_tensor_to_runtime_fp8(
+            layer.weight.data, layer.weight_scale.data
+        )
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(fp8_weight, requires_grad=False)
+        )
+        del layer.weight_scale
+        layer.register_parameter(
+            "weight_scale", nn.Parameter(scale, requires_grad=False)
+        )
+        if hasattr(layer, "input_scale") and layer.input_scale.dim() == 0:
+            layer.input_scale = nn.Parameter(
+                layer.input_scale.reshape(1), requires_grad=False
+            )
+
+
+@register_quant_method("fp8_online")
+class Fp8OnlineLinearMethod(QuantizeMethodBase):
+    """Online FP8 per-tensor quantization.
+
+    Loads BF16/FP16 weights from ckpt, quantizes to float8_e4m3fn at load time,
+    and runs forward via real FP8 GEMM (torch._scaled_mm) with dynamic per-tensor
+    activation quantization.
+    """
+
+    # Class-level flags: the diagnostic log fires at most once across ALL
+    # instances in a process. Safe under RTP-LLM's process model where each
+    # backend process loads the model once and does not reload. If dynamic
+    # reload (e.g. hot-swap, multi-model serving) is ever added, move these to
+    # __init__ so each instance can log once.
+    _quant_logged: bool = False
+    _apply_logged: bool = False
+    _quant_count: int = 0
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        # Stage as params_dtype so existing param.data.copy_(bf16_tensor) in
+        # linear.py's load_weights() works. process_weights_after_loading will
+        # replace this Parameter with a fp8 one.
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(torch.ones(1, dtype=torch.float32), requires_grad=False),
+        )
+
+    def process_weights_after_loading(self, layer):
+        weight = layer.weight.data
+        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+
+        weight = _require_cuda_weight_for_online_quant(
+            layer, weight, type(self).__name__
+        )
+        if bool(getattr(layer, "_new_loader_force_cpu_load_weights", False)):
+            fp8_weight, scale = cpu_per_tensor_quant_like_legacy(weight)
+        else:
+            fp8_weight, scale = _resolve_per_tensor_quant()(weight)
+
+        # nn.Parameter dtype is immutable; rebind both attributes so the
+        # post-load model.to(device) sees a consistent (cuda, fp8/fp32) pair.
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(fp8_weight, requires_grad=False)
+        )
+        del layer.weight_scale
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(scale.view(1).contiguous(), requires_grad=False),
+        )
+
+        Fp8OnlineLinearMethod._quant_count += 1
+        if not Fp8OnlineLinearMethod._quant_logged:
+            logger.info(
+                "[Fp8OnlineLinearMethod] online-quantized FIRST weight: "
+                "prefix=%r, weight.shape=%s, weight.dtype=%s, "
+                "scale=%.6f, weight.device=%s",
+                getattr(layer, "prefix", "?"),
+                tuple(fp8_weight.shape),
+                fp8_weight.dtype,
+                float(scale.view(1)[0].item()),
+                fp8_weight.device,
+            )
+            Fp8OnlineLinearMethod._quant_logged = True
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        out_dtype = x.dtype
+        input_2d = x.reshape(-1, x.shape[-1])
+        out_features = layer.weight.shape[0]
+        output_shape = list(x.shape[:-1]) + [out_features]
+
+        qinput, x_scale = _resolve_per_tensor_quant()(input_2d)
+
+        if not Fp8OnlineLinearMethod._apply_logged:
+            logger.info(
+                "[Fp8OnlineLinearMethod] FIRST forward via torch._scaled_mm: "
+                "prefix=%r, x.dtype=%s, x.shape=%s, qinput.dtype=%s, "
+                "weight.dtype=%s, weight.shape=%s, weight_scale=%.6f, "
+                "x_scale=%.6f, total_quanted_weights=%d",
+                getattr(layer, "prefix", "?"),
+                x.dtype,
+                tuple(x.shape),
+                qinput.dtype,
+                layer.weight.dtype,
+                tuple(layer.weight.shape),
+                float(layer.weight_scale.view(1)[0].item()),
+                float(x_scale.view(1)[0].item()),
+                Fp8OnlineLinearMethod._quant_count,
+            )
+            Fp8OnlineLinearMethod._apply_logged = True
+
+        output = torch._scaled_mm(
+            qinput,
+            layer.weight.t(),
+            scale_a=x_scale,
+            scale_b=layer.weight_scale,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+        if isinstance(output, tuple):
+            output = output[0]
+
+        return output.view(*output_shape)
+
+
+@register_quant_method("fp8_per_channel_online")
+class Fp8PerChannelOnlineLinearMethod(QuantizeMethodBase):
+    """Online FP8 per-channel quantization for the new loader.
+
+    Loads BF16/FP16 weights from ckpt, quantizes to float8_e4m3fn at load time
+    with one fp32 scale per output channel (per-row of [N, K]), and runs forward
+    via torch._scaled_mm with online per-token activation quantization
+    (one fp32 scale per token-row of [M, K]).
+
+    Same `per_token_quant_fp8` CUDA op is reused for both weight quant
+    (rows of [N, K]) and activation quant (rows of [M, K]).
+    """
+
+    # Class-level flags: the diagnostic log fires at most once across ALL
+    # instances in a process. Safe under RTP-LLM's process model where each
+    # backend process loads the model once and does not reload. If dynamic
+    # reload (e.g. hot-swap, multi-model serving) is ever added, move these to
+    # __init__ so each instance can log once.
+    _quant_logged: bool = False
+    _apply_logged: bool = False
+    _quant_count: int = 0
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        # Stage as params_dtype (bf16) so existing param.data.copy_ flows in
+        # linear.py work; process_weights_after_loading replaces with fp8.
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(
+                torch.ones(output_size, 1, dtype=torch.float32),
+                requires_grad=False,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer):
+        weight = layer.weight.data
+        weight = _require_cuda_weight_for_online_quant(
+            layer, weight, type(self).__name__
+        )
+        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+
+        # Treat weight rows as "tokens" → per-output-channel quant.
+        # fp8_weight: [N, K] float8_e4m3fn, scale: [N, 1] float32.
+        fp8_weight, scale = _resolve_per_token_quant()(weight)
+
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(fp8_weight.contiguous(), requires_grad=False)
+        )
+        # Store scale already shaped [1, N] contiguous so apply() can pass
+        # layer.weight_scale directly to torch._scaled_mm as scale_b without
+        # per-call reshape+contiguous (was a measurable per-token decode cost).
+        del layer.weight_scale
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(scale.view(1, -1).contiguous(), requires_grad=False),
+        )
+
+        Fp8PerChannelOnlineLinearMethod._quant_count += 1
+        if not Fp8PerChannelOnlineLinearMethod._quant_logged:
+            logger.info(
+                "[Fp8PerChannelOnlineLinearMethod] online-quantized FIRST weight: "
+                "prefix=%r, weight.shape=%s, weight.dtype=%s, "
+                "scale.shape=%s, scale.mean=%.6f, weight.device=%s",
+                getattr(layer, "prefix", "?"),
+                tuple(fp8_weight.shape),
+                fp8_weight.dtype,
+                tuple(scale.shape),
+                float(scale.mean().item()),
+                fp8_weight.device,
+            )
+            Fp8PerChannelOnlineLinearMethod._quant_logged = True
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        out_dtype = x.dtype
+        input_2d = x.reshape(-1, x.shape[-1])
+        if not input_2d.is_contiguous():
+            input_2d = input_2d.contiguous()
+        N = layer.weight.shape[0]
+        output_shape = list(x.shape[:-1]) + [N]
+
+        # Per-token activation quant: [M, K] bf16 -> [M, K] fp8 + [M, 1] fp32.
+        qinput, x_scale = _resolve_per_token_quant()(input_2d)
+
+        # Weight scale was already shaped [1, N] contiguous in
+        # process_weights_after_loading — use it directly.
+        weight_scale_b = layer.weight_scale
+
+        if not Fp8PerChannelOnlineLinearMethod._apply_logged:
+            logger.info(
+                "[Fp8PerChannelOnlineLinearMethod] FIRST forward via torch._scaled_mm: "
+                "prefix=%r, x.dtype=%s, x.shape=%s, qinput.dtype=%s, qinput.shape=%s, "
+                "x_scale.shape=%s, weight.dtype=%s, weight.shape=%s, "
+                "weight_scale.shape=%s, scale_b.shape=%s, total_quanted_weights=%d",
+                getattr(layer, "prefix", "?"),
+                x.dtype,
+                tuple(x.shape),
+                qinput.dtype,
+                tuple(qinput.shape),
+                tuple(x_scale.shape),
+                layer.weight.dtype,
+                tuple(layer.weight.shape),
+                tuple(layer.weight_scale.shape),
+                tuple(weight_scale_b.shape),
+                Fp8PerChannelOnlineLinearMethod._quant_count,
+            )
+            Fp8PerChannelOnlineLinearMethod._apply_logged = True
+
+        output = torch._scaled_mm(
+            qinput,
+            layer.weight.t(),
+            scale_a=x_scale,
+            scale_b=weight_scale_b,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+        if isinstance(output, tuple):
+            output = output[0]
+
+        return output.view(*output_shape)
+
+
+@register_quant_method(
+    "fp8_per_channel",
+    "FP8_PER_CHANNEL_COMPRESSED",
+    "FP8_PER_CHANNEL_QUARK",
+)
+class Fp8PerChannelLinearMethod(QuantizeMethodBase):
+    """Already-quantized FP8 per-channel ckpt loader (compressed-tensors / Quark).
+
+    ckpt provides:
+      - weight: float8_e4m3fn [N, K]
+      - weight_scale: fp32 [N] or [N, 1]
+
+    Forward: torch._scaled_mm with online per-token activation quantization
+    (one fp32 scale per token-row of [M, K]), reusing
+    Fp8PerChannelOnlineLinearMethod's apply path.
+    """
+
+    # Class-level flag: the diagnostic log fires at most once across ALL
+    # instances in a process. See Fp8OnlineLinearMethod for the assumption.
+    _apply_logged: bool = False
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=_runtime_fp8_dtype()),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(
+                torch.ones(output_size, 1, dtype=torch.float32),
+                requires_grad=False,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer):
+        # ckpt scale may arrive as [N] or [N, 1]. ROCm fp8 kernels expect the
+        # platform runtime dtype (e4m3fnuz on MI308X), so convert already-FP8
+        # checkpoint weights once after loading and store scale as [1, N].
+        fp8_weight, scale = _requant_per_channel_to_runtime_fp8(
+            layer.weight.data, layer.weight_scale.data
+        )
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(fp8_weight, requires_grad=False)
+        )
+        del layer.weight_scale
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(scale, requires_grad=False),
+        )
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        out_dtype = x.dtype
+        input_2d = x.reshape(-1, x.shape[-1])
+        if not input_2d.is_contiguous():
+            input_2d = input_2d.contiguous()
+        N = layer.weight.shape[0]
+        output_shape = list(x.shape[:-1]) + [N]
+
+        qinput, x_scale = _resolve_per_token_quant()(input_2d)
+        # weight_scale was already shaped [1, N] contiguous in
+        # process_weights_after_loading — use it directly.
+        weight_scale_b = layer.weight_scale
+
+        if not Fp8PerChannelLinearMethod._apply_logged:
+            logger.info(
+                "[Fp8PerChannelLinearMethod] FIRST forward via torch._scaled_mm: "
+                "prefix=%r, x.shape=%s, weight.shape=%s, weight_scale.shape=%s",
+                getattr(layer, "prefix", "?"),
+                tuple(x.shape),
+                tuple(layer.weight.shape),
+                tuple(layer.weight_scale.shape),
+            )
+            Fp8PerChannelLinearMethod._apply_logged = True
+
+        output = torch._scaled_mm(
+            qinput,
+            layer.weight.t(),
+            scale_a=x_scale,
+            scale_b=weight_scale_b,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+        if isinstance(output, tuple):
+            output = output[0]
+        return output.view(*output_shape)
+
+
+@register_quant_method("fp8_block_online")
+class Fp8BlockOnlineLinearMethod(QuantizeMethodBase):
+    """Online FP8 per-block (128x128) quantization for the new loader.
+
+    Loads BF16/FP16 weights from ckpt, quantizes to float8_e4m3fn at load time
+    using DeepSeek-style 128x128 block scales, and runs forward via DeepGEMM
+    fp8_gemm_nt with online per-token-group (128) activation quantization.
+    """
+
+    BLOCK: int = 128
+
+    # Class-level flags: the diagnostic log fires at most once across ALL
+    # instances in a process. Safe under RTP-LLM's process model where each
+    # backend process loads the model once and does not reload. If dynamic
+    # reload (e.g. hot-swap, multi-model serving) is ever added, move these to
+    # __init__ so each instance can log once.
+    _quant_logged: bool = False
+    _apply_logged: bool = False
+    _quant_count: int = 0
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        # Stage as params_dtype (bf16) so existing param.data.copy_ flows in
+        # linear.py work; process_weights_after_loading replaces with fp8.
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        n_blocks = (output_size + self.BLOCK - 1) // self.BLOCK
+        k_blocks = (input_size + self.BLOCK - 1) // self.BLOCK
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(
+                torch.ones(n_blocks, k_blocks, dtype=torch.float32),
+                requires_grad=False,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer):
+        weight = layer.weight.data
+        weight = _require_cuda_weight_for_online_quant(
+            layer, weight, type(self).__name__
+        )
+        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+
+        # Match the legacy W8A8 per-block online loader exactly. The CUDA helper
+        # below is also DeepGEMM-derived, but the smoke baseline was produced by
+        # the Python loader-side quantizer.
+        from rtp_llm.model_loader.per_block_fp8_quant_weight import (
+            per_block_cast_to_fp8 as legacy_per_block_cast_to_fp8,
+        )
+
+        fp8_weight, scale = legacy_per_block_cast_to_fp8(weight, self.BLOCK)
+
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(fp8_weight.contiguous(), requires_grad=False)
+        )
+        del layer.weight_scale
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(scale.contiguous(), requires_grad=False),
+        )
+
+        Fp8BlockOnlineLinearMethod._quant_count += 1
+        if not Fp8BlockOnlineLinearMethod._quant_logged:
+            logger.info(
+                "[Fp8BlockOnlineLinearMethod] online-quantized FIRST weight: "
+                "prefix=%r, weight.shape=%s, weight.dtype=%s, "
+                "scale.shape=%s, scale.dtype=%s, scale.mean=%.6f, "
+                "weight.device=%s",
+                getattr(layer, "prefix", "?"),
+                tuple(fp8_weight.shape),
+                fp8_weight.dtype,
+                tuple(scale.shape),
+                scale.dtype,
+                float(scale.mean().item()),
+                fp8_weight.device,
+            )
+            Fp8BlockOnlineLinearMethod._quant_logged = True
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if not has_deep_gemm():
+            if not hasattr(layer, "weight_scale"):
+                return torch.nn.functional.linear(x, layer.weight, bias)
+            raise RuntimeError(
+                "Fp8BlockOnlineLinearMethod requires DeepGEMM at forward time; "
+                "install the `deep_gemm` package or load fp8_block weights "
+                "through the no-DeepGEMM dequant fallback."
+            )
+
+        out_dtype = x.dtype
+        input_2d = x.reshape(-1, x.shape[-1])
+        if not input_2d.is_contiguous():
+            input_2d = input_2d.contiguous()
+        M, K = input_2d.shape
+        N = layer.weight.shape[0]
+        output_shape = list(x.shape[:-1]) + [N]
+
+        # Online per-token-group activation quant (group_size=128).
+        scale_ue8m0 = getattr(layer, "weight_scale", None) is not None and (
+            layer.weight_scale.dtype == torch.int32
+        )
+        qinput, x_scales = _resolve_sgl_per_token_group_quant()(
+            input_2d,
+            group_size=self.BLOCK,
+            eps=1e-4,
+            column_major_scales=True,
+            scale_tma_aligned=True,
+            scale_ue8m0=scale_ue8m0,
+        )
+
+        output = torch.empty(M, N, dtype=out_dtype, device=input_2d.device)
+        _resolve_fp8_gemm_nt()(
+            (qinput, x_scales),
+            (layer.weight, layer.weight_scale),
+            output,
+            c=None,
+            disable_ue8m0_cast=not scale_ue8m0,
+        )
+
+        if not Fp8BlockOnlineLinearMethod._apply_logged:
+            logger.info(
+                "[Fp8BlockOnlineLinearMethod] FIRST forward via deep_gemm.fp8_gemm_nt: "
+                "prefix=%r, x.dtype=%s, x.shape=%s, qinput.dtype=%s, qinput.shape=%s, "
+                "x_scales.shape=%s, weight.dtype=%s, weight.shape=%s, "
+                "weight_scale.shape=%s, total_quanted_weights=%d",
+                getattr(layer, "prefix", "?"),
+                x.dtype,
+                tuple(x.shape),
+                qinput.dtype,
+                tuple(qinput.shape),
+                tuple(x_scales.shape),
+                layer.weight.dtype,
+                tuple(layer.weight.shape),
+                tuple(layer.weight_scale.shape),
+                Fp8BlockOnlineLinearMethod._quant_count,
+            )
+            Fp8BlockOnlineLinearMethod._apply_logged = True
+
+        if bias is not None:
+            output = output + bias.to(out_dtype)
+        return output.view(*output_shape)
+
+
+@register_quant_method("fp8_block", "FP8_PER_BLOCK")
+class Fp8BlockLinearMethod(Fp8BlockOnlineLinearMethod):
+    """Already-quantized FP8 per-block (128x128) ckpt loader.
+
+    ckpt provides:
+      - weight: float8_e4m3fn [N, K]
+      - weight_scale_inv: fp32 [ceil(N/128), ceil(K/128)]
+
+    Unlike the online sibling (which loads BF16 and quantizes at load time),
+    the weight is ALREADY fp8 + block-scaled. create_weights allocates the fp8
+    weight plus a `weight_scale_inv` parameter; the parallel-linear load path
+    (linear.py) TP-slices / shard-merges that block grid. process_weights_after_
+    loading simply renames `weight_scale_inv` -> `weight_scale` so the inherited
+    apply() (DeepGEMM fp8_gemm_nt, which reads `weight` + `weight_scale`) runs
+    identically to the online path — see TestFp8BlockForward.
+    """
+
+    _create_logged: bool = False
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        weight = nn.Parameter(
+            torch.empty(output_size, input_size, dtype=torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+        block_n, block_k = _normalize_weight_block_size(layer, self.BLOCK)
+        if not Fp8BlockLinearMethod._create_logged:
+            logger.info(
+                "[Fp8BlockLinearMethod] create_weights prefix=%r quant_type=%s "
+                "source_config=%s weight_block_size=%s input=%d output=%d",
+                getattr(layer, "prefix", "?"),
+                getattr(layer.quant_config, "quant_type", None),
+                (
+                    type(getattr(layer.quant_config, "source_config", None)).__name__
+                    if getattr(layer.quant_config, "source_config", None) is not None
+                    else None
+                ),
+                getattr(layer.quant_config, "weight_block_size", None),
+                input_size,
+                output_size,
+            )
+            Fp8BlockLinearMethod._create_logged = True
+        n_blocks = (output_size + block_n - 1) // block_n
+        k_blocks = (input_size + block_k - 1) // block_k
+        layer.register_parameter(
+            "weight_scale_inv",
+            nn.Parameter(
+                torch.ones(n_blocks, k_blocks, dtype=torch.float32),
+                requires_grad=False,
+            ),
+        )
+
+    def process_weights_after_loading(self, layer):
+        # The weight is already fp8. With DeepGEMM available, expose the block
+        # scale under the name the inherited apply() expects (`weight_scale`).
+        # ROCm/test containers do not provide CUDA DeepGEMM, so dequantize once
+        # at load time and use a plain bf16 linear fallback for smoke coverage.
+        block_size = _normalize_weight_block_size(layer, self.BLOCK)
+        if not has_deep_gemm():
+            if list(block_size) == [self.BLOCK, self.BLOCK]:
+                weight_dequant = _dequant_block_to_bf16(
+                    layer.weight.data, layer.weight_scale_inv.data, self.BLOCK
+                )
+            else:
+                from rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel import (
+                    block_quant_dequant,
+                )
+
+                weight_dequant = block_quant_dequant(
+                    layer.weight.data,
+                    layer.weight_scale_inv.data,
+                    list(block_size),
+                    torch.bfloat16,
+                )
+            del layer.weight
+            layer.register_parameter(
+                "weight", nn.Parameter(weight_dequant.contiguous(), requires_grad=False)
+            )
+            del layer.weight_scale_inv
+            logger.info(
+                "[Fp8BlockLinearMethod] DeepGEMM unavailable; dequantized %r to bf16 for fallback linear",
+                getattr(layer, "prefix", "?"),
+            )
+            return
+
+        if list(block_size) != [self.BLOCK, self.BLOCK]:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel import (
+                block_quant_dequant,
+            )
+
+            weight_dequant = block_quant_dequant(
+                layer.weight.data,
+                layer.weight_scale_inv.data,
+                list(block_size),
+                torch.bfloat16,
+            )
+            weight, scale = _resolve_per_block_cast()(weight_dequant, use_ue8m0=False)
+            del layer.weight
+            layer.register_parameter(
+                "weight", nn.Parameter(weight.contiguous(), requires_grad=False)
+            )
+        else:
+            scale = layer.weight_scale_inv.data
+        del layer.weight_scale_inv
+        layer.register_parameter(
+            "weight_scale",
+            nn.Parameter(scale.contiguous(), requires_grad=False),
+        )
+
+
+def _dequant_block_to_bf16(
+    weight: torch.Tensor, scale_inv: torch.Tensor, block: int = 128
+) -> torch.Tensor:
+    """Dequantize a DeepSeek FP8 per-block (128x128) weight [N,K] to bf16.
+
+    scale_inv is the standard [ceil(N/128), ceil(K/128)] block grid. Expand it
+    to full [N, K] (cropping any partial trailing block) and scale.
+    """
+    n, k = weight.shape
+    s = scale_inv.to(torch.float32)
+    s = s.repeat_interleave(block, dim=0).repeat_interleave(block, dim=1)
+    s = s[:n, :k]
+    return (weight.to(torch.float32) * s).to(torch.bfloat16)
+
+
+@register_quant_method("fp8_block_dequant")
+class Fp8BlockDequantLinearMethod(Fp8BlockLinearMethod):
+    """Already-quantized FP8 per-block ckpt, DEQUANTIZED to bf16 at load.
+
+    Same ckpt contract as Fp8BlockLinearMethod (fp8 weight + weight_scale_inv,
+    block-aware TP / shard-merge handled in linear.py), but
+    process_weights_after_loading expands the block scale and converts the
+    weight back to bf16, so apply() is a plain F.linear (no DeepGEMM).
+
+    For models whose downstream math needs bf16 weights or that must match a
+    bf16 reference — e.g. DeepSeek-V3.2's MLA, where the absorb path derives
+    kc/vc via torch.bmm (no fp8 kernel) and fp8 GEMM would diverge from the
+    validated bf16 baseline. The routed experts keep fp8 separately.
+    """
+
+    def process_weights_after_loading(self, layer):
+        block_size = _normalize_weight_block_size(layer, self.BLOCK)
+        if list(block_size) == [self.BLOCK, self.BLOCK]:
+            bf16 = _dequant_block_to_bf16(
+                layer.weight.data, layer.weight_scale_inv.data, self.BLOCK
+            )
+        else:
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel import (
+                block_quant_dequant,
+            )
+
+            bf16 = block_quant_dequant(
+                layer.weight.data,
+                layer.weight_scale_inv.data,
+                list(block_size),
+                torch.bfloat16,
+            )
+        del layer.weight
+        layer.register_parameter(
+            "weight", nn.Parameter(bf16.contiguous(), requires_grad=False)
+        )
+        del layer.weight_scale_inv
+
+    def apply(self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None):
+        return torch.nn.functional.linear(x, layer.weight, bias)

--- a/rtp_llm/models_py/quant_methods/fp8.py
+++ b/rtp_llm/models_py/quant_methods/fp8.py
@@ -324,6 +324,8 @@ class Fp8LinearMethod(QuantizeMethodBase):
     ) -> torch.Tensor:
         out_dtype = x.dtype
         input_2d = x.reshape(-1, x.shape[-1])
+        if not input_2d.is_contiguous():
+            input_2d = input_2d.contiguous()
         out_features = layer.weight.shape[0]
         output_shape = list(x.shape[:-1]) + [out_features]
 
@@ -456,6 +458,8 @@ class Fp8OnlineLinearMethod(QuantizeMethodBase):
     ) -> torch.Tensor:
         out_dtype = x.dtype
         input_2d = x.reshape(-1, x.shape[-1])
+        if not input_2d.is_contiguous():
+            input_2d = input_2d.contiguous()
         out_features = layer.weight.shape[0]
         output_shape = list(x.shape[:-1]) + [out_features]
 

--- a/rtp_llm/models_py/quant_methods/fp8.py
+++ b/rtp_llm/models_py/quant_methods/fp8.py
@@ -414,7 +414,8 @@ class Fp8OnlineLinearMethod(QuantizeMethodBase):
 
     def process_weights_after_loading(self, layer):
         weight = layer.weight.data
-        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+        if weight.ndim != 2:
+            raise ValueError(f"expected 2D weight, got {weight.shape}")
 
         weight = _require_cuda_weight_for_online_quant(
             layer, weight, type(self).__name__, allow_force_cpu=True
@@ -543,7 +544,8 @@ class Fp8PerChannelOnlineLinearMethod(QuantizeMethodBase):
         weight = _require_cuda_weight_for_online_quant(
             layer, weight, type(self).__name__
         )
-        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+        if weight.ndim != 2:
+            raise ValueError(f"expected 2D weight, got {weight.shape}")
 
         # Treat weight rows as "tokens" → per-output-channel quant.
         # fp8_weight: [N, K] float8_e4m3fn, scale: [N, 1] float32.
@@ -778,7 +780,8 @@ class Fp8BlockOnlineLinearMethod(QuantizeMethodBase):
         weight = _require_cuda_weight_for_online_quant(
             layer, weight, type(self).__name__
         )
-        assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
+        if weight.ndim != 2:
+            raise ValueError(f"expected 2D weight, got {weight.shape}")
 
         # Match the legacy W8A8 per-block online loader exactly. The CUDA helper
         # below is also DeepGEMM-derived, but the smoke baseline was produced by

--- a/rtp_llm/models_py/quant_methods/fp8.py
+++ b/rtp_llm/models_py/quant_methods/fp8.py
@@ -200,14 +200,25 @@ def _normalize_weight_block_size(layer, default_block: int) -> List[int]:
     return [block_n, block_k]
 
 
-def _require_cuda_weight_for_online_quant(layer, weight: torch.Tensor, method: str):
+def _require_cuda_weight_for_online_quant(
+    layer, weight: torch.Tensor, method: str, allow_force_cpu: bool = False
+):
     if weight.is_cuda:
         return weight
+    if allow_force_cpu and bool(
+        getattr(layer, "_new_loader_force_cpu_load_weights", False)
+    ):
+        return weight
+    cpu_hint = (
+        " or enable force_cpu_load_weights for CPU-side post-load quantization"
+        if allow_force_cpu
+        else " or use an already-quantized/non-online quant method for CPU load"
+    )
     raise RuntimeError(
         f"{method} requires weights to be on CUDA/ROCm before post-load "
         f"quantization, got device={weight.device} for prefix="
         f"{getattr(layer, 'prefix', '?')!r}. Set LoadConfig.device to a CUDA "
-        "device or use an already-quantized/non-online quant method for CPU load."
+        f"device{cpu_hint}."
     )
 
 
@@ -406,7 +417,7 @@ class Fp8OnlineLinearMethod(QuantizeMethodBase):
         assert weight.ndim == 2, f"expected 2D weight, got {weight.shape}"
 
         weight = _require_cuda_weight_for_online_quant(
-            layer, weight, type(self).__name__
+            layer, weight, type(self).__name__, allow_force_cpu=True
         )
         if bool(getattr(layer, "_new_loader_force_cpu_load_weights", False)):
             fp8_weight, scale = cpu_per_tensor_quant_like_legacy(weight)

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -453,6 +453,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         layer.w2 = nn.Parameter(new_w2.to(device), requires_grad=False)
 
     def _online_per_block(self, layer):
+        if bool(getattr(layer, "_new_loader_force_cpu_load_weights", False)):
+            raise RuntimeError(
+                "fp8_per_block_online MoE requires CUDA/ROCm post-load "
+                "quantization; force_cpu_load_weights is only supported for "
+                "per-tensor fp8_online MoE."
+            )
         BS = layer._FP8_BLOCK_SIZE
         block_size = self._weight_block_size(layer)
         if block_size != [BS, BS]:

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -517,6 +517,16 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         block_size = getattr(
             layer, "_fp8_moe_weight_block_size", [layer._FP8_BLOCK_SIZE] * 2
         )
+        if (
+            bool(getattr(layer, "_new_loader_force_cpu_load_weights", False))
+            and layer.w13.device.type == "cpu"
+        ):
+            raise RuntimeError(
+                "fp8_per_block MoE cannot run device-specific post-load "
+                "requantization while force_cpu_load_weights keeps weights on CPU; "
+                "disable force_cpu_load_weights or use a quantization path with CPU "
+                "post-load support."
+            )
         from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
             is_deep_gemm_e8m0_used,
         )

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -398,12 +398,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         del layer._down_ch_scales
 
     def _online_per_tensor(self, layer):
-        from rtp_llm.models_py.quant_methods.fp8 import (
-            _resolve_per_tensor_quant,
-            cpu_per_tensor_quant_like_legacy,
-        )
+        from rtp_llm.models_py.quant_methods.fp8 import cpu_per_tensor_quant_like_legacy
 
-        per_tensor_quant = _resolve_per_tensor_quant()
         E = layer.num_local_experts
         device = layer.w13.data.device
         new_w13 = torch.empty_like(layer.w13.data, dtype=_runtime_fp8_dtype())
@@ -411,13 +407,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         force_cpu_quant = bool(
             getattr(layer, "_new_loader_force_cpu_load_weights", False)
         )
+        if force_cpu_quant:
+            quant = cpu_per_tensor_quant_like_legacy
+        else:
+            from rtp_llm.models_py.quant_methods.fp8 import _resolve_per_tensor_quant
+
+            quant = _resolve_per_tensor_quant()
 
         for e in range(E):
-            quant = (
-                cpu_per_tensor_quant_like_legacy
-                if force_cpu_quant
-                else per_tensor_quant
-            )
             qw, sc = quant(layer.w13.data[e].contiguous())
             new_w13[e].copy_(qw)
             layer.w13_scale[e] = sc.view(-1)[0]

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -220,8 +220,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 # Source MXFP8 scales can be much larger than the execution
                 # format. Keep them as plain CPU tensors so model.to(cuda)
                 # does not move all source scales before post-load requant.
-                layer.w13_scale = torch.zeros(E, 2 * nb, hb, dtype=torch.float32)
-                layer.w2_scale = torch.zeros(E, h_nb, k_nb, dtype=torch.float32)
+                # Explicit device is required because fastsafetensors creates
+                # the model under torch.device("meta") before to_empty().
+                layer.w13_scale = torch.zeros(
+                    E, 2 * nb, hb, dtype=torch.float32, device="cpu"
+                )
+                layer.w2_scale = torch.zeros(
+                    E, h_nb, k_nb, dtype=torch.float32, device="cpu"
+                )
 
         elif qf in (
             "fp8_per_tensor_online",
@@ -545,6 +551,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         src_w13_scale = layer.w13_scale
         src_w2_scale = layer.w2_scale
+        if src_w13_scale.is_meta or src_w2_scale.is_meta:
+            raise RuntimeError(
+                "FP8 MoE custom block source scales must be materialized before "
+                "post-load requantization"
+            )
         new_w13_scale = []
         new_w2_scale = []
         device = layer.w13.device

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -1,0 +1,584 @@
+"""FP8 MoE quant methods for the new loader.
+
+This module owns the registered FP8 MoE loading paths. It mirrors the legacy
+buffer layout used by BaseMoEExperts, but the per-tensor fusion intentionally
+uses max-scale rescaling for merged gate/up/down shards, so it is not a
+byte-for-byte copy of the older fallback implementation. Forward execution still
+runs through BaseMoEExperts.forward and fused_moe after these buffers are built.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.quant_methods.base import (
+    FusedMoEMethodBase,
+    register_moe_quant_method,
+)
+from rtp_llm.utils.model_weight import W
+
+logger = logging.getLogger(__name__)
+
+# 与 BaseMoEExperts 一致的 fp8 常量（也可经 layer 取，这里就近定义保持自洽）。
+_FP8_E4M3_MAX: float = 448.0
+_FP8_MIN_SCALE: float = 1.0 / (448.0 * 512.0)
+
+
+def _runtime_fp8_dtype() -> torch.dtype:
+    if getattr(torch.version, "hip", None) is None:
+        return torch.float8_e4m3fn
+    try:
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
+            get_rocm_fp8_dtype,
+        )
+
+        return get_rocm_fp8_dtype()
+    except Exception:
+        return torch.float8_e4m3fn
+
+
+def _requant_per_tensor_to_runtime_fp8(
+    weight: torch.Tensor, scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    runtime_dtype = _runtime_fp8_dtype()
+    if weight.dtype == runtime_dtype:
+        return weight.contiguous(), scale.contiguous()
+    scale_view = scale.float().view(-1, 1, 1)
+    deq = weight.float() * scale_view
+    fp8_max = float(torch.finfo(runtime_dtype).max)
+    new_scale = deq.abs().amax(dim=(1, 2)).clamp_min(_FP8_MIN_SCALE) / fp8_max
+    requant = (deq / new_scale.view(-1, 1, 1)).to(runtime_dtype)
+    return requant.contiguous(), new_scale.to(torch.float32).contiguous()
+
+
+def _requant_per_channel_to_runtime_fp8(
+    weight: torch.Tensor, scale: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    runtime_dtype = _runtime_fp8_dtype()
+    if weight.dtype == runtime_dtype:
+        return weight.contiguous(), scale.contiguous()
+    if scale.shape != weight.shape[:2]:
+        raise ValueError(
+            f"MoE FP8 per-channel scale/weight mismatch: "
+            f"weight={tuple(weight.shape)} scale={tuple(scale.shape)}"
+        )
+    deq = weight.float() * scale.float().unsqueeze(-1)
+    fp8_max = float(torch.finfo(runtime_dtype).max)
+    new_scale = deq.abs().amax(dim=2).clamp_min(_FP8_MIN_SCALE) / fp8_max
+    requant = (deq / new_scale.unsqueeze(-1)).to(runtime_dtype)
+    return requant.contiguous(), new_scale.to(torch.float32).contiguous()
+
+
+@register_moe_quant_method(
+    # per_tensor 子族
+    "fp8",
+    "FP8_PER_TENSOR_COMPRESSED",
+    "FP8_DYNAMIC_PER_TENSOR",
+    # per_block 子族
+    "FP8_PER_BLOCK",
+    "fp8_block",
+    # per_channel 子族
+    "FP8_PER_CHANNEL_COMPRESSED",
+    "fp8_per_channel",
+    "FP8_PER_CHANNEL_QUARK",
+    # 在线 BF16->FP8 子族
+    "fp8_online",
+    "fp8_block_online",
+    "fp8_per_channel_online",
+)
+class Fp8MoEMethod(FusedMoEMethodBase):
+    def __init__(self, quant_config: Any = None):
+        self.quant_config = quant_config
+
+    @staticmethod
+    def _ceil_div(x: int, y: int) -> int:
+        return (x + y - 1) // y
+
+    def _weight_block_size(self, layer) -> List[int]:
+        block_size = getattr(
+            getattr(layer, "_quant_config", None), "weight_block_size", None
+        )
+        if block_size is None:
+            block_size = getattr(self.quant_config, "weight_block_size", None)
+        if block_size is None:
+            block_size = [128, 128]
+        if len(block_size) != 2:
+            raise ValueError(f"weight_block_size must have 2 values, got {block_size}")
+        block_n, block_k = int(block_size[0]), int(block_size[1])
+        if block_n <= 0 or block_k <= 0:
+            raise ValueError(
+                f"weight_block_size values must be positive, got {block_size}"
+            )
+        return [block_n, block_k]
+
+    def _requant_block_to_runtime_fp8(
+        self, weight: torch.Tensor, scale: torch.Tensor, block_size: List[int]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        runtime_dtype = _runtime_fp8_dtype()
+        if weight.dtype == runtime_dtype:
+            return weight.contiguous(), scale.contiguous()
+
+        block_n, block_k = block_size
+        e, out_dim, in_dim = weight.shape
+        if out_dim % block_n != 0 or in_dim % block_k != 0:
+            raise ValueError(
+                f"MoE FP8 block requant requires divisible dims, got "
+                f"weight={tuple(weight.shape)} block={block_size}"
+            )
+
+        out_blocks = out_dim // block_n
+        in_blocks = in_dim // block_k
+        deq = weight.float().reshape(e, out_blocks, block_n, in_blocks, block_k)
+        deq = deq * scale.float().reshape(e, out_blocks, 1, in_blocks, 1)
+        fp8_max = float(torch.finfo(runtime_dtype).max)
+        new_scale = (
+            deq.abs().amax(dim=(2, 4), keepdim=True).clamp_min(_FP8_MIN_SCALE)
+            / fp8_max
+        )
+        requant = (deq / new_scale).to(runtime_dtype).reshape(e, out_dim, in_dim)
+        new_scale = new_scale.squeeze(2).squeeze(-1).to(torch.float32)
+        return requant.contiguous(), new_scale.contiguous()
+
+    # ------------------------------------------------------------------ #
+    #  create_weights ← _init_buffers 的 fp8/online 分支
+    # ------------------------------------------------------------------ #
+    def create_weights(
+        self,
+        layer,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        E, M_tp, H = num_experts, intermediate_size, hidden_size
+        qf = layer._quant_family
+        dt = torch.float8_e4m3fn
+        BS = layer._FP8_BLOCK_SIZE
+        block_n, block_k = self._weight_block_size(layer)
+
+        if qf == "fp8_per_tensor":
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M_tp, H, dtype=dt), requires_grad=False
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M_tp, dtype=dt), requires_grad=False
+            )
+            layer.register_buffer("_gate_scales", torch.zeros(E, dtype=torch.float32))
+            layer.register_buffer("_up_scales", torch.zeros(E, dtype=torch.float32))
+            layer.register_buffer("_down_scales", torch.zeros(E, dtype=torch.float32))
+            layer.register_buffer("w13_scale", torch.zeros(E, dtype=torch.float32))
+            layer.register_buffer("w2_scale", torch.zeros(E, dtype=torch.float32))
+
+        elif qf == "fp8_per_channel":
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M_tp, H, dtype=dt), requires_grad=False
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M_tp, dtype=dt), requires_grad=False
+            )
+            layer.register_buffer(
+                "_gate_ch_scales", torch.zeros(E, M_tp, dtype=torch.float32)
+            )
+            layer.register_buffer(
+                "_up_ch_scales", torch.zeros(E, M_tp, dtype=torch.float32)
+            )
+            layer.register_buffer(
+                "_down_ch_scales", torch.zeros(E, H, dtype=torch.float32)
+            )
+            layer.register_buffer(
+                "w13_scale", torch.zeros(E, 2 * M_tp, dtype=torch.float32)
+            )
+            layer.register_buffer("w2_scale", torch.zeros(E, H, dtype=torch.float32))
+
+        elif qf == "fp8_per_block":
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M_tp, H, dtype=dt), requires_grad=False
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M_tp, dtype=dt), requires_grad=False
+            )
+            nb = self._ceil_div(M_tp, block_n)
+            hb = self._ceil_div(H, block_k)
+            h_nb = self._ceil_div(H, block_n)
+            k_nb = self._ceil_div(M_tp, block_k)
+            layer._n_scale_blocks_per_proj = nb
+            layer._k_scale_blocks_per_proj = k_nb
+            layer._fp8_moe_weight_block_size = [block_n, block_k]
+            if [block_n, block_k] == [BS, BS]:
+                layer.register_buffer(
+                    "w13_scale",
+                    torch.zeros(E, 2 * nb, hb, dtype=torch.float32),
+                )
+                layer.register_buffer(
+                    "w2_scale",
+                    torch.zeros(E, h_nb, k_nb, dtype=torch.float32),
+                )
+            else:
+                # Source MXFP8 scales can be much larger than the execution
+                # format. Keep them as plain CPU tensors so model.to(cuda)
+                # does not move all source scales before post-load requant.
+                layer.w13_scale = torch.zeros(E, 2 * nb, hb, dtype=torch.float32)
+                layer.w2_scale = torch.zeros(E, h_nb, k_nb, dtype=torch.float32)
+
+        elif qf in (
+            "fp8_per_tensor_online",
+            "fp8_per_channel_online",
+            "fp8_per_block_online",
+        ):
+            # 在线量化:buffer 先存源 dtype，process_weights 时再量化到 fp8。
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M_tp, H, dtype=params_dtype), requires_grad=False
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M_tp, dtype=params_dtype), requires_grad=False
+            )
+            if qf == "fp8_per_tensor_online":
+                layer.register_buffer("w13_scale", torch.zeros(E, dtype=torch.float32))
+                layer.register_buffer("w2_scale", torch.zeros(E, dtype=torch.float32))
+            elif qf == "fp8_per_channel_online":
+                layer.register_buffer(
+                    "w13_scale", torch.zeros(E, 2 * M_tp, dtype=torch.float32)
+                )
+                layer.register_buffer(
+                    "w2_scale", torch.zeros(E, H, dtype=torch.float32)
+                )
+            else:  # fp8_per_block_online
+                nb = self._ceil_div(M_tp, block_n)
+                hb = self._ceil_div(H, block_k)
+                h_nb = self._ceil_div(H, block_n)
+                k_nb = self._ceil_div(M_tp, block_k)
+                layer._n_scale_blocks_per_proj = nb
+                layer._k_scale_blocks_per_proj = k_nb
+                layer._fp8_moe_weight_block_size = [block_n, block_k]
+                layer.register_buffer(
+                    "w13_scale",
+                    torch.zeros(E, 2 * nb, hb, dtype=torch.float32),
+                )
+                layer.register_buffer(
+                    "w2_scale",
+                    torch.zeros(E, h_nb, k_nb, dtype=torch.float32),
+                )
+        else:
+            raise ValueError(f"Fp8MoEMethod 不支持的 quant_family: {qf!r}")
+
+    # ------------------------------------------------------------------ #
+    #  dispatch_scale ← _dispatch_scale + 两个 copy 助手
+    # ------------------------------------------------------------------ #
+    def dispatch_scale(self, layer, local_id, proj, param_name, tensor):
+        qf = layer._quant_family
+
+        # online 家族不该收到已量化 ckpt 的 weight_scale，否则是 ckpt 与 QUANTIZATION 不匹配。
+        if param_name in ("weight_scale", "weight_scale_inv") and qf in (
+            "fp8_per_tensor_online",
+            "fp8_per_channel_online",
+            "fp8_per_block_online",
+        ):
+            raise RuntimeError(
+                f"[Fp8MoEMethod] Got {param_name!r} for proj={proj!r} while in "
+                f"online quant family {qf!r}; ckpt 已是预量化 FP8 但 QUANTIZATION 选了"
+                f"在线路径。请改用 QUANTIZATION=FP8（已量化路径），或确保 ckpt 的"
+                f" config.json 带 quantization_config 让 load_from_ckpt 自动选对。"
+            )
+
+        if param_name == "weight_scale" and qf == "fp8_per_tensor":
+            scale_val = tensor.float().squeeze().item()
+            if proj == "gate_proj":
+                layer._gate_scales[local_id] = scale_val
+            elif proj == "up_proj":
+                layer._up_scales[local_id] = scale_val
+            elif proj == "down_proj":
+                layer._down_scales[local_id] = scale_val
+
+        elif param_name == "weight_scale" and qf == "fp8_per_channel":
+            self._copy_per_channel_scale(layer, local_id, proj, tensor)
+
+        elif param_name == "weight_scale_inv" and qf == "fp8_per_block":
+            self._copy_block_scale(layer, local_id, proj, tensor)
+
+    def _copy_per_channel_scale(self, layer, expert_id, proj, tensor):
+        scale = tensor.float().squeeze()
+        if proj == "gate_proj":
+            start = layer.moe_expert_tp_rank * layer.moe_inter_tp
+            layer._gate_ch_scales.data[expert_id].copy_(
+                scale.narrow(0, start, layer.moe_inter_tp)
+            )
+        elif proj == "up_proj":
+            start = layer.moe_expert_tp_rank * layer.moe_inter_tp
+            layer._up_ch_scales.data[expert_id].copy_(
+                scale.narrow(0, start, layer.moe_inter_tp)
+            )
+        elif proj == "down_proj":
+            layer._down_ch_scales.data[expert_id].copy_(scale)
+
+    def _copy_block_scale(self, layer, expert_id, proj, tensor):
+        block_n, block_k = getattr(
+            layer, "_fp8_moe_weight_block_size", [layer._FP8_BLOCK_SIZE] * 2
+        )
+        nb = layer._n_scale_blocks_per_proj
+        if proj in ("gate_proj", "up_proj"):
+            start_block = (layer.moe_expert_tp_rank * layer.moe_inter_tp) // block_n
+            sliced = tensor.narrow(0, start_block, nb).contiguous()
+            row_start = nb if proj == "gate_proj" else 0
+            layer.w13_scale.data[expert_id, row_start : row_start + nb].copy_(sliced)
+        elif proj == "down_proj":
+            start_block = (layer.moe_expert_tp_rank * layer.moe_inter_tp) // block_k
+            k_nb = getattr(layer, "_k_scale_blocks_per_proj", nb)
+            sliced = tensor.narrow(1, start_block, k_nb).contiguous()
+            layer.w2_scale.data[expert_id].copy_(sliced)
+
+    # ------------------------------------------------------------------ #
+    #  process_weights_after_loading ← _fuse_* / _online_quantize_*
+    # ------------------------------------------------------------------ #
+    def process_weights_after_loading(self, layer):
+        qf = layer._quant_family
+        if qf == "fp8_per_tensor":
+            self._fuse_per_tensor(layer)
+        elif qf == "fp8_per_channel":
+            self._fuse_per_channel(layer)
+        elif qf == "fp8_per_tensor_online":
+            self._online_per_tensor(layer)
+        elif qf == "fp8_per_channel_online":
+            self._online_per_channel(layer)
+        elif qf == "fp8_per_block_online":
+            self._online_per_block(layer)
+        elif qf == "fp8_per_block":
+            self._requant_per_block_if_needed(layer)
+
+    def _fuse_per_tensor(self, layer):
+        M_tp = layer.moe_inter_tp
+
+        for e in range(layer.num_local_experts):
+            up_s = float(layer._up_scales[e].item())
+            gate_s = float(layer._gate_scales[e].item())
+            down_s = float(layer._down_scales[e].item())
+            max_s = max(up_s, gate_s)
+
+            if up_s != max_s:
+                up_half = layer.w13.data[e, :M_tp].to(torch.float16) * (up_s / max_s)
+                layer.w13.data[e, :M_tp] = up_half.to(layer.w13.dtype)
+            if gate_s != max_s:
+                gate_half = layer.w13.data[e, M_tp:].to(torch.float16) * (gate_s / max_s)
+                layer.w13.data[e, M_tp:] = gate_half.to(layer.w13.dtype)
+            layer.w13_scale[e] = max_s
+            layer.w2_scale[e] = down_s
+
+        layer.w13.data, layer.w13_scale.data = _requant_per_tensor_to_runtime_fp8(
+            layer.w13.data, layer.w13_scale
+        )
+        layer.w2.data, layer.w2_scale.data = _requant_per_tensor_to_runtime_fp8(
+            layer.w2.data, layer.w2_scale
+        )
+
+        del layer._gate_scales
+        del layer._up_scales
+        del layer._down_scales
+
+    def _fuse_per_channel(self, layer):
+        for e in range(layer.num_local_experts):
+            layer.w13_scale.data[e, : layer.moe_inter_tp] = layer._up_ch_scales[e]
+            layer.w13_scale.data[e, layer.moe_inter_tp :] = layer._gate_ch_scales[e]
+            layer.w2_scale.data[e] = layer._down_ch_scales[e]
+        layer.w13.data, layer.w13_scale.data = _requant_per_channel_to_runtime_fp8(
+            layer.w13.data, layer.w13_scale
+        )
+        layer.w2.data, layer.w2_scale.data = _requant_per_channel_to_runtime_fp8(
+            layer.w2.data, layer.w2_scale
+        )
+        del layer._gate_ch_scales
+        del layer._up_ch_scales
+        del layer._down_ch_scales
+
+    def _online_per_tensor(self, layer):
+        from rtp_llm.models_py.quant_methods.fp8 import (
+            _resolve_per_tensor_quant,
+            cpu_per_tensor_quant_like_legacy,
+        )
+
+        per_tensor_quant = _resolve_per_tensor_quant()
+        E = layer.num_local_experts
+        device = layer.w13.data.device
+        new_w13 = torch.empty_like(layer.w13.data, dtype=_runtime_fp8_dtype())
+        new_w2 = torch.empty_like(layer.w2.data, dtype=_runtime_fp8_dtype())
+        force_cpu_quant = bool(
+            getattr(layer, "_new_loader_force_cpu_load_weights", False)
+        )
+
+        for e in range(E):
+            quant = (
+                cpu_per_tensor_quant_like_legacy
+                if force_cpu_quant
+                else per_tensor_quant
+            )
+            qw, sc = quant(layer.w13.data[e].contiguous())
+            new_w13[e].copy_(qw)
+            layer.w13_scale[e] = sc.view(-1)[0]
+
+            qw, sc = quant(layer.w2.data[e].contiguous())
+            new_w2[e].copy_(qw)
+            layer.w2_scale[e] = sc.view(-1)[0]
+
+        layer.w13 = nn.Parameter(new_w13.to(device), requires_grad=False)
+        layer.w2 = nn.Parameter(new_w2.to(device), requires_grad=False)
+
+    def _online_per_channel(self, layer):
+        E = layer.num_local_experts
+        device = layer.w13.data.device
+        new_w13 = torch.empty_like(layer.w13.data, dtype=_runtime_fp8_dtype())
+        new_w2 = torch.empty_like(layer.w2.data, dtype=_runtime_fp8_dtype())
+        fp8_max = _FP8_E4M3_MAX
+
+        for e in range(E):
+            w13_e = layer.w13.data[e].float()
+            row_max = w13_e.abs().amax(dim=1)
+            row_scale = (row_max / fp8_max).clamp_min(_FP8_MIN_SCALE)
+            new_w13[e] = (w13_e / row_scale.unsqueeze(1)).to(_runtime_fp8_dtype())
+            layer.w13_scale.data[e] = row_scale
+
+            w2_e = layer.w2.data[e].float()
+            row_max = w2_e.abs().amax(dim=1)
+            row_scale = (row_max / fp8_max).clamp_min(_FP8_MIN_SCALE)
+            new_w2[e] = (w2_e / row_scale.unsqueeze(1)).to(_runtime_fp8_dtype())
+            layer.w2_scale.data[e] = row_scale
+
+        layer.w13 = nn.Parameter(new_w13.to(device), requires_grad=False)
+        layer.w2 = nn.Parameter(new_w2.to(device), requires_grad=False)
+
+    def _online_per_block(self, layer):
+        BS = layer._FP8_BLOCK_SIZE
+        block_size = self._weight_block_size(layer)
+        if block_size != [BS, BS]:
+            raise ValueError(
+                f"fp8_per_block_online MoE only supports [{BS}, {BS}] "
+                f"runtime block size, got {block_size}"
+            )
+        from rtp_llm.model_loader.per_block_fp8_quant_weight import (
+            per_block_cast_to_fp8 as legacy_per_block_cast_to_fp8,
+        )
+
+        # Use the same vectorized loader-side quantizer as linear online
+        # fp8_block. The old Python block loop synchronized once per 128x128
+        # block via .item(), making large MoE checkpoints exceed smoke timeout.
+        new_w13, w13_scale = legacy_per_block_cast_to_fp8(
+            layer.w13.data.contiguous(), BS
+        )
+        new_w2, w2_scale = legacy_per_block_cast_to_fp8(layer.w2.data.contiguous(), BS)
+
+        layer.w13 = nn.Parameter(new_w13.contiguous(), requires_grad=False)
+        layer.w2 = nn.Parameter(new_w2.contiguous(), requires_grad=False)
+        layer.w13_scale.data.copy_(w13_scale.contiguous())
+        layer.w2_scale.data.copy_(w2_scale.contiguous())
+
+    def _requant_per_block_if_needed(self, layer):
+        block_size = getattr(
+            layer, "_fp8_moe_weight_block_size", [layer._FP8_BLOCK_SIZE] * 2
+        )
+        from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import (
+            is_deep_gemm_e8m0_used,
+        )
+
+        if list(block_size) == [layer._FP8_BLOCK_SIZE, layer._FP8_BLOCK_SIZE]:
+            runtime_dtype = _runtime_fp8_dtype()
+            if layer.w13.dtype != runtime_dtype or layer.w2.dtype != runtime_dtype:
+                layer.w13.data, layer.w13_scale = self._requant_block_to_runtime_fp8(
+                    layer.w13.data.contiguous(),
+                    layer.w13_scale.to(layer.w13.device, non_blocking=True).contiguous(),
+                    list(block_size),
+                )
+                layer.w2.data, layer.w2_scale = self._requant_block_to_runtime_fp8(
+                    layer.w2.data.contiguous(),
+                    layer.w2_scale.to(layer.w2.device, non_blocking=True).contiguous(),
+                    list(block_size),
+                )
+                logger.info(
+                    "[Fp8MoEMethod] requantized MoE fp8 block weights to runtime dtype: "
+                    "dtype=%s w13=%s w13_scale=%s w2=%s w2_scale=%s",
+                    runtime_dtype,
+                    tuple(layer.w13.shape),
+                    tuple(layer.w13_scale.shape),
+                    tuple(layer.w2.shape),
+                    tuple(layer.w2_scale.shape),
+                )
+
+            if not is_deep_gemm_e8m0_used():
+                return
+
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel import (
+                requant_weight_ue8m0,
+            )
+
+            layer.w13.data, layer.w13_scale = requant_weight_ue8m0(
+                layer.w13.data.contiguous(),
+                layer.w13_scale.to(layer.w13.device, non_blocking=True).contiguous(),
+            )
+            layer.w2.data, layer.w2_scale = requant_weight_ue8m0(
+                layer.w2.data.contiguous(),
+                layer.w2_scale.to(layer.w2.device, non_blocking=True).contiguous(),
+            )
+            logger.info(
+                "[Fp8MoEMethod] requantized MoE fp8 block scales to UE8M0: "
+                "w13=%s w13_scale=%s/%s w2=%s w2_scale=%s/%s",
+                tuple(layer.w13.shape),
+                layer.w13_scale.dtype,
+                tuple(layer.w13_scale.shape),
+                tuple(layer.w2.shape),
+                layer.w2_scale.dtype,
+                tuple(layer.w2_scale.shape),
+            )
+            return
+
+        from rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel import (
+            block_quant_dequant,
+            per_block_cast_to_fp8,
+        )
+
+        def requant_weight_fp8_block_float(weight, weight_scale):
+            weight_dequant = block_quant_dequant(
+                weight,
+                weight_scale,
+                list(block_size),
+                torch.bfloat16,
+            )
+            return per_block_cast_to_fp8(weight_dequant, use_ue8m0=False)
+
+        src_w13_scale = layer.w13_scale
+        src_w2_scale = layer.w2_scale
+        new_w13_scale = []
+        new_w2_scale = []
+        device = layer.w13.device
+        for e in range(layer.num_local_experts):
+            w, s = requant_weight_fp8_block_float(
+                layer.w13.data[e].contiguous(),
+                src_w13_scale[e].to(device, non_blocking=True).contiguous(),
+            )
+            layer.w13.data[e].copy_(w)
+            new_w13_scale.append(s)
+            del w
+            w, s = requant_weight_fp8_block_float(
+                layer.w2.data[e].contiguous(),
+                src_w2_scale[e].to(device, non_blocking=True).contiguous(),
+            )
+            layer.w2.data[e].copy_(w)
+            new_w2_scale.append(s)
+            del w
+
+        layer.w13_scale = torch.stack(new_w13_scale, dim=0).contiguous()
+        layer.w2_scale = torch.stack(new_w2_scale, dim=0).contiguous()
+        logger.info(
+            "[Fp8MoEMethod] requantized MoE fp8 block scales from %s to [128, 128]: "
+            "w13=%s w13_scale=%s w2=%s w2_scale=%s",
+            block_size,
+            tuple(layer.w13.shape),
+            tuple(layer.w13_scale.shape),
+            tuple(layer.w2.shape),
+            tuple(layer.w2_scale.shape),
+        )
+
+    # ------------------------------------------------------------------ #
+    #  add_weight_tensors ← _build_weights_dict 的 fp8 scale 注入
+    # ------------------------------------------------------------------ #
+    def add_weight_tensors(self, layer, weights_dict: Dict[str, Any]) -> None:
+        weights_dict[W.moe_s1] = layer.w13_scale
+        weights_dict[W.moe_s2] = layer.w2_scale

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -200,6 +200,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w2 = nn.Parameter(
                 torch.empty(E, H, M_tp, dtype=dt), requires_grad=False
             )
+            if layer.moe_expert_tp_size > 1 and (
+                M_tp % block_n != 0 or M_tp % block_k != 0
+            ):
+                raise ValueError(
+                    f"MoE FP8 block scale TP shard requires block-aligned "
+                    f"moe_intermediate per rank, got moe_inter_tp={M_tp}, "
+                    f"block_n={block_n}, block_k={block_k}, "
+                    f"tp_size={layer.moe_expert_tp_size}"
+                )
             nb = self._ceil_div(M_tp, block_n)
             hb = self._ceil_div(H, block_k)
             h_nb = self._ceil_div(H, block_n)
@@ -324,16 +333,39 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer, "_fp8_moe_weight_block_size", [layer._FP8_BLOCK_SIZE] * 2
         )
         nb = layer._n_scale_blocks_per_proj
+        shard_start = layer.moe_expert_tp_rank * layer.moe_inter_tp
         if proj in ("gate_proj", "up_proj"):
-            start_block = (layer.moe_expert_tp_rank * layer.moe_inter_tp) // block_n
+            self._check_block_aligned(
+                shard_start,
+                layer.moe_inter_tp,
+                block_n,
+                f"MoE FP8 block scale {proj} TP shard",
+            )
+            start_block = shard_start // block_n
             sliced = tensor.narrow(0, start_block, nb).contiguous()
             row_start = nb if proj == "gate_proj" else 0
             layer.w13_scale.data[expert_id, row_start : row_start + nb].copy_(sliced)
         elif proj == "down_proj":
-            start_block = (layer.moe_expert_tp_rank * layer.moe_inter_tp) // block_k
+            self._check_block_aligned(
+                shard_start,
+                layer.moe_inter_tp,
+                block_k,
+                "MoE FP8 block scale down_proj TP shard",
+            )
+            start_block = shard_start // block_k
             k_nb = getattr(layer, "_k_scale_blocks_per_proj", nb)
             sliced = tensor.narrow(1, start_block, k_nb).contiguous()
             layer.w2_scale.data[expert_id].copy_(sliced)
+
+    @staticmethod
+    def _check_block_aligned(start: int, size: int, block: int, what: str):
+        if start % block != 0 or size % block != 0:
+            raise ValueError(
+                f"{what} requires block-aligned shard boundaries, got "
+                f"start={start}, size={size}, block={block}. Non-aligned "
+                f"FP8 block scales would overlap checkpoint blocks and cannot "
+                f"be copied safely without requantization."
+            )
 
     # ------------------------------------------------------------------ #
     #  process_weights_after_loading ← _fuse_* / _online_quantize_*

--- a/rtp_llm/models_py/quant_methods/fp8_moe.py
+++ b/rtp_llm/models_py/quant_methods/fp8_moe.py
@@ -21,9 +21,8 @@ from rtp_llm.utils.model_weight import W
 
 logger = logging.getLogger(__name__)
 
-# 与 BaseMoEExperts 一致的 fp8 常量（也可经 layer 取，这里就近定义保持自洽）。
-_FP8_E4M3_MAX: float = 448.0
-_FP8_MIN_SCALE: float = 1.0 / (448.0 * 512.0)
+def _fp8_min_scale(fp8_max: float) -> float:
+    return 1.0 / (fp8_max * 512.0)
 
 
 def _runtime_fp8_dtype() -> torch.dtype:
@@ -48,7 +47,7 @@ def _requant_per_tensor_to_runtime_fp8(
     scale_view = scale.float().view(-1, 1, 1)
     deq = weight.float() * scale_view
     fp8_max = float(torch.finfo(runtime_dtype).max)
-    new_scale = deq.abs().amax(dim=(1, 2)).clamp_min(_FP8_MIN_SCALE) / fp8_max
+    new_scale = deq.abs().amax(dim=(1, 2)).clamp_min(_fp8_min_scale(fp8_max)) / fp8_max
     requant = (deq / new_scale.view(-1, 1, 1)).to(runtime_dtype)
     return requant.contiguous(), new_scale.to(torch.float32).contiguous()
 
@@ -66,7 +65,7 @@ def _requant_per_channel_to_runtime_fp8(
         )
     deq = weight.float() * scale.float().unsqueeze(-1)
     fp8_max = float(torch.finfo(runtime_dtype).max)
-    new_scale = deq.abs().amax(dim=2).clamp_min(_FP8_MIN_SCALE) / fp8_max
+    new_scale = deq.abs().amax(dim=2).clamp_min(_fp8_min_scale(fp8_max)) / fp8_max
     requant = (deq / new_scale.unsqueeze(-1)).to(runtime_dtype)
     return requant.contiguous(), new_scale.to(torch.float32).contiguous()
 
@@ -134,7 +133,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         deq = deq * scale.float().reshape(e, out_blocks, 1, in_blocks, 1)
         fp8_max = float(torch.finfo(runtime_dtype).max)
         new_scale = (
-            deq.abs().amax(dim=(2, 4), keepdim=True).clamp_min(_FP8_MIN_SCALE)
+            deq.abs().amax(dim=(2, 4), keepdim=True).clamp_min(_fp8_min_scale(fp8_max))
             / fp8_max
         )
         requant = (deq / new_scale).to(runtime_dtype).reshape(e, out_dim, in_dim)
@@ -461,21 +460,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def _online_per_channel(self, layer):
         E = layer.num_local_experts
         device = layer.w13.data.device
-        new_w13 = torch.empty_like(layer.w13.data, dtype=_runtime_fp8_dtype())
-        new_w2 = torch.empty_like(layer.w2.data, dtype=_runtime_fp8_dtype())
-        fp8_max = _FP8_E4M3_MAX
+        runtime_dtype = _runtime_fp8_dtype()
+        new_w13 = torch.empty_like(layer.w13.data, dtype=runtime_dtype)
+        new_w2 = torch.empty_like(layer.w2.data, dtype=runtime_dtype)
+        fp8_max = float(torch.finfo(runtime_dtype).max)
+        min_scale = _fp8_min_scale(fp8_max)
 
         for e in range(E):
             w13_e = layer.w13.data[e].float()
             row_max = w13_e.abs().amax(dim=1)
-            row_scale = (row_max / fp8_max).clamp_min(_FP8_MIN_SCALE)
-            new_w13[e] = (w13_e / row_scale.unsqueeze(1)).to(_runtime_fp8_dtype())
+            row_scale = (row_max / fp8_max).clamp_min(min_scale)
+            new_w13[e] = (w13_e / row_scale.unsqueeze(1)).to(runtime_dtype)
             layer.w13_scale.data[e] = row_scale
 
             w2_e = layer.w2.data[e].float()
             row_max = w2_e.abs().amax(dim=1)
-            row_scale = (row_max / fp8_max).clamp_min(_FP8_MIN_SCALE)
-            new_w2[e] = (w2_e / row_scale.unsqueeze(1)).to(_runtime_fp8_dtype())
+            row_scale = (row_max / fp8_max).clamp_min(min_scale)
+            new_w2[e] = (w2_e / row_scale.unsqueeze(1)).to(runtime_dtype)
             layer.w2_scale.data[e] = row_scale
 
         layer.w13 = nn.Parameter(new_w13.to(device), requires_grad=False)

--- a/rtp_llm/models_py/quant_methods/test/BUILD
+++ b/rtp_llm/models_py/quant_methods/test/BUILD
@@ -24,3 +24,11 @@ py_test(
         "//rtp_llm/models_py/standalone:py_standalone_testlib",
     ],
 )
+
+py_test(
+    name = "test_new_weight_loader_imports",
+    srcs = ["test_new_weight_loader_imports.py"],
+    deps = [
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/quant_methods/test/BUILD
+++ b/rtp_llm/models_py/quant_methods/test/BUILD
@@ -1,0 +1,26 @@
+py_test(
+    name = "test_fp8_already_quantized",
+    srcs = ["test_fp8_already_quantized.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {"gpu": "H20", "gpu_count": "1"},
+)
+
+py_test(
+    name = "verify_phase1_dispatch",
+    srcs = ["verify_phase1_dispatch.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+)
+
+py_test(
+    name = "test_load_integrity",
+    srcs = ["test_load_integrity.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+)

--- a/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
@@ -481,6 +481,37 @@ class TestFp8MoEAlreadyQuantizedLoad(unittest.TestCase):
         self.assertEqual(layer.w13.device.type, "cpu")
         self.assertEqual(layer.w2.device.type, "cpu")
 
+    def test_online_per_tensor_moe_force_cpu_does_not_resolve_cuda_quant(self):
+        layer = self._make_moe("fp8_online")
+        layer._new_loader_force_cpu_load_weights = True
+        for name in (
+            "0.gate_proj.weight",
+            "0.up_proj.weight",
+            "0.down_proj.weight",
+        ):
+            layer.load_weights({name: torch.zeros(4, 4, dtype=torch.bfloat16)})
+
+        def fake_cpu_quant(weight):
+            return (
+                torch.zeros_like(weight, dtype=fp8_moe._runtime_fp8_dtype()),
+                torch.ones(1, dtype=torch.float32),
+            )
+
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None), \
+             mock.patch(
+                 "rtp_llm.models_py.quant_methods.fp8._resolve_per_tensor_quant",
+                 side_effect=ImportError("missing cuda quant kernel"),
+             ), \
+             mock.patch(
+                 "rtp_llm.models_py.quant_methods.fp8.cpu_per_tensor_quant_like_legacy",
+                 side_effect=fake_cpu_quant,
+             ) as cpu_quant:
+            layer.process_weights_after_loading()
+
+        self.assertEqual(cpu_quant.call_count, 2)
+        self.assertEqual(layer.w13.dtype, fp8_moe._runtime_fp8_dtype())
+        self.assertEqual(layer.w2.dtype, fp8_moe._runtime_fp8_dtype())
+
     def test_online_block_moe_rejects_force_cpu_post_load(self):
         layer = self._make_moe("fp8_block_online")
         layer._new_loader_force_cpu_load_weights = True

--- a/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
@@ -452,6 +452,50 @@ class TestFp8MoEAlreadyQuantizedLoad(unittest.TestCase):
         torch.testing.assert_close(actual_w13[0], expected_w13, rtol=0.1, atol=0.1)
         torch.testing.assert_close(actual_w2[0], expected_w2, rtol=0.1, atol=0.1)
 
+    def test_online_per_channel_moe_uses_runtime_fp8_dtype_range(self):
+        layer = self._make_moe("fp8_per_channel_online")
+        runtime_dtype = torch.float8_e4m3fnuz
+        fp8_max = float(torch.finfo(runtime_dtype).max)
+        gate = torch.tensor(
+            [[fp8_max, fp8_max / 2, -fp8_max, 0.0]] * 4, dtype=torch.bfloat16
+        )
+        up = torch.tensor(
+            [[fp8_max / 2, -fp8_max, fp8_max / 4, 0.0]] * 4,
+            dtype=torch.bfloat16,
+        )
+        down = torch.tensor(
+            [[fp8_max, -fp8_max, fp8_max / 4, 0.0]] * 4, dtype=torch.bfloat16
+        )
+        layer.load_weights({"0.gate_proj.weight": gate})
+        layer.load_weights({"0.up_proj.weight": up})
+        layer.load_weights({"0.down_proj.weight": down})
+
+        with mock.patch.object(
+            BaseMoEExperts, "_maybe_build_fused_moe", return_value=None
+        ), mock.patch(
+            "rtp_llm.models_py.quant_methods.fp8_moe._runtime_fp8_dtype",
+            return_value=runtime_dtype,
+        ):
+            layer.process_weights_after_loading()
+
+        self.assertEqual(layer.w13.dtype, runtime_dtype)
+        self.assertEqual(layer.w2.dtype, runtime_dtype)
+        expected_w13 = torch.cat([up.float(), gate.float()], dim=0)
+        min_scale = 1.0 / (fp8_max * 512.0)
+        expected_w13_scale = (expected_w13.abs().amax(dim=1) / fp8_max).clamp_min(
+            min_scale
+        )
+        expected_w2 = down.float().t().contiguous()
+        expected_w2_scale = (expected_w2.abs().amax(dim=1) / fp8_max).clamp_min(
+            min_scale
+        )
+        torch.testing.assert_close(layer.w13_scale[0], expected_w13_scale)
+        torch.testing.assert_close(layer.w2_scale[0], expected_w2_scale)
+        deq_w13 = layer.w13.float() * layer.w13_scale.view(1, -1, 1)
+        deq_w2 = layer.w2.float() * layer.w2_scale.view(1, -1, 1)
+        torch.testing.assert_close(deq_w13, expected_w13.unsqueeze(0), rtol=0, atol=1.0)
+        torch.testing.assert_close(deq_w2, expected_w2.unsqueeze(0), rtol=0, atol=1.0)
+
     def test_online_per_tensor_moe_allows_cpu_post_load_when_force_cpu_enabled(self):
         layer = self._make_moe("fp8_online")
         layer._new_loader_force_cpu_load_weights = True

--- a/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
@@ -462,6 +462,75 @@ class TestFp8MoEAlreadyQuantizedLoad(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "only supports"):
                 layer.process_weights_after_loading()
 
+    def test_custom_block_moe_source_scales_materialized_after_meta_to_empty(self):
+        qc = _make_qc("fp8_block")
+        qc.weight_block_size = [2, 4]
+        with torch.device("meta"):
+            layer = BaseMoEExperts(
+                num_experts=1,
+                hidden_size=4,
+                moe_intermediate_size=4,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                params_dtype=torch.bfloat16,
+                model_config=type(
+                    "Cfg",
+                    (),
+                    {"data_type": "bf16", "quant_config": None, "exported_device": None},
+                )(),
+                parallelism_config=type("Parallel", (), {"dp_size": 1})(),
+                moe_config=type("MoeCfg", (), {})(),
+                quant_config=qc,
+                layer_idx=0,
+            )
+        layer.to_empty(device="cpu")
+        self.assertFalse(layer.w13_scale.is_meta)
+        self.assertFalse(layer.w2_scale.is_meta)
+        self.assertEqual(layer.w13_scale.device.type, "cpu")
+        self.assertEqual(layer.w2_scale.device.type, "cpu")
+
+        fp8_weight = torch.zeros(4, 4, dtype=torch.float8_e4m3fn)
+        layer.load_weights(
+            {
+                "0.gate_proj.weight": fp8_weight,
+                "0.gate_proj.weight_scale_inv": torch.ones(2, 1),
+                "0.up_proj.weight": fp8_weight,
+                "0.up_proj.weight_scale_inv": torch.ones(2, 1) * 2,
+                "0.down_proj.weight": fp8_weight,
+                "0.down_proj.weight_scale_inv": torch.ones(2, 1) * 3,
+            }
+        )
+        self.assertFalse(layer.w13_scale.is_meta)
+        self.assertFalse(layer.w2_scale.is_meta)
+
+        def fake_dequant(weight, scale, block_size, dtype):
+            self.assertFalse(scale.is_meta)
+            return torch.zeros_like(weight, dtype=torch.bfloat16)
+
+        def fake_cast(weight, use_ue8m0=False):
+            return (
+                torch.zeros_like(weight, dtype=fp8_moe._runtime_fp8_dtype()),
+                torch.ones(2, 1, dtype=torch.float32),
+            )
+
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None), \
+             mock.patch(
+                 "rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel.block_quant_dequant",
+                 side_effect=fake_dequant,
+             ), \
+             mock.patch(
+                 "rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel.per_block_cast_to_fp8",
+                 side_effect=fake_cast,
+             ):
+            layer.process_weights_after_loading()
+
+        self.assertFalse(layer.w13_scale.is_meta)
+        self.assertFalse(layer.w2_scale.is_meta)
+        self.assertEqual(layer.w13_scale.shape, (1, 2, 1))
+        self.assertEqual(layer.w2_scale.shape, (1, 2, 1))
+
 class TestFp8BlockLoad(unittest.TestCase):
     """Already-quantized FP8 per-block (128x128) -> {Col,Row,Merged,QKV}Parallel.
 

--- a/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
@@ -1,0 +1,916 @@
+"""Tests for FP8 already-quantized direct-read paths in the new loader.
+
+Covers:
+- Fp8LinearMethod (key="fp8"): per-tensor compressed ckpt -> ColumnParallel.
+- Fp8PerChannelLinearMethod (key="fp8_per_channel"): per-channel compressed
+  / Quark ckpt -> ColumnParallel / RowParallel.
+- MergedColumnParallelLinear: per-channel weight_scale cat across shards,
+  per-tensor weight_scale max-merge across shards.
+- QKVParallelLinear: per-channel weight_scale cat across q/k/v.
+
+The forward (`apply`) path uses `torch._scaled_mm` and requires CUDA; those
+tests are gated by `torch.cuda.is_available()`. Layer-level load_weights
+routing tests run on CPU.
+"""
+import unittest
+from unittest import mock
+
+import torch
+
+import rtp_llm.models_py.quant_methods.fp8_moe as fp8_moe
+from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
+from rtp_llm.models_py.quant_methods.fp8 import _runtime_fp8_dtype
+from rtp_llm.models_py.utils.arch import is_cuda
+
+
+def _make_qc(quant_type: str) -> QuantizationConfig:
+    return QuantizationConfig(quant_type=quant_type)
+
+
+class TestRuntimeFp8Dtype(unittest.TestCase):
+    def test_cuda_runtime_dtype_is_e4m3fn_for_linear_and_moe(self):
+        with mock.patch.object(torch.version, "hip", None):
+            self.assertEqual(_runtime_fp8_dtype(), torch.float8_e4m3fn)
+            self.assertEqual(fp8_moe._runtime_fp8_dtype(), torch.float8_e4m3fn)
+
+    def test_cuda_fp8_apply_uses_matching_activation_and_weight_dtype(self):
+        with mock.patch.object(torch.version, "hip", None):
+            layer = ColumnParallelLinear(
+                input_size=4,
+                output_size=4,
+                quant_config=_make_qc("fp8"),
+                prefix="fp8",
+                params_dtype=torch.bfloat16,
+            )
+        self.assertEqual(layer.weight.dtype, torch.float8_e4m3fn)
+        layer.weight_scale.data.fill_(1.0)
+        qinput = torch.zeros(2, 4, dtype=torch.float8_e4m3fn)
+        x_scale = torch.ones(1, dtype=torch.float32)
+
+        def fake_scaled_mm(input, weight, **kwargs):
+            self.assertEqual(input.dtype, torch.float8_e4m3fn)
+            self.assertEqual(weight.dtype, torch.float8_e4m3fn)
+            return torch.zeros(2, 4, dtype=torch.bfloat16)
+
+        with mock.patch(
+            "rtp_llm.models_py.quant_methods.fp8._resolve_per_tensor_quant",
+            return_value=lambda tensor: (qinput, x_scale),
+        ), mock.patch("torch._scaled_mm", side_effect=fake_scaled_mm):
+            output = layer(torch.zeros(2, 4, dtype=torch.bfloat16))
+        self.assertEqual(output.dtype, torch.bfloat16)
+
+    @unittest.skipUnless(
+        hasattr(torch, "float8_e4m3fnuz"), "requires torch.float8_e4m3fnuz"
+    )
+    def test_rocm_runtime_dtype_uses_rocm_helper_for_linear_and_moe(self):
+        helper = (
+            "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils."
+            "get_rocm_fp8_dtype"
+        )
+        with mock.patch.object(torch.version, "hip", "6.4"), mock.patch(
+            helper, return_value=torch.float8_e4m3fnuz
+        ) as get_dtype:
+            self.assertEqual(_runtime_fp8_dtype(), torch.float8_e4m3fnuz)
+            self.assertEqual(fp8_moe._runtime_fp8_dtype(), torch.float8_e4m3fnuz)
+            self.assertEqual(get_dtype.call_count, 2)
+
+
+class TestFp8PerTensorLoad(unittest.TestCase):
+    """Already-quantized FP8 per-tensor compressed -> ColumnParallel."""
+
+    def test_online_quant_rejects_cpu_post_load_device(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_make_qc("fp8_online"),
+            prefix="online",
+            params_dtype=torch.bfloat16,
+        )
+        layer.load_weights({"online.weight": torch.zeros(4, 4, dtype=torch.bfloat16)})
+        with self.assertRaisesRegex(RuntimeError, "requires weights to be on CUDA"):
+            layer.process_weights_after_loading()
+
+    def test_load_into_column_parallel(self):
+        N, K = 16, 32
+        qc = _make_qc("fp8")
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        # Hand-craft an "already-quantized" ckpt:
+        weight_bf16 = torch.randn(N, K, dtype=torch.bfloat16)
+        scale = (weight_bf16.abs().max() / 448.0).float()
+        fp8_weight = (weight_bf16 / scale).to(_runtime_fp8_dtype())
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale": scale.reshape(1),
+                "test.input_scale": torch.tensor([1.0], dtype=torch.float32),
+            }
+        )
+        layer.process_weights_after_loading()
+
+        self.assertEqual(layer.weight.dtype, _runtime_fp8_dtype())
+        self.assertEqual(layer.weight.shape, (N, K))
+        self.assertEqual(layer.weight_scale.shape, (1,))
+        self.assertAlmostEqual(layer.weight_scale.item(), scale.item(), places=4)
+
+
+class TestFp8PerChannelLoad(unittest.TestCase):
+    """Already-quantized FP8 per-channel (compressed/Quark) -> {Col,Row}Parallel."""
+
+    def test_load_into_column_parallel_normalize_1d_scale(self):
+        N, K = 16, 32
+        qc = _make_qc("fp8_per_channel")
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        # ckpt scale comes as [N] (1D); process_weights_after_loading should
+        # normalize it to [1, N] for torch._scaled_mm scale_b.
+        scale_1d = torch.rand(N, dtype=torch.float32) + 0.01
+        fp8_weight = torch.zeros(N, K, dtype=_runtime_fp8_dtype())
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale": scale_1d,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        self.assertEqual(layer.weight_scale.shape, (1, N))
+        torch.testing.assert_close(
+            layer.weight_scale.flatten(), scale_1d, rtol=0, atol=0
+        )
+
+    def test_load_into_row_parallel_no_scale_shard(self):
+        # RowParallel splits along input dim; per-channel weight_scale
+        # is on output side and must NOT be sharded.
+        N, K = 16, 32
+        tp = 2
+        qc = _make_qc("fp8_per_channel")
+        layer = RowParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=tp,
+            tp_rank=1,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        fp8_weight = torch.zeros(N, K, dtype=_runtime_fp8_dtype())
+        # weight is sharded along K (dim 1), so ckpt has full K.
+        # weight_scale is per output-channel, full N.
+        scale_2d = torch.rand(N, 1, dtype=torch.float32) + 0.01
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale": scale_2d,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        self.assertEqual(layer.weight.shape, (N, K // tp))
+        self.assertEqual(layer.weight_scale.shape, (1, N))
+
+
+class TestMergedColumnPerChannelScale(unittest.TestCase):
+    """gate_up_proj per-channel weight_scale should cat across shards."""
+
+    def test_merged_column_per_channel_scale_cat(self):
+        H = 32  # input
+        N = 16  # gate/up shard size, total 2*N output
+        qc = _make_qc("fp8_per_channel")
+        layer = MergedColumnParallelLinear(
+            input_size=H,
+            output_size=2 * N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.bfloat16,
+        )
+        gate_w = torch.zeros(N, H, dtype=_runtime_fp8_dtype())
+        up_w = torch.zeros(N, H, dtype=_runtime_fp8_dtype())
+        gate_scale = torch.full((N,), 0.1, dtype=torch.float32)
+        up_scale = torch.full((N,), 0.2, dtype=torch.float32)
+
+        layer.load_weights(
+            {
+                "gate_up_proj.gate_proj.weight": gate_w,
+                "gate_up_proj.gate_proj.weight_scale": gate_scale,
+                "gate_up_proj.up_proj.weight": up_w,
+                "gate_up_proj.up_proj.weight_scale": up_scale,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        # process_weights_after_loading reshapes [2N] -> [1, 2N]
+        self.assertEqual(layer.weight_scale.shape, (1, 2 * N))
+        torch.testing.assert_close(
+            layer.weight_scale[0, :N], gate_scale, rtol=0, atol=0
+        )
+        torch.testing.assert_close(layer.weight_scale[0, N:], up_scale, rtol=0, atol=0)
+
+    def test_merged_column_per_tensor_scale_max_merge(self):
+        H = 32
+        N = 16
+        qc = _make_qc("fp8")
+        layer = MergedColumnParallelLinear(
+            input_size=H,
+            output_size=2 * N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.bfloat16,
+        )
+        gate_w = torch.zeros(N, H, dtype=torch.float8_e4m3fn)
+        up_w = torch.zeros(N, H, dtype=torch.float8_e4m3fn)
+        gate_scale = torch.tensor([0.1], dtype=torch.float32)
+        up_scale = torch.tensor([0.3], dtype=torch.float32)
+
+        layer.load_weights(
+            {
+                "gate_up_proj.gate_proj.weight": gate_w,
+                "gate_up_proj.gate_proj.weight_scale": gate_scale,
+                "gate_up_proj.up_proj.weight": up_w,
+                "gate_up_proj.up_proj.weight_scale": up_scale,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        # Max of {0.1, 0.3} = 0.3
+        self.assertAlmostEqual(layer.weight_scale.item(), 0.3, places=5)
+
+    def test_merged_column_per_tensor_scale_streaming_rescales_shards(self):
+        H = 8
+        N = 4
+        qc = _make_qc("fp8")
+        layer = MergedColumnParallelLinear(
+            input_size=H,
+            output_size=2 * N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.bfloat16,
+        )
+        gate_w = torch.full((N, H), 16.0).to(_runtime_fp8_dtype())
+        up_w = torch.full((N, H), 16.0).to(_runtime_fp8_dtype())
+
+        # Simulate RtpModule's streaming dispatch: each call carries one tensor,
+        # so gate/up scalar scales are only both available in post-load.
+        layer.load_weights({"gate_up_proj.gate_proj.weight": gate_w})
+        layer.load_weights(
+            {"gate_up_proj.gate_proj.weight_scale": torch.tensor([0.1])}
+        )
+        layer.load_weights({"gate_up_proj.up_proj.weight": up_w})
+        layer.load_weights({"gate_up_proj.up_proj.weight_scale": torch.tensor([0.2])})
+        layer.process_weights_after_loading()
+
+        self.assertAlmostEqual(layer.weight_scale.item(), 0.2, places=5)
+        torch.testing.assert_close(
+            layer.weight[:N].float(),
+            torch.full((N, H), 8.0),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            layer.weight[N:].float(),
+            torch.full((N, H), 16.0),
+            rtol=0,
+            atol=0,
+        )
+
+
+class TestQkvPerChannelScale(unittest.TestCase):
+    """q_proj/k_proj/v_proj per-channel weight_scale should cat in qkv order."""
+
+    def test_qkv_per_channel_scale_cat(self):
+        hidden = 32
+        head_dim = 8
+        num_heads = 4  # q_size = 32
+        num_kv_heads = 2  # kv_size = 16
+
+        qc = _make_qc("fp8_per_channel")
+        layer = QKVParallelLinear(
+            hidden_size=hidden,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="qkv_proj",
+            params_dtype=torch.bfloat16,
+        )
+
+        q_w = torch.zeros(num_heads * head_dim, hidden, dtype=_runtime_fp8_dtype())
+        k_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=_runtime_fp8_dtype())
+        v_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=_runtime_fp8_dtype())
+
+        q_scale = torch.full((num_heads * head_dim,), 0.1, dtype=torch.float32)
+        k_scale = torch.full((num_kv_heads * head_dim,), 0.2, dtype=torch.float32)
+        v_scale = torch.full((num_kv_heads * head_dim,), 0.3, dtype=torch.float32)
+
+        layer.load_weights(
+            {
+                "qkv_proj.q_proj.weight": q_w,
+                "qkv_proj.q_proj.weight_scale": q_scale,
+                "qkv_proj.k_proj.weight": k_w,
+                "qkv_proj.k_proj.weight_scale": k_scale,
+                "qkv_proj.v_proj.weight": v_w,
+                "qkv_proj.v_proj.weight_scale": v_scale,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        total = num_heads * head_dim + 2 * num_kv_heads * head_dim
+        self.assertEqual(layer.weight_scale.shape, (1, total))
+        # q segment
+        torch.testing.assert_close(
+            layer.weight_scale[0, : num_heads * head_dim], q_scale, rtol=0, atol=0
+        )
+        # k segment
+        torch.testing.assert_close(
+            layer.weight_scale[
+                0,
+                num_heads * head_dim : num_heads * head_dim + num_kv_heads * head_dim,
+            ],
+            k_scale,
+            rtol=0,
+            atol=0,
+        )
+        # v segment
+        torch.testing.assert_close(
+            layer.weight_scale[0, num_heads * head_dim + num_kv_heads * head_dim :],
+            v_scale,
+            rtol=0,
+            atol=0,
+        )
+
+
+
+class TestFp8MoEAlreadyQuantizedLoad(unittest.TestCase):
+    def _make_moe(self, quant_type="fp8"):
+        return BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.bfloat16,
+            model_config=type("Cfg", (), {"data_type": "bf16", "quant_config": None, "exported_device": None})(),
+            parallelism_config=type("Parallel", (), {"dp_size": 1})(),
+            moe_config=type("MoeCfg", (), {})(),
+            quant_config=_make_qc(quant_type),
+            layer_idx=0,
+        )
+
+    def test_per_tensor_requants_to_runtime_dtype_and_preserves_scale_semantics(self):
+        layer = self._make_moe("fp8")
+        source_dtype = torch.float8_e4m3fn
+        runtime_dtype = fp8_moe._runtime_fp8_dtype()
+        gate_scale = torch.tensor([0.25], dtype=torch.float32)
+        up_scale = torch.tensor([0.5], dtype=torch.float32)
+        down_scale = torch.tensor([0.125], dtype=torch.float32)
+        gate = torch.full((4, 4), 4.0, dtype=torch.float32).to(source_dtype)
+        up = torch.full((4, 4), 8.0, dtype=torch.float32).to(source_dtype)
+        down = torch.full((4, 4), 2.0, dtype=torch.float32).to(source_dtype)
+
+        expected_w13 = torch.cat(
+            [up.float() * up_scale.item(), gate.float() * gate_scale.item()], dim=0
+        )
+        expected_w2 = down.float() * down_scale.item()
+
+        layer.load_weights(
+            {
+                "0.gate_proj.weight": gate,
+                "0.gate_proj.weight_scale": gate_scale,
+                "0.up_proj.weight": up,
+                "0.up_proj.weight_scale": up_scale,
+                "0.down_proj.weight": down,
+                "0.down_proj.weight_scale": down_scale,
+            }
+        )
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None):
+            layer.process_weights_after_loading()
+
+        self.assertEqual(layer.w13.dtype, runtime_dtype)
+        self.assertEqual(layer.w2.dtype, runtime_dtype)
+        actual_w13 = layer.w13.float() * layer.w13_scale.view(-1, 1, 1)
+        actual_w2 = layer.w2.float() * layer.w2_scale.view(-1, 1, 1)
+        torch.testing.assert_close(actual_w13[0], expected_w13, rtol=0.1, atol=0.1)
+        torch.testing.assert_close(actual_w2[0], expected_w2, rtol=0.1, atol=0.1)
+
+    def test_online_block_moe_rejects_custom_block_size(self):
+        qc = _make_qc("fp8_block_online")
+        qc.weight_block_size = [2, 4]
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.bfloat16,
+            model_config=type(
+                "Cfg",
+                (),
+                {"data_type": "bf16", "quant_config": None, "exported_device": None},
+            )(),
+            parallelism_config=type("Parallel", (), {"dp_size": 1})(),
+            moe_config=type("MoeCfg", (), {})(),
+            quant_config=qc,
+            layer_idx=0,
+        )
+        for name in (
+            "0.gate_proj.weight",
+            "0.up_proj.weight",
+            "0.down_proj.weight",
+        ):
+            layer.load_weights({name: torch.zeros(4, 4, dtype=torch.bfloat16)})
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None):
+            with self.assertRaisesRegex(ValueError, "only supports"):
+                layer.process_weights_after_loading()
+
+class TestFp8BlockLoad(unittest.TestCase):
+    """Already-quantized FP8 per-block (128x128) -> {Col,Row,Merged,QKV}Parallel.
+
+    The ckpt provides:
+      - weight: float8_e4m3fn [N, K]
+      - weight_scale_inv: fp32 [ceil(N/128), ceil(K/128)]
+    After load_weights + process_weights_after_loading, the param is renamed
+    to `weight_scale` so apply() can share the contract with the online sibling.
+    """
+
+    BLOCK = 128
+
+    def test_load_into_column_parallel(self):
+        N, K = 256, 256  # 2 blocks each
+        qc = _make_qc("fp8_block")
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        fp8_weight = torch.zeros(N, K, dtype=torch.float8_e4m3fn)
+        scale_inv = (
+            torch.rand(N // self.BLOCK, K // self.BLOCK, dtype=torch.float32) + 0.01
+        )
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale_inv": scale_inv,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        self.assertEqual(layer.weight.shape, (N, K))
+        self.assertFalse(hasattr(layer, "weight_scale_inv"))
+        if has_deep_gemm():
+            self.assertEqual(layer.weight.dtype, torch.float8_e4m3fn)
+            self.assertEqual(layer.weight_scale.shape, (2, 2))
+            torch.testing.assert_close(layer.weight_scale, scale_inv, rtol=0, atol=0)
+        else:
+            self.assertEqual(layer.weight.dtype, torch.bfloat16)
+            self.assertFalse(hasattr(layer, "weight_scale"))
+
+    def test_load_into_column_parallel_tp(self):
+        N, K = 512, 256  # N=4 blocks total, 2 blocks per rank
+        tp = 2
+        qc = _make_qc("fp8_block")
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=tp,
+            tp_rank=1,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        fp8_weight = torch.zeros(N, K, dtype=torch.float8_e4m3fn)
+        scale_inv = (
+            torch.arange(
+                (N // self.BLOCK) * (K // self.BLOCK), dtype=torch.float32
+            ).reshape(N // self.BLOCK, K // self.BLOCK)
+            + 0.01
+        )
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale_inv": scale_inv,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        # Rank 1 should get the second half of the dim-0 blocks.
+        if has_deep_gemm():
+            self.assertEqual(layer.weight_scale.shape, (2, 2))
+            torch.testing.assert_close(
+                layer.weight_scale, scale_inv[2:4, :], rtol=0, atol=0
+            )
+        else:
+            self.assertEqual(layer.weight.dtype, torch.bfloat16)
+            self.assertFalse(hasattr(layer, "weight_scale"))
+
+    def test_load_into_row_parallel_tp(self):
+        N, K = 256, 512  # K=4 blocks, 2 per rank along K
+        tp = 2
+        qc = _make_qc("fp8_block")
+        layer = RowParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=tp,
+            tp_rank=1,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        )
+        fp8_weight = torch.zeros(N, K, dtype=torch.float8_e4m3fn)
+        scale_inv = (
+            torch.arange(
+                (N // self.BLOCK) * (K // self.BLOCK), dtype=torch.float32
+            ).reshape(N // self.BLOCK, K // self.BLOCK)
+            + 0.01
+        )
+
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight,
+                "test.weight_scale_inv": scale_inv,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        # Rank 1 should get the second half of the dim-1 blocks.
+        if has_deep_gemm():
+            self.assertEqual(layer.weight_scale.shape, (2, 2))
+            torch.testing.assert_close(
+                layer.weight_scale, scale_inv[:, 2:4], rtol=0, atol=0
+            )
+        else:
+            self.assertEqual(layer.weight.dtype, torch.bfloat16)
+            self.assertFalse(hasattr(layer, "weight_scale"))
+
+    def test_load_into_merged_column(self):
+        H = 256  # input
+        N = 256  # gate/up shard size each (= 2 blocks); total 4 blocks output
+        qc = _make_qc("fp8_block")
+        layer = MergedColumnParallelLinear(
+            input_size=H,
+            output_size=2 * N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.bfloat16,
+        )
+        gate_w = torch.zeros(N, H, dtype=torch.float8_e4m3fn)
+        up_w = torch.zeros(N, H, dtype=torch.float8_e4m3fn)
+        gate_scale = torch.full(
+            (N // self.BLOCK, H // self.BLOCK), 0.1, dtype=torch.float32
+        )
+        up_scale = torch.full(
+            (N // self.BLOCK, H // self.BLOCK), 0.2, dtype=torch.float32
+        )
+
+        layer.load_weights(
+            {
+                "gate_up_proj.gate_proj.weight": gate_w,
+                "gate_up_proj.gate_proj.weight_scale_inv": gate_scale,
+                "gate_up_proj.up_proj.weight": up_w,
+                "gate_up_proj.up_proj.weight_scale_inv": up_scale,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        # Total N_blocks = 2 (gate) + 2 (up) = 4; K_blocks = 2.
+        if has_deep_gemm():
+            self.assertEqual(layer.weight_scale.shape, (4, 2))
+            torch.testing.assert_close(layer.weight_scale[:2], gate_scale, rtol=0, atol=0)
+            torch.testing.assert_close(layer.weight_scale[2:], up_scale, rtol=0, atol=0)
+        else:
+            self.assertEqual(layer.weight.dtype, torch.bfloat16)
+            self.assertFalse(hasattr(layer, "weight_scale"))
+
+    def test_load_into_qkv_parallel(self):
+        hidden = 256  # K = 2 blocks
+        head_dim = 128
+        num_heads = 4  # q_size = 512 = 4 blocks
+        num_kv_heads = 2  # kv_size = 256 = 2 blocks per kv shard
+
+        qc = _make_qc("fp8_block")
+        layer = QKVParallelLinear(
+            hidden_size=hidden,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="qkv_proj",
+            params_dtype=torch.bfloat16,
+        )
+
+        q_w = torch.zeros(num_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+        k_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+        v_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+
+        q_scale = torch.full(
+            (num_heads * head_dim // self.BLOCK, hidden // self.BLOCK),
+            0.1,
+            dtype=torch.float32,
+        )
+        k_scale = torch.full(
+            (num_kv_heads * head_dim // self.BLOCK, hidden // self.BLOCK),
+            0.2,
+            dtype=torch.float32,
+        )
+        v_scale = torch.full(
+            (num_kv_heads * head_dim // self.BLOCK, hidden // self.BLOCK),
+            0.3,
+            dtype=torch.float32,
+        )
+
+        layer.load_weights(
+            {
+                "qkv_proj.q_proj.weight": q_w,
+                "qkv_proj.q_proj.weight_scale_inv": q_scale,
+                "qkv_proj.k_proj.weight": k_w,
+                "qkv_proj.k_proj.weight_scale_inv": k_scale,
+                "qkv_proj.v_proj.weight": v_w,
+                "qkv_proj.v_proj.weight_scale_inv": v_scale,
+            }
+        )
+        layer.process_weights_after_loading()
+
+        q_blocks = num_heads * head_dim // self.BLOCK
+        kv_blocks = num_kv_heads * head_dim // self.BLOCK
+        total_blocks = q_blocks + 2 * kv_blocks
+        k_blocks_in = hidden // self.BLOCK
+        if has_deep_gemm():
+            self.assertEqual(layer.weight_scale.shape, (total_blocks, k_blocks_in))
+            torch.testing.assert_close(
+                layer.weight_scale[:q_blocks], q_scale, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                layer.weight_scale[q_blocks : q_blocks + kv_blocks],
+                k_scale,
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(
+                layer.weight_scale[q_blocks + kv_blocks :], v_scale, rtol=0, atol=0
+            )
+        else:
+            self.assertEqual(layer.weight.dtype, torch.bfloat16)
+            self.assertFalse(hasattr(layer, "weight_scale"))
+
+    def test_qkv_block_scale_uses_custom_block_size_with_tp(self):
+        hidden = 256
+        head_dim = 64
+        num_heads = 4
+        num_kv_heads = 4
+        tp = 2
+        tp_rank = 1
+        block_n = 64
+        block_k = 128
+
+        qc = _make_qc("fp8_block")
+        qc.weight_block_size = [block_n, block_k]
+        layer = QKVParallelLinear(
+            hidden_size=hidden,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tp_size=tp,
+            tp_rank=tp_rank,
+            quant_config=qc,
+            prefix="qkv_proj",
+            params_dtype=torch.bfloat16,
+        )
+
+        q_w = torch.zeros(num_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+        k_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+        v_w = torch.zeros(num_kv_heads * head_dim, hidden, dtype=torch.float8_e4m3fn)
+
+        in_blocks = hidden // block_k
+        rows_per_rank = (num_heads // tp) * head_dim
+        blocks_per_rank = rows_per_rank // block_n
+        q_blocks = num_heads * head_dim // block_n
+        kv_blocks = num_kv_heads * head_dim // block_n
+        start = tp_rank * blocks_per_rank
+
+        q_scale = torch.arange(q_blocks * in_blocks, dtype=torch.float32).reshape(
+            q_blocks, in_blocks
+        )
+        k_scale = (
+            torch.arange(kv_blocks * in_blocks, dtype=torch.float32).reshape(
+                kv_blocks, in_blocks
+            )
+            + 100
+        )
+        v_scale = (
+            torch.arange(kv_blocks * in_blocks, dtype=torch.float32).reshape(
+                kv_blocks, in_blocks
+            )
+            + 200
+        )
+
+        layer.load_weights(
+            {
+                "qkv_proj.q_proj.weight": q_w,
+                "qkv_proj.q_proj.weight_scale_inv": q_scale,
+                "qkv_proj.k_proj.weight": k_w,
+                "qkv_proj.k_proj.weight_scale_inv": k_scale,
+                "qkv_proj.v_proj.weight": v_w,
+                "qkv_proj.v_proj.weight_scale_inv": v_scale,
+            }
+        )
+
+        expected = torch.cat(
+            [
+                q_scale[start : start + blocks_per_rank],
+                k_scale[start : start + blocks_per_rank],
+                v_scale[start : start + blocks_per_rank],
+            ],
+            dim=0,
+        )
+        torch.testing.assert_close(
+            layer.weight_scale_inv.detach(), expected, rtol=0, atol=0
+        )
+
+
+    def test_fp8_block_dequant_uses_custom_block_size(self):
+        N, K = 4, 8
+        qc = _make_qc("fp8_block_dequant")
+        qc.weight_block_size = [2, 4]
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="dequant",
+            params_dtype=torch.bfloat16,
+        )
+        weight = torch.zeros(N, K, dtype=torch.float8_e4m3fn)
+        scale = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+        expected = torch.full((N, K), 3.0, dtype=torch.bfloat16)
+        layer.load_weights(
+            {
+                "dequant.weight": weight,
+                "dequant.weight_scale_inv": scale,
+            }
+        )
+        with mock.patch(
+            "rtp_llm.models_py.kernels.cuda.fp8_kernel.fp8_kernel.block_quant_dequant",
+            return_value=expected,
+        ) as dequant:
+            layer.process_weights_after_loading()
+        dequant.assert_called_once()
+        self.assertEqual(dequant.call_args.args[2], [2, 4])
+        torch.testing.assert_close(layer.weight, expected, rtol=0, atol=0)
+        self.assertFalse(hasattr(layer, "weight_scale_inv"))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA + DeepGEMM")
+class TestFp8BlockForward(unittest.TestCase):
+    """End-to-end: load fp8-block ckpt vs online path, forward should match."""
+
+    def test_forward_matches_online_path(self):
+        try:
+            from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
+            from rtp_llm.models_py.kernels.cuda.fp8_kernel import per_block_cast_to_fp8
+        except ImportError:
+            self.skipTest("deepgemm/fp8_kernel not available")
+        if not has_deep_gemm():
+            self.skipTest("DeepGEMM kernel not available at runtime")
+
+        N, K, M = 256, 256, 32  # 2x2 weight blocks
+        device = "cuda"
+
+        weight_bf16 = torch.randn(N, K, dtype=torch.bfloat16, device=device) * 0.05
+        # Use the same kernel the online path uses to produce fp8 + scale.
+        fp8_weight, scale = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
+
+        # Offline path
+        offline = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=_make_qc("fp8_block"),
+            prefix="off",
+            params_dtype=torch.bfloat16,
+        ).to(device)
+        offline.load_weights(
+            {
+                "off.weight": fp8_weight,
+                "off.weight_scale_inv": scale,
+            }
+        )
+        offline.process_weights_after_loading()
+
+        # Online path
+        online = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=_make_qc("fp8_block_online"),
+            prefix="on",
+            params_dtype=torch.bfloat16,
+        ).to(device)
+        online.load_weights({"on.weight": weight_bf16})
+        online.process_weights_after_loading()
+
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device) * 0.1
+        out_offline = offline(x)
+        out_online = online(x)
+
+        torch.testing.assert_close(out_offline, out_online, rtol=0, atol=0)
+
+
+@unittest.skipUnless(torch.cuda.is_available() and is_cuda(), "requires CUDA + torch._scaled_mm")
+class TestFp8AlreadyQuantizedForward(unittest.TestCase):
+    """End-to-end: load already-quantized ckpt -> forward via _scaled_mm."""
+
+    def test_fp8_per_tensor_forward_matches_dequant_reference(self):
+        N, K, M = 32, 64, 8
+        device = "cuda"
+        weight_bf16 = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+        scale = (weight_bf16.abs().max() / 448.0).float()
+        fp8_weight = (weight_bf16 / scale).to(_runtime_fp8_dtype())
+
+        qc = _make_qc("fp8")
+        layer = ColumnParallelLinear(
+            input_size=K,
+            output_size=N,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="test",
+            params_dtype=torch.bfloat16,
+        ).to(device)
+        layer.load_weights(
+            {
+                "test.weight": fp8_weight.to(device),
+                "test.weight_scale": scale.reshape(1).to(device),
+                "test.input_scale": torch.tensor(
+                    [1.0], dtype=torch.float32, device=device
+                ),
+            }
+        )
+        layer.process_weights_after_loading()
+
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+        out = layer(x)
+
+        # Reference: dequant fp8 weight back to bf16 and compute regular linear.
+        weight_dequant = fp8_weight.to(torch.bfloat16).to(device) * scale.to(device)
+        ref = torch.nn.functional.linear(x, weight_dequant)
+
+        # _scaled_mm with dynamic per-tensor activation quant introduces a
+        # small relative error vs full-precision reference.
+        torch.testing.assert_close(out, ref, rtol=0.05, atol=0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_fp8_already_quantized.py
@@ -98,6 +98,28 @@ class TestFp8PerTensorLoad(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "requires weights to be on CUDA"):
             layer.process_weights_after_loading()
 
+    def test_online_quant_allows_cpu_post_load_when_force_cpu_enabled(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_make_qc("fp8_online"),
+            prefix="online",
+            params_dtype=torch.bfloat16,
+        )
+        layer.load_weights({"online.weight": torch.zeros(4, 4, dtype=torch.bfloat16)})
+        layer._new_loader_force_cpu_load_weights = True
+        with mock.patch(
+            "rtp_llm.models_py.quant_methods.fp8.cpu_per_tensor_quant_like_legacy",
+            return_value=(
+                torch.zeros(4, 4, dtype=fp8_moe._runtime_fp8_dtype()),
+                torch.ones(1, dtype=torch.float32),
+            ),
+        ) as cpu_quant:
+            layer.process_weights_after_loading()
+        cpu_quant.assert_called_once()
+        self.assertEqual(layer.weight.dtype, fp8_moe._runtime_fp8_dtype())
+        self.assertEqual(layer.weight.device.type, "cpu")
+
     def test_load_into_column_parallel(self):
         N, K = 16, 32
         qc = _make_qc("fp8")
@@ -430,6 +452,48 @@ class TestFp8MoEAlreadyQuantizedLoad(unittest.TestCase):
         torch.testing.assert_close(actual_w13[0], expected_w13, rtol=0.1, atol=0.1)
         torch.testing.assert_close(actual_w2[0], expected_w2, rtol=0.1, atol=0.1)
 
+    def test_online_per_tensor_moe_allows_cpu_post_load_when_force_cpu_enabled(self):
+        layer = self._make_moe("fp8_online")
+        layer._new_loader_force_cpu_load_weights = True
+        for name in (
+            "0.gate_proj.weight",
+            "0.up_proj.weight",
+            "0.down_proj.weight",
+        ):
+            layer.load_weights({name: torch.zeros(4, 4, dtype=torch.bfloat16)})
+
+        def fake_cpu_quant(weight):
+            return (
+                torch.zeros_like(weight, dtype=fp8_moe._runtime_fp8_dtype()),
+                torch.ones(1, dtype=torch.float32),
+            )
+
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None), \
+             mock.patch(
+                 "rtp_llm.models_py.quant_methods.fp8.cpu_per_tensor_quant_like_legacy",
+                 side_effect=fake_cpu_quant,
+             ) as cpu_quant:
+            layer.process_weights_after_loading()
+
+        self.assertEqual(cpu_quant.call_count, 2)
+        self.assertEqual(layer.w13.dtype, fp8_moe._runtime_fp8_dtype())
+        self.assertEqual(layer.w2.dtype, fp8_moe._runtime_fp8_dtype())
+        self.assertEqual(layer.w13.device.type, "cpu")
+        self.assertEqual(layer.w2.device.type, "cpu")
+
+    def test_online_block_moe_rejects_force_cpu_post_load(self):
+        layer = self._make_moe("fp8_block_online")
+        layer._new_loader_force_cpu_load_weights = True
+        for name in (
+            "0.gate_proj.weight",
+            "0.up_proj.weight",
+            "0.down_proj.weight",
+        ):
+            layer.load_weights({name: torch.zeros(4, 4, dtype=torch.bfloat16)})
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "force_cpu_load_weights"):
+                layer.process_weights_after_loading()
+
     def test_online_block_moe_rejects_custom_block_size(self):
         qc = _make_qc("fp8_block_online")
         qc.weight_block_size = [2, 4]
@@ -542,6 +606,21 @@ class TestFp8BlockLoad(unittest.TestCase):
     """
 
     BLOCK = 128
+
+    def test_block_online_still_rejects_cpu_post_load_when_force_cpu_enabled(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_make_qc("fp8_block_online"),
+            prefix="online_block",
+            params_dtype=torch.bfloat16,
+        )
+        layer.load_weights(
+            {"online_block.weight": torch.zeros(4, 4, dtype=torch.bfloat16)}
+        )
+        layer._new_loader_force_cpu_load_weights = True
+        with self.assertRaisesRegex(RuntimeError, "requires weights to be on CUDA"):
+            layer.process_weights_after_loading()
 
     def test_load_into_column_parallel(self):
         N, K = 256, 256  # 2 blocks each
@@ -844,7 +923,6 @@ class TestFp8BlockLoad(unittest.TestCase):
         torch.testing.assert_close(
             layer.weight_scale_inv.detach(), expected, rtol=0, atol=0
         )
-
 
     def test_fp8_block_dequant_uses_custom_block_size(self):
         N, K = 4, 8

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -38,6 +38,7 @@ from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dt
 
 # Register MoE quant methods for BaseMoEExperts tests.
 import rtp_llm.models_py.quant_methods.fp8_moe  # noqa: F401
+import rtp_llm.models_py.quant_methods.w4a8_moe  # noqa: F401
 
 
 def _qc(quant_type: str) -> QuantizationConfig:
@@ -967,6 +968,52 @@ class TestMoELoadCompleteness(unittest.TestCase):
         self.assertEqual(
             layer._loaded_keys, {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")}
         )
+
+    def test_w4a8_online_rejects_odd_hidden_or_intermediate_size(self):
+        with self.assertRaisesRegex(ValueError, "expects even H/M"):
+            BaseMoEExperts(
+                num_experts=2,
+                hidden_size=5,
+                moe_intermediate_size=8,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                params_dtype=torch.float32,
+                model_config=types.SimpleNamespace(
+                    data_type="fp32", quant_config=None, exported_device=None
+                ),
+                parallelism_config=types.SimpleNamespace(dp_size=1),
+                moe_config=types.SimpleNamespace(),
+                quant_config=QuantizationConfig(
+                    quant_type="W4A8_INT4_PER_CHANNEL",
+                    source_config=types.SimpleNamespace(group_size=lambda: 1),
+                ),
+                layer_idx=0,
+            )
+
+    def test_w4a8_online_rejects_non_divisible_group_size(self):
+        with self.assertRaisesRegex(ValueError, "group_size=4.*divide"):
+            BaseMoEExperts(
+                num_experts=2,
+                hidden_size=8,
+                moe_intermediate_size=10,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                params_dtype=torch.float32,
+                model_config=types.SimpleNamespace(
+                    data_type="fp32", quant_config=None, exported_device=None
+                ),
+                parallelism_config=types.SimpleNamespace(dp_size=1),
+                moe_config=types.SimpleNamespace(),
+                quant_config=QuantizationConfig(
+                    quant_type="W4A8_INT4_PER_CHANNEL",
+                    source_config=types.SimpleNamespace(group_size=lambda: 4),
+                ),
+                layer_idx=0,
+            )
 
     def _make_moe(self):
         return BaseMoEExperts(

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -694,6 +694,40 @@ class TestLinearLoadCompleteness(unittest.TestCase):
             layer.process_weights_after_loading()
 
 
+    def test_qkv_fp8_block_scale_rejects_non_aligned_tp_rows(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [128, 128]
+        layer = QKVParallelLinear(
+            hidden_size=384,
+            num_heads=6,
+            num_kv_heads=6,
+            head_dim=64,
+            tp_size=2,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="qkv_proj",
+            params_dtype=torch.float32,
+        )
+        scale = torch.ones(3, 3, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "FP8 block QKV scale"):
+            layer.load_weights({"qkv_proj.q_proj.weight_scale_inv": scale})
+
+    def test_merged_fp8_block_scale_rejects_non_aligned_gate_up_boundary(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [128, 128]
+        layer = MergedColumnParallelLinear(
+            input_size=256,
+            output_size=384,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        scale = torch.ones(2, 2, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "FP8 block merged scale"):
+            layer.load_weights({"gate_up_proj.gate_proj.weight_scale_inv": scale})
+
+
     def test_row_parallel_adds_bias_after_all_reduce(self):
         layer = RowParallelLinear(
             input_size=4,
@@ -873,6 +907,28 @@ class TestMoELoadCompleteness(unittest.TestCase):
                 parallelism_config=types.SimpleNamespace(dp_size=1),
                 moe_config=types.SimpleNamespace(),
                 quant_config=_qc("none"),
+                layer_idx=0,
+            )
+
+    def test_moe_fp8_block_scale_rejects_non_aligned_tp_intermediate(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [128, 128]
+        with self.assertRaisesRegex(ValueError, "MoE FP8 block scale TP shard"):
+            BaseMoEExperts(
+                num_experts=1,
+                hidden_size=256,
+                moe_intermediate_size=384,
+                tp_size=2,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                params_dtype=torch.float32,
+                model_config=types.SimpleNamespace(
+                    data_type="fp32", quant_config=None, exported_device=None
+                ),
+                parallelism_config=types.SimpleNamespace(dp_size=1),
+                moe_config=types.SimpleNamespace(),
+                quant_config=qc,
                 layer_idx=0,
             )
 

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -81,6 +81,7 @@ from rtp_llm.models_py.model_loader import (
     _create_ep_filter,
     _discover_ckpt_files,
     _get_all_weights,
+    _HF_TO_ENGINE_LORA,
     _is_quantized_load,
     _normalize_fastsafetensors_stacked_moe_weights,
     _tp_slice,
@@ -110,6 +111,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.strategy_registry import Strate
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import MoEConfigAdapter
 
 BaseMoEExperts = None
 
@@ -227,6 +229,47 @@ class TestWeightMapperStreaming(unittest.TestCase):
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0][0], "x.weight")
         self.assertTrue(torch.equal(loaded[0][1], torch.ones(1)))
+
+    def test_lora_load_transposes_before_engine_tp_slice(self):
+        class FakeLoRAWeights:
+            instances = []
+
+            def __init__(self, num_layers):
+                self.num_layers = num_layers
+                self.weights = {}
+                FakeLoRAWeights.instances.append(self)
+
+            def set_lora_rank(self, rank):
+                self.rank = rank
+
+            def set_layer_weight(self, is_draft, layer_id, name, tensor):
+                self.weights[(layer_id, name)] = tensor.clone()
+
+            def apply_scale(self, scale):
+                self.scale = scale
+
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method=LoadMethod.SCRATCH),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        loader.load_config.tp_size = 2
+        loader.load_config.tp_rank = 1
+        hf_tensor = torch.arange(4 * 6, dtype=torch.float32).view(4, 6)
+        with mock.patch.object(
+            loader, "_read_lora_config", return_value={"rank": 4, "lora_alpha": 8}
+        ), mock.patch.object(
+            loader,
+            "_load_lora_state_dict",
+            return_value={"base_model.model.model.layers.0.mlp.gate_proj.lora_B.weight": hf_tensor},
+        ), mock.patch("rtp_llm.lora.lora_weights.LoRAWeights", FakeLoRAWeights):
+            result = loader.load_lora_weights("adapter", "/tmp/lora", device="cpu")
+        self.assertIs(result, FakeLoRAWeights.instances[-1])
+        engine_name = _HF_TO_ENGINE_LORA["mlp.gate_proj"] + ".lora_B"
+        expected = hf_tensor.t().contiguous().narrow(-1, 2, 2)
+        self.assertTrue(torch.equal(result.weights[(0, engine_name)], expected))
+        self.assertEqual(result.scale, 2.0)
 
     def test_lora_tp_slice_rejects_non_divisible_dim(self):
         with self.assertRaisesRegex(ValueError, "LoRA TP slice.*divisible"):
@@ -675,6 +718,53 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
             )
         )
 
+    def test_moe_config_adapter_inherits_or_explicitly_overrides_quant_config(self):
+        class FakeQuant:
+            def get_method(self):
+                return "FP8"
+
+        class Parallel:
+            ep_size = 1
+            ep_rank = 0
+            dp_size = 1
+            dp_rank = 0
+            world_size = 1
+            local_rank = 0
+
+            def get_attn_tp_size(self):
+                return 1
+
+            def get_attn_tp_rank(self):
+                return 0
+
+        quant = FakeQuant()
+        model_config = types.SimpleNamespace(
+            quant_config=quant,
+            expert_num=1,
+            moe_k=1,
+            moe_topk_group=1,
+            hidden_size=4,
+            data_type="fp32",
+            attn_config=types.SimpleNamespace(head_num=1),
+            activation_type="SiGLU",
+        )
+        moe_config = types.SimpleNamespace(
+            ll_num_max_token=1,
+            masked_max_token_num=1,
+            moe_strategy="",
+            use_mori_ep=False,
+            use_deepep_moe=False,
+        )
+        inherited = MoEConfigAdapter(model_config, Parallel(), moe_config=moe_config)
+        self.assertIs(inherited.quant_config, quant)
+        self.assertTrue(MoeConfigResolver.has_quantization(inherited))
+        self.assertEqual(MoeConfigResolver.get_quant_method(inherited), "FP8")
+        explicit_none = MoEConfigAdapter(
+            model_config, Parallel(), moe_config=moe_config, quant_config=None
+        )
+        self.assertIsNone(explicit_none.quant_config)
+        self.assertFalse(MoeConfigResolver.has_quantization(explicit_none))
+
     def test_explicit_config_fastsafetensors_failure_does_not_fallback(self):
         loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
         err = RuntimeError("fast path failed")
@@ -749,6 +839,33 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
         ) as scratch:
             self.assertIs(loader.load(), scratch_model)
         scratch.assert_called_once()
+
+    def test_distributed_auto_uses_single_scratch_decision_if_any_rank_ineligible(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
+        ), mock.patch.object(
+            loader,
+            "_all_gather_load_decision",
+            return_value=[(True, "ok"), (False, "rank1 cuda unavailable")],
+        ), mock.patch.object(loader, "_load_via_fastsafetensors") as fast, mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        fast.assert_not_called()
+        scratch.assert_called_once()
+
+    def test_distributed_fastsafetensors_runtime_failure_does_not_local_fallback(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        with mock.patch.object(
+            loader, "_resolve_load_method", return_value=(LoadMethod.FASTSAFETENSORS, False)
+        ), mock.patch.object(loader, "_distributed_world_size", return_value=2), mock.patch.object(
+            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("rank1 read failed")
+        ), mock.patch.object(loader, "_load_via_scratch") as scratch:
+            with self.assertRaisesRegex(RuntimeError, "rank1 read failed"):
+                loader.load()
+        scratch.assert_not_called()
 
     def test_auto_uses_scratch_when_fastsafetensors_is_not_eligible(self):
         loader = self._new_loader(LoadMethod.AUTO)
@@ -1135,22 +1252,36 @@ class TestLinearLoadCompleteness(unittest.TestCase):
             out = layer(x)
         torch.testing.assert_close(out, torch.full((1, 3), 7.0), rtol=0, atol=0)
 
-    def test_qkv_allows_gcd_kv_group_when_kv_heads_not_divisible_by_tp(self):
+    def test_qkv_rejects_illegal_gqa_head_ratio(self):
+        with self.assertRaisesRegex(ValueError, "num_heads.*num_kv_heads"):
+            QKVParallelLinear(
+                hidden_size=8,
+                num_heads=8,
+                num_kv_heads=6,
+                head_dim=1,
+                tp_size=4,
+                tp_rank=0,
+                quant_config=_qc("none"),
+                prefix="qkv_proj",
+                params_dtype=torch.float32,
+            )
+
+    def test_qkv_allows_valid_kv_heads_less_than_tp_gcd_group(self):
         layer = QKVParallelLinear(
             hidden_size=8,
             num_heads=8,
-            num_kv_heads=6,
+            num_kv_heads=2,
             head_dim=1,
-            tp_size=4,
-            tp_rank=3,
+            tp_size=8,
+            tp_rank=5,
             quant_config=_qc("none"),
             prefix="qkv_proj",
             params_dtype=torch.float32,
         )
         self.assertEqual(layer.kv_tp_size, 2)
-        self.assertEqual(layer.kv_replication_group_size, 2)
+        self.assertEqual(layer.kv_replication_group_size, 4)
         self.assertEqual(layer.kv_tp_rank, 1)
-        self.assertEqual(layer.num_kv_heads_per_partition, 3)
+        self.assertEqual(layer.num_kv_heads_per_partition, 1)
 
     def test_column_rejects_non_divisible_output_tp(self):
         with self.assertRaisesRegex(ValueError, "output_size.*divisible"):
@@ -1657,6 +1788,42 @@ class TestMoELoadCompleteness(unittest.TestCase):
             )
         finally:
             FusedMoeFactory.set_registry(old_registry)
+
+    def test_force_cpu_deferred_moe_executor_builds_after_device_migration(self):
+        class FakeLoader(NewModelLoader):
+            def _create_model(self_inner):
+                return torch.nn.Module()
+
+        class FakeMoe(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.ones(1))
+                self.quant_method = None
+                self.built_device = None
+
+            def process_weights_after_loading(self):
+                if bool(getattr(self, "_new_loader_defer_moe_executor_build", False)):
+                    self._new_loader_deferred_moe_executor = True
+                    return
+                self._maybe_build_fused_moe()
+
+            def _maybe_build_fused_moe(self):
+                self.built_device = self.weight.device
+
+        model = torch.nn.Module()
+        model.moe = FakeMoe()
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy"),
+            LoadConfig(compute_dtype=torch.float32, device="cpu", force_cpu_load_weights=True),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        loader._run_post_load_hooks(model, defer_moe_executor_build=True)
+        self.assertIsNone(model.moe.built_device)
+        model.to("cpu")
+        loader._build_deferred_moe_executors(model)
+        self.assertEqual(model.moe.built_device.type, "cpu")
+
 
 
 

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -1,0 +1,1126 @@
+"""Load completeness and input-layout regression tests for newloader."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+
+from rtp_llm.models_py.layers.attention import MMEncoderAttention
+from rtp_llm.models_py.layers.embedding import HiddenParallelEmbedding, ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.norm import LayerNorm, RMSNorm
+from rtp_llm.models_py.layers.conv import Conv3dLayer
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
+from rtp_llm.models_py import weight_mapper
+from rtp_llm.models_py.model_loader import (
+    LoadConfig,
+    LoadMethod,
+    NewModelLoader,
+    _create_ep_filter,
+    _discover_ckpt_files,
+    _get_all_weights,
+    _normalize_fastsafetensors_stacked_moe_weights,
+    _tp_slice,
+)
+from rtp_llm.models_py.new_models.bert import BertForEmbedding, RobertaForEmbedding
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dtype
+
+# Register MoE quant methods for BaseMoEExperts tests.
+import rtp_llm.models_py.quant_methods.fp8_moe  # noqa: F401
+
+
+def _qc(quant_type: str) -> QuantizationConfig:
+    return QuantizationConfig(quant_type=quant_type)
+
+
+class TestNewModelRegistry(unittest.TestCase):
+    def test_existing_embedding_models_resolve_via_newloader_registry(self):
+        for model_type, expected_name in (
+            ("bert", "BertForEmbedding"),
+            ("roberta", "RobertaForEmbedding"),
+        ):
+            config = types.SimpleNamespace(model_type=model_type, num_layers=1)
+            loader = NewModelLoader(
+                config,
+                LoadConfig(compute_dtype=torch.float32, device="cpu"),
+                model_path="/tmp",
+                device="cpu",
+            )
+            model = loader._create_model()
+            self.assertEqual(type(model).__name__, expected_name)
+
+
+class TestWeightMapperStreaming(unittest.TestCase):
+    def test_safetensors_loader_reads_one_tensor_at_a_time(self):
+        class FakeSafeOpen:
+            def __enter__(self):
+                self.read_names = []
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def keys(self):
+                return ["a.weight", "b.weight"]
+
+            def get_tensor(self, name):
+                self.read_names.append(name)
+                return torch.full((1,), len(self.read_names), dtype=torch.float32)
+
+        fake = FakeSafeOpen()
+
+        def fake_safe_open(path, framework, device):
+            self.assertEqual(path, "model.safetensors")
+            self.assertEqual(framework, "pt")
+            self.assertEqual(device, "cpu")
+            return fake
+
+        with mock.patch("safetensors.safe_open", side_effect=fake_safe_open):
+            items = list(
+                weight_mapper.get_all_weights(["model.safetensors"], device="cpu")
+            )
+
+        self.assertEqual([name for name, _ in items], ["a.weight", "b.weight"])
+        self.assertEqual(fake.read_names, ["a.weight", "b.weight"])
+
+
+
+    def test_pytorch_loader_unwraps_state_dict_and_model_containers(self):
+        tensors = {
+            "linear.weight": torch.ones(2, 2),
+            "linear.bias": torch.zeros(2),
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for container_key in ("state_dict", "model"):
+                path = os.path.join(tmpdir, f"wrapped_{container_key}.pt")
+                torch.save({container_key: dict(tensors), "epoch": 1}, path)
+                loaded = dict(weight_mapper.get_all_weights([path], device="cpu"))
+                self.assertEqual(set(loaded), set(tensors))
+                self.assertTrue(torch.equal(loaded["linear.weight"], tensors["linear.weight"]))
+
+    def test_scratch_loader_unwraps_wrapped_pytorch_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "wrapped.bin")
+            torch.save({"state_dict": {"x.weight": torch.ones(1)}}, path)
+            loaded = list(_get_all_weights([path], device="cpu"))
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0][0], "x.weight")
+        self.assertTrue(torch.equal(loaded[0][1], torch.ones(1)))
+
+    def test_lora_tp_slice_rejects_non_divisible_dim(self):
+        with self.assertRaisesRegex(ValueError, "LoRA TP slice.*divisible"):
+            _tp_slice(torch.zeros(5, 4), tp_size=2, tp_rank=0, rule=(0, "split"))
+
+
+
+    def test_fastsafetensors_path_normalizes_stacked_moe_names_before_load(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.loaded = []
+
+            def to_empty(self, device):
+                return self
+
+            def load_weights(self, weights_iter):
+                self.loaded = list(weights_iter)
+
+        model = CaptureModel()
+        config = types.SimpleNamespace(model_type="dummy", num_layers=1)
+        loader = NewModelLoader(
+            config,
+            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method="fastsafetensors"),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        gate_up = torch.zeros(4, 16)
+        down = torch.zeros(8, 4)
+        with mock.patch.object(loader, "_create_model", return_value=model), \
+             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
+             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
+             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
+             mock.patch(
+                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
+                 return_value=iter(
+                     [
+                         ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
+                         ("model.layers.0.mlp.experts.0.down_proj", down),
+                     ]
+                 ),
+             ):
+            loaded_model = loader._load_via_fastsafetensors()
+        self.assertIs(loaded_model, model)
+        self.assertEqual(
+            [name for name, _ in model.loaded],
+            [
+                "model.layers.0.mlp.experts.0.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.0.down_proj.weight",
+            ],
+        )
+
+    def test_load_config_device_cpu_is_used_by_scratch_loader(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.to_device = None
+
+            def load_weights(self, weights_iter):
+                list(weights_iter)
+
+            def to(self, device):
+                self.to_device = device
+                return self
+
+        model = CaptureModel()
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(compute_dtype=torch.float32, device="cpu"),
+            model_path="/tmp/nonexistent",
+        )
+        with mock.patch.object(
+            loader, "_create_model", return_value=model
+        ), mock.patch.object(
+            loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]
+        ), mock.patch(
+            "rtp_llm.models_py.model_loader._get_all_weights", return_value=iter([])
+        ), mock.patch.object(
+            loader, "_run_post_load_hooks", return_value=None
+        ), mock.patch.object(
+            loader, "_log_peak_gpu_memory", return_value=None
+        ):
+            self.assertIs(loader._load_via_scratch(), model)
+        self.assertEqual(loader.device, "cpu")
+        self.assertEqual(model.to_device, "cpu")
+
+    def test_load_config_device_cpu_is_used_by_fastsafetensors_loader(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.to_empty_device = None
+
+            def to_empty(self, device):
+                self.to_empty_device = device
+                return self
+
+            def load_weights(self, weights_iter):
+                self.loaded = list(weights_iter)
+
+        model = CaptureModel()
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(
+                compute_dtype=torch.float32,
+                device="cpu",
+                load_method=LoadMethod.FASTSAFETENSORS,
+            ),
+            model_path="/tmp/nonexistent",
+        )
+        with mock.patch.object(
+            loader, "_create_model", return_value=model
+        ), mock.patch.object(
+            loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]
+        ), mock.patch.object(
+            loader, "_run_post_load_hooks", return_value=None
+        ), mock.patch.object(
+            loader, "_log_peak_gpu_memory", return_value=None
+        ), mock.patch(
+            "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
+            return_value=iter([]),
+        ):
+            self.assertIs(loader._load_via_fastsafetensors(), model)
+        self.assertEqual(loader.device, "cpu")
+        self.assertEqual(model.to_empty_device, "cpu")
+
+    def test_fastsafetensors_cuda_target_uses_current_device_not_global_rank(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.loaded = []
+                self.to_empty_device = None
+
+            def to_empty(self, device):
+                self.to_empty_device = device
+                return self
+
+            def load_weights(self, weights_iter):
+                self.loaded = list(weights_iter)
+
+        def fake_get_fastsafetensors_weights(ckpt_files, device):
+            self.assertEqual(device, "cuda:0")
+            return iter([("dummy.weight", torch.ones(1))])
+
+        model = CaptureModel()
+        config = types.SimpleNamespace(model_type="dummy", num_layers=1)
+        loader = NewModelLoader(
+            config,
+            LoadConfig(
+                compute_dtype=torch.float32,
+                device="cuda",
+                load_method="fastsafetensors",
+            ),
+            model_path="/tmp/nonexistent",
+            device="cuda",
+        )
+        with mock.patch.object(loader, "_create_model", return_value=model), \
+             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
+             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
+             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
+             mock.patch("torch.cuda.current_device", return_value=0), \
+             mock.patch("torch.distributed.is_available", return_value=True), \
+             mock.patch("torch.distributed.is_initialized", return_value=True), \
+             mock.patch("torch.distributed.get_rank", return_value=17), \
+             mock.patch(
+                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
+                 side_effect=fake_get_fastsafetensors_weights,
+             ):
+            loaded_model = loader._load_via_fastsafetensors()
+
+        self.assertIs(loaded_model, model)
+        self.assertEqual(model.to_empty_device, "cuda:0")
+        self.assertEqual([name for name, _ in model.loaded], ["dummy.weight"])
+
+
+class TestCheckpointDiscovery(unittest.TestCase):
+    def test_optimizer_only_bin_does_not_hide_pt_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            optimizer = os.path.join(tmpdir, "optimizer.bin")
+            model_pt = os.path.join(tmpdir, "model.pt")
+            open(optimizer, "wb").close()
+            open(model_pt, "wb").close()
+            self.assertEqual(weight_mapper.discover_ckpt_files(tmpdir), [model_pt])
+            self.assertEqual(_discover_ckpt_files(tmpdir), [model_pt])
+
+
+class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
+    def _new_loader(self, load_method=LoadMethod.AUTO):
+        return NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(
+                compute_dtype=torch.float32,
+                device="cuda",
+                load_method=load_method,
+            ),
+            model_path="/tmp/nonexistent",
+            device="cuda",
+        )
+
+    def test_is_quanted_method_false_uses_full_rank_share_for_memory_gate(self):
+        class NotQuantizedConfig:
+            def is_quanted(self):
+                return False
+
+        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
+        loader.load_config.quant_source_config = NotQuantizedConfig()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt = os.path.join(tmpdir, "model.safetensors")
+            with open(ckpt, "wb") as f:
+                f.truncate(1000)
+            loader.model_path = tmpdir
+            with mock.patch.dict(
+                sys.modules, {"fastsafetensors": types.ModuleType("fastsafetensors")}
+            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
+                "torch.cuda.mem_get_info", return_value=(3600, 10000)
+            ):
+                ok, reason = loader._fastsafetensors_eligible()
+        self.assertFalse(ok)
+        self.assertEqual(reason, "insufficient GPU free memory")
+
+    def test_explicit_config_fastsafetensors_failure_does_not_fallback(self):
+        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
+        err = RuntimeError("fast path failed")
+        with mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "")
+        ), mock.patch.object(
+            loader, "_load_via_fastsafetensors", side_effect=err
+        ), mock.patch.object(
+            loader, "_load_via_scratch"
+        ) as scratch:
+            with self.assertRaisesRegex(RuntimeError, "fast path failed"):
+                loader.load()
+        scratch.assert_not_called()
+
+    def test_env_fastsafetensors_failure_does_not_fallback(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        err = RuntimeError("env fast path failed")
+        with mock.patch.dict(
+            os.environ, {"LOAD_METHOD": LoadMethod.FASTSAFETENSORS}
+        ), mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "")
+        ), mock.patch.object(
+            loader, "_load_via_fastsafetensors", side_effect=err
+        ), mock.patch.object(
+            loader, "_load_via_scratch"
+        ) as scratch:
+            with self.assertRaisesRegex(RuntimeError, "env fast path failed"):
+                loader.load()
+        scratch.assert_not_called()
+
+    def test_auto_fastsafetensors_failure_can_fallback(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader,
+            "_resolve_load_method",
+            return_value=(LoadMethod.FASTSAFETENSORS, False),
+        ), mock.patch.object(
+            loader,
+            "_load_via_fastsafetensors",
+            side_effect=RuntimeError("auto fast path failed"),
+        ), mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        scratch.assert_called_once()
+
+    def test_auto_selects_fastsafetensors_when_eligible_without_mocking_resolve(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        fast_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
+        ) as eligible, mock.patch.object(
+            loader, "_load_via_fastsafetensors", return_value=fast_model
+        ) as fast, mock.patch.object(
+            loader, "_load_via_scratch"
+        ) as scratch:
+            self.assertIs(loader.load(), fast_model)
+        eligible.assert_called_once()
+        fast.assert_called_once()
+        scratch.assert_not_called()
+
+    def test_auto_fastsafetensors_failure_falls_back_without_mocking_resolve(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
+        ), mock.patch.object(
+            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("auto failed")
+        ), mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        scratch.assert_called_once()
+
+    def test_auto_uses_scratch_when_fastsafetensors_is_not_eligible(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(False, "not eligible")
+        ) as eligible, mock.patch.object(
+            loader, "_load_via_fastsafetensors"
+        ) as fast, mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        eligible.assert_called_once()
+        fast.assert_not_called()
+        scratch.assert_called_once()
+
+    def test_invalid_explicit_load_method_fails_fast(self):
+        loader = self._new_loader("typo")
+        with self.assertRaisesRegex(ValueError, "Unsupported load_method"):
+            loader._resolve_load_method()
+
+    def test_invalid_load_method_env_fails_fast(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        with mock.patch.dict(os.environ, {"LOAD_METHOD": "typo"}):
+            with self.assertRaisesRegex(ValueError, "Unsupported LOAD_METHOD"):
+                loader._resolve_load_method()
+
+    def test_auto_load_method_env_keeps_auto_selection(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        with mock.patch.dict(os.environ, {"LOAD_METHOD": LoadMethod.AUTO}), mock.patch.object(
+            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
+        ):
+            self.assertEqual(
+                loader._resolve_load_method(), (LoadMethod.FASTSAFETENSORS, False)
+            )
+
+    def test_fastsafetensors_memory_gate_uses_target_device(self):
+        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
+        loader.device = "cuda:1"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt = os.path.join(tmpdir, "model.safetensors")
+            with open(ckpt, "wb") as f:
+                f.truncate(1000)
+            loader.model_path = tmpdir
+            with mock.patch.dict(
+                sys.modules, {"fastsafetensors": types.ModuleType("fastsafetensors")}
+            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
+                "torch.cuda.mem_get_info", return_value=(10000, 20000)
+            ) as mem_info:
+                ok, reason = loader._fastsafetensors_eligible()
+        self.assertTrue(ok, reason)
+        mem_info.assert_called_once_with("cuda:1")
+
+    def test_explicit_fastsafetensors_memory_recheck_uses_target_device(self):
+        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
+        loader.device = "cuda:1"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ckpt = os.path.join(tmpdir, "model.safetensors")
+            with open(ckpt, "wb") as f:
+                f.truncate(1000)
+            loader.model_path = tmpdir
+            with mock.patch.object(
+                loader,
+                "_fastsafetensors_eligible",
+                return_value=(False, "insufficient GPU free memory"),
+            ), mock.patch(
+                "torch.cuda.mem_get_info", return_value=(2000, 20000)
+            ) as mem_info:
+                method, explicit = loader._resolve_load_method()
+        self.assertEqual((method, explicit), (LoadMethod.FASTSAFETENSORS, True))
+        mem_info.assert_called_once_with("cuda:1")
+
+
+class TestRtpModuleDispatchIntegrity(unittest.TestCase):
+    class Container(RtpModule):
+        def __init__(self):
+            super().__init__()
+            self.child = torch.nn.Linear(2, 2, bias=False)
+            self.layers = torch.nn.ModuleList([torch.nn.Linear(2, 2, bias=False)])
+
+    def test_nested_missing_leaf_fails(self):
+        module = self.Container()
+        with self.assertRaisesRegex(RuntimeError, "child.missing"):
+            module.load_weights({"child.missing": torch.zeros(2, 2)})
+
+    def test_module_list_bad_index_fails(self):
+        module = self.Container()
+        with self.assertRaisesRegex(RuntimeError, "layers.3.weight"):
+            module.load_weights({"layers.3.weight": torch.zeros(2, 2)})
+
+
+class TestLinearLoadCompleteness(unittest.TestCase):
+    def test_column_missing_weight_fails_before_post_load(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_qc("none"),
+            prefix="linear",
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(RuntimeError, "missing required checkpoint tensors"):
+            layer.process_weights_after_loading()
+
+    def test_fp8_missing_scale_fails(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_qc("fp8"),
+            prefix="fp8_linear",
+            params_dtype=torch.float32,
+        )
+        layer.load_weights({"fp8_linear.weight": torch.zeros(4, 4, dtype=_runtime_fp8_dtype())})
+        with self.assertRaisesRegex(RuntimeError, "weight_scale"):
+            layer.process_weights_after_loading()
+
+    def test_merged_missing_shard_fails(self):
+        layer = MergedColumnParallelLinear(
+            input_size=4,
+            output_size=8,
+            quant_config=_qc("none"),
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        layer.load_weights({"gate_up_proj.gate_proj.weight": torch.zeros(4, 4)})
+        with self.assertRaisesRegex(RuntimeError, "up_proj|1"):
+            layer.process_weights_after_loading()
+
+    def test_merged_shard_rejects_non_divisible_tp_checkpoint_dim(self):
+        layer = MergedColumnParallelLinear(
+            input_size=4,
+            output_size=12,
+            tp_size=3,
+            tp_rank=0,
+            quant_config=_qc("none"),
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(ValueError, "divisible"):
+            layer.load_weights({"gate_up_proj.gate_proj.weight": torch.zeros(5, 4)})
+
+    def test_qkv_missing_v_shard_fails(self):
+        layer = QKVParallelLinear(
+            hidden_size=4,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=2,
+            quant_config=_qc("none"),
+            prefix="qkv_proj",
+            params_dtype=torch.float32,
+        )
+        layer.load_weights(
+            {
+                "qkv_proj.q_proj.weight": torch.zeros(4, 4),
+                "qkv_proj.k_proj.weight": torch.zeros(2, 4),
+            }
+        )
+        with self.assertRaisesRegex(RuntimeError, "v"):
+            layer.process_weights_after_loading()
+
+
+    def test_row_parallel_adds_bias_after_all_reduce(self):
+        layer = RowParallelLinear(
+            input_size=4,
+            output_size=3,
+            tp_size=2,
+            tp_rank=0,
+            quant_config=_qc("none"),
+            prefix="row",
+            bias=True,
+            params_dtype=torch.float32,
+        )
+        layer.weight.data.fill_(1.0)
+        layer.bias.data.fill_(3.0)
+        x = torch.ones(1, 2, dtype=torch.float32)
+        with mock.patch(
+            "rtp_llm.models_py.layers.linear.all_reduce",
+            side_effect=lambda tensor, group: tensor * 2,
+        ):
+            out = layer(x)
+        torch.testing.assert_close(out, torch.full((1, 3), 7.0), rtol=0, atol=0)
+
+    def test_qkv_rejects_non_divisible_kv_heads(self):
+        with self.assertRaisesRegex(ValueError, "num_kv_heads"):
+            QKVParallelLinear(
+                hidden_size=8,
+                num_heads=8,
+                num_kv_heads=6,
+                head_dim=1,
+                tp_size=4,
+                tp_rank=0,
+                quant_config=_qc("none"),
+                prefix="qkv_proj",
+                params_dtype=torch.float32,
+            )
+
+    def test_column_rejects_non_divisible_output_tp(self):
+        with self.assertRaisesRegex(ValueError, "output_size.*divisible"):
+            ColumnParallelLinear(
+                input_size=4,
+                output_size=10,
+                tp_size=3,
+                quant_config=_qc("none"),
+                prefix="linear",
+                params_dtype=torch.float32,
+            )
+
+    def test_row_rejects_non_divisible_input_tp(self):
+        with self.assertRaisesRegex(ValueError, "input_size.*divisible"):
+            RowParallelLinear(
+                input_size=10,
+                output_size=4,
+                tp_size=3,
+                quant_config=_qc("none"),
+                prefix="linear",
+                params_dtype=torch.float32,
+            )
+
+    def test_linear_rejects_invalid_tp_rank(self):
+        with self.assertRaisesRegex(ValueError, "tp_rank"):
+            ColumnParallelLinear(
+                input_size=4,
+                output_size=4,
+                tp_size=2,
+                tp_rank=2,
+                quant_config=_qc("none"),
+                prefix="linear",
+                params_dtype=torch.float32,
+            )
+
+    def test_embedding_rejects_invalid_tp_rank(self):
+        with self.assertRaisesRegex(ValueError, "tp_rank"):
+            VocabParallelEmbedding(
+                vocab_size=4,
+                embedding_dim=4,
+                tp_size=2,
+                tp_rank=2,
+                params_dtype=torch.float32,
+            )
+
+    def test_merged_rejects_non_divisible_shards_at_construction(self):
+        with self.assertRaisesRegex(ValueError, "num_shards"):
+            MergedColumnParallelLinear(
+                input_size=4,
+                output_size=10,
+                tp_size=1,
+                tp_rank=0,
+                quant_config=_qc("none"),
+                prefix="gate_up_proj",
+                shard_names=["gate_proj", "up_proj", "extra_proj"],
+                params_dtype=torch.float32,
+            )
+
+    def test_split_weight_rejects_non_divisible_checkpoint_dim(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=9,
+            tp_size=3,
+            quant_config=_qc("none"),
+            prefix="linear",
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(ValueError, "tensor dim 0.*divisible"):
+            layer._split_weight(torch.zeros(10, 4), dim=0)
+
+    def test_lora_tp_slice_rejects_invalid_rank(self):
+        with self.assertRaisesRegex(ValueError, "tp_rank"):
+            _tp_slice(torch.zeros(4, 4), tp_size=2, tp_rank=2, rule=(0, "split"))
+
+
+class TestMoELoadCompleteness(unittest.TestCase):
+
+    def test_fastsafetensors_stacked_moe_names_are_normalized_to_expert_weights(self):
+        gate_up = torch.arange(4 * 16, dtype=torch.float32).reshape(4, 16)
+        down = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        items = list(
+            _normalize_fastsafetensors_stacked_moe_weights(
+                iter(
+                    [
+                        ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
+                        ("model.layers.0.mlp.experts.0.down_proj", down),
+                    ]
+                )
+            )
+        )
+        self.assertEqual(
+            [name for name, _ in items],
+            [
+                "model.layers.0.mlp.experts.0.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.0.down_proj.weight",
+            ],
+        )
+        self.assertIs(items[0][1], gate_up)
+        self.assertIs(items[1][1], down)
+
+    def test_ep_filter_rejects_non_divisible_experts(self):
+        with self.assertRaisesRegex(ValueError, "num_experts.*divisible"):
+            _create_ep_filter(ep_size=2, ep_rank=0, num_experts=3)
+
+    def test_ep_filter_rejects_invalid_rank(self):
+        with self.assertRaisesRegex(ValueError, "ep_rank"):
+            _create_ep_filter(ep_size=2, ep_rank=2, num_experts=4)
+
+    def test_moe_rejects_non_divisible_ep_experts(self):
+        with self.assertRaisesRegex(ValueError, "num_experts.*divisible"):
+            BaseMoEExperts(
+                num_experts=3,
+                hidden_size=4,
+                moe_intermediate_size=8,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=2,
+                ep_rank=0,
+                params_dtype=torch.float32,
+                model_config=types.SimpleNamespace(
+                    data_type="fp32", quant_config=None, exported_device=None
+                ),
+                parallelism_config=types.SimpleNamespace(dp_size=1),
+                moe_config=types.SimpleNamespace(),
+                quant_config=_qc("none"),
+                layer_idx=0,
+            )
+
+    def test_moe_rejects_invalid_ep_rank(self):
+        with self.assertRaisesRegex(ValueError, "ep_rank"):
+            BaseMoEExperts(
+                num_experts=4,
+                hidden_size=4,
+                moe_intermediate_size=8,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=2,
+                ep_rank=2,
+                params_dtype=torch.float32,
+                model_config=types.SimpleNamespace(
+                    data_type="fp32", quant_config=None, exported_device=None
+                ),
+                parallelism_config=types.SimpleNamespace(dp_size=1),
+                moe_config=types.SimpleNamespace(),
+                quant_config=_qc("none"),
+                layer_idx=0,
+            )
+
+    def _make_unquant_moe(self, hidden_size=8, moe_intermediate_size=2):
+        return BaseMoEExperts(
+            num_experts=1,
+            hidden_size=hidden_size,
+            moe_intermediate_size=moe_intermediate_size,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=_qc("none"),
+            layer_idx=0,
+        )
+
+    def test_moe_gate_up_weight_uses_config_for_h_2m_layout(self):
+        layer = self._make_unquant_moe(hidden_size=8, moe_intermediate_size=2)
+        gate_up = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        layer.load_weights({"0.gate_up_proj.weight": gate_up})
+        torch.testing.assert_close(layer.w13[0, :2], gate_up[:, 2:].t())
+        torch.testing.assert_close(layer.w13[0, 2:], gate_up[:, :2].t())
+
+    def test_moe_gate_up_weight_uses_config_for_2m_h_layout(self):
+        layer = self._make_unquant_moe(hidden_size=8, moe_intermediate_size=2)
+        gate_up = torch.arange(4 * 8, dtype=torch.float32).reshape(4, 8)
+        layer.load_weights({"0.gate_up_proj.weight": gate_up})
+        torch.testing.assert_close(layer.w13[0, :2], gate_up[2:])
+        torch.testing.assert_close(layer.w13[0, 2:], gate_up[:2])
+
+    def test_stacked_moe_gate_up_scale_scratch_name_splits_gate_up(self):
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=_qc("fp8_per_channel"),
+            layer_idx=0,
+        )
+        scale = torch.arange(8, dtype=torch.float32).reshape(1, 8)
+        layer.load_weights({"gate_up_proj.weight_scale": scale})
+        torch.testing.assert_close(layer._gate_ch_scales[0], scale[0, :4])
+        torch.testing.assert_close(layer._up_ch_scales[0], scale[0, 4:])
+
+    def test_stacked_moe_gate_up_scale_fastsafetensors_name_splits_gate_up(self):
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=_qc("fp8_per_channel"),
+            layer_idx=0,
+        )
+        scale = torch.arange(8, dtype=torch.float32)
+        layer.load_weights({"0.gate_up_proj.weight_scale": scale})
+        torch.testing.assert_close(layer._gate_ch_scales[0], scale[:4])
+        torch.testing.assert_close(layer._up_ch_scales[0], scale[4:])
+
+    def test_moe_accepts_normalized_fastsafetensors_stacked_projection_names(self):
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=8,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=_qc("none"),
+            layer_idx=0,
+        )
+        gate_up = torch.arange(4 * 16, dtype=torch.float32).reshape(4, 16)
+        down = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        for full_name, tensor in _normalize_fastsafetensors_stacked_moe_weights(
+            iter(
+                [
+                    ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
+                    ("model.layers.0.mlp.experts.0.down_proj", down),
+                ]
+            )
+        ):
+            expert_name = full_name.split("experts.", 1)[1]
+            layer.load_weights({expert_name: tensor})
+        with mock.patch.object(
+            BaseMoEExperts, "_maybe_build_fused_moe", return_value=None
+        ):
+            layer.process_weights_after_loading()
+        self.assertEqual(
+            layer._loaded_keys, {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")}
+        )
+
+    def _make_moe(self):
+        return BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=_qc("fp8"),
+            layer_idx=0,
+        )
+
+    def test_missing_quant_scale_fails(self):
+        layer = self._make_moe()
+        layer.load_weights(
+            {
+                "0.gate_proj.weight": torch.zeros(4, 4, dtype=_runtime_fp8_dtype()),
+                "0.up_proj.weight": torch.zeros(4, 4, dtype=_runtime_fp8_dtype()),
+                "0.down_proj.weight": torch.zeros(4, 4, dtype=_runtime_fp8_dtype()),
+            }
+        )
+        with self.assertRaisesRegex(RuntimeError, "auxiliary tensors"):
+            layer.process_weights_after_loading()
+
+
+class TestAttentionConstructionIntegrity(unittest.TestCase):
+    def test_mm_encoder_attention_rejects_hidden_not_divisible_by_heads(self):
+        with self.assertRaisesRegex(ValueError, "hidden_size.*divisible"):
+            MMEncoderAttention(
+                hidden_size=10,
+                num_heads=3,
+                tp_size=1,
+                params_dtype=torch.float32,
+            )
+
+    def test_mm_encoder_attention_rejects_heads_not_divisible_by_tp(self):
+        with self.assertRaisesRegex(ValueError, "num_heads.*divisible"):
+            MMEncoderAttention(
+                hidden_size=12,
+                num_heads=3,
+                tp_size=2,
+                params_dtype=torch.float32,
+            )
+
+    def test_mm_encoder_attention_rejects_invalid_tp_rank(self):
+        with self.assertRaisesRegex(ValueError, "tp_rank"):
+            MMEncoderAttention(
+                hidden_size=12,
+                num_heads=3,
+                tp_size=1,
+                tp_rank=1,
+                params_dtype=torch.float32,
+            )
+
+    def test_mm_encoder_attention_qkv_block_scale_splits_qkv_aware(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [4, 4]
+        layer = MMEncoderAttention(
+            hidden_size=8,
+            num_heads=4,
+            tp_size=2,
+            tp_rank=1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=qc,
+        )
+        weight = torch.zeros(24, 8, dtype=torch.float8_e4m3fn)
+        scale = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+        layer.load_weights({"qkv.weight": weight, "qkv.weight_scale_inv": scale})
+        expected = torch.stack([scale[1], scale[3], scale[5]], dim=0)
+        torch.testing.assert_close(layer.qkv.weight_scale_inv.detach(), expected)
+
+    def test_mm_encoder_attention_tp2_matches_full_attention(self):
+        torch.manual_seed(123)
+        hidden = 8
+        heads = 4
+        x = torch.randn(2, 3, hidden, dtype=torch.float32)
+        qkv_w = torch.randn(3 * hidden, hidden, dtype=torch.float32) * 0.1
+        proj_w = torch.randn(hidden, hidden, dtype=torch.float32) * 0.1
+
+        full = MMEncoderAttention(
+            hidden_size=hidden,
+            num_heads=heads,
+            tp_size=1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=_qc("none"),
+        )
+        full.load_weights({"qkv.weight": qkv_w, "proj.weight": proj_w})
+
+        parts = []
+        for rank in range(2):
+            part = MMEncoderAttention(
+                hidden_size=hidden,
+                num_heads=heads,
+                tp_size=2,
+                tp_rank=rank,
+                bias=False,
+                params_dtype=torch.float32,
+                quant_config=_qc("none"),
+            )
+            part.proj.reduce_output = False
+            part.load_weights({"qkv.weight": qkv_w, "proj.weight": proj_w})
+            parts.append(part(x))
+
+        torch.testing.assert_close(
+            parts[0] + parts[1], full(x), rtol=1e-5, atol=1e-5
+        )
+
+
+class TestOtherLayerLoadCompleteness(unittest.TestCase):
+    def test_embedding_missing_weight_fails(self):
+        layer = VocabParallelEmbedding(8, 4, params_dtype=torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "weight"):
+            layer.process_weights_after_loading()
+
+    def test_embedding_tp_dims_fail_fast_when_non_divisible(self):
+        with self.assertRaisesRegex(ValueError, "vocab_size.*divisible"):
+            VocabParallelEmbedding(10, 4, tp_size=3, params_dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "embedding_dim.*divisible"):
+            HiddenParallelEmbedding(8, 10, tp_size=3, params_dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "vocab_size.*divisible"):
+            ParallelLMHead(10, 4, tp_size=3, params_dtype=torch.float32)
+
+    def test_norm_missing_weight_fails(self):
+        layer = RMSNorm(4, params_dtype=torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "weight"):
+            layer.process_weights_after_loading()
+
+    def test_layernorm_missing_bias_fails(self):
+        layer = LayerNorm(4, params_dtype=torch.float32)
+        layer.load_weights({"weight": torch.ones(4)})
+        with self.assertRaisesRegex(RuntimeError, "bias"):
+            layer.process_weights_after_loading()
+
+    def test_conv_missing_bias_fails(self):
+        layer = Conv3dLayer(1, 1, (1, 1, 1), params_dtype=torch.float32)
+        layer.load_weights({"weight": torch.ones_like(layer.conv.weight)})
+        with self.assertRaisesRegex(RuntimeError, "bias"):
+            layer.process_weights_after_loading()
+
+
+
+class TestBertNewLoaderCompatibility(unittest.TestCase):
+    def _bert_config(self):
+        return types.SimpleNamespace(
+            model_type="bert",
+            num_layers=1,
+            hidden_size=4,
+            inter_size=8,
+            type_vocab_size=2,
+            max_generate_batch_size=1,
+            quant_config=None,
+        )
+
+    def _gamma_beta_weights(self, prefix="bert"):
+        h = 4
+        inter = 8
+        return {
+            f"{prefix}.embeddings.word_embeddings.weight": torch.ones(8, h),
+            f"{prefix}.embeddings.position_embeddings.weight": torch.ones(16, h),
+            f"{prefix}.embeddings.token_type_embeddings.weight": torch.ones(2, h),
+            f"{prefix}.embeddings.LayerNorm.gamma": torch.full((h,), 2.0),
+            f"{prefix}.embeddings.LayerNorm.beta": torch.full((h,), 3.0),
+            f"{prefix}.encoder.layer.0.attention.self.query.weight": torch.ones(h, h),
+            f"{prefix}.encoder.layer.0.attention.self.query.bias": torch.zeros(h),
+            f"{prefix}.encoder.layer.0.attention.self.key.weight": torch.ones(h, h),
+            f"{prefix}.encoder.layer.0.attention.self.key.bias": torch.zeros(h),
+            f"{prefix}.encoder.layer.0.attention.self.value.weight": torch.ones(h, h),
+            f"{prefix}.encoder.layer.0.attention.self.value.bias": torch.zeros(h),
+            f"{prefix}.encoder.layer.0.attention.output.dense.weight": torch.ones(h, h),
+            f"{prefix}.encoder.layer.0.attention.output.dense.bias": torch.zeros(h),
+            f"{prefix}.encoder.layer.0.attention.output.LayerNorm.gamma": torch.full((h,), 4.0),
+            f"{prefix}.encoder.layer.0.attention.output.LayerNorm.beta": torch.full((h,), 5.0),
+            f"{prefix}.encoder.layer.0.intermediate.dense.weight": torch.ones(inter, h),
+            f"{prefix}.encoder.layer.0.intermediate.dense.bias": torch.zeros(inter),
+            f"{prefix}.encoder.layer.0.output.dense.weight": torch.ones(h, inter),
+            f"{prefix}.encoder.layer.0.output.dense.bias": torch.zeros(h),
+            f"{prefix}.encoder.layer.0.output.LayerNorm.gamma": torch.full((h,), 6.0),
+            f"{prefix}.encoder.layer.0.output.LayerNorm.beta": torch.full((h,), 7.0),
+        }
+
+    def test_bert_accepts_layernorm_gamma_beta_checkpoint_names(self):
+        model = BertForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
+        with mock.patch.object(BertForEmbedding, "_build_inner_model", return_value=None):
+            model.load_weights(self._gamma_beta_weights("bert"))
+        self.assertTrue(torch.equal(model.embeddings.layernorm_weight, torch.full((4,), 2.0)))
+        self.assertTrue(torch.equal(model.layers[0].attention_output_layernorm_weight, torch.full((4,), 4.0)))
+        self.assertTrue(torch.equal(model.layers[0].output_layernorm_bias, torch.full((4,), 7.0)))
+
+    def test_roberta_accepts_layernorm_gamma_beta_checkpoint_names(self):
+        model = RobertaForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
+        with mock.patch.object(RobertaForEmbedding, "_build_inner_model", return_value=None):
+            model.load_weights(self._gamma_beta_weights("roberta"))
+        self.assertTrue(torch.equal(model.embeddings.layernorm_bias, torch.full((4,), 3.0)))
+
+
+class TestAwqRegistrationSafety(unittest.TestCase):
+    def test_awq_reference_path_is_not_registered_for_hot_forward(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=8,
+            quant_config=_qc("none"),
+            prefix="linear",
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(ValueError, "Unsupported linear quant_type 'awq'"):
+            _qc("awq").get_quant_method(layer, "linear")
+
+class TestFp8ForwardInputLayout(unittest.TestCase):
+    def test_fp8_per_tensor_accepts_non_contiguous_input(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=3,
+            quant_config=_qc("fp8"),
+            prefix="fp8_linear",
+            params_dtype=torch.float32,
+        )
+        layer.load_weights(
+            {
+                "fp8_linear.weight": torch.zeros(3, 4, dtype=_runtime_fp8_dtype()),
+                "fp8_linear.weight_scale": torch.tensor([1.0], dtype=torch.float32),
+            }
+        )
+        layer.process_weights_after_loading()
+        x = torch.randn(2, 4, 3).transpose(1, 2)
+        self.assertFalse(x.is_contiguous())
+
+        def fake_quant(inp):
+            self.assertEqual(inp.shape, (6, 4))
+            self.assertTrue(inp.is_contiguous())
+            return inp.to(_runtime_fp8_dtype()), torch.ones(1, dtype=torch.float32)
+
+        def fake_scaled_mm(a, b, **kwargs):
+            return torch.zeros(a.shape[0], b.shape[1], dtype=torch.float32)
+
+        with mock.patch(
+            "rtp_llm.models_py.quant_methods.fp8._resolve_per_tensor_quant",
+            return_value=fake_quant,
+        ), mock.patch.object(torch, "_scaled_mm", side_effect=fake_scaled_mm):
+            out = layer(x)
+        self.assertEqual(out.shape, (2, 3, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -83,7 +83,6 @@ from rtp_llm.models_py.model_loader import (
     _get_all_weights,
     _HF_TO_ENGINE_LORA,
     _is_quantized_load,
-    _normalize_fastsafetensors_stacked_moe_weights,
     _tp_slice,
 )
 from rtp_llm.models_py.new_models.bert import BertForEmbedding, RobertaForEmbedding
@@ -314,113 +313,7 @@ class TestWeightMapperStreaming(unittest.TestCase):
 
 
 
-    def test_fastsafetensors_path_normalizes_stacked_moe_names_before_load(self):
-        class CaptureModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.loaded = []
 
-            def to_empty(self, device):
-                return self
-
-            def load_weights(self, weights_iter):
-                self.loaded = list(weights_iter)
-
-        model = CaptureModel()
-        config = types.SimpleNamespace(model_type="dummy", num_layers=1)
-        loader = NewModelLoader(
-            config,
-            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method="fastsafetensors"),
-            model_path="/tmp/nonexistent",
-            device="cpu",
-        )
-        gate_up = torch.zeros(4, 16)
-        down = torch.zeros(8, 4)
-        with mock.patch.object(loader, "_create_model", return_value=model), \
-             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
-             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
-             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
-             mock.patch(
-                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
-                 return_value=iter(
-                     [
-                         ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
-                         ("model.layers.0.mlp.experts.0.down_proj", down),
-                     ]
-                 ),
-             ):
-            loaded_model = loader._load_via_fastsafetensors()
-        self.assertIs(loaded_model, model)
-        self.assertEqual(
-            [name for name, _ in model.loaded],
-            [
-                "model.layers.0.mlp.experts.0.gate_up_proj.weight",
-                "model.layers.0.mlp.experts.0.down_proj.weight",
-            ],
-        )
-
-    def test_fastsafetensors_path_ep_filters_stacked_moe_before_load(self):
-        class CaptureModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.loaded = []
-
-            def to_empty(self, device):
-                return self
-
-            def load_weights(self, weights_iter):
-                self.loaded = list(weights_iter)
-
-        model = CaptureModel()
-        config = types.SimpleNamespace(model_type="dummy", num_layers=1, expert_num=4)
-        loader = NewModelLoader(
-            config,
-            LoadConfig(
-                compute_dtype=torch.float32,
-                device="cpu",
-                load_method="fastsafetensors",
-                ep_size=2,
-                ep_rank=1,
-            ),
-            model_path="/tmp/nonexistent",
-            device="cpu",
-        )
-        gate_up = torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3)
-        down = torch.arange(4 * 3 * 2, dtype=torch.float32).reshape(4, 3, 2)
-        gate_scale = torch.arange(4 * 2, dtype=torch.float32).reshape(4, 2)
-        with mock.patch.object(loader, "_create_model", return_value=model), \
-             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
-             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
-             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
-             mock.patch(
-                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
-                 return_value=iter(
-                     [
-                         ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
-                         ("model.layers.0.mlp.experts.down_proj", down),
-                         ("model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv", gate_scale),
-                     ]
-                 ),
-             ):
-            loaded_model = loader._load_via_fastsafetensors()
-        self.assertIs(loaded_model, model)
-        self.assertEqual(
-            [name for name, _ in model.loaded],
-            [
-                "model.layers.0.mlp.experts.2.gate_up_proj.weight",
-                "model.layers.0.mlp.experts.3.gate_up_proj.weight",
-                "model.layers.0.mlp.experts.2.down_proj.weight",
-                "model.layers.0.mlp.experts.3.down_proj.weight",
-                "model.layers.0.mlp.experts.2.gate_up_proj.weight_scale_inv",
-                "model.layers.0.mlp.experts.3.gate_up_proj.weight_scale_inv",
-            ],
-        )
-        torch.testing.assert_close(model.loaded[0][1], gate_up[2])
-        torch.testing.assert_close(model.loaded[1][1], gate_up[3])
-        torch.testing.assert_close(model.loaded[2][1], down[2])
-        torch.testing.assert_close(model.loaded[3][1], down[3])
-        torch.testing.assert_close(model.loaded[4][1], gate_scale[2])
-        torch.testing.assert_close(model.loaded[5][1], gate_scale[3])
 
     def test_load_config_device_cpu_is_used_by_scratch_loader(self):
         class CaptureModel(torch.nn.Module):
@@ -508,118 +401,7 @@ class TestWeightMapperStreaming(unittest.TestCase):
             self.assertIs(loader._load_via_scratch(), model)
         self.assertEqual(model.events, [("hook", True), ("to", "cuda")])
 
-    def test_auto_fastsafetensors_fallback_releases_before_scratch(self):
-        loader = NewModelLoader(
-            types.SimpleNamespace(model_type="dummy", num_layers=1),
-            LoadConfig(compute_dtype=torch.float32, device="cuda"),
-            model_path="/tmp/nonexistent",
-            device="cuda",
-        )
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_resolve_load_method", return_value=(LoadMethod.FASTSAFETENSORS, False)
-        ), mock.patch.object(
-            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("fast failed")
-        ), mock.patch(
-            "gc.collect"
-        ) as collect, mock.patch(
-            "torch.cuda.is_available", return_value=True
-        ), mock.patch(
-            "torch.cuda.empty_cache"
-        ) as empty_cache, mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        collect.assert_called_once()
-        empty_cache.assert_called_once()
-        scratch.assert_called_once()
 
-    def test_load_config_device_cpu_is_used_by_fastsafetensors_loader(self):
-        class CaptureModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.to_empty_device = None
-
-            def to_empty(self, device):
-                self.to_empty_device = device
-                return self
-
-            def load_weights(self, weights_iter):
-                self.loaded = list(weights_iter)
-
-        model = CaptureModel()
-        loader = NewModelLoader(
-            types.SimpleNamespace(model_type="dummy", num_layers=1),
-            LoadConfig(
-                compute_dtype=torch.float32,
-                device="cpu",
-                load_method=LoadMethod.FASTSAFETENSORS,
-            ),
-            model_path="/tmp/nonexistent",
-        )
-        with mock.patch.object(
-            loader, "_create_model", return_value=model
-        ), mock.patch.object(
-            loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]
-        ), mock.patch.object(
-            loader, "_run_post_load_hooks", return_value=None
-        ), mock.patch.object(
-            loader, "_log_peak_gpu_memory", return_value=None
-        ), mock.patch(
-            "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
-            return_value=iter([]),
-        ):
-            self.assertIs(loader._load_via_fastsafetensors(), model)
-        self.assertEqual(loader.device, "cpu")
-        self.assertEqual(model.to_empty_device, "cpu")
-
-    def test_fastsafetensors_cuda_target_uses_current_device_not_global_rank(self):
-        class CaptureModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.loaded = []
-                self.to_empty_device = None
-
-            def to_empty(self, device):
-                self.to_empty_device = device
-                return self
-
-            def load_weights(self, weights_iter):
-                self.loaded = list(weights_iter)
-
-        def fake_get_fastsafetensors_weights(ckpt_files, device):
-            self.assertEqual(device, "cuda:0")
-            return iter([("dummy.weight", torch.ones(1))])
-
-        model = CaptureModel()
-        config = types.SimpleNamespace(model_type="dummy", num_layers=1)
-        loader = NewModelLoader(
-            config,
-            LoadConfig(
-                compute_dtype=torch.float32,
-                device="cuda",
-                load_method="fastsafetensors",
-            ),
-            model_path="/tmp/nonexistent",
-            device="cuda",
-        )
-        with mock.patch.object(loader, "_create_model", return_value=model), \
-             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
-             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
-             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
-             mock.patch("torch.cuda.current_device", return_value=0), \
-             mock.patch("torch.distributed.is_available", return_value=True), \
-             mock.patch("torch.distributed.is_initialized", return_value=True), \
-             mock.patch("torch.distributed.get_rank", return_value=17), \
-             mock.patch(
-                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
-                 side_effect=fake_get_fastsafetensors_weights,
-             ):
-            loaded_model = loader._load_via_fastsafetensors()
-
-        self.assertIs(loaded_model, model)
-        self.assertEqual(model.to_empty_device, "cuda:0")
-        self.assertEqual([name for name, _ in model.loaded], ["dummy.weight"])
 
 
 class TestCheckpointDiscovery(unittest.TestCase):
@@ -646,26 +428,6 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
             device="cuda",
         )
 
-    def test_is_quanted_method_false_uses_full_rank_share_for_memory_gate(self):
-        class NotQuantizedConfig:
-            def is_quanted(self):
-                return False
-
-        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
-        loader.load_config.quant_source_config = NotQuantizedConfig()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ckpt = os.path.join(tmpdir, "model.safetensors")
-            with open(ckpt, "wb") as f:
-                f.truncate(1000)
-            loader.model_path = tmpdir
-            with mock.patch.dict(
-                sys.modules, {"fastsafetensors": types.ModuleType("fastsafetensors")}
-            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch.object(
-                loader, "_target_cuda_mem_get_info", return_value=(3600, 10000)
-            ):
-                ok, reason = loader._fastsafetensors_eligible()
-        self.assertFalse(ok)
-        self.assertEqual(reason, "insufficient GPU free memory")
 
     def test_quantized_load_treats_empty_defaults_as_unquantized(self):
         load_config = LoadConfig(compute_dtype=torch.float32, device="cpu")
@@ -765,140 +527,33 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
         self.assertIsNone(explicit_none.quant_config)
         self.assertFalse(MoeConfigResolver.has_quantization(explicit_none))
 
-    def test_explicit_config_fastsafetensors_failure_does_not_fallback(self):
+    def test_explicit_config_fastsafetensors_is_disabled_in_core_pr(self):
         loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
-        err = RuntimeError("fast path failed")
-        with mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "")
-        ), mock.patch.object(
-            loader, "_load_via_fastsafetensors", side_effect=err
-        ), mock.patch.object(
-            loader, "_load_via_scratch"
-        ) as scratch:
-            with self.assertRaisesRegex(RuntimeError, "fast path failed"):
+        with mock.patch.object(loader, "_load_via_scratch") as scratch:
+            with self.assertRaisesRegex(RuntimeError, "not enabled in the newloader core PR"):
                 loader.load()
         scratch.assert_not_called()
 
-    def test_env_fastsafetensors_failure_does_not_fallback(self):
+    def test_env_fastsafetensors_is_disabled_in_core_pr(self):
         loader = self._new_loader(LoadMethod.AUTO)
-        err = RuntimeError("env fast path failed")
-        with mock.patch.dict(
-            os.environ, {"LOAD_METHOD": LoadMethod.FASTSAFETENSORS}
-        ), mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "")
-        ), mock.patch.object(
-            loader, "_load_via_fastsafetensors", side_effect=err
-        ), mock.patch.object(
+        with mock.patch.dict(os.environ, {"LOAD_METHOD": LoadMethod.FASTSAFETENSORS}), mock.patch.object(
             loader, "_load_via_scratch"
         ) as scratch:
-            with self.assertRaisesRegex(RuntimeError, "env fast path failed"):
+            with self.assertRaisesRegex(RuntimeError, "not enabled in the newloader core PR"):
                 loader.load()
         scratch.assert_not_called()
 
-    def test_auto_fastsafetensors_failure_can_fallback(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader,
-            "_resolve_load_method",
-            return_value=(LoadMethod.FASTSAFETENSORS, False),
-        ), mock.patch.object(
-            loader,
-            "_load_via_fastsafetensors",
-            side_effect=RuntimeError("auto fast path failed"),
-        ), mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        scratch.assert_called_once()
 
-    def test_auto_selects_fastsafetensors_when_eligible_without_mocking_resolve(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        fast_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
-        ) as eligible, mock.patch.object(
-            loader, "_load_via_fastsafetensors", return_value=fast_model
-        ) as fast, mock.patch.object(
-            loader, "_load_via_scratch"
-        ) as scratch:
-            self.assertIs(loader.load(), fast_model)
-        eligible.assert_called_once()
-        fast.assert_called_once()
-        scratch.assert_not_called()
 
-    def test_auto_fastsafetensors_failure_falls_back_without_mocking_resolve(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
-        ), mock.patch.object(
-            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("auto failed")
-        ), mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        scratch.assert_called_once()
 
-    def test_distributed_auto_uses_single_scratch_decision_if_any_rank_ineligible(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
-        ), mock.patch.object(
-            loader,
-            "_all_gather_load_decision",
-            return_value=[(True, "ok"), (False, "rank1 cuda unavailable")],
-        ), mock.patch.object(loader, "_load_via_fastsafetensors") as fast, mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        fast.assert_not_called()
-        scratch.assert_called_once()
 
-    def test_distributed_fastsafetensors_runtime_failure_does_not_local_fallback(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        with mock.patch.object(
-            loader, "_resolve_load_method", return_value=(LoadMethod.FASTSAFETENSORS, False)
-        ), mock.patch.object(loader, "_distributed_world_size", return_value=2), mock.patch.object(
-            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("rank1 read failed")
-        ), mock.patch.object(loader, "_load_via_scratch") as scratch:
-            with self.assertRaisesRegex(RuntimeError, "rank1 read failed"):
-                loader.load()
-        scratch.assert_not_called()
 
-    def test_auto_uses_scratch_when_fastsafetensors_is_not_eligible(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(False, "not eligible")
-        ) as eligible, mock.patch.object(
-            loader, "_load_via_fastsafetensors"
-        ) as fast, mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        eligible.assert_called_once()
-        fast.assert_not_called()
-        scratch.assert_called_once()
 
-    def test_force_cpu_auto_uses_scratch_without_fastsafetensors(self):
-        loader = self._new_loader(LoadMethod.AUTO)
-        loader.load_config.force_cpu_load_weights = True
-        scratch_model = torch.nn.Module()
-        with mock.patch.object(
-            loader, "_load_via_fastsafetensors"
-        ) as fast, mock.patch.object(
-            loader, "_load_via_scratch", return_value=scratch_model
-        ) as scratch:
-            self.assertIs(loader.load(), scratch_model)
-        fast.assert_not_called()
-        scratch.assert_called_once()
 
     def test_force_cpu_explicit_fastsafetensors_fails_fast(self):
         loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
         loader.load_config.force_cpu_load_weights = True
-        with self.assertRaisesRegex(RuntimeError, "force_cpu_load_weights"):
+        with self.assertRaisesRegex(RuntimeError, "not enabled in the newloader core PR"):
             loader._resolve_load_method()
 
     def test_invalid_explicit_load_method_fails_fast(self):
@@ -912,50 +567,11 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "Unsupported LOAD_METHOD"):
                 loader._resolve_load_method()
 
-    def test_auto_load_method_env_keeps_auto_selection(self):
+    def test_auto_load_method_env_keeps_scratch_selection(self):
         loader = self._new_loader(LoadMethod.AUTO)
-        with mock.patch.dict(os.environ, {"LOAD_METHOD": LoadMethod.AUTO}), mock.patch.object(
-            loader, "_fastsafetensors_eligible", return_value=(True, "ok")
-        ):
-            self.assertEqual(
-                loader._resolve_load_method(), (LoadMethod.FASTSAFETENSORS, False)
-            )
+        with mock.patch.dict(os.environ, {"LOAD_METHOD": LoadMethod.AUTO}):
+            self.assertEqual(loader._resolve_load_method(), (LoadMethod.SCRATCH, False))
 
-    def test_fastsafetensors_memory_gate_uses_target_device(self):
-        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
-        loader.device = "cuda:1"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ckpt = os.path.join(tmpdir, "model.safetensors")
-            with open(ckpt, "wb") as f:
-                f.truncate(1000)
-            loader.model_path = tmpdir
-            with mock.patch.dict(
-                sys.modules, {"fastsafetensors": types.ModuleType("fastsafetensors")}
-            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
-                "torch.cuda.mem_get_info", return_value=(10000, 20000)
-            ) as mem_info:
-                ok, reason = loader._fastsafetensors_eligible()
-        self.assertTrue(ok, reason)
-        mem_info.assert_called_once_with("cuda:1")
-
-    def test_explicit_fastsafetensors_memory_recheck_uses_target_device(self):
-        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
-        loader.device = "cuda:1"
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ckpt = os.path.join(tmpdir, "model.safetensors")
-            with open(ckpt, "wb") as f:
-                f.truncate(1000)
-            loader.model_path = tmpdir
-            with mock.patch.object(
-                loader,
-                "_fastsafetensors_eligible",
-                return_value=(False, "insufficient GPU free memory"),
-            ), mock.patch(
-                "torch.cuda.mem_get_info", return_value=(2000, 20000)
-            ) as mem_info:
-                method, explicit = loader._resolve_load_method()
-        self.assertEqual((method, explicit), (LoadMethod.FASTSAFETENSORS, True))
-        mem_info.assert_called_once_with("cuda:1")
 
 
 class TestRtpModuleDispatchIntegrity(unittest.TestCase):
@@ -1362,28 +978,6 @@ class TestMoELoadCompleteness(unittest.TestCase):
     def setUpClass(cls):
         _ensure_moe_test_deps()
 
-    def test_fastsafetensors_stacked_moe_names_are_normalized_to_expert_weights(self):
-        gate_up = torch.arange(4 * 16, dtype=torch.float32).reshape(4, 16)
-        down = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
-        items = list(
-            _normalize_fastsafetensors_stacked_moe_weights(
-                iter(
-                    [
-                        ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
-                        ("model.layers.0.mlp.experts.0.down_proj", down),
-                    ]
-                )
-            )
-        )
-        self.assertEqual(
-            [name for name, _ in items],
-            [
-                "model.layers.0.mlp.experts.0.gate_up_proj.weight",
-                "model.layers.0.mlp.experts.0.down_proj.weight",
-            ],
-        )
-        self.assertIs(items[0][1], gate_up)
-        self.assertIs(items[1][1], down)
 
     def test_ep_filter_rejects_non_divisible_experts(self):
         with self.assertRaisesRegex(ValueError, "num_experts.*divisible"):
@@ -1511,66 +1105,7 @@ class TestMoELoadCompleteness(unittest.TestCase):
         torch.testing.assert_close(layer._gate_ch_scales[0], scale[0, :4])
         torch.testing.assert_close(layer._up_ch_scales[0], scale[0, 4:])
 
-    def test_stacked_moe_gate_up_scale_fastsafetensors_name_splits_gate_up(self):
-        layer = BaseMoEExperts(
-            num_experts=1,
-            hidden_size=4,
-            moe_intermediate_size=4,
-            tp_size=1,
-            tp_rank=0,
-            ep_size=1,
-            ep_rank=0,
-            params_dtype=torch.float32,
-            model_config=types.SimpleNamespace(
-                data_type="fp32", quant_config=None, exported_device=None
-            ),
-            parallelism_config=types.SimpleNamespace(dp_size=1),
-            moe_config=types.SimpleNamespace(),
-            quant_config=_qc("fp8_per_channel"),
-            layer_idx=0,
-        )
-        scale = torch.arange(8, dtype=torch.float32)
-        layer.load_weights({"0.gate_up_proj.weight_scale": scale})
-        torch.testing.assert_close(layer._gate_ch_scales[0], scale[:4])
-        torch.testing.assert_close(layer._up_ch_scales[0], scale[4:])
 
-    def test_moe_accepts_normalized_fastsafetensors_stacked_projection_names(self):
-        layer = BaseMoEExperts(
-            num_experts=1,
-            hidden_size=4,
-            moe_intermediate_size=8,
-            tp_size=1,
-            tp_rank=0,
-            ep_size=1,
-            ep_rank=0,
-            params_dtype=torch.float32,
-            model_config=types.SimpleNamespace(
-                data_type="fp32", quant_config=None, exported_device=None
-            ),
-            parallelism_config=types.SimpleNamespace(dp_size=1),
-            moe_config=types.SimpleNamespace(),
-            quant_config=_qc("none"),
-            layer_idx=0,
-        )
-        gate_up = torch.arange(4 * 16, dtype=torch.float32).reshape(4, 16)
-        down = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
-        for full_name, tensor in _normalize_fastsafetensors_stacked_moe_weights(
-            iter(
-                [
-                    ("model.layers.0.mlp.experts.0.gate_up_proj", gate_up),
-                    ("model.layers.0.mlp.experts.0.down_proj", down),
-                ]
-            )
-        ):
-            expert_name = full_name.split("experts.", 1)[1]
-            layer.load_weights({expert_name: tensor})
-        with mock.patch.object(
-            BaseMoEExperts, "_maybe_build_fused_moe", return_value=None
-        ):
-            layer.process_weights_after_loading()
-        self.assertEqual(
-            layer._loaded_keys, {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")}
-        )
 
     def test_w4a8_online_rejects_odd_hidden_or_intermediate_size(self):
         with self.assertRaisesRegex(ValueError, "expects even H/M"):

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -91,6 +91,25 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, Fp8OnlineLinearMethod, _runtime_fp8_dtype
 from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
 from rtp_llm.utils.model_weight import W
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    FusedMoeDataRouter,
+    FusedMoeExpertExecutor,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.priority_attributes import (
+    StrategyAttributes,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.strategy_base import MoeStrategy
+from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType, RouterType
+from rtp_llm.models_py.modules.factory.fused_moe.factory import FusedMoeFactory
+from rtp_llm.models_py.modules.factory.fused_moe.strategy_registry import StrategyRegistry
+from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+    MoeConfigResolver,
+)
 
 BaseMoEExperts = None
 
@@ -951,6 +970,96 @@ class TestLinearLoadCompleteness(unittest.TestCase):
         layer.load_weights({"qkv_proj.weight_scale_inv": scale})
         self.assertTrue(torch.equal(layer.weight_scale_inv, scale))
 
+    def test_qkv_fused_weight_splits_qkv_aware_for_each_tp_rank(self):
+        hidden_size = 4
+        num_heads = 4
+        num_kv_heads = 2
+        head_dim = 2
+        q_rows = num_heads * head_dim
+        kv_rows = num_kv_heads * head_dim
+        fused = torch.arange((q_rows + 2 * kv_rows) * hidden_size, dtype=torch.float32).view(
+            q_rows + 2 * kv_rows, hidden_size
+        )
+        q, k, v = torch.split(fused, [q_rows, kv_rows, kv_rows], dim=0)
+        for rank in range(2):
+            layer = QKVParallelLinear(
+                hidden_size=hidden_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                tp_size=2,
+                tp_rank=rank,
+                quant_config=_qc("none"),
+                prefix="qkv_proj",
+                params_dtype=torch.float32,
+            )
+            layer.load_weights({"qkv_proj.weight": fused})
+            expected = torch.cat(
+                [
+                    q.narrow(0, rank * 4, 4),
+                    k.narrow(0, rank * 2, 2),
+                    v.narrow(0, rank * 2, 2),
+                ],
+                dim=0,
+            )
+            self.assertTrue(torch.equal(layer.weight, expected))
+
+    def test_qkv_kv_heads_less_than_tp_use_gcd_replication_groups(self):
+        hidden_size = 3
+        num_heads = 8
+        num_kv_heads = 2
+        head_dim = 1
+        fused = torch.arange((num_heads + 2 * num_kv_heads) * hidden_size, dtype=torch.float32).view(
+            num_heads + 2 * num_kv_heads, hidden_size
+        )
+        q, k, v = torch.split(fused, [num_heads, num_kv_heads, num_kv_heads], dim=0)
+        for rank in range(8):
+            layer = QKVParallelLinear(
+                hidden_size=hidden_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                tp_size=8,
+                tp_rank=rank,
+                quant_config=_qc("none"),
+                prefix="qkv_proj",
+                params_dtype=torch.float32,
+            )
+            layer.load_weights({"qkv_proj.weight": fused})
+            kv_rank = rank // 4
+            expected = torch.cat(
+                [q.narrow(0, rank, 1), k.narrow(0, kv_rank, 1), v.narrow(0, kv_rank, 1)],
+                dim=0,
+            )
+            self.assertTrue(torch.equal(layer.weight, expected), msg=f"rank={rank}")
+
+    def test_qkv_fused_block_scale_splits_qkv_aware_for_tp(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [2, 4]
+        fused_scale = torch.arange(8, dtype=torch.float32).view(8, 1)
+        for rank in range(2):
+            layer = QKVParallelLinear(
+                hidden_size=4,
+                num_heads=4,
+                num_kv_heads=2,
+                head_dim=2,
+                tp_size=2,
+                tp_rank=rank,
+                quant_config=qc,
+                prefix="qkv_proj",
+                params_dtype=torch.float32,
+            )
+            layer.load_weights({"qkv_proj.weight_scale_inv": fused_scale})
+            expected = torch.cat(
+                [
+                    fused_scale.narrow(0, rank * 2, 2),
+                    fused_scale.narrow(0, 4 + rank, 1),
+                    fused_scale.narrow(0, 6 + rank, 1),
+                ],
+                dim=0,
+            )
+            self.assertTrue(torch.equal(layer.weight_scale_inv, expected), msg=f"rank={rank}")
+
     def test_qkv_missing_v_shard_fails(self):
         layer = QKVParallelLinear(
             hidden_size=4,
@@ -1026,19 +1135,22 @@ class TestLinearLoadCompleteness(unittest.TestCase):
             out = layer(x)
         torch.testing.assert_close(out, torch.full((1, 3), 7.0), rtol=0, atol=0)
 
-    def test_qkv_rejects_non_divisible_kv_heads(self):
-        with self.assertRaisesRegex(ValueError, "num_kv_heads"):
-            QKVParallelLinear(
-                hidden_size=8,
-                num_heads=8,
-                num_kv_heads=6,
-                head_dim=1,
-                tp_size=4,
-                tp_rank=0,
-                quant_config=_qc("none"),
-                prefix="qkv_proj",
-                params_dtype=torch.float32,
-            )
+    def test_qkv_allows_gcd_kv_group_when_kv_heads_not_divisible_by_tp(self):
+        layer = QKVParallelLinear(
+            hidden_size=8,
+            num_heads=8,
+            num_kv_heads=6,
+            head_dim=1,
+            tp_size=4,
+            tp_rank=3,
+            quant_config=_qc("none"),
+            prefix="qkv_proj",
+            params_dtype=torch.float32,
+        )
+        self.assertEqual(layer.kv_tp_size, 2)
+        self.assertEqual(layer.kv_replication_group_size, 2)
+        self.assertEqual(layer.kv_tp_rank, 1)
+        self.assertEqual(layer.num_kv_heads_per_partition, 3)
 
     def test_column_rejects_non_divisible_output_tp(self):
         with self.assertRaisesRegex(ValueError, "output_size.*divisible"):
@@ -1406,44 +1518,145 @@ class TestMoELoadCompleteness(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "auxiliary tensors"):
             layer.process_weights_after_loading()
 
-    def test_ignored_moe_layer_uses_unquantized_method_without_scale_tensors(self):
-        qc = QuantizationConfig(
-            quant_type="fp8",
-            ignored_layers=["model.layers.0.mlp.experts"],
-        )
-        layer = BaseMoEExperts(
-            num_experts=1,
-            hidden_size=4,
-            moe_intermediate_size=4,
-            tp_size=1,
-            tp_rank=0,
-            ep_size=1,
-            ep_rank=0,
-            params_dtype=torch.float32,
-            model_config=types.SimpleNamespace(
-                data_type="fp32", quant_config=None, exported_device=None
-            ),
-            parallelism_config=types.SimpleNamespace(dp_size=1),
-            moe_config=types.SimpleNamespace(),
-            quant_config=qc,
-            layer_idx=0,
-        )
-        self.assertEqual(layer._quant_family, "none")
-        self.assertEqual(layer._required_aux_param_names(), ())
-        self.assertFalse(hasattr(layer, "w13_scale"))
-        layer.load_weights(
-            {
-                "0.gate_proj.weight": torch.zeros(4, 4),
-                "0.up_proj.weight": torch.zeros(4, 4),
-                "0.down_proj.weight": torch.zeros(4, 4),
-            }
-        )
-        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None):
+    def test_ignored_moe_layer_uses_unquantized_runtime_strategy(self):
+        from rtp_llm.config.quant_config import Fp8PerTensorQuantConfig
+
+        class _FakeDevice:
+            def shuffle_moe_weight(self, tensor, data_type, name):
+                return tensor
+
+        class _ParallelConfig:
+            ep_size = 1
+            ep_rank = 0
+            dp_size = 1
+            dp_rank = 0
+            world_size = 1
+            local_rank = 0
+            tp_size = 1
+
+            def get_attn_tp_size(self):
+                return 1
+
+            def get_attn_tp_rank(self):
+                return 0
+
+        class _Router(FusedMoeDataRouter):
+            @classmethod
+            def router_type(cls):
+                return RouterType.BATCHED_DATA
+
+            @classmethod
+            def check_conditions(cls, checker, config):
+                pass
+
+            def prepare(self, a1, a1_scale, a2_scale, topk_weights, topk_ids):
+                return ExpertForwardPayload(expert_x=a1)
+
+            def finalize(
+                self,
+                payload,
+                topk_weights,
+                topk_ids,
+                apply_router_weight_on_input,
+                extra_finalize_args,
+            ):
+                return payload.fused_expert_output
+
+        class _Executor(FusedMoeExpertExecutor):
+            @classmethod
+            def executor_type(cls):
+                return ExecutorType.BATCHED_TRITON
+
+            def execute(
+                self,
+                payload,
+                activation,
+                expert_map,
+                a2_scale,
+                apply_router_weight_on_input,
+                extra_expert_args,
+            ):
+                return CombineForwardPayload(fused_expert_output=payload.expert_x)
+
+        class _NoQuantStrategy(MoeStrategy):
+            @classmethod
+            def check_conditions(cls, checker, config):
+                checker.check(
+                    not MoeConfigResolver.has_quantization(config),
+                    reason="ignored layer should resolve to no-quant runtime config",
+                )
+
+            def get_attributes(self):
+                return StrategyAttributes(_Router, _Executor, FusedMoEQuantConfig(quant_dtype=None))
+
+        class _QuantStrategy(_NoQuantStrategy):
+            @classmethod
+            def check_conditions(cls, checker, config):
+                checker.check(MoeConfigResolver.has_quantization(config), reason="quant config present")
+
+        registry = StrategyRegistry()
+        registry.register(_QuantStrategy())
+        registry.register(_NoQuantStrategy())
+        old_registry = FusedMoeFactory._registry
+        FusedMoeFactory.set_registry(registry)
+        try:
+            config_side_quant = Fp8PerTensorQuantConfig(is_quanted=True)
+            model_config = types.SimpleNamespace(
+                data_type="fp32",
+                quant_config=config_side_quant,
+                exported_device=_FakeDevice(),
+                expert_num=1,
+                moe_k=1,
+                moe_topk_group=1,
+                hidden_size=4,
+                attn_config=types.SimpleNamespace(head_num=1),
+                activation_type="SiGLU",
+            )
+            qc = QuantizationConfig(
+                quant_type="fp8",
+                ignored_layers=["model.layers.0.mlp.experts"],
+            )
+            layer = BaseMoEExperts(
+                num_experts=1,
+                hidden_size=4,
+                moe_intermediate_size=4,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                params_dtype=torch.float32,
+                model_config=model_config,
+                parallelism_config=_ParallelConfig(),
+                moe_config=types.SimpleNamespace(
+                    ll_num_max_token=1,
+                    masked_max_token_num=1,
+                    moe_strategy="",
+                    use_mori_ep=False,
+                    use_deepep_moe=False,
+                    use_deepep_low_latency=False,
+                ),
+                quant_config=qc,
+                layer_idx=0,
+            )
+            self.assertEqual(layer._quant_family, "none")
+            self.assertIsNone(layer._effective_model_quant_config)
+            self.assertEqual(layer._required_aux_param_names(), ())
+            self.assertFalse(hasattr(layer, "w13_scale"))
+            layer.load_weights(
+                {
+                    "0.gate_proj.weight": torch.zeros(4, 4),
+                    "0.up_proj.weight": torch.zeros(4, 4),
+                    "0.down_proj.weight": torch.zeros(4, 4),
+                }
+            )
             layer.process_weights_after_loading()
-        self.assertEqual(
-            layer._loaded_keys,
-            {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")},
-        )
+            self.assertIsNone(layer.fused_moe.fused_experts.config.quant_config)
+            self.assertEqual(
+                layer._loaded_keys,
+                {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")},
+            )
+        finally:
+            FusedMoeFactory.set_registry(old_registry)
 
 
 

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -877,6 +877,35 @@ class TestLinearLoadCompleteness(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "up_proj|1"):
             layer.process_weights_after_loading()
 
+    def test_merged_fused_weight_name_uses_direct_path_not_shard_substring(self):
+        layer = MergedColumnParallelLinear(
+            input_size=4,
+            output_size=8,
+            quant_config=_qc("none"),
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        weight = torch.arange(32, dtype=torch.float32).view(8, 4)
+        layer.load_weights({"gate_up_proj.weight": weight})
+        layer.process_weights_after_loading()
+        self.assertTrue(torch.equal(layer.weight, weight))
+
+    def test_merged_fused_aux_name_uses_direct_path_not_shard_substring(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [4, 4]
+        layer = MergedColumnParallelLinear(
+            input_size=8,
+            output_size=8,
+            quant_config=qc,
+            prefix="gate_up_proj",
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        scale = torch.arange(4, dtype=torch.float32).view(2, 2)
+        layer.load_weights({"gate_up_proj.weight_scale_inv": scale})
+        self.assertTrue(torch.equal(layer.weight_scale_inv, scale))
+
     def test_merged_shard_rejects_non_divisible_tp_checkpoint_dim(self):
         layer = MergedColumnParallelLinear(
             input_size=4,
@@ -890,6 +919,37 @@ class TestLinearLoadCompleteness(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "divisible"):
             layer.load_weights({"gate_up_proj.gate_proj.weight": torch.zeros(5, 4)})
+
+    def test_qkv_fused_weight_name_uses_direct_path_not_shard_substring(self):
+        layer = QKVParallelLinear(
+            hidden_size=4,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=2,
+            quant_config=_qc("none"),
+            prefix="qkv_proj",
+            params_dtype=torch.float32,
+        )
+        weight = torch.arange(32, dtype=torch.float32).view(8, 4)
+        layer.load_weights({"qkv_proj.weight": weight})
+        layer.process_weights_after_loading()
+        self.assertTrue(torch.equal(layer.weight, weight))
+
+    def test_qkv_fused_aux_name_uses_direct_path_not_shard_substring(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [4, 4]
+        layer = QKVParallelLinear(
+            hidden_size=4,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=2,
+            quant_config=qc,
+            prefix="qkv_proj",
+            params_dtype=torch.float32,
+        )
+        scale = torch.arange(2, dtype=torch.float32).view(2, 1)
+        layer.load_weights({"qkv_proj.weight_scale_inv": scale})
+        self.assertTrue(torch.equal(layer.weight_scale_inv, scale))
 
     def test_qkv_missing_v_shard_fails(self):
         layer = QKVParallelLinear(

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -90,6 +90,7 @@ from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dtype
 from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
+from rtp_llm.utils.model_weight import W
 
 BaseMoEExperts = None
 
@@ -1516,6 +1517,22 @@ class TestBertNewLoaderCompatibility(unittest.TestCase):
         with mock.patch.object(RobertaForEmbedding, "_build_inner_model", return_value=None):
             model.load_weights(self._gamma_beta_weights("roberta"))
         self.assertTrue(torch.equal(model.embeddings.layernorm_bias, torch.full((4,), 3.0)))
+
+    def test_missing_token_type_embedding_fallback_inherits_target_device_and_dtype(self):
+        checkpoint = dict(self._gamma_beta_weights("bert"))
+        checkpoint.pop("bert.embeddings.token_type_embeddings.weight")
+        model = BertForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
+        with mock.patch.object(BertForEmbedding, "_build_inner_model", return_value=None):
+            model.load_weights(checkpoint)
+        fallback = model.weights.get_global_weight(W.token_type_embedding)
+        self.assertEqual(fallback.device, model.embeddings.word_embeddings_weight.device)
+        self.assertEqual(fallback.dtype, model.embeddings.word_embeddings_weight.dtype)
+
+        target_device = "cuda" if torch.cuda.is_available() else "meta"
+        model.to(target_device)
+        fallback = model.weights.get_global_weight(W.token_type_embedding)
+        self.assertEqual(fallback.device, model.embeddings.word_embeddings_weight.device)
+        self.assertEqual(fallback.dtype, model.embeddings.word_embeddings_weight.dtype)
 
 
 class TestAwqRegistrationSafety(unittest.TestCase):

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -35,6 +35,7 @@ from rtp_llm.models_py.new_models.bert import BertForEmbedding, RobertaForEmbedd
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dtype
+from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
 
 # Register MoE quant methods for BaseMoEExperts tests.
 import rtp_llm.models_py.quant_methods.fp8_moe  # noqa: F401
@@ -60,6 +61,29 @@ class TestNewModelRegistry(unittest.TestCase):
             )
             model = loader._create_model()
             self.assertEqual(type(model).__name__, expected_name)
+
+
+class TestQuantMethodValidation(unittest.TestCase):
+    def test_awq_dequant_rejects_empty_scale_before_group_size_division(self):
+        with self.assertRaisesRegex(ValueError, "at least one group"):
+            awq_dequantize_triton(
+                torch.empty(4, 1, dtype=torch.int32),
+                torch.empty(0, 8, dtype=torch.float16),
+                torch.empty(0, 1, dtype=torch.int32),
+            )
+
+    def test_fp8_online_post_load_rejects_non_2d_weight(self):
+        layer = ColumnParallelLinear(
+            input_size=4,
+            output_size=4,
+            quant_config=_qc("fp8_online"),
+            prefix="fp8_online",
+            params_dtype=torch.float32,
+        )
+        layer.weight = torch.nn.Parameter(torch.zeros(2, 2, 2), requires_grad=False)
+        layer._new_loader_force_cpu_load_weights = True
+        with self.assertRaisesRegex(ValueError, "expected 2D weight"):
+            layer.quant_method.process_weights_after_loading(layer)
 
 
 class TestWeightMapperStreaming(unittest.TestCase):

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -147,6 +147,43 @@ class TestWeightMapperStreaming(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "LoRA TP slice.*divisible"):
             _tp_slice(torch.zeros(5, 4), tp_size=2, tp_rank=0, rule=(0, "split"))
 
+    def test_scratch_ep_filter_expands_stacked_moe_to_local_experts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "stacked.pt")
+            gate_up = torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3)
+            down = torch.arange(4 * 3 * 2, dtype=torch.float32).reshape(4, 3, 2)
+            gate_scale = torch.arange(4 * 2, dtype=torch.float32).reshape(4, 2)
+            torch.save(
+                {
+                    "model.layers.0.mlp.experts.gate_up_proj": gate_up,
+                    "model.layers.0.mlp.experts.down_proj": down,
+                    "model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv": gate_scale,
+                    "model.layers.0.input_layernorm.weight": torch.ones(2),
+                },
+                path,
+            )
+            ep_filter = _create_ep_filter(ep_size=2, ep_rank=1, num_experts=4)
+            loaded = list(_get_all_weights([path], device="cpu", name_filter=ep_filter))
+
+        self.assertEqual(
+            [name for name, _ in loaded],
+            [
+                "model.layers.0.mlp.experts.2.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.3.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.2.down_proj.weight",
+                "model.layers.0.mlp.experts.3.down_proj.weight",
+                "model.layers.0.mlp.experts.2.gate_up_proj.weight_scale_inv",
+                "model.layers.0.mlp.experts.3.gate_up_proj.weight_scale_inv",
+                "model.layers.0.input_layernorm.weight",
+            ],
+        )
+        torch.testing.assert_close(loaded[0][1], gate_up[2])
+        torch.testing.assert_close(loaded[1][1], gate_up[3])
+        torch.testing.assert_close(loaded[2][1], down[2])
+        torch.testing.assert_close(loaded[3][1], down[3])
+        torch.testing.assert_close(loaded[4][1], gate_scale[2])
+        torch.testing.assert_close(loaded[5][1], gate_scale[3])
+
 
 
     def test_fastsafetensors_path_normalizes_stacked_moe_names_before_load(self):
@@ -193,6 +230,69 @@ class TestWeightMapperStreaming(unittest.TestCase):
                 "model.layers.0.mlp.experts.0.down_proj.weight",
             ],
         )
+
+    def test_fastsafetensors_path_ep_filters_stacked_moe_before_load(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.loaded = []
+
+            def to_empty(self, device):
+                return self
+
+            def load_weights(self, weights_iter):
+                self.loaded = list(weights_iter)
+
+        model = CaptureModel()
+        config = types.SimpleNamespace(model_type="dummy", num_layers=1, expert_num=4)
+        loader = NewModelLoader(
+            config,
+            LoadConfig(
+                compute_dtype=torch.float32,
+                device="cpu",
+                load_method="fastsafetensors",
+                ep_size=2,
+                ep_rank=1,
+            ),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        gate_up = torch.arange(4 * 2 * 3, dtype=torch.float32).reshape(4, 2, 3)
+        down = torch.arange(4 * 3 * 2, dtype=torch.float32).reshape(4, 3, 2)
+        gate_scale = torch.arange(4 * 2, dtype=torch.float32).reshape(4, 2)
+        with mock.patch.object(loader, "_create_model", return_value=model), \
+             mock.patch.object(loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]), \
+             mock.patch.object(loader, "_run_post_load_hooks", return_value=None), \
+             mock.patch.object(loader, "_log_peak_gpu_memory", return_value=None), \
+             mock.patch(
+                 "rtp_llm.models_py.model_loader._get_fastsafetensors_weights",
+                 return_value=iter(
+                     [
+                         ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
+                         ("model.layers.0.mlp.experts.down_proj", down),
+                         ("model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv", gate_scale),
+                     ]
+                 ),
+             ):
+            loaded_model = loader._load_via_fastsafetensors()
+        self.assertIs(loaded_model, model)
+        self.assertEqual(
+            [name for name, _ in model.loaded],
+            [
+                "model.layers.0.mlp.experts.2.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.3.gate_up_proj.weight",
+                "model.layers.0.mlp.experts.2.down_proj.weight",
+                "model.layers.0.mlp.experts.3.down_proj.weight",
+                "model.layers.0.mlp.experts.2.gate_up_proj.weight_scale_inv",
+                "model.layers.0.mlp.experts.3.gate_up_proj.weight_scale_inv",
+            ],
+        )
+        torch.testing.assert_close(model.loaded[0][1], gate_up[2])
+        torch.testing.assert_close(model.loaded[1][1], gate_up[3])
+        torch.testing.assert_close(model.loaded[2][1], down[2])
+        torch.testing.assert_close(model.loaded[3][1], down[3])
+        torch.testing.assert_close(model.loaded[4][1], gate_scale[2])
+        torch.testing.assert_close(model.loaded[5][1], gate_scale[3])
 
     def test_load_config_device_cpu_is_used_by_scratch_loader(self):
         class CaptureModel(torch.nn.Module):

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -81,6 +81,7 @@ from rtp_llm.models_py.model_loader import (
     _create_ep_filter,
     _discover_ckpt_files,
     _get_all_weights,
+    _is_quantized_load,
     _normalize_fastsafetensors_stacked_moe_weights,
     _tp_slice,
 )
@@ -602,6 +603,57 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
                 ok, reason = loader._fastsafetensors_eligible()
         self.assertFalse(ok)
         self.assertEqual(reason, "insufficient GPU free memory")
+
+    def test_quantized_load_treats_empty_defaults_as_unquantized(self):
+        load_config = LoadConfig(compute_dtype=torch.float32, device="cpu")
+        for value in (None, "", "none", "None", " null "):
+            with self.subTest(value=value):
+                self.assertFalse(
+                    _is_quantized_load(
+                        types.SimpleNamespace(quantization=value), load_config
+                    )
+                )
+
+    def test_quantized_load_detects_real_quantization_configs(self):
+        class FakeQuantConfig:
+            def __init__(self, quanted):
+                self.quanted = quanted
+
+            def is_quanted(self):
+                return self.quanted
+
+        self.assertTrue(
+            _is_quantized_load(
+                types.SimpleNamespace(quantization="fp8"),
+                LoadConfig(compute_dtype=torch.float32, device="cpu"),
+            )
+        )
+        self.assertTrue(
+            _is_quantized_load(
+                types.SimpleNamespace(quantization=""),
+                LoadConfig(
+                    compute_dtype=torch.float32,
+                    device="cpu",
+                    quant_source_config=FakeQuantConfig(True),
+                ),
+            )
+        )
+        self.assertTrue(
+            _is_quantized_load(
+                types.SimpleNamespace(
+                    quantization="", quant_config=FakeQuantConfig(True)
+                ),
+                LoadConfig(compute_dtype=torch.float32, device="cpu"),
+            )
+        )
+        self.assertFalse(
+            _is_quantized_load(
+                types.SimpleNamespace(
+                    quantization="", quant_config=FakeQuantConfig(False)
+                ),
+                LoadConfig(compute_dtype=torch.float32, device="cpu"),
+            )
+        )
 
     def test_explicit_config_fastsafetensors_failure_does_not_fallback(self):
         loader = self._new_loader(LoadMethod.FASTSAFETENSORS)

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -813,6 +813,41 @@ class TestLinearLoadCompleteness(unittest.TestCase):
             layer.process_weights_after_loading()
 
 
+
+    def test_column_fp8_block_scale_rejects_non_aligned_tp_rows(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [128, 128]
+        layer = ColumnParallelLinear(
+            input_size=256,
+            output_size=384,
+            tp_size=2,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="fp8_col",
+            params_dtype=torch.float32,
+        )
+        # Scale grid has 3 rows, so a naive floor/ceil grid split looks possible,
+        # but the underlying 192-row TP shard cuts through 128-row FP8 blocks.
+        with self.assertRaisesRegex(ValueError, "FP8 block ColumnParallel scale"):
+            layer.load_weights({"fp8_col.weight_scale_inv": torch.ones(3, 2)})
+
+    def test_row_fp8_block_scale_rejects_non_aligned_tp_cols(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [128, 128]
+        layer = RowParallelLinear(
+            input_size=384,
+            output_size=256,
+            tp_size=2,
+            tp_rank=0,
+            quant_config=qc,
+            prefix="fp8_row",
+            params_dtype=torch.float32,
+        )
+        # Scale grid has 3 columns, but the underlying 192-column TP shard
+        # cuts through 128-column FP8 blocks.
+        with self.assertRaisesRegex(ValueError, "FP8 block RowParallel scale"):
+            layer.load_weights({"fp8_row.weight_scale_inv": torch.ones(2, 3)})
+
     def test_qkv_fp8_block_scale_rejects_non_aligned_tp_rows(self):
         qc = _qc("fp8_block")
         qc.weight_block_size = [128, 128]
@@ -1081,6 +1116,87 @@ class TestMoELoadCompleteness(unittest.TestCase):
         layer.load_weights({"0.gate_up_proj.weight": gate_up})
         torch.testing.assert_close(layer.w13[0, :2], gate_up[2:])
         torch.testing.assert_close(layer.w13[0, 2:], gate_up[:2])
+
+    def _make_stacked_suffix_moe(self, num_experts=2, ep_size=1, ep_rank=0):
+        return BaseMoEExperts(
+            num_experts=num_experts,
+            hidden_size=32,
+            moe_intermediate_size=32,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32",
+                quant_config=None,
+                exported_device=None,
+                expert_num=num_experts,
+                moe_k=1,
+                moe_topk_group=1,
+                hidden_size=32,
+                activation_type="Gelu",
+                attn_config=types.SimpleNamespace(head_num=1),
+            ),
+            parallelism_config=types.SimpleNamespace(
+                dp_size=1,
+                dp_rank=0,
+                ep_size=ep_size,
+                ep_rank=ep_rank,
+                tp_size=1,
+                tp_rank=0,
+                world_size=1,
+                local_rank=0,
+                get_attn_tp_size=lambda: 1,
+                get_attn_tp_rank=lambda: 0,
+            ),
+            moe_config=types.SimpleNamespace(
+                ll_num_max_token=1,
+                masked_max_token_num=1,
+                moe_strategy=0,
+                use_mori_ep=False,
+                use_deepep_moe=False,
+                use_all_gather=True,
+            ),
+            quant_config=_qc("none"),
+            layer_idx=0,
+        )
+
+    def test_stacked_moe_weight_suffix_loads_as_weight_for_single_ep_rank(self):
+        layer = self._make_stacked_suffix_moe(num_experts=2)
+        gate_up = torch.arange(2 * 32 * 64, dtype=torch.float32).reshape(2, 32, 64)
+        down = torch.arange(2 * 32 * 32, dtype=torch.float32).reshape(2, 32, 32)
+        layer.load_weights(
+            {
+                "gate_up_proj.weight": gate_up,
+                "down_proj.weight": down,
+            }
+        )
+        layer.process_weights_after_loading()
+        torch.testing.assert_close(layer.w13[0, :32], gate_up[0, :, 32:].t())
+        torch.testing.assert_close(layer.w13[0, 32:], gate_up[0, :, :32].t())
+        torch.testing.assert_close(layer.w2[0], down[0].t())
+        torch.testing.assert_close(layer.w13[1, :32], gate_up[1, :, 32:].t())
+        torch.testing.assert_close(layer.w13[1, 32:], gate_up[1, :, :32].t())
+        torch.testing.assert_close(layer.w2[1], down[1].t())
+
+    def test_stacked_moe_weight_suffix_loads_only_local_ep_range(self):
+        layer = self._make_stacked_suffix_moe(num_experts=4, ep_size=2, ep_rank=1)
+        gate_up = torch.arange(4 * 32 * 64, dtype=torch.float32).reshape(4, 32, 64)
+        down = torch.arange(4 * 32 * 32, dtype=torch.float32).reshape(4, 32, 32)
+        layer.load_weights(
+            {
+                "gate_up_proj.weight": gate_up,
+                "down_proj.weight": down,
+            }
+        )
+        layer._check_load_complete()
+        torch.testing.assert_close(layer.w13[0, :32], gate_up[2, :, 32:].t())
+        torch.testing.assert_close(layer.w13[0, 32:], gate_up[2, :, :32].t())
+        torch.testing.assert_close(layer.w2[0], down[2].t())
+        torch.testing.assert_close(layer.w13[1, :32], gate_up[3, :, 32:].t())
+        torch.testing.assert_close(layer.w13[1, 32:], gate_up[3, :, :32].t())
+        torch.testing.assert_close(layer.w2[1], down[3].t())
 
     def test_stacked_moe_gate_up_scale_scratch_name_splits_gate_up(self):
         layer = BaseMoEExperts(

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -9,6 +9,60 @@ from unittest import mock
 
 import torch
 
+try:
+    import librtp_compute_ops  # noqa: F401
+    import librtp_compute_ops.rtp_llm_ops  # noqa: F401
+except ImportError:
+    librtp_stub = types.ModuleType("librtp_compute_ops")
+    rtp_ops_stub = types.ModuleType("librtp_compute_ops.rtp_llm_ops")
+    compute_ops_stub = types.ModuleType("rtp_llm.ops.compute_ops")
+
+    class _MissingComputeOp:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "librtp_compute_ops is unavailable in this CPU test environment"
+            )
+
+    class _RtpOpsStub:
+        def __getattr__(self, name):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            return _MissingComputeOp
+
+    def _missing_compute_op(*args, **kwargs):
+        raise RuntimeError("librtp_compute_ops is unavailable in this CPU test environment")
+
+    def _compute_ops_getattr(name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        if name == "get_device_id":
+            return lambda: 0
+        if name == "rtp_llm_ops":
+            return _RtpOpsStub()
+        return _MissingComputeOp
+
+    librtp_stub.get_device_id = lambda: 0
+    librtp_stub.preprocess_gemm_weight_by_key = _missing_compute_op
+    librtp_stub.preprocess_weight_scale = _missing_compute_op
+    librtp_stub.rtp_llm_ops = rtp_ops_stub
+    def _rtp_ops_getattr(name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return _MissingComputeOp
+
+    librtp_stub.__file__ = "<librtp_compute_ops test stub>"
+    rtp_ops_stub.__file__ = "<librtp_compute_ops.rtp_llm_ops test stub>"
+    compute_ops_stub.__file__ = "<rtp_llm.ops.compute_ops test stub>"
+    rtp_ops_stub.__getattr__ = _rtp_ops_getattr
+    compute_ops_stub.__getattr__ = _compute_ops_getattr
+    compute_ops_stub.get_device_id = lambda: 0
+    compute_ops_stub.preprocess_gemm_weight_by_key = _missing_compute_op
+    compute_ops_stub.preprocess_weight_scale = _missing_compute_op
+    compute_ops_stub.rtp_llm_ops = _RtpOpsStub()
+    sys.modules.setdefault("librtp_compute_ops", librtp_stub)
+    sys.modules.setdefault("librtp_compute_ops.rtp_llm_ops", rtp_ops_stub)
+    sys.modules.setdefault("rtp_llm.ops.compute_ops", compute_ops_stub)
+
 from rtp_llm.models_py.layers.attention import MMEncoderAttention
 from rtp_llm.models_py.layers.embedding import HiddenParallelEmbedding, ParallelLMHead, VocabParallelEmbedding
 from rtp_llm.models_py.layers.norm import LayerNorm, RMSNorm
@@ -19,7 +73,6 @@ from rtp_llm.models_py.layers.linear import (
     QKVParallelLinear,
     RowParallelLinear,
 )
-from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
 from rtp_llm.models_py import weight_mapper
 from rtp_llm.models_py.model_loader import (
     LoadConfig,
@@ -37,9 +90,20 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dtype
 from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
 
-# Register MoE quant methods for BaseMoEExperts tests.
-import rtp_llm.models_py.quant_methods.fp8_moe  # noqa: F401
-import rtp_llm.models_py.quant_methods.w4a8_moe  # noqa: F401
+BaseMoEExperts = None
+
+
+def _ensure_moe_test_deps():
+    global BaseMoEExperts
+    if BaseMoEExperts is not None:
+        return
+    try:
+        from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts as _BaseMoEExperts
+        import rtp_llm.models_py.quant_methods.fp8_moe  # noqa: F401
+        import rtp_llm.models_py.quant_methods.w4a8_moe  # noqa: F401
+    except Exception as exc:
+        raise unittest.SkipTest(f"MoE test dependencies unavailable: {exc}") from exc
+    BaseMoEExperts = _BaseMoEExperts
 
 
 def _qc(quant_type: str) -> QuantizationConfig:
@@ -938,6 +1002,9 @@ class TestLinearLoadCompleteness(unittest.TestCase):
 
 
 class TestMoELoadCompleteness(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_moe_test_deps()
 
     def test_fastsafetensors_stacked_moe_names_are_normalized_to_expert_weights(self):
         gate_up = torch.arange(4 * 16, dtype=torch.float32).reshape(4, 16)

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -598,8 +598,8 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
             loader.model_path = tmpdir
             with mock.patch.dict(
                 sys.modules, {"fastsafetensors": types.ModuleType("fastsafetensors")}
-            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
-                "torch.cuda.mem_get_info", return_value=(3600, 10000)
+            ), mock.patch("torch.cuda.is_available", return_value=True), mock.patch.object(
+                loader, "_target_cuda_mem_get_info", return_value=(3600, 10000)
             ):
                 ok, reason = loader._fastsafetensors_eligible()
         self.assertFalse(ok)

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -1988,6 +1988,7 @@ class TestBertNewLoaderCompatibility(unittest.TestCase):
         model = BertForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
         with mock.patch.object(BertForEmbedding, "_build_inner_model", return_value=None):
             model.load_weights(self._gamma_beta_weights("bert"))
+            model.process_weights_after_loading()
         self.assertTrue(torch.equal(model.embeddings.layernorm_weight, torch.full((4,), 2.0)))
         self.assertTrue(torch.equal(model.layers[0].attention_output_layernorm_weight, torch.full((4,), 4.0)))
         self.assertTrue(torch.equal(model.layers[0].output_layernorm_bias, torch.full((4,), 7.0)))
@@ -1996,6 +1997,7 @@ class TestBertNewLoaderCompatibility(unittest.TestCase):
         model = RobertaForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
         with mock.patch.object(RobertaForEmbedding, "_build_inner_model", return_value=None):
             model.load_weights(self._gamma_beta_weights("roberta"))
+            model.process_weights_after_loading()
         self.assertTrue(torch.equal(model.embeddings.layernorm_bias, torch.full((4,), 3.0)))
 
     def test_missing_token_type_embedding_fallback_inherits_target_device_and_dtype(self):
@@ -2004,6 +2006,7 @@ class TestBertNewLoaderCompatibility(unittest.TestCase):
         model = BertForEmbedding(self._bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
         with mock.patch.object(BertForEmbedding, "_build_inner_model", return_value=None):
             model.load_weights(checkpoint)
+            model.process_weights_after_loading()
         fallback = model.weights.get_global_weight(W.token_type_embedding)
         self.assertEqual(fallback.device, model.embeddings.word_embeddings_weight.device)
         self.assertEqual(fallback.dtype, model.embeddings.word_embeddings_weight.dtype)

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -203,6 +203,84 @@ class TestWeightMapperStreaming(unittest.TestCase):
         self.assertEqual(loader.device, "cpu")
         self.assertEqual(model.to_device, "cpu")
 
+    def test_force_cpu_scratch_runs_post_load_before_device_move(self):
+        class CaptureModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.events = []
+                self.child = torch.nn.Module()
+
+                def hook():
+                    self.events.append(
+                        (
+                            "hook",
+                            getattr(
+                                self.child,
+                                "_new_loader_force_cpu_load_weights",
+                                None,
+                            ),
+                        )
+                    )
+
+                self.child.process_weights_after_loading = hook
+
+            def load_weights(self, weights_iter):
+                list(weights_iter)
+
+            def to(self, device):
+                self.events.append(("to", device))
+                return self
+
+        model = CaptureModel()
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(
+                compute_dtype=torch.float32,
+                device="cuda",
+                force_cpu_load_weights=True,
+            ),
+            model_path="/tmp/nonexistent",
+        )
+        with mock.patch.object(
+            loader, "_create_model", return_value=model
+        ), mock.patch.object(
+            loader, "_discover_ckpt_files_cached", return_value=["dummy.safetensors"]
+        ), mock.patch(
+            "rtp_llm.models_py.model_loader._get_all_weights", return_value=iter([])
+        ), mock.patch.object(
+            loader, "_log_peak_gpu_memory", return_value=None
+        ), mock.patch(
+            "torch.cuda.is_available", return_value=False
+        ):
+            self.assertIs(loader._load_via_scratch(), model)
+        self.assertEqual(model.events, [("hook", True), ("to", "cuda")])
+
+    def test_auto_fastsafetensors_fallback_releases_before_scratch(self):
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(compute_dtype=torch.float32, device="cuda"),
+            model_path="/tmp/nonexistent",
+            device="cuda",
+        )
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_resolve_load_method", return_value=(LoadMethod.FASTSAFETENSORS, False)
+        ), mock.patch.object(
+            loader, "_load_via_fastsafetensors", side_effect=RuntimeError("fast failed")
+        ), mock.patch(
+            "gc.collect"
+        ) as collect, mock.patch(
+            "torch.cuda.is_available", return_value=True
+        ), mock.patch(
+            "torch.cuda.empty_cache"
+        ) as empty_cache, mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        collect.assert_called_once()
+        empty_cache.assert_called_once()
+        scratch.assert_called_once()
+
     def test_load_config_device_cpu_is_used_by_fastsafetensors_loader(self):
         class CaptureModel(torch.nn.Module):
             def __init__(self):
@@ -425,6 +503,25 @@ class TestFastSafetensorsFallbackSemantics(unittest.TestCase):
         eligible.assert_called_once()
         fast.assert_not_called()
         scratch.assert_called_once()
+
+    def test_force_cpu_auto_uses_scratch_without_fastsafetensors(self):
+        loader = self._new_loader(LoadMethod.AUTO)
+        loader.load_config.force_cpu_load_weights = True
+        scratch_model = torch.nn.Module()
+        with mock.patch.object(
+            loader, "_load_via_fastsafetensors"
+        ) as fast, mock.patch.object(
+            loader, "_load_via_scratch", return_value=scratch_model
+        ) as scratch:
+            self.assertIs(loader.load(), scratch_model)
+        fast.assert_not_called()
+        scratch.assert_called_once()
+
+    def test_force_cpu_explicit_fastsafetensors_fails_fast(self):
+        loader = self._new_loader(LoadMethod.FASTSAFETENSORS)
+        loader.load_config.force_cpu_load_weights = True
+        with self.assertRaisesRegex(RuntimeError, "force_cpu_load_weights"):
+            loader._resolve_load_method()
 
     def test_invalid_explicit_load_method_fails_fast(self):
         loader = self._new_loader("typo")

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -88,7 +88,7 @@ from rtp_llm.models_py.model_loader import (
 from rtp_llm.models_py.new_models.bert import BertForEmbedding, RobertaForEmbedding
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
-from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, _runtime_fp8_dtype
+from rtp_llm.models_py.quant_methods.fp8 import Fp8LinearMethod, Fp8OnlineLinearMethod, _runtime_fp8_dtype
 from rtp_llm.models_py.quant_methods.awq_triton import awq_dequantize_triton
 from rtp_llm.utils.model_weight import W
 
@@ -1594,6 +1594,13 @@ class TestBertNewLoaderCompatibility(unittest.TestCase):
         self.assertEqual(fallback.device, model.embeddings.word_embeddings_weight.device)
         self.assertEqual(fallback.dtype, model.embeddings.word_embeddings_weight.dtype)
 
+    def test_bert_newloader_fails_fast_for_tensor_parallel_until_partitioned(self):
+        with self.assertRaisesRegex(NotImplementedError, "tensor parallel"):
+            BertForEmbedding(
+                self._bert_config(),
+                LoadConfig(compute_dtype=torch.float32, device="cpu", tp_size=2, tp_rank=0),
+            )
+
 
 class TestAwqRegistrationSafety(unittest.TestCase):
     def test_awq_reference_path_is_not_registered_for_hot_forward(self):
@@ -1623,8 +1630,10 @@ class TestFp8ForwardInputLayout(unittest.TestCase):
             }
         )
         layer.process_weights_after_loading()
-        x = torch.randn(2, 4, 3).transpose(1, 2)
+        base = torch.randn(2, 3, 8)
+        x = base[:, :, ::2]
         self.assertFalse(x.is_contiguous())
+        self.assertFalse(x.reshape(-1, x.shape[-1]).is_contiguous())
 
         def fake_quant(inp):
             self.assertEqual(inp.shape, (6, 4))
@@ -1639,6 +1648,32 @@ class TestFp8ForwardInputLayout(unittest.TestCase):
             return_value=fake_quant,
         ), mock.patch.object(torch, "_scaled_mm", side_effect=fake_scaled_mm):
             out = layer(x)
+        self.assertEqual(out.shape, (2, 3, 3))
+
+    def test_fp8_online_per_tensor_accepts_stride_slice_input(self):
+        layer = types.SimpleNamespace(
+            prefix="fp8_online_linear",
+            weight=torch.empty(3, 4, dtype=_runtime_fp8_dtype()),
+            weight_scale=torch.ones(1, dtype=torch.float32),
+        )
+        base = torch.randn(2, 3, 8)
+        x = base[:, :, ::2]
+        self.assertFalse(x.is_contiguous())
+        self.assertFalse(x.reshape(-1, x.shape[-1]).is_contiguous())
+
+        def fake_quant(inp):
+            self.assertEqual(inp.shape, (6, 4))
+            self.assertTrue(inp.is_contiguous())
+            return inp.to(_runtime_fp8_dtype()), torch.ones(1, dtype=torch.float32)
+
+        def fake_scaled_mm(a, b, **kwargs):
+            return torch.zeros(a.shape[0], b.shape[1], dtype=torch.float32)
+
+        with mock.patch(
+            "rtp_llm.models_py.quant_methods.fp8._resolve_per_tensor_quant",
+            return_value=fake_quant,
+        ), mock.patch.object(torch, "_scaled_mm", side_effect=fake_scaled_mm):
+            out = Fp8OnlineLinearMethod().apply(layer, x)
         self.assertEqual(out.shape, (2, 3, 3))
 
 

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -256,12 +256,16 @@ class TestWeightMapperStreaming(unittest.TestCase):
         loader.load_config.tp_size = 2
         loader.load_config.tp_rank = 1
         hf_tensor = torch.arange(4 * 6, dtype=torch.float32).view(4, 6)
+        hf_a_tensor = torch.arange(4 * 4, dtype=torch.float32).view(4, 4)
         with mock.patch.object(
             loader, "_read_lora_config", return_value={"rank": 4, "lora_alpha": 8}
         ), mock.patch.object(
             loader,
             "_load_lora_state_dict",
-            return_value={"base_model.model.model.layers.0.mlp.gate_proj.lora_B.weight": hf_tensor},
+            return_value={
+                "base_model.model.model.layers.0.mlp.gate_proj.lora_A.weight": hf_a_tensor,
+                "base_model.model.model.layers.0.mlp.gate_proj.lora_B.weight": hf_tensor,
+            },
         ), mock.patch("rtp_llm.lora.lora_weights.LoRAWeights", FakeLoRAWeights):
             result = loader.load_lora_weights("adapter", "/tmp/lora", device="cpu")
         self.assertIs(result, FakeLoRAWeights.instances[-1])
@@ -269,6 +273,40 @@ class TestWeightMapperStreaming(unittest.TestCase):
         expected = hf_tensor.t().contiguous().narrow(-1, 2, 2)
         self.assertTrue(torch.equal(result.weights[(0, engine_name)], expected))
         self.assertEqual(result.scale, 2.0)
+
+    def test_lora_load_fails_when_no_tensor_is_mapped(self):
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method=LoadMethod.SCRATCH),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        with mock.patch.object(
+            loader, "_read_lora_config", return_value={"rank": 4, "lora_alpha": 8}
+        ), mock.patch.object(
+            loader,
+            "_load_lora_state_dict",
+            return_value={"bert.encoder.layer.0.attention.self.query.lora_A.weight": torch.zeros(4, 4)},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "did not contain any mappable"):
+                loader.load_lora_weights("adapter", "/tmp/lora", device="cpu")
+
+    def test_lora_load_fails_when_a_b_pair_is_incomplete(self):
+        loader = NewModelLoader(
+            types.SimpleNamespace(model_type="dummy", num_layers=1),
+            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method=LoadMethod.SCRATCH),
+            model_path="/tmp/nonexistent",
+            device="cpu",
+        )
+        with mock.patch.object(
+            loader, "_read_lora_config", return_value={"rank": 4, "lora_alpha": 8}
+        ), mock.patch.object(
+            loader,
+            "_load_lora_state_dict",
+            return_value={"base_model.model.model.layers.0.mlp.gate_proj.lora_A.weight": torch.zeros(4, 4)},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "incomplete A/B tensor pairs"):
+                loader.load_lora_weights("adapter", "/tmp/lora", device="cpu")
 
     def test_lora_tp_slice_rejects_non_divisible_dim(self):
         with self.assertRaisesRegex(ValueError, "LoRA TP slice.*divisible"):
@@ -903,6 +941,34 @@ class TestLinearLoadCompleteness(unittest.TestCase):
             out = layer(x)
         torch.testing.assert_close(out, torch.full((1, 3), 7.0), rtol=0, atol=0)
 
+    def test_row_parallel_copies_1d_per_channel_weight_scale_when_n_equals_k(self):
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            quant_config=_qc("fp8_per_channel"),
+            prefix="row_fp8",
+            params_dtype=torch.float32,
+        )
+        scale = torch.arange(8, dtype=torch.float32)
+        layer.load_weights({"row_fp8.weight_scale": scale})
+        torch.testing.assert_close(layer.weight_scale.detach(), scale.reshape(8, 1))
+
+    def test_row_parallel_copies_2d_per_channel_weight_scale_when_n_equals_k(self):
+        layer = RowParallelLinear(
+            input_size=8,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            quant_config=_qc("fp8_per_channel"),
+            prefix="row_fp8",
+            params_dtype=torch.float32,
+        )
+        scale = torch.arange(8, dtype=torch.float32).reshape(8, 1)
+        layer.load_weights({"row_fp8.weight_scale": scale})
+        torch.testing.assert_close(layer.weight_scale.detach(), scale)
+
     def test_qkv_rejects_illegal_gqa_head_ratio(self):
         with self.assertRaisesRegex(ValueError, "num_heads.*num_kv_heads"):
             QKVParallelLinear(
@@ -1220,6 +1286,54 @@ class TestMoELoadCompleteness(unittest.TestCase):
         layer.load_weights({"gate_up_proj.weight_scale": scale})
         torch.testing.assert_close(layer._gate_ch_scales[0], scale[0, :4])
         torch.testing.assert_close(layer._up_ch_scales[0], scale[0, 4:])
+
+    def test_stacked_moe_gate_up_block_scale_last_dim_splits_and_transposes(self):
+        qc = _qc("fp8_block")
+        qc.weight_block_size = [4, 4]
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=8,
+            moe_intermediate_size=8,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=qc,
+            layer_idx=0,
+        )
+        scale = torch.arange(8, dtype=torch.float32).reshape(1, 2, 4)
+        layer.load_weights({"gate_up_proj.weight_scale_inv": scale})
+        torch.testing.assert_close(layer.w13_scale[0, :2], scale[0, :, 2:].t())
+        torch.testing.assert_close(layer.w13_scale[0, 2:], scale[0, :, :2].t())
+
+    def test_force_cpu_fp8_block_moe_rejects_cpu_requant_path(self):
+        qc = _qc("fp8_block")
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=128,
+            moe_intermediate_size=128,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=qc,
+            layer_idx=0,
+        )
+        layer._new_loader_force_cpu_load_weights = True
+        with self.assertRaisesRegex(RuntimeError, "force_cpu_load_weights"):
+            layer.quant_method.process_weights_after_loading(layer)
 
 
 

--- a/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
+++ b/rtp_llm/models_py/quant_methods/test/test_load_integrity.py
@@ -1406,6 +1406,46 @@ class TestMoELoadCompleteness(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "auxiliary tensors"):
             layer.process_weights_after_loading()
 
+    def test_ignored_moe_layer_uses_unquantized_method_without_scale_tensors(self):
+        qc = QuantizationConfig(
+            quant_type="fp8",
+            ignored_layers=["model.layers.0.mlp.experts"],
+        )
+        layer = BaseMoEExperts(
+            num_experts=1,
+            hidden_size=4,
+            moe_intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.float32,
+            model_config=types.SimpleNamespace(
+                data_type="fp32", quant_config=None, exported_device=None
+            ),
+            parallelism_config=types.SimpleNamespace(dp_size=1),
+            moe_config=types.SimpleNamespace(),
+            quant_config=qc,
+            layer_idx=0,
+        )
+        self.assertEqual(layer._quant_family, "none")
+        self.assertEqual(layer._required_aux_param_names(), ())
+        self.assertFalse(hasattr(layer, "w13_scale"))
+        layer.load_weights(
+            {
+                "0.gate_proj.weight": torch.zeros(4, 4),
+                "0.up_proj.weight": torch.zeros(4, 4),
+                "0.down_proj.weight": torch.zeros(4, 4),
+            }
+        )
+        with mock.patch.object(BaseMoEExperts, "_maybe_build_fused_moe", return_value=None):
+            layer.process_weights_after_loading()
+        self.assertEqual(
+            layer._loaded_keys,
+            {(0, "gate_proj"), (0, "up_proj"), (0, "down_proj")},
+        )
+
+
 
 class TestAttentionConstructionIntegrity(unittest.TestCase):
     def test_mm_encoder_attention_rejects_hidden_not_divisible_by_heads(self):

--- a/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
+++ b/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
@@ -1,21 +1,30 @@
 """Smoke test for the public new_weight_loader Bazel target runfiles."""
 
+import tempfile
 import types
-from unittest import mock
 
 import torch
+from safetensors.torch import save_file
 
 
 def _bert_config():
-    return types.SimpleNamespace(
-        model_type="bert",
-        num_layers=1,
-        hidden_size=4,
-        inter_size=8,
-        type_vocab_size=2,
-        max_generate_batch_size=1,
-        quant_config=None,
-    )
+    from rtp_llm.config.model_config import ModelConfig
+
+    config = ModelConfig()
+    config.model_type = "bert"
+    config.num_layers = 1
+    config.vocab_size = 8
+    config.hidden_size = 4
+    config.inter_size = 8
+    config.type_vocab_size = 2
+    config.max_seq_len = 16
+    config.layernorm_eps = 1e-5
+    config.activation_type = "Gelu"
+    config.quant_config = None
+    config.attn_config.head_num = 1
+    config.attn_config.kv_head_num = 1
+    config.attn_config.size_per_head = 4
+    return config
 
 
 def _bert_weights():
@@ -53,6 +62,7 @@ def main():
     from rtp_llm.models_py.quant_methods import QuantizationConfig
     from rtp_llm.models_py.registry import list_models
     from rtp_llm.models_py.model_desc.bert import BertModel
+    from rtp_llm.ops import PyModelInitResources
 
     assert LoadMethod.AUTO == "auto"
     assert LoadConfig(device="cpu").device == "cpu"
@@ -62,13 +72,19 @@ def main():
     assert QuantizationConfig(quant_type="none").quant_type == "none"
     assert "bert" in list_models()
 
-    model = BertForEmbedding(_bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
-    with mock.patch.object(BertModel, "__init__", return_value=None) as build_inner:
-        model.load_weights(_bert_weights())
-        assert not build_inner.called
-        model.process_weights_after_loading()
-    assert build_inner.called
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_file(_bert_weights(), f"{tmpdir}/model.safetensors")
+        loader = NewModelLoader(
+            _bert_config(),
+            LoadConfig(compute_dtype=torch.float32, device="cpu", load_method=LoadMethod.SCRATCH),
+            model_path=tmpdir,
+        )
+        model = loader.load()
+    assert isinstance(model, BertForEmbedding)
     assert isinstance(model.model, BertModel)
+    assert model.weights is not None
+    assert model.embeddings.word_embeddings_weight.device.type == "cpu"
+    assert model.initialize(PyModelInitResources())
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
+++ b/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
@@ -1,11 +1,58 @@
 """Smoke test for the public new_weight_loader Bazel target runfiles."""
 
+import types
+from unittest import mock
+
+import torch
+
+
+def _bert_config():
+    return types.SimpleNamespace(
+        model_type="bert",
+        num_layers=1,
+        hidden_size=4,
+        inter_size=8,
+        type_vocab_size=2,
+        max_generate_batch_size=1,
+        quant_config=None,
+    )
+
+
+def _bert_weights():
+    h = 4
+    inter = 8
+    return {
+        "bert.embeddings.word_embeddings.weight": torch.ones(8, h),
+        "bert.embeddings.position_embeddings.weight": torch.ones(16, h),
+        "bert.embeddings.token_type_embeddings.weight": torch.ones(2, h),
+        "bert.embeddings.LayerNorm.weight": torch.ones(h),
+        "bert.embeddings.LayerNorm.bias": torch.zeros(h),
+        "bert.encoder.layer.0.attention.self.query.weight": torch.ones(h, h),
+        "bert.encoder.layer.0.attention.self.query.bias": torch.zeros(h),
+        "bert.encoder.layer.0.attention.self.key.weight": torch.ones(h, h),
+        "bert.encoder.layer.0.attention.self.key.bias": torch.zeros(h),
+        "bert.encoder.layer.0.attention.self.value.weight": torch.ones(h, h),
+        "bert.encoder.layer.0.attention.self.value.bias": torch.zeros(h),
+        "bert.encoder.layer.0.attention.output.dense.weight": torch.ones(h, h),
+        "bert.encoder.layer.0.attention.output.dense.bias": torch.zeros(h),
+        "bert.encoder.layer.0.attention.output.LayerNorm.weight": torch.ones(h),
+        "bert.encoder.layer.0.attention.output.LayerNorm.bias": torch.zeros(h),
+        "bert.encoder.layer.0.intermediate.dense.weight": torch.ones(inter, h),
+        "bert.encoder.layer.0.intermediate.dense.bias": torch.zeros(inter),
+        "bert.encoder.layer.0.output.dense.weight": torch.ones(h, inter),
+        "bert.encoder.layer.0.output.dense.bias": torch.zeros(h),
+        "bert.encoder.layer.0.output.LayerNorm.weight": torch.ones(h),
+        "bert.encoder.layer.0.output.LayerNorm.bias": torch.zeros(h),
+    }
+
 
 def main():
     from rtp_llm.models_py.model_loader import LoadConfig, LoadMethod, NewModelLoader
     from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
+    from rtp_llm.models_py.new_models.bert import BertForEmbedding
     from rtp_llm.models_py.quant_methods import QuantizationConfig
     from rtp_llm.models_py.registry import list_models
+    from rtp_llm.models_py.model_desc.bert import BertModel
 
     assert LoadMethod.AUTO == "auto"
     assert LoadConfig(device="cpu").device == "cpu"
@@ -14,6 +61,12 @@ def main():
     assert RowParallelLinear is not None
     assert QuantizationConfig(quant_type="none").quant_type == "none"
     assert "bert" in list_models()
+
+    model = BertForEmbedding(_bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
+    with mock.patch.object(BertModel, "__init__", return_value=None) as build_inner:
+        model.load_weights(_bert_weights())
+    assert build_inner.called
+    assert isinstance(model.model, BertModel)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
+++ b/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
@@ -65,6 +65,8 @@ def main():
     model = BertForEmbedding(_bert_config(), LoadConfig(compute_dtype=torch.float32, device="cpu"))
     with mock.patch.object(BertModel, "__init__", return_value=None) as build_inner:
         model.load_weights(_bert_weights())
+        assert not build_inner.called
+        model.process_weights_after_loading()
     assert build_inner.called
     assert isinstance(model.model, BertModel)
 

--- a/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
+++ b/rtp_llm/models_py/quant_methods/test/test_new_weight_loader_imports.py
@@ -1,0 +1,20 @@
+"""Smoke test for the public new_weight_loader Bazel target runfiles."""
+
+
+def main():
+    from rtp_llm.models_py.model_loader import LoadConfig, LoadMethod, NewModelLoader
+    from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
+    from rtp_llm.models_py.quant_methods import QuantizationConfig
+    from rtp_llm.models_py.registry import list_models
+
+    assert LoadMethod.AUTO == "auto"
+    assert LoadConfig(device="cpu").device == "cpu"
+    assert NewModelLoader is not None
+    assert ColumnParallelLinear is not None
+    assert RowParallelLinear is not None
+    assert QuantizationConfig(quant_type="none").quant_type == "none"
+    assert "bert" in list_models()
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/quant_methods/test/verify_phase1_dispatch.py
+++ b/rtp_llm/models_py/quant_methods/test/verify_phase1_dispatch.py
@@ -1,0 +1,127 @@
+"""Phase 1 派发骨架静态自检（不加载模型、不需要 ckpt）。
+
+验证点:
+1. 双注册表填充正确（fp8 系在 Linear 注册表、none 在 Linear 注册表）。
+2. Linear 层派发 → 拿到对应 Linear 方法（行为同改动前）。
+3. prefix 命中 ignore → 拿到 UnquantizedLinearMethod（新能力)。
+4. source_config 的 ignore 字段能被自动提取（走法1 富配置打通）。
+
+运行（容器内，bazel 环境）:
+    python -m rtp_llm.models_py.quant_methods.test.verify_phase1_dispatch
+或在 server_test 的 runfiles python 下直接跑本文件。
+"""
+
+
+def main() -> None:
+    import torch
+
+    # 触发注册
+    import rtp_llm.models_py.quant_methods.fp8  # noqa: F401
+    import rtp_llm.models_py.quant_methods.unquantized  # noqa: F401
+    from rtp_llm.models_py.layers.linear import ColumnParallelLinear
+    from rtp_llm.models_py.quant_methods.base import (
+        _LINEAR_METHOD_REGISTRY,
+        _MOE_METHOD_REGISTRY,
+        QuantizationConfig,
+    )
+    from rtp_llm.models_py.quant_methods.unquantized import UnquantizedLinearMethod
+
+    ok = True
+
+    # 1. 注册表
+    linear_keys = (
+        "none",
+        "",
+        "fp8",
+        "fp8_online",
+        "fp8_per_channel",
+        "fp8_block",
+        "FP8_PER_TENSOR_COMPRESSED",
+        "FP8_DYNAMIC_PER_TENSOR",
+        "FP8_PER_BLOCK",
+        "FP8_PER_CHANNEL_COMPRESSED",
+        "FP8_PER_CHANNEL_QUARK",
+    )
+    for k in linear_keys:
+        present = k in _LINEAR_METHOD_REGISTRY
+        print(f"[reg] linear[{k!r}] present = {present}")
+        ok &= present
+    print(
+        f"[reg] moe registry keys = {list(_MOE_METHOD_REGISTRY.keys())} "
+        f"(Phase 1 预期为空，Phase 2 再填)"
+    )
+
+    # 2. Linear 派发(用一个非 MoE 的假层即可，get_quant_method 只按类型分流)
+    class _FakeLinear:  # 非 BaseMoEExperts → 走 Linear 分支
+        pass
+
+    fake = _FakeLinear()
+
+    qc_none = QuantizationConfig(quant_type="none")
+    m = qc_none.get_quant_method(fake, "model.layers.0.mlp.gate_proj")
+    print(f"[dispatch] none -> {type(m).__name__}")
+    ok &= isinstance(m, UnquantizedLinearMethod)
+
+    qc_fp8 = QuantizationConfig(quant_type="fp8")
+    m = qc_fp8.get_quant_method(fake, "model.layers.0.mlp.gate_proj")
+    print(f"[dispatch] fp8  -> {type(m).__name__}")
+    ok &= type(m).__name__ == "Fp8LinearMethod"
+
+    canonical_dispatch = {
+        "FP8_PER_TENSOR_COMPRESSED": "Fp8LinearMethod",
+        "FP8_DYNAMIC_PER_TENSOR": "Fp8LinearMethod",
+        "FP8_PER_BLOCK": "Fp8BlockLinearMethod",
+        "FP8_PER_CHANNEL_COMPRESSED": "Fp8PerChannelLinearMethod",
+        "FP8_PER_CHANNEL_QUARK": "Fp8PerChannelLinearMethod",
+    }
+    for quant_type, expected_cls in canonical_dispatch.items():
+        qc = QuantizationConfig(quant_type=quant_type)
+        m = qc.get_quant_method(fake, "model.layers.0.mlp.gate_proj")
+        print(f"[dispatch] {quant_type} -> {type(m).__name__}")
+        ok &= type(m).__name__ == expected_cls
+
+        layer = ColumnParallelLinear(
+            4,
+            8,
+            quant_config=qc,
+            prefix="model.layers.0.mlp.gate_proj",
+            params_dtype=torch.float32,
+        )
+        print(f"[construct] {quant_type} -> {type(layer.quant_method).__name__}")
+        ok &= type(layer.quant_method).__name__ == expected_cls
+        if quant_type == "FP8_PER_BLOCK":
+            ok &= hasattr(layer, "weight_scale_inv")
+        elif "CHANNEL" in quant_type:
+            ok &= hasattr(layer, "weight_scale")
+            ok &= layer.weight_scale.shape[0] == 8
+        else:
+            ok &= hasattr(layer, "weight_scale")
+            ok &= layer.weight_scale.numel() == 1
+
+    # 3. ignore 命中 → 未量化(即使 quant_type=fp8)
+    qc_ig = QuantizationConfig(quant_type="fp8", ignored_layers=["lm_head"])
+    m = qc_ig.get_quant_method(fake, "model.lm_head")
+    print(f"[ignore] fp8 + ignore lm_head -> {type(m).__name__}")
+    ok &= isinstance(m, UnquantizedLinearMethod)
+    # 非 ignore 模块仍走 fp8
+    m = qc_ig.get_quant_method(fake, "model.layers.0.mlp.gate_proj")
+    ok &= type(m).__name__ == "Fp8LinearMethod"
+
+    # 4. source_config 自动提取 ignore（走法1）
+    class _FakeSrc:
+        ignore_patterns = ["re:.*lm_head.*", "vision"]
+
+    qc_src = QuantizationConfig(quant_type="fp8", source_config=_FakeSrc())
+    print(f"[source_config] extracted ignored_layers = {qc_src.ignored_layers}")
+    ok &= qc_src.ignored_layers == ["re:.*lm_head.*", "vision"]
+    ok &= qc_src.is_layer_ignored("model.visionxxx") is False
+    ok &= qc_src.is_layer_ignored("vision.encoder") is True
+    ok &= qc_src.is_layer_ignored("model.lm_head") is True
+
+    print("\nRESULT:", "PASS ✅" if ok else "FAIL ❌")
+    if not ok:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/quant_methods/unquantized.py
+++ b/rtp_llm/models_py/quant_methods/unquantized.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, Optional
+
+import torch
+
+from rtp_llm.models_py.quant_methods.base import (
+    FusedMoEMethodBase,
+    QuantizeMethodBase,
+    register_moe_quant_method,
+    register_quant_method,
+)
+
+
+@register_quant_method("none", "")
+class UnquantizedLinearMethod(QuantizeMethodBase):
+
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        weight = torch.nn.Parameter(
+            torch.empty(output_size, input_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        layer.register_parameter("weight", weight)
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        return torch.nn.functional.linear(x, layer.weight, bias)
+
+    def process_weights_after_loading(self, layer):
+        pass
+
+
+@register_moe_quant_method("none", "")
+class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
+    """MoE 未量化（BF16/FP16）方法。
+
+    对齐 vLLM:连「不量化」也是一个 method，使 BaseMoEExperts 像 vLLM 的 FusedMoE
+    一样成为「不认识量化」的纯壳。行为与 BaseMoEExperts._init_buffers 的 else 分支
+    逐字一致:只建 bf16 的 w13 [E, 2*M_tp, H] / w2 [E, H, M_tp]，无 scale、无后处理、
+    不往权重字典加 scale（dispatch_scale / add_weight_tensors 用基类默认 no-op）。
+    """
+
+    def __init__(self, quant_config: Any = None):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        layer.w13 = torch.nn.Parameter(
+            torch.empty(
+                num_experts, 2 * intermediate_size, hidden_size, dtype=params_dtype
+            ),
+            requires_grad=False,
+        )
+        layer.w2 = torch.nn.Parameter(
+            torch.empty(
+                num_experts, hidden_size, intermediate_size, dtype=params_dtype
+            ),
+            requires_grad=False,
+        )
+
+    def process_weights_after_loading(self, layer):
+        # BF16/FP16 无需后处理（无 scale 融合 / 在线量化）。
+        return None

--- a/rtp_llm/models_py/quant_methods/w4a8_moe.py
+++ b/rtp_llm/models_py/quant_methods/w4a8_moe.py
@@ -21,10 +21,13 @@ def _group_size(source_config: Any, default: int = 128) -> int:
         return default
     group_size = getattr(source_config, "group_size", None)
     if callable(group_size):
-        return int(group_size())
-    if group_size is not None:
-        return int(group_size)
-    return default
+        group_size = group_size()
+    if group_size in (-1, 0, None):
+        return default
+    group_size = int(group_size)
+    if group_size <= 0:
+        raise ValueError(f"W4A8 INT4 group_size must be positive, got {group_size}")
+    return group_size
 
 
 @register_moe_quant_method(
@@ -62,13 +65,14 @@ class W4A8Int4MoEMethod(FusedMoEMethodBase):
         M = intermediate_size
         gs = self.group_size
 
+        if H % 2 != 0 or M % 2 != 0:
+            raise ValueError(f"W4A8 INT4 expects even H/M, got H={H}, M={M}")
+        if H % gs != 0 or M % gs != 0:
+            raise ValueError(
+                f"W4A8 INT4 group_size={gs} must divide H={H} and M={M}"
+            )
+
         if self.compressed:
-            if H % 2 != 0 or M % 2 != 0:
-                raise ValueError(f"W4A8 INT4 expects even H/M, got H={H}, M={M}")
-            if H % gs != 0 or M % gs != 0:
-                raise ValueError(
-                    f"W4A8 INT4 group_size={gs} must divide H={H} and M={M}"
-                )
             layer.w13 = nn.Parameter(
                 torch.empty(E, 2 * M, H // 2, dtype=torch.int8),
                 requires_grad=False,

--- a/rtp_llm/models_py/quant_methods/w4a8_moe.py
+++ b/rtp_llm/models_py/quant_methods/w4a8_moe.py
@@ -1,0 +1,263 @@
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.model_loader.compressed_w4a8_int4_per_channel_weight import (
+    repack_compressed_int4_to_cutlass,
+)
+from rtp_llm.model_loader.w4a8_int4_per_channel_quant_weight import (
+    quantize_weight_to_int4b,
+)
+from rtp_llm.models_py.quant_methods.base import (
+    FusedMoEMethodBase,
+    register_moe_quant_method,
+)
+from rtp_llm.utils.model_weight import W
+
+
+def _group_size(source_config: Any, default: int = 128) -> int:
+    if source_config is None:
+        return default
+    group_size = getattr(source_config, "group_size", None)
+    if callable(group_size):
+        return int(group_size())
+    if group_size is not None:
+        return int(group_size)
+    return default
+
+
+@register_moe_quant_method(
+    "W4A8_INT4_PER_CHANNEL",
+    "W4A8_INT4_PER_CHANNEL_COMPRESSED",
+)
+class W4A8Int4MoEMethod(FusedMoEMethodBase):
+    """W4A8 INT4 MoE loader path matching the legacy loader.
+
+    - W4A8_INT4_PER_CHANNEL: load BF16/FP16 ``*.weight`` tensors, then call
+      legacy ``quantize_weight_to_int4b`` per expert.
+    - W4A8_INT4_PER_CHANNEL_COMPRESSED: load pre-packed
+      ``*.weight_packed`` + ``*.weight_scale`` tensors, then call legacy
+      compressed-tensors repack to cutlass layout.
+    """
+
+    def __init__(self, quant_config: Any = None):
+        super().__init__(quant_config)
+        self.source_config = getattr(quant_config, "source_config", None)
+        self.quant_type = getattr(quant_config, "quant_type", "")
+        self.group_size = _group_size(self.source_config)
+        self.compressed = self.quant_type == "W4A8_INT4_PER_CHANNEL_COMPRESSED"
+
+    def create_weights(
+        self,
+        layer,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        params_dtype: torch.dtype,
+        **kwargs,
+    ):
+        E = num_experts
+        H = hidden_size
+        M = intermediate_size
+        gs = self.group_size
+
+        if self.compressed:
+            if H % 2 != 0 or M % 2 != 0:
+                raise ValueError(f"W4A8 INT4 expects even H/M, got H={H}, M={M}")
+            if H % gs != 0 or M % gs != 0:
+                raise ValueError(
+                    f"W4A8 INT4 group_size={gs} must divide H={H} and M={M}"
+                )
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M, H // 2, dtype=torch.int8),
+                requires_grad=False,
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M // 2, dtype=torch.int8),
+                requires_grad=False,
+            )
+            layer.register_buffer(
+                "w13_scale",
+                torch.empty(E, H // gs, 2 * M, 8, dtype=torch.float8_e4m3fn),
+            )
+            layer.register_buffer(
+                "w2_scale",
+                torch.empty(E, M // gs, H, 8, dtype=torch.float8_e4m3fn),
+            )
+        else:
+            layer.w13 = nn.Parameter(
+                torch.empty(E, 2 * M, H, dtype=params_dtype),
+                requires_grad=False,
+            )
+            layer.w2 = nn.Parameter(
+                torch.empty(E, H, M, dtype=params_dtype),
+                requires_grad=False,
+            )
+
+    def dispatch_weight(self, layer, local_id: int, proj: str, param_name: str, tensor):
+        if not self.compressed or param_name != "weight_packed":
+            return False
+        if proj in ("gate_proj", "up_proj"):
+            packed, scale = self._pending_gate_up(layer, local_id, proj)
+            packed.copy_(self._slice_gate_up_packed(layer, tensor))
+        elif proj == "down_proj":
+            packed, scale = self._pending_down(layer, local_id)
+            packed.copy_(self._slice_down_packed(layer, tensor))
+        else:
+            return False
+        return True
+
+    def dispatch_scale(self, layer, local_id: int, proj: str, param_name: str, tensor):
+        if not self.compressed or param_name != "weight_scale":
+            return None
+        if proj in ("gate_proj", "up_proj"):
+            packed, scale = self._pending_gate_up(layer, local_id, proj)
+            scale.copy_(self._slice_gate_up_scale(layer, tensor))
+        elif proj == "down_proj":
+            packed, scale = self._pending_down(layer, local_id)
+            scale.copy_(self._slice_down_scale(layer, tensor))
+        return None
+
+    def process_weights_after_loading(self, layer):
+        if self.compressed:
+            self._repack_compressed(layer)
+        else:
+            self._online_quantize(layer)
+
+    def add_weight_tensors(self, layer, weights_dict: Dict[str, Any]) -> None:
+        weights_dict[W.moe_s1] = layer.w13_scale
+        weights_dict[W.moe_s2] = layer.w2_scale
+
+    def _online_quantize(self, layer):
+        E = layer.num_local_experts
+        gs = self.group_size
+        device = layer.w13.data.device
+        w13 = layer.w13.data
+        w2 = layer.w2.data
+        n1, k1 = w13.shape[1], w13.shape[2]
+        n2, k2 = w2.shape[1], w2.shape[2]
+
+        q13 = torch.empty(E, n1, k1 // 2, device=device, dtype=torch.int8)
+        s13 = torch.empty(E, k1 // gs, n1, 8, device=device, dtype=torch.float8_e4m3fn)
+        q2 = torch.empty(E, n2, k2 // 2, device=device, dtype=torch.int8)
+        s2 = torch.empty(E, k2 // gs, n2, 8, device=device, dtype=torch.float8_e4m3fn)
+
+        for e in range(E):
+            q13[e], s13[e] = quantize_weight_to_int4b(w13[e], gs)
+            q2[e], s2[e] = quantize_weight_to_int4b(w2[e], gs)
+
+        layer.w13 = nn.Parameter(q13, requires_grad=False)
+        layer.w2 = nn.Parameter(q2, requires_grad=False)
+        layer.register_buffer("w13_scale", s13)
+        layer.register_buffer("w2_scale", s2)
+
+    def _repack_compressed(self, layer):
+        M = layer.moe_inter_tp
+        for e in range(layer.num_local_experts):
+            up_w, up_s = self._pending_gate_up(layer, e, "up_proj")
+            gate_w, gate_s = self._pending_gate_up(layer, e, "gate_proj")
+            down_w, down_s = self._pending_down(layer, e)
+
+            qw, qs = repack_compressed_int4_to_cutlass(up_w, up_s, self.group_size)
+            layer.w13.data[e, :M].copy_(qw)
+            layer.w13_scale.data[e, :, :M].copy_(qs)
+
+            qw, qs = repack_compressed_int4_to_cutlass(gate_w, gate_s, self.group_size)
+            layer.w13.data[e, M : 2 * M].copy_(qw)
+            layer.w13_scale.data[e, :, M : 2 * M].copy_(qs)
+
+            qw, qs = repack_compressed_int4_to_cutlass(down_w, down_s, self.group_size)
+            layer.w2.data[e].copy_(qw)
+            layer.w2_scale.data[e].copy_(qs)
+
+        del layer._w4a8_gate_packed
+        del layer._w4a8_up_packed
+        del layer._w4a8_down_packed
+        del layer._w4a8_gate_scale
+        del layer._w4a8_up_scale
+        del layer._w4a8_down_scale
+
+    def _ensure_pending(self, layer):
+        if hasattr(layer, "_w4a8_gate_packed"):
+            return
+        E = layer.num_local_experts
+        M = layer.moe_inter_tp
+        H = layer.hidden_size
+        gs = self.group_size
+        dev = layer.w13.device
+        layer.register_buffer(
+            "_w4a8_gate_packed", torch.empty(E, M, H // 2, dtype=torch.int8, device=dev)
+        )
+        layer.register_buffer(
+            "_w4a8_up_packed", torch.empty(E, M, H // 2, dtype=torch.int8, device=dev)
+        )
+        layer.register_buffer(
+            "_w4a8_down_packed", torch.empty(E, H, M // 2, dtype=torch.int8, device=dev)
+        )
+        layer.register_buffer(
+            "_w4a8_gate_scale",
+            torch.empty(E, M, H // gs, dtype=torch.bfloat16, device=dev),
+        )
+        layer.register_buffer(
+            "_w4a8_up_scale",
+            torch.empty(E, M, H // gs, dtype=torch.bfloat16, device=dev),
+        )
+        layer.register_buffer(
+            "_w4a8_down_scale",
+            torch.empty(E, H, M // gs, dtype=torch.bfloat16, device=dev),
+        )
+
+    def _pending_gate_up(self, layer, local_id: int, proj: str):
+        self._ensure_pending(layer)
+        if proj == "gate_proj":
+            return layer._w4a8_gate_packed[local_id], layer._w4a8_gate_scale[local_id]
+        return layer._w4a8_up_packed[local_id], layer._w4a8_up_scale[local_id]
+
+    def _pending_down(self, layer, local_id: int):
+        self._ensure_pending(layer)
+        return layer._w4a8_down_packed[local_id], layer._w4a8_down_scale[local_id]
+
+    def _slice_gate_up_packed(self, layer, tensor: torch.Tensor) -> torch.Tensor:
+        rows = layer.moe_inter_tp
+        full_rows = rows * layer.moe_expert_tp_size
+        if tensor.shape[0] != full_rows:
+            raise ValueError(
+                f"W4A8 gate/up packed rows {tensor.shape[0]} != expected {full_rows}"
+            )
+        start = layer.moe_expert_tp_rank * rows
+        return tensor.narrow(0, start, rows).contiguous().view(torch.int8)
+
+    def _slice_gate_up_scale(self, layer, tensor: torch.Tensor) -> torch.Tensor:
+        rows = layer.moe_inter_tp
+        full_rows = rows * layer.moe_expert_tp_size
+        if tensor.shape[0] != full_rows:
+            raise ValueError(
+                f"W4A8 gate/up scale rows {tensor.shape[0]} != expected {full_rows}"
+            )
+        start = layer.moe_expert_tp_rank * rows
+        return tensor.narrow(0, start, rows).contiguous()
+
+    def _slice_down_packed(self, layer, tensor: torch.Tensor) -> torch.Tensor:
+        cols = layer.moe_inter_tp
+        full_cols = cols * layer.moe_expert_tp_size
+        packed_cols = cols // 2
+        packed = tensor.contiguous().view(torch.int8)
+        if packed.shape[1] != full_cols // 2:
+            raise ValueError(
+                f"W4A8 down packed cols {packed.shape[1]} != expected {full_cols // 2}"
+            )
+        start = layer.moe_expert_tp_rank * packed_cols
+        return packed.narrow(1, start, packed_cols).contiguous()
+
+    def _slice_down_scale(self, layer, tensor: torch.Tensor) -> torch.Tensor:
+        cols = layer.moe_inter_tp
+        full_cols = cols * layer.moe_expert_tp_size
+        groups = cols // self.group_size
+        if tensor.shape[1] != full_cols // self.group_size:
+            raise ValueError(
+                f"W4A8 down scale cols {tensor.shape[1]} "
+                f"!= expected {full_cols // self.group_size}"
+            )
+        start = layer.moe_expert_tp_rank * groups
+        return tensor.narrow(1, start, groups).contiguous()

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -1,0 +1,138 @@
+import importlib
+import inspect
+import logging
+from typing import Dict, Tuple, Type
+
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# 仅声明模型名称到其对应的导入路径和类名
+_LAZY_MODEL_REGISTRY: Dict[str, Tuple[str, str]] = {
+    "bert": ("rtp_llm.models_py.new_models.bert", "BertForEmbedding"),
+    "roberta": ("rtp_llm.models_py.new_models.bert", "RobertaForEmbedding"),
+}
+
+
+
+def _registry_keys():
+    return tuple(dict.fromkeys([*_LAZY_MODEL_REGISTRY.keys(), *dict.keys(MODEL_REGISTRY)]))
+
+
+class LazyRegistryDict(dict):
+    """A dictionary that lazily imports and registers models on demand.
+
+    This ensures we remain 100% backward compatible with external code that
+    directly accesses or iterates over MODEL_REGISTRY, while preventing
+    eager imports of all model dependencies during package initialization.
+    """
+
+    def __getitem__(self, key):
+        if not dict.__contains__(self, key) and key in _LAZY_MODEL_REGISTRY:
+            # Trigger lazy load
+            cls = get_model_class(key)
+            dict.__setitem__(self, key, cls)
+        return super().__getitem__(key)
+
+    def __contains__(self, key):
+        return key in _LAZY_MODEL_REGISTRY or super().__contains__(key)
+
+    def keys(self):
+        return _registry_keys()
+
+    def __iter__(self):
+        return iter(_registry_keys())
+
+    def __len__(self):
+        return len(_registry_keys())
+
+    def items(self):
+        for k in _registry_keys():
+            yield k, self[k]
+
+    def values(self):
+        for k in _registry_keys():
+            yield self[k]
+
+
+MODEL_REGISTRY: Dict[str, Type[nn.Module]] = LazyRegistryDict()
+
+
+def _safe_class_file(cls: Type[nn.Module]) -> str:
+    try:
+        return inspect.getfile(cls)
+    except TypeError:
+        return "<unknown>"
+
+
+def register_model(model_type: str):
+    def decorator(cls):
+        caller = inspect.stack()[1]
+        cls_file = _safe_class_file(cls)
+        if model_type in MODEL_REGISTRY and model_type not in _LAZY_MODEL_REGISTRY:
+            existing_cls = MODEL_REGISTRY[model_type]
+            logger.warning(
+                "NewModelRegistry duplicate registration: model_type=%s "
+                "new_cls=%s new_module=%s new_file=%s caller=%s:%s "
+                "existing_cls=%s existing_module=%s existing_file=%s",
+                model_type,
+                cls.__qualname__,
+                cls.__module__,
+                cls_file,
+                caller.filename,
+                caller.lineno,
+                existing_cls.__qualname__,
+                existing_cls.__module__,
+                _safe_class_file(existing_cls),
+            )
+            raise ValueError(
+                f"Model type '{model_type}' is already registered by "
+                f"{MODEL_REGISTRY[model_type].__name__}. Cannot register {cls.__name__}."
+            )
+        logger.info(
+            "NewModelRegistry register_model: model_type=%s cls=%s module=%s "
+            "file=%s caller=%s:%s",
+            model_type,
+            cls.__qualname__,
+            cls.__module__,
+            cls_file,
+            caller.filename,
+            caller.lineno,
+        )
+        # Directly set the item in base dict to cache it
+        dict.__setitem__(MODEL_REGISTRY, model_type, cls)
+        return cls
+
+    return decorator
+
+
+def get_model_class(model_type: str) -> Type[nn.Module]:
+    # Check physical cache first (registered classes)
+    if not dict.__contains__(MODEL_REGISTRY, model_type):
+        if model_type in _LAZY_MODEL_REGISTRY:
+            module_path, class_name = _LAZY_MODEL_REGISTRY[model_type]
+            try:
+                mod = importlib.import_module(module_path)
+                cls = getattr(mod, class_name)
+                dict.__setitem__(MODEL_REGISTRY, model_type, cls)
+            except Exception as e:
+                logger.error(
+                    "NewModelRegistry failed to lazy load model_type=%s from %s.%s: %s",
+                    model_type,
+                    module_path,
+                    class_name,
+                    e,
+                )
+                raise ImportError(
+                    f"Failed to dynamically load model '{model_type}' from {module_path}.{class_name}: {e}"
+                ) from e
+        else:
+            raise KeyError(
+                f"Model type '{model_type}' not found in registry. "
+                f"Available types: {list(_LAZY_MODEL_REGISTRY.keys())}"
+            )
+    return dict.__getitem__(MODEL_REGISTRY, model_type)
+
+
+def list_models():
+    return list(_registry_keys())

--- a/rtp_llm/models_py/weight_mapper.py
+++ b/rtp_llm/models_py/weight_mapper.py
@@ -1,0 +1,126 @@
+import re
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import torch
+
+
+class WeightsMapper:
+
+    def __init__(
+        self,
+        exact_mapping: Optional[Dict[str, str]] = None,
+        prefix_mapping: Optional[Dict[str, str]] = None,
+        regex_mapping: Optional[List[Tuple[str, str]]] = None,
+    ):
+        self.exact_mapping = exact_mapping or {}
+        self.prefix_mapping = dict(
+            sorted(
+                (prefix_mapping or {}).items(), key=lambda x: len(x[0]), reverse=True
+            )
+        )
+        self.regex_mapping = regex_mapping or []
+
+    def map_name(self, name: str) -> str:
+        if name in self.exact_mapping:
+            return self.exact_mapping[name]
+        for old_prefix, new_prefix in self.prefix_mapping.items():
+            if name.startswith(old_prefix):
+                return new_prefix + name[len(old_prefix) :]
+        for pattern, replacement in self.regex_mapping:
+            new_name = re.sub(pattern, replacement, name)
+            if new_name != name:
+                return new_name
+        return name
+
+    def apply(
+        self, weights_iterator: Iterator[Tuple[str, torch.Tensor]]
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        for name, tensor in weights_iterator:
+            yield self.map_name(name), tensor
+
+
+class WeightsFilter:
+
+    def __init__(
+        self,
+        include_patterns: Optional[List[str]] = None,
+        exclude_patterns: Optional[List[str]] = None,
+    ):
+        self.include_patterns = [re.compile(p) for p in (include_patterns or [])]
+        self.exclude_patterns = [re.compile(p) for p in (exclude_patterns or [])]
+
+    def should_load(self, name: str) -> bool:
+        if self.include_patterns:
+            if not any(p.search(name) for p in self.include_patterns):
+                return False
+        if self.exclude_patterns:
+            if any(p.search(name) for p in self.exclude_patterns):
+                return False
+        return True
+
+    def apply(
+        self, weights_iterator: Iterator[Tuple[str, torch.Tensor]]
+    ) -> Iterator[Tuple[str, torch.Tensor]]:
+        for name, tensor in weights_iterator:
+            if self.should_load(name):
+                yield name, tensor
+
+
+def get_all_weights(
+    ckpt_paths: List[str], device: str = "cpu"
+) -> Iterator[Tuple[str, torch.Tensor]]:
+    for path in ckpt_paths:
+        if path.endswith(".safetensors"):
+            yield from _load_safetensors(path, device)
+        elif path.endswith(".bin") or path.endswith(".pt"):
+            yield from _load_pytorch(path, device)
+        else:
+            raise ValueError(f"Unsupported checkpoint format: {path}")
+
+
+def _load_safetensors(path: str, device: str) -> Iterator[Tuple[str, torch.Tensor]]:
+    from safetensors import safe_open
+
+    with safe_open(path, framework="pt", device=device) as f:
+        for name in f.keys():
+            yield name, f.get_tensor(name)
+
+
+def _unwrap_pytorch_state_dict(payload):
+    if not isinstance(payload, dict):
+        raise TypeError(f"PyTorch checkpoint payload must be a dict, got {type(payload).__name__}")
+    for key in ("state_dict", "model"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            return nested
+    return payload
+
+
+def _load_pytorch(path: str, device: str) -> Iterator[Tuple[str, torch.Tensor]]:
+    state_dict = _unwrap_pytorch_state_dict(
+        torch.load(path, map_location=device, weights_only=True)
+    )
+    for name, tensor in state_dict.items():
+        if isinstance(tensor, torch.Tensor):
+            yield name, tensor
+
+
+def discover_ckpt_files(model_path: str) -> List[str]:
+    import glob
+    import os
+
+    safetensor_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+    if safetensor_files:
+        return safetensor_files
+
+    bin_files = sorted(glob.glob(os.path.join(model_path, "*.bin")))
+    if bin_files:
+        bin_files = [f for f in bin_files if "optimizer" not in os.path.basename(f)]
+        if bin_files:
+            return bin_files
+
+    pt_files = sorted(glob.glob(os.path.join(model_path, "*.pt")))
+    if pt_files:
+        return pt_files
+
+    return []


### PR DESCRIPTION
This PR introduces the core framework for the new Python weight loader.

  Included:
  - NewModelLoader and LoadConfig
  - RtpModule streaming weight dispatch
  - weight_mapper checkpoint discovery and tensor streaming
  - reusable newloader layers
  - quant_methods dispatch framework
  - FP8/GPTQ/AWQ/weight-only quant method implementations
  - empty lazy registry framework for follow-up model adaptation PRs

  Not included:
  - model-specific newloader adaptations
  - runtime input contract changes
  - multimodal/VIT changes
  - smoke/golden updates
  - scheduler/profiler/metrics changes

  Validation:
  - Python compile check passed for newloader core files
  - Diff is limited to rtp_llm/models_py