### PR TITLE
feat(attn): dynamic decode attention backend selection at CUDA graph capture

### DIFF
--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -205,7 +205,8 @@ std::string HWKernelConfig::to_string() const {
         << "prefill_capture_seq_lens size: " << prefill_capture_seq_lens.size() << "\n"
         << "decode_capture_batch_sizes size: " << decode_capture_batch_sizes.size() << "\n"
         << "disable_dpc_random: " << disable_dpc_random << "\n"
-        << "rocm_disable_custom_ag: " << rocm_disable_custom_ag;
+        << "rocm_disable_custom_ag: " << rocm_disable_custom_ag << "\n"
+        << "enable_dynamic_decode_backend: " << enable_dynamic_decode_backend;
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -246,7 +246,12 @@ struct HWKernelConfig {
     std::vector<int> decode_capture_batch_sizes;
     bool             disable_dpc_random     = false;
     bool             rocm_disable_custom_ag = true;
-    std::string      to_string() const;
+    // Dynamic decode attention backend selection: when enabled, the engine
+    // benchmarks eligible decode backends per capture bs (real capture path) and
+    // bakes the per-bs winner into the graph instead of fixed-priority first-match.
+    // Off by default; also gated on enable_cuda_graph.
+    bool        enable_dynamic_decode_backend = false;
+    std::string to_string() const;
 };
 
 struct DeviceResourceConfig {

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_base.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_base.h
@@ -18,13 +18,16 @@ struct CudaGraphState {
 };
 
 struct GraphParams {
-    bool             enable_cuda_graph            = false;
-    bool             enable_cuda_graph_debug_mode = false;
-    bool             is_prefill_cuda_graph_mode   = false;
-    bool             is_target_verify             = false;
-    int              max_seq_len                  = 0;
-    int              tokens_per_block             = 0;  // physical kv block size
-    int              kernel_tokens_per_block      = 0;  // must be explicitly configured
+    bool enable_cuda_graph            = false;
+    bool enable_cuda_graph_debug_mode = false;
+    // When true, decode capture benchmarks eligible backends per bs and bakes the
+    // per-bs winner into the graph (vs fixed-priority first-match). See dispatch/.
+    bool             enable_dynamic_decode_backend = false;
+    bool             is_prefill_cuda_graph_mode    = false;
+    bool             is_target_verify              = false;
+    int              max_seq_len                   = 0;
+    int              tokens_per_block              = 0;  // physical kv block size
+    int              kernel_tokens_per_block       = 0;  // must be explicitly configured
     int              num_tokens_per_bs      = 1;  // Number of tokens per batch (1 for decode, max_seq_len for prefill)
     int              sp_steps               = 0;
     size_t           max_context_batch_size = 128;

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_decode.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_decode.cc
@@ -63,6 +63,27 @@ void CudaGraphRunner::captureDecode() {
         refreshTaggedAttentionInputs(inputs);
 
         graph_instances_[bs].mem_hold_ = createCaptureMemoryHold(inputs, bs * num_tokens_per_bs_);
+        // Dynamic decode backend selection: benchmark eligible backends on this bs's
+        // real inputs (real capture path) and record the per-bs winner into the model's
+        // backend_plan; the following prepare_fmha_impl then instantiates that winner.
+        // Must complete (and fully sync, done Python-side) before captureDecodeOneBatchSize.
+        // Capability misses and pre-probe orchestration failures leave the plan empty,
+        // so prepare_fmha_impl uses fixed priority. Once an on-device probe starts,
+        // Python terminates the worker rather than returning an exception here.
+        // Guard: only run for real decode (1 token per batch). Target-model verify/score
+        // has num_tokens_per_bs_ > 1 and uses PREFILL FMHA; selecting a DECODE backend
+        // would produce wrong output shape (bs * hidden vs tokens * hidden).
+        if (enable_dynamic_decode_backend_ && num_tokens_per_bs_ == 1 && py_select_method_
+            && !py_select_method_.is_none()) {
+            try {
+                py_select_method_(graph_instances_[bs].mem_hold_.py_model_inputs_, true);
+            } catch (const std::exception& e) {
+                RTP_LLM_LOG_WARNING("dynamic decode backend selection failed for bs=%d: %s, "
+                                    "falling back to fixed priority",
+                                    bs,
+                                    e.what());
+            }
+        }
         graph_instances_[bs].mem_hold_.attn_pyobj_ =
             py_attn_pyobj_method_(graph_instances_[bs].mem_hold_.py_model_inputs_, true);
         captureDecodeOneBatchSize(bs);

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
@@ -21,6 +21,7 @@ public:
     CudaGraphRunner(const GraphParams& graph_params, py::object py_instance):
         GraphBase(std::move(py_instance)),
         enable_cuda_graph_(graph_params.enable_cuda_graph),
+        enable_dynamic_decode_backend_(graph_params.enable_dynamic_decode_backend),
         is_prefill_cuda_graph_mode_(graph_params.is_prefill_cuda_graph_mode),
         is_target_verify_(graph_params.is_target_verify),
         capture_stream_(cuda_graph::graphGetStreamFromPool(true)),
@@ -46,8 +47,11 @@ public:
         max_bs_               = graph_params.max_context_batch_size;
         py_attn_pyobj_method_ = py_instance_.attr("prepare_fmha_impl");
         py_forward_method_    = py_instance_.attr("forward");
-        options_cuda_int32_   = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA).requires_grad(false);
-        options_cpu_int32_    = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU).requires_grad(false);
+        if (enable_dynamic_decode_backend_ && py::hasattr(py_instance_, "select_decode_backend")) {
+            py_select_method_ = py_instance_.attr("select_decode_backend");
+        }
+        options_cuda_int32_ = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA).requires_grad(false);
+        options_cpu_int32_  = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU).requires_grad(false);
         options_cuda_float_ = torch::TensorOptions().dtype(model_data_type_).device(torch::kCUDA).requires_grad(false);
         RTP_LLM_LOG_INFO("Initialize CudaGraphRunner with parameters below: \n \
             enable_cuda_graph_: %d, max_bs_: %d, enable_cuda_graph_debug_mode_: %d, max_seq_len_: %d, kernel_seq_size_per_block_: %d, \
@@ -120,7 +124,9 @@ private:
     void                    initCaptureAttentionInputsPost();
     py::object              py_forward_method_;
     py::object              py_attn_pyobj_method_;
+    py::object              py_select_method_;  // model.select_decode_backend (dynamic decode backend)
     bool                    enable_cuda_graph_{false};
+    bool                    enable_dynamic_decode_backend_{false};
     bool                    is_prefill_cuda_graph_mode_{false};
     bool                    is_target_verify_{false};
     cuda_graph::GraphStream capture_stream_;

--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -82,6 +82,10 @@ public:
         return false;
     }
 
+    // Trigger any deferred CUDA graph capture held by the underlying model(s).
+    // Default no-op for executors that capture eagerly during construction.
+    virtual void triggerInitCapture() {}
+
 public:
 };
 

--- a/rtp_llm/cpp/models/ModelTypes.h
+++ b/rtp_llm/cpp/models/ModelTypes.h
@@ -124,6 +124,10 @@ public:
     virtual ~ModelBase()                                          = default;
     virtual GptModelOutputs forward(const GptModelInputs& inputs) = 0;
     virtual void            releaseBuffers() {}
+    // Trigger any deferred CUDA graph capture. No-op for models that capture
+    // eagerly in their constructor; PyWrappedModel overrides this when capture
+    // is deferred (e.g. so an accuracy gate can run before the graph is frozen).
+    virtual void triggerInitCapture() {}
 
     rtp_llm::Weights            weights_;
     rtp_llm::OverallExpertStats overall_expert_stats_;

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -48,6 +48,29 @@ torch::Tensor PyWrappedModel::tensorHoldHostAndToCuda(const torch::Tensor& tenso
     return cuda_tensor;
 }
 
+void PyWrappedModel::triggerInitCapture() {
+    if (!enable_cuda_graph_ || graph_runner_ == nullptr) {
+        // CUDA graph disabled / skipped (e.g. warmup, no kv layout): nothing to do.
+        return;
+    }
+    if (capture_done_) {
+        RTP_LLM_LOG_WARNING("PyWrappedModel::triggerInitCapture called but capture already done, skip");
+        return;
+    }
+#if USING_CUDA || USING_ROCM
+    // Mirror the guards the constructor held when it would have captured:
+    // InferenceMode for the capture forwards, GIL for the Python model calls.
+    c10::InferenceMode     inference_guard(true);
+    py::gil_scoped_acquire gil;
+    RTP_LLM_LOG_INFO("PyWrappedModel: triggering deferred CUDA graph capture");
+    graph_runner_->initCapture();
+    capture_done_ = true;
+    RTP_LLM_LOG_INFO("PyWrappedModel: deferred CUDA graph capture done");
+#else
+    RTP_LLM_CHECK_WITH_INFO(false, "CUDA/HIP Graph is only supported on CUDA/ROCm platform");
+#endif
+}
+
 void PyWrappedModel::releaseBuffers() {
     if (held_attn_pyobj_.ptr()) {
         py::gil_scoped_acquire gil;

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -28,18 +28,37 @@ namespace rtp_llm {
 
 class KVCacheManager;  // Forward declaration
 
+namespace dynamic_decode_detail {
+
+inline bool
+enabledForGraph(const HWKernelConfig& hw_kernel_config, bool is_prefill_cuda_graph_mode, SpeculativeType sp_type) {
+    return hw_kernel_config.enable_cuda_graph && hw_kernel_config.enable_dynamic_decode_backend
+           && !is_prefill_cuda_graph_mode && sp_type == SP_TYPE_NONE;
+}
+
+inline bool shouldDeferCapture(bool warm_up, const HWKernelConfig& hw_kernel_config, SpeculativeType sp_type) {
+    return !warm_up && enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, sp_type);
+}
+
+}  // namespace dynamic_decode_detail
+
 class PyWrappedModel: public ModelBase {
 public:
     // py_instance is `py_model` indeedly.
     PyWrappedModel(const GptModelInitParams& params,
                    py::object                py_instance,
                    bool                      is_prefill_cuda_graph_mode = false,
-                   bool                      use_spec_decoding          = false);
+                   bool                      use_spec_decoding          = false,
+                   bool                      defer_capture              = false);
     ~PyWrappedModel();
 
     GptModelOutputs forward(const GptModelInputs& inputs) override;
     GptModelOutputs forwardMicroBatched(const GptModelInputs& inputs);
     void            releaseBuffers() override;
+    // Run the CUDA graph capture that was skipped in the constructor when
+    // defer_capture was set. Idempotent and safe to call when capture is not
+    // deferred / CUDA graph is disabled (then it is a no-op).
+    void triggerInitCapture() override;
 
 private:
     std::optional<PyCacheStoreInputs> prepareWriteCacheParams(const GptModelInputs& inputs);
@@ -93,6 +112,11 @@ private:
     bool       use_spec_decoding_{false};
     bool       enable_device_perf_{false};
     bool       check_nan_{false};
+    // When true, the constructor skips graph_runner_->initCapture() and leaves it
+    // for an explicit triggerInitCapture() call. capture_done_ guards against
+    // double capture (whether done eagerly in ctor or later via trigger).
+    bool defer_capture_{false};
+    bool capture_done_{false};
 
     std::unique_ptr<IContextParallelProcessor> context_parallel_processor_{nullptr};
     std::unique_ptr<CacheStoreAsyncWriter>     cache_store_async_writer_;
@@ -109,7 +133,8 @@ private:
 inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
                                       py::object                py_instance,
                                       bool                      is_prefill_cuda_graph_mode,
-                                      bool                      use_spec_decoding):
+                                      bool                      use_spec_decoding,
+                                      bool                      defer_capture):
     device_props_(buildExecProperties(params.parallelism_config, params.device_resource_config)),
     mla_ops_type_(params.mla_ops_type),
     layer_num_(params.weights.layers.size()),
@@ -119,7 +144,8 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
     is_prefill_cuda_graph_mode_(is_prefill_cuda_graph_mode),
     use_spec_decoding_(use_spec_decoding),
     enable_device_perf_(params.profile_debug_logging_config.enable_device_perf),
-    check_nan_(params.profile_debug_logging_config.check_nan) {
+    check_nan_(params.profile_debug_logging_config.check_nan),
+    defer_capture_(defer_capture) {
 
     c10::InferenceMode inference_guard(true);
 
@@ -171,17 +197,19 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
 
         // Create GraphParams from individual config fields
         GraphParams graph_params;
-        graph_params.enable_cuda_graph            = params.hw_kernel_config.enable_cuda_graph;
-        graph_params.enable_cuda_graph_debug_mode = params.hw_kernel_config.enable_cuda_graph_debug_mode;
-        graph_params.is_prefill_cuda_graph_mode   = is_prefill_cuda_graph_mode;
-        graph_params.max_seq_len                  = params.max_seq_len;
-        graph_params.tokens_per_block             = params.tokens_per_block;
-        graph_params.kernel_tokens_per_block      = params.kernel_tokens_per_block;
-        graph_params.hidden_size                  = params.hidden_size;
-        graph_params.model_data_type              = dtype;
-        graph_params.max_context_batch_size       = params.concurrency_config.concurrency_limit;
-        graph_params.prefill_capture_seq_lens     = params.hw_kernel_config.prefill_capture_seq_lens;
-        graph_params.decode_capture_batch_sizes   = params.hw_kernel_config.decode_capture_batch_sizes;
+        graph_params.enable_cuda_graph             = params.hw_kernel_config.enable_cuda_graph;
+        graph_params.enable_cuda_graph_debug_mode  = params.hw_kernel_config.enable_cuda_graph_debug_mode;
+        graph_params.enable_dynamic_decode_backend = dynamic_decode_detail::enabledForGraph(
+            params.hw_kernel_config, is_prefill_cuda_graph_mode, params.sp_config.type);
+        graph_params.is_prefill_cuda_graph_mode = is_prefill_cuda_graph_mode;
+        graph_params.max_seq_len                = params.max_seq_len;
+        graph_params.tokens_per_block           = params.tokens_per_block;
+        graph_params.kernel_tokens_per_block    = params.kernel_tokens_per_block;
+        graph_params.hidden_size                = params.hidden_size;
+        graph_params.model_data_type            = dtype;
+        graph_params.max_context_batch_size     = params.concurrency_config.concurrency_limit;
+        graph_params.prefill_capture_seq_lens   = params.hw_kernel_config.prefill_capture_seq_lens;
+        graph_params.decode_capture_batch_sizes = params.hw_kernel_config.decode_capture_batch_sizes;
         if (params.kv_cache_layer_layout.has_value()) {
             graph_params.kv_cache_group_tags = params.kv_cache_layer_layout->topology().groupTagsSnapshot();
         }
@@ -250,7 +278,15 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
         RTP_LLM_CHECK_WITH_INFO(graph_runner_ != nullptr, "graph_runner_ can't be null");
         auto py_initialize_method = py_instance.attr("initialize");
         py_init_result            = py_initialize_method(init_resources);
-        graph_runner_->initCapture();
+        if (defer_capture_) {
+            // Capture is deferred: leave graph_runner_ created-but-not-captured.
+            // The owner calls triggerInitCapture() after serving initialization
+            // and before the graph is used.
+            RTP_LLM_LOG_INFO("PyWrappedModel: CUDA graph capture deferred, awaiting triggerInitCapture()");
+        } else {
+            graph_runner_->initCapture();
+            capture_done_ = true;
+        }
     }
 
     auto py_init_success = py_init_result.cast<bool>();

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -9,6 +9,7 @@
 #include "rtp_llm/cpp/engine_base/schedulers/BatchDecodeScheduler.h"
 #include "rtp_llm/cpp/cache/CacheConfigCreator.h"
 #include "rtp_llm/cpp/engine_base/system_prompt/SystemPromptConstructor.h"
+#include "rtp_llm/cpp/models/PyWrappedModel.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/cpp/utils/ProfilingScope.h"
@@ -66,6 +67,14 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
                    params.parallelism_config.dp_rank * params.parallelism_config.tp_size
                        + params.parallelism_config.tp_rank) {
     RTP_LLM_LOG_INFO(__PRETTY_FUNCTION__);
+    if (parallelism_config.world_rank == 0 && params.hw_kernel_config.enable_dynamic_decode_backend
+        && !params.hw_kernel_config.enable_cuda_graph && params.sp_config.type == SP_TYPE_NONE) {
+        RTP_LLM_LOG_WARNING(
+            "dynamic_decode_fallback_static reason=cuda_graph_disabled enable_dynamic_decode_backend=%d "
+            "enable_cuda_graph=%d policy=fixed-priority",
+            int(params.hw_kernel_config.enable_dynamic_decode_backend),
+            int(params.hw_kernel_config.enable_cuda_graph));
+    }
 #if !USING_CUDA
     // On ROCm, this constructor runs on a gRPC handler thread that defaults to
     // GPU 0. Set the correct device so all GPU allocations (KV cache, etc.) go
@@ -108,6 +117,11 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
     }
 
     RTP_LLM_LOG_INFO("create normal executor done");
