### PR TITLE
fix(speculative): make greedy MTP decoding deterministic

### DIFF
--- a/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
@@ -53,39 +53,89 @@ void SpeculativeSampler::batchSample(SpeculativeSamplerOutput&           sample_
     auto draft_token_probs  = draft_sampler_output.all_probs;
     auto target_token_probs = target_sampler_output.all_probs;
 
-    // prepare data for chain speculative sampling
+    // Prepare per-stream sampling mode. Greedy verification must compare the
+    // draft and target tokens directly and must not depend on random numbers.
+    auto do_sample_h  = torch::empty({batch_size}, torch::TensorOptions().device(host_device).dtype(torch::kBool));
+    bool has_sampling = false;
+    bool has_greedy   = false;
+    int  stream_idx   = 0;
+    for (const auto& stream : streams) {
+        const bool do_sample                       = stream->generateConfig()->do_sample;
+        do_sample_h.data_ptr<bool>()[stream_idx++] = do_sample;
+        has_sampling                               = has_sampling || do_sample;
+        has_greedy                                 = has_greedy || !do_sample;
+    }
+
     auto          draft_token_ids_d_t    = draft_token_ids.to(target_device).clone();
     auto          draft_token_probs_d_t  = draft_token_probs;
     auto          target_token_probs_d_t = target_token_probs;
+    auto          target_token_ids_d_t   = target_token_ids.to(target_device).contiguous();
     auto          rand_options           = torch::TensorOptions().device(target_device).dtype(torch::kFloat);
-    torch::Tensor uniform_samples_d      = torch::rand({(long)batch_size, (long)propose_step_ + 1}, rand_options);
+    torch::Tensor uniform_samples_d;
+    if (has_sampling && !has_greedy) {
+        uniform_samples_d = torch::rand({(long)batch_size, (long)propose_step_ + 1}, rand_options);
+    } else {
+        uniform_samples_d = torch::zeros({(long)batch_size, (long)propose_step_ + 1}, rand_options);
+    }
 
-    // Override per-stream uniform samples with seeded generator when random_seed is set,
-    // ensuring deterministic acceptance for reproducible iter_count.
-    {
+    // Sampling rows retain the existing rejection-sampling behavior. Greedy
+    // rows neither consume their generator nor receive unseeded random values.
+    if (has_sampling) {
         int idx = 0;
         for (const auto& stream : streams) {
-            auto gen = stream->getGenerator();
-            if (gen.defined()) {
-                uniform_samples_d[idx] = torch::rand({(long)propose_step_ + 1}, gen, std::nullopt, rand_options);
+            if (do_sample_h.data_ptr<bool>()[idx]) {
+                auto gen = stream->getGenerator();
+                if (gen.defined()) {
+                    uniform_samples_d[idx].copy_(
+                        torch::rand({(long)propose_step_ + 1}, gen, std::nullopt, rand_options));
+                } else if (has_greedy) {
+                    uniform_samples_d[idx].copy_(torch::rand({(long)propose_step_ + 1}, rand_options));
+                }
             }
             idx++;
         }
     }
-    torch::Tensor output_token_ids_d     = torch::zeros({(long)batch_size, (long)propose_step_ + 1},
+    torch::Tensor output_token_ids_d = torch::zeros({(long)batch_size, (long)propose_step_ + 1},
                                                     torch::TensorOptions().device(target_device).dtype(torch::kInt32));
     torch::Tensor output_accepted_token_num_d =
         torch::zeros({(long)batch_size}, torch::TensorOptions().device(target_device).dtype(torch::kInt32));
     torch::Tensor output_emitted_token_num_d =
         torch::zeros({(long)batch_size}, torch::TensorOptions().device(target_device).dtype(torch::kInt32));
 
-    execChainSpeculativeSampling({draft_token_probs_d_t,
-                                  draft_token_ids_d_t,
-                                  uniform_samples_d,
-                                  target_token_probs_d_t,
-                                  output_token_ids_d,
-                                  output_accepted_token_num_d,
-                                  output_emitted_token_num_d});
+    if (has_sampling) {
+        execChainSpeculativeSampling({draft_token_probs_d_t,
+                                      draft_token_ids_d_t,
+                                      uniform_samples_d,
+                                      target_token_probs_d_t,
+                                      output_token_ids_d,
+                                      output_accepted_token_num_d,
+                                      output_emitted_token_num_d});
+    }
+
+    if (has_greedy) {
+        auto greedy_output_token_ids_d = has_sampling ? torch::zeros_like(output_token_ids_d) : output_token_ids_d;
+        auto greedy_emitted_token_num_d =
+            has_sampling ? torch::zeros_like(output_emitted_token_num_d) : output_emitted_token_num_d;
+        auto greedy_do_sample_d =
+            torch::zeros({batch_size}, torch::TensorOptions().device(target_device).dtype(torch::kBool));
+
+        execRejectionSampling({draft_token_probs_d_t,
+                               draft_token_ids_d_t,
+                               uniform_samples_d,
+                               target_token_probs_d_t,
+                               target_token_ids_d_t,
+                               greedy_output_token_ids_d,
+                               greedy_emitted_token_num_d,
+                               greedy_do_sample_d});
+
+        if (has_sampling) {
+            auto do_sample_d = do_sample_h.to(target_device, true);
+            output_token_ids_d =
+                torch::where(do_sample_d.reshape({batch_size, 1}), output_token_ids_d, greedy_output_token_ids_d);
+            output_emitted_token_num_d =
+                torch::where(do_sample_d, output_emitted_token_num_d, greedy_emitted_token_num_d);
+        }
+    }
 
     // back to host
     torch::Tensor output_token_ids_h         = output_token_ids_d.to(host_device, true);
@@ -99,7 +149,7 @@ void SpeculativeSampler::batchSample(SpeculativeSamplerOutput&           sample_
         }
     }
 
-    int stream_idx = 0;
+    stream_idx = 0;
     for (const GenerateStreamPtr& stream : streams) {
         torch::Tensor accept_tokens;
         size_t        accept_len = 0;

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
@@ -268,10 +268,14 @@ public:
     GenerateStreamPtr createContextStream(const ModelConfig&     model_config,
                                           const RuntimeConfig&   runtime_config,
                                           const ResourceContext& resource_context,
-                                          const vector<int>&     input_ids) {
+                                          const vector<int>&     input_ids,
+                                          bool                   do_sample   = true,
+                                          std::optional<int>     random_seed = std::nullopt) {
         std::shared_ptr<GenerateInput> query = make_shared<GenerateInput>();
         query->input_ids       = torch::tensor(std::vector<int32_t>(input_ids.begin(), input_ids.end()), torch::kInt32);
         query->generate_config = make_shared<GenerateConfig>();
+        query->generate_config->do_sample   = do_sample;
+        query->generate_config->random_seed = random_seed;
         GenerateStreamPtr stream =
             make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
         return stream;
@@ -455,6 +459,70 @@ public:
         return output;
     }
 };
+
+TEST_F(MtpExecutorTest, testSpeculativeSamplerGreedyDoesNotConsumeRng) {
+    MtpExecutorTestConfig test_config;
+    test_config.vocab_size        = 10;
+    test_config.gen_num_per_cycle = 4;
+    auto components               = createMtpExecutorComponents(test_config);
+
+    auto stream = createContextStream(
+        components.model_config, components.runtime_config, components.resource_context, {0}, false, 42);
+    auto baseline_stream = createContextStream(
+        components.model_config, components.runtime_config, components.resource_context, {0}, false, 42);
+
+    auto          device = getTorchCudaDevice();
+    SamplerOutput draft_output;
+    draft_output.token_ids = torch::tensor({1, 2, 3, 4}, torch::kInt32).reshape({1, 4}).to(device);
+    draft_output.all_probs =
+        torch::full({1, 4, 10}, 0.1f, torch::TensorOptions().device(device).dtype(torch::kFloat32));
+
+    SamplerOutput target_output;
+    target_output.token_ids = torch::tensor({1, 2, 9, 4, 5}, torch::kInt32).reshape({5, 1}).to(device);
+    target_output.all_probs =
+        torch::full({1, 5, 10}, 0.1f, torch::TensorOptions().device(device).dtype(torch::kFloat32));
+
+    spec::SpeculativeSampler sampler(test_config.gen_num_per_cycle);
+    auto                     result = sampler.forward({stream}, draft_output, target_output);
+
+    ASSERT_EQ(result.accept_len, vector<int>({3}));
+    ASSERT_EQ(toVec<int32_t>(result.accept_tokens[0]), vector<int32_t>({1, 2, 9}));
+
+    auto rand_options = torch::TensorOptions().device(device).dtype(torch::kFloat32);
+    auto actual_next  = torch::rand({8}, stream->getGenerator(), std::nullopt, rand_options);
+    auto expect_next  = torch::rand({8}, baseline_stream->getGenerator(), std::nullopt, rand_options);
+    EXPECT_TRUE(torch::equal(actual_next, expect_next));
+}
+
+TEST_F(MtpExecutorTest, testSpeculativeSamplerMixedBatchKeepsPerStreamMode) {
+    MtpExecutorTestConfig test_config;
+    test_config.vocab_size        = 10;
+    test_config.gen_num_per_cycle = 4;
+    auto components               = createMtpExecutorComponents(test_config);
+
+    auto greedy_stream = createContextStream(
+        components.model_config, components.runtime_config, components.resource_context, {0}, false, 42);
+    auto sampling_stream = createContextStream(
+        components.model_config, components.runtime_config, components.resource_context, {0}, true, 42);
+
+    auto          device = getTorchCudaDevice();
+    SamplerOutput draft_output;
+    draft_output.token_ids = torch::tensor({1, 2, 3, 4, 5, 6, 7, 8}, torch::kInt32).reshape({2, 4}).to(device);
+    draft_output.all_probs =
+        torch::full({2, 4, 10}, 0.1f, torch::TensorOptions().device(device).dtype(torch::kFloat32));
+
+    SamplerOutput target_output;
+    target_output.token_ids = torch::tensor({1, 9, 3, 4, 5, 5, 6, 7, 8, 9}, torch::kInt32).reshape({10, 1}).to(device);
+    target_output.all_probs =
+        torch::full({2, 5, 10}, 0.1f, torch::TensorOptions().device(device).dtype(torch::kFloat32));
+
+    spec::SpeculativeSampler sampler(test_config.gen_num_per_cycle);
+    auto                     result = sampler.forward({greedy_stream, sampling_stream}, draft_output, target_output);
+
+    ASSERT_EQ(result.accept_len, vector<int>({2, 5}));
+    ASSERT_EQ(toVec<int32_t>(result.accept_tokens[0]), vector<int32_t>({1, 9}));
+    ASSERT_EQ(toVec<int32_t>(result.accept_tokens[1]), vector<int32_t>({5, 6, 7, 8, 9}));
+}
 
 TEST_F(MtpExecutorTest, testSingleBatchPrefill) {
     MtpExecutorTestConfig test_config;

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json
@@ -13,9 +13,9 @@
                 ],
                 "max_tokens": 100,
                 "temperature": 0.0,
-                "top_p": 0,
-                "top_k": 1,
-                "random_seed": 42
+                "extra_configs": {
+                    "do_sample": false
+                }
             },
             "result": {
                 "id": "chat-",
@@ -88,9 +88,9 @@
                 ],
                 "max_tokens": 20,
                 "temperature": 0.0,
-                "top_p": 0,
-                "top_k": 1,
-                "random_seed": 42
+                "extra_configs": {
+                    "do_sample": false
+                }
             },
             "result": {
                 "id": "chat-",

--- a/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/q_r_next_fp8_tp2_mtp_cudagraph.json
@@ -13,9 +13,9 @@
                 ],
                 "max_tokens": 100,
                 "temperature": 0.0,
-                "top_p": 0,
-                "top_k": 1,
-                "random_seed": 42
+                "extra_configs": {
+                    "do_sample": false
+                }
             },
             "result": {
                 "choices": [


### PR DESCRIPTION
#### Background

Greedy MTP decoding with `do_sample=false` still reused the sampling rejection path, which made verification depend on random numbers. As a result, the accepted token count and final output of greedy decoding could become RNG-dependent, causing MTP smoke cases to be unstable when no fixed seed is provided.

#### Changes

- Split speculative verification behavior by each stream’s `do_sample` mode:
  - greedy streams with `do_sample=false` verify draft tokens through exact target-token matching;
  - the greedy path does not consume the stream generator and does not depend on unseeded random samples;
  - sampling streams with `do_sample=true` keep the existing rejection sampling behavior;
  - mixed batches merge outputs according to each stream’s own `do_sample` mode.
- Added MTP executor unit test coverage for:
  - greedy mode not consuming RNG;
  - mixed batches preserving per-stream greedy / sampling behavior.
- Updated Qwen3 Next MTP smoke configurations:
  - explicitly set `extra_configs.do_sample=false` for the target OpenAI chat queries;
  - cover both normal MTP and CUDA Graph MTP smoke cases.

#### Validation

- Added unit tests:
  - `testSpeculativeSamplerGreedyDoesNotConsumeRng`
  - `testSpeculativeSamplerMixedBatchKeepsPerStreamMode`
- Validated through multiple CUDA functional CI runs, covering:
  - `ut-sm8x`
  - `ut-sm9x`
  - `smoke-light-sm8x`
  - `smoke-sm8x`
  - `smoke-light-sm9x`
  - `smoke-sm9x`
- `perf-test` is not part of the acceptance criteria for this fix.