### PR TITLE
Feat/adapt sm120 build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,6 +66,8 @@ build:sm8x --action_env  TF_CUDA_COMPUTE_CAPABILITIES="8.0,8.6,8.9"
 build:sm9x --action_env TF_CUDA_COMPUTE_CAPABILITIES="9.0"
 build:sm9x --action_env  TF_CUDA_COMPUTE_CAPABILITIES="9.0"
 build:sm10x --action_env  TF_CUDA_COMPUTE_CAPABILITIES="10.0"
+build:sm12x --action_env TF_CUDA_COMPUTE_CAPABILITIES="12.0"
+build:sm12x --host_action_env TF_CUDA_COMPUTE_CAPABILITIES="12.0"
 build:cuda12 --action_env TF_CUDA_VERSION="12.4"
 build:cuda12 --host_action_env TF_CUDA_VERSION="12.4"
 build:cuda12 --define=using_cuda12=true

--- a/3rdparty/contextFusedMultiHeadAttention/BUILD
+++ b/3rdparty/contextFusedMultiHeadAttention/BUILD
@@ -71,6 +71,10 @@ sm90_cuda_copts = [
     '--cuda-include-ptx=sm_90a', '--cuda-gpu-arch=sm_90a',
 ]
 
+sm120_cuda_copts = [
+    '--cuda-include-ptx=sm_120a', '--cuda-gpu-arch=sm_120a',
+]
+
 cc_library(
     name = "context_attention_kernels_sm80",
     srcs = glob([
@@ -124,6 +128,19 @@ cc_library(
 )
 
 cc_library(
+    name = "context_attention_kernels_sm120",
+    srcs = glob([
+        "fmha_v2_cu/*sm120.cu",
+    ]),
+    deps = [
+        ":fmha_v2_impl_src_header",
+    ],
+    copts = sm120_cuda_copts + base_cuda_copts,
+    visibility = ["//visibility:public"],
+    alwayslink = True
+)
+
+cc_library(
     name = "fmha_v2_cubin",
     hdrs = glob([
         "cubin/fmha_cubin.h"
@@ -134,7 +151,10 @@ cc_library(
     deps = [
         ":fmha_v2_impl_src_header",
     ],
-    copts = copts() + ["-DEXCLUDE_SM_100=1", "-DEXCLUDE_SM_120=1"],
+    copts = copts() + ["-DEXCLUDE_SM_100=1"] + select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["-DEXCLUDE_SM_120=1"],
+    }),
     visibility = ["//visibility:public"],
     alwayslink = True,
 )
@@ -155,7 +175,15 @@ cc_library(
             ":context_attention_kernels_sm90",
         ],
         "//conditions:default": [],
+    }) + select({
+        "@//:using_cuda12_9_x86": [
+            ":context_attention_kernels_sm120",
+        ],
+        "//conditions:default": [],
     }),
-    copts = cuda_copts() + ["-DEXCLUDE_SM_100=1", "-DEXCLUDE_SM_120=1"],
+    copts = cuda_copts() + ["-DEXCLUDE_SM_100=1"] + select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["-DEXCLUDE_SM_120=1"],
+    }),
     visibility = ["//visibility:public"],
 )

--- a/deps/requirements_lock_torch_gpu_cuda12_9.txt
+++ b/deps/requirements_lock_torch_gpu_cuda12_9.txt
@@ -786,14 +786,14 @@ flash-attn-3 @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129
 flash-mla @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flash_mla-1.0.0%2Bca58fed-cp310-cp310-linux_x86_64.whl \
     --hash=sha256:960fecb602f90f0f882b6e460f9ddebaec0c3cedca3b01594330445c90afaa5e
     # via -r deps/requirements_torch_gpu_cuda12_9.txt
-flashinfer-cubin @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_cubin-0.6.6-py3-none-any.whl \
-    --hash=sha256:3363511f06b0315b9267fc3976412b7f844750fdfe451c44f3f84076bffac641
+flashinfer-cubin @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_cubin-0.6.6%2Bsm120-py3-none-any.whl \
+    --hash=sha256:04df6c418b5558be5fbaad758639fbcedd29560e6a0b036c904ec6d52721306c
     # via -r deps/requirements_torch_gpu_cuda12_9.txt
-flashinfer-jit-cache @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_jit_cache-0.6.6-cp39-abi3-manylinux_2_28_x86_64.whl \
-    --hash=sha256:346bb153c2fab3922e017f9f1fb41d5dad679849d787c2dac9d2fc7102a74e64
+flashinfer-jit-cache @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_jit_cache-0.6.6%2Bsm120-cp39-abi3-manylinux_2_28_x86_64.whl \
+    --hash=sha256:d9c07da23b8b671e11173ff65e905fcdd44810e52f96d2509998c44ec237eade
     # via -r deps/requirements_torch_gpu_cuda12_9.txt
-flashinfer-python @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_python-0.6.6-py3-none-any.whl \
-    --hash=sha256:4ee501a8cc6a4479c6a23e6fb4f0a1ebcce3212d72d6ae15c9bcf9a79571efa5
+flashinfer-python @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_python-0.6.6%2Bsm120-py3-none-any.whl \
+    --hash=sha256:982a3c58ba438fa7d4af4462a546e7c14380bb2835f4c31e97c9f201577188a3
     # via
     #   -r deps/requirements_torch_gpu_cuda12_9.txt
     #   rtp-kernel

--- a/deps/requirements_lock_torch_gpu_cuda12_9.txt
+++ b/deps/requirements_lock_torch_gpu_cuda12_9.txt
@@ -3492,8 +3492,8 @@ rouge==1.0.1 \
     --hash=sha256:12b48346ca47d6bcf3c45061f315452b9ccec0620ee895ec85b7efc3d54aae34 \
     --hash=sha256:28d118536e8c774dc47d1d15ec266479b4dd0914c4672ce117d4002789bdc644
     # via auto-gptq