+
+    if (dynamic_decode_detail::shouldDeferCapture(
+            /*warm_up=*/false, params.hw_kernel_config, params.sp_config.type)) {
+        executor_->triggerInitCapture();
+    }
 
     // 释放模型加载过程中使用的临时host内存
     // 此时checkpoint已加载完成，可以将glibc缓存的内存归还给操作系统

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.cc
@@ -110,7 +110,13 @@ NormalExecutor::NormalExecutor(const EngineInitParams&                params,
     }
     if (!params.py_model.is_none()) {
         RTP_LLM_LOG_INFO("init executor with python model");
-        model_.reset(new PyWrappedModel(model_init_params, params.py_model));
+        const bool defer_capture =
+            dynamic_decode_detail::shouldDeferCapture(warm_up_, params.hw_kernel_config, params.sp_config.type);
+        model_.reset(new PyWrappedModel(model_init_params,
+                                        params.py_model,
+                                        /*is_prefill_cuda_graph_mode=*/false,
+                                        /*use_spec_decoding=*/false,
+                                        defer_capture));
     } else if (test_model_factory) {
         RTP_LLM_LOG_INFO("init executor with test model factory");
         model_ = test_model_factory(model_init_params);

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.h
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.h
@@ -47,6 +47,12 @@ public:
 
     bool updateEplbConfig(const EPLBConfig& config) override;
 
+    void triggerInitCapture() override {
+        if (model_) {
+            model_->triggerInitCapture();
+        }
+    }
+
 private:
     std::unique_ptr<ModelBase>                                               model_;
     std::unique_ptr<Sampler>                                                 sampler_;

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -219,6 +219,12 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
 
     if (!params.py_model.is_none()) {
         RTP_LLM_LOG_INFO("init executor with python model");
+        // The MTP / speculative decoding path does not participate in dynamic attention
+        // backend selection and needs no pre-capture gate/select window, so this model
+        // (and draft_model_ / sp_prefill_draft_model_ below) keep eager capture
+        // (defer_capture defaults to false, capturing inside the ctor) and do not implement
+        // triggerInitCapture() -- inheriting the Executor base no-op is correct here, since
+        // there is no deferred capture to trigger.
         model_.reset(new PyWrappedModel(model_init_params, params.py_model, false, true));
     }
 

--- a/rtp_llm/cpp/normal_engine/test/EngineTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/EngineTest.cc
@@ -4,6 +4,7 @@
 
 #include "rtp_llm/models_py/bindings/core/Types.h"
 #include "rtp_llm/cpp/testing/TestBase.h"
+#include "rtp_llm/cpp/models/PyWrappedModel.h"
 #include "rtp_llm/cpp/models/models_weight/W.h"
 #include "rtp_llm/cpp/normal_engine/NormalEngine.h"
 #include "rtp_llm/cpp/engine_base/schedulers/FIFOScheduler.h"
@@ -12,6 +13,7 @@
 #include "gmock/gmock-function-mocker.h"
 #include "gtest/gtest.h"
 #include <memory>
+#include <vector>
 
 using namespace std;
 namespace W = rtp_llm::W;
@@ -21,6 +23,65 @@ namespace rtp_llm {
 class NormalEngineTest: public DeviceTestBase {
 public:
 };
+
+TEST_F(NormalEngineTest, testDynamicDecodeBackendRoleMatrix) {
+    HWKernelConfig hw_kernel_config;
+    hw_kernel_config.enable_dynamic_decode_backend = true;
+
+    EXPECT_FALSE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, SP_TYPE_NONE));
+    EXPECT_FALSE(dynamic_decode_detail::shouldDeferCapture(
+        /*warm_up=*/false, hw_kernel_config, SP_TYPE_NONE));
+
+    hw_kernel_config.enable_cuda_graph = true;
+    EXPECT_TRUE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, SP_TYPE_NONE));
+    EXPECT_TRUE(dynamic_decode_detail::shouldDeferCapture(
+        /*warm_up=*/false, hw_kernel_config, SP_TYPE_NONE));
+    EXPECT_FALSE(dynamic_decode_detail::shouldDeferCapture(
+        /*warm_up=*/true, hw_kernel_config, SP_TYPE_NONE));
+    // Target verify decode.
+    EXPECT_FALSE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, SP_TYPE_MTP));
+    // Draft decode.
+    EXPECT_FALSE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, SP_TYPE_EAGLE));
+    // Draft prefill.
+    EXPECT_FALSE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/true, SP_TYPE_MTP));
+
+    hw_kernel_config.enable_dynamic_decode_backend = false;
+    EXPECT_FALSE(
+        dynamic_decode_detail::enabledForGraph(hw_kernel_config, /*is_prefill_cuda_graph_mode=*/false, SP_TYPE_NONE));
+}
+
+TEST_F(NormalEngineTest, testDynamicDecodeCaptureTriggerLifecycle) {
+    struct TestCase {
+        const char*     name;
+        bool            enable_cuda_graph;
+        bool            enable_dynamic_decode_backend;
+        SpeculativeType sp_type;
+        size_t          expected_trigger_count;
+    };
+    const std::vector<TestCase> cases = {
+        {"default", false, false, SP_TYPE_NONE, 0},
+        {"dynamic_without_graph", false, true, SP_TYPE_NONE, 0},
+        {"ordinary_decode", true, true, SP_TYPE_NONE, 1},
+        {"speculative_decode", true, true, SP_TYPE_MTP, 0},
+    };
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        CustomConfig config;
+        config.enable_cuda_graph             = test_case.enable_cuda_graph;
+        config.enable_dynamic_decode_backend = test_case.enable_dynamic_decode_backend;
+        config.sp_type                       = test_case.sp_type;
+        auto lifecycle                       = std::make_shared<MockModelLifecycle>();
+        auto engine                          = createMockEngine(config, lifecycle);
+
+        EXPECT_EQ(lifecycle->trigger_init_capture_count, test_case.expected_trigger_count);
+    }
+}
 
 TEST_F(NormalEngineTest, testFp8KVCache) {
     CustomConfig config;

--- a/rtp_llm/cpp/normal_engine/test/MockEngine.h
+++ b/rtp_llm/cpp/normal_engine/test/MockEngine.h
@@ -23,10 +23,15 @@ namespace W = rtp_llm::W;
 
 namespace rtp_llm {
 
+struct MockModelLifecycle {
+    size_t trigger_init_capture_count = 0;
+};
+
 // Mock model that returns random logits for testing NormalEngine without Python
 class MockModel: public ModelBase {
 public:
-    MockModel(size_t vocab_size): vocab_size_(vocab_size) {}
+    MockModel(size_t vocab_size, std::shared_ptr<MockModelLifecycle> lifecycle = nullptr):
+        vocab_size_(vocab_size), lifecycle_(std::move(lifecycle)) {}
 
     GptModelOutputs forward(const GptModelInputs& inputs) override {
         GptModelOutputs outputs;
@@ -37,14 +42,24 @@ public:
         return outputs;
     }
 
+    void triggerInitCapture() override {
+        if (lifecycle_) {
+            ++lifecycle_->trigger_init_capture_count;
+        }
+    }
+
 private:
-    size_t vocab_size_;
+    size_t                              vocab_size_;
+    std::shared_ptr<MockModelLifecycle> lifecycle_;
 };
 
 struct CustomConfig {
     bool                                    reuse_cache        = false;
     DataType                                kv_cache_data_type = DataType::TYPE_FP16;
     std::map<std::string, std::vector<int>> multi_task_prompt_tokens;
+    bool                                    enable_cuda_graph             = false;
+    bool                                    enable_dynamic_decode_backend = false;
+    SpeculativeType                         sp_type                       = SP_TYPE_NONE;
 };
 
 inline void setDefaultMhaKVCacheSpecDescs(rtp_llm::ModelConfig& model_config) {
@@ -143,6 +158,10 @@ rtp_llm::EngineInitParams createEngineInitParams(const CustomConfig&     config,
     rtp_llm::FfnDisAggregateConfig       ffn_disaggregate_config;
     rtp_llm::VitConfig                   vit_config;
 
+    hw_kernel_config.enable_cuda_graph             = config.enable_cuda_graph;
+    hw_kernel_config.enable_dynamic_decode_backend = config.enable_dynamic_decode_backend;
+    sp_config.type                                 = config.sp_type;
+
     rtp_llm::EngineInitParams rtp_llm_params(0,
                                              model_config,
                                              parallelism_config,
@@ -167,15 +186,16 @@ rtp_llm::EngineInitParams createEngineInitParams(const CustomConfig&     config,
     return rtp_llm_params;
 }
 
-std::shared_ptr<NormalEngine> createMockEngine(const CustomConfig& config) {
+std::shared_ptr<NormalEngine> createMockEngine(const CustomConfig&                        config,
+                                               const std::shared_ptr<MockModelLifecycle>& lifecycle = nullptr) {
     rtp_llm::ModelConfig   model_config;
     rtp_llm::RuntimeConfig runtime_config;
     rtp_llm::KVCacheConfig kv_cache_config;
     EngineInitParams rtp_llm_params = createEngineInitParams(config, model_config, runtime_config, kv_cache_config);
     // Set test model factory before engine construction so the model is available during startLoop()
     size_t vocab                       = model_config.vocab_size;
-    NormalExecutor::test_model_factory = [vocab](const GptModelInitParams&) {
-        return std::make_unique<MockModel>(vocab);
+    NormalExecutor::test_model_factory = [vocab, lifecycle](const GptModelInitParams&) {
+        return std::make_unique<MockModel>(vocab, lifecycle);
     };
     std::shared_ptr<NormalEngine> engine = make_shared<NormalEngine>(rtp_llm_params, nullptr);
     NormalExecutor::test_model_factory   = nullptr;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -680,6 +680,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("decode_capture_batch_sizes", &HWKernelConfig::decode_capture_batch_sizes)
         .def_readwrite("disable_dpc_random", &HWKernelConfig::disable_dpc_random)
         .def_readwrite("rocm_disable_custom_ag", &HWKernelConfig::rocm_disable_custom_ag)
+        .def_readwrite("enable_dynamic_decode_backend", &HWKernelConfig::enable_dynamic_decode_backend)
         .def("to_string", &HWKernelConfig::to_string)
         .def(py::pickle(
             [](const HWKernelConfig& self) {
@@ -696,10 +697,14 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.prefill_capture_seq_lens,
                                       self.decode_capture_batch_sizes,
                                       self.disable_dpc_random,
-                                      self.rocm_disable_custom_ag);
+                                      self.rocm_disable_custom_ag,
+                                      self.enable_dynamic_decode_backend);
             },
             [](py::tuple t) {
-                if (t.size() != 14)
+                // Backward compat: 14-field pickle predates enable_dynamic_decode_backend
+                // (added as t[14]). Accept both so mixed-version pickle data
+                // (rolling upgrade / multiprocessing spawn) does not throw.
+                if (t.size() != 14 && t.size() != 15)
                     throw std::runtime_error("Invalid state!");
                 HWKernelConfig c;
                 try {
@@ -717,6 +722,12 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.decode_capture_batch_sizes   = t[11].cast<std::vector<int>>();
                     c.disable_dpc_random           = t[12].cast<bool>();
                     c.rocm_disable_custom_ag       = t[13].cast<bool>();
+                    if (t.size() == 15) {
+                        c.enable_dynamic_decode_backend = t[14].cast<bool>();
+                    } else {
+                        // Legacy pickle: degrade to fixed-priority backend selection.
+                        c.enable_dynamic_decode_backend = false;
+                    }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("HWKernelConfig unpickle error: ") + e.what());
                 }

--- a/rtp_llm/models_py/bindings/cuda/XQAAttnOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/XQAAttnOp.cc
@@ -10,7 +10,9 @@ namespace rtp_llm {
 XQAAttnOp::XQAAttnOp(const AttentionConfigs& attn_configs): attn_configs_(attn_configs) {}
 
 bool XQAAttnOp::support(torch_ext::PyAttentionInputs attn_inputs) {
-    return get_sm() >= 90
+    // XQA kernels are compiled with --cuda-gpu-arch=sm_90a (Hopper-specific);
+    // they are not forward-compatible with SM100/SM120 (cudaErrorInvalidSymbol).
+    return get_sm() == 90
            && supportXqa(DataType::TYPE_BF16,
                          DataType::TYPE_BF16,
                          DataType::TYPE_FP8_E4M3,

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -54,6 +54,16 @@ class GptModelBase(nn.Module):
         self.kv_cache: Optional[KVCache] = None
         self.device_type: DeviceType = get_device_type()
 
+        ## Dynamic decode backend dispatch result. Key absence means selection has
+        ## not completed, None means a completed fixed-priority plan miss, and a
+        ## class name is an already-broadcast winner.
+        self.backend_plan: dict[int, Optional[str]] = {}
+
+        ## Dedup for the "decode backend in use" log: capture bs -> last logged backend
+        ## name, so prepare_fmha_impl emits one line per (bs, backend) at capture instead
+        ## of once per replay step.
+        self._logged_decode_backend: dict[int, str] = {}
+
     def initialize(self, init_resource: PyModelInitResources) -> bool:
         self.kv_cache = init_resource.kv_cache
         if self.kv_cache is not None:
@@ -73,6 +83,75 @@ class GptModelBase(nn.Module):
                 f"layer0_scale_groups={layer0_scale_count}, "
             )
         return True
+
+    def select_decode_backend(
+        self, inputs: PyModelInputs, is_cuda_graph: bool = True
+    ) -> None:
+        """Called per bs by the engine at capture time: benchmark on-device and pick a
+        decode backend, writing the winner into self.backend_plan[bs].
+
+        Capability guards leave the key absent. Plan misses and recoverable pre-probe
+        errors write None, so prepare_fmha_impl uses fixed priority. An exception after an
+        on-device probe starts terminates the worker instead of returning here. Under
+        TP all ranks must call in lockstep (the C++ side drives this per bs in the same
+        order on every rank); internally only rank0 benchmarks and the winner is
+        broadcast. Active only when enable_dynamic_decode_backend is on and the kv
+        cache is ready.
+        """
+        if not getattr(
+            self.py_hw_kernel_config, "enable_dynamic_decode_backend", False
+        ):
+            return
+        # CUDA-only feature: the selectable backends are FlashInfer-based decode impls
+        # that only exist on CUDA. On ROCm/PPU/CPU the on-device bench would drive the
+        # platform's paged-attention (e.g. aiter pa on ROCm) through the CUDA-graph
+        # capture path with synthetic bench inputs, which faults. Skip here so those
+        # platforms keep their fixed-priority decode backend (no behavior change).
+        if self.device_type != DeviceType.Cuda:
+            return
+        if self.kv_cache is None:
+            return
+        # MLA models use a dedicated backend path (get_mla_impl) with no
+        # selectable alternatives; skip the MHA-oriented bench entirely.
+        attn_configs = self.config.getAttentionConfigs(
+            self.parallelism_config.get_attn_tp_size()
+        )
+        if attn_configs.use_mla:
+            return
+        # Hybrid models (linear + full attention) have multi-group KV caches
+        # whose layout is incompatible with MHA-only bench infrastructure;
+        # the bench cannot safely construct valid inputs for XQA/FlashInfer.
+        # Their full_attention layers use fixed-priority backend selection.
+        hybrid_cfg = getattr(self.config, "hybrid_attention_config", None)
+        if (
+            hybrid_cfg is not None
+            and len(getattr(hybrid_cfg, "hybrid_attention_types", [])) > 0
+        ):
+            return
+        attention_inputs = get_attention_inputs_value(inputs)
+        if isinstance(attention_inputs, Mapping):
+            return
+        bs = int(attention_inputs.input_lengths.size(0))
+        try:
+            from rtp_llm.models_py.modules.factory.attention.dispatch import (
+                backend_selector,
+            )
+        except Exception as e:  # noqa: BLE001 -- import is before device probing
+            self.backend_plan[bs] = None
+            logging.warning(
+                f"select_decode_backend failed, fallback to fixed priority: {e}"
+            )
+            return
+        try:
+            winner = backend_selector.run_backend_selection(self, inputs)
+            self.backend_plan[bs] = winner
+        except backend_selector.DynamicDecodeFatalError:
+            raise
+        except Exception as e:  # noqa: BLE001 -- recoverable failure before probing
+            self.backend_plan[bs] = None
+            logging.warning(
+                f"select_decode_backend failed, fallback to fixed priority: {e}"
+            )
 
     def prepare_fmha_impl(
         self, inputs: PyModelInputs, is_cuda_graph: bool = False
@@ -99,7 +178,38 @@ class GptModelBase(nn.Module):
                 )
                 for tag, group_inputs in selected_group_inputs
             }
-        return AttnImplFactory.get_fmha_impl(
+
+        # Dynamic dispatch lookup: only on the cuda graph capture path, and only when the
+        # selection has completed for this bs. A winner must be applied or fail-stop;
+        # an explicit None falls through to fixed priority.
+        # Guard: backend_plan only contains DECODE backends; skip when is_prefill
+        # (target-model verify/score has is_prefill=True with num_tokens_per_bs > 1).
+        selection_complete = False
+        if is_cuda_graph and not attention_inputs.is_prefill:
+            bs = int(attention_inputs.input_lengths.size(0))
+            selection_complete = bs in self.backend_plan
+            name = self.backend_plan.get(bs)
+            if selection_complete and name is not None:
+                from rtp_llm.models_py.modules.factory.attention.dispatch import (
+                    backend_selector,
+                )
+
+                inst = backend_selector.instantiate_decode_impl(
+                    self, attention_inputs, name, is_cuda_graph
+                )
+                if self._logged_decode_backend.get(bs) != name:
+                    self._logged_decode_backend[bs] = name
+                    logging.info(
+                        "dynamic_decode_plan_applied bs=%d backend=%s "
+                        "tp_rank=%d dp_rank=%d",
+                        bs,
+                        name,
+                        int(self.parallelism_config.tp_rank),
+                        int(self.parallelism_config.dp_rank),
+                    )
+                return inst
+
+        fmha_impl = AttnImplFactory.get_fmha_impl(
             self.config,
             self.parallelism_config,
             self.weight,
@@ -107,10 +217,35 @@ class GptModelBase(nn.Module):
             self.fmha_config,
             is_cuda_graph,
         )
+        # Authoritative single log of the decode backend actually in use: only on the
+        # cuda graph capture path (once per bs bucket, not per replay step) and only when
+        # dynamic dispatch is on, so the fixed-priority fallback (plan miss) is visible too.
+        if (
+            is_cuda_graph
+            and not attention_inputs.is_prefill
+            and selection_complete
+            and getattr(
+                self.py_hw_kernel_config, "enable_dynamic_decode_backend", False
+            )
+        ):
+            bs = int(attention_inputs.input_lengths.size(0))
+            self._log_decode_backend_once(
+                bs, type(fmha_impl).__name__, "fixed-priority"
+            )
+        return fmha_impl
 
     def _get_fmha_group_tags(self) -> Optional[list[str]]:
         """Model hook: None means every attention-input tag requires FMHA."""
         return None
+
+    def _log_decode_backend_once(self, bs: int, name: str, source: str) -> None:
+        """Log a fixed-priority decode fallback once per capture bucket."""
+        if self._logged_decode_backend.get(bs) == name:
+            return
+        self._logged_decode_backend[bs] = name
+        logging.info(
+            "[dispatcher] decode backend in use: bs=%d -> %s (%s)", bs, name, source
+        )
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
         raise NotImplementedError("forward method must be implemented in subclass")

--- a/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
+++ b/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import torch
 from torch import nn
 
+from rtp_llm.device.device_type import DeviceType
 from rtp_llm.models_py.model_desc.block_map import get_group_tags_for_layers
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.model_desc.qwen3_next import (
@@ -33,6 +34,35 @@ class RoutingModel(GptModelBase):
 
     def _get_fmha_group_tags(self) -> list[str] | None:
         return self.fmha_group_tags
+
+
+def _dynamic_routing_model():
+    model = RoutingModel(None)
+    model.py_hw_kernel_config = SimpleNamespace(enable_dynamic_decode_backend=True)
+    model.backend_plan = {}
+    model._logged_decode_backend = {}
+    model.device_type = DeviceType.Cuda
+    model.kv_cache = object()
+    model.fmha_config = object()
+    model.parallelism_config = SimpleNamespace(
+        tp_rank=0,
+        tp_size=1,
+        dp_rank=0,
+        get_attn_tp_size=lambda: 1,
+    )
+    model.config = SimpleNamespace(
+        headwise_config=None,
+        hybrid_attention_config=None,
+        getAttentionConfigs=lambda _tp: SimpleNamespace(use_mla=False),
+    )
+    return model
+
+
+def _decode_inputs(bs=2, *, is_prefill=False):
+    return SimpleNamespace(
+        input_lengths=torch.ones(bs, dtype=torch.int32),
+        is_prefill=is_prefill,
+    )
 
 
 class AttentionInputRoutingTest(unittest.TestCase):
@@ -159,6 +189,191 @@ class AttentionInputRoutingTest(unittest.TestCase):
 
         self.assertEqual(fmha_impl, inputs_by_tag)
         self.assertEqual(factory.call_count, 2)
+
+    def test_dynamic_output_probe_does_not_log_or_mark_backend(self):
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+        static_impl = object()
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=attention_inputs,
+            ),
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl",
+                return_value=static_impl,
+            ) as factory,
+            patch.object(model, "_log_decode_backend_once") as log_backend,
+        ):
+            actual = model.prepare_fmha_impl(object(), is_cuda_graph=True)
+
+        self.assertIs(actual, static_impl)
+        factory.assert_called_once()
+        log_backend.assert_not_called()
+        self.assertEqual(model._logged_decode_backend, {})
+
+    def test_completed_plan_miss_logs_fixed_priority_once(self):
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+
+        class StaticImpl:
+            pass
+
+        model.backend_plan[2] = None
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=attention_inputs,
+            ),
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl",
+                return_value=StaticImpl(),
+            ) as factory,
+            patch("rtp_llm.models_py.model_desc.module_base.logging.info") as info,
+        ):
+            model.prepare_fmha_impl(object(), is_cuda_graph=True)
+            model.prepare_fmha_impl(object(), is_cuda_graph=True)
+
+        self.assertEqual(factory.call_count, 2)
+        info.assert_called_once_with(
+            "[dispatcher] decode backend in use: bs=%d -> %s (%s)",
+            2,
+            "StaticImpl",
+            "fixed-priority",
+        )
+        self.assertEqual(model._logged_decode_backend, {2: "StaticImpl"})
+
+    def test_completed_winner_applies_and_logs_once_without_static_factory(self):
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+        winner_impl = object()
+        model.backend_plan[2] = "WinnerImpl"
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=attention_inputs,
+            ),
+            patch(
+                "rtp_llm.models_py.modules.factory.attention.dispatch.backend_selector.instantiate_decode_impl",
+                return_value=winner_impl,
+            ) as instantiate,
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl"
+            ) as factory,
+            patch("rtp_llm.models_py.model_desc.module_base.logging.info") as info,
+        ):
+            first = model.prepare_fmha_impl(object(), is_cuda_graph=True)
+            second = model.prepare_fmha_impl(object(), is_cuda_graph=True)
+
+        self.assertIs(first, winner_impl)
+        self.assertIs(second, winner_impl)
+        self.assertEqual(instantiate.call_count, 2)
+        factory.assert_not_called()
+        info.assert_called_once_with(
+            "dynamic_decode_plan_applied bs=%d backend=%s tp_rank=%d dp_rank=%d",
+            2,
+            "WinnerImpl",
+            0,
+            0,
+        )
+
+    def test_winner_apply_failure_never_uses_static_factory(self):
+        from rtp_llm.models_py.modules.factory.attention.dispatch import (
+            backend_selector,
+        )
+
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+        model.backend_plan[2] = "WinnerImpl"
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=attention_inputs,
+            ),
+            patch.object(
+                backend_selector,
+                "instantiate_decode_impl",
+                side_effect=backend_selector.DynamicDecodeFatalError("fatal"),
+            ),
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl"
+            ) as factory,
+        ):
+            with self.assertRaises(backend_selector.DynamicDecodeFatalError):
+                model.prepare_fmha_impl(object(), is_cuda_graph=True)
+
+        factory.assert_not_called()
+        self.assertEqual(model._logged_decode_backend, {})
+
+    def test_selection_miss_and_recoverable_exception_write_explicit_none(self):
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+        from rtp_llm.models_py.modules.factory.attention.dispatch import (
+            backend_selector,
+        )
+
+        with patch(
+            "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+            return_value=attention_inputs,
+        ):
+            with patch.object(
+                backend_selector, "run_backend_selection", return_value=None
+            ):
+                model.select_decode_backend(object())
+            self.assertIn(2, model.backend_plan)
+            self.assertIsNone(model.backend_plan[2])
+
+            model.backend_plan.clear()
+            with patch.object(
+                backend_selector,
+                "run_backend_selection",
+                side_effect=RuntimeError("pre-probe failure"),
+            ):
+                model.select_decode_backend(object())
+            self.assertIn(2, model.backend_plan)
+            self.assertIsNone(model.backend_plan[2])
+
+    def test_capability_guard_and_nonfinal_paths_keep_plan_and_logs_empty(self):
+        model = _dynamic_routing_model()
+        attention_inputs = _decode_inputs()
+        model.py_hw_kernel_config.enable_dynamic_decode_backend = False
+        with patch(
+            "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+            return_value=attention_inputs,
+        ):
+            model.select_decode_backend(object())
+        self.assertEqual(model.backend_plan, {})
+
+        model.py_hw_kernel_config.enable_dynamic_decode_backend = True
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=attention_inputs,
+            ),
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl",
+                return_value=object(),
+            ),
+            patch.object(model, "_log_decode_backend_once") as log_backend,
+        ):
+            model.prepare_fmha_impl(object(), is_cuda_graph=False)
+        log_backend.assert_not_called()
+
+        prefill_inputs = _decode_inputs(is_prefill=True)
+        model.backend_plan[2] = None
+        with (
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.get_attention_inputs_value",
+                return_value=prefill_inputs,
+            ),
+            patch(
+                "rtp_llm.models_py.model_desc.module_base.AttnImplFactory.get_fmha_impl",
+                return_value=object(),
+            ),
+            patch.object(model, "_log_decode_backend_once") as log_backend,
+        ):
+            model.prepare_fmha_impl(object(), is_cuda_graph=True)
+        log_backend.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -86,10 +86,8 @@ else:
             ]
         )
         DECODE_MHA_IMPS.extend([FlashInferTRTLLMDecodeImpl])
-        # XQAImpl (TRT GMMA) before XQADecodeImpl (FlashInfer HMMA): different
-        # accumulation paths produce <1 ULP divergence that flips tokens in long
-        # generations.  Existing golden data was generated with XQAImpl, so keep
-        # it higher-priority to avoid unnecessary golden refreshes.
+        # Keep the static SM90 implementation as the fixed-priority default;
+        # dynamic selection may still choose the FlashInfer XQA implementation.
         DECODE_MHA_IMPS.append(XQAImpl)
         _xqa_decode_impl = get_xqa_impl()
         if _xqa_decode_impl is not XQAImpl:

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/benchmark_workspace.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/benchmark_workspace.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+_benchmark_workspace_scope: ContextVar[bool] = ContextVar(
+    "benchmark_workspace_scope", default=False
+)
+
+
+def in_benchmark_workspace_scope() -> bool:
+    return _benchmark_workspace_scope.get()
+
+
+@contextmanager
+def benchmark_workspace_scope() -> Iterator[None]:
+    token = _benchmark_workspace_scope.set(True)
+    try:
+        yield
+    finally:
+        _benchmark_workspace_scope.reset(token)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -683,12 +683,21 @@ class PyFlashinferDecodeAttnOp(object):
         return get_scalar_type(attn_inputs.dtype)
 
     def _requires_fa2_cuda_graph_replan(self) -> bool:
-        # FlashInfer BatchDecode routes tensor-core decode through fa2 BatchPrefill.
-        # fa3 prefill paths do not need this replay-time plan refresh.
+        # Tensor-core BatchDecode routes through the FA2 batch-prefill planner.
         return self.use_tensor_core
 
-    def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
-        if self._requires_fa2_cuda_graph_replan():
+    def _plan_decode_wrapper(
+        self, attn_inputs: PyAttentionInputs, *, for_cuda_graph: bool = False
+    ) -> None:
+        """Refresh FlashInfer scheduling metadata for the current page table."""
+        if for_cuda_graph:
+            # The scheduler consumes indptr and last-page lengths on the host,
+            # while the wrapper copies page indices into its device buffer.
+            page_indptr = self.fmha_params.decode_page_indptr_h
+            page_indice = self.fmha_params.page_indice_d
+            last_page_len = self.fmha_params.paged_kv_last_page_len_h
+            plan_kwargs = {"non_blocking": True}
+        elif self._requires_fa2_cuda_graph_replan():
             page_indptr = self.fmha_params.decode_page_indptr_h
             page_indice = self.fmha_params.page_indice_h
             last_page_len = self.fmha_params.paged_kv_last_page_len_h
@@ -751,11 +760,12 @@ class PyFlashinferDecodeAttnOp(object):
                     device=self.g_workspace_buffer.device,
                 )
 
-        self._plan_decode_wrapper(attn_inputs)
+        # CUDA Graph planning uses host scheduler inputs and device page indices.
+        self._plan_decode_wrapper(attn_inputs, for_cuda_graph=self.enable_cuda_graph)
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
-        """Refresh FlashInfer runtime buffers before replaying the captured graph."""
+        """Refresh page tables and scheduling metadata before graph replay."""
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
@@ -764,8 +774,8 @@ class PyFlashinferDecodeAttnOp(object):
             self.seq_size_per_block,
             forbid_realloc=True,
         )
-        if self._requires_fa2_cuda_graph_replan():
-            self._plan_decode_wrapper(attn_inputs)
+        # Runtime KV lengths change the schedule for both decode implementations.
+        self._plan_decode_wrapper(attn_inputs, for_cuda_graph=True)
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -8,6 +8,9 @@ from flashinfer.prefill import (
 )
 
 from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    in_benchmark_workspace_scope,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb import (
     MhaRotaryEmbeddingOp,
 )
@@ -653,7 +656,15 @@ class PyFlashinferDecodeAttnOp(object):
         attn_configs: AttentionConfigs,
         attn_inputs: PyAttentionInputs,
     ) -> None:
-        self.g_workspace_buffer = get_py_flashinfer_workspace_buffer()
+        self._workspace_from_pool = not in_benchmark_workspace_scope()
+        if self._workspace_from_pool:
+            self.g_workspace_buffer = get_py_flashinfer_workspace_buffer()
+        else:
+            self.g_workspace_buffer = torch.zeros(
+                DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
+                dtype=torch.uint8,
+                device="cuda",
+            )
         # attn_configs already has head_num and kv_head_num divided by tp_size
         self.local_head_num = attn_configs.head_num
         self.local_kv_head_num = attn_configs.kv_head_num
