### PR TITLE
Features/amd qwen

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -67,12 +67,14 @@ xft_dep = select({
 arch_dep = select({
     "@//:using_arm": [],
     "@//:using_cuda12_arm": [],
+    "@//:using_rocm": [],
     "//conditions:default": [":decord", ":av"],
 })
 
 arch_with_version_dep = select({
     "@//:using_arm": [],
     "@//:using_cuda12_arm": [],
+    "@//:using_rocm": [],
     "//conditions:default": ["decord==0.6.0", "av==16.1.0"],
 })
 

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -436,6 +436,9 @@ def setup_default_args(py_env_configs):
         py_env_configs.role_config.role_type == RoleType.PREFILL
         or py_env_configs.role_config.role_type == RoleType.DECODE
     ):
+        py_env_configs.pd_separation_config.cache_store_rdma_mode = (
+            py_env_configs.cache_store_config.cache_store_rdma_mode
+        )
         if py_env_configs.pd_separation_config.cache_store_rdma_mode == True:
             # AcclBarex envs in cache store, can be replaced by user config
             if os.getenv("ACCL_MAX_USER_MR_GB") is None:

--- a/rtp_llm/config/test/server_config_setup_test.py
+++ b/rtp_llm/config/test/server_config_setup_test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest import TestCase
 from unittest.mock import patch
@@ -152,6 +153,33 @@ class GenerateConfigTest(TestCase):
         self.assertEqual(py_env_configs.moe_config.use_deepep_low_latency, True)
         self.assertEqual(py_env_configs.moe_config.use_deepep_internode, False)
         self.assertEqual(py_env_configs.moe_config.ll_num_max_token, 160)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "TP_SIZE": "2",
+            "PP_SIZE": "1",
+            "WORLD_SIZE": "2",
+            "WORLD_RANK": "0",
+            "LOCAL_WORLD_SIZE": "2",
+            "CONCURRENCY_LIMIT": "32",
+            "START_PORT": "20000",
+            "MODEL_TYPE": "fake_model",
+            "ROLE_TYPE": "DECODE",
+            "CACHE_STORE_RDMA_MODE": "0",
+            "USE_ALL_GATHER": "0",
+        },
+        clear=True,
+    )
+    def test_pd_cache_store_rdma_disabled_before_default_accl_env(self):
+        py_env_configs: PyEnvConfigs = setup_args()
+        setup_and_configure_server(py_env_configs)
+
+        self.assertEqual(
+            py_env_configs.pd_separation_config.cache_store_rdma_mode, False
+        )
+        self.assertIsNone(os.environ.get("ACCL_MAX_USER_MR_GB"))
+        self.assertIsNone(os.environ.get("ACCL_SOFT_TX_DEPTH"))
 
     @patch.dict(
         "os.environ",

--- a/rtp_llm/cpp/cuda_graph/BUILD
+++ b/rtp_llm/cpp/cuda_graph/BUILD
@@ -11,6 +11,13 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "combo_position_ids_validation",
+    hdrs = ["combo_position_ids_validation.h"],
+    deps = torch_deps(),
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "cuda_graph_srcs",
     srcs = [
@@ -27,6 +34,7 @@ filegroup(
     name = "cuda_graph_hdrs",
     srcs = [
         "cuda_graph_base.h",
+        "combo_position_ids_validation.h",
         "cuda_graph_device_shims.h",
         "cuda_graph_utils.h",
         "cuda_graph_runner.h",
@@ -65,6 +73,7 @@ cc_library(
     ],
     deps = torch_deps() + [
         ":cuda_graph_base",
+        ":combo_position_ids_validation",
         ":cuda_graph_hdrs_lib",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/cpp/utils:core_utils",

--- a/rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h
+++ b/rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstddef>
+
+#include <torch/torch.h>
+
+namespace rtp_llm {
+
+inline bool validateComboPositionIdsForReplay(int                  position_id_len_factor,
+                                              int                  token_count,
+                                              const torch::Tensor& position_ids,
+                                              const torch::Tensor& captured_position_ids,
+                                              size_t&              copy_numel) {
+    copy_numel = 0;
+    if (position_id_len_factor <= 0) {
+        return true;
+    }
+
+    if (!position_ids.defined() || !position_ids.has_storage() || position_ids.numel() <= 0
+        || !captured_position_ids.defined() || !captured_position_ids.has_storage()
+        || captured_position_ids.numel() <= 0) {
+        return false;
+    }
+    if (position_ids.scalar_type() != torch::kInt32 || captured_position_ids.scalar_type() != torch::kInt32
+        || !position_ids.is_contiguous() || !captured_position_ids.is_contiguous()
+        || position_ids.numel() % position_id_len_factor != 0) {
+        return false;
+    }
+
+    if (token_count <= 0) {
+        return false;
+    }
+    copy_numel = static_cast<size_t>(token_count) * static_cast<size_t>(position_id_len_factor);
+    return static_cast<size_t>(position_ids.numel()) >= copy_numel
+           && static_cast<size_t>(captured_position_ids.numel()) >= copy_numel;
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_runner.h"
+#include "rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h"
 
 #include <algorithm>
 #include <cstring>
@@ -194,6 +195,21 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
                              py_model_inputs_.attention_inputs.kv_cache_kernel_block_id_device);
     }
 
+    if (position_id_len_factor_ > 0) {
+        size_t copy_numel = 0;
+        RTP_LLM_CHECK_WITH_INFO(
+            validateComboPositionIds(inputs, state, py_model_inputs_.combo_position_ids, copy_numel),
+            "invalid combo_position_ids before CUDA graph replay: factor=%d, src_numel=%lld, dst_numel=%lld",
+            position_id_len_factor_,
+            inputs.combo_position_ids.defined() ? static_cast<long long>(inputs.combo_position_ids.numel()) : -1LL,
+            py_model_inputs_.combo_position_ids.defined() ?
+                static_cast<long long>(py_model_inputs_.combo_position_ids.numel()) :
+                -1LL);
+        optimizedCopyAsync(inputs.combo_position_ids,
+                           py_model_inputs_.combo_position_ids,
+                           copy_numel * inputs.combo_position_ids.element_size());
+    }
+
     if (!is_prefill_cuda_graph_mode_) {
         // D2D copies — collected for single batched kernel launch
         tryAddD2DCopy(inputs.attention_inputs.sequence_lengths_plus_1_device,
@@ -202,21 +218,6 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
         tryAddD2DCopy(inputs.attention_inputs.decode_cu_seqlens_device,
                       py_model_inputs_.attention_inputs.decode_cu_seqlens_device,
                       (state.current_batch_size + 1) * sizeof(int));
-
-        if (inputs.combo_position_ids.defined() && inputs.combo_position_ids.numel() > 0
-            && inputs.combo_position_ids.has_storage()) {
-            if (!py_model_inputs_.combo_position_ids.defined()) {
-                RTP_LLM_LOG_WARNING("combo_position_ids not defined in graph but present in input, skipping copy");
-            } else {
-                const size_t copy_size   = inputs.combo_position_ids.numel() * sizeof(int);
-                const size_t target_size = py_model_inputs_.combo_position_ids.numel() * sizeof(int);
-                RTP_LLM_CHECK_WITH_INFO(target_size >= copy_size,
-                                        "combo_position_ids target tensor size (%zu) is smaller than needed (%zu)",
-                                        target_size,
-                                        copy_size);
-                optimizedCopyAsync(inputs.combo_position_ids, py_model_inputs_.combo_position_ids, copy_size);
-            }
-        }
     } else {
         // D2D copy
         if (inputs.bert_embedding_inputs.position_encoding.numel() > 0) {
@@ -421,6 +422,38 @@ bool CudaGraphRunner::tryGetRealGraphDecodeBatchSize(const PyModelInputs& inputs
     return true;
 }
 
+bool CudaGraphRunner::validateComboPositionIds(const PyModelInputs&  inputs,
+                                               const CudaGraphState& state,
+                                               const torch::Tensor&  captured_position_ids,
+                                               size_t&               copy_numel) const {
+    const int token_count = is_prefill_cuda_graph_mode_ ? state.current_seq_len : state.seq_len_sum;
+    return validateComboPositionIdsForReplay(
+        position_id_len_factor_, token_count, inputs.combo_position_ids, captured_position_ids, copy_numel);
+}
+
+bool CudaGraphRunner::canReplaySelectedGraph(const PyModelInputs& inputs, const CudaGraphState& state) const {
+    const int  graph_key = is_prefill_cuda_graph_mode_ ? state.current_real_graph_seq_len : state.current_real_graph_bs;
+    const auto graph_it  = graph_instances_.find(graph_key);
+    if (graph_it == graph_instances_.end()) {
+        RTP_LLM_LOG_WARNING("CUDA graph key %d was not captured, fallback to normal run", graph_key);
+        return false;
+    }
+
+    size_t      copy_numel            = 0;
+    const auto& captured_position_ids = graph_it->second.mem_hold_.py_model_inputs_.combo_position_ids;
+    if (!validateComboPositionIds(inputs, state, captured_position_ids, copy_numel)) {
+        RTP_LLM_LOG_WARNING(
+            "combo_position_ids are incompatible with CUDA graph key %d: factor=%d, src_numel=%lld, "
+            "dst_numel=%lld; fallback to normal run",
+            graph_key,
+            position_id_len_factor_,
+            inputs.combo_position_ids.defined() ? static_cast<long long>(inputs.combo_position_ids.numel()) : -1LL,
+            captured_position_ids.defined() ? static_cast<long long>(captured_position_ids.numel()) : -1LL);
+        return false;
+    }
+    return true;
+}
+
 bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state) {
     RTP_LLM_PROFILE_SCOPE("cuda_graph.canRun");
     if (kv_cache_group_tags_.size() > 1) {
@@ -449,7 +482,7 @@ bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state)
         if (inputs.attention_inputs.is_target_verify) {
             // Target-verify must also respect captured decode range.
             // Otherwise we may replay an uncaptured graph key.
-            return tryGetRealGraphDecodeBatchSize(inputs, state);
+            return tryGetRealGraphDecodeBatchSize(inputs, state) && canReplaySelectedGraph(inputs, state);
         }
         return false;
     }
@@ -469,7 +502,7 @@ bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state)
             return false;
         }
     }
-    return true;
+    return canReplaySelectedGraph(inputs, state);
 }
 
 void CudaGraphRunner::initKernelInternalMemory() {

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -519,8 +519,7 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     // (non-Mrope models pay zero memory and the captured graph never references it).
     if (position_id_len_factor_ > 0) {
         inputs.combo_position_ids =
-            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cpu_int32_);
-        inputs.combo_position_ids                  = inputs.combo_position_ids.pin_memory();
+            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cuda_int32_);
         inputs.attention_inputs.combo_position_ids = inputs.combo_position_ids;
     }
 
@@ -556,7 +555,8 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     inputs.attention_inputs.padding_offset = inputs.attention_inputs.padding_offset.pin_memory();
     inputs.attention_inputs.dtype          = model_data_type_;
     inputs.attention_inputs.is_s_padded    = true;
-    inputs.attention_inputs.sequence_lengths_plus_1_device = torch::zeros({int(max_bs_)}, options_cuda_int32_);
+    auto sequence_lengths_plus_1           = inputs.attention_inputs.sequence_lengths.add(1).pin_memory();
+    inputs.attention_inputs.sequence_lengths_plus_1_device = sequence_lengths_plus_1.cuda();
     // Step=1 is intentional: when num_tokens_per_bs_ > 1 (target verify), is_prefill is set to true
     // so the factory selects PREFILL impls (which use cu_seqlens, not decode_cu_seqlens).
     // XQADecodeImpl/XQAWrapper (the consumers of decode_cu_seqlens_host) are never reached in that path.
@@ -686,7 +686,15 @@ void CudaGraphRunner::initCapture() {
         // get real output data type (params already prepared in attn impl __init__/create_params)
         auto attn_pyobj = py_attn_pyobj_method_(capture_mem_hold_.py_model_inputs_, true);
         RTP_LLM_LOG_INFO("initCapture forward for output datatype start");
-        py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        try {
+            py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        } catch (const py::error_already_set& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with Python exception: %s", e.what());
+            throw;
+        } catch (const std::exception& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with C++ exception: %s", e.what());
+            throw;
+        }
         RTP_LLM_LOG_INFO("initCapture forward for output datatype end");
         output = torch::zeros({max_num_token_, hidden_size_}, options_cuda_float_);
         capture_mem_hold_.setHiddenStates(output);

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
@@ -115,6 +115,11 @@ private:
     bool tryGetRealGraphDecodeBatchSize(const PyModelInputs& inputs, CudaGraphState& state);
     /// Select graph key for prefill; false if capture_range_ empty or seq_len above max captured (lower_bound hit end).
     bool                    tryGetRealGraphPrefillSeqLen(const PyModelInputs& inputs, CudaGraphState& state);
+    bool                    validateComboPositionIds(const PyModelInputs&  inputs,
+                                                     const CudaGraphState& state,
+                                                     const torch::Tensor&  captured_position_ids,
+                                                     size_t&               copy_numel) const;
+    bool                    canReplaySelectedGraph(const PyModelInputs& inputs, const CudaGraphState& state) const;
     void                    initCaptureAttentionInputs(PyModelInputs& inputs, int max_bs, int num_tokens_per_bs);
     void                    initCaptureBertEmbeddingInputs(PyModelInputs& inputs, int max_bs, int max_num_token);
     void                    initCaptureAttentionInputsPost();

--- a/rtp_llm/cpp/cuda_graph/tests/BUILD
+++ b/rtp_llm/cpp/cuda_graph/tests/BUILD
@@ -1,6 +1,16 @@
 load("//:def.bzl", "copts")
 load("@arch_config//:arch_select.bzl", "torch_deps")
 
+cc_test(
+    name = "combo_position_ids_validation_test",
+    srcs = ["combo_position_ids_validation_test.cc"],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/cpp/cuda_graph:combo_position_ids_validation",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps(),
+)
+
 cc_library(
     name = "test_cuda_graph_runner_libs",
     srcs = [

--- a/rtp_llm/cpp/cuda_graph/tests/combo_position_ids_validation_test.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/combo_position_ids_validation_test.cc
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h"
+
+namespace rtp_llm {
+namespace {
+
+TEST(ComboPositionIdsValidationTest, AcceptsExactSourceAndDestinationSizes) {
+    const auto options = torch::TensorOptions().dtype(torch::kInt32);
+    const auto src     = torch::zeros({6}, options);
+    const auto dst     = torch::zeros({6}, options);
+    size_t     copy_numel;
+
+    EXPECT_TRUE(validateComboPositionIdsForReplay(3, 2, src, dst, copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+}
+
+TEST(ComboPositionIdsValidationTest, RejectsTooSmallSourceOrDestination) {
+    const auto options = torch::TensorOptions().dtype(torch::kInt32);
+    size_t     copy_numel;
+
+    EXPECT_FALSE(
+        validateComboPositionIdsForReplay(3, 2, torch::zeros({3}, options), torch::zeros({6}, options), copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+    EXPECT_FALSE(
+        validateComboPositionIdsForReplay(3, 2, torch::zeros({6}, options), torch::zeros({3}, options), copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+}
+
+TEST(ComboPositionIdsValidationTest, RejectsInvalidTensorContracts) {
+    const auto int_options = torch::TensorOptions().dtype(torch::kInt32);
+    const auto valid       = torch::zeros({6}, int_options);
+    size_t     copy_numel;
+
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::Tensor(), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({6}, torch::kInt64), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({2, 3}, int_options).t(), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({5}, int_options), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 0, valid, valid, copy_numel));
+}
+
+TEST(ComboPositionIdsValidationTest, DisabledFactorNeedsNoPositionIds) {
+    size_t copy_numel = 1;
+    EXPECT_TRUE(validateComboPositionIdsForReplay(0, 0, torch::Tensor(), torch::Tensor(), copy_numel));
+    EXPECT_EQ(copy_numel, 0);
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/disaggregate/cache_store/BUILD
+++ b/rtp_llm/cpp/disaggregate/cache_store/BUILD
@@ -30,6 +30,7 @@ cc_library(
 )
 
 interface_includes = [
+    "CacheStoreTensorUtils.h",
     "CommonDefine.h",
     "CacheStore.h",
     "CacheStoreMetricsCollector.h",

--- a/rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h
+++ b/rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <torch/torch.h>
+#include <c10/core/DeviceGuard.h>
+
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm {
+
+inline torch::TensorOptions cacheStoreByteTensorOptions(bool gpu_mem) {
+    auto options = torch::TensorOptions().dtype(torch::kUInt8);
+    if (!gpu_mem) {
+        return options.device(torch::kCPU);
+    }
+
+    const int device_id = isRuntimeInitialized() ? static_cast<int>(getDeviceId()) : 0;
+    return options.device(torch::Device(torch::kCUDA, device_id));
+}
+
+inline torch::Tensor cacheStoreByteTensorFromBlob(void* data, int64_t len, bool gpu_mem) {
+    return torch::from_blob(data, {len}, cacheStoreByteTensorOptions(gpu_mem));
+}
+
+inline void
+cacheStoreCopyByteTensor(void* dst, int64_t dst_len, bool dst_gpu, void* src, int64_t src_len, bool src_gpu) {
+    const bool needs_gpu = dst_gpu || src_gpu;
+    if (needs_gpu) {
+        const int        device_id = isRuntimeInitialized() ? static_cast<int>(getDeviceId()) : 0;
+        c10::DeviceGuard guard(c10::Device(c10::kCUDA, static_cast<c10::DeviceIndex>(device_id)));
+        cudaPreRun(device_id);
+        execNoBlockCopy(
+            {cacheStoreByteTensorFromBlob(dst, dst_len, dst_gpu), cacheStoreByteTensorFromBlob(src, src_len, src_gpu)});
+        return;
+    }
+    execNoBlockCopy(
+        {cacheStoreByteTensorFromBlob(dst, dst_len, false), cacheStoreByteTensorFromBlob(src, src_len, false)});
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/disaggregate/cache_store/RequestBlockBufferStore.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/RequestBlockBufferStore.cpp
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/RequestBlockBufferStore.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/TimeUtil.h"
@@ -179,15 +180,12 @@ bool RequestBlockBufferStore::copyBlock(const std::shared_ptr<BlockBuffer>& dst_
 
     RTP_LLM_INTERVAL_LOG(120, INFO, "copy block cache once, may affect performance");
 
-    execNoBlockCopy(
-        {torch::from_blob(
-             dst_block->addr.get(),
-             {(int64_t)dst_block->len},
-             torch::TensorOptions().dtype(torch::kUInt8).device(dst_block->gpu_mem ? torch::kCUDA : torch::kCPU)),
-         torch::from_blob(
-             src_block->addr.get(),
-             {(int64_t)src_block->len},
-             torch::TensorOptions().dtype(torch::kUInt8).device(src_block->gpu_mem ? torch::kCUDA : torch::kCPU))});
+    cacheStoreCopyByteTensor(dst_block->addr.get(),
+                             dst_block->len,
+                             dst_block->gpu_mem,
+                             src_block->addr.get(),
+                             src_block->len,
+                             src_block->gpu_mem);
     return true;
 }
 

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpBlockReadClosure.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpBlockReadClosure.cpp
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/TcpBlockReadClosure.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreDevicePin.h"
 #include "rtp_llm/cpp/utils/Logger.h"
@@ -67,14 +68,12 @@ void TcpBlockReadClosure::Run() {
             return;
         }
 
-        auto dst_tensor = torch::from_blob(
-            unload_block->addr.get(),
-            {(int64_t)unload_block->len},
-            torch::TensorOptions().dtype(torch::kUInt8).device(unload_block->gpu_mem ? torch::kCUDA : torch::kCPU));
-        auto src_tensor = torch::from_blob(const_cast<char*>(block.content().data()),
-                                           {(int64_t)unload_block->len},
-                                           torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU));
-        execNoBlockCopy({dst_tensor, src_tensor});
+        cacheStoreCopyByteTensor(unload_block->addr.get(),
+                                 unload_block->len,
+                                 unload_block->gpu_mem,
+                                 const_cast<char*>(block.content().data()),
+                                 unload_block->len,
+                                 false);
     }
     end(true, CacheStoreErrorCode::None);
 }

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.cpp
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreLoadServiceClosure.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreDevicePin.h"
 #include "rtp_llm/cpp/disaggregate/cache_store/MemoryUtil.h"
@@ -58,14 +59,12 @@ void TcpCacheStoreLoadServiceClosure::Run() {
             return;
         }
 
-        auto dst_tensor = torch::from_blob(
-            unload_block->addr.get(),
-            {(int64_t)unload_block->len},
-            torch::TensorOptions().dtype(torch::kUInt8).device(unload_block->gpu_mem ? torch::kCUDA : torch::kCPU));
-        auto src_tensor = torch::from_blob(const_cast<char*>(block.content().data()),
-                                           {(int64_t)block.len()},
-                                           torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU));
-        execNoBlockCopy({dst_tensor, src_tensor});
+        cacheStoreCopyByteTensor(unload_block->addr.get(),
+                                 unload_block->len,
+                                 unload_block->gpu_mem,
+                                 const_cast<char*>(block.content().data()),
+                                 block.len(),
+                                 false);
     }
     end(true, CacheStoreErrorCode::None);
 }

--- a/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreServiceImpl.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreServiceImpl.cpp
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreServiceImpl.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreDevicePin.h"
 #include "rtp_llm/cpp/utils/Logger.h"
@@ -121,17 +122,10 @@ void TcpCacheStoreServiceImpl::blockReadImpl(::google::protobuf::RpcController* 
             resp_block_info->set_addr(block_info.addr());
             resp_block_info->set_len(block_info.len());
 
-            // ROCm PyTorch exposes ordinary GPU tensors through the CUDA device type.
-            auto src_tensor = torch::from_blob((void*)block_info.addr(),
-                                               {(int64_t)block_info.len()},
-                                               torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
-
             auto tmp_buffer = static_cast<char*>(malloc(block_info.len()));
-            auto dst_tensor = torch::from_blob(tmp_buffer,
-                                               {(int64_t)block_info.len()},
-                                               torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCPU));
 
-            execNoBlockCopy({dst_tensor, src_tensor});
+            cacheStoreCopyByteTensor(
+                tmp_buffer, block_info.len(), false, (void*)block_info.addr(), block_info.len(), block_buffer->gpu_mem);
             resp_block_info->set_content(tmp_buffer, block_info.len());
             free(tmp_buffer);
         }

--- a/rtp_llm/cpp/disaggregate/cache_store/test/BUILD
+++ b/rtp_llm/cpp/disaggregate/cache_store/test/BUILD
@@ -32,8 +32,22 @@ cc_library(
 )
 
 cc_test(
+    name = "cache_store_tensor_utils_gtest",
+    srcs = ["CacheStoreTensorUtilsTest.cpp"],
+    deps = [
+        "//rtp_llm/cpp/disaggregate/cache_store:cache_store_base",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    copts = ["-fno-access-control"] + copts(),
+)
+
+cc_test(
     name = "cache_store_gtest",
-    srcs = glob(["*.cpp"], exclude = test_base_sources),
+    srcs = glob(
+        ["*.cpp"],
+        exclude = test_base_sources + ["CacheStoreTensorUtilsTest.cpp"],
+    ),
     deps = [
         "//rtp_llm/cpp/disaggregate/cache_store:cache_store",
         ":cache_store_test_base",
@@ -47,4 +61,3 @@ cc_test(
     copts = ["-fno-access-control"] + copts(),
     exec_properties = {'gpu':'H20'},
 )
-

--- a/rtp_llm/cpp/disaggregate/cache_store/test/CacheStoreTensorUtilsTest.cpp
+++ b/rtp_llm/cpp/disaggregate/cache_store/test/CacheStoreTensorUtilsTest.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "rtp_llm/cpp/disaggregate/cache_store/CacheStoreTensorUtils.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/LockedBlockBufferManager.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/MemoryUtil.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/RequestBlockBufferStore.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/TcpCacheStoreServiceImpl.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/TcpClient.h"
+#include "rtp_llm/cpp/disaggregate/cache_store/TimerManager.h"
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm {
+
+namespace {
+bool    runtime_initialized = false;
+int64_t runtime_device_id   = 0;
+}
+
+bool isRuntimeInitialized() {
+    return runtime_initialized;
+}
+
+int64_t getDeviceId() {
+    return runtime_device_id;
+}
+
+void cudaPreRun(int) {}
+
+void execNoBlockCopy(const CopyParams& params) {
+    params.check();
+    params.dst.copy_(params.src, false);
+}
+
+namespace {
+
+class TestMemoryUtil: public MemoryUtil {
+public:
+    bool regUserMr(void*, uint64_t, bool, uint64_t) override {
+        return true;
+    }
+
+    bool deregUserMr(void*, bool) override {
+        return true;
+    }
+
+    bool isMemoryMr(void*, uint64_t, bool, bool) override {
+        return true;
+    }
+
+    bool findMemoryMr(void*, void*, uint64_t, bool, bool) override {
+        return true;
+    }
+
+    bool isRdmaMode() override {
+        return false;
+    }
+};
+
+class TestClosure: public google::protobuf::Closure {
+public:
+    void Run() override {
+        called = true;
+    }
+
+    bool called{false};
+};
+
+class TestTcpCacheStoreServiceImpl: public TcpCacheStoreServiceImpl {
+public:
+    using TcpCacheStoreServiceImpl::TcpCacheStoreServiceImpl;
+
+    void blockRead(::google::protobuf::RpcController* controller,
+                   const ::BlockReadRequest*          request,
+                   BlockReadResponse*                 response,
+                   ::google::protobuf::Closure*       done) {
+        blockReadImpl(controller, request, response, done);
+    }
+};
+
+}  // namespace
+
+TEST(CacheStoreTensorUtilsTest, BlockReadUsesCpuTensorForCpuBlocks) {
+    auto                         memory_util                = std::make_shared<TestMemoryUtil>();
+    auto                         request_block_buffer_store = std::make_shared<RequestBlockBufferStore>(memory_util);
+    auto                         timer_manager              = std::make_shared<TimerManager>();
+    auto                         locked_block_manager       = std::make_shared<LockedBlockBufferManager>();
+    auto                         tcp_client                 = std::make_shared<TcpClient>();
+    TestTcpCacheStoreServiceImpl service(
+        memory_util, request_block_buffer_store, nullptr, timer_manager, locked_block_manager, tcp_client, 0);
+
+    std::vector<char> cpu_data{'a', 'b', 'c', 'd', 'e', 'f'};
+    auto              cpu_addr = std::shared_ptr<void>(cpu_data.data(), [](void*) {});
+    auto              cpu_block =
+        std::make_shared<BlockBuffer>("cpu_block", cpu_addr, static_cast<uint32_t>(cpu_data.size()), false, true);
+    ASSERT_TRUE(request_block_buffer_store->regUserBuffers({cpu_block}));
+
+    BlockReadRequest request;
+    auto*            block = request.add_blocks();
+    block->set_key("cpu_block");
+    block->set_addr(reinterpret_cast<int64_t>(cpu_data.data()) + 1);
+    block->set_len(3);
+
+    BlockReadResponse response;
+    TestClosure       done;
+    service.blockRead(nullptr, &request, &response, &done);
+
+    ASSERT_TRUE(done.called);
+    ASSERT_EQ(response.error_code(), KvCacheStoreServiceErrorCode::EC_SUCCESS);
+    ASSERT_EQ(response.blocks_size(), 1);
+    EXPECT_EQ(response.blocks(0).content(), "bcd");
+}
+
+TEST(CacheStoreTensorUtilsTest, UsesRuntimeDeviceForGpuTensorOptions) {
+    runtime_initialized = true;
+    runtime_device_id   = 3;
+
+    const auto options = cacheStoreByteTensorOptions(true);
+
+    EXPECT_EQ(options.device().type(), torch::kCUDA);
+    EXPECT_EQ(options.device().index(), 3);
+
+    runtime_initialized = false;
+    runtime_device_id   = 0;
+}
+
+TEST(CacheStoreTensorUtilsTest, DefaultsToDeviceZeroBeforeRuntimeInitialization) {
+    runtime_initialized = false;
+    runtime_device_id   = 7;
+
+    const auto options = cacheStoreByteTensorOptions(true);
+
+    EXPECT_EQ(options.device().type(), torch::kCUDA);
+    EXPECT_EQ(options.device().index(), 0);
+
+    runtime_device_id = 0;
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/model_utils/RopeConfig.cc
+++ b/rtp_llm/cpp/model_utils/RopeConfig.cc
@@ -19,8 +19,8 @@ std::string RopeConfig::DebugRopeConfigStr() const {
     oss << "  mrope_dim1: " << mrope_dim1 << std::endl;
     oss << "  mrope_dim2: " << mrope_dim2 << std::endl;
     oss << "  mrope_dim3: " << mrope_dim3 << std::endl;
+    oss << "  mrope_interleaved: " << mrope_interleaved << std::endl;
     return oss.str();
 }
 
 }  // namespace rtp_llm
-

--- a/rtp_llm/cpp/model_utils/RopeConfig.h
+++ b/rtp_llm/cpp/model_utils/RopeConfig.h
@@ -34,6 +34,7 @@ struct RopeConfig {
     int   mrope_dim1            = 0;
     int   mrope_dim2            = 0;
     int   mrope_dim3            = 0;
+    bool  mrope_interleaved     = false;
     bool  is_neox_style         = true;
     bool  indexer_is_neox_style = true;
 

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1426,6 +1426,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("mrope_dim1", &RopeConfig::mrope_dim1)
         .def_readwrite("mrope_dim2", &RopeConfig::mrope_dim2)
         .def_readwrite("mrope_dim3", &RopeConfig::mrope_dim3)
+        .def_readwrite("mrope_interleaved", &RopeConfig::mrope_interleaved)
         .def_readwrite("is_neox_style", &RopeConfig::is_neox_style)
         .def_readwrite("indexer_is_neox_style", &RopeConfig::indexer_is_neox_style);
 

--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -889,6 +889,9 @@ class RocmImpl(GpuImpl):
     def shuffle_moe_weight(
         self, x: torch.Tensor, datatype: torch.dtype, name: str
     ) -> torch.Tensor:
+        from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+        load_aiter()
         from aiter.ops.shuffle import shuffle_weight
 
         is_gate = name in [W.moe_w1, W.moe_s1]
@@ -916,7 +919,9 @@ class RocmImpl(GpuImpl):
                 raise RuntimeError(
                     "Quark MXFP4 MoE scale shuffle requires gfx950 (MI355)."
                 )
+            load_aiter()
             from aiter.utility.fp4_utils import e8m0_shuffle
+
             if x_.dim() == 3:
                 s0, s1, _ = x_.shape
                 x_ = e8m0_shuffle(x_.contiguous().view(s0 * s1, -1)).view(s0, s1, -1)

--- a/rtp_llm/models/qwen2_vl.py
+++ b/rtp_llm/models/qwen2_vl.py
@@ -259,6 +259,9 @@ class QWen2_VL(QWen_VL):
         rope_config.mrope_dim1 = mrope_section[0]
         rope_config.mrope_dim2 = mrope_section[1]
         rope_config.mrope_dim3 = mrope_section[2]
+        rope_config.mrope_interleaved = config_json.get("rope_scaling", {}).get(
+            "mrope_interleaved", False
+        )
         rope_config.dim = 128
 
     @staticmethod

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -11,10 +11,7 @@ from rtp_llm.models.qwen3_next.qwen3_next_weight import (
     Qwen35DenseWeight,
     Qwen35MoeWeight,
 )
-from rtp_llm.ops import (
-    KVCacheSpecType,
-    HybridAttentionType,
-)
+from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
 
 
 class Qwen3NextBase(BaseModel):
@@ -200,9 +197,11 @@ class Qwen35Moe(Qwen3NextBase):
     @classmethod
     def _parse_rope_config(cls, config_json: dict, config: ModelConfig):
         rope_parameters = config_json["rope_parameters"]
-        # TODO@xieshui support mrope in cuda graph and reopen config
-        mrope_interleaved = rope_parameters["mrope_interleaved"]
-        assert mrope_interleaved, "mrope_interleaved should be True"
+        mrope_interleaved = rope_parameters.get("mrope_interleaved", True)
+        if not mrope_interleaved:
+            raise ValueError(
+                "Qwen3Next requires rope_parameters.mrope_interleaved to be true"
+            )
         config.attn_config.rope_config.style = 7
         config.attn_config.rope_config.base = rope_parameters["rope_theta"]
         config.partial_rotary_factor = rope_parameters["partial_rotary_factor"]
@@ -214,6 +213,7 @@ class Qwen35Moe(Qwen3NextBase):
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = mrope_interleaved
         config.mm_model_config.mm_position_ids_style = 2
 
     @classmethod
@@ -233,10 +233,11 @@ class Qwen35Moe(Qwen3NextBase):
         moe_config = self.moe_config
         max_generate_batch_size = self.max_generate_batch_size
 
+        from rtp_llm.device.device_type import is_hip
         from rtp_llm.models_py.utils.arch import is_cuda
 
-        if not is_cuda():
-            raise RuntimeError("Qwen3Next is only supported in cuda arch")
+        if not is_cuda() and not is_hip():
+            raise RuntimeError("Qwen3Next is only supported in cuda/rocm arch")
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -101,11 +101,16 @@ class QWen3_VL(QwenV3):
         config.config_dtype = config_json.get("torch_dtype", None)
 
         config.attn_config.rope_config.style = 7
-        mrope_section = config_json["rope_scaling"].get("mrope_section", [16, 24, 24])
+        # Qwen3-VL interleaves T/H/W rotary pairs; the model default for a
+        # 128-dim rotary region is 24/20/20 (64 pairs total).
+        mrope_section = config_json["rope_scaling"].get("mrope_section", [24, 20, 20])
         config.attn_config.rope_config.index_factor = len(mrope_section)
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = config_json[
+            "rope_scaling"
+        ].get("mrope_interleaved", True)
         config.mm_model_config.mm_position_ids_style = 2
 
         config.mm_related_params.config["ckpt_path"] = config.ckpt_path

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -47,6 +47,7 @@ py_library(
     ],
     deps = [
         ":utils",
+        "//rtp_llm:utils",
         "//rtp_llm/models_py/triton_kernels:triton_kernels",
         "//rtp_llm/models_py/distributed:deepep_wrapper",
         "//rtp_llm/models_py/distributed:moriep_wrapper",
@@ -101,7 +102,10 @@ py_library(
     srcs = glob([
         "kernels/*.py",
         "kernels/**/*.py",
-    ])
+    ]),
+    deps = [
+        "//rtp_llm:utils",
+    ],
 )
 
 py_library(

--- a/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
+++ b/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
@@ -1015,7 +1015,7 @@ __device__ inline void context_rope(RopeConfig    rope_config,
         input_len = input_len + prefix_prompt_length;
         seqidx    = seqidx + prefix_prompt_length;
     }
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         seqidx = position_id;
     }
 
@@ -1046,7 +1046,7 @@ __device__ inline void attention_rope(RopeConfig rope_config,
         prefix_prompt_length = 0;
     }
 
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         tlength = position_id;
     }
 

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -12,6 +12,58 @@
 
 namespace rtp_llm {
 
+namespace {
+
+void validateMropeConfig(const AttentionConfigs& attn_configs) {
+    const RopeConfig& rope_config = attn_configs.rope_config;
+    if (rope_config.style != RopeStyle::Mrope) {
+        return;
+    }
+    if (!rope_config.mrope_interleaved) {
+        throw std::runtime_error("ROCm FusedRopeKVCache does not support MRoPE with mrope_interleaved=false. "
+                                 "Use mrope_interleaved=true or disable the fused rope path.");
+    }
+    if (rope_config.index_factor != 3) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE requires index_factor=3, got "
+                                 + std::to_string(rope_config.index_factor));
+    }
+    if (rope_config.dim <= 0 || rope_config.dim % 2 != 0) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE requires a positive even rope dim, got "
+                                 + std::to_string(rope_config.dim));
+    }
+    if (rope_config.dim > attn_configs.size_per_head) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE rope dim exceeds size_per_head: rope dim="
+                                 + std::to_string(rope_config.dim)
+                                 + ", size_per_head=" + std::to_string(attn_configs.size_per_head));
+    }
+    if (rope_config.mrope_dim1 < 0 || rope_config.mrope_dim2 < 0 || rope_config.mrope_dim3 < 0) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE sections must be non-negative");
+    }
+
+    const int64_t section_sum = static_cast<int64_t>(rope_config.mrope_dim1)
+                                + static_cast<int64_t>(rope_config.mrope_dim2)
+                                + static_cast<int64_t>(rope_config.mrope_dim3);
+    const int rotary_pair_count = rope_config.dim / 2;
+    if (section_sum != rotary_pair_count) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE section sum must equal rope dim / 2: got "
+                                 + std::to_string(section_sum) + ", expected " + std::to_string(rotary_pair_count));
+    }
+
+    // Qwen3/3.5 interleaves pair indices as T,H,W,T,H,W,... and leaves
+    // unclaimed H/W slots on the temporal axis. Each requested section must
+    // therefore fit the number of corresponding slots in the rotary region.
+    const int max_height_pairs = (rotary_pair_count + 1) / 3;
+    const int max_width_pairs  = rotary_pair_count / 3;
+    if (rope_config.mrope_dim2 > max_height_pairs || rope_config.mrope_dim3 > max_width_pairs) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE sections exceed interleaved H/W capacity: H="
+                                 + std::to_string(rope_config.mrope_dim2) + " (max " + std::to_string(max_height_pairs)
+                                 + "), W=" + std::to_string(rope_config.mrope_dim3) + " (max "
+                                 + std::to_string(max_width_pairs) + ")");
+    }
+}
+
+}  // namespace
+
 static at::ScalarType get_fp8_dtype() {
     hipDeviceProp_t prop;
     int             device_id = 0;
@@ -84,22 +136,9 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
-    }
-}
-
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
+    validateMropeConfig(attn_configs_);
 }
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
@@ -144,14 +183,29 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
         attn_params->prefix_lengths = attn_inputs.prefix_lengths;
     }
     attn_params->kv_block_array.cache_type = attn_configs_.kv_cache_dtype;