-rtp-kernel @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/rtp_kernel_260423/rtp_kernel-0.1.0%2B125c29e5.20260423102158-cp310-cp310-linux_x86_64.whl \
-    --hash=sha256:e3fc27a3ebe834045ce526572742573d7b240655ff723d00b2cce748ebc3dd18
+rtp-kernel @ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/rtp_kernel_260612/rtp_kernel-0.1.0%2B125c29e5-cp310-cp310-linux_x86_64.whl \
+    --hash=sha256:a74c8d99e7c9026fad5f96397a54f9cf4eedb7086a2fa4448b3e5b64a4cc371f
     # via -r open_source/deps/requirements_torch_gpu_cuda12_9.txt
 safetensors==0.6.2 \
     --hash=sha256:1d2d2b3ce1e2509c68932ca03ab8f20570920cd9754b05063d4368ee52833ecd \

--- a/deps/requirements_torch_gpu_cuda12_9.txt
+++ b/deps/requirements_torch_gpu_cuda12_9.txt
@@ -18,7 +18,7 @@ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_cubin-0.6.6%2Bsm120-py3-none-any.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flash_mla-1.0.0%2Bca58fed-cp310-cp310-linux_x86_64.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/fast_hadamard_transform-1.0.4.post1-cp310-cp310-linux_x86_64.whl
-https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/rtp_kernel_260423/rtp_kernel-0.1.0%2B125c29e5.20260423102158-cp310-cp310-linux_x86_64.whl
+https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/rtp_kernel_260612/rtp_kernel-0.1.0%2B125c29e5-cp310-cp310-linux_x86_64.whl
 mysql-connector-python
 tensorrt==10.3.0
 tensorrt-cu12-bindings==10.3.0

--- a/deps/requirements_torch_gpu_cuda12_9.txt
+++ b/deps/requirements_torch_gpu_cuda12_9.txt
@@ -13,9 +13,9 @@ https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/torch-2.8.0%2B
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/torchvision-0.23.0%2Bcu129-cp310-cp310-manylinux_2_28_x86_64.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/deep_ep-1.2.1.10%2Bd7d7b48-cp310-cp310-linux_x86_64.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/deep_gemm-2.1.1%2Blocal-cp310-cp310-linux_x86_64.whl
-https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_python-0.6.6-py3-none-any.whl
-https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_jit_cache-0.6.6-cp39-abi3-manylinux_2_28_x86_64.whl
-https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260319/flashinfer_cubin-0.6.6-py3-none-any.whl
+https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_python-0.6.6%2Bsm120-py3-none-any.whl
+https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_jit_cache-0.6.6%2Bsm120-cp39-abi3-manylinux_2_28_x86_64.whl
+https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flashinfer_260709/flashinfer_cubin-0.6.6%2Bsm120-py3-none-any.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/flash_mla-1.0.0%2Bca58fed-cp310-cp310-linux_x86_64.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/fast_hadamard_transform-1.0.4.post1-cp310-cp310-linux_x86_64.whl
 https://rtp-opensource.oss-cn-hangzhou.aliyuncs.com/rtp_llm/cu129/rtp_kernel_260423/rtp_kernel-0.1.0%2B125c29e5.20260423102158-cp310-cp310-linux_x86_64.whl

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -197,8 +197,7 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
                 == py_model_inputs_.attention_inputs.kv_cache_kernel_block_id_device_by_group.size(),
             "kv_cache_kernel_block_id_device_by_group size mismatch");
         hybrid_cache_group = inputs.attention_inputs.kv_cache_kernel_block_id_device_by_group.size();
-        RTP_LLM_CHECK_WITH_INFO(inputs.attention_inputs.kv_cache_kernel_block_id_by_group.size()
-                                        == hybrid_cache_group
+        RTP_LLM_CHECK_WITH_INFO(inputs.attention_inputs.kv_cache_kernel_block_id_by_group.size() == hybrid_cache_group
                                     && py_model_inputs_.attention_inputs.kv_cache_kernel_block_id_by_group.size()
                                            == hybrid_cache_group,
                                 "kv_cache_kernel_block_id_by_group size mismatch");
@@ -428,7 +427,7 @@ void CudaGraphRunner::initKernelInternalMemory() {
     if (prefix_lengths.defined() && prefix_lengths.size(0) > 0) {
         cu_kv_seqlens.slice(0, 1, max_bs_ + 1) = input_lengths.add(prefix_lengths).cumsum(0);
     }
-    capture_mem_hold_.py_model_inputs_.attention_inputs.cu_seqlens      = cu_seqlens;
+    capture_mem_hold_.py_model_inputs_.attention_inputs.cu_seqlens           = cu_seqlens;
     capture_mem_hold_.py_model_inputs_.attention_inputs.cu_seqlens_device    = cu_seqlens.cuda();
     capture_mem_hold_.py_model_inputs_.attention_inputs.cu_kv_seqlens_device = cu_kv_seqlens.cuda();
 }
@@ -444,8 +443,8 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     // input_ids [tokens_nums] = [batch_size * num_tokens_per_bs]
     inputs.input_ids = torch::zeros({max_num_token_}, options_cuda_int32_);
     // input_lengths [batch_size, int32] (decode only)
-    inputs.attention_inputs.input_lengths   = torch::full({int(max_bs_)}, num_tokens_per_bs_, options_cpu_int32_);
-    inputs.attention_inputs.input_lengths   = inputs.attention_inputs.input_lengths.pin_memory();
+    inputs.attention_inputs.input_lengths        = torch::full({int(max_bs_)}, num_tokens_per_bs_, options_cpu_int32_);
+    inputs.attention_inputs.input_lengths        = inputs.attention_inputs.input_lengths.pin_memory();
     inputs.attention_inputs.input_lengths_device = inputs.attention_inputs.input_lengths.cuda();
     // sequence_lengths [batch_size, int32] (decode only)
     // sequence_length should in pinned memory
@@ -522,10 +521,10 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
         inputs.attention_inputs.prefix_lengths = torch::empty({0}, options_cpu_int32_).pin_memory();
     }
     // padding_offset [max_num_token_, int32] (for attention padding)