@@ -671,7 +682,12 @@ class PyFlashinferDecodeAttnOp(object):
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
-        release_py_flashinfer_workspace_buffer(self.g_workspace_buffer)
+        workspace_buffer = getattr(self, "g_workspace_buffer", None)
+        if (
+            getattr(self, "_workspace_from_pool", False)
+            and workspace_buffer is not None
+        ):
+            release_py_flashinfer_workspace_buffer(workspace_buffer)
 
     def set_params(self, params: rtp_llm_ops.FlashInferMlaAttnParams) -> None:
         """Set the params object to be used by this op."""

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -1,6 +1,5 @@
 import logging
 import math
-import sys
 import unittest
 from typing import List
 
@@ -294,12 +293,12 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     Verifies the critical invariants that the C++ CUDA graph runner depends on:
     1. prepare() with is_cuda_graph=True sets _fixed_batch_size and wires up
        the decode_wrapper's internal buffers for graph capture.
-    2. prepare_for_cuda_graph_replay() refreshes both page tables and, only
-       for FlashInfer fa2, cached plan metadata without reallocating buffers.
+    2. prepare_for_cuda_graph_replay() refreshes the page tables AND calls
+       plan() to update workspace scheduling metadata for ALL decode paths
+       (both FA2 tensor-core and non-tensor-core), without reallocating buffers.
 
