### PR TITLE
Feat/adapt sm120 fp8

### DIFF
--- a/rtp_llm/cpp/cache/MemoryLayoutStrategy.cc
+++ b/rtp_llm/cpp/cache/MemoryLayoutStrategy.cc
@@ -34,6 +34,9 @@ void MemoryLayoutStrategy::clearKVTensor(torch::Tensor& kv_cache_tensor) {
 void MemoryLayoutStrategy::clearScaleTensor(torch::Tensor& kv_scale_tensor) {
     if (config_.hasScale()) {
         if (config_.dtype == rtp_llm::TYPE_FP8_E4M3) {
+            // PyFlashinfer writes FP8 KV entries with an implicit scale of 1
+            // and relies on this allocator invariant without synchronizing the
+            // device from each layer's cache-write hot path.
             kv_scale_tensor.fill_(1.0);
         } else {
             kv_scale_tensor.fill_(0);

--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -771,10 +771,16 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
             is_deep_gemm_e8m0_used,
         )
         from rtp_llm.models_py.kernels.cuda.fp8_kernel import requant_weight_ue8m0
+        from rtp_llm.models_py.utils.arch import is_sm12x
+
+        # SM120 dense layers use the CUTLASS float-scale backend. Preserve the
+        # existing DeepGEMM scale contract for MoE, which is outside this PR.
+        is_moe_weight = self.kernel.name in (W.moe_w1, W.moe_w2)
+        use_e8m0 = is_deep_gemm_e8m0_used() and (not is_sm12x() or is_moe_weight)
 
         # e8m0 not reshape, weight scale need be non contiguous
         # TODO: rm reshape all time
-        if not is_deep_gemm_e8m0_used():
+        if not use_e8m0:
             kernel_weight = (
                 kernel_weight.reshape(kernel_weight.shape[-1], -1)
                 if kernel_weight.dim() == 2
@@ -783,7 +789,7 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
         processed_res[self.kernel.name] = kernel_weight
         if self.scale is not None:
             scale_weight = processed_res[self.scale.name]
-            if not is_deep_gemm_e8m0_used():
+            if not use_e8m0:
                 scale_weight = (
                     scale_weight.reshape(scale_weight.shape[-1], -1)
                     if scale_weight.dim() == 2
@@ -797,7 +803,7 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
             )
             # kernel_weight, scale_weight = load_config.exported_device.convert_fp8_weight_params(kernel_weight, scale_weight)
 
-            if is_deep_gemm_e8m0_used():
+            if use_e8m0:
                 kernel_weight, scale_weight = requant_weight_ue8m0(
                     kernel_weight, scale_weight
                 )

--- a/rtp_llm/model_loader/per_block_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_block_fp8_quant_weight.py
@@ -53,6 +53,29 @@ QS_SUFFIX = ".weight_scale_inv"
 APPEND_SUFFIX = "_scale_inv"
 
 
+def use_e8m0_scale_layout(
+    *,
+    is_sm12x_device: bool,
+    is_sm120_device: bool,
+    is_moe_weight: bool,
+    deep_gemm_e8m0_enabled: bool,
+) -> bool:
+    """Resolve the FP8 scale layout before mutating loaded tensors."""
+    check_with_info(
+        not (is_sm12x_device and not is_sm120_device),
+        "FP8_PER_BLOCK is unsupported on SM12x devices other than exact sm_120; "
+        "use another quantization method or a supported device architecture",
+    )
+    check_with_info(
+        not (is_sm120_device and is_moe_weight),
+        (
+            "FP8_PER_BLOCK MoE is unsupported on SM12x; use a dense model, "
+            "another quantization method, or a supported device architecture"
+        ),
+    )
+    return deep_gemm_e8m0_enabled and not is_sm120_device
+
+
 def dequant_weight_split_k(
     ts: List[torch.Tensor],
     block_size: int,
@@ -771,12 +794,26 @@ class PerBlockFp8Weight(CompositeWeight, QuantWeight):
             is_deep_gemm_e8m0_used,
         )
         from rtp_llm.models_py.kernels.cuda.fp8_kernel import requant_weight_ue8m0
-        from rtp_llm.models_py.utils.arch import is_sm12x
+        from rtp_llm.models_py.utils.arch import is_sm12x, is_sm120
 
-        # SM120 dense layers use the CUTLASS float-scale backend. Preserve the
-        # existing DeepGEMM scale contract for MoE, which is outside this PR.
+        # SM12x dense layers must keep float scales because DeepGEMM does not
+        # support that family. The reshape below stores physical (N, K) data
+        # behind the loader's logical (K, N) shape; the inverse contract is
+        # CudaFp8VllmBlockwiseLinear._restore_blockwise_weight_layout.
+        # MoE has no SM12x FP8_PER_BLOCK backend here.
         is_moe_weight = self.kernel.name in (W.moe_w1, W.moe_w2)
-        use_e8m0 = is_deep_gemm_e8m0_used() and (not is_sm12x() or is_moe_weight)
+        # Weight conversion may intentionally run on the host before the
+        # tensors are copied to CUDA.  The layout, however, is consumed by the
+        # runtime GPU, so use that device whenever CUDA is available.
+        layout_device = None if torch.cuda.is_available() else torch.device(device)
+        is_sm12x_device = is_sm12x(layout_device)
+        is_sm120_device = is_sm120(layout_device)
+        use_e8m0 = use_e8m0_scale_layout(
+            is_sm12x_device=is_sm12x_device,
+            is_sm120_device=is_sm120_device,
+            is_moe_weight=is_moe_weight,
+            deep_gemm_e8m0_enabled=is_deep_gemm_e8m0_used(),
+        )
 
         # e8m0 not reshape, weight scale need be non contiguous
         # TODO: rm reshape all time

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -29,6 +29,12 @@ py_test(
 )
 
 py_test(
+    name = "test_per_block_fp8_layout",
+    srcs = ["test_per_block_fp8_layout.py"],
+    deps = py_test_deps,
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps,

--- a/rtp_llm/model_loader/test/test_per_block_fp8_layout.py
+++ b/rtp_llm/model_loader/test/test_per_block_fp8_layout.py
@@ -1,0 +1,169 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from rtp_llm.model_loader.per_block_fp8_quant_weight import (
+    PerBlockFp8Weight,
+    use_e8m0_scale_layout,
+)
+from rtp_llm.model_loader.weight_module import CompositeWeight
+from rtp_llm.models_py.utils.arch import is_sm120
+from rtp_llm.utils.model_weight import W
+
+
+class PerBlockFp8LayoutTest(unittest.TestCase):
+    @staticmethod
+    def _make_weight(kernel_name, scale_name):
+        weight = object.__new__(PerBlockFp8Weight)
+        weight.kernel = SimpleNamespace(name=kernel_name)
+        weight.scale = SimpleNamespace(name=scale_name)
+        return weight
+
+    @staticmethod
+    def _load_config():
+        return SimpleNamespace(
+            exported_device=SimpleNamespace(
+                maybe_rewrite_weight_by_key=lambda _key, tensor: tensor
+            )
+        )
+
+    def test_sm12x_dense_keeps_float_scale_layout(self):
+        self.assertFalse(
+            use_e8m0_scale_layout(
+                is_sm12x_device=True,
+                is_sm120_device=True,
+                is_moe_weight=False,
+                deep_gemm_e8m0_enabled=True,
+            )
+        )
+
+    def test_sm12x_moe_fails_before_layout_mutation(self):
+        with self.assertRaisesRegex(Exception, "unsupported on SM12x"):
+            use_e8m0_scale_layout(
+                is_sm12x_device=True,
+                is_sm120_device=True,
+                is_moe_weight=True,
+                deep_gemm_e8m0_enabled=False,
+            )
+
+    def test_non_sm120_sm12x_fails_before_layout_mutation(self):
+        with self.assertRaisesRegex(Exception, "other than exact sm_120"):
+            use_e8m0_scale_layout(
+                is_sm12x_device=True,
+                is_sm120_device=False,
+                is_moe_weight=False,
+                deep_gemm_e8m0_enabled=False,
+            )
+
+    def test_non_sm12x_preserves_deep_gemm_layout_choice(self):
+        self.assertTrue(
+            use_e8m0_scale_layout(
+                is_sm12x_device=False,
+                is_sm120_device=False,
+                is_moe_weight=True,
+                deep_gemm_e8m0_enabled=True,
+            )
+        )
+        self.assertFalse(
+            use_e8m0_scale_layout(
+                is_sm12x_device=False,
+                is_sm120_device=False,
+                is_moe_weight=False,
+                deep_gemm_e8m0_enabled=False,
+            )
+        )
+
+    @mock.patch("rtp_llm.models_py.utils.arch.is_sm120", return_value=True)
+    @mock.patch("rtp_llm.models_py.utils.arch.is_sm12x", return_value=True)
+    def test_sm12x_dense_postprocess_keeps_float_scale_physical_layout(
+        self, _is_sm12x, _is_sm120
+    ):
+        weight = self._make_weight(W.ffn_w1, W.ffn_s1)
+        physical_weight = torch.arange(256 * 128).reshape(256, 128)
+        physical_scale = torch.arange(2).reshape(2, 1).float()
+        loaded = {W.ffn_w1: physical_weight, W.ffn_s1: physical_scale}
+        fp8_kernel = SimpleNamespace(requant_weight_ue8m0=mock.Mock())
+
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.kernels.cuda.deepgemm_wrapper": SimpleNamespace(
+                        is_deep_gemm_e8m0_used=mock.Mock(return_value=True)
+                    ),
+                    "rtp_llm.models_py.kernels.cuda.fp8_kernel": fp8_kernel,
+                },
+            ),
+            mock.patch.object(CompositeWeight, "_postprocess", return_value=loaded),
+        ):
+            processed = weight._postprocess(None, "cpu", self._load_config())
+
+        fp8_kernel.requant_weight_ue8m0.assert_not_called()
+        self.assertEqual((128, 256), processed[W.ffn_w1].shape)
+        self.assertEqual((1, 2), processed[W.ffn_s1].shape)
+        torch.testing.assert_close(
+            processed[W.ffn_w1].flatten(), physical_weight.flatten()
+        )
+        torch.testing.assert_close(
+            processed[W.ffn_s1].flatten(), physical_scale.flatten()
+        )
+
+    @unittest.skipUnless(is_sm120(), "requires an sm_120 runtime GPU")
+    def test_cpu_conversion_uses_sm120_runtime_layout(self):
+        """Host-side conversion must still select the runtime GPU layout."""
+        weight = self._make_weight(W.ffn_w1, W.ffn_s1)
+        physical_weight = torch.arange(256 * 128).reshape(256, 128)
+        physical_scale = torch.arange(2).reshape(2, 1).float()
+        loaded = {W.ffn_w1: physical_weight, W.ffn_s1: physical_scale}
+        fp8_kernel = SimpleNamespace(requant_weight_ue8m0=mock.Mock())
+
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.kernels.cuda.deepgemm_wrapper": SimpleNamespace(
+                        is_deep_gemm_e8m0_used=mock.Mock(return_value=True)
+                    ),
+                    "rtp_llm.models_py.kernels.cuda.fp8_kernel": fp8_kernel,
+                },
+            ),
+            mock.patch.object(CompositeWeight, "_postprocess", return_value=loaded),
+        ):
+            processed = weight._postprocess(None, "cpu", self._load_config())
+
+        fp8_kernel.requant_weight_ue8m0.assert_not_called()
+        self.assertEqual((128, 256), processed[W.ffn_w1].shape)
+        self.assertEqual((1, 2), processed[W.ffn_s1].shape)
+
+    @mock.patch("rtp_llm.models_py.utils.arch.is_sm120", return_value=True)
+    @mock.patch("rtp_llm.models_py.utils.arch.is_sm12x", return_value=True)
+    def test_sm12x_moe_postprocess_rejects_unsupported_path(self, _is_sm12x, _is_sm120):
+        weight = self._make_weight(W.moe_w1, W.moe_s1)
+        loaded = {
+            W.moe_w1: torch.empty((1, 128, 128)),
+            W.moe_s1: torch.empty((1, 1, 1)),
+        }
+
+        with (
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "rtp_llm.models_py.kernels.cuda.deepgemm_wrapper": SimpleNamespace(
+                        is_deep_gemm_e8m0_used=mock.Mock(return_value=False)
+                    ),
+                    "rtp_llm.models_py.kernels.cuda.fp8_kernel": SimpleNamespace(
+                        requant_weight_ue8m0=mock.Mock()
+                    ),
+                },
+            ),
+            mock.patch.object(CompositeWeight, "_postprocess", return_value=loaded),
+            self.assertRaisesRegex(Exception, "unsupported on SM12x"),
+        ):
+            weight._postprocess(None, "cpu", self._load_config())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -101,7 +101,10 @@ py_library(
     srcs = glob([
         "kernels/*.py",
         "kernels/**/*.py",
-    ])
+    ]),
+    visibility = [
+        ":__subpackages__",
+    ],
 )
 
 py_library(

--- a/rtp_llm/models_py/bindings/cuda/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/BUILD
@@ -196,6 +196,10 @@ cc_library(
         "RegisterCudaOps.cc",
     ],
     copts = copts() + ["-fno-strict-aliasing"],
+    local_defines = select({
+        "@//:using_cuda12_9_x86": ["ENABLE_FP8_SM120=1"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//rtp_llm/models_py/bindings:register_ops_hdr",
         ":cuda_bindings_base",
@@ -203,6 +207,15 @@ cc_library(
     ] + select({
         "@//:using_cuda12_9": [
             "//rtp_llm/models_py/bindings/cuda/cutlass:fp4_gemm_cu",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        # sm_120 consumer Blackwell (RTX 5090 / RTX PRO 5000) is x86-only;
+        # GB200 (cuda12_9_arm) is sm_10x and would trap on this kernel.
+        # local_defines above and this dependency share this same select so
+        # registration and linking cannot drift apart.
+        "@//:using_cuda12_9_x86": [
+            "//rtp_llm/models_py/bindings/cuda/cutlass:fp8_blockwise_sm120_cu",
         ],
         "//conditions:default": [],
     }),

--- a/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
+++ b/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
@@ -7,6 +7,10 @@
 #include "rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp4_gemm/nvfp4_scaled_mm.h"
 #endif
 
+#if defined(ENABLE_FP8_SM120)
+#include "rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h"
+#endif
+
 #include "rtp_llm/models_py/bindings/cuda/kernels/scaled_fp8_quant.h"
 #include "rtp_llm/models_py/bindings/common/kernels/moe/ep_utils.h"
 
@@ -58,6 +62,16 @@ void registerPyModuleOps(py::module& rtp_ops_m) {
                   py::arg("input_global_scale"),
                   py::arg("mask"),
                   py::arg("use_silu_and_mul"));
+#endif
+
+#if defined(ENABLE_FP8_SM120)
+    rtp_ops_m.def("cutlass_scaled_mm_blockwise_sm120_fp8",
+                  &cutlass_scaled_mm_blockwise_sm120_fp8,
+                  py::arg("D"),
+                  py::arg("A"),
+                  py::arg("B"),
+                  py::arg("A_sf"),
+                  py::arg("B_sf"));
 #endif
 
     rtp_ops_m.def("moe_pre_reorder",

--- a/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
+++ b/rtp_llm/models_py/bindings/cuda/RegisterCudaOps.cc
@@ -65,6 +65,10 @@ void registerPyModuleOps(py::module& rtp_ops_m) {
 #endif
 
 #if defined(ENABLE_FP8_SM120)
+    // Keep an explicit capability probe paired with the BUILD/local_defines
+    // gate so Python can reject a future registration/linkage mismatch before
+    // selecting the backend.
+    rtp_ops_m.def("has_cutlass_scaled_mm_blockwise_sm120_fp8", &has_cutlass_scaled_mm_blockwise_sm120_fp8);
     rtp_ops_m.def("cutlass_scaled_mm_blockwise_sm120_fp8",
                   &cutlass_scaled_mm_blockwise_sm120_fp8,
                   py::arg("D"),

--- a/rtp_llm/models_py/bindings/cuda/cutlass/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/cutlass/BUILD
@@ -7,6 +7,12 @@ sm100_cuda_copts = copts() + cuda_default_copts_without_arch() + [
     '--cuda-include-ptx=sm_100a', '--cuda-gpu-arch=sm_100a',
 ]
 
+sm120_cuda_copts = copts() + cuda_default_copts_without_arch() + [
+    # CUTLASS block-scaled instructions are architecture-conditional and must
+    # be compiled for the accelerated SM120 target.
+    '--cuda-include-ptx=sm_120a', '--cuda-gpu-arch=sm_120a',
+]
+
 cc_library(
     name = "fp4_gemm_cu",
     srcs = glob([
@@ -25,6 +31,31 @@ cc_library(
     ] + torch_deps(),
     copts = sm100_cuda_copts + [
         "-DCUTLASS_ARCH_MMA_SM100_SUPPORTED",
+    ],
+    alwayslink = True,
+    visibility = ["//visibility:public"],
+)
+
+# FP8 PER_BLOCK GEMM for sm_120 family (consumer Blackwell). Ported from vLLM
+# (Apache 2.0). Standalone target — no cross-deps with fp4_gemm_cu.
+cc_library(
+    name = "fp8_blockwise_sm120_cu",
+    srcs = glob([
+        "cutlass_kernels/fp8_blockwise_sm120/*.cu",
+    ]),
+    hdrs = glob([
+        "cutlass_kernels/fp8_blockwise_sm120/*.h",
+        "cutlass_kernels/fp8_blockwise_sm120/*.cuh",
+    ]),
+    deps = [
+        "@cutlass4.0//:cutlass",
+        "@cutlass4.0//:cutlass_utils",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart",
+        "@local_config_cuda//cuda:cuda_driver",
+    ] + torch_deps(),
+    copts = sm120_cuda_copts + [
+        "-DCUTLASS_ARCH_MMA_SM120_SUPPORTED",
     ],
     alwayslink = True,
     visibility = ["//visibility:public"],

--- a/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
+++ b/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <torch/all.h>
+
+// FP8 PER_BLOCK GEMM for sm_120 family (consumer Blackwell: RTX 5090 / RTX PRO
+// 5000 / 6000). Based on vLLM's scaled_mm_blockwise_sm120_fp8 (Apache 2.0,
+// commit 6f955986e). DeepGEMM 2.1.x ships no sm_120 cubin; FlashInfer's
+// blockwise FP8 path stalls at <200 TFLOPs on sm_120 (see deep-dives/
+// fp8-gemm-sm120.md). This kernel hits ~442 TFLOPs at 4096^3 (1.78x BF16).
+//
+// Inputs:
+//   D: (M, N) bf16/fp16 row-major
+//   A: (M, K) float8_e4m3fn row-major
+//   B: (K, N) float8_e4m3fn col-major (i.e. weight stored (N, K) row-major)
+//   A_sf: per-token-group scale, MN-major layout (output of
+//         sgl_per_token_group_quant_fp8 with column_major_scales=True,
+//         scale_tma_aligned=True)
+//   B_sf: per-block weight scale, K-major layout (shape (N, K/128) ->
+//         flattened consistently with cutlass Sm120BlockwiseScaleConfig)
+void cutlass_scaled_mm_blockwise_sm120_fp8(torch::Tensor&       D,
+                                           torch::Tensor const& A,
+                                           torch::Tensor const& B,
+                                           torch::Tensor const& A_sf,
+                                           torch::Tensor const& B_sf);

--- a/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
+++ b/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
@@ -11,11 +11,13 @@
 // Inputs:
 //   D: (M, N) bf16/fp16 row-major
 //   A: (M, K) float8_e4m3fn row-major
-//   B: (K, N) float8_e4m3fn col-major (i.e. weight stored (N, K) row-major)
+//   B: (N, K) float8_e4m3fn row-major contiguous weight.  CUTLASS sm120
+//      blockwise uses RowMajor-style packed strides for B (K-stride=1,
+//      N-stride=K) despite LayoutB=ColumnMajor in the template.
 //   A_sf: per-token-group scale, MN-major layout (output of
 //         sgl_per_token_group_quant_fp8 with column_major_scales=True,
-//         scale_tma_aligned=True)
-//   B_sf: per-block weight scale, K-major layout (shape (N, K/128) ->
+//         scale_tma_aligned=False)
+//   B_sf: per-block weight scale, K-major layout (shape (N/128, K/128) ->
 //         flattened consistently with cutlass Sm120BlockwiseScaleConfig)
 void cutlass_scaled_mm_blockwise_sm120_fp8(torch::Tensor&       D,
                                            torch::Tensor const& A,

--- a/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
+++ b/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8.h
@@ -4,12 +4,11 @@
 
 // FP8 PER_BLOCK GEMM for sm_120 family (consumer Blackwell: RTX 5090 / RTX PRO
 // 5000 / 6000). Based on vLLM's scaled_mm_blockwise_sm120_fp8 (Apache 2.0,
-// commit 6f955986e). DeepGEMM 2.1.x ships no sm_120 cubin; FlashInfer's
-// blockwise FP8 path stalls at <200 TFLOPs on sm_120 (see deep-dives/
-// fp8-gemm-sm120.md). This kernel hits ~442 TFLOPs at 4096^3 (1.78x BF16).
+// commit 6f955986e). DeepGEMM 2.1.x ships no sm_120 cubin. This implementation
+// is validated on RTX PRO 5000 72GB Blackwell (sm_120).
 //
 // Inputs:
-//   D: (M, N) bf16/fp16 row-major
+//   D: (M, N) bf16 row-major
 //   A: (M, K) float8_e4m3fn row-major
 //   B: (N, K) float8_e4m3fn row-major contiguous weight.  CUTLASS sm120
 //      blockwise uses RowMajor-style packed strides for B (K-stride=1,
@@ -19,6 +18,8 @@
 //         scale_tma_aligned=False)
 //   B_sf: per-block weight scale, K-major layout (shape (N/128, K/128) ->
 //         flattened consistently with cutlass Sm120BlockwiseScaleConfig)
+bool has_cutlass_scaled_mm_blockwise_sm120_fp8();
+
 void cutlass_scaled_mm_blockwise_sm120_fp8(torch::Tensor&       D,
                                            torch::Tensor const& A,
                                            torch::Tensor const& B,

--- a/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8_kernels.cu
+++ b/rtp_llm/models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/cutlass_scaled_mm_blockwise_sm120_fp8_kernels.cu
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// FP8 PER_BLOCK GEMM for sm_120 family (consumer Blackwell).
+//
+// Adapted from vLLM (Apache 2.0):
+//   csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/
+//     scaled_mm_blockwise_sm120_fp8.cu
+//     scaled_mm_blockwise_sm120_fp8_dispatch.cuh
+//   csrc/cutlass_extensions/common.hpp
+// Source: https://github.com/vllm-project/vllm  commit 6f955986e (2026-05-24)
+//
+// Modifications for RTP-LLM:
+//   - Replace torch::stable / torch::Library with torch::Tensor (eager) + a
+//     C++ wrapper compatible with the existing fp4_gemm wiring style.
+//   - Replace torch::stable::empty workspace with torch::empty (fp4 pattern).
+//   - Inline enable_sm120_family<> instead of vendoring cutlass_extensions/.
+//
+// Validated on RTX PRO 5000 72GB Blackwell (sm_120).
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime_api.h>
+#include <torch/all.h>
+
+#include <utility>
+
+#include <type_traits>
+
+#include "cutlass_scaled_mm_blockwise_sm120_fp8.h"
+
+// clang-format off
+#include "cutlass/cutlass.h"
+#include "cutlass/numeric_types.h"
+
+#include "cute/tensor.hpp"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/kernel/tile_scheduler_params.h"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/util/packed_stride.hpp"
+// clang-format on
+
+#define CUTLASS_CHECK(status)                                                                                          \
+    do {                                                                                                               \
+        cutlass::Status error = (status);                                                                              \
+        TORCH_CHECK(error == cutlass::Status::kSuccess, cutlassGetStatusString(error));                                \
+    } while (0)
+
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+
+using namespace cute;
+
+namespace {
+
+int64_t ceil_div(int64_t x, int64_t y) {
+    return (x + y - 1) / y;
+}
+
+void check_cuda_same_device(torch::Tensor const& tensor, char const* name, c10::Device const& device) {
+    TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(
+        tensor.device() == device, name, " must be on the same device as A, got ", tensor.device(), " vs ", device);
+}
+
+void check_contiguous(torch::Tensor const& tensor, char const* name) {
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+struct CachedDeviceProperties {
+    int major;
+    int minor;
+    int sm_count;
+};
+
+CachedDeviceProperties get_cached_device_properties(int device) {
+    // Inference worker threads normally stay on one CUDA device. Cache the
+    // capability per thread so the GEMM hot path does not repeatedly enter
+    // the CUDA Runtime while still validating the actual runtime device.
+    thread_local int cached_device   = -1;
+    thread_local int cached_major    = -1;
+    thread_local int cached_minor    = -1;
+    thread_local int cached_sm_count = -1;
+    if (cached_device != device) {
+        cudaDeviceProp props;
+        cudaError_t    status = cudaGetDeviceProperties(&props, device);
+        TORCH_CHECK(status == cudaSuccess,
+                    "Failed to query CUDA device properties for device ",
+                    device,
+                    ": ",
+                    cudaGetErrorString(status));
+        cached_device   = device;
+        cached_major    = props.major;
+        cached_minor    = props.minor;
+        cached_sm_count = props.multiProcessorCount;
+    }
+    return {cached_major, cached_minor, cached_sm_count};
+}
+
+// Exact SM120 CUDA_ARCH gate; host/runtime selection uses the same contract.
+template<typename Kernel>
+struct enable_sm120_family: Kernel {
+    template<typename... Args>
+    CUTLASS_DEVICE void operator()(Args&&... args) {
+#if defined __CUDA_ARCH__
+#if (__CUDA_ARCH__ == 1200)
+        Kernel::operator()(std::forward<Args>(args)...);
+#else
+        printf("FP8 PER_BLOCK SM120 kernel only supports sm120f.\n");
+        asm("trap;");
+#endif
+#endif
+    }
+};
+
+// GEMM type factory (verbatim from vllm scaled_mm_blockwise_sm120_fp8_dispatch.cuh)
+template<class OutType,
+         int ScaleGranularityM,
+         int ScaleGranularityN,
+         int ScaleGranularityK,
+         class MmaTileShape,
+         class ClusterShape,
+         class EpilogueScheduler,
+         class MainloopScheduler,
+         bool swap_ab_ = false>
+struct cutlass_3x_gemm_fp8_blockwise {
+    static constexpr bool swap_ab = swap_ab_;
+    using ElementAB               = cutlass::float_e4m3_t;
+
+    using ElementA                  = ElementAB;
+    using LayoutA                   = cutlass::layout::RowMajor;
+    using LayoutA_Transpose         = typename cutlass::layout::LayoutTranspose<LayoutA>::type;
+    static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+
+    using ElementB                  = ElementAB;
+    using LayoutB                   = cutlass::layout::ColumnMajor;
+    using LayoutB_Transpose         = typename cutlass::layout::LayoutTranspose<LayoutB>::type;
+    static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+
+    using ElementD                  = OutType;
+    using LayoutD                   = cutlass::layout::RowMajor;
+    using LayoutD_Transpose         = typename cutlass::layout::LayoutTranspose<LayoutD>::type;
+    static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+
+    using ElementC                  = void;
+    using LayoutC                   = LayoutD;
+    using LayoutC_Transpose         = LayoutD_Transpose;
+    static constexpr int AlignmentC = AlignmentD;
+
+    using ElementAccumulator = float;
+    using ElementCompute     = float;
+    using ElementBlockScale  = float;
+
+    using ScaleConfig = std::conditional_t<swap_ab,
+                                           cutlass::detail::Sm120BlockwiseScaleConfig<ScaleGranularityM,
+                                                                                      ScaleGranularityN,
+                                                                                      ScaleGranularityK,
+                                                                                      cute::UMMA::Major::K,
+                                                                                      cute::UMMA::Major::MN>,
+                                           cutlass::detail::Sm120BlockwiseScaleConfig<ScaleGranularityM,
+                                                                                      ScaleGranularityN,
+                                                                                      ScaleGranularityK,
+                                                                                      cute::UMMA::Major::MN,
+                                                                                      cute::UMMA::Major::K>>;
+
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+
+    using ArchTag       = cutlass::arch::Sm120;
+    using OperatorClass = cutlass::arch::OpClassTensorOp;
+
+    static constexpr auto RoundStyle = cutlass::FloatRoundStyle::round_to_nearest;
+    using ElementScalar              = float;
+    using DefaultOperation =
+        cutlass::epilogue::fusion::LinearCombination<ElementD, ElementCompute, ElementC, ElementScalar, RoundStyle>;
+
+    using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        ArchTag,
+        OperatorClass,
+        MmaTileShape,
+        ClusterShape,
+        cutlass::epilogue::collective::EpilogueTileAuto,
+        ElementAccumulator,
+        ElementCompute,
+        ElementC,
+        std::conditional_t<swap_ab, LayoutC_Transpose, LayoutC>,
+        AlignmentC,
+        ElementD,
+        std::conditional_t<swap_ab, LayoutD_Transpose, LayoutD>,
+        AlignmentD,
+        EpilogueScheduler,
+        DefaultOperation>::CollectiveOp;
+
+    using StageCountType = cutlass::gemm::collective::StageCountAuto;
+    using CollectiveMainloop =
+        std::conditional_t<swap_ab,
+                           typename cutlass::gemm::collective::CollectiveBuilder<
+                               ArchTag,
+                               OperatorClass,
+                               ElementB,
+                               cute::tuple<LayoutB_Transpose, LayoutSFA>,
+                               AlignmentB,
+                               ElementA,
+                               cute::tuple<LayoutA_Transpose, LayoutSFB>,
+                               AlignmentA,
+                               ElementAccumulator,
+                               MmaTileShape,
+                               ClusterShape,
+                               cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+                                   sizeof(typename CollectiveEpilogue::SharedStorage))>,
+                               MainloopScheduler>::CollectiveOp,
+                           typename cutlass::gemm::collective::CollectiveBuilder<
+                               ArchTag,
+                               OperatorClass,
+                               ElementA,
+                               cute::tuple<LayoutA, LayoutSFA>,
+                               AlignmentA,
+                               ElementB,
+                               cute::tuple<LayoutB, LayoutSFB>,
+                               AlignmentB,
+                               ElementAccumulator,
+                               MmaTileShape,
+                               ClusterShape,
+                               cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+                                   sizeof(typename CollectiveEpilogue::SharedStorage))>,
+                               MainloopScheduler>::CollectiveOp>;
+
+    using KernelType = enable_sm120_family<
+        cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue>>;
+
+    struct GemmKernel: public KernelType {};
+};
+
+// Tile configurations (verbatim from vllm dispatch.cuh)
+template<typename OutType>
+struct sm120_blockwise_fp8_config_default {
+    using KernelSchedule   = cutlass::gemm::collective::KernelScheduleAuto;
+    using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+    using TileShape        = Shape<_128, _128, _128>;
+    using ClusterShape     = Shape<_1, _1, _1>;
+    using Gemm =
+        cutlass_3x_gemm_fp8_blockwise<OutType, 1, 128, 128, TileShape, ClusterShape, EpilogueSchedule, KernelSchedule>;
+};
+
+template<typename OutType>
+struct sm120_blockwise_fp8_config_pingpong {
+    using KernelSchedule   = cutlass::gemm::KernelTmaWarpSpecializedBlockwisePingpongSm120;
+    using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+    using TileShape        = Shape<_64, _128, _128>;
+    using ClusterShape     = Shape<_1, _1, _1>;
+    using Gemm =
+        cutlass_3x_gemm_fp8_blockwise<OutType, 1, 128, 128, TileShape, ClusterShape, EpilogueSchedule, KernelSchedule>;
+};
+
+template<typename OutType>
+struct sm120_blockwise_fp8_config_swapab {
+    using KernelSchedule   = cutlass::gemm::KernelTmaWarpSpecializedBlockwiseCooperativeSm120;
+    using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+    using TileShape        = Shape<_128, _32, _128>;
+    using ClusterShape     = Shape<_1, _1, _1>;
+    using Gemm             = cutlass_3x_gemm_fp8_blockwise<OutType,
+                                                           128,
+                                                           1,
+                                                           128,
+                                                           TileShape,
+                                                           ClusterShape,
+                                                           EpilogueSchedule,
+                                                           KernelSchedule,
+                                                           true>;
+};
+
+// Launcher (port of vllm cutlass_gemm_caller_blockwise; uses torch::empty for
+// workspace per the existing fp4_gemm pattern).
+template<typename Gemm>
+void launch_one(torch::Tensor&       D,
+                torch::Tensor const& A,
+                torch::Tensor const& B,
+                torch::Tensor const& A_sf,
+                torch::Tensor const& B_sf,
+                int                  M,
+                int                  N,
+                int                  K,
+                cudaStream_t         stream) {
+    static constexpr bool swap_ab = Gemm::swap_ab;
+    using GemmKernel              = typename Gemm::GemmKernel;
+    using StrideA                 = typename GemmKernel::StrideA;
+    using StrideB                 = typename GemmKernel::StrideB;
+    using StrideC                 = typename GemmKernel::StrideC;
+    using LayoutSFA               = typename Gemm::LayoutSFA;
+    using LayoutSFB               = typename Gemm::LayoutSFB;
+    using ScaleConfig             = typename Gemm::ScaleConfig;
+
+    using ElementAB         = typename Gemm::ElementAB;
+    using ElementD          = typename Gemm::ElementD;
+    using ElementBlockScale = typename Gemm::ElementBlockScale;
+
+    StrideA a_stride = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, 1));
+    StrideB b_stride = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, 1));
+    StrideC c_stride =
+        cutlass::make_cute_packed_stride(StrideC{}, swap_ab ? cute::make_shape(N, M, 1) : cute::make_shape(M, N, 1));
+
+    LayoutSFA layout_SFA = swap_ab ? ScaleConfig::tile_atom_to_shape_SFA(make_shape(N, M, K, 1)) :
+                                     ScaleConfig::tile_atom_to_shape_SFA(make_shape(M, N, K, 1));
+    LayoutSFB layout_SFB = swap_ab ? ScaleConfig::tile_atom_to_shape_SFB(make_shape(N, M, K, 1)) :
+                                     ScaleConfig::tile_atom_to_shape_SFB(make_shape(M, N, K, 1));
+
+    auto a_e = static_cast<ElementAB const*>(A.const_data_ptr());
+    auto b_e = static_cast<ElementAB const*>(B.const_data_ptr());
+    auto sa  = static_cast<ElementBlockScale const*>(A_sf.const_data_ptr());
+    auto sb  = static_cast<ElementBlockScale const*>(B_sf.const_data_ptr());
+
+    typename GemmKernel::MainloopArguments mainloop_args{};
+    mainloop_args.layout_SFA = layout_SFA;
+    mainloop_args.layout_SFB = layout_SFB;
+    if (swap_ab) {
+        mainloop_args.ptr_A   = b_e;
+        mainloop_args.dA      = b_stride;
+        mainloop_args.ptr_B   = a_e;
+        mainloop_args.dB      = a_stride;
+        mainloop_args.ptr_SFA = sb;
+        mainloop_args.ptr_SFB = sa;
+    } else {
+        mainloop_args.ptr_A   = a_e;
+        mainloop_args.dA      = a_stride;
+        mainloop_args.ptr_B   = b_e;
+        mainloop_args.dB      = b_stride;
+        mainloop_args.ptr_SFA = sa;
+        mainloop_args.ptr_SFB = sb;
+    }
+    auto prob_shape = swap_ab ? cute::make_shape(N, M, K, 1) : cute::make_shape(M, N, K, 1);
+
+    auto                                   cd = static_cast<ElementD*>(D.data_ptr());
+    typename GemmKernel::EpilogueArguments epilogue_args{{}, cd, c_stride, cd, c_stride};
+
+    auto                        device_props = get_cached_device_properties(A.get_device());
+    cutlass::KernelHardwareInfo hw_info;
+    hw_info.device_id = A.get_device();
+    hw_info.sm_count  = device_props.sm_count;
+    typename GemmKernel::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm, prob_shape, mainloop_args, epilogue_args, hw_info, {}};
+
+    using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+    GemmOp gemm_op;
+    CUTLASS_CHECK(gemm_op.can_implement(args));
+
+    size_t        workspace_size = gemm_op.get_workspace_size(args);
+    torch::Tensor workspace;
+    void*         workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+        // PyTorch's CUDA-graph-aware allocator keeps allocations made during
+        // capture in the graph-private pool, so this pointer remains valid for
+        // replay even after the temporary Tensor wrapper leaves this scope.
+        auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(A.device());
+        workspace                    = torch::empty(static_cast<int64_t>(workspace_size), workspace_options);
+        workspace_ptr                = workspace.data_ptr();
+    }
+
+    CUTLASS_CHECK(gemm_op.run(args, workspace_ptr, stream));
+}
+
+// M-tier dispatch + M<=64 swap-AB heuristic (verbatim from vllm
+// cutlass_gemm_blockwise_sm120_fp8_dispatch).
+template<typename OutType>
+void dispatch_blockwise_sm120(torch::Tensor&       D,
+                              torch::Tensor const& A,
+                              torch::Tensor const& B,
+                              torch::Tensor const& A_sf,
+                              torch::Tensor const& B_sf,
+                              int                  M,
+                              int                  N,
+                              int                  K,
+                              cudaStream_t         stream) {
+    bool swap_ab = (M <= 64) || (M % 4 != 0);
+    if (!swap_ab) {
+        if (M <= 256) {
+            launch_one<typename sm120_blockwise_fp8_config_pingpong<OutType>::Gemm>(
+                D, A, B, A_sf, B_sf, M, N, K, stream);
+        } else {
+            launch_one<typename sm120_blockwise_fp8_config_default<OutType>::Gemm>(
+                D, A, B, A_sf, B_sf, M, N, K, stream);
+        }
+    } else {
+        launch_one<typename sm120_blockwise_fp8_config_swapab<OutType>::Gemm>(D, A, B, A_sf, B_sf, M, N, K, stream);
+    }
+}
+
+}  // anonymous namespace
+
+#endif  // CUTLASS_ARCH_MMA_SM120_SUPPORTED
+
+bool has_cutlass_scaled_mm_blockwise_sm120_fp8() {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    return true;
+#else
+    return false;
+#endif
+}
+
+void cutlass_scaled_mm_blockwise_sm120_fp8(torch::Tensor&       D,
+                                           torch::Tensor const& A,
+                                           torch::Tensor const& B,
+                                           torch::Tensor const& A_sf,
+                                           torch::Tensor const& B_sf) {
+#if defined(CUTLASS_ARCH_MMA_SM120_SUPPORTED)
+    TORCH_CHECK(A.is_cuda(), "A must be a CUDA tensor");
+    auto device = A.device();
+    check_cuda_same_device(B, "B", device);
+    check_cuda_same_device(D, "D", device);
+    check_cuda_same_device(A_sf, "A_sf", device);
+    check_cuda_same_device(B_sf, "B_sf", device);
+
+    check_contiguous(A, "A");
+    check_contiguous(B, "B");
+    check_contiguous(D, "D");
+
+    TORCH_CHECK(A.dtype() == torch::kFloat8_e4m3fn, "A must be float8_e4m3fn");
+    TORCH_CHECK(B.dtype() == torch::kFloat8_e4m3fn, "B must be float8_e4m3fn");
+    TORCH_CHECK(A_sf.dtype() == torch::kFloat32, "A_sf must be float32");
+    TORCH_CHECK(B_sf.dtype() == torch::kFloat32, "B_sf must be float32");
+    TORCH_CHECK(D.dtype() == at::ScalarType::BFloat16, "D must be bfloat16, got ", D.dtype());
+    TORCH_CHECK(A.dim() == 2 && B.dim() == 2 && D.dim() == 2,
+                "A/B/D must be 2D, got dims A=",
+                A.dim(),
+                ", B=",
+                B.dim(),
+                ", D=",
+                D.dim());
+
+    int M = static_cast<int>(A.size(0));
+    int K = static_cast<int>(A.size(1));
+    // B is passed as (N, K) row-major contiguous.  CUTLASS sm120 blockwise
+    // produces RowMajor-style packed strides for StrideB (K-stride=1,
+    // N-stride=K) despite LayoutB=ColumnMajor in the template.
+    int N = static_cast<int>(B.size(0));
+    TORCH_CHECK(B.size(1) == K, "B.size(1) (", B.size(1), ") must equal K (", K, ")");
+    TORCH_CHECK(
+        D.size(0) == M && D.size(1) == N, "D shape (", D.size(0), ",", D.size(1), ") must be (M=", M, ", N=", N, ")");
+    TORCH_CHECK(K % 128 == 0 && N % 128 == 0,
+                "K and N must be multiples of the 128-element scale block, got K=",
+                K,
+                " and N=",
+                N);
+
+    at::cuda::CUDAGuard device_guard{(char)A.get_device()};
+    auto                device_props = get_cached_device_properties(A.get_device());
+    auto                device_major = device_props.major;
+    auto                device_minor = device_props.minor;
+    TORCH_CHECK(device_major == 12 && device_minor == 0,
+                "cutlass_scaled_mm_blockwise_sm120_fp8 was compiled for sm_120, got sm_",
+                device_major,
+                device_minor,
+                " on device ",
+                A.get_device(),
+                "; use a backend compiled for the current device architecture");
+    if (M == 0) {
+        return;
+    }
+
+    int64_t scale_k = ceil_div(K, 128);
+    int64_t scale_n = ceil_div(N, 128);
+    TORCH_CHECK(A_sf.dim() == 2, "A_sf must be 2D, got ", A_sf.dim(), "D");
+    TORCH_CHECK(A_sf.size(0) == M && A_sf.size(1) == scale_k,
+                "A_sf shape (",
+                A_sf.size(0),
+                ",",
+                A_sf.size(1),
+                ") must be (M=",
+                M,
+                ", ceil_div(K, 128)=",
+                scale_k,
+                ")");
+    TORCH_CHECK(A_sf.stride(0) == 1 && A_sf.stride(1) == M,
+                "A_sf must use MN-major scale layout with stride (1, M), got (",
+                A_sf.stride(0),
+                ",",
+                A_sf.stride(1),
+                ")");
+    TORCH_CHECK(B_sf.dim() == 2, "B_sf must be 2D, got ", B_sf.dim(), "D");
+    TORCH_CHECK(B_sf.size(0) == scale_n && B_sf.size(1) == scale_k,
+                "B_sf shape (",
+                B_sf.size(0),
+                ",",
+                B_sf.size(1),
+                ") must be (ceil_div(N, 128)=",
+                scale_n,
+                ", ceil_div(K, 128)=",
+                scale_k,
+                ")");
+    TORCH_CHECK(B_sf.stride(0) == scale_k && B_sf.stride(1) == 1,
+                "B_sf must use K-major contiguous scale layout with stride (ceil_div(K, 128), 1), got (",
+                B_sf.stride(0),
+                ",",
+                B_sf.stride(1),
+                ")");
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream(A.get_device());
+
+    dispatch_blockwise_sm120<cutlass::bfloat16_t>(D, A, B, A_sf, B_sf, M, N, K, stream);
+#else
+    TORCH_CHECK(false,
+                "cutlass_scaled_mm_blockwise_sm120_fp8 was not compiled with "
+                "CUTLASS_ARCH_MMA_SM120_SUPPORTED. Rebuild on x86 with "
+                "--config=cuda12_9; this backend is unavailable on arm/sm_10x.");
+#endif
+}

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/kv_cache_write_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/kv_cache_write_op.py
@@ -1,5 +1,6 @@
 """KV Cache Write Operation for paged KV cache."""
 
+import logging
 from typing import Any, Optional, Tuple
 
 import flashinfer.page as page
@@ -7,15 +8,32 @@ import torch
 
 from rtp_llm.ops.compute_ops import LayerKVCache
 
+logger = logging.getLogger(__name__)
+
 
 class KVCacheWriteOp:
     """Operator for writing key-value pairs to paged KV cache."""
+
+    _fp8_scale_warning_emitted = False
+
+    @classmethod
+    def _warn_fp8_implicit_scale_once(cls) -> None:
+        if cls._fp8_scale_warning_emitted:
+            return
+        logger.warning(
+            "PyFlashinfer FP8 KV cache uses implicit scale=1; values outside "
+            "the finite E4M3 range are saturated. This mode can lose accuracy "
+            "for models with KV outliers; disable fp8_kv_cache to fall back "
+            "to the configured non-FP8 cache dtype"
+        )
+        cls._fp8_scale_warning_emitted = True
 
     def __init__(
         self,
         num_kv_heads: int,
         head_size: int,
         token_per_block: int,
+        kv_cache_dtype: Optional[torch.dtype] = None,
     ) -> None:
         """
         Initialize KV Cache Write operator.
@@ -24,11 +42,32 @@ class KVCacheWriteOp:
             num_kv_heads: Number of key-value heads
             head_size: Dimension of each attention head
             token_per_block: Number of tokens per KV cache block (page size)
+            kv_cache_dtype: Cache dtype used by warmup. ``None`` keeps the
+                activation dtype for non-FP8 cache configurations.
         """
         self.num_kv_heads = num_kv_heads
         self.head_size = head_size
         self.token_per_block = token_per_block
+        self.kv_cache_dtype = kv_cache_dtype
         self.params = None
+        if kv_cache_dtype == torch.float8_e4m3fn:
+            self._warn_fp8_implicit_scale_once()
+
+    @staticmethod
+    def _cast_for_cache(tensor: torch.Tensor, cache_dtype: torch.dtype) -> torch.Tensor:
+        if tensor.dtype == cache_dtype:
+            return tensor
+        if cache_dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "KVCacheWriteOp only converts activations for FP8 E4M3 cache; "
+                f"got activation dtype {tensor.dtype} and cache dtype {cache_dtype}"
+            )
+        # PyFlashinfer FP8 KV uses an implicit scale of 1. Values outside the
+        # finite E4M3 range are saturated before conversion, so overflow does
+        # not create NaN; NaN inputs remain NaN. This conversion intentionally
+        # has no per-token scale.
+        limit = torch.finfo(cache_dtype).max
+        return tensor.clamp(min=-limit, max=limit).to(cache_dtype)
 
     def set_params(self, params: Any):
         """Set the params object to be used by this op."""
@@ -58,6 +97,30 @@ class KVCacheWriteOp:
                 :, 1, :, :, :
             ]  # [num_pages, num_kv_heads, page_size, head_dim]
 
+            if self.kv_cache_dtype not in (None, k_cache.dtype):
+                raise RuntimeError(
+                    "PyFlashinfer KV cache dtype mismatch: configured "
+                    f"{self.kv_cache_dtype}, actual {k_cache.dtype}"
+                )
+
+            if k_cache.dtype == torch.float8_e4m3fn:
+                self._warn_fp8_implicit_scale_once()
+                # MemoryLayoutStrategy initializes every FP8 scale entry to
+                # 1.0 before execution. PyFlashinfer writes direct-cast values,
+                # so checking tensor contents here would add a device sync to
+                # every layer and is unsafe during CUDA graph capture. Keep the
+                # hot-path check structural and rely on that allocator contract.
+                kv_scale = kv_cache.kv_scale_base
+                if kv_scale is None or kv_scale.numel() == 0:
+                    raise RuntimeError(
+                        "PyFlashinfer FP8 KV cache requires an initialized "
+                        "kv_scale_base buffer with implicit scale=1"
+                    )
+
+            # append_paged_kv_cache copies elements without converting dtype.
+            key = self._cast_for_cache(key, k_cache.dtype)
+            value = self._cast_for_cache(value, v_cache.dtype)
+
             # Append K and V to paged cache using HND layout
             page.append_paged_kv_cache(  # type: ignore
                 key,  # append_key: [total_tokens, num_kv_heads, head_dim]
@@ -81,6 +144,10 @@ class KVCacheWriteOp:
                 max_num_pages,
             ) = self._prepare_warmup_cache_indices(value.size(0), value.device)
 
+            cache_dtype = self.kv_cache_dtype or value.dtype
+            key = self._cast_for_cache(key, cache_dtype)
+            value = self._cast_for_cache(value, cache_dtype)
+
             # Create MHA KV cache: [num_pages, num_kv_heads, page_size, head_dim] (HND layout)
             k_cache = torch.empty(
                 (
@@ -89,7 +156,7 @@ class KVCacheWriteOp:
                     self.token_per_block,
                     self.head_size,
                 ),
-                dtype=value.dtype,
+                dtype=cache_dtype,
                 device=value.device,
             )
             v_cache = torch.empty(
@@ -99,7 +166,7 @@ class KVCacheWriteOp:
                     self.token_per_block,
                     self.head_size,
                 ),
-                dtype=value.dtype,
+                dtype=cache_dtype,
                 device=value.device,
             )
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Optional
 
 import torch
@@ -18,7 +19,7 @@ from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla im
     check_attention_inputs,
 )
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
-from rtp_llm.models_py.utils.arch import is_sm10x
+from rtp_llm.models_py.utils.arch import is_sm10x, is_sm120
 from rtp_llm.ops import (
     AttentionConfigs,
     FMHAType,
@@ -36,12 +37,15 @@ from rtp_llm.ops.compute_ops import (
     rtp_llm_ops,
 )
 
+logger = logging.getLogger(__name__)
+
 # Constants
 DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB = 128
 
 # Global workspace buffer pool
 _g_py_flashinfer_workspace_pool: list[torch.Tensor] = []
 _g_py_flashinfer_pool_lock = __import__("threading").Lock()
+_cuda_core_host_replan_logged = False
 
 
 def get_py_flashinfer_workspace_buffer(device: str = "cuda") -> torch.Tensor:
@@ -63,6 +67,15 @@ def release_py_flashinfer_workspace_buffer(buffer: torch.Tensor) -> None:
     """Release a PyFlashInfer workspace buffer back to the pool."""
     with _g_py_flashinfer_pool_lock:
         _g_py_flashinfer_workspace_pool.append(buffer)
+
+
+def _configured_kv_cache_torch_dtype(
+    kv_cache_dtype: KvCacheDataType,
+) -> Optional[torch.dtype]:
+    """Return an explicit cache dtype when the config overrides activations."""
+    if kv_cache_dtype == KvCacheDataType.FP8:
+        return torch.float8_e4m3fn
+    return None
 
 
 class PyFlashinferPrefillPagedAttnOp(object):
@@ -661,6 +674,22 @@ class PyFlashinferDecodeAttnOp(object):
         self.head_dim_vo = attn_configs.size_per_head
         self.seq_size_per_block = attn_configs.kernel_tokens_per_block
         self.use_tensor_core = determine_use_tensor_core_from_configs(attn_configs)
+        # Qwen3-1.7B CUDA-core decode reproduced stale-plan replay hangs on
+        # sm_120. Tensor-core always replans; other CUDA-core devices keep the
+        # mainline replay contract.
+        cuda_core_replan = is_sm120()
+        self._replan_from_host = self.use_tensor_core or cuda_core_replan
+        global _cuda_core_host_replan_logged
+        if (
+            not self.use_tensor_core
+            and cuda_core_replan
+            and not _cuda_core_host_replan_logged
+        ):
+            logger.info(
+                "FlashInfer CUDA-core host replan enabled on sm_120 (device=%s)",
+                torch.cuda.get_device_capability(),
+            )
+            _cuda_core_host_replan_logged = True
         self.decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
             self.g_workspace_buffer,
             "HND",
@@ -669,6 +698,7 @@ class PyFlashinferDecodeAttnOp(object):
         self.kv_cache_dtype = attn_configs.kv_cache_dtype
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        self._plan_copy_done_event: Optional[torch.cuda.Event] = None
 
     def __del__(self):
         release_py_flashinfer_workspace_buffer(self.g_workspace_buffer)
@@ -678,27 +708,27 @@ class PyFlashinferDecodeAttnOp(object):
         self.fmha_params = params
 
     def _get_kv_data_type(self, attn_inputs: PyAttentionInputs) -> torch.dtype:
-        if self.kv_cache_dtype == KvCacheDataType.FP8:
-            return torch.float8_e4m3fn
-        return get_scalar_type(attn_inputs.dtype)
+        return _configured_kv_cache_torch_dtype(self.kv_cache_dtype) or get_scalar_type(
+            attn_inputs.dtype
+        )
 
-    def _requires_fa2_cuda_graph_replan(self) -> bool:
-        # FlashInfer BatchDecode routes tensor-core decode through fa2 BatchPrefill.
-        # fa3 prefill paths do not need this replay-time plan refresh.
-        return self.use_tensor_core
+    def _uses_host_plan_inputs(self) -> bool:
+        """Whether replay must replan from reusable pinned host metadata."""
+        return self._replan_from_host
 
     def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
-        if self._requires_fa2_cuda_graph_replan():
+        use_host_plan_inputs = self._uses_host_plan_inputs()
+        if use_host_plan_inputs:
             page_indptr = self.fmha_params.decode_page_indptr_h
             page_indice = self.fmha_params.page_indice_h
             last_page_len = self.fmha_params.paged_kv_last_page_len_h
             plan_kwargs = {"non_blocking": True}
         else:
+            # Preserve the mainline CUDA-core contract on non-SM120 devices.
             page_indptr = self.fmha_params.decode_page_indptr_d
             page_indice = self.fmha_params.page_indice_d
             last_page_len = self.fmha_params.paged_kv_last_page_len_d
             plan_kwargs = {}
-
         self.decode_wrapper.plan(
             page_indptr,
             page_indice,
@@ -711,6 +741,18 @@ class PyFlashinferDecodeAttnOp(object):
             kv_data_type=self._get_kv_data_type(attn_inputs),
             **plan_kwargs,
         )
+        if use_host_plan_inputs:
+            if self._plan_copy_done_event is None:
+                self._plan_copy_done_event = torch.cuda.Event()
+            self._plan_copy_done_event.record(torch.cuda.current_stream())
+
+    def _wait_for_plan_copies(self) -> None:
+        """Do not overwrite reusable pinned plan inputs while H2D is pending."""
+        if (
+            self._plan_copy_done_event is not None
+            and not self._plan_copy_done_event.query()
+        ):
+            self._plan_copy_done_event.synchronize()
 
     def prepare(
         self,
@@ -722,6 +764,7 @@ class PyFlashinferDecodeAttnOp(object):
 
         forbid_realloc: True only when called from prepare_cuda_graph (replay); forbids buffer realloc.
         """
+        self._wait_for_plan_copies()
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
@@ -756,6 +799,7 @@ class PyFlashinferDecodeAttnOp(object):
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
         """Refresh FlashInfer runtime buffers before replaying the captured graph."""
+        self._wait_for_plan_copies()
         self.fmha_params.fill_params(
             attn_inputs.prefix_lengths,
             attn_inputs.sequence_lengths,
@@ -764,7 +808,10 @@ class PyFlashinferDecodeAttnOp(object):
             self.seq_size_per_block,
             forbid_realloc=True,
         )
-        if self._requires_fa2_cuda_graph_replan():
+        # Tensor-core decode already replans on every replay. SM120 CUDA-core
+        # follows the same contract because its plan metadata changes with the
+        # runtime page table; other CUDA-core devices retain mainline behavior.
+        if self._uses_host_plan_inputs():
             self._plan_decode_wrapper(attn_inputs)
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -95,10 +95,9 @@ class PyFlashinferPrefillPagedAttnOp(object):
         self.page_size = attn_configs.kernel_tokens_per_block
         self.datatype = attn_configs.dtype
         self.kv_cache_dtype = attn_configs.kv_cache_dtype
-        if self.kv_cache_dtype == KvCacheDataType.FP8:
-            self.kv_datatype = torch.float8_e4m3fn
-        else:
-            self.kv_datatype = self.datatype
+        self.kv_datatype = (
+            _configured_kv_cache_torch_dtype(self.kv_cache_dtype) or self.datatype
+        )
         self.max_seq_len = attn_configs.max_seq_len
         self.is_causal = attn_configs.is_causal
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
@@ -443,6 +442,9 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
             num_kv_heads=attn_configs.kv_head_num,
             head_size=attn_configs.size_per_head,
             token_per_block=attn_configs.kernel_tokens_per_block,
+            kv_cache_dtype=_configured_kv_cache_torch_dtype(
+                attn_configs.kv_cache_dtype
+            ),
         )
         self.create_params(attn_inputs)
         self.fmha_impl.prepare(attn_inputs)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/BUILD
@@ -53,6 +53,31 @@ py_test(
     },
 )
 
+# Intentionally run the complete decode suite on real SM120 hardware: this
+# covers the SM120-only CUDA-core replay cases without an architecture mock and
+# also guards common FlashInfer decode behavior on the newly supported device.
+py_test(
+    name = "test_py_flashinfer_mha_decode_sm120",
+    main = "test_py_flashinfer_mha_decode.py",
+    srcs = [
+        "test_py_flashinfer_mha_decode.py",
+        "attention_ref.py",
+        "base_attention_test.py"
+    ],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["RTX_5000_PRO", "cuda12_9"],
+    target_compatible_with = select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    exec_properties = {
+        'gpu': 'RTX_5000_PRO',
+    },
+)
+
 py_test(
     name = "test_xqa",
     srcs = [
@@ -256,5 +281,38 @@ py_test(
     tags = ["H20"],
     exec_properties = {
         'gpu': 'H20',
+    },
+)
+
+py_test(
+    name = "test_kv_cache_write_op",
+    srcs = ["test_kv_cache_write_op.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["H20"],
+    exec_properties = {
+        'gpu': 'H20',
+    },
+)
+
+# Exercise FlashInfer's FP8 append kernel on the architecture this PR enables.
+py_test(
+    name = "test_kv_cache_write_op_sm120",
+    main = "test_kv_cache_write_op.py",
+    srcs = ["test_kv_cache_write_op.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "//conditions:default": [],
+    }),
+    tags = ["RTX_5000_PRO", "cuda12_9"],
+    target_compatible_with = select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    exec_properties = {
+        'gpu': 'RTX_5000_PRO',
     },
 )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_kv_cache_write_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_kv_cache_write_op.py
@@ -1,0 +1,221 @@
+"""Unit tests for PyFlashinfer's paged KV cache write operation."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
+    KVCacheWriteOp,
+)
+from rtp_llm.ops.compute_ops import LayerKVCache
+
+
+class KVCacheWriteOpDtypeTest(unittest.TestCase):
+    def _make_inputs(self, magnitude: float = 1.0):
+        key = torch.randn((1, 2, 4), dtype=torch.bfloat16) * magnitude
+        value = torch.randn((1, 2, 4), dtype=torch.bfloat16) * magnitude
+        return key, value
+
+    def _make_op(self, kv_cache_dtype=None):
+        op = KVCacheWriteOp(
+            num_kv_heads=2,
+            head_size=4,
+            token_per_block=8,
+            kv_cache_dtype=kv_cache_dtype,
+        )
+        op.set_params(
+            SimpleNamespace(
+                batch_indice_d=torch.tensor([0], dtype=torch.int32),
+                positions_d=torch.tensor([0], dtype=torch.int32),
+                page_indice_d=torch.tensor([0], dtype=torch.int32),
+                decode_page_indptr_d=torch.tensor([0, 1], dtype=torch.int32),
+                paged_kv_last_page_len_d=torch.tensor([1], dtype=torch.int32),
+            )
+        )
+        return op
+
+    def _run_write(self, cache_dtype: torch.dtype, magnitude: float = 1.0):
+        op = self._make_op()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=cache_dtype)
+        if cache_dtype == torch.float8_e4m3fn:
+            kv_cache.kv_scale_base = torch.ones((1, 32), dtype=torch.float32)
+        key, value = self._make_inputs(magnitude)
+
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op.page.append_paged_kv_cache"
+        ) as append:
+            op.forward(key, value, kv_cache)
+
+        written_key, written_value = append.call_args.args[:2]
+        return key, value, written_key, written_value
+
+    def test_fp8_cache_casts_bf16_inputs_before_append(self):
+        _, _, written_key, written_value = self._run_write(torch.float8_e4m3fn)
+        self.assertEqual(written_key.dtype, torch.float8_e4m3fn)
+        self.assertEqual(written_value.dtype, torch.float8_e4m3fn)
+
+    def test_bf16_cache_preserves_input_tensors(self):
+        key, value, written_key, written_value = self._run_write(torch.bfloat16)
+        self.assertIs(written_key, key)
+        self.assertIs(written_value, value)
+
+    def test_fp8_cache_clamps_outliers_to_finite_values(self):
+        _, _, written_key, written_value = self._run_write(
+            torch.float8_e4m3fn, magnitude=1e4
+        )
+        limit = torch.finfo(torch.float8_e4m3fn).max
+        for written in (written_key, written_value):
+            self.assertFalse(written.float().isnan().any())
+            self.assertLessEqual(written.float().abs().max().item(), limit)
+
+    def test_non_fp8_dtype_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "only converts activations for FP8"):
+            self._run_write(torch.float16)
+
+    def test_fp8_warmup_uses_real_cache_dtype(self):
+        op = self._make_op(torch.float8_e4m3fn)
+        key, value = self._make_inputs()
+        with mock.patch(
+            "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op.page.append_paged_kv_cache"
+        ) as append:
+            op.forward(key, value, None)
+
+        written_key, written_value, _, _, caches = append.call_args.args[:5]
+        self.assertEqual(written_key.dtype, torch.float8_e4m3fn)
+        self.assertEqual(written_value.dtype, torch.float8_e4m3fn)
+        self.assertEqual(caches[0].dtype, torch.float8_e4m3fn)
+        self.assertEqual(caches[1].dtype, torch.float8_e4m3fn)
+
+    def test_fp8_cache_requires_scale_buffer(self):
+        op = self._make_op()
+        key, value = self._make_inputs()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=torch.float8_e4m3fn)
+
+        with self.assertRaisesRegex(RuntimeError, "requires an initialized"):
+            op.forward(key, value, kv_cache)
+
+    def test_fp8_cache_rejects_empty_scale_buffer(self):
+        op = self._make_op()
+        key, value = self._make_inputs()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=torch.float8_e4m3fn)
+        kv_cache.kv_scale_base = torch.empty(0, dtype=torch.float32)
+
+        with self.assertRaisesRegex(RuntimeError, "requires an initialized"):
+            op.forward(key, value, kv_cache)
+
+    def test_fp8_cache_does_not_synchronize_scale_view_in_hot_path(self):
+        op = self._make_op()
+        key, value = self._make_inputs()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=torch.float8_e4m3fn)
+        scale_storage = torch.ones((32,), dtype=torch.float32)
+        kv_cache.kv_scale_base = scale_storage.view(1, 32)
+
+        with (
+            mock.patch.object(torch.Tensor, "item", side_effect=AssertionError("sync")),
+            mock.patch(
+                "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op.page.append_paged_kv_cache"
+            ),
+        ):
+            op.forward(key, value, kv_cache)
+            kv_cache.kv_scale_base = scale_storage.view(1, 32)
+            op.forward(key, value, kv_cache)
+
+    def test_fp8_cache_rejects_configured_dtype_mismatch(self):
+        op = self._make_op(torch.bfloat16)
+        key, value = self._make_inputs()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=torch.float8_e4m3fn)
+        kv_cache.kv_scale_base = torch.ones((1, 32), dtype=torch.float32)
+
+        with self.assertRaisesRegex(RuntimeError, "dtype mismatch"):
+            op.forward(key, value, kv_cache)
+
+    def test_non_fp8_cache_rejects_configured_fp8_dtype(self):
+        op = self._make_op(torch.float8_e4m3fn)
+        key, value = self._make_inputs()
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty((1, 2, 2, 8, 4), dtype=torch.bfloat16)
+
+        with self.assertRaisesRegex(RuntimeError, "dtype mismatch"):
+            op.forward(key, value, kv_cache)
+
+    def test_fp8_scale_warning_is_emitted_once(self):
+        with (
+            mock.patch.object(KVCacheWriteOp, "_fp8_scale_warning_emitted", False),
+            self.assertLogs(
+                "rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op",
+                level="WARNING",
+            ) as logs,
+        ):
+            self._make_op(torch.float8_e4m3fn)
+            self._make_op(torch.float8_e4m3fn)
+
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("implicit scale=1", logs.output[0])
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_real_fp8_append_writes_single_and_cross_page_tokens(self):
+        num_tokens = 9
+        head_size = 64
+        op = KVCacheWriteOp(num_kv_heads=2, head_size=head_size, token_per_block=8)
+        op.set_params(
+            SimpleNamespace(
+                batch_indice_d=torch.zeros(
+                    num_tokens, dtype=torch.int32, device="cuda"
+                ),
+                positions_d=torch.arange(num_tokens, dtype=torch.int32, device="cuda"),
+                page_indice_d=torch.tensor([0, 1], dtype=torch.int32, device="cuda"),
+                decode_page_indptr_d=torch.tensor(
+                    [0, 2], dtype=torch.int32, device="cuda"
+                ),
+                paged_kv_last_page_len_d=torch.tensor(
+                    [1], dtype=torch.int32, device="cuda"
+                ),
+            )
+        )
+        key = torch.linspace(
+            -600,
+            600,
+            num_tokens * 2 * head_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        ).reshape(num_tokens, 2, head_size)
+        value = -key
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.zeros(
+            (2, 2, 2, 8, head_size), dtype=torch.float8_e4m3fn, device="cuda"
+        )
+        kv_cache.kv_scale_base = torch.ones((2, 32), dtype=torch.float32, device="cuda")
+
+        op.forward(key, value, kv_cache)
+
+        written_key = torch.cat(
+            (
+                kv_cache.kv_cache_base[0, 0].permute(1, 0, 2),
+                kv_cache.kv_cache_base[1, 0, :, :1, :].permute(1, 0, 2),
+            )
+        )
+        written_value = torch.cat(
+            (
+                kv_cache.kv_cache_base[0, 1].permute(1, 0, 2),
+                kv_cache.kv_cache_base[1, 1, :, :1, :].permute(1, 0, 2),
+            )
+        )
+        # Keep the oracle independent from the production helper under test.
+        expected_key = key.clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        expected_value = value.clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+        torch.testing.assert_close(written_key.float(), expected_key.float())
+        torch.testing.assert_close(written_value.float(), expected_value.float())
+        torch.testing.assert_close(
+            kv_cache.kv_scale_base, torch.ones_like(kv_cache.kv_scale_base)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -3,6 +3,7 @@ import math
 import sys
 import unittest
 from typing import List
+from unittest import mock
 
 import torch
 from attention_ref import compute_flashinfer_decode_reference
@@ -11,7 +12,10 @@ from base_attention_test import BaseAttentionTest, compare_tensors
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferDecodeAttnOp,
 )
