### PR TITLE
feat(loader): add Qwen3 dense newloader path

### DIFF
--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -350,8 +350,43 @@ class BaseModel(object):
                 "force_cpu_load_weights is not supported by the Qwen dense "
                 "newloader slice"
             )
+        if getattr(self.model_config, "ptuning_path", None):
+            raise ValueError("p-tuning is not supported by this newloader slice")
         if getattr(self.model_config, "lora_infos", None):
             raise ValueError("LoRA loading is not supported by this newloader slice")
+
+        parallelism = self.parallelism_config
+        attn_tp = (
+            parallelism.get_attn_tp_size(),
+            parallelism.get_attn_tp_rank(),
+        )
+        ffn_tp = (
+            parallelism.get_ffn_tp_size(),
+            parallelism.get_ffn_tp_rank(),
+        )
+        physical_tp = (parallelism.tp_size, parallelism.tp_rank)
+        prefill_cp = getattr(parallelism, "prefill_cp_config", None)
+        cp_enabled = False
+        if prefill_cp is not None:
+            for checker_name in ("is_enabled", "is_prefill_enabled"):
+                checker = getattr(prefill_cp, checker_name, None)
+                if callable(checker) and bool(checker()):
+                    cp_enabled = True
+                    break
+        if cp_enabled or attn_tp != physical_tp:
+            raise ValueError(
+                "Context parallelism is not supported by the Qwen dense newloader slice"
+            )
+        if ffn_tp != attn_tp:
+            raise ValueError(
+                "Independent FFN TP/sequence parallelism is not supported by the "
+                "Qwen dense newloader slice"
+            )
+        ffn_disaggregate = getattr(parallelism, "ffn_disaggregate_config", None)
+        if bool(getattr(ffn_disaggregate, "enable_ffn_disaggregate", False)):
+            raise ValueError(
+                "FFN disaggregation is not supported by the Qwen dense newloader slice"
+            )
 
         self.custom_module = self._init_custom_module()
         if self.custom_module is not None:
@@ -363,8 +398,14 @@ class BaseModel(object):
         load_method = NewLoaderLoadMethod(str(configured_method).lower())
         device = self._get_device_str()
         load_config = NewLoaderConfig(
-            tp_size=self.parallelism_config.tp_size,
-            tp_rank=self.parallelism_config.tp_rank,
+            tp_size=physical_tp[0],
+            tp_rank=physical_tp[1],
+            attn_tp_size=attn_tp[0],
+            attn_tp_rank=attn_tp[1],
+            ffn_tp_size=ffn_tp[0],
+            ffn_tp_rank=ffn_tp[1],
+            lm_head_tp_size=physical_tp[0],
+            lm_head_tp_rank=physical_tp[1],
             ep_size=getattr(self.parallelism_config, "ep_size", 1),
             ep_rank=getattr(self.parallelism_config, "ep_rank", 0),
             compute_dtype=self.model_config.compute_dtype,
@@ -383,6 +424,7 @@ class BaseModel(object):
         self.device = device
         self.py_model = loader.load()
         self.weight = self._build_new_loader_weight_view(self.py_model)
+        self.py_model.weight = self.weight
         self.model_weights_loader = loader
         self.weight_manager = None
         self.py_eplb = None

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -20,11 +20,11 @@ from rtp_llm.model_loader.weight_manager import WeightManager
 from rtp_llm.models.downstream_modules.custom_module import CustomModule
 from rtp_llm.models.downstream_modules.utils import create_custom_module
 from rtp_llm.ops import (
-    KVCacheSpecType,
     DeviceResourceConfig,
     FMHAConfig,
     HWKernelConfig,
     KVCacheSpecDesc,
+    KVCacheSpecType,
     MlaOpsType,
     MoeConfig,
     ParallelismConfig,
@@ -135,6 +135,12 @@ class BaseModel(object):
             and self.support_cuda_graph() is False
         ):
             raise Exception("current model can't support cuda graph in py model mode")
+
+        if self._use_new_loader():
+            if skip_python_model:
+                raise ValueError("newloader requires the Python model runtime")
+            self._load_with_new_loader()
+            return
 
         self.custom_module = self._init_custom_module()
         self.model_weights_loader = self.create_model_loader()
@@ -311,6 +317,98 @@ class BaseModel(object):
     def _load_custom_module(self):
         if self.custom_module is not None:
             self.custom_module.init(self.weight)
+
+    def _use_new_loader(self) -> bool:
+        return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
+            getattr(self.model_config, "use_new_loader", False)
+        )
+
+    def _new_loader_quant_type(self) -> str:
+        quant_config = getattr(self.model_config, "quant_config", None)
+        if quant_config is None:
+            return "none"
+        method = getattr(quant_config, "get_runtime_method_key", None)
+        if not callable(method):
+            method = getattr(quant_config, "get_method", None)
+        if not callable(method):
+            raise TypeError(
+                "model_config.quant_config must define get_method() or "
+                "get_runtime_method_key()"
+            )
+        return method() or "none"
+
+    def _load_with_new_loader(self) -> None:
+        from rtp_llm.models_py.model_loader import (
+            NewLoaderConfig,
+            NewLoaderLoadMethod,
+            NewModelLoader,
+        )
+        from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+        if self.force_cpu_load_weights:
+            raise ValueError(
+                "force_cpu_load_weights is not supported by the Qwen dense "
+                "newloader slice"
+            )
+        if getattr(self.model_config, "lora_infos", None):
+            raise ValueError("LoRA loading is not supported by this newloader slice")
+
+        self.custom_module = self._init_custom_module()
+        if self.custom_module is not None:
+            raise ValueError(
+                "Custom downstream modules are not supported by this newloader slice"
+            )
+
+        configured_method = getattr(self.load_method, "value", self.load_method)
+        load_method = NewLoaderLoadMethod(str(configured_method).lower())
+        device = self._get_device_str()
+        load_config = NewLoaderConfig(
+            tp_size=self.parallelism_config.tp_size,
+            tp_rank=self.parallelism_config.tp_rank,
+            ep_size=getattr(self.parallelism_config, "ep_size", 1),
+            ep_rank=getattr(self.parallelism_config, "ep_rank", 0),
+            compute_dtype=self.model_config.compute_dtype,
+            device=device,
+            load_method=load_method,
+            quant_config=QuantizationConfig(self._new_loader_quant_type()),
+            parallelism_config=self.parallelism_config,
+            fmha_config=self.fmha_config,
+            device_resource_config=self.device_resource_config,
+        )
+        loader = NewModelLoader(
+            model_config=self.model_config,
+            load_config=load_config,
+            model_path=self.model_config.ckpt_path,
+        )
+        self.device = device
+        self.py_model = loader.load()
+        self.weight = self._build_new_loader_weight_view(self.py_model)
+        self.model_weights_loader = loader
+        self.weight_manager = None
+        self.py_eplb = None
+        logging.info("NewModelLoader: Qwen dense model loaded successfully")
+
+    def _build_new_loader_weight_view(self, module: torch.nn.Module) -> ModelWeights:
+        export = getattr(module, "runtime_weight_view", None)
+        if not callable(export):
+            raise TypeError(
+                f"{type(module).__name__} must define runtime_weight_view()"
+            )
+        runtime_weights = export()
+        if not isinstance(runtime_weights, dict) or not runtime_weights:
+            raise TypeError("runtime_weight_view() must return a non-empty dict")
+        weights = ModelWeights(
+            self.model_config.num_layers,
+            self.device,
+            self.model_config.compute_dtype,
+        )
+        for name, tensor in runtime_weights.items():
+            if not isinstance(name, str) or not name:
+                raise TypeError("Runtime weight names must be non-empty strings")
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(f"Runtime weight {name!r} must be a torch.Tensor")
+            weights.set_global_weight(name, tensor)
+        return weights
 
     def create_model_loader(self) -> ModelLoader:
         # Create database locally, only used for model loading

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -350,6 +350,11 @@ class BaseModel(object):
                 "force_cpu_load_weights is not supported by the Qwen dense "
                 "newloader slice"
             )
+        device_resource_config = getattr(self, "device_resource_config", None)
+        if getattr(device_resource_config, "enable_layer_micro_batch", 0) != 0:
+            raise ValueError(
+                "layer micro-batch is not supported by the Qwen dense newloader slice"
+            )
         if getattr(self.model_config, "ptuning_path", None):
             raise ValueError("p-tuning is not supported by this newloader slice")
         if getattr(self.model_config, "lora_infos", None):

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -120,10 +120,26 @@ py_library(
         "module_base.py",
         "registry.py",
         "weight_mapper.py",
-    ],
+    ] + glob([
+        "layers/*.py",
+        "new_models/*.py",
+        "new_models/qwen3/*.py",
+        "quant_methods/*.py",
+    ]),
     deps = [
+        ":modules",
+        "//rtp_llm:_ft_pickler",
+        "//rtp_llm:config",
+        "//rtp_llm:device",
+        "//rtp_llm:ops",
         "//rtp_llm:safetensors",
         "//rtp_llm:torch",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    data = [
+        "//:rtp_compute_ops",
+        "//:th_transformer",
+        "//:th_transformer_config",
     ],
     visibility = ["//visibility:public"],
 )