-    Full forward correctness under CUDA graph capture/replay cannot be tested
-    at the Python UT level — that path is exercised by smoke tests with real
-    model inference via cuda_graph_runner.cc.
+    Real CUDA graph capture/replay is compared against eager execution for both
+    decode paths in the Bazel test process.
     """
 
     def _create_cuda_graph_inputs(
@@ -333,6 +332,50 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         attn_inputs.dtype = get_typemeta(torch.zeros([1], dtype=dtype))
         return attn_inputs
 
+    def _assert_cuda_graph_plan_call(self, plan_calls, fmha_params):
+        """Verify replay planning uses the CUDA Graph parameter mirrors."""
+        self.assertEqual(len(plan_calls), 1)
+        plan_args, plan_kwargs = plan_calls[0]
+
+        self.assertEqual(
+            plan_args[0].data_ptr(), fmha_params.decode_page_indptr_h.data_ptr()
+        )
+        self.assertEqual(plan_args[1].data_ptr(), fmha_params.page_indice_d.data_ptr())
+        self.assertEqual(
+            plan_args[2].data_ptr(),
+            fmha_params.paged_kv_last_page_len_h.data_ptr(),
+        )
+        self.assertFalse(plan_args[0].is_cuda, "indptr must use the host mirror")
+        self.assertTrue(plan_args[1].is_cuda, "indices must use the device mirror")
+        self.assertFalse(
+            plan_args[2].is_cuda,
+            "last_page_len must use the host mirror",
+        )
+        self.assertTrue(plan_kwargs.get("non_blocking", False))
+        self.assertNotIn("disable_split_kv", plan_kwargs)
+
+    @staticmethod
+    def _cuda_graph_plan_layout(attn_op):
+        """Return the fixed buffer layout consumed by the captured graph."""
+        buffer_names = [
+            "_paged_kv_indptr_buf",
+            "_paged_kv_indices_buf",
+            "_paged_kv_last_page_len_buf",
+            "_qo_indptr_buf",
+        ]
+        buffer_ptrs = {
+            name: getattr(attn_op.decode_wrapper, name).data_ptr()
+            for name in buffer_names
+            if hasattr(attn_op.decode_wrapper, name)
+        }
+        # FlashInfer passes _plan_info by value to run() during capture. Runtime
+        # schedule data may change in-place, but these offsets and launch fields
+        # must remain identical for the captured graph to keep using that data.
+        return {
+            "plan_info": tuple(attn_op.decode_wrapper._plan_info),
+            "buffer_ptrs": buffer_ptrs,
+        }
+
     def test_capture_sets_fixed_batch_size(self):
         """prepare() with is_cuda_graph=True must set _fixed_batch_size."""
         config = self._create_config()
@@ -357,7 +400,7 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         logging.info("_fixed_batch_size correctly set after prepare()")
 
     def test_replay_refreshes_plan_metadata(self):
-        """prepare_for_cuda_graph_replay() must refresh FlashInfer fa2 plan metadata."""
+        """Tensor-core replay refreshes scheduling with graph-safe mirrors."""
         config = self._create_config()
         capture_bs = 8
         capture_seq_lens = [64, 128, 256, 512, 64, 128, 256, 512]
@@ -375,6 +418,7 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         attn_op.prepare(capture_inputs)
 
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+        capture_layout = self._cuda_graph_plan_layout(attn_op)
 
         original_plan = attn_op.decode_wrapper.plan
         plan_calls = []
@@ -393,16 +437,13 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
-        self.assertEqual(len(plan_calls), 1)
-        plan_args, plan_kwargs = plan_calls[0]
-        self.assertFalse(plan_args[0].is_cuda)
-        self.assertFalse(plan_args[1].is_cuda)
-        self.assertFalse(plan_args[2].is_cuda)
-        self.assertTrue(plan_kwargs["non_blocking"])
+        self._assert_cuda_graph_plan_call(plan_calls, fmha_params)
 
-        # _fixed_batch_size must stay at the captured graph size.
+        # Planning may update workspace contents, but not the captured layout.
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+        self.assertEqual(self._cuda_graph_plan_layout(attn_op), capture_layout)
 
+        # Device buffers should be updated by fill_params (verify they exist).
         page_indptr = fmha_params.decode_page_indptr_h
         self.assertIsNotNone(page_indptr)
         self.assertGreaterEqual(len(page_indptr), capture_bs + 1)
@@ -411,8 +452,8 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             f"page_indptr={page_indptr.tolist()}"
         )
 
-    def test_non_fa2_replay_does_not_replan(self):
-        """Non-fa2 decode keeps the original replay contract: fill params only."""
+    def test_non_fa2_replay_also_replans(self):
+        """Non-tensor-core replay refreshes scheduling with graph-safe mirrors."""
         config = self._create_config(head_num=32, head_num_kv=32)
         capture_bs = 4
         capture_seq_lens = [64, 128, 256, 512]
@@ -444,11 +485,15 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             fmha_params.paged_kv_last_page_len_d.data_ptr(),
         )
         self.assertFalse(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
+        capture_layout = self._cuda_graph_plan_layout(attn_op)
 
         plan_calls = []
 
+        original_plan = attn_op.decode_wrapper.plan
+
         def counted_plan(*args, **kwargs):
             plan_calls.append((args, kwargs))
+            return original_plan(*args, **kwargs)
 
         attn_op.decode_wrapper.plan = counted_plan
 
@@ -460,7 +505,9 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
-        self.assertEqual(len(plan_calls), 0)
+        self._assert_cuda_graph_plan_call(plan_calls, fmha_params)
+        self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+        self.assertEqual(self._cuda_graph_plan_layout(attn_op), capture_layout)
 
     def test_replay_updates_page_tables(self):
         """Page table buffers must reflect the replay inputs, not capture inputs."""
@@ -517,6 +564,108 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             f"Page table update OK: indptr={expected_indptr}, "
             f"last_page_len={expected_last_page_lens}"
         )
+
+    # (head_num_kv, use_tensor_core, label) covers both decode graph paths:
+    #   - kv=8: ratio 4, tensor-core path
+    #   - kv=16: ratio 2, non-tensor-core path
+    _CUDA_GRAPH_CONFIGS = [(8, True, "fa2"), (16, False, "non_fa2")]
+
+    def _run_cuda_graph_case(self, head_num_kv: int, expect_tc: bool, label: str):
+        """Compare CUDA Graph replay with eager execution in this test process."""
+        config = self._create_config(
+            head_num=32,
+            head_num_kv=head_num_kv,
+            size_per_head=128,
+            seq_size_per_block=32,
+        )
+        batch_size = 4
+        capture_seq_lens = [128, 256, 192, 224]
+        replay_seq_lens = [64, 128, 96, 160]
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+
+        capture_inputs = self._create_cuda_graph_inputs(
+            batch_size,
+            capture_seq_lens,
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertIs(attn_op.use_tensor_core, expect_tc)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+        capture_layout = self._cuda_graph_plan_layout(attn_op)
+
+        total_blocks = self._calculate_total_blocks(
+            capture_seq_lens, config.seq_size_per_block
+        )
+        kv_cache, _, _ = self._create_kv_cache(
+            total_blocks,
+            config.seq_size_per_block,
+            local_kv_head_num,
+            config.size_per_head,
+        )
+        q = self._create_query_tensor(batch_size, local_head_num, config.size_per_head)
+
+        torch.cuda.synchronize()
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            attn_op.forward(q, kv_cache, fmha_params)
+        stream.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            graph_output = attn_op.forward(q, kv_cache, fmha_params)
+        stream.synchronize()
+
+        replay_inputs = self._create_cuda_graph_inputs(
+            batch_size,
+            replay_seq_lens,
+            config.seq_size_per_block,
+        )
+        with torch.cuda.stream(stream):
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+            replay_layout = self._cuda_graph_plan_layout(attn_op)
+            graph.replay()
+        stream.synchronize()
+
+        self.assertEqual(replay_layout, capture_layout)
+        self.assertEqual(
+            graph_output.shape,
+            (batch_size, local_head_num, config.size_per_head),
+        )
+        replay_output = graph_output.clone()
+
+        eager_inputs = self._create_cuda_graph_inputs(
+            batch_size,
+            replay_seq_lens,
+            config.seq_size_per_block,
+        )
+        eager_inputs.is_cuda_graph = False
+        eager_op = PyFlashinferDecodeAttnOp(config.attn_configs, eager_inputs)
+        eager_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        eager_op.set_params(eager_params)
+        eager_op.prepare(eager_inputs)
+        eager_output = eager_op.forward(q, kv_cache, eager_params)
+
+        torch.testing.assert_close(
+            replay_output,
+            eager_output,
+            rtol=1e-2,
+            atol=1e-2,
+            msg=lambda msg: f"[{label}] CUDA Graph replay differs from eager: {msg}",
+        )
+
+    def test_cuda_graph_capture_replay_matches_eager(self):
+        """End-to-end CUDA graph replay matches eager execution.
+
+        Covers both decode CUDA Graph paths in _CUDA_GRAPH_CONFIGS:
+        - FA2 tensor-core path (GQA 4:1, use_tensor_core=True)
+        - non-FA2 path (GQA 2:1, use_tensor_core=False)
+        """
+        for head_num_kv, expect_tc, label in self._CUDA_GRAPH_CONFIGS:
+            with self.subTest(path=label):
+                self._run_cuda_graph_case(head_num_kv, expect_tc, label)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_xqa.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_xqa.py
@@ -1,11 +1,16 @@
 import logging
 import unittest
 from typing import List
+from unittest.mock import patch
 
 import torch
 from attention_ref import compute_flashinfer_decode_reference
 from base_attention_test import BaseAttentionTest, compare_tensors
 
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.xqa import (
+    XQADecodeImpl,
+    XQAImpl,
+)
 from rtp_llm.ops.compute_ops import PyAttentionInputs, XQAAttnOp, XQAParams
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -322,6 +327,40 @@ class TestXQAAttnOp(BaseAttentionTest):
             )
 
         logging.info("\n=== XQAAttnOp support() testing completed ===")
+
+    def test_decode_impl_architecture_matrix(self):
+        config = self._create_config()
+        attn_inputs = self._create_attention_inputs(
+            batch_size=1,
+            sequence_lengths=[128],
+            seq_size_per_block=config.seq_size_per_block,
+        )
+
+        for sm, expected in [
+            ((8, 0), False),
+            ((9, 0), True),
+            ((10, 0), False),
+            ((12, 0), False),
+        ]:
+            with self.subTest(sm=sm), patch(
+                "rtp_llm.models_py.modules.factory.attention.cuda_impl.xqa.get_sm",
+                return_value=sm,
+            ):
+                self.assertEqual(
+                    XQADecodeImpl.support(config.attn_configs, attn_inputs), expected
+                )
+
+    def test_decode_impl_registry_keeps_static_xqa_as_default(self):
+        from rtp_llm.models_py.modules.factory.attention.attn_factory import (
+            DECODE_MHA_IMPS,
+        )
+
+        self.assertIn(XQAImpl, DECODE_MHA_IMPS)
+        if XQADecodeImpl in DECODE_MHA_IMPS:
+            self.assertLess(
+                DECODE_MHA_IMPS.index(XQAImpl),
+                DECODE_MHA_IMPS.index(XQADecodeImpl),
+            )
 
     def test_support_functionality(self):
         """Test XQAAttnOp support function with various configurations"""

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/trtllm_gen.py
@@ -6,6 +6,9 @@ import triton
 import triton.language as tl
 
 from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    in_benchmark_workspace_scope,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.models_py.utils.arch import is_blackwell, is_sm12x
 from rtp_llm.ops import AttentionConfigs, FMHAType, ParallelismConfig
@@ -439,10 +442,23 @@ class FlashInferTRTLLMDecodeOp(object):
         self.seq_size_per_block = attn_configs.kernel_tokens_per_block
         self.local_head_num = attn_configs.head_num
         self.local_head_kv_num = attn_configs.kv_head_num
-        self.workspace_buffer = get_trt_workspace_buffer()
+        self._workspace_from_pool = not in_benchmark_workspace_scope()
+        if self._workspace_from_pool:
+            self.workspace_buffer = get_trt_workspace_buffer()
+        else:
+            self.workspace_buffer = torch.zeros(
+                DEFAULT_TRT_WORKSPACE_SIZE_MB * 1024 * 1024,
+                dtype=torch.uint8,
+                device="cuda",
+            )
 
     def __del__(self):
-        release_trt_workspace_buffer(self.workspace_buffer)
+        workspace_buffer = getattr(self, "workspace_buffer", None)
+        if (
+            getattr(self, "_workspace_from_pool", False)
+            and workspace_buffer is not None
+        ):
+            release_trt_workspace_buffer(workspace_buffer)
 
     def support(self, attention_inputs: PyAttentionInputs):
         if not is_blackwell():

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/xqa.py
@@ -5,14 +5,12 @@ from typing import Any, Optional, Type
 import torch
 
 from rtp_llm.models_py.modules.factory.attention import common
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    in_benchmark_workspace_scope,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.models_py.utils.arch import get_num_device_sms, get_sm, is_sm12x
-from rtp_llm.ops import (
-    AttentionConfigs,
-    FMHAConfig,
-    FMHAType,
-    ParallelismConfig,
-)
+from rtp_llm.ops import AttentionConfigs, FMHAConfig, FMHAType, ParallelismConfig
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOp,
     LayerKVCache,
@@ -83,10 +81,12 @@ class XQAImpl(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        if attn_configs.use_mla:
+            return False
         # XQA cubin covers sm_90 only; sm_120a (Blackwell consumer, e.g.
         # RTX 5000 Pro) lacks a binding and triggers cudaErrorInvalidSymbol
-        # at first forward. C++ XQAAttnOp.support gate is `>= kSM_90` and
-        # passes sm_120 erroneously — short-circuit here so dispatch falls
+        # at first forward. Keep this Python guard aligned with the strict
+        # SM90 check in C++ so dispatch falls
         # through to PyFlashinferPaged. See blockers.md R-4.
         if is_sm12x():
             return False
@@ -148,16 +148,13 @@ class XQADecodeImpl(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
+        if attn_configs.use_mla:
+            return False
         if attn_inputs.is_prefill:
             return False
-        # sm_120a consumer Blackwell: the FlashInfer xqa() build here rejects
-        # the nb_sub_seq_per_seq kwarg used in forward(), and XQA has no
-        # sm_120a binding anyway. Gate it off so decode dispatch falls through
-        # to PyFlashinferDecodeImpl (the working sm_120 path), mirroring the
-        # XQAImpl.support gate.
-        if is_sm12x():
-            return False
-        if get_sm()[0] not in [9, 10]:
+        # SM100 capture/replay succeeds, but the FP8 KV-cache path failed the
+        # independent SM100 output golden during hardware qualification.
+        if get_sm()[0] != 9:
             return False
         group_size = attn_configs.head_num // attn_configs.kv_head_num
         return (
@@ -236,7 +233,15 @@ class XQAWrapper:
         self.attn_inputs = attn_inputs
         self.cu_qseqlens = attn_inputs.cu_seqlens_device
         assert not self.attn_inputs.is_prefill, "XQA is not supported"
-        self.workspace_buffer = get_xqa_workspace_buffer()
+        self._workspace_from_pool = not in_benchmark_workspace_scope()
+        if self._workspace_from_pool:
+            self.workspace_buffer = get_xqa_workspace_buffer()
+        else:
+            self.workspace_buffer = torch.zeros(
+                DEFAULT_XQA_WORKSPACE_SIZE_MB * 1024 * 1024,
+                dtype=torch.uint8,
+                device="cuda",
+            )
         self.semaphores = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device="cuda")
 
         self.enable_pdl = False
@@ -259,7 +264,12 @@ class XQAWrapper:
         self._seq_lens_4d: Optional[torch.Tensor] = None
 
     def __del__(self):
-        release_xqa_workspace_buffer(self.workspace_buffer)
+        workspace_buffer = getattr(self, "workspace_buffer", None)
+        if (
+            getattr(self, "_workspace_from_pool", False)
+            and workspace_buffer is not None
+        ):
+            release_xqa_workspace_buffer(workspace_buffer)
 
     def support(self, attn_inputs: Any) -> bool:
         group_size = self.config.head_num // self.config.kv_head_num
@@ -471,30 +481,25 @@ class XQAWrapper:
 
 
 def get_xqa_impl() -> Type[FMHAImplBase]:
-    """
-    Select the appropriate XQA implementation based on CUDA version and flashinfer availability.
-
-    Returns XQADecodeImpl if CUDA >= 12.8 and flashinfer.xqa is available,
-    otherwise falls back to XQAImpl.
-    """
+    """Return the optional FlashInfer XQA decode candidate when available."""
     try:
         major, minor = map(int, torch.version.cuda.split(".")[:2])
         if (major, minor) >= (12, 8):
             try:
-                from flashinfer.xqa import xqa
+                from flashinfer.xqa import xqa  # noqa: F401
 
-                logging.info(
-                    "CUDA >= 12.8 and flashinfer.xqa available, using XQADecodeImpl"
+                logging.debug(
+                    "CUDA >= 12.8 and flashinfer.xqa available, registering XQADecodeImpl as fallback candidate"
                 )
                 return XQADecodeImpl
             except (ImportError, AttributeError) as e:
-                logging.info(
-                    f"CUDA >= 12.8 but flashinfer.xqa not available ({e}), falling back to XQAImpl"
+                logging.debug(
+                    f"CUDA >= 12.8 but flashinfer.xqa not available ({e}), skipping XQADecodeImpl"
                 )
-                return XQAImpl
         else:
-            logging.info(f"CUDA version {major}.{minor} < 12.8, using XQAImpl")
-            return XQAImpl
+            logging.debug(
+                f"CUDA version {major}.{minor} < 12.8, skipping XQADecodeImpl"
+            )
     except Exception as e:
-        logging.warning(f"Failed to check CUDA version ({e}), using XQAImpl")
-        return XQAImpl
+        logging.warning(f"Failed to check CUDA version ({e}), skipping XQADecodeImpl")
+    return XQAImpl

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/__init__.py
@@ -1,0 +1,13 @@
+"""Dynamic decode attention backend dispatch.
+
+During CUDA graph capture, pick the best backend per decode graph for each bs
+bucket, using support filtering and real-machine performance comparison.
+Fixed-priority first-match cannot pick the best backend when the winner flips
+with bs (measured in roughly 78% of cases); this package replaces that with a
+data-driven approach.
+
+Module layering:
+  - selector: pure CPU selection logic, unit-testable in CI.
+  - backend_bench: real capture-path timing (GPU).
+  - backend_selector: startup-time orchestration and TP broadcast (GPU + NCCL).
+"""

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/backend_bench.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/backend_bench.py
@@ -1,0 +1,344 @@
+"""Real capture-path timing (GPU).
+
+Does not hand-build PyAttentionInputs (hand-building drifts with the schema and
+frequently goes all N/A); the inputs are taken from the engine's real
+attention_inputs and LayerKVCache, and only qkv is synthesized (randn; latency
+depends only on shape and memory access, it does not measure precision). Each kv
+grid point does one real-machine capture+replay timing, going through the same
+path and the same kernel as the engine's actual capture, so the schema is always
+correct.
+
+Hard constraints:
+  - The throwaway cuda graph uses a private pool (does not pass the shared pool);
+    otherwise, after release, returning to the shared pool and being reused by
+    the actual capture would corrupt it.
+  - After each (impl, kv) capture, release the graph, closures, implementation,
+    workspace, and temporary tensors before synchronizing and emptying the cache;
+    otherwise private-pool reservations can accumulate until OOM.
+  - The caller must ensure this module fully finishes and syncs before entering
+    the engine's actual capture, to avoid nested capture.
+  - Only modify sequence-length fields on the clone, never touch the engine's
+    shared attn_inputs.
+"""
+
+from __future__ import annotations
+
+import copy
+import statistics
+from typing import List, Optional
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    benchmark_workspace_scope,
+)
+
+_L2_FLUSH_MB = 256
+
+# Each bench uses a dedicated private graph pool, to avoid crossing pool space with the engine's actual capture.
+_bench_graph_pool_id: Optional[int] = None
+
+
+def _get_bench_pool() -> int:
+    """Return the bench-dedicated CUDA graph memory pool handle (process-unique)."""
+    global _bench_graph_pool_id
+    if _bench_graph_pool_id is None:
+        _bench_graph_pool_id = torch.cuda.graph_pool_handle()
+    return _bench_graph_pool_id
+
+
+def _clone_attn_inputs(attn_inputs):
+    """Deep clone PyAttentionInputs -- .clone() every Tensor field, copy scalars/None as-is.
+
+    Purpose: any modification to attn_inputs during the bench phase (FlashInfer
+    plan writing back buffer pointers, workspace allocation, etc.) does not leak
+    onto the engine's shared attn_inputs object.
+    """
+    cloned = copy.copy(
+        attn_inputs
+    )  # shallow copy the C++ binding object (copies scalar fields)
+    # clone Tensors field by field (prevent reference leaks; list[Tensor] is cloned element by element too)
+    for attr in dir(cloned):
+        if attr.startswith("_"):
+            continue
+        val = getattr(cloned, attr)
+        if isinstance(val, torch.Tensor):
+            cloned_val = val.clone()
+            try:
+                setattr(cloned, attr, cloned_val)
+            except AttributeError:
+                pass  # skip read-only properties
+        elif isinstance(val, list) and val and isinstance(val[0], torch.Tensor):
+            cloned_val = [t.clone() for t in val]
+            try:
+                setattr(cloned, attr, cloned_val)
+            except AttributeError:
+                pass
+    # Read-only properties cannot be replaced. Fail loud if a field the benchmark
+    # relies on ended up aliasing the engine-shared original.
+    for _f in (
+        "input_lengths",
+        "sequence_lengths",
+        "sequence_lengths_plus_1_device",
+    ):
+        _orig = getattr(attn_inputs, _f, None)
+        _new = getattr(cloned, _f, None)
+        if isinstance(_orig, torch.Tensor) and isinstance(_new, torch.Tensor):
+            assert (
+                _orig.data_ptr() != _new.data_ptr()
+            ), f"_clone_attn_inputs: field '{_f}' was not independently cloned"
+    return cloned
+
+
+def _make_l2_filler(fill_mode: str):
+    """L2 preprocessing closure (run before each iteration, outside timing). store = zero_() a 256MB buffer each iteration to flush L2.
+    Returns (do_fill, keepalive_bufs)."""
+    if fill_mode == "store":
+        buf = torch.empty(_L2_FLUSH_MB * 1024 * 1024, dtype=torch.int8, device="cuda")
+        return (lambda: buf.zero_()), (buf,)
+    if fill_mode == "none":
+        return (lambda: None), ()
+    raise ValueError(f"unknown l2 fill_mode: {fill_mode!r} (store/none)")
+
+
+def _bench_graph(
+    fn,
+    warmup: int,
+    iters: int,
+    l2_fill_mode: str,
+    prepare_fn=None,
+    attention_layer_count: int = 1,
+) -> List[float]:
+    """CUDA Graph capture+replay model-step score, including host overhead.
+
+    Safe-isolation measures:
+      1. Use a private pool, not sharing pool space with the engine's actual capture.
+      2. Do a side-stream warmup before capture, so the backend's lazy-init
+         allocations complete before capture; otherwise dynamic allocs get
+         captured into the graph and replay behavior becomes undefined.
+      3. After capture, do the replay timing, and del g at the end to release the
+         private pool reservation.
+      4. On healthy completion, synchronize and release unused cached allocations.
+
+    If prepare_fn is provided, it is called before each replay to simulate
+    production's per-step prepare_for_cuda_graph_replay overhead (including
+    FlashInfer plan and sync), and is included in the timing interval. The
+    production implementation prepares once per model step and is then reused
+    by every attention layer. For multi-layer models, replay-only cost is
+    measured on the same graph and scaled by attention_layer_count.
+    """
+    if attention_layer_count < 1:
+        raise ValueError("attention_layer_count must be positive")
+    do_fill, _keep = _make_l2_filler(l2_fill_mode)
+
+    # --- warmup on side stream (not counted into the default stream's graph dependencies) ---
+    torch.cuda.synchronize()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(max(3, warmup)):
+            fn()
+    torch.cuda.current_stream().wait_stream(s)
+    torch.cuda.synchronize()
+
+    # --- capture (private pool) ---
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, pool=_get_bench_pool()):
+        fn()
+    torch.cuda.synchronize()
+
+    # --- replay warmup ---
+    for _ in range(warmup):
+        do_fill()
+        if prepare_fn:
+            prepare_fn()
+        g.replay()
+    torch.cuda.synchronize()
+
+    times = _time_graph_replays(g, do_fill, iters, prepare_fn)
+    if attention_layer_count > 1:
+        replay_only_times = (
+            times
+            if prepare_fn is None
+            else _time_graph_replays(g, do_fill, iters, prepare_fn=None)
+        )
+        times = _model_step_times(times, replay_only_times, attention_layer_count)
+        del replay_only_times
+
+    # The caller drops the graph closures, implementation, workspace, and
+    # temporary tensors before performing allocator cleanup.
+    del g
+    del do_fill, _keep
+    return times
+
+
+def _time_graph_replays(g, do_fill, iters: int, prepare_fn) -> List[float]:
+    """Measure graph replay, optionally including one per-step prepare call."""
+    # Synchronizing each start event excludes the asynchronous L2 filler while
+    # establishing the timing boundary before host-side replay preparation.
+    st = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    en = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for i in range(iters):
+        do_fill()
+        st[i].record()
+        st[i].synchronize()
+        if prepare_fn:
+            prepare_fn()
+        g.replay()
+        en[i].record()
+    torch.cuda.synchronize()
+    times = [st[i].elapsed_time(en[i]) * 1000.0 for i in range(iters)]
+    return times
+
+
+def _model_step_times(
+    combined_times: List[float],
+    replay_only_times: List[float],
+    attention_layer_count: int,
+) -> List[float]:
+    """Scale one prepare plus one replay to one prepare plus all layer replays."""
+    if attention_layer_count < 1:
+        raise ValueError("attention_layer_count must be positive")
+    replay_us = statistics.median(replay_only_times)
+    return [
+        combined_us + (attention_layer_count - 1) * replay_us
+        for combined_us in combined_times
+    ]
+
+
+def _qkv_dim(attn_configs) -> int:
+    return (
+        attn_configs.head_num + 2 * attn_configs.kv_head_num
+    ) * attn_configs.size_per_head
+
+
+def _fill_synthetic_kv_block(kv_base) -> None:
+    """Fill the benchmarked cache block through a universally supported dtype."""
+    if kv_base is None or kv_base.dim() < 1 or kv_base.shape[0] == 0:
+        return
+    block = kv_base[0]
+    random_block = torch.randn(block.shape, dtype=torch.float32, device=block.device)
+    block.copy_(random_block)
+
+
+def _set_uniform_seq_len(cloned_inputs, bs: int, kv: int) -> None:
+    """Set host and replay-device KV-length mirrors on benchmark inputs.
+
+    The host tensor is consumed when an implementation is constructed. Production
+    replay also refreshes implementation state from sequence_lengths_plus_1_device,
+    so the benchmark must update that mirror in place before capture and replay.
+    The block table remains unchanged: logical blocks still map to the valid
+    physical block 0 used by the benchmark fixture.
+    """
+    fields = (
+        ("sequence_lengths", "cpu"),
+        ("sequence_lengths_plus_1_device", "cuda"),
+    )
+    tensors = {}
+    for field, expected_device in fields:
+        tensor = getattr(cloned_inputs, field, None)
+        context = f"field={field} bs={bs} kv={kv}"
+        if not isinstance(tensor, torch.Tensor):
+            raise ValueError(f"{context}: required tensor is missing")
+        if tensor.dtype != torch.int32:
+            raise ValueError(
+                f"{context}: expected dtype=torch.int32, got {tensor.dtype}"
+            )
+        if tensor.device.type != expected_device:
+            raise ValueError(
+                f"{context}: expected device={expected_device}, got {tensor.device}"
+            )
+        if tensor.dim() < 1 or tensor.size(0) < bs:
+            raise ValueError(
+                f"{context}: expected first dimension >= {bs}, got shape={tuple(tensor.shape)}"
+            )
+        tensors[field] = tensor
+
+    cloned_inputs.sequence_lengths = torch.full(
+        (bs,), int(kv), dtype=torch.int32
+    ).pin_memory()
+    tensors["sequence_lengths_plus_1_device"][:bs].fill_(int(kv) + 1)
+
+
+def bench_backend_grid(
+    impl_cls,
+    attn_configs,
+    attn_inputs,
+    layer_kv_cache,
+    parallelism_config,
+    kv_list: List[int],
+    *,
+    attention_layer_count: int = 1,
+    warmup: int = 10,
+    iters: int = 50,
+    l2_fill_mode: str = "store",
+) -> Optional[List[float]]:
+    """Multi-kv-point real-machine timing: for each kv, set sequence_lengths=kv on a clone, and time capture+replay separately.
+
+    Returns model-step-equivalent median_us values aligned with kv_list. Prepare
+    runs once per step while attention replay cost is scaled to the model's
+    attention layer count. A real instance reporting no CUDA Graph support
+    returns None as a normal unavailable-candidate result; probe exceptions
+    propagate to the selector's fatal boundary. Each kv uses an independent
+    clone so captured addresses cannot contaminate shared inputs.
+    """
+    bs = int(attn_inputs.input_lengths.size(0))
+    with benchmark_workspace_scope():
+        qkv = torch.randn(
+            bs, _qkv_dim(attn_configs), dtype=attn_configs.dtype, device="cuda"
+        )
+        # Fill KV cache block 0 with random data so the kernel operates on non-trivial
+        # values (avoids degenerate all-zero softmax). Block table remains all-zero
+        # (all logical blocks -> physical block 0), so only block 0 is actually read.
+        _fill_synthetic_kv_block(layer_kv_cache.kv_cache_base)
+        lats: List[float] = []
+        for kv in kv_list:
+            bench_inputs = _clone_attn_inputs(attn_inputs)
+            # Force CG mode on the clone: the harness always captures+replays, so the
+            # wrapper must be built in CG mode (fixed buffers). is_cuda_graph is still
+            # False on the engine inputs at selection time; leaving it False makes the
+            # impl non-CG, and CG-capturing a non-CG wrapper is undefined behavior
+            # (crash / hang / inflated replay).
+            bench_inputs.is_cuda_graph = True
+            _set_uniform_seq_len(bench_inputs, bs, kv)
+            # 3-arg unconditionally (all impls take parallelism_config=None); a TypeError
+            # fallback would mask a real internal TypeError, see instantiate_decode_impl.
+            impl = impl_cls(attn_configs, bench_inputs, parallelism_config)
+            if not impl.support_cuda_graph():
+                del impl, bench_inputs, qkv
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+                return None
+
+            def fn():
+                impl.forward(qkv, layer_kv_cache, 0)
+
+            torch.cuda.synchronize()
+            fn()  # warmup + verify it can forward
+            torch.cuda.synchronize()
+
+            prepare_fn = None
+            _prepare_cg = getattr(impl, "prepare_cuda_graph", None)
+            if callable(_prepare_cg):
+                # bind bench_inputs via default arg to avoid late-binding closure risk
+                prepare_fn = lambda bi=bench_inputs: _prepare_cg(bi)  # noqa: E731
+            times = _bench_graph(
+                fn,
+                warmup,
+                iters,
+                l2_fill_mode,
+                prepare_fn=prepare_fn,
+                attention_layer_count=attention_layer_count,
+            )
+            lats.append(statistics.median(times))
+            # Drop closures before impl so its temporary workspace becomes
+            # unreferenced before healthy-path allocator cleanup.
+            del fn
+            del prepare_fn, _prepare_cg
+            del impl, bench_inputs, times
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+        del qkv
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+    return lats

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/backend_selector.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/backend_selector.py
@@ -1,0 +1,515 @@
+"""Startup-time decode backend selection orchestration (GPU + NCCL).
+
+Called by the engine per bs during capture: for that bs, real-machine benchmark
+the candidate backends intersected with support (going through the real capture
+path, see backend_bench), and pick the winner by the aggregation criterion.
+Only rank0 benchmarks and selects, then broadcasts the winner's registry index
+to Group.TP so every rank gets the same winner; otherwise each rank would pick
+a different backend due to noise, bake different graphs, and NCCL would hang.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from typing import List, NoReturn, Optional
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    benchmark_workspace_scope,
+)
+from rtp_llm.models_py.modules.factory.attention.dispatch import backend_bench
+from rtp_llm.models_py.modules.factory.attention.dispatch.selector import (
+    STABLE_CLUSTER_MARGIN,
+    STABLE_THRESHOLD,
+    Selector,
+    kv_grid,
+    select_stable,
+)
+
+logger = logging.getLogger(__name__)
+
+_FATAL_PROBE_EXIT_CODE = 70
+
+
+class DynamicDecodeFatalError(RuntimeError):
+    """Raised only if the process exit primitive unexpectedly returns in tests."""
+
+
+class _SelectorConfigError(ValueError):
+    def __init__(self, variable: str, raw_value: str, reason: str):
+        super().__init__(
+            f"{variable}={raw_value!r} must be a finite non-negative float: {reason}"
+        )
+        self.variable = variable
+        self.raw_value = raw_value
+        self.reason = reason
+
+
+class _FatalProbeError(RuntimeError):
+    """Marks an exception raised after real on-device probing has started."""
+
+    def __init__(self, backend: str):
+        super().__init__(f"fatal decode backend probe failure: {backend}")
+        self.backend = backend
+
+
+def _terminate_probe_worker(bs: int, backend: str, error: BaseException) -> NoReturn:
+    """Terminate without CUDA cleanup, TP broadcast, or in-process fallback."""
+    cause = error.__cause__ or error
+    logger.critical(
+        "[dispatcher] bs=%d backend=%s fatal probe exception; terminating worker",
+        bs,
+        backend,
+        exc_info=(type(cause), cause, cause.__traceback__),
+    )
+    os._exit(_FATAL_PROBE_EXIT_CODE)
+
+
+def _terminate_config_worker(
+    bs: int, error: _SelectorConfigError, parallelism_config
+) -> NoReturn:
+    logger.critical(
+        "dynamic_decode_config_invalid variable=%s value=%r "
+        "rule=finite_nonnegative_float bs=%d tp_rank=%d tp_size=%d dp_rank=%d "
+        "reason=%s",
+        error.variable,
+        error.raw_value,
+        bs,
+        int(parallelism_config.tp_rank),
+        int(parallelism_config.tp_size),
+        int(parallelism_config.dp_rank),
+        error.reason,
+    )
+    os._exit(_FATAL_PROBE_EXIT_CODE)
+
+
+def _terminate_plan_application_worker(
+    bs: int,
+    backend: str,
+    registry_idx: int,
+    parallelism_config,
+    stage: str,
+    error: BaseException,
+) -> NoReturn:
+    logger.critical(
+        "dynamic_decode_plan_apply_failed bs=%d backend=%s registry_idx=%d "
+        "tp_rank=%d tp_size=%d dp_rank=%d stage=%s reason=%r",
+        bs,
+        backend,
+        registry_idx,
+        int(parallelism_config.tp_rank),
+        int(parallelism_config.tp_size),
+        int(parallelism_config.dp_rank),
+        stage,
+        error,
+        exc_info=(type(error), error, error.__traceback__),
+    )
+    os._exit(_FATAL_PROBE_EXIT_CODE)
+
+
+def _read_selector_config() -> tuple[float, float]:
+    def read_one(variable: str, default: float) -> float:
+        raw_value = os.environ.get(variable)
+        if raw_value is None:
+            return default
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError) as error:
+            raise _SelectorConfigError(variable, raw_value, str(error)) from error
+        if not math.isfinite(value):
+            raise _SelectorConfigError(variable, raw_value, "value is not finite")
+        if value < 0:
+            raise _SelectorConfigError(variable, raw_value, "value is negative")
+        return value
+
+    return (
+        read_one("DYN_DECODE_THRESHOLD", STABLE_THRESHOLD),
+        read_one("DYN_DECODE_CLUSTER_MARGIN", STABLE_CLUSTER_MARGIN),
+    )
+
+
+def _decode_registry() -> List[str]:
+    """All-rank ordered registry class names (position is identity); DECODE_MHA_IMPS is already registered per device at import time."""
+    from rtp_llm.models_py.modules.factory.attention.attn_factory import DECODE_MHA_IMPS
+
+    return [c.__name__ for c in DECODE_MHA_IMPS]
+
+
+def _tp_geometry(parallelism_config):
+    """(tp_size, is_tp_root, src_global_rank). The TP group = the tp_size ranks with the same dp_rank,
+    the global root = dp_rank*tp_size (broadcast src is a global rank, not literal 0).
+    """
+    tp_size = int(parallelism_config.tp_size)
+    tp_rank = int(parallelism_config.tp_rank)
+    dp_rank = int(parallelism_config.dp_rank)
+    return tp_size, (tp_rank == 0), dp_rank * tp_size
+
+
+def _eligible(
+    attn_configs, attn_inputs, parallelism_config, fmha_config=None
+) -> List[str]:
+    from rtp_llm.models_py.modules.factory.attention.attn_factory import (
+        DECODE_MHA_IMPS,
+        _is_fmha_impl_disabled,
+    )
+
+    names: List[str] = []
+    # Registry contract: a decode implementation must be registered for dynamic
+    # probing only after its CUDA Graph decode path, lack of TP collectives,
+    # numerical behavior, and benchmark resource lifetime have been validated.
+    probe_started = False
+    probe_backend = "support-probe"
+    with benchmark_workspace_scope():
+        for impl in DECODE_MHA_IMPS:
+            try:
+                name = impl.__name__
+                probe_backend = name
+                # Respect fmha_config disable flags (disable_flash_infer / enable_xqa /
+                # ...), mirroring the fixed-priority get_fmha_impl path.
+                if _is_fmha_impl_disabled(name, fmha_config):
+                    continue
+                probe_started = True
+                if not impl.support(attn_configs, attn_inputs):
+                    continue
+                if not impl.support_parallelism_config(parallelism_config):
+                    continue
+            except Exception as e:
+                if probe_started:
+                    # support() may allocate and probe the GPU (TRT-LLM Gen does),
+                    # so every later exception is past the safe fallback boundary.
+                    raise _FatalProbeError(probe_backend) from e
+                raise
+            names.append(name)
+    return names
+
+
+def run_backend_selection(
+    model,
+    inputs,
+    *,
+    selector: Optional[Selector] = None,
+    warmup: int = 10,
+    iters: int = 50,
+    l2_fill_mode: str = "store",
+) -> Optional[str]:
+    """Select the decode backend for a single capture bs, returning the winner class name (None = left empty, capture falls back to fixed priority).
+
+    Only rank0 does the real-machine benchmark + selection; the winner registry
+    index is broadcast to Group.TP so every rank gets the same winner.
+    """
+    parallelism_config = model.parallelism_config
+    attn_configs = model.config.getAttentionConfigs(
+        parallelism_config.get_attn_tp_size()
+    )
+    attn_inputs = inputs.attention_inputs
+    bs = int(attn_inputs.input_lengths.size(0))
+    max_seq_len = int(getattr(model.config, "max_seq_len", 0)) or int(
+        attn_configs.max_seq_len
+    )
+    grid = kv_grid(max_seq_len)
+    registry = _decode_registry()
+    tp_size, is_tp_root, src = _tp_geometry(parallelism_config)
+
+    try:
+        code = torch.full((1,), -1, dtype=torch.int32, device="cuda")
+    except Exception as e:
+        # Every rank must reach the same TP rendezvous. A rank-local CUDA
+        # allocation failure cannot fall back while its peers enter broadcast.
+        _terminate_probe_worker(bs, "selection-control", e)
+        raise RuntimeError("fatal probe termination returned unexpectedly") from e
+    if is_tp_root:
+        # Contract: benchmarked decode attention forward must be free of collective
+        # communication (allreduce/broadcast). rank0 runs bench alone; a backend
+        # whose forward triggers TP collectives would deadlock here.
+        try:
+            winner = _select_on_root(
+                model,
+                attn_configs,
+                attn_inputs,
+                parallelism_config,
+                grid,
+                selector,
+                bs,
+                max_seq_len,
+                warmup,
+                iters,
+                l2_fill_mode,
+            )
+            if winner is not None and winner in registry:
+                try:
+                    code[0] = registry.index(winner)
+                except Exception as e:
+                    # The winner write is the final CUDA operation after a real
+                    # probe. Do not enter a TP collective if it fails.
+                    raise _FatalProbeError(winner) from e
+        except _SelectorConfigError as e:
+            _terminate_config_worker(bs, e, parallelism_config)
+            raise DynamicDecodeFatalError(
+                "fatal configuration termination returned unexpectedly"
+            ) from e
+        except _FatalProbeError as e:
+            _terminate_probe_worker(bs, e.backend, e)
+            raise DynamicDecodeFatalError(
+                "fatal probe termination returned unexpectedly"
+            ) from e
+        except Exception as e:
+            # Pre-probe orchestration errors remain normal plan misses. Root must
+            # still broadcast the empty code so all healthy ranks stay in lockstep.
+            logger.warning(
+                "[dispatcher] bs=%d root selection exception, no dynamic plan: %r",
+                bs,
+                e,
+            )
+
+    try:
+        if tp_size > 1:
+            from rtp_llm.models_py.distributed.collective_torch import Group, broadcast
+
+            # src is a global rank (dp_rank * tp_size).
+            broadcast(code, src, group=Group.TP)
+
+        idx = int(code[0].item())
+    except Exception as e:
+        # NCCL and CUDA readback failures may leave the process group or device
+        # unusable. Never let the outer capture path turn them into a local
+        # fixed-priority fallback.
+        _terminate_probe_worker(bs, "selection-control", e)
+        raise DynamicDecodeFatalError(
+            "fatal probe termination returned unexpectedly"
+        ) from e
+    if idx == -1:
+        chosen = None
+    elif 0 <= idx < len(registry):
+        chosen = registry[idx]
+    else:
+        error = ValueError(
+            f"broadcast registry index {idx} is outside [0, {len(registry)})"
+        )
+        _terminate_plan_application_worker(
+            bs,
+            "<invalid-registry-index>",
+            idx,
+            parallelism_config,
+            "registry-index",
+            error,
+        )
+        raise DynamicDecodeFatalError(
+            "fatal plan application termination returned unexpectedly"
+        ) from error
+    if chosen is not None:
+        logger.info(
+            "dynamic_decode_plan_received bs=%d registry_idx=%d backend=%s "
+            "tp_rank=%d tp_size=%d dp_rank=%d",
+            bs,
+            idx,
+            chosen,
+            int(parallelism_config.tp_rank),
+            tp_size,
+            int(parallelism_config.dp_rank),
+        )
+    logger.debug(
+        "[dispatcher] bs=%d -> %s",
+        bs,
+        chosen or "(left empty, fall back to fixed priority)",
+    )
+    return chosen
+
+
+def _select_on_root(
+    model,
+    attn_configs,
+    attn_inputs,
+    parallelism_config,
+    grid,
+    selector,
+    bs,
+    max_seq_len,
+    warmup,
+    iters,
+    l2_fill_mode,
+) -> Optional[str]:
+    # Hybrid models are rejected by GptModelBase.select_decode_backend because
+    # their multi-group cache layout is not supported by this benchmark.
+    layer_kv_cache = model.kv_cache.get_layer_cache(0)
+    # clip the kv grid to the upper bound of the engine's capture sequence_lengths (real-machine dump: = max_seq_len-2;
+    # the page table only covers up to here, exceeding it goes out of bounds, see backend_bench._set_uniform_seq_len).
+    seq_cap = (
+        int(attn_inputs.sequence_lengths.flatten()[0].item())
+        if attn_inputs.sequence_lengths.numel()
+        else max_seq_len
+    )
+    kv_list = [kv for kv in grid if kv <= seq_cap] or [seq_cap]
+
+    selector_config = _read_selector_config() if selector is None else None
+
+    # Everything above this point is CPU-side preparation. support() may allocate
+    # or launch GPU work, so after _eligible starts there is no safe in-process
+    # fallback or TP broadcast path for an unexpected exception.
+    eligible = _eligible(
+        attn_configs, attn_inputs, parallelism_config, model.fmha_config
+    )
+    probe_backend = eligible[0] if eligible else "support-probe"
+    try:
+        matrix = {}
+        last_probed_backend = None
+        for name in eligible:
+            probe_backend = name
+            impl_cls = _impl_by_name(name)
+            if impl_cls is None:
+                continue
+            # multi-kv-point: for each kv, set sequence_lengths on a clone and time real-machine capture+replay;
+            # the per-kv latencies are collected into `matrix`, then select_stable (below) does two-level
+            # deterministic selection to pick this bs bucket's backend.
+            # bench_backend_grid owns the one real benchmark instance and checks
+            # support_cuda_graph() on it before prepare/forward.
+            last_probed_backend = name
+            lats = backend_bench.bench_backend_grid(
+                impl_cls,
+                attn_configs,
+                attn_inputs,
+                layer_kv_cache,
+                parallelism_config,
+                kv_list,
+                attention_layer_count=int(model.layer_num),
+                warmup=warmup,
+                iters=iters,
+                l2_fill_mode=l2_fill_mode,
+            )
+            if lats is not None:
+                matrix[name] = lats
+        if last_probed_backend is not None:
+            # Return only after all benchmark work finishes, before real capture.
+            torch.cuda.synchronize()
+
+        if not matrix:
+            reason = "eligible empty" if not eligible else "eligible all N/A"
+            logger.warning(
+                "[dispatcher] bs=%d %s -> no dynamic plan",
+                bs,
+                reason,
+            )
+            return None
+
+        # Use select_stable by default: two-level deterministic selection
+        # (threshold filter + registry-order tiebreaker) for CI and production stability.
+        if selector is not None:
+            choice = selector(matrix)
+        else:
+            assert selector_config is not None
+            threshold, cluster_margin = selector_config
+            registry = _decode_registry()
+            # Use registry priority only among candidates whose real benchmark
+            # completed successfully. Do not construct another backend merely to
+            # discover the fixed-priority baseline.
+            default_backend = next((name for name in registry if name in matrix), None)
+            choice = select_stable(
+                matrix, registry, default_backend, threshold, cluster_margin
+            )
+
+        if choice is not None:
+            return choice
+        logger.warning(
+            "[dispatcher] bs=%d selection returned None -> no dynamic plan", bs
+        )
+        return None
+    except _FatalProbeError:
+        raise
+    except Exception as e:
+        raise _FatalProbeError(probe_backend) from e
+
+
+def _impl_by_name(name: str):
+    from rtp_llm.models_py.modules.factory.attention.attn_factory import DECODE_MHA_IMPS
+
+    for c in DECODE_MHA_IMPS:
+        if c.__name__ == name:
+            return c
+    return None
+
+
+def instantiate_decode_impl(model, attn_inputs, name: str, is_cuda_graph: bool):
+    """Instantiate an already-broadcast winner or terminate the worker."""
+    parallelism_config = model.parallelism_config
+    bs = int(attn_inputs.input_lengths.size(0))
+    try:
+        registry_idx = _decode_registry().index(name)
+    except Exception:  # noqa: BLE001 -- failure is reported by the stage below
+        registry_idx = -1
+
+    def fail(stage: str, error: BaseException) -> NoReturn:
+        _terminate_plan_application_worker(
+            bs,
+            name,
+            registry_idx,
+            parallelism_config,
+            stage,
+            error,
+        )
+        raise DynamicDecodeFatalError(
+            "fatal plan application termination returned unexpectedly"
+        ) from error
+
+    try:
+        cls = _impl_by_name(name)
+    except Exception as error:  # noqa: BLE001
+        fail("class-lookup", error)
+    if cls is None:
+        fail("class-missing", LookupError(f"backend class {name!r} is not registered"))
+
+    try:
+        from rtp_llm.models_py.modules.factory.attention.attn_factory import (
+            _is_fmha_impl_disabled,
+        )
+    except Exception as error:  # noqa: BLE001
+        fail("disable-check", error)
+
+    try:
+        if _is_fmha_impl_disabled(name, getattr(model, "fmha_config", None)):
+            fail("disabled", RuntimeError(f"backend {name!r} is disabled"))
+        attn_configs = model.config.getAttentionConfigs(
+            parallelism_config.get_attn_tp_size()
+        )
+        attn_inputs.is_cuda_graph = is_cuda_graph
+        attn_inputs.headwise_config = getattr(model.config, "headwise_config", None)
+    except DynamicDecodeFatalError:
+        raise
+    except Exception as error:  # noqa: BLE001
+        fail("input-configuration", error)
+
+    try:
+        if not cls.support(attn_configs, attn_inputs):
+            fail("support", RuntimeError(f"backend {name!r} support() returned false"))
+    except DynamicDecodeFatalError:
+        raise
+    except Exception as error:  # noqa: BLE001
+        fail("support", error)
+    try:
+        if not cls.support_parallelism_config(parallelism_config):
+            fail(
+                "parallelism",
+                RuntimeError(
+                    f"backend {name!r} support_parallelism_config() returned false"
+                ),
+            )
+    except DynamicDecodeFatalError:
+        raise
+    except Exception as error:  # noqa: BLE001
+        fail("parallelism", error)
+    try:
+        inst = cls(attn_configs, attn_inputs, parallelism_config)
+    except Exception as error:  # noqa: BLE001
+        fail("constructor", error)
+    if is_cuda_graph:
+        try:
+            graph_supported = inst.support_cuda_graph()
+        except Exception as error:  # noqa: BLE001
+            fail("cuda-graph-support", error)
+        if not graph_supported:
+            fail(
+                "cuda-graph-support",
+                RuntimeError(f"backend {name!r} does not support CUDA Graph"),
+            )
+    return inst

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/selector.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/selector.py
@@ -1,0 +1,106 @@
+"""Pure-CPU selection policies for the attention backend dispatcher."""
+
+from __future__ import annotations
+
+import statistics
+from typing import Callable, Dict, List, Optional
+
+# select_stable thresholds
+# Tunable at runtime via env: DYN_DECODE_THRESHOLD / DYN_DECODE_CLUSTER_MARGIN.
+# Level 1: only switch if the winner's improvement meets this ratio.
+STABLE_THRESHOLD = 0.05
+# Level 2: survivors within this margin of each other -> tiebreak by registry order
+STABLE_CLUSTER_MARGIN = 0.05
+
+
+# kv grid: log2-equispaced; equal weighting is a log-uniform prior
+_KV_GRID_FULL = (256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144)
+
+
+def kv_grid(max_seq_len: int) -> List[int]:
+    """log-uniform kv grid, with the upper bound clipped to max_seq_len.
+
+    Points exceeding max_seq_len are dropped; if max_seq_len falls between two
+    buckets and is greater than the largest retained point, one max_seq_len point
+    is appended to cover the production long tail. When max_seq_len is smaller
+    than the smallest bucket, it degenerates to the single point [max_seq_len].
+    """
+    if max_seq_len < 1:
+        raise ValueError(f"max_seq_len must be >= 1, got {max_seq_len}")
+    grid = [kv for kv in _KV_GRID_FULL if kv <= max_seq_len]
+    if not grid:
+        return [max_seq_len]
+    if grid[-1] < max_seq_len:
+        grid.append(max_seq_len)  # append the long-tail upper-bound point
+    return grid
+
+
+# Aggregation/selection criteria
+# selector: {backend name: [that backend's latency at each kv grid point]} -> selected backend name (empty matrix -> None).
+Selector = Callable[[Dict[str, List[float]]], Optional[str]]
+
+
+def select_stable(
+    matrix: Dict[str, List[float]],
+    registry_order: List[str],
+    default_backend: Optional[str] = None,
+    threshold: float = STABLE_THRESHOLD,
+    cluster_margin: float = STABLE_CLUSTER_MARGIN,
+) -> Optional[str]:
+    """Two-level deterministic selection: threshold filter + registry-order tiebreaker.
+
+    Level 1 (threshold filter): only keep backends that are significantly faster
+    than the default_backend (improvement >= threshold). If none pass, return
+    default_backend (no switch).
+
+    Level 2 (cluster tiebreaker): among survivors, if mutual differences are
+    within cluster_margin, pick the one with highest priority in registry_order
+    (deterministic, noise-immune). Only when a backend is clearly faster than
+    all others (gap > cluster_margin) does it win outright.
+
+    Guarantee: as long as threshold is comfortably larger than the GPU bench
+    noise band, the selection result is deterministic across runs on the same
+    hardware. Concrete default ratios live in the STABLE_THRESHOLD /
+    STABLE_CLUSTER_MARGIN constants (env-overridable), not here, so this doc
+    stays correct if the values change.
+    """
+    if not matrix:
+        return None
+
+    means = {impl: statistics.fmean(lats) for impl, lats in matrix.items()}
+
+    # --- Level 1: threshold filter vs default_backend ---
+    baseline_cost = means.get(default_backend) if default_backend else None
+    if baseline_cost is not None and baseline_cost > 0:
+        survivors = {
+            impl: cost
+            for impl, cost in means.items()
+            if (baseline_cost - cost) / baseline_cost >= threshold
+        }
+    else:
+        # No baseline available: all candidates are survivors
+        survivors = dict(means)
+
+    if not survivors:
+        return default_backend  # Nothing significantly better -> use default
+
+    if len(survivors) == 1:
+        return list(survivors.keys())[0]
+
+    # --- Level 2: cluster + registry-order tiebreaker ---
+    best_impl = min(survivors, key=survivors.get)
+    best_cost = survivors[best_impl]
+
+    # Cluster: backends within cluster_margin of the best are in the "same performance tier"
+    cluster = [
+        impl
+        for impl, cost in survivors.items()
+        if best_cost == 0 or (cost - best_cost) / best_cost < cluster_margin
+    ]
+
+    # Deterministic tiebreaker: pick the highest-priority one in registration order
+    for name in registry_order:
+        if name in cluster:
+            return name
+
+    return best_impl  # fallback (should not be reached)

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/tests/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/tests/BUILD
@@ -1,0 +1,20 @@
+# Dynamic decode attention backend dispatch tests. The aggregate deliberately
+# owns the production attention import closure and exercises real CUDA benchmark
+# behavior; pure policy and mocked orchestration regressions run inside the same
+# established native boundary rather than creating GPU-pinned CPU-only targets.
+
+py_test_deps = [
+    "//rtp_llm/models_py/standalone:py_standalone_testlib",
+]
+
+py_test(
+    name = "test_backend_bench",
+    srcs = [
+        "test_backend_bench.py",
+        "test_backend_selector.py",
+        "test_selector.py",
+    ],
+    deps = py_test_deps,
+    tags = ["H20"],
+    exec_properties = {"gpu": "H20"},
+)

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_backend_bench.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_backend_bench.py
@@ -1,0 +1,668 @@
+"""backend_bench tests: clone isolation, timing boundaries, and workspace lifetime.
+
+Some tests require CUDA; on GPU-less machines only the CPU logic runs.
+"""
+
+import gc
+import statistics
+import sys
+import time
+import unittest
+import weakref
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+try:
+    import torch
+
+    HAS_CUDA = torch.cuda.is_available()
+except ImportError:
+    HAS_CUDA = False
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    benchmark_workspace_scope,
+    in_benchmark_workspace_scope,
+)
+from rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench import (
+    _bench_graph,
+    _clone_attn_inputs,
+    _fill_synthetic_kv_block,
+    _get_bench_pool,
+    _model_step_times,
+    _set_uniform_seq_len,
+    bench_backend_grid,
+)
+
+requires_cuda = unittest.skipIf(not HAS_CUDA, "CUDA not available")
+
+
+# _clone_attn_inputs tests
+
+
+class _FakeAttnInputs:
+    """Mimic the key field layout of PyAttentionInputs."""
+
+    def __init__(self):
+        if HAS_CUDA:
+            self.input_lengths = torch.tensor([1, 2, 3], device="cuda")
+            self.sequence_lengths = torch.tensor([10, 20, 30], device="cuda")
+            self.kv_cache_kernel_block_id = torch.zeros(
+                3, 4, dtype=torch.int32, device="cuda"
+            )
+            self.kv_cache_kernel_block_id_by_group = [
+                torch.zeros(3, 4, dtype=torch.int32, device="cuda"),
+                torch.ones(3, 4, dtype=torch.int32, device="cuda"),
+            ]
+        else:
+            self.input_lengths = torch.tensor([1, 2, 3])
+            self.sequence_lengths = torch.tensor([10, 20, 30])
+            self.kv_cache_kernel_block_id = torch.zeros(3, 4, dtype=torch.int32)
+            self.kv_cache_kernel_block_id_by_group = [
+                torch.zeros(3, 4, dtype=torch.int32),
+                torch.ones(3, 4, dtype=torch.int32),
+            ]
+        self.is_cuda_graph = True
+        self.total_tokens = 6
+
+    def __copy__(self):
+        new = _FakeAttnInputs.__new__(_FakeAttnInputs)
+        new.__dict__.update(self.__dict__)
+        return new
+
+
+def test_clone_attn_inputs_tensor_isolation():
+    """After clone, modifying the clone's Tensor does not affect the original object."""
+    orig = _FakeAttnInputs()
+    cloned = _clone_attn_inputs(orig)
+
+    # modify the clone
+    cloned.sequence_lengths.fill_(999)
+    cloned.kv_cache_kernel_block_id_by_group[0].fill_(777)
+
+    # original unchanged
+    assert orig.sequence_lengths.tolist() == [10, 20, 30]
+    assert orig.kv_cache_kernel_block_id_by_group[0].sum().item() == 0
+
+
+def test_clone_attn_inputs_tensors_are_different_objects():
+    """The clone's Tensors are new objects (not the same storage)."""
+    orig = _FakeAttnInputs()
+    cloned = _clone_attn_inputs(orig)
+    assert cloned.input_lengths.data_ptr() != orig.input_lengths.data_ptr()
+    assert (
+        cloned.kv_cache_kernel_block_id_by_group[1].data_ptr()
+        != orig.kv_cache_kernel_block_id_by_group[1].data_ptr()
+    )
+
+
+# CUDA Graph timing-boundary tests
+
+
+def _mocked_graph_actions(prepare_fn):
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    actions = []
+
+    class FakeStream:
+        def wait_stream(self, other):
+            actions.append("wait_stream")
+
+    class FakeGraph:
+        def replay(self):
+            actions.append("replay")
+
+    event_count = 0
+
+    class FakeEvent:
+        def __init__(self, enable_timing):
+            nonlocal event_count
+            self.name = "start" if event_count == 0 else "end"
+            event_count += 1
+
+        def record(self):
+            actions.append(f"{self.name}.record")
+
+        def synchronize(self):
+            actions.append(f"{self.name}.synchronize")
+
+        def elapsed_time(self, other):
+            return 0.001
+
+    with (
+        patch.object(
+            bb,
+            "_make_l2_filler",
+            return_value=(lambda: actions.append("fill"), ()),
+        ),
+        patch.object(bb, "_get_bench_pool", return_value=1),
+        patch.object(bb.torch.cuda, "Event", FakeEvent),
+        patch.object(bb.torch.cuda, "Stream", FakeStream),
+        patch.object(bb.torch.cuda, "CUDAGraph", FakeGraph),
+        patch.object(bb.torch.cuda, "current_stream", return_value=FakeStream()),
+        patch.object(bb.torch.cuda, "stream", side_effect=lambda stream: nullcontext()),
+        patch.object(
+            bb.torch.cuda, "graph", side_effect=lambda graph, pool: nullcontext()
+        ),
+        patch.object(
+            bb.torch.cuda,
+            "synchronize",
+            side_effect=lambda: actions.append("cuda.synchronize"),
+        ),
+        patch.object(bb.torch.cuda, "empty_cache"),
+    ):
+        _bench_graph(
+            lambda: actions.append("fn"),
+            warmup=0,
+            iters=1,
+            l2_fill_mode="none",
+            prepare_fn=prepare_fn(actions) if prepare_fn else None,
+        )
+    return actions
+
+
+def test_bench_graph_timing_order_includes_prepare():
+    actions = _mocked_graph_actions(lambda log: lambda: log.append("prepare"))
+    measured = actions.index("fill")
+    assert actions[measured : measured + 6] == [
+        "fill",
+        "start.record",
+        "start.synchronize",
+        "prepare",
+        "replay",
+        "end.record",
+    ]
+
+
+def test_bench_graph_timing_order_without_prepare_uses_same_boundary():
+    actions = _mocked_graph_actions(None)
+    measured = actions.index("fill")
+    assert actions[measured : measured + 5] == [
+        "fill",
+        "start.record",
+        "start.synchronize",
+        "replay",
+        "end.record",
+    ]
+
+
+@requires_cuda
+def test_bench_graph_measures_host_prepare_delay_with_and_without_l2_fill():
+    buf = torch.zeros(1, device="cuda")
+
+    def fn():
+        buf.add_(1)
+
+    prepare_delay_s = 0.02
+    for fill_mode in ("none", "store"):
+        times = _bench_graph(
+            fn,
+            warmup=1,
+            iters=3,
+            l2_fill_mode=fill_mode,
+            prepare_fn=lambda: time.sleep(prepare_delay_s),
+        )
+        assert statistics.median(times) >= prepare_delay_s * 1_000_000 * 0.75
+
+
+def test_model_step_times_amortize_prepare_once_across_attention_layers():
+    fast_kernel = _model_step_times([10.0], [5.0], attention_layer_count=32)
+    fast_prepare = _model_step_times([8.0], [7.0], attention_layer_count=32)
+
+    # A one-layer prepare+replay measurement prefers fast_prepare (8 < 10), but
+    # the 32-layer model-step score correctly prefers the faster replay kernel.
+    assert fast_kernel == [165.0]
+    assert fast_prepare == [225.0]
+    assert fast_kernel[0] < fast_prepare[0]
+
+
+# Benchmark workspace and failure-boundary tests
+
+
+class _Workspace:
+    pass
+
+
+class _FakeBenchConfig:
+    head_num = 8
+    kv_head_num = 2
+    size_per_head = 64
+    dtype = torch.bfloat16
+
+
+class _FakeBenchInputs:
+    input_lengths = torch.ones(1)
+    is_cuda_graph = False
+
+
+class _FakeKVCache:
+    kv_cache_base = None
+
+
+def _assert_production_wrapper_workspace_ownership(
+    module, pool_name, workspace_name, construct
+):
+    production_workspace = _Workspace()
+    production_pool = [production_workspace]
+
+    with (
+        patch.object(module, pool_name, production_pool),
+        patch.object(
+            module.torch, "zeros", side_effect=lambda *args, **kwargs: _Workspace()
+        ),
+    ):
+        production_op = construct()
+        assert getattr(production_op, workspace_name) is production_workspace
+        assert production_pool == []
+        del production_op
+        gc.collect()
+        assert production_pool == [production_workspace]
+        assert production_pool[0] is production_workspace
+
+        with benchmark_workspace_scope():
+            benchmark_op = construct()
+        benchmark_workspace = getattr(benchmark_op, workspace_name)
+        assert benchmark_workspace is not production_workspace
+        assert production_pool == [production_workspace]
+        benchmark_workspace_ref = weakref.ref(benchmark_workspace)
+        del benchmark_workspace, benchmark_op
+        gc.collect()
+
+        assert benchmark_workspace_ref() is None
+        assert production_pool == [production_workspace]
+        assert production_pool[0] is production_workspace
+
+
+def test_xqa_wrapper_preserves_production_workspace_pool_during_benchmark():
+    from rtp_llm.models_py.modules.factory.attention.cuda_impl import xqa
+
+    config = SimpleNamespace()
+    inputs = SimpleNamespace(
+        cu_seqlens_device=object(),
+        is_prefill=False,
+    )
+    with (
+        patch.object(xqa.torch.cuda, "get_device_capability", return_value=(9, 0)),
+        patch.object(xqa, "get_num_device_sms", return_value=1),
+        patch.object(xqa, "_load_xqa_fn", return_value=(object(), False)),
+    ):
+        _assert_production_wrapper_workspace_ownership(
+            xqa,
+            "_g_xqa_workspace_pool",
+            "workspace_buffer",
+            lambda: xqa.XQAWrapper(config, inputs),
+        )
+
+
+def test_py_flashinfer_wrapper_preserves_production_workspace_pool_during_benchmark():
+    from rtp_llm.models_py.modules.factory.attention.cuda_impl import py_flashinfer_mha
+
+    config = SimpleNamespace(
+        head_num=8,
+        kv_head_num=2,
+        size_per_head=64,
+        kernel_tokens_per_block=16,
+        kv_cache_dtype=None,
+    )
+    inputs = SimpleNamespace(is_cuda_graph=True)
+    fake_ops = SimpleNamespace(FlashInferMlaAttnParams=lambda: object())
+    with (
+        patch.object(
+            py_flashinfer_mha,
+            "BatchDecodeWithPagedKVCacheWrapper",
+            new=lambda *args, **kwargs: object(),
+        ),
+        patch.object(py_flashinfer_mha, "rtp_llm_ops", fake_ops),
+    ):
+        _assert_production_wrapper_workspace_ownership(
+            py_flashinfer_mha,
+            "_g_py_flashinfer_workspace_pool",
+            "g_workspace_buffer",
+            lambda: py_flashinfer_mha.PyFlashinferDecodeAttnOp(config, inputs),
+        )
+
+
+def test_trt_wrapper_preserves_production_workspace_pool_during_benchmark():
+    from rtp_llm.models_py.modules.factory.attention.cuda_impl import trtllm_gen
+
+    config = SimpleNamespace(
+        size_per_head=128,
+        head_num=8,
+        kernel_tokens_per_block=16,
+        kv_head_num=2,
+    )
+    _assert_production_wrapper_workspace_ownership(
+        trtllm_gen,
+        "_g_trt_workspace_pool",
+        "workspace_buffer",
+        lambda: trtllm_gen.FlashInferTRTLLMDecodeOp(config),
+    )
+
+
+def test_bench_grid_uses_temporary_workspace_and_releases_before_empty_cache():
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    class Workspace:
+        pass
+
+    production_workspace = Workspace()
+    production_pool = [production_workspace]
+    benchmark_workspace_refs = []
+
+    class FakeImpl:
+        def __init__(self, ac, ai, pc):
+            assert in_benchmark_workspace_scope()
+            if in_benchmark_workspace_scope():
+                self.workspace = Workspace()
+                self.workspace_from_pool = False
+            else:
+                self.workspace = production_pool.pop()
+                self.workspace_from_pool = True
+            benchmark_workspace_refs.append(weakref.ref(self.workspace))
+
+        def forward(self, qkv, kv_cache, layer_idx):
+            pass
+
+        def support_cuda_graph(self):
+            return True
+
+        def __del__(self):
+            if self.workspace_from_pool:
+                production_pool.append(self.workspace)
+
+    def assert_workspace_released():
+        assert benchmark_workspace_refs
+        assert all(ref() is None for ref in benchmark_workspace_refs)
+
+    with (
+        patch.object(bb.torch, "randn", return_value=object()),
+        patch.object(bb, "_clone_attn_inputs", return_value=_FakeBenchInputs()),
+        patch.object(bb, "_set_uniform_seq_len"),
+        patch.object(bb, "_bench_graph", return_value=[3.0, 1.0, 2.0]),
+        patch.object(bb.torch.cuda, "synchronize"),
+        patch.object(
+            bb.torch.cuda, "empty_cache", side_effect=assert_workspace_released
+        ),
+    ):
+        result = bench_backend_grid(
+            FakeImpl,
+            _FakeBenchConfig(),
+            _FakeBenchInputs(),
+            _FakeKVCache(),
+            None,
+            [128],
+        )
+
+    assert result == [2.0]
+    assert production_pool == [production_workspace]
+    assert production_pool[0] is production_workspace
+    assert all(ref() is None for ref in benchmark_workspace_refs)
+    assert not in_benchmark_workspace_scope()
+
+
+@requires_cuda
+def test_synthetic_kv_fill_supports_fp8_cache_storage():
+    kv_base = torch.zeros((2, 64), dtype=torch.float8_e4m3fn, device="cuda")
+    _fill_synthetic_kv_block(kv_base)
+    assert torch.isfinite(kv_base[0].float()).all().item()
+
+
+def test_bench_grid_construction_exception_propagates_without_cuda_cleanup():
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    class BrokenImpl:
+        def __init__(self, *args):
+            assert in_benchmark_workspace_scope()
+            raise RuntimeError("cannot instantiate")
+
+    with (
+        patch.object(bb.torch, "randn", return_value=object()),
+        patch.object(bb, "_clone_attn_inputs", return_value=_FakeBenchInputs()),
+        patch.object(bb, "_set_uniform_seq_len"),
+        patch.object(bb.torch.cuda, "synchronize") as synchronize,
+        patch.object(bb.torch.cuda, "empty_cache") as empty_cache,
+    ):
+        with unittest.TestCase().assertRaisesRegex(RuntimeError, "cannot instantiate"):
+            bench_backend_grid(
+                BrokenImpl,
+                _FakeBenchConfig(),
+                _FakeBenchInputs(),
+                _FakeKVCache(),
+                None,
+                [128],
+            )
+        synchronize.assert_not_called()
+        empty_cache.assert_not_called()
+    assert not in_benchmark_workspace_scope()
+
+
+def test_bench_grid_graph_exception_skips_healthy_cleanup():
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    class FakeImpl:
+        def __init__(self, *args):
+            assert in_benchmark_workspace_scope()
+
+        def forward(self, qkv, kv_cache, layer_idx):
+            pass
+
+        def support_cuda_graph(self):
+            return True
+
+    with (
+        patch.object(bb.torch, "randn", return_value=object()),
+        patch.object(bb, "_clone_attn_inputs", return_value=_FakeBenchInputs()),
+        patch.object(bb, "_set_uniform_seq_len"),
+        patch.object(bb, "_bench_graph", side_effect=RuntimeError("capture failed")),
+        patch.object(bb.torch.cuda, "synchronize") as synchronize,
+        patch.object(bb.torch.cuda, "empty_cache") as empty_cache,
+    ):
+        with unittest.TestCase().assertRaisesRegex(RuntimeError, "capture failed"):
+            bench_backend_grid(
+                FakeImpl,
+                _FakeBenchConfig(),
+                _FakeBenchInputs(),
+                _FakeKVCache(),
+                None,
+                [128],
+            )
+        assert synchronize.call_count == 2
+        empty_cache.assert_not_called()
+
+
+def test_bench_backend_grid_unsupported_graph_is_normal_unavailable():
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    class UnsupportedImpl:
+        def __init__(self, *args):
+            assert in_benchmark_workspace_scope()
+
+        def support_cuda_graph(self):
+            return False
+
+    with (
+        patch.object(bb.torch, "randn", return_value=object()),
+        patch.object(bb, "_clone_attn_inputs", return_value=_FakeBenchInputs()),
+        patch.object(bb, "_set_uniform_seq_len"),
+        patch.object(bb.torch.cuda, "synchronize") as synchronize,
+        patch.object(bb.torch.cuda, "empty_cache") as empty_cache,
+    ):
+        result = bench_backend_grid(
+            UnsupportedImpl,
+            _FakeBenchConfig(),
+            _FakeBenchInputs(),
+            _FakeKVCache(),
+            None,
+            [128],
+        )
+        assert result is None
+        synchronize.assert_called_once()
+        empty_cache.assert_called_once()
+
+
+@requires_cuda
+def test_uniform_seq_len_updates_replay_mirror_in_place():
+    inputs = SimpleNamespace(
+        sequence_lengths=torch.zeros(3, dtype=torch.int32).pin_memory(),
+        sequence_lengths_plus_1_device=torch.zeros(3, dtype=torch.int32, device="cuda"),
+    )
+    mirror_address = inputs.sequence_lengths_plus_1_device.data_ptr()
+
+    for kv in (17, 257):
+        _set_uniform_seq_len(inputs, bs=3, kv=kv)
+        assert inputs.sequence_lengths.tolist() == [kv, kv, kv]
+        assert inputs.sequence_lengths.is_pinned()
+        assert inputs.sequence_lengths_plus_1_device.tolist() == [kv + 1] * 3
+        assert inputs.sequence_lengths_plus_1_device.data_ptr() == mirror_address
+
+
+@requires_cuda
+def test_uniform_seq_len_validates_both_length_tensors():
+    def valid_inputs():
+        return SimpleNamespace(
+            sequence_lengths=torch.zeros(2, dtype=torch.int32).pin_memory(),
+            sequence_lengths_plus_1_device=torch.zeros(
+                2, dtype=torch.int32, device="cuda"
+            ),
+        )
+
+    invalid_values = {
+        "sequence_lengths": (
+            None,
+            torch.zeros(2, dtype=torch.float32).pin_memory(),
+            torch.zeros(2, dtype=torch.int32, device="cuda"),
+            torch.zeros(1, dtype=torch.int32).pin_memory(),
+        ),
+        "sequence_lengths_plus_1_device": (
+            None,
+            torch.zeros(2, dtype=torch.float32, device="cuda"),
+            torch.zeros(2, dtype=torch.int32),
+            torch.zeros(1, dtype=torch.int32, device="cuda"),
+        ),
+    }
+    for field, values in invalid_values.items():
+        for value in values:
+            inputs = valid_inputs()
+            setattr(inputs, field, value)
+            with unittest.TestCase().assertRaisesRegex(
+                ValueError, rf"field={field} bs=2 kv=31"
+            ):
+                _set_uniform_seq_len(inputs, bs=2, kv=31)
+
+
+@requires_cuda
+def test_bench_grid_prepare_observes_each_replay_mirror_value():
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    observed = []
+
+    class GraphAwareImpl:
+        def __init__(self, _config, inputs, _parallelism_config):
+            self.inputs = inputs
+
+        def support_cuda_graph(self):
+            return True
+
+        def forward(self, _qkv, _kv_cache, _layer_idx):
+            pass
+
+        def prepare_cuda_graph(self, inputs):
+            assert inputs is self.inputs
+            observed.append(inputs.sequence_lengths_plus_1_device.tolist())
+
+    class FakeConfig:
+        head_num = 8
+        kv_head_num = 2
+        size_per_head = 64
+        dtype = torch.bfloat16
+
+    class FakeInputs:
+        def __init__(self):
+            self.input_lengths = torch.ones(2, dtype=torch.int32, device="cuda")
+            self.sequence_lengths = torch.zeros(2, dtype=torch.int32).pin_memory()
+            self.sequence_lengths_plus_1_device = torch.zeros(
+                2, dtype=torch.int32, device="cuda"
+            )
+            self.is_cuda_graph = False
+
+        def __copy__(self):
+            new = FakeInputs.__new__(FakeInputs)
+            new.__dict__.update(self.__dict__)
+            return new
+
+    def run_graph(
+        _fn,
+        _warmup,
+        _iters,
+        _l2_fill_mode,
+        prepare_fn=None,
+        attention_layer_count=1,
+    ):
+        assert attention_layer_count == 1
+        prepare_fn()
+        return [1.0]
+
+    with (
+        patch.object(bb.torch, "randn", return_value=object()),
+        patch.object(bb, "_bench_graph", side_effect=run_graph),
+        patch.object(bb.torch.cuda, "synchronize"),
+        patch.object(bb.torch.cuda, "empty_cache"),
+    ):
+        result = bench_backend_grid(
+            GraphAwareImpl,
+            FakeConfig(),
+            FakeInputs(),
+            SimpleNamespace(kv_cache_base=None),
+            None,
+            [16, 32],
+            warmup=0,
+            iters=1,
+        )
+
+    assert result == [1.0, 1.0]
+    assert observed == [[17, 17], [33, 33]]
+
+
+# _get_bench_pool tests
+
+
+@requires_cuda
+def test_get_bench_pool_is_stable():
+    """Multiple calls within the same process return the same pool handle."""
+    import rtp_llm.models_py.modules.factory.attention.dispatch.backend_bench as bb
+
+    # reset global state
+    bb._bench_graph_pool_id = None
+    p1 = _get_bench_pool()
+    p2 = _get_bench_pool()
+    assert p1 == p2
+
+
+# Bind the module-level test_* functions (incl. @requires_cuda skips) onto a
+# TestCase so bazel's unittest runner (no pytest available) discovers them.
+class BackendBenchTest(unittest.TestCase):
+    pass
+
+
+for _name, _fn in list(globals().items()):
+    if _name.startswith("test_") and callable(_fn):
+        setattr(BackendBenchTest, _name, staticmethod(_fn))
+del _name, _fn  # don't leak a class/func ref that unittest would re-collect
+
+
+if __name__ == "__main__":
+    from rtp_llm.models_py.modules.factory.attention.dispatch.tests import (
+        test_backend_selector,
+        test_selector,
+    )
+
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite(
+        [
+            loader.loadTestsFromModule(sys.modules[__name__]),
+            loader.loadTestsFromModule(test_backend_selector),
+            loader.loadTestsFromModule(test_selector),
+        ]
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    raise SystemExit(not result.wasSuccessful())

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_backend_selector.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_backend_selector.py
@@ -1,0 +1,986 @@
+"""Focused tests for dynamic decode backend eligibility and fatal probes.
+
+Pure-CPU: DECODE_MHA_IMPS is monkeypatched with fake impls; the *real*
+_is_fmha_impl_disabled (class-name matching) is exercised. No GPU / torch compute.
+The probe tests also replace torch allocation, benchmarking, fatal termination,
+and TP broadcast so failure-boundary behavior is deterministic.
+"""
+
+import contextlib
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.benchmark_workspace import (
+    in_benchmark_workspace_scope,
+)
+from rtp_llm.models_py.modules.factory.attention.dispatch import backend_selector
+
+_ATTN_FACTORY = "rtp_llm.models_py.modules.factory.attention.attn_factory"
+
+
+def _make_fake_impl(
+    name,
+    *,
+    supports=True,
+    support_error=None,
+    construction_error=None,
+    support_observer=None,
+    parallelism_supports=True,
+    graph_supports=True,
+):
+    """A minimal decode impl stub that always 'supports' everything."""
+
+    class _Fake:
+        construction_count = 0
+        graph_support_check_count = 0
+
+        @classmethod
+        def support(cls, attn_configs, attn_inputs):
+            if support_observer is not None:
+                support_observer()
+            if support_error is not None:
+                raise support_error
+            return supports
+
+        @classmethod
+        def support_parallelism_config(cls, parallelism_config):
+            return parallelism_supports
+
+        def __init__(self, attn_configs, attn_inputs, parallelism_config=None):
+            type(self).construction_count += 1
+            if construction_error is not None:
+                raise construction_error
+
+        def support_cuda_graph(self):
+            type(self).graph_support_check_count += 1
+            return graph_supports
+
+    _Fake.__name__ = name
+    return _Fake
+
+
+def _fmha_config(**overrides):
+    """SimpleNamespace mirroring the fields FMHAConfig exposes."""
+    cfg = dict(
+        enable_fmha=True,
+        enable_trt_fmha=True,
+        enable_paged_trt_fmha=True,
+        enable_open_source_fmha=True,
+        enable_paged_open_source_fmha=True,
+        enable_trtv1_fmha=True,
+        disable_flashinfer_native=False,
+        enable_xqa=True,
+        use_aiter_pa=True,
+        use_asm_pa=True,
+        use_triton_pa=False,
+    )
+    cfg.update(overrides)
+    return types.SimpleNamespace(**cfg)
+
+
+def _patch_impls(names):
+    fakes = [_make_fake_impl(n) for n in names]
+    return mock.patch(f"{_ATTN_FACTORY}.DECODE_MHA_IMPS", fakes)
+
+
+_NAMES = ["PyFlashinferDecodeImpl", "XQADecodeImpl"]
+
+
+# _eligible respects fmha_config
+def test_eligible_excludes_flashinfer_when_disabled():
+    with _patch_impls(_NAMES):
+        eligible = backend_selector._eligible(
+            None, None, None, _fmha_config(disable_flashinfer_native=True)
+        )
+    assert "PyFlashinferDecodeImpl" not in eligible
+    assert "XQADecodeImpl" in eligible
+
+
+def test_eligible_excludes_xqa_when_disabled():
+    with _patch_impls(_NAMES):
+        eligible = backend_selector._eligible(
+            None, None, None, _fmha_config(enable_xqa=False)
+        )
+    assert "XQADecodeImpl" not in eligible
+    assert "PyFlashinferDecodeImpl" in eligible
+
+
+def test_eligible_keeps_all_when_nothing_disabled():
+    with _patch_impls(_NAMES):
+        eligible = backend_selector._eligible(None, None, None, _fmha_config())
+    assert set(eligible) == set(_NAMES)
+
+
+def test_eligible_none_fmha_config_keeps_all():
+    with _patch_impls(_NAMES):
+        eligible = backend_selector._eligible(None, None, None, None)
+    assert set(eligible) == set(_NAMES)
+
+
+def test_eligible_support_false_is_normal_and_does_not_construct():
+    support_scope = []
+    unsupported = _make_fake_impl(
+        "PyFlashinferDecodeImpl",
+        supports=False,
+        support_observer=lambda: support_scope.append(in_benchmark_workspace_scope()),
+    )
+    with mock.patch(f"{_ATTN_FACTORY}.DECODE_MHA_IMPS", [unsupported]):
+        eligible = backend_selector._eligible(None, None, None, _fmha_config())
+
+    assert eligible == []
+    assert unsupported.construction_count == 0
+    assert support_scope == [True]
+    assert not in_benchmark_workspace_scope()
+
+
+def test_eligible_does_not_construct_only_to_check_cuda_graph_support():
+    candidate = _make_fake_impl("PyFlashinferDecodeImpl")
+    with mock.patch(f"{_ATTN_FACTORY}.DECODE_MHA_IMPS", [candidate]):
+        eligible = backend_selector._eligible(None, None, None, _fmha_config())
+
+    assert eligible == ["PyFlashinferDecodeImpl"]
+    assert candidate.construction_count == 0
+    assert candidate.graph_support_check_count == 0
+
+
+class _FakeScalar:
+    def __init__(self, value):
+        self.value = value
+
+    def item(self):
+        return self.value
+
+
+class _FakeCode:
+    def __init__(self):
+        self.value = -1
+
+    def __getitem__(self, _index):
+        return _FakeScalar(self.value)
+
+    def __setitem__(self, _index, value):
+        self.value = value
+
+
+class _FailingCodeWrite(_FakeCode):
+    def __setitem__(self, _index, value):
+        raise RuntimeError("winner code write failed")
+
+
+class _FailingCodeRead(_FakeCode):
+    def __getitem__(self, _index):
+        raise RuntimeError("winner code read failed")
+
+
+class _FakeInputLengths:
+    def size(self, dim):
+        assert dim == 0
+        return 1
+
+
+class _FakeSequenceLengths:
+    def numel(self):
+        return 1
+
+    def flatten(self):
+        return self
+
+    def __getitem__(self, _index):
+        return _FakeScalar(8)
+
+
+def _selection_fixture(*, tp_size=1, tp_rank=0, dp_rank=0):
+    attn_configs = types.SimpleNamespace(max_seq_len=8)
+    parallelism_config = types.SimpleNamespace(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        dp_rank=dp_rank,
+        get_attn_tp_size=lambda: tp_size,
+    )
+    model = types.SimpleNamespace(
+        layer_num=32,
+        parallelism_config=parallelism_config,
+        fmha_config=_fmha_config(),
+        config=types.SimpleNamespace(
+            max_seq_len=8,
+            hybrid_attention_config=None,
+            headwise_config=None,
+            getAttentionConfigs=lambda _tp: attn_configs,
+        ),
+        kv_cache=types.SimpleNamespace(get_layer_cache=lambda _idx: object()),
+    )
+    attention_inputs = types.SimpleNamespace(
+        input_lengths=_FakeInputLengths(),
+        sequence_lengths=_FakeSequenceLengths(),
+    )
+    return (
+        model,
+        types.SimpleNamespace(attention_inputs=attention_inputs),
+        attn_configs,
+        parallelism_config,
+    )
+
+
+def _assert_fatal_probe(
+    impl_cls,
+    *,
+    bench_side_effect=None,
+    bench_result=None,
+    synchronize_side_effect=None,
+    support_probe=False,
+    impl_lookup_side_effect=None,
+    code=None,
+):
+    model, inputs, _, _ = _selection_fixture(tp_size=2)
+
+    collective_module = types.ModuleType("collective_torch")
+    collective_module.Group = types.SimpleNamespace(TP=object())
+    collective_module.broadcast = mock.Mock()
+    fatal = mock.Mock()
+    fixed_priority = mock.Mock()
+    bench = mock.Mock(side_effect=bench_side_effect, return_value=bench_result)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector,
+                "_decode_registry",
+                return_value=[impl_cls.__name__],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "kv_grid", return_value=[8])
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "_terminate_probe_worker", fatal)
+        )
+        stack.enter_context(
+            mock.patch(f"{_ATTN_FACTORY}.get_fmha_impl", fixed_priority)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector.torch,
+                "full",
+                return_value=code if code is not None else _FakeCode(),
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector.backend_bench,
+                "bench_backend_grid",
+                bench,
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector.torch.cuda,
+                "synchronize",
+                side_effect=synchronize_side_effect,
+            )
+        )
+        stack.enter_context(
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.distributed.collective_torch": collective_module,
+                },
+            )
+        )
+        if support_probe:
+            stack.enter_context(
+                mock.patch(f"{_ATTN_FACTORY}.DECODE_MHA_IMPS", [impl_cls])
+            )
+        else:
+            stack.enter_context(
+                mock.patch.object(
+                    backend_selector,
+                    "_eligible",
+                    return_value=[impl_cls.__name__],
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    backend_selector,
+                    "_impl_by_name",
+                    return_value=impl_cls,
+                    side_effect=impl_lookup_side_effect,
+                )
+            )
+
+        try:
+            backend_selector.run_backend_selection(model, inputs, warmup=0, iters=1)
+        except RuntimeError as error:
+            assert str(error) == "fatal probe termination returned unexpectedly"
+        else:
+            raise AssertionError("fatal probe unexpectedly returned to selection")
+
+    fatal.assert_called_once()
+    assert fatal.call_args.args[0] == 1
+    assert fatal.call_args.args[1] == impl_cls.__name__
+    probe_error = fatal.call_args.args[2]
+    assert isinstance(probe_error, backend_selector._FatalProbeError)
+    assert isinstance(probe_error.__cause__, RuntimeError)
+    collective_module.broadcast.assert_not_called()
+    fixed_priority.assert_not_called()
+    if support_probe:
+        bench.assert_not_called()
+
+
+def test_support_probe_exception_is_fatal():
+    impl_cls = _make_fake_impl(
+        "PyFlashinferDecodeImpl",
+        support_error=RuntimeError("support probe failed"),
+    )
+    _assert_fatal_probe(impl_cls, support_probe=True)
+
+
+def test_candidate_construction_exception_is_fatal():
+    impl_cls = _make_fake_impl(
+        "FailingConstructionImpl",
+        construction_error=RuntimeError("construction failed"),
+    )
+
+    def construct_candidate(
+        candidate_cls,
+        attn_configs,
+        attn_inputs,
+        _layer_kv_cache,
+        parallelism_config,
+        _kv_list,
+        **_kwargs,
+    ):
+        candidate_cls(attn_configs, attn_inputs, parallelism_config)
+
+    _assert_fatal_probe(impl_cls, bench_side_effect=construct_candidate)
+
+
+def test_post_construction_benchmark_exception_is_fatal():
+    impl_cls = _make_fake_impl("FailingBenchmarkImpl")
+    _assert_fatal_probe(
+        impl_cls,
+        bench_side_effect=RuntimeError("capture failed"),
+    )
+
+
+def test_post_benchmark_synchronize_exception_is_fatal():
+    impl_cls = _make_fake_impl("FailingSynchronizationImpl")
+    _assert_fatal_probe(
+        impl_cls,
+        bench_result=[1.0],
+        synchronize_side_effect=RuntimeError("synchronize failed"),
+    )
+
+
+def test_post_support_impl_lookup_exception_is_fatal():
+    impl_cls = _make_fake_impl("FailingLookupImpl")
+    _assert_fatal_probe(
+        impl_cls,
+        impl_lookup_side_effect=RuntimeError("implementation lookup failed"),
+    )
+
+
+def test_post_probe_winner_code_write_exception_is_fatal():
+    impl_cls = _make_fake_impl("FailingWinnerWriteImpl")
+    _assert_fatal_probe(
+        impl_cls,
+        bench_result=[1.0],
+        code=_FailingCodeWrite(),
+    )
+
+
+def _assert_selection_control_failure(
+    *, tp_rank, full_side_effect=None, broadcast_side_effect=None, code=None
+):
+    model, inputs, _, _ = _selection_fixture(tp_size=2, tp_rank=tp_rank)
+    collective_module = types.ModuleType("collective_torch")
+    collective_module.Group = types.SimpleNamespace(TP=object())
+    collective_module.broadcast = mock.Mock(side_effect=broadcast_side_effect)
+    fatal = mock.Mock()
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector, "_decode_registry", return_value=["XQADecodeImpl"]
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "kv_grid", return_value=[8])
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector.torch,
+                "full",
+                side_effect=full_side_effect,
+                return_value=code if code is not None else _FakeCode(),
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "_select_on_root", return_value=None)
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "_terminate_probe_worker", fatal)
+        )
+        stack.enter_context(
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.distributed.collective_torch": collective_module,
+                },
+            )
+        )
+
+        try:
+            backend_selector.run_backend_selection(model, inputs)
+        except RuntimeError as error:
+            assert str(error) == "fatal probe termination returned unexpectedly"
+        else:
+            raise AssertionError(
+                "fatal selection-control failure unexpectedly returned"
+            )
+
+    fatal.assert_called_once()
+    assert fatal.call_args.args[0:2] == (1, "selection-control")
+    assert isinstance(fatal.call_args.args[2], RuntimeError)
+    return collective_module.broadcast
+
+
+def test_control_tensor_allocation_failure_is_fatal_on_every_tp_rank():
+    for tp_rank in (0, 1):
+        broadcast = _assert_selection_control_failure(
+            tp_rank=tp_rank,
+            full_side_effect=RuntimeError("control tensor allocation failed"),
+        )
+        broadcast.assert_not_called()
+
+
+def test_tp_broadcast_failure_is_fatal():
+    broadcast = _assert_selection_control_failure(
+        tp_rank=1,
+        broadcast_side_effect=RuntimeError("TP broadcast failed"),
+    )
+    broadcast.assert_called_once()
+
+
+def test_control_tensor_readback_failure_is_fatal():
+    broadcast = _assert_selection_control_failure(
+        tp_rank=1,
+        code=_FailingCodeRead(),
+    )
+    broadcast.assert_called_once()
+
+
+def test_non_root_logs_received_plan_after_tp_broadcast():
+    model, inputs, _, _ = _selection_fixture(tp_size=2, tp_rank=1)
+    code = _FakeCode()
+    collective_module = types.ModuleType("collective_torch")
+    collective_module.Group = types.SimpleNamespace(TP=object())
+
+    def broadcast(selected_code, _src, group):
+        assert group is collective_module.Group.TP
+        selected_code[0] = 0
+
+    collective_module.broadcast = mock.Mock(side_effect=broadcast)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector, "_decode_registry", return_value=["XQADecodeImpl"]
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector, "kv_grid", return_value=[8])
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector.torch, "full", return_value=code)
+        )
+        info = stack.enter_context(mock.patch.object(backend_selector.logger, "info"))
+        stack.enter_context(
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.distributed.collective_torch": collective_module,
+                },
+            )
+        )
+        choice = backend_selector.run_backend_selection(model, inputs)
+
+    assert choice == "XQADecodeImpl"
+    collective_module.broadcast.assert_called_once()
+    info.assert_called_once_with(
+        "dynamic_decode_plan_received bs=%d registry_idx=%d backend=%s "
+        "tp_rank=%d tp_size=%d dp_rank=%d",
+        1,
+        0,
+        "XQADecodeImpl",
+        1,
+        2,
+        0,
+    )
+
+
+def _root_selection_fixture():
+    model, inputs, attn_configs, parallelism_config = _selection_fixture()
+    return model, attn_configs, inputs.attention_inputs, parallelism_config
+
+
+def _select_on_root_for_test(
+    model, attn_configs, attn_inputs, parallelism_config, selector=None
+):
+    return backend_selector._select_on_root(
+        model,
+        attn_configs,
+        attn_inputs,
+        parallelism_config,
+        [8],
+        selector,
+        1,
+        8,
+        0,
+        1,
+        "store",
+    )
+
+
+def test_no_latency_matrix_returns_no_plan_without_fixed_priority_construction():
+    model, attn_configs, attn_inputs, parallelism_config = _root_selection_fixture()
+    fixed_priority = mock.Mock()
+    synchronize = mock.Mock()
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(backend_selector, "_eligible", return_value=[])
+        )
+        stack.enter_context(
+            mock.patch(f"{_ATTN_FACTORY}.get_fmha_impl", fixed_priority)
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector.torch.cuda, "synchronize", synchronize)
+        )
+        choice = _select_on_root_for_test(
+            model, attn_configs, attn_inputs, parallelism_config
+        )
+
+    assert choice is None
+    fixed_priority.assert_not_called()
+    synchronize.assert_not_called()
+
+
+def test_measured_baseline_uses_registry_priority_without_extra_construction():
+    model, attn_configs, attn_inputs, parallelism_config = _root_selection_fixture()
+    high_priority = _make_fake_impl("HighPriorityImpl")
+    low_priority = _make_fake_impl("LowPriorityImpl")
+    implementations = {
+        high_priority.__name__: high_priority,
+        low_priority.__name__: low_priority,
+    }
+    fixed_priority = mock.Mock()
+    bench = mock.Mock(return_value=[10.0])
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector,
+                "_eligible",
+                return_value=[low_priority.__name__, high_priority.__name__],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector,
+                "_decode_registry",
+                return_value=[high_priority.__name__, low_priority.__name__],
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector,
+                "_impl_by_name",
+                side_effect=implementations.get,
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                backend_selector.backend_bench,
+                "bench_backend_grid",
+                bench,
+            )
+        )
+        stack.enter_context(
+            mock.patch(f"{_ATTN_FACTORY}.get_fmha_impl", fixed_priority)
+        )
+        stack.enter_context(
+            mock.patch.object(backend_selector.torch.cuda, "synchronize")
+        )
+        choice = _select_on_root_for_test(
+            model, attn_configs, attn_inputs, parallelism_config
+        )
+
+    assert choice == high_priority.__name__
+    assert bench.call_count == 2
+    assert all(
+        call.kwargs["attention_layer_count"] == 32 for call in bench.call_args_list
+    )
+    assert high_priority.construction_count == 0
+    assert low_priority.construction_count == 0
+    fixed_priority.assert_not_called()
+
+
+def test_production_selector_receives_validated_values_without_clamping():
+    model, attn_configs, attn_inputs, parallelism_config = _root_selection_fixture()
+    candidate = _make_fake_impl("ConfiguredImpl")
+    stable = mock.Mock(return_value=candidate.__name__)
+    with (
+        mock.patch.dict(
+            os.environ,
+            {
+                "DYN_DECODE_THRESHOLD": "1.0",
+                "DYN_DECODE_CLUSTER_MARGIN": "1.25",
+            },
+            clear=True,
+        ),
+        mock.patch.object(
+            backend_selector, "_eligible", return_value=[candidate.__name__]
+        ),
+        mock.patch.object(
+            backend_selector, "_decode_registry", return_value=[candidate.__name__]
+        ),
+        mock.patch.object(backend_selector, "_impl_by_name", return_value=candidate),
+        mock.patch.object(
+            backend_selector.backend_bench,
+            "bench_backend_grid",
+            return_value=[4.0],
+        ),
+        mock.patch.object(backend_selector, "select_stable", stable),
+        mock.patch.object(backend_selector.torch.cuda, "synchronize"),
+    ):
+        choice = _select_on_root_for_test(
+            model, attn_configs, attn_inputs, parallelism_config
+        )
+
+    assert choice == candidate.__name__
+    stable.assert_called_once_with(
+        {candidate.__name__: [4.0]},
+        [candidate.__name__],
+        candidate.__name__,
+        1.0,
+        1.25,
+    )
+
+
+def test_selector_config_defaults_and_legal_overrides():
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert backend_selector._read_selector_config() == (0.05, 0.05)
+
+    legal = (
+        ("DYN_DECODE_THRESHOLD", "0", (0.0, 0.05)),
+        ("DYN_DECODE_THRESHOLD", "0.05", (0.05, 0.05)),
+        ("DYN_DECODE_THRESHOLD", "1.0", (1.0, 0.05)),
+        ("DYN_DECODE_CLUSTER_MARGIN", "0", (0.05, 0.0)),
+        ("DYN_DECODE_CLUSTER_MARGIN", "0.05", (0.05, 0.05)),
+        ("DYN_DECODE_CLUSTER_MARGIN", "1.25", (0.05, 1.25)),
+    )
+    for variable, value, expected in legal:
+        with mock.patch.dict(os.environ, {variable: value}, clear=True):
+            assert backend_selector._read_selector_config() == expected
+
+
+def test_selector_config_rejects_each_invalid_explicit_value():
+    for variable in ("DYN_DECODE_THRESHOLD", "DYN_DECODE_CLUSTER_MARGIN"):
+        for value in ("not-a-number", "nan", "inf", "-inf", "-0.01"):
+            with mock.patch.dict(os.environ, {variable: value}, clear=True):
+                with unittest.TestCase().assertRaisesRegex(
+                    backend_selector._SelectorConfigError,
+                    variable,
+                ) as raised:
+                    backend_selector._read_selector_config()
+            assert raised.exception.variable == variable
+            assert raised.exception.raw_value == value
+
+
+def test_invalid_production_selector_config_fails_before_probe():
+    model, inputs, _, _ = _selection_fixture(dp_rank=3)
+    fatal = mock.Mock()
+    eligible = mock.Mock()
+    bench = mock.Mock()
+    synchronize = mock.Mock()
+    fixed_priority = mock.Mock()
+
+    with (
+        mock.patch.dict(
+            os.environ, {"DYN_DECODE_THRESHOLD": "not-a-number"}, clear=True
+        ),
+        mock.patch.object(backend_selector, "_decode_registry", return_value=[]),
+        mock.patch.object(backend_selector, "kv_grid", return_value=[8]),
+        mock.patch.object(backend_selector.torch, "full", return_value=_FakeCode()),
+        mock.patch.object(backend_selector, "_eligible", eligible),
+        mock.patch.object(backend_selector.backend_bench, "bench_backend_grid", bench),
+        mock.patch.object(backend_selector.torch.cuda, "synchronize", synchronize),
+        mock.patch.object(backend_selector, "_terminate_config_worker", fatal),
+        mock.patch(f"{_ATTN_FACTORY}.get_fmha_impl", fixed_priority),
+    ):
+        with unittest.TestCase().assertRaisesRegex(
+            backend_selector.DynamicDecodeFatalError,
+            "fatal configuration termination returned unexpectedly",
+        ):
+            backend_selector.run_backend_selection(model, inputs)
+
+    fatal.assert_called_once()
+    assert fatal.call_args.args[0] == 1
+    error = fatal.call_args.args[1]
+    assert error.variable == "DYN_DECODE_THRESHOLD"
+    eligible.assert_not_called()
+    bench.assert_not_called()
+    synchronize.assert_not_called()
+    fixed_priority.assert_not_called()
+
+
+def test_config_fatal_log_has_config_and_rank_context_once():
+    error = backend_selector._SelectorConfigError(
+        "DYN_DECODE_CLUSTER_MARGIN", "nan", "value is not finite"
+    )
+    parallelism_config = types.SimpleNamespace(tp_rank=0, tp_size=2, dp_rank=4)
+    with (
+        mock.patch.object(backend_selector.logger, "critical") as critical,
+        mock.patch.object(
+            backend_selector.os, "_exit", side_effect=SystemExit(70)
+        ) as exit_process,
+    ):
+        with unittest.TestCase().assertRaises(SystemExit):
+            backend_selector._terminate_config_worker(8, error, parallelism_config)
+
+    critical.assert_called_once()
+    message = critical.call_args.args[0]
+    assert message.startswith("dynamic_decode_config_invalid")
+    assert critical.call_args.args[1:8] == (
+        "DYN_DECODE_CLUSTER_MARGIN",
+        "nan",
+        8,
+        0,
+        2,
+        4,
+        "value is not finite",
+    )
+    exit_process.assert_called_once_with(70)
+
+
+def test_plan_application_fatal_log_has_stage_rank_and_traceback_once():
+    error = RuntimeError("constructor failed")
+    parallelism_config = types.SimpleNamespace(tp_rank=1, tp_size=2, dp_rank=3)
+    with (
+        mock.patch.object(backend_selector.logger, "critical") as critical,
+        mock.patch.object(
+            backend_selector.os, "_exit", side_effect=SystemExit(70)
+        ) as exit_process,
+    ):
+        with unittest.TestCase().assertRaises(SystemExit):
+            backend_selector._terminate_plan_application_worker(
+                4,
+                "WinnerImpl",
+                7,
+                parallelism_config,
+                "constructor",
+                error,
+            )
+
+    critical.assert_called_once()
+    assert critical.call_args.args[0].startswith("dynamic_decode_plan_apply_failed")
+    assert critical.call_args.args[1:9] == (
+        4,
+        "WinnerImpl",
+        7,
+        1,
+        2,
+        3,
+        "constructor",
+        error,
+    )
+    assert critical.call_args.kwargs["exc_info"] == (
+        RuntimeError,
+        error,
+        error.__traceback__,
+    )
+    exit_process.assert_called_once_with(70)
+
+
+def test_custom_selector_does_not_read_production_environment():
+    model, attn_configs, attn_inputs, parallelism_config = _root_selection_fixture()
+    candidate = _make_fake_impl("CustomSelectorImpl")
+    custom_selector = mock.Mock(return_value=candidate.__name__)
+    with (
+        mock.patch.dict(os.environ, {"DYN_DECODE_THRESHOLD": "invalid"}, clear=True),
+        mock.patch.object(
+            backend_selector, "_eligible", return_value=[candidate.__name__]
+        ),
+        mock.patch.object(backend_selector, "_impl_by_name", return_value=candidate),
+        mock.patch.object(
+            backend_selector.backend_bench,
+            "bench_backend_grid",
+            return_value=[3.0],
+        ),
+        mock.patch.object(backend_selector.torch.cuda, "synchronize"),
+    ):
+        choice = _select_on_root_for_test(
+            model,
+            attn_configs,
+            attn_inputs,
+            parallelism_config,
+            selector=custom_selector,
+        )
+
+    assert choice == candidate.__name__
+    custom_selector.assert_called_once_with({candidate.__name__: [3.0]})
+
+
+def _plan_application_fixture(tp_size=1, tp_rank=0):
+    model, inputs, _, _ = _selection_fixture(
+        tp_size=tp_size, tp_rank=tp_rank, dp_rank=2
+    )
+    return model, inputs.attention_inputs
+
+
+def _assert_plan_application_failure(
+    expected_stage, *, impl=None, disabled=False, tp_size=1, tp_rank=0
+):
+    name = "PlannedImpl"
+    model, inputs = _plan_application_fixture(tp_size, tp_rank)
+    fatal = mock.Mock()
+    with (
+        mock.patch.object(backend_selector, "_decode_registry", return_value=[name]),
+        mock.patch.object(backend_selector, "_impl_by_name", return_value=impl),
+        mock.patch(f"{_ATTN_FACTORY}._is_fmha_impl_disabled", return_value=disabled),
+        mock.patch.object(
+            backend_selector, "_terminate_plan_application_worker", fatal
+        ),
+    ):
+        with unittest.TestCase().assertRaisesRegex(
+            backend_selector.DynamicDecodeFatalError,
+            "fatal plan application termination returned unexpectedly",
+        ):
+            backend_selector.instantiate_decode_impl(model, inputs, name, True)
+
+    fatal.assert_called_once()
+    args = fatal.call_args.args
+    assert args[0:3] == (1, name, 0)
+    assert args[3] is model.parallelism_config
+    assert args[4] == expected_stage
+    assert isinstance(args[5], BaseException)
+
+
+def test_each_winner_application_failure_is_fatal():
+    _assert_plan_application_failure("class-missing")
+    _assert_plan_application_failure(
+        "disabled", impl=_make_fake_impl("PlannedImpl"), disabled=True
+    )
+    _assert_plan_application_failure(
+        "support", impl=_make_fake_impl("PlannedImpl", supports=False)
+    )
+    _assert_plan_application_failure(
+        "parallelism",
+        impl=_make_fake_impl("PlannedImpl", parallelism_supports=False),
+    )
+    _assert_plan_application_failure(
+        "constructor",
+        impl=_make_fake_impl(
+            "PlannedImpl", construction_error=RuntimeError("constructor failed")
+        ),
+    )
+    _assert_plan_application_failure(
+        "cuda-graph-support",
+        impl=_make_fake_impl("PlannedImpl", graph_supports=False),
+    )
+
+
+def test_winner_application_failure_semantics_cover_single_and_non_root_tp():
+    _assert_plan_application_failure("class-missing", tp_size=2, tp_rank=1)
+
+
+def test_invalid_nonnegative_broadcast_index_is_fatal_but_minus_one_is_miss():
+    model, inputs, _, _ = _selection_fixture(tp_size=2, tp_rank=1)
+    collective_module = types.ModuleType("collective_torch")
+    collective_module.Group = types.SimpleNamespace(TP=object())
+
+    for broadcast_index, should_fail in ((4, True), (-1, False)):
+        code = _FakeCode()
+
+        def broadcast(selected_code, _src, group, value=broadcast_index):
+            assert group is collective_module.Group.TP
+            selected_code[0] = value
+
+        collective_module.broadcast = mock.Mock(side_effect=broadcast)
+        fatal = mock.Mock()
+        with (
+            mock.patch.object(
+                backend_selector, "_decode_registry", return_value=["OnlyImpl"]
+            ),
+            mock.patch.object(backend_selector, "kv_grid", return_value=[8]),
+            mock.patch.object(backend_selector.torch, "full", return_value=code),
+            mock.patch.object(
+                backend_selector, "_terminate_plan_application_worker", fatal
+            ),
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.distributed.collective_torch": collective_module,
+                },
+            ),
+        ):
+            if should_fail:
+                with unittest.TestCase().assertRaises(
+                    backend_selector.DynamicDecodeFatalError
+                ):
+                    backend_selector.run_backend_selection(model, inputs)
+            else:
+                assert backend_selector.run_backend_selection(model, inputs) is None
+
+        if should_fail:
+            fatal.assert_called_once()
+            assert fatal.call_args.args[0:3] == (
+                1,
+                "<invalid-registry-index>",
+                4,
+            )
+            assert fatal.call_args.args[4] == "registry-index"
+        else:
+            fatal.assert_not_called()
+
+
+def test_instantiate_decode_impl_instantiates_when_enabled():
+    model = types.SimpleNamespace(
+        fmha_config=_fmha_config(),
+        config=types.SimpleNamespace(
+            getAttentionConfigs=lambda tp: None, headwise_config=None
+        ),
+        parallelism_config=types.SimpleNamespace(
+            tp_size=1,
+            tp_rank=0,
+            dp_rank=0,
+            get_attn_tp_size=lambda: 1,
+        ),
+    )
+    with _patch_impls(_NAMES):
+        inst = backend_selector.instantiate_decode_impl(
+            model,
+            types.SimpleNamespace(input_lengths=_FakeInputLengths()),
+            "PyFlashinferDecodeImpl",
+            True,
+        )
+    assert inst is not None
+
+
+# Bind the module-level test_* functions onto a TestCase so bazel's unittest
+# runner (no pytest available) discovers and runs them.
+class BackendSelectorTest(unittest.TestCase):
+    pass
+
+
+for _name, _fn in list(globals().items()):
+    if _name.startswith("test_") and callable(_fn):
+        setattr(BackendSelectorTest, _name, staticmethod(_fn))
+del _name, _fn  # don't leak a class/func ref that unittest would re-collect
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_selector.py
+++ b/rtp_llm/models_py/modules/factory/attention/dispatch/tests/test_selector.py
@@ -1,0 +1,89 @@
+"""Pure-CPU tests for decode backend selection policies."""
+
+import unittest
+
+from rtp_llm.models_py.modules.factory.attention.dispatch.selector import (
+    kv_grid,
+    select_stable,
+)
+
+
+# kv grid
+def test_kv_grid_clips_to_max_seq_len():
+    assert kv_grid(8192) == [256, 512, 1024, 2048, 4096, 8192]
+
+
+def test_kv_grid_at_64k():
+    assert kv_grid(65536) == [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+
+
+def test_kv_grid_full_at_256k():
+    assert kv_grid(262144) == [
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+        65536,
+        131072,
+        262144,
+    ]
+
+
+def test_kv_grid_appends_tail_boundary():
+    g = kv_grid(40000)
+    assert g[-1] == 40000
+    assert g[:-1] == [256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+
+
+def test_kv_grid_degenerate_small():
+    assert kv_grid(100) == [100]
+
+
+# stable production selection
+def test_select_stable_empty_matrix_returns_none():
+    assert select_stable({}, ["A", "B"], "A") is None
+
+
+def test_select_stable_keeps_default_below_threshold():
+    matrix = {"A": [100.0], "B": [96.0]}
+    assert select_stable(matrix, ["A", "B"], "A", threshold=0.05) == "A"
+
+
+def test_select_stable_switches_for_significant_improvement():
+    matrix = {"A": [100.0], "B": [90.0]}
+    assert select_stable(matrix, ["A", "B"], "A", threshold=0.05) == "B"
+
+
+def test_select_stable_uses_registry_order_within_cluster():
+    matrix = {"A": [100.0], "B": [102.0]}
+    assert select_stable(matrix, ["B", "A"], cluster_margin=0.05) == "B"
+
+
+def test_select_stable_clearly_fastest_wins_over_registry_priority():
+    matrix = {"A": [100.0], "B": [120.0]}
+    assert select_stable(matrix, ["B", "A"], cluster_margin=0.05) == "A"
+
+
+def test_select_stable_works_when_default_is_not_measured():
+    matrix = {"A": [100.0], "B": [90.0]}
+    assert select_stable(matrix, ["A", "B"], "default") == "B"
+
+
+# Bind the module-level test_* functions onto a TestCase so bazel's unittest
+# runner (no pytest available) discovers and runs them.
+class SelectorTest(unittest.TestCase):
+    pass
+
+
+for _name, _fn in list(globals().items()):
+    if _name.startswith("test_") and callable(_fn):
+        setattr(SelectorTest, _name, staticmethod(_fn))
+del _name, _fn  # don't leak a class/func ref that unittest would re-collect
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -571,6 +571,7 @@ class HWKernelConfig:
     disable_dpc_random: bool
     enable_cuda_graph: bool
     enable_cuda_graph_debug_mode: bool
+    enable_dynamic_decode_backend: bool
     enable_multi_block_mode: bool
     enable_native_cuda_graph: bool
     enable_stable_scatter_add: bool

--- a/rtp_llm/server/server_args/hw_kernel_group_args.py
+++ b/rtp_llm/server/server_args/hw_kernel_group_args.py
@@ -20,6 +20,15 @@ def init_hw_kernel_group_args(parser, hw_kernel_config):
     )
 
     hw_kernel_group.add_argument(
+        "--enable_dynamic_decode_backend",
+        env_name="ENABLE_DYNAMIC_DECODE_BACKEND",
+        bind_to=(hw_kernel_config, "enable_dynamic_decode_backend"),
+        type=str2bool,
+        default=False,
+        help="At CUDA graph capture time, dynamically pick the decode attention backend per bs bucket via on-device benchmarking; when off, use fixed priority",
+    )
+
+    hw_kernel_group.add_argument(
         "--enable_cuda_graph_debug_mode",
         env_name="ENABLE_CUDA_GRAPH_DEBUG_MODE",
         bind_to=(hw_kernel_config, "enable_cuda_graph_debug_mode"),

--- a/rtp_llm/test/smoke/case_runner.py
+++ b/rtp_llm/test/smoke/case_runner.py
@@ -2,11 +2,13 @@ import concurrent.futures
 import json
 import logging
 import os
-import traceback
+import re
 import time
+import traceback
 
 try:
     import torch
+
     _HAS_TORCH = True
 except ImportError:
     _HAS_TORCH = False
@@ -17,12 +19,15 @@ class _TensorEncoder(json.JSONEncoder):
         if _HAS_TORCH and isinstance(o, torch.Tensor):
             return o.tolist()
         return super().default(o)
+
+
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from smoke.cache_status_comparer import CacheStatusComparer
 from smoke.classifier_comparer import ClassifierComparer
 from smoke.common_def import QueryStatus, SmokeException, Tracer
+from smoke.embedding_comparer import EmbeddingComparer
 from smoke.gpu_diagnostics import (
     ExceptionType,
     ProcessFailureType,
@@ -32,21 +37,18 @@ from smoke.gpu_diagnostics import (
     scan_process_log,
     snapshot_dmesg,
 )
-from smoke.embedding_comparer import EmbeddingComparer
 from smoke.normal_comparer import NormalComparer
 from smoke.openai_comparer import OpenaiComparer
+from smoke.remote_kvcm_server import RemoteKVCMServer
 from smoke.reranker_comparer import RerankerComparer
 from smoke.similarity_comparer import SimilarityComparer
 from smoke.task_info import TaskInfo, TaskStates
 from smoke.tau2_bench_comparer import Tau2BenchComparer
 from smoke.worker_status_comparer import WorkerStatusComparer
-from smoke.remote_kvcm_server import RemoteKVCMServer
 
-from rtp_llm.utils.util import (
-    str_to_bool,
-)
 from rtp_llm.test.utils.coredump_util import summarize_and_cleanup_coredumps
 from rtp_llm.test.utils.maga_server_manager import MagaServerManager
+from rtp_llm.utils.util import str_to_bool
 
 
 def _iterate_modidfy_qr(origin: Dict[str, Any], new: Dict[str, Any]):
@@ -121,10 +123,107 @@ class CaseRunner(object):
                     return default
         return default
 
+    @staticmethod
+    def _verify_dynamic_decode_plan(
+        log_file_path: Optional[str], expected_dp_size: int, expected_tp_size: int
+    ) -> None:
+        assert log_file_path, "dynamic decode process log path is missing"
+        with open(log_file_path, "r", encoding="utf-8") as log_file:
+            process_log = log_file.read()
+
+        capture_buckets = {
+            int(bs)
+            for bs in re.findall(
+                r"capture success for batch size:\s*(\d+)", process_log
+            )
+        }
+        received: Dict[int, Dict[Tuple[int, int], Tuple[int, str, int]]] = defaultdict(
+            dict
+        )
+        applied: Dict[int, Dict[Tuple[int, int], str]] = defaultdict(dict)
+
+        for bs, registry_idx, backend, tp_rank, tp_size, dp_rank in re.findall(
+            r"dynamic_decode_plan_received bs=(\d+) registry_idx=(\d+) "
+            r"backend=([A-Za-z_][A-Za-z0-9_]*) tp_rank=(\d+) tp_size=(\d+) "
+            r"dp_rank=(\d+)",
+            process_log,
+        ):
+            bucket = int(bs)
+            rank = (int(dp_rank), int(tp_rank))
+            assert rank not in received[bucket], (
+                f"duplicate dynamic decode received record for bs={bucket} "
+                f"dp_rank={rank[0]} tp_rank={rank[1]}"
+            )
+            received[bucket][rank] = (int(registry_idx), backend, int(tp_size))
+
+        for bs, backend, tp_rank, dp_rank in re.findall(
+            r"dynamic_decode_plan_applied bs=(\d+) "
+            r"backend=([A-Za-z_][A-Za-z0-9_]*) tp_rank=(\d+) dp_rank=(\d+)",
+            process_log,
+        ):
+            bucket = int(bs)
+            rank = (int(dp_rank), int(tp_rank))
+            assert rank not in applied[bucket], (
+                f"duplicate dynamic decode applied record for bs={bucket} "
+                f"dp_rank={rank[0]} tp_rank={rank[1]}"
+            )
+            applied[bucket][rank] = backend
+
+        assert capture_buckets, "dynamic decode smoke captured no decode buckets"
+        assert capture_buckets == set(received), (
+            "dynamic decode received buckets do not match captured buckets: "
+            f"captured={sorted(capture_buckets)}, received={sorted(received)}"
+        )
+        assert capture_buckets == set(applied), (
+            "dynamic decode applied buckets do not match captured buckets: "
+            f"captured={sorted(capture_buckets)}, applied={sorted(applied)}"
+        )
+
+        for bucket in sorted(capture_buckets):
+            received_by_rank = received[bucket]
+            applied_by_rank = applied[bucket]
+            tp_sizes = {record[2] for record in received_by_rank.values()}
+            assert tp_sizes == {expected_tp_size}, (
+                f"unexpected tp_size in dynamic decode plan for bs={bucket}: "
+                f"expected={expected_tp_size}, actual={sorted(tp_sizes)}"
+            )
+            expected_ranks = {
+                (dp_rank, tp_rank)
+                for dp_rank in range(expected_dp_size)
+                for tp_rank in range(expected_tp_size)
+            }
+            assert set(received_by_rank) == expected_ranks, (
+                f"missing received ranks for bs={bucket}: "
+                f"expected={sorted(expected_ranks)}, "
+                f"actual={sorted(received_by_rank)}"
+            )
+            assert set(applied_by_rank) == expected_ranks, (
+                f"missing applied ranks for bs={bucket}: "
+                f"expected={sorted(expected_ranks)}, actual={sorted(applied_by_rank)}"
+            )
+            for dp_rank in range(expected_dp_size):
+                selections = {
+                    (record[0], record[1])
+                    for (record_dp_rank, _), record in received_by_rank.items()
+                    if record_dp_rank == dp_rank
+                }
+                assert len(selections) == 1, (
+                    "TP ranks received different dynamic decode plans for "
+                    f"bs={bucket} dp_rank={dp_rank}: {sorted(selections)}"
+                )
+            for rank, (_, backend, _) in received_by_rank.items():
+                assert applied_by_rank[rank] == backend, (
+                    f"dynamic decode plan was not applied for bs={bucket} "
+                    f"dp_rank={rank[0]} tp_rank={rank[1]}: received={backend}, "
+                    f"applied={applied_by_rank[rank]}"
+                )
+
     def run(self):
         self._dmesg_baseline = snapshot_dmesg()
         env_dict = self.create_env_from_args(self.env_args)
-        enable_remote_cache = self._extract_bool_arg(self.smoke_args_str, "--enable_remote_cache")
+        enable_remote_cache = self._extract_bool_arg(
+            self.smoke_args_str, "--enable_remote_cache"
+        )
         if enable_remote_cache:
             self.remote_kvcm_server = self._start_remote_kvcm_server()
             assert self.remote_kvcm_server is not None, "remote kvcm shoule not be None"
@@ -133,7 +232,10 @@ class CaseRunner(object):
         logging.info(f"smoke_args_str: {self.smoke_args_str}")
         try:
             server_manager = self.start_server(
-                env_dict, task_states, self.task_info, smoke_args_str=self.smoke_args_str
+                env_dict,
+                task_states,
+                self.task_info,
+                smoke_args_str=self.smoke_args_str,
             )
             if server_manager is None:
                 task_states.ret = False
@@ -143,6 +245,14 @@ class CaseRunner(object):
                 return task_states
             assert server_manager is not None, "server manager should not be None"
             server_manager.stop_server()
+            if self._extract_bool_arg(
+                self.smoke_args_str, "--enable_dynamic_decode_backend"
+            ):
+                self._verify_dynamic_decode_plan(
+                    server_manager.log_file_path,
+                    self._extract_int_arg(self.smoke_args_str, "--dp_size", 1),
+                    self._extract_int_arg(self.smoke_args_str, "--tp_size", 1),
+                )
             if enable_remote_cache and self.remote_kvcm_server is not None:
                 self.remote_kvcm_server.stop_server()
                 self.remote_kvcm_server.copy_logs()
@@ -153,20 +263,23 @@ class CaseRunner(object):
             )
 
     def _start_remote_kvcm_server(self) -> Optional[RemoteKVCMServer]:
-        server_path = os.path.join(os.environ["TEST_SRCDIR"], os.environ["TEST_WORKSPACE"], "external/remote_kv_cache_manager_server")
+        server_path = os.path.join(
+            os.environ["TEST_SRCDIR"],
+            os.environ["TEST_WORKSPACE"],
+            "external/remote_kv_cache_manager_server",
+        )
         kvcm_src_logs_path = os.path.join(os.environ["TEST_SRCDIR"], "rtp_llm/logs")
         bazel_outputs_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
         kvcm_dst_logs_path = os.path.join(bazel_outputs_dir, "kvcm_logs")
-        remote_kvcm_server = RemoteKVCMServer(server_path, self.kvcm_config, kvcm_src_logs_path, kvcm_dst_logs_path)
+        remote_kvcm_server = RemoteKVCMServer(
+            server_path, self.kvcm_config, kvcm_src_logs_path, kvcm_dst_logs_path
+        )
         if remote_kvcm_server.start_server():
             return remote_kvcm_server
         logging.error("start remote_kvcm_server")
         return None
 
-
-    def curl_server(
-        self, server_manager: MagaServerManager
-    ) -> TaskStates:
+    def curl_server(self, server_manager: MagaServerManager) -> TaskStates:
         if self.concurrency_test:
             task_states = TaskStates()
             with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
@@ -241,13 +354,20 @@ class CaseRunner(object):
             return RerankerComparer
         elif q_r.get("mainse_module", None) == True:
             if q_r.get("use_decode_arpc", None) == True:
-                from smoke.mainse.mainse_decode_arpc_comparer import MainseDecodeArpcComparer
+                from smoke.mainse.mainse_decode_arpc_comparer import (
+                    MainseDecodeArpcComparer,
+                )
+
                 return MainseDecodeArpcComparer
             elif q_r.get("use_emb_arpc", None) == True:
-                from smoke.mainse.mainse_embedding_arpc_comparer import MainseEmbeddingArpcComparer
+                from smoke.mainse.mainse_embedding_arpc_comparer import (
+                    MainseEmbeddingArpcComparer,
+                )
+
                 return MainseEmbeddingArpcComparer
             else:
                 from smoke.mainse.mainse_comparer import MainseComparer
+
                 return MainseComparer
         return NormalComparer
 
@@ -257,35 +377,51 @@ class CaseRunner(object):
         task_info: TaskInfo,
         task_states: TaskStates,
     ) -> None:
-        repeat_count = int(os.environ.get('STABILITY_REPEAT', '0'))
+        repeat_count = int(os.environ.get("STABILITY_REPEAT", "0"))
         if repeat_count <= 0 or task_states.ret == False:
             return
 
         qr_array = task_info.query_result
         task_endpoint = task_info.endpoint
         num_queries = len(qr_array)
-        logging.info(f"[STABILITY_TEST] Starting {repeat_count} repeat iterations for {num_queries} queries")
+        logging.info(
+            f"[STABILITY_TEST] Starting {repeat_count} repeat iterations for {num_queries} queries"
+        )
 
         per_query_pass: Dict[int, int] = defaultdict(int)
         per_query_fail: Dict[int, int] = defaultdict(int)
-        per_query_responses: Dict[int, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        per_query_responses: Dict[int, Dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
 
         for iter_idx in range(repeat_count):
             for q_idx, q_r in enumerate(qr_array):
                 request_endpoint = self._resolve_endpoint(q_r, task_endpoint)
                 comparer_cls = self._get_comparer_cls(q_r, request_endpoint)
                 try:
-                    comparer_cls(server_manager, request_endpoint, q_r, Tracer(), self.batch_infer).run()
+                    comparer_cls(
+                        server_manager,
+                        request_endpoint,
+                        q_r,
+                        Tracer(),
+                        self.batch_infer,
+                    ).run()
                     per_query_pass[q_idx] += 1
-                    logging.info(f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] PASS")
+                    logging.info(
+                        f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] PASS"
+                    )
                 except Exception as e:
                     exc_type = classify_exception(e)
                     if exc_type != ExceptionType.NOT_GPU_ERROR:
-                        output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
+                        output_dir = os.environ.get(
+                            "TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd()
+                        )
                         dump_gpu_state(
                             exc=e,
                             failure_context=f"stability repeat ({exc_type.value})",
-                            log_path=os.path.join(output_dir, "gpu_state_stability.log"),
+                            log_path=os.path.join(
+                                output_dir, "gpu_state_stability.log"
+                            ),
                             dmesg_baseline=getattr(self, "_dmesg_baseline", 0),
                         )
                     per_query_fail[q_idx] += 1
@@ -293,18 +429,24 @@ class CaseRunner(object):
                     if "actual.response" in err_msg:
                         start = err_msg.find("actual.response = [")
                         if start != -1:
-                            resp = err_msg[start + len("actual.response = ["):]
+                            resp = err_msg[start + len("actual.response = [") :]
                             resp = resp.rstrip("]").rstrip()
                             per_query_responses[q_idx][resp] += 1
-                    logging.warning(f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] FAIL: {e}")
+                    logging.warning(
+                        f"[STABILITY_TEST iter={iter_idx+1}/{repeat_count} query={q_idx}] FAIL: {e}"
+                    )
 
         total_checks = repeat_count * num_queries
         total_pass = sum(per_query_pass.values())
         total_fail = sum(per_query_fail.values())
         pass_rate = total_pass / total_checks * 100 if total_checks > 0 else 0
 
-        logging.info(f"[STABILITY_SUMMARY] Total: {repeat_count} iterations x {num_queries} queries = {total_checks} checks")
-        logging.info(f"[STABILITY_SUMMARY] Pass: {total_pass}, Fail: {total_fail} (rate: {pass_rate:.1f}%)")
+        logging.info(
+            f"[STABILITY_SUMMARY] Total: {repeat_count} iterations x {num_queries} queries = {total_checks} checks"
+        )
+        logging.info(
+            f"[STABILITY_SUMMARY] Pass: {total_pass}, Fail: {total_fail} (rate: {pass_rate:.1f}%)"
+        )
         for q_idx in range(num_queries):
             p = per_query_pass.get(q_idx, 0)
             f = per_query_fail.get(q_idx, 0)
@@ -316,9 +458,12 @@ class CaseRunner(object):
         if total_fail > 0:
             task_states.ret = False
             task_states.query_status.append(
-                (QueryStatus.OTHERS,
-                 f"Stability test: {total_fail}/{total_checks} failures in {repeat_count} iterations",
-                 Tracer()))
+                (
+                    QueryStatus.OTHERS,
+                    f"Stability test: {total_fail}/{total_checks} failures in {repeat_count} iterations",
+                    Tracer(),
+                )
+            )
 
     def _curl_server_impl(
         self, server_manager: MagaServerManager, task_info: TaskInfo
@@ -335,7 +480,9 @@ class CaseRunner(object):
             request_endpoint = self._resolve_endpoint(q_r, task_endpoint)
             try:
                 comparer_cls = self._get_comparer_cls(q_r, request_endpoint)
-                comparer_cls(server_manager, request_endpoint, q_r, tracer, self.batch_infer).run()
+                comparer_cls(
+                    server_manager, request_endpoint, q_r, tracer, self.batch_infer
+                ).run()
                 task_states.query_status.append((QueryStatus.OK, f"", tracer))
             except SmokeException as e:
                 task_states.ret = False
@@ -343,7 +490,9 @@ class CaseRunner(object):
             except Exception as e:
                 exc_type = classify_exception(e)
                 if exc_type != ExceptionType.NOT_GPU_ERROR:
-                    output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
+                    output_dir = os.environ.get(
+                        "TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd()
+                    )
                     dump_gpu_state(
                         exc=e,
                         failure_context=f"query exception ({exc_type.value})",
@@ -355,10 +504,12 @@ class CaseRunner(object):
                 task_states.query_status.append((QueryStatus.OTHERS, str(e), tracer))
             if self.sleep_time_qr > 0:
                 time.sleep(self.sleep_time_qr)
-            if self.kill_remote and getattr(self, 'remote_kvcm_server', None) is not None:
+            if (
+                self.kill_remote
+                and getattr(self, "remote_kvcm_server", None) is not None
+            ):
                 self.remote_kvcm_server.stop_server()
                 logging.info("manually stop remote_kvcm_server")
-
 
         self._run_stability_repeat(server_manager, task_info, task_states)
 
@@ -369,6 +520,7 @@ class CaseRunner(object):
             with open(task_info.taskinfo_rel_path, "r") as f:
                 try:
                     import json5
+
                     origin_json = json5.load(f)
                 except ImportError:
                     origin_json = json.load(f)
@@ -389,7 +541,9 @@ class CaseRunner(object):
                     _iterate_modidfy_qr(origin_qr["result"], now_result)
 
             out_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
-            rewrite_path = os.path.join(out_dir, "smoke_actual", os.path.basename(task_info.taskinfo_rel_path))
+            rewrite_path = os.path.join(
+                out_dir, "smoke_actual", os.path.basename(task_info.taskinfo_rel_path)
+            )
             os.makedirs(os.path.dirname(rewrite_path), exist_ok=True)
             with open(rewrite_path, "w") as f:
                 json.dump(
@@ -460,11 +614,15 @@ class CaseRunner(object):
         if ret is False:
             task_states.ret = False
             failure_type, failure_desc = classify_process_exit(server_manager.exit_code)
-            task_states.err_msg = f"start server failed: {failure_type.value} — {failure_desc}"
+            task_states.err_msg = (
+                f"start server failed: {failure_type.value} — {failure_desc}"
+            )
 
             log_errors = scan_process_log(server_manager.log_file_path, max_lines=30)
             if log_errors:
-                task_states.err_msg += "\n[process.log errors]\n" + "\n".join(log_errors)
+                task_states.err_msg += "\n[process.log errors]\n" + "\n".join(
+                    log_errors
+                )
 
             output_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", os.getcwd())
             dump_gpu_state(

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_new_model_py_fp8_kv_cache_dyn_decode_cudagraph.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_new_model_py_fp8_kv_cache_dyn_decode_cudagraph.json
@@ -1,0 +1,42 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:s2"
+                    }
+                ],
+                "max_tokens": 10,
+                "temperature": 0.0,
+                "top_p": 1.0
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1705333930,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "当然可以！以下是几个英语听力方法的听力",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 37,
+                    "total_tokens": 47,
+                    "completion_tokens": 10
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_block_fp8_tp2_dyn_decode.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_block_fp8_tp2_dyn_decode.json
@@ -1,0 +1,233 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B-FP8/snapshots/98342881667bac235ed8605b5ffd8a64a5b99aec",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777280342,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您的需求，但目前我无法提供与新高考相关的具体规划和升学指导服务。如果您有其他问题或需要帮助，欢迎随时告诉我！",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "stop",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 531,
+                    "completion_tokens": 34,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 817.134,
+                    "iter_count": 34,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 34,
+                    "step_output_len": 34,
+                    "first_token_cost_time": 308.257,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1777280342,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您的需求，但目前我无法提供与新高考相关的具体规划和升学指导服务。如果您有其他问题或需要帮助，欢迎随时告诉我！",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null
+                        },
+                        "finish_reason": "stop",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 531,
+                    "completion_tokens": 34,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_h20_dyn_decode.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_h20_dyn_decode.json
@@ -1,0 +1,233 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B/snapshots/0060bc56d46589041c1048efd1a397421b1142b5",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777280360,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等。以下是一些关键点，帮助您规划学业与职业生涯：\n\n### 1. **强基计划择校**\n强基计划旨在选拔具有突出学科特长和潜力的高中生，提供进入顶尖高校的机会。建议您：\n- **提前了解目标高校**：研究各高校的招生要求、专业设置和科研方向。\n- **参加相关考试**：如数学、物理等学科的全国统一考试，以及高校组织的选拔考试。\n- **关注高校动态**：及时获取高校的招生简章和录取分数线，调整择校策略。\n\n### 2. **综合评价咨询**\n综合评价是高校录取的重要依据，建议您：\n- **了解综合评价体系**：包括学业成绩、综合素质评价、学科竞赛、科研项目等。\n- **提升综合素质**：积极参与课外活动、志愿服务、社会实践，以增强综合素质评价。\n- **准备相关材料**：如个人陈述、推荐信、作品集等，展示您的特长和潜力。\n\n### 3. **志愿填报**\n志愿填报是决定升学结果的关键步骤，建议您：\n- **关注分数线**：了解本省、本校的录取分数线，合理设定志愿。\n- **使用志愿填报工具**：利用高校和招生部门提供的在线工具，模拟填报志愿。\n- **关注政策变化**：及时了解政策调整，如招生计划、录取批次等。\n\n### 4. **海外院校申请**\n如果您有意向申请海外院校，建议您：\n- **选择合适的院校**：根据自身兴趣和专业需求，选择与之匹配的海外院校。\n- **准备申请材料**：包括个人陈述、推荐信、成绩单、语言成绩等。\n- **了解申请流程**：熟悉海外院校的申请流程和截止日期，确保按时提交材料。\n\n### 5. **学业与职业生涯规划**\n- **学业规划**：根据高考成绩和兴趣，选择适合的学科和专业，制定学习计划。\n- **职业规划**：结合个人兴趣和市场需求，探索未来的职业方向，制定长期目标。\n- **持续学习**：保持学习热情，积极参与学术研究和实践，提升自身竞争力。\n\n### 6. **其他建议**\n- **保持积极心态**：高考是人生的重要阶段，保持信心和积极的心态至关重要。\n- **寻求专业指导**：与老师、家长和升学顾问保持沟通，获取专业建议。\n- **关注心理健康**：合理安排时间，保持良好的作息和心态，避免过度焦虑。\n\n如果您需要更具体的指导，如某所高校的招生要求、志愿填报策略或海外申请建议，欢迎进一步咨询！",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "stop",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 1067,
+                    "completion_tokens": 570,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 6255.432,
+                    "iter_count": 570,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 570,
+                    "step_output_len": 570,
+                    "first_token_cost_time": 227.599,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1777280366,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等。以下是一些关键点，帮助您规划学业与职业生涯：\n\n### 1. **强基计划择校**\n强基计划旨在选拔具有突出学科特长和潜力的高中生，提供进入顶尖高校的机会。建议您：\n- **提前了解目标高校**：研究各高校的招生要求、专业设置和科研方向。\n- **参加相关考试**：如数学、物理等学科的全国统一考试，以及高校组织的选拔考试。\n- **关注高校动态**：及时获取高校的招生简章和录取分数线，调整择校策略。\n\n### 2. **综合评价咨询**\n综合评价是高校录取的重要依据，建议您：\n- **了解综合评价体系**：包括学业成绩、综合素质评价、学科竞赛、科研项目等。\n- **提升综合素质**：积极参与课外活动、志愿服务、社会实践，以增强综合素质评价。\n- **准备相关材料**：如个人陈述、推荐信、作品集等，展示您的特长和潜力。\n\n### 3. **志愿填报**\n志愿填报是决定升学结果的关键步骤，建议您：\n- **关注分数线**：了解本省、本校的录取分数线，合理设定志愿。\n- **使用志愿填报工具**：利用高校和招生部门提供的在线工具，模拟填报志愿。\n- **关注政策变化**：及时了解政策调整，如招生计划、录取批次等。\n\n### 4. **海外院校申请**\n如果您有意向申请海外院校，建议您：\n- **选择合适的院校**：根据自身兴趣和专业需求，选择与之匹配的海外院校。\n- **准备申请材料**：包括个人陈述、推荐信、成绩单、语言成绩等。\n- **了解申请流程**：熟悉海外院校的申请流程和截止日期，确保按时提交材料。\n\n### 5. **学业与职业生涯规划**\n- **学业规划**：根据高考成绩和兴趣，选择适合的学科和专业，制定学习计划。\n- **职业规划**：结合个人兴趣和市场需求，探索未来的职业方向，制定长期目标。\n- **持续学习**：保持学习热情，积极参与学术研究和实践，提升自身竞争力。\n\n### 6. **其他建议**\n- **保持积极心态**：高考是人生的重要阶段，保持信心和积极的心态至关重要。\n- **寻求专业指导**：与老师、家长和升学顾问保持沟通，获取专业建议。\n- **关注心理健康**：合理安排时间，保持良好的作息和心态，避免过度焦虑。\n\n如果您需要更具体的指导，如某所高校的招生要求、志愿填报策略或海外申请建议，欢迎进一步咨询！",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null
+                        },
+                        "finish_reason": "stop",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 1067,
+                    "completion_tokens": 570,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_fp8_per_tensor_dyn_decode_30b.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_fp8_per_tensor_dyn_decode_30b.json
@@ -1,0 +1,21 @@
+{
+    "model_type": "qwen_3_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3-30B-A3B-Fp8-pt-hf-dynamic",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s3",
+                "generate_config": {
+                    "max_new_tokens": 32,
+                    "temperature": 0.0,
+                    "top_p": 0,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response": "\n\nI'm trying to run this code, but I get the error: NameError: name 'screen\\_manager' is not defined\n\nI think the issue",
+                "finished": true
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -199,6 +199,13 @@ def h20_oss_suites():
                 },
                 gpu_type=["H20"],
             ),
+            smoke_test(
+                name="moe_fp8pt_deepep_dyn_decode",
+                task_info="data/model/qwen3_moe/q_r_fp8_per_tensor_dyn_decode_30b.json",
+                smoke_args="--reserver_runtime_mem_mb 20000 --warm_up 0 --act_type BF16 --enable_cuda_graph 1 --enable_dynamic_decode_backend 1 --use_deepep_moe 1 --use_deepep_low_latency 1 --dp_size 2 --ep_size 2",
+                envs=["ACCL_LOW_LATENCY_OPTIMIZE=1", "DYN_DECODE_THRESHOLD=1.0"],
+                gpu_type=["H20"],
+            ),
         ],
     )
 
