### PR TITLE
refactor: simplify ViT RDMA transport. 

### DIFF
--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -282,19 +282,16 @@ class VitConfig:
         self.disable_access_log: bool = False
         self.use_local_preprocess: bool = False
         self.vit_proxy_load_balance_strategy: str = "round_robin"
-        # ---- Encoder(ViT)<->LLM embedding transport over GPUDirect RDMA ----
-        self.mm_rdma_enable: bool = False
+        # ---- Encoder(ViT)<->LLM embedding transport ----
+        self.mm_transport_mode: str = "auto"
         self.mm_rdma_bind_ip: str = ""
         self.mm_rdma_port: int = 0
-        self.mm_rdma_min_bytes: int = (
-            256 * 1024
-        )  # encoder-side RDMA/bytes threshold (Python only)
         self.mm_rdma_connect_timeout_ms: int = 250
         self.mm_rdma_read_timeout_ms: int = 30 * 1000
         self.mm_rdma_release_timeout_ms: int = 1000
         self.mm_rdma_slot_gc_timeout_ms: int = 60 * 1000
         self.mm_rdma_max_inflight_bytes: int = 8 * 1024 * 1024 * 1024
-        self.mm_rdma_max_slot_bytes: int = 2000 * 1024 * 1024
+        self.mm_rdma_max_slot_bytes: int = 1024 * 1024 * 1024
         # ---- GPU embedding batch scheduler (MMScheduler) ----
         self.use_gpu_batch: bool = False
         self.gpu_batch_wait_ms: int = 10
@@ -351,10 +348,9 @@ class VitConfig:
             f"disable_access_log: {self.disable_access_log}\n"
             f"use_local_preprocess: {self.use_local_preprocess}\n"
             f"vit_proxy_load_balance_strategy: {self.vit_proxy_load_balance_strategy}\n"
-            f"mm_rdma_enable: {self.mm_rdma_enable}\n"
+            f"mm_transport_mode: {self.mm_transport_mode}\n"
             f"mm_rdma_bind_ip: {self.mm_rdma_bind_ip}\n"
             f"mm_rdma_port: {self.mm_rdma_port}\n"
-            f"mm_rdma_min_bytes: {self.mm_rdma_min_bytes}\n"
             f"mm_rdma_connect_timeout_ms: {self.mm_rdma_connect_timeout_ms}\n"
             f"mm_rdma_read_timeout_ms: {self.mm_rdma_read_timeout_ms}\n"
             f"mm_rdma_release_timeout_ms: {self.mm_rdma_release_timeout_ms}\n"

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -321,7 +321,7 @@ std::string VitConfig::to_string() const {
             vit_sep_str = "UNKNOWN(" + std::to_string(static_cast<int>(vit_separation)) + ")";
             break;
     }
