### PR TITLE
Refactor newloader Qwen3 runtime onto GptModelBase

### DIFF
--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -117,6 +117,7 @@ py_library(
     srcs = [
         "__init__.py",
         "model_loader.py",
+        "model_desc/module_base.py",
         "module_base.py",
         "registry.py",
         "weight_mapper.py",

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
+from torch import Tensor
+
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.module_base import RtpModule
@@ -12,13 +14,12 @@ from rtp_llm.ops.compute_ops import (
     PyModelInputs,
     PyModelOutputs,
 )
-from torch import Tensor
 
 if TYPE_CHECKING:
     from rtp_llm.model_loader.model_weight_info import ModelWeights
 
 
-def _required_config_value(config: Any, *names: str) -> Any:
+def required_config_value(config: Any, *names: str) -> Any:
     for name in names:
         value = (
             config.get(name)
@@ -35,8 +36,8 @@ class GptModelBase(RtpModule):
         self,
         config: ModelConfig,
         parallelism_config,
-        weight: Optional["ModelWeights"],
-        max_generate_batch_size: int,
+        weight: Optional["ModelWeights"] = None,
+        max_generate_batch_size: int = 0,
         fmha_config=None,  # Optional FMHAConfig
         py_hw_kernel_config=None,  # Optional HWKernelConfig
         device_resource_config: Optional[
@@ -55,10 +56,10 @@ class GptModelBase(RtpModule):
             and device_resource_config.enable_layer_micro_batch == 0
             else 2
         )
-        self.layer_num = _required_config_value(
+        self.layer_num = required_config_value(
             config, "num_layers", "num_hidden_layers"
         )
-        self.vocab_size = _required_config_value(config, "vocab_size")
+        self.vocab_size = required_config_value(config, "vocab_size")
 
         self.kv_cache: Optional[KVCache] = None
         self.device_type: DeviceType = get_device_type()
@@ -94,11 +95,13 @@ class GptModelBase(RtpModule):
         replay_batch_size: int,
         capture_batch_size: int,
         seq_size_per_block: int,
-    ):
-        assert capture_batch_size in self.params_dict
-        params_ptr = self.params_dict[capture_batch_size]
-        assert params_ptr is not None
-        params_ptr.fillParams(
+    ) -> None:
+        if capture_batch_size not in self.params_dict:
+            raise ValueError(f"No captured FMHA params for batch {capture_batch_size}")
+        params = self.params_dict[capture_batch_size]
+        if params is None:
+            raise RuntimeError("Captured FMHA params cannot be None")
+        params.fillParams(
             sequence_lengths,
             input_lengths,
             kv_cache_block_id_host,

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -1,11 +1,9 @@
 import logging
-from typing import Any, Optional
-
-from torch import Tensor, nn
+from typing import TYPE_CHECKING, Any, Optional
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.device.device_type import DeviceType, get_device_type
-from rtp_llm.model_loader.model_weight_info import ModelWeights
+from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.modules import AttnImplFactory
 from rtp_llm.ops import DeviceResourceConfig
 from rtp_llm.ops.compute_ops import (
@@ -14,15 +12,30 @@ from rtp_llm.ops.compute_ops import (
     PyModelInputs,
     PyModelOutputs,
 )
-from rtp_llm.utils.model_weight import W
+from torch import Tensor
+
+if TYPE_CHECKING:
+    from rtp_llm.model_loader.model_weight_info import ModelWeights
 
 
-class GptModelBase(nn.Module):
+def _required_config_value(config: Any, *names: str) -> Any:
+    for name in names:
+        value = (
+            config.get(name)
+            if isinstance(config, dict)
+            else getattr(config, name, None)
+        )
+        if value is not None:
+            return value
+    raise ValueError(f"Model config requires one of {names}")
+
+
+class GptModelBase(RtpModule):
     def __init__(
         self,
         config: ModelConfig,
         parallelism_config,
-        weight: ModelWeights,
+        weight: Optional["ModelWeights"],
         max_generate_batch_size: int,
         fmha_config=None,  # Optional FMHAConfig
         py_hw_kernel_config=None,  # Optional HWKernelConfig
@@ -42,8 +55,10 @@ class GptModelBase(nn.Module):
             and device_resource_config.enable_layer_micro_batch == 0
             else 2
         )
-        self.layer_num: int = config.num_layers
-        self.vocab_size: int = config.vocab_size
+        self.layer_num = _required_config_value(
+            config, "num_layers", "num_hidden_layers"
+        )
+        self.vocab_size = _required_config_value(config, "vocab_size")
 
         self.kv_cache: Optional[KVCache] = None
         self.device_type: DeviceType = get_device_type()

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -1,7 +1,8 @@
-import logging
-from typing import Callable, Dict, List, Optional, Union
+from __future__ import annotations
 
-from rtp_llm.model_loader.model_weight_info import ModelWeights
+import logging
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import (
     FMHAImplBase,
     MlaImplBase,
@@ -15,6 +16,9 @@ from rtp_llm.ops import (
 )
 from rtp_llm.ops.compute_ops import PyAttentionInputs
 from rtp_llm.utils.model_weight import W
+
+if TYPE_CHECKING:
+    from rtp_llm.model_loader.model_weight_info import ModelWeights
 
 # Lists to store registered implementations
 PREFILL_MHA_IMPS: List[type[FMHAImplBase]] = []
@@ -44,7 +48,8 @@ def get_mla_impl(
         # TODO: support fast path for cp prefill
         use_fast_path = (
             attn_inputs.is_prefill
-            and attn_inputs.cu_kv_seqlens_device.max().item() <= attn_configs.indexer_topk
+            and attn_inputs.cu_kv_seqlens_device.max().item()
+            <= attn_configs.indexer_topk
             and not (
                 parallelism_config and parallelism_config.prefill_cp_config.is_enabled()
             )

--- a/rtp_llm/models_py/new_models/model_base.py
+++ b/rtp_llm/models_py/new_models/model_base.py
@@ -1,5 +1,6 @@
-from typing import Any, Optional
+from typing import Optional
 
+from rtp_llm.models_py.model_desc.module_base import required_config_value
 from rtp_llm.ops.compute_ops import PyAttentionInputs
 
 
@@ -27,14 +28,3 @@ def select_block_map_for_layer(
             attention_inputs.kv_cache_kernel_block_id_by_group[gid]
         )
     return gid
-
-
-def required_config_value(config: Any, *names: str) -> Any:
-    for name in names:
-        if isinstance(config, dict):
-            value = config.get(name)
-        else:
-            value = getattr(config, name, None)
-        if value is not None:
-            return value
-    raise ValueError(f"Model config requires one of {names}")

--- a/rtp_llm/models_py/new_models/model_base.py
+++ b/rtp_llm/models_py/new_models/model_base.py
@@ -1,16 +1,6 @@
 from typing import Any, Optional
 
-from torch import Tensor
-
-from rtp_llm.models_py.module_base import RtpModule
-from rtp_llm.ops import DeviceResourceConfig
-from rtp_llm.ops.compute_ops import (
-    KVCache,
-    PyAttentionInputs,
-    PyModelInitResources,
-    PyModelInputs,
-    PyModelOutputs,
-)
+from rtp_llm.ops.compute_ops import PyAttentionInputs
 
 
 def select_block_map_for_layer(
@@ -48,80 +38,3 @@ def required_config_value(config: Any, *names: str) -> Any:
         if value is not None:
             return value
     raise ValueError(f"Model config requires one of {names}")
-
-
-class NewLoaderModelBase(RtpModule):
-    """Runtime base for models whose parameters are owned by the PyModel."""
-
-    supports_rank_local_checkpoint = False
-
-    def __init__(
-        self,
-        config: Any,
-        parallelism_config,
-        fmha_config=None,
-        device_resource_config: Optional[DeviceResourceConfig] = None,
-    ) -> None:
-        super().__init__()
-        self.config = config
-        self.parallelism_config = parallelism_config
-        self.fmha_config = fmha_config
-        self.weight = None
-        self.micro_batch_size = (
-            1
-            if device_resource_config
-            and device_resource_config.enable_layer_micro_batch == 0
-            else 2
-        )
-        self.layer_num = required_config_value(
-            config, "num_layers", "num_hidden_layers"
-        )
-        self.vocab_size = required_config_value(config, "vocab_size")
-        self.kv_cache: Optional[KVCache] = None
-        self.params_dict: dict[int, Any] = {}
-
-    def initialize(self, init_resource: PyModelInitResources) -> bool:
-        self.kv_cache = init_resource.kv_cache
-        return True
-
-    def fill_params(
-        self,
-        sequence_lengths: Tensor,
-        input_lengths: Tensor,
-        kv_cache_block_id_host: Tensor,
-        replay_batch_size: int,
-        capture_batch_size: int,
-        seq_size_per_block: int,
-    ) -> None:
-        if capture_batch_size not in self.params_dict:
-            raise ValueError(f"No captured FMHA params for batch {capture_batch_size}")
-        params = self.params_dict[capture_batch_size]
-        if params is None:
-            raise RuntimeError("Captured FMHA params cannot be None")
-        params.fillParams(
-            sequence_lengths,
-            input_lengths,
-            kv_cache_block_id_host,
-            replay_batch_size,
-            seq_size_per_block,
-        )
-
-    def prepare_fmha_impl(
-        self, inputs: PyModelInputs, is_cuda_graph: bool = False
-    ) -> Any:
-        from rtp_llm.models_py.modules import AttnImplFactory
-
-        return AttnImplFactory.get_fmha_impl(
-            self.config,
-            self.parallelism_config,
-            self.weight,
-            inputs.attention_inputs,
-            self.fmha_config,
-            is_cuda_graph,
-        )
-
-    def runtime_weight_view(self) -> dict[str, Tensor]:
-        raise NotImplementedError
-
-    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
-        raise NotImplementedError

--- a/rtp_llm/models_py/new_models/qwen3/language.py
+++ b/rtp_llm/models_py/new_models/qwen3/language.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 
 import torch
 import torch.nn as nn
+
 from rtp_llm.models_py.layers.activation import silu_and_mul
 from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
 from rtp_llm.models_py.layers.linear import (

--- a/rtp_llm/models_py/new_models/qwen3/language.py
+++ b/rtp_llm/models_py/new_models/qwen3/language.py
@@ -5,7 +5,6 @@ from typing import Any, Optional
 
 import torch
 import torch.nn as nn
-
 from rtp_llm.models_py.layers.activation import silu_and_mul
 from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
 from rtp_llm.models_py.layers.linear import (
@@ -14,9 +13,9 @@ from rtp_llm.models_py.layers.linear import (
     RowParallelLinear,
 )
 from rtp_llm.models_py.layers.norm import RMSNorm
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.model_base import (
-    NewLoaderModelBase,
     required_config_value,
     select_block_map_for_layer,
 )
@@ -423,7 +422,7 @@ def _validate_supported_parallelism(parallelism_config: Any) -> None:
         )
 
 
-class Qwen3ForCausalLM(NewLoaderModelBase):
+class Qwen3ForCausalLM(GptModelBase):
 
     WEIGHTS_MAPPER = WeightsMapper(
         prefix_mapping={"model.": ""},
@@ -479,6 +478,8 @@ class Qwen3ForCausalLM(NewLoaderModelBase):
         super().__init__(
             config=model_config,
             parallelism_config=parallelism_config,
+            weight=None,
+            max_generate_batch_size=0,
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -5,11 +5,12 @@ import unittest
 from unittest.mock import patch
 
 import torch
-from safetensors.torch import save_file
-
 from rtp_llm.model_loader.load_config import LoadMethod
 from rtp_llm.models.base_model import BaseModel
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+from safetensors.torch import save_file
 
 
 def _model_config():
@@ -98,6 +99,8 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
                 base_model.load()
 
         self.assertIsInstance(base_model.py_model, Qwen3ForCausalLM)
+        self.assertIsInstance(base_model.py_model, GptModelBase)
+        self.assertIsInstance(base_model.py_model, RtpModule)
         self.assertFalse(base_model.py_model.training)
         self.assertIs(base_model.py_model.weight, base_model.weight)
         self.assertIs(base_model.weight_manager, None)

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -5,12 +5,13 @@ import unittest
 from unittest.mock import patch
 
 import torch
+from safetensors.torch import save_file
+
 from rtp_llm.model_loader.load_config import LoadMethod
 from rtp_llm.models.base_model import BaseModel
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
-from safetensors.torch import save_file
 
 
 def _model_config():
@@ -74,6 +75,22 @@ def _weights():
 
 
 class Qwen3BaseModelIntegrationTest(unittest.TestCase):
+    def test_gpt_runtime_base_rejects_invalid_graph_capture_state(self):
+        runtime = GptModelBase(
+            config=_model_config(),
+            parallelism_config=_parallelism_config(),
+            weight=None,
+            max_generate_batch_size=0,
+        )
+        empty = torch.empty(0, dtype=torch.int32)
+
+        with self.assertRaisesRegex(ValueError, "No captured FMHA params"):
+            runtime.fill_params(empty, empty, empty, 1, 4, 16)
+
+        runtime.params_dict[4] = None
+        with self.assertRaisesRegex(RuntimeError, "cannot be None"):
+            runtime.fill_params(empty, empty, empty, 1, 4, 16)
+
     def test_base_model_entry_loads_registered_qwen_runtime(self):
         config = _model_config()
         base_model = object.__new__(BaseModel)


### PR DESCRIPTION
## Summary

  This PR is a follow-up to the previously merged Qwen3 Dense newloader path. It does not add another Qwen3 implementation.

  It aligns the merged Qwen3 Dense runtime with the intended newloader architecture that was previously validated on ROCm:

  - make `GptModelBase` inherit from `RtpModule`
  - make Qwen3 Dense use the shared `GptModelBase` runtime directly
  - remove the redundant `NewLoaderModelBase`
  - keep the reviewed Qwen3 loading, parallelism, LM-head, FMHA and runtime behavior unchanged
  - avoid runtime imports of legacy loader-only weight types from the standalone newloader target
  - preserve explicit configuration and CUDA Graph validation semantics

  ## Scope

  This PR only adjusts the shared runtime hierarchy and Qwen3 Dense integration.

  It does not include:

  - Qwen3-MoE support
  - BERT/Roberta support
  - new quantization implementations
  - golden or smoke-test data changes
  - legacy loader removal

  ## Architecture

  The resulting hierarchy is:

  `RtpModule -> GptModelBase -> Qwen3ForCausalLM`

  Child layers continue to use the `RtpModule` loading contract:

  1. create the Python model
  2. stream checkpoint tensors to owning submodules
  3. run post-load processing
  4. build runtime/kernel-specific weight views where required

  ## Validation

  - Bazel build:
    - `//rtp_llm/models_py:new_weight_loader`
    - `//rtp_llm/models_py:models`
  - Bazel tests:
    - `//rtp_llm/models_py/new_loader_test:foundation_test`
    - `//rtp_llm/models_py/new_models/qwen3/test:test_qwen3_dense_load`
    - `//rtp_llm/models_py/new_models/qwen3/test:test_qwen3_base_model_integration`
  - ROCm Qwen3 Dense TP1 prefill/decode smoke passed with `USE_NEW_LOADER=1`
  - Legacy Qwen3 Dense TP1 smoke remained valid
  - Black, isort, `py_compile` and `git diff --check` passed