@@ -217,6 +224,12 @@ def h20_oss_suites():
                 name="dense_fp8kv_flashinfer_prefill",
                 task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_flashinfer_prefill.json",
                 smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 0 --disable_flashinfer_native 0 --frontend_server_count 1",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_flashinfer_dyn_decode_cudagraph",
+                task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_dyn_decode_cudagraph.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --max_seq_len 512 --enable_cuda_graph 1 --decode_capture_config '1' --enable_dynamic_decode_backend 1 --enable_xqa 0 --enable_flashinfer_trtllm_gen 0 --disable_flashinfer_native 0",
                 gpu_type=["H20"],
             ),
             smoke_test(
@@ -254,6 +267,20 @@ def h20_oss_suites():
                 name="dense_prompt_scoring",
                 task_info="data/model/qwen25/q_r_prompt_scoring.json",
                 smoke_args="--act_type BF16 --warm_up 0",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8pb_dyn_decode",
+                task_info="data/model/qwen3/q_r_h20_dyn_decode.json",
+                smoke_args="--disable_flashinfer_native 1 --quantization FP8_PER_BLOCK --act_type BF16 --warm_up 0 --enable_cuda_graph 1 --enable_dynamic_decode_backend 1",
+                envs=["DYN_DECODE_THRESHOLD=1.0"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8pb_tp2_dyn_decode",
+                task_info="data/model/qwen3/q_r_block_fp8_tp2_dyn_decode.json",
+                smoke_args="--disable_flashinfer_native 1 --act_type BF16 --reserver_runtime_mem_mb 8192 --tp_size 2 --warm_up 0 --enable_cuda_graph 1 --enable_dynamic_decode_backend 1",
+                envs=["DYN_DECODE_THRESHOLD=1.0"],
                 gpu_type=["H20"],
             ),
         ],

