### PR TITLE
fix: clear stale MTP target verify graph inputs [DO NOT MERGE]

### DIFF
--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -129,6 +129,12 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
     // Common device copy
     int token_num = is_prefill_cuda_graph_mode_ ? state.current_seq_len : inputs.input_ids.size(0);
 
+    // Refresh the dynamic half of the graph layout contract. Capture capacity
+    // and graph batch size remain immutable in the graph instance.
+    auto& graph_meta             = py_model_inputs_.attention_inputs.cuda_graph_metadata;
+    graph_meta.active_batch_size = state.current_batch_size;
+    graph_meta.actual_token_num  = is_target_verify_ ? state.seq_len_sum : token_num;
+
     tryAddD2DCopy(inputs.input_ids, py_model_inputs_.input_ids, token_num * sizeof(int));
     tryAddD2DCopy(inputs.input_hiddens,
                   py_model_inputs_.input_hiddens,
@@ -244,6 +250,9 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
                            state.current_batch_size * sizeof(int));
         if (state.current_batch_size < max_bs_) {
             py_model_inputs_.attention_inputs.sequence_lengths.slice(0, state.current_batch_size, max_bs_).fill_(0);
+            py_model_inputs_.attention_inputs.sequence_lengths_plus_1_device
+                .slice(0, state.current_batch_size, max_bs_)
+                .fill_(0);
         }
     } else {
         optimizedCopyAsync(inputs.attention_inputs.padding_offset,
@@ -265,14 +274,20 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
         }
     }
 