-    oss << "vit_separation: " << vit_sep_str << ", mm_rdma_enable: " << mm_rdma_enable
+    oss << "vit_separation: " << vit_sep_str << ", mm_transport_mode: " << mm_transport_mode
         << ", mm_rdma_bind_ip: " << mm_rdma_bind_ip << ", mm_rdma_port: " << mm_rdma_port
         << ", mm_rdma_connect_timeout_ms: " << mm_rdma_connect_timeout_ms
         << ", mm_rdma_read_timeout_ms: " << mm_rdma_read_timeout_ms

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -337,21 +337,18 @@ struct SpeculativeExecutionConfig {
 struct VitConfig {
     VitSeparation vit_separation = VitSeparation::VIT_SEPARATION_LOCAL;
 
-    // ---- Encoder(ViT) <-> LLM embedding transport over GPUDirect RDMA ----
-    // Master switch for the RDMA data-plane fast path. Control plane (gRPC
-    // RemoteMultimodalEmbedding negotiation) is unchanged. When disabled, or when
-    // any precondition fails, the embedding falls back to inline TensorPB bytes.
-    bool mm_rdma_enable = false;
+    // ---- Encoder(ViT) <-> LLM embedding transport ----
+    // "auto" prefers GPUDirect RDMA and falls back to inline gRPC bytes when unavailable;
+    // "grpc" disables the RDMA data plane.
+    std::string mm_transport_mode = "auto";
     // Encoder-side OOB bind IP for RdmaServer (LLM connects here to exchange QP info).
     // Empty means auto-detect via getBindIp() (management network IP).
     std::string mm_rdma_bind_ip;
     // Encoder-side RdmaServer listen port (the LLM connects here for one-sided READ).
     int mm_rdma_port = 0;
-    // RDMA connect timeout (mirrors CacheStoreConfig). Thread/QP sizing is fixed inside the
-    // transport impl to keep the config surface small. The min-bytes RDMA/bytes threshold
-    // lives only on the Python encoder side (the C++ side never consults it).
+    // RDMA connect timeout. Thread/QP sizing is fixed inside the transport impl.
     int mm_rdma_connect_timeout_ms = 250;
-    // Max wait for a single READ to complete on the LLM side before giving up (fallback).
+    // Max wait for one READ before the caller retries the request over gRPC.
     int64_t mm_rdma_read_timeout_ms = 30 * 1000;
     // Deadline for the best-effort ReleaseMultimodalEmbedding RPC. This runs on the
     // inference path, so it must stay short: a slow/hung encoder must never stall the
@@ -360,19 +357,13 @@ struct VitConfig {
     // Encoder-side slot lifetime: force-reclaim a slot this long after export if no
     // Release(handle) arrived (backstop against LLM crash / READ failure -> leak).
     int64_t mm_rdma_slot_gc_timeout_ms = 60 * 1000;
-    // Encoder-side soft cap on the total bytes of live (registered, not-yet-released)
-    // embedding slots. A backstop so the vision RDMA arena cannot grow without bound and
-    // starve the KV cache / activations that share the same process-wide RDMA pool
-    // (plain AllocBuffer is NOT bounded by the pool's gpuMaxTotalBytes). When exceeding
-    // the cap, exportEmbedding fails and the request transparently falls back to bytes.
+    // Encoder-side soft cap on the physical allocation buckets of live, unreleased slots.
+    // AllocLimitBuffer also enforces the process-wide RDMA pool bound. When this cap is
+    // exceeded, exportEmbedding fails and the request transparently falls back to gRPC.
     // 0 disables the cap.
     int64_t mm_rdma_max_inflight_bytes = 8L * 1024 * 1024 * 1024;
-    // Encoder-side upper bound on ONE RDMA slot. The RDMA GPU mempool caps a single allocation
-    // at ~2GiB (power-of-2 bucketed, kmax_single_alloc_size). When a request's packed output
-    // exceeds this, the encoder splits it into multiple <= this-many-bytes slots/descriptors
-    // (output_rdma_chunks) instead of falling back to inline bytes. Must stay <= 2GiB; default
-    // leaves headroom below the 2GiB bucket for per-tensor alignment padding.
-    int64_t mm_rdma_max_slot_bytes = 2000L * 1024 * 1024;
+    // Upper bound on one RDMA slot. Larger outputs use the existing multi-slot protocol.
+    int64_t mm_rdma_max_slot_bytes = 1024L * 1024 * 1024;
 
     std::string to_string() const;
 };

--- a/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
+++ b/rtp_llm/cpp/model_rpc/proto/model_rpc_service.proto
@@ -189,8 +189,8 @@ message MultimodalOutputPB {
     // stays inline — the LLM needs it to slice the RDMA-read embedding/pos_id per image.
     // Used when the whole output fits in ONE slot (<= mm_rdma_max_slot_bytes).
     MMRdmaDescPB output_rdma = 5;
-    // RDMA fast-path, chunked: used instead of output_rdma when the output exceeds one slot
-    // (single-slot alloc is capped at ~2GiB by the RDMA mempool). Each entry describes one
+    // RDMA fast-path, chunked: used instead of output_rdma when the output exceeds one slot.
+    // The ViT transport config caps each slot at exactly 1GiB. Each entry describes one
     // <=mm_rdma_max_slot_bytes slot; the LLM reads every chunk in order and concatenates the
     // per-role tensors (see MMRdmaTensorPB.Role) before applying split_size. Exactly one of
     // output_rdma / output_rdma_chunks is set on the RDMA path; both empty => inline bytes.

--- a/rtp_llm/cpp/multimodal_processor/MMRdmaEncoderOp.h
+++ b/rtp_llm/cpp/multimodal_processor/MMRdmaEncoderOp.h
@@ -31,8 +31,8 @@ public:
 
     // Pack the whole output of one request (the concat-ed embedding, the optional concat-ed
     // position ids, and the per-image extra_input tensors, in that order) into one or more RDMA
-    // slots and return one serialized MMRdmaDescPB per slot. A single RDMA slot is capped at
-    // ~2GiB (mm_rdma_max_slot_bytes / the mempool's kmax_single_alloc_size), so when the output
+    // slots and return one serialized MMRdmaDescPB per slot. A single RDMA slot is capped by
+    // mm_rdma_max_slot_bytes (1 GiB by default), so when the output
     // is larger the embedding is row-split and the tensors are greedily packed across multiple
     // slots — the LLM concatenates the EMBEDDING chunks back in order. Returns a 1-element list
     // for the common (fits-in-one-slot) case, N elements when chunked, and an EMPTY list on

--- a/rtp_llm/cpp/multimodal_processor/MMRdmaTransport.cc
+++ b/rtp_llm/cpp/multimodal_processor/MMRdmaTransport.cc
@@ -13,13 +13,17 @@ void registerMMRdmaTransportCreator(MMRdmaTransportCreator creator) {
 }
 
 std::shared_ptr<MMRdmaTransport> createMMRdmaTransport(const VitConfig& vit_config, MMRdmaRole role) {
-    if (!vit_config.mm_rdma_enable) {
-        RTP_LLM_LOG_INFO("mm rdma disabled, fall back to inline-bytes multimodal embedding transport");
+    if (vit_config.mm_transport_mode == "grpc") {
+        RTP_LLM_LOG_INFO("mm transport mode is grpc, skip rdma initialization");
+        return nullptr;
+    }
+    if (vit_config.mm_transport_mode != "auto") {
+        RTP_LLM_LOG_WARNING("unknown mm transport mode '%s', fall back to grpc", vit_config.mm_transport_mode.c_str());
         return nullptr;
     }
     if (g_mm_rdma_transport_creator == nullptr) {
         RTP_LLM_LOG_WARNING(
-            "mm_rdma_enable=true but no MMRdmaTransport implementation is linked (open-source build?), "
+            "mm transport mode is auto but no MMRdmaTransport implementation is linked (open-source build?), "
             "fall back to inline-bytes path");
         return nullptr;
     }

--- a/rtp_llm/cpp/multimodal_processor/MMRdmaTransport.h
+++ b/rtp_llm/cpp/multimodal_processor/MMRdmaTransport.h
@@ -53,8 +53,8 @@ public:
 using MMRdmaTransportCreator = std::shared_ptr<MMRdmaTransport> (*)(const VitConfig&, MMRdmaRole);
 void registerMMRdmaTransportCreator(MMRdmaTransportCreator creator);
 
-// Returns nullptr when RDMA is disabled (mm_rdma_enable=false), unavailable
-// (open-source build / no NIC) or initialization fails.
+// Returns nullptr in grpc mode, when RDMA is unavailable (open-source build / no NIC),
+// or when initialization fails. Auto mode callers then use inline gRPC bytes.
 std::shared_ptr<MMRdmaTransport> createMMRdmaTransport(const VitConfig& vit_config, MMRdmaRole role);
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/multimodal_processor/MMRdmaVitConfig.h
+++ b/rtp_llm/cpp/multimodal_processor/MMRdmaVitConfig.h
@@ -11,9 +11,6 @@ namespace rtp_llm {
 // Copy the optional mm-rdma fields from the Python VitConfig into the C++ VitConfig.
 // Guarded by hasattr so older Python configs (without these fields) stay compatible.
 inline void extractMMRdmaVitConfig(const py::object& vit_config, VitConfig& cfg) {
-    auto get_bool = [&](const char* name, bool def) {
-        return py::hasattr(vit_config, name) ? vit_config.attr(name).cast<bool>() : def;
-    };
     auto get_int = [&](const char* name, int def) {
         return py::hasattr(vit_config, name) ? vit_config.attr(name).cast<int>() : def;
     };
@@ -24,7 +21,7 @@ inline void extractMMRdmaVitConfig(const py::object& vit_config, VitConfig& cfg)
         return py::hasattr(vit_config, name) ? vit_config.attr(name).cast<std::string>() : def;
     };
 
-    cfg.mm_rdma_enable             = get_bool("mm_rdma_enable", cfg.mm_rdma_enable);
+    cfg.mm_transport_mode          = get_str("mm_transport_mode", cfg.mm_transport_mode);
     cfg.mm_rdma_bind_ip            = get_str("mm_rdma_bind_ip", cfg.mm_rdma_bind_ip);
     cfg.mm_rdma_port               = get_int("mm_rdma_port", cfg.mm_rdma_port);
     cfg.mm_rdma_connect_timeout_ms = get_int("mm_rdma_connect_timeout_ms", cfg.mm_rdma_connect_timeout_ms);

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1764,7 +1764,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
     py::class_<VitConfig>(m, "VitConfig")
         .def(py::init<>())
         .def_readwrite("vit_separation", &VitConfig::vit_separation)
-        .def_readwrite("mm_rdma_enable", &VitConfig::mm_rdma_enable)
+        .def_readwrite("mm_transport_mode", &VitConfig::mm_transport_mode)
         .def_readwrite("mm_rdma_bind_ip", &VitConfig::mm_rdma_bind_ip)
         .def_readwrite("mm_rdma_port", &VitConfig::mm_rdma_port)
         .def_readwrite("mm_rdma_connect_timeout_ms", &VitConfig::mm_rdma_connect_timeout_ms)
@@ -1777,7 +1777,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def(py::pickle(
             [](const VitConfig& self) {
                 return py::make_tuple(self.vit_separation,
-                                      self.mm_rdma_enable,
+                                      self.mm_transport_mode,
                                       self.mm_rdma_bind_ip,
                                       self.mm_rdma_port,
                                       self.mm_rdma_connect_timeout_ms,
@@ -1793,7 +1793,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                 VitConfig c;
                 try {
                     c.vit_separation             = t[0].cast<VitSeparation>();
-                    c.mm_rdma_enable             = t[1].cast<bool>();
+                    c.mm_transport_mode          = t[1].cast<std::string>();
                     c.mm_rdma_bind_ip            = t[2].cast<std::string>();
                     c.mm_rdma_port               = t[3].cast<int>();
                     c.mm_rdma_connect_timeout_ms = t[4].cast<int>();

--- a/rtp_llm/server/server_args/vit_group_args.py
+++ b/rtp_llm/server/server_args/vit_group_args.py
@@ -258,12 +258,13 @@ def init_vit_group_args(parser, vit_config):
     )
     # ---- Encoder(ViT)<->LLM embedding transport over GPUDirect RDMA ----
     vit_group.add_argument(
-        "--mm_rdma_enable",
-        env_name="MM_RDMA_ENABLE",
-        bind_to=(vit_config, "mm_rdma_enable"),
-        type=str2bool,
-        default=False,
-        help="开启 encoder<->LLM 多模态 embedding 的 GPUDirect RDMA 数据面（关闭时回退 bytes）",
+        "--mm_transport_mode",
+        env_name="MM_TRANSPORT_MODE",
+        bind_to=(vit_config, "mm_transport_mode"),
+        type=str,
+        choices=["auto", "grpc"],
+        default="auto",
+        help="多模态输出传输模式：auto 优先 RDMA 并自动回退 gRPC，grpc 强制使用 gRPC",
     )
     vit_group.add_argument(
         "--mm_rdma_bind_ip",
@@ -280,14 +281,6 @@ def init_vit_group_args(parser, vit_config):
         type=int,
         default=0,
         help="encoder 侧 RdmaServer 监听端口，0 表示随机端口",
-    )
-    vit_group.add_argument(
-        "--mm_rdma_min_bytes",
-        env_name="MM_RDMA_MIN_BYTES",
-        bind_to=(vit_config, "mm_rdma_min_bytes"),
-        type=int,
-        default=256 * 1024,
-        help="只有大于该字节数的 embedding 才走 RDMA，更小的走 bytes",
     )
     vit_group.add_argument(
         "--mm_rdma_connect_timeout_ms",
@@ -334,9 +327,8 @@ def init_vit_group_args(parser, vit_config):
         env_name="MM_RDMA_MAX_SLOT_BYTES",
         bind_to=(vit_config, "mm_rdma_max_slot_bytes"),
         type=int,
-        default=2000 * 1024 * 1024,
-        help="encoder 侧单个 RDMA slot 的字节上限（RDMA 显存池单次分配硬上限约 2GiB）。"
-        "请求输出超过该值时，自动切成多个 <= 该值的 slot/描述符分块传输，而非回退 bytes。须 <= 2GiB",
+        default=1024 * 1024 * 1024,
+        help="encoder 侧单个 RDMA slot 的字节上限，默认 1GiB；更大的输出沿用现有协议自动分块",
     )
     # ---- GPU embedding batch scheduler (MMScheduler) ----
     vit_group.add_argument(

--- a/rtp_llm/server/test/vit_proxy_server_test.py
+++ b/rtp_llm/server/test/vit_proxy_server_test.py
@@ -2,7 +2,17 @@ import threading
 from unittest import TestCase, main
 from unittest.mock import MagicMock, patch
 
-from rtp_llm.server.vit_proxy_server import LoadBalancer, WorkerConnectionPool
+from rtp_llm.cpp.model_rpc.proto.model_rpc_service_pb2 import (
+    MMRdmaDescPB,
+    MultimodalInputsPB,
+    MultimodalOutputPB,
+    ReleaseEmbeddingPB,
+)
+from rtp_llm.server.vit_proxy_server import (
+    LoadBalancer,
+    VitProxyRpcServer,
+    WorkerConnectionPool,
+)
 
 
 class LoadBalancerRoundRobinTest(TestCase):
@@ -165,6 +175,45 @@ class WorkerConnectionPoolTest(TestCase):
         # should not propagate
         pool.close_all()
         self.assertEqual(pool.channels, {})
+
+
+class VitProxyRdmaReleaseTest(TestCase):
+    @patch("rtp_llm.server.vit_proxy_server.kmonitor.init")
+    @patch("rtp_llm.server.vit_proxy_server.kmonitor.report")
+    def test_release_is_forwarded_to_workers_that_created_handles(
+        self, _mock_report, _mock_init
+    ):
+        load_balancer = MagicMock()
+        load_balancer.get_worker.side_effect = ["worker-a", "worker-b"]
+        connection_pool = MagicMock()
+        stub_a = MagicMock()
+        stub_b = MagicMock()
+        connection_pool.get_stub.side_effect = lambda address: {
+            "worker-a": stub_a,
+            "worker-b": stub_b,
+        }[address]
+        stub_a.RemoteMultimodalEmbedding.return_value = MultimodalOutputPB(
+            output_rdma=MMRdmaDescPB(handle="handle-a")
+        )
+        response_b = MultimodalOutputPB()
+        response_b.output_rdma_chunks.add(handle="handle-b-1")
+        response_b.output_rdma_chunks.add(handle="handle-b-2")
+        stub_b.RemoteMultimodalEmbedding.return_value = response_b
+
+        servicer = VitProxyRpcServer(load_balancer, connection_pool)
+        servicer.RemoteMultimodalEmbedding(MultimodalInputsPB(), MagicMock())
+        servicer.RemoteMultimodalEmbedding(MultimodalInputsPB(), MagicMock())
+        servicer.ReleaseMultimodalEmbedding(
+            ReleaseEmbeddingPB(handle=["handle-a", "handle-b-1", "handle-b-2"]),
+            MagicMock(),
+        )
+
+        request_a = stub_a.ReleaseMultimodalEmbedding.call_args.args[0]
+        request_b = stub_b.ReleaseMultimodalEmbedding.call_args.args[0]
+        self.assertEqual(list(request_a.handle), ["handle-a"])
+        self.assertEqual(list(request_b.handle), ["handle-b-1", "handle-b-2"])
+        self.assertEqual(stub_a.ReleaseMultimodalEmbedding.call_args.kwargs["timeout"], 1.0)
+        self.assertEqual(stub_b.ReleaseMultimodalEmbedding.call_args.kwargs["timeout"], 1.0)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/server/vit_proxy_server.py
+++ b/rtp_llm/server/vit_proxy_server.py
@@ -5,6 +5,7 @@ VIT Proxy Server - 主进程代理服务器
 
 import logging
 import threading
+import time
 from collections import defaultdict
 from concurrent import futures
 from typing import Optional
@@ -17,6 +18,7 @@ from rtp_llm.cpp.model_rpc.proto.model_rpc_service_pb2 import (
     EmptyPB,
     MultimodalInputsPB,
     MultimodalOutputPB,
+    ReleaseEmbeddingPB,
     StatusVersionPB,
     WorkerStatusPB,
 )
@@ -33,6 +35,7 @@ from rtp_llm.multimodal.mm_profiler import MMProfiler
 # hung worker from exhausting the 200-thread proxy pool (see RemoteMultimodalEmbedding).
 # Per-request override comes from MMPreprocessConfigPB.mm_timeout_ms if set (>0).
 DEFAULT_PROXY_RPC_TIMEOUT_SECONDS = 30.0
+RDMA_HANDLE_ROUTE_TTL_SECONDS = 120.0
 
 
 def _resolve_rpc_timeout_seconds(request: "MultimodalInputsPB") -> float:
@@ -168,7 +171,31 @@ class VitProxyRpcServer(MultimodalRpcServiceServicer):
         self.load_balancer = load_balancer
         self.connection_pool = connection_pool
         self.profiler = MMProfiler()
+        self._rdma_handle_routes: dict[str, tuple[str, float]] = {}
+        self._rdma_handle_routes_lock = threading.Lock()
         kmonitor.init()
+
+    def _record_rdma_handles(
+        self, response: MultimodalOutputPB, worker_address: str
+    ) -> None:
+        now = time.monotonic()
+        handles = []
+        if response.HasField("output_rdma") and response.output_rdma.handle:
+            handles.append(response.output_rdma.handle)
+        handles.extend(
+            desc.handle for desc in response.output_rdma_chunks if desc.handle
+        )
+        if not handles:
+            return
+        with self._rdma_handle_routes_lock:
+            cutoff = now - RDMA_HANDLE_ROUTE_TTL_SECONDS
+            self._rdma_handle_routes = {
+                handle: route
+                for handle, route in self._rdma_handle_routes.items()
+                if route[1] >= cutoff
+            }
+            for handle in handles:
+                self._rdma_handle_routes[handle] = (worker_address, now)
 
     def RemoteMultimodalEmbedding(
         self, request: MultimodalInputsPB, context
@@ -190,6 +217,7 @@ class VitProxyRpcServer(MultimodalRpcServiceServicer):
                 f"timeout: {timeout_s}s"
             )
             response = stub.RemoteMultimodalEmbedding(request, timeout=timeout_s)
+            self._record_rdma_handles(response, worker_address)
 
             kmonitor.report(AccMetrics.VIT_SUCCESS_QPS_METRIC, 1)
             self.profiler.on_request_complete()
@@ -208,6 +236,35 @@ class VitProxyRpcServer(MultimodalRpcServiceServicer):
         finally:
             if worker_address:
                 self.load_balancer.decrement_connections(worker_address)
+
+    def ReleaseMultimodalEmbedding(
+        self, request: ReleaseEmbeddingPB, context
+    ) -> EmptyPB:
+        handles_by_worker: dict[str, list[str]] = defaultdict(list)
+        now = time.monotonic()
+        with self._rdma_handle_routes_lock:
+            for handle in request.handle:
+                route = self._rdma_handle_routes.pop(handle, None)
+                if route is None or now - route[1] > RDMA_HANDLE_ROUTE_TTL_SECONDS:
+                    logging.warning(
+                        "No live VIT worker route for RDMA handle %s; worker GC will reclaim it",
+                        handle,
+                    )
+                    continue
+                handles_by_worker[route[0]].append(handle)
+
+        for worker_address, handles in handles_by_worker.items():
+            try:
+                stub = self.connection_pool.get_stub(worker_address)
+                stub.ReleaseMultimodalEmbedding(
+                    ReleaseEmbeddingPB(handle=handles), timeout=1.0
+                )
+            except Exception:
+                logging.exception(
+                    "Failed to release RDMA handles on VIT worker %s; worker GC will reclaim them",
+                    worker_address,
+                )
+        return EmptyPB()
 
     def AsyncSubmitEmbedding(self, request: MultimodalInputsPB, context) -> EmptyPB:
         worker_address = None

--- a/rtp_llm/server/vit_rpc_server.py
+++ b/rtp_llm/server/vit_rpc_server.py
@@ -56,19 +56,15 @@ class MultimodalRpcServer(MultimodalRpcServiceServicer):
     def __init__(self, mm_process_engine: MMProcessEngine, vit_config=None):
         self.engine = mm_process_engine
         self._rdma = None
-        self._rdma_min_bytes = 0
-        if vit_config is not None and getattr(vit_config, "mm_rdma_enable", False):
+        if (
+            vit_config is not None
+            and getattr(vit_config, "mm_transport_mode", "auto") == "auto"
+        ):
             try:
                 rdma = MMRdmaEncoderOp(vit_config)
                 if rdma.enabled():
                     self._rdma = rdma
-                    self._rdma_min_bytes = int(
-                        getattr(vit_config, "mm_rdma_min_bytes", 256 * 1024)
-                    )
-                    logging.info(
-                        "[VIT] mm rdma encoder enabled, min_bytes=%d",
-                        self._rdma_min_bytes,
-                    )
+                    logging.info("[VIT] mm rdma encoder enabled")
                 else:
                     logging.warning(
                         "[VIT] mm rdma requested but unavailable, fall back to bytes"
@@ -96,26 +92,23 @@ class MultimodalRpcServer(MultimodalRpcServiceServicer):
 
         pos = None
         if res.position_ids is not None and len(res.position_ids) > 0:
-            pos = torch.concat(res.position_ids).contiguous()
+            pos = torch.concat(res.position_ids).to(device=emb.device).contiguous()
         extras = []
         if res.extra_input is not None and len(res.extra_input) > 0:
-            extras = [e.contiguous() for e in res.extra_input]
-
-        # Threshold on the TOTAL payload (embedding + pos_id + extra_input): extra_input
-        # (deepstack) is often the larger share, so it must count toward the decision.
-        nbytes = emb.numel() * emb.element_size()
-        if pos is not None:
-            nbytes += pos.numel() * pos.element_size()
-        for extra in extras:
-            nbytes += extra.numel() * extra.element_size()
-        if nbytes < self._rdma_min_bytes:
-            return None
+            extras = [e.to(device=emb.device).contiguous() for e in res.extra_input]
 
         # export_embedding returns a list of serialized MMRdmaDescPB (one per RDMA slot): a single
         # element for the common fits-in-one-slot case, N when the output was chunked, and an empty
         # list on failure (-> fall back to inline bytes).
         desc_bytes_list = self._rdma.export_embedding(emb, pos, extras)
         if not desc_bytes_list:
+            logging.warning(
+                "[VIT] mm rdma export failed; falling back to inline bytes "
+                "(embedding_bytes=%d, pos=%s, extra_count=%d)",
+                emb.numel() * emb.element_size(),
+                pos is not None,
+                len(extras),
+            )
             return None
         descs = []
         for desc_bytes in desc_bytes_list:
@@ -167,6 +160,12 @@ class MultimodalRpcServer(MultimodalRpcServiceServicer):
             converted_inputs = trans_mm_input(multimodal_inputs)
             results = self.engine.get_embedding_result(converted_inputs)
             merged = merge_embedding_results(results)
+            logging.debug(
+                "[VIT] transport negotiation: support_rdma=%s, rdma_ready=%s, embeddings=%d",
+                getattr(multimodal_inputs, "support_rdma", False),
+                self._rdma is not None,
+                len(merged.embeddings),
+            )
             if (
                 getattr(multimodal_inputs, "support_rdma", False)
                 and self._rdma is not None


### PR DESCRIPTION
Use auto/grpc transport selection with automatic gRPC fallback. 
Transfer all ViT outputs through raw Barex RDMA READ and add 1 GiB automatic chunking. 
Add multi-connection failover for ViT RDMA transport