+from rtp_llm.models_py.utils.arch import is_sm120
+from rtp_llm.ops import KvCacheDataType
 from rtp_llm.ops.compute_ops import (
+    LayerKVCache,
     PyAttentionInputs,
     fill_mla_params,
     get_typemeta,
@@ -294,8 +298,9 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     Verifies the critical invariants that the C++ CUDA graph runner depends on:
     1. prepare() with is_cuda_graph=True sets _fixed_batch_size and wires up
        the decode_wrapper's internal buffers for graph capture.
-    2. prepare_for_cuda_graph_replay() refreshes both page tables and, only
-       for FlashInfer fa2, cached plan metadata without reallocating buffers.
+    2. prepare_for_cuda_graph_replay() refreshes page tables and the cached
+       plan metadata used by tensor-core decode and SM120 CUDA-core decode
+       without reallocating buffers.
 
     Full forward correctness under CUDA graph capture/replay cannot be tested
     at the Python UT level — that path is exercised by smoke tests with real
@@ -356,8 +361,8 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
         logging.info("_fixed_batch_size correctly set after prepare()")
 
-    def test_replay_refreshes_plan_metadata(self):
-        """prepare_for_cuda_graph_replay() must refresh FlashInfer fa2 plan metadata."""
+    def test_tensor_core_replay_refreshes_plan_metadata(self):
+        """prepare_for_cuda_graph_replay() must refresh tensor-core plan metadata."""
         config = self._create_config()
         capture_bs = 8
         capture_seq_lens = [64, 128, 256, 512, 64, 128, 256, 512]
@@ -369,7 +374,6 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         self.assertTrue(attn_op.use_tensor_core)
-        self.assertTrue(attn_op._requires_fa2_cuda_graph_replan())
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
         attn_op.prepare(capture_inputs)
@@ -411,9 +415,15 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             f"page_indptr={page_indptr.tolist()}"
         )
 