-    // Reset unused batch portions to prevent stale data (prefill only)
-    if (is_prefill_cuda_graph_mode_) {
+    // Reset unused batch portions to prevent stale data when a smaller batch reuses a larger graph.
+    if (is_prefill_cuda_graph_mode_ || is_target_verify_) {
         if (state.current_batch_size < max_bs_) {
             py_model_inputs_.attention_inputs.prefix_lengths.slice(0, state.current_batch_size, max_bs_).fill_(0);
+            py_model_inputs_.attention_inputs.prefix_lengths_device
+                .slice(0, state.current_batch_size, max_bs_)
+                .fill_(0);
             py_model_inputs_.attention_inputs.input_lengths.slice(0, state.current_batch_size, max_bs_).fill_(0);
+            py_model_inputs_.attention_inputs.input_lengths_device
+                .slice(0, state.current_batch_size, max_bs_)
+                .fill_(0);
         }
 
-        int last_valid_q = state.current_seq_len;
+        int last_valid_q = is_target_verify_ ? state.seq_len_sum : state.current_seq_len;
         int last_valid_kv =
             last_valid_q
             + inputs.attention_inputs.prefix_lengths.slice(0, 0, state.current_batch_size).sum().item<int>();
@@ -739,6 +754,14 @@ void CudaGraphRunner::prepareCaptureInputs(PyModelInputs& inputs, int batch_size
     // Common slice operations for input_ids and padding_offset
     inputs.attention_inputs.is_prefill       = is_prefill_cuda_graph_mode_ || num_tokens_per_bs_ > 1;
     inputs.attention_inputs.is_target_verify = is_target_verify_;
+    auto& graph_meta                               = inputs.attention_inputs.cuda_graph_metadata;
+    graph_meta.requires_full_token_metadata        = is_target_verify_;
+    graph_meta.graph_batch_size                    = batch_size;
+    graph_meta.active_batch_size                   = batch_size;
+    graph_meta.tokens_per_batch                    = num_tokens_per_bs_;
+    graph_meta.actual_token_num                    = seq_len_or_tokens;
+    graph_meta.token_capacity                      = seq_len_or_tokens;
+    graph_meta.dummy_kv_block_id                   = 0;
     inputs.input_ids     = capture_mem_hold_.py_model_inputs_.input_ids.slice(0, 0, seq_len_or_tokens);
     inputs.input_hiddens = capture_mem_hold_.py_model_inputs_.input_hiddens.slice(0, 0, seq_len_or_tokens);
     inputs.attention_inputs.input_lengths =

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_utils.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_utils.h
@@ -54,6 +54,7 @@ public:
         py_model_inputs_.attention_inputs.padding_offset          = inputs.attention_inputs.padding_offset;
         py_model_inputs_.attention_inputs.is_prefill              = inputs.attention_inputs.is_prefill;
         py_model_inputs_.attention_inputs.is_target_verify        = inputs.attention_inputs.is_target_verify;
+        py_model_inputs_.attention_inputs.cuda_graph_metadata     = inputs.attention_inputs.cuda_graph_metadata;
         py_model_inputs_.attention_inputs.dtype                   = inputs.attention_inputs.dtype;
         py_model_inputs_.attention_inputs.context_total_kv_length = inputs.attention_inputs.context_total_kv_length;
 

--- a/rtp_llm/cpp/cuda_graph/tests/BUILD
+++ b/rtp_llm/cpp/cuda_graph/tests/BUILD
@@ -59,6 +59,30 @@ py_test(
 )
 
 py_test(
+    name = "cuda_graph_target_verify_padding",
+    srcs = [
+        "cuda_graph_target_verify_padding.py",
+    ],
+    data = [
+        ":test_cuda_graph_runner",
+        "//:th_transformer",
+    ],
+    deps = [
+        ":cuda_graph_test_utils",
+        "//rtp_llm/test/model_test/test_util:test_util",
+    ],
+    env = {
+        "LOAD_METHOD": "scratch",
+        "NOT_USE_DEFAULT_STREAM": "1",
+        "TEST_USING_DEVICE": "CUDA",
+        "HACK_LAYER_NUM": "1",
+        "ENABLE_CUDA_GRAPH_DEBUG_MODE": "1",
+    },
+    tags = ["H20"],
+    exec_properties = {"gpu": "H20"},
+)
+
+py_test(
     name = "cuda_graph_prefill",
     srcs = [
         "cuda_graph_prefill.py",

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_target_verify_padding.py
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_target_verify_padding.py
@@ -1,0 +1,224 @@
+import logging
+import os
+import unittest
+
+import torch
+
+import rtp_llm.models
+from rtp_llm.cpp.cuda_graph.tests.cuda_graph_test_utils import (
+    CudaGraphTestModelBuilder,
+    ModelBuildConfig,
+)
+from rtp_llm.cpp.cuda_graph.tests.libtest_cuda_graph_runner import CudaGraphRunner
+from rtp_llm.ops.compute_ops import PyAttentionInputs, PyModelInputs, get_typemeta
+
+
+class ScratchCudaGraphTestModelBuilder(CudaGraphTestModelBuilder):
+    """Keep this test's loader choice local instead of changing the shared builder."""
+
+    def _set_configs(self) -> None:
+        super()._set_configs()
+        assert self.py_env_configs is not None
+        self.py_env_configs.load_config.load_method = "scratch"
+
+
+class TestCudaGraphTargetVerifyPadding(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["RESERVER_RUNTIME_MEM_MB"] = "10240"
+        self.device = "cuda:0"
+        self.max_seq_len = 64
+        self.tokens_per_block = 64
+        self.num_tokens_per_bs = 2
+        self.decode_capture_batch_sizes = [1, 8]
+
+        self.model_builder = ScratchCudaGraphTestModelBuilder(
+            ModelBuildConfig(
+                model_path="/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+                max_seq_len=self.max_seq_len,
+                tokens_per_block=self.tokens_per_block,
+                device=self.device,
+            )
+        )
+
+        graph_build = self.model_builder.build_model(init_kv_cache=True)
+        self.graph_model = graph_build.model
+        self.graph_cache = graph_build.kv_cache
+        self.compute_dtype = graph_build.compute_dtype
+        self.hidden_size = graph_build.hidden_size
+        self.kernel_tokens_per_block = int(
+            graph_build.model_config.attn_config.kernel_tokens_per_block
+        )
+
+        self.graph_runner = CudaGraphRunner()
+        self.graph_runner.init_target_verify(
+            self.graph_model,
+            self.hidden_size,
+            self.max_seq_len,
+            self.tokens_per_block,
+            self.kernel_tokens_per_block,
+            self.num_tokens_per_bs,
+            self.decode_capture_batch_sizes,
+        )
+
+        reference_build = self.model_builder.build_model(init_kv_cache=True)
+        self.reference_model = reference_build.model
+        self.reference_cache = reference_build.kv_cache
+
+        # Graph capture and its warmups can touch the dummy cache block. Start
+        # the non-Graph reference from exactly the same post-capture cache state
+        # so the full cache comparison below detects replay-only pollution.
+        self._copy_cache(self.graph_cache, self.reference_cache)
+
+    @staticmethod
+    def _copy_cache(source, destination) -> None:
+        torch.cuda.synchronize()
+        for source_tensor, destination_tensor in zip(
+            source.kv_cache_base_by_layer, destination.kv_cache_base_by_layer
+        ):
+            destination_tensor.copy_(source_tensor)
+        for source_tensor, destination_tensor in zip(
+            source.kv_scale_base_by_layer, destination.kv_scale_base_by_layer
+        ):
+            destination_tensor.copy_(source_tensor)
+        torch.cuda.synchronize()
+
+    def _build_inputs(self, batch_size: int) -> PyModelInputs:
+        token_count = batch_size * self.num_tokens_per_bs
+        inputs = PyModelInputs()
+        attention_inputs = PyAttentionInputs()
+
+        inputs.input_ids = (
+            torch.arange(token_count, dtype=torch.int32, device=self.device) % 32
+        ) + 1
+        inputs.input_hiddens = torch.zeros(
+            (token_count, self.hidden_size),
+            dtype=self.compute_dtype,
+            device=self.device,
+        )
+
+        input_lengths = torch.full(
+            (batch_size,), self.num_tokens_per_bs, dtype=torch.int32
+        ).pin_memory()
+        # input_lengths_device and prefix_lengths_device are intentionally
+        # read-only in the Python binding. Match the values used to initialize
+        # the capture buffers so active rows already contain the right device
+        # metadata; prepareInputs still has to clear rows [batch_size, 8).
+        prefix_lengths = torch.full(
+            (batch_size,),
+            self.max_seq_len - self.num_tokens_per_bs,
+            dtype=torch.int32,
+        ).pin_memory()
+        sequence_lengths = torch.empty(0, dtype=torch.int32).pin_memory()
+
+        cu_seqlens = torch.zeros(batch_size + 1, dtype=torch.int32).pin_memory()
+        cu_seqlens[1:] = input_lengths.cumsum(0)
+        cu_kv_seqlens = torch.zeros(
+            batch_size + 1, dtype=torch.int32
+        ).pin_memory()
+        cu_kv_seqlens[1:] = (input_lengths + prefix_lengths).cumsum(0)
+        decode_cu_seqlens = torch.arange(
+            batch_size + 1, dtype=torch.int32
+        ).pin_memory()
+
+        sp_steps = self.num_tokens_per_bs - 1
+        physical_blocks = (
+            (self.max_seq_len + self.tokens_per_block - 1)
+            // self.tokens_per_block
+        ) + sp_steps
+        kernel_blocks = (
+            physical_blocks
+            * self.tokens_per_block
+            // self.kernel_tokens_per_block
+        )
+        block_ids = torch.arange(
+            1, batch_size * kernel_blocks + 1, dtype=torch.int32
+        ).reshape(batch_size, kernel_blocks)
+        block_ids = block_ids.pin_memory()
+        block_ids_device = block_ids.to(self.device, non_blocking=True)
+
+        attention_inputs.is_prefill = True
+        attention_inputs.is_target_verify = True
+        attention_inputs.is_s_padded = True
+        attention_inputs.dtype = get_typemeta(
+            torch.zeros(1, dtype=self.compute_dtype)
+        )
+        attention_inputs.input_lengths = input_lengths
+        attention_inputs.prefix_lengths = prefix_lengths
+        attention_inputs.sequence_lengths = sequence_lengths
+        attention_inputs.sequence_lengths_plus_1_device = (
+            prefix_lengths + 1
+        ).to(self.device, non_blocking=True)
+        attention_inputs.cu_seqlens = cu_seqlens
+        attention_inputs.cu_seqlens_device = cu_seqlens.to(
+            self.device, non_blocking=True
+        )
+        attention_inputs.cu_kv_seqlens_device = cu_kv_seqlens.to(
+            self.device, non_blocking=True
+        )
+        attention_inputs.decode_cu_seqlens = decode_cu_seqlens
+        attention_inputs.decode_cu_seqlens_device = decode_cu_seqlens.to(
+            self.device, non_blocking=True
+        )
+        attention_inputs.kv_cache_kernel_block_id = block_ids
+        attention_inputs.kv_cache_kernel_block_id_device = block_ids_device
+        attention_inputs.kv_cache_block_id = block_ids
+        attention_inputs.kv_cache_block_id_device = block_ids_device
+        attention_inputs.padding_offset = torch.zeros(
+            token_count, dtype=torch.int32, device=self.device
+        )
+        attention_inputs.context_total_kv_length = int(cu_kv_seqlens[-1].item())
+        attention_inputs.total_tokens = token_count
+
+        inputs.attention_inputs = attention_inputs
+        return inputs
+
+    def _assert_cache_matches_reference(self) -> None:
+        for layer_id, (graph_tensor, reference_tensor) in enumerate(
+            zip(
+                self.graph_cache.kv_cache_base_by_layer,
+                self.reference_cache.kv_cache_base_by_layer,
+            )
+        ):
+            # BlockPool reserves physical block 0 for internal/dummy use. A padded
+            # graph replay may write its fixed-launch tail there; every allocatable
+            # cache block must still match the non-Graph reference exactly.
+            torch.testing.assert_close(
+                graph_tensor[1:],
+                reference_tensor[1:],
+                rtol=1e-2,
+                atol=1e-2,
+                msg=lambda msg: f"KV cache mismatch at layer {layer_id}: {msg}",
+            )
+
+    def _run_and_compare(self, batch_size: int, expected_graph_size: int) -> None:
+        graph_inputs = self._build_inputs(batch_size)
+        reference_inputs = self._build_inputs(batch_size)
+
+        self.assertTrue(self.graph_runner.canRun(graph_inputs))
+        graph_outputs = self.graph_runner.forward(graph_inputs)
+        torch.cuda.synchronize()
+        reference_outputs = self.reference_model.forward(reference_inputs)
+        torch.cuda.synchronize()
+
+        self.assertEqual(
+            self.graph_runner.getCurrentRealGraphSize(), expected_graph_size
+        )
+        torch.testing.assert_close(
+            graph_outputs.hidden_states,
+            reference_outputs.hidden_states.to(graph_outputs.hidden_states.dtype),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        self._assert_cache_matches_reference()
+
+    def test_smaller_target_verify_batch_reuses_larger_graph(self) -> None:
+        # Populate every row of the batch-8 graph, then replay batch 3 through
+        # the same graph key. The second replay exercises all target-verify
+        # metadata tails and the seq_len_sum cumulative-length boundary.
+        self._run_and_compare(batch_size=8, expected_graph_size=8)
+        self._run_and_compare(batch_size=3, expected_graph_size=8)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/cuda_graph_test_runner.cc
@@ -1,6 +1,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <stdexcept>
+
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_base.h"
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_runner.h"
 #include "rtp_llm/models_py/bindings/OpDefs.h"
@@ -63,6 +65,37 @@ public:
         runner_ = CudaGraphRunner::createForDecode(std::move(py_instance), std::move(params));
     }
 
+    void init_target_verify(py::object       py_instance,
+                            int64_t          hidden_size,
+                            int64_t          max_seq_len,
+                            int64_t          tokens_per_block,
+                            int64_t          kernel_tokens_per_block,
+                            int64_t          num_tokens_per_bs,
+                            std::vector<int> decode_capture_batch_sizes) {
+        if (num_tokens_per_bs <= 1) {
+            throw std::invalid_argument("target verify requires num_tokens_per_bs > 1");
+        }
+
+        reset_runner();
+        GraphParams params;
+        params.enable_cuda_graph_debug_mode = false;
+        params.is_prefill_cuda_graph_mode   = false;
+        params.is_target_verify             = true;
+        params.max_seq_len                  = static_cast<int>(max_seq_len);
+        params.tokens_per_block             = static_cast<int>(tokens_per_block);
+        params.kernel_tokens_per_block      = static_cast<int>(kernel_tokens_per_block);
+        params.num_tokens_per_bs            = static_cast<int>(num_tokens_per_bs);
+        params.sp_steps                     = static_cast<int>(num_tokens_per_bs - 1);
+        params.hidden_size                  = static_cast<size_t>(hidden_size);
+        params.model_data_type              = c10::ScalarType::BFloat16;
+        params.max_context_batch_size       = 128;
+        params.decode_capture_batch_sizes   = std::move(decode_capture_batch_sizes);
+        params.kv_cache_layer_to_group      = {};  // test: no hybrid kv cache
+        params.kv_cache_group_num           = 0;
+
+        runner_ = CudaGraphRunner::createForDecode(std::move(py_instance), std::move(params));
+    }
+
     bool canRun(torch_ext::PyModelInputs& inputs) {
         return runner_ != nullptr && runner_->canRun(inputs, state_);
     }
@@ -113,6 +146,15 @@ PYBIND11_MODULE(libtest_cuda_graph_runner, m) {
              py::arg("max_seq_len"),
              py::arg("tokens_per_block"),
              py::arg("kernel_tokens_per_block"),
+             py::arg("decode_capture_batch_sizes"))
+        .def("init_target_verify",
+             &CudaGraphTestRunner::init_target_verify,
+             py::arg("py_instance"),
+             py::arg("hidden_size"),
+             py::arg("max_seq_len"),
+             py::arg("tokens_per_block"),
+             py::arg("kernel_tokens_per_block"),
+             py::arg("num_tokens_per_bs"),
              py::arg("decode_capture_batch_sizes"))
         .def("canRun", &CudaGraphTestRunner::canRun)
         .def("forward", &CudaGraphTestRunner::forward)

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -89,10 +89,21 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_readwrite("prefill_qkv_padding_mask", &PyContextParallelParams::prefill_qkv_padding_mask)
         .def_readwrite("prefill_actual_input_lengths_cpu", &PyContextParallelParams::prefill_actual_input_lengths_cpu);
 
+    pybind11::class_<PyCudaGraphMetadata>(m, "PyCudaGraphMetadata")
+        .def(pybind11::init<>())
+        .def_readwrite("requires_full_token_metadata", &PyCudaGraphMetadata::requires_full_token_metadata)
+        .def_readwrite("graph_batch_size", &PyCudaGraphMetadata::graph_batch_size)
+        .def_readwrite("active_batch_size", &PyCudaGraphMetadata::active_batch_size)
+        .def_readwrite("tokens_per_batch", &PyCudaGraphMetadata::tokens_per_batch)
+        .def_readwrite("actual_token_num", &PyCudaGraphMetadata::actual_token_num)
+        .def_readwrite("token_capacity", &PyCudaGraphMetadata::token_capacity)
+        .def_readwrite("dummy_kv_block_id", &PyCudaGraphMetadata::dummy_kv_block_id);
+
     pybind11::class_<PyAttentionInputs>(m, "PyAttentionInputs")
         .def(pybind11::init<>())
         .def_readwrite("is_prefill", &PyAttentionInputs::is_prefill)
         .def_readwrite("is_cuda_graph", &PyAttentionInputs::is_cuda_graph)
+        .def_readwrite("cuda_graph_metadata", &PyAttentionInputs::cuda_graph_metadata)
         .def_readwrite("is_target_verify", &PyAttentionInputs::is_target_verify)
         .def_readwrite("prefix_lengths", &PyAttentionInputs::prefix_lengths)
         .def_readwrite("sequence_lengths", &PyAttentionInputs::sequence_lengths)

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -157,6 +157,31 @@ struct PyContextParallelParams {
     torch::Tensor prefill_actual_input_lengths_cpu;
 };
 
+// Runtime layout contract for a captured CUDA Graph. The runner owns these
+// values; attention backends only materialize their backend-specific metadata
+// from this description and must not infer graph capacity from tensor buffers.
+struct PyCudaGraphMetadata {
+    bool requires_full_token_metadata{false};
+    int  graph_batch_size{0};
+    int  active_batch_size{0};
+    int  tokens_per_batch{0};
+    int  actual_token_num{0};
+    int  token_capacity{0};
+    int  dummy_kv_block_id{0};
+
+    bool needsTokenPadding() const {
+        return requires_full_token_metadata && token_capacity > actual_token_num;
+    }
+
+    int paddingBatchBegin() const {
+        return active_batch_size;
+    }
+
+    int paddingTokenNum() const {
+        return token_capacity - actual_token_num;
+    }
+};
+
 // Naming convention: the host (pinned CPU) tensor uses the bare name; its device (CUDA)
 // counterpart carries a _device suffix.
 struct PyAttentionInputs {
@@ -203,6 +228,8 @@ struct PyAttentionInputs {
 
     // CUDA Graph mode flags
     bool is_cuda_graph = false;  // True when running in CUDA graph mode (capture or replay)
+
+    PyCudaGraphMetadata cuda_graph_metadata;
 
     std::optional<PyContextParallelParams> context_parallel_info;
 

--- a/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.cc
+++ b/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.cc
@@ -405,7 +405,8 @@ void FlashInferMlaAttnParams::fillParams(torch::Tensor t_prefix_lengths,
                                          torch::Tensor t_input_lengths,
                                          torch::Tensor t_kv_cache_block_id_host,
                                          int           seq_size_per_block,
-                                         bool          forbid_realloc) {
+                                         bool          forbid_realloc,
+                                         const PyCudaGraphMetadata& cuda_graph_metadata) {
     const int batch_size = t_input_lengths.size(0);
 
     // First pass: calculate required sizes accurately
@@ -436,8 +437,77 @@ void FlashInferMlaAttnParams::fillParams(torch::Tensor t_prefix_lengths,
         page_num += (seq_len + seq_size_per_block - 1) / seq_size_per_block;
     }
 
+    const int requested_input_token_num = input_token_num;
+    const int captured_input_token_num = cuda_graph_metadata.requires_full_token_metadata ?
+                                             cuda_graph_metadata.token_capacity :
+                                             requested_input_token_num;
+    RTP_LLM_CHECK_WITH_INFO(captured_input_token_num >= requested_input_token_num,
+                            "CUDA graph token capacity %d is smaller than requested token count %d",
+                            captured_input_token_num,
+                            requested_input_token_num);
+    const bool pad_fixed_capacity_tokens = forbid_realloc && prefix_lengths_ptr != nullptr
+                                           && cuda_graph_metadata.needsTokenPadding();
+
+    int padding_batch_begin       = cuda_graph_metadata.paddingBatchBegin();
+    int captured_tokens_per_batch = cuda_graph_metadata.tokens_per_batch;
+    int dummy_page_num            = 0;
+    if (pad_fixed_capacity_tokens) {
+        RTP_LLM_CHECK_WITH_INFO(cuda_graph_metadata.graph_batch_size == batch_size,
+                                "CUDA graph metadata batch size mismatch: contract=%d, input=%d",
+                                cuda_graph_metadata.graph_batch_size,
+                                batch_size);
+        RTP_LLM_CHECK_WITH_INFO(padding_batch_begin >= 0 && padding_batch_begin < batch_size,
+                                "CUDA graph active batch size %d is invalid for graph batch size %d",
+                                padding_batch_begin,
+                                batch_size);
+        RTP_LLM_CHECK_WITH_INFO(captured_tokens_per_batch > 0,
+                                "fixed-width CUDA graph tokens per batch must be positive");
+        RTP_LLM_CHECK_WITH_INFO(captured_input_token_num == batch_size * captured_tokens_per_batch,
+                                "CUDA graph token capacity %d does not match batch layout %d x %d",
+                                captured_input_token_num,
+                                batch_size,
+                                captured_tokens_per_batch);
+        RTP_LLM_CHECK_WITH_INFO(cuda_graph_metadata.actual_token_num == requested_input_token_num,
+                                "CUDA graph actual token mismatch: contract=%d, derived=%d",
+                                cuda_graph_metadata.actual_token_num,
+                                requested_input_token_num);
+        RTP_LLM_CHECK_WITH_INFO(requested_input_token_num == padding_batch_begin * captured_tokens_per_batch,
+                                "CUDA graph actual tokens %d do not match active layout %d x %d",
+                                requested_input_token_num,
+                                padding_batch_begin,
+                                captured_tokens_per_batch);
+        RTP_LLM_CHECK_WITH_INFO(cuda_graph_metadata.paddingTokenNum()
+                                    == (batch_size - padding_batch_begin) * captured_tokens_per_batch,
+                                "CUDA graph padding tokens do not match the inactive batch tail");
+
+        for (int i = 0; i < padding_batch_begin; ++i) {
+            RTP_LLM_CHECK_WITH_INFO(input_lengths_ptr[i] == captured_tokens_per_batch,
+                                    "fixed-width CUDA graph active batch %d has %d tokens, expected width %d",
+                                    i,
+                                    input_lengths_ptr[i],
+                                    captured_tokens_per_batch);
+        }
+        for (int i = padding_batch_begin; i < batch_size; ++i) {
+            RTP_LLM_CHECK_WITH_INFO(input_lengths_ptr[i] == 0 && prefix_lengths_ptr[i] == 0,
+                                    "fixed-width CUDA graph padding must be a zero-length batch tail");
+        }
+        RTP_LLM_CHECK_WITH_INFO(requested_input_token_num
+                                    + (batch_size - padding_batch_begin) * captured_tokens_per_batch
+                                    == captured_input_token_num,
+                                "fixed-width CUDA graph token padding does not match captured capacity");
+
+        const int safe_page_size = std::max(seq_size_per_block, 1);
+        dummy_page_num = (batch_size - padding_batch_begin)
+                         * ((captured_tokens_per_batch + safe_page_size - 1) / safe_page_size);
+    }
+
     // Ensure tensors are allocated with sufficient size
-    ensureTensorSize(batch_size, input_token_num, page_num, reuse_page_num, batch_reuse_info_size, forbid_realloc);
+    ensureTensorSize(batch_size,
+                     pad_fixed_capacity_tokens ? captured_input_token_num : input_token_num,
+                     page_num + dummy_page_num,
+                     reuse_page_num,
+                     batch_reuse_info_size,
+                     forbid_realloc);
 
     // Fill params directly into HOST tensors
     fillParamsInternal(t_prefix_lengths,
@@ -450,6 +520,51 @@ void FlashInferMlaAttnParams::fillParams(torch::Tensor t_prefix_lengths,
                        page_num,
                        reuse_page_num,
                        batch_reuse_info_size);
+
+    if (pad_fixed_capacity_tokens) {
+        auto batch_indice_ptr                 = batch_indice_h.data_ptr<int32_t>();
+        auto page_indice_ptr                  = page_indice_h.data_ptr<int32_t>();
+        auto decode_page_indptr_ptr           = decode_page_indptr_h.data_ptr<int32_t>();
+        auto prefill_ragged_kv_len_indptr_ptr = prefill_ragged_kv_len_indptr_h.data_ptr<int32_t>();
+        auto paged_kv_last_page_len_ptr       = paged_kv_last_page_len_h.data_ptr<int32_t>();
+        auto kvlen_ptr                        = kvlen_h.data_ptr<int32_t>();
+        auto positions_ptr                    = positions_h.data_ptr<int32_t>();
+
+        const int safe_page_size = std::max(seq_size_per_block, 1);
+        int       token_offset   = requested_input_token_num;
+        int       page_offset    = page_num;
+        int       accumulated_kv = prefill_ragged_kv_len_indptr_ptr[padding_batch_begin];
+
+        for (int batch = padding_batch_begin; batch < batch_size; ++batch) {
+            for (int token = 0; token < captured_tokens_per_batch; ++token) {
+                batch_indice_ptr[token_offset] = batch;
+                positions_ptr[token_offset]    = token;
+                ++token_offset;
+            }
+
+            const int pages = (captured_tokens_per_batch + safe_page_size - 1) / safe_page_size;
+            for (int page = 0; page < pages; ++page) {
+                page_indice_ptr[page_offset++] = cuda_graph_metadata.dummy_kv_block_id;
+            }
+
+            kvlen_ptr[batch] = captured_tokens_per_batch;
+            paged_kv_last_page_len_ptr[batch] =
+                (captured_tokens_per_batch - 1) % safe_page_size + 1;
+            decode_page_indptr_ptr[batch + 1] = page_offset;
+            accumulated_kv += captured_tokens_per_batch;
+            prefill_ragged_kv_len_indptr_ptr[batch + 1] = accumulated_kv;
+            // qo_indptr remains unchanged: dummy batches have no query tokens for attention.
+        }
+
+        RTP_LLM_CHECK_WITH_INFO(token_offset == captured_input_token_num,
+                                "fixed-width CUDA graph token padding produced %d tokens, expected %d",
+                                token_offset,
+                                captured_input_token_num);
+        RTP_LLM_CHECK_WITH_INFO(page_offset == page_num + dummy_page_num,
+                                "fixed-width CUDA graph page padding produced an unexpected page count");
+        input_token_num = captured_input_token_num;
+        page_num        = page_offset;
+    }
 
     // Refresh buffer (copy to DEVICE and update shapes)
     refreshBuffer(batch_size, input_token_num, page_num, reuse_page_num, batch_reuse_info_size);
@@ -476,6 +591,12 @@ void FlashInferMlaAttnParams::fillParams(torch::Tensor t_prefix_lengths,
         auto slot_mapping_ptr = slot_mapping_h_.data_ptr<int64_t>();
 
         for (int64_t i = 0; i < input_token_num; ++i) {
+            if (pad_fixed_capacity_tokens && i >= requested_input_token_num) {
+                slot_mapping_ptr[i] = static_cast<int64_t>(cuda_graph_metadata.dummy_kv_block_id)
+                                          * seq_size_per_block
+                                      + positions_ptr[i] % seq_size_per_block;
+                continue;
+            }
             const int32_t batch_id     = batch_indice_ptr[i];
             const int32_t position     = positions_ptr[i];
             const int32_t block_index  = position / seq_size_per_block;
@@ -510,13 +631,15 @@ void registerPyFlashInferMlaParams(pybind11::module& m) {
                torch::Tensor                     input_lengths,
                torch::Tensor                     kv_cache_block_id_host,
                int                               seq_size_per_block,
-               bool                              forbid_realloc) {
+               bool                              forbid_realloc,
+               PyCudaGraphMetadata               cuda_graph_metadata) {
                 self.fillParams(prefix_lengths,
                                 sequence_lengths,
                                 input_lengths,
                                 kv_cache_block_id_host,
                                 seq_size_per_block,
-                                forbid_realloc);
+                                forbid_realloc,
+                                cuda_graph_metadata);
             },
             pybind11::arg("prefix_lengths"),
             pybind11::arg("sequence_lengths"),
@@ -524,6 +647,7 @@ void registerPyFlashInferMlaParams(pybind11::module& m) {
             pybind11::arg("kv_cache_block_id_host"),
             pybind11::arg("seq_size_per_block"),
             pybind11::arg("forbid_realloc") = false,
+            pybind11::arg("cuda_graph_metadata") = PyCudaGraphMetadata{},
             "Fill parameters for attention execution (forbid_realloc=true only when called from prepare_cuda_graph/replay)")
         // HOST tensors (_h suffix)
         .def_readonly("batch_indice_h", &FlashInferMlaAttnParams::batch_indice_h, "Batch indices on HOST")

--- a/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.h
+++ b/rtp_llm/models_py/bindings/cuda/FlashInferMlaParams.h
@@ -65,8 +65,9 @@ public:
                     torch::Tensor t_sequence_lengths,
                     torch::Tensor t_input_lengths,
                     torch::Tensor t_kv_cache_block_id_host,
-                    int           seq_size_per_block,
-                    bool          forbid_realloc = false);
+                    int                        seq_size_per_block,
+                    bool                       forbid_realloc      = false,
+                    const PyCudaGraphMetadata& cuda_graph_metadata = PyCudaGraphMetadata{});
 
     // Tensor views into buf_h and buf_d
     torch::Tensor batch_indice_h;

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -125,6 +125,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
             attn_inputs.kv_cache_kernel_block_id,
             self.page_size,
             forbid_realloc,
+            cuda_graph_metadata=attn_inputs.cuda_graph_metadata,
         )
         # Store CUDA graph copy parameters
         # Define qo_indptr early for CUDA graph initialization

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -455,6 +455,17 @@ def h20_oss_suites():
                 gpu_type=["H20"],
                 concurrency_test=True,
             ),
+            # Regression coverage for target-verify graph padding. Concurrent requests
+            # shrink from a multi-request batch while capture sizes stay sparse, forcing
+            # batches 2..7 to reuse the batch-8 graph and exercise stale-tail cleanup.
+            smoke_test(
+                name="eagle_mtp_cudagraph_padded_batch_concurrent",
+                task_info="data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json",
+                smoke_args="--max_seq_len 16384 --ft_disable_custom_ar 1 --eplb_mode NONE --redundant_expert 0 --act_type FP16 --concurrency_limit 16 --frontend_server_count 1 --warm_up 0 --reserver_runtime_mem_mb 42000 --seq_size_per_block 64 --enable_xqa 1 --sp_type eagle --gen_num_per_cycle 4 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --sp_act_type FP16 --decode_capture_config '1,8' --prefill_capture_config '80:1' --enable_cuda_graph 1 --tp_size 2",
+                envs=["NCCL_DISABLE_ABORT=1", "NCCL_DEBUG=INFO", "LOG_LEVEL=INFO"],
+                gpu_type=["H20"],
+                concurrency_test=True,
+            ),
             smoke_test(
                 name="eagle_mtp_no_cudagraph_concurrent",
                 task_info="data/model/qwen2_14b/q_r_mtp_cuda_graph_concurrent.json",


### PR DESCRIPTION
## Summary

Fix stale attention metadata when MTP target verification reuses a CUDA graph captured with a larger batch size.

## Problem

During MTP target verification, a smaller batch may reuse a CUDA graph captured for a larger batch. The unused portions of the graph input buffers can retain data from a previous replay.

In addition, target verification was using `current_seq_len` as the final valid query offset. This value does not represent the total number of verification tokens on this path; `seq_len_sum` does.

These stale or incorrect length values can produce invalid cumulative sequence metadata, including an incorrect `qo_indptr`.

## Changes

- Clear unused host-side `input_lengths` and `prefix_lengths`.
- Clear the corresponding device-side length buffers.
- Apply stale-input cleanup to MTP target verification as well as prefill CUDA graph mode.
- Use `seq_len_sum` as the final valid query offset for target verification.
- Fill unused cumulative sequence entries with the correct final Q/KV offsets.