-    attn_params->position_ids = attn_inputs.combo_position_ids;
+    attn_params->position_ids              = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error("MRoPE prefill requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num    = int(attn_inputs.input_lengths.sum().item<int64_t>());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error("MRoPE prefill combo_position_ids too small: got "
+                                     + std::to_string(attn_params->position_ids.numel()) + ", expected at least "
+                                     + std::to_string(min_expected) + " (token_num=" + std::to_string(token_num)
+                                     + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
 
-// Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
+    // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
         attn_params->position_ids =
             attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
     }
-    
+
     int max_prefix_length = 0;
     if (has_prefix && attn_params->prefix_lengths.defined() && attn_params->prefix_lengths.numel() > 0) {
         max_prefix_length = attn_params->prefix_lengths.max().item<int32_t>();
@@ -353,7 +407,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
+    validateMropeConfig(attn_configs_);
 }
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
@@ -392,6 +446,21 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     attn_params->prefix_lengths            = attn_inputs.prefix_lengths;
     attn_params->padding_offset            = attn_inputs.padding_offset;
     attn_params->position_ids              = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error("MRoPE requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num    = int(attn_inputs.sequence_lengths.numel());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error("MRoPE combo_position_ids too small: got "
+                                     + std::to_string(attn_params->position_ids.numel()) + ", expected at least "
+                                     + std::to_string(min_expected) + " (token_num=" + std::to_string(token_num)
+                                     + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
     // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
         attn_params->position_ids =

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -101,6 +101,33 @@ inline __device__ type_out* reinterpret_ptr(void* ptr, size_t offset) {
     return reinterpret_cast<type_out*>(reinterpret_cast<type_in*>(ptr) + offset);
 }
 
+__device__ __forceinline__ int get_mrope_position_dim(const RopeConfig& rope_config, const int tidx) {
+    // Vec_t<T> contains one rotary pair after RotaryHalfRead, so tidx is
+    // the frequency-pair index. Qwen3/3.5 assigns H/W to interleaved slots
+    // and keeps all remaining slots on the temporal axis. The host validates
+    // that the three section counts sum to rope_config.dim / 2 and fit these
+    // interleaved slots before launching the kernel.
+    if (tidx % 3 == 1 && tidx < rope_config.mrope_dim2 * 3) {
+        return 1;
+    }
+    if (tidx % 3 == 2 && tidx < rope_config.mrope_dim3 * 3) {
+        return 2;
+    }
+    return 0;
+}
+
+__device__ __forceinline__ int
+get_rope_position_id(const RopeConfig& rope_config, const int* position_ids, const int token_idx, const int tidx) {
+    if (!position_ids) {
+        return -1;
+    }
+    if (rope_config.style == RopeStyle::Mrope) {
+        const int now_dim = get_mrope_position_dim(rope_config, tidx);
+        return position_ids[token_idx * rope_config.index_factor + now_dim];
+    }
+    return position_ids[token_idx * rope_config.index_factor];
+}
+
 inline __device__ void convert_to_fp8(__hip_fp8x2_e4m3_fnuz* v, const amd_bfloat162 u) {
     __hip_bfloat162_raw   raw_bf16  = *reinterpret_cast<const __hip_bfloat162_raw*>(&u);
     __hip_fp8x2_storage_t raw_fp8x2 = __hip_cvt_bfloat16raw2_to_fp8x2(raw_bf16, __HIP_SATFINITE, __HIP_E4M3_FNUZ);
@@ -215,21 +242,9 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
-    const int pre_len   = cu_seqlens[batch_idx];
-    const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
+    int       position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    const int pre_len     = cu_seqlens[batch_idx];
+    const int input_len   = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                        q,
                                        k,
@@ -385,21 +400,27 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
 // V3 must match its caller's layout or the FMHA reader will see garbage V.
 // =====================================================================================
 template<bool V_VEC_LAYOUT>
-__global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
-    __nv_bfloat16*                 q_buf,
-    __nv_bfloat16*                 k_buf,
-    __nv_bfloat16*                 v_buf,
-    const __nv_bfloat16*           QKV,
-    const __nv_bfloat16* __restrict qkv_bias,
-    const int*           __restrict padding_offset,
-    const float2*        __restrict cos_sin_cache,
-    PrefixPromptBatchWeightsParam   param,
-    int token_num, int head_num, int head_num_kv, int head_dim, int seq_len,
-    int rot_dim, float rope_base, float rope_scale,
-    bool store_kv, bool store_cache) {
-    constexpr int VEC = 8;
-    constexpr int K_TOK = 4;
-    extern __shared__ __nv_bfloat16 smem[];   // [K_TOK][head_dim] BF16
+__global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(__nv_bfloat16*       q_buf,
+                                                                 __nv_bfloat16*       k_buf,
+                                                                 __nv_bfloat16*       v_buf,
+                                                                 const __nv_bfloat16* QKV,
+                                                                 const __nv_bfloat16* __restrict qkv_bias,
+                                                                 const int* __restrict padding_offset,
+                                                                 const float2* __restrict cos_sin_cache,
+                                                                 PrefixPromptBatchWeightsParam param,
+                                                                 int                           token_num,
+                                                                 int                           head_num,
+                                                                 int                           head_num_kv,
+                                                                 int                           head_dim,
+                                                                 int                           seq_len,
+                                                                 int                           rot_dim,
+                                                                 float                         rope_base,
+                                                                 float                         rope_scale,
+                                                                 bool                          store_kv,
+                                                                 bool                          store_cache) {
+    constexpr int                   VEC   = 8;
+    constexpr int                   K_TOK = 4;
+    extern __shared__ __nv_bfloat16 smem[];  // [K_TOK][head_dim] BF16
 
     const int tok_local = threadIdx.y;
     const int token_idx = blockIdx.x * K_TOK + tok_local;
@@ -425,21 +446,21 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
     const int  d_part  = is_lo ? (d + half_r) : (d - half_r);
     const int  rope_d  = is_lo ? d : d_part;
 
-    const int  token_padding_offset = padding_offset ? padding_offset[safe_token_idx] : 0;
-    const int  tgt_token_idx = safe_token_idx + token_padding_offset;
-    const int  batch_idx = tgt_token_idx / seq_len;
-    const int  dst_kv_seq_idx = tgt_token_idx % seq_len;
+    const int token_padding_offset = padding_offset ? padding_offset[safe_token_idx] : 0;
+    const int tgt_token_idx        = safe_token_idx + token_padding_offset;
+    const int batch_idx            = tgt_token_idx / seq_len;
+    const int dst_kv_seq_idx       = tgt_token_idx % seq_len;
     // V3 dispatch guard enforces prefix==0, so batch-local seq_idx is the
     // absolute RoPE position — no external position_ids needed.
-    const int  pos_id = dst_kv_seq_idx;
+    const int pos_id = dst_kv_seq_idx;
 
-    const int n      = head_num    * head_dim;
-    const int kv_n   = head_num_kv * head_dim;
-    const int hidden = n + 2 * kv_n;
+    const int n       = head_num * head_dim;
+    const int kv_n    = head_num_kv * head_dim;
+    const int hidden  = n + 2 * kv_n;
     const int row_off = safe_token_idx * hidden;
 
-    auto load8  = [](const __nv_bfloat16* p) { return *reinterpret_cast<const int4*>(p); };
-    auto store8 = [](__nv_bfloat16* p, int4 v) { *reinterpret_cast<int4*>(p) = v; };
+    auto           load8    = [](const __nv_bfloat16* p) { return *reinterpret_cast<const int4*>(p); };
+    auto           store8   = [](__nv_bfloat16* p, int4 v) { *reinterpret_cast<int4*>(p) = v; };
     __nv_bfloat16* smem_row = smem + tok_local * head_dim;
 
     // ---- inv_freq (per thread, shared across all heads) ----
@@ -449,49 +470,52 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
     // (__powf ~6 ULP, __sincosf ~2-3 ULP) drift enough across many layers/heads
     // to flip greedy decoding at marginal logit positions (observed regression
     // in Eagle speculative decoding on Qwen2-14B).
-    float inv_freq_lo[VEC/2], inv_freq_hi[VEC/2];
+    float inv_freq_lo[VEC / 2], inv_freq_hi[VEC / 2];
     if (in_rope && !cos_sin_cache) {
         const float inv_rot_dim = 1.0f / float(rot_dim);
-        #pragma unroll
-        for (int i = 0; i < VEC/2; ++i) {
-            inv_freq_lo[i] = powf(rope_base, -float(2 * (rope_d + 2*i))     * inv_rot_dim);
-            inv_freq_hi[i] = powf(rope_base, -float(2 * (rope_d + 2*i + 1)) * inv_rot_dim);
+#pragma unroll
+        for (int i = 0; i < VEC / 2; ++i) {
+            inv_freq_lo[i] = powf(rope_base, -float(2 * (rope_d + 2 * i)) * inv_rot_dim);
+            inv_freq_hi[i] = powf(rope_base, -float(2 * (rope_d + 2 * i + 1)) * inv_rot_dim);
         }
     }
 
     // ---- cs_lo/cs_hi (per token, shared across all heads of this block) ----
-    float2 cs_lo[VEC/2], cs_hi[VEC/2];
+    float2 cs_lo[VEC / 2], cs_hi[VEC / 2];
     if (in_rope) {
-        #pragma unroll
-        for (int i = 0; i < VEC/2; ++i) {
+#pragma unroll
+        for (int i = 0; i < VEC / 2; ++i) {
             if (cos_sin_cache) {
-                cs_lo[i] = cos_sin_cache[pos_id * half_r + rope_d + 2*i];
-                cs_hi[i] = cos_sin_cache[pos_id * half_r + rope_d + 2*i + 1];
+                cs_lo[i] = cos_sin_cache[pos_id * half_r + rope_d + 2 * i];
+                cs_hi[i] = cos_sin_cache[pos_id * half_r + rope_d + 2 * i + 1];
             } else {
                 // Compute angle in float, but evaluate sincos in double to
                 // match V1 (rotary_position_embedding.h:340 declares
                 // `double sin_i, cos_i;` for ROCm before calling sincos).
-                float angle0 = float(pos_id) * inv_freq_lo[i] / rope_scale;
-                float angle1 = float(pos_id) * inv_freq_hi[i] / rope_scale;
+                float  angle0 = float(pos_id) * inv_freq_lo[i] / rope_scale;
+                float  angle1 = float(pos_id) * inv_freq_hi[i] / rope_scale;
                 double s0, c0, s1, c1;
                 sincos((double)angle0, &s0, &c0);
                 sincos((double)angle1, &s1, &c1);
-                cs_lo[i].x = (float)c0; cs_lo[i].y = (float)s0;
-                cs_hi[i].x = (float)c1; cs_hi[i].y = (float)s1;
+                cs_lo[i].x = (float)c0;
+                cs_lo[i].y = (float)s0;
+                cs_hi[i].x = (float)c1;
+                cs_hi[i].y = (float)s1;
             }
         }
     }
 
     // ---- Process all Q heads ----
     for (int h = 0; h < head_num; ++h) {
-        const int q_off = h * head_dim;
-        int4 q_pack = load8(&QKV[row_off + q_off + d]);
-        auto* q2 = reinterpret_cast<__nv_bfloat162*>(&q_pack);
+        const int q_off  = h * head_dim;
+        int4      q_pack = load8(&QKV[row_off + q_off + d]);
+        auto*     q2     = reinterpret_cast<__nv_bfloat162*>(&q_pack);
         if (qkv_bias) {
-            int4 qb_pack = load8(&qkv_bias[q_off + d]);
-            auto* qb2 = reinterpret_cast<__nv_bfloat162*>(&qb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) q2[i] = __hadd2(q2[i], qb2[i]);
+            int4  qb_pack = load8(&qkv_bias[q_off + d]);
+            auto* qb2     = reinterpret_cast<__nv_bfloat162*>(&qb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                q2[i] = __hadd2(q2[i], qb2[i]);
         }
         // Partner exchange via smem. Only rotary-region threads (in_rope=true)
         // need to read their partner; passthrough threads still write so the
@@ -500,82 +524,82 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
         __syncthreads();
         int4 q_out_pack = q_pack;  // passthrough default
         if (in_rope) {
-            int4 q_partner_pack = load8(&smem_row[d_part]);
-            auto* qp2 = reinterpret_cast<__nv_bfloat162*>(&q_partner_pack);
-            auto* qo2 = reinterpret_cast<__nv_bfloat162*>(&q_out_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) {
+            int4  q_partner_pack = load8(&smem_row[d_part]);
+            auto* qp2            = reinterpret_cast<__nv_bfloat162*>(&q_partner_pack);
+            auto* qo2            = reinterpret_cast<__nv_bfloat162*>(&q_out_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i) {
                 float2 cs0 = cs_lo[i], cs1 = cs_hi[i];
-                float s0 = __bfloat162float(__low2bfloat16(q2[i]));
-                float s1 = __bfloat162float(__high2bfloat16(q2[i]));
-                float p0 = __bfloat162float(__low2bfloat16(qp2[i]));
-                float p1 = __bfloat162float(__high2bfloat16(qp2[i]));
-                float o0 = is_lo ? (s0*cs0.x - p0*cs0.y) : (s0*cs0.x + p0*cs0.y);
-                float o1 = is_lo ? (s1*cs1.x - p1*cs1.y) : (s1*cs1.x + p1*cs1.y);
-                qo2[i] = __floats2bfloat162_rn(o0, o1);
+                float  s0 = __bfloat162float(__low2bfloat16(q2[i]));
+                float  s1 = __bfloat162float(__high2bfloat16(q2[i]));
+                float  p0 = __bfloat162float(__low2bfloat16(qp2[i]));
+                float  p1 = __bfloat162float(__high2bfloat16(qp2[i]));
+                float  o0 = is_lo ? (s0 * cs0.x - p0 * cs0.y) : (s0 * cs0.x + p0 * cs0.y);
+                float  o1 = is_lo ? (s1 * cs1.x - p1 * cs1.y) : (s1 * cs1.x + p1 * cs1.y);
+                qo2[i]    = __floats2bfloat162_rn(o0, o1);
             }
         }
         if (active) {
             store8(&q_buf[(size_t)token_idx * n + q_off + d], q_out_pack);
         }
-        __syncthreads();   // before next head reuses smem
+        __syncthreads();  // before next head reuses smem
     }
 
     // ---- Process all K, V heads ----
-    KVBlockArray kv_block_array;
+    KVBlockArray   kv_block_array;
     __nv_bfloat16 *k_cache = nullptr, *v_cache = nullptr;
     if (store_cache && active) {
         kv_block_array = param.kv_block_array;
-        k_cache = reinterpret_cast<__nv_bfloat16*>(
-            kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
-        v_cache = reinterpret_cast<__nv_bfloat16*>(
-            kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
+        k_cache        = reinterpret_cast<__nv_bfloat16*>(kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
+        v_cache        = reinterpret_cast<__nv_bfloat16*>(kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
     }
     for (int h = 0; h < head_num_kv; ++h) {
         const int k_off = n + h * head_dim;
         const int v_off = n + kv_n + h * head_dim;
 
         // K
-        int4 k_pack = load8(&QKV[row_off + k_off + d]);
-        auto* k2 = reinterpret_cast<__nv_bfloat162*>(&k_pack);
+        int4  k_pack = load8(&QKV[row_off + k_off + d]);
+        auto* k2     = reinterpret_cast<__nv_bfloat162*>(&k_pack);
         if (qkv_bias) {
-            int4 kb_pack = load8(&qkv_bias[k_off + d]);
-            auto* kb2 = reinterpret_cast<__nv_bfloat162*>(&kb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) k2[i] = __hadd2(k2[i], kb2[i]);
+            int4  kb_pack = load8(&qkv_bias[k_off + d]);
+            auto* kb2     = reinterpret_cast<__nv_bfloat162*>(&kb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                k2[i] = __hadd2(k2[i], kb2[i]);
         }
         store8(&smem_row[d], k_pack);
         __syncthreads();
         int4 k_out_pack = k_pack;  // passthrough default
         if (in_rope) {
-            int4 k_partner_pack = load8(&smem_row[d_part]);
-            auto* kp2 = reinterpret_cast<__nv_bfloat162*>(&k_partner_pack);
-            auto* ko2 = reinterpret_cast<__nv_bfloat162*>(&k_out_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) {
+            int4  k_partner_pack = load8(&smem_row[d_part]);
+            auto* kp2            = reinterpret_cast<__nv_bfloat162*>(&k_partner_pack);
+            auto* ko2            = reinterpret_cast<__nv_bfloat162*>(&k_out_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i) {
                 float2 cs0 = cs_lo[i], cs1 = cs_hi[i];
-                float s0 = __bfloat162float(__low2bfloat16(k2[i]));
-                float s1 = __bfloat162float(__high2bfloat16(k2[i]));
-                float p0 = __bfloat162float(__low2bfloat16(kp2[i]));
-                float p1 = __bfloat162float(__high2bfloat16(kp2[i]));
-                float o0 = is_lo ? (s0*cs0.x - p0*cs0.y) : (s0*cs0.x + p0*cs0.y);
-                float o1 = is_lo ? (s1*cs1.x - p1*cs1.y) : (s1*cs1.x + p1*cs1.y);
-                ko2[i] = __floats2bfloat162_rn(o0, o1);
+                float  s0 = __bfloat162float(__low2bfloat16(k2[i]));
+                float  s1 = __bfloat162float(__high2bfloat16(k2[i]));
+                float  p0 = __bfloat162float(__low2bfloat16(kp2[i]));
+                float  p1 = __bfloat162float(__high2bfloat16(kp2[i]));
+                float  o0 = is_lo ? (s0 * cs0.x - p0 * cs0.y) : (s0 * cs0.x + p0 * cs0.y);
+                float  o1 = is_lo ? (s1 * cs1.x - p1 * cs1.y) : (s1 * cs1.x + p1 * cs1.y);
+                ko2[i]    = __floats2bfloat162_rn(o0, o1);
             }
         }
         if (active && store_kv) {
             store8(&k_buf[(size_t)token_idx * kv_n + h * head_dim + d], k_out_pack);
         }
-        __syncthreads();   // before next iteration uses smem
+        __syncthreads();  // before next iteration uses smem
 
         // V (no RoPE)
-        int4 v_pack = load8(&QKV[row_off + v_off + d]);
-        auto* v2 = reinterpret_cast<__nv_bfloat162*>(&v_pack);
+        int4  v_pack = load8(&QKV[row_off + v_off + d]);
+        auto* v2     = reinterpret_cast<__nv_bfloat162*>(&v_pack);
         if (qkv_bias) {
-            int4 vb_pack = load8(&qkv_bias[v_off + d]);
-            auto* vb2 = reinterpret_cast<__nv_bfloat162*>(&vb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) v2[i] = __hadd2(v2[i], vb2[i]);
+            int4  vb_pack = load8(&qkv_bias[v_off + d]);
+            auto* vb2     = reinterpret_cast<__nv_bfloat162*>(&vb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                v2[i] = __hadd2(v2[i], vb2[i]);
         }
         if (active && store_kv) {
             store8(&v_buf[(size_t)token_idx * kv_n + h * head_dim + d], v_pack);
@@ -583,17 +607,15 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
 
         // Cache write
         if (store_cache && active) {
-            const int inK = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
-                dst_kv_seq_idx, h, head_dim, d);
+            const int inK = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(dst_kv_seq_idx, h, head_dim, d);
             *reinterpret_cast<int4*>(&k_cache[inK]) = k_out_pack;
-            const __nv_bfloat16* v_src = reinterpret_cast<const __nv_bfloat16*>(&v_pack);
-            #pragma unroll
+            const __nv_bfloat16* v_src              = reinterpret_cast<const __nv_bfloat16*>(&v_pack);
+#pragma unroll
             for (int vi = 0; vi < VEC; ++vi) {
-                const int inV = V_VEC_LAYOUT
-                    ? kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(
-                          dst_kv_seq_idx, h, head_dim, d + vi)
-                    : kv_block_array.getVLocalIdx(
-                          dst_kv_seq_idx, h, head_dim, d + vi);
+                const int inV =
+                    V_VEC_LAYOUT ?
+                        kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(dst_kv_seq_idx, h, head_dim, d + vi) :
+                        kv_block_array.getVLocalIdx(dst_kv_seq_idx, h, head_dim, d + vi);
                 v_cache[inV] = v_src[vi];
             }
         }
@@ -603,46 +625,105 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
 // Compile-time dispatcher: only BF16 specialization actually launches v3.
 template<typename T>
 struct V3OptKernelDispatch {
-    static bool try_launch(T*, T*, T*, const T*, const T*,
-                           const int*, const float2*,
+    static bool try_launch(T*,
+                           T*,
+                           T*,
+                           const T*,
+                           const T*,
+                           const int*,
+                           const float2*,
                            PrefixPromptBatchWeightsParam&,
-                           int, int, int, int, int, int, float, float, bool, bool, bool, cudaStream_t) {
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           float,
+                           float,
+                           bool,
+                           bool,
+                           bool,
+                           cudaStream_t) {
         return false;
     }
 };
 template<>
 struct V3OptKernelDispatch<__nv_bfloat16> {
-    static bool try_launch(__nv_bfloat16* q_buf, __nv_bfloat16* k_buf, __nv_bfloat16* v_buf,
-                           const __nv_bfloat16* QKV, const __nv_bfloat16* qkv_bias,
-                           const int* padding_offset, const float2* cos_sin_cache,
+    static bool try_launch(__nv_bfloat16*                 q_buf,
+                           __nv_bfloat16*                 k_buf,
+                           __nv_bfloat16*                 v_buf,
+                           const __nv_bfloat16*           QKV,
+                           const __nv_bfloat16*           qkv_bias,
+                           const int*                     padding_offset,
+                           const float2*                  cos_sin_cache,
                            PrefixPromptBatchWeightsParam& param,
-                           int token_num, int head_num, int head_num_kv, int head_dim, int seq_len,
-                           int rot_dim, float rope_base, float rope_scale,
-                           bool store_kv, bool store_cache, bool v_vec_layout, cudaStream_t stream) {
+                           int                            token_num,
+                           int                            head_num,
+                           int                            head_num_kv,
+                           int                            head_dim,
+                           int                            seq_len,
+                           int                            rot_dim,
+                           float                          rope_base,
+                           float                          rope_scale,
+                           bool                           store_kv,
+                           bool                           store_cache,
+                           bool                           v_vec_layout,
+                           cudaStream_t                   stream) {
         constexpr int VEC = 8, K_TOK = 4;
-        if (head_dim % VEC != 0) return false;
-        if (head_dim % 2 != 0) return false;
+        if (head_dim % VEC != 0)
+            return false;
+        if (head_dim % 2 != 0)
+            return false;
         // Partial rotary requires rot_dim aligned to VEC*2 so each thread is
         // either fully in the rotary region or fully passthrough, and the
         // partner index (rope_d ± half_r) stays inside the rotary region.
-        if (rot_dim % (VEC * 2) != 0) return false;
-        if (rot_dim > head_dim) return false;
+        if (rot_dim % (VEC * 2) != 0)
+            return false;
+        if (rot_dim > head_dim)
+            return false;
         dim3 block(head_dim / VEC, K_TOK);
         // v3: one block per token-chunk, iterates ALL heads inside
-        dim3 grid((token_num + K_TOK - 1) / K_TOK, 1);
+        dim3   grid((token_num + K_TOK - 1) / K_TOK, 1);
         size_t smem = K_TOK * head_dim * sizeof(__nv_bfloat16);
         if (v_vec_layout) {
-            add_fusedQKV_bias_transpose_prefill_v3_all_heads<true>
-                <<<grid, block, smem, stream>>>(
-                    q_buf, k_buf, v_buf, QKV, qkv_bias, padding_offset, cos_sin_cache,
-                    param, token_num, head_num, head_num_kv, head_dim, seq_len,
-                    rot_dim, rope_base, rope_scale, store_kv, store_cache);
+            add_fusedQKV_bias_transpose_prefill_v3_all_heads<true><<<grid, block, smem, stream>>>(q_buf,
+                                                                                                  k_buf,
+                                                                                                  v_buf,
+                                                                                                  QKV,
+                                                                                                  qkv_bias,
+                                                                                                  padding_offset,
+                                                                                                  cos_sin_cache,
+                                                                                                  param,
+                                                                                                  token_num,
+                                                                                                  head_num,
+                                                                                                  head_num_kv,
+                                                                                                  head_dim,
+                                                                                                  seq_len,
+                                                                                                  rot_dim,
+                                                                                                  rope_base,
+                                                                                                  rope_scale,
+                                                                                                  store_kv,
+                                                                                                  store_cache);
         } else {
-            add_fusedQKV_bias_transpose_prefill_v3_all_heads<false>
-                <<<grid, block, smem, stream>>>(
-                    q_buf, k_buf, v_buf, QKV, qkv_bias, padding_offset, cos_sin_cache,
-                    param, token_num, head_num, head_num_kv, head_dim, seq_len,
-                    rot_dim, rope_base, rope_scale, store_kv, store_cache);
+            add_fusedQKV_bias_transpose_prefill_v3_all_heads<false><<<grid, block, smem, stream>>>(q_buf,
+                                                                                                   k_buf,
+                                                                                                   v_buf,
+                                                                                                   QKV,
+                                                                                                   qkv_bias,
+                                                                                                   padding_offset,
+                                                                                                   cos_sin_cache,
+                                                                                                   param,
+                                                                                                   token_num,
+                                                                                                   head_num,
+                                                                                                   head_num_kv,
+                                                                                                   head_dim,
+                                                                                                   seq_len,
+                                                                                                   rot_dim,
+                                                                                                   rope_base,
+                                                                                                   rope_scale,
+                                                                                                   store_kv,
+                                                                                                   store_cache);
         }
         return true;
     }
@@ -676,7 +757,7 @@ void invokeAddFusedQKVBiasTransposePrefillV1(T*                             q_bu
                                              const bool                     store_cache,
                                              const float2*                  cos_sin_cache,
                                              cudaStream_t                   stream) {
-    auto&  param = *param_ptr;
+    auto& param = *param_ptr;
 
     // ---- v3 fast path (default ON) ----
     // Hand-tuned BF16 kernel: vec=8 + 4 tokens/block + smem partner exchange + cos/sin
@@ -692,27 +773,36 @@ void invokeAddFusedQKVBiasTransposePrefillV1(T*                             q_bu
     // in BHSD ([batch, head_kv, seq, dim]) layout, while V3 uses THD ([token,
     // head_kv, dim]). Production NonAsm uses store_kv=false (K/V only flow into
     // paged cache), so V3 fires by writing only to the paged cache.
-    if (use_paged_fmha
-        && param.max_prefix_prompt_length == 0
-        && store_q && !store_qkv && !store_kv && store_cache
+    if (use_paged_fmha && param.max_prefix_prompt_length == 0 && store_q && !store_qkv && !store_kv && store_cache
         && rope_config.style == RopeStyle::Base
         && rope_config.dim <= size_per_head  // partial rotary supported (rot_dim<=head_dim)
-        && rope_config.scale == 1.0f  // V3 scale path lacks precision tests; fall back to V1
-        && !use_logn_attn
-        && QuantizedQKV == nullptr
+        && rope_config.scale == 1.0f         // V3 scale path lacks precision tests; fall back to V1
+        && !use_logn_attn && QuantizedQKV == nullptr
         && qkv_bias == nullptr  // bias path is implemented but untested; fall back
         && param.kv_block_array.cache_type == KvCacheDataType::BASE) {
         // V1 invoker (NonAsm path) writes V cache in non-templated layout
         // [numHeads, dimsPerHead, mTokensPerBlock]. Pass v_vec_layout=false so
         // V3's V cache write matches what the NonAsm CK FMHA reader expects.
-        if (V3OptKernelDispatch<T>::try_launch(q_buf, k_buf, v_buf, QKV, qkv_bias,
-                                                padding_offset, cos_sin_cache,
-                                                param,
-                                                token_num, head_num, head_num_kv, size_per_head,
-                                                seq_len,
-                                                rope_config.dim, rope_config.base, rope_config.scale,
-                                                store_kv, store_cache, /*v_vec_layout=*/false,
-                                                stream)) {
+        if (V3OptKernelDispatch<T>::try_launch(q_buf,
+                                               k_buf,
+                                               v_buf,
+                                               QKV,
+                                               qkv_bias,
+                                               padding_offset,
+                                               cos_sin_cache,
+                                               param,
+                                               token_num,
+                                               head_num,
+                                               head_num_kv,
+                                               size_per_head,
+                                               seq_len,
+                                               rope_config.dim,
+                                               rope_config.base,
+                                               rope_config.scale,
+                                               store_kv,
+                                               store_cache,
+                                               /*v_vec_layout=*/false,
+                                               stream)) {
             return;
         }
     }
@@ -849,21 +939,9 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel(T*                   
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
-    const int pre_len   = cu_seqlens[batch_idx];
-    const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
+    int       position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    const int pre_len     = cu_seqlens[batch_idx];
+    const int input_len   = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                        q,
                                        k,
@@ -1027,7 +1105,7 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
                                            const float2*                  cos_sin_cache,
                                            const bool                     pad_query,
                                            cudaStream_t                   stream) {
-    auto&  param = *param_ptr;
+    auto& param = *param_ptr;
 
     // ---- v3 fast path (default ON, ASM-side invoker) ----
     // Mirrors the V3 dispatch in invokeAddFusedQKVBiasTransposePrefillV1. Required
@@ -1044,15 +1122,10 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
     // store_kv is excluded because the in-tree ASM kernel writes packed K/V in
     // BHSD layout while V3 uses THD; in production store_kv=false anyway, so
     // V3 only writes to the paged cache.
-    if (use_paged_fmha
-        && !pad_query
-        && param.max_prefix_prompt_length == 0
-        && store_q && !store_qkv && !store_kv && store_cache
-        && rope_config.style == RopeStyle::Base
+    if (use_paged_fmha && !pad_query && param.max_prefix_prompt_length == 0 && store_q && !store_qkv && !store_kv
+        && store_cache && rope_config.style == RopeStyle::Base
         && rope_config.dim <= size_per_head  // partial rotary supported
-        && rope_config.scale == 1.0f
-        && !use_logn_attn
-        && QuantizedQKV == nullptr
+        && rope_config.scale == 1.0f && !use_logn_attn && QuantizedQKV == nullptr
         && qkv_bias == nullptr  // bias path is implemented but untested; fall back
         && param.kv_block_array.cache_type == KvCacheDataType::BASE) {
         // ASM invoker writes V cache via getVLocalIdx<KvCacheDataType::BASE>
@@ -1060,14 +1133,26 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
         // Pass v_vec_layout=true so V3 produces the layout the ASM-flash FMHA
         // reader expects — using the V1-style flat layout here corrupts V cache
         // and yields garbage attention output (root cause of the precision bug).
-        if (V3OptKernelDispatch<T>::try_launch(q_buf, k_buf, v_buf, QKV, qkv_bias,
-                                                padding_offset, cos_sin_cache,
-                                                param,
-                                                token_num, head_num, head_num_kv, size_per_head,
-                                                seq_len,
-                                                rope_config.dim, rope_config.base, rope_config.scale,
-                                                store_kv, store_cache, /*v_vec_layout=*/true,
-                                                stream)) {
+        if (V3OptKernelDispatch<T>::try_launch(q_buf,
+                                               k_buf,
+                                               v_buf,
+                                               QKV,
+                                               qkv_bias,
+                                               padding_offset,
+                                               cos_sin_cache,
+                                               param,
+                                               token_num,
+                                               head_num,
+                                               head_num_kv,
+                                               size_per_head,
+                                               seq_len,
+                                               rope_config.dim,
+                                               rope_config.base,
+                                               rope_config.scale,
+                                               store_kv,
+                                               store_cache,
+                                               /*v_vec_layout=*/true,
+                                               stream)) {
             return;
         }
     }
@@ -1200,7 +1285,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int        position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;
@@ -1360,7 +1445,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int        position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;

--- a/rtp_llm/models_py/kernels/rocm/fp8_kernel.py
+++ b/rtp_llm/models_py/kernels/rocm/fp8_kernel.py
@@ -1,18 +1,22 @@
 import functools
+import importlib
 import json
 import logging
 import os
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
-import aiter.utility.dtypes as dtypes
 import torch
 import triton
-from aiter.ops.quant import (
-    dynamic_per_tensor_quant,
-    dynamic_per_token_scaled_quant,
-    static_per_tensor_quant,
-)
+
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+dtypes = importlib.import_module("aiter.utility.dtypes")
+_quant_ops = importlib.import_module("aiter.ops.quant")
+dynamic_per_tensor_quant = _quant_ops.dynamic_per_tensor_quant
+dynamic_per_token_scaled_quant = _quant_ops.dynamic_per_token_scaled_quant
+static_per_tensor_quant = _quant_ops.static_per_tensor_quant
 
 logger = logging.getLogger(__name__)
 

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -399,6 +399,17 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
 
 
 class Qwen3NextGatedDeltaNetDecode(Qwen3NextGatedDeltaNetBase):
+    def _get_fla_block_map(self, attn_inputs: PyAttentionInputs) -> torch.Tensor:
+        block_map = attn_inputs.kv_cache_kernel_block_id_device
+        if (
+            attn_inputs.is_cuda_graph
+            and block_map is not None
+            and block_map.ndim == 2
+            and block_map.shape[1] > 1
+        ):
+            return block_map[:, :1]
+        return block_map
+
     def _conv1d(
         self,
         mixed_qkv: torch.Tensor,
@@ -473,7 +484,7 @@ class Qwen3NextGatedDeltaNetDecode(Qwen3NextGatedDeltaNetBase):
             scale=None,
             initial_state=ssm_states,
             inplace_final_state=True,
-            block_map=attn_inputs.kv_cache_kernel_block_id_device,
+            block_map=self._get_fla_block_map(attn_inputs),
             seq_size_per_block=seq_size_per_block,
             sequence_lengths=attn_inputs.sequence_lengths_plus_1_device,
             use_qk_l2norm_in_kernel=True,

--- a/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
+++ b/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
@@ -8,6 +8,7 @@ from torch import nn
 from rtp_llm.models_py.model_desc.block_map import get_group_tags_for_layers
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.model_desc.qwen3_next import (
+    Qwen3NextGatedDeltaNetDecode,
     Qwen3NextMetadata,
     _maybe_write_cp_cache_store,
     _write_cp_cache_store,
@@ -36,6 +37,30 @@ class RoutingModel(GptModelBase):
 
 
 class AttentionInputRoutingTest(unittest.TestCase):
+    def test_qwen3_next_cuda_graph_uses_narrow_block_map_view(self):
+        block_map = torch.arange(12, dtype=torch.int32).reshape(3, 4)
+        attention_inputs = SimpleNamespace(
+            is_cuda_graph=True,
+            kv_cache_kernel_block_id_device=block_map,
+        )
+        decode = object.__new__(Qwen3NextGatedDeltaNetDecode)
+
+        narrowed = decode._get_fla_block_map(attention_inputs)
+
+        self.assertEqual(narrowed.shape, (3, 1))
+        self.assertEqual(narrowed.stride(0), block_map.stride(0))
+        self.assertEqual(narrowed[:, 0].tolist(), [0, 4, 8])
+
+    def test_qwen3_next_non_graph_keeps_full_block_map(self):
+        block_map = torch.arange(12, dtype=torch.int32).reshape(3, 4)
+        attention_inputs = SimpleNamespace(
+            is_cuda_graph=False,
+            kv_cache_kernel_block_id_device=block_map,
+        )
+        decode = object.__new__(Qwen3NextGatedDeltaNetDecode)
+
+        self.assertIs(decode._get_fla_block_map(attention_inputs), block_map)
+
     def test_cp_cache_store_uses_each_layer_tag_metadata(self):
         expected = {}
         layer_inputs = {}

--- a/rtp_llm/models_py/modules/base/rocm/BUILD
+++ b/rtp_llm/models_py/modules/base/rocm/BUILD
@@ -6,6 +6,7 @@ py_library(
     ),
     deps = [
         "//rtp_llm:torch",
+        "//rtp_llm:utils",
     ],
     data = [
         "//:rtp_compute_ops",

--- a/rtp_llm/models_py/modules/base/rocm/activation.py
+++ b/rtp_llm/models_py/modules/base/rocm/activation.py
@@ -1,9 +1,14 @@
 """ROCm-specific activation function implementations."""
 
-import aiter
+import importlib
+
 import torch
 
 from rtp_llm.models_py.modules.base.common.activation import SiluAndMulBase
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+silu_and_mul = importlib.import_module("aiter.ops.activation").silu_and_mul
 
 
 class FusedSiluAndMul(SiluAndMulBase):
@@ -20,5 +25,5 @@ class FusedSiluAndMul(SiluAndMulBase):
         d = gate_up.shape[-1] // 2
         output_shape = gate_up.shape[:-1] + (d,)
         output = torch.empty(output_shape, dtype=gate_up.dtype, device=gate_up.device)
-        aiter.silu_and_mul(output, gate_up)
+        silu_and_mul(output, gate_up)
         return output

--- a/rtp_llm/models_py/modules/base/rocm/norm.py
+++ b/rtp_llm/models_py/modules/base/rocm/norm.py
@@ -1,11 +1,8 @@
+import importlib
 from typing import Tuple
 
 import torch
 import torch.nn.functional as F
-from aiter import layernorm2d_fwd as layernorm2d_fwd
-from aiter import layernorm2d_fwd_with_add as layernorm2d_fwd_with_add
-from aiter import rms_norm
-from aiter import rmsnorm2d_fwd_with_add as fused_add_rmsnorm
 from torch import nn
 
 from rtp_llm.models_py.modules.base.common.norm import (
@@ -15,6 +12,15 @@ from rtp_llm.models_py.modules.base.common.norm import (
     BaseResNorm,
 )
 from rtp_llm.ops.compute_ops import rtp_llm_ops
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+_norm_ops = importlib.import_module("aiter.ops.norm")
+_rmsnorm_ops = importlib.import_module("aiter.ops.rmsnorm")
+layernorm2d_fwd = _norm_ops.layernorm2d_fwd
+layernorm2d_fwd_with_add = _norm_ops.layernorm2d_fwd_with_add
+rms_norm = _rmsnorm_ops.rms_norm
+fused_add_rmsnorm = _rmsnorm_ops.rmsnorm2d_fwd_with_add
 
 # Fast-path guard for VisionBert-style AddBiasResLayerNorm. The aiter
 # fused-add 2D kernel was validated for request-sized batches with hidden <=

--- a/rtp_llm/models_py/modules/base/rocm/select_topk.py
+++ b/rtp_llm/models_py/modules/base/rocm/select_topk.py
@@ -1,8 +1,13 @@
-import aiter
+import importlib
+
 import torch
 from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+topk_softmax = importlib.import_module("aiter.ops.moe_op").topk_softmax
 
 
 class SelectTopk(nn.Module):
@@ -21,7 +26,7 @@ class SelectTopk(nn.Module):
             topk_ids.shape[0], self.top_k, dtype=torch.int32, device=topk_ids.device
         )
         topk_ids = topk_ids.int()
-        aiter.topk_softmax(
+        topk_softmax(
             topk_weights,
             topk_ids,
             token_expert_indicies,

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -16,7 +16,13 @@ from rtp_llm.models_py.modules.factory.attention.rocm_impl._attn_utils import (
     split_raw_qkv,
     unpad_kv_vectorized,
 )
-from rtp_llm.ops import AttentionConfigs, FMHAType, KvCacheDataType, ParallelismConfig
+from rtp_llm.ops import (
+    AttentionConfigs,
+    FMHAType,
+    KvCacheDataType,
+    ParallelismConfig,
+    RopeStyle,
+)
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOpAsm,
     FusedRopeKVCacheDecodeOpNonAsm,
@@ -27,6 +33,14 @@ from rtp_llm.ops.compute_ops import (
     PyAttentionInputs,
     paged_attention_atrex,
 )
+
+
+def _mrope_interleaved_supported(attn_configs: AttentionConfigs) -> bool:
+    """Return whether ROCm fused RoPE supports the configured MRoPE layout."""
+    return not (
+        attn_configs.rope_config.style == RopeStyle.Mrope
+        and not attn_configs.rope_config.mrope_interleaved
+    )
 
 
 # Pure Python implementation of FMHAParams
@@ -1397,7 +1411,7 @@ class AiterPrefillImplAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1457,7 +1471,7 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1716,7 +1730,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1763,7 +1777,7 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1809,7 +1823,7 @@ class AiterDecodeImplTriton(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -1,12 +1,9 @@
+import importlib
 import logging
 import math
 from typing import Any, List, Optional
 
-import aiter
 import torch
-from aiter_meta.csrc.cpp_itfs.pa_gluon_aot.pa_decode_gluon_aot import (
-    pa_decode_gluon_aot,
-)
 
 from rtp_llm.models_py.modules.factory.attention import common
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
@@ -33,6 +30,14 @@ from rtp_llm.ops.compute_ops import (
     PyAttentionInputs,
     paged_attention_atrex,
 )
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+_attention_ops = importlib.import_module("aiter.ops.attention")
+_mha_ops = importlib.import_module("aiter.ops.mha")
+pa_decode_gluon_aot = importlib.import_module(
+    "aiter_meta.csrc.cpp_itfs.pa_gluon_aot.pa_decode_gluon_aot"
+).pa_decode_gluon_aot
 
 
 def _mrope_interleaved_supported(attn_configs: AttentionConfigs) -> bool:
@@ -473,7 +478,7 @@ class AiterPrefillAttnOp:
             cu_seqlens_q = cu_seqlens_q.to(query.device, non_blocking=True)
         if cu_seqlens_k.device != query.device:
             cu_seqlens_k = cu_seqlens_k.to(query.device, non_blocking=True)
-        res = aiter.flash_attn_varlen_func(
+        res = _mha_ops.flash_attn_varlen_func(
             query,
             key,
             value,
@@ -560,7 +565,7 @@ class AiterPrefillAttnOp:
             k_descale = self._fp8_descale
             v_descale = self._fp8_descale
 
-        res = aiter.mha_batch_prefill_func(
+        res = _mha_ops.mha_batch_prefill_func(
             q_tensor,
             k_cache,
             v_cache,
@@ -597,7 +602,7 @@ class AiterPrefillAttnOp:
             # cu_seqlens are already on GPU from FMHAParams.__init__
             cu_seqlens_q = fmha_params.cu_seqlens_q
             cu_seqlens_k = fmha_params.cu_seqlens_k
-            res = aiter.flash_attn_varlen_fp8_pertensor_func(
+            res = _mha_ops.flash_attn_varlen_fp8_pertensor_func(
                 query,
                 key,
                 value,
@@ -877,7 +882,7 @@ class AiterPrefillAttnOpPaged:
                 k_descale = torch.ones(1, dtype=torch.float32, device=device)
                 v_descale = torch.ones(1, dtype=torch.float32, device=device)
 
-        res = aiter.mha_batch_prefill_func(
+        res = _mha_ops.mha_batch_prefill_func(
             q_tensor,
             key_cache,
             value_cache,
@@ -1189,7 +1194,7 @@ class AiterDecodeAttnOpAsm(AiterDecodeAttnOpBase):
             K_QScale = kv_cache.kv_scale_base.select(1, 0)
             V_QScale = kv_cache.kv_scale_base.select(1, 1)
         out_ = self._get_output(query)
-        output = aiter.pa_fwd_asm(
+        output = _attention_ops.pa_fwd_asm(
             query,  # [num_seqs, num_heads, head_size]
             key_cache,  # [num_blocks, num_kv_heads, block_size, head_size/x, x]
             value_cache,  # [num_blocks, num_kv_heads, block_size, head_size/x, x]
@@ -1327,7 +1332,7 @@ class AiterDecodeAttnOpNonAsm(AiterDecodeAttnOpBase):
             default_scale = self._get_default_scale(query)
             k_scale = K_QScale if kv_cache and K_QScale is not None else default_scale
             v_scale = V_QScale if kv_cache and V_QScale is not None else default_scale
-            aiter.paged_attention_rocm(
+            _attention_ops.paged_attention_rocm(
                 output,
                 exp_sums,
                 max_logits,

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -20,7 +20,7 @@ on the rest of the fleet.
 
 import math
 import unittest
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import torch
 import torch.nn.functional as F
@@ -28,7 +28,9 @@ import torch.nn.functional as F
 # Both imports may fail outside the ROCm runtime; we want a clean skip rather
 # than a collection-time error so the rest of the test suite is unaffected.
 try:
-    import aiter  # noqa: F401
+    from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+    aiter = load_aiter()
 
     _AITER_AVAILABLE = True
 except ImportError:
@@ -50,7 +52,14 @@ try:
         RopeConfig,
         RopeStyle,
     )
-    from rtp_llm.ops.compute_ops import get_typemeta
+    from rtp_llm.ops.compute_ops import (
+        FusedRopeKVCacheDecodeOpAsm,
+        FusedRopeKVCacheDecodeOpNonAsm,
+        FusedRopeKVCachePrefillOpAsm,
+        FusedRopeKVCachePrefillOpNonAsm,
+        LayerKVCache,
+        get_typemeta,
+    )
 
     _OPS_IMPORTABLE = True
 except ImportError:
@@ -113,6 +122,28 @@ def _make_rope_attn_configs(
     return cfg
 
 
+def _make_mrope_attn_configs(
+    head_num: int,
+    head_num_kv: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    rope_dim: int = 64,
+    mrope_sections: Sequence[int] = (11, 11, 10),
+    tokens_per_block: int = 16,
+):
+    cfg = _make_rope_attn_configs(
+        head_num, head_num_kv, head_dim, dtype, tokens_per_block
+    )
+    cfg.rope_config.style = RopeStyle.Mrope
+    cfg.rope_config.dim = rope_dim
+    cfg.rope_config.index_factor = 3
+    cfg.rope_config.mrope_dim1 = mrope_sections[0]
+    cfg.rope_config.mrope_dim2 = mrope_sections[1]
+    cfg.rope_config.mrope_dim3 = mrope_sections[2]
+    cfg.rope_config.mrope_interleaved = True
+    return cfg
+
+
 def _make_rope_prefill_inputs(
     input_lengths: List[int], device: torch.device, dtype: torch.dtype
 ):
@@ -149,6 +180,125 @@ def _make_rope_prefill_inputs(
     return attn_inputs
 
 
+def _make_mrope_prefill_inputs(
+    input_lengths: List[int], device: torch.device, dtype: torch.dtype
+):
+    attn_inputs = _make_rope_prefill_inputs(input_lengths, device, dtype)
+    total_tokens = sum(input_lengths)
+    position_ids = torch.zeros(total_tokens, 3, dtype=torch.int32, device=device)
+    cursor = 0
+    for seq_len in input_lengths:
+        positions = torch.arange(seq_len, dtype=torch.int32, device=device)
+        position_ids[cursor : cursor + seq_len, 0] = positions
+        position_ids[cursor : cursor + seq_len, 1] = positions // 2
+        position_ids[cursor : cursor + seq_len, 2] = positions % 3
+        cursor += seq_len
+    attn_inputs.combo_position_ids = position_ids.contiguous()
+    return attn_inputs
+
+
+def _make_mrope_decode_inputs(
+    sequence_lengths: List[int],
+    position_ids: torch.Tensor,
+    device: torch.device,
+    dtype: torch.dtype,
+    tokens_per_block: int = 16,
+):
+    """Build one-token-per-request decode inputs and an isolated block table."""
+    batch_size = len(sequence_lengths)
+    attn_inputs = PyAttentionInputs()
+    attn_inputs.is_prefill = False
+    attn_inputs.dtype = get_typemeta(torch.zeros([1], dtype=dtype))
+    attn_inputs.sequence_lengths = torch.tensor(
+        sequence_lengths, dtype=torch.int32, device=device
+    )
+    attn_inputs.input_lengths = torch.ones(batch_size, dtype=torch.int32, device=device)
+    # Empty is the production no-prefix representation. A nonempty CUDA tensor
+    # would make decode forward call .max().item() during graph capture.
+    attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32)
+    attn_inputs.padding_offset = torch.zeros(
+        batch_size, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_seqlens_device = torch.arange(
+        batch_size + 1, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_kv_seqlens_device = attn_inputs.cu_seqlens_device
+    attn_inputs.combo_position_ids = position_ids.contiguous()
+
+    block_counts = [
+        (seq_len + 1 + tokens_per_block - 1) // tokens_per_block
+        for seq_len in sequence_lengths
+    ]
+    max_blocks = max(block_counts)
+    block_table = torch.zeros(batch_size, max_blocks, dtype=torch.int32)
+    per_batch_block_ids = []
+    next_block = 0
+    for batch_idx, block_count in enumerate(block_counts):
+        block_ids = list(range(next_block, next_block + block_count))
+        per_batch_block_ids.append(block_ids)
+        block_table[batch_idx, :block_count] = torch.tensor(
+            block_ids, dtype=torch.int32
+        )
+        next_block += block_count
+    attn_inputs.kv_cache_kernel_block_id = block_table
+    attn_inputs.kv_cache_kernel_block_id_device = block_table.to(device)
+    return attn_inputs, per_batch_block_ids, next_block
+
+
+def _alloc_decode_kv_cache(
+    num_blocks: int,
+    head_num_kv: int,
+    tokens_per_block: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+):
+    pool = torch.zeros(
+        [num_blocks, 2, head_num_kv, tokens_per_block, head_dim],
+        dtype=dtype,
+        device=device,
+    )
+    layer_cache = LayerKVCache()
+    layer_cache.kv_cache_base = pool
+    return layer_cache, pool
+
+
+def _read_decode_k_from_pool(
+    pool: torch.Tensor,
+    per_batch_block_ids: List[List[int]],
+    sequence_lengths: List[int],
+    head_num_kv: int,
+    head_dim: int,
+    tokens_per_block: int,
+):
+    """Read the K written at each request's decode position."""
+    vector_size = 16 // pool.element_size()
+    result = torch.empty(
+        len(sequence_lengths),
+        head_num_kv,
+        head_dim,
+        dtype=pool.dtype,
+        device=pool.device,
+    )
+    for batch_idx, sequence_length in enumerate(sequence_lengths):
+        block_id = per_batch_block_ids[batch_idx][sequence_length // tokens_per_block]
+        local_position = sequence_length % tokens_per_block
+        k_kernel = (
+            pool[block_id, 0]
+            .contiguous()
+            .view(
+                head_num_kv,
+                head_dim // vector_size,
+                tokens_per_block,
+                vector_size,
+            )
+        )
+        result[batch_idx] = k_kernel.permute(0, 2, 1, 3).reshape(
+            head_num_kv, tokens_per_block, head_dim
+        )[:, local_position, :]
+    return result
+
+
 def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int]):
     """Torch reference for base RoPE (style=Base, base=10000) — matches the
     RopeConfig produced by _make_rope_attn_configs. Used to validate the C++
@@ -171,6 +321,47 @@ def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int])
         cos_b = cos.unsqueeze(1)
         sin_b = sin.unsqueeze(1)
         return torch.cat([lo * cos_b - hi * sin_b, hi * cos_b + lo * sin_b], dim=-1)
+
+    return rot(q).to(q.dtype), rot(k).to(k.dtype)
+
+
+def _apply_mrope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    mrope_sections: Sequence[int],
+    rope_dim: int,
+):
+    """Independent Qwen3/3.5 interleaved-MRoPE reference."""
+    head_dim = q.shape[-1]
+    assert 0 < rope_dim <= head_dim and rope_dim % 2 == 0
+    rotary_pairs = rope_dim // 2
+    assert len(mrope_sections) == 3
+    assert sum(mrope_sections) == rotary_pairs
+
+    # Match the model contract: start with temporal frequencies, then replace
+    # H/W slots at offsets 1/2 in the THW interleaving.
+    axes = torch.zeros(rotary_pairs, dtype=torch.long, device=q.device)
+    axes[1 : 3 * mrope_sections[1] : 3] = 1
+    axes[2 : 3 * mrope_sections[2] : 3] = 2
+    assert int((axes == 1).sum()) == mrope_sections[1]
+    assert int((axes == 2).sum()) == mrope_sections[2]
+    positions = position_ids[:, axes].to(torch.float32)
+    inv_freq = 10000 ** (
+        -2.0
+        * torch.arange(rotary_pairs, dtype=torch.float32, device=q.device)
+        / rope_dim
+    )
+    angle = positions * inv_freq.unsqueeze(0)
+    cos = torch.cos(angle).unsqueeze(1)
+    sin = torch.sin(angle).unsqueeze(1)
+
+    def rot(x):
+        x_float = x.float()
+        lo = x_float[..., :rotary_pairs]
+        hi = x_float[..., rotary_pairs:rope_dim]
+        tail = x_float[..., rope_dim:]
+        return torch.cat([lo * cos - hi * sin, hi * cos + lo * sin, tail], dim=-1)
 
     return rot(q).to(q.dtype), rot(k).to(k.dtype)
 
@@ -1256,6 +1447,284 @@ class TestAiterPrefillImplNoKvRopeRealOp(unittest.TestCase):
 
     def test_nonasm_no_kv_rope_real_op_matches_reference(self):
         self._check_real_no_kv_rope_path(AiterPrefillImplNonAsm)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestFusedRopeKVCacheMropeContract(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(2)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.head_num = 4
+        self.head_num_kv = 2
+        self.head_dim = 256
+        self.rope_dim = 64
+        self.sections = (11, 11, 10)
+        self.tokens_per_block = 16
+
+    def _make_config(self):
+        return _make_mrope_attn_configs(
+            head_num=self.head_num,
+            head_num_kv=self.head_num_kv,
+            head_dim=self.head_dim,
+            dtype=self.dtype,
+            rope_dim=self.rope_dim,
+            mrope_sections=self.sections,
+            tokens_per_block=self.tokens_per_block,
+        )
+
+    def test_prefill_and_decode_reject_section_sum_mismatch(self):
+        op_classes = (
+            FusedRopeKVCachePrefillOpAsm,
+            FusedRopeKVCachePrefillOpNonAsm,
+            FusedRopeKVCacheDecodeOpAsm,
+            FusedRopeKVCacheDecodeOpNonAsm,
+        )
+        for op_class in op_classes:
+            cfg = self._make_config()
+            cfg.rope_config.mrope_dim3 += 1
+            with self.subTest(op_class=op_class.__name__):
+                with self.assertRaisesRegex(RuntimeError, "section sum"):
+                    op_class(cfg)
+
+    def test_rejects_invalid_axis_count_and_interleaved_capacity(self):
+        cfg = self._make_config()
+        cfg.rope_config.index_factor = 4
+        with self.assertRaisesRegex(RuntimeError, "index_factor=3"):
+            FusedRopeKVCacheDecodeOpAsm(cfg)
+
+        # Although 12+12+8 is 32 pairs, H=12 cannot fit the 11 H slots in a
+        # 32-pair THW-interleaved region. This is why the review's proposed
+        # contiguous 12/12/8 fix is not valid for mrope_interleaved=true.
+        cfg = _make_mrope_attn_configs(
+            self.head_num,
+            self.head_num_kv,
+            self.head_dim,
+            self.dtype,
+            rope_dim=self.rope_dim,
+            mrope_sections=(12, 12, 8),
+        )
+        with self.assertRaisesRegex(RuntimeError, "interleaved H/W capacity"):
+            FusedRopeKVCachePrefillOpAsm(cfg)
+
+    def _build_decode_case(self, op_class):
+        sequence_lengths = [5, 3]
+        position_ids = torch.tensor(
+            [[5, 2, 1], [3, 7, 2]], dtype=torch.int32, device=self.device
+        )
+        attn_inputs, per_batch_block_ids, num_blocks = _make_mrope_decode_inputs(
+            sequence_lengths,
+            position_ids,
+            self.device,
+            self.dtype,
+            self.tokens_per_block,
+        )
+        cfg = self._make_config()
+        op = op_class(cfg)
+        params = op.prepare(attn_inputs)
+        layer_cache, pool = _alloc_decode_kv_cache(
+            num_blocks,
+            self.head_num_kv,
+            self.tokens_per_block,
+            self.head_dim,
+            self.dtype,
+            self.device,
+        )
+        q = torch.randn(
+            len(sequence_lengths),
+            self.head_num,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        k = torch.randn(
+            len(sequence_lengths),
+            self.head_num_kv,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        v = torch.randn_like(k)
+        return (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        )
+
+    def _assert_decode_matches_reference(self, op_class):
+        (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        ) = self._build_decode_case(op_class)
+
+        actual_q = op.forward(_pack_qkv(q, k, v), layer_cache, params)
+        expected_q, expected_k = _apply_mrope(
+            q,
+            k,
+            attn_inputs.combo_position_ids,
+            self.sections,
+            self.rope_dim,
+        )
+        actual_k = _read_decode_k_from_pool(
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            self.head_num_kv,
+            self.head_dim,
+            self.tokens_per_block,
+        )
+        torch.testing.assert_close(actual_q, expected_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, expected_k, atol=1e-2, rtol=1e-2)
+
+    def test_asm_decode_q_and_k_cache_match_reference(self):
+        self._assert_decode_matches_reference(FusedRopeKVCacheDecodeOpAsm)
+
+    def test_nonasm_decode_q_and_k_cache_match_reference(self):
+        self._assert_decode_matches_reference(FusedRopeKVCacheDecodeOpNonAsm)
+
+    def _assert_cuda_graph_replay_uses_new_position_ids(self, op_class):
+        (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        ) = self._build_decode_case(op_class)
+        qkv = _pack_qkv(q, k, v)
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            op.forward(qkv, layer_cache, params)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        pool.zero_()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured_q = op.forward(qkv, layer_cache, params)
+
+        replay_position_ids = torch.tensor(
+            [[9, 1, 6], [4, 8, 2]], dtype=torch.int32, device=self.device
+        )
+        attn_inputs.combo_position_ids.copy_(replay_position_ids)
+        pool.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected_q, expected_k = _apply_mrope(
+            q,
+            k,
+            replay_position_ids,
+            self.sections,
+            self.rope_dim,
+        )
+        actual_k = _read_decode_k_from_pool(
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            self.head_num_kv,
+            self.head_dim,
+            self.tokens_per_block,
+        )
+        torch.testing.assert_close(captured_q, expected_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, expected_k, atol=1e-2, rtol=1e-2)
+
+    def test_asm_cuda_graph_replay_uses_new_position_ids(self):
+        self._assert_cuda_graph_replay_uses_new_position_ids(
+            FusedRopeKVCacheDecodeOpAsm
+        )
+
+    def test_nonasm_cuda_graph_replay_uses_new_position_ids(self):
+        self._assert_cuda_graph_replay_uses_new_position_ids(
+            FusedRopeKVCacheDecodeOpNonAsm
+        )
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplMropePositionIds(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(1)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_mrope_matches_reference(self, impl_cls):
+        input_lengths = [5, 3]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 256
+        rope_dim = 64
+        mrope_sections = (11, 11, 10)
+        cfg = _make_mrope_attn_configs(
+            head_num=head_num,
+            head_num_kv=head_num_kv,
+            head_dim=head_dim,
+            dtype=self.dtype,
+            rope_dim=rope_dim,
+            mrope_sections=mrope_sections,
+        )
+        attn_inputs = _make_mrope_prefill_inputs(input_lengths, self.device, self.dtype)
+
+        impl = impl_cls(cfg, attn_inputs)
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+
+        actual = impl.forward(_pack_qkv(q, k, v), kv_cache=None, layer_idx=0)
+        q_rope, k_rope = _apply_mrope(
+            q,
+            k,
+            attn_inputs.combo_position_ids,
+            mrope_sections,
+            rope_dim,
+        )
+        ref = _sdpa_reference(
+            q_rope,
+            k_rope,
+            v,
+            attn_inputs.cu_seqlens_device,
+            attn_inputs.cu_kv_seqlens_device,
+            causal=True,
+        )
+
+        self.assertTrue(impl.rope_params.position_ids.defined())
+        self.assertEqual(tuple(impl.rope_params.position_ids.shape), (8, 3))
+        torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
+
+    def test_asm_mrope_matches_reference(self):
+        self._check_mrope_matches_reference(AiterPrefillImplAsm)
+
+    def test_nonasm_mrope_matches_reference(self):
+        self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deepep_normal_fused_moe_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/deepep_normal_fused_moe_executor.py
@@ -1,6 +1,6 @@
+import importlib
 from typing import Any, Dict, Optional
 
-import aiter
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -17,7 +17,12 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
     FusedMoEQuantConfig,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.type import ExecutorType
+from rtp_llm.utils.aiter_jit_patch import load_aiter
 from rtp_llm.utils.model_weight import W
+
+load_aiter()
+_moe_ops = importlib.import_module("aiter.ops.moe_op")
+moe_sorting_fwd = importlib.import_module("aiter.ops.moe_sorting").moe_sorting_fwd
 
 BLOCK_SIZE_M = 32
 
@@ -118,7 +123,7 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         num_valid_ids = torch.empty((2,), dtype=torch.int32, device=device)
         moe_buf = torch.empty((M, model_dim), dtype=moebuf_dtype, device=device)
 
-        aiter.moe_sorting_fwd(
+        moe_sorting_fwd(
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             sorted_token_ids=sorted_ids,
@@ -202,7 +207,7 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         a1_scale = None
         # act_op = 1 if activation == "silu" else 0  # 1 = silu_and_mul
 
-        aiter.ck_moe_stage1(
+        _moe_ops.ck_moe_stage1(
             hidden_states=a1,
             w1=self.w13_weight,
             w2=self.w2_weight,
@@ -224,7 +229,7 @@ class FusedMoeExecutor(FusedMoeExpertExecutor):
         fc2_scale = None
         a2_scale = None
 
-        aiter.ck_moe_stage2(
+        _moe_ops.ck_moe_stage2(
             inter_states=a2,  # [M*topk, inter_dim//2]
             w1=self.w13_weight,
             w2=self.w2_weight,

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -1,9 +1,8 @@
 import copy
+import importlib
 from typing import Any, Dict, Optional
 
-import aiter
 import torch
-from aiter.fused_moe import fused_moe
 
 from rtp_llm.device.device_impl import is_gfx950
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
@@ -24,13 +23,20 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm._utils import (
 from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
     MoeConfigResolver,
 )
+from rtp_llm.utils.aiter_jit_patch import load_aiter
 from rtp_llm.utils.model_weight import W
 
+load_aiter()
+fused_moe = importlib.import_module("aiter.fused_moe").fused_moe
+_aiter_enum = importlib.import_module("aiter.ops.enum")
+ActivationType = _aiter_enum.ActivationType
+QuantType = _aiter_enum.QuantType
 
-def _moe_activation_type(activation: str) -> aiter.ActivationType:
+
+def _moe_activation_type(activation: str) -> ActivationType:
     if activation in ("silu", "SiGLU"):
-        return aiter.ActivationType.Silu
-    return aiter.ActivationType.Gelu
+        return ActivationType.Silu
+    return ActivationType.Gelu
 
 
 def build_ep_expert_mask(
@@ -262,7 +268,7 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             self.w2,
             topk_weights,
             topk_ids,
-            quant_type=aiter.QuantType.per_Token,
+            quant_type=QuantType.per_Token,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
             activation=_moe_activation_type(activation),
@@ -320,6 +326,7 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
         )
+
     @property
     def local_num_experts(self) -> int:
         return self.w1.size(0)
@@ -374,7 +381,7 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
             self.w2,
             topk_weights,
             topk_ids,
-            quant_type=aiter.QuantType.per_128x128,
+            quant_type=QuantType.per_128x128,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
             activation=_moe_activation_type(activation),
@@ -518,7 +525,7 @@ class RocmExpertsFp4PerGroup(FusedMoeExpertExecutor):
             w2,
             topk_weights,
             topk_ids,
-            quant_type=aiter.QuantType.per_1x32,
+            quant_type=QuantType.per_1x32,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
             activation=_moe_activation_type(activation),
@@ -574,7 +581,9 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         self.w2_scale = weights[W.moe_s2]
 
         self.hidden_size_raw = config.hidden_size
-        self.intermediate_size_raw = config.model_config.moe_inter_size // config.tp_size
+        self.intermediate_size_raw = (
+            config.model_config.moe_inter_size // config.tp_size
+        )
         packed_factor = 2 if self.w1.dtype == torch.uint8 else 1
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
@@ -625,7 +634,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-        
+
         # view w1 and w2 to float4_e2m1fn_x2 if they are uint8
         w1 = self.w1
         w2 = self.w2
@@ -648,7 +657,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             w2,
             topk_weights,
             topk_ids,
-            quant_type=aiter.QuantType.per_1x32,
+            quant_type=QuantType.per_1x32,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
             activation=_moe_activation_type(activation),

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
@@ -1,14 +1,10 @@
 from abc import abstractmethod
 from typing import Any, Optional, Tuple
 
-import aiter
 import torch
 
 from rtp_llm.device.device_impl import is_gfx950
-from rtp_llm.models_py.distributed.collective_torch import (
-    Group,
-    all_reduce,
-)
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -194,6 +190,7 @@ class PureTpRouterFusedQuant(PureTpRouterBase):
             fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
         return fused_expert_output
 
+
 class PureTpRouterFp8PerBlockPassthrough(PureTpRouterBase):
     """Pure TP router for FP8 PerBlock: accepts FP8_PER_BLOCK quant but passes through BF16 without quantization (executor handles quantization internally)."""
 
@@ -216,6 +213,7 @@ class PureTpRouterFp8PerBlockPassthrough(PureTpRouterBase):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return a1, None
 
+
 class PureTpRouterMXFp4Passthrough(PureTpRouterBase):
     """Pure TP router for the MXFP4 passthrough path."""
 
@@ -233,7 +231,7 @@ class PureTpRouterMXFp4Passthrough(PureTpRouterBase):
         quant_method = resolver.get_quant_method(config)
         checker.check(quant_method == "QuarkMXFP4")
         checker.check(is_gfx950())
-        
+
     def _do_quant(
         self, a1: torch.Tensor
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/f16_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/f16_linear.py
@@ -1,14 +1,21 @@
 """ROCm F16 (non-quantized) Linear implementation"""
 
+import importlib
 import os
+from functools import lru_cache
 from typing import Optional
 
 import torch
 
 from rtp_llm.models_py.modules.factory.linear import LinearBase
-from aiter import hipb_mm, hipb_create_extension
-from functools import lru_cache
 from rtp_llm.ops import HWKernelConfig
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+_gradlib_ops = importlib.import_module("aiter.ops.gradlib")
+hipb_mm = _gradlib_ops.hipb_mm
+hipb_create_extension = _gradlib_ops.hipb_create_extension
+
 
 class RocmF16LinearBase(LinearBase):
     """ROCm F16 (non-quantized) Linear"""
@@ -19,7 +26,7 @@ class RocmF16LinearBase(LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
@@ -34,12 +41,13 @@ class RocmF16LinearBase(LinearBase):
         quant_config: object = None,
         weight_scale_2: Optional[torch.Tensor] = None,
     ):
-        super().__init__(weight, weight_scales, input_scales,
-                         bias, quant_config, weight_scale_2)
+        super().__init__(
+            weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
+        )
         self.weight = weight
         self.bias = bias
-        
-    @staticmethod    
+
+    @staticmethod
     @lru_cache(maxsize=1)
     def init_hipblas():
         hipb_create_extension()
@@ -47,7 +55,7 @@ class RocmF16LinearBase(LinearBase):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("Subclasses must implement `forward`.")
 
-        
+
 class RocmF16LinearWithSwizzle(RocmF16LinearBase):
 
     @classmethod
@@ -56,11 +64,15 @@ class RocmF16LinearWithSwizzle(RocmF16LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'],
+        hw_kernel_config: Optional["HWKernelConfig"],
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
-        return weight_scales is None and hw_kernel_config is not None and hw_kernel_config.use_swizzleA
+        return (
+            weight_scales is None
+            and hw_kernel_config is not None
+            and hw_kernel_config.use_swizzleA
+        )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         self.init_hipblas()
@@ -75,7 +87,8 @@ class RocmF16LinearWithSwizzle(RocmF16LinearBase):
             scaleOut=None,
             bpreshuffle=True,
         )
-        
+
+
 class RocmF16LinearNoSwizzle(RocmF16LinearBase):
 
     @classmethod
@@ -84,7 +97,7 @@ class RocmF16LinearNoSwizzle(RocmF16LinearBase):
         quant_config: object,
         weight: torch.Tensor,
         weight_scales: Optional[torch.Tensor],
-        hw_kernel_config: Optional['HWKernelConfig'],
+        hw_kernel_config: Optional["HWKernelConfig"],
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_deepgemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_deepgemm_linear.py
@@ -1,17 +1,23 @@
 """ROCm FP8 DeepGEMM quantized Linear implementation"""
 
+import importlib
 import logging
 from typing import Optional
 
-import aiter
 import torch
 
 from rtp_llm.models_py.modules.factory.linear import LinearBase
+from rtp_llm.utils.aiter_jit_patch import load_aiter
 
 logger = logging.getLogger(__name__)
 
 from rtp_llm.models_py.kernels.rocm.fp8_kernel import rocm_per_token_group_quant_fp8
 from rtp_llm.ops import HWKernelConfig
+
+load_aiter()
+gemm_a8w8_blockscale_bpreshuffle = importlib.import_module(
+    "aiter.ops.gemm_op_a8w8"
+).gemm_a8w8_blockscale_bpreshuffle
 
 
 class RocmFp8DeepGEMMLinear(LinearBase):
@@ -86,7 +92,7 @@ class RocmFp8DeepGEMMLinear(LinearBase):
         x_scales = input_scales.transpose(0, 1).contiguous().view(*input_scales.shape)
         w_scales = self.weight_scales
 
-        output = aiter.gemm_a8w8_blockscale_bpreshuffle(
+        output = gemm_a8w8_blockscale_bpreshuffle(
             input_fp8,  # XQ
             self.weight,  # WQ (pre-shuffled layout)
             x_scales,  # x_scale (bpreshuffle layout)

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_ptpc_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/fp8_ptpc_linear.py
@@ -1,5 +1,6 @@
 """ROCm FP8 PTPC (Per-Token Per-Channel) quantized Linear implementation."""
 
+import importlib
 import importlib.metadata as importlib_metadata
 import json
 import logging
@@ -7,14 +8,18 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional, Tuple
 
-import aiter
 import torch
 import torch.nn.functional as F
-from aiter.ops.gemm_op_a8w8 import gemm_a8w8_bpreshuffle_cktile
 
 from rtp_llm.models_py.kernels.rocm.fp8_kernel import rocm_per_token_quant_fp8
 from rtp_llm.models_py.modules.factory.linear import LinearBase
 from rtp_llm.ops import HWKernelConfig
+from rtp_llm.utils.aiter_jit_patch import load_aiter
+
+load_aiter()
+_gemm_ops = importlib.import_module("aiter.ops.gemm_op_a8w8")
+_gradlib_ops = importlib.import_module("aiter.ops.gradlib")
+gemm_a8w8_bpreshuffle_cktile = _gemm_ops.gemm_a8w8_bpreshuffle_cktile
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +74,7 @@ class RocmFp8PTPCLinearBase(LinearBase):
     @staticmethod
     @lru_cache(maxsize=1)
     def init_hipblas() -> None:
-        aiter.hipb_create_extension()
+        _gradlib_ops.hipb_create_extension()
 
     @staticmethod
     def _as_hipb_weight_view(weight: torch.Tensor) -> torch.Tensor:
@@ -164,7 +169,7 @@ class RocmFp8PTPCLinearNoSwizzle(RocmFp8PTPCLinearBase):
                 input_fp8, self.weight, input_scales, self.weight_scales, output
             )
         else:
-            output = aiter.gemm_a8w8_bpreshuffle(
+            output = _gemm_ops.gemm_a8w8_bpreshuffle(
                 input_fp8,
                 self.weight,
                 input_scales,
@@ -316,7 +321,7 @@ class RocmFp8PTPCLinearWithSwizzle(RocmFp8PTPCLinearBase):
         )
         if use_gelu:
             kwargs["use_gelu"] = True
-        output = aiter.hipb_mm(input_fp8, self.weight, solution_index, **kwargs)
+        output = _gradlib_ops.hipb_mm(input_fp8, self.weight, solution_index, **kwargs)
         return self._restore_dtype(output, original_dtype)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/rtp_llm/models_py/triton_kernels/common/offset.py
+++ b/rtp_llm/models_py/triton_kernels/common/offset.py
@@ -1,0 +1,8 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def linear_offset_64(index, stride):
+    """Compute a linear element offset without overflowing int32."""
+    return index.to(tl.int64) * stride

--- a/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
+++ b/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
@@ -10,6 +10,8 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
+
 
 @triton.jit
 def _scatter_qkv_kernel(
@@ -24,12 +26,12 @@ def _scatter_qkv_kernel(
     BLK_V: tl.constexpr,
 ):
     row = tl.program_id(0)
-    src = row * stride_src_row
+    src = linear_offset_64(row, stride_src_row)
 
     offs_qk = tl.arange(0, BLK_QK)
     mask_qk = offs_qk < K_DIM
-    q_dst = row * K_DIM + offs_qk
-    k_dst = row * K_DIM + offs_qk
+    q_dst = linear_offset_64(row, K_DIM) + offs_qk
+    k_dst = linear_offset_64(row, K_DIM) + offs_qk
     tl.store(
         q_ptr + q_dst, tl.load(src_ptr + src + offs_qk, mask=mask_qk), mask=mask_qk
     )
@@ -41,7 +43,7 @@ def _scatter_qkv_kernel(
 
     offs_v = tl.arange(0, BLK_V)
     mask_v = offs_v < V_DIM
-    v_dst = row * V_DIM + offs_v
+    v_dst = linear_offset_64(row, V_DIM) + offs_v
     tl.store(
         v_ptr + v_dst,
         tl.load(src_ptr + src + 2 * K_DIM + offs_v, mask=mask_v),

--- a/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
@@ -1,8 +1,16 @@
 import unittest
 
 import torch
+import triton
+import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.common.scatter_qkv import scatter_qkv
+
+
+@triton.jit
+def _linear_offset_test_kernel(output, row, stride):
+    tl.store(output, linear_offset_64(row, stride))
 
 
 def _split_view_baseline(
@@ -78,6 +86,15 @@ class TestScatterQKV(unittest.TestCase):
         for M in (2047, 2048, 2049):
             with self.subTest(M=M):
                 self._assert_equivalent(M, 8, 16, 128, 128, torch.bfloat16)
+
+    def test_large_packed_prefill_offset_uses_int64(self) -> None:
+        """Cover Qwen3.5 TP1/TP2 rows where row * qkv_stride exceeds INT32_MAX."""
+        output = torch.empty(1, dtype=torch.int64, device=self.device)
+        for row, stride in ((209716, 10240), (419431, 5120), (524288, 4096)):
+            with self.subTest(row=row, stride=stride):
+                _linear_offset_test_kernel[(1,)](output, row, stride)
+                self.assertEqual(output.item(), row * stride)
+                self.assertGreater(output.item(), torch.iinfo(torch.int32).max)
 
     def test_dtypes(self) -> None:
         """bf16 is the production dtype; fp16/fp32 should also work."""

--- a/rtp_llm/models_py/triton_kernels/fla/block.py
+++ b/rtp_llm/models_py/triton_kernels/fla/block.py
@@ -2,6 +2,7 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 
 
@@ -94,6 +95,57 @@ def load_initial_state_from_block_map(
     )
 
 
+@triton.jit
+def _store_ssm_state_block(
+    source_ptr,
+    dest_block_pos,
+    batch,
+    i_h,
+    v_offset,
+    block_map: tl.tensor,
+    ssm_states: tl.tensor,
+    max_block_size: tl.int32,
+    SSM_PER_HEAD: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+    CONV_STRIDE_TOKEN: tl.constexpr,
+):
+    block_idx = tl.load(block_map + batch * max_block_size + dest_block_pos).to(
+        tl.int64
+    )
+
+    if block_idx > 0:
+        dest_ptr = (
+            ssm_states
+            + linear_offset_64(block_idx, CONV_STRIDE_TOKEN)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
+
+        p_in = tl.make_block_ptr(
+            source_ptr,
+            (V, K),
+            (K, 1),
+            (v_offset, 0),
+            (BLOCK_V, K),
+            (1, 0),
+        )
+        p_out = tl.make_block_ptr(
+            dest_ptr,
+            (V, K),
+            (K, 1),
+            (v_offset, 0),
+            (BLOCK_V, K),
+            (1, 0),
+        )
+
+        tl.store(
+            p_out,
+            tl.load(p_in, boundary_check=(0, 1)).to(ssm_states.dtype.element_ty),
+            boundary_check=(0, 1),
+        )
+
+
 @triton.jit(do_not_specialize=["max_block_size"])
 def store_ssm_state_to_block_map_kernel(
     chunk_indices: tl.tensor,
@@ -126,56 +178,54 @@ def store_ssm_state_to_block_map_kernel(
     eos = tl.load(cu_seqlens + batch + 1).to(tl.int32)
     input_len = eos - bos
 
-    should_write = False
-    dest_block_pos = 0
-    source_ptr = final_states
-
-    # last chunk always record to final states
+    # Keep source pointers branch-local. Triton 3.7 cannot canonicalize a
+    # pointer phi whose branches use different offset widths.
     if (chunk + 1) * CHUNK_SIZE >= input_len:
-        source_ptr = final_states + batch * SSM_PER_BATCH + i_h * SSM_PER_HEAD
+        source_ptr = (
+            final_states
+            + linear_offset_64(batch, SSM_PER_BATCH)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
         dest_block_pos = (prefix + input_len - 1) // SEQ_SIZE_PER_BLOCK
-        should_write = True
+        _store_ssm_state_block(
+            source_ptr,
+            dest_block_pos,
+            batch,
+            i_h,
+            v_offset,
+            block_map,
+            ssm_states,
+            max_block_size,
+            SSM_PER_HEAD,
+            V,
+            K,
+            BLOCK_V,
+            CONV_STRIDE_TOKEN,
+        )
     elif chunk > 0 and (chunk + 1) * CHUNK_SIZE % SEQ_SIZE_PER_BLOCK == 0:
+        source_ptr = (
+            h
+            + linear_offset_64(i_c + 1, SSM_PER_BATCH)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
         dest_block_pos = (
             prefix + chunk * CHUNK_SIZE + CHUNK_SIZE - 1
         ) // SEQ_SIZE_PER_BLOCK
-        source_ptr = h + (i_c + 1) * SSM_PER_BATCH + i_h * SSM_PER_HEAD
-        should_write = True
-
-    if not should_write:
-        return
-
-    block_idx = tl.load(block_map + batch * max_block_size + dest_block_pos).to(
-        tl.int64
-    )
-
-    if block_idx <= 0:
-        return
-
-    dest_ptr = ssm_states + block_idx * CONV_STRIDE_TOKEN + i_h * SSM_PER_HEAD
-
-    p_in = tl.make_block_ptr(
-        source_ptr,
-        (V, K),
-        (K, 1),
-        (v_offset, 0),
-        (BLOCK_V, K),
-        (1, 0),
-    )
-    p_out = tl.make_block_ptr(
-        dest_ptr,
-        (V, K),
-        (K, 1),
-        (v_offset, 0),
-        (BLOCK_V, K),
-        (1, 0),
-    )
-
-    tl.store(
-        p_out,
-        tl.load(p_in, boundary_check=(0, 1)).to(ssm_states.dtype.element_ty),
-        boundary_check=(0, 1),
-    )
+        _store_ssm_state_block(
+            source_ptr,
+            dest_block_pos,
+            batch,
+            i_h,
+            v_offset,
+            block_map,
+            ssm_states,
+            max_block_size,
+            SSM_PER_HEAD,
+            V,
+            K,
+            BLOCK_V,
+            CONV_STRIDE_TOKEN,
+        )
 
 
 def store_ssm_state_to_block_map(

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
+import logging
 from typing import Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
@@ -20,7 +22,6 @@ from rtp_llm.models_py.triton_kernels.fla.utils import (
     is_nvidia_hopper,
 )
 
-import logging
 logger = logging.getLogger(__name__)
 
 # TODO(V-first migration): Gluon CDNA4 chunk-h path is disabled until the mfma
@@ -107,20 +108,20 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
 
     # calculate offset
-    h += ((boh * H + i_h) * K * V).to(tl.int64)
-    v += ((bos * H + i_h) * V).to(tl.int64)
-    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
-    w += ((bos * H + i_h) * K).to(tl.int64)
+    h += linear_offset_64(boh, H * K * V) + linear_offset_64(i_h, K * V)
+    v += linear_offset_64(bos, H * V) + linear_offset_64(i_h, V)
+    k += linear_offset_64(bos, Hg * K) + linear_offset_64(i_h // (H // Hg), K)
+    w += linear_offset_64(bos, H * K) + linear_offset_64(i_h, K)
     if SAVE_NEW_VALUE:
-        v_new += ((bos * H + i_h) * V).to(tl.int64)
+        v_new += linear_offset_64(bos, H * V) + linear_offset_64(i_h, V)
     stride_v = H * V
     stride_h = H * K * V
     stride_k = Hg * K
     stride_w = H * K
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 += linear_offset_64(i_nh, K * V)
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht += linear_offset_64(i_nh, K * V)
 
     # load initial state — V-first view: (V, K) + strides (K, 1)
     if USE_INITIAL_STATE:
@@ -144,23 +145,24 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # main recurrence
     for i_t in range(NT):
+        h_chunk = h + linear_offset_64(i_t, stride_h)
         p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+            h_chunk, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
         )
         tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
             p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
             )
             tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
             p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
             )
             tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
             p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
             )
             tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
 
@@ -201,17 +203,15 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
+            g_base = g + linear_offset_64(bos, H) + i_h
+            g_last = g_base + linear_offset_64(last_idx, H)
             if IS_LOG2:
                 # AMD path: g is in log2 domain (RCP_LN2-scaled cumsum upstream).
                 # The fp32 promotions, int64 index and m_t mask are robustness
                 # tweaks added together with the log2 rewrite for MI355X/MI308X.
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                b_g_last = tl.load(g + (bos * H + last_idx * H + i_h).to(tl.int64)).to(
-                    tl.float32
-                )
-                p_g = tl.make_block_ptr(
-                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-                )
+                b_g_last = tl.load(g_last).to(tl.float32)
+                p_g = tl.make_block_ptr(g_base, (T,), (H,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
@@ -219,10 +219,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 # NVIDIA path: g is in natural-log domain. Keep the original
                 # exp/safe_exp formulation and integer indexing for bit-level
                 # parity with the pre-optimization implementation.
-                b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-                p_g = tl.make_block_ptr(
-                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-                )
+                b_g_last = tl.load(g_last)
+                p_g = tl.make_block_ptr(g_base, (T,), (H,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,))
                 b_v = b_v * safe_exp(b_g_last - b_g)[:, None]
                 b_g_last = exp(b_g_last)
@@ -235,9 +233,11 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 b_h4 = b_h4 * b_g_last
 
         if USE_GK:
+            gk_base = gk + linear_offset_64(bos, H * K) + linear_offset_64(i_h, K)
+            gk_last = gk_base + linear_offset_64(last_idx, H * K)
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
-                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                gk_last + o_k1,
                 mask=(o_k1 < K),
                 other=0.0,
             )
@@ -249,7 +249,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 64:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,
+                    gk_last + o_k2,
                     mask=(o_k2 < K),
                     other=0.0,
                 )
@@ -260,7 +260,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 128:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    gk_last + o_k3,
                     mask=(o_k3 < K),
                     other=0.0,
                 )
@@ -271,7 +271,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 192:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,
+                    gk_last + o_k4,
                     mask=(o_k4 < K),
                     other=0.0,
                 )

--- a/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
+++ b/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
@@ -42,7 +42,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     cu_seqlens,
     block_map,
     sequence_lengths,
-    max_block_size: tl.int32,
+    block_map_stride_b: tl.int64,
     scale,
     N,  # num of sequences
     T,  # num of tokens
@@ -118,7 +118,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         if IS_CONTINUOUS_BATCHING:
             load_block_offset = cal_block_idx(sequence_length - 1, SEQ_SIZE_PER_BLOCK)
             read_block_id = tl.load(
-                block_map + i_n * max_block_size + load_block_offset
+                block_map + i_n * block_map_stride_b + load_block_offset
             ).to(tl.int64)
             if read_block_id <= 0:
                 return
@@ -159,7 +159,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
                 cal_block_idx(sequence_length, SEQ_SIZE_PER_BLOCK) + i_t
             )
             write_block_id = tl.load(
-                block_map + i_n * max_block_size + write_block_offset
+                block_map + i_n * block_map_stride_b + write_block_offset
             ).to(tl.int64)
             p_ht = ht + write_block_id * stride_final_state_token
         else:
@@ -217,10 +217,10 @@ def fused_recurrent_gated_delta_rule_fwd(
         q.stride(3) == 1 and k.stride(3) == 1 and v.stride(3) == 1
     ), "stride_qd, stride_kd, stride_vd must be 1"
 
-    max_block_size = 0
+    block_map_stride_b = 0
     if block_map is not None:
         assert block_map.ndim == 2, "block_map must be a 2D tensor"
-        max_block_size = block_map.shape[1]
+        block_map_stride_b = block_map.stride(0)
 
     grid = (NK, NV, N * HV)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
@@ -235,7 +235,7 @@ def fused_recurrent_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens,
         block_map=block_map,
         sequence_lengths=sequence_lengths,
-        max_block_size=max_block_size,
+        block_map_stride_b=block_map_stride_b,
         scale=scale,
         N=N,
         T=T,

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
@@ -5,7 +5,10 @@ import unittest
 from typing import List
 
 import torch
+import triton
+import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla import (
     load_initial_state_from_block_map,
     store_ssm_state_to_block_map,
@@ -21,7 +24,24 @@ SSM_STATE_DTYPES = [torch.bfloat16, torch.float32]
 INTERMEDIATE_DTYPE = torch.float32
 
 
+@triton.jit
+def _linear_offset_test_kernel(output, index, stride):
+    tl.store(output, linear_offset_64(index, stride))
+
+
 class BlockTest(unittest.TestCase):
+    def test_large_chunk_state_offset_uses_int64(self):
+        output = torch.empty(1, dtype=torch.int64, device="cuda")
+        cases = [
+            (8192, 16 * 128 * 128),
+            (4096, 32 * 128 * 128),
+        ]
+        for chunk_index, ssm_per_chunk in cases:
+            with self.subTest(chunk_index=chunk_index, ssm_per_chunk=ssm_per_chunk):
+                _linear_offset_test_kernel[(1,)](output, chunk_index, ssm_per_chunk)
+                self.assertEqual(output.item(), chunk_index * ssm_per_chunk)
+                self.assertEqual(output.item(), 1 << 31)
+
     def test_load_initial_state_from_block_map(self):
         device = torch.device("cuda")
         head_nums = [1, 4, 8, 16]

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1468,6 +1468,7 @@ class RopeConfig:
     mrope_dim1: int
     mrope_dim2: int
     mrope_dim3: int
+    mrope_interleaved: bool
     mscale: float
     offset: int
     scale: float

--- a/rtp_llm/test/kv_cache_specs_test.py
+++ b/rtp_llm/test/kv_cache_specs_test.py
@@ -4,8 +4,10 @@ from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.models.deepseek_v2 import DeepSeekV3Mtp
 from rtp_llm.models.hybrid_kv_cache import calculate_hybrid_group_layer_num
 from rtp_llm.models.kimi_linear.kimi_linear import KimiLinear
+from rtp_llm.models.qwen2_vl import QWen2_VL
 from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next
 from rtp_llm.models.qwen3_next.qwen3_next_mtp import Qwen3NextMTP
+from rtp_llm.models.qwen3_vl import QWen3_VL
 from rtp_llm.models.qwen_v2 import QwenV2MTP
 from rtp_llm.ops import HybridAttentionType, KVCacheSpecDesc, KVCacheSpecType
 
@@ -120,6 +122,77 @@ class HybridKVCacheSpecTest(TestCase):
 
         with self.assertRaisesRegex(ValueError, "Qwen3Next requires.*true"):
             Qwen3Next._parse_rope_config({"rope_parameters": rope_parameters}, config)
+
+    def test_qwen3_vl_defaults_to_interleaved_mrope_sections(self):
+        config = ModelConfig()
+        QWen3_VL._from_config_json(
+            config,
+            {
+                "vision_start_token_id": 1,
+                "vision_end_token_id": 2,
+                "text_config": {
+                    "intermediate_size": 256,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "head_dim": 128,
+                    "hidden_size": 256,
+                    "num_hidden_layers": 2,
+                    "vocab_size": 1024,
+                    "rope_scaling": {},
+                },
+            },
+        )
+
+        rope_config = config.attn_config.rope_config
+        self.assertTrue(rope_config.mrope_interleaved)
+        self.assertEqual(rope_config.index_factor, 3)
+        self.assertEqual(
+            [
+                rope_config.mrope_dim1,
+                rope_config.mrope_dim2,
+                rope_config.mrope_dim3,
+            ],
+            [24, 20, 20],
+        )
+        self.assertEqual(
+            rope_config.mrope_dim1
+            + rope_config.mrope_dim2
+            + rope_config.mrope_dim3,
+            rope_config.dim // 2,
+        )
+
+    def test_qwen2_vl_parses_explicit_mrope_layout(self):
+        config = ModelConfig()
+        QWen2_VL._from_hf(
+            config,
+            {
+                "vocab_size": 1024,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "hidden_size": 256,
+                "head_dim": 128,
+                "num_hidden_layers": 2,
+                "intermediate_size": 256,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 1_000_000,
+                "rope_scaling": {
+                    "mrope_section": [20, 22, 22],
+                    "mrope_interleaved": True,
+                },
+            },
+        )
+
+        rope_config = config.attn_config.rope_config
+        self.assertTrue(rope_config.mrope_interleaved)
+        self.assertEqual(rope_config.index_factor, 3)
+        self.assertEqual(
+            [
+                rope_config.mrope_dim1,
+                rope_config.mrope_dim2,
+                rope_config.mrope_dim3,
+            ],
+            [20, 22, 22],
+        )
 
     def test_kimi_linear_uses_contiguous_tags_across_hybrid_cycles(self):
         tags = self._kimi_post_build_tags(

--- a/rtp_llm/test/kv_cache_specs_test.py
+++ b/rtp_llm/test/kv_cache_specs_test.py
@@ -67,7 +67,9 @@ class HybridKVCacheSpecTest(TestCase):
 
         self.assertEqual(len(config.kv_cache_spec_descs), 1)
         self.assertEqual(config.kv_cache_spec_descs[0][0].tag, "full")
-        self.assertEqual(config.kv_cache_spec_descs[0][0].cache_type, KVCacheSpecType.MHA)
+        self.assertEqual(
+            config.kv_cache_spec_descs[0][0].cache_type, KVCacheSpecType.MHA
+        )
 
     def test_calculate_group_layer_num_uses_full_count_fallback(self):
         self.assertEqual(calculate_hybrid_group_layer_num(30, 10), 10)
@@ -92,6 +94,32 @@ class HybridKVCacheSpecTest(TestCase):
         self.assertEqual(tags[11], "full")
         self.assertEqual(tags[12], "linear0")
         self.assertEqual(tags[13], "linear1")
+
+    def test_qwen3_next_defaults_missing_mrope_interleaved_to_true(self):
+        config = ModelConfig()
+        config.attn_config.size_per_head = 256
+        rope_parameters = {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+            "mrope_section": [11, 11, 10],
+        }
+
+        Qwen3Next._parse_rope_config({"rope_parameters": rope_parameters}, config)
+
+        self.assertTrue(config.attn_config.rope_config.mrope_interleaved)
+
+    def test_qwen3_next_rejects_non_interleaved_mrope(self):
+        config = ModelConfig()
+        config.attn_config.size_per_head = 256
+        rope_parameters = {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+            "mrope_section": [11, 11, 10],
+            "mrope_interleaved": False,
+        }
+
+        with self.assertRaisesRegex(ValueError, "Qwen3Next requires.*true"):
+            Qwen3Next._parse_rope_config({"rope_parameters": rope_parameters}, config)
 
     def test_kimi_linear_uses_contiguous_tags_across_hybrid_cycles(self):
         tags = self._kimi_post_build_tags(

--- a/rtp_llm/test/perf_test/perf_config.py
+++ b/rtp_llm/test/perf_test/perf_config.py
@@ -98,6 +98,12 @@ def parse_args() -> Tuple[argparse.Namespace, List[str]]:
     return args, remaining
 
 
+def _arg_was_explicit(argv: List[str], key: str) -> bool:
+    flag = f"--{key}"
+    prefix = f"--{key}="
+    return any(arg == flag or arg.startswith(prefix) for arg in argv)
+
+
 def _replace_cli_value(argv: List[str], key: str, new_value: str) -> None:
     flag = f"--{key}"
     prefix = f"--{key}="
@@ -174,6 +180,11 @@ def prepare_config(args: argparse.Namespace, remaining: List[str]) -> PerfTestCo
 
     # Grid mode
     input_len_list = [int(x) for x in args.input_len.split(",")]
+    needed_seq_len = max(input_len_list) + args.decode_test_length
+    if _arg_was_explicit(sys.argv[1:], "max_seq_len"):
+        max_seq_len = max(needed_seq_len, args.max_seq_len)
+    else:
+        max_seq_len = needed_seq_len
 
     # Prefill mode (partial=2): always BS=1, no need for large BS list
     if args.partial == 2:
@@ -194,6 +205,6 @@ def prepare_config(args: argparse.Namespace, remaining: List[str]) -> PerfTestCo
         all_seq_lens=input_len_list,
         batch_size_list=batch_size_list,
         input_len_list=input_len_list,
-        max_seq_len=max(input_len_list) + args.decode_test_length,
+        max_seq_len=max_seq_len,
         max_concurrency=effective_max_concurrency,
     )

--- a/rtp_llm/test/perf_test/server.py
+++ b/rtp_llm/test/perf_test/server.py
@@ -26,7 +26,7 @@ class EngineServer:
         engine_cli = self._build_engine_cli(max_seq_len, max_concurrency)
 
         env: Dict[str, str] = {
-            "FAKE_BALANCE_EXPERT": "1",
+            "FAKE_BALANCE_EXPERT": os.environ.get("FAKE_BALANCE_EXPERT", "1"),
             "BATCH_DECODE_SCHEDULER_WARMUP_TYPE": (
                 "0" if self._args.partial in (0, 1) else "1"
             ),

--- a/rtp_llm/test/perf_test/test_perf_config_and_runners.py
+++ b/rtp_llm/test/perf_test/test_perf_config_and_runners.py
@@ -69,6 +69,13 @@ class TestPrepareConfig(unittest.TestCase):
         self.assertEqual(config.max_concurrency, 8)
         self.assertIsNone(config.test_config)
 
+    def test_grid_mode_explicit_max_seq_len_preserved(self):
+        with patch.object(sys, "argv", ["prog", "--max_seq_len", "409600"]):
+            args = _make_args(input_len="128", max_seq_len=409600)
+            config = _prepare_config(args, [])
+
+        self.assertEqual(config.max_seq_len, 409600)
+
     def test_grid_mode_auto_bs(self):
         with patch.object(sys, "argv", ["prog"]):
             args = _make_args(concurrency_limit=32)

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -18,6 +18,29 @@ filegroup(
     srcs = glob(["data/model/**/*.json"]),
 )
 
+py_test(
+    name = "multi_inst_case_runner_test",
+    srcs = glob(["*.py"]),
+    main = "multi_inst_case_runner_test.py",
+    imports = [".."],
+    deps = [
+        "//rtp_llm/test/utils:maga_server_manager",
+        "//rtp_llm:uvicorn",
+        "//rtp_llm:fastapi",
+        "//rtp_llm:psutil",
+        "//rtp_llm:tiktoken",
+        "//rtp_llm:testlib",
+        "//rtp_llm:pydantic",
+        "//rtp_llm:json5",
+        "//rtp_llm:dashscope",
+        "//rtp_llm:jieba",
+        "//rtp_llm:partial_json_parser",
+        "//rtp_llm:openai",
+        "//rtp_llm/test/utils:device_resource",
+        "//rtp_llm/test/utils:test_util",
+    ],
+)
+
 # ============================================================================
 # Open-source smoke test suites (platform-grouped)
 # ============================================================================
@@ -62,6 +85,8 @@ test_suite(
         ":smoke_rocm_basic",
         ":smoke_rocm_dense",
         ":smoke_rocm_moe",
+        ":smoke_rocm_qwen35",
+        ":smoke_rocm_vl",
         ":smoke_rocm_eagle",
         ":smoke_rocm_pd",
         ":smoke_rocm_embedding",

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_27b_fp8_pd_tp2x2_cg_long_prefill.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_27b_fp8_pd_tp2x2_cg_long_prefill.json
@@ -1,0 +1,55 @@
+{
+    "model_type": "qwen35_dense",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-27B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:x2*30",
+                    "$prompt:x2*29",
+                    "$prompt:x2*29",
+                    "$prompt:x2*29"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 1,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "reuse_cache": false,
+                    "aux_info": true
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "各位",
+                        "aux_info": {
+                            "input_len": 108360,
+                            "reuse_len": 0
+                        }
+                    },
+                    {
+                        "response": "各位",
+                        "aux_info": {
+                            "input_len": 104748,
+                            "reuse_len": 0
+                        }
+                    },
+                    {
+                        "response": "各位",
+                        "aux_info": {
+                            "input_len": 104748,
+                            "reuse_len": 0
+                        }
+                    },
+                    {
+                        "response": "各位",
+                        "aux_info": {
+                            "input_len": 104748,
+                            "reuse_len": 0
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm.json
@@ -1,0 +1,41 @@
+{
+    "model_type": "qwen35_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-35B-A3B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm_reuse.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm_reuse.json
@@ -1,0 +1,86 @@
+{
+    "model_type": "qwen35_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-35B-A3B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:x2",
+                "generate_config": {
+                    "max_new_tokens": 5,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "enable_device_cache": false,
+                    "enable_memory_cache": true
+                }
+            },
+            "result": {
+                "response": "\r\n\r\n——基本形成靠拢",
+                "aux_info": {
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0
+                }
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:x2",
+                "generate_config": {
+                    "max_new_tokens": 5,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "enable_device_cache": false,
+                    "enable_memory_cache": true
+                }
+            },
+            "result": {
+                "response": "\r\n\r\n——基本形成靠拢",
+                "aux_info": {
+                    "reuse_len": 3072,
+                    "local_reuse_len": 3072,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 3072
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_fp8_rocm_cg_reuse.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_fp8_rocm_cg_reuse.json
@@ -1,0 +1,154 @@
+{
+    "model_type": "qwen35_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-35B-A3B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "\n\nThe CAP Theorem, also known as Brewer",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP Theorem, also known as Brewer",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data/model/qwen_vl/1.jpeg"
+                                }
+                            },
+                            {
+                                "type": "text",
+                                "text": "Describe this image."
+                            }
+                        ]
+                    }
+                ],
+                "max_tokens": 20,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "The user wants a description of the provided image.\n\n1.  **Identify the main subjects"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 971,
+                    "total_tokens": 991,
+                    "completion_tokens": 20
+                }
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:x2"
+                    }
+                ],
+                "max_tokens": 5,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here's a thinking process"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 3622,
+                    "total_tokens": 3627,
+                    "completion_tokens": 5
+                }
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:x2"
+                    }
+                ],
+                "max_tokens": 5,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here's a thinking process"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 3622,
+                    "total_tokens": 3627,
+                    "completion_tokens": 5,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 3072
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_fp8_rocm_tp2_cg_reuse.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_fp8_rocm_tp2_cg_reuse.json
@@ -1,0 +1,111 @@
+{
+    "model_type": "qwen35_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-35B-A3B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "\n\nThe CAP Theorem, also known as Brewer",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer",
+                            "\n\nThe CAP theorem, also known as Brewer's"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:x2"
+                    }
+                ],
+                "max_tokens": 5,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here's a thinking process"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 3622,
+                    "total_tokens": 3627,
+                    "completion_tokens": 5
+                }
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:x2"
+                    }
+                ],
+                "max_tokens": 5,
+                "temperature": 0.0,
+                "top_p": 0,
+                "top_k": 1
+            },
+            "result": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here's a thinking process"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 3622,
+                    "total_tokens": 3627,
+                    "completion_tokens": 5,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 3072
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/multi_inst_case_runner.py
+++ b/rtp_llm/test/smoke/multi_inst_case_runner.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, List, Union
+import os
+from typing import Dict, List, Optional, Union
 
 from smoke.case_runner import CaseRunner
 from smoke.task_info import TaskInfo, TaskStates
@@ -12,6 +13,17 @@ PREFILL_ROLE_NAME = "prefill"
 DECODE_ROLE_NAME = "decode"
 FRONTEND_ROLE_NAME = "frontend"
 PD_FUNSION_ROLE_NAME = "pd_fusion"
+
+
+def _set_visible_devices(envs: Dict[str, Optional[str]], gpu_ids: List[str]):
+    visible_devices = ",".join(gpu_ids)
+    if "HIP_VISIBLE_DEVICES" in os.environ or "HIP_VISIBLE_DEVICES" in envs:
+        envs["HIP_VISIBLE_DEVICES"] = visible_devices
+        envs["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(len(gpu_ids)))
+        envs["ROCR_VISIBLE_DEVICES"] = None
+        return
+
+    envs["CUDA_VISIBLE_DEVICES"] = visible_devices
 
 
 class PdSeperationCaseRunner(CaseRunner):
@@ -98,13 +110,13 @@ class PdSeperationCaseRunner(CaseRunner):
                 role_name="frontend",
             )
 
-        decode_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[:decode_gpu_size])
+        _set_visible_devices(decode_envs, gpu_ids[:decode_gpu_size])
         decode_envs["REMOTE_RPC_SERVER_IP"] = "localhost"
         decode_envs["REMOTE_SERVER_PORT"] = prefill_port
 
         prefill_envs["REMOTE_SERVER_PORT"] = decode_port
         prefill_envs["REMOTE_RPC_SERVER_IP"] = "localhost"
-        prefill_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[decode_gpu_size:])
+        _set_visible_devices(prefill_envs, gpu_ids[decode_gpu_size:])
         prefill_envs["MODEL_SERVICE_CONFIG"] = service_route.model_dump_json()
 
         server_configs = [
@@ -257,14 +269,14 @@ class DpSeperationCaseRunner(CaseRunner):
             )
 
         # prepare server configurations for parallel start
-        decode_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[:decode_gpu_size])
+        _set_visible_devices(decode_envs, gpu_ids[:decode_gpu_size])
         decode_envs["REMOTE_RPC_SERVER_IP"] = "localhost"
         decode_envs["REMOTE_SERVER_PORT"] = prefill_port
         decode_envs["MODEL_SERVICE_CONFIG"] = service_route.model_dump_json()
 
         prefill_envs["REMOTE_SERVER_PORT"] = decode_port
         prefill_envs["REMOTE_RPC_SERVER_IP"] = "localhost"
-        prefill_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[decode_gpu_size:])
+        _set_visible_devices(prefill_envs, gpu_ids[decode_gpu_size:])
 
         server_configs = [
             {
@@ -389,7 +401,7 @@ class FrontAppSeperationCaseRunner(CaseRunner):
         ), "frontend server manager should not be None"
 
         # start PDFUSION server after frontend is ready
-        pd_fusion_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[:gpu_size])
+        _set_visible_devices(pd_fusion_envs, gpu_ids[:gpu_size])
         pd_fusion_envs["REMOTE_RPC_SERVER_IP"] = "localhost"
         pd_fusion_envs["REMOTE_SERVER_PORT"] = pd_fusion_port
         task_states = TaskStates()
@@ -466,12 +478,12 @@ class VitSeperationCaseRunner(CaseRunner):
 
         llm_envs["MODEL_SERVICE_CONFIG"] = service_route.model_dump_json()
         # prepare server configurations for parallel start
-        llm_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[:llm_gpu_size])
+        _set_visible_devices(llm_envs, gpu_ids[:llm_gpu_size])
         llm_envs["REMOTE_VIT_SERVER_IP"] = "localhost"
         llm_envs["REMOTE_SERVER_PORT"] = vit_port
         llm_envs["VIT_SEPARATION"] = "2"
 
-        vit_envs["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_ids[llm_gpu_size:])
+        _set_visible_devices(vit_envs, gpu_ids[llm_gpu_size:])
         vit_envs["VIT_SEPARATION"] = "1"
         vit_envs["ROLE_TYPE"] = "VIT"
         vit_envs["MODEL_SERVICE_CONFIG"] = service_route.model_dump_json()

--- a/rtp_llm/test/smoke/multi_inst_case_runner_test.py
+++ b/rtp_llm/test/smoke/multi_inst_case_runner_test.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+from smoke.multi_inst_case_runner import _set_visible_devices
+
+from rtp_llm.test.utils.maga_server_manager import _apply_env_args
+
+
+class MultiInstCaseRunnerTest(unittest.TestCase):
+    @patch.dict("os.environ", {"HIP_VISIBLE_DEVICES": "0,1,2,3"}, clear=True)
+    def test_pd_tp2x2_visible_devices_are_split_for_rocm(self):
+        gpu_ids = ["0", "1", "2", "3"]
+        decode_envs = {"WORLD_SIZE": "2"}
+        prefill_envs = {"WORLD_SIZE": "2"}
+
+        _set_visible_devices(decode_envs, gpu_ids[:2])
+        _set_visible_devices(prefill_envs, gpu_ids[2:])
+
+        self.assertEqual("0,1", decode_envs["HIP_VISIBLE_DEVICES"])
+        self.assertEqual("0,1", decode_envs["CUDA_VISIBLE_DEVICES"])
+        self.assertIsNone(decode_envs["ROCR_VISIBLE_DEVICES"])
+
+        self.assertEqual("2,3", prefill_envs["HIP_VISIBLE_DEVICES"])
+        self.assertEqual("0,1", prefill_envs["CUDA_VISIBLE_DEVICES"])
+        self.assertIsNone(prefill_envs["ROCR_VISIBLE_DEVICES"])
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_visible_devices_use_cuda_for_non_rocm(self):
+        envs = {"WORLD_SIZE": "2"}
+
+        _set_visible_devices(envs, ["2", "3"])
+
+        self.assertEqual("2,3", envs["CUDA_VISIBLE_DEVICES"])
+        self.assertNotIn("HIP_VISIBLE_DEVICES", envs)
+        self.assertNotIn("ROCR_VISIBLE_DEVICES", envs)
+
+    def test_none_env_override_removes_inherited_var(self):
+        current_env = {"ROCR_VISIBLE_DEVICES": "0,1", "HIP_VISIBLE_DEVICES": "0,1"}
+
+        _apply_env_args(current_env, {"ROCR_VISIBLE_DEVICES": None})
+
+        self.assertNotIn("ROCR_VISIBLE_DEVICES", current_env)
+        self.assertEqual("0,1", current_env["HIP_VISIBLE_DEVICES"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/smoke/multi_inst_case_runner_test.py
+++ b/rtp_llm/test/smoke/multi_inst_case_runner_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from smoke.multi_inst_case_runner import _set_visible_devices
+from smoke.utils import resolve_prompt_refs
 
 from rtp_llm.test.utils.maga_server_manager import _apply_env_args
 
@@ -41,6 +42,17 @@ class MultiInstCaseRunnerTest(unittest.TestCase):
 
         self.assertNotIn("ROCR_VISIBLE_DEVICES", current_env)
         self.assertEqual("0,1", current_env["HIP_VISIBLE_DEVICES"])
+
+
+class PromptReferenceTest(unittest.TestCase):
+    @patch("smoke.utils._load_prompt_candidates", return_value={"long": "abc"})
+    def test_repeat_prompt_reference(self, _):
+        self.assertEqual("abcabcabc", resolve_prompt_refs("$prompt:long*3"))
+
+    @patch("smoke.utils._load_prompt_candidates", return_value={"long": "abc"})
+    def test_repeat_prompt_reference_requires_positive_count(self, _):
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            resolve_prompt_refs("$prompt:long*0")
 
 
 if __name__ == "__main__":

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -88,6 +88,43 @@ def rocm_oss_suites():
         ],
     )
 
+    # ROCm Qwen3.5 (MI308X): compact online-shape coverage.
+    native.test_suite(
+        name = "smoke_rocm_qwen35",
+        tests = [
+            smoke_test(
+                name="rocm_qwen35_bf16_reuse",
+                task_info="data/model/qwen35/qwen35_bf16_rocm_reuse.json",
+                smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --reuse_cache 1 --enable_memory_cache 1 --memory_cache_size_mb 1024 --write_cache_sync 1",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+            smoke_test(
+                name="rocm_qwen35_fp8_cg_reuse",
+                task_info="data/model/qwen35/qwen35_fp8_rocm_cg_reuse.json",
+                smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --reuse_cache 1 --enable_memory_cache 1 --memory_cache_size_mb 1024 --write_cache_sync 1 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
+                data=native.glob(['data/model/qwen_vl/*.jpeg']),
+            ),
+            smoke_test(
+                name="rocm_qwen35_fp8_tp2_cg_reuse",
+                task_info="data/model/qwen35/qwen35_fp8_rocm_tp2_cg_reuse.json",
+                smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 2 --world_size 2 --ep_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --reuse_cache 1 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+            # Qwen3.5-27B TP2 packs 422604 tokens: the QKV source offset reaches
+            # 2163727360 and the FLA chunk-state offset reaches 2597191680.
+            smoke_test(
+                name="rocm_qwen35_27b_fp8_pd_tp2x2_cg_long_prefill",
+                task_info="data/model/qwen35/qwen35_27b_fp8_pd_tp2x2_cg_long_prefill.json",
+                smoke_args={
+                    "prefill": "--load_cache_timeout_ms 900000 --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 131072 --max_context_batch_size 4 --max_batch_tokens_size 524288 --tp_size 2 --world_size 2 --ep_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --reuse_cache 0 --concurrency_limit 4 --cache_store_rdma_mode 0 --use_local 1 --role_type PREFILL",
+                    "decode": "--load_cache_timeout_ms 900000 --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 131072 --max_context_batch_size 4 --max_batch_tokens_size 524288 --tp_size 2 --world_size 2 --ep_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --reuse_cache 0 --concurrency_limit 4 --cache_store_rdma_mode 0 --use_local 1 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4' --role_type DECODE",
+                },
+                gpu_type=["MI308X-ROCM7"],
+            ),
+        ],
+    )
+
 
     # ROCm Eagle (Qwen2-14B + draft)
     native.test_suite(
@@ -113,6 +150,15 @@ def rocm_oss_suites():
                 smoke_args= {
                     "prefill": "--test_block_num 10 --warm_up 0 --seq_size_per_block 16 --act_type bf16 --use_swizzleA 1 --use_asm_pa 1 --disable_flashinfer_native 1 --use_aiter_pa 1 --use_local 1 --role_type PREFILL --world_size 1",
                     "decode": "--test_block_num 10 --warm_up 0 --seq_size_per_block 16 --act_type bf16 --use_swizzleA 1 --use_asm_pa 1 --disable_flashinfer_native 1 --use_aiter_pa 1 --use_local 1 --role_type DECODE --world_size 1"
+                },
+                gpu_type=["MI308X-ROCM7"]
+            ),
+            smoke_test(
+                name="rocm_pd_qwen35_bf16_tp2_cg",
+                task_info="data/model/qwen35/qwen35_bf16_rocm.json",
+                smoke_args= {
+                    "prefill": "--load_cache_timeout_ms 120000 --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 2 --world_size 2 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --cache_store_rdma_mode 0 --use_local 1 --role_type PREFILL",
+                    "decode": "--load_cache_timeout_ms 120000 --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 2 --world_size 2 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --cache_store_rdma_mode 0 --use_local 1 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4' --role_type DECODE"
                 },
                 gpu_type=["MI308X-ROCM7"]
             ),
@@ -185,6 +231,19 @@ def rocm_oss_suites():
                 task_info="data/model/qwen3/ptpc_q_r_fp8_py.json",
                 gpu_type=["MI308X-ROCM7"],
                 smoke_args="--enable_cuda_graph 1 --reserver_runtime_mem_mb 107813 --use_aiter_pa 1 --seq_size_per_block 16 --fp8_kv_cache 1",
+            ),
+        ],
+    )
+
+    # ROCm VL (Qwen3-VL dense)
+    native.test_suite(
+        name = "smoke_rocm_vl",
+        tests = [
+            smoke_test(
+                name="rocm_qwen3_vl_cg",
+                task_info="data/model/qwen_vl/q_r_3.json",
+                smoke_args="--act_type BF16 --reserver_runtime_mem_mb 51200 --tp_size 1 --world_size 1 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
             ),
         ],
     )

--- a/rtp_llm/test/smoke/utils.py
+++ b/rtp_llm/test/smoke/utils.py
@@ -38,6 +38,8 @@ def no_compare() -> bool:
 
 
 _PROMPT_CACHE = None
+_PROMPT_REF_RE = re.compile(r"^\$prompt:([^*]+?)(?:\*(\d+))?$")
+
 
 def _load_prompt_candidates():
     global _PROMPT_CACHE
@@ -50,20 +52,33 @@ def _load_prompt_candidates():
     with open(candidates_path, "r", encoding="utf-8") as f:
         data = json.load(f)
     _PROMPT_CACHE = {k: v["content"] for k, v in data.get("prompts", {}).items()}
-    logging.info("Loaded %d prompt candidates from %s", len(_PROMPT_CACHE), candidates_path)
+    logging.info(
+        "Loaded %d prompt candidates from %s", len(_PROMPT_CACHE), candidates_path
+    )
     return _PROMPT_CACHE
 
 
 def resolve_prompt_refs(obj: Any) -> Any:
-    """Recursively replace '$prompt:xxx' references with actual prompt content."""
+    """Resolve ``$prompt:id`` and optional ``$prompt:id*N`` references."""
     if isinstance(obj, str) and obj.startswith("$prompt:"):
-        pid = obj[len("$prompt:"):]
+        match = _PROMPT_REF_RE.fullmatch(obj)
+        if match is None:
+            raise ValueError(f"Invalid prompt reference: {obj!r}")
+        pid, repeat = match.groups()
         prompts = _load_prompt_candidates()
         if pid not in prompts:
-            raise ValueError(f"Unknown prompt candidate ID: '{pid}'. Available: {list(prompts.keys())}")
-        return prompts[pid]
+            raise ValueError(
+                f"Unknown prompt candidate ID: '{pid}'. Available: {list(prompts.keys())}"
+            )
+        repeat_count = int(repeat) if repeat is not None else 1
+        if repeat_count < 1:
+            raise ValueError(f"Prompt repeat count must be positive: {obj!r}")
+        return prompts[pid] * repeat_count
     elif isinstance(obj, dict):
-        return {k: (v if k == "_prompt_source" else resolve_prompt_refs(v)) for k, v in obj.items()}
+        return {
+            k: (v if k == "_prompt_source" else resolve_prompt_refs(v))
+            for k, v in obj.items()
+        }
     elif isinstance(obj, list):
         return [resolve_prompt_refs(v) for v in obj]
     return obj

--- a/rtp_llm/test/utils/maga_server_manager.py
+++ b/rtp_llm/test/utils/maga_server_manager.py
@@ -26,6 +26,14 @@ LOG_PATH = "LOG_PATH"
 long_live_port_locks = []
 
 
+def _apply_env_args(current_env: Dict[str, str], env_args: Dict[str, Any]):
+    for k, v in env_args.items():
+        if v is None:
+            current_env.pop(k, None)
+        else:
+            current_env[k] = v
+
+
 class MagaServerManager(object):
     def __init__(
         self,
@@ -148,9 +156,7 @@ class MagaServerManager(object):
 
         role_log_name = self._role_name + "_logs"
         current_env: Dict[str, str] = os.environ.copy()
-        for k, v in self._env_args.items():
-            if v is not None:
-                current_env[k] = v
+        _apply_env_args(current_env, self._env_args)
 
         if model_type is not None:
             current_env[MODEL_TYPE] = model_type

--- a/rtp_llm/utils/aiter_jit_patch.py
+++ b/rtp_llm/utils/aiter_jit_patch.py
@@ -1,0 +1,951 @@
+import fcntl
+import functools
+import importlib
+import json
+import logging
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+import types
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Callable, Iterator, Optional
+
+import torch
+
+_LOGGER = logging.getLogger(__name__)
+_DISABLE_ENV = "RTP_LLM_DISABLE_AITER_JIT_PATCH"
+_AITER_AOT_IMPORT_ENV = "AITER_AOT_IMPORT"
+_FILE_BATON_ORIGINAL_ATTR = "_rtp_llm_original_file_baton"
+_AITER_CODEGEN_SCRIPTS = {
+    "codegen.py",
+    "gen_instances.py",
+    "gen_instances_cktile.py",
+    "generate.py",
+    "generate_binaryop.py",
+}
+_SHELL_CONTROL_CHARS = frozenset(";&|<>")
+_PATCH_LOCK = threading.RLock()
+_AITER_BUILD_LOCK_TIMEOUT_SECONDS = 600.0
+_AITER_BUILD_LOCK_STALE_SECONDS = 30.0
+_AITER_BUILD_LOCK_POLL_SECONDS = 0.05
+
+
+class _ModuleProxy:
+    """Delegate module attributes while overriding a small, explicit subset."""
+
+    def __init__(self, target: object, overrides: dict[str, object]):
+        self._target = target
+        self._overrides = overrides
+
+    def __getattr__(self, name: str) -> object:
+        if name in self._overrides:
+            return self._overrides[name]
+        return getattr(self._target, name)
+
+
+@dataclass(frozen=True)
+class _PatchState:
+    core: types.ModuleType
+    original_os: object
+    original_importlib: object
+    os_proxy: _ModuleProxy
+    importlib_proxy: _ModuleProxy
+    file_baton_bindings: tuple["_FileBatonBinding", ...]
+
+
+@dataclass(frozen=True)
+class _FileBatonBinding:
+    namespace: dict[str, object]
+    name: str
+    original: type
+    patched: type
+    label: str
+
+
+@dataclass(frozen=True)
+class _BuildLockOwner:
+    token: str
+    pid: int
+    hostname: str
+    boot_id: Optional[str]
+    pid_namespace: Optional[str]
+
+
+@dataclass(frozen=True)
+class _OwnedBuildLock:
+    fd: int
+    device: int
+    inode: int
+    owner: _BuildLockOwner
+
+
+class _AiterBuildLockTimeout(RuntimeError):
+    """AITER's file baton did not become available before the deadline."""
+
+
+_PATCH_STATE: Optional[_PatchState] = None
+
+
+class _StaleModuleRecovery(Enum):
+    NOT_HANDLED = auto()
+    REBUILD = auto()
+    RETRY_IMPORT = auto()
+
+
+def _is_rocm_runtime() -> bool:
+    return torch.version.hip is not None
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@functools.lru_cache(maxsize=1)
+def _aiter_package_roots() -> tuple[str, ...]:
+    roots = []
+    for module_name in ("aiter", "aiter_meta"):
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except (ImportError, ValueError):
+            continue
+        if spec is None or spec.submodule_search_locations is None:
+            continue
+        roots.extend(os.path.abspath(path) for path in spec.submodule_search_locations)
+    return tuple(roots)
+
+
+def _aiter_jit_roots() -> tuple[str, ...]:
+    roots = [os.path.join(root, "jit") for root in _aiter_package_roots()]
+    configured_root = os.environ.get("AITER_JIT_DIR")
+    if configured_root:
+        roots.append(os.path.abspath(os.path.expanduser(configured_root)))
+    roots.append(os.path.abspath(os.path.expanduser("~/.aiter/jit")))
+    return tuple(dict.fromkeys(roots))
+
+
+def _is_within_root(path: str, root: str) -> bool:
+    try:
+        logical_path = os.path.abspath(path)
+        logical_root = os.path.abspath(root)
+        if os.path.commonpath((logical_path, logical_root)) == logical_root:
+            return True
+        real_path = os.path.realpath(path)
+        real_root = os.path.realpath(root)
+        return os.path.commonpath((real_path, real_root)) == real_root
+    except ValueError:
+        return False
+
+
+def _split_aiter_codegen_command(command: object) -> Optional[list[str]]:
+    if not isinstance(command, str):
+        return None
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        args = list(lexer)
+    except ValueError:
+        return None
+    if not args or any(
+        any(char in arg for char in _SHELL_CONTROL_CHARS) for arg in args
+    ):
+        return None
+
+    package_roots = _aiter_package_roots()
+    matching_script_indices = [
+        index
+        for index, arg in enumerate(args)
+        if os.path.basename(arg) in _AITER_CODEGEN_SCRIPTS
+        and any(_is_within_root(arg, root) for root in package_roots)
+    ]
+    # AITER constructs every codegen command as ``<python> <script> ...``.
+    # Requiring the script in argv[1] prevents an unrelated command from being
+    # intercepted merely because one of its data arguments names a codegen file.
+    return args if matching_script_indices == [1] else None
+
+
+def _is_aiter_codegen_command(command: object) -> bool:
+    return _split_aiter_codegen_command(command) is not None
+
+
+def _run_aiter_codegen_command(command: str) -> int:
+    args = _split_aiter_codegen_command(command)
+    if args is None:
+        _LOGGER.error("refusing to run malformed or compound aiter JIT codegen command")
+        return 1
+    try:
+        return subprocess.run(args, check=False).returncode
+    except OSError as error:
+        _LOGGER.error("failed to run aiter JIT codegen command: %s", error)
+        return 1
+
+
+def _extract_shared_object_path(error_message: str) -> Optional[str]:
+    match = re.search(
+        r"(/[^\s:]+\.so):\s+"
+        r"(?:undefined symbol:|file too short(?:\s*$)|invalid ELF header(?:\s*$))",
+        error_message,
+    )
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _valid_stale_module_path(module_name: str, so_path: str) -> bool:
+    module_leaf = module_name.rsplit(".", 1)[-1]
+    if os.path.basename(so_path) != f"{module_leaf}.so":
+        return False
+    return any(_is_within_root(so_path, root) for root in _aiter_jit_roots())
+
+
+def _read_pid_namespace() -> Optional[str]:
+    try:
+        return os.readlink("/proc/self/ns/pid")
+    except OSError:
+        return None
+
+
+def _read_boot_id() -> Optional[str]:
+    try:
+        with open("/proc/sys/kernel/random/boot_id", encoding="utf-8") as file:
+            return file.read().strip() or None
+    except OSError:
+        return None
+
+
+def _new_build_lock_owner() -> _BuildLockOwner:
+    return _BuildLockOwner(
+        token=os.urandom(16).hex(),
+        pid=os.getpid(),
+        hostname=socket.gethostname(),
+        boot_id=_read_boot_id(),
+        pid_namespace=_read_pid_namespace(),
+    )
+
+
+def _build_lock_owner_payload(owner: _BuildLockOwner) -> bytes:
+    return json.dumps(
+        {
+            "token": owner.token,
+            "pid": owner.pid,
+            "hostname": owner.hostname,
+            "boot_id": owner.boot_id,
+            "pid_namespace": owner.pid_namespace,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _parse_build_lock_owner(payload: bytes) -> Optional[_BuildLockOwner]:
+    try:
+        record = json.loads(payload.decode("utf-8"))
+        owner = _BuildLockOwner(
+            token=record["token"],
+            pid=record["pid"],
+            hostname=record["hostname"],
+            boot_id=record["boot_id"],
+            pid_namespace=record["pid_namespace"],
+        )
+    except (KeyError, TypeError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if (
+        not isinstance(owner.token, str)
+        or not owner.token
+        or not isinstance(owner.pid, int)
+        or isinstance(owner.pid, bool)
+        or owner.pid <= 0
+        or not isinstance(owner.hostname, str)
+        or not owner.hostname
+        or (owner.boot_id is not None and not isinstance(owner.boot_id, str))
+        or (
+            owner.pid_namespace is not None and not isinstance(owner.pid_namespace, str)
+        )
+    ):
+        return None
+    return owner
+
+
+def _read_build_lock_owner(lock_fd: int) -> Optional[_BuildLockOwner]:
+    try:
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        payload = os.read(lock_fd, 4097)
+    except OSError:
+        return None
+    if not payload or len(payload) > 4096:
+        return None
+    return _parse_build_lock_owner(payload)
+
+
+def _same_lock_inode(lock_path: str, device: int, inode: int) -> bool:
+    try:
+        current = os.stat(lock_path, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return current.st_dev == device and current.st_ino == inode
+
+
+def _owner_process_is_dead(owner: _BuildLockOwner) -> Optional[bool]:
+    if (
+        owner.hostname != socket.gethostname()
+        or owner.boot_id is None
+        or owner.boot_id != _read_boot_id()
+        or owner.pid_namespace is None
+        or owner.pid_namespace != _read_pid_namespace()
+    ):
+        return None
+
+    try:
+        os.kill(owner.pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    except OSError:
+        return None
+    return False
+
+
+def _try_create_owned_build_lock(lock_path: str) -> Optional[_OwnedBuildLock]:
+    try:
+        lock_fd = os.open(
+            lock_path,
+            os.O_CREAT | os.O_EXCL | os.O_RDWR,
+            0o644,
+        )
+    except FileExistsError:
+        return None
+
+    lock_stat = None
+    try:
+        lock_stat = os.fstat(lock_fd)
+        owner = _new_build_lock_owner()
+        payload = _build_lock_owner_payload(owner)
+        if os.write(lock_fd, payload) != len(payload):
+            raise OSError(f"short write while recording AITER lock owner: {lock_path}")
+        os.fsync(lock_fd)
+        return _OwnedBuildLock(
+            fd=lock_fd,
+            device=lock_stat.st_dev,
+            inode=lock_stat.st_ino,
+            owner=owner,
+        )
+    except BaseException:
+        try:
+            if lock_stat is not None and _same_lock_inode(
+                lock_path, lock_stat.st_dev, lock_stat.st_ino
+            ):
+                os.remove(lock_path)
+        finally:
+            os.close(lock_fd)
+        raise
+
+
+def _try_reclaim_stale_build_lock(lock_path: str, stale_lock_seconds: float) -> str:
+    # The sidecar path may persist, but its kernel lock is released on process
+    # exit. It serializes reclaimers without becoming another stale-file baton.
+    guard_fd = os.open(f"{lock_path}.rtp_reclaim", os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        try:
+            fcntl.flock(guard_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return "another process is checking the lock owner"
+        try:
+            lock_fd = os.open(lock_path, os.O_RDONLY)
+        except FileNotFoundError:
+            return "lock was released"
+        except OSError as error:
+            return f"lock metadata is unreadable: {error}"
+        try:
+            lock_stat = os.fstat(lock_fd)
+            owner = _read_build_lock_owner(lock_fd)
+        finally:
+            os.close(lock_fd)
+        if owner is None:
+            return "owner is unknown (legacy or malformed lock)"
+
+        age_seconds = max(0.0, (time.time_ns() - lock_stat.st_mtime_ns) / 1e9)
+        if age_seconds < stale_lock_seconds:
+            return f"owner pid={owner.pid} lock age={age_seconds:.1f}s"
+
+        owner_is_dead = _owner_process_is_dead(owner)
+        if owner_is_dead is not True:
+            state = "alive" if owner_is_dead is False else "not locally verifiable"
+            return f"owner pid={owner.pid} host={owner.hostname} is {state}"
+
+        if not _same_lock_inode(lock_path, lock_stat.st_dev, lock_stat.st_ino):
+            return "lock owner changed while checking staleness"
+        try:
+            os.remove(lock_path)
+        except FileNotFoundError:
+            return "lock was released while checking staleness"
+        _LOGGER.warning(
+            "reclaimed stale aiter JIT build lock %s from dead owner pid=%d age=%.1fs",
+            lock_path,
+            owner.pid,
+            age_seconds,
+        )
+        return f"reclaimed dead owner pid={owner.pid}"
+    finally:
+        os.close(guard_fd)
+
+
+def _release_owned_build_lock(lock_path: str, lock: _OwnedBuildLock) -> None:
+    try:
+        current_owner = None
+        try:
+            current_fd = os.open(lock_path, os.O_RDONLY)
+        except FileNotFoundError:
+            current_fd = None
+        if current_fd is not None:
+            try:
+                current_owner = _read_build_lock_owner(current_fd)
+            finally:
+                os.close(current_fd)
+        if (
+            _same_lock_inode(lock_path, lock.device, lock.inode)
+            and current_owner == lock.owner
+        ):
+            os.remove(lock_path)
+        elif os.path.lexists(lock_path):
+            _LOGGER.warning(
+                "AITER build lock owner changed before release; preserving peer lock: %s",
+                lock_path,
+            )
+    except FileNotFoundError:
+        pass
+    finally:
+        os.close(lock.fd)
+
+
+@contextmanager
+def _aiter_build_lock(
+    so_path: str,
+    *,
+    timeout_seconds: Optional[float] = None,
+    stale_lock_seconds: Optional[float] = None,
+    poll_seconds: Optional[float] = None,
+) -> Iterator[None]:
+    """Acquire AITER's file-baton path with bounded, owner-safe recovery."""
+
+    module_base = os.path.splitext(os.path.basename(so_path))[0]
+    build_root = os.path.join(os.path.dirname(so_path), "build")
+    os.makedirs(build_root, exist_ok=True)
+    lock_path = os.path.join(build_root, f"lock_{module_base}")
+    timeout_seconds = (
+        _AITER_BUILD_LOCK_TIMEOUT_SECONDS
+        if timeout_seconds is None
+        else timeout_seconds
+    )
+    stale_lock_seconds = (
+        _AITER_BUILD_LOCK_STALE_SECONDS
+        if stale_lock_seconds is None
+        else stale_lock_seconds
+    )
+    poll_seconds = (
+        _AITER_BUILD_LOCK_POLL_SECONDS if poll_seconds is None else poll_seconds
+    )
+    if timeout_seconds <= 0 or stale_lock_seconds < 0 or poll_seconds <= 0:
+        raise ValueError(
+            "AITER build lock timeout/poll must be positive and stale age non-negative"
+        )
+
+    deadline = time.monotonic() + timeout_seconds
+    lock = None
+    last_status = "not inspected"
+    logged_wait = False
+    try:
+        while lock is None:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise _AiterBuildLockTimeout(
+                    f"timed out after {timeout_seconds:.1f}s waiting for AITER JIT "
+                    f"build lock {lock_path}: {last_status}. The lock was preserved "
+                    "because no stale owner could be proven safe to reclaim."
+                )
+
+            lock = _try_create_owned_build_lock(lock_path)
+            if lock is not None:
+                break
+
+            last_status = _try_reclaim_stale_build_lock(lock_path, stale_lock_seconds)
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                continue
+            if not logged_wait:
+                _LOGGER.info(
+                    "waiting up to %.1fs for AITER JIT build lock %s: %s",
+                    timeout_seconds,
+                    lock_path,
+                    last_status,
+                )
+                logged_wait = True
+            time.sleep(min(poll_seconds, remaining_seconds))
+        yield
+    finally:
+        if lock is not None:
+            _release_owned_build_lock(lock_path, lock)
+
+
+def _make_bounded_file_baton(original_file_baton: type) -> type:
+    """Add owner-safe recovery and a deadline to AITER's file baton."""
+
+    class _BoundedFileBaton(original_file_baton):
+        def try_acquire(self) -> bool:
+            lock = _try_create_owned_build_lock(self.lock_file_path)
+            if lock is None:
+                return False
+            self.fd = lock.fd
+            self._rtp_owned_lock = lock
+            return True
+
+        def wait(self) -> None:
+            timeout_seconds = _AITER_BUILD_LOCK_TIMEOUT_SECONDS
+            stale_lock_seconds = _AITER_BUILD_LOCK_STALE_SECONDS
+            try:
+                poll_seconds = float(self.wait_seconds)
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    "AITER file-baton poll interval must be numeric"
+                ) from error
+            if timeout_seconds <= 0 or stale_lock_seconds < 0 or poll_seconds <= 0:
+                raise ValueError(
+                    "AITER file-baton timeout/poll must be positive and stale age "
+                    "non-negative"
+                )
+
+            deadline = time.monotonic() + timeout_seconds
+            last_status = "not inspected"
+            _LOGGER.info(
+                "waiting up to %.1fs for AITER JIT file baton %s",
+                timeout_seconds,
+                self.lock_file_path,
+            )
+            while os.path.exists(self.lock_file_path):
+                remaining_seconds = deadline - time.monotonic()
+                if remaining_seconds <= 0:
+                    raise _AiterBuildLockTimeout(
+                        f"timed out after {timeout_seconds:.1f}s waiting for AITER "
+                        f"JIT file baton {self.lock_file_path}: {last_status}. The "
+                        "lock was preserved because no stale owner could be proven "
+                        "safe to reclaim."
+                    )
+
+                last_status = _try_reclaim_stale_build_lock(
+                    self.lock_file_path, stale_lock_seconds
+                )
+                remaining_seconds = deadline - time.monotonic()
+                if remaining_seconds <= 0:
+                    continue
+                time.sleep(min(poll_seconds, remaining_seconds))
+
+        def release(self) -> None:
+            lock = getattr(self, "_rtp_owned_lock", None)
+            if lock is None:
+                super().release()
+                return
+            try:
+                _release_owned_build_lock(self.lock_file_path, lock)
+            finally:
+                self.fd = None
+                self._rtp_owned_lock = None
+
+    _BoundedFileBaton.__name__ = f"RtpBounded{original_file_baton.__name__}"
+    _BoundedFileBaton.__qualname__ = _BoundedFileBaton.__name__
+    setattr(_BoundedFileBaton, _FILE_BATON_ORIGINAL_ATTR, original_file_baton)
+    return _BoundedFileBaton
+
+
+def _maybe_remove_stale_aiter_jit_module(
+    module_name: str,
+    error: ImportError,
+    import_started_ns: Optional[int] = None,
+) -> _StaleModuleRecovery:
+    so_path = _extract_shared_object_path(str(error))
+    if so_path is None or not _valid_stale_module_path(module_name, so_path):
+        return _StaleModuleRecovery.NOT_HANDLED
+
+    try:
+        with _aiter_build_lock(so_path):
+            # A peer may already have removed the same stale file. Treat that as
+            # a successful cleanup so every rank proceeds to AITER's build lock.
+            removed_here = False
+            if os.path.exists(so_path):
+                # A peer may have rebuilt while this import was failing. Retrying
+                # the import avoids deleting or redundantly rebuilding its result.
+                if (
+                    import_started_ns is not None
+                    and os.stat(so_path).st_mtime_ns > import_started_ns
+                ):
+                    return _StaleModuleRecovery.RETRY_IMPORT
+                os.remove(so_path)
+                removed_here = True
+            module_base = os.path.splitext(os.path.basename(so_path))[0]
+            build_dir = os.path.join(os.path.dirname(so_path), "build", module_base)
+            # Only the rank that removed the stale .so clears its build tree.
+            # Peers that arrive later must not delete an in-progress rebuild.
+            if removed_here and os.path.exists(build_dir):
+                shutil.rmtree(build_dir)
+        if removed_here:
+            _LOGGER.warning(
+                "removed stale aiter JIT module after import failure: %s", so_path
+            )
+        else:
+            _LOGGER.info(
+                "stale aiter JIT module was already removed by a peer: %s",
+                so_path,
+            )
+        return _StaleModuleRecovery.REBUILD
+    except OSError as remove_error:
+        _LOGGER.warning(
+            "failed to remove stale aiter JIT module %s: %s",
+            so_path,
+            remove_error,
+        )
+        return _StaleModuleRecovery.NOT_HANDLED
+
+
+def _make_patched_system(original_system: Callable[..., int]) -> Callable[..., int]:
+    def patched_system(command: object) -> int:
+        if not _is_aiter_codegen_command(command):
+            return original_system(command)
+        ret = _run_aiter_codegen_command(command)
+        if ret != 0:
+            raise RuntimeError(f"aiter JIT codegen failed with exit code {ret}")
+        return ret
+
+    return patched_system
+
+
+def _make_patched_import_module(
+    original_import_module: Callable[..., types.ModuleType],
+) -> Callable[..., types.ModuleType]:
+    def patched_import_module(
+        name: str, package: Optional[str] = None
+    ) -> types.ModuleType:
+        import_started_ns = time.time_ns()
+        try:
+            return original_import_module(name, package)
+        except ImportError as error:
+            recovery = _maybe_remove_stale_aiter_jit_module(
+                name, error, import_started_ns
+            )
+            if recovery is _StaleModuleRecovery.RETRY_IMPORT:
+                return original_import_module(name, package)
+            if recovery is _StaleModuleRecovery.REBUILD:
+                raise ModuleNotFoundError(
+                    f"removed stale aiter JIT module {name}; rebuild required"
+                ) from error
+            raise
+
+    return patched_import_module
+
+
+@contextmanager
+def _temporary_stdlib_hooks() -> Iterator[None]:
+    """Patch only while AITER's eager import runs, then restore in ``finally``."""
+
+    original_system = os.system
+    original_import_module = importlib.import_module
+    patched_system = _make_patched_system(original_system)
+    patched_import_module = _make_patched_import_module(original_import_module)
+    os.system = patched_system
+    importlib.import_module = patched_import_module
+    try:
+        yield
+    finally:
+        if os.system is patched_system:
+            os.system = original_system
+        else:
+            _LOGGER.warning(
+                "os.system changed during AITER bootstrap; "
+                "leaving the newer value intact"
+            )
+        if importlib.import_module is patched_import_module:
+            importlib.import_module = original_import_module
+        else:
+            _LOGGER.warning(
+                "importlib.import_module changed during AITER bootstrap; "
+                "leaving the newer value intact"
+            )
+
+
+def _get_aiter_core(aiter_module: types.ModuleType) -> types.ModuleType:
+    core = getattr(aiter_module, "core", None)
+    if core is None:
+        core = sys.modules.get("aiter.jit.core")
+    if not isinstance(core, types.ModuleType):
+        raise RuntimeError("AITER JIT core was not initialized by import aiter")
+    return core
+
+
+def _import_aiter_file_baton_module() -> None:
+    module_name = "aiter.jit.utils.file_baton"
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError as error:
+        if error.name != module_name:
+            raise
+
+
+def _bootstrap_aiter_core() -> types.ModuleType:
+    # AITER's normal top-level import invokes module_aiter_core while importing
+    # aiter.ops.enum. Preload only its JIT core in the supported AOT mode, patch
+    # both file batons, then reload with the caller's original mode. This closes
+    # the orphan-lock window before the first eager JIT build starts.
+    needs_bounded_preload = (
+        "aiter" not in sys.modules and os.environ.get(_AITER_AOT_IMPORT_ENV) != "1"
+    )
+    if not needs_bounded_preload:
+        with _temporary_stdlib_hooks():
+            aiter_module = importlib.import_module("aiter")
+            _import_aiter_file_baton_module()
+        return _get_aiter_core(aiter_module)
+
+    missing = object()
+    original_aot_import = os.environ.get(_AITER_AOT_IMPORT_ENV, missing)
+    os.environ[_AITER_AOT_IMPORT_ENV] = "1"
+    try:
+        with _temporary_stdlib_hooks():
+            aiter_module = importlib.import_module("aiter")
+            _import_aiter_file_baton_module()
+    finally:
+        if os.environ.get(_AITER_AOT_IMPORT_ENV) != "1":
+            _LOGGER.warning(
+                "%s changed during AITER bootstrap; leaving the newer value intact",
+                _AITER_AOT_IMPORT_ENV,
+            )
+        elif original_aot_import is missing:
+            os.environ.pop(_AITER_AOT_IMPORT_ENV, None)
+        else:
+            os.environ[_AITER_AOT_IMPORT_ENV] = original_aot_import
+
+    bootstrap_bindings: tuple[_FileBatonBinding, ...] = ()
+    try:
+        core = _get_aiter_core(aiter_module)
+        bootstrap_bindings = _file_baton_bindings(core)
+        _apply_file_baton_bindings(bootstrap_bindings)
+        with _temporary_stdlib_hooks():
+            reloaded_aiter = importlib.reload(aiter_module)
+        reloaded_core = _get_aiter_core(reloaded_aiter)
+        if reloaded_core is not core:
+            raise RuntimeError("AITER JIT core changed during bounded bootstrap")
+        return core
+    except BaseException:
+        if bootstrap_bindings:
+            _restore_file_baton_bindings(bootstrap_bindings, warn_on_change=False)
+        if sys.modules.get("aiter") is aiter_module:
+            sys.modules.pop("aiter", None)
+        raise
+
+
+def _file_baton_bindings(core: types.ModuleType) -> tuple[_FileBatonBinding, ...]:
+    namespaces: list[tuple[str, dict[str, object]]] = [
+        ("aiter.jit.core.FileBaton", core.__dict__)
+    ]
+    jit_compile = getattr(core, "_jit_compile", None)
+    jit_compile_globals = getattr(jit_compile, "__globals__", None)
+    if isinstance(jit_compile_globals, dict):
+        namespaces.append(
+            ("aiter.jit.utils.cpp_extension.FileBaton", jit_compile_globals)
+        )
+
+    current_core_file_baton = core.__dict__.get("FileBaton")
+    if not isinstance(current_core_file_baton, type):
+        raise RuntimeError("AITER JIT core does not expose a FileBaton class")
+    core_file_baton = getattr(
+        current_core_file_baton,
+        _FILE_BATON_ORIGINAL_ATTR,
+        current_core_file_baton,
+    )
+    if not isinstance(core_file_baton, type):
+        raise RuntimeError("AITER JIT FileBaton original binding is invalid")
+    file_baton_module_names = (
+        core_file_baton.__module__,
+        "file_baton",
+        "aiter.jit.utils.file_baton",
+    )
+    for module_name in dict.fromkeys(file_baton_module_names):
+        file_baton_module = sys.modules.get(module_name)
+        if isinstance(file_baton_module, types.ModuleType) and isinstance(
+            file_baton_module.__dict__.get("FileBaton"), type
+        ):
+            namespaces.append((f"{module_name}.FileBaton", file_baton_module.__dict__))
+
+    bindings = []
+    patched_classes: dict[type, type] = {}
+    if current_core_file_baton is not core_file_baton:
+        patched_classes[core_file_baton] = current_core_file_baton
+    seen_namespaces = set()
+    for label, namespace in namespaces:
+        namespace_key = (id(namespace), "FileBaton")
+        if namespace_key in seen_namespaces:
+            continue
+        seen_namespaces.add(namespace_key)
+        current_file_baton = namespace.get("FileBaton")
+        if not isinstance(current_file_baton, type):
+            continue
+        original_file_baton = getattr(
+            current_file_baton,
+            _FILE_BATON_ORIGINAL_ATTR,
+            current_file_baton,
+        )
+        if not isinstance(original_file_baton, type):
+            continue
+        if current_file_baton is not original_file_baton:
+            patched_classes.setdefault(original_file_baton, current_file_baton)
+        patched_file_baton = patched_classes.get(original_file_baton)
+        if patched_file_baton is None:
+            patched_file_baton = _make_bounded_file_baton(original_file_baton)
+            patched_classes[original_file_baton] = patched_file_baton
+        bindings.append(
+            _FileBatonBinding(
+                namespace=namespace,
+                name="FileBaton",
+                original=original_file_baton,
+                patched=patched_file_baton,
+                label=label,
+            )
+        )
+    return tuple(bindings)
+
+
+def _apply_file_baton_bindings(
+    bindings: tuple[_FileBatonBinding, ...],
+) -> None:
+    for binding in bindings:
+        binding.namespace[binding.name] = binding.patched
+
+
+def _restore_file_baton_bindings(
+    bindings: tuple[_FileBatonBinding, ...], *, warn_on_change: bool
+) -> None:
+    for binding in bindings:
+        if binding.namespace.get(binding.name) is binding.patched:
+            binding.namespace[binding.name] = binding.original
+        elif warn_on_change:
+            _LOGGER.warning(
+                "%s changed after installation; not overwriting it",
+                binding.label,
+            )
+
+
+def _install_core_patch(core: types.ModuleType) -> _PatchState:
+    original_os = core.os
+    original_importlib = core.importlib
+    os_proxy = _ModuleProxy(
+        original_os,
+        {"system": _make_patched_system(getattr(original_os, "system"))},
+    )
+    importlib_proxy = _ModuleProxy(
+        original_importlib,
+        {
+            "import_module": _make_patched_import_module(
+                getattr(original_importlib, "import_module")
+            )
+        },
+    )
+    file_baton_bindings = _file_baton_bindings(core)
+    core.os = os_proxy
+    core.importlib = importlib_proxy
+    _apply_file_baton_bindings(file_baton_bindings)
+    return _PatchState(
+        core=core,
+        original_os=original_os,
+        original_importlib=original_importlib,
+        os_proxy=os_proxy,
+        importlib_proxy=importlib_proxy,
+        file_baton_bindings=file_baton_bindings,
+    )
+
+
+def _uninstall_locked() -> bool:
+    global _PATCH_STATE
+    state = _PATCH_STATE
+    if state is None:
+        return False
+    if state.core.os is state.os_proxy:
+        state.core.os = state.original_os
+    else:
+        _LOGGER.warning(
+            "AITER core os binding changed after installation; not overwriting it"
+        )
+    if state.core.importlib is state.importlib_proxy:
+        state.core.importlib = state.original_importlib
+    else:
+        _LOGGER.warning(
+            "AITER core importlib binding changed after installation; "
+            "not overwriting it"
+        )
+    _restore_file_baton_bindings(state.file_baton_bindings, warn_on_change=True)
+    _PATCH_STATE = None
+    return True
+
+
+def install_aiter_jit_patch(*, enabled: Optional[bool] = None) -> bool:
+    """Initialize AITER and install process-local compatibility at its JIT boundary.
+
+    Standard-library hooks exist only during AITER's eager import and are always
+    restored. Lazy JIT calls are handled through proxies stored on
+    ``aiter.jit.core`` itself. Set ``RTP_LLM_DISABLE_AITER_JIT_PATCH=1`` (or pass
+    ``enabled=False``) to use upstream AITER behavior unchanged.
+    """
+
+    global _PATCH_STATE
+    disabled = enabled is False or (enabled is None and _env_flag_enabled(_DISABLE_ENV))
+    if disabled:
+        with _PATCH_LOCK:
+            _uninstall_locked()
+        return False
+    if enabled is not True and not _is_rocm_runtime():
+        return False
+
+    with _PATCH_LOCK:
+        if _PATCH_STATE is not None:
+            state = _PATCH_STATE
+            if (
+                state.core.os is state.os_proxy
+                and state.core.importlib is state.importlib_proxy
+                and all(
+                    binding.namespace.get(binding.name) is binding.patched
+                    for binding in state.file_baton_bindings
+                )
+            ):
+                return True
+            _uninstall_locked()
+        core = _bootstrap_aiter_core()
+        try:
+            _PATCH_STATE = _install_core_patch(core)
+        except BaseException:
+            _restore_file_baton_bindings(
+                _file_baton_bindings(core), warn_on_change=False
+            )
+            raise
+        return True
+
+
+def load_aiter() -> types.ModuleType:
+    """Load AITER through the scoped JIT compatibility boundary.
+
+    ROCm modules intentionally call this at import time, before importing any
+    AITER submodule, so AITER's first import installs the JIT compatibility
+    hooks. On non-ROCm runtimes the patch installation is a no-op.
+    """
+
+    install_aiter_jit_patch()
+    return importlib.import_module("aiter")
+
+
+def uninstall_aiter_jit_patch() -> bool:
+    """Restore AITER core bindings installed by :func:`install_aiter_jit_patch`."""
+
+    with _PATCH_LOCK:
+        return _uninstall_locked()

--- a/rtp_llm/utils/flash_attn_utils.py
+++ b/rtp_llm/utils/flash_attn_utils.py
@@ -1,8 +1,13 @@
+import importlib.util
+
 import torch
 
 
 def can_use_flash_attn(device_id=0):
     """Check if a GPU supports FlashAttention."""
+    if importlib.util.find_spec("flash_attn") is None:
+        return False
+
     major, minor = torch.cuda.get_device_capability(device_id)
     device_full_name = torch.cuda.get_device_name(device_id)
     device_name = device_full_name.split()[-1]
@@ -10,7 +15,7 @@ def can_use_flash_attn(device_id=0):
     # Check if the GPU architecture is Ampere (SM 8.x) or newer (SM 9.0)
     is_sm8x = major == 8 and minor >= 0
     is_sm90 = major == 9 and minor == 0
-    if 'MI308X' in device_name:
-       is_sm90 = major == 9 and minor >= 0
+    if "MI308X" in device_name:
+        is_sm90 = major == 9 and minor >= 0
 
     return is_sm8x or is_sm90

--- a/rtp_llm/utils/test/BUILD
+++ b/rtp_llm/utils/test/BUILD
@@ -34,6 +34,26 @@ py_test(
     ],
 )
 
+py_test(
+    name = "flash_attn_utils_test",
+    srcs = [
+        "flash_attn_utils_test.py",
+    ],
+    deps = [
+        "//rtp_llm:utils",
+    ],
+)
+
+py_test(
+    name = "aiter_jit_patch_test",
+    srcs = [
+        "aiter_jit_patch_test.py",
+    ],
+    deps = [
+        "//rtp_llm:utils",
+    ],
+)
+
 
 py_test(
     name = "util_test",

--- a/rtp_llm/utils/test/aiter_jit_patch_test.py
+++ b/rtp_llm/utils/test/aiter_jit_patch_test.py
@@ -1,0 +1,960 @@
+import importlib
+import multiprocessing
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
+
+from rtp_llm.utils import aiter_jit_patch
+
+
+def _publish_module_under_aiter_lock(
+    lock_path, so_path, published_mtime_ns, acquired_event, release_event
+):
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    try:
+        acquired_event.set()
+        if not release_event.wait(10):
+            raise RuntimeError("timed out waiting to publish test AITER module")
+        with open(so_path, "w") as file:
+            file.write("fresh")
+        os.utime(so_path, ns=(published_mtime_ns, published_mtime_ns))
+    finally:
+        os.close(lock_fd)
+        os.remove(lock_path)
+
+
+def _hold_owned_aiter_lock(so_path, acquired_event, release_event):
+    with aiter_jit_patch._aiter_build_lock(so_path):
+        acquired_event.set()
+        if not release_event.wait(10):
+            raise RuntimeError("timed out waiting to release test AITER lock")
+
+
+def _abandon_owned_aiter_lock(so_path, acquired_event):
+    with aiter_jit_patch._aiter_build_lock(so_path):
+        acquired_event.set()
+        # Simulate SIGKILL/segfault semantics: process fds are closed, but the
+        # context manager cannot unlink the file-baton path.
+        os._exit(0)
+
+
+class _FakeFileBaton:
+    def __init__(self, lock_file_path, wait_seconds=0.2):
+        self.lock_file_path = lock_file_path
+        self.wait_seconds = wait_seconds
+        self.fd = None
+
+    def try_acquire(self):
+        try:
+            self.fd = os.open(
+                self.lock_file_path,
+                os.O_CREAT | os.O_EXCL | os.O_RDWR,
+                0o644,
+            )
+            return True
+        except FileExistsError:
+            return False
+
+    def wait(self):
+        while os.path.exists(self.lock_file_path):
+            time.sleep(self.wait_seconds)
+
+    def release(self):
+        if self.fd is not None:
+            os.close(self.fd)
+        os.remove(self.lock_file_path)
+
+
+class AiterJitPatchTest(unittest.TestCase):
+    def tearDown(self):
+        aiter_jit_patch.uninstall_aiter_jit_patch()
+
+    def test_matches_only_codegen_scripts_inside_aiter_packages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            aiter_root = os.path.join(tmpdir, "site-packages", "aiter_meta")
+            os.makedirs(aiter_root)
+            aiter_script = os.path.join(aiter_root, "generate.py")
+            unrelated_script = os.path.join(tmpdir, "generate.py")
+            with mock.patch.object(
+                aiter_jit_patch,
+                "_aiter_package_roots",
+                return_value=(aiter_root,),
+            ):
+                self.assertTrue(
+                    aiter_jit_patch._is_aiter_codegen_command(
+                        f"{sys.executable} {aiter_script} --output_dir /tmp/out"
+                    )
+                )
+                self.assertFalse(
+                    aiter_jit_patch._is_aiter_codegen_command(
+                        f"{sys.executable} {unrelated_script} --output_dir /tmp/out"
+                    )
+                )
+
+    def test_rejects_compound_shell_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script = os.path.join(tmpdir, "generate.py")
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_package_roots", return_value=(tmpdir,)
+            ):
+                self.assertFalse(
+                    aiter_jit_patch._is_aiter_codegen_command(
+                        f"{sys.executable} {script} && rm -rf /tmp/unrelated"
+                    )
+                )
+
+    def test_matches_bazel_runfiles_script_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            aiter_root = os.path.join(tmpdir, "runfiles", "aiter_meta")
+            real_script = os.path.join(tmpdir, "external", "codegen.py")
+            logical_script = os.path.join(aiter_root, "hsa", "codegen.py")
+            os.makedirs(os.path.dirname(real_script))
+            os.makedirs(os.path.dirname(logical_script))
+            with open(real_script, "w"):
+                pass
+            os.symlink(real_script, logical_script)
+            with mock.patch.object(
+                aiter_jit_patch,
+                "_aiter_package_roots",
+                return_value=(aiter_root,),
+            ):
+                self.assertTrue(
+                    aiter_jit_patch._is_aiter_codegen_command(
+                        f"{sys.executable} {logical_script} --output_dir /tmp/out"
+                    )
+                )
+
+    def test_codegen_command_does_not_expand_filter_globs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = os.path.join(tmpdir, "generate.py")
+            args_path = os.path.join(tmpdir, "args.txt")
+            with open(script_path, "w") as file:
+                file.write(
+                    "import pathlib, sys\n"
+                    f"pathlib.Path({args_path!r}).write_text('\\n'.join(sys.argv[1:]))\n"
+                )
+
+            cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                open("fmha_fwd_d256_bf16_kernel.o", "w").close()
+                command = (
+                    f"{sys.executable} {script_path} "
+                    "--filter *bf16*_nlogits* --output_dir /tmp/out"
+                )
+                with mock.patch.object(
+                    aiter_jit_patch,
+                    "_aiter_package_roots",
+                    return_value=(tmpdir,),
+                ):
+                    ret = aiter_jit_patch._run_aiter_codegen_command(command)
+            finally:
+                os.chdir(cwd)
+
+            self.assertEqual(ret, 0)
+            with open(args_path) as file:
+                args = file.read().splitlines()
+            self.assertIn("*bf16*_nlogits*", args)
+            self.assertNotIn("fmha_fwd_d256_bf16_kernel.o", args)
+
+    def test_codegen_command_preserves_exit_code(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = os.path.join(tmpdir, "generate.py")
+            with open(script_path, "w") as file:
+                file.write("import sys\nsys.exit(7)\n")
+
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_package_roots", return_value=(tmpdir,)
+            ):
+                ret = aiter_jit_patch._run_aiter_codegen_command(
+                    f"{sys.executable} {script_path}"
+                )
+
+            self.assertEqual(ret, 7)
+
+    def test_non_aiter_system_call_preserves_original_contract(self):
+        original_system = mock.Mock(return_value=1792)
+        patched_system = aiter_jit_patch._make_patched_system(original_system)
+
+        self.assertEqual(patched_system("exit 7"), 1792)
+        original_system.assert_called_once_with("exit 7")
+
+    def test_remove_stale_aiter_jit_module(self):
+        error_details = (
+            "undefined symbol: fmha_batch_prefill",
+            "file too short",
+            "invalid ELF header",
+        )
+        for error_detail in error_details:
+            with self.subTest(error_detail=error_detail):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    jit_dir = os.path.join(tmpdir, "aiter", "jit")
+                    build_dir = os.path.join(jit_dir, "build", "mha_batch_prefill_bad")
+                    os.makedirs(build_dir)
+                    so_path = os.path.join(jit_dir, "mha_batch_prefill_bad.so")
+                    with open(so_path, "w"):
+                        pass
+
+                    with mock.patch.object(
+                        aiter_jit_patch,
+                        "_aiter_jit_roots",
+                        return_value=(jit_dir,),
+                    ):
+                        removed = aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                            "aiter.jit.mha_batch_prefill_bad",
+                            ImportError(f"{so_path}: {error_detail}"),
+                        )
+
+                    self.assertIs(
+                        removed,
+                        aiter_jit_patch._StaleModuleRecovery.REBUILD,
+                    )
+                    self.assertFalse(os.path.exists(so_path))
+                    self.assertFalse(os.path.exists(build_dir))
+
+    def test_stale_cleanup_rejects_path_or_module_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            outside_dir = os.path.join(tmpdir, "outside")
+            os.makedirs(jit_dir)
+            os.makedirs(outside_dir)
+            outside_so = os.path.join(outside_dir, "bad.so")
+            mismatched_so = os.path.join(jit_dir, "other.so")
+            for path in (outside_so, mismatched_so):
+                with open(path, "w"):
+                    pass
+
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_jit_roots", return_value=(jit_dir,)
+            ):
+                self.assertIs(
+                    aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                        "aiter.jit.bad",
+                        ImportError(f"{outside_so}: undefined symbol: bad"),
+                    ),
+                    aiter_jit_patch._StaleModuleRecovery.NOT_HANDLED,
+                )
+                self.assertIs(
+                    aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                        "aiter.jit.bad",
+                        ImportError(f"{mismatched_so}: undefined symbol: bad"),
+                    ),
+                    aiter_jit_patch._StaleModuleRecovery.NOT_HANDLED,
+                )
+
+            self.assertTrue(os.path.exists(outside_so))
+            self.assertTrue(os.path.exists(mismatched_so))
+
+    def test_stale_cleanup_rejects_unrelated_import_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            os.makedirs(jit_dir)
+            so_path = os.path.join(jit_dir, "bad.so")
+            with open(so_path, "w"):
+                pass
+
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_jit_roots", return_value=(jit_dir,)
+            ):
+                recovery = aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                    "aiter.jit.bad",
+                    ImportError(
+                        f"{so_path}: libmissing.so: cannot open shared object file"
+                    ),
+                )
+
+            self.assertIs(
+                recovery,
+                aiter_jit_patch._StaleModuleRecovery.NOT_HANDLED,
+            )
+            self.assertTrue(os.path.exists(so_path))
+
+    def test_concurrent_stale_cleanup_allows_every_caller_to_rebuild(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            os.makedirs(jit_dir)
+            so_path = os.path.join(jit_dir, "bad.so")
+            with open(so_path, "w"):
+                pass
+            error = ImportError(f"{so_path}: undefined symbol: bad")
+
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_jit_roots", return_value=(jit_dir,)
+            ):
+                with ThreadPoolExecutor(max_workers=4) as executor:
+                    results = list(
+                        executor.map(
+                            lambda _: (
+                                aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                                    "aiter.jit.bad", error
+                                )
+                            ),
+                            range(8),
+                        )
+                    )
+
+            self.assertEqual(
+                results,
+                [aiter_jit_patch._StaleModuleRecovery.REBUILD] * 8,
+            )
+            self.assertFalse(os.path.exists(so_path))
+
+    def test_peer_cleanup_does_not_delete_an_in_progress_build(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            build_dir = os.path.join(jit_dir, "build", "bad")
+            os.makedirs(build_dir)
+            sentinel = os.path.join(build_dir, "compiling.o")
+            with open(sentinel, "w"):
+                pass
+            so_path = os.path.join(jit_dir, "bad.so")
+
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_jit_roots", return_value=(jit_dir,)
+            ):
+                removed_by_peer = aiter_jit_patch._maybe_remove_stale_aiter_jit_module(
+                    "aiter.jit.bad",
+                    ImportError(f"{so_path}: undefined symbol: bad"),
+                )
+
+            self.assertIs(
+                removed_by_peer,
+                aiter_jit_patch._StaleModuleRecovery.REBUILD,
+            )
+            self.assertTrue(os.path.exists(sentinel))
+
+    def test_cleanup_waits_for_aiter_builder_and_retries_fresh_module(self):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            self.skipTest("AITER JIT is supported only on Linux/fork platforms")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            build_dir = os.path.join(jit_dir, "build")
+            os.makedirs(build_dir)
+            so_path = os.path.join(jit_dir, "bad.so")
+            with open(so_path, "w") as file:
+                file.write("stale")
+
+            import_started_ns = time.time_ns()
+            lock_path = os.path.join(build_dir, "lock_bad")
+            context = multiprocessing.get_context("fork")
+            acquired_event = context.Event()
+            release_event = context.Event()
+            process = context.Process(
+                target=_publish_module_under_aiter_lock,
+                args=(
+                    lock_path,
+                    so_path,
+                    import_started_ns + 1_000_000,
+                    acquired_event,
+                    release_event,
+                ),
+            )
+            process.start()
+            try:
+                self.assertTrue(acquired_event.wait(5))
+                with mock.patch.object(
+                    aiter_jit_patch,
+                    "_aiter_jit_roots",
+                    return_value=(jit_dir,),
+                ):
+                    with ThreadPoolExecutor(max_workers=1) as executor:
+                        recovery = executor.submit(
+                            aiter_jit_patch._maybe_remove_stale_aiter_jit_module,
+                            "aiter.jit.bad",
+                            ImportError(f"{so_path}: undefined symbol: bad"),
+                            import_started_ns,
+                        )
+                        time.sleep(0.1)
+                        self.assertFalse(recovery.done())
+                        release_event.set()
+                        self.assertIs(
+                            recovery.result(timeout=5),
+                            aiter_jit_patch._StaleModuleRecovery.RETRY_IMPORT,
+                        )
+            finally:
+                release_event.set()
+                process.join(5)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(5)
+
+            self.assertEqual(process.exitcode, 0)
+            with open(so_path) as file:
+                self.assertEqual(file.read(), "fresh")
+
+    def test_reclaims_old_build_lock_from_dead_local_owner(self):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            self.skipTest("AITER JIT is supported only on Linux/fork platforms")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            so_path = os.path.join(tmpdir, "bad.so")
+            lock_path = os.path.join(tmpdir, "build", "lock_bad")
+            context = multiprocessing.get_context("fork")
+            acquired_event = context.Event()
+            process = context.Process(
+                target=_abandon_owned_aiter_lock,
+                args=(so_path, acquired_event),
+            )
+            process.start()
+            try:
+                self.assertTrue(acquired_event.wait(5))
+                process.join(5)
+                if process.is_alive():
+                    self.fail("orphan-lock owner did not exit")
+            finally:
+                if process.is_alive():
+                    process.terminate()
+                    process.join(5)
+
+            self.assertEqual(process.exitcode, 0)
+            self.assertTrue(os.path.exists(lock_path))
+            old_timestamp = time.time() - 60
+            os.utime(lock_path, (old_timestamp, old_timestamp))
+
+            started = time.monotonic()
+            with aiter_jit_patch._aiter_build_lock(
+                so_path,
+                timeout_seconds=1,
+                stale_lock_seconds=0,
+                poll_seconds=0.01,
+            ):
+                self.assertTrue(os.path.exists(lock_path))
+            self.assertLess(time.monotonic() - started, 1)
+            self.assertFalse(os.path.exists(lock_path))
+
+    def test_old_build_lock_from_live_owner_times_out_without_removal(self):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            self.skipTest("AITER JIT is supported only on Linux/fork platforms")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            so_path = os.path.join(tmpdir, "bad.so")
+            lock_path = os.path.join(tmpdir, "build", "lock_bad")
+            context = multiprocessing.get_context("fork")
+            acquired_event = context.Event()
+            release_event = context.Event()
+            process = context.Process(
+                target=_hold_owned_aiter_lock,
+                args=(so_path, acquired_event, release_event),
+            )
+            process.start()
+            try:
+                self.assertTrue(acquired_event.wait(5))
+                old_timestamp = time.time() - 60
+                os.utime(lock_path, (old_timestamp, old_timestamp))
+                original_inode = os.stat(lock_path).st_ino
+
+                started = time.monotonic()
+                with self.assertRaisesRegex(
+                    aiter_jit_patch._AiterBuildLockTimeout,
+                    "owner pid=.* is alive",
+                ):
+                    with aiter_jit_patch._aiter_build_lock(
+                        so_path,
+                        timeout_seconds=0.15,
+                        stale_lock_seconds=0,
+                        poll_seconds=0.01,
+                    ):
+                        self.fail("contender unexpectedly acquired a live peer lock")
+                self.assertLess(time.monotonic() - started, 1)
+                self.assertEqual(os.stat(lock_path).st_ino, original_inode)
+            finally:
+                release_event.set()
+                process.join(5)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(5)
+
+            self.assertEqual(process.exitcode, 0)
+            self.assertFalse(os.path.exists(lock_path))
+
+    def test_legacy_orphan_lock_fails_fast_and_propagates_from_import(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jit_dir = os.path.join(tmpdir, "aiter", "jit")
+            build_root = os.path.join(jit_dir, "build")
+            os.makedirs(build_root)
+            so_path = os.path.join(jit_dir, "bad.so")
+            lock_path = os.path.join(build_root, "lock_bad")
+            with open(so_path, "w"):
+                pass
+            with open(lock_path, "w"):
+                pass
+            old_timestamp = time.time() - 60
+            os.utime(lock_path, (old_timestamp, old_timestamp))
+            original_inode = os.stat(lock_path).st_ino
+
+            original_import = mock.Mock(
+                side_effect=ImportError(f"{so_path}: undefined symbol: bad")
+            )
+            patched_import = aiter_jit_patch._make_patched_import_module(
+                original_import
+            )
+            started = time.monotonic()
+            with mock.patch.object(
+                aiter_jit_patch, "_aiter_jit_roots", return_value=(jit_dir,)
+            ), mock.patch.multiple(
+                aiter_jit_patch,
+                _AITER_BUILD_LOCK_TIMEOUT_SECONDS=0.15,
+                _AITER_BUILD_LOCK_STALE_SECONDS=0,
+                _AITER_BUILD_LOCK_POLL_SECONDS=0.01,
+            ):
+                with self.assertRaisesRegex(
+                    aiter_jit_patch._AiterBuildLockTimeout,
+                    "owner is unknown.*preserved",
+                ):
+                    patched_import("aiter.jit.bad")
+
+            self.assertLess(time.monotonic() - started, 1)
+            self.assertEqual(original_import.call_count, 1)
+            self.assertEqual(os.stat(lock_path).st_ino, original_inode)
+            self.assertTrue(os.path.exists(so_path))
+
+    def test_lock_release_preserves_replacement_owner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            so_path = os.path.join(tmpdir, "bad.so")
+            lock_path = os.path.join(tmpdir, "build", "lock_bad")
+            with aiter_jit_patch._aiter_build_lock(so_path):
+                owned_inode = os.stat(lock_path).st_ino
+                os.remove(lock_path)
+                with open(lock_path, "w") as file:
+                    file.write("peer")
+                self.assertNotEqual(os.stat(lock_path).st_ino, owned_inode)
+
+            self.assertTrue(os.path.exists(lock_path))
+            with open(lock_path) as file:
+                self.assertEqual(file.read(), "peer")
+
+    def test_repeated_lock_owner_changes_still_respect_deadline(self):
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.object(
+            aiter_jit_patch, "_try_create_owned_build_lock", return_value=None
+        ), mock.patch.object(
+            aiter_jit_patch,
+            "_try_reclaim_stale_build_lock",
+            return_value="lock owner changed while checking staleness",
+        ):
+            started = time.monotonic()
+            with self.assertRaisesRegex(
+                aiter_jit_patch._AiterBuildLockTimeout,
+                "lock owner changed.*preserved",
+            ):
+                with aiter_jit_patch._aiter_build_lock(
+                    os.path.join(tmpdir, "bad.so"),
+                    timeout_seconds=0.05,
+                    stale_lock_seconds=0,
+                    poll_seconds=0.01,
+                ):
+                    self.fail("lock churn unexpectedly bypassed the deadline")
+            self.assertLess(time.monotonic() - started, 1)
+
+    def test_import_wrapper_retries_after_peer_rebuild(self):
+        module = types.ModuleType("aiter.jit.bad")
+        original_import = mock.Mock(
+            side_effect=[
+                ImportError("/tmp/bad.so: undefined symbol: bad"),
+                module,
+            ]
+        )
+        patched_import = aiter_jit_patch._make_patched_import_module(original_import)
+        with mock.patch.object(
+            aiter_jit_patch,
+            "_maybe_remove_stale_aiter_jit_module",
+            return_value=aiter_jit_patch._StaleModuleRecovery.RETRY_IMPORT,
+        ):
+            self.assertIs(patched_import("aiter.jit.bad"), module)
+        self.assertEqual(original_import.call_count, 2)
+
+    def test_temporary_hooks_restore_stdlib_on_success_and_exception(self):
+        original_system = os.system
+        original_import_module = importlib.import_module
+
+        with aiter_jit_patch._temporary_stdlib_hooks():
+            self.assertIsNot(os.system, original_system)
+            self.assertIsNot(importlib.import_module, original_import_module)
+        self.assertIs(os.system, original_system)
+        self.assertIs(importlib.import_module, original_import_module)
+
+    def test_temporary_hooks_do_not_overwrite_newer_stdlib_bindings(self):
+        original_system = os.system
+        original_import_module = importlib.import_module
+        newer_system = mock.Mock(return_value=0)
+        newer_import_module = mock.Mock()
+        try:
+            with aiter_jit_patch._temporary_stdlib_hooks():
+                os.system = newer_system
+                importlib.import_module = newer_import_module
+            self.assertIs(os.system, newer_system)
+            self.assertIs(importlib.import_module, newer_import_module)
+        finally:
+            os.system = original_system
+            importlib.import_module = original_import_module
+
+    def test_install_restores_stdlib_when_aiter_bootstrap_fails(self):
+        original_system = os.system
+        original_import_module = importlib.import_module
+
+        def fail_aiter_import(name, package=None):
+            if name == "aiter":
+                raise RuntimeError("aiter bootstrap failed")
+            return original_import_module(name, package)
+
+        with mock.patch.object(
+            importlib, "import_module", side_effect=fail_aiter_import
+        ) as bootstrap_import:
+            with self.assertRaisesRegex(RuntimeError, "aiter bootstrap failed"):
+                aiter_jit_patch.install_aiter_jit_patch(enabled=True)
+            self.assertIs(os.system, original_system)
+            self.assertIs(importlib.import_module, bootstrap_import)
+
+        with self.assertRaisesRegex(RuntimeError, "bootstrap failed"):
+            with aiter_jit_patch._temporary_stdlib_hooks():
+                raise RuntimeError("bootstrap failed")
+        self.assertIs(os.system, original_system)
+        self.assertIs(importlib.import_module, original_import_module)
+
+    def test_install_is_local_idempotent_and_reversible(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        original_system = os.system
+        original_import_module = importlib.import_module
+
+        with mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ) as bootstrap:
+            self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+            installed_os = core.os
+            installed_importlib = core.importlib
+            installed_file_baton = core.FileBaton
+            self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+
+        bootstrap.assert_called_once_with()
+        self.assertIs(core.os, installed_os)
+        self.assertIs(core.importlib, installed_importlib)
+        self.assertIs(core.FileBaton, installed_file_baton)
+        self.assertIsNot(core.FileBaton, _FakeFileBaton)
+        self.assertIs(os.system, original_system)
+        self.assertIs(importlib.import_module, original_import_module)
+
+        self.assertTrue(aiter_jit_patch.uninstall_aiter_jit_patch())
+        self.assertIs(core.os, os)
+        self.assertIs(core.importlib, importlib)
+        self.assertIs(core.FileBaton, _FakeFileBaton)
+        self.assertFalse(aiter_jit_patch.uninstall_aiter_jit_patch())
+
+    def test_bootstrap_file_baton_times_out_before_first_eager_jit(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        jit_compile_globals = {"FileBaton": _FakeFileBaton}
+        core._jit_compile = types.FunctionType(
+            (lambda: None).__code__, jit_compile_globals, "_jit_compile"
+        )
+        aiter_module = types.ModuleType("aiter")
+        aiter_module.core = core
+        qualified_file_baton = types.ModuleType("aiter.jit.utils.file_baton")
+        qualified_file_baton.FileBaton = _FakeFileBaton
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, "build", "lock_module_aiter_core")
+            os.makedirs(os.path.dirname(lock_path))
+            with open(lock_path, "w"):
+                pass
+            original_inode = os.stat(lock_path).st_ino
+
+            def fake_import(name, package=None):
+                if name == "aiter":
+                    self.assertEqual(
+                        os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "1"
+                    )
+                    sys.modules["aiter"] = aiter_module
+                    return aiter_module
+                if name == "aiter.jit.utils.file_baton":
+                    return qualified_file_baton
+                self.fail(f"unexpected bootstrap import: {name}")
+
+            def fake_reload(module):
+                self.assertIs(module, aiter_module)
+                self.assertEqual(os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "0")
+                self.assertIsNot(core.FileBaton, _FakeFileBaton)
+                self.assertIs(core.FileBaton, jit_compile_globals["FileBaton"])
+                self.assertIs(core.FileBaton, qualified_file_baton.FileBaton)
+                baton = core.FileBaton(lock_path, wait_seconds=0.01)
+                self.assertFalse(baton.try_acquire())
+                baton.wait()
+                self.fail("orphaned bootstrap baton unexpectedly became available")
+
+            with mock.patch.dict(sys.modules, {}, clear=False):
+                sys.modules.pop("aiter", None)
+                sys.modules["aiter.jit.utils.file_baton"] = qualified_file_baton
+                with mock.patch.dict(
+                    os.environ,
+                    {aiter_jit_patch._AITER_AOT_IMPORT_ENV: "0"},
+                    clear=False,
+                ), mock.patch.object(
+                    importlib, "import_module", side_effect=fake_import
+                ), mock.patch.object(
+                    importlib, "reload", side_effect=fake_reload
+                ) as reload_aiter, mock.patch.multiple(
+                    aiter_jit_patch,
+                    _AITER_BUILD_LOCK_TIMEOUT_SECONDS=0.05,
+                    _AITER_BUILD_LOCK_STALE_SECONDS=0,
+                ):
+                    started = time.monotonic()
+                    with self.assertRaisesRegex(
+                        aiter_jit_patch._AiterBuildLockTimeout,
+                        "owner is unknown.*preserved",
+                    ):
+                        aiter_jit_patch._bootstrap_aiter_core()
+                    self.assertEqual(
+                        os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "0"
+                    )
+                reload_aiter.assert_called_once_with(aiter_module)
+
+            self.assertLess(time.monotonic() - started, 1)
+            self.assertEqual(os.stat(lock_path).st_ino, original_inode)
+            self.assertIs(core.FileBaton, _FakeFileBaton)
+            self.assertIs(jit_compile_globals["FileBaton"], _FakeFileBaton)
+            self.assertIs(qualified_file_baton.FileBaton, _FakeFileBaton)
+
+    def test_install_adopts_bootstrap_file_batons_and_restores_them(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        jit_compile_globals = {"FileBaton": _FakeFileBaton}
+        core._jit_compile = types.FunctionType(
+            (lambda: None).__code__, jit_compile_globals, "_jit_compile"
+        )
+        aiter_module = types.ModuleType("aiter")
+        aiter_module.core = core
+        qualified_file_baton = types.ModuleType("aiter.jit.utils.file_baton")
+        qualified_file_baton.FileBaton = _FakeFileBaton
+
+        def fake_import(name, package=None):
+            if name == "aiter":
+                self.assertEqual(os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "1")
+                sys.modules["aiter"] = aiter_module
+                return aiter_module
+            if name == "aiter.jit.utils.file_baton":
+                return qualified_file_baton
+            self.fail(f"unexpected bootstrap import: {name}")
+
+        def fake_reload(module):
+            self.assertIs(module, aiter_module)
+            self.assertEqual(os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "0")
+            self.assertIs(core.FileBaton, jit_compile_globals["FileBaton"])
+            self.assertIs(core.FileBaton, qualified_file_baton.FileBaton)
+            return module
+
+        with mock.patch.dict(sys.modules, {}, clear=False):
+            sys.modules.pop("aiter", None)
+            sys.modules["aiter.jit.utils.file_baton"] = qualified_file_baton
+            with mock.patch.dict(
+                os.environ,
+                {aiter_jit_patch._AITER_AOT_IMPORT_ENV: "0"},
+                clear=False,
+            ), mock.patch.object(
+                importlib, "import_module", side_effect=fake_import
+            ), mock.patch.object(
+                importlib, "reload", side_effect=fake_reload
+            ) as reload_aiter:
+                self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+                installed_file_baton = core.FileBaton
+                self.assertIsNot(installed_file_baton, _FakeFileBaton)
+                self.assertIs(
+                    installed_file_baton,
+                    jit_compile_globals["FileBaton"],
+                )
+                self.assertIs(
+                    installed_file_baton,
+                    qualified_file_baton.FileBaton,
+                )
+                self.assertEqual(os.environ[aiter_jit_patch._AITER_AOT_IMPORT_ENV], "0")
+                self.assertTrue(aiter_jit_patch.uninstall_aiter_jit_patch())
+
+            reload_aiter.assert_called_once_with(aiter_module)
+            self.assertIs(core.FileBaton, _FakeFileBaton)
+            self.assertIs(jit_compile_globals["FileBaton"], _FakeFileBaton)
+            self.assertIs(qualified_file_baton.FileBaton, _FakeFileBaton)
+
+    def test_installed_file_baton_times_out_on_legacy_orphan_without_module(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_path = os.path.join(tmpdir, "build", "lock_bad")
+            os.makedirs(os.path.dirname(lock_path))
+            with open(lock_path, "w"):
+                pass
+            old_timestamp = time.time() - 60
+            os.utime(lock_path, (old_timestamp, old_timestamp))
+            original_inode = os.stat(lock_path).st_ino
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "bad.so")))
+
+            with mock.patch.object(
+                aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+            ), mock.patch.multiple(
+                aiter_jit_patch,
+                _AITER_BUILD_LOCK_TIMEOUT_SECONDS=0.05,
+                _AITER_BUILD_LOCK_STALE_SECONDS=0,
+            ):
+                self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+                baton = core.FileBaton(lock_path, wait_seconds=0.01)
+                self.assertFalse(baton.try_acquire())
+                started = time.monotonic()
+                with self.assertRaisesRegex(
+                    aiter_jit_patch._AiterBuildLockTimeout,
+                    "owner is unknown.*preserved",
+                ):
+                    baton.wait()
+
+            self.assertLess(time.monotonic() - started, 1)
+            self.assertEqual(os.stat(lock_path).st_ino, original_inode)
+
+    def test_installed_file_baton_records_owner_and_releases(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+
+        with tempfile.TemporaryDirectory() as tmpdir, mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ):
+            self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+            lock_path = os.path.join(tmpdir, "lock")
+            baton = core.FileBaton(lock_path)
+            self.assertTrue(baton.try_acquire())
+            with open(lock_path, "rb") as file:
+                owner = aiter_jit_patch._parse_build_lock_owner(file.read())
+            self.assertIsNotNone(owner)
+            self.assertEqual(owner.pid, os.getpid())
+            baton.release()
+            self.assertFalse(os.path.exists(lock_path))
+
+    def test_install_patches_jit_compile_file_baton_binding(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        jit_compile_globals = {"FileBaton": _FakeFileBaton}
+        core._jit_compile = types.FunctionType(
+            (lambda: None).__code__, jit_compile_globals, "_jit_compile"
+        )
+        qualified_file_baton = types.ModuleType("aiter.jit.utils.file_baton")
+        qualified_file_baton.FileBaton = _FakeFileBaton
+
+        with mock.patch.dict(
+            sys.modules,
+            {"aiter.jit.utils.file_baton": qualified_file_baton},
+        ), mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ):
+            self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+            self.assertIs(core.FileBaton, jit_compile_globals["FileBaton"])
+            self.assertIs(core.FileBaton, qualified_file_baton.FileBaton)
+            self.assertIsNot(core.FileBaton, _FakeFileBaton)
+            self.assertTrue(aiter_jit_patch.uninstall_aiter_jit_patch())
+            self.assertIs(core.FileBaton, _FakeFileBaton)
+            self.assertIs(jit_compile_globals["FileBaton"], _FakeFileBaton)
+            self.assertIs(qualified_file_baton.FileBaton, _FakeFileBaton)
+
+    def test_install_can_be_disabled(self):
+        with mock.patch.object(aiter_jit_patch, "_bootstrap_aiter_core") as bootstrap:
+            self.assertFalse(aiter_jit_patch.install_aiter_jit_patch(enabled=False))
+            with mock.patch.dict(
+                os.environ,
+                {"RTP_LLM_DISABLE_AITER_JIT_PATCH": "1"},
+                clear=False,
+            ):
+                self.assertFalse(aiter_jit_patch.install_aiter_jit_patch())
+        bootstrap.assert_not_called()
+
+    def test_disabling_an_installed_patch_restores_aiter_core(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        with mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ):
+            self.assertTrue(aiter_jit_patch.install_aiter_jit_patch(enabled=True))
+
+        self.assertIsNot(core.os, os)
+        self.assertFalse(aiter_jit_patch.install_aiter_jit_patch(enabled=False))
+        self.assertIs(core.os, os)
+        self.assertIs(core.importlib, importlib)
+        self.assertIs(core.FileBaton, _FakeFileBaton)
+
+    def test_concurrent_install_bootstraps_once(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        with mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ) as bootstrap:
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                results = list(
+                    executor.map(
+                        lambda _: aiter_jit_patch.install_aiter_jit_patch(enabled=True),
+                        range(32),
+                    )
+                )
+
+        self.assertEqual(results, [True] * 32)
+        bootstrap.assert_called_once_with()
+
+    def test_uninstall_does_not_overwrite_a_newer_core_binding(self):
+        core = types.ModuleType("aiter.jit.core")
+        core.os = os
+        core.importlib = importlib
+        core.FileBaton = _FakeFileBaton
+        with mock.patch.object(
+            aiter_jit_patch, "_bootstrap_aiter_core", return_value=core
+        ):
+            aiter_jit_patch.install_aiter_jit_patch(enabled=True)
+
+        newer_os_binding = object()
+        newer_file_baton = type("NewerFileBaton", (), {})
+        core.os = newer_os_binding
+        core.FileBaton = newer_file_baton
+        self.assertTrue(aiter_jit_patch.uninstall_aiter_jit_patch())
+        self.assertIs(core.os, newer_os_binding)
+        self.assertIs(core.importlib, importlib)
+        self.assertIs(core.FileBaton, newer_file_baton)
+
+    def test_import_rtp_llm_does_not_change_stdlib_bindings(self):
+        # Run in a fresh interpreter: this test must record identities before
+        # the package's first import or the old permanent hook would look clean.
+        script = f"""
+import sys
+sys.path[:0] = {sys.path!r}
+import importlib
+import os
+original_system = os.system
+original_import_module = importlib.import_module
+import rtp_llm
+assert os.system is original_system
+assert importlib.import_module is original_import_module
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/test/flash_attn_utils_test.py
+++ b/rtp_llm/utils/test/flash_attn_utils_test.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest import mock
+
+from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+
+
+class FlashAttnUtilsTest(unittest.TestCase):
+    @mock.patch("importlib.util.find_spec", return_value=None)
+    @mock.patch("torch.cuda.get_device_name", return_value="AMD Instinct MI308X")
+    @mock.patch("torch.cuda.get_device_capability", return_value=(9, 0))
+    def test_returns_false_when_flash_attn_package_is_missing(
+        self, mock_capability, mock_name, mock_find_spec
+    ):
+        self.assertFalse(can_use_flash_attn())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds ROCm support and validation coverage for Qwen3.5/Qwen3-VL on MI308.

  Main changes:

  - Support MRoPE position ids on ROCm, including ROCm fused RoPE KV cache path, Qwen3-Next/Qwen3-VL model config propagation, and CUDA Graph replay handling for combo_position_ids.

  - Harden ROCm Qwen3.5 runtime integration, including AITER JIT patching, flash-attn ROCm handling, AITER prefill test coverage, and Qwen VL checkpoint prefix compatibility.