-    def test_non_fa2_replay_does_not_replan(self):
-        """Non-fa2 decode keeps the original replay contract: fill params only."""
-        config = self._create_config(head_num=32, head_num_kv=32)
+    def test_cuda_core_replay_refreshes_plan_metadata(self):
+        """CUDA-core decode must also refresh plan metadata for graph replay.
+
+        Qwen3-1.7B uses head_num/head_num_kv = 16/8, which selects this
+        non-tensor-core FlashInfer decode path.
+        """
+        if not is_sm120():
+            self.skipTest("SM120 CUDA-core replay requires an sm_120 device")
+        config = self._create_config(head_num=16, head_num_kv=8)
         capture_bs = 4
         capture_seq_lens = [64, 128, 256, 512]
 
@@ -424,7 +434,6 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         self.assertFalse(attn_op.use_tensor_core)
-        self.assertFalse(attn_op._requires_fa2_cuda_graph_replan())
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
         attn_op.prepare(capture_inputs)
@@ -445,10 +454,18 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         self.assertFalse(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
 
+        indptr_ptr = attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr()
+        indices_ptr = attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr()
+        last_page_len_ptr = (
+            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr()
+        )
+
+        original_plan = attn_op.decode_wrapper.plan
         plan_calls = []
 
         def counted_plan(*args, **kwargs):
             plan_calls.append((args, kwargs))
+            return original_plan(*args, **kwargs)
 
         attn_op.decode_wrapper.plan = counted_plan
 
@@ -460,12 +477,139 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
-        self.assertEqual(len(plan_calls), 0)
+        self.assertEqual(len(plan_calls), 1)
+        plan_args, plan_kwargs = plan_calls[0]
+        self.assertFalse(plan_args[0].is_cuda)
+        self.assertFalse(plan_args[1].is_cuda)
+        self.assertFalse(plan_args[2].is_cuda)
+        self.assertTrue(plan_kwargs["non_blocking"])
+        self.assertEqual(plan_kwargs["q_data_type"], torch.float16)
+        self.assertEqual(plan_kwargs["kv_data_type"], torch.float16)
+
+        # CUDA graph replay relies on stable buffer addresses.
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(), indptr_ptr
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(), indices_ptr
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
+            last_page_len_ptr,
+        )
+
+    def test_tensor_core_replay_waits_for_pending_plan_copy(self):
+        """Tensor-core replay must not overwrite pinned inputs during H2D."""
+        config = self._create_config()
+        capture_bs = 4
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [64, 128, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertTrue(attn_op.use_tensor_core)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+        self.assertIsNotNone(attn_op._plan_copy_done_event)
+
+        pending_copy = mock.Mock()
+        pending_copy.query.return_value = False
+        attn_op._plan_copy_done_event = pending_copy
+
+        run_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [100, 200, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+
+        pending_copy.query.assert_called_once_with()
+        pending_copy.synchronize.assert_called_once_with()
+        pending_copy.record.assert_called_once()
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha.is_sm120",
+        return_value=False,
+    )
+    def test_non_sm120_cuda_core_keeps_mainline_replay_contract(self, _is_sm120):
+        """Non-SM120 CUDA-core decode keeps device plan inputs and no replan."""
+        config = self._create_config(head_num=16, head_num_kv=8)
+        capture_bs = 4
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [64, 128, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertFalse(attn_op.use_tensor_core)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+        self.assertIsNone(attn_op._plan_copy_done_event)
+
+        original_plan = attn_op.decode_wrapper.plan
+        plan_calls = []
+
+        def counted_plan(*args, **kwargs):
+            plan_calls.append((args, kwargs))
+            return original_plan(*args, **kwargs)
+
+        attn_op.decode_wrapper.plan = counted_plan
+        run_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [100, 200, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+
+        self.assertEqual(plan_calls, [])
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha.is_sm120",
+        return_value=True,
+    )
+    def test_sm120_cuda_core_uses_host_plan_contract(self, _is_sm120):
+        config = self._create_config(head_num=16, head_num_kv=8)
+        capture_bs = 4
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [64, 128, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertFalse(attn_op.use_tensor_core)
+        self.assertTrue(attn_op._uses_host_plan_inputs())
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+
+        plan_calls = []
+        original_plan = attn_op.decode_wrapper.plan
+
+        def counted_plan(*args, **kwargs):
+            plan_calls.append((args, kwargs))
+            return original_plan(*args, **kwargs)
+
+        attn_op.decode_wrapper.plan = counted_plan
+        run_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [100, 200, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+
+        self.assertEqual(len(plan_calls), 1)
+        plan_args, plan_kwargs = plan_calls[0]
+        self.assertFalse(plan_args[0].is_cuda)
+        self.assertFalse(plan_args[1].is_cuda)
+        self.assertFalse(plan_args[2].is_cuda)
+        self.assertTrue(plan_kwargs["non_blocking"])
+        self.assertIsNotNone(attn_op._plan_copy_done_event)
 
     def test_replay_updates_page_tables(self):
         """Page table buffers must reflect the replay inputs, not capture inputs."""
-        import math
-
         config = self._create_config(seq_size_per_block=64)
         capture_bs = 4
         capture_seq_lens = [64, 128, 256, 512]

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -291,6 +291,74 @@ class TestPyFlashinferDecodeAttnOp(BaseAttentionTest):
                 seq_size_per_block=64,
             )
 
+    def test_fp8_kv_decode_matches_bf16_kv(self):
+        """FP8 cache decode stays numerically close to the same BF16 cache."""
+        batch_size = 2
+        sequence_lengths = [32, 64]
+        config = self._create_config(
+            head_num=16,
+            head_num_kv=8,
+            size_per_head=128,
+            seq_size_per_block=64,
+            data_type="bf16",
+        )
+        attn_inputs = self._create_attention_inputs(
+            batch_size,
+            sequence_lengths,
+            config.seq_size_per_block,
+            dtype=torch.bfloat16,
+        )
+        total_blocks = self._calculate_total_blocks(
+            sequence_lengths, config.seq_size_per_block
+        )
+        base_cache = torch.randn(
+            total_blocks,
+            2,
+            config.head_num_kv,
+            config.seq_size_per_block,
+            config.size_per_head,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        q = self._create_query_tensor(
+            batch_size,
+            config.head_num,
+            config.size_per_head,
+            dtype=torch.bfloat16,
+        )
+
+        quantized_cache = base_cache.to(torch.float8_e4m3fn)
+
+        def run(cache: torch.Tensor, kv_cache_type: KvCacheDataType):
+            original_cache_type = config.attn_configs.kv_cache_dtype
+            try:
+                config.attn_configs.kv_cache_dtype = kv_cache_type
+                op = PyFlashinferDecodeAttnOp(config.attn_configs, attn_inputs)
+                fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+                op.set_params(fmha_params)
+                params = op.prepare(attn_inputs)
+                kv_cache = LayerKVCache()
+                kv_cache.kv_cache_base = cache
+                if cache.dtype == torch.float8_e4m3fn:
+                    kv_cache.kv_scale_base = torch.ones(
+                        total_blocks,
+                        2 * config.head_num_kv * config.seq_size_per_block,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+                return op.forward(q, kv_cache, params)
+            finally:
+                config.attn_configs.kv_cache_dtype = original_cache_type
+
+        # Use the same quantized values for both paths so this comparison
+        # measures FP8 cache reads rather than the cache quantization error.
+        bf16_output = run(quantized_cache.to(torch.bfloat16), KvCacheDataType.BASE)
+        fp8_output = run(quantized_cache, KvCacheDataType.FP8)
+
+        torch.testing.assert_close(
+            fp8_output.float(), bf16_output.float(), rtol=1e-2, atol=1e-2
+        )
+
 
 class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     """Test CUDA graph buffer management for PyFlashinferDecodeAttnOp.

--- a/rtp_llm/models_py/modules/factory/linear/factory.py
+++ b/rtp_llm/models_py/modules/factory/linear/factory.py
@@ -9,17 +9,19 @@ from typing import Dict, List, Optional, Type
 import torch
 from torch import nn
 
-from .linear_base import LinearBase
-
 from rtp_llm.ops import HWKernelConfig
+
+from .linear_base import LinearBase
 
 try:
     # Fix nvidia-cutlass-dsl cutlass module path on sm100 or upper device
-    import sys
     import os
+    import sys
+
     import nvidia_cutlass_dsl
+
     pkg_dir = nvidia_cutlass_dsl.__path__[0]
-    python_packages_dir = os.path.join(pkg_dir, 'python_packages')
+    python_packages_dir = os.path.join(pkg_dir, "python_packages")
 
     if os.path.isdir(python_packages_dir) and python_packages_dir not in sys.path:
         sys.path.insert(0, python_packages_dir)
@@ -38,6 +40,28 @@ class LinearFactory:
     """
 
     _strategies: List[Type[LinearBase]] = []
+
+    @staticmethod
+    def _merge_sm120_blockwise_tensors(
+        tensors: List[torch.Tensor], dim: int
+    ) -> torch.Tensor:
+        """Merge logical (K, N) views while preserving physical (N, K) data."""
+        if dim not in (-1, 1) or any(tensor.dim() != 2 for tensor in tensors):
+            raise ValueError(
+                "SM120 FP8_PER_BLOCK merged linear only supports 2D tensors "
+                "merged along the output dimension"
+            )
+        K = tensors[0].shape[0]
+        if any(
+            tensor.shape[0] != K or not tensor.is_contiguous() for tensor in tensors
+        ):
+            raise ValueError(
+                "SM120 FP8_PER_BLOCK merged tensors must have the same K and "
+                "contiguous loader storage"
+            )
+        physical = [tensor.reshape(tensor.shape[1], K) for tensor in tensors]
+        merged_n = sum(tensor.shape[1] for tensor in tensors)
+        return torch.cat(physical, dim=0).reshape(K, merged_n)
 
     @classmethod
     def register(cls, strategy_class: type) -> None:
@@ -62,7 +86,7 @@ class LinearFactory:
         scale_key: Optional[str] = None,
         bias_key: Optional[str] = None,
         quant_config: object = None,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2_key: Optional[str] = None,
         input_scale_key: Optional[str] = None,
     ) -> LinearBase:
@@ -86,11 +110,20 @@ class LinearFactory:
         weight = weights[weight_key]
         weight_scales = weights.get(scale_key) if scale_key else None
         bias = weights.get(bias_key) if bias_key else None
-        weight_scale_2 = weights.get(weight_scale_2_key, None) if weight_scale_2_key else None
+        weight_scale_2 = (
+            weights.get(weight_scale_2_key, None) if weight_scale_2_key else None
+        )
         input_scale = weights.get(input_scale_key, None) if input_scale_key else None
 
-        return cls.create_linear(weight, bias, weight_scales, quant_config, hw_kernel_config,
-                                 weight_scale_2, input_scale)
+        return cls.create_linear(
+            weight,
+            bias,
+            weight_scales,
+            quant_config,
+            hw_kernel_config,
+            weight_scale_2,
+            input_scale,
+        )
 
     @classmethod
     def create_linear(
@@ -99,23 +132,54 @@ class LinearFactory:
         bias: Optional[torch.Tensor],
         weight_scales: Optional[torch.Tensor],
         quant_config: object,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ):
         candidates = [
             strategy_class
             for strategy_class in cls._strategies
-            if strategy_class.can_handle(quant_config, weight, weight_scales, hw_kernel_config,
-                                         weight_scale_2, input_scale)
+            if strategy_class.can_handle(
+                quant_config,
+                weight,
+                weight_scales,
+                hw_kernel_config,
+                weight_scale_2,
+                input_scale,
+            )
         ]
 
         if not candidates:
+            rejection_reasons = []
+            for strategy_class in cls._strategies:
+                try:
+                    reason = strategy_class.rejection_reason(
+                        quant_config,
+                        weight,
+                        weight_scales,
+                        hw_kernel_config,
+                        weight_scale_2,
+                        input_scale,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Linear strategy %s rejection diagnostic failed",
+                        strategy_class.__name__,
+                        exc_info=True,
+                    )
+                    continue
+                if reason is not None and reason not in rejection_reasons:
+                    rejection_reasons.append(reason)
+            details = (
+                f" Rejections: {'; '.join(rejection_reasons)}"
+                if rejection_reasons
+                else ""
+            )
             raise ValueError(
                 f"No suitable Linear strategy found for:"
                 f"weight.dtype={weight.dtype}, "
                 f"has_scales={weight_scales is not None}, "
-                f"quant_config={quant_config}"
+                f"quant_config={quant_config}.{details}"
             )
 
         # Check uniqueness - should only have one matching strategy
@@ -156,24 +220,41 @@ class LinearFactory:
         input_scale_keys: Optional[List[str]],
         quant_config: object,
         dim: int = -1,
-        hw_kernel_config: Optional['HWKernelConfig'] = None,
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
     ) -> nn.Module:
         """Create merged Linear layer (e.g., gate_up_proj)."""
         # Check FP8 usage based on first weight
-        use_fp8 = LinearFactory.should_use_fp8_linear(quant_config, weights, weight_keys[0])
-        
+        use_fp8 = LinearFactory.should_use_fp8_linear(
+            quant_config, weights, weight_keys[0]
+        )
+
         # Check FP4 usage based on first weight
-        use_fp4 = LinearFactory.should_use_fp4_linear(quant_config, weights, weight_keys[0])
+        use_fp4 = LinearFactory.should_use_fp4_linear(
+            quant_config, weights, weight_keys[0]
+        )
 
         # Merge weights
         weight_tensors = [weights[key] for key in weight_keys]
-        merged_weight = torch.cat(weight_tensors, dim=dim)
+        use_sm120_blockwise_layout = False
+        if use_fp8 and quant_config.get_method() == "FP8_PER_BLOCK":
+            from rtp_llm.models_py.utils.arch import is_sm120
+
+            use_sm120_blockwise_layout = is_sm120(weight_tensors[0].device)
+        merged_weight = (
+            cls._merge_sm120_blockwise_tensors(weight_tensors, dim)
+            if use_sm120_blockwise_layout
+            else torch.cat(weight_tensors, dim=dim)
+        )
 
         # Merge scales if needed (for both FP8 and NVFP4)
         merged_scales = None
         if (use_fp8 or use_fp4) and scale_keys:
             scale_tensors = [weights[key] for key in scale_keys]
-            merged_scales = torch.cat(scale_tensors, dim=dim)
+            merged_scales = (
+                cls._merge_sm120_blockwise_tensors(scale_tensors, dim)
+                if use_sm120_blockwise_layout
+                else torch.cat(scale_tensors, dim=dim)
+            )
 
         # Merge bias if exists
         merged_bias = None
@@ -186,7 +267,7 @@ class LinearFactory:
 
             if bias_tensors:
                 merged_bias = torch.cat(bias_tensors, dim=dim)
-        
+
         # Merge scale2 and input_scale if exists
         weight_scale_2 = None
         if use_fp4 and scale2_keys:
@@ -273,4 +354,3 @@ class LinearFactory:
             return False
 
         return weight.dtype == torch.uint8
-

--- a/rtp_llm/models_py/modules/factory/linear/factory.py
+++ b/rtp_llm/models_py/modules/factory/linear/factory.py
@@ -273,3 +273,4 @@ class LinearFactory:
             return False
 
         return weight.dtype == torch.uint8
+

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/__init__.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/__init__.py
@@ -7,7 +7,7 @@ logger.debug("Registered CUDA Linear strategies")
 
 
 from rtp_llm.models_py.modules.factory.linear import LinearFactory
-from rtp_llm.models_py.utils.arch import get_sm, is_cuda
+from rtp_llm.models_py.utils.arch import get_sm, is_cuda, is_sm12x
 
 # Register CUDA strategies
 from .f16_linear import CudaF16Linear
@@ -23,6 +23,11 @@ if is_cuda():
         from .fp4_linear import CudaFp4GEMMLinear
 
         LinearFactory.register(CudaFp4GEMMLinear)
+
+    if is_sm12x():
+        from .fp8_vllm_blockwise_sm120_linear import CudaFp8VllmBlockwiseLinear
+
+        LinearFactory.register(CudaFp8VllmBlockwiseLinear)
 
     LinearFactory.register(CudaFp8PerTensorLinear)
     LinearFactory.register(CudaFp8GEMMLinear)

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/__init__.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/__init__.py
@@ -25,9 +25,34 @@ if is_cuda():
         LinearFactory.register(CudaFp4GEMMLinear)
 
     if is_sm12x():
-        from .fp8_vllm_blockwise_sm120_linear import CudaFp8VllmBlockwiseLinear
+        if (major, minor) != (12, 0):
+            logger.debug(
+                "CudaFp8VllmBlockwiseLinear supports exact sm_120 devices only; "
+                "current device is sm_%d%d.",
+                major,
+                minor,
+            )
+        else:
+            try:
+                from .fp8_vllm_blockwise_sm120_linear import (
+                    CudaFp8VllmBlockwiseLinear,
+                    sm120_blockwise_backend_available,
+                )
 
-        LinearFactory.register(CudaFp8VllmBlockwiseLinear)
+                if sm120_blockwise_backend_available():
+                    LinearFactory.register(CudaFp8VllmBlockwiseLinear)
+                else:
+                    logger.warning(
+                        "CudaFp8VllmBlockwiseLinear unavailable on sm_120: "
+                        "cutlass_scaled_mm_blockwise_sm120_fp8 was not compiled. "
+                        "Rebuild with --config=cuda12_9 to enable this backend."
+                    )
+            except ImportError as e:
+                logger.warning(
+                    "CudaFp8VllmBlockwiseLinear unavailable on sm_120: %s; "
+                    "rebuild with --config=cuda12_9 to enable this backend.",
+                    e,
+                )
 
     LinearFactory.register(CudaFp8PerTensorLinear)
     LinearFactory.register(CudaFp8GEMMLinear)

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
@@ -48,7 +48,10 @@ class CudaFp8DeepGEMMLinear(LinearBase):
 
         # DeepGEMM 2.1.x wheel ships only sm_90/sm_100 cubins. Let sm_12x
         # consumer Blackwell use the CUTLASS blockwise backend instead.
-        if not has_deep_gemm() or is_sm12x():
+        # Keep the pre-existing factory contract on sm90/sm100: select this
+        # strategy and let __init__ report the actionable installation error
+        # when DeepGEMM is unavailable. Only sm12x is routed away from it.
+        if is_sm12x(weight.device):
             return False
 
         # Check quantization method - handle all other FP8 methods
@@ -75,7 +78,7 @@ class CudaFp8DeepGEMMLinear(LinearBase):
         self.bias = bias
 
         # Check if DeepGEMM is available
-        if not has_deep_gemm() or is_sm12x():
+        if not has_deep_gemm() or is_sm12x(weight.device):
             if not has_deep_gemm():
                 error_msg = (
                     "DeepGEMM is not available. Please install the `deep_gemm` "

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_deepgemm_linear.py
@@ -16,6 +16,7 @@ from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
     sgl_per_token_group_quant_fp8,
 )
 from rtp_llm.models_py.modules.factory.linear import LinearBase
+from rtp_llm.models_py.utils.arch import is_sm12x
 from rtp_llm.ops import HWKernelConfig
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,11 @@ class CudaFp8DeepGEMMLinear(LinearBase):
         if weight.dtype not in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
             return False
 
+        # DeepGEMM 2.1.x wheel ships only sm_90/sm_100 cubins. Let sm_12x
+        # consumer Blackwell use the CUTLASS blockwise backend instead.
+        if not has_deep_gemm() or is_sm12x():
+            return False
+
         # Check quantization method - handle all other FP8 methods
         quant_method = quant_config.get_method()
         return quant_method == "FP8_PER_BLOCK"
@@ -69,8 +75,18 @@ class CudaFp8DeepGEMMLinear(LinearBase):
         self.bias = bias
 
         # Check if DeepGEMM is available
-        if not has_deep_gemm():
-            error_msg = "DeepGEMM is not available. Please install the `deep_gemm` package to enable DeepGEMM kernels."
+        if not has_deep_gemm() or is_sm12x():
+            if not has_deep_gemm():
+                error_msg = (
+                    "DeepGEMM is not available. Please install the `deep_gemm` "
+                    "package to enable DeepGEMM kernels."
+                )
+            else:
+                error_msg = (
+                    "DeepGEMM is unavailable on the current device. The bundled "
+                    "wheel supports sm90/sm100 only; sm12x FP8_PER_BLOCK dense "
+                    "layers use the CUTLASS backend."
+                )
             logger.error(error_msg)
             raise RuntimeError(error_msg)
         # Check weight and weight scale dimensions

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_gemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_gemm_linear.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import torch
 
+from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
 from rtp_llm.models_py.modules.factory.linear import LinearBase
 from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear import (
     CudaFp8DeepGEMMLinear,
@@ -11,6 +12,7 @@ from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear impo
 from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_flashinfer_linear import (
     CudaFp8FlashinferLinear,
 )
+from rtp_llm.models_py.utils.arch import is_sm12x
 from rtp_llm.ops import HWKernelConfig
 
 
@@ -18,6 +20,20 @@ class CudaFp8GEMMLinear(LinearBase):
     """CUDA FP8 GEMM wrapper."""
 
     FLASHINFER_M_THRESHOLD = CudaFp8FlashinferLinear.FLASHINFER_M_THRESHOLD
+
+    @classmethod
+    def _is_fp8_per_block_candidate(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+    ) -> bool:
+        return (
+            weight_scales is not None
+            and quant_config is not None
+            and weight.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+            and quant_config.get_method() == "FP8_PER_BLOCK"
+        )
 
     @classmethod
     def can_handle(
@@ -29,11 +45,9 @@ class CudaFp8GEMMLinear(LinearBase):
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
-        if weight_scales is None or quant_config is None:
+        if not cls._is_fp8_per_block_candidate(quant_config, weight, weight_scales):
             return False
-        if weight.dtype not in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
-            return False
-        return quant_config.get_method() == "FP8_PER_BLOCK"
+        return has_deep_gemm() and not is_sm12x()
 
     @torch.inference_mode()
     def __init__(

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_gemm_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_gemm_linear.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import torch
 
-from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import has_deep_gemm
 from rtp_llm.models_py.modules.factory.linear import LinearBase
 from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear import (
     CudaFp8DeepGEMMLinear,
@@ -47,7 +46,41 @@ class CudaFp8GEMMLinear(LinearBase):
     ) -> bool:
         if not cls._is_fp8_per_block_candidate(quant_config, weight, weight_scales):
             return False
-        return has_deep_gemm() and not is_sm12x()
+        # Preserve the sm90/sm100 behavior where construction reports the
+        # actionable DeepGEMM installation error. Only sm12x is excluded from
+        # this strategy because it uses the SM120 CUTLASS backend instead.
+        if not is_sm12x(weight.device):
+            return True
+
+        return False
+
+    @classmethod
+    def rejection_reason(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
+        weight_scale_2: Optional[torch.Tensor] = None,
+        input_scale: Optional[torch.Tensor] = None,
+    ) -> Optional[str]:
+        if not is_sm12x(weight.device) or not cls._is_fp8_per_block_candidate(
+            quant_config, weight, weight_scales
+        ):
+            return None
+        # The SM120 strategy can be absent from the registry when its binding
+        # was not compiled. Preserve its public diagnostic in that case.
+        try:
+            from .fp8_vllm_blockwise_sm120_linear import CudaFp8VllmBlockwiseLinear
+        except ImportError as error:
+            return (
+                "SM120 FP8_PER_BLOCK backend is unavailable; rebuild on x86 "
+                f"with --config=cuda12_9 (ENABLE_FP8_SM120): {error}"
+            )
+
+        return CudaFp8VllmBlockwiseLinear.rejection_reason(
+            quant_config, weight, weight_scales
+        )
 
     @torch.inference_mode()
     def __init__(

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_vllm_blockwise_sm120_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_vllm_blockwise_sm120_linear.py
@@ -12,17 +12,17 @@ import torch
 
 from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
 from rtp_llm.models_py.modules.factory.linear import LinearBase
-from rtp_llm.models_py.utils.arch import get_sm, is_cuda, is_sm12x
+from rtp_llm.models_py.utils.arch import is_sm12x, is_sm120
 from rtp_llm.ops import HWKernelConfig
 
 
-def _is_sm120_runtime() -> bool:
+def _is_sm120_runtime(device_id=None) -> bool:
     """Match the exact SASS architectures emitted by ``sm120_cuda_copts``."""
-    return is_cuda() and is_sm12x() and get_sm() == (12, 0)
+    return is_sm120(device_id)
 
 
-def _get_cutlass_scaled_mm_blockwise_sm120_fp8():
-    if not _is_sm120_runtime():
+def _get_cutlass_scaled_mm_blockwise_sm120_fp8(device_id=None):
+    if not _is_sm120_runtime(device_id):
         return None
     try:
         from rtp_llm.ops.compute_ops import (
@@ -37,8 +37,9 @@ def _get_cutlass_scaled_mm_blockwise_sm120_fp8():
         return None
 
 
-def _has_cutlass_scaled_mm_blockwise_sm120_fp8() -> bool:
-    return _get_cutlass_scaled_mm_blockwise_sm120_fp8() is not None
+def sm120_blockwise_backend_available(device_id=None) -> bool:
+    """Return whether the SM120 blockwise binding can run on this device."""
+    return _get_cutlass_scaled_mm_blockwise_sm120_fp8(device_id) is not None
 
 
 class CudaFp8VllmBlockwiseLinear(LinearBase):
@@ -64,7 +65,13 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
         weight_scales: torch.Tensor,
         block_size: int = 128,
     ) -> tuple[torch.Tensor, torch.Tensor, int, int, int, int]:
-        """Restore SM120 loader tensors from logical (K,N) to physical (N,K)."""
+        """Restore SM120 loader tensors from logical (K,N) to physical (N,K).
+
+        This is the inverse of PerBlockFp8Weight._postprocess's SM12x reshape;
+        keep both sides and their integration smoke coverage in sync.
+        """
+        if weight.device.type != "cuda" or weight_scales.device.type != "cuda":
+            raise ValueError("SM120 FP8 blockwise weights must be on a CUDA device")
         if not weight.is_contiguous():
             raise ValueError("SM120 FP8 blockwise weight must be contiguous")
         if not weight_scales.is_contiguous():
@@ -88,7 +95,7 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
         )
 
     @classmethod
-    def _classify_support(
+    def classify_support(
         cls,
         quant_config: object,
         weight: torch.Tensor,
@@ -98,10 +105,16 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
         if (
             weight_scales is None
             or quant_config is None
-            or not _is_sm120_runtime()
             or quant_config.get_method() != "FP8_PER_BLOCK"
             or weight.dtype != torch.float8_e4m3fn
         ):
+            return False, None
+        if not _is_sm120_runtime(weight.device):
+            if is_sm12x(weight.device):
+                return False, (
+                    "SM12x FP8_PER_BLOCK CUTLASS backend currently supports exact "
+                    "sm_120 devices only; this device needs a matching SM12x kernel"
+                )
             return False, None
         if weight_scales.dtype != torch.float32:
             detail = f"got {weight_scales.dtype}"
@@ -113,7 +126,7 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
                 False,
                 f"SM120 FP8_PER_BLOCK requires float32 weight scales, {detail}",
             )
-        if not _has_cutlass_scaled_mm_blockwise_sm120_fp8():
+        if not sm120_blockwise_backend_available(weight.device):
             return False, (
                 "SM120 FP8_PER_BLOCK backend is unavailable; rebuild on x86 "
                 "with --config=cuda12_9 (ENABLE_FP8_SM120)"
@@ -139,8 +152,21 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
         weight_scale_2: Optional[torch.Tensor] = None,
         input_scale: Optional[torch.Tensor] = None,
     ) -> bool:
-        supported, _ = cls._classify_support(quant_config, weight, weight_scales)
+        supported, _ = cls.classify_support(quant_config, weight, weight_scales)
         return supported
+
+    @classmethod
+    def rejection_reason(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
+        weight_scale_2: Optional[torch.Tensor] = None,
+        input_scale: Optional[torch.Tensor] = None,
+    ) -> Optional[str]:
+        _, reason = cls.classify_support(quant_config, weight, weight_scales)
+        return reason
 
     @torch.inference_mode()
     def __init__(
@@ -157,7 +183,7 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
         )
         if weight_scales is None:
             raise ValueError("SM120 FP8 blockwise GEMM requires weight_scales")
-        self._gemm_op = _get_cutlass_scaled_mm_blockwise_sm120_fp8()
+        self._gemm_op = _get_cutlass_scaled_mm_blockwise_sm120_fp8(weight.device)
         if self._gemm_op is None:
             raise RuntimeError(
                 "cutlass_scaled_mm_blockwise_sm120_fp8 op is not available; "
@@ -210,6 +236,7 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
                 )
             if self.bias.dtype != torch.bfloat16:
                 raise ValueError(f"Bias dtype must be bfloat16, got {self.bias.dtype}")
+            self.bias = self.bias.to(device=self.weight.device)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if input.dtype != torch.bfloat16:
@@ -246,6 +273,5 @@ class CudaFp8VllmBlockwiseLinear(LinearBase):
             self.weight_scales,
         )
         if self.bias is not None:
-            output = output + self.bias.to(device=output.device, dtype=output.dtype)
+            output.add_(self.bias)
         return output
-

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_vllm_blockwise_sm120_linear.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/fp8_vllm_blockwise_sm120_linear.py
@@ -1,0 +1,251 @@
+"""CUDA FP8 PER_BLOCK GEMM for sm_120 family (consumer Blackwell).
+
+Backend wraps the vLLM-ported `cutlass_scaled_mm_blockwise_sm120_fp8`
+kernel (see `models_py/bindings/cuda/cutlass/cutlass_kernels/fp8_blockwise_sm120/`).
+Selected by LinearFactory only on the compiled sm_120 architecture; sm_9x / sm_10x
+keep using DeepGEMM via `CudaFp8GEMMLinear`.
+"""
+
+from typing import Optional
+
+import torch
+
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
+from rtp_llm.models_py.modules.factory.linear import LinearBase
+from rtp_llm.models_py.utils.arch import get_sm, is_cuda, is_sm12x
+from rtp_llm.ops import HWKernelConfig
+
+
+def _is_sm120_runtime() -> bool:
+    """Match the exact SASS architectures emitted by ``sm120_cuda_copts``."""
+    return is_cuda() and is_sm12x() and get_sm() == (12, 0)
+
+
+def _get_cutlass_scaled_mm_blockwise_sm120_fp8():
+    if not _is_sm120_runtime():
+        return None
+    try:
+        from rtp_llm.ops.compute_ops import (
+            cutlass_scaled_mm_blockwise_sm120_fp8,
+            has_cutlass_scaled_mm_blockwise_sm120_fp8,
+        )
+
+        if has_cutlass_scaled_mm_blockwise_sm120_fp8():
+            return cutlass_scaled_mm_blockwise_sm120_fp8
+        return None
+    except ImportError:
+        return None
+
+
+def _has_cutlass_scaled_mm_blockwise_sm120_fp8() -> bool:
+    return _get_cutlass_scaled_mm_blockwise_sm120_fp8() is not None
+
+
+class CudaFp8VllmBlockwiseLinear(LinearBase):
+    """CUDA FP8 PER_BLOCK Linear for sm_120 (RTX PRO 5000 / 5090).
+
+    Only BF16 activations, output, and bias are currently supported. K and N
+    must both be multiples of the 128-element block size. ``weight_scales`` is
+    required; its Optional annotation only preserves the LinearBase/factory
+    constructor signature.
+
+    Scale layout (matches CUTLASS Sm120BlockwiseScaleConfig<1, 128, 128, MN, K>):
+      - input_scales : (M, K//128), MN-major (M-stride=1, K-group-stride=M)
+      - weight_scales: (N//128, K//128), K-major  (K-stride = 1)
+    Input scales use column_major_scales=True, scale_tma_aligned=False
+    because CUTLASS tile_atom_to_shape_SFA computes K-group stride as exactly
+    M (no alignment padding).  scale_tma_aligned=True would pad to ceil4(M),
+    causing a stride mismatch for non-multiple-of-4 M values.
+    """
+
+    @staticmethod
+    def _restore_blockwise_weight_layout(
+        weight: torch.Tensor,
+        weight_scales: torch.Tensor,
+        block_size: int = 128,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, int, int, int]:
+        """Restore SM120 loader tensors from logical (K,N) to physical (N,K)."""
+        if not weight.is_contiguous():
+            raise ValueError("SM120 FP8 blockwise weight must be contiguous")
+        if not weight_scales.is_contiguous():
+            raise ValueError("SM120 FP8 blockwise weight scales must be contiguous")
+        K, N = weight.shape
+        scale_K, scale_N = weight_scales.shape
+        if (N + block_size - 1) // block_size != scale_N or (
+            K + block_size - 1
+        ) // block_size != scale_K:
+            raise ValueError(
+                "SM120 FP8 blockwise weight scale dimension mismatch: "
+                f"N={N}, scale_N={scale_N}, K={K}, scale_K={scale_K}"
+            )
+        return (
+            weight.reshape(N, K),
+            weight_scales.reshape(scale_N, scale_K),
+            K,
+            N,
+            scale_K,
+            scale_N,
+        )
+
+    @classmethod
+    def _classify_support(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+    ) -> tuple[bool, Optional[str]]:
+        """Return whether this strategy matches and any actionable rejection."""
+        if (
+            weight_scales is None
+            or quant_config is None
+            or not _is_sm120_runtime()
+            or quant_config.get_method() != "FP8_PER_BLOCK"
+            or weight.dtype != torch.float8_e4m3fn
+        ):
+            return False, None
+        if weight_scales.dtype != torch.float32:
+            detail = f"got {weight_scales.dtype}"
+            if weight_scales.dtype == torch.int32:
+                detail += (
+                    "; UE8M0 int32 scales are only supported by DeepGEMM on sm90/sm100"
+                )
+            return (
+                False,
+                f"SM120 FP8_PER_BLOCK requires float32 weight scales, {detail}",
+            )
+        if not _has_cutlass_scaled_mm_blockwise_sm120_fp8():
+            return False, (
+                "SM120 FP8_PER_BLOCK backend is unavailable; rebuild on x86 "
+                "with --config=cuda12_9 (ENABLE_FP8_SM120)"
+            )
+        if weight.dim() != 2 or weight_scales.dim() != 2:
+            return False, (
+                "SM120 FP8_PER_BLOCK requires 2D weight and weight_scales tensors"
+            )
+        if weight.shape[0] % 128 != 0 or weight.shape[1] % 128 != 0:
+            return False, (
+                "SM120 FP8_PER_BLOCK requires K and N to be multiples of 128, "
+                f"got K={weight.shape[0]} and N={weight.shape[1]}"
+            )
+        return True, None
+
+    @classmethod
+    def can_handle(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
+        weight_scale_2: Optional[torch.Tensor] = None,
+        input_scale: Optional[torch.Tensor] = None,
+    ) -> bool:
+        supported, _ = cls._classify_support(quant_config, weight, weight_scales)
+        return supported
+
+    @torch.inference_mode()
+    def __init__(
+        self,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor] = None,
+        input_scales: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+        quant_config: object = None,
+        weight_scale_2: Optional[torch.Tensor] = None,
+    ):
+        super().__init__(
+            weight, weight_scales, input_scales, bias, quant_config, weight_scale_2
+        )
+        if weight_scales is None:
+            raise ValueError("SM120 FP8 blockwise GEMM requires weight_scales")
+        self._gemm_op = _get_cutlass_scaled_mm_blockwise_sm120_fp8()
+        if self._gemm_op is None:
+            raise RuntimeError(
+                "cutlass_scaled_mm_blockwise_sm120_fp8 op is not available; "
+                "this backend requires a cuda12_9_x86 build with -DENABLE_FP8_SM120."
+            )
+
+        self.weight = weight
+        self.weight_scales = weight_scales
+        self.input_scales = input_scales
+        self.bias = bias
+
+        if self.weight.dim() != 2 or self.weight_scales.dim() != 2:
+            raise ValueError(
+                f"Weight and weight scale must be 2D tensors, got weight dim "
+                f"{self.weight.dim()} and weight scale dim {self.weight_scales.dim()}"
+            )
+
+        logical_K, logical_N = self.weight.shape
+        if logical_K % 128 != 0 or logical_N % 128 != 0:
+            raise ValueError(
+                f"SM120 FP8 blockwise GEMM requires K and N to be multiples of "
+                f"128, got K={logical_K} and N={logical_N}"
+            )
+        (
+            self.weight,
+            self.weight_scales,
+            self.K,
+            self.N,
+            self.scale_K,
+            self.scale_N,
+        ) = self._restore_blockwise_weight_layout(self.weight, self.weight_scales)
+
+        if self.weight.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"Weight dtype must be float8_e4m3fn, got {self.weight.dtype}"
+            )
+
+        if self.bias is not None:
+            if self.bias.dim() not in (1, 2):
+                raise ValueError(
+                    f"Bias dimension must be 1 or 2, got {self.bias.dim()}"
+                )
+            if self.bias.shape[-1] != self.N:
+                raise ValueError(
+                    f"Bias last dimension must be {self.N}, got {self.bias.shape[-1]}"
+                )
+            if self.bias.dim() == 2 and self.bias.shape[0] != 1:
+                raise ValueError(
+                    f"Bias first dimension must be 1, got {self.bias.shape[0]}"
+                )
+            if self.bias.dtype != torch.bfloat16:
+                raise ValueError(f"Bias dtype must be bfloat16, got {self.bias.dtype}")
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if input.dtype != torch.bfloat16:
+            raise ValueError(f"Input tensor dtype must be bfloat16, got {input.dtype}")
+        if input.dim() != 2:
+            raise ValueError(
+                f"Input tensor dimension must be 2, got {input.dim()}D tensor"
+            )
+        M, K = input.shape
+        if K != self.K:
+            raise ValueError(
+                f"Input tensor inner dimension expected to be {self.K}, got {K}"
+            )
+        if not input.is_contiguous():
+            raise ValueError("SM120 FP8 blockwise GEMM input must be contiguous")
+        if M == 0:
+            return torch.empty(0, self.N, dtype=torch.bfloat16, device=input.device)
+
+        input_fp8, input_scales = sgl_per_token_group_quant_fp8(
+            input,
+            group_size=128,
+            eps=1e-4,
+            column_major_scales=True,
+            scale_tma_aligned=False,
+            scale_ue8m0=False,
+        )
+
+        output = torch.empty(M, self.N, dtype=torch.bfloat16, device=input.device)
+        self._gemm_op(
+            output,
+            input_fp8,
+            self.weight,
+            input_scales,
+            self.weight_scales,
+        )
+        if self.bias is not None:
+            output = output + self.bias.to(device=output.device, dtype=output.dtype)
+        return output
+

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/BUILD
@@ -2,6 +2,15 @@ py_test_deps = [
     "//rtp_llm/models_py/standalone:py_standalone_testlib",
 ]
 
+py_library(
+    name = "sm120_test_utils",
+    srcs = ["sm120_test_utils.py"],
+    deps = [
+        "//rtp_llm/models_py:kernels",
+        "//rtp_llm/test/utils:test_util",
+    ],
+)
+
 py_test(
     name = "fp8_linear_test",
     srcs = ["fp8_linear_test.py"],
@@ -14,9 +23,15 @@ py_test(
 # and prove that the host guard rejects launch before entering device code.
 py_test(
     name = "fp8_vllm_blockwise_non_sm120_guard_test",
-    srcs = ["fp8_vllm_blockwise_non_sm120_guard_test.py"],
-    deps = py_test_deps,
+    srcs = [
+        "fp8_vllm_blockwise_non_sm120_guard_test.py",
+    ],
+    deps = py_test_deps + [":sm120_test_utils"],
     tags = ["H20", "cuda12_9"],
+    target_compatible_with = select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     exec_properties = {'gpu':'H20'},
 )
 
@@ -54,12 +69,27 @@ py_test(
     name = "fp8_vllm_blockwise_sm120_factory_test",
     srcs = ["fp8_vllm_blockwise_sm120_factory_test.py"],
     deps = py_test_deps,
+    tags = ["H20", "cuda12_9"],
+    target_compatible_with = select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    exec_properties = {'gpu':'H20'},
 )
 
 py_test(
     name = "fp8_vllm_blockwise_sm120_linear_test",
-    srcs = ["fp8_vllm_blockwise_sm120_linear_test.py"],
-    deps = py_test_deps,
-    tags = ["RTX_5000_PRO"],
+    srcs = [
+        "fp8_vllm_blockwise_sm120_linear_test.py",
+    ],
+    deps = py_test_deps + [
+        ":sm120_test_utils",
+        "//rtp_llm/test/utils:test_util",
+    ],
+    tags = ["RTX_5000_PRO", "cuda12_9"],
+    target_compatible_with = select({
+        "@//:using_cuda12_9_x86": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     exec_properties = {'gpu':'RTX_5000_PRO'},
 )

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/BUILD
@@ -10,6 +10,16 @@ py_test(
     exec_properties = {'gpu':'H20'},
 )
 
+# cuda12_9 x86-only contract: this target must import the SM120 binding on H20
+# and prove that the host guard rejects launch before entering device code.
+py_test(
+    name = "fp8_vllm_blockwise_non_sm120_guard_test",
+    srcs = ["fp8_vllm_blockwise_non_sm120_guard_test.py"],
+    deps = py_test_deps,
+    tags = ["H20", "cuda12_9"],
+    exec_properties = {'gpu':'H20'},
+)
+
 py_test(
     name = "fp8_deepgemm_linear_sm100_test",
     srcs = [
@@ -38,4 +48,18 @@ py_test(
     deps = py_test_deps,
     tags = ["SM100_ARM"],
     exec_properties = {'gpu':'SM100_ARM'},
+)
+
+py_test(
+    name = "fp8_vllm_blockwise_sm120_factory_test",
+    srcs = ["fp8_vllm_blockwise_sm120_factory_test.py"],
+    deps = py_test_deps,
+)
+
+py_test(
+    name = "fp8_vllm_blockwise_sm120_linear_test",
+    srcs = ["fp8_vllm_blockwise_sm120_linear_test.py"],
+    deps = py_test_deps,
+    tags = ["RTX_5000_PRO"],
+    exec_properties = {'gpu':'RTX_5000_PRO'},
 )

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_non_sm120_guard_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_non_sm120_guard_test.py
@@ -1,24 +1,39 @@
 """Cross-architecture launch guard for the SM120 CUTLASS binding.
 
-This target is intentionally built only by the cuda12_9 x86 H20 job.  A
-missing binding is therefore a build-contract failure, not a reason to skip.
+This target is intentionally built only by the cuda12_9 x86 H20 job. A
+missing binding is therefore a BUILD select/local_defines contract failure,
+not a reason to skip.
 """
 
 import unittest
 
 import torch
 
-from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
-from rtp_llm.models_py.utils.arch import is_sm12x
-from rtp_llm.ops.compute_ops import cutlass_scaled_mm_blockwise_sm120_fp8
-from rtp_llm.test.utils.numeric_util import per_block_cast_to_fp8
-
-
-@unittest.skipUnless(
-    torch.cuda.is_available() and not is_sm12x(),
-    "Non-SM120 direct binding guard requires a non-sm12x CUDA device",
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.test.sm120_test_utils import (
+    make_blockwise_op_inputs,
 )
+from rtp_llm.models_py.utils.arch import is_sm120
+from rtp_llm.ops import compute_ops
+
+
+@unittest.skipIf(is_sm120(), "Non-SM120 direct binding guard requires non-sm120")
 class CudaFp8VllmBlockwiseNonSM120GuardTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise RuntimeError("H20 guard target requires a working CUDA runtime")
+        try:
+            backend_compiled = compute_ops.has_cutlass_scaled_mm_blockwise_sm120_fp8()
+        except AttributeError as error:
+            raise RuntimeError("SM120 capability probe is missing") from error
+        if not backend_compiled:
+            raise RuntimeError(
+                "SM120 backend is missing from the cuda12_9 x86 build; keep "
+                "BUILD local_defines and dependency using_cuda12_9_x86 paired. "
+                "If this target ran under another build config, check the "
+                "cuda12_9 CI tag filter."
+            )
 
     def setUp(self):
         torch.manual_seed(42)
@@ -28,28 +43,12 @@ class CudaFp8VllmBlockwiseNonSM120GuardTest(unittest.TestCase):
         self.N = 128
 
     def _make_op_inputs(self):
-        input_tensor = torch.randn(
-            self.M, self.K, dtype=torch.bfloat16, device="cuda"
-        ).contiguous()
-        weight_bf16 = (
-            torch.randn((self.N, self.K), dtype=torch.bfloat16, device="cuda") * 0.1
-        ).contiguous()
-        A, A_sf = sgl_per_token_group_quant_fp8(
-            input_tensor,
-            group_size=128,
-            eps=1e-4,
-            column_major_scales=True,
-            scale_tma_aligned=False,
-            scale_ue8m0=False,
-        )
-        B, B_sf = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
-        D = torch.empty(self.M, self.N, dtype=torch.bfloat16, device="cuda")
-        return D, A, B, A_sf, B_sf
+        return make_blockwise_op_inputs(self.M, self.K, self.N)
 
     def test_direct_binding_rejects_non_sm120_before_launch(self):
         D, A, B, A_sf, B_sf = self._make_op_inputs()
-        with self.assertRaisesRegex(RuntimeError, "requires sm_120 family"):
-            cutlass_scaled_mm_blockwise_sm120_fp8(D, A, B, A_sf, B_sf)
+        with self.assertRaisesRegex(RuntimeError, "was compiled for sm_120"):
+            compute_ops.cutlass_scaled_mm_blockwise_sm120_fp8(D, A, B, A_sf, B_sf)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_non_sm120_guard_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_non_sm120_guard_test.py
@@ -1,0 +1,56 @@
+"""Cross-architecture launch guard for the SM120 CUTLASS binding.
+
+This target is intentionally built only by the cuda12_9 x86 H20 job.  A
+missing binding is therefore a build-contract failure, not a reason to skip.
+"""
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
+from rtp_llm.models_py.utils.arch import is_sm12x
+from rtp_llm.ops.compute_ops import cutlass_scaled_mm_blockwise_sm120_fp8
+from rtp_llm.test.utils.numeric_util import per_block_cast_to_fp8
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and not is_sm12x(),
+    "Non-SM120 direct binding guard requires a non-sm12x CUDA device",
+)
+class CudaFp8VllmBlockwiseNonSM120GuardTest(unittest.TestCase):
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        self.M = 8
+        self.K = 128
+        self.N = 128
+
+    def _make_op_inputs(self):
+        input_tensor = torch.randn(
+            self.M, self.K, dtype=torch.bfloat16, device="cuda"
+        ).contiguous()
+        weight_bf16 = (
+            torch.randn((self.N, self.K), dtype=torch.bfloat16, device="cuda") * 0.1
+        ).contiguous()
+        A, A_sf = sgl_per_token_group_quant_fp8(
+            input_tensor,
+            group_size=128,
+            eps=1e-4,
+            column_major_scales=True,
+            scale_tma_aligned=False,
+            scale_ue8m0=False,
+        )
+        B, B_sf = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
+        D = torch.empty(self.M, self.N, dtype=torch.bfloat16, device="cuda")
+        return D, A, B, A_sf, B_sf
+
+    def test_direct_binding_rejects_non_sm120_before_launch(self):
+        D, A, B, A_sf, B_sf = self._make_op_inputs()
+        with self.assertRaisesRegex(RuntimeError, "requires sm_120 family"):
+            cutlass_scaled_mm_blockwise_sm120_fp8(D, A, B, A_sf, B_sf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_sm120_factory_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_sm120_factory_test.py
@@ -1,0 +1,255 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from rtp_llm.config.quant_config import init_quant_config
+from rtp_llm.models_py.modules.factory.linear import LinearFactory
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear import (
+    CudaFp8DeepGEMMLinear,
+)
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_gemm_linear import (
+    CudaFp8GEMMLinear,
+)
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear import (
+    CudaFp8VllmBlockwiseLinear,
+)
+
+
+class SM120FactoryDiagnosticTest(unittest.TestCase):
+
+    def test_merge_preserves_physical_blockwise_layout(self):
+        K = 4
+        physical_a = torch.arange(8).reshape(2, K)
+        physical_b = torch.arange(12).reshape(3, K) + 100
+        logical_a = physical_a.reshape(K, 2)
+        logical_b = physical_b.reshape(K, 3)
+
+        merged = LinearFactory._merge_sm120_blockwise_tensors(
+            [logical_a, logical_b], dim=-1
+        )
+
+        self.assertEqual((K, 5), merged.shape)
+        torch.testing.assert_close(
+            merged.reshape(5, K), torch.cat([physical_a, physical_b], dim=0)
+        )
+
+    @mock.patch("rtp_llm.models_py.utils.arch.is_sm120", return_value=True)
+    def test_create_merged_linear_preserves_sm120_loader_layout(self, _is_sm120):
+        K = 128
+        physical_a = (torch.arange(128 * K).reshape(128, K) % 32).to(
+            torch.float8_e4m3fn
+        )
+        physical_b = (torch.arange(256 * K).reshape(256, K) % 32).to(
+            torch.float8_e4m3fn
+        )
+        weights = {
+            "a": physical_a.reshape(K, 128),
+            "b": physical_b.reshape(K, 256),
+            "sa": torch.tensor([[1.0]]),
+            "sb": torch.tensor([[2.0], [3.0]]).reshape(1, 2),
+        }
+
+        with mock.patch.object(LinearFactory, "create_linear") as create_linear:
+            LinearFactory.create_merged_linear(
+                weights=weights,
+                weight_keys=["a", "b"],
+                scale_keys=["sa", "sb"],
+                bias_keys=None,
+                scale2_keys=None,
+                input_scale_keys=None,
+                quant_config=init_quant_config("FP8_PER_BLOCK"),
+            )
+
+        merged_weight = create_linear.call_args.kwargs["weight"]
+        merged_scales = create_linear.call_args.kwargs["weight_scales"]
+        torch.testing.assert_close(
+            merged_weight.reshape(384, K), torch.cat([physical_a, physical_b])
+        )
+        torch.testing.assert_close(
+            merged_scales.reshape(3, 1), torch.tensor([[1.0], [2.0], [3.0]])
+        )
+
+    def test_factory_ignores_broken_rejection_diagnostic(self):
+        class BrokenDiagnosticStrategy:
+            @classmethod
+            def can_handle(cls, *args, **kwargs):
+                return False
+
+            @classmethod
+            def rejection_reason(cls, *args, **kwargs):
+                raise RuntimeError("diagnostic failed")
+
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.ones((1, 1), dtype=torch.float32)
+
+        with (
+            mock.patch.object(LinearFactory, "_strategies", [BrokenDiagnosticStrategy]),
+            self.assertRaisesRegex(ValueError, "No suitable Linear strategy"),
+        ):
+            LinearFactory.create_linear(weight, None, weight_scales, quant_config)
+
+    def test_constructor_rejects_missing_weight_scales(self):
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        with self.assertRaisesRegex(ValueError, "requires weight_scales"):
+            CudaFp8VllmBlockwiseLinear(weight=weight, weight_scales=None)
+
+    def test_restore_non_square_blockwise_layout(self):
+        weight = torch.arange(384 * 256, device="cuda").reshape(384, 256)
+        weight_scales = torch.arange(3 * 2, device="cuda").reshape(3, 2)
+
+        restored = CudaFp8VllmBlockwiseLinear._restore_blockwise_weight_layout(
+            weight, weight_scales
+        )
+
+        restored_weight, restored_scales, K, N, scale_K, scale_N = restored
+        self.assertEqual((N, K), restored_weight.shape)
+        self.assertEqual((scale_N, scale_K), restored_scales.shape)
+        self.assertEqual((K, N, scale_K, scale_N), (384, 256, 3, 2))
+        torch.testing.assert_close(restored_weight.flatten(), weight.flatten())
+        torch.testing.assert_close(restored_scales.flatten(), weight_scales.flatten())
+
+    def test_restore_rejects_scale_shape_mismatch(self):
+        weight = torch.empty((384, 256), device="cuda")
+        weight_scales = torch.empty((2, 2), device="cuda")
+        with self.assertRaisesRegex(ValueError, "scale dimension mismatch"):
+            CudaFp8VllmBlockwiseLinear._restore_blockwise_weight_layout(
+                weight, weight_scales
+            )
+
+    def test_restore_rejects_non_contiguous_inputs(self):
+        weight = torch.empty((256, 384), device="cuda").transpose(0, 1)
+        weight_scales = torch.empty((2, 3), device="cuda").transpose(0, 1)
+        with self.assertRaisesRegex(ValueError, "weight must be contiguous"):
+            CudaFp8VllmBlockwiseLinear._restore_blockwise_weight_layout(
+                weight, torch.empty((3, 2), device="cuda")
+            )
+        with self.assertRaisesRegex(ValueError, "scales must be contiguous"):
+            CudaFp8VllmBlockwiseLinear._restore_blockwise_weight_layout(
+                torch.empty((384, 256), device="cuda"), weight_scales
+            )
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear.has_deep_gemm",
+        return_value=False,
+    )
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_gemm_linear.is_sm12x",
+        return_value=False,
+    )
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_deepgemm_linear.is_sm12x",
+        return_value=False,
+    )
+    def test_deepgemm_unavailable_keeps_actionable_constructor_error(
+        self, _deepgemm_is_sm12x, _wrapper_is_sm12x, _has_deep_gemm
+    ):
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.ones((1, 1), dtype=torch.float32)
+
+        self.assertTrue(
+            CudaFp8GEMMLinear.can_handle(quant_config, weight, weight_scales)
+        )
+        with self.assertRaisesRegex(RuntimeError, "install the `deep_gemm` package"):
+            CudaFp8DeepGEMMLinear(
+                weight=weight,
+                weight_scales=weight_scales,
+                quant_config=quant_config,
+            )
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear._is_sm120_runtime",
+        return_value=False,
+    )
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear.is_sm12x",
+        return_value=True,
+    )
+    def test_other_sm12x_minor_has_actionable_rejection(
+        self, _is_sm12x, _is_sm120_runtime
+    ):
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.ones((1, 1), dtype=torch.float32)
+
+        supported, reason = CudaFp8VllmBlockwiseLinear.classify_support(
+            quant_config, weight, weight_scales
+        )
+
+        self.assertFalse(supported)
+        self.assertIn("supports exact sm_120 devices only", reason)
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear._is_sm120_runtime",
+        return_value=True,
+    )
+    def test_factory_reports_int32_scale_rejection(self, _is_sm120_runtime):
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.zeros((128, 1), dtype=torch.int32)
+
+        with (
+            mock.patch.object(
+                LinearFactory,
+                "_strategies",
+                [CudaFp8VllmBlockwiseLinear],
+            ),
+            self.assertRaisesRegex(ValueError, "requires float32 weight scales"),
+        ):
+            LinearFactory.create_linear(weight, None, weight_scales, quant_config)
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear.sm120_blockwise_backend_available",
+        return_value=True,
+    )
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear._is_sm120_runtime",
+        return_value=True,
+    )
+    def test_factory_reports_unaligned_shape_rejection(
+        self, _is_sm120_runtime, _has_backend
+    ):
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 192), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.ones((1, 2), dtype=torch.float32)
+
+        with (
+            mock.patch.object(
+                LinearFactory,
+                "_strategies",
+                [CudaFp8VllmBlockwiseLinear],
+            ),
+            self.assertRaisesRegex(ValueError, "K and N to be multiples of 128"),
+        ):
+            LinearFactory.create_linear(weight, None, weight_scales, quant_config)
+
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear.sm120_blockwise_backend_available",
+        return_value=False,
+    )
+    @mock.patch(
+        "rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear._is_sm120_runtime",
+        return_value=True,
+    )
+    def test_factory_reports_unavailable_sm120_backend(
+        self, _is_sm120_runtime, _has_backend
+    ):
+        quant_config = init_quant_config("FP8_PER_BLOCK")
+        weight = torch.empty((128, 128), dtype=torch.float8_e4m3fn)
+        weight_scales = torch.ones((1, 1), dtype=torch.float32)
+
+        self.assertFalse(
+            CudaFp8VllmBlockwiseLinear.can_handle(quant_config, weight, weight_scales)
+        )
+        self.assertIn(
+            "backend is unavailable",
+            CudaFp8VllmBlockwiseLinear.rejection_reason(
+                quant_config, weight, weight_scales
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_sm120_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/fp8_vllm_blockwise_sm120_linear_test.py
@@ -1,0 +1,312 @@
+"""sm12x-only numerical sanity tests for CudaFp8VllmBlockwiseLinear.
+
+Quantizes a BF16 weight with per_block_cast_to_fp8 (block 128x128), runs
+the kernel and compares against a fp32 reference matmul (+ optional bias).
+Catches regressions in the three M-tier dispatch branches
+(swap_ab / pingpong / default) and bias epilogue fusion.
+"""
+
+import unittest
+
+import torch
+
+from rtp_llm.config.quant_config import init_quant_config
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.fp8_vllm_blockwise_sm120_linear import (
+    CudaFp8VllmBlockwiseLinear,
+    _get_cutlass_scaled_mm_blockwise_sm120_fp8,
+)
+from rtp_llm.models_py.modules.factory.linear.impl.cuda.test.sm120_test_utils import (
+    make_blockwise_op_inputs,
+)
+from rtp_llm.models_py.utils.arch import is_sm120
+from rtp_llm.test.utils.numeric_util import calc_diff, per_block_cast_to_fp8
+
+
+class CudaFp8VllmBlockwiseLinearNumericalTest(unittest.TestCase):
+
+    test_shapes = [(256, 256), (384, 256), (256, 384)]
+    # Boundary values around dispatch_blockwise_sm120 thresholds:
+    #   M<=64 or M%4!=0 -> swap_ab
+    #   64<M<=256 + M%4==0 -> pingpong
+    #   M>256 + M%4==0 -> default
+    test_batch_sizes = [1, 7, 31, 32, 64, 65, 128, 256, 257, 512]
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available() or not is_sm120():
+            raise unittest.SkipTest(
+                "CudaFp8VllmBlockwiseLinear requires sm_120 (consumer Blackwell)"
+            )
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        self.device = "cuda"
+        self.quant_config = init_quant_config("FP8_PER_BLOCK")
+
+    def _make_weight(self, K: int, N: int):
+        self.weight_bf16 = (
+            torch.randn(N, K, dtype=torch.bfloat16, device=self.device) * 0.05
+        )
+        weight_fp8, weight_scales = per_block_cast_to_fp8(
+            self.weight_bf16, use_ue8m0=False
+        )
+        scale_K = (K + 127) // 128
+        scale_N = (N + 127) // 128
+        self.weight_fp8 = weight_fp8.reshape(K, N)
+        self.weight_scales = weight_scales.reshape(scale_K, scale_N)
+
+    def _run(self, M: int, K: int, N: int, with_bias: bool):
+        self._make_weight(K, N)
+        bias = (
+            torch.randn(N, dtype=torch.bfloat16, device=self.device) * 0.01
+            if with_bias
+            else None
+        )
+        linear = CudaFp8VllmBlockwiseLinear(
+            weight=self.weight_fp8,
+            weight_scales=self.weight_scales,
+            bias=bias,
+            quant_config=self.quant_config,
+        )
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+        out = linear(x)
+        ref = x.float() @ self.weight_bf16.float().t()
+        if bias is not None:
+            ref = ref + bias.float()
+        ref = ref.to(torch.bfloat16)
+        diff = calc_diff(out, ref)
+        self.assertLess(
+            diff, 0.0011, f"M={M} K={K} N={N} with_bias={with_bias} diff={diff}"
+        )
+        self.assertEqual(out.shape, (M, N))
+        self.assertEqual(out.dtype, torch.bfloat16)
+        self.assertFalse(torch.isnan(out).any())
+        self.assertFalse(torch.isinf(out).any())
+
+    def test_no_bias_all_dispatch_tiers(self):
+        for K, N in self.test_shapes[:2]:
+            for M in self.test_batch_sizes:
+                with self.subTest(M=M, K=K, N=N):
+                    self._run(M, K=K, N=N, with_bias=False)
+
+    def test_with_bias_epilogue_fusion(self):
+        for K, N in (self.test_shapes[0], self.test_shapes[2]):
+            for M in [1, 33, 128, 257, 512]:
+                with self.subTest(M=M, K=K, N=N):
+                    self._run(M, K=K, N=N, with_bias=True)
+
+    def test_reject_fp16_input(self):
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        linear = CudaFp8VllmBlockwiseLinear(
+            weight=self.weight_fp8,
+            weight_scales=self.weight_scales,
+            quant_config=self.quant_config,
+        )
+        input_fp16 = torch.randn(8, K, dtype=torch.float16, device=self.device)
+
+        with self.assertRaisesRegex(
+            ValueError, "Input tensor dtype must be bfloat16.*torch.float16"
+        ):
+            linear(input_fp16)
+
+    def test_reject_noncontiguous_input(self):
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        linear = CudaFp8VllmBlockwiseLinear(
+            weight=self.weight_fp8,
+            weight_scales=self.weight_scales,
+            quant_config=self.quant_config,
+        )
+        input_noncontiguous = torch.randn(
+            K, 8, dtype=torch.bfloat16, device=self.device
+        ).t()
+        self.assertFalse(input_noncontiguous.is_contiguous())
+
+        with self.assertRaisesRegex(ValueError, "input must be contiguous"):
+            linear(input_noncontiguous)
+
+    def test_empty_batch_returns_empty_output(self):
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        linear = CudaFp8VllmBlockwiseLinear(
+            weight=self.weight_fp8,
+            weight_scales=self.weight_scales,
+            quant_config=self.quant_config,
+        )
+
+        output = linear(torch.empty(0, K, dtype=torch.bfloat16, device=self.device))
+
+        self.assertEqual(output.shape, (0, N))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(output.device.type, "cuda")
+
+    def test_reject_unaligned_weight_shape(self):
+        for K, N in [(320, 256), (256, 320)]:
+            with self.subTest(K=K, N=N):
+                self._make_weight(K, N)
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"K and N to be multiples of 128, got K={K} and N={N}",
+                ):
+                    CudaFp8VllmBlockwiseLinear(
+                        weight=self.weight_fp8,
+                        weight_scales=self.weight_scales,
+                        quant_config=self.quant_config,
+                    )
+
+    def test_reject_noncontiguous_weight_layout(self):
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        noncontiguous_weight = self.weight_fp8.reshape(N, K).t()
+        self.assertFalse(noncontiguous_weight.is_contiguous())
+        with self.assertRaisesRegex(ValueError, "weight must be contiguous"):
+            CudaFp8VllmBlockwiseLinear(
+                weight=noncontiguous_weight,
+                weight_scales=self.weight_scales,
+                quant_config=self.quant_config,
+            )
+
+    def test_reject_noncontiguous_weight_scale_layout(self):
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        noncontiguous_scales = self.weight_scales.t()
+        self.assertFalse(noncontiguous_scales.is_contiguous())
+        with self.assertRaisesRegex(ValueError, "weight scales must be contiguous"):
+            CudaFp8VllmBlockwiseLinear(
+                weight=self.weight_fp8,
+                weight_scales=noncontiguous_scales,
+                quant_config=self.quant_config,
+            )
+
+    def test_factory_selects_only_sm120_blockwise_backend(self):
+        from rtp_llm.models_py.modules.factory.linear import LinearFactory
+
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        linear = LinearFactory.create_linear(
+            weight=self.weight_fp8,
+            bias=None,
+            weight_scales=self.weight_scales,
+            quant_config=self.quant_config,
+        )
+        self.assertIsInstance(linear, CudaFp8VllmBlockwiseLinear)
+
+    def test_factory_non_square_weight_matches_reference(self):
+        from rtp_llm.models_py.modules.factory.linear import LinearFactory
+
+        M, K, N = 7, 384, 256
+        self._make_weight(K, N)
+        linear = LinearFactory.create_linear(
+            weight=self.weight_fp8,
+            bias=None,
+            weight_scales=self.weight_scales,
+            quant_config=self.quant_config,
+        )
+        x = torch.randn(M, K, dtype=torch.bfloat16, device=self.device) * 0.1
+
+        output = linear(x)
+        reference = (x.float() @ self.weight_bf16.float().t()).to(torch.bfloat16)
+
+        self.assertLess(calc_diff(output, reference), 0.0011)
+        self.assertEqual(output.shape, (M, N))
+
+    def test_factory_rejects_ue8m0_weight_scales(self):
+        from rtp_llm.models_py.modules.factory.linear import LinearFactory
+
+        K, N = self.test_shapes[0]
+        self._make_weight(K, N)
+        ue8m0_scales = torch.zeros(
+            N, (K + 511) // 512, dtype=torch.int32, device=self.device
+        )
+        with self.assertRaisesRegex(ValueError, "requires float32 weight scales"):
+            LinearFactory.create_linear(
+                self.weight_fp8,
+                None,
+                ue8m0_scales,
+                self.quant_config,
+            )
+
+
+class CudaFp8VllmBlockwiseSM120BoundaryTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available() or not is_sm120():
+            raise unittest.SkipTest(
+                "SM120 FP8 blockwise op requires an sm_120 CUDA device"
+            )
+        cls.gemm_op = _get_cutlass_scaled_mm_blockwise_sm120_fp8()
+        if cls.gemm_op is None:
+            raise RuntimeError("SM120 FP8 blockwise binding is missing")
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+        self.device = "cuda"
+        self.M = 8
+        # Use at least two K scale groups so making A_sf contiguous actually
+        # changes its MN-major stride and exercises the boundary check.
+        self.K = 256
+        self.N = 128
+
+    def _make_op_inputs(self):
+        return make_blockwise_op_inputs(self.M, self.K, self.N, self.device)
+
+    def test_rejects_wrong_input_scale_stride(self):
+        D, A, B, A_sf, B_sf = self._make_op_inputs()
+        bad_A_sf = A_sf.contiguous()
+        with self.assertRaisesRegex(RuntimeError, "A_sf must use MN-major"):
+            self.gemm_op(D, A, B, bad_A_sf, B_sf)
+
+    def test_direct_binding_rejects_non_aligned_n(self):
+        _, A, B, A_sf, B_sf = self._make_op_inputs()
+        bad_n = 96
+        B = B[:bad_n].contiguous()
+        D = torch.empty(self.M, bad_n, dtype=torch.bfloat16, device=self.device)
+        with self.assertRaisesRegex(RuntimeError, "K and N must be multiples"):
+            self.gemm_op(D, A, B, A_sf, B_sf)
+
+    def test_wrapper_normalizes_cpu_bias_during_construction(self):
+        weight_bf16 = torch.randn(
+            self.N, self.K, dtype=torch.bfloat16, device=self.device
+        )
+        weight, weight_scales = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
+        weight = weight.reshape(self.K, self.N)
+        weight_scales = weight_scales.reshape(
+            (self.K + 127) // 128, (self.N + 127) // 128
+        )
+        bias = torch.randn(self.N, dtype=torch.bfloat16)
+        linear = CudaFp8VllmBlockwiseLinear(weight, weight_scales, bias=bias)
+        self.assertEqual(linear.bias.device.type, "cuda")
+        input_tensor = torch.randn(
+            self.M, self.K, dtype=torch.bfloat16, device=self.device
+        )
+        output = linear(input_tensor)
+        cuda_bias_linear = CudaFp8VllmBlockwiseLinear(
+            weight, weight_scales, bias=bias.to(self.device)
+        )
+        expected = cuda_bias_linear(input_tensor)
+        self.assertEqual(output.shape, (self.M, self.N))
+        self.assertEqual(output.device.type, "cuda")
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+    def test_direct_binding_empty_batch_is_noop(self):
+        _, _, B, _, B_sf = make_blockwise_op_inputs(1, self.K, self.N)
+        D = torch.empty(0, self.N, dtype=torch.bfloat16, device=self.device)
+        A = torch.empty(0, self.K, dtype=torch.float8_e4m3fn, device=self.device)
+        A_sf = torch.empty_strided(
+            (0, self.K // 128),
+            (1, 0),
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        self.gemm_op(D, A, B, A_sf, B_sf)
+        # M == 0 returns before scale-layout validation and launches no kernel.
+        torch.cuda.synchronize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/sm120_test_utils.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/cuda/test/sm120_test_utils.py
@@ -1,0 +1,24 @@
+"""Shared input construction for direct SM120 FP8 binding contract tests."""
+
+import torch
+
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
+from rtp_llm.test.utils.numeric_util import per_block_cast_to_fp8
+
+
+def make_blockwise_op_inputs(M: int, K: int, N: int, device: str = "cuda"):
+    input_tensor = torch.randn(M, K, dtype=torch.bfloat16, device=device).contiguous()
+    weight_bf16 = (
+        torch.randn((N, K), dtype=torch.bfloat16, device=device) * 0.1
+    ).contiguous()
+    A, A_sf = sgl_per_token_group_quant_fp8(
+        input_tensor,
+        group_size=128,
+        eps=1e-4,
+        column_major_scales=True,
+        scale_tma_aligned=False,
+        scale_ue8m0=False,
+    )
+    B, B_sf = per_block_cast_to_fp8(weight_bf16, use_ue8m0=False)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device=device)
+    return D, A, B, A_sf, B_sf

--- a/rtp_llm/models_py/modules/factory/linear/linear_base.py
+++ b/rtp_llm/models_py/modules/factory/linear/linear_base.py
@@ -45,6 +45,19 @@ class LinearBase(nn.Module, ABC):
         """
         pass
 
+    @classmethod
+    def rejection_reason(
+        cls,
+        quant_config: object,
+        weight: torch.Tensor,
+        weight_scales: Optional[torch.Tensor],
+        hw_kernel_config: Optional["HWKernelConfig"] = None,
+        weight_scale_2: Optional[torch.Tensor] = None,
+        input_scale: Optional[torch.Tensor] = None,
+    ) -> Optional[str]:
+        """Return an actionable reason after ``can_handle`` returned False."""
+        return None
+
     @abstractmethod
     def __init__(
         self,

--- a/rtp_llm/models_py/utils/arch.py
+++ b/rtp_llm/models_py/utils/arch.py
@@ -10,6 +10,8 @@ def _canonical_cuda_device(device_id: Optional[Union[int, torch.device]]) -> int
     if device_id is None:
         return torch.cuda.current_device()
     if isinstance(device_id, torch.device):
+        if device_id.type != "cuda":
+            raise ValueError(f"expected a CUDA device, got {device_id}")
         if device_id.index is None:
             return torch.cuda.current_device()
         return device_id.index
@@ -24,14 +26,14 @@ def _get_sm_for_device(device_id: int) -> Tuple[int, int]:
 
 def is_sm90(device_id: Optional[Union[int, torch.device]] = None) -> bool:
     """SM 9.x Hopper (H100 / H200 / H800 / H20)."""
-    if not is_cuda():
+    if not is_cuda() or _is_explicit_non_cuda_device(device_id):
         return False
     return get_sm(device_id)[0] == 9
 
 
 def is_sm10x(device_id: Optional[Union[int, torch.device]] = None) -> bool:
     """SM 10.x datacenter Blackwell (B200 / GB200)."""
-    if not is_cuda():
+    if not is_cuda() or _is_explicit_non_cuda_device(device_id):
         return False
     return get_sm(device_id)[0] == 10
 
@@ -51,15 +53,28 @@ def get_sm(device_id: Optional[Union[int, torch.device]] = None) -> Tuple[int, i
     return _get_sm_for_device(device_id)
 
 
+def _is_explicit_non_cuda_device(
+    device_id: Optional[Union[int, torch.device]],
+) -> bool:
+    return isinstance(device_id, torch.device) and device_id.type != "cuda"
+
+
 def is_sm12x(device_id: Optional[Union[int, torch.device]] = None) -> bool:
     """SM 12.x consumer Blackwell (RTX PRO 5000 / 6000, RTX 5090)."""
-    if not is_cuda():
+    if not is_cuda() or _is_explicit_non_cuda_device(device_id):
         return False
     return get_sm(device_id)[0] == 12
 
 
+def is_sm120(device_id: Optional[Union[int, torch.device]] = None) -> bool:
+    """Exact SM 12.0 devices supported by the current SM120 kernels."""
+    if not is_cuda() or _is_explicit_non_cuda_device(device_id):
+        return False
+    return get_sm(device_id) == (12, 0)
+
+
 def is_blackwell(device_id: Optional[Union[int, torch.device]] = None) -> bool:
     """Blackwell-class: SM 10.x datacenter (B200/GB200) or SM 12.x consumer."""
-    if not is_cuda():
+    if not is_cuda() or _is_explicit_non_cuda_device(device_id):
         return False
     return get_sm(device_id)[0] in (10, 12)

--- a/rtp_llm/models_py/utils/test/arch_test.py
+++ b/rtp_llm/models_py/utils/test/arch_test.py
@@ -24,11 +24,33 @@ class ArchTest(TestCase):
             ) as get_device_capability,
         ):
             self.assertEqual(arch.get_sm(), (12, 0))
+            self.assertTrue(arch.is_sm120())
             self.assertFalse(arch.is_sm10x())
             self.assertTrue(arch.is_sm12x())
             self.assertFalse(arch.is_sm90())
             self.assertTrue(arch.is_blackwell())
             get_device_capability.assert_called_once_with(1)
+
+    def test_is_sm120_rejects_other_sm12x_minors(self):
+        with (
+            patch("rtp_llm.models_py.utils.arch.is_cuda", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(12, 1)),
+        ):
+            self.assertTrue(arch.is_sm12x(0))
+            self.assertFalse(arch.is_sm120(0))
+
+    def test_is_sm120_rejects_non_cuda_device(self):
+        with patch("rtp_llm.models_py.utils.arch.is_cuda", return_value=True):
+            for probe in (
+                arch.is_sm90,
+                arch.is_sm10x,
+                arch.is_sm12x,
+                arch.is_sm120,
+                arch.is_blackwell,
+            ):
+                self.assertFalse(probe(torch.device("cpu")))
+            with self.assertRaisesRegex(ValueError, "expected a CUDA device"):
+                arch.get_sm(torch.device("cpu"))
 
     def test_arch_helpers_cache_by_resolved_device_id(self):
         queried_devices = []

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -6,7 +6,7 @@ import librtp_compute_ops
 import libth_transformer_config
 import torch
 import typing
-__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'debug_kernel', 'dispose_communicator', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send', 'write_cache_store']
+__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'cutlass_scaled_mm_blockwise_sm120_fp8', 'debug_kernel', 'dispose_communicator', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send', 'write_cache_store']
 
 
 class FlashInferMlaAttnParams(librtp_compute_ops.ParamsBase):
@@ -231,6 +231,9 @@ def cutlass_moe_mm(out_tensors: torch.Tensor, a_tensors: torch.Tensor, b_tensors
     ...
 def cutlass_scaled_fp4_mm(out: torch.Tensor, a: torch.Tensor, b: torch.Tensor, a_sf: torch.Tensor, b_sf: torch.Tensor, alpha: torch.Tensor) -> None:
     ...
+
+def cutlass_scaled_mm_blockwise_sm120_fp8(D: torch.Tensor, A: torch.Tensor, B: torch.Tensor, A_sf: torch.Tensor, B_sf: torch.Tensor, bias: torch.Tensor | None = None) -> None:
+    ...
 def debug_kernel(data: torch.Tensor, start_row: int, start_col: int, m: int, n: int, row_len: int, info_id: int) -> None:
     """
     Debug kernel to print 2D data blocks from GPU tensor
@@ -401,4 +404,3 @@ class TrtllmArFusionHandle:
         """
         AllReduce kernel
         """
-

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -232,7 +232,7 @@ def cutlass_moe_mm(out_tensors: torch.Tensor, a_tensors: torch.Tensor, b_tensors
 def cutlass_scaled_fp4_mm(out: torch.Tensor, a: torch.Tensor, b: torch.Tensor, a_sf: torch.Tensor, b_sf: torch.Tensor, alpha: torch.Tensor) -> None:
     ...
 
-def cutlass_scaled_mm_blockwise_sm120_fp8(D: torch.Tensor, A: torch.Tensor, B: torch.Tensor, A_sf: torch.Tensor, B_sf: torch.Tensor, bias: torch.Tensor | None = None) -> None:
+def cutlass_scaled_mm_blockwise_sm120_fp8(D: torch.Tensor, A: torch.Tensor, B: torch.Tensor, A_sf: torch.Tensor, B_sf: torch.Tensor) -> None:
     """SM120 FP8 binding; call only after guarded runtime feature detection."""
     ...
 def has_cutlass_scaled_mm_blockwise_sm120_fp8() -> bool:

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -6,7 +6,7 @@ import librtp_compute_ops
 import libth_transformer_config
 import torch
 import typing
-__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'cutlass_scaled_mm_blockwise_sm120_fp8', 'debug_kernel', 'dispose_communicator', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send', 'write_cache_store']
+__all__: list[str] = ['FlashInferMlaAttnParams', 'GroupTopKOp', 'SelectTopkOp', 'SparseMlaParams', 'XQAAttnOp', 'XQAParams', 'allocate_shared_buffer', 'concat_and_cache_mla', 'cp_gather_and_upconvert_fp8_kv_cache', 'cp_gather_indexer_k_quant_cache', 'cuda_graph_copy_large2small', 'cuda_graph_copy_small2large', 'cutlass_scaled_fp4_mm', 'cutlass_scaled_mm_blockwise_sm120_fp8', 'debug_kernel', 'dispose_communicator', 'embedding', 'embedding_bert', 'fast_topk_transform_fused', 'fast_topk_transform_ragged_fused', 'fast_topk_v2', 'fill_mla_params', 'fused_add_layernorm', 'fused_add_rmsnorm', 'fused_qk_rmsnorm', 'has_cutlass_scaled_mm_blockwise_sm120_fp8', 'indexer_k_quant_and_cache', 'init_communicator', 'layernorm', 'mla_k_merge', 'moe_post_reorder', 'moe_pre_reorder', 'moe_topk_softmax', 'open_ipc_handle', 'per_tensor_quant_fp8', 'per_token_group_quant_fp8', 'per_token_group_quant_fp8_v2', 'per_token_group_quant_int8', 'per_token_quant_fp8', 'prepare_sparse_mla_params', 'register_buffer_to_communicator', 'reuse_kv_cache_indexed_batched', 'rmsnorm', 'scaled_fp4_experts_quant', 'scaled_fp4_quant', 'silu_and_mul', 'silu_and_mul_scaled_fp4_experts_quant', 'trt_fp8_quantize_128', 'trt_fp8_quantize_128_inplace', 'userbuffers_recv', 'userbuffers_ring_all_gather', 'userbuffers_send', 'write_cache_store']
 
 
 class FlashInferMlaAttnParams(librtp_compute_ops.ParamsBase):
@@ -233,6 +233,10 @@ def cutlass_scaled_fp4_mm(out: torch.Tensor, a: torch.Tensor, b: torch.Tensor, a
     ...
 
 def cutlass_scaled_mm_blockwise_sm120_fp8(D: torch.Tensor, A: torch.Tensor, B: torch.Tensor, A_sf: torch.Tensor, B_sf: torch.Tensor, bias: torch.Tensor | None = None) -> None:
+    """SM120 FP8 binding; call only after guarded runtime feature detection."""
+    ...
+def has_cutlass_scaled_mm_blockwise_sm120_fp8() -> bool:
+    """Conditional cuda12_9 x86 symbol; callers must also tolerate its absence."""
     ...
 def debug_kernel(data: torch.Tensor, start_row: int, start_col: int, m: int, n: int, row_len: int, info_id: int) -> None:
     """

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -68,5 +68,6 @@ test_suite(
         ":smoke_rocm_embedding",
         ":smoke_sm100_dense",
         ":smoke_sm100_moe",
+        ":smoke_sm120_dense",
     ],
 )

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_kv_cache_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_kv_cache_sm120.json
@@ -1,0 +1,42 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "$prompt:s2"
+                    }
+                ],
+                "max_tokens": 10,
+                "temperature": 0.0,
+                "top_p": 1.0
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1780031380,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "1. How do you typically listen to English?\n",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 37,
+                    "total_tokens": 47,
+                    "completion_tokens": 10
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_kv_cache_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_kv_cache_sm120.json
@@ -25,7 +25,7 @@
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "1. How do you typically listen to English?\n",
+                            "content": "当然可以！以下是几个英语听力方法的听力",
                             "partial": false
                         },
                         "finish_reason": "length"

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_1_7b_prequant_fp8_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_1_7b_prequant_fp8_sm120.json
@@ -1,0 +1,226 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B-FP8/snapshots/98342881667bac235ed8605b5ffd8a64a5b99aec",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "max_new_tokens": 32,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1780011380,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的全面规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 529,
+                    "completion_tokens": 32,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 577.904,
+                    "iter_count": 32,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 32,
+                    "step_output_len": 32,
+                    "first_token_cost_time": 247.698,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "max_new_tokens": 32,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1780011382,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的全面规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 529,
+                    "completion_tokens": 32,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_fp8pb_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_fp8pb_sm120.json
@@ -1,0 +1,226 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B/snapshots/0060bc56d46589041c1048efd1a397421b1142b5",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "max_new_tokens": 24,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1780011380,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的全面规划与升学指导服务。以下是一些关键方面的建议，帮助",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 521,
+                    "completion_tokens": 24,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 2292.03,
+                    "iter_count": 24,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 24,
+                    "step_output_len": 24,
+                    "first_token_cost_time": 2129.851,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "max_new_tokens": 24,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1780011382,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的全面规划与升学指导服务。以下是一些关键方面的建议，帮助"
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 521,
+                    "completion_tokens": 24,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_fp8pt_sm120.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_fp8pt_sm120.json
@@ -1,0 +1,237 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B/snapshots/0060bc56d46589041c1048efd1a397421b1142b5",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "max_tokens": 6,
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1784811861,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null,
+                            "partial": false,
+                            "tool_call_id": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 503,
+                    "completion_tokens": 6,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "cost_time": 417.871,
+                    "iter_count": 6,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 6,
+                    "step_output_len": 6,
+                    "first_token_cost_time": 377.083,
+                    "wait_time": 0.197,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "multimodal_lengths": {},
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null,
+                "prompt_logprobs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "max_tokens": 6,
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1784811861,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于",
+                            "reasoning_content": null,
+                            "function_call": null,
+                            "tool_calls": null
+                        },
+                        "finish_reason": "length",
+                        "logprobs": null
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 503,
+                    "completion_tokens": 6,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_sm120.bzl
+++ b/rtp_llm/test/smoke/suites_sm120.bzl
@@ -54,6 +54,13 @@ def sm120_suites():
                 gpu_type = ["RTX_5000_PRO"],
             ),
             smoke_test(
+                name = "dense_fp8pb_dynamic_cudagraph_sm120",
+                task_info = "data/model/qwen3/q_r_fp8pb_sm120.json",
+                envs = ["LOAD_PYTHON_MODEL=1"],
+                smoke_args = "--quantization FP8_PER_BLOCK --act_type BF16 --warm_up 0 --enable_cuda_graph 1",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
                 name = "dense_fp8pt_dynamic_sm120",
                 task_info = "data/model/qwen3/q_r_fp8pt_sm120.json",
                 envs = ["LOAD_PYTHON_MODEL=1"],

--- a/rtp_llm/test/smoke/suites_sm120.bzl
+++ b/rtp_llm/test/smoke/suites_sm120.bzl
@@ -42,3 +42,37 @@ def sm120_suites():
             ),
         ],
     )
+
+    native.test_suite(
+        name = "smoke_sm120_dense",
+        tests = [
+            smoke_test(
+                name = "dense_fp8pb_dynamic_sm120",
+                task_info = "data/model/qwen3/q_r_fp8pb_sm120.json",
+                envs = ["LOAD_PYTHON_MODEL=1"],
+                smoke_args = "--quantization FP8_PER_BLOCK --act_type BF16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "dense_fp8pt_dynamic_sm120",
+                task_info = "data/model/qwen3/q_r_fp8pt_sm120.json",
+                envs = ["LOAD_PYTHON_MODEL=1"],
+                smoke_args = "--quantization FP8_DYNAMIC_PER_TENSOR --act_type BF16 --warm_up 0",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "dense_fp8kv_cudagraph_sm120",
+                task_info = "data/model/qwen25/q_r_fp8_kv_cache_sm120.json",
+                envs = ["LOAD_PYTHON_MODEL=1"],
+                smoke_args = "--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 1",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+            smoke_test(
+                name = "qwen3_1_7b_prequant_fp8pb_sm120",
+                task_info = "data/model/qwen3/q_r_1_7b_prequant_fp8_sm120.json",
+                envs = ["LOAD_PYTHON_MODEL=1"],
+                smoke_args = "--act_type BF16 --warm_up 0 --enable_cuda_graph 1",
+                gpu_type = ["RTX_5000_PRO"],
+            ),
+        ],
+    )


### PR DESCRIPTION
  本 PR 补充 RTX 5000 Pro / SM120 平台的 FP8 PER_BLOCK 推理能力，并完善相关性能优化与测试覆盖。

  - 从 vLLM 移植基于 CUTLASS 的 SM120 FP8 blockwise GEMM kernel，并完成 Bazel 与 Pybind 接入。
  - 新增 CudaFp8VllmBlockwiseLinear 后端，使 SM120 上的 FP8 PER_BLOCK 模型使用对应 CUTLASS 实现。
  - 支持 GEMM epilogue bias 融合，减少额外 elementwise kernel。
  - 优化 per-token group quantization，降低量化阶段的访存和执行开销。
  - 增加 SM120 backend import 保护、bias 缓存和 warm-up，完善异常环境下的 fallback 行为。
  - 在 SM120 上禁用不支持的 DeepGEMM FP8 PER_BLOCK 路径，避免选择无可用 kernel 的后端。
  - 移除 Vision-BERT embedding/no-KV-cache 路径中冗余的 fused-QKV bias transpose。

  ## 测试与验证

  - 补充 FP8 Linear backend 数值单测和量化一致性测试。
  - 覆盖 BF16/FP16 输入、INT8/FP8 输出及不同 scale layout。
  - 新增 SM120 FP8 dense 与 Vision-BERT smoke 用例。
  - 在内部 CI 中增加对应的 SM120 FP8/BERT smoke 任务。