-    inputs.attention_inputs.padding_offset            = torch::zeros({int(max_seq_len_ * max_bs_)}, options_cpu_int32_);
-    inputs.attention_inputs.padding_offset            = inputs.attention_inputs.padding_offset.pin_memory();
-    inputs.attention_inputs.dtype                     = model_data_type_;
-    inputs.attention_inputs.is_s_padded               = true;
+    inputs.attention_inputs.padding_offset = torch::zeros({int(max_seq_len_ * max_bs_)}, options_cpu_int32_);
+    inputs.attention_inputs.padding_offset = inputs.attention_inputs.padding_offset.pin_memory();
+    inputs.attention_inputs.dtype          = model_data_type_;
+    inputs.attention_inputs.is_s_padded    = true;
     inputs.attention_inputs.sequence_lengths_plus_1_device = torch::zeros({int(max_bs_)}, options_cuda_int32_);
     // Step=1 is intentional: when num_tokens_per_bs_ > 1 (target verify), is_prefill is set to true
     // so the factory selects PREFILL impls (which use cu_seqlens, not decode_cu_seqlens).

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -31,6 +31,7 @@ from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
+from rtp_llm.models_py.utils.arch import is_sm_100
 from rtp_llm.ops import SpeculativeType
 
 __all__ = [
@@ -53,8 +54,7 @@ def use_accl_ep() -> bool:
 
 def allow_mnnvl() -> bool:
     """Check if MNNVL is allowed based on architecture and GPU capability."""
-    is_sm_100 = torch.cuda.get_device_capability()[0] in [10]
-    return "aarch64" in platform.machine() and is_sm_100
+    return "aarch64" in platform.machine() and is_sm_100()
 
 
 class DeepEPMode(IntEnum):

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -14,10 +14,10 @@ from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
     KVCacheWriteOp,
 )
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_sm10x
 from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla import (
     check_attention_inputs,
 )
-from rtp_llm.models_py.utils.arch import is_sm_100
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import (
     AttentionConfigs,
@@ -577,14 +577,14 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
         """Check if paged prefill implementation is supported.
 
         Returns True if:
-        1. Not running on datacenter Blackwell (sm_100). sm_120 consumer
-           Blackwell is supported by FlashInfer and has no sm_120a TRT-LLM
-           Gen cubin, so it relies on this paged FlashInfer path.
+        1. Not running on SM10x datacenter Blackwell, where TRTLLMGen is preferred.
+           SM12x consumer Blackwell keeps this FlashInfer paged fallback because
+           TRTLLMGen/XQA do not have sm_120a support in this build.
         2. The underlying paged FMHA op supports the inputs
         3. MhaRotaryEmbeddingOp supports the inputs
         """
         return (
-            not is_sm_100()
+            not is_sm10x()
             and PyFlashinferPrefillPagedAttnOp.support(attn_inputs)
             and attn_configs.rope_config.style != RopeStyle.Mrope
         )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -14,10 +14,10 @@ from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
     KVCacheWriteOp,
 )
-from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_sm_100
 from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla import (
     check_attention_inputs,
 )
+from rtp_llm.models_py.utils.arch import is_sm_100
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import (
     AttentionConfigs,
@@ -87,6 +87,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
         else:
             self.kv_datatype = self.datatype
         self.max_seq_len = attn_configs.max_seq_len
+        self.is_causal = attn_configs.is_causal
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
         self.prefill_cuda_graph_copy_params = None
@@ -210,7 +211,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
             self.local_kv_head_num,
             self.head_dim_qk,
             self.page_size,
-            causal=True,
+            causal=self.is_causal,
             q_data_type=self.datatype,
             kv_data_type=self.kv_datatype,
         )
@@ -346,6 +347,7 @@ class PyFlashinferPrefillAttnOp(object):
             backend=backend,
         )
         self.datatype = attn_configs.dtype
+        self.is_causal = attn_configs.is_causal
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
@@ -365,11 +367,17 @@ class PyFlashinferPrefillAttnOp(object):
         batch_size = attn_inputs.input_lengths.size(0)
         cu_seqlens = attn_inputs.cu_seqlens_device[: batch_size + 1]
 
+        # Encoder-only models (BERT) have no paged kv cache; fill_params
+        # pybind requires a Tensor, so substitute an empty int32 tensor.
+        kv_block_id_host = attn_inputs.kv_cache_kernel_block_id
+        if kv_block_id_host is None:
+            kv_block_id_host = torch.empty(0, dtype=torch.int32)
+
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
             attn_inputs.input_lengths,
-            attn_inputs.kv_cache_kernel_block_id,
+            kv_block_id_host,
             self.page_size,
         )
 
@@ -380,7 +388,7 @@ class PyFlashinferPrefillAttnOp(object):
             self.local_kv_head_num,
             self.head_dim_qk,
             self.head_dim_vo,
-            causal=True,
+            causal=self.is_causal,
             q_data_type=get_scalar_type(attn_inputs.dtype),
         )
         return self.fmha_params
@@ -569,7 +577,9 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
         """Check if paged prefill implementation is supported.
 
         Returns True if:
-        1. Not running on SM 10.0 (Blackwell) architecture
+        1. Not running on datacenter Blackwell (sm_100). sm_120 consumer
+           Blackwell is supported by FlashInfer and has no sm_120a TRT-LLM
+           Gen cubin, so it relies on this paged FlashInfer path.
         2. The underlying paged FMHA op supports the inputs
         3. MhaRotaryEmbeddingOp supports the inputs
         """
