### PR TITLE
fix: fix MTP issues with context parallelism

### DIFF
--- a/rtp_llm/cpp/models/ModelTypes.cc
+++ b/rtp_llm/cpp/models/ModelTypes.cc
@@ -180,8 +180,11 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
         }
         if (shape_hints_ptr[GptModelInputIndex::mtpHiddenStates]) {
             auto hidden_states_dim0 = (size_t)shape_hints_ptr[GptModelInputIndex::comboTokens];
+            RTP_LLM_CHECK_WITH_INFO(hidden_states_dim0 > 0 && hidden_states_size % hidden_states_dim0 == 0,
+                                    "invalid mtp hidden size after TP sync: combo_tokens=%ld, hidden_numel=%ld",
+                                    hidden_states_dim0,
+                                    hidden_states_size);
             auto hidden_states_dim1 = (size_t)hidden_states_size / hidden_states_dim0;
-            RTP_LLM_CHECK(hidden_states_size % hidden_states_dim0 == 0);
             inputs.last_hidden_states =
                 allocBuf((rtp_llm::DataType)shape_hints_ptr[GptModelInputIndex::mtpHiddenStatesDtype],
                          {hidden_states_dim0, hidden_states_dim1},

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -4,6 +4,7 @@
 #include "rtp_llm/cpp/utils/DebugUtils.h"
 #include "rtp_llm/cpp/utils/utils.h"
 #include "rtp_llm/cpp/model_utils/AttentionConfig.h"
+#include <algorithm>
 #include <cstdint>
 #include <stdexcept>
 #include <mutex>
@@ -452,6 +453,22 @@ torch_ext::PyMultimodalInputs PyWrappedModel::buildPyMultimodalInputs(const GptM
     return multimodal_input;
 }
 
+bool PyWrappedModel::shouldUseContextParallel(const GptModelInputs& inputs, bool enable_prefill_cp) {
+    if (!enable_prefill_cp || inputs.prefix_lengths.numel() == 0 || inputs.is_target_verify) {
+        return false;
+    }
+    const bool has_multimodal_input =
+        (inputs.multimodal_features.has_value() && !inputs.multimodal_features->empty())
+        || (inputs.mm_extra_input.has_value() && !inputs.mm_extra_input->empty())
+        || (inputs.mm_features_locs.defined() && inputs.mm_features_locs.numel() > 0)
+        || (inputs.text_tokens_mask.defined() && inputs.text_tokens_mask.numel() > 0);
+    const bool has_mtp_hidden_states =
+        inputs.last_hidden_states.defined() && inputs.last_hidden_states.numel() > 0;
+    const bool has_explicit_position_ids =
+        inputs.combo_position_ids.defined() && inputs.combo_position_ids.numel() > 0;
+    return !has_multimodal_input && !has_mtp_hidden_states && !has_explicit_position_ids;
+}
+
 GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
     RTP_LLM_PROFILE_SCOPE("py_model.forward");
     d2d_copies_.clear();
@@ -467,33 +484,38 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             return forwardMicroBatched(inputs);
         }
         PyContextParallelParams cp_params;
-        if (device_props_.enable_prefill_cp) {
-            context_parallel_processor_->handleInputs(const_cast<GptModelInputs&>(inputs), cp_params);
+        GptModelInputs          cp_inputs;
+        const bool enable_context_parallel = shouldUseContextParallel(inputs, device_props_.enable_prefill_cp);
+        if (enable_context_parallel) {
+            cp_inputs               = inputs;
+            cp_inputs.input_lengths = inputs.input_lengths.clone().pin_memory();
+            context_parallel_processor_->handleInputs(cp_inputs, cp_params);
         }
+        const GptModelInputs& forward_inputs = enable_context_parallel ? cp_inputs : inputs;
 
         torch::Tensor token_ids;
-        token_ids = tensorHoldHostAndToCuda(inputs.combo_tokens);
+        token_ids = tensorHoldHostAndToCuda(forward_inputs.combo_tokens);
 
         torch::Tensor input_hiddens =
-            inputs.last_hidden_states.defined() ? inputs.last_hidden_states : torch::empty({0});
+            forward_inputs.last_hidden_states.defined() ? forward_inputs.last_hidden_states : torch::empty({0});
 
-        torch::Tensor combo_position_ids = inputs.combo_position_ids.defined() ?
-                                               tensorHoldHostAndToCuda(inputs.combo_position_ids) :
+        torch::Tensor combo_position_ids = forward_inputs.combo_position_ids.defined() ?
+                                               tensorHoldHostAndToCuda(forward_inputs.combo_position_ids) :
                                                torch::empty({0});
 
-        auto embedding_inputs      = buildPyEmbeddingInputs(inputs);
-        auto multimodal_inputs     = buildPyMultimodalInputs(inputs);
-        auto attention_inputs      = buildPyAttentionInputs(inputs);
-        auto bert_embedding_inputs = buildBertEmbeddingInputs(inputs);
-        if (device_props_.enable_prefill_cp) {
+        auto embedding_inputs      = buildPyEmbeddingInputs(forward_inputs);
+        auto multimodal_inputs     = buildPyMultimodalInputs(forward_inputs);
+        auto attention_inputs      = buildPyAttentionInputs(forward_inputs);
+        auto bert_embedding_inputs = buildBertEmbeddingInputs(forward_inputs);
+        if (enable_context_parallel) {
             attention_inputs.context_parallel_info = cp_params;
         }
 
-        if (!inputs.warmup && inputs.pd_separation) {
-            attention_inputs.cache_store_inputs = prepareWriteCacheParams(inputs);
+        if (!forward_inputs.warmup && forward_inputs.pd_separation) {
+            attention_inputs.cache_store_inputs = prepareWriteCacheParams(forward_inputs);
             cache_store_async_writer_->init();
         }
-        setupKVCacheForAttentionInputs(attention_inputs, inputs);
+        setupKVCacheForAttentionInputs(attention_inputs, forward_inputs);
 
         calculatePaddingOffset(attention_inputs);
         attention_inputs.padding_offset = tensorHoldHostAndToCuda(attention_inputs.padding_offset);
@@ -540,16 +562,16 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             hidden_states         = py_model_outputs.hidden_states.clone();
         }
 
-        if (!inputs.warmup && inputs.pd_separation) {
+        if (!forward_inputs.warmup && forward_inputs.pd_separation) {
             cache_store_async_writer_->waitAllDone();
         }
 
         RTP_LLM_LOG_DEBUG("Python object instance forward method called successfully.");
-        if (device_props_.enable_prefill_cp) {
-            size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, inputs, cp_params);
-            return callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens);
+        if (enable_context_parallel) {
+            size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, forward_inputs, cp_params);
+            return callForwardPostLayers(hidden_states, forward_inputs, true, num_valid_tokens);
         }
-        return callForwardPostLayers(hidden_states, inputs, true);
+        return callForwardPostLayers(hidden_states, forward_inputs, true);
 
     } catch (const py::error_already_set& e) {
         RTP_LLM_LOG_ERROR("Python error during forward call on Python instance: %s", e.what());

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -51,6 +51,7 @@ private:
     torch_ext::PyEmbeddingInputs   buildPyEmbeddingInputs(const GptModelInputs& inputs);
     torch_ext::PyMultimodalInputs  buildPyMultimodalInputs(const GptModelInputs& inputs);
     torch_ext::BertEmbeddingInputs buildBertEmbeddingInputs(const GptModelInputs& inputs);
+    static bool shouldUseContextParallel(const GptModelInputs& inputs, bool enable_prefill_cp);
     void setupKVCacheForAttentionInputs(torch_ext::PyAttentionInputs& py_attn_inputs, const GptModelInputs& inputs);
     GptModelOutputs callForwardPostLayers(torch::Tensor         hidden_states,
                                           const GptModelInputs& inputs,

--- a/rtp_llm/cpp/models/test/ModelDataTest.cc
+++ b/rtp_llm/cpp/models/test/ModelDataTest.cc
@@ -3,6 +3,7 @@
 
 #include "rtp_llm/cpp/testing/TestBase.h"
 #include "rtp_llm/cpp/models/ModelTypes.h"
+#include "rtp_llm/cpp/models/PyWrappedModel.h"
 #include "rtp_llm/cpp/models/Sampler.h"
 
 using namespace std;
@@ -57,6 +58,46 @@ TEST_F(ModelDataTest, testConstruct) {
     builder.setSequenceLengths(sampler_inputs, sequence_lengths);
     auto sl = sampler_inputs.sequence_lengths;
     EXPECT_EQ(std::vector<int>(sl.data_ptr<int>(), sl.data_ptr<int>() + sl.numel()), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(ModelDataTest, contextParallelFallsBackForUnsupportedInputs) {
+    GptModelInputs inputs;
+    inputs.prefix_lengths = torch::tensor({0}, torch::kInt32);
+    EXPECT_TRUE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, false));
+
+    inputs.multimodal_features = std::vector<torch::Tensor>{torch::ones({1, 2})};
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.mm_extra_input       = std::vector<torch::Tensor>{torch::ones({2})};
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.mm_features_locs     = torch::tensor({0}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.text_tokens_mask     = torch::tensor({1}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.last_hidden_states   = torch::ones({4, 8});
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.combo_position_ids   = torch::tensor({0, 0, 0, 1, 1, 1}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs                      = GptModelInputs{};
+    inputs.prefix_lengths       = torch::tensor({0}, torch::kInt32);
+    inputs.is_target_verify     = true;
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -31,8 +31,6 @@ from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
-from rtp_llm.ops import SpeculativeType
-
 __all__ = [
     "DeepepWrapperConfig",
     "DeepEPWrapper",
@@ -651,14 +649,11 @@ def init_deepep_wrapper(
 
     ll_num_max_token_per_rank = 0
     if engine_config.moe_config.use_deepep_low_latency:
-        ll_num_max_token = engine_config.runtime_config.max_generate_batch_size
-        if engine_config.sp_config.type != SpeculativeType.NONE:
-            ll_num_max_token *= engine_config.sp_config.gen_num_per_cycle + 1
         ll_num_max_token_per_rank = (
             DeepepWrapperConfig.calc_low_latency_max_token_per_rank(
-                ll_num_max_token,
-                engine_config.parallelism_config.tp_size,
-                model_config.quant_config,
+                deepep_config_adapter.ll_num_max_token,
+                deepep_config_adapter.tp_size,
+                deepep_config_adapter.quant_config,
             )
         )
 

--- a/rtp_llm/models_py/distributed/test/BUILD
+++ b/rtp_llm/models_py/distributed/test/BUILD
@@ -12,6 +12,20 @@ py_test (
     exec_properties = {'gpu':'H20', 'gpu_count':'2'},
 )
 
+py_test(
+    name = "deepep_wrapper_config_test",
+    srcs = ["deepep_wrapper_config_test.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py:modules",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["open_skip", "H20"],
+    exec_properties = {'gpu':'H20', 'gpu_count':'1'},
+)
+
 py_test (
     name = "moriep_test",
     srcs = ["moriep_test.py"],

--- a/rtp_llm/models_py/distributed/test/deepep_wrapper_config_test.py
+++ b/rtp_llm/models_py/distributed/test/deepep_wrapper_config_test.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest import TestCase, main
+from unittest.mock import patch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.distributed.deepep_wrapper import (
+    DeepEPWrapper,
+    init_deepep_wrapper,
+)
+from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig
+
+
+class DeepEPWrapperConfigTest(TestCase):
+    def test_cp_low_latency_uses_router_token_capacity(self) -> None:
+        model_config = ModelConfig()
+        model_config.hidden_size = 2048
+        model_config.expert_num = 256
+        model_config.moe_k = 8
+
+        parallelism_config = ParallelismConfig()
+        parallelism_config.dp_size = 1
+        parallelism_config.dp_rank = 0
+        parallelism_config.tp_size = 2
+        parallelism_config.tp_rank = 0
+        parallelism_config.ep_size = 2
+        parallelism_config.ep_rank = 0
+        parallelism_config.world_size = 2
+        parallelism_config.local_rank = 0
+        parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        self.assertEqual(parallelism_config.get_attn_tp_size(), 1)
+
+        moe_config = MoeConfig()
+        moe_config.use_deepep_low_latency = True
+        engine_config = SimpleNamespace(
+            hw_kernel_config=None,
+            parallelism_config=parallelism_config,
+            moe_config=moe_config,
+        )
+
+        cases = [
+            ("base", 1757, 1792),
+            ("mtp_eagle_gen4", 1757 * (4 + 1), 8832),
+        ]
+        with patch.object(DeepEPWrapper, "supported", return_value=True), patch.object(
+            DeepEPWrapper, "create"
+        ) as mock_create, patch(
+            "rtp_llm.models_py.distributed.deepep_wrapper.allow_mnnvl",
+            return_value=False,
+        ):
+            for case_name, ll_num_max_token, expected_per_rank in cases:
+                with self.subTest(case=case_name):
+                    moe_config.ll_num_max_token = ll_num_max_token
+                    mock_create.reset_mock()
+
+                    init_deepep_wrapper(engine_config, model_config)
+
+                    created_config = mock_create.call_args.args[0]
+                    self.assertEqual(created_config.tp_size, 2)
+                    self.assertEqual(
+                        created_config.ll_num_max_token_per_rank,
+                        expected_per_rank,
+                    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from typing import Any, Dict, Optional
 
@@ -516,6 +515,7 @@ class Qwen3NextAttention(CausalAttention):
         layernorm_eps: float,
         quant_config: Optional[object] = None,
         hw_kernel_config: Optional["HWKernelConfig"] = None,
+        layer_idx: int = 0,
     ):
         super().__init__(
             attn_config,
@@ -524,6 +524,7 @@ class Qwen3NextAttention(CausalAttention):
             layernorm_eps,
             quant_config,
             hw_kernel_config=hw_kernel_config,
+            layer_idx=layer_idx,
         )
         # maybe fuse gate in qkv_proj later
         self.gate = LinearFactory.create_linear_from_weights(
@@ -951,6 +952,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 config.layernorm_eps,
                 config.quant_config,
                 hw_kernel_config=hw_kernel_config,
+                layer_idx=layer_idx,
             )
 
         if config.moe_style == 2:
@@ -1122,7 +1124,7 @@ class Qwen3NextModel(GptModelBase):
         attention_inputs: PyAttentionInputs = inputs.attention_inputs
         prefill_conv1d_meta = None
         is_target_verify = attention_inputs.is_target_verify
-        is_cp = self.parallelism_config.prefill_cp_config.is_enabled()
+        is_cp = attention_inputs.context_parallel_info is not None
 
         full_prefill_conv1d_meta = None
         full_prefill_cu_seqlens = None

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -35,6 +35,7 @@ def get_mla_impl(
 ) -> MlaImplBase:
 
     mla_impls = PREFILL_MLA_IMPS if attn_inputs.is_prefill else DECODE_MLA_IMPS
+    is_context_parallel = attn_inputs.context_parallel_info is not None
     for impl in mla_impls:
         # Check support before creating instance
         if not impl.support(attn_configs, attn_inputs):
@@ -45,13 +46,14 @@ def get_mla_impl(
         use_fast_path = (
             attn_inputs.is_prefill
             and attn_inputs.cu_kv_seqlens_device.max().item() <= attn_configs.indexer_topk
-            and not (
-                parallelism_config and parallelism_config.prefill_cp_config.is_enabled()
-            )
+            and not is_context_parallel
         )
 
+        parallelism_config_for_support = (
+            parallelism_config if is_context_parallel else None
+        )
         if not use_fast_path and not impl.support_parallelism_config(
-            parallelism_config
+            parallelism_config_for_support
         ):
             continue
 
@@ -149,6 +151,7 @@ def get_fmha_impl(
     attn_inputs.is_cuda_graph = is_cuda_graph
 
     mha_impls = PREFILL_MHA_IMPS if attn_inputs.is_prefill else DECODE_MHA_IMPS
+    is_context_parallel = attn_inputs.context_parallel_info is not None
 
     for impl in mha_impls:
         # Check if this FMHA implementation is disabled before creating instance
@@ -162,8 +165,10 @@ def get_fmha_impl(
         if not impl.support(attn_configs, attn_inputs):
             continue
 
-        # Check if implementation supports parallelism config
-        if not impl.support_parallelism_config(parallelism_config):
+        parallelism_config_for_support = (
+            parallelism_config if is_context_parallel else None
+        )
+        if not impl.support_parallelism_config(parallelism_config_for_support):
             continue
         try:
             instance = impl(attn_configs, attn_inputs, parallelism_config)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
@@ -164,7 +164,7 @@ class CPFlashInferImpl(FMHAImplBase):
 
     @classmethod
     def support(cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs):
-        return True
+        return attn_inputs.context_parallel_info is not None
 
     def fmha_type(self) -> FMHAType:
         return FMHAType.CP_FLASH_INFER
@@ -177,10 +177,10 @@ class CPFlashInferImpl(FMHAImplBase):
         self,
         qkv: torch.Tensor,
         kv_cache: Optional[KVCache],
-        need_rope_kv_cache: bool = True,
+        layer_idx: int = 0,
     ) -> torch.Tensor:
         assert self.rope_kvcache_impl is not None and self.rope_params is not None
-        if need_rope_kv_cache:
+        if self.need_rope_kv_cache:
             fmha_input = self.rope_kvcache_impl.forward(qkv, None, self.rope_params)
         else:
             fmha_input = qkv

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
@@ -76,3 +76,15 @@ py_test(
     tags = ["manual"],
     exec_properties = {'gpu': 'H20'},
 )
+
+py_test(
+    name = "test_prefill_cp_flashinfer",
+    srcs = ["test_prefill_cp_flashinfer.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20'},
+)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_prefill_cp_flashinfer.py
@@ -1,0 +1,216 @@
+import unittest
+from itertools import accumulate
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_cp_flashinfer import (
+    CPFlashInferImpl,
+)
+from rtp_llm.ops.compute_ops import get_typemeta
+from rtp_llm.ops.fused_rope_kvcache_op import FusedRopeKVCachePrefillOpBase
+
+
+class _FakeRope:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def forward(self, qkv, kv_cache, params):
+        self.calls += 1
+        return qkv + 1
+
+
+class _FakeFmha:
+    def forward(self, fmha_input, kv_cache, params):
+        return fmha_input
+
+
+class TestCPFlashInferImpl(unittest.TestCase):
+    @staticmethod
+    def _make_impl(need_rope_kv_cache: bool) -> CPFlashInferImpl:
+        impl = object.__new__(CPFlashInferImpl)
+        impl.need_rope_kv_cache = need_rope_kv_cache
+        impl.rope_kvcache_impl = _FakeRope()
+        impl.rope_params = object()
+        impl.fmha_impl = _FakeFmha()
+        impl.fmha_params = object()
+        impl.attn_inputs = SimpleNamespace(cache_store_inputs=None)
+        impl.write_cache_store_impl = None
+        return impl
+
+    def test_support_requires_runtime_cp_metadata(self) -> None:
+        no_cp_inputs = SimpleNamespace(context_parallel_info=None)
+        cp_inputs = SimpleNamespace(context_parallel_info=object())
+
+        self.assertFalse(CPFlashInferImpl.support(None, no_cp_inputs))
+        self.assertTrue(CPFlashInferImpl.support(None, cp_inputs))
+
+    def test_layer_zero_still_runs_configured_rope(self) -> None:
+        impl = self._make_impl(need_rope_kv_cache=True)
+        qkv = torch.tensor([1.0])
+
+        output = impl.forward(qkv, kv_cache=None, layer_idx=0)
+
+        self.assertEqual(impl.rope_kvcache_impl.calls, 1)
+        self.assertTrue(torch.equal(output, qkv + 1))
+
+    def test_nonzero_layer_does_not_override_disabled_rope(self) -> None:
+        impl = self._make_impl(need_rope_kv_cache=False)
+        qkv = torch.tensor([1.0])
+
+        output = impl.forward(qkv, kv_cache=None, layer_idx=7)
+
+        self.assertEqual(impl.rope_kvcache_impl.calls, 0)
+        self.assertTrue(torch.equal(output, qkv))
+
+
+class TestCPRopePositionIds(unittest.TestCase):
+    @staticmethod
+    def _make_attn_inputs(
+        shuffle_indices,
+        combo_position_ids=None,
+        prefix_lengths=(0,),
+        chunk_lengths=None,
+        actual_input_lengths=None,
+    ):
+        token_count = len(shuffle_indices)
+        if chunk_lengths is None:
+            chunk_lengths = (token_count,)
+        if actual_input_lengths is None:
+            actual_input_lengths = (max(shuffle_indices) + 1,)
+        cu_seqlens = torch.tensor([0, *accumulate(chunk_lengths)], dtype=torch.int32)
+        return SimpleNamespace(
+            kv_cache_kernel_block_id=None,
+            combo_position_ids=combo_position_ids,
+            context_parallel_info=SimpleNamespace(
+                prefill_shuffle_indices=torch.tensor(
+                    shuffle_indices, dtype=torch.int32
+                ),
+                prefill_cp_chunk_lengths=torch.tensor(
+                    chunk_lengths, dtype=torch.int32
+                ),
+                prefill_actual_input_lengths_cpu=torch.tensor(
+                    actual_input_lengths, dtype=torch.int32
+                ),
+            ),
+            total_tokens=token_count,
+            padding_offset=None,
+            cu_seqlens_device=cu_seqlens,
+            cu_kv_seqlens_device=cu_seqlens,
+            input_lengths=torch.tensor(chunk_lengths, dtype=torch.int32),
+            prefix_lengths=torch.tensor(prefix_lengths, dtype=torch.int32),
+            prefix_lengths_device=torch.tensor(prefix_lengths, dtype=torch.int32),
+            sequence_lengths=torch.empty(0, dtype=torch.int32),
+            context_total_kv_length=token_count + sum(prefix_lengths),
+            dtype=get_typemeta(torch.empty(0, dtype=torch.bfloat16)),
+        )
+
+    @staticmethod
+    def _make_op(index_factor: int) -> FusedRopeKVCachePrefillOpBase:
+        return FusedRopeKVCachePrefillOpBase(
+            SimpleNamespace(rope_config=SimpleNamespace(index_factor=index_factor))
+        )
+
+    def test_plain_rope_uses_cp_shuffle_indices(self) -> None:
+        attn_inputs = self._make_attn_inputs(
+            [0, 1, 6, 7], torch.empty(0, dtype=torch.int32)
+        )
+
+        params = self._make_op(index_factor=1).prepare(attn_inputs)
+
+        self.assertIs(
+            params.position_ids,
+            attn_inputs.context_parallel_info.prefill_shuffle_indices,
+        )
+
+    def test_plain_rope_adds_prefix_per_request_and_zeros_padding(self) -> None:
+        attn_inputs = self._make_attn_inputs(
+            [0, 1, 6, 7, 0, 3],
+            torch.empty(0, dtype=torch.int32),
+            prefix_lengths=(4, 8),
+            chunk_lengths=(4, 2),
+            actual_input_lengths=(7, 4),
+        )
+
+        params = self._make_op(index_factor=1).prepare(attn_inputs)
+
+        self.assertEqual(params.position_ids.tolist(), [4, 5, 10, 0, 8, 11])
+
+    def test_explicit_mrope_position_ids_take_precedence(self) -> None:
+        combo_position_ids = torch.tensor(
+            [0, 10, 20, 1, 11, 21, 6, 16, 26, 7, 17, 27],
+            dtype=torch.int32,
+        )
+        attn_inputs = self._make_attn_inputs([0, 1, 6, 7], combo_position_ids)
+
+        params = self._make_op(index_factor=3).prepare(attn_inputs)
+
+        self.assertIs(params.position_ids, combo_position_ids)
+
+
+class _CaptureDecoderLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attn_meta = None
+
+    def forward(
+        self,
+        hidden_states,
+        residual,
+        fmha_impl,
+        kv_cache,
+        attention_inputs,
+        attn_meta,
+    ):
+        self.attn_meta = attn_meta
+        return hidden_states, residual
+
+
+class _IdentityNorm(torch.nn.Module):
+    def forward(self, hidden_states, residual):
+        return hidden_states, residual
+
+
+class TestQwen3NextCPRuntimeSelection(unittest.TestCase):
+    def test_target_verify_uses_non_cp_metadata(self):
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextModel
+        from rtp_llm.ops import CPRotateMethod, ParallelismConfig
+
+        parallelism_config = ParallelismConfig()
+        parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+
+        model = object.__new__(Qwen3NextModel)
+        torch.nn.Module.__init__(model)
+        model.parallelism_config = parallelism_config
+        capture_layer = _CaptureDecoderLayer()
+        model.layers = torch.nn.ModuleList([capture_layer])
+        model.norm = _IdentityNorm()
+        model.kv_cache = None
+
+        hidden_states = torch.randn(4, 8)
+        attention_inputs = SimpleNamespace(
+            is_prefill=True,
+            is_target_verify=True,
+            prefix_lengths=torch.tensor([3], dtype=torch.int32),
+            cu_seqlens_device=torch.tensor([0, 4], dtype=torch.int32),
+            context_parallel_info=None,
+            cache_store_inputs=object(),
+        )
+        inputs = SimpleNamespace(attention_inputs=attention_inputs)
+        fmha_impl = SimpleNamespace(fmha_params=None)
+
+        with patch.object(Qwen3NextModel, "word_embedding", return_value=hidden_states):
+            with patch(
+                "rtp_llm.models_py.model_desc.qwen3_next.select_block_map_for_layer"
+            ):
+                output = model.forward(inputs, fmha_impl)
+
+        self.assertIsNone(capture_layer.attn_meta.prefill_conv1d_meta)
+        self.assertTrue(capture_layer.attn_meta.is_target_verify)
+        self.assertFalse(capture_layer.attn_meta.is_cp_linear_attn)
+        self.assertIsNone(capture_layer.attn_meta.cp_write_cache_store_impl)
+        torch.testing.assert_close(output.hidden_states, hidden_states)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/ops/fused_rope_kvcache_op.py
+++ b/rtp_llm/ops/fused_rope_kvcache_op.py
@@ -39,6 +39,41 @@ class FusedRopeKVCachePrefillOpBase:
     def __init__(self, attn_configs: AttentionConfigs) -> None:
         self.attn_configs = attn_configs
 
+    @staticmethod
+    def _get_cp_position_ids(attn_inputs: PyAttentionInputs) -> torch.Tensor:
+        cp_info = attn_inputs.context_parallel_info
+        shuffle_indices = cp_info.prefill_shuffle_indices
+        if not attn_inputs.prefix_lengths.any().item():
+            return shuffle_indices
+
+        # Explicit position_ids override the kernel's prefix offset. Convert each
+        # request-local CP index to an absolute position and keep padding at zero.
+        chunk_lengths = cp_info.prefill_cp_chunk_lengths
+        output_size = shuffle_indices.numel()
+        prefix_lengths = torch.repeat_interleave(
+            attn_inputs.prefix_lengths_device,
+            chunk_lengths,
+            output_size=output_size,
+        )
+        actual_input_lengths = cp_info.prefill_actual_input_lengths_cpu.to(
+            device=shuffle_indices.device,
+            dtype=shuffle_indices.dtype,
+            non_blocking=True,
+        )
+        actual_input_lengths = torch.repeat_interleave(
+            actual_input_lengths,
+            chunk_lengths,
+            output_size=output_size,
+        )
+        valid_tokens = shuffle_indices.ge(0) & shuffle_indices.lt(
+            actual_input_lengths
+        )
+        return torch.where(
+            valid_tokens,
+            shuffle_indices + prefix_lengths,
+            torch.zeros_like(shuffle_indices),
+        )
+
     def prepare(self, attn_inputs: PyAttentionInputs) -> FusedRopeAttnParams:
         if (
             attn_inputs.kv_cache_kernel_block_id is not None
@@ -52,8 +87,14 @@ class FusedRopeKVCachePrefillOpBase:
         kv_cache_offset_h = None # not used
 
         position_ids = attn_inputs.combo_position_ids
-        if attn_inputs.context_parallel_info is not None:
-            position_ids = attn_inputs.context_parallel_info.prefill_shuffle_indices
+        has_explicit_position_ids = (
+            position_ids is not None and position_ids.numel() > 0
+        )
+        if (
+            attn_inputs.context_parallel_info is not None
+            and not has_explicit_position_ids
+        ):
+            position_ids = self._get_cp_position_ids(attn_inputs)
 
         return FusedRopeAttnParams(
             kv_cache_offset,

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -269,6 +269,13 @@ def h20_oss_suites():
                 gpu_type=["H20"],
             ),
             smoke_test(
+                name="next_mtp_cp2_multimodal",
+                task_info="data/model/qwen35/q_r_35b_moe_vl_fp8.json",
+                smoke_args="--use_local 1 --act_type BF16 --seq_size_per_block 2048 --tp_size 2 --ep_size 2 --world_size 2 --local_world_size 2 --max_seq_len 12800 --reserver_runtime_mem_mb 30000 --enable_cuda_graph 0 --warm_up 0 --cp_rotate_method ALL_GATHER --use_all_gather=0 --sp_model_type qwen35_moe_mtp --gen_num_per_cycle 4 --sp_type eagle --sp_checkpoint_path /mnt/nas1/hf/Qwen3.5-35B-A3B-FP8 --sp_act_type bf16",
+                gpu_type=["H20"],
+                data=native.glob(['data/model/qwen_vl/*.jpeg']),
+            ),
+            smoke_test(
                 name="next_mtp_reuse",
                 task_info="data/model/qwen3_next/q_r_next_fp8_tp2_mtp_reuse_cache.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 2048 --tp_size 2 --max_seq_len 12800 --reserver_runtime_mem_mb 10000 --sp_model_type qwen35_moe_mtp --gen_num_per_cycle 4 --sp_type eagle --sp_checkpoint_path /mnt/nas1/hf/Qwen3.5-35B-A3B-FP8 --sp_act_type bf16 --reuse_cache 1",


### PR DESCRIPTION
## Summary

This PR fixes several correctness and stability issues when MTP is used together with Context Parallelism (CP), including MTP input shape mismatches, attention implementation selection failures, fused RoPE illegal memory access, and inconsistent DeepEP low-latency initialization.

The main change is to preserve one consistent CP mapping across all per-token MTP inputs:

```text
combo_tokens[i]
last_hidden_states[i, :]
combo_position_ids[i, :]
```

## Problem

Previously, CP partitioned and reordered `combo_tokens` without applying the same mapping to MTP hidden states and position IDs. In MTP + CP2 workloads, this caused local/global input mismatches such as 626 token rows versus 1252 hidden-state rows.

After that mismatch was bypassed, two additional issues were exposed:

- CP attention could be selected for draft decode or target verification inputs that did not carry valid CP prefill metadata, resulting in `can not find mha type`.
- Fused RoPE replaced the model position IDs with one-dimensional CP shuffle indices. Qwen3.5 MRoPE requires three position values per token, so a 794-element buffer was read as 2382 elements and triggered a CUDA illegal address followed by SIGABRT.

CP2 with DeepEP low-latency also failed during model initialization because server pre-initialization and the MoE router used different effective TP sizes when calculating the per-rank token capacity.

## Changes

- Apply the same CP partition, reorder, and padding plan to tokens, MTP hidden states, and position IDs.
  - Preserve decode rows in their original order.
  - Support both one-dimensional RoPE and multi-axis MRoPE position IDs without model-specific hardcoding.
  - Avoid repartitioning hidden states that are already rank-local.
- Preserve MTP input contracts across execution boundaries.
  - Broadcast both dimensions of MTP hidden states instead of inferring their shape from token count.
  - Slice hidden states and position IDs together with tokens during microbatching.
  - Keep draft tokens and position IDs in contiguous pinned host memory for the next CP partition.
  - Synchronize draft tokens and position IDs across TP ranks before the next forward pass.
- Restrict CP execution to supported prefill inputs with valid host-side metadata, excluding target verification and unsupported prefix layouts.
- Select CP attention only when valid CP metadata is present; draft decode and target verification continue to use the normal attention path.
- Make CP FlashInfer honor its configured fused-RoPE setting instead of treating the layer index as the enable flag.
- Always pass the reordered model position IDs to fused RoPE instead of CP shuffle indices, and validate the position buffer length before launching the CUDA kernel.
- Derive DeepEP low-latency capacity from the same `MoEConfigAdapter` values used by the router, keeping MTP token expansion and CP effective TP semantics consistent.