@@ -139,6 +155,7 @@ py_library(
         ":modules",
         ":kernels",
         ":configs",
+        ":new_weight_loader",
         "//rtp_llm/model_loader:loader",
     ] + select({
         "@//:using_cuda12": [

--- a/rtp_llm/models_py/layers/__init__.py
+++ b/rtp_llm/models_py/layers/__init__.py
@@ -1,0 +1,20 @@
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    LinearBase,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.norm import RMSNorm
+
+__all__ = [
+    "LinearBase",
+    "ColumnParallelLinear",
+    "RowParallelLinear",
+    "MergedColumnParallelLinear",
+    "QKVParallelLinear",
+    "RMSNorm",
+    "VocabParallelEmbedding",
+    "ParallelLMHead",
+]

--- a/rtp_llm/models_py/layers/activation.py
+++ b/rtp_llm/models_py/layers/activation.py
@@ -1,0 +1,46 @@
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+_SILU_FUSED_ENABLED = True
+
+
+def silu_and_mul(gate_up: torch.Tensor) -> torch.Tensor:
+    """Apply the fused SwiGLU activation to a ``[gate, up]`` tensor."""
+    global _SILU_FUSED_ENABLED
+
+    if gate_up.shape[-1] <= 0 or gate_up.shape[-1] % 2 != 0:
+        raise ValueError(
+            f"SwiGLU input width must be positive and even, got " f"{gate_up.shape[-1]}"
+        )
+    if gate_up.is_cuda and _SILU_FUSED_ENABLED:
+        try:
+            output = torch.empty(
+                gate_up.shape[:-1] + (gate_up.shape[-1] // 2,),
+                dtype=gate_up.dtype,
+                device=gate_up.device,
+            )
+            if getattr(torch.version, "hip", None) is not None:
+                import aiter
+
+                aiter.silu_and_mul(output, gate_up)
+                return output
+
+            from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+            stream_id = torch.cuda.current_stream().cuda_stream
+            rtp_llm_ops.silu_and_mul(output, gate_up, stream_id)
+            return output
+        except Exception as exc:
+            if isinstance(exc, torch.cuda.OutOfMemoryError):
+                raise
+            _SILU_FUSED_ENABLED = False
+            logger.warning(
+                "Fused silu_and_mul is unavailable; disabling it and using eager "
+                "fallback: %s",
+                exc,
+            )
+
+    gate, up = gate_up.chunk(2, dim=-1)
+    return (torch.nn.functional.silu(gate.float()) * up.float()).to(gate_up.dtype)

--- a/rtp_llm/models_py/layers/embedding.py
+++ b/rtp_llm/models_py/layers/embedding.py
@@ -1,0 +1,126 @@
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
+from rtp_llm.models_py.module_base import RtpModule
+
+
+def _validate_vocab_partition(vocab_size: int, tp_size: int, tp_rank: int) -> None:
+    if vocab_size <= 0:
+        raise ValueError(f"vocab_size must be positive, got {vocab_size}")
+    if tp_size <= 0 or not 0 <= tp_rank < tp_size:
+        raise ValueError(f"Invalid TP partition: rank={tp_rank}, size={tp_size}")
+    if vocab_size % tp_size != 0:
+        raise ValueError(
+            f"vocab_size={vocab_size} must be divisible by tp_size={tp_size}"
+        )
+
+
+class VocabParallelEmbedding(RtpModule):
+    def __init__(
+        self,
+        vocab_size: int,
+        embedding_dim: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        _validate_vocab_partition(vocab_size, tp_size, tp_rank)
+        if embedding_dim <= 0:
+            raise ValueError(f"embedding_dim must be positive, got {embedding_dim}")
+
+        self.vocab_size = vocab_size
+        self.embedding_dim = embedding_dim
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.vocab_size_per_partition = vocab_size // tp_size
+        self.vocab_start_idx = tp_rank * self.vocab_size_per_partition
+        self.vocab_end_idx = self.vocab_start_idx + self.vocab_size_per_partition
+        self.weight = nn.Parameter(
+            torch.empty(
+                self.vocab_size_per_partition,
+                embedding_dim,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            if name != "weight":
+                raise RuntimeError(f"Unsupported embedding tensor {name!r}")
+            if tensor.shape[0] != self.vocab_size:
+                raise ValueError(
+                    f"Embedding checkpoint rows must be {self.vocab_size}, "
+                    f"got {tensor.shape[0]}"
+                )
+            local = tensor[self.vocab_start_idx : self.vocab_end_idx]
+            if not self._assign_weight(self, "weight", local.contiguous()):
+                raise RuntimeError("Failed to assign embedding weight")
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self.tp_size == 1:
+            return torch.nn.functional.embedding(input_ids, self.weight)
+
+        mask = (input_ids >= self.vocab_start_idx) & (input_ids < self.vocab_end_idx)
+        local_ids = torch.where(
+            mask,
+            input_ids - self.vocab_start_idx,
+            torch.zeros_like(input_ids),
+        )
+        output = torch.nn.functional.embedding(local_ids, self.weight)
+        output = output * mask.unsqueeze(-1)
+        return all_reduce(output, group=Group.TP)
+
+
+class ParallelLMHead(RtpModule):
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        _validate_vocab_partition(vocab_size, tp_size, tp_rank)
+        if hidden_size <= 0:
+            raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.vocab_size_per_partition = vocab_size // tp_size
+        self.weight = nn.Parameter(
+            torch.empty(
+                self.vocab_size_per_partition,
+                hidden_size,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+
+    def _copy_weight(self, tensor: torch.Tensor) -> None:
+        if tensor.shape[0] == self.vocab_size:
+            start = self.tp_rank * self.vocab_size_per_partition
+            tensor = tensor[start : start + self.vocab_size_per_partition]
+        elif tensor.shape[0] != self.vocab_size_per_partition:
+            raise ValueError(
+                f"LM head rows must be {self.vocab_size} or "
+                f"{self.vocab_size_per_partition}, got {tensor.shape[0]}"
+            )
+        if not self._assign_weight(self, "weight", tensor.contiguous()):
+            raise RuntimeError("Failed to assign LM head weight")
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            if name != "weight":
+                raise RuntimeError(f"Unsupported LM head tensor {name!r}")
+            self._copy_weight(tensor)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.linear(x, self.weight)

--- a/rtp_llm/models_py/layers/embedding.py
+++ b/rtp_llm/models_py/layers/embedding.py
@@ -7,10 +7,17 @@ from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.module_base import RtpModule
 
 
+def _positive_int(value: int, label: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
+
+
 def _validate_vocab_partition(vocab_size: int, tp_size: int, tp_rank: int) -> None:
-    if vocab_size <= 0:
-        raise ValueError(f"vocab_size must be positive, got {vocab_size}")
-    if tp_size <= 0 or not 0 <= tp_rank < tp_size:
+    _positive_int(vocab_size, "vocab_size")
+    _positive_int(tp_size, "tp_size")
+    if isinstance(tp_rank, bool) or not isinstance(tp_rank, int):
+        raise ValueError(f"tp_rank must be an integer, got {tp_rank!r}")
+    if not 0 <= tp_rank < tp_size:
         raise ValueError(f"Invalid TP partition: rank={tp_rank}, size={tp_size}")
     if vocab_size % tp_size != 0:
         raise ValueError(
@@ -29,8 +36,7 @@ class VocabParallelEmbedding(RtpModule):
     ):
         super().__init__()
         _validate_vocab_partition(vocab_size, tp_size, tp_rank)
-        if embedding_dim <= 0:
-            raise ValueError(f"embedding_dim must be positive, got {embedding_dim}")
+        _positive_int(embedding_dim, "embedding_dim")
 
         self.vocab_size = vocab_size
         self.embedding_dim = embedding_dim
@@ -87,8 +93,7 @@ class ParallelLMHead(RtpModule):
     ):
         super().__init__()
         _validate_vocab_partition(vocab_size, tp_size, tp_rank)
-        if hidden_size <= 0:
-            raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+        _positive_int(hidden_size, "hidden_size")
 
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
@@ -105,16 +110,24 @@ class ParallelLMHead(RtpModule):
         )
 
     def _copy_weight(self, tensor: torch.Tensor) -> None:
-        if tensor.shape[0] == self.vocab_size:
-            start = self.tp_rank * self.vocab_size_per_partition
-            tensor = tensor[start : start + self.vocab_size_per_partition]
-        elif tensor.shape[0] != self.vocab_size_per_partition:
+        if tensor.shape[0] != self.vocab_size:
             raise ValueError(
-                f"LM head rows must be {self.vocab_size} or "
-                f"{self.vocab_size_per_partition}, got {tensor.shape[0]}"
+                f"LM head checkpoint rows must be {self.vocab_size}, "
+                f"got {tensor.shape[0]}"
             )
+        start = self.tp_rank * self.vocab_size_per_partition
+        tensor = tensor[start : start + self.vocab_size_per_partition]
         if not self._assign_weight(self, "weight", tensor.contiguous()):
             raise RuntimeError("Failed to assign LM head weight")
+
+    def _copy_local_tied_weight(self, tensor: torch.Tensor) -> None:
+        if tuple(tensor.shape) != tuple(self.weight.shape):
+            raise ValueError(
+                f"Tied LM head shard must have shape {tuple(self.weight.shape)}, "
+                f"got {tuple(tensor.shape)}"
+            )
+        if not self._assign_weight(self, "weight", tensor.contiguous()):
+            raise RuntimeError("Failed to assign tied LM head weight")
 
     def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
         for name, tensor in weights.items():

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -9,12 +9,22 @@ from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 
 
+def _require_positive_int(value: int, label: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
+
+
 def _validate_parallel_partition(size: int, rank: int, label: str) -> None:
-    if size <= 0 or not 0 <= rank < size:
+    _require_positive_int(size, f"{label} size")
+    if isinstance(rank, bool) or not isinstance(rank, int):
+        raise ValueError(f"{label} rank must be an integer, got {rank!r}")
+    if not 0 <= rank < size:
         raise ValueError(f"Invalid {label} partition: rank={rank}, size={size}")
 
 
 def _require_divisible(value: int, divisor: int, label: str) -> None:
+    _require_positive_int(value, label)
+    _require_positive_int(divisor, "divisor")
     if value % divisor != 0:
         raise ValueError(f"{label}={value} must be divisible by {divisor}")
 
@@ -47,6 +57,8 @@ class LinearBase(RtpModule):
     ):
         super().__init__()
         _validate_parallel_partition(tp_size, tp_rank, "TP")
+        _require_positive_int(input_size, "input_size")
+        _require_positive_int(output_size, "output_size")
         self.input_size = input_size
         self.output_size = output_size
         self.tp_size = tp_size
@@ -119,6 +131,11 @@ class ColumnParallelLinear(LinearBase):
         gather_output: bool = False,
         params_dtype: torch.dtype = torch.float16,
     ):
+        _validate_parallel_partition(tp_size, tp_rank, "TP")
+        if gather_output:
+            raise ValueError(
+                "gather_output is not supported by the Qwen dense newloader slice"
+            )
         _require_divisible(output_size, tp_size, "output_size")
         self.output_size_per_partition = output_size // tp_size
         self.gather_output = gather_output
@@ -164,6 +181,7 @@ class RowParallelLinear(LinearBase):
         reduce_output: bool = True,
         params_dtype: torch.dtype = torch.float16,
     ):
+        _validate_parallel_partition(tp_size, tp_rank, "TP")
         _require_divisible(input_size, tp_size, "input_size")
         self.input_size_per_partition = input_size // tp_size
         self.reduce_output = reduce_output
@@ -331,8 +349,10 @@ class QKVParallelLinear(ColumnParallelLinear):
         params_dtype: torch.dtype = torch.float16,
     ):
         _validate_parallel_partition(tp_size, tp_rank, "TP")
-        if num_heads <= 0 or num_kv_heads <= 0 or head_dim <= 0:
-            raise ValueError("QKV head counts and head_dim must be positive")
+        _require_positive_int(hidden_size, "hidden_size")
+        _require_positive_int(num_heads, "num_heads")
+        _require_positive_int(num_kv_heads, "num_kv_heads")
+        _require_positive_int(head_dim, "head_dim")
         _require_divisible(num_heads, num_kv_heads, "num_heads")
         _require_divisible(num_heads, tp_size, "num_heads")
         if num_kv_heads >= tp_size:

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -1,0 +1,465 @@
+from collections import defaultdict
+from typing import Dict, List, Optional, Set
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+
+
+def _validate_parallel_partition(size: int, rank: int, label: str) -> None:
+    if size <= 0 or not 0 <= rank < size:
+        raise ValueError(f"Invalid {label} partition: rank={rank}, size={size}")
+
+
+def _require_divisible(value: int, divisor: int, label: str) -> None:
+    if value % divisor != 0:
+        raise ValueError(f"{label}={value} must be divisible by {divisor}")
+
+
+def _parameter_name(weight_name: str) -> str:
+    return weight_name.rsplit(".", 1)[-1]
+
+
+def _projection_name(weight_name: str, shard_names: List[str]) -> Optional[str]:
+    parts = weight_name.split(".")
+    if len(parts) < 2:
+        return None
+    candidate = parts[-2]
+    return candidate if candidate in shard_names else None
+
+
+class LinearBase(RtpModule):
+    shard_names: List[str] = []
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        _validate_parallel_partition(tp_size, tp_rank, "TP")
+        self.input_size = input_size
+        self.output_size = output_size
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.prefix = prefix
+        self.params_dtype = params_dtype
+        self.quant_config = quant_config or QuantizationConfig("none")
+        self.quant_method = self.quant_config.get_quant_method(self, prefix)
+        if bias:
+            self.bias = nn.Parameter(
+                torch.empty(output_size, dtype=params_dtype), requires_grad=False
+            )
+        else:
+            self.register_parameter("bias", None)
+
+    def _copy_parameter(self, name: str, tensor: torch.Tensor) -> None:
+        if not self._assign_weight(self, name, tensor):
+            raise RuntimeError(f"Unknown parameter {self.prefix}.{name}")
+
+    def _copy_parameter_slice(
+        self, name: str, offset: int, tensor: torch.Tensor
+    ) -> None:
+        target = getattr(self, name, None)
+        if not isinstance(target, nn.Parameter):
+            raise RuntimeError(f"Unknown parameter {self.prefix}.{name}")
+        target_slice = target[offset : offset + tensor.shape[0]]
+        if tuple(target_slice.shape) != tuple(tensor.shape):
+            raise ValueError(
+                f"Shape mismatch for {self.prefix}.{name} shard: expected "
+                f"{tuple(target_slice.shape)}, got {tuple(tensor.shape)}"
+            )
+        if target_slice.dtype != tensor.dtype and not (
+            target_slice.is_floating_point() and tensor.is_floating_point()
+        ):
+            raise TypeError(
+                f"Dtype mismatch for {self.prefix}.{name} shard: expected "
+                f"{target_slice.dtype}, got {tensor.dtype}"
+            )
+        with torch.no_grad():
+            target_slice.copy_(tensor)
+
+    def process_weights_after_loading(self) -> None:
+        if getattr(self, "_post_load_done", False):
+            return
+        self.quant_method.process_weights_after_loading(self)
+        self._post_load_done = True
+
+    def _validate_input(self, x: torch.Tensor) -> None:
+        if x.ndim == 0 or x.shape[-1] != self.input_size:
+            raise ValueError(
+                f"{self.prefix or type(self).__name__} expected input width "
+                f"{self.input_size}, got shape {tuple(x.shape)}"
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self._validate_input(x)
+        return self.quant_method.apply(self, x, self.bias)
+
+
+class ColumnParallelLinear(LinearBase):
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        gather_output: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        _require_divisible(output_size, tp_size, "output_size")
+        self.output_size_per_partition = output_size // tp_size
+        self.gather_output = gather_output
+        super().__init__(
+            input_size,
+            self.output_size_per_partition,
+            tp_size,
+            tp_rank,
+            quant_config,
+            prefix,
+            bias,
+            params_dtype,
+        )
+        self.quant_method.create_weights(
+            self, input_size, self.output_size_per_partition, params_dtype
+        )
+
+    def _split_output(self, tensor: torch.Tensor) -> torch.Tensor:
+        _require_divisible(tensor.shape[0], self.tp_size, "checkpoint output")
+        rows = tensor.shape[0] // self.tp_size
+        return tensor.narrow(0, self.tp_rank * rows, rows).contiguous()
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            parameter_name = _parameter_name(name)
+            if parameter_name not in ("weight", "bias"):
+                raise RuntimeError(f"Unsupported tensor {self.prefix}.{name}")
+            if parameter_name == "bias" and self.bias is None:
+                raise RuntimeError(f"Unexpected bias tensor {self.prefix}.{name}")
+            self._copy_parameter(parameter_name, self._split_output(tensor))
+
+
+class RowParallelLinear(LinearBase):
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        reduce_output: bool = True,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        _require_divisible(input_size, tp_size, "input_size")
+        self.input_size_per_partition = input_size // tp_size
+        self.reduce_output = reduce_output
+        super().__init__(
+            self.input_size_per_partition,
+            output_size,
+            tp_size,
+            tp_rank,
+            quant_config,
+            prefix,
+            bias,
+            params_dtype,
+        )
+        self.quant_method.create_weights(
+            self, self.input_size_per_partition, output_size, params_dtype
+        )
+
+    def _split_input(self, tensor: torch.Tensor) -> torch.Tensor:
+        _require_divisible(tensor.shape[1], self.tp_size, "checkpoint input")
+        columns = tensor.shape[1] // self.tp_size
+        return tensor.narrow(1, self.tp_rank * columns, columns).contiguous()
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            parameter_name = _parameter_name(name)
+            if parameter_name == "weight":
+                self._copy_parameter("weight", self._split_input(tensor))
+            elif parameter_name == "bias" and self.bias is not None:
+                self._copy_parameter("bias", tensor)
+            else:
+                raise RuntimeError(f"Unsupported tensor {self.prefix}.{name}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self._validate_input(x)
+        output = self.quant_method.apply(self, x, None)
+        if self.reduce_output and self.tp_size > 1:
+            output = all_reduce(output, group=Group.TP)
+        if self.bias is not None:
+            output = output + self.bias
+        return output
+
+
+class MergedColumnParallelLinear(ColumnParallelLinear):
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        shard_names: Optional[List[str]] = None,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        self.shard_names = list(shard_names or [])
+        if not self.shard_names:
+            raise ValueError("MergedColumnParallelLinear requires shard_names")
+        _require_divisible(output_size, len(self.shard_names), "output_size")
+        global_shard_size = output_size // len(self.shard_names)
+        _require_divisible(global_shard_size, tp_size, "merged shard size")
+        self.global_shard_size = global_shard_size
+        self.local_shard_size = global_shard_size // tp_size
+        self._loaded_shards: Dict[str, Set[str]] = defaultdict(set)
+        super().__init__(
+            input_size,
+            output_size,
+            tp_size,
+            tp_rank,
+            quant_config,
+            prefix,
+            bias,
+            False,
+            params_dtype,
+        )
+
+    def _mark_shard(self, parameter_name: str, shard_name: str) -> None:
+        loaded = self._loaded_shards[parameter_name]
+        if shard_name in loaded:
+            raise RuntimeError(
+                f"Duplicate {self.prefix}.{shard_name}.{parameter_name} shard"
+            )
+        loaded.add(shard_name)
+        if loaded == set(self.shard_names):
+            self._mark_weight_loaded(parameter_name)
+
+    def _copy_fused(self, parameter_name: str, tensor: torch.Tensor) -> None:
+        if self._loaded_shards[parameter_name]:
+            raise RuntimeError(
+                f"Cannot mix fused and per-shard {self.prefix}.{parameter_name}"
+            )
+        expected_rows = self.global_shard_size * len(self.shard_names)
+        if tensor.shape[0] != expected_rows:
+            raise ValueError(
+                f"Fused {self.prefix}.{parameter_name} rows must be "
+                f"{expected_rows}, got {tensor.shape[0]}"
+            )
+        pieces = []
+        for index in range(len(self.shard_names)):
+            start = (
+                index * self.global_shard_size + self.tp_rank * self.local_shard_size
+            )
+            pieces.append(tensor.narrow(0, start, self.local_shard_size).contiguous())
+        self._copy_parameter(parameter_name, torch.cat(pieces, dim=0))
+        self._loaded_shards[parameter_name] = set(self.shard_names)
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            parameter_name = _parameter_name(name)
+            if parameter_name not in ("weight", "bias"):
+                raise RuntimeError(f"Unsupported tensor {self.prefix}.{name}")
+            if parameter_name == "bias" and self.bias is None:
+                raise RuntimeError(f"Unexpected bias tensor {self.prefix}.{name}")
+            shard_name = _projection_name(name, self.shard_names)
+            if shard_name is None:
+                self._copy_fused(parameter_name, tensor)
+                continue
+            if self._loaded_shards[parameter_name] == set(self.shard_names):
+                raise RuntimeError(
+                    f"Cannot mix fused and per-shard {self.prefix}.{parameter_name}"
+                )
+            if shard_name in self._loaded_shards[parameter_name]:
+                raise RuntimeError(
+                    f"Duplicate {self.prefix}.{shard_name}.{parameter_name} shard"
+                )
+            if tensor.shape[0] != self.global_shard_size:
+                raise ValueError(
+                    f"{self.prefix}.{shard_name}.{parameter_name} rows must be "
+                    f"{self.global_shard_size}, got {tensor.shape[0]}"
+                )
+            shard_index = self.shard_names.index(shard_name)
+            start = self.tp_rank * self.local_shard_size
+            local = tensor.narrow(0, start, self.local_shard_size).contiguous()
+            offset = shard_index * self.local_shard_size
+            self._copy_parameter_slice(parameter_name, offset, local)
+            self._mark_shard(parameter_name, shard_name)
+
+    def validate_weights_loaded(self, loaded_tensor_ids=None) -> None:
+        for parameter_name in ("weight", "bias"):
+            if parameter_name == "bias" and self.bias is None:
+                continue
+            missing = set(self.shard_names) - self._loaded_shards[parameter_name]
+            if missing:
+                raise RuntimeError(
+                    f"{self.prefix}.{parameter_name} is missing shards "
+                    f"{sorted(missing)}"
+                )
+        super().validate_weights_loaded(loaded_tensor_ids)
+
+
+class QKVParallelLinear(ColumnParallelLinear):
+    shard_names = ["q_proj", "k_proj", "v_proj"]
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        _validate_parallel_partition(tp_size, tp_rank, "TP")
+        if num_heads <= 0 or num_kv_heads <= 0 or head_dim <= 0:
+            raise ValueError("QKV head counts and head_dim must be positive")
+        _require_divisible(num_heads, num_kv_heads, "num_heads")
+        _require_divisible(num_heads, tp_size, "num_heads")
+        if num_kv_heads >= tp_size:
+            _require_divisible(num_kv_heads, tp_size, "num_kv_heads")
+            self.num_kv_heads_per_partition = num_kv_heads // tp_size
+            self.kv_head_rank = tp_rank
+        else:
+            _require_divisible(tp_size, num_kv_heads, "tp_size")
+            self.num_kv_heads_per_partition = 1
+            replicas = tp_size // num_kv_heads
+            self.kv_head_rank = tp_rank // replicas
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.num_heads_per_partition = num_heads // tp_size
+        self.q_size = self.num_heads_per_partition * head_dim
+        self.kv_size = self.num_kv_heads_per_partition * head_dim
+        self._loaded_shards: Dict[str, Set[str]] = defaultdict(set)
+
+        LinearBase.__init__(
+            self,
+            hidden_size,
+            self.q_size + 2 * self.kv_size,
+            tp_size,
+            tp_rank,
+            quant_config,
+            prefix,
+            bias,
+            params_dtype,
+        )
+        self.output_size_per_partition = self.output_size
+        self.gather_output = False
+        self.quant_method.create_weights(
+            self, hidden_size, self.output_size, params_dtype
+        )
+
+    def _local_qkv(self, shard_name: str, tensor: torch.Tensor) -> torch.Tensor:
+        if shard_name == "q_proj":
+            start_head = self.tp_rank * self.num_heads_per_partition
+            head_count = self.num_heads_per_partition
+        else:
+            start_head = self.kv_head_rank * self.num_kv_heads_per_partition
+            head_count = self.num_kv_heads_per_partition
+        start = start_head * self.head_dim
+        rows = head_count * self.head_dim
+        return tensor.narrow(0, start, rows).contiguous()
+
+    def _offset(self, shard_name: str) -> int:
+        if shard_name == "q_proj":
+            return 0
+        if shard_name == "k_proj":
+            return self.q_size
+        return self.q_size + self.kv_size
+
+    def _mark_shard(self, parameter_name: str, shard_name: str) -> None:
+        loaded = self._loaded_shards[parameter_name]
+        if shard_name in loaded:
+            raise RuntimeError(
+                f"Duplicate {self.prefix}.{shard_name}.{parameter_name} shard"
+            )
+        loaded.add(shard_name)
+        if loaded == set(self.shard_names):
+            self._mark_weight_loaded(parameter_name)
+
+    def _load_shard(
+        self, shard_name: str, parameter_name: str, tensor: torch.Tensor
+    ) -> None:
+        if shard_name in self._loaded_shards[parameter_name]:
+            raise RuntimeError(
+                f"Duplicate {self.prefix}.{shard_name}.{parameter_name} shard"
+            )
+        expected_rows = (
+            self.num_heads if shard_name == "q_proj" else self.num_kv_heads
+        ) * self.head_dim
+        if tensor.shape[0] != expected_rows:
+            raise ValueError(
+                f"{self.prefix}.{shard_name}.{parameter_name} rows must be "
+                f"{expected_rows}, got {tensor.shape[0]}"
+            )
+        local = self._local_qkv(shard_name, tensor)
+        offset = self._offset(shard_name)
+        self._copy_parameter_slice(parameter_name, offset, local)
+        self._mark_shard(parameter_name, shard_name)
+
+    def _load_fused(self, parameter_name: str, tensor: torch.Tensor) -> None:
+        if self._loaded_shards[parameter_name]:
+            raise RuntimeError(
+                f"Cannot mix fused and per-shard {self.prefix}.{parameter_name}"
+            )
+        q_rows = self.num_heads * self.head_dim
+        kv_rows = self.num_kv_heads * self.head_dim
+        if tensor.shape[0] != q_rows + 2 * kv_rows:
+            raise ValueError(
+                f"Fused QKV rows {tensor.shape[0]} do not match "
+                f"{q_rows + 2 * kv_rows}"
+            )
+        q, k, v = torch.split(tensor, [q_rows, kv_rows, kv_rows], dim=0)
+        for shard_name, shard in zip(self.shard_names, (q, k, v)):
+            self._load_shard(shard_name, parameter_name, shard)
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            parameter_name = _parameter_name(name)
+            if parameter_name not in ("weight", "bias"):
+                raise RuntimeError(f"Unsupported tensor {self.prefix}.{name}")
+            if parameter_name == "bias" and self.bias is None:
+                raise RuntimeError(f"Unexpected bias tensor {self.prefix}.{name}")
+            shard_name = _projection_name(name, self.shard_names)
+            if shard_name is None:
+                self._load_fused(parameter_name, tensor)
+            else:
+                if self._loaded_shards[parameter_name] == set(self.shard_names):
+                    raise RuntimeError(
+                        f"Cannot mix fused and per-shard "
+                        f"{self.prefix}.{parameter_name}"
+                    )
+                self._load_shard(shard_name, parameter_name, tensor)
+
+    def validate_weights_loaded(self, loaded_tensor_ids=None) -> None:
+        for parameter_name in ("weight", "bias"):
+            if parameter_name == "bias" and self.bias is None:
+                continue
+            missing = set(self.shard_names) - self._loaded_shards[parameter_name]
+            if missing:
+                raise RuntimeError(
+                    f"{self.prefix}.{parameter_name} is missing shards "
+                    f"{sorted(missing)}"
+                )
+        super().validate_weights_loaded(loaded_tensor_ids)

--- a/rtp_llm/models_py/layers/norm.py
+++ b/rtp_llm/models_py/layers/norm.py
@@ -1,0 +1,81 @@
+import logging
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.module_base import RtpModule
+
+logger = logging.getLogger(__name__)
+_RMSNORM_FUSED_ENABLED = True
+
+
+class RMSNorm(RtpModule):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        if hidden_size <= 0:
+            raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+        if eps <= 0:
+            raise ValueError(f"eps must be positive, got {eps}")
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=params_dtype), requires_grad=False
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        for name, tensor in weights.items():
+            if name != "weight":
+                raise RuntimeError(f"Unsupported RMSNorm tensor {name!r}")
+            if not self._assign_weight(self, "weight", tensor):
+                raise RuntimeError("Failed to assign RMSNorm weight")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        global _RMSNORM_FUSED_ENABLED
+
+        if x.ndim == 0 or x.shape[-1] != self.hidden_size:
+            raise ValueError(
+                f"RMSNorm expected last dimension {self.hidden_size}, "
+                f"got shape {tuple(x.shape)}"
+            )
+        if x.is_cuda and _RMSNORM_FUSED_ENABLED:
+            try:
+                original_shape = x.shape
+                input_2d = x.reshape(-1, original_shape[-1]).contiguous()
+                if getattr(torch.version, "hip", None) is not None:
+                    from aiter import rms_norm
+
+                    output = rms_norm(input_2d, self.weight.data, self.eps)
+                else:
+                    from rtp_llm.ops.compute_ops import rtp_llm_ops
+
+                    output = torch.empty_like(input_2d)
+                    stream_id = torch.cuda.current_stream().cuda_stream
+                    rtp_llm_ops.rmsnorm(
+                        output,
+                        input_2d,
+                        self.weight.data,
+                        self.eps,
+                        stream_id,
+                    )
+                return output.reshape(original_shape)
+            except Exception as exc:
+                if isinstance(exc, torch.cuda.OutOfMemoryError):
+                    raise
+                _RMSNORM_FUSED_ENABLED = False
+                logger.warning(
+                    "Fused RMSNorm is unavailable; disabling it and using eager "
+                    "fallback: %s",
+                    exc,
+                )
+
+        input_dtype = x.dtype
+        fp32 = x.float()
+        variance = fp32.pow(2).mean(-1, keepdim=True)
+        normalized = fp32 * torch.rsqrt(variance + self.eps)
+        return (self.weight * normalized).to(input_dtype)

--- a/rtp_llm/models_py/model_desc/block_map.py
+++ b/rtp_llm/models_py/model_desc/block_map.py
@@ -1,27 +1,3 @@
-from rtp_llm.ops.compute_ops import PyAttentionInputs
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
 
-
-def select_block_map_for_layer(
-    attention_inputs: PyAttentionInputs, layer_idx: int
-) -> int:
-    if attention_inputs.kv_cache_kernel_block_id_device_by_group is None:
-        return
-
-    gid = 0
-    if attention_inputs.kv_cache_layer_to_group is not None:
-        gid = int(attention_inputs.kv_cache_layer_to_group[layer_idx].item())
-
-    if attention_inputs.kv_cache_kernel_block_id_device_by_group is not None and len(
-        attention_inputs.kv_cache_kernel_block_id_device_by_group
-    ):
-        attention_inputs.kv_cache_kernel_block_id_device = (
-            attention_inputs.kv_cache_kernel_block_id_device_by_group[gid]
-        )
-
-    if attention_inputs.kv_cache_kernel_block_id_by_group is not None and len(
-        attention_inputs.kv_cache_kernel_block_id_by_group
-    ):
-        attention_inputs.kv_cache_kernel_block_id = (
-            attention_inputs.kv_cache_kernel_block_id_by_group[gid]
-        )
-    return gid
+__all__ = ["select_block_map_for_layer"]

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -44,6 +44,10 @@ class NewLoaderConfig:
     compute_dtype: torch.dtype = torch.float16
     device: str = "cuda"
     load_method: NewLoaderLoadMethod = NewLoaderLoadMethod.AUTO
+    quant_config: Any = None
+    parallelism_config: Any = None
+    fmha_config: Any = None
+    device_resource_config: Any = None
 
     def __post_init__(self) -> None:
         if isinstance(self.load_method, str):
@@ -79,6 +83,28 @@ class NewLoaderConfig:
         if not isinstance(self.compute_dtype, torch.dtype):
             raise TypeError("compute_dtype must be a torch.dtype")
         _validate_runtime_device(self.device, "device")
+        if self.parallelism_config is not None:
+            for prefix in ("tp", "ep"):
+                configured_size = getattr(
+                    self.parallelism_config, f"{prefix}_size", None
+                )
+                configured_rank = getattr(
+                    self.parallelism_config, f"{prefix}_rank", None
+                )
+                if configured_size is None and configured_rank is None:
+                    continue
+                expected = (
+                    (self.tp_size, self.tp_rank)
+                    if prefix == "tp"
+                    else (self.ep_size, self.ep_rank)
+                )
+                if (configured_size, configured_rank) != expected:
+                    raise ValueError(
+                        f"parallelism_config {prefix.upper()} partition does not "
+                        f"match NewLoaderConfig: parallelism="
+                        f"({configured_rank}, {configured_size}) loader="
+                        f"({expected[1]}, {expected[0]})"
+                    )
 
 
 class NewModelLoader:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -48,6 +48,12 @@ class NewLoaderConfig:
     parallelism_config: Any = None
     fmha_config: Any = None
     device_resource_config: Any = None
+    attn_tp_size: Optional[int] = None
+    attn_tp_rank: Optional[int] = None
+    ffn_tp_size: Optional[int] = None
+    ffn_tp_rank: Optional[int] = None
+    lm_head_tp_size: Optional[int] = None
+    lm_head_tp_rank: Optional[int] = None
 
     def __post_init__(self) -> None:
         if isinstance(self.load_method, str):
@@ -76,6 +82,27 @@ class NewLoaderConfig:
             raise ValueError(
                 f"Invalid TP partition: rank={self.tp_rank}, size={self.tp_size}"
             )
+        for prefix in ("attn_tp", "ffn_tp", "lm_head_tp"):
+            size_name = f"{prefix}_size"
+            rank_name = f"{prefix}_rank"
+            size = getattr(self, size_name)
+            rank = getattr(self, rank_name)
+            if size is None and rank is None:
+                size, rank = self.tp_size, self.tp_rank
+                object.__setattr__(self, size_name, size)
+                object.__setattr__(self, rank_name, rank)
+            elif size is None or rank is None:
+                raise ValueError(
+                    f"{size_name} and {rank_name} must be configured together"
+                )
+            if isinstance(size, bool) or not isinstance(size, int):
+                raise TypeError(f"{size_name} must be an integer")
+            if isinstance(rank, bool) or not isinstance(rank, int):
+                raise TypeError(f"{rank_name} must be an integer")
+            if size <= 0 or not 0 <= rank < size:
+                raise ValueError(
+                    f"Invalid {prefix} partition: rank={rank}, size={size}"
+                )
         if self.ep_size <= 0 or not 0 <= self.ep_rank < self.ep_size:
             raise ValueError(
                 f"Invalid EP partition: rank={self.ep_rank}, size={self.ep_size}"
@@ -104,6 +131,33 @@ class NewLoaderConfig:
                         f"match NewLoaderConfig: parallelism="
                         f"({configured_rank}, {configured_size}) loader="
                         f"({expected[1]}, {expected[0]})"
+                    )
+            topology_getters = {
+                "attn_tp": ("get_attn_tp_size", "get_attn_tp_rank"),
+                "ffn_tp": ("get_ffn_tp_size", "get_ffn_tp_rank"),
+                "lm_head_tp": ("tp_size", "tp_rank"),
+            }
+            for prefix, (
+                size_getter_name,
+                rank_getter_name,
+            ) in topology_getters.items():
+                size_source = getattr(self.parallelism_config, size_getter_name, None)
+                rank_source = getattr(self.parallelism_config, rank_getter_name, None)
+                if callable(size_source) and callable(rank_source):
+                    actual = (size_source(), rank_source())
+                elif size_source is not None and rank_source is not None:
+                    actual = (size_source, rank_source)
+                else:
+                    continue
+                expected = (
+                    getattr(self, f"{prefix}_size"),
+                    getattr(self, f"{prefix}_rank"),
+                )
+                if actual != expected:
+                    raise ValueError(
+                        f"parallelism_config {prefix} partition does not match "
+                        f"NewLoaderConfig: parallelism=({actual[1]}, {actual[0]}) "
+                        f"loader=({expected[1]}, {expected[0]})"
                     )
 
 
@@ -247,10 +301,18 @@ class NewModelLoader:
         method = self._resolve_load_method()
         if method != NewLoaderLoadMethod.SCRATCH:
             raise RuntimeError(f"Resolved unsupported load method: {method}")
+        checkpoint_files = self._checkpoint_files()
         model = self._create_model()
+        if weight_mapper.is_rank_local_checkpoint(checkpoint_files) and not bool(
+            getattr(model, "supports_rank_local_checkpoint", False)
+        ):
+            raise ValueError(
+                f"{type(model).__name__} does not support rank-local consolidated "
+                "checkpoints; use a global HF checkpoint"
+            )
         started = time.time()
         model.load_weights(
-            weight_mapper.get_all_weights(self._checkpoint_files(), device="cpu")
+            weight_mapper.get_all_weights(checkpoint_files, device="cpu")
         )
         self._validate_loaded_weights(model)
         logger.info("Streamed checkpoint tensors in %.2fs", time.time() - started)

--- a/rtp_llm/models_py/module_base.py
+++ b/rtp_llm/models_py/module_base.py
@@ -163,11 +163,15 @@ class RtpModule(nn.Module):
     def _mark_weight_loaded(self, name: str) -> None:
         parameter = self._parameters.get(name)
         buffer = self._buffers.get(name)
-        if not isinstance(parameter, nn.Parameter) and not isinstance(
-            buffer, torch.Tensor
-        ):
+        is_parameter = isinstance(parameter, nn.Parameter)
+        is_persistent_buffer = (
+            isinstance(buffer, torch.Tensor)
+            and name not in self._non_persistent_buffers_set
+        )
+        if not is_parameter and not is_persistent_buffer:
             raise KeyError(
-                f"{type(self).__name__} has no parameter or buffer named {name!r}"
+                f"{type(self).__name__} has no loadable parameter or persistent "
+                f"buffer named {name!r}"
             )
         _mark_loaded(self, name)
 

--- a/rtp_llm/models_py/module_base.py
+++ b/rtp_llm/models_py/module_base.py
@@ -160,6 +160,31 @@ class RtpModule(nn.Module):
         _mark_loaded(module, name)
         return True
 
+    def _mark_weight_loaded(self, name: str) -> None:
+        parameter = self._parameters.get(name)
+        buffer = self._buffers.get(name)
+        if not isinstance(parameter, nn.Parameter) and not isinstance(
+            buffer, torch.Tensor
+        ):
+            raise KeyError(
+                f"{type(self).__name__} has no parameter or buffer named {name!r}"
+            )
+        _mark_loaded(self, name)
+
+    @staticmethod
+    def _fused_shard_target(module: nn.Module, shard_name: str):
+        matches = []
+        for child in module.children():
+            shard_names = getattr(child, "shard_names", ())
+            if shard_name in shard_names:
+                matches.append(child)
+        if len(matches) > 1:
+            raise RuntimeError(
+                f"Ambiguous fused shard {shard_name!r} under "
+                f"{type(module).__name__}"
+            )
+        return matches[0] if matches else None
+
     def _dispatch_to_module_list(
         self, module_list: nn.ModuleList, name: str, tensor: torch.Tensor
     ) -> bool:
@@ -184,6 +209,11 @@ class RtpModule(nn.Module):
             return self._assign_weight(module, name, tensor)
         prefix, rest = name.split(".", 1)
         child = module._modules.get(prefix)
+        if child is None:
+            child = self._fused_shard_target(module, prefix)
+            if child is not None:
+                child.load_weights({name: tensor})
+                return True
         if isinstance(child, nn.ModuleList):
             return self._dispatch_to_module_list(child, rest, tensor)
         if not isinstance(child, nn.Module):

--- a/rtp_llm/models_py/new_loader_test/foundation_test.py
+++ b/rtp_llm/models_py/new_loader_test/foundation_test.py
@@ -33,6 +33,8 @@ class _Block(RtpModule):
 
 
 class _FoundationModel(RtpModule):
+    supports_rank_local_checkpoint = True
+
     def __init__(self, model_config, load_config):
         super().__init__()
         self.layers = nn.ModuleList([_Block()])

--- a/rtp_llm/models_py/new_models/__init__.py
+++ b/rtp_llm/models_py/new_models/__init__.py
@@ -1,0 +1,6 @@
+"""Lazy new-loader model package.
+
+Model classes are imported by rtp_llm.models_py.registry on demand.
+"""
+
+__all__ = []

--- a/rtp_llm/models_py/new_models/model_base.py
+++ b/rtp_llm/models_py/new_models/model_base.py
@@ -1,0 +1,98 @@
+from typing import Any, Optional
+
+from torch import Tensor
+
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.ops import DeviceResourceConfig
+from rtp_llm.ops.compute_ops import (
+    KVCache,
+    PyModelInitResources,
+    PyModelInputs,
+    PyModelOutputs,
+)
+
+
+def required_config_value(config: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(config, dict):
+            value = config.get(name)
+        else:
+            value = getattr(config, name, None)
+        if value is not None:
+            return value
+    raise ValueError(f"Model config requires one of {names}")
+
+
+class NewLoaderModelBase(RtpModule):
+    """Runtime base for models whose parameters are owned by the PyModel."""
+
+    def __init__(
+        self,
+        config: Any,
+        parallelism_config,
+        fmha_config=None,
+        device_resource_config: Optional[DeviceResourceConfig] = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.parallelism_config = parallelism_config
+        self.fmha_config = fmha_config
+        self.weight = None
+        self.micro_batch_size = (
+            1
+            if device_resource_config
+            and device_resource_config.enable_layer_micro_batch == 0
+            else 2
+        )
+        self.layer_num = required_config_value(
+            config, "num_layers", "num_hidden_layers"
+        )
+        self.vocab_size = required_config_value(config, "vocab_size")
+        self.kv_cache: Optional[KVCache] = None
+        self.params_dict: dict[int, Any] = {}
+
+    def initialize(self, init_resource: PyModelInitResources) -> bool:
+        self.kv_cache = init_resource.kv_cache
+        return True
+
+    def fill_params(
+        self,
+        sequence_lengths: Tensor,
+        input_lengths: Tensor,
+        kv_cache_block_id_host: Tensor,
+        replay_batch_size: int,
+        capture_batch_size: int,
+        seq_size_per_block: int,
+    ) -> None:
+        if capture_batch_size not in self.params_dict:
+            raise ValueError(f"No captured FMHA params for batch {capture_batch_size}")
+        params = self.params_dict[capture_batch_size]
+        if params is None:
+            raise RuntimeError("Captured FMHA params cannot be None")
+        params.fillParams(
+            sequence_lengths,
+            input_lengths,
+            kv_cache_block_id_host,
+            replay_batch_size,
+            seq_size_per_block,
+        )
+
+    def prepare_fmha_impl(
+        self, inputs: PyModelInputs, is_cuda_graph: bool = False
+    ) -> Any:
+        from rtp_llm.models_py.modules import AttnImplFactory
+
+        return AttnImplFactory.get_fmha_impl(
+            self.config,
+            self.parallelism_config,
+            self.weight,
+            inputs.attention_inputs,
+            self.fmha_config,
+            is_cuda_graph,
+        )
+
+    def runtime_weight_view(self) -> dict[str, Tensor]:
+        raise NotImplementedError
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        raise NotImplementedError

--- a/rtp_llm/models_py/new_models/model_base.py
+++ b/rtp_llm/models_py/new_models/model_base.py
@@ -6,10 +6,37 @@ from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.ops import DeviceResourceConfig
 from rtp_llm.ops.compute_ops import (
     KVCache,
+    PyAttentionInputs,
     PyModelInitResources,
     PyModelInputs,
     PyModelOutputs,
 )
+
+
+def select_block_map_for_layer(
+    attention_inputs: PyAttentionInputs, layer_idx: int
+) -> Optional[int]:
+    if attention_inputs.kv_cache_kernel_block_id_device_by_group is None:
+        return
+
+    gid = 0
+    if attention_inputs.kv_cache_layer_to_group is not None:
+        gid = int(attention_inputs.kv_cache_layer_to_group[layer_idx].item())
+
+    if attention_inputs.kv_cache_kernel_block_id_device_by_group is not None and len(
+        attention_inputs.kv_cache_kernel_block_id_device_by_group
+    ):
+        attention_inputs.kv_cache_kernel_block_id_device = (
+            attention_inputs.kv_cache_kernel_block_id_device_by_group[gid]
+        )
+
+    if attention_inputs.kv_cache_kernel_block_id_by_group is not None and len(
+        attention_inputs.kv_cache_kernel_block_id_by_group
+    ):
+        attention_inputs.kv_cache_kernel_block_id = (
+            attention_inputs.kv_cache_kernel_block_id_by_group[gid]
+        )
+    return gid
 
 
 def required_config_value(config: Any, *names: str) -> Any:
@@ -25,6 +52,8 @@ def required_config_value(config: Any, *names: str) -> Any:
 
 class NewLoaderModelBase(RtpModule):
     """Runtime base for models whose parameters are owned by the PyModel."""
+
+    supports_rank_local_checkpoint = False
 
     def __init__(
         self,

--- a/rtp_llm/models_py/new_models/qwen3/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen3/__init__.py
@@ -1,0 +1,3 @@
+from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+
+__all__ = ["Qwen3ForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen3/language.py
+++ b/rtp_llm/models_py/new_models/qwen3/language.py
@@ -16,6 +16,7 @@ from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.model_base import (
     NewLoaderModelBase,
     required_config_value,
+    select_block_map_for_layer,
 )
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.weight_mapper import WeightsMapper
@@ -213,8 +214,10 @@ class Qwen3DecoderLayer(RtpModule):
         intermediate_size: int,
         head_dim: int,
         layer_idx: int = 0,
-        tp_size: int = 1,
-        tp_rank: int = 0,
+        attn_tp_size: int = 1,
+        attn_tp_rank: int = 0,
+        ffn_tp_size: int = 1,
+        ffn_tp_rank: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         params_dtype: torch.dtype = torch.float16,
         rms_norm_eps: float = 1e-6,
@@ -229,8 +232,8 @@ class Qwen3DecoderLayer(RtpModule):
             num_kv_heads=num_kv_heads,
             head_dim=head_dim,
             layer_idx=layer_idx,
-            tp_size=tp_size,
-            tp_rank=tp_rank,
+            tp_size=attn_tp_size,
+            tp_rank=attn_tp_rank,
             quant_config=quant_config,
             params_dtype=params_dtype,
             rms_norm_eps=rms_norm_eps,
@@ -241,8 +244,8 @@ class Qwen3DecoderLayer(RtpModule):
         self.mlp = Qwen3MLP(
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            tp_size=tp_size,
-            tp_rank=tp_rank,
+            tp_size=ffn_tp_size,
+            tp_rank=ffn_tp_rank,
             quant_config=quant_config,
             params_dtype=params_dtype,
         )
@@ -308,6 +311,8 @@ def _extract_config_values(model_config: Any, load_config: Any):
         if attn_config is not None:
             num_heads = required_config_value(attn_config, "head_num")
             num_kv_heads = getattr(attn_config, "kv_head_num", num_heads)
+            if num_kv_heads == -1:
+                num_kv_heads = num_heads
             head_dim = _resolve_head_dim(
                 hidden_size,
                 num_heads,
@@ -327,6 +332,12 @@ def _extract_config_values(model_config: Any, load_config: Any):
 
     tp_size = required_config_value(load_config, "tp_size")
     tp_rank = required_config_value(load_config, "tp_rank")
+    attn_tp_size = required_config_value(load_config, "attn_tp_size")
+    attn_tp_rank = required_config_value(load_config, "attn_tp_rank")
+    ffn_tp_size = required_config_value(load_config, "ffn_tp_size")
+    ffn_tp_rank = required_config_value(load_config, "ffn_tp_rank")
+    lm_head_tp_size = required_config_value(load_config, "lm_head_tp_size")
+    lm_head_tp_rank = required_config_value(load_config, "lm_head_tp_rank")
     quant_config = getattr(load_config, "quant_config", None)
     params_dtype = getattr(load_config, "compute_dtype", torch.float16)
     enable_fp32_lm_head = (
@@ -346,6 +357,29 @@ def _extract_config_values(model_config: Any, load_config: Any):
     }
     for name, value in dimensions.items():
         _positive_int(value, name)
+    for name, size, rank in (
+        ("TP", tp_size, tp_rank),
+        ("attention TP", attn_tp_size, attn_tp_rank),
+        ("FFN TP", ffn_tp_size, ffn_tp_rank),
+        ("LM head TP", lm_head_tp_size, lm_head_tp_rank),
+    ):
+        _positive_int(size, f"{name} size")
+        if isinstance(rank, bool) or not isinstance(rank, int) or not 0 <= rank < size:
+            raise ValueError(f"Invalid {name} partition: rank={rank}, size={size}")
+    if (attn_tp_size, attn_tp_rank) != (tp_size, tp_rank):
+        raise ValueError(
+            "Context parallelism is not supported by the Qwen dense newloader slice"
+        )
+    if (ffn_tp_size, ffn_tp_rank) != (attn_tp_size, attn_tp_rank):
+        raise ValueError(
+            "Independent FFN TP/sequence parallelism is not supported by the "
+            "Qwen dense newloader slice"
+        )
+    if (lm_head_tp_size, lm_head_tp_rank) != (tp_size, tp_rank):
+        raise ValueError(
+            "A separate LM head topology is not supported by the Qwen dense "
+            "newloader slice"
+        )
 
     return dict(
         hidden_size=hidden_size,
@@ -358,10 +392,33 @@ def _extract_config_values(model_config: Any, load_config: Any):
         rms_norm_eps=rms_norm_eps,
         tp_size=tp_size,
         tp_rank=tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+        ffn_tp_size=ffn_tp_size,
+        ffn_tp_rank=ffn_tp_rank,
+        lm_head_tp_size=lm_head_tp_size,
+        lm_head_tp_rank=lm_head_tp_rank,
         quant_config=quant_config,
         params_dtype=params_dtype,
         lm_head_params_dtype=torch.float32 if enable_fp32_lm_head else params_dtype,
     )
+
+
+def _validate_supported_parallelism(parallelism_config: Any) -> None:
+    prefill_cp = getattr(parallelism_config, "prefill_cp_config", None)
+    if prefill_cp is not None:
+        for checker_name in ("is_enabled", "is_prefill_enabled"):
+            checker = getattr(prefill_cp, checker_name, None)
+            if callable(checker) and bool(checker()):
+                raise ValueError(
+                    "Context parallelism is not supported by the Qwen dense "
+                    "newloader slice"
+                )
+    ffn_disaggregate = getattr(parallelism_config, "ffn_disaggregate_config", None)
+    if bool(getattr(ffn_disaggregate, "enable_ffn_disaggregate", False)):
+        raise ValueError(
+            "FFN disaggregation is not supported by the Qwen dense newloader slice"
+        )
 
 
 class Qwen3ForCausalLM(NewLoaderModelBase):
@@ -390,12 +447,12 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
         # Qwen3 small variants (e.g. Qwen3-0.6B) tie lm_head to embed_tokens.
         # Mirror HF transformers: when no lm_head.weight is in the ckpt, copy
         # the embedding weights into lm_head so the projection isn't random.
-        if not has_lm_head:
+        if not has_lm_head and self.tie_word_embeddings:
             logging.info(
                 "[Qwen3ForCausalLM] lm_head.weight not found in ckpt; "
                 "tying lm_head to embed_tokens (tie_word_embeddings)"
             )
-            self.lm_head._copy_weight(self.embed_tokens.weight.data)
+            self.lm_head._copy_local_tied_weight(self.embed_tokens.weight.data)
 
     def __init__(self, model_config: Any, load_config: Any):
         parallelism_config = getattr(load_config, "parallelism_config", None)
@@ -412,12 +469,18 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
         )
 
         cfg = _extract_config_values(model_config, load_config)
+        _validate_supported_parallelism(parallelism_config)
+        self.tie_word_embeddings = (
+            bool(model_config.get("tie_word_embeddings", False))
+            if isinstance(model_config, dict)
+            else bool(getattr(model_config, "tie_word_embeddings", False))
+        )
 
         self.embed_tokens = VocabParallelEmbedding(
             vocab_size=cfg["vocab_size"],
             embedding_dim=cfg["hidden_size"],
-            tp_size=cfg["tp_size"],
-            tp_rank=cfg["tp_rank"],
+            tp_size=cfg["attn_tp_size"],
+            tp_rank=cfg["attn_tp_rank"],
             params_dtype=cfg["params_dtype"],
         )
         self.layers = nn.ModuleList(
@@ -429,8 +492,10 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
                     intermediate_size=cfg["intermediate_size"],
                     head_dim=cfg["head_dim"],
                     layer_idx=i,
-                    tp_size=cfg["tp_size"],
-                    tp_rank=cfg["tp_rank"],
+                    attn_tp_size=cfg["attn_tp_size"],
+                    attn_tp_rank=cfg["attn_tp_rank"],
+                    ffn_tp_size=cfg["ffn_tp_size"],
+                    ffn_tp_rank=cfg["ffn_tp_rank"],
                     quant_config=cfg["quant_config"],
                     params_dtype=cfg["params_dtype"],
                     rms_norm_eps=cfg["rms_norm_eps"],
@@ -446,8 +511,8 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
         self.lm_head = ParallelLMHead(
             vocab_size=cfg["vocab_size"],
             hidden_size=cfg["hidden_size"],
-            tp_size=cfg["tp_size"],
-            tp_rank=cfg["tp_rank"],
+            tp_size=cfg["lm_head_tp_size"],
+            tp_rank=cfg["lm_head_tp_rank"],
             params_dtype=cfg["lm_head_params_dtype"],
         )
 
@@ -464,6 +529,7 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
         if fmha_impl is None:
             fmha_impl = self.prepare_fmha_impl(inputs)
         for i, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, i)
             hidden_states = layer(
                 hidden_states,
                 fmha_impl,

--- a/rtp_llm/models_py/new_models/qwen3/language.py
+++ b/rtp_llm/models_py/new_models/qwen3/language.py
@@ -1,4 +1,6 @@
 import logging
+import math
+from numbers import Real
 from typing import Any, Optional
 
 import torch
@@ -454,6 +456,19 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
             )
             self.lm_head._copy_local_tied_weight(self.embed_tokens.weight.data)
 
+    def process_weights_after_loading(self) -> None:
+        if self._lm_head_postprocessed:
+            return
+        processed = self.lm_head.weight
+        if self.normalize_lm_head_weight:
+            processed = torch.nn.functional.normalize(processed, dim=1)
+        if self.logit_scale != 1.0:
+            processed = processed * self.logit_scale
+        if processed is not self.lm_head.weight:
+            with torch.no_grad():
+                self.lm_head.weight.copy_(processed)
+        self._lm_head_postprocessed = True
+
     def __init__(self, model_config: Any, load_config: Any):
         parallelism_config = getattr(load_config, "parallelism_config", None)
         if parallelism_config is None:
@@ -475,6 +490,26 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
             if isinstance(model_config, dict)
             else bool(getattr(model_config, "tie_word_embeddings", False))
         )
+        normalize_lm_head_weight = (
+            model_config.get("normalize_lm_head_weight", False)
+            if isinstance(model_config, dict)
+            else getattr(model_config, "normalize_lm_head_weight", False)
+        )
+        if not isinstance(normalize_lm_head_weight, bool):
+            raise TypeError("normalize_lm_head_weight must be a bool")
+        raw_logit_scale = (
+            model_config.get("logit_scale", 1.0)
+            if isinstance(model_config, dict)
+            else getattr(model_config, "logit_scale", 1.0)
+        )
+        if isinstance(raw_logit_scale, bool) or not isinstance(raw_logit_scale, Real):
+            raise TypeError("logit_scale must be a finite real number")
+        logit_scale = float(raw_logit_scale)
+        if not math.isfinite(logit_scale):
+            raise ValueError("logit_scale must be finite")
+        self.normalize_lm_head_weight = normalize_lm_head_weight
+        self.logit_scale = logit_scale
+        self._lm_head_postprocessed = False
 
         self.embed_tokens = VocabParallelEmbedding(
             vocab_size=cfg["vocab_size"],

--- a/rtp_llm/models_py/new_models/qwen3/language.py
+++ b/rtp_llm/models_py/new_models/qwen3/language.py
@@ -1,0 +1,473 @@
+import logging
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.layers.activation import silu_and_mul
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.norm import RMSNorm
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.new_models.model_base import (
+    NewLoaderModelBase,
+    required_config_value,
+)
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import (
+    LayerKVCache,
+    PyModelInputs,
+    PyModelOutputs,
+    rtp_llm_ops,
+)
+
+
+class Qwen3MLP(RtpModule):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+    ):
+        super().__init__()
+        self.tp_size = tp_size
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=2 * intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="gate_up_proj",
+            bias=False,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=params_dtype,
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="down_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up = self.gate_up_proj(x)
+        act = silu_and_mul(gate_up)
+        x = self.down_proj(act)
+        return x
+
+
+class Qwen3Attention(RtpModule):
+    """Qwen3 dense attention.
+
+    Differs from Qwen2 attention by:
+      * No qkv bias (Qwen3 dense ckpts ship without it).
+      * Adds per-head RMSNorm on Q and K (`q_norm`, `k_norm`) applied between
+        qkv_proj and fmha_impl. Weight shape is [head_dim].
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        layer_idx: int = 0,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+        rms_norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.layer_idx = layer_idx
+        self.tp_size = tp_size
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="qkv_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        self.num_heads_per_partition = self.qkv_proj.num_heads_per_partition
+        self.num_kv_heads_per_partition = self.qkv_proj.num_kv_heads_per_partition
+        self.q_size = self.qkv_proj.q_size
+        self.kv_size = self.qkv_proj.kv_size
+        self.q_norm = RMSNorm(head_dim, eps=rms_norm_eps, params_dtype=params_dtype)
+        self.k_norm = RMSNorm(head_dim, eps=rms_norm_eps, params_dtype=params_dtype)
+        self.o_proj = RowParallelLinear(
+            input_size=num_heads * head_dim,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="o_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def _apply_qk_norm(self, qkv: torch.Tensor) -> torch.Tensor:
+        if (
+            qkv.is_cuda
+            and qkv.dim() == 2
+            and getattr(torch.version, "hip", None) is not None
+        ):
+            qkv = qkv.contiguous()
+            m, n = qkv.shape
+            rtp_llm_ops.fused_qk_rmsnorm_v2(
+                qkv,
+                self.q_norm.weight.data,
+                self.k_norm.weight.data,
+                self.q_norm.eps,
+                self.num_heads_per_partition,
+                self.num_kv_heads_per_partition,
+                m,
+                n,
+                self.head_dim,
+            )
+            return qkv
+
+        if qkv.is_cuda and qkv.dim() == 2:
+            try:
+                import flashinfer
+
+                m, n = qkv.shape
+                qkv_view = qkv.reshape(
+                    m,
+                    self.num_heads_per_partition + self.num_kv_heads_per_partition * 2,
+                    self.head_dim,
+                )
+                q = qkv_view[:, : self.num_heads_per_partition, :]
+                k = qkv_view[
+                    :,
+                    self.num_heads_per_partition : self.num_heads_per_partition
+                    + self.num_kv_heads_per_partition,
+                    :,
+                ]
+                flashinfer.norm.rmsnorm(
+                    q, self.q_norm.weight.data, eps=self.q_norm.eps, out=q
+                )
+                flashinfer.norm.rmsnorm(
+                    k, self.k_norm.weight.data, eps=self.k_norm.eps, out=k
+                )
+                return qkv_view.reshape(m, n)
+            except ModuleNotFoundError:
+                pass
+
+        prefix_shape = qkv.shape[:-1]
+        q = qkv[..., : self.q_size].reshape(
+            *prefix_shape, self.num_heads_per_partition, self.head_dim
+        )
+        k = qkv[..., self.q_size : self.q_size + self.kv_size].reshape(
+            *prefix_shape, self.num_kv_heads_per_partition, self.head_dim
+        )
+        v = qkv[..., self.q_size + self.kv_size :]
+        q = self.q_norm(q).reshape(*prefix_shape, self.q_size)
+        k = self.k_norm(k).reshape(*prefix_shape, self.kv_size)
+        return torch.cat([q, k, v], dim=-1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        qkv = self.qkv_proj(hidden_states)
+        qkv = self._apply_qk_norm(qkv)
+        attn_output = fmha_impl.forward(qkv, kv_cache, self.layer_idx)
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        output = self.o_proj(attn_output)
+        return output
+
+
+class Qwen3DecoderLayer(RtpModule):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        intermediate_size: int,
+        head_dim: int,
+        layer_idx: int = 0,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+        rms_norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.input_layernorm = RMSNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.self_attn = Qwen3Attention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            layer_idx=layer_idx,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            rms_norm_eps=rms_norm_eps,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, fmha_impl, kv_cache)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def _resolve_head_dim(hidden_size: Any, num_heads: Any, configured: Any) -> int:
+    hidden_size = _positive_int(hidden_size, "hidden_size")
+    num_heads = _positive_int(num_heads, "num_heads")
+    if configured is not None:
+        return _positive_int(configured, "head_dim")
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"hidden_size={hidden_size} must be divisible by num_heads={num_heads} "
+            "when head_dim is not configured"
+        )
+    return hidden_size // num_heads
+
+
+def _extract_config_values(model_config: Any, load_config: Any):
+    if isinstance(model_config, dict):
+        hidden_size = required_config_value(model_config, "hidden_size")
+        num_heads = required_config_value(model_config, "num_attention_heads")
+        num_kv_heads = model_config.get("num_key_value_heads", num_heads)
+        intermediate_size = required_config_value(model_config, "intermediate_size")
+        num_layers = required_config_value(model_config, "num_hidden_layers")
+        vocab_size = required_config_value(model_config, "vocab_size")
+        head_dim = _resolve_head_dim(
+            hidden_size, num_heads, model_config.get("head_dim")
+        )
+        rms_norm_eps = model_config.get("rms_norm_eps", 1e-6)
+    else:
+        hidden_size = required_config_value(model_config, "hidden_size")
+        num_layers = required_config_value(
+            model_config, "num_layers", "num_hidden_layers"
+        )
+        vocab_size = required_config_value(model_config, "vocab_size")
+        intermediate_size = required_config_value(
+            model_config, "inter_size", "intermediate_size"
+        )
+        attn_config = getattr(model_config, "attn_config", None)
+        if attn_config is not None:
+            num_heads = required_config_value(attn_config, "head_num")
+            num_kv_heads = getattr(attn_config, "kv_head_num", num_heads)
+            head_dim = _resolve_head_dim(
+                hidden_size,
+                num_heads,
+                getattr(attn_config, "size_per_head", None),
+            )
+        else:
+            num_heads = required_config_value(model_config, "num_attention_heads")
+            num_kv_heads = getattr(model_config, "num_key_value_heads", num_heads)
+            head_dim = _resolve_head_dim(
+                hidden_size, num_heads, getattr(model_config, "head_dim", None)
+            )
+        rms_norm_eps = getattr(
+            model_config,
+            "layernorm_eps",
+            getattr(model_config, "rms_norm_eps", 1e-6),
+        )
+
+    tp_size = required_config_value(load_config, "tp_size")
+    tp_rank = required_config_value(load_config, "tp_rank")
+    quant_config = getattr(load_config, "quant_config", None)
+    params_dtype = getattr(load_config, "compute_dtype", torch.float16)
+    enable_fp32_lm_head = (
+        model_config.get("enable_fp32_lm_head", True)
+        if isinstance(model_config, dict)
+        else getattr(model_config, "enable_fp32_lm_head", True)
+    )
+
+    dimensions = {
+        "hidden_size": hidden_size,
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "intermediate_size": intermediate_size,
+        "num_layers": num_layers,
+        "vocab_size": vocab_size,
+        "head_dim": head_dim,
+    }
+    for name, value in dimensions.items():
+        _positive_int(value, name)
+
+    return dict(
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        intermediate_size=intermediate_size,
+        num_layers=num_layers,
+        vocab_size=vocab_size,
+        head_dim=head_dim,
+        rms_norm_eps=rms_norm_eps,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        quant_config=quant_config,
+        params_dtype=params_dtype,
+        lm_head_params_dtype=torch.float32 if enable_fp32_lm_head else params_dtype,
+    )
+
+
+class Qwen3ForCausalLM(NewLoaderModelBase):
+
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.": ""},
+    )
+
+    def load_weights(self, weights):
+        if isinstance(weights, dict):
+            weights_iter = iter(weights.items())
+        else:
+            weights_iter = weights
+        has_lm_head = False
+
+        def _track(it):
+            nonlocal has_lm_head
+            for name, tensor in it:
+                if name == "lm_head.weight":
+                    has_lm_head = True
+                yield name, tensor
+
+        mapped_iter = self.WEIGHTS_MAPPER.apply(weights_iter)
+        super().load_weights(_track(mapped_iter))
+
+        # Qwen3 small variants (e.g. Qwen3-0.6B) tie lm_head to embed_tokens.
+        # Mirror HF transformers: when no lm_head.weight is in the ckpt, copy
+        # the embedding weights into lm_head so the projection isn't random.
+        if not has_lm_head:
+            logging.info(
+                "[Qwen3ForCausalLM] lm_head.weight not found in ckpt; "
+                "tying lm_head to embed_tokens (tie_word_embeddings)"
+            )
+            self.lm_head._copy_weight(self.embed_tokens.weight.data)
+
+    def __init__(self, model_config: Any, load_config: Any):
+        parallelism_config = getattr(load_config, "parallelism_config", None)
+        if parallelism_config is None:
+            raise ValueError("Qwen3 newloader requires parallelism_config")
+        fmha_config = getattr(load_config, "fmha_config", None)
+        device_resource_config = getattr(load_config, "device_resource_config", None)
+
+        super().__init__(
+            config=model_config,
+            parallelism_config=parallelism_config,
+            fmha_config=fmha_config,
+            device_resource_config=device_resource_config,
+        )
+
+        cfg = _extract_config_values(model_config, load_config)
+
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size=cfg["vocab_size"],
+            embedding_dim=cfg["hidden_size"],
+            tp_size=cfg["tp_size"],
+            tp_rank=cfg["tp_rank"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DecoderLayer(
+                    hidden_size=cfg["hidden_size"],
+                    num_heads=cfg["num_heads"],
+                    num_kv_heads=cfg["num_kv_heads"],
+                    intermediate_size=cfg["intermediate_size"],
+                    head_dim=cfg["head_dim"],
+                    layer_idx=i,
+                    tp_size=cfg["tp_size"],
+                    tp_rank=cfg["tp_rank"],
+                    quant_config=cfg["quant_config"],
+                    params_dtype=cfg["params_dtype"],
+                    rms_norm_eps=cfg["rms_norm_eps"],
+                )
+                for i in range(cfg["num_layers"])
+            ]
+        )
+        self.norm = RMSNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.lm_head = ParallelLMHead(
+            vocab_size=cfg["vocab_size"],
+            hidden_size=cfg["hidden_size"],
+            tp_size=cfg["tp_size"],
+            tp_rank=cfg["tp_rank"],
+            params_dtype=cfg["lm_head_params_dtype"],
+        )
+
+    def runtime_weight_view(self) -> dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids = inputs.input_ids
+        hidden_states = self.embed_tokens(input_ids)
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+        for i, layer in enumerate(self.layers):
+            hidden_states = layer(
+                hidden_states,
+                fmha_impl,
+                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+            )
+        hidden_states = self.norm(hidden_states)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/new_models/qwen3/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen3/test/BUILD
@@ -1,0 +1,10 @@
+py_test(
+    name = "test_qwen3_dense_load",
+    srcs = ["test_qwen3_dense_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen3/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen3/test/BUILD
@@ -8,3 +8,17 @@ py_test(
         "//rtp_llm/models_py:new_weight_loader",
     ],
 )
+
+py_test(
+    name = "test_qwen3_base_model_integration",
+    srcs = ["test_qwen3_base_model_integration.py"],
+    deps = [
+        "//rtp_llm:async_model",
+        "//rtp_llm:models",
+        "//rtp_llm:numpy",
+        "//rtp_llm:rtp_llm_frontend_lib",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -117,6 +117,26 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "p-tuning is not supported"):
             base_model._load_with_new_loader()
 
+    def test_layer_micro_batch_is_rejected_by_public_load(self):
+        config = _model_config()
+        base_model = object.__new__(BaseModel)
+        base_model.model_config = config
+        base_model.parallelism_config = _parallelism_config()
+        base_model.force_cpu_load_weights = False
+        base_model.load_method = LoadMethod.SCRATCH
+        base_model.fmha_config = None
+        base_model.tokenizer = None
+        base_model.hw_kernel_config = types.SimpleNamespace(enable_cuda_graph=False)
+        base_model.device_resource_config = types.SimpleNamespace(
+            enable_layer_micro_batch=1
+        )
+
+        with patch.dict(os.environ, {"USE_NEW_LOADER": "1"}, clear=False):
+            with self.assertRaisesRegex(
+                ValueError, "layer micro-batch is not supported"
+            ):
+                base_model.load()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import types
 import unittest
@@ -82,14 +83,19 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
         base_model.fmha_config = None
         base_model.device_resource_config = None
         base_model.tokenizer = None
+        base_model.hw_kernel_config = types.SimpleNamespace(enable_cuda_graph=False)
 
         with tempfile.TemporaryDirectory() as model_path:
             config.ckpt_path = model_path
             save_file(_weights(), f"{model_path}/model.safetensors")
             with patch.object(
                 BaseModel, "_get_device_str", return_value="cpu"
-            ), patch.object(BaseModel, "_init_custom_module", return_value=None):
-                base_model._load_with_new_loader()
+            ), patch.object(
+                BaseModel, "_init_custom_module", return_value=None
+            ), patch.dict(
+                os.environ, {"USE_NEW_LOADER": "1"}, clear=False
+            ):
+                base_model.load()
 
         self.assertIsInstance(base_model.py_model, Qwen3ForCausalLM)
         self.assertFalse(base_model.py_model.training)

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -1,0 +1,116 @@
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models.base_model import BaseModel
+from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+
+
+def _model_config():
+    return types.SimpleNamespace(
+        model_type="qwen_3",
+        num_layers=1,
+        vocab_size=8,
+        hidden_size=4,
+        inter_size=4,
+        attn_config=types.SimpleNamespace(
+            head_num=2,
+            kv_head_num=1,
+            size_per_head=2,
+        ),
+        layernorm_eps=1e-6,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=True,
+        compute_dtype=torch.float32,
+        lora_infos={},
+        quant_config=types.SimpleNamespace(get_runtime_method_key=lambda: "none"),
+    )
+
+
+def _parallelism_config():
+    return types.SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        local_rank=0,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+        get_attn_tp_size=lambda: 1,
+        get_attn_tp_rank=lambda: 0,
+        get_ffn_tp_size=lambda: 1,
+        get_ffn_tp_rank=lambda: 0,
+    )
+
+
+def _weights():
+    return {
+        "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+            8, 4
+        ),
+        "model.layers.0.input_layernorm.weight": torch.ones(4),
+        "model.layers.0.self_attn.q_proj.weight": torch.ones(4, 4),
+        "model.layers.0.self_attn.k_proj.weight": torch.ones(2, 4),
+        "model.layers.0.self_attn.v_proj.weight": torch.ones(2, 4),
+        "model.layers.0.self_attn.q_norm.weight": torch.ones(2),
+        "model.layers.0.self_attn.k_norm.weight": torch.ones(2),
+        "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+        "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+        "model.layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+        "model.layers.0.mlp.up_proj.weight": torch.ones(4, 4),
+        "model.layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+        "model.norm.weight": torch.ones(4),
+    }
+
+
+class Qwen3BaseModelIntegrationTest(unittest.TestCase):
+    def test_base_model_entry_loads_registered_qwen_runtime(self):
+        config = _model_config()
+        base_model = object.__new__(BaseModel)
+        base_model.model_config = config
+        base_model.parallelism_config = _parallelism_config()
+        base_model.force_cpu_load_weights = False
+        base_model.load_method = LoadMethod.SCRATCH
+        base_model.fmha_config = None
+        base_model.device_resource_config = None
+        base_model.tokenizer = None
+
+        with tempfile.TemporaryDirectory() as model_path:
+            config.ckpt_path = model_path
+            save_file(_weights(), f"{model_path}/model.safetensors")
+            with patch.object(
+                BaseModel, "_get_device_str", return_value="cpu"
+            ), patch.object(BaseModel, "_init_custom_module", return_value=None):
+                base_model._load_with_new_loader()
+
+        self.assertIsInstance(base_model.py_model, Qwen3ForCausalLM)
+        self.assertFalse(base_model.py_model.training)
+        self.assertIs(base_model.py_model.weight, base_model.weight)
+        self.assertIs(base_model.weight_manager, None)
+        self.assertEqual(
+            set(base_model.py_model.runtime_weight_view()),
+            {"embedding", "final_layernorm.gamma", "lm_head"},
+        )
+
+    def test_ptuning_configuration_is_rejected(self):
+        config = _model_config()
+        config.ptuning_path = "/tmp/unsupported-ptuning"
+        base_model = object.__new__(BaseModel)
+        base_model.model_config = config
+        base_model.parallelism_config = _parallelism_config()
+        base_model.force_cpu_load_weights = False
+
+        with self.assertRaisesRegex(ValueError, "p-tuning is not supported"):
+            base_model._load_with_new_loader()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
@@ -1,0 +1,286 @@
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.module_base import collect_loaded_tensor_ids
+from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+
+def _validate(module) -> None:
+    NewModelLoader._validate_loaded_weights(module)
+
+
+class LinearPartitionTest(unittest.TestCase):
+    def test_merged_separate_and_fused_weights_match_for_tp(self):
+        gate = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        up = torch.arange(8, 16, dtype=torch.float32).reshape(4, 2)
+
+        separate = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        separate.load_weights({"gate_proj.weight": gate, "up_proj.weight": up})
+
+        fused = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        fused.load_weights({"gate_up_proj.weight": torch.cat((gate, up), dim=0)})
+
+        expected = torch.cat((gate[2:], up[2:]), dim=0)
+        torch.testing.assert_close(separate.weight, expected)
+        torch.testing.assert_close(fused.weight, expected)
+        _validate(separate)
+        _validate(fused)
+
+    def test_qkv_kv_replication_uses_contiguous_rank_groups(self):
+        q = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+        k = torch.tensor([[20.0, 21.0], [30.0, 31.0]])
+        v = torch.tensor([[40.0, 41.0], [50.0, 51.0]])
+        expected_kv_heads = [0, 0, 1, 1]
+
+        for rank, kv_head in enumerate(expected_kv_heads):
+            layer = QKVParallelLinear(
+                hidden_size=2,
+                num_heads=8,
+                num_kv_heads=2,
+                head_dim=1,
+                tp_size=4,
+                tp_rank=rank,
+                params_dtype=torch.float32,
+            )
+            layer.load_weights(
+                {
+                    "q_proj.weight": q,
+                    "k_proj.weight": k,
+                    "v_proj.weight": v,
+                }
+            )
+            expected = torch.cat(
+                (
+                    q[rank * 2 : rank * 2 + 2],
+                    k[kv_head : kv_head + 1],
+                    v[kv_head : kv_head + 1],
+                ),
+                dim=0,
+            )
+            torch.testing.assert_close(layer.weight, expected)
+            _validate(layer)
+
+    def test_row_parallel_reduces_before_adding_bias(self):
+        layer = RowParallelLinear(
+            input_size=4,
+            output_size=2,
+            tp_size=2,
+            tp_rank=0,
+            bias=True,
+            params_dtype=torch.float32,
+        )
+        layer.load_weights(
+            {
+                "weight": torch.tensor([[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0]]),
+                "bias": torch.tensor([3.0, 5.0]),
+            }
+        )
+        inputs = torch.tensor([[2.0, 4.0]])
+        with patch(
+            "rtp_llm.models_py.layers.linear.all_reduce",
+            side_effect=lambda tensor, group: tensor * 2,
+        ):
+            output = layer(inputs)
+        torch.testing.assert_close(output, torch.tensor([[7.0, 13.0]]))
+
+    def test_merged_rejects_mixed_and_oversized_shards(self):
+        layer = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(ValueError, "rows must be 4"):
+            layer.load_weights({"gate_proj.weight": torch.ones(5, 2)})
+
+        layer.load_weights({"gate_proj.weight": torch.ones(4, 2)})
+        with self.assertRaisesRegex(RuntimeError, "Duplicate"):
+            layer.load_weights({"gate_proj.weight": torch.zeros(4, 2)})
+        torch.testing.assert_close(layer.weight[:4], torch.ones(4, 2))
+        with self.assertRaisesRegex(RuntimeError, "mix fused and per-shard"):
+            layer.load_weights({"gate_up_proj.weight": torch.ones(8, 2)})
+
+    def test_merged_rejects_non_floating_shard_conversion(self):
+        layer = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+
+        with self.assertRaisesRegex(TypeError, "Dtype mismatch"):
+            layer.load_weights(
+                {"gate_proj.weight": torch.ones(4, 2, dtype=torch.int32)}
+            )
+
+    def test_qkv_rejects_invalid_gqa(self):
+        with self.assertRaisesRegex(ValueError, "num_heads=8"):
+            QKVParallelLinear(
+                hidden_size=8,
+                num_heads=8,
+                num_kv_heads=6,
+                head_dim=1,
+                tp_size=4,
+                params_dtype=torch.float32,
+            )
+
+
+class Qwen3LoadTest(unittest.TestCase):
+    def _config(self):
+        return types.SimpleNamespace(
+            model_type="qwen_3",
+            num_layers=1,
+            vocab_size=8,
+            hidden_size=4,
+            inter_size=4,
+            attn_config=types.SimpleNamespace(
+                head_num=2,
+                kv_head_num=1,
+                size_per_head=2,
+            ),
+            layernorm_eps=1e-6,
+            enable_fp32_lm_head=False,
+        )
+
+    def _load_config(self):
+        parallelism = types.SimpleNamespace(tp_size=1, tp_rank=0)
+        return NewLoaderConfig(
+            compute_dtype=torch.float32,
+            device="cpu",
+            quant_config=QuantizationConfig("none"),
+            parallelism_config=parallelism,
+        )
+
+    def _model(self):
+        return Qwen3ForCausalLM(self._config(), self._load_config())
+
+    def _weights(self):
+        values = {
+            "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+                8, 4
+            ),
+            "model.layers.0.input_layernorm.weight": torch.ones(4),
+            "model.layers.0.self_attn.q_proj.weight": torch.arange(
+                16, dtype=torch.float32
+            ).reshape(4, 4),
+            "model.layers.0.self_attn.k_proj.weight": torch.arange(
+                8, dtype=torch.float32
+            ).reshape(2, 4),
+            "model.layers.0.self_attn.v_proj.weight": torch.arange(
+                8, 16, dtype=torch.float32
+            ).reshape(2, 4),
+            "model.layers.0.self_attn.q_norm.weight": torch.ones(2),
+            "model.layers.0.self_attn.k_norm.weight": torch.ones(2),
+            "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+            "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+            "model.layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+            "model.layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+            "model.layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+            "model.norm.weight": torch.ones(4),
+        }
+        return values
+
+    def test_real_model_load_validates_and_ties_missing_lm_head(self):
+        model = self._model()
+        weights = self._weights()
+
+        model.load_weights(weights)
+        _validate(model)
+
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertIn(id(model.lm_head.weight), collect_loaded_tensor_ids(model))
+        self.assertEqual(
+            set(model.runtime_weight_view()),
+            {"embedding", "final_layernorm.gamma", "lm_head"},
+        )
+
+    def test_new_model_loader_streams_real_safetensors(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(self._weights(), f"{model_path}/model.safetensors")
+            loader = NewModelLoader(
+                self._config(),
+                self._load_config(),
+                model_path=model_path,
+            )
+
+            model = loader.load()
+
+        self.assertIsInstance(model, Qwen3ForCausalLM)
+        self.assertFalse(model.training)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+
+    def test_unknown_checkpoint_tensor_fails(self):
+        model = self._model()
+        weights = self._weights()
+        weights["model.layers.0.mlp.gate_prjo.weight"] = torch.ones(4, 4)
+
+        with self.assertRaisesRegex(RuntimeError, "could not dispatch"):
+            model.load_weights(weights)
+
+    def test_unsupported_quantization_fails_fast(self):
+        config = QuantizationConfig("fp8")
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            QKVParallelLinear(
+                hidden_size=4,
+                num_heads=2,
+                num_kv_heads=1,
+                head_dim=2,
+                quant_config=config,
+            )
+
+    def test_missing_required_config_value_fails_fast(self):
+        config = self._config()
+        del config.hidden_size
+
+        with self.assertRaisesRegex(ValueError, "hidden_size"):
+            Qwen3ForCausalLM(config, self._load_config())
+
+    def test_hf_dict_config_constructs_same_model_shape(self):
+        config = {
+            "model_type": "qwen_3",
+            "num_hidden_layers": 1,
+            "vocab_size": 8,
+            "hidden_size": 4,
+            "intermediate_size": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 2,
+            "rms_norm_eps": 1e-6,
+            "enable_fp32_lm_head": False,
+        }
+
+        model = Qwen3ForCausalLM(config, self._load_config())
+
+        self.assertEqual(len(model.layers), 1)
+        self.assertEqual(model.embed_tokens.weight.shape, (8, 4))
+        self.assertEqual(model.layers[0].self_attn.qkv_proj.weight.shape, (8, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
@@ -4,9 +4,11 @@ import unittest
 from unittest.mock import patch
 
 import torch
+import torch.nn.functional as F
 from safetensors.torch import save_file
 
 from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
@@ -15,6 +17,7 @@ from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.module_base import collect_loaded_tensor_ids
 from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
 from rtp_llm.models_py.quant_methods import QuantizationConfig
+from rtp_llm.ops.compute_ops import PyModelInputs
 
 
 def _validate(module) -> None:
@@ -22,6 +25,15 @@ def _validate(module) -> None:
 
 
 class LinearPartitionTest(unittest.TestCase):
+    def test_column_parallel_rejects_unimplemented_gather_output(self):
+        with self.assertRaisesRegex(ValueError, "gather_output is not supported"):
+            ColumnParallelLinear(
+                input_size=2,
+                output_size=4,
+                gather_output=True,
+                params_dtype=torch.float32,
+            )
+
     def test_merged_separate_and_fused_weights_match_for_tp(self):
         gate = torch.arange(8, dtype=torch.float32).reshape(4, 2)
         up = torch.arange(8, 16, dtype=torch.float32).reshape(4, 2)
@@ -166,11 +178,55 @@ class Qwen3LoadTest(unittest.TestCase):
             ),
             layernorm_eps=1e-6,
             enable_fp32_lm_head=False,
+            tie_word_embeddings=True,
         )
 
-    def _load_config(self):
-        parallelism = types.SimpleNamespace(tp_size=1, tp_rank=0)
+    def _load_config(
+        self,
+        tp_size=1,
+        tp_rank=0,
+        attn_tp_size=None,
+        attn_tp_rank=None,
+        ffn_tp_size=None,
+        ffn_tp_rank=None,
+        lm_head_tp_size=None,
+        lm_head_tp_rank=None,
+        cp_enabled=False,
+        prefill_cp_enabled=False,
+        ffn_disaggregate=False,
+    ):
+        attn_tp_size = tp_size if attn_tp_size is None else attn_tp_size
+        attn_tp_rank = tp_rank if attn_tp_rank is None else attn_tp_rank
+        ffn_tp_size = tp_size if ffn_tp_size is None else ffn_tp_size
+        ffn_tp_rank = tp_rank if ffn_tp_rank is None else ffn_tp_rank
+        lm_head_tp_size = tp_size if lm_head_tp_size is None else lm_head_tp_size
+        lm_head_tp_rank = tp_rank if lm_head_tp_rank is None else lm_head_tp_rank
+        parallelism = types.SimpleNamespace(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            ep_size=1,
+            ep_rank=0,
+            prefill_cp_config=types.SimpleNamespace(
+                is_enabled=lambda: cp_enabled,
+                is_prefill_enabled=lambda: prefill_cp_enabled,
+            ),
+            ffn_disaggregate_config=types.SimpleNamespace(
+                enable_ffn_disaggregate=ffn_disaggregate
+            ),
+            get_attn_tp_size=lambda: attn_tp_size,
+            get_attn_tp_rank=lambda: attn_tp_rank,
+            get_ffn_tp_size=lambda: ffn_tp_size,
+            get_ffn_tp_rank=lambda: ffn_tp_rank,
+        )
         return NewLoaderConfig(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            attn_tp_size=attn_tp_size,
+            attn_tp_rank=attn_tp_rank,
+            ffn_tp_size=ffn_tp_size,
+            ffn_tp_rank=ffn_tp_rank,
+            lm_head_tp_size=lm_head_tp_size,
+            lm_head_tp_rank=lm_head_tp_rank,
             compute_dtype=torch.float32,
             device="cpu",
             quant_config=QuantizationConfig("none"),
@@ -220,6 +276,118 @@ class Qwen3LoadTest(unittest.TestCase):
             {"embedding", "final_layernorm.gamma", "lm_head"},
         )
 
+    def test_untied_model_rejects_missing_lm_head(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen3ForCausalLM(config, self._load_config())
+
+        model.load_weights(self._weights())
+
+        with self.assertRaisesRegex(RuntimeError, "ParallelLMHead.*weight"):
+            _validate(model)
+
+    def test_untied_model_loads_explicit_lm_head(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen3ForCausalLM(config, self._load_config())
+        weights = self._weights()
+        weights["lm_head.weight"] = torch.arange(32, 64, dtype=torch.float32).reshape(
+            8, 4
+        )
+
+        model.load_weights(weights)
+        _validate(model)
+
+        torch.testing.assert_close(model.lm_head.weight, weights["lm_head.weight"])
+
+    def test_checkpoint_lm_head_must_use_global_vocab_shape(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen3ForCausalLM(config, self._load_config(tp_size=2))
+        weights = self._weights()
+        weights["lm_head.weight"] = torch.ones(4, 4)
+
+        with self.assertRaisesRegex(ValueError, "checkpoint rows must be 8"):
+            model.load_weights(weights)
+
+    def test_parallel_topologies_are_applied_to_their_owners(self):
+        model = Qwen3ForCausalLM(
+            self._config(), self._load_config(tp_size=2, tp_rank=1)
+        )
+
+        self.assertEqual(
+            (model.embed_tokens.tp_size, model.embed_tokens.tp_rank), (2, 1)
+        )
+        self.assertEqual(
+            (
+                model.layers[0].self_attn.qkv_proj.tp_size,
+                model.layers[0].self_attn.qkv_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+        self.assertEqual(
+            (
+                model.layers[0].mlp.gate_up_proj.tp_size,
+                model.layers[0].mlp.gate_up_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+        self.assertEqual((model.lm_head.tp_size, model.lm_head.tp_rank), (2, 1))
+
+    def test_legacy_negative_one_kv_head_sentinel_uses_q_head_count(self):
+        config = self._config()
+        config.attn_config.kv_head_num = -1
+
+        model = Qwen3ForCausalLM(config, self._load_config())
+
+        self.assertEqual(model.layers[0].self_attn.num_kv_heads, 2)
+
+    def test_context_parallel_topology_is_rejected(self):
+        load_config = self._load_config(
+            tp_size=2,
+            tp_rank=1,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+            ffn_tp_size=1,
+            ffn_tp_rank=0,
+            cp_enabled=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Context parallelism"):
+            Qwen3ForCausalLM(self._config(), load_config)
+
+    def test_prefill_context_parallel_mode_is_rejected(self):
+        load_config = self._load_config(prefill_cp_enabled=True)
+
+        with self.assertRaisesRegex(ValueError, "Context parallelism"):
+            Qwen3ForCausalLM(self._config(), load_config)
+
+    def test_independent_ffn_topology_is_rejected(self):
+        load_config = self._load_config(
+            tp_size=2,
+            tp_rank=1,
+            ffn_tp_size=1,
+            ffn_tp_rank=0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Independent FFN"):
+            Qwen3ForCausalLM(self._config(), load_config)
+
+    def test_ffn_disaggregation_is_rejected(self):
+        load_config = self._load_config(ffn_disaggregate=True)
+
+        with self.assertRaisesRegex(ValueError, "FFN disaggregation"):
+            Qwen3ForCausalLM(self._config(), load_config)
+
+    def test_separate_lm_head_topology_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "lm_head_tp partition"):
+            self._load_config(
+                tp_size=2,
+                tp_rank=1,
+                lm_head_tp_size=1,
+                lm_head_tp_rank=0,
+            )
+
     def test_new_model_loader_streams_real_safetensors(self):
         with tempfile.TemporaryDirectory() as model_path:
             save_file(self._weights(), f"{model_path}/model.safetensors")
@@ -234,6 +402,80 @@ class Qwen3LoadTest(unittest.TestCase):
         self.assertIsInstance(model, Qwen3ForCausalLM)
         self.assertFalse(model.training)
         torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+
+    def test_rank_local_consolidated_checkpoint_is_rejected_explicitly(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(self._weights(), f"{model_path}/consolidated.00.pth")
+            loader = NewModelLoader(
+                self._config(),
+                self._load_config(),
+                model_path=model_path,
+            )
+
+            with self.assertRaisesRegex(
+                ValueError, "does not support rank-local consolidated checkpoints"
+            ):
+                loader.load()
+
+    def test_real_model_forward_matches_cpu_reference(self):
+        weights = self._weights()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                self._config(), self._load_config(), model_path=model_path
+            ).load()
+
+        class QOnlyFmha:
+            fmha_params = None
+
+            def __init__(self, q_size):
+                self.q_size = q_size
+
+            def forward(self, qkv, kv_cache, layer_idx):
+                return qkv[..., : self.q_size]
+
+        def rms_norm(x, weight, eps=1e-6):
+            normalized = x.float() * torch.rsqrt(
+                x.float().pow(2).mean(dim=-1, keepdim=True) + eps
+            )
+            return (normalized * weight).to(x.dtype)
+
+        input_ids = torch.tensor([0, 3, 7], dtype=torch.int32)
+        fmha = QOnlyFmha(model.layers[0].self_attn.q_size)
+        inputs = PyModelInputs(input_ids=input_ids)
+        with patch(
+            "rtp_llm.models_py.new_models.qwen3.language.select_block_map_for_layer"
+        ) as select_block_map:
+            outputs = model(inputs, fmha_impl=fmha)
+        select_block_map.assert_called_once_with(inputs.attention_inputs, 0)
+
+        hidden = F.embedding(input_ids.long(), weights["model.embed_tokens.weight"])
+        residual = hidden
+        hidden = rms_norm(hidden, weights["model.layers.0.input_layernorm.weight"])
+        q = F.linear(hidden, weights["model.layers.0.self_attn.q_proj.weight"])
+        q = q.reshape(-1, 2, 2)
+        q = rms_norm(q, weights["model.layers.0.self_attn.q_norm.weight"])
+        q = q.reshape(-1, 4)
+        hidden = F.linear(q, weights["model.layers.0.self_attn.o_proj.weight"])
+        hidden = residual + hidden
+        residual = hidden
+        hidden = rms_norm(
+            hidden, weights["model.layers.0.post_attention_layernorm.weight"]
+        )
+        gate = F.linear(hidden, weights["model.layers.0.mlp.gate_proj.weight"])
+        up = F.linear(hidden, weights["model.layers.0.mlp.up_proj.weight"])
+        hidden = F.linear(
+            F.silu(gate.float()) * up.float(),
+            weights["model.layers.0.mlp.down_proj.weight"],
+        )
+        hidden = residual + hidden
+        expected = rms_norm(hidden, weights["model.norm.weight"])
+
+        torch.testing.assert_close(outputs.hidden_states, expected)
+        torch.testing.assert_close(
+            model.lm_head(outputs.hidden_states),
+            F.linear(expected, weights["model.embed_tokens.weight"]),
+        )
 
     def test_unknown_checkpoint_tensor_fails(self):
         model = self._model()
@@ -273,6 +515,7 @@ class Qwen3LoadTest(unittest.TestCase):
             "head_dim": 2,
             "rms_norm_eps": 1e-6,
             "enable_fp32_lm_head": False,
+            "tie_word_embeddings": True,
         }
 
         model = Qwen3ForCausalLM(config, self._load_config())

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_dense_load.py
@@ -300,6 +300,37 @@ class Qwen3LoadTest(unittest.TestCase):
 
         torch.testing.assert_close(model.lm_head.weight, weights["lm_head.weight"])
 
+    def test_lm_head_postprocess_matches_legacy_logits_for_tp(self):
+        hidden_states = torch.tensor([[1.0, -2.0, 0.5, 3.0], [-1.0, 0.25, 2.0, 0.75]])
+        explicit_lm_head = torch.arange(32, 64, dtype=torch.float32).reshape(8, 4)
+
+        for tied in (True, False):
+            config = self._config()
+            config.tie_word_embeddings = tied
+            config.normalize_lm_head_weight = True
+            config.logit_scale = 0.25
+            weights = self._weights()
+            source = weights["model.embed_tokens.weight"]
+            if not tied:
+                weights["lm_head.weight"] = explicit_lm_head
+                source = explicit_lm_head
+
+            with self.subTest(tied=tied), tempfile.TemporaryDirectory() as model_path:
+                save_file(weights, f"{model_path}/model.safetensors")
+                for rank in range(2):
+                    model = NewModelLoader(
+                        model_config=config,
+                        load_config=self._load_config(tp_size=2, tp_rank=rank),
+                        model_path=model_path,
+                    ).load()
+                    local_source = source[rank * 4 : (rank + 1) * 4]
+                    expected_weight = F.normalize(local_source, dim=1) * 0.25
+                    torch.testing.assert_close(model.lm_head.weight, expected_weight)
+                    torch.testing.assert_close(
+                        F.linear(hidden_states, model.runtime_weight_view()["lm_head"]),
+                        F.linear(hidden_states, expected_weight),
+                    )
+
     def test_checkpoint_lm_head_must_use_global_vocab_shape(self):
         config = self._config()
         config.tie_word_embeddings = False

--- a/rtp_llm/models_py/quant_methods/__init__.py
+++ b/rtp_llm/models_py/quant_methods/__init__.py
@@ -1,0 +1,8 @@
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig, QuantizeMethodBase
+from rtp_llm.models_py.quant_methods.unquantized import UnquantizedLinearMethod
+
+__all__ = [
+    "QuantizationConfig",
+    "QuantizeMethodBase",
+    "UnquantizedLinearMethod",
+]

--- a/rtp_llm/models_py/quant_methods/base.py
+++ b/rtp_llm/models_py/quant_methods/base.py
@@ -1,0 +1,67 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Type
+
+import torch
+
+
+class QuantizeMethodBase(ABC):
+    @abstractmethod
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer) -> None:
+        raise NotImplementedError
+
+
+_LINEAR_METHOD_REGISTRY: Dict[str, Type[QuantizeMethodBase]] = {}
+
+
+def register_quant_method(*keys: str):
+    def decorator(cls: Type[QuantizeMethodBase]) -> Type[QuantizeMethodBase]:
+        for key in keys:
+            existing = _LINEAR_METHOD_REGISTRY.get(key)
+            if existing is not None and existing is not cls:
+                raise ValueError(
+                    f"Quant method {key!r} is already registered to "
+                    f"{existing.__name__}"
+                )
+            _LINEAR_METHOD_REGISTRY[key] = cls
+        return cls
+
+    return decorator
+
+
+class QuantizationConfig:
+    """Typed dispatch config for the first unquantized newloader model slice."""
+
+    def __init__(self, quant_type: str = "none"):
+        if not isinstance(quant_type, str):
+            raise TypeError("quant_type must be a string")
+        normalized = quant_type.strip().lower()
+        if normalized in ("", "none"):
+            normalized = "none"
+        self.quant_type = normalized
+
+    def get_quant_method(self, layer, prefix: str = "") -> QuantizeMethodBase:
+        from rtp_llm.models_py.quant_methods import unquantized  # noqa: F401
+
+        method_cls = _LINEAR_METHOD_REGISTRY.get(self.quant_type)
+        if method_cls is None:
+            raise ValueError(
+                f"Quantization {self.quant_type!r} is not supported by the "
+                "Qwen dense newloader slice"
+            )
+        return method_cls()

--- a/rtp_llm/models_py/quant_methods/test/BUILD
+++ b/rtp_llm/models_py/quant_methods/test/BUILD
@@ -1,0 +1,7 @@
+py_test(
+    name = "test_unquantized",
+    srcs = ["test_unquantized.py"],
+    deps = [
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/quant_methods/test/test_unquantized.py
+++ b/rtp_llm/models_py/quant_methods/test/test_unquantized.py
@@ -1,0 +1,57 @@
+import unittest
+
+import torch
+
+from rtp_llm.models_py.quant_methods.unquantized import UnquantizedLinearMethod
+
+
+class TestUnquantizedLinearMethod(unittest.TestCase):
+    def test_post_load_preserves_values_and_uses_transpose_view(self):
+        layer = torch.nn.Module()
+        method = UnquantizedLinearMethod()
+        method.create_weights(
+            layer,
+            input_size=5,
+            output_size=3,
+            params_dtype=torch.float32,
+        )
+        source = torch.arange(15, dtype=torch.float32).reshape(3, 5)
+        with torch.no_grad():
+            layer.weight.copy_(source)
+
+        original_parameter = layer.weight
+        method.process_weights_after_loading(layer)
+
+        self.assertIs(layer.weight, original_parameter)
+        self.assertEqual(layer.weight.shape, (3, 5))
+        self.assertEqual(layer.weight.stride(), (1, 3))
+        torch.testing.assert_close(layer.weight, source, rtol=0, atol=0)
+
+        inputs = torch.arange(10, dtype=torch.float32).reshape(2, 5)
+        torch.testing.assert_close(
+            method.apply(layer, inputs),
+            torch.nn.functional.linear(inputs, source),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_post_load_is_idempotent(self):
+        layer = torch.nn.Module()
+        method = UnquantizedLinearMethod()
+        method.create_weights(
+            layer,
+            input_size=5,
+            output_size=3,
+            params_dtype=torch.float32,
+        )
+        method.process_weights_after_loading(layer)
+        data_ptr = layer.weight.data_ptr()
+
+        method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight.stride(), (1, 3))
+        self.assertEqual(layer.weight.data_ptr(), data_ptr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/quant_methods/unquantized.py
+++ b/rtp_llm/models_py/quant_methods/unquantized.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+import torch
+
+from rtp_llm.models_py.quant_methods.base import (
+    QuantizeMethodBase,
+    register_quant_method,
+)
+
+
+@register_quant_method("none")
+class UnquantizedLinearMethod(QuantizeMethodBase):
+    def create_weights(
+        self,
+        layer,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> None:
+        backing = torch.empty(input_size, output_size, dtype=params_dtype)
+        layer.register_parameter(
+            "weight",
+            torch.nn.Parameter(
+                backing.T,
+                requires_grad=False,
+            ),
+        )
+
+    def apply(
+        self, layer, x: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        return torch.nn.functional.linear(x, layer.weight, bias)
+
+    def process_weights_after_loading(self, layer) -> None:
+        expected_stride = (1, layer.weight.shape[0])
+        if layer.weight.ndim != 2 or layer.weight.stride() != expected_stride:
+            raise RuntimeError(
+                f"Unquantized weight has unexpected stride {layer.weight.stride()}; "
+                f"expected {expected_stride}"
+            )

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -101,3 +101,15 @@ def get_model_class(model_type: str) -> Type[nn.Module]:
 
 def list_models():
     return sorted(set(MODEL_REGISTRY) | set(_LAZY_MODEL_REGISTRY))
+
+
+register_lazy_model(
+    "qwen_3",
+    "rtp_llm.models_py.new_models.qwen3",
+    "Qwen3ForCausalLM",
+)
+register_lazy_model(
+    "qwen_3_tool",
+    "rtp_llm.models_py.new_models.qwen3",
+    "Qwen3ForCausalLM",
+)

--- a/rtp_llm/models_py/weight_mapper.py
+++ b/rtp_llm/models_py/weight_mapper.py
@@ -9,6 +9,7 @@ import torch
 
 _SAFETENSORS_INDEX = "model.safetensors.index.json"
 _PYTORCH_INDEX = "pytorch_model.bin.index.json"
+_CONSOLIDATED_RANK_RE = re.compile(r"^consolidated[._-](\d+)(?:[._-]|$)", re.IGNORECASE)
 _EXCLUDED_WEIGHT_FILES = {
     "adapter_model.bin",
     "adapter_model.safetensors",
@@ -194,6 +195,13 @@ def _is_consolidated_weight_file(path: str) -> bool:
     return os.path.basename(path).lower().startswith("consolidated")
 
 
+def is_rank_local_checkpoint(files: List[str]) -> bool:
+    return any(
+        _CONSOLIDATED_RANK_RE.match(os.path.basename(path)) is not None
+        for path in files
+    )
+
+
 def _is_model_weight_file(path: str, allow_consolidated: bool = False) -> bool:
     name = os.path.basename(path).lower()
     if name in _EXCLUDED_WEIGHT_FILES:
@@ -227,10 +235,7 @@ def _select_consolidated_files(
     ranked_files = {}
     unranked_files = []
     for path in files:
-        match = re.match(
-            r"^consolidated[._-](\d+)(?:[._-]|$)",
-            os.path.basename(path).lower(),
-        )
+        match = _CONSOLIDATED_RANK_RE.match(os.path.basename(path))
         if match is None:
             unranked_files.append(path)
             continue

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -53,6 +53,7 @@ test_suite(
     tests = [
         ":smoke_h20_mla",
         ":smoke_h20_moe",
+        ":smoke_h20_newloader",
         ":smoke_h20_next",
         ":smoke_h20_kimi_linear",
         ":smoke_cuda_remote_cache",

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -4,6 +4,21 @@ def h20_oss_suites():
     # H20 (SM9x) — Architecture-grouped suites
     # ============================================================================
 
+    # Qwen3 dense newloader production boundary: public server startup, TP2,
+    # prefill/decode, final logits, and CUDA Graph replay.
+    native.test_suite(
+        name = "smoke_h20_newloader",
+        tests = [
+            smoke_test(
+                name="h20_dense_qwen3_8b_newloader_cudagraph_tp2",
+                task_info="data/model/qwen3/q_r_new_model_py.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 16 --act_type BF16 --test_block_num 1000 --reserver_runtime_mem_mb 20000 --enable_cuda_graph 1 --decode_capture_config '1,2,3,4,5,6,7,8' --tp_size 2 --world_size 2",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                gpu_type=["H20"],
+            ),
+        ],
+    )
+
     # H20 MLA (DeepSeek V2/V3.2, GLM-5)
     native.test_suite(
         name = "smoke_h20_mla",

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -38,6 +38,7 @@ def rocm_oss_suites():
                 name="rocm_dense_qwen3_8b_hipgraph_tp2",
                 task_info="data/model/qwen3/q_r_new_model_py.json",
                 smoke_args="--use_swizzleA 1 --use_asm_pa 1 --disable_flash_infer 1 --warm_up 0 --use_aiter_pa 1 --seq_size_per_block 16 --act_type BF16 --test_block_num 1000 --reserver_runtime_mem_mb 70000 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4,5,6,7,8' --tp_size 2 --world_size 2",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
                 gpu_type=["MI308X-ROCM7"]
             ),
             # Simplified from Qwen3-32B-FP8-Dynamic → Qwen3-8B; result placeholder, needs rewrite_smoke regen on MI308X
@@ -188,4 +189,3 @@ def rocm_oss_suites():
             ),
         ],
     )
-


### PR DESCRIPTION
## Summary

  Add the first model implementation on top of the newloader streaming foundation.

  This PR adds unquantized Qwen3 dense support. It intentionally excludes FP8, MoE, BERT, Roberta, LoRA, and fastsafetensors paths.

  ## Implementation

  - Create the Qwen3 PyModel before loading checkpoint tensors.
  - Stream checkpoint tensors directly into owning submodules.
  - Add Qwen3-required embedding, RMSNorm, activation, and TP linear layers.
  - Support separate and fused QKV/gate-up checkpoint layouts.
  - Validate TP partitions, tensor shapes, dtypes, duplicate shards, and load completeness.
  - Run device migration and post-load layout processing only after loading succeeds.
  - Export only the lightweight runtime weight view required by existing kernels.
  - Fail fast for unsupported quantization and loading configurations.

  The loading path does not use legacy `ModelWeightInfo` or rebuild the full model through legacy `ModelWeights`.

  ## Validation

  Passed:

  - `//rtp_llm/models_py/new_models/qwen3/test:test_qwen3_dense_load`
  - `//rtp_llm/models_py/new_loader_test:foundation_test`
  - `//rtp_llm/models_py/quant_methods/test:test_unquantized`
  - `//rtp_llm/models_py:new_weight_loader`
  - `//rtp_llm/models_py:models`
  - `//rtp_llm:models`
  - Black, isort, and `git diff --check`

  ROCm TP2 smoke was started successfully with both ranks, but the host failed during RCCL communicator initialization because the kernel command line is missing `iommu=pt`. The failure occurred before model loading, so no model-result claim is
  made from that run.

  ## Scope

  Base branch: `develop/hengcang.wyd/new_loader`

  This PR contains only Qwen3 dense newloader code and focused tests. It does not modify smoke golden data or environment files.