@@ -629,14 +639,19 @@ class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
         """Check if ragged prefill implementation is supported.
 
         Returns True if:
-        1. Not running on SM 10.0 (Blackwell) architecture
-        2. The underlying ragged FMHA op supports the inputs
+        1. The underlying ragged FMHA op supports the inputs
            (requires prefix_lengths to be empty or zero)
-        3. MhaRotaryEmbeddingOp supports the inputs
+        2. MhaRotaryEmbeddingOp supports the inputs
+        3. Mrope is not used
+
+        Note: Unlike the paged variant, ragged prefill is kept enabled on
+        Blackwell: TRT-LLM Gen prefill requires a paged kv cache and
+        therefore does not cover BERT-style encoder-only inputs that lack
+        one. Without this fallback, sm_120 has no usable prefill impl for
+        such cases.
         """
         return (
-            not is_sm_100()
-            and PyFlashinferPrefillAttnOp.support(attn_inputs)
+            PyFlashinferPrefillAttnOp.support(attn_inputs)
             and attn_configs.rope_config.style != RopeStyle.Mrope
         )
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -634,6 +634,9 @@ class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
 
         return qkv
 
+    def support_cuda_graph(self) -> bool:
+        return False
+
     @staticmethod
     def support(attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs) -> bool:
         """Check if ragged prefill implementation is supported.

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
@@ -151,6 +151,24 @@ py_test(
     },
 )
 
+py_test(
+    name = "test_py_flashinfer_ragged_mha_prefill_sm120",
+    srcs = [
+        "test_flashinfer_prefill/test_py_flashinfer_ragged_mha_prefill_sm120.py",
+        "attention_ref.py",
+        "base_attention_test.py"
+    ],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["RTX_5000_PRO"],
+    exec_properties = {
+        'gpu': 'RTX_5000_PRO',
+    },
+)
+
 # Test for PyFlashinferPrefillPagedAttnOp paged prefill attention implementation
 py_test(
     name = "test_py_flashinfer_paged_mha_prefill",
@@ -200,4 +218,3 @@ py_test(
         'gpu': 'H20',
     },
 )
-

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/base_attention_test.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/base_attention_test.py
@@ -191,6 +191,7 @@ class BaseAttentionTest(unittest.TestCase):
         sequence_lengths: List[int],
         seq_size_per_block: int,
         dtype: torch.dtype = torch.float16,
+        with_kv_cache_block_ids: bool = True,
     ) -> PyAttentionInputs:
         """Helper to create PyAttentionInputs for prefill mode
 
@@ -199,6 +200,7 @@ class BaseAttentionTest(unittest.TestCase):
             sequence_lengths: List of sequence lengths for each batch item
             seq_size_per_block: Number of tokens per block (page size)
             dtype: Data type for attention computation (default: torch.float16)
+            with_kv_cache_block_ids: Whether to populate paged KV cache block IDs
 
         Returns:
             PyAttentionInputs configured for prefill mode
@@ -223,14 +225,16 @@ class BaseAttentionTest(unittest.TestCase):
             batch_size, dtype=torch.int32, device="cpu"
         )
 
