### PR TITLE
Develop/hengcang/newloader qwen2 dense moe

### DIFF
--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -124,6 +124,8 @@ py_library(
     ] + glob([
         "layers/*.py",
         "new_models/*.py",
+        "new_models/qwen2/*.py",
+        "new_models/qwen2_moe/*.py",
         "new_models/qwen3/*.py",
         "new_models/qwen3_moe/*.py",
         "quant_methods/*.py",

--- a/rtp_llm/models_py/new_models/qwen2/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen2/__init__.py
@@ -1,0 +1,3 @@
+from rtp_llm.models_py.new_models.qwen2.language import Qwen2ForCausalLM
+
+__all__ = ["Qwen2ForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen2/language.py
+++ b/rtp_llm/models_py/new_models/qwen2/language.py
@@ -1,0 +1,507 @@
+import logging
+import math
+from numbers import Real
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+from rtp_llm.models_py.layers.activation import silu_and_mul
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.norm import RMSNorm
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.new_models.model_base import (
+    required_config_value,
+    select_block_map_for_layer,
+)
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import LayerKVCache, PyModelInputs, PyModelOutputs
+
+
+class Qwen2MLP(RtpModule):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+        prefix: str = "mlp",
+    ):
+        super().__init__()
+        self.tp_size = tp_size
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=2 * intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+            bias=False,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=params_dtype,
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up = self.gate_up_proj(x)
+        act = silu_and_mul(gate_up)
+        x = self.down_proj(act)
+        return x
+
+
+class Qwen2Attention(RtpModule):
+    """Qwen2 attention with biased Q/K/V projections and no Q/K norm."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        layer_idx: int = 0,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+        prefix: str = "self_attn",
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.layer_idx = layer_idx
+        self.tp_size = tp_size
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+            bias=True,
+            params_dtype=params_dtype,
+        )
+        self.o_proj = RowParallelLinear(
+            input_size=num_heads * head_dim,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        qkv = self.qkv_proj(hidden_states)
+        attn_output = fmha_impl.forward(qkv, kv_cache, self.layer_idx)
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        output = self.o_proj(attn_output)
+        return output
+
+
+class Qwen2DecoderLayer(RtpModule):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        intermediate_size: int,
+        head_dim: int,
+        layer_idx: int = 0,
+        attn_tp_size: int = 1,
+        attn_tp_rank: int = 0,
+        ffn_tp_size: int = 1,
+        ffn_tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.float16,
+        rms_norm_eps: float = 1e-6,
+        prefix: str = "layer",
+    ):
+        super().__init__()
+        self.input_layernorm = RMSNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.self_attn = Qwen2Attention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            layer_idx=layer_idx,
+            tp_size=attn_tp_size,
+            tp_rank=attn_tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            prefix=f"{prefix}.self_attn",
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.mlp = Qwen2MLP(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            tp_size=ffn_tp_size,
+            tp_rank=ffn_tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            prefix=f"{prefix}.mlp",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, fmha_impl, kv_cache)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def _resolve_head_dim(hidden_size: Any, num_heads: Any, configured: Any) -> int:
+    hidden_size = _positive_int(hidden_size, "hidden_size")
+    num_heads = _positive_int(num_heads, "num_heads")
+    if configured is not None:
+        return _positive_int(configured, "head_dim")
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"hidden_size={hidden_size} must be divisible by num_heads={num_heads} "
+            "when head_dim is not configured"
+        )
+    return hidden_size // num_heads
+
+
+def _extract_config_values(
+    model_config: Any,
+    load_config: Any,
+    *,
+    validate_intermediate_size: bool = True,
+):
+    if isinstance(model_config, dict):
+        hidden_size = required_config_value(model_config, "hidden_size")
+        num_heads = required_config_value(model_config, "num_attention_heads")
+        num_kv_heads = model_config.get("num_key_value_heads", num_heads)
+        intermediate_size = required_config_value(model_config, "intermediate_size")
+        num_layers = required_config_value(model_config, "num_hidden_layers")
+        vocab_size = required_config_value(model_config, "vocab_size")
+        head_dim = _resolve_head_dim(
+            hidden_size, num_heads, model_config.get("head_dim")
+        )
+        rms_norm_eps = model_config.get("rms_norm_eps", 1e-6)
+    else:
+        hidden_size = required_config_value(model_config, "hidden_size")
+        num_layers = required_config_value(
+            model_config, "num_layers", "num_hidden_layers"
+        )
+        vocab_size = required_config_value(model_config, "vocab_size")
+        intermediate_size = required_config_value(
+            model_config, "inter_size", "intermediate_size"
+        )
+        attn_config = getattr(model_config, "attn_config", None)
+        if attn_config is not None:
+            num_heads = required_config_value(attn_config, "head_num")
+            num_kv_heads = getattr(attn_config, "kv_head_num", num_heads)
+            if num_kv_heads == -1:
+                num_kv_heads = num_heads
+            head_dim = _resolve_head_dim(
+                hidden_size,
+                num_heads,
+                getattr(attn_config, "size_per_head", None),
+            )
+        else:
+            num_heads = required_config_value(model_config, "num_attention_heads")
+            num_kv_heads = getattr(model_config, "num_key_value_heads", num_heads)
+            head_dim = _resolve_head_dim(
+                hidden_size, num_heads, getattr(model_config, "head_dim", None)
+            )
+        rms_norm_eps = getattr(
+            model_config,
+            "layernorm_eps",
+            getattr(model_config, "rms_norm_eps", 1e-6),
+        )
+
+    tp_size = required_config_value(load_config, "tp_size")
+    tp_rank = required_config_value(load_config, "tp_rank")
+    attn_tp_size = required_config_value(load_config, "attn_tp_size")
+    attn_tp_rank = required_config_value(load_config, "attn_tp_rank")
+    ffn_tp_size = required_config_value(load_config, "ffn_tp_size")
+    ffn_tp_rank = required_config_value(load_config, "ffn_tp_rank")
+    lm_head_tp_size = required_config_value(load_config, "lm_head_tp_size")
+    lm_head_tp_rank = required_config_value(load_config, "lm_head_tp_rank")
+    quant_config = getattr(load_config, "quant_config", None)
+    params_dtype = getattr(load_config, "compute_dtype", torch.float16)
+    enable_fp32_lm_head = (
+        model_config.get("enable_fp32_lm_head", True)
+        if isinstance(model_config, dict)
+        else getattr(model_config, "enable_fp32_lm_head", True)
+    )
+
+    dimensions = {
+        "hidden_size": hidden_size,
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "num_layers": num_layers,
+        "vocab_size": vocab_size,
+        "head_dim": head_dim,
+    }
+    if validate_intermediate_size:
+        dimensions["intermediate_size"] = intermediate_size
+    for name, value in dimensions.items():
+        _positive_int(value, name)
+    for name, size, rank in (
+        ("TP", tp_size, tp_rank),
+        ("attention TP", attn_tp_size, attn_tp_rank),
+        ("FFN TP", ffn_tp_size, ffn_tp_rank),
+        ("LM head TP", lm_head_tp_size, lm_head_tp_rank),
+    ):
+        _positive_int(size, f"{name} size")
+        if isinstance(rank, bool) or not isinstance(rank, int) or not 0 <= rank < size:
+            raise ValueError(f"Invalid {name} partition: rank={rank}, size={size}")
+    if (attn_tp_size, attn_tp_rank) != (tp_size, tp_rank):
+        raise ValueError(
+            "Context parallelism is not supported by the Qwen2 dense newloader slice"
+        )
+    if (ffn_tp_size, ffn_tp_rank) != (attn_tp_size, attn_tp_rank):
+        raise ValueError(
+            "Independent FFN TP/sequence parallelism is not supported by the "
+            "Qwen2 dense newloader slice"
+        )
+    if (lm_head_tp_size, lm_head_tp_rank) != (tp_size, tp_rank):
+        raise ValueError(
+            "A separate LM head topology is not supported by the Qwen2 dense "
+            "newloader slice"
+        )
+
+    return dict(
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        intermediate_size=intermediate_size,
+        num_layers=num_layers,
+        vocab_size=vocab_size,
+        head_dim=head_dim,
+        rms_norm_eps=rms_norm_eps,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+        ffn_tp_size=ffn_tp_size,
+        ffn_tp_rank=ffn_tp_rank,
+        lm_head_tp_size=lm_head_tp_size,
+        lm_head_tp_rank=lm_head_tp_rank,
+        quant_config=quant_config,
+        params_dtype=params_dtype,
+        lm_head_params_dtype=torch.float32 if enable_fp32_lm_head else params_dtype,
+    )
+
+
+def _validate_supported_parallelism(parallelism_config: Any) -> None:
+    prefill_cp = getattr(parallelism_config, "prefill_cp_config", None)
+    if prefill_cp is not None:
+        for checker_name in ("is_enabled", "is_prefill_enabled"):
+            checker = getattr(prefill_cp, checker_name, None)
+            if callable(checker) and bool(checker()):
+                raise ValueError(
+                    "Context parallelism is not supported by the Qwen2 dense "
+                    "newloader slice"
+                )
+    ffn_disaggregate = getattr(parallelism_config, "ffn_disaggregate_config", None)
+    if bool(getattr(ffn_disaggregate, "enable_ffn_disaggregate", False)):
+        raise ValueError(
+            "FFN disaggregation is not supported by the Qwen2 dense newloader slice"
+        )
+
+
+class Qwen2ForCausalLM(GptModelBase):
+
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.": ""},
+    )
+
+    def load_weights(self, weights):
+        if isinstance(weights, dict):
+            weights_iter = iter(weights.items())
+        else:
+            weights_iter = weights
+        has_lm_head = False
+
+        def _track(it):
+            nonlocal has_lm_head
+            for name, tensor in it:
+                if name == "lm_head.weight":
+                    has_lm_head = True
+                yield name, tensor
+
+        mapped_iter = self.WEIGHTS_MAPPER.apply(weights_iter)
+        super().load_weights(_track(mapped_iter))
+
+        # Small Qwen2/Qwen2.5 variants can tie lm_head to embed_tokens.
+        # Mirror HF transformers: when no lm_head.weight is in the ckpt, copy
+        # the embedding weights into lm_head so the projection isn't random.
+        if not has_lm_head and self.tie_word_embeddings:
+            logging.info(
+                "[Qwen2ForCausalLM] lm_head.weight not found in ckpt; "
+                "tying lm_head to embed_tokens (tie_word_embeddings)"
+            )
+            self.lm_head._copy_local_tied_weight(self.embed_tokens.weight.data)
+
+    def process_weights_after_loading(self) -> None:
+        if self._lm_head_postprocessed:
+            return
+        processed = self.lm_head.weight
+        if self.normalize_lm_head_weight:
+            processed = torch.nn.functional.normalize(processed, dim=1)
+        if self.logit_scale != 1.0:
+            processed = processed * self.logit_scale
+        if processed is not self.lm_head.weight:
+            with torch.no_grad():
+                self.lm_head.weight.copy_(processed)
+        self._lm_head_postprocessed = True
+
+    def __init__(self, model_config: Any, load_config: Any):
+        parallelism_config = getattr(load_config, "parallelism_config", None)
+        if parallelism_config is None:
+            raise ValueError("Qwen2 newloader requires parallelism_config")
+        fmha_config = getattr(load_config, "fmha_config", None)
+        device_resource_config = getattr(load_config, "device_resource_config", None)
+
+        super().__init__(
+            config=model_config,
+            parallelism_config=parallelism_config,
+            weight=None,
+            max_generate_batch_size=0,
+            fmha_config=fmha_config,
+            device_resource_config=device_resource_config,
+        )
+
+        cfg = _extract_config_values(model_config, load_config)
+        _validate_supported_parallelism(parallelism_config)
+        self.tie_word_embeddings = (
+            bool(model_config.get("tie_word_embeddings", False))
+            if isinstance(model_config, dict)
+            else bool(getattr(model_config, "tie_word_embeddings", False))
+        )
+        normalize_lm_head_weight = (
+            model_config.get("normalize_lm_head_weight", False)
+            if isinstance(model_config, dict)
+            else getattr(model_config, "normalize_lm_head_weight", False)
+        )
+        if not isinstance(normalize_lm_head_weight, bool):
+            raise TypeError("normalize_lm_head_weight must be a bool")
+        raw_logit_scale = (
+            model_config.get("logit_scale", 1.0)
+            if isinstance(model_config, dict)
+            else getattr(model_config, "logit_scale", 1.0)
+        )
+        if isinstance(raw_logit_scale, bool) or not isinstance(raw_logit_scale, Real):
+            raise TypeError("logit_scale must be a finite real number")
+        logit_scale = float(raw_logit_scale)
+        if not math.isfinite(logit_scale):
+            raise ValueError("logit_scale must be finite")
+        self.normalize_lm_head_weight = normalize_lm_head_weight
+        self.logit_scale = logit_scale
+        self._lm_head_postprocessed = False
+
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size=cfg["vocab_size"],
+            embedding_dim=cfg["hidden_size"],
+            tp_size=cfg["attn_tp_size"],
+            tp_rank=cfg["attn_tp_rank"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen2DecoderLayer(
+                    hidden_size=cfg["hidden_size"],
+                    num_heads=cfg["num_heads"],
+                    num_kv_heads=cfg["num_kv_heads"],
+                    intermediate_size=cfg["intermediate_size"],
+                    head_dim=cfg["head_dim"],
+                    layer_idx=i,
+                    attn_tp_size=cfg["attn_tp_size"],
+                    attn_tp_rank=cfg["attn_tp_rank"],
+                    ffn_tp_size=cfg["ffn_tp_size"],
+                    ffn_tp_rank=cfg["ffn_tp_rank"],
+                    quant_config=cfg["quant_config"],
+                    params_dtype=cfg["params_dtype"],
+                    rms_norm_eps=cfg["rms_norm_eps"],
+                    prefix=f"layers.{i}",
+                )
+                for i in range(cfg["num_layers"])
+            ]
+        )
+        self.norm = RMSNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.lm_head = ParallelLMHead(
+            vocab_size=cfg["vocab_size"],
+            hidden_size=cfg["hidden_size"],
+            tp_size=cfg["lm_head_tp_size"],
+            tp_rank=cfg["lm_head_tp_rank"],
+            params_dtype=cfg["lm_head_params_dtype"],
+        )
+
+    def runtime_weight_view(self) -> dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids = inputs.input_ids
+        hidden_states = self.embed_tokens(input_ids)
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+        for i, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, i)
+            hidden_states = layer(
+                hidden_states,
+                fmha_impl,
+                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+            )
+        hidden_states = self.norm(hidden_states)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/new_models/qwen2/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2/test/BUILD
@@ -1,0 +1,10 @@
+py_test(
+    name = "test_qwen2_dense_load",
+    srcs = ["test_qwen2_dense_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen2/test/test_qwen2_dense_load.py
+++ b/rtp_llm/models_py/new_models/qwen2/test/test_qwen2_dense_load.py
@@ -1,0 +1,572 @@
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.module_base import collect_loaded_tensor_ids
+from rtp_llm.models_py.new_models.qwen2.language import Qwen2ForCausalLM
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+from rtp_llm.ops.compute_ops import PyModelInputs
+from safetensors.torch import save_file
+
+
+def _validate(module) -> None:
+    NewModelLoader._validate_loaded_weights(module)
+
+
+class LinearPartitionTest(unittest.TestCase):
+    def test_column_parallel_rejects_unimplemented_gather_output(self):
+        with self.assertRaisesRegex(ValueError, "gather_output is not supported"):
+            ColumnParallelLinear(
+                input_size=2,
+                output_size=4,
+                gather_output=True,
+                params_dtype=torch.float32,
+            )
+
+    def test_merged_separate_and_fused_weights_match_for_tp(self):
+        gate = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+        up = torch.arange(8, 16, dtype=torch.float32).reshape(4, 2)
+
+        separate = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        separate.load_weights({"gate_proj.weight": gate, "up_proj.weight": up})
+
+        fused = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            tp_size=2,
+            tp_rank=1,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        fused.load_weights({"gate_up_proj.weight": torch.cat((gate, up), dim=0)})
+
+        expected = torch.cat((gate[2:], up[2:]), dim=0)
+        torch.testing.assert_close(separate.weight, expected)
+        torch.testing.assert_close(fused.weight, expected)
+        _validate(separate)
+        _validate(fused)
+
+    def test_qkv_kv_replication_uses_contiguous_rank_groups(self):
+        q = torch.arange(16, dtype=torch.float32).reshape(8, 2)
+        k = torch.tensor([[20.0, 21.0], [30.0, 31.0]])
+        v = torch.tensor([[40.0, 41.0], [50.0, 51.0]])
+        expected_kv_heads = [0, 0, 1, 1]
+
+        for rank, kv_head in enumerate(expected_kv_heads):
+            layer = QKVParallelLinear(
+                hidden_size=2,
+                num_heads=8,
+                num_kv_heads=2,
+                head_dim=1,
+                tp_size=4,
+                tp_rank=rank,
+                params_dtype=torch.float32,
+            )
+            layer.load_weights(
+                {
+                    "q_proj.weight": q,
+                    "k_proj.weight": k,
+                    "v_proj.weight": v,
+                }
+            )
+            expected = torch.cat(
+                (
+                    q[rank * 2 : rank * 2 + 2],
+                    k[kv_head : kv_head + 1],
+                    v[kv_head : kv_head + 1],
+                ),
+                dim=0,
+            )
+            torch.testing.assert_close(layer.weight, expected)
+            _validate(layer)
+
+    def test_row_parallel_reduces_before_adding_bias(self):
+        layer = RowParallelLinear(
+            input_size=4,
+            output_size=2,
+            tp_size=2,
+            tp_rank=0,
+            bias=True,
+            params_dtype=torch.float32,
+        )
+        layer.load_weights(
+            {
+                "weight": torch.tensor([[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0]]),
+                "bias": torch.tensor([3.0, 5.0]),
+            }
+        )
+        inputs = torch.tensor([[2.0, 4.0]])
+        with patch(
+            "rtp_llm.models_py.layers.linear.all_reduce",
+            side_effect=lambda tensor, group: tensor * 2,
+        ):
+            output = layer(inputs)
+        torch.testing.assert_close(output, torch.tensor([[7.0, 13.0]]))
+
+    def test_merged_rejects_mixed_and_oversized_shards(self):
+        layer = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+        with self.assertRaisesRegex(ValueError, "rows must be 4"):
+            layer.load_weights({"gate_proj.weight": torch.ones(5, 2)})
+
+        layer.load_weights({"gate_proj.weight": torch.ones(4, 2)})
+        with self.assertRaisesRegex(RuntimeError, "Duplicate"):
+            layer.load_weights({"gate_proj.weight": torch.zeros(4, 2)})
+        torch.testing.assert_close(layer.weight[:4], torch.ones(4, 2))
+        with self.assertRaisesRegex(RuntimeError, "mix fused and per-shard"):
+            layer.load_weights({"gate_up_proj.weight": torch.ones(8, 2)})
+
+    def test_merged_rejects_non_floating_shard_conversion(self):
+        layer = MergedColumnParallelLinear(
+            input_size=2,
+            output_size=8,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=torch.float32,
+        )
+
+        with self.assertRaisesRegex(TypeError, "Dtype mismatch"):
+            layer.load_weights(
+                {"gate_proj.weight": torch.ones(4, 2, dtype=torch.int32)}
+            )
+
+    def test_qkv_rejects_invalid_gqa(self):
+        with self.assertRaisesRegex(ValueError, "num_heads=8"):
+            QKVParallelLinear(
+                hidden_size=8,
+                num_heads=8,
+                num_kv_heads=6,
+                head_dim=1,
+                tp_size=4,
+                params_dtype=torch.float32,
+            )
+
+    def test_qkv_rejects_misaligned_gcd_topology(self):
+        with self.assertRaisesRegex(ValueError, "mutually divisible"):
+            QKVParallelLinear(
+                hidden_size=12,
+                num_heads=12,
+                num_kv_heads=6,
+                head_dim=1,
+                tp_size=4,
+                params_dtype=torch.float32,
+            )
+
+
+class Qwen2LoadTest(unittest.TestCase):
+    def _config(self):
+        return types.SimpleNamespace(
+            model_type="qwen_2",
+            num_layers=1,
+            vocab_size=8,
+            hidden_size=4,
+            inter_size=4,
+            attn_config=types.SimpleNamespace(
+                head_num=2,
+                kv_head_num=1,
+                size_per_head=2,
+            ),
+            layernorm_eps=1e-6,
+            enable_fp32_lm_head=False,
+            tie_word_embeddings=True,
+        )
+
+    def _load_config(
+        self,
+        tp_size=1,
+        tp_rank=0,
+        attn_tp_size=None,
+        attn_tp_rank=None,
+        ffn_tp_size=None,
+        ffn_tp_rank=None,
+        lm_head_tp_size=None,
+        lm_head_tp_rank=None,
+        cp_enabled=False,
+        prefill_cp_enabled=False,
+        ffn_disaggregate=False,
+    ):
+        attn_tp_size = tp_size if attn_tp_size is None else attn_tp_size
+        attn_tp_rank = tp_rank if attn_tp_rank is None else attn_tp_rank
+        ffn_tp_size = tp_size if ffn_tp_size is None else ffn_tp_size
+        ffn_tp_rank = tp_rank if ffn_tp_rank is None else ffn_tp_rank
+        lm_head_tp_size = tp_size if lm_head_tp_size is None else lm_head_tp_size
+        lm_head_tp_rank = tp_rank if lm_head_tp_rank is None else lm_head_tp_rank
+        parallelism = types.SimpleNamespace(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            ep_size=1,
+            ep_rank=0,
+            prefill_cp_config=types.SimpleNamespace(
+                is_enabled=lambda: cp_enabled,
+                is_prefill_enabled=lambda: prefill_cp_enabled,
+            ),
+            ffn_disaggregate_config=types.SimpleNamespace(
+                enable_ffn_disaggregate=ffn_disaggregate
+            ),
+            get_attn_tp_size=lambda: attn_tp_size,
+            get_attn_tp_rank=lambda: attn_tp_rank,
+            get_ffn_tp_size=lambda: ffn_tp_size,
+            get_ffn_tp_rank=lambda: ffn_tp_rank,
+        )
+        return NewLoaderConfig(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            attn_tp_size=attn_tp_size,
+            attn_tp_rank=attn_tp_rank,
+            ffn_tp_size=ffn_tp_size,
+            ffn_tp_rank=ffn_tp_rank,
+            lm_head_tp_size=lm_head_tp_size,
+            lm_head_tp_rank=lm_head_tp_rank,
+            compute_dtype=torch.float32,
+            device="cpu",
+            quant_config=QuantizationConfig("none"),
+            parallelism_config=parallelism,
+        )
+
+    def _model(self):
+        return Qwen2ForCausalLM(self._config(), self._load_config())
+
+    def _weights(self):
+        values = {
+            "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+                8, 4
+            ),
+            "model.layers.0.input_layernorm.weight": torch.ones(4),
+            "model.layers.0.self_attn.q_proj.weight": torch.arange(
+                16, dtype=torch.float32
+            ).reshape(4, 4),
+            "model.layers.0.self_attn.k_proj.weight": torch.arange(
+                8, dtype=torch.float32
+            ).reshape(2, 4),
+            "model.layers.0.self_attn.v_proj.weight": torch.arange(
+                8, 16, dtype=torch.float32
+            ).reshape(2, 4),
+            "model.layers.0.self_attn.q_proj.bias": torch.full((4,), 0.5),
+            "model.layers.0.self_attn.k_proj.bias": torch.full((2,), -0.25),
+            "model.layers.0.self_attn.v_proj.bias": torch.full((2,), 0.75),
+            "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+            "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+            "model.layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+            "model.layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+            "model.layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+            "model.norm.weight": torch.ones(4),
+        }
+        return values
+
+    def test_real_model_load_validates_and_ties_missing_lm_head(self):
+        model = self._model()
+        weights = self._weights()
+
+        model.load_weights(weights)
+        _validate(model)
+
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertIn(id(model.lm_head.weight), collect_loaded_tensor_ids(model))
+        self.assertEqual(
+            set(model.runtime_weight_view()),
+            {"embedding", "final_layernorm.gamma", "lm_head"},
+        )
+
+    def test_untied_model_rejects_missing_lm_head(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen2ForCausalLM(config, self._load_config())
+
+        model.load_weights(self._weights())
+
+        with self.assertRaisesRegex(RuntimeError, "ParallelLMHead.*weight"):
+            _validate(model)
+
+    def test_untied_model_loads_explicit_lm_head(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen2ForCausalLM(config, self._load_config())
+        weights = self._weights()
+        weights["lm_head.weight"] = torch.arange(32, 64, dtype=torch.float32).reshape(
+            8, 4
+        )
+
+        model.load_weights(weights)
+        _validate(model)
+
+        torch.testing.assert_close(model.lm_head.weight, weights["lm_head.weight"])
+
+    def test_lm_head_postprocess_matches_legacy_logits_for_tp(self):
+        hidden_states = torch.tensor([[1.0, -2.0, 0.5, 3.0], [-1.0, 0.25, 2.0, 0.75]])
+        explicit_lm_head = torch.arange(32, 64, dtype=torch.float32).reshape(8, 4)
+
+        for tied in (True, False):
+            config = self._config()
+            config.tie_word_embeddings = tied
+            config.normalize_lm_head_weight = True
+            config.logit_scale = 0.25
+            weights = self._weights()
+            source = weights["model.embed_tokens.weight"]
+            if not tied:
+                weights["lm_head.weight"] = explicit_lm_head
+                source = explicit_lm_head
+
+            with self.subTest(tied=tied), tempfile.TemporaryDirectory() as model_path:
+                save_file(weights, f"{model_path}/model.safetensors")
+                for rank in range(2):
+                    model = NewModelLoader(
+                        model_config=config,
+                        load_config=self._load_config(tp_size=2, tp_rank=rank),
+                        model_path=model_path,
+                    ).load()
+                    local_source = source[rank * 4 : (rank + 1) * 4]
+                    expected_weight = F.normalize(local_source, dim=1) * 0.25
+                    torch.testing.assert_close(model.lm_head.weight, expected_weight)
+                    torch.testing.assert_close(
+                        F.linear(hidden_states, model.runtime_weight_view()["lm_head"]),
+                        F.linear(hidden_states, expected_weight),
+                    )
+
+    def test_checkpoint_lm_head_must_use_global_vocab_shape(self):
+        config = self._config()
+        config.tie_word_embeddings = False
+        model = Qwen2ForCausalLM(config, self._load_config(tp_size=2))
+        weights = self._weights()
+        weights["lm_head.weight"] = torch.ones(4, 4)
+
+        with self.assertRaisesRegex(ValueError, "checkpoint rows must be 8"):
+            model.load_weights(weights)
+
+    def test_parallel_topologies_are_applied_to_their_owners(self):
+        model = Qwen2ForCausalLM(
+            self._config(), self._load_config(tp_size=2, tp_rank=1)
+        )
+
+        self.assertEqual(
+            (model.embed_tokens.tp_size, model.embed_tokens.tp_rank), (2, 1)
+        )
+        self.assertEqual(
+            (
+                model.layers[0].self_attn.qkv_proj.tp_size,
+                model.layers[0].self_attn.qkv_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+        self.assertEqual(
+            (
+                model.layers[0].mlp.gate_up_proj.tp_size,
+                model.layers[0].mlp.gate_up_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+        self.assertEqual((model.lm_head.tp_size, model.lm_head.tp_rank), (2, 1))
+
+    def test_legacy_negative_one_kv_head_sentinel_uses_q_head_count(self):
+        config = self._config()
+        config.attn_config.kv_head_num = -1
+
+        model = Qwen2ForCausalLM(config, self._load_config())
+
+        self.assertEqual(model.layers[0].self_attn.num_kv_heads, 2)
+
+    def test_context_parallel_topology_is_rejected(self):
+        load_config = self._load_config(
+            tp_size=2,
+            tp_rank=1,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+            ffn_tp_size=1,
+            ffn_tp_rank=0,
+            cp_enabled=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Context parallelism"):
+            Qwen2ForCausalLM(self._config(), load_config)
+
+    def test_prefill_context_parallel_mode_is_rejected(self):
+        load_config = self._load_config(prefill_cp_enabled=True)
+
+        with self.assertRaisesRegex(ValueError, "Context parallelism"):
+            Qwen2ForCausalLM(self._config(), load_config)
+
+    def test_independent_ffn_topology_is_rejected(self):
+        load_config = self._load_config(
+            tp_size=2,
+            tp_rank=1,
+            ffn_tp_size=1,
+            ffn_tp_rank=0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Independent FFN"):
+            Qwen2ForCausalLM(self._config(), load_config)
+
+    def test_ffn_disaggregation_is_rejected(self):
+        load_config = self._load_config(ffn_disaggregate=True)
+
+        with self.assertRaisesRegex(ValueError, "FFN disaggregation"):
+            Qwen2ForCausalLM(self._config(), load_config)
+
+    def test_separate_lm_head_topology_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "lm_head_tp partition"):
+            self._load_config(
+                tp_size=2,
+                tp_rank=1,
+                lm_head_tp_size=1,
+                lm_head_tp_rank=0,
+            )
+
+    def test_new_model_loader_streams_real_safetensors(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(self._weights(), f"{model_path}/model.safetensors")
+            loader = NewModelLoader(
+                self._config(),
+                self._load_config(),
+                model_path=model_path,
+            )
+
+            model = loader.load()
+
+        self.assertIsInstance(model, Qwen2ForCausalLM)
+        self.assertFalse(model.training)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+
+    def test_rank_local_consolidated_checkpoint_is_rejected_explicitly(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(self._weights(), f"{model_path}/consolidated.00.pth")
+            loader = NewModelLoader(
+                self._config(),
+                self._load_config(),
+                model_path=model_path,
+            )
+
+            with self.assertRaisesRegex(
+                ValueError, "does not support rank-local consolidated checkpoints"
+            ):
+                loader.load()
+
+    def test_real_model_forward_matches_cpu_reference(self):
+        weights = self._weights()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                self._config(), self._load_config(), model_path=model_path
+            ).load()
+
+        class QOnlyFmha:
+            fmha_params = None
+
+            def __init__(self, q_size):
+                self.q_size = q_size
+
+            def forward(self, qkv, kv_cache, layer_idx):
+                return qkv[..., : self.q_size]
+
+        def rms_norm(x, weight, eps=1e-6):
+            normalized = x.float() * torch.rsqrt(
+                x.float().pow(2).mean(dim=-1, keepdim=True) + eps
+            )
+            return (normalized * weight).to(x.dtype)
+
+        input_ids = torch.tensor([0, 3, 7], dtype=torch.int32)
+        fmha = QOnlyFmha(model.layers[0].self_attn.qkv_proj.q_size)
+        inputs = PyModelInputs(input_ids=input_ids)
+        with patch(
+            "rtp_llm.models_py.new_models.qwen2.language.select_block_map_for_layer"
+        ) as select_block_map:
+            outputs = model(inputs, fmha_impl=fmha)
+        select_block_map.assert_called_once_with(inputs.attention_inputs, 0)
+
+        hidden = F.embedding(input_ids.long(), weights["model.embed_tokens.weight"])
+        residual = hidden
+        hidden = rms_norm(hidden, weights["model.layers.0.input_layernorm.weight"])
+        q = F.linear(
+            hidden,
+            weights["model.layers.0.self_attn.q_proj.weight"],
+            weights["model.layers.0.self_attn.q_proj.bias"],
+        )
+        hidden = F.linear(q, weights["model.layers.0.self_attn.o_proj.weight"])
+        hidden = residual + hidden
+        residual = hidden
+        hidden = rms_norm(
+            hidden, weights["model.layers.0.post_attention_layernorm.weight"]
+        )
+        gate = F.linear(hidden, weights["model.layers.0.mlp.gate_proj.weight"])
+        up = F.linear(hidden, weights["model.layers.0.mlp.up_proj.weight"])
+        hidden = F.linear(
+            F.silu(gate.float()) * up.float(),
+            weights["model.layers.0.mlp.down_proj.weight"],
+        )
+        hidden = residual + hidden
+        expected = rms_norm(hidden, weights["model.norm.weight"])
+
+        torch.testing.assert_close(outputs.hidden_states, expected)
+        torch.testing.assert_close(
+            model.lm_head(outputs.hidden_states),
+            F.linear(expected, weights["model.embed_tokens.weight"]),
+        )
+
+    def test_unknown_checkpoint_tensor_fails(self):
+        model = self._model()
+        weights = self._weights()
+        weights["model.layers.0.mlp.gate_prjo.weight"] = torch.ones(4, 4)
+
+        with self.assertRaisesRegex(RuntimeError, "could not dispatch"):
+            model.load_weights(weights)
+
+    def test_unsupported_quantization_fails_fast(self):
+        config = QuantizationConfig("definitely_unsupported")
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            QKVParallelLinear(
+                hidden_size=4,
+                num_heads=2,
+                num_kv_heads=1,
+                head_dim=2,
+                quant_config=config,
+            )
+
+    def test_missing_required_config_value_fails_fast(self):
+        config = self._config()
+        del config.hidden_size
+
+        with self.assertRaisesRegex(ValueError, "hidden_size"):
+            Qwen2ForCausalLM(config, self._load_config())
+
+    def test_hf_dict_config_constructs_same_model_shape(self):
+        config = {
+            "model_type": "qwen_2",
+            "num_hidden_layers": 1,
+            "vocab_size": 8,
+            "hidden_size": 4,
+            "intermediate_size": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 2,
+            "rms_norm_eps": 1e-6,
+            "enable_fp32_lm_head": False,
+            "tie_word_embeddings": True,
+        }
+
+        model = Qwen2ForCausalLM(config, self._load_config())
+
+        self.assertEqual(len(model.layers), 1)
+        self.assertEqual(model.embed_tokens.weight.shape, (8, 4))
+        self.assertEqual(model.layers[0].self_attn.qkv_proj.weight.shape, (8, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_moe/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen2_moe/__init__.py
@@ -1,0 +1,3 @@
+from rtp_llm.models_py.new_models.qwen2_moe.language import Qwen2MoeForCausalLM
+
+__all__ = ["Qwen2MoeForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen2_moe/language.py
+++ b/rtp_llm/models_py/new_models/qwen2_moe/language.py
@@ -1,0 +1,501 @@
+import logging
+import math
+from numbers import Real
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.layers.activation import silu_and_mul
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
+from rtp_llm.models_py.layers.norm import RMSResNorm
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules import FakeBalanceExpert, SelectTopk
+from rtp_llm.models_py.new_models.model_base import (
+    required_config_value,
+    select_block_map_for_layer,
+)
+from rtp_llm.models_py.new_models.qwen2.language import (
+    Qwen2Attention,
+    _extract_config_values,
+    _positive_int,
+    _validate_supported_parallelism,
+)
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import LayerKVCache, PyModelInputs, PyModelOutputs
+
+
+class Qwen2Experts(BaseMoEExperts):
+    """Qwen2 expert layout implemented by the shared newloader MoE layer."""
+
+
+class Qwen2SharedExpert(RtpModule):
+    """Tensor-parallel gated FFN used by every token."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int,
+        tp_rank: int,
+        quant_config: Optional[QuantizationConfig],
+        params_dtype: torch.dtype,
+        prefix: str,
+    ):
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=2 * intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+            bias=False,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=params_dtype,
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(silu_and_mul(self.gate_up_proj(hidden_states)))
+
+
+class Qwen2MoeBlock(RtpModule):
+    def __init__(
+        self,
+        hidden_size: int,
+        moe_intermediate_size: int,
+        shared_expert_intermediate_size: int,
+        num_experts: int,
+        top_k: int,
+        layer_idx: int,
+        ffn_tp_size: int,
+        ffn_tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        model_config: ModelConfig,
+        parallelism_config: Any,
+        moe_config: Any,
+        quant_config: Optional[QuantizationConfig],
+        params_dtype: torch.dtype,
+        prefix: str,
+    ):
+        super().__init__()
+        self.top_k = top_k
+        self.gate = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=num_experts,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=None,
+            prefix=f"{prefix}.gate",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        if model_config.expert_num != num_experts or model_config.moe_k != top_k:
+            raise ValueError(
+                "Qwen2 MoE router dimensions disagree with ModelConfig: "
+                f"experts={model_config.expert_num}/{num_experts}, "
+                f"top_k={model_config.moe_k}/{top_k}"
+            )
+        self.select_topk = SelectTopk(config=model_config)
+        fake_balance_expert = getattr(moe_config, "fake_balance_expert", False)
+        if not isinstance(fake_balance_expert, bool):
+            raise TypeError("moe_config.fake_balance_expert must be a bool")
+        if fake_balance_expert:
+            self.fake_balance_expert = FakeBalanceExpert(
+                expert_num=num_experts,
+                moe_k=top_k,
+                dp_rank=parallelism_config.dp_rank,
+                dp_size=parallelism_config.dp_size,
+                ep_size=ep_size,
+            )
+        else:
+            self.fake_balance_expert = None
+        self.experts = Qwen2Experts(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            moe_intermediate_size=moe_intermediate_size,
+            tp_size=ffn_tp_size,
+            tp_rank=ffn_tp_rank,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            params_dtype=params_dtype,
+            model_config=model_config,
+            parallelism_config=parallelism_config,
+            moe_config=moe_config,
+            quant_config=quant_config,
+            layer_idx=layer_idx,
+            prefix=f"{prefix}.experts",
+        )
+        self.shared_expert = Qwen2SharedExpert(
+            hidden_size=hidden_size,
+            intermediate_size=shared_expert_intermediate_size,
+            tp_size=ffn_tp_size,
+            tp_rank=ffn_tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            prefix=f"{prefix}.shared_expert",
+        )
+        self.shared_expert_gate = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=1,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=None,
+            prefix=f"{prefix}.shared_expert_gate",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.experts.fused_moe is None:
+            raise RuntimeError(
+                "Qwen2 MoE executor is not initialized; load and postprocess "
+                "all expert weights before forward"
+            )
+        if hidden_states.dim() != 2:
+            raise ValueError(
+                "Qwen2 MoE expects a two-dimensional token matrix, got "
+                f"{tuple(hidden_states.shape)}"
+            )
+        router_logits = self.gate(hidden_states).float()
+        shape = (hidden_states.shape[0], self.top_k)
+        topk_weights = torch.empty(
+            shape, dtype=torch.float32, device=hidden_states.device
+        )
+        topk_ids = torch.empty(
+            shape,
+            dtype=self.experts.fused_moe.topk_ids_dtype,
+            device=hidden_states.device,
+        )
+        self.select_topk(router_logits, topk_ids, topk_weights)
+        if self.fake_balance_expert is not None:
+            self.fake_balance_expert(topk_ids, topk_weights)
+        routed = self.experts(hidden_states, topk_weights, topk_ids)
+        shared = self.shared_expert(hidden_states)
+        shared_gate = torch.sigmoid(self.shared_expert_gate(hidden_states).float())
+        return routed + shared * shared_gate.to(dtype=shared.dtype)
+
+
+class Qwen2MoeDecoderLayer(RtpModule):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        moe_intermediate_size: int,
+        shared_expert_intermediate_size: int,
+        num_experts: int,
+        top_k: int,
+        head_dim: int,
+        layer_idx: int,
+        attn_tp_size: int,
+        attn_tp_rank: int,
+        ffn_tp_size: int,
+        ffn_tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        model_config: ModelConfig,
+        parallelism_config: Any,
+        moe_config: Any,
+        quant_config: Optional[QuantizationConfig],
+        params_dtype: torch.dtype,
+        rms_norm_eps: float,
+        prefix: str,
+    ):
+        super().__init__()
+        self.input_layernorm = RMSResNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.self_attn = Qwen2Attention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            layer_idx=layer_idx,
+            tp_size=attn_tp_size,
+            tp_rank=attn_tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            prefix=f"{prefix}.self_attn",
+        )
+        self.post_attention_layernorm = RMSResNorm(
+            hidden_size, eps=rms_norm_eps, params_dtype=params_dtype
+        )
+        self.mlp = Qwen2MoeBlock(
+            hidden_size=hidden_size,
+            moe_intermediate_size=moe_intermediate_size,
+            shared_expert_intermediate_size=shared_expert_intermediate_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            layer_idx=layer_idx,
+            ffn_tp_size=ffn_tp_size,
+            ffn_tp_rank=ffn_tp_rank,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            model_config=model_config,
+            parallelism_config=parallelism_config,
+            moe_config=moe_config,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            prefix=f"{prefix}.mlp",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(hidden_states, fmha_impl, kv_cache)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+def _model_value(model_config: Any, *names: str):
+    return required_config_value(model_config, *names)
+
+
+def _extract_moe_config_values(model_config: ModelConfig, load_config: Any):
+    values = _extract_config_values(
+        model_config, load_config, validate_intermediate_size=False
+    )
+    moe_style = _model_value(model_config, "moe_style")
+    if isinstance(moe_style, bool) or not isinstance(moe_style, int) or moe_style != 2:
+        raise ValueError(
+            "Qwen2 MoE newloader requires moe_style=2 (shared and routed "
+            f"experts), got {moe_style!r}"
+        )
+    num_experts = _model_value(model_config, "expert_num")
+    top_k = _model_value(model_config, "moe_k")
+    moe_intermediate_size = _model_value(model_config, "moe_inter_size")
+    shared_expert_intermediate_size = _model_value(model_config, "inter_size")
+    num_experts = _positive_int(num_experts, "num_experts")
+    top_k = _positive_int(top_k, "top_k")
+    moe_intermediate_size = _positive_int(
+        moe_intermediate_size, "moe_intermediate_size"
+    )
+    shared_expert_intermediate_size = _positive_int(
+        shared_expert_intermediate_size, "shared_expert_intermediate_size"
+    )
+    expected_moe_layers = list(range(values["num_layers"]))
+    moe_layer_index = getattr(model_config, "moe_layer_index", None)
+    if (
+        not isinstance(moe_layer_index, (list, tuple))
+        or list(moe_layer_index) != expected_moe_layers
+    ):
+        raise ValueError(
+            "Qwen2 MoE newloader requires every decoder layer to be an MoE "
+            f"layer; expected moe_layer_index={expected_moe_layers}, got "
+            f"{moe_layer_index!r}"
+        )
+    if top_k > num_experts:
+        raise ValueError(f"top_k={top_k} cannot exceed num_experts={num_experts}")
+    ep_size = _positive_int(required_config_value(load_config, "ep_size"), "EP size")
+    ep_rank = required_config_value(load_config, "ep_rank")
+    if (
+        isinstance(ep_rank, bool)
+        or not isinstance(ep_rank, int)
+        or not 0 <= ep_rank < ep_size
+    ):
+        raise ValueError(f"Invalid EP partition: rank={ep_rank}, size={ep_size}")
+    if num_experts % ep_size != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by ep_size={ep_size}"
+        )
+    parallelism_config = required_config_value(load_config, "parallelism_config")
+    moe_config = required_config_value(load_config, "moe_config")
+    dp_size = getattr(parallelism_config, "dp_size", None)
+    dp_rank = getattr(parallelism_config, "dp_rank", None)
+    if isinstance(dp_size, bool) or not isinstance(dp_size, int) or dp_size <= 0:
+        raise ValueError(f"DP size must be a positive integer, got {dp_size!r}")
+    if (
+        isinstance(dp_rank, bool)
+        or not isinstance(dp_rank, int)
+        or not 0 <= dp_rank < dp_size
+    ):
+        raise ValueError(f"Invalid DP partition: rank={dp_rank}, size={dp_size}")
+    eplb_config = getattr(model_config, "eplb_config", None)
+    enable_eplb = getattr(eplb_config, "enable_eplb", False)
+    if callable(enable_eplb):
+        enable_eplb = enable_eplb()
+    if not isinstance(enable_eplb, bool):
+        raise TypeError("eplb_config.enable_eplb must be a bool")
+    if enable_eplb:
+        raise ValueError("EPLB is not supported by the Qwen2 MoE newloader path")
+    values.update(
+        num_experts=num_experts,
+        top_k=top_k,
+        moe_intermediate_size=moe_intermediate_size,
+        shared_expert_intermediate_size=shared_expert_intermediate_size,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        model_config=model_config,
+        parallelism_config=parallelism_config,
+        moe_config=moe_config,
+    )
+    return values
+
+
+class Qwen2MoeForCausalLM(GptModelBase):
+    WEIGHTS_MAPPER = WeightsMapper(prefix_mapping={"model.": ""})
+
+    def load_weights(self, weights) -> None:
+        iterator = weights.items() if isinstance(weights, dict) else weights
+        has_lm_head = False
+
+        def track(mapped):
+            nonlocal has_lm_head
+            for name, tensor in mapped:
+                if name == "lm_head.weight":
+                    has_lm_head = True
+                yield name, tensor
+
+        super().load_weights(track(self.WEIGHTS_MAPPER.apply(iterator)))
+        if not has_lm_head and self.tie_word_embeddings:
+            logging.info("Qwen2MoeForCausalLM is tying lm_head to embed_tokens")
+            self.lm_head._copy_local_tied_weight(self.embed_tokens.weight.data)
+
+    def process_weights_after_loading(self) -> None:
+        if self._lm_head_postprocessed:
+            return
+        processed = self.lm_head.weight
+        if self.normalize_lm_head_weight:
+            processed = torch.nn.functional.normalize(processed, dim=1)
+        if self.logit_scale != 1.0:
+            processed = processed * self.logit_scale
+        if processed is not self.lm_head.weight:
+            with torch.no_grad():
+                self.lm_head.weight.copy_(processed)
+        self._lm_head_postprocessed = True
+
+    def __init__(self, model_config: ModelConfig, load_config: Any):
+        if not isinstance(model_config, ModelConfig):
+            raise TypeError(
+                "Qwen2 MoE newloader requires a typed ModelConfig; normalize "
+                "raw Hugging Face config.json data at the BaseModel boundary"
+            )
+        parallelism_config = required_config_value(load_config, "parallelism_config")
+        _validate_supported_parallelism(parallelism_config)
+        super().__init__(
+            config=model_config,
+            parallelism_config=parallelism_config,
+            weight=None,
+            max_generate_batch_size=0,
+            fmha_config=getattr(load_config, "fmha_config", None),
+            device_resource_config=getattr(load_config, "device_resource_config", None),
+        )
+        cfg = _extract_moe_config_values(model_config, load_config)
+        tie_word_embeddings = getattr(model_config, "tie_word_embeddings", False)
+        if not isinstance(tie_word_embeddings, bool):
+            raise TypeError("tie_word_embeddings must be a bool")
+        self.tie_word_embeddings = tie_word_embeddings
+        normalize = getattr(model_config, "normalize_lm_head_weight", False)
+        if not isinstance(normalize, bool):
+            raise TypeError("normalize_lm_head_weight must be a bool")
+        raw_scale = getattr(model_config, "logit_scale", 1.0)
+        if isinstance(raw_scale, bool) or not isinstance(raw_scale, Real):
+            raise TypeError("logit_scale must be a finite real number")
+        self.logit_scale = float(raw_scale)
+        if not math.isfinite(self.logit_scale):
+            raise ValueError("logit_scale must be finite")
+        self.normalize_lm_head_weight = normalize
+        self._lm_head_postprocessed = False
+
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size=cfg["vocab_size"],
+            embedding_dim=cfg["hidden_size"],
+            tp_size=cfg["attn_tp_size"],
+            tp_rank=cfg["attn_tp_rank"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen2MoeDecoderLayer(
+                    hidden_size=cfg["hidden_size"],
+                    num_heads=cfg["num_heads"],
+                    num_kv_heads=cfg["num_kv_heads"],
+                    moe_intermediate_size=cfg["moe_intermediate_size"],
+                    shared_expert_intermediate_size=cfg[
+                        "shared_expert_intermediate_size"
+                    ],
+                    num_experts=cfg["num_experts"],
+                    top_k=cfg["top_k"],
+                    head_dim=cfg["head_dim"],
+                    layer_idx=layer_idx,
+                    attn_tp_size=cfg["attn_tp_size"],
+                    attn_tp_rank=cfg["attn_tp_rank"],
+                    ffn_tp_size=cfg["ffn_tp_size"],
+                    ffn_tp_rank=cfg["ffn_tp_rank"],
+                    ep_size=cfg["ep_size"],
+                    ep_rank=cfg["ep_rank"],
+                    model_config=cfg["model_config"],
+                    parallelism_config=cfg["parallelism_config"],
+                    moe_config=cfg["moe_config"],
+                    quant_config=cfg["quant_config"],
+                    params_dtype=cfg["params_dtype"],
+                    rms_norm_eps=cfg["rms_norm_eps"],
+                    prefix=f"layers.{layer_idx}",
+                )
+                for layer_idx in range(cfg["num_layers"])
+            ]
+        )
+        self.norm = RMSResNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.lm_head = ParallelLMHead(
+            vocab_size=cfg["vocab_size"],
+            hidden_size=cfg["hidden_size"],
+            tp_size=cfg["lm_head_tp_size"],
+            tp_rank=cfg["lm_head_tp_rank"],
+            params_dtype=cfg["lm_head_params_dtype"],
+        )
+
+    def runtime_weight_view(self) -> dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        hidden_states = self.embed_tokens(inputs.input_ids)
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+        residual = torch.zeros_like(hidden_states)
+        for layer_idx, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, layer_idx)
+            hidden_states, residual = layer(
+                hidden_states,
+                residual,
+                fmha_impl,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(layer_idx) if self.kv_cache else None
+                ),
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/new_models/qwen2_moe/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2_moe/test/BUILD
@@ -1,0 +1,9 @@
+py_test(
+    name = "test_qwen2_moe_load",
+    srcs = ["test_qwen2_moe_load.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen2_moe/test/test_qwen2_moe_load.py
+++ b/rtp_llm/models_py/new_models/qwen2_moe/test/test_qwen2_moe_load.py
@@ -1,0 +1,242 @@
+import types
+import unittest
+
+import torch
+import torch.nn.functional as F
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen2_moe.language import (
+    Qwen2MoeForCausalLM,
+    Qwen2SharedExpert,
+)
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+from rtp_llm.models_py.quant_methods.unquantized import UnquantizedLinearMethod
+from rtp_llm.models_py.registry import get_model_class
+
+
+def _parallelism(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0):
+    return types.SimpleNamespace(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        dp_size=1,
+        dp_rank=0,
+        world_size=max(tp_size, ep_size),
+        local_rank=tp_rank,
+        get_attn_tp_size=lambda: tp_size,
+        get_attn_tp_rank=lambda: tp_rank,
+        get_ffn_tp_size=lambda: tp_size,
+        get_ffn_tp_rank=lambda: tp_rank,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+    )
+
+
+def _moe_config():
+    return types.SimpleNamespace(
+        ll_num_max_token=1,
+        masked_max_token_num=1,
+        moe_strategy=0,
+        use_mori_ep=False,
+        use_deepep_moe=False,
+        use_deepep_low_latency=False,
+        use_all_gather=True,
+        fake_balance_expert=False,
+    )
+
+
+def _config(tie_word_embeddings=True):
+    config = ModelConfig()
+    config.model_type = "qwen_2_moe"
+    config.num_layers = 1
+    config.vocab_size = 8
+    config.hidden_size = 4
+    config.inter_size = 4
+    config.expert_num = 2
+    config.moe_inter_size = 4
+    config.moe_k = 1
+    config.moe_style = 2
+    config.moe_topk_group = 1
+    config.attn_config.head_num = 2
+    config.attn_config.kv_head_num = 1
+    config.attn_config.size_per_head = 2
+    config.layernorm_eps = 1e-6
+    config.enable_fp32_lm_head = False
+    config.tie_word_embeddings = tie_word_embeddings
+    config.data_type = "fp32"
+    config.quant_config = None
+    config.activation_type = "SiGLU"
+    config.moe_layer_index = [0]
+    return config
+
+
+def _load_config(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0, quant_config=None):
+    parallelism = _parallelism(tp_size, tp_rank, ep_size, ep_rank)
+    return NewLoaderConfig(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        compute_dtype=torch.float32,
+        device="cpu",
+        quant_config=quant_config or QuantizationConfig("none"),
+        parallelism_config=parallelism,
+        moe_config=_moe_config(),
+    )
+
+
+def _weights():
+    weights = {
+        "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+            8, 4
+        ),
+        "model.layers.0.input_layernorm.weight": torch.ones(4),
+        "model.layers.0.self_attn.q_proj.weight": torch.ones(4, 4),
+        "model.layers.0.self_attn.k_proj.weight": torch.ones(2, 4),
+        "model.layers.0.self_attn.v_proj.weight": torch.ones(2, 4),
+        "model.layers.0.self_attn.q_proj.bias": torch.zeros(4),
+        "model.layers.0.self_attn.k_proj.bias": torch.zeros(2),
+        "model.layers.0.self_attn.v_proj.bias": torch.zeros(2),
+        "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+        "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+        "model.layers.0.mlp.gate.weight": torch.ones(2, 4),
+        "model.layers.0.mlp.shared_expert.gate_proj.weight": torch.ones(4, 4),
+        "model.layers.0.mlp.shared_expert.up_proj.weight": torch.full((4, 4), 2.0),
+        "model.layers.0.mlp.shared_expert.down_proj.weight": torch.eye(4),
+        "model.layers.0.mlp.shared_expert_gate.weight": torch.ones(1, 4),
+        "model.norm.weight": torch.ones(4),
+    }
+    for expert_id in range(2):
+        prefix = f"model.layers.0.mlp.experts.{expert_id}"
+        weights[f"{prefix}.gate_proj.weight"] = torch.ones(4, 4)
+        weights[f"{prefix}.up_proj.weight"] = torch.full((4, 4), 2.0)
+        weights[f"{prefix}.down_proj.weight"] = torch.eye(4)
+    return weights
+
+
+class Qwen2MoeLoadTest(unittest.TestCase):
+    def test_registry_exposes_qwen2_dense_and_moe(self):
+        self.assertEqual(get_model_class("qwen_2").__name__, "Qwen2ForCausalLM")
+        self.assertIs(get_model_class("qwen_2_moe"), Qwen2MoeForCausalLM)
+
+    def test_real_tree_loads_shared_and_routed_experts(self):
+        model = Qwen2MoeForCausalLM(_config(), _load_config())
+        model.load_weights(_weights())
+        NewModelLoader._validate_loaded_weights(model)
+
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertEqual(model.layers[0].mlp.experts._loaded_count, 6)
+        shared_gate_up = model.layers[0].mlp.shared_expert.gate_up_proj.weight
+        torch.testing.assert_close(shared_gate_up[:4], torch.ones(4, 4))
+        torch.testing.assert_close(shared_gate_up[4:], torch.full((4, 4), 2.0))
+
+    def test_untied_missing_lm_head_fails_integrity(self):
+        model = Qwen2MoeForCausalLM(_config(tie_word_embeddings=False), _load_config())
+        model.load_weights(_weights())
+
+        with self.assertRaisesRegex(RuntimeError, "ParallelLMHead.*weight"):
+            NewModelLoader._validate_loaded_weights(model)
+
+    def test_partial_moe_layer_config_is_rejected(self):
+        config = _config()
+        config.moe_layer_index = []
+
+        with self.assertRaisesRegex(ValueError, "every decoder layer"):
+            Qwen2MoeForCausalLM(config, _load_config())
+
+    def test_non_hybrid_moe_style_is_rejected(self):
+        config = _config()
+        config.moe_style = 1
+
+        with self.assertRaisesRegex(ValueError, "moe_style=2"):
+            Qwen2MoeForCausalLM(config, _load_config())
+
+    def test_raw_hf_dict_is_rejected_before_router_construction(self):
+        with self.assertRaisesRegex(TypeError, "requires a typed ModelConfig"):
+            Qwen2MoeForCausalLM(
+                {
+                    "model_type": "qwen_2_moe",
+                    "num_hidden_layers": 1,
+                    "num_experts": 2,
+                    "num_experts_per_tok": 1,
+                },
+                _load_config(),
+            )
+
+    def test_invalid_shared_expert_size_fails_fast(self):
+        config = _config()
+        config.inter_size = 0
+
+        with self.assertRaisesRegex(ValueError, "shared_expert_intermediate_size"):
+            Qwen2MoeForCausalLM(config, _load_config())
+
+    def test_tp_topology_is_applied_to_attention_experts_and_shared_ffn(self):
+        model = Qwen2MoeForCausalLM(_config(), _load_config(tp_size=2, tp_rank=1))
+        layer = model.layers[0]
+
+        self.assertEqual(
+            (layer.self_attn.qkv_proj.tp_size, layer.self_attn.qkv_proj.tp_rank), (2, 1)
+        )
+        self.assertEqual(
+            (
+                layer.mlp.experts.moe_expert_tp_size,
+                layer.mlp.experts.moe_expert_tp_rank,
+            ),
+            (2, 1),
+        )
+        self.assertEqual(
+            (
+                layer.mlp.shared_expert.gate_up_proj.tp_size,
+                layer.mlp.shared_expert.gate_up_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+
+    def test_router_and_shared_gate_stay_unquantized(self):
+        config = _config()
+        config.quant_config = types.SimpleNamespace(
+            get_runtime_method_key=lambda: "fp8",
+            get_method=lambda: "fp8",
+        )
+        model = Qwen2MoeForCausalLM(
+            config, _load_config(quant_config=QuantizationConfig("fp8"))
+        )
+        block = model.layers[0].mlp
+
+        self.assertIsInstance(block.gate.quant_method, UnquantizedLinearMethod)
+        self.assertIsInstance(
+            block.shared_expert_gate.quant_method, UnquantizedLinearMethod
+        )
+
+    def test_shared_expert_matches_dense_reference(self):
+        layer = Qwen2SharedExpert(
+            hidden_size=4,
+            intermediate_size=4,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=QuantizationConfig("none"),
+            params_dtype=torch.float32,
+            prefix="layers.0.mlp.shared_expert",
+        )
+        gate = torch.arange(16, dtype=torch.float32).reshape(4, 4) / 10
+        up = torch.arange(16, 32, dtype=torch.float32).reshape(4, 4) / 10
+        down = torch.eye(4)
+        layer.load_weights(
+            {
+                "gate_proj.weight": gate,
+                "up_proj.weight": up,
+                "down_proj.weight": down,
+            }
+        )
+        hidden = torch.tensor([[1.0, -1.0, 0.5, 2.0]])
+
+        expected = F.linear(F.silu(F.linear(hidden, gate)) * F.linear(hidden, up), down)
+        torch.testing.assert_close(layer(hidden), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_moe/test/test_qwen2_moe_load.py
+++ b/rtp_llm/models_py/new_models/qwen2_moe/test/test_qwen2_moe_load.py
@@ -118,6 +118,60 @@ def _weights():
     return weights
 
 
+class _CpuSelectTopk(torch.nn.Module):
+    def forward(self, router_logits, topk_ids, topk_weights):
+        probabilities = torch.softmax(router_logits, dim=-1)
+        values, indices = torch.topk(probabilities, topk_ids.shape[-1], dim=-1)
+        topk_ids.copy_(indices)
+        topk_weights.copy_(values)
+
+
+class _CpuFusedMoe(torch.nn.Module):
+    topk_ids_dtype = torch.int64
+
+    def __init__(self, w13, w2):
+        super().__init__()
+        self.register_buffer("w13", w13.detach().clone())
+        self.register_buffer("w2", w2.detach().clone())
+
+    def forward(self, hidden_states, topk_weights, topk_ids, activation):
+        if activation != "SiGLU":
+            raise AssertionError(f"unexpected activation {activation!r}")
+        intermediate_size = self.w13.shape[1] // 2
+        output = torch.zeros_like(hidden_states)
+        for token_idx in range(hidden_states.shape[0]):
+            token = hidden_states[token_idx : token_idx + 1]
+            for slot_idx in range(topk_ids.shape[1]):
+                expert_idx = int(topk_ids[token_idx, slot_idx])
+                up = self.w13[expert_idx, :intermediate_size]
+                gate = self.w13[expert_idx, intermediate_size:]
+                down = self.w2[expert_idx]
+                expert_output = F.linear(
+                    F.silu(F.linear(token, gate)) * F.linear(token, up), down
+                )
+                output[token_idx] += topk_weights[
+                    token_idx, slot_idx
+                ] * expert_output.squeeze(0)
+        return output
+
+
+class _IdentityAttention(torch.nn.Module):
+    def forward(self, hidden_states, fmha_impl, kv_cache=None):
+        return hidden_states
+
+
+def _rms_norm_reference(hidden_states, weight, eps):
+    variance = hidden_states.float().pow(2).mean(-1, keepdim=True)
+    normalized = hidden_states.float() * torch.rsqrt(variance + eps)
+    return (normalized * weight.float()).to(hidden_states.dtype)
+
+
+def _expert_reference(hidden_states, gate, up, down):
+    return F.linear(
+        F.silu(F.linear(hidden_states, gate)) * F.linear(hidden_states, up), down
+    )
+
+
 class Qwen2MoeLoadTest(unittest.TestCase):
     def test_registry_exposes_qwen2_dense_and_moe(self):
         self.assertEqual(get_model_class("qwen_2").__name__, "Qwen2ForCausalLM")
@@ -236,6 +290,82 @@ class Qwen2MoeLoadTest(unittest.TestCase):
 
         expected = F.linear(F.silu(F.linear(hidden, gate)) * F.linear(hidden, up), down)
         torch.testing.assert_close(layer(hidden), expected)
+
+    def test_moe_decoder_forward_matches_cpu_reference(self):
+        weights = _weights()
+        weights["model.layers.0.mlp.gate.weight"] = torch.tensor(
+            [[1.0, -0.5, 0.25, 0.0], [-0.75, 0.5, 0.0, 0.25]]
+        )
+        weights["model.layers.0.mlp.shared_expert_gate.weight"] = torch.tensor(
+            [[0.5, -0.25, 0.75, 0.1]]
+        )
+        for expert_idx, scale in enumerate((0.25, 0.75)):
+            prefix = f"model.layers.0.mlp.experts.{expert_idx}"
+            weights[f"{prefix}.gate_proj.weight"] = torch.eye(4) * (scale + 0.5)
+            weights[f"{prefix}.up_proj.weight"] = torch.eye(4) * (scale + 1.0)
+            weights[f"{prefix}.down_proj.weight"] = torch.eye(4) * (scale + 1.5)
+
+        model = Qwen2MoeForCausalLM(_config(), _load_config())
+        model.load_weights(weights)
+        NewModelLoader._validate_loaded_weights(model)
+        layer = model.layers[0]
+        layer.self_attn = _IdentityAttention()
+        layer.mlp.select_topk = _CpuSelectTopk()
+        layer.mlp.experts.fused_moe = _CpuFusedMoe(
+            layer.mlp.experts.w13, layer.mlp.experts.w2
+        )
+
+        hidden_states = torch.tensor(
+            [[0.5, -1.0, 0.75, 1.5], [-0.25, 1.25, -0.5, 0.75]]
+        )
+        residual = torch.tensor([[0.1, 0.2, -0.3, 0.4], [0.5, -0.25, 0.75, -1.0]])
+        actual_hidden, actual_residual = layer(hidden_states, residual, fmha_impl=None)
+
+        first_residual = hidden_states + residual
+        attention_input = _rms_norm_reference(
+            first_residual,
+            weights["model.layers.0.input_layernorm.weight"],
+            layer.input_layernorm.eps,
+        )
+        expected_residual = attention_input + first_residual
+        mlp_input = _rms_norm_reference(
+            expected_residual,
+            weights["model.layers.0.post_attention_layernorm.weight"],
+            layer.post_attention_layernorm.eps,
+        )
+
+        router_logits = F.linear(mlp_input, weights["model.layers.0.mlp.gate.weight"])
+        shifted_logits = router_logits - router_logits.max(dim=-1, keepdim=True).values
+        router_probabilities = shifted_logits.exp()
+        router_probabilities /= router_probabilities.sum(dim=-1, keepdim=True)
+        selected_probabilities, selected_experts = router_probabilities.max(dim=-1)
+        self.assertEqual(selected_experts.tolist(), [0, 1])
+        routed = torch.empty_like(mlp_input)
+        for token_idx, expert_idx in enumerate(selected_experts.tolist()):
+            prefix = f"model.layers.0.mlp.experts.{expert_idx}"
+            routed[token_idx] = selected_probabilities[token_idx] * _expert_reference(
+                mlp_input[token_idx : token_idx + 1],
+                weights[f"{prefix}.gate_proj.weight"],
+                weights[f"{prefix}.up_proj.weight"],
+                weights[f"{prefix}.down_proj.weight"],
+            ).squeeze(0)
+
+        shared = _expert_reference(
+            mlp_input,
+            weights["model.layers.0.mlp.shared_expert.gate_proj.weight"],
+            weights["model.layers.0.mlp.shared_expert.up_proj.weight"],
+            weights["model.layers.0.mlp.shared_expert.down_proj.weight"],
+        )
+        shared_gate = torch.sigmoid(
+            F.linear(
+                mlp_input,
+                weights["model.layers.0.mlp.shared_expert_gate.weight"],
+            )
+        )
+        expected_hidden = routed + shared * shared_gate
+
+        torch.testing.assert_close(actual_residual, expected_residual)
+        torch.testing.assert_close(actual_hidden, expected_hidden)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -118,3 +118,23 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen3_moe",
     "Qwen3MoeForCausalLM",
 )
+register_lazy_model(
+    "qwen_2",
+    "rtp_llm.models_py.new_models.qwen2",
+    "Qwen2ForCausalLM",
+)
+register_lazy_model(
+    "qwen_agent",
+    "rtp_llm.models_py.new_models.qwen2",
+    "Qwen2ForCausalLM",
+)
+register_lazy_model(
+    "qwen_tool",
+    "rtp_llm.models_py.new_models.qwen2",
+    "Qwen2ForCausalLM",
+)
+register_lazy_model(
+    "qwen_2_moe",
+    "rtp_llm.models_py.new_models.qwen2_moe",
+    "Qwen2MoeForCausalLM",
+)

--- a/rtp_llm/test/smoke/data/model/qwen2_moe/q_r_bf16_tp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen2_moe/q_r_bf16_tp2.json
@@ -1,0 +1,21 @@
+{
+    "model_type": "qwen_2_moe",
+    "model_path": "/mnt/nas1/hf/Qwen1.5-MoE-A2.7B-Chat",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s1",
+                "generate_config": {
+                    "max_new_tokens": 5,
+                    "temperature": 0.0,
+                    "top_p": 0,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response": " The CAP Theorem is",
+                "finished": true
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -200,6 +200,13 @@ def h20_oss_suites():
                 gpu_type=["H20"],
             ),
             smoke_test(
+                name="moe_newloader_qwen2_bf16_tp2",
+                task_info="data/model/qwen2_moe/q_r_bf16_tp2.json",
+                smoke_args="--warm_up 0 --act_type BF16 --tp_size 2 --world_size 2 --ep_size 1 --reserver_runtime_mem_mb 16005 --seq_size_per_block 64 --concurrency_limit 64",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
                 name="moe_deepep_continuous_dp2",
                 task_info="data/model/qwen3_moe/q_r_30b_py.json",
                 smoke_args="--warm_up 0 --act_type BF16 --reserver_runtime_mem_mb 8192 --use_deepep_moe 1 --use_deepep_low_latency 0 --dp_size 2",
@@ -261,6 +268,7 @@ def h20_oss_suites():
                 name="dense_fp8kv_cudagraph",
                 task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_cudagraph.json",
                 smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 1  --disable_flash_infer 1",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
                 gpu_type=["H20"],
             ),
             smoke_test(


### PR DESCRIPTION
 ## Summary

  - Add clean newloader paths for Qwen2/Qwen2.5 Dense and Qwen2-MoE.
  - Stream checkpoint tensors directly into `RtpModule` submodules with TP/EP-aware layouts and unified post-load validation.
  - Add Qwen2 biased Q/K/V handling and Qwen2-MoE routed/shared expert execution.
  - Register `qwen_2`, `qwen_agent`, `qwen_tool`, and `qwen_2_moe`.

  ## Correctness

  - Preserve tied/untied LM-head semantics, LM-head normalization, and logit scaling.
  - Preserve unquantized Qwen2-MoE router/shared-gate semantics while allowing expert and shared FFN quantization.
  - Require the supported Qwen2-MoE topology: `moe_style=2` with every decoder layer using shared and routed experts.
  - Fail fast for unsupported CP, FFN disaggregation, EPLB, partial-MoE, and rank-local consolidated layouts.
  - Validate missing, extra, malformed, and incomplete weights.
  - Avoid dependencies on `ModelWeightInfo`, `CustomAtomicWeight`, `CustomGlobalWeight`, and legacy default weight loading.

  ## Validation

  - H20 Qwen2 Dense, Qwen2-MoE, Qwen3 Dense, and Qwen3-MoE Bazel tests passed.
  - H20 Qwen2.5 newloader smoke passed with FP8 KV cache and CUDA Graph.
  - H20 Qwen2-MoE BF16 TP2 newloader smoke passed.
  - Qwen2-MoE generated tokens exactly matched Hugging Face:
    `[576, 26101, 576, 13173, 374]` / ` The CAP Theorem is`.
  - ROCm 7.2 Qwen2 Dense and Qwen2-MoE Bazel tests passed.
  - Black, isort, Python compilation, Bazel dependency, diff, and legacy dependency checks passed.