--- a/rtp_llm/test/smoke/suites_sm100.bzl
+++ b/rtp_llm/test/smoke/suites_sm100.bzl
@@ -21,6 +21,13 @@ def sm100_suites():
                 gpu_type=["SM100_ARM"],
             ),
             smoke_test(
+                name="dense_tp1_sm100_dyn_decode",
+                task_info="data/model/qwen3/q_r_l20a_fp4_tp1_py.json",
+                smoke_args="--decode_capture_config '1,2' --warm_up 0 --enable_cuda_graph 1 --enable_dynamic_decode_backend 1 --act_type BF16 --tp_size 1 --world_size 1 --reserver_runtime_mem_mb 8192 --fp8_kv_cache 1 --seq_size_per_block 64 --concurrency_limit 64 --blockwise_use_fp8_kv_cache 1",
+                envs=["DYN_DECODE_THRESHOLD=1.0"],
+                gpu_type=["SM100_ARM"],
+            ),
+            smoke_test(
                 name="fp8_attention_sm100",
                 task_info="data/model/qwen3/q_r_block_fp8.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 64 --fp8_kv_cache 1 --reserver_runtime_mem_mb 178125 --warm_up 0",


### PR DESCRIPTION
## Summary

Add runtime selection of the fastest decode attention backend per batch-size
bucket during CUDA graph capture, replacing the fixed first-match priority.

Controlled by `--enable_dynamic_decode_backend` (env `ENABLE_DYNAMIC_DECODE_BACKEND`),
default OFF — zero behavior change when the flag is off.



### How it works

At CUDA graph capture time, for each decode batch-size bucket:

1. **Benchmark**: run real on-device micro-benchmarks across a KV-length grid
   for each candidate backend (XQA TRT, FlashInfer XQA, PyFlashinfer, etc.)
2. **Select**: pick the stably fastest backend via `select_stable` (requires
   consistent wins, falls back to priority on tie)
3. **Dispatch**: `prepare_fmha_impl` looks up `backend_plan[bs]` at decode time
   (cache miss → fixed priority fallback)

### Key changes

1. **Deferred CG capture** — move CUDA graph capture out of `PyWrappedModel`
   constructor to engine-driven `triggerInitCapture()`, opening a window for
   bench/dispatch before graphs are recorded.

2. **dispatch/ package** — new `selector`, `backend_bench`, `backend_selector`
   modules + C++ wiring (`enable_dynamic_decode_backend` config flag,
   `CudaGraphDecode` plan storage, `module_base` backend lookup).

3. **PyFlashinfer CG replay fix** — call `plan()` before every CG replay for
   all decode paths (FA2 and non-FA2) with CG-safe tensor placement, fixing a
   hang on replay.

4. **Smoke tests** — dyn_decode cases for dense (qwen3 fp8pb, fp8pb tp2) and
   moe (qwen3_moe fp8pt deepep). Also adds `kernel_seq_size_per_block` to
   next/moe_vl cases and updates affected goldens.

### Testing

- CPU unit tests: `test_selector`, `test_backend_bench`, `test_backend_selector`
- GPU integration: decode CG capture/replay including non-FA2 hang detection
- Smoke: dense + moe dyn_decode cases with dedicated golden data