-        # Create KV cache block IDs using the extracted helper
-        kv_cache_block_id = self._create_kv_cache_block_ids(
-            batch_size, sequence_lengths, seq_size_per_block
-        )
-        attn_inputs.kv_cache_block_id = kv_cache_block_id
-        attn_inputs.kv_cache_block_id_device = kv_cache_block_id.to(self.device)
-        attn_inputs.kv_cache_kernel_block_id = kv_cache_block_id
-        attn_inputs.kv_cache_kernel_block_id_device = kv_cache_block_id.to(self.device)
+        if with_kv_cache_block_ids:
+            kv_cache_block_id = self._create_kv_cache_block_ids(
+                batch_size, sequence_lengths, seq_size_per_block
+            )
+            attn_inputs.kv_cache_block_id = kv_cache_block_id
+            attn_inputs.kv_cache_block_id_device = kv_cache_block_id.to(self.device)
+            attn_inputs.kv_cache_kernel_block_id = kv_cache_block_id
+            attn_inputs.kv_cache_kernel_block_id_device = kv_cache_block_id.to(
+                self.device
+            )
 
         # Create cu_seqlens (cumulative sequence lengths) for ragged tensor
         cu_seqlens = [0]

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_ragged_mha_prefill_sm120.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_py_flashinfer_ragged_mha_prefill_sm120.py
@@ -1,0 +1,84 @@
+import logging
+import unittest
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
+    PyFlashinferPrefillAttnOp,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.test.attention_ref import (
+    compute_flashinfer_prefill_reference,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.test.base_attention_test import (
+    BaseAttentionTest,
+    compare_tensors,
+)
+from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+class TestPyFlashinferRaggedPrefillSm120(BaseAttentionTest):
+    def test_non_causal_prefill_without_kv_block_table(self):
+        """Test encoder-only ragged prefill with no paged KV block table."""
+        logging.info("\n=== Testing non-causal prefill without KV block table ===")
+
+        sequence_lengths = [10, 20]
+        batch_size = len(sequence_lengths)
+        config = self._create_config(
+            head_num=8,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+        )
+        config.attn_configs.is_causal = False
+
+        attn_inputs = self._create_prefill_attention_inputs(
+            batch_size,
+            sequence_lengths,
+            config.seq_size_per_block,
+            with_kv_cache_block_ids=False,
+        )
+
+        attn_op = PyFlashinferPrefillAttnOp(config.attn_configs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        self.assertTrue(attn_op.support(attn_inputs))
+        params = attn_op.prepare(attn_inputs)
+        self.assertIsNotNone(params)
+
+        total_tokens = sum(sequence_lengths)
+        hidden_size_q = config.size_per_head * config.head_num
+        hidden_size_k = config.size_per_head * config.head_num_kv
+        hidden_size_v = config.size_per_head * config.head_num_kv
+
+        qkv = torch.randn(
+            total_tokens,
+            hidden_size_q + hidden_size_k + hidden_size_v,
+            dtype=torch.float16,
+            device=self.device,
+        )
+        q_flat, k_flat, v_flat = torch.split(
+            qkv,
+            [hidden_size_q, hidden_size_k, hidden_size_v],
+            dim=-1,
+        )
+        q = q_flat.reshape(total_tokens, config.head_num, config.size_per_head)
+        k = k_flat.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+        v = v_flat.reshape(total_tokens, config.head_num_kv, config.size_per_head)
+
+        output = attn_op.forward(qkv, None)
+        ref_output = compute_flashinfer_prefill_reference(
+            q, k, v, attn_inputs.cu_seqlens_device, causal=False
+        )
+
+        compare_tensors(
+            output,
+            ref_output,
+            rtol=1e-2,
+            atol=1e-2,
+            name="Non-causal prefill output without KV block table",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -8,6 +8,7 @@ import triton.language as tl
 from rtp_llm.models_py.modules.factory.attention import common
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_blackwell
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
+from rtp_llm.models_py.utils.arch import is_sm12x
 from rtp_llm.ops import AttentionConfigs, FMHAType, ParallelismConfig
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOp,
@@ -331,6 +332,13 @@ class FlashInferTRTLLMPrefillOp(object):
         release_trt_workspace_buffer(self.workspace_buffer)
 
     def support(self, attention_inputs: PyAttentionInputs):
+        # TllmGenFmhaRunner cubin covers sm_90a / sm_100a only; sm_120a
+        # (Blackwell consumer, e.g. RTX 5000 Pro) has no binding and the
+        # runner throws "Unsupported architecture" (fmhaRunner.cuh:37) on
+        # forward. Fall through so dispatch picks the paged
+        # PyFlashinferPagedPrefillImpl instead.
+        if is_sm12x():
+            return False
         return (
             is_blackwell()
             and attention_inputs.is_prefill
@@ -439,6 +447,13 @@ class FlashInferTRTLLMDecodeOp(object):
 
     def support(self, attention_inputs: PyAttentionInputs):
         if not is_blackwell():
+            return False
+        # TllmGenFmhaRunner cubin covers sm_90a / sm_100a only; sm_120a
+        # (Blackwell consumer, e.g. RTX 5000 Pro) has no binding and the
+        # runner throws "Unsupported architecture" (fmhaRunner.cuh:37) on
+        # the first decode forward. Fall through so dispatch picks the
+        # ragged PyFlashinferPaged path instead.
+        if is_sm12x():
             return False
         # Note: this max q length is used for mtp decode verification.
         decode_kernel_max_q_len = 11

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -6,7 +6,7 @@ import triton
 import triton.language as tl
 
 from rtp_llm.models_py.modules.factory.attention import common
-from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_sm_100
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.utils import is_blackwell
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import AttentionConfigs, FMHAType, ParallelismConfig
 from rtp_llm.ops.compute_ops import (
@@ -332,7 +332,7 @@ class FlashInferTRTLLMPrefillOp(object):
 
     def support(self, attention_inputs: PyAttentionInputs):
         return (
-            is_sm_100()
+            is_blackwell()
             and attention_inputs.is_prefill
             and attention_inputs.kv_cache_kernel_block_id_device is not None
         )
@@ -438,7 +438,7 @@ class FlashInferTRTLLMDecodeOp(object):
         release_trt_workspace_buffer(self.workspace_buffer)
 
     def support(self, attention_inputs: PyAttentionInputs):
-        if not is_sm_100():
+        if not is_blackwell():
             return False
         # Note: this max q length is used for mtp decode verification.
         decode_kernel_max_q_len = 11

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/utils.py
@@ -1,11 +1,5 @@
 """Shared utilities for CUDA attention implementations."""
 
-import functools
+from rtp_llm.models_py.utils.arch import is_blackwell, is_sm10x
 
-import torch
-
-
-@functools.cache
-def is_blackwell() -> bool:
-    """Check if current GPU is Blackwell-class (SM 10.0 server / SM 12.0 consumer)."""
-    return torch.cuda.get_device_capability()[0] in [10, 12]
+__all__ = ["is_blackwell", "is_sm10x"]

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/utils.py
@@ -6,6 +6,6 @@ import torch
 
 
 @functools.cache
-def is_sm_100() -> bool:
-    """Check if current GPU is SM 10.0 (Blackwell architecture)."""
-    return torch.cuda.get_device_capability()[0] in [10]
+def is_blackwell() -> bool:
+    """Check if current GPU is Blackwell-class (SM 10.0 server / SM 12.0 consumer)."""
+    return torch.cuda.get_device_capability()[0] in [10, 12]

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
@@ -6,12 +6,11 @@ import torch
 
 from rtp_llm.models_py.modules.factory.attention import common
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
-from rtp_llm.models_py.utils.arch import get_num_device_sms
+from rtp_llm.models_py.utils.arch import get_num_device_sms, get_sm, is_sm12x
 from rtp_llm.ops import (
     AttentionConfigs,
     FMHAConfig,
     FMHAType,
-    KvCacheDataType,
     ParallelismConfig,
 )
 from rtp_llm.ops.compute_ops import (
@@ -84,6 +83,13 @@ class XQAImpl(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        # XQA cubin covers sm_90 only; sm_120a (Blackwell consumer, e.g.
+        # RTX 5000 Pro) lacks a binding and triggers cudaErrorInvalidSymbol
+        # at first forward. C++ XQAAttnOp.support gate is `>= kSM_90` and
+        # passes sm_120 erroneously — short-circuit here so dispatch falls
+        # through to PyFlashinferPaged. See blockers.md R-4.
+        if is_sm12x():
+            return False
         fmha_impl = XQAAttnOp(attn_configs)
         return fmha_impl.support(attn_inputs)
 
@@ -144,7 +150,14 @@ class XQADecodeImpl(FMHAImplBase):
     ) -> bool:
         if attn_inputs.is_prefill:
             return False
-        if torch.cuda.get_device_capability()[0] not in [9, 10, 12]:
+        # sm_120a consumer Blackwell: the FlashInfer xqa() build here rejects
+        # the nb_sub_seq_per_seq kwarg used in forward(), and XQA has no
+        # sm_120a binding anyway. Gate it off so decode dispatch falls through
+        # to PyFlashinferDecodeImpl (the working sm_120 path), mirroring the
+        # XQAImpl.support gate.
+        if is_sm12x():
+            return False
+        if get_sm()[0] not in [9, 10]:
             return False
         group_size = attn_configs.head_num // attn_configs.kv_head_num
         return (

--- a/rtp_llm/models_py/utils/arch.py
+++ b/rtp_llm/models_py/utils/arch.py
@@ -1,15 +1,37 @@
-from typing import Tuple
+import functools
+from typing import Optional, Tuple, Union
 
 import torch
 
 from rtp_llm.device.device_type import DeviceType, get_device_type, is_cuda, is_hip
 
 
-def is_sm_100() -> bool:
+def _canonical_cuda_device(device_id: Optional[Union[int, torch.device]]) -> int:
+    if device_id is None:
+        return torch.cuda.current_device()
+    if isinstance(device_id, torch.device):
+        if device_id.index is None:
+            return torch.cuda.current_device()
+        return device_id.index
+    return int(device_id)
+
+
+@functools.cache
+def _get_sm_for_device(device_id: int) -> Tuple[int, int]:
+    major, minor = torch.cuda.get_device_capability(device_id)
+    return major, minor
+
+
+def is_sm_100(device_id: Optional[Union[int, torch.device]] = None) -> bool:
+    """SM 10.x datacenter Blackwell (B200 / GB200)."""
+    return is_sm10x(device_id)
+
+
+def is_sm10x(device_id: Optional[Union[int, torch.device]] = None) -> bool:
     """SM 10.x datacenter Blackwell (B200 / GB200)."""
     if not is_cuda():
         return False
-    return get_sm()[0] == 10
+    return get_sm(device_id)[0] == 10
 
 
 def get_num_device_sms() -> int:
@@ -22,6 +44,20 @@ def get_num_device_sms() -> int:
         raise NotImplementedError("Only cuda is supported get_num_device_sms yet")
 
 
-def get_sm(device_id: int = 0) -> Tuple[int, int]:
-    major, minor = torch.cuda.get_device_capability(device_id)
-    return major, minor
+def get_sm(device_id: Optional[Union[int, torch.device]] = None) -> Tuple[int, int]:
+    device_id = _canonical_cuda_device(device_id)
+    return _get_sm_for_device(device_id)
+
+
+def is_sm12x(device_id: Optional[Union[int, torch.device]] = None) -> bool:
+    """SM 12.x consumer Blackwell (RTX PRO 5000 / 6000, RTX 5090)."""
+    if not is_cuda():
+        return False
+    return get_sm(device_id)[0] == 12
+
+
+def is_blackwell(device_id: Optional[Union[int, torch.device]] = None) -> bool:
+    """Blackwell-class: SM 10.x datacenter (B200/GB200) or SM 12.x consumer."""
+    if not is_cuda():
+        return False
+    return get_sm(device_id)[0] in (10, 12)

--- a/rtp_llm/models_py/utils/arch.py
+++ b/rtp_llm/models_py/utils/arch.py
@@ -5,6 +5,13 @@ import torch
 from rtp_llm.device.device_type import DeviceType, get_device_type, is_cuda, is_hip
 
 
+def is_sm_100() -> bool:
+    """SM 10.x datacenter Blackwell (B200 / GB200)."""
+    if not is_cuda():
+        return False
+    return get_sm()[0] == 10
+
+
 def get_num_device_sms() -> int:
     if is_cuda():
         assert torch.cuda.is_available()

--- a/rtp_llm/models_py/utils/test/BUILD
+++ b/rtp_llm/models_py/utils/test/BUILD
@@ -1,4 +1,15 @@
 py_test (
+    name = "arch_test",
+    srcs = ["arch_test.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["RTX_5000_PRO"],
+    exec_properties = {'gpu':'RTX_5000_PRO', 'gpu_count':'1'},
+)
+
+py_test (
     name = "deepgemm_test",
     srcs = ["deepgemm_test.py"],
     deps = [

--- a/rtp_llm/models_py/utils/test/arch_test.py
+++ b/rtp_llm/models_py/utils/test/arch_test.py
@@ -1,0 +1,58 @@
+from unittest import TestCase, main
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.models_py.utils import arch
+
+
+class ArchTest(TestCase):
+
+    def setUp(self):
+        arch._get_sm_for_device.cache_clear()
+
+    def tearDown(self):
+        arch._get_sm_for_device.cache_clear()
+
+    def test_get_sm_defaults_to_current_cuda_device(self):
+        with (
+            patch("rtp_llm.models_py.utils.arch.is_cuda", return_value=True),
+            patch("torch.cuda.current_device", return_value=1),
+            patch(
+                "torch.cuda.get_device_capability",
+                side_effect=lambda device_id: {0: (10, 0), 1: (12, 0)}[device_id],
+            ) as get_device_capability,
+        ):
+            self.assertEqual(arch.get_sm(), (12, 0))
+            self.assertFalse(arch.is_sm10x())
+            self.assertTrue(arch.is_sm12x())
+            self.assertTrue(arch.is_blackwell())
+            get_device_capability.assert_called_once_with(1)
+
+    def test_arch_helpers_cache_by_resolved_device_id(self):
+        queried_devices = []
+
+        def get_device_capability(device_id):
+            queried_devices.append(device_id)
+            return {0: (10, 0), 1: (12, 0), 2: (9, 0)}[device_id]
+
+        with (
+            patch("rtp_llm.models_py.utils.arch.is_cuda", return_value=True),
+            patch(
+                "torch.cuda.get_device_capability", side_effect=get_device_capability
+            ),
+        ):
+            with patch("torch.cuda.current_device", return_value=1):
+                self.assertTrue(arch.is_sm12x())
+                self.assertFalse(arch.is_sm10x())
+            with patch("torch.cuda.current_device", return_value=0):
+                self.assertTrue(arch.is_sm10x())
+                self.assertFalse(arch.is_sm12x())
+
+            self.assertTrue(arch.is_blackwell(torch.device("cuda:1")))
+            self.assertFalse(arch.is_blackwell(2))
+            self.assertEqual(queried_devices, [1, 0, 2])
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 # Framework source files for cross-package smoke tests.
-# Used as data dep (not srcs/deps) to avoid __init__.py creation
-# that breaks namespace package merging with internal smoke/.
+# Used as data dep (not srcs/deps) so internal smoke targets can merge their
+# own smoke/ children through smoke.__path__ without duplicating runner srcs.
 filegroup(
     name = "smoke_framework_srcs",
     srcs = glob(["*.py"]),
@@ -25,12 +25,14 @@ filegroup(
 load("//rtp_llm/test/smoke:suites_h20_oss.bzl", "h20_oss_suites")
 load("//rtp_llm/test/smoke:suites_sm8x.bzl", "sm8x_suites")
 load("//rtp_llm/test/smoke:suites_sm100.bzl", "sm100_suites")
+load("//rtp_llm/test/smoke:suites_sm120.bzl", "sm120_suites")
 load("//rtp_llm/test/smoke:suites_rocm_oss.bzl", "rocm_oss_suites")
 load("//rtp_llm/test/smoke:suites_remote_cache.bzl", "remote_cache_suites")
 
 h20_oss_suites()
 sm8x_suites()
 sm100_suites()
+sm120_suites()
 rocm_oss_suites()
 remote_cache_suites()
 
@@ -45,6 +47,7 @@ test_suite(
         ":smoke_h20_dense",
         ":smoke_h20_eagle",
         ":smoke_sm8x_basic",
+        ":smoke_sm120_basic",
     ],
 )
 

--- a/rtp_llm/test/smoke/__init__.py
+++ b/rtp_llm/test/smoke/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/rtp_llm/test/smoke/data/model/qwen25/logits_index_q_r_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/logits_index_q_r_sm120.json
@@ -1,0 +1,155 @@
+{
+    "model_type": "qwen_tool",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s1",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_logits": true,
+                    "select_tokens_id": [
+                        1,
+                        2
+                    ],
+                    "logits_index": 2,
+                    "return_incremental": true,
+                    "is_streaming": true
+                }
+            },
+            "result": {
+                "response": " The CAP theorem is a fundamental result in the field",
+                "response_alternatives": null,
+                "hidden_states": null,
+                "logits": [
+                    [
+                        5.465275287628174,
+                        2.522678852081299
+                    ]
+                ],
+                "loss": null,
+                "input_ids": null,
+                "output_ids": null,
+                "aux_info": {
+                    "input_len": 6,
+                    "prefix_len": 0,
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "output_len": 10,
+                    "step_output_len": 1,
+                    "iter_count": 10,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "pd_sep": false,
+                    "softmax_probs": []
+                }
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "what is CAP Theorem ?"
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s1"
+                    }
+                ],
+                "extra_configs": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_logits": true,
+                    "select_tokens_id": [
+                        1,
+                        2
+                    ],
+                    "logits_index": 2,
+                    "return_incremental": true,
+                    "is_streaming": true
+                },
+                "stream": false
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777196861,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "The CAP theorem is a fundamental result in network design"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 25,
+                    "total_tokens": 35,
+                    "completion_tokens": 10,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 46.319,
+                    "iter_count": 10,
+                    "prefix_len": 0,
+                    "input_len": 25,
+                    "output_len": 10,
+                    "step_output_len": 1,
+                    "first_token_cost_time": 9.243,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": {
+                    "hidden_states": null,
+                    "all_hidden_states": null,
+                    "loss": null,
+                    "logits": [
+                        [
+                            5.973734378814697,
+                            2.3883185386657715
+                        ]
+                    ],
+                    "output_ids": null,
+                    "input_ids": null
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_s_bf16_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_s_bf16_sm120.json
@@ -1,0 +1,126 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s5",
+                    "$prompt:s3"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 9,
+                    "top_k": 1,
+                    "top_p": 0
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": " Flask is a lightweight web framework for Python,"
+                    },
+                    {
+                        "response": "\n\nI am trying to use the screen manager"
+                    }
+                ],
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "num_return_sequences": 2,
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": [
+                    " Flask is a lightweight web framework for Python, and",
+                    " Flask is a lightweight web framework for Python, and"
+                ],
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": false
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_incremental": true,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_s_fp16_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_s_fp16_sm120.json
@@ -1,0 +1,126 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s5",
+                    "$prompt:s3"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 9,
+                    "top_k": 1,
+                    "top_p": 0
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": " Flask is a lightweight web framework for Python,"
+                    },
+                    {
+                        "response": "\n\nI am trying to use the screen\\_"
+                    }
+                ],
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "num_return_sequences": 2,
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": [
+                    " Flask is a lightweight web framework for Python, and",
+                    " Flask is a lightweight web framework for Python, and"
+                ],
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": false
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_incremental": true,
+                    "stop_words_str": [
+                        "a lighthouse"
+                    ]
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "iter_count": 10,
+                "finished": true
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_softmax_probs_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_softmax_probs_sm120.json
@@ -1,0 +1,165 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_softmax_probs": true
+                },
+                "yield_generator": false
+            },
+            "result": {
+                "response": " Flask is a lightweight web framework for Python, and",
+                "response_alternatives": null,
+                "hidden_states": null,
+                "logits": null,
+                "loss": null,
+                "input_ids": null,
+                "output_ids": null,
+                "aux_info": {
+                    "input_len": 13,
+                    "prefix_len": 0,
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "output_len": 10,
+                    "step_output_len": 10,
+                    "iter_count": 10,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "pd_sep": false,
+                    "softmax_probs": [
+                        0.19489963352680206,
+                        0.2209184616804123,
+                        0.7173435091972351,
+                        0.2812597155570984,
+                        0.3804025650024414,
+                        0.9763463735580444,
+                        0.4251047968864441,
+                        0.8162611126899719,
+                        0.3448791205883026,
+                        0.1805284321308136
+                    ]
+                }
+            }
+        },
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s5",
+                    "$prompt:s3"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 9,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "return_softmax_probs": true
+                },
+                "yield_generator": false
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": " Flask is a lightweight web framework for Python,",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 13,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 9,
+                            "step_output_len": 9,
+                            "iter_count": 9,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": false,
+                            "softmax_probs": [
+                                0.19483770430088043,
+                                0.22123083472251892,
+                                0.7165234684944153,
+                                0.283765971660614,
+                                0.37993067502975464,
+                                0.9764654040336609,
+                                0.42605310678482056,
+                                0.8182101845741272,
+                                0.34456101059913635
+                            ]
+                        }
+                    },
+                    {
+                        "response": "\n\nI am trying to use the screen\\_",
+                        "response_alternatives": null,
+                        "hidden_states": null,
+                        "logits": null,
+                        "loss": null,
+                        "input_ids": null,
+                        "output_ids": null,
+                        "aux_info": {
+                            "input_len": 12,
+                            "prefix_len": 0,
+                            "reuse_len": 0,
+                            "local_reuse_len": 0,
+                            "remote_reuse_len": 0,
+                            "memory_reuse_len": 0,
+                            "prefill_total_reuse_len": 0,
+                            "prefill_local_reuse_len": 0,
+                            "prefill_remote_reuse_len": 0,
+                            "prefill_memory_reuse_len": 0,
+                            "decode_total_reuse_len": 0,
+                            "decode_local_reuse_len": 0,
+                            "decode_remote_reuse_len": 0,
+                            "decode_memory_reuse_len": 0,
+                            "output_len": 9,
+                            "step_output_len": 9,
+                            "iter_count": 9,
+                            "cum_log_probs": [],
+                            "beam_responses": [],
+                            "pd_sep": false,
+                            "softmax_probs": [
+                                0.47629284858703613,
+                                0.24555420875549316,
+                                0.32773610949516296,
+                                0.4147791564464569,
+                                0.9847739934921265,
+                                0.18305791914463043,
+                                0.2808398902416229,
+                                0.2355845719575882,
+                                0.4154934287071228
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/test_random_seed_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/test_random_seed_sm120.json
@@ -1,0 +1,50 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s5",
+                    "$prompt:s5"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 100,
+                    "random_seed": 46
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": " In Python's Flask framework, Django North and its"
+                    },
+                    {
+                        "response": " In Python's Flask framework, Django North and its"
+                    }
+                ]
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s5",
+                "generate_config": {
+                    "num_return_sequences": 2,
+                    "max_new_tokens": 10,
+                    "top_k": 100,
+                    "random_seed": 46
+                },
+                "yield_generator": true
+            },
+            "result": {
+                "response": [
+                    " In Flask, consider the `request`, `session",
+                    " Flask has its own extensibility via Flask-"
+                ],
+                "iter_count": 10,
+                "finished": true
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_sm120.bzl
+++ b/rtp_llm/test/smoke/suites_sm120.bzl
@@ -1,0 +1,44 @@
+load("//rtp_llm/test/smoke:defs.bzl", "smoke_test")
+
+def sm120_suites():
+    native.test_suite(
+        name = "smoke_sm120_basic",
+        tests = [
+            smoke_test(
+                name = "softmax_probs_sm120",
+                task_info = "data/model/qwen25/q_r_softmax_probs_sm120.json",
+                smoke_args = "--act_type FP16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "fp16_sm120",
+                task_info = "data/model/qwen25/q_r_s_fp16_sm120.json",
+                smoke_args = "--act_type FP16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "bf16_sm120",
+                task_info = "data/model/qwen25/q_r_s_bf16_sm120.json",
+                smoke_args = "--act_type BF16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "bf16_cuda_graph_sm120",
+                task_info = "data/model/qwen25/q_r_s_bf16_sm120.json",
+                smoke_args = "--act_type BF16 --warm_up 0 --seq_size_per_block 64 --enable_cuda_graph 1 --decode_capture_config '1,2'",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "random_seed_sm120",
+                task_info = "data/model/qwen25/test_random_seed_sm120.json",
+                smoke_args = "--act_type FP16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "logits_index_sm120",
+                task_info = "data/model/qwen25/logits_index_q_r_sm120.json",
+                smoke_args = "--act_type FP16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+        ],
+    )


### PR DESCRIPTION
  本 PR 为 SM120 / RTX 5000 Pro 适配拆分的第一阶段，主要建立基础构建、运行时分发和最小 CI 覆盖。

  主要改动：
  - 增加 SM120/RTX 5000 Pro 相关架构识别与 Bazel 构建配置。
  - 更新 CUDA 12.9 依赖，接入支持 SM120 的 FlashInfer、rtp-kernel 与 context FMHA 构建。
  - 在 attention backend 选择中为 SM120 禁用暂不支持的 XQA 路径，并回退到可用实现。
  - 增加不支持 CUDA Graph 的 ragged prefill 显式拒绝，避免无 KV cache prefill 走入不可 capture 路径。
  - 增加 RTX 5000 Pro 最小 smoke/UT 覆盖，包括 SM120 基础 Qwen2.5 smoke、CUDA Graph smoke、BERT/mainse 内源 smoke 与 backend selection 测试。
  - 接入 SM12x CI 入口，使 SM120 case 在 CUDA 12.9 镜像和 RTX 5000 Pro 标签下执行。

  验证重点：
  - CUDA 12.9 x86 构建仍覆盖既有 SM8x/SM9x 路径。
  - SM120 smoke 使用 RTX 5000 Pro 执行，覆盖基础 prefill/decode、CUDA Graph 以及非因果 BERT 路径。
  - 该 PR 不包含 FP8/NVFP4/MoE 等后续功能，仅建立 SM120 基础运行与 CI 框架。