### PR TITLE
feat: add fast output readiness reporting for GenerateStream

### DIFF
--- a/rtp_llm/config/exceptions.py
+++ b/rtp_llm/config/exceptions.py
@@ -26,6 +26,7 @@ class ExceptionType(IntEnum):
     OUTPUT_QUEUE_FULL = 8102
     OUTPUT_QUEUE_IS_EMPTY = 8103
     FINISHED = 8104
+    OUTPUT_QUEUE_NO_UPDATE = 8105
 
     # rpc error
     GET_HOST_FAILED = 8200

--- a/rtp_llm/cpp/api_server/ChatService.cc
+++ b/rtp_llm/cpp/api_server/ChatService.cc
@@ -57,13 +57,15 @@ void ChatService::generateResponse(const std::shared_ptr<GenerateConfig>&       
     ctx->init(num_return_sequences, body, chat_render);
 
     GenerateOutputs outputs;
-    // 需要检查 !hasError(): 之前 finished() 表示完成且无错，现在 FINISHED 状态可能包含错误
-    // 如果流有错误，应该停止消费输出
-    while (stream->isActive() || stream->hasOutput()) {
+    while (true) {
         const auto result = stream->nextOutput();
         if (!result.ok()) {
-            RTP_LLM_LOG_INFO("stream nextOutput failed");
-            break;
+            const auto& status = result.status();
+            if (status.code() == ErrorCode::FINISHED) {
+                break;
+            }
+            RTP_LLM_LOG_WARNING("stream nextOutput failed: %s", status.ToString().c_str());
+            throw streamErrorToHttpException(status);
         }
         outputs = result.value();
         RTP_LLM_CHECK_WITH_INFO(outputs.generate_outputs.size() == num_return_sequences,
@@ -131,13 +133,21 @@ void ChatService::generateStreamingResponse(const std::shared_ptr<GenerateConfig
 
     writer->SetWriteType(http_server::HttpResponseWriter::WriteType::Stream);
     GenerateOutputs outputs;
-    // 需要检查 !hasError(): 之前 finished() 表示完成且无错，现在 FINISHED 状态可能包含错误
-    // 如果流有错误，应该停止消费输出
-    while (stream->isActive()) {
+    while (true) {
         const auto output_status = stream->nextOutput();
         if (!output_status.ok()) {
-            RTP_LLM_LOG_INFO("stream nextOutput failed");
-            break;
+            const auto& status = output_status.status();
+            if (status.code() == ErrorCode::FINISHED) {
+                break;
+            }
+
+            RTP_LLM_LOG_WARNING("stream nextOutput failed: %s", status.ToString().c_str());
+            const auto exception = streamErrorToHttpException(status);
+            metric_reporter_->reportErrorQpsMetric(chat_request.source.value_or("unknown"), exception.getType());
+            AccessLogWrapper::logExceptionAccess(body, request_id, exception.what());
+            write_sse_response(formatException(exception));
+            writer->WriteDone();
+            return;
         }
         outputs = output_status.value();
         RTP_LLM_CHECK_WITH_INFO(outputs.generate_outputs.size() == num_return_sequences,

--- a/rtp_llm/cpp/api_server/Exception.h
+++ b/rtp_llm/cpp/api_server/Exception.h
@@ -11,6 +11,7 @@
 #include "rtp_llm/cpp/api_server/ApiServerMetrics.h"
 #include "rtp_llm/cpp/api_server/ErrorResponse.h"
 #include "rtp_llm/cpp/api_server/AccessLogWrapper.h"
+#include "rtp_llm/cpp/utils/ErrorCode.h"
 
 namespace rtp_llm {
 
@@ -105,6 +106,16 @@ private:
     Type        type_;
     std::string message_;
 };
+
+inline HttpApiServerException streamErrorToHttpException(const ErrorInfo& status) {
+    auto http_error = HttpApiServerException::UNKNOWN_ERROR;
+    if (status.code() == ErrorCode::GENERATE_TIMEOUT) {
+        http_error = HttpApiServerException::GENERATE_TIMEOUT_ERROR;
+    } else if (status.code() == ErrorCode::CANCELLED) {
+        http_error = HttpApiServerException::CANCELLED_ERROR;
+    }
+    return HttpApiServerException(http_error, status.ToString());
+}
 
 template<typename T>
 inline std::string formatException(const T& e) {

--- a/rtp_llm/cpp/api_server/GenerateStreamWrapper.cc
+++ b/rtp_llm/cpp/api_server/GenerateStreamWrapper.cc
@@ -23,17 +23,15 @@ void GenerateStreamWrapper::init(GenerateStreamPtr stream, const std::shared_ptr
 }
 
 std::pair<MultiSeqsResponse, bool> GenerateStreamWrapper::generateResponse() {
-    // 需要检查 !hasError(): 之前 finished() 表示完成且无错，现在 FINISHED 状态可能包含错误
-    // 如果流有错误，不应该返回"正常完成"的响应，应该让后续逻辑处理错误
-    if (!stream_->hasError() && stream_->isFinished() && stream_->hasOutput() == false) {
-        RTP_LLM_LOG_INFO("stream finished.");
-        return std::make_pair(MultiSeqsResponse(), true);
-    }
-
     const auto result = stream_->nextOutput();
     if (!result.ok()) {
-        RTP_LLM_LOG_INFO("stream nextOutput failed.");
-        return std::make_pair(MultiSeqsResponse(), true);
+        const auto& status = result.status();
+        if (status.code() == ErrorCode::FINISHED) {
+            return std::make_pair(MultiSeqsResponse(), true);
+        }
+
+        RTP_LLM_LOG_WARNING("stream nextOutput failed: %s", status.ToString().c_str());
+        throw streamErrorToHttpException(status);
     }
     auto outputs = result.value();
 

--- a/rtp_llm/cpp/api_server/test/ChatServiceTest.cc
+++ b/rtp_llm/cpp/api_server/test/ChatServiceTest.cc
@@ -13,6 +13,21 @@
 
 using namespace ::testing;
 namespace rtp_llm {
+namespace {
+
+struct StreamErrorCase {
+    ErrorCode                    error_code;
+    HttpApiServerException::Type expected_type;
+    std::string                  message;
+};
+
+const std::vector<StreamErrorCase> kStreamErrorCases = {
+    {ErrorCode::GENERATE_TIMEOUT, HttpApiServerException::GENERATE_TIMEOUT_ERROR, "generation timed out"},
+    {ErrorCode::CANCELLED, HttpApiServerException::CANCELLED_ERROR, "generation cancelled"},
+    {ErrorCode::EXECUTION_EXCEPTION, HttpApiServerException::UNKNOWN_ERROR, "private backend detail"},
+};
+
+}  // namespace
 
 class ChatServiceTest: public ::testing::Test {
 public:
@@ -159,7 +174,7 @@ TEST_F(ChatServiceTest, ChatCompletions_ThrowException) {
 
     // outputs.generate_outputs 为空, 模拟抛出异常的情况
     GenerateOutputs outputs;
-    EXPECT_CALL(*mock_stream, nextOutput()).WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))));
+    EXPECT_CALL(*mock_stream, nextOutput(_)).WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))));
 
     // EXPECT_CALL(*mock_metric_reporter_, reportErrorQpsMetric)
     //     .WillOnce(Invoke([](const std::string& source, int error_code) {
@@ -281,10 +296,9 @@ TEST_F(ChatServiceTest, ChatCompletions) {
     GenerateOutputs outputs;
     outputs.generate_outputs.push_back(output);
 
-    // nextOutput 第一次正常返回, 第二次返回错误
-    EXPECT_CALL(*mock_stream, nextOutput())
+    EXPECT_CALL(*mock_stream, nextOutput(_))
         .WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))))
-        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::OUTPUT_QUEUE_IS_EMPTY, "output queue is empty")));
+        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::FINISHED, "finished")));
 
     EXPECT_CALL(*mock_metric_reporter_, reportResponseFirstTokenLatencyMs).WillOnce(Invoke([](double val) {
         EXPECT_TRUE(val >= 0);
@@ -315,6 +329,112 @@ TEST_F(ChatServiceTest, ChatCompletions) {
 
     EXPECT_EQ(writer_->_type, http_server::HttpResponseWriter::WriteType::Stream);
     EXPECT_EQ(writer_->_headers.count("Content-Type"), 1);
+    EXPECT_EQ(writer_->_headers.at("Content-Type"), "text/event-stream");
+}
+
+TEST_F(ChatServiceTest, NonStreamingStreamErrorsUseHttpExceptionPath) {
+    for (const auto& [error_code, expected_type, message] : kStreamErrorCases) {
+        http_server::HttpRequest request;
+        const std::string        body = R"del({
+    "messages": [{"role": "user", "content": "who are you?"}],
+    "stream": false,
+    "source": "test_source"
+})del";
+        request._request              = CreateHttpPacket(body);
+
+        auto generate_config = std::make_shared<GenerateConfig>();
+        EXPECT_CALL(*mock_openai_endpoint_, extract_generation_config).WillOnce(Return(generate_config));
+        EXPECT_CALL(*mock_metric_reporter_, reportFTInputTokenLengthMetric).Times(1);
+        EXPECT_CALL(*mock_metric_reporter_, reportFTNumBeansMetric).Times(1);
+
+        RenderedInputs rendered_inputs{std::vector<int>(), std::vector<MultimodalInput>(), std::string()};
+        EXPECT_CALL(*mock_render_, render_chat_request).WillOnce(Return(rendered_inputs));
+
+        auto mock_stream = CreateMockGenerateStream();
+        auto stream      = std::dynamic_pointer_cast<GenerateStream>(mock_stream);
+        EXPECT_CALL(*mock_engine_, enqueue(Matcher<const std::shared_ptr<GenerateInput>&>(_))).WillOnce(Return(stream));
+
+        auto mock_ctx = std::make_shared<MockRenderContext>();
+        auto ctx      = std::dynamic_pointer_cast<RenderContext>(mock_ctx);
+        EXPECT_CALL(*mock_render_, getRenderContext).WillOnce(Return(ctx));
+        EXPECT_CALL(*mock_ctx, init).WillOnce(Return());
+        EXPECT_CALL(*mock_stream, nextOutput(_)).WillOnce(Return(ErrorResult<GenerateOutputs>(error_code, message)));
+
+        try {
+            chat_service_->chatCompletions(writer_, request, 10086);
+            FAIL() << "expected stream error";
+        } catch (const HttpApiServerException& error) {
+            EXPECT_EQ(error.getType(), expected_type);
+            EXPECT_EQ(error.getMessage(), message);
+        }
+    }
+}
+
+TEST_F(ChatServiceTest, StreamingStreamErrorsUseSseErrorPath) {
+    EXPECT_CALL(*mock_metric_reporter_, reportSuccessQpsMetric).Times(0);
+    EXPECT_CALL(*mock_metric_reporter_, reportResponseIterateCountMetric).Times(0);
+    EXPECT_CALL(*mock_metric_reporter_, reportResponseLatencyMs).Times(0);
+    EXPECT_CALL(*mock_metric_reporter_, reportFTIterateCountMetric).Times(0);
+    EXPECT_CALL(*mock_metric_reporter_, reportFTOutputTokenLengthMetric).Times(0);
+
+    for (const auto& [error_code, expected_type, message] : kStreamErrorCases) {
+        http_server::HttpRequest request;
+        const std::string        body = R"del({
+    "messages": [{"role": "user", "content": "who are you?"}],
+    "stream": true,
+    "source": "test_source"
+})del";
+        request._request              = CreateHttpPacket(body);
+
+        auto generate_config = std::make_shared<GenerateConfig>();
+        EXPECT_CALL(*mock_openai_endpoint_, extract_generation_config).Times(2).WillRepeatedly(Return(generate_config));
+        EXPECT_CALL(*mock_metric_reporter_, reportFTInputTokenLengthMetric).Times(1);
+        EXPECT_CALL(*mock_metric_reporter_, reportFTNumBeansMetric).Times(1);
+
+        RenderedInputs rendered_inputs{std::vector<int>(), std::vector<MultimodalInput>(), std::string()};
+        EXPECT_CALL(*mock_render_, render_chat_request).WillOnce(Return(rendered_inputs));
+
+        auto mock_stream = CreateMockGenerateStream();
+        auto stream      = std::dynamic_pointer_cast<GenerateStream>(mock_stream);
+        EXPECT_CALL(*mock_engine_, enqueue(Matcher<const std::shared_ptr<GenerateInput>&>(_))).WillOnce(Return(stream));
+
+        auto mock_ctx = std::make_shared<MockRenderContext>();
+        auto ctx      = std::dynamic_pointer_cast<RenderContext>(mock_ctx);
+        EXPECT_CALL(*mock_render_, getRenderContext).WillOnce(Return(ctx));
+        EXPECT_CALL(*mock_ctx, init).WillOnce(Return());
+
+        const std::string first_response = "first response";
+        const std::string token_response = "token response";
+        EXPECT_CALL(*mock_ctx, render_stream_response_first).WillOnce(Return(first_response));
+        EXPECT_CALL(*mock_ctx, render_stream_response).WillOnce(Return(token_response));
+        EXPECT_CALL(*mock_ctx, render_stream_response_flush).Times(0);
+        EXPECT_CALL(*mock_ctx, render_stream_response_final).Times(0);
+
+        GenerateOutput output;
+        output.output_ids = CreateOutputIdsTensor();
+        GenerateOutputs outputs;
+        outputs.generate_outputs.push_back(std::move(output));
+        EXPECT_CALL(*mock_stream, nextOutput(_))
+            .WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))))
+            .WillOnce(Return(ErrorResult<GenerateOutputs>(error_code, message)));
+
+        const HttpApiServerException expected_error(expected_type, message);
+        EXPECT_CALL(*mock_metric_reporter_, reportResponseFirstTokenLatencyMs).Times(1);
+        EXPECT_CALL(*mock_metric_reporter_, reportResponseIterateLatencyMs).Times(1);
+        EXPECT_CALL(*mock_metric_reporter_, reportErrorQpsMetric("test_source", expected_type)).Times(1);
+        {
+            InSequence sequence;
+            EXPECT_CALL(*mock_writer_, Write(ChatService::sseResponse(first_response))).WillOnce(Return(true));
+            EXPECT_CALL(*mock_writer_, Write(ChatService::sseResponse(token_response))).WillOnce(Return(true));
+            EXPECT_CALL(*mock_writer_, Write(ChatService::sseResponse(formatException(expected_error))))
+                .WillOnce(Return(true));
+            EXPECT_CALL(*mock_writer_, WriteDone).WillOnce(Return(true));
+        }
+
+        EXPECT_NO_THROW(chat_service_->chatCompletions(writer_, request, 10086));
+    }
+
+    EXPECT_EQ(writer_->_type, http_server::HttpResponseWriter::WriteType::Stream);
     EXPECT_EQ(writer_->_headers.at("Content-Type"), "text/event-stream");
 }
 

--- a/rtp_llm/cpp/api_server/test/GenerateStreamWrapperTest.cc
+++ b/rtp_llm/cpp/api_server/test/GenerateStreamWrapperTest.cc
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "rtp_llm/cpp/api_server/GenerateStreamWrapper.h"
+#include "rtp_llm/cpp/api_server/Exception.h"
 
 #include "rtp_llm/cpp/api_server/test/mock/MockEngineBase.h"
 #include "rtp_llm/cpp/api_server/test/mock/MockGenerateStream.h"
@@ -44,11 +45,9 @@ TEST_F(GenerateStreamWrapperTest, generateResponse) {
     EXPECT_CALL(*mock_engine_, enqueue(Matcher<const std::shared_ptr<GenerateInput>&>(_))).WillOnce(Return(stream));
 
     GenerateOutputs outputs;
-    EXPECT_CALL(*mock_stream, nextOutput())
+    EXPECT_CALL(*mock_stream, nextOutput(_))
         .WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))))
-        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::OUTPUT_QUEUE_IS_EMPTY, "output queue is empty")));
-
-    EXPECT_CALL(*mock_stream, getStatus()).Times(2).WillRepeatedly(Return(StreamState::RUNNING));
+        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::FINISHED, "finished")));
 
     EXPECT_CALL(*mock_token_processor_, getTokenProcessorCtx(_, _, _)).WillOnce(Return(nullptr));
     EXPECT_CALL(*mock_token_processor_, decodeTokens(_, _, _, _)).WillOnce(Return(std::vector<std::string>()));
@@ -76,6 +75,59 @@ TEST_F(GenerateStreamWrapperTest, generateResponse) {
     {
         auto [response, finished] = stream_wrapper.generateResponse();
         ASSERT_EQ(finished, true);
+    }
+}
+
+TEST_F(GenerateStreamWrapperTest, generateResponseMapsStreamErrors) {
+    const auto verify_error_mapping = [](ErrorCode                    code,
+                                         HttpApiServerException::Type expected_type,
+                                         const std::string&           expected_message) {
+        auto mock_stream = CreateMockGenerateStream();
+        EXPECT_CALL(*mock_stream, nextOutput(_)).WillOnce(Return(ErrorResult<GenerateOutputs>(code, expected_message)));
+
+        GenerateStreamWrapper stream_wrapper(nullptr, nullptr);
+        stream_wrapper.init(std::dynamic_pointer_cast<GenerateStream>(mock_stream), nullptr);
+
+        try {
+            stream_wrapper.generateResponse();
+            FAIL() << "expected stream error";
+        } catch (const HttpApiServerException& error) {
+            EXPECT_EQ(error.getType(), expected_type);
+            EXPECT_EQ(error.getMessage(), expected_message);
+        }
+    };
+
+    verify_error_mapping(
+        ErrorCode::GENERATE_TIMEOUT, HttpApiServerException::GENERATE_TIMEOUT_ERROR, "generation timed out");
+    verify_error_mapping(ErrorCode::CANCELLED, HttpApiServerException::CANCELLED_ERROR, "generation cancelled");
+    verify_error_mapping(
+        ErrorCode::EXECUTION_EXCEPTION, HttpApiServerException::UNKNOWN_ERROR, "private backend detail");
+}
+
+TEST_F(GenerateStreamWrapperTest, generateResponseMapsErrorAfterOutput) {
+    auto mock_token_processor = std::make_shared<MockTokenProcessor>();
+    auto token_processor      = std::dynamic_pointer_cast<TokenProcessor>(mock_token_processor);
+    auto mock_stream          = CreateMockGenerateStream();
+
+    GenerateOutputs outputs;
+    EXPECT_CALL(*mock_stream, nextOutput(_))
+        .WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))))
+        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::EXECUTION_EXCEPTION, "private backend detail")));
+    EXPECT_CALL(*mock_token_processor, getTokenProcessorCtx(_, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*mock_token_processor, decodeTokens(_, _, _, _)).WillOnce(Return(std::vector<std::string>()));
+
+    GenerateStreamWrapper stream_wrapper(nullptr, token_processor);
+    stream_wrapper.init(std::dynamic_pointer_cast<GenerateStream>(mock_stream), nullptr);
+
+    const auto [response, finished] = stream_wrapper.generateResponse();
+    EXPECT_FALSE(finished);
+
+    try {
+        stream_wrapper.generateResponse();
+        FAIL() << "expected stream error after initial output";
+    } catch (const HttpApiServerException& error) {
+        EXPECT_EQ(error.getType(), HttpApiServerException::UNKNOWN_ERROR);
+        EXPECT_EQ(error.getMessage(), "private backend detail");
     }
 }
 

--- a/rtp_llm/cpp/api_server/test/InferenceServiceTest.cc
+++ b/rtp_llm/cpp/api_server/test/InferenceServiceTest.cc
@@ -278,10 +278,9 @@ TEST_F(InferenceServiceTest, InferResponseSuccess) {
     // stream
     GenerateOutputs outputs;
     outputs.generate_outputs.emplace_back(GenerateOutput());
-    EXPECT_CALL(*mock_stream, nextOutput())
+    EXPECT_CALL(*mock_stream, nextOutput(_))
         .WillOnce(Return(ErrorResult<GenerateOutputs>(std::move(outputs))))
-        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::OUTPUT_QUEUE_IS_EMPTY, "output queue is empty")));
-    EXPECT_CALL(*mock_stream, getStatus()).Times(2).WillRepeatedly(Return(StreamState::RUNNING));
+        .WillOnce(Return(ErrorResult<GenerateOutputs>(ErrorCode::FINISHED, "finished")));
 
     // writer
     EXPECT_CALL(*mock_writer_, isConnected()).WillOnce(Return(true));

--- a/rtp_llm/cpp/api_server/test/mock/MockGenerateStream.h
+++ b/rtp_llm/cpp/api_server/test/mock/MockGenerateStream.h
@@ -19,7 +19,7 @@ public:
 public:
     MOCK_CONST_METHOD0(getStatus, StreamState());
     MOCK_CONST_METHOD0(hasError, bool());
-    MOCK_METHOD0(nextOutput, ErrorResult<GenerateOutputs>());
+    MOCK_METHOD1(nextOutput, ErrorResult<GenerateOutputs>(int64_t));
     MOCK_METHOD1(updateOutput, void(const StreamUpdateInfo&));
 };
 

--- a/rtp_llm/cpp/cache/connector/p2p/test/MockGenerateStream.h
+++ b/rtp_llm/cpp/cache/connector/p2p/test/MockGenerateStream.h
@@ -20,7 +20,7 @@ public:
     MockGenerateStream(const std::shared_ptr<GenerateInput>& input):
         GenerateStream(input, createMockModelConfig(), RuntimeConfig{}, ResourceContext{}, nullptr) {}
 
-    ErrorResult<GenerateOutputs> nextOutput() override {
+    ErrorResult<GenerateOutputs> nextOutput(int64_t = 0) override {
         return ErrorResult<GenerateOutputs>(GenerateOutputs{});
     }
     void updateOutput(const StreamUpdateInfo&) override {}

--- a/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStateMachine.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <type_traits>
+#include <utility>
+
 #include <atomic>
 #include <cstdint>
 #include <memory>
@@ -25,11 +28,12 @@ public:
 
     // 统一的事件上报接口
     // 注意：此方法非线程安全，外部应当仅通过GenerateStream在持锁路径下调用
+    template<typename T = std::string>
     void reportEvent(StreamEvents::EventType event,
                      ErrorCode               error_code = ErrorCode::NONE_ERROR,
-                     const std::string&      error_msg  = "") {
+                     T&&                     error_msg  = std::decay_t<T>{}) {
         if (error_info.ok() && event == StreamEvents::Error) {
-            error_info = ErrorInfo(error_code, error_msg);
+            error_info = ErrorInfo(error_code, std::forward<T>(error_msg));
         }
         events_.append(event);
     }

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -37,7 +37,7 @@ GenerateStream::GenerateStream(const shared_ptr<GenerateInput>& input,
     metrics_reporter_(metrics_reporter),
     special_tokens_(model_config.special_tokens),
     mutex_(std::make_shared<std::mutex>()),
-    cv_(std::make_shared<std::condition_variable>()),
+    consumer_cv_(std::make_shared<std::condition_variable>()),
     mm_position_ids_style_(PositionIdsStyle(model_config.mm_model_config.mm_position_ids_style)),
     dtype_(model_config.data_type),
     hidden_size_(model_config.hidden_size) {
@@ -150,7 +150,7 @@ int GenerateStream::nextNeedBlockNums(int reserve_step) const {
 
 int GenerateStream::estimateKVNeedBlocks(int remaining_tokens, int target_batch_size) const {
     const int reserve_step   = complete_token_ids_->getReserveStep();
-    int common_seq_len = std::min(complete_token_ids_->commonSeqLength(), seqLength());
+    int       common_seq_len = std::min(complete_token_ids_->commonSeqLength(), seqLength());
     if (target_batch_size > 1) {
         common_seq_len = common_seq_len / seqSizePerBlock() * seqSizePerBlock();
     }
@@ -502,38 +502,34 @@ int64_t GenerateStream::getTimeoutMs() const {
     return generate_input_->generate_config->timeout_ms;
 }
 
-void GenerateStream::checkTimeout() {
+void GenerateStream::checkTimeoutWithoutLock() {
+    // Consumer-visible events and timeout publication share mutex_. Once a
+    // consumer-ready event has linearized, a later scheduler timeout must not
+    // replace it with the higher-precedence timeout error.
+    if (consumerReadyWithoutLock()) {
+        return;
+    }
+
     auto running_time_ms = (autil::TimeUtility::currentTimeInMicroSeconds() - begin_time_us_) / 1000;
     auto timeout_ms      = getTimeoutMs();
     if (timeout_ms > 0 && timeout_ms < running_time_ms) {
-        reportEvent(StreamEvents::Error,
-                    ErrorCode::GENERATE_TIMEOUT,
-                    "query has been running " + std::to_string(running_time_ms) + " ms, "
-                        + "timeout_ms = " + std::to_string(timeout_ms) + ", it's timeout");
+        reportTimeoutWithoutLock(running_time_ms, timeout_ms);
     }
 }
 
-// 统一的事件上报接口，替代原先所有 reportXX 方法。
-// 外部线程调用时自动加锁保护 error_info 和 events_ 的一致性。
-void GenerateStream::reportEvent(StreamEvents::EventType event, ErrorCode error_code, const std::string& error_msg) {
-    std::lock_guard<std::mutex> lock(*mutex_);
-    generate_status_->reportEvent(event, error_code, error_msg);
-}
-
-// 无锁版本，供已持有 mutex_ 的内部调用路径使用（如 update/specUpdate/moveToNext 链路）。
-void GenerateStream::reportEventWithoutLock(StreamEvents::EventType event,
-                                            ErrorCode               error_code,
-                                            const std::string&      error_msg) {
-    generate_status_->reportEvent(event, error_code, error_msg);
-}
-
-void GenerateStream::reportError(ErrorCode error_code, const std::string& error_msg) {
-    std::lock_guard<std::mutex> lock(*mutex_);
-    generate_status_->reportEvent(StreamEvents::Error, error_code, error_msg);
+void GenerateStream::reportTimeoutWithoutLock(int64_t running_time_ms, int64_t timeout_ms) {
+    reportEventWithoutLock(StreamEvents::Error,
+                           ErrorCode::GENERATE_TIMEOUT,
+                           "query has been running " + std::to_string(running_time_ms) + " ms, "
+                               + "timeout_ms = " + std::to_string(timeout_ms) + ", it's timeout");
 }
 
 bool GenerateStream::hasEvent(StreamEvents::EventType event) const {
     std::lock_guard<std::mutex> lock(*mutex_);
+    return hasEventWithoutLock(event);
+}
+
+bool GenerateStream::hasEventWithoutLock(StreamEvents::EventType event) const {
     return generate_status_->hasEvent(event);
 }
 
@@ -546,7 +542,8 @@ bool GenerateStream::isFinished() const {
 }
 
 bool GenerateStream::isActive() const {
-    return !hasError() && getStatus() != StreamState::FINISHED;
+    std::lock_guard<std::mutex> lock(*mutex_);
+    return !hasErrorWithoutLock() && getStatus() != StreamState::FINISHED;
 }
 
 void GenerateStream::setReserveStep(size_t reserve_step) {
@@ -557,24 +554,28 @@ void GenerateStream::setReserveStep(size_t reserve_step) {
 }
 
 StreamState GenerateStream::moveToNext() {
-    checkTimeout();
     std::lock_guard<std::mutex> lock(*mutex_);
-    const auto                  old_status = getStatus();
-    StreamState                 state      = generate_status_->moveToNext();
-    const auto                  new_status = getStatus();
+    checkTimeoutWithoutLock();
+    const auto  old_status = getStatus();
+    StreamState state      = generate_status_->moveToNext();
+    const auto  new_status = getStatus();
 
     if (old_status == StreamState::WAITING && new_status != StreamState::WAITING) {
         wait_time_us_ = autil::TimeUtility::currentTimeInMicroSeconds() - begin_time_us_;
     }
 
-    // notify one thread waiting for stream completion
-    if (new_status == StreamState::FINISHED) {
-        cv_->notify_one();
+    if (new_status != old_status) {
+        consumer_cv_->notify_all();
     }
     return state;
 }
 
 bool GenerateStream::hasError() const {
+    std::lock_guard<std::mutex> lock(*mutex_);
+    return hasErrorWithoutLock();
+}
+
+bool GenerateStream::hasErrorWithoutLock() const {
     return generate_status_->error_info.hasError();
 }
 
@@ -584,12 +585,26 @@ bool GenerateStream::isSubGenerateDoneWithoutLock(int batch_id) const {
 
 ErrorInfo GenerateStream::statusInfo() {
     std::lock_guard<std::mutex> lock(*mutex_);
+    return statusInfoWithoutLock();
+}
+
+ErrorInfo GenerateStream::statusInfoWithoutLock() const {
     return generate_status_->error_info;
+}
+
+bool GenerateStream::consumerFinishedWithoutLock() const {
+    // Consumer completion includes pending GenerateDone, but lifecycle commit and
+    // resource release remain scheduler-owned through moveToNext().
+    return hasEventWithoutLock(StreamEvents::NeedRemoteGenerate) || generate_status_->checkFinished();
+}
+
+bool GenerateStream::consumerReadyWithoutLock() const {
+    return hasErrorWithoutLock() || consumerFinishedWithoutLock();
 }
 
 std::string GenerateStream::stopReason() {
     std::lock_guard<std::mutex> lock(*mutex_);
-    return generate_status_->error_info.ToString();
+    return statusInfoWithoutLock().ToString();
 }
 
 size_t GenerateStream::iterCount() const {
@@ -675,20 +690,6 @@ void GenerateStream::matchEosToken(int batch_id) {
     }
 }
 
-bool GenerateStream::waitForRemoteGenerate() {
-    std::unique_lock<std::mutex> lock(*mutex_);
-    // Wait until stream status -> NeedRemoteGenerate
-    cv_->wait(lock, [this] { return generate_status_->hasEvent(StreamEvents::NeedRemoteGenerate); });
-    // If stream status is abnormal, log the error info
-    if (hasError()) {
-        RTP_LLM_LOG_WARNING("waitForRemoteGenerate exits due to stream [%ld] error: %s",
-                            streamId(),
-                            generate_status_->error_info.ToString().c_str());
-    }
-
-    return !hasError();
-}
-
 std::vector<int> GenerateStream::getLatestTokens(size_t token_num) {
     return complete_token_ids_->getLatestTokens(token_num);
 }
@@ -726,7 +727,7 @@ void GenerateStream::specUpdate(const StreamSpecUpdateInfo& update_info) {
     std::lock_guard<std::mutex> lock(*mutex_);
     RTP_LLM_LOG_DEBUG("stream [%ld] spec update", streamId());
     *is_context_stream_ = false;
-    if (hasError() && !update_info.force_update_info) {
+    if (hasErrorWithoutLock() && !update_info.force_update_info) {
         return;
     }
 
@@ -815,7 +816,7 @@ void GenerateStream::update(const StreamUpdateInfo& update_info) {
     std::lock_guard<std::mutex> lock(*mutex_);
     RTP_LLM_LOG_DEBUG("stream [%ld] update", streamId());
     *is_context_stream_ = false;
-    if (hasError() && !update_info.force_update_info) {
+    if (hasErrorWithoutLock() && !update_info.force_update_info) {
         return;
     }
 

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -2,7 +2,6 @@
 
 #include "absl/status/statusor.h"
 #include "autil/TimeUtility.h"
-#include "autil/SynchronizedQueue.h"
 #include "kmonitor/client/MetricsReporter.h"
 #include "rtp_llm/cpp/models/ModelTypes.h"
 #include "rtp_llm/cpp/config/ModelConfig.h"
@@ -15,8 +14,11 @@
 #include "rtp_llm/cpp/models/position_ids/PositionIdsGenerator.h"
 #include "rtp_llm/cpp/model_rpc/proto/model_rpc_service.pb.h"
 #include <iterator>
+#include <condition_variable>
+#include <type_traits>
 #include <mutex>
 #include <optional>
+#include <utility>
 
 namespace rtp_llm {
 
@@ -119,7 +121,10 @@ public:
         return is_fake_stream_;
     }
 
-    virtual ErrorResult<GenerateOutputs> nextOutput() = 0;
+    // A positive wait_timeout_ms bounds only the consumer condition-variable
+    // wait. Zero waits without a caller interval; a request deadline, when
+    // configured, remains authoritative.
+    virtual ErrorResult<GenerateOutputs> nextOutput(int64_t wait_timeout_ms = 0) = 0;
     virtual bool                         hasOutput() {
         return false;
     }
@@ -235,16 +240,35 @@ public:
     torch::Tensor              multimodalLocations() const;
 
     int64_t getTimeoutMs() const;
-    void    checkTimeout();
 
+    // 统一的事件上报接口，替代原先所有 reportXX 方法。
+    // 外部线程调用时自动加锁保护 error_info 和 events_ 的一致性。
+    template<typename T = std::string>
     void reportEvent(StreamEvents::EventType event,
                      ErrorCode               error_code = ErrorCode::NONE_ERROR,
-                     const std::string&      error_msg  = "");
+                     T&&                     error_msg  = std::decay_t<T>{}) {
+        std::lock_guard<std::mutex> lock(*mutex_);
+        reportEventWithoutLock(event, error_code, std::forward<T>(error_msg));
+    }
+
+    // 无锁版本，供已持有 mutex_ 的内部调用路径使用（如 update/specUpdate/moveToNext 链路）。
+    template<typename T = std::string>
     void reportEventWithoutLock(StreamEvents::EventType event,
                                 ErrorCode               error_code = ErrorCode::NONE_ERROR,
-                                const std::string&      error_msg  = "");
+                                T&&                     error_msg  = std::decay_t<T>{}) {
+        generate_status_->reportEvent(event, error_code, std::forward<T>(error_msg));
+        if (event == StreamEvents::Error || event == StreamEvents::GenerateDone
+            || event == StreamEvents::NeedRemoteGenerate) {
+            consumer_cv_->notify_all();
+        }
+    }
 
-    void         reportError(ErrorCode error_code = ErrorCode::NONE_ERROR, const std::string& error_msg = "");
+    template<typename T = std::string>
+    void reportError(ErrorCode error_code = ErrorCode::NONE_ERROR, T&& error_msg = std::decay_t<T>{}) {
+        std::lock_guard<std::mutex> lock(*mutex_);
+        reportEventWithoutLock(StreamEvents::Error, error_code, std::forward<T>(error_msg));
+    }
+
     bool         hasEvent(StreamEvents::EventType event) const;
     virtual bool hasError() const;
     ErrorInfo    statusInfo();
@@ -347,7 +371,6 @@ public:
         return return_all_hidden_states_;
     }
 
-    bool waitForRemoteGenerate();
     void holdKVCacheForPDSep();
     void releaseKVCacheForPDSep();
 
@@ -539,6 +562,16 @@ public:
     bool     queryPdSep() const;
 
 protected:
+    // Consumer-visible state is read and written under mutex_. Public readers
+    // acquire the lock; already-locked engine paths use these helpers.
+    void         checkTimeoutWithoutLock();
+    void         reportTimeoutWithoutLock(int64_t running_time_ms, int64_t timeout_ms);
+    bool         hasEventWithoutLock(StreamEvents::EventType event) const;
+    bool         hasErrorWithoutLock() const;
+    ErrorInfo    statusInfoWithoutLock() const;
+    bool         consumerFinishedWithoutLock() const;
+    virtual bool consumerReadyWithoutLock() const;
+
     int  estimateKVNeedBlocks(int remaining_tokens, int target_batch_size) const;
     void updateLogitProcessorMultiSeqStatus(const torch::Tensor& src_batch_indices);
     void updateLogitProcessorStatus(const StreamUpdateInfo& update_info);
@@ -612,7 +645,7 @@ protected:
     torch::Tensor                            last_hidden_states_;
     int                                      loss_index_ = 0;
     std::shared_ptr<std::mutex>              mutex_;
-    std::shared_ptr<std::condition_variable> cv_;
+    std::shared_ptr<std::condition_variable> consumer_cv_;
 
     GenerateStreamPtr propose_stream_ = nullptr;
     GenerateStreamPtr score_stream_   = nullptr;

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -244,7 +244,7 @@ void StreamCacheResource::releaseResource() {
             RTP_LLM_LOG_ERROR("  stream id:                     %ld", stream_->streamId());
             RTP_LLM_LOG_ERROR("  stream state:                  %s",
                               StreamStateToString(stream_->generate_status_->status).c_str());
-            RTP_LLM_LOG_ERROR("  stream hasError:                %d", stream_->hasError());
+            RTP_LLM_LOG_ERROR("  stream hasError:                %d", stream_->hasErrorWithoutLock());
             RTP_LLM_LOG_ERROR("  stream hasNumBeams:            %d", stream_->hasNumBeams());
         }
         RTP_LLM_LOG_ERROR("  batch_kv_cache_resource_ use_count: %ld", batch_kv_cache_resource_.use_count());
@@ -257,7 +257,7 @@ void StreamCacheResource::releaseResource() {
         abort();
     }
     // do not reuse cache from stopped beam search streams, whose states are likely corrupted
-    if (!need_release_resource_ && (!stream_->hasNumBeams() || !stream_->hasError())) {
+    if (!need_release_resource_ && (!stream_->hasNumBeams() || !stream_->hasErrorWithoutLock())) {
         return;
     }
     RTP_LLM_LOG_DEBUG("releaseResource: stream=%ld, curBlocksNum=%d, pd_kvcache_ref=%p",
@@ -289,7 +289,7 @@ int StreamCacheResource::tryReleaseKVBlock(size_t nums) {
     RTP_LLM_CHECK(nums == total_blocks);
 
     if (total_blocks > 0) {
-        if (reuseCache() && !stream_->hasError() && stream_->getStatus() == StreamState::FINISHED) {
+        if (reuseCache() && !stream_->hasErrorWithoutLock() && stream_->getStatus() == StreamState::FINISHED) {
             RTP_LLM_LOG_DEBUG(
                 "tryReleaseKVBlock: stream=%ld, storing cache, curBlocksNum=%d", stream_->streamId(), total_blocks);
             // save cache to gpu
@@ -308,7 +308,7 @@ int StreamCacheResource::tryReleaseKVBlock(size_t nums) {
             RTP_LLM_LOG_DEBUG("tryReleaseKVBlock: stream=%ld, NOT storing cache, reuseCache=%d, hasError=%d, status=%s",
                               stream_->streamId(),
                               reuseCache(),
-                              stream_->hasError(),
+                              stream_->hasErrorWithoutLock(),
                               StreamStateToString(stream_->getStatus()).c_str());
         }
 

--- a/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/GenerateStreamTest.cc
@@ -9,6 +9,11 @@
 #include "rtp_llm/cpp/testing/TestBase.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
 
+#include <chrono>
+#include <future>
+#include <mutex>
+#include <vector>
+
 using namespace std;
 
 namespace rtp_llm {
@@ -17,6 +22,7 @@ class GenerateStreamBuilder {
 public:
     GenerateStreamBuilder() {
         model_config_.max_seq_len = 2048;
+        model_config_.vocab_size  = 1024;
     }
 
     CacheConfig init_config() {
@@ -29,6 +35,7 @@ public:
         std::shared_ptr<GenerateConfig> generate_config(new GenerateConfig());
         ResourceContext                 resource_context;
         generate_input->generate_config = generate_config;
+        generate_input->begin_time_us   = autil::TimeUtility::currentTimeInMicroSeconds();
         generate_input->input_ids =
             torch::tensor(std::vector<int32_t>(input_ids.begin(), input_ids.end()), torch::kInt32);
         return std::make_shared<NormalGenerateStream>(
@@ -48,12 +55,14 @@ public:
         std::shared_ptr<GenerateInput>  generate_input(new GenerateInput());
         std::shared_ptr<GenerateConfig> generate_config(new GenerateConfig());
         generate_config->num_return_sequences = 2;
+        generate_input->begin_time_us         = autil::TimeUtility::currentTimeInMicroSeconds();
         generate_input->input_ids =
             torch::tensor(std::vector<int32_t>(input_ids.begin(), input_ids.end()), torch::kInt32);
         generate_input->generate_config = generate_config;
         ModelConfig   model_config;
         RuntimeConfig runtime_config;
         model_config.max_seq_len = 2048;
+        model_config.vocab_size  = 1024;
         auto stream              = std::make_shared<NormalGenerateStream>(
             generate_input, model_config, runtime_config, resource_context, nullptr);
 
@@ -65,6 +74,7 @@ public:
         std::shared_ptr<GenerateConfig> generate_config(new GenerateConfig());
         ResourceContext                 resource_context;
         generate_input->generate_config = generate_config;
+        generate_input->begin_time_us   = autil::TimeUtility::currentTimeInMicroSeconds();
         generate_input->input_ids =
             torch::tensor(std::vector<int32_t>(input_ids.begin(), input_ids.end()), torch::kInt32);
         auto stream_ptr = std::make_shared<NormalGenerateStream>(
@@ -87,6 +97,16 @@ class GenerateStreamTest: public DeviceTestBase {
 protected:
 };
 
+template<typename T>
+void waitForConsumer(std::future<T>& future, const std::shared_ptr<NormalGenerateStream>& stream) {
+    const auto status = future.wait_for(std::chrono::seconds(5));
+    if (status != std::future_status::ready) {
+        stream->reportError(ErrorCode::EXECUTION_EXCEPTION, "test consumer timed out");
+    }
+    EXPECT_EQ(status, std::future_status::ready);
+    future.wait();
+}
+
 TEST_F(GenerateStreamTest, testConstruct) {
     auto builder = GenerateStreamBuilder();
     auto stream1 = builder.createContextStream({{1, 2, 3, 4, 5}, {}});
@@ -107,6 +127,384 @@ TEST_F(GenerateStreamTest, testGenerateStreamReuseCacheMethod) {
     // flip back to true and verify
     stream->generate_input_->generate_config->reuse_cache = true;
     ASSERT_TRUE(stream->reuseCache());
+}
+
+TEST_F(GenerateStreamTest, zeroWaitTimeoutBlocksUntilOutputIsPublished) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    std::promise<void> consumer_started;
+    auto               consumer_ready = consumer_started.get_future();
+    auto               consumer       = std::async(std::launch::async, [stream, &consumer_started] {
+        consumer_started.set_value();
+        return stream->nextOutput(0);
+    });
+    consumer_ready.get();
+
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        GenerateOutputs             outputs;
+        outputs.request_id = 123;
+        stream->enqueueGenerateOutput(std::move(outputs));
+    }
+
+    waitForConsumer(consumer, stream);
+    auto result = consumer.get();
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result.value().request_id, 123);
+}
+
+TEST_F(GenerateStreamTest, outputPublishedBeforeConsumerWaitIsObserved) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    GenerateOutputs outputs;
+    outputs.request_id = 321;
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(outputs));
+    }
+
+    auto result = stream->nextOutput(1);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(result.value().request_id, 321);
+}
+
+TEST_F(GenerateStreamTest, pendingCompletionIsConsumerVisibleBeforeSchedulerCommit) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createComplexContextStream({1, 2, 3}));
+    stream->setNeedReleaseResource(true);
+    stream->generate_status_->status.store(StreamState::RUNNING);
+
+    std::promise<void> consumer_started;
+    auto               consumer_ready = consumer_started.get_future();
+    auto               consumer       = std::async(std::launch::async, [stream, &consumer_started] {
+        consumer_started.set_value();
+        return stream->nextOutput();
+    });
+    consumer_ready.get();
+
+    stream->reportEvent(StreamEvents::GenerateDone);
+    waitForConsumer(consumer, stream);
+    auto finished_result = consumer.get();
+    ASSERT_FALSE(finished_result.ok());
+    EXPECT_EQ(finished_result.status().code(), ErrorCode::FINISHED);
+
+    EXPECT_EQ(stream->getStatus(), StreamState::RUNNING);
+    EXPECT_FALSE(stream->stream_cache_resource_->isResourceReleased());
+
+    EXPECT_EQ(stream->moveToNext(), StreamState::FINISHED);
+    EXPECT_TRUE(stream->stream_cache_resource_->isResourceReleased());
+}
+
+TEST_F(GenerateStreamTest, nextOutputDrainsFinalOutputBeforeCompletion) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+    stream->generate_status_->status.store(StreamState::RUNNING);
+
+    GenerateOutputs outputs;
+    outputs.request_id = 456;
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(outputs));
+        stream->reportEventWithoutLock(StreamEvents::GenerateDone);
+    }
+
+    auto output_result = stream->nextOutput();
+    ASSERT_TRUE(output_result.ok());
+    EXPECT_EQ(output_result.value().request_id, 456);
+
+    auto finished_result = stream->nextOutput();
+    ASSERT_FALSE(finished_result.ok());
+    EXPECT_EQ(finished_result.status().code(), ErrorCode::FINISHED);
+
+    EXPECT_EQ(stream->getStatus(), StreamState::RUNNING);
+}
+
+TEST_F(GenerateStreamTest, consumerWaitWakesOnError) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    std::promise<void> consumer_started;
+    auto               consumer_ready = consumer_started.get_future();
+    auto               consumer       = std::async(std::launch::async, [stream, &consumer_started] {
+        consumer_started.set_value();
+        return stream->nextOutput();
+    });
+    consumer_ready.get();
+    stream->reportError(ErrorCode::CANCELLED, "cancelled");
+
+    waitForConsumer(consumer, stream);
+    auto result = consumer.get();
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::CANCELLED);
+}
+
+TEST_F(GenerateStreamTest, errorTakesPrecedenceOverQueuedOutput) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    GenerateOutputs outputs;
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(outputs));
+        stream->reportEventWithoutLock(StreamEvents::Error, ErrorCode::CANCELLED, "cancelled");
+    }
+
+    auto result = stream->nextOutput();
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::CANCELLED);
+    EXPECT_TRUE(stream->hasOutput());
+}
+
+TEST_F(GenerateStreamTest, outputQueueCapacityReportsFullWithoutDeadlock) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        for (size_t output = 0; output < stream->kOutputCapacity; ++output) {
+            GenerateOutputs generate_outputs;
+            generate_outputs.request_id = output;
+            stream->enqueueGenerateOutput(std::move(generate_outputs));
+        }
+        EXPECT_EQ(stream->generate_outputs_.size(), stream->kOutputCapacity);
+
+        GenerateOutputs overflow_output;
+        overflow_output.request_id = stream->kOutputCapacity;
+        stream->enqueueGenerateOutput(std::move(overflow_output));
+        EXPECT_EQ(stream->generate_outputs_.size(), stream->kOutputCapacity);
+    }
+
+    const auto result = stream->nextOutput();
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::OUTPUT_QUEUE_FULL);
+    EXPECT_EQ(stream->getStatus(), StreamState::WAITING);
+}
+
+TEST_F(GenerateStreamTest, consumerWaitWakesOnNeedRemoteGenerate) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    std::promise<void> consumer_started;
+    auto               consumer_ready = consumer_started.get_future();
+    auto               consumer       = std::async(std::launch::async, [stream, &consumer_started] {
+        consumer_started.set_value();
+        return stream->nextOutput();
+    });
+    consumer_ready.get();
+    stream->reportEvent(StreamEvents::NeedRemoteGenerate);
+
+    waitForConsumer(consumer, stream);
+    auto result = consumer.get();
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::FINISHED);
+    EXPECT_NE(stream->getStatus(), StreamState::FINISHED);
+}
+
+TEST_F(GenerateStreamTest, pdUpdatePublishesOutputBeforeRemoteHandoffCompletion) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createComplexContextStream({1, 2, 3}));
+    stream->generateConfig()->num_return_sequences = 1;
+    stream->generateConfig()->pd_separation        = true;
+    stream->generate_status_->status.store(StreamState::RUNNING);
+
+    const auto new_tokens = torch::tensor({{42}}, torch::kInt32);
+    stream->update({new_tokens,
+                    1,
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    torch::Tensor(),
+                    true,
+                    false});
+
+    ASSERT_TRUE(stream->hasEvent(StreamEvents::NeedRemoteGenerate));
+    auto output_result = stream->nextOutput();
+    ASSERT_TRUE(output_result.ok());
+    ASSERT_EQ(output_result.value().generate_outputs.size(), 1);
+    EXPECT_EQ(output_result.value().generate_outputs[0].output_ids.item<int>(), 42);
+
+    auto finished_result = stream->nextOutput();
+    ASSERT_FALSE(finished_result.ok());
+    EXPECT_EQ(finished_result.status().code(), ErrorCode::FINISHED);
+    EXPECT_EQ(stream->getStatus(), StreamState::RUNNING);
+}
+
+TEST_F(GenerateStreamTest, expiredConsumerDeadlineReportsTimeout) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+    stream->generateConfig()->timeout_ms = 50;
+    stream->resetBeginTime(autil::TimeUtility::currentTimeInMicroSeconds() - 100 * 1000);
+
+    auto result = stream->nextOutput();
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::GENERATE_TIMEOUT);
+}
+
+TEST_F(GenerateStreamTest, positiveWaitTimeoutReturnsNoUpdateWithoutChangingStreamState) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    auto result = stream->nextOutput(1);
+
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ(result.status().code(), ErrorCode::OUTPUT_QUEUE_NO_UPDATE);
+    EXPECT_TRUE(stream->statusInfo().ok());
+    EXPECT_EQ(stream->getStatus(), StreamState::WAITING);
+}
+
+TEST_F(GenerateStreamTest, queuedOutputWinsOverExpiredDeadline) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+    stream->generateConfig()->timeout_ms = 20;
+    stream->resetBeginTime(autil::TimeUtility::currentTimeInMicroSeconds() - 40 * 1000);
+
+    GenerateOutputs outputs;
+    outputs.request_id = 789;
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(outputs));
+    }
+
+    auto output_result = stream->nextOutput();
+    ASSERT_TRUE(output_result.ok());
+    EXPECT_EQ(output_result.value().request_id, 789);
+
+    const auto timeout_result = stream->nextOutput();
+    ASSERT_FALSE(timeout_result.ok());
+    EXPECT_EQ(timeout_result.status().code(), ErrorCode::GENERATE_TIMEOUT);
+}
+
+TEST_F(GenerateStreamTest, schedulerTimeoutDoesNotOverrideQueuedOutput) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+    stream->generateConfig()->timeout_ms = 10;
+    stream->resetBeginTime(autil::TimeUtility::currentTimeInMicroSeconds() - 20 * 1000);
+
+    GenerateOutputs outputs;
+    outputs.request_id = 901;
+    {
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(outputs));
+    }
+    EXPECT_EQ(stream->moveToNext(), StreamState::WAITING);
+    EXPECT_TRUE(stream->statusInfo().ok());
+
+    auto output_result = stream->nextOutput();
+    ASSERT_TRUE(output_result.ok());
+    EXPECT_EQ(output_result.value().request_id, 901);
+}
+
+TEST_F(GenerateStreamTest, schedulerTimeoutDoesNotOverridePendingCompletion) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createComplexContextStream({1, 2, 3}));
+    stream->setNeedReleaseResource(true);
+    stream->generate_status_->status.store(StreamState::RUNNING);
+    stream->generateConfig()->timeout_ms = 10;
+    stream->resetBeginTime(autil::TimeUtility::currentTimeInMicroSeconds() - 20 * 1000);
+
+    stream->reportEvent(StreamEvents::GenerateDone);
+
+    EXPECT_EQ(stream->moveToNext(), StreamState::FINISHED);
+    EXPECT_TRUE(stream->statusInfo().ok());
+
+    auto finished_result = stream->nextOutput();
+    ASSERT_FALSE(finished_result.ok());
+    EXPECT_EQ(finished_result.status().code(), ErrorCode::FINISHED);
+}
+
+TEST_F(GenerateStreamTest, schedulerTimeoutDoesNotOverrideRemoteHandoff) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+    stream->generateConfig()->timeout_ms = 10;
+    stream->resetBeginTime(autil::TimeUtility::currentTimeInMicroSeconds() - 20 * 1000);
+
+    stream->reportEvent(StreamEvents::NeedRemoteGenerate);
+
+    EXPECT_EQ(stream->moveToNext(), StreamState::WAITING);
+    EXPECT_TRUE(stream->statusInfo().ok());
+
+    auto finished_result = stream->nextOutput();
+    ASSERT_FALSE(finished_result.ok());
+    EXPECT_EQ(finished_result.status().code(), ErrorCode::FINISHED);
+}
+
+TEST_F(GenerateStreamTest, singleProducerConsumerPreservesOutputOrder) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    constexpr size_t output_count = 200;
+    auto             consumer     = std::async(std::launch::async, [stream] {
+        std::vector<int64_t> request_ids;
+        request_ids.reserve(output_count);
+        for (size_t output = 0; output < output_count; ++output) {
+            auto result = stream->nextOutput();
+            if (!result.ok()) {
+                return std::vector<int64_t>{};
+            }
+            request_ids.push_back(result.value().request_id);
+        }
+        return request_ids;
+    });
+
+    for (size_t output = 0; output < output_count; ++output) {
+        GenerateOutputs generate_outputs;
+        generate_outputs.request_id = output;
+        std::lock_guard<std::mutex> lock(*stream->mutex_);
+        stream->enqueueGenerateOutput(std::move(generate_outputs));
+    }
+
+    waitForConsumer(consumer, stream);
+    const auto request_ids = consumer.get();
+    ASSERT_EQ(request_ids.size(), output_count);
+    for (size_t output = 0; output < output_count; ++output) {
+        EXPECT_EQ(request_ids[output], output);
+    }
+    EXPECT_TRUE(stream->statusInfo().ok());
+}
+
+TEST_F(GenerateStreamTest, publicReadinessReaderIsSafeDuringPublication) {
+    auto builder = GenerateStreamBuilder();
+    auto stream  = std::dynamic_pointer_cast<NormalGenerateStream>(builder.createContextStream({1, 2, 3}));
+
+    std::promise<void> start;
+    auto               start_signal = start.get_future().share();
+    auto               reader       = std::async(std::launch::async, [stream, start_signal] {
+        start_signal.wait();
+        for (size_t iteration = 0; iteration < 2000; ++iteration) {
+            static_cast<void>(stream->hasError());
+            static_cast<void>(stream->isActive());
+            static_cast<void>(stream->hasEvent(StreamEvents::GenerateDone));
+            static_cast<void>(stream->hasOutput());
+        }
+    });
+
+    auto publisher = std::async(std::launch::async, [stream, start_signal] {
+        start_signal.wait();
+        for (size_t output = 0; output < 200; ++output) {
+            GenerateOutputs generate_outputs;
+            generate_outputs.request_id = output;
+            std::lock_guard<std::mutex> lock(*stream->mutex_);
+            stream->enqueueGenerateOutput(std::move(generate_outputs));
+        }
+        stream->reportEvent(StreamEvents::GenerateDone);
+        stream->reportError(ErrorCode::CANCELLED, "cancelled");
+    });
+
+    start.set_value();
+    waitForConsumer(reader, stream);
+    waitForConsumer(publisher, stream);
+    reader.get();
+    publisher.get();
+
+    EXPECT_TRUE(stream->hasOutput());
+    EXPECT_TRUE(stream->hasEvent(StreamEvents::GenerateDone));
+    EXPECT_EQ(stream->statusInfo().code(), ErrorCode::CANCELLED);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
@@ -15,6 +15,10 @@ using namespace std;
 
 namespace rtp_llm {
 
+namespace {
+constexpr int64_t kRpcOutputWaitTimeoutMs = 500;
+}
+
 grpc::Status LocalRpcServer::init(const EngineInitParams&                       maga_init_params,
                                   std::unique_ptr<ProposeModelEngineInitParams> propose_params,
                                   py::object                                    mm_process_engine) {
@@ -78,11 +82,17 @@ grpc::Status LocalRpcServer::pollStreamOutput(grpc::ServerContext*             c
                                               WriterInterface*                 writer,
                                               std::shared_ptr<GenerateStream>& stream) {
     RTP_LLM_PROFILE_FUNCTION();
-    // 需要检查 !hasError(): 之前 finished() 表示完成且无错，现在 FINISHED 状态可能包含错误
-    // 如果流有错误，应该停止消费输出
-    while (stream->isActive() || stream->hasOutput()) {
-        const auto result = stream->nextOutput();
+    while (true) {
+        const auto result = stream->nextOutput(kRpcOutputWaitTimeoutMs);
+        if (isCancelled(context)) {
+            stream->reportError(ErrorCode::CANCELLED, "request cancelled by user");
+            RTP_LLM_LOG_WARNING("request [%s] cancelled by user", request_key.c_str());
+            return grpc::Status(grpc::StatusCode::CANCELLED, "request cancelled by user");
+        }
         if (!result.ok()) {
+            if (result.status().code() == ErrorCode::OUTPUT_QUEUE_NO_UPDATE) {
+                continue;
+            }
             if (result.status().code() != ErrorCode::FINISHED) {
                 return serializeErrorMsg(request_key, result.status());
             } else {
@@ -97,21 +107,12 @@ grpc::Status LocalRpcServer::pollStreamOutput(grpc::ServerContext*             c
                                       stream->generateConfig()->aux_info,
                                       maga_init_params_.misc_config.aux_string,
                                       stream->specialTokens().eos_token_id);
-        if (context->IsCancelled()) {
-            stream->reportError(ErrorCode::CANCELLED, "request cancelled by user");
-            RTP_LLM_LOG_WARNING("request [%s] cancelled by user", request_key.c_str());
-            return grpc::Status(grpc::StatusCode::CANCELLED, "request cancelled by user");
-        }
         if (!writer->Write(outputs_pb)) {
             stream->reportError(ErrorCode::CANCELLED, "write outputs pb failed");
             RTP_LLM_LOG_WARNING("request [%s] write outputs pb failed", request_key.c_str());
             return grpc::Status(grpc::StatusCode::INTERNAL, "request write outputs pb failed");
         }
         if (stream->hasEvent(StreamEvents::NeedRemoteGenerate)) {
-            break;
-        }
-        if (stream->queryPdSep()) {
-            stream->waitForRemoteGenerate();
             break;
         }
     }
@@ -136,13 +137,16 @@ ErrorInfo LocalRpcServer::collectStreamOutput(grpc::ServerContext*              
                                               std::shared_ptr<GenerateStream>&      stream,
                                               const std::shared_ptr<GenerateInput>& input,
                                               GenerateOutputs&                      last_outputs) {
-    while (!stream->isFinished() || stream->hasOutput()) {
-        if (context->IsCancelled()) {
+    while (true) {
+        const auto output_result = stream->nextOutput(kRpcOutputWaitTimeoutMs);
+        if (isCancelled(context)) {
             stream->reportError(ErrorCode::CANCELLED, "request cancelled by client");
             return ErrorInfo(ErrorCode::CANCELLED, "request cancelled by client");
         }
-        const auto output_result = stream->nextOutput();
         if (!output_result.ok()) {
+            if (output_result.status().code() == ErrorCode::OUTPUT_QUEUE_NO_UPDATE) {
+                continue;
+            }
             if (output_result.status().code() != ErrorCode::FINISHED) {
                 return output_result.status();
             }

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.h
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.h
@@ -102,6 +102,10 @@ public:
     typedef grpc::internal::WriterInterface<GenerateOutputsPB> WriterInterface;
 
 protected:
+    virtual bool isCancelled(grpc::ServerContext* context) const {
+        return context->IsCancelled();
+    }
+
     grpc::Status serializeErrorMsg(const std::string& request_key, ErrorInfo error_info);
     grpc::Status pollStreamOutput(grpc::ServerContext*             context,
                                   const std::string&               request_key,

--- a/rtp_llm/cpp/model_rpc/test/BUILD
+++ b/rtp_llm/cpp/model_rpc/test/BUILD
@@ -29,6 +29,7 @@ test_deps = [
     "//rtp_llm/cpp/config:config_modules",
     "//rtp_llm/cpp/model_rpc/proto:model_rpc_service_cc_proto",
     "//rtp_llm/cpp/model_rpc:model_rpc_server",
+    "//rtp_llm/cpp/normal_engine:normal_engine",
     "//rtp_llm/cpp/testing:test_log_capture",
     "@com_google_googletest//:gtest",
     "@com_google_googletest//:gtest_main",
@@ -51,6 +52,15 @@ test_deps = [
 #         "//rtp_llm/cpp/utils:utils",
 #     ] + torch_deps(),
 # )
+
+cc_test(
+    name = "local_rpc_server_test",
+    srcs = ["LocalRpcServerTest.cc"],
+    copts = test_copts,
+    deps = test_deps,
+    env = {},
+    exec_properties = {'gpu':'H20'},
+)
 
 cc_test(
     name = "query_converter_test",

--- a/rtp_llm/cpp/model_rpc/test/LocalRpcServerTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/LocalRpcServerTest.cc
@@ -1,0 +1,237 @@
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <mutex>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/model_rpc/LocalRpcServer.h"
+#include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
+
+using namespace ::testing;
+
+namespace rtp_llm {
+
+class MockGenerateStream: public GenerateStream {
+public:
+    MockGenerateStream(const std::shared_ptr<GenerateInput>& input,
+                       const ModelConfig&                    model_config,
+                       const RuntimeConfig&                  runtime_config):
+        GenerateStream(input, model_config, runtime_config, ResourceContext{}, nullptr) {}
+
+    MOCK_METHOD((ErrorResult<GenerateOutputs>), nextOutput, (int64_t), (override));
+    MOCK_METHOD(void, updateOutput, (const StreamUpdateInfo&), (override));
+};
+
+class TestLocalRpcServer: public LocalRpcServer {
+public:
+    grpc::Status poll(std::shared_ptr<GenerateStream>& stream) {
+        return pollStreamOutput(nullptr, "request", nullptr, stream);
+    }
+
+    grpc::Status poll(WriterInterface* writer, std::shared_ptr<GenerateStream>& stream) {
+        return pollStreamOutput(nullptr, "request", writer, stream);
+    }
+
+    ErrorInfo collect(std::shared_ptr<GenerateStream>& stream) {
+        GenerateOutputs last_outputs;
+        return collectStreamOutput(nullptr, stream, nullptr, last_outputs);
+    }
+
+    std::future<void> cancellationChecked() {
+        return cancellation_checked_.get_future();
+    }
+
+    std::atomic<bool> cancelled{false};
+
+protected:
+    bool isCancelled(grpc::ServerContext*) const override {
+        std::call_once(cancellation_check_once_, [this] { cancellation_checked_.set_value(); });
+        return cancelled.load();
+    }
+
+private:
+    mutable std::once_flag     cancellation_check_once_;
+    mutable std::promise<void> cancellation_checked_;
+};
+
+class RecordingWriter: public LocalRpcServer::WriterInterface {
+public:
+    bool Write(const GenerateOutputsPB& outputs, grpc::WriteOptions) override {
+        outputs_.push_back(outputs);
+        return true;
+    }
+
+    std::vector<GenerateOutputsPB> outputs_;
+};
+
+enum class WakeReason {
+    OUTPUT,
+    FINISHED,
+    STREAM_ERROR,
+    TIMEOUT
+};
+
+std::shared_ptr<MockGenerateStream> createMockStream() {
+    auto input             = std::make_shared<GenerateInput>();
+    input->generate_config = std::make_shared<GenerateConfig>();
+    input->input_ids       = torch::tensor({1, 2, 3}, torch::kInt32);
+
+    ModelConfig model_config;
+    model_config.max_seq_len = 3;
+    return std::make_shared<MockGenerateStream>(input, model_config, RuntimeConfig{});
+}
+
+std::shared_ptr<NormalGenerateStream> createNormalStream() {
+    auto input             = std::make_shared<GenerateInput>();
+    input->generate_config = std::make_shared<GenerateConfig>();
+    input->begin_time_us   = autil::TimeUtility::currentTimeInMicroSeconds();
+    input->input_ids       = torch::tensor({1, 2, 3}, torch::kInt32);
+
+    ModelConfig model_config;
+    model_config.max_seq_len = 3;
+    return std::make_shared<NormalGenerateStream>(input, model_config, RuntimeConfig{}, ResourceContext{}, nullptr);
+}
+
+ErrorResult<GenerateOutputs> wakeResult(WakeReason reason) {
+    switch (reason) {
+        case WakeReason::OUTPUT: {
+            GenerateOutputs outputs;
+            return ErrorResult<GenerateOutputs>(std::move(outputs));
+        }
+        case WakeReason::FINISHED:
+            return ErrorResult<GenerateOutputs>(ErrorCode::FINISHED, "finished");
+        case WakeReason::STREAM_ERROR:
+            return ErrorResult<GenerateOutputs>(ErrorCode::EXECUTION_EXCEPTION, "failed");
+        case WakeReason::TIMEOUT:
+            return ErrorResult<GenerateOutputs>(ErrorCode::GENERATE_TIMEOUT, "timeout");
+    }
+    return ErrorResult<GenerateOutputs>(ErrorCode::UNKNOWN_ERROR, "unknown wake reason");
+}
+
+void publishWakeError(MockGenerateStream* stream, WakeReason reason) {
+    if (reason == WakeReason::STREAM_ERROR) {
+        stream->reportError(ErrorCode::EXECUTION_EXCEPTION, "failed");
+    } else if (reason == WakeReason::TIMEOUT) {
+        stream->reportError(ErrorCode::GENERATE_TIMEOUT, "timeout");
+    }
+}
+
+ErrorCode expectedStreamError(WakeReason reason) {
+    if (reason == WakeReason::STREAM_ERROR) {
+        return ErrorCode::EXECUTION_EXCEPTION;
+    }
+    if (reason == WakeReason::TIMEOUT) {
+        return ErrorCode::GENERATE_TIMEOUT;
+    }
+    return ErrorCode::CANCELLED;
+}
+
+TEST(LocalRpcServerTest, PollChecksCancellationBeforeHandlingEveryWakeReason) {
+    for (const auto reason :
+         std::array{WakeReason::OUTPUT, WakeReason::FINISHED, WakeReason::STREAM_ERROR, WakeReason::TIMEOUT}) {
+        TestLocalRpcServer server;
+        auto               mock_stream     = createMockStream();
+        auto*              mock_stream_ptr = mock_stream.get();
+        EXPECT_CALL(*mock_stream, nextOutput(_)).WillOnce(InvokeWithoutArgs([&server, mock_stream_ptr, reason] {
+            publishWakeError(mock_stream_ptr, reason);
+            server.cancelled = true;
+            return wakeResult(reason);
+        }));
+        std::shared_ptr<GenerateStream> stream = mock_stream;
+
+        const auto status = server.poll(stream);
+
+        EXPECT_EQ(status.error_code(), grpc::StatusCode::CANCELLED);
+        EXPECT_EQ(stream->statusInfo().code(), expectedStreamError(reason));
+    }
+}
+
+TEST(LocalRpcServerTest, CollectChecksCancellationBeforeHandlingEveryWakeReason) {
+    for (const auto reason :
+         std::array{WakeReason::OUTPUT, WakeReason::FINISHED, WakeReason::STREAM_ERROR, WakeReason::TIMEOUT}) {
+        TestLocalRpcServer server;
+        auto               mock_stream     = createMockStream();
+        auto*              mock_stream_ptr = mock_stream.get();
+        EXPECT_CALL(*mock_stream, nextOutput(_)).WillOnce(InvokeWithoutArgs([&server, mock_stream_ptr, reason] {
+            publishWakeError(mock_stream_ptr, reason);
+            server.cancelled = true;
+            return wakeResult(reason);
+        }));
+        std::shared_ptr<GenerateStream> stream = mock_stream;
+
+        const auto status = server.collect(stream);
+
+        EXPECT_EQ(status.code(), ErrorCode::CANCELLED);
+        EXPECT_EQ(stream->statusInfo().code(), expectedStreamError(reason));
+    }
+}
+
+TEST(LocalRpcServerTest, PollInterruptsBlockedNextOutputAfterClientCancellation) {
+    TestLocalRpcServer              server;
+    auto                            cancellation_checked = server.cancellationChecked();
+    std::shared_ptr<GenerateStream> stream               = createNormalStream();
+    auto poll_result = std::async(std::launch::async, [&server, &stream] { return server.poll(stream); });
+
+    EXPECT_EQ(cancellation_checked.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    server.cancelled = true;
+
+    const auto wait_status = poll_result.wait_for(std::chrono::seconds(5));
+    if (wait_status != std::future_status::ready) {
+        stream->reportError(ErrorCode::EXECUTION_EXCEPTION, "test poll cancellation timed out");
+    }
+    EXPECT_EQ(wait_status, std::future_status::ready);
+    EXPECT_EQ(poll_result.get().error_code(), grpc::StatusCode::CANCELLED);
+    EXPECT_EQ(stream->statusInfo().code(), ErrorCode::CANCELLED);
+}
+
+TEST(LocalRpcServerTest, CollectInterruptsBlockedNextOutputAfterClientCancellation) {
+    TestLocalRpcServer              server;
+    auto                            cancellation_checked = server.cancellationChecked();
+    std::shared_ptr<GenerateStream> stream               = createNormalStream();
+    auto collect_result = std::async(std::launch::async, [&server, &stream] { return server.collect(stream); });
+
+    EXPECT_EQ(cancellation_checked.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    server.cancelled = true;
+
+    const auto wait_status = collect_result.wait_for(std::chrono::seconds(5));
+    if (wait_status != std::future_status::ready) {
+        stream->reportError(ErrorCode::EXECUTION_EXCEPTION, "test collect cancellation timed out");
+    }
+    EXPECT_EQ(wait_status, std::future_status::ready);
+    EXPECT_EQ(collect_result.get().code(), ErrorCode::CANCELLED);
+    EXPECT_EQ(stream->statusInfo().code(), ErrorCode::CANCELLED);
+}
+
+TEST(LocalRpcServerTest, PollWritesFinalLocalOutputBeforeRemoteHandoff) {
+    TestLocalRpcServer              server;
+    RecordingWriter                 writer;
+    auto                            normal_stream = createNormalStream();
+    std::shared_ptr<GenerateStream> stream        = normal_stream;
+    normal_stream->setNeedReleaseResource(true);
+    normal_stream->generate_status_->status.store(StreamState::RUNNING);
+
+    {
+        std::lock_guard<std::mutex> lock(*normal_stream->mutex_);
+        GenerateOutputs             outputs;
+        outputs.request_id = 123;
+        normal_stream->enqueueGenerateOutput(std::move(outputs));
+        normal_stream->reportEventWithoutLock(StreamEvents::NeedRemoteGenerate);
+    }
+
+    const auto status = server.poll(&writer, stream);
+
+    EXPECT_TRUE(status.ok());
+    ASSERT_EQ(writer.outputs_.size(), 1);
+    EXPECT_EQ(writer.outputs_[0].request_id(), 123);
+    EXPECT_TRUE(stream->hasEvent(StreamEvents::NeedRemoteGenerate));
+    EXPECT_EQ(stream->getStatus(), StreamState::RUNNING);
+    EXPECT_FALSE(normal_stream->stream_cache_resource_->isResourceReleased());
+    EXPECT_FALSE(normal_stream->hasOutput());
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/normal_engine/NormalGenerateStream.cc
+++ b/rtp_llm/cpp/normal_engine/NormalGenerateStream.cc
@@ -1,28 +1,73 @@
 #include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
 
+#include <algorithm>
+#include <chrono>
+
 namespace rtp_llm {
 
-ErrorResult<GenerateOutputs> NormalGenerateStream::nextOutput() {
-    // TODO(xinfei.sxf) 某些case下会出现1s的等待
-    while ((!hasError()) && getStatus() != StreamState::FINISHED && generate_outputs_queue_.isEmpty()) {
-        checkTimeout();
-        generate_outputs_queue_.waitNotEmpty();
+ErrorResult<GenerateOutputs> NormalGenerateStream::nextOutput(int64_t wait_timeout_ms) {
+    RTP_LLM_CHECK_WITH_INFO(wait_timeout_ms >= 0, "nextOutput wait_timeout_ms must be non-negative");
+
+    const auto stream_timeout_ms = getTimeoutMs();
+    auto       stream_deadline   = std::chrono::steady_clock::time_point::max();
+
+    std::unique_lock<std::mutex> lock(*mutex_);
+
+    if (stream_timeout_ms > 0) {
+        const auto elapsed_us   = autil::TimeUtility::currentTimeInMicroSeconds() - begin_time_us_;
+        const auto remaining_us = std::max<int64_t>(stream_timeout_ms * 1000 - elapsed_us, 0);
+        stream_deadline         = std::chrono::steady_clock::now() + std::chrono::microseconds(remaining_us);
     }
-    if (hasError()) {
-        return statusInfo();
-    }
-    if (generate_outputs_queue_.isEmpty()) {
-        if (isFinished()) {
-            return ErrorInfo(ErrorCode::FINISHED, "finished");
+
+    if (!consumerReadyWithoutLock()) {
+        if (wait_timeout_ms == 0 && stream_timeout_ms <= 0) {
+            consumer_cv_->wait(lock, [this] { return consumerReadyWithoutLock(); });
         } else {
-            return ErrorInfo(ErrorCode::OUTPUT_QUEUE_IS_EMPTY, "output queue is empty");
+            auto wait_deadline = stream_deadline;
+            if (wait_timeout_ms > 0) {
+                wait_deadline = std::min(stream_deadline,
+                                         std::chrono::steady_clock::now() + std::chrono::milliseconds(wait_timeout_ms));
+            }
+
+            if (!consumer_cv_->wait_until(lock, wait_deadline, [this] { return consumerReadyWithoutLock(); })) {
+                if (stream_timeout_ms > 0 && std::chrono::steady_clock::now() >= stream_deadline) {
+                    const auto running_time_ms =
+                        (autil::TimeUtility::currentTimeInMicroSeconds() - begin_time_us_) / 1000;
+                    reportTimeoutWithoutLock(running_time_ms, stream_timeout_ms);
+                } else {
+                    return ErrorInfo(ErrorCode::OUTPUT_QUEUE_NO_UPDATE,
+                                     "output queue has no update within " + std::to_string(wait_timeout_ms) + " ms");
+                }
+            }
         }
     }
-    return generate_outputs_queue_.getAndPopFront();
+
+    // Preserve existing precedence: terminal errors override queued output.
+    if (hasErrorWithoutLock()) {
+        return statusInfoWithoutLock();
+    }
+
+    // Normal completion is reported only after the final output is drained.
+    if (!generate_outputs_.empty()) {
+        auto output = std::move(generate_outputs_.front());
+        generate_outputs_.pop_front();
+        return output;
+    }
+
+    if (consumerFinishedWithoutLock()) {
+        return ErrorInfo(ErrorCode::FINISHED, "finished");
+    }
+
+    RTP_LLM_FAIL("consumer is ready without an error, output, or finished state");
 }
 
 bool NormalGenerateStream::hasOutput() {
-    return !generate_outputs_queue_.isEmpty();
+    std::lock_guard<std::mutex> lock(*mutex_);
+    return !generate_outputs_.empty();
+}
+
+bool NormalGenerateStream::consumerReadyWithoutLock() const {
+    return hasErrorWithoutLock() || !generate_outputs_.empty() || consumerFinishedWithoutLock();
 }
 
 GenerateOutputs NormalGenerateStream::prepareGenerateOutput(const StreamUpdateInfo& update_info) {
@@ -152,12 +197,13 @@ GenerateOutputs NormalGenerateStream::prepareGenerateOutput(const StreamUpdateIn
 }
 
 void NormalGenerateStream::enqueueGenerateOutput(GenerateOutputs&& generate_results) {
-    if (generate_outputs_queue_.getSize() >= generate_outputs_queue_.getCapacity()) {
+    if (generate_outputs_.size() >= kOutputCapacity) {
         /* No matter if the queue is full for any reason,
            the stream will be set to stop directly to prevent the push to queue from getting stuck. */
         reportEventWithoutLock(StreamEvents::Error, ErrorCode::OUTPUT_QUEUE_FULL, "output queue is full");
     } else {
-        generate_outputs_queue_.push(std::move(generate_results));
+        generate_outputs_.push_back(std::move(generate_results));
+        consumer_cv_->notify_all();
     }
 }
 
@@ -219,7 +265,7 @@ void NormalGenerateStream::updateOutput(const StreamUpdateInfo& update_info) {
     RTP_LLM_LOG_DEBUG("stream [%ld] enqueue generate output", streamId());
     enqueueGenerateOutput(prepareGenerateOutput(update_info));
 
-    if (hasError()) {
+    if (hasErrorWithoutLock()) {
         return;
     }
 

--- a/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
+++ b/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "rtp_llm/cpp/engine_base/stream/GenerateStream.h"
 #include <cstdint>
+#include <deque>
 
 namespace rtp_llm {
 
@@ -8,7 +9,6 @@ class NormalGenerateStream: public GenerateStream {
 public:
     NormalGenerateStream(const GenerateStream& stream): GenerateStream(stream) {
         CopyOnWrite(stream);
-        generate_outputs_queue_.setCapacity(1000);
     }
 
     NormalGenerateStream(const std::shared_ptr<GenerateInput>& query,
@@ -18,25 +18,28 @@ public:
                          kmonitor::MetricsReporterPtr          metrics_reporter,
                          size_t                                extra_reserve_token_num = 0,
                          bool                                  perf_test               = false):
-        GenerateStream(query, model_config, runtime_config, resource_context, metrics_reporter, extra_reserve_token_num, perf_test),
-        request_id_(query->request_id) {
-        generate_outputs_queue_.setCapacity(1000);
-    }
-
-    ~NormalGenerateStream() {
-        generate_outputs_queue_.wakeup();
-    }
+        GenerateStream(query,
+                       model_config,
+                       runtime_config,
+                       resource_context,
+                       metrics_reporter,
+                       extra_reserve_token_num,
+                       perf_test),
+        request_id_(query->request_id) {}
 
     bool                         hasOutput() override;
-    ErrorResult<GenerateOutputs> nextOutput() override;
+    ErrorResult<GenerateOutputs> nextOutput(int64_t wait_timeout_ms = 0) override;
     void                         updateOutput(const StreamUpdateInfo& update_info) override;
 
 private:
     GenerateOutputs prepareGenerateOutput(const StreamUpdateInfo& update_info);
     void            enqueueGenerateOutput(GenerateOutputs&& generate_results);
+    bool            consumerReadyWithoutLock() const override;
 
-    int64_t                                   request_id_{0};
-    bool                                      finished_{false};
-    autil::SynchronizedQueue<GenerateOutputs> generate_outputs_queue_;
+    static constexpr size_t kOutputCapacity = 1000;
+
+    int64_t                     request_id_{0};
+    bool                        finished_{false};
+    std::deque<GenerateOutputs> generate_outputs_;
 };
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/utils/ErrorCode.h
+++ b/rtp_llm/cpp/utils/ErrorCode.h
@@ -22,11 +22,12 @@ enum class ErrorCode {
     MM_DOWNLOAD_FAILED     = 906,
 
     // Error codes starting from 8000 can be retried
-    CANCELLED             = 8100,
-    OUT_OF_VOCAB_RANGE    = 8101,
-    OUTPUT_QUEUE_FULL     = 8102,
-    OUTPUT_QUEUE_IS_EMPTY = 8103,
-    FINISHED              = 8104,
+    CANCELLED              = 8100,
+    OUT_OF_VOCAB_RANGE     = 8101,
+    OUTPUT_QUEUE_FULL      = 8102,
+    OUTPUT_QUEUE_IS_EMPTY  = 8103,
+    FINISHED               = 8104,
+    OUTPUT_QUEUE_NO_UPDATE = 8105,
 
     // rpc error
     GET_HOST_FAILED                       = 8200,
@@ -108,6 +109,8 @@ inline std::string ErrorCodeToString(ErrorCode code) {
             return "OUTPUT_QUEUE_IS_EMPTY";
         case ErrorCode::FINISHED:
             return "FINISHED";
+        case ErrorCode::OUTPUT_QUEUE_NO_UPDATE:
+            return "OUTPUT_QUEUE_NO_UPDATE";
         case ErrorCode::EXCEEDS_KV_CACHE_MAX_LEN:
             return "EXCEEDS_KV_CACHE_MAX_LEN";
         case ErrorCode::GET_HOST_FAILED:
@@ -215,14 +218,11 @@ class ErrorInfo {
 public:
     ErrorInfo() {}
     ErrorInfo(ErrorCode code, const std::string& message): code_(code), message_(message) {}
-    ErrorInfo(const ErrorInfo& other): code_(other.code_), message_(other.message_) {}
-    ErrorInfo& operator=(const ErrorInfo& other) {
-        if (this != &other) {
-            code_    = other.code_;
-            message_ = other.message_;
-        }
-        return *this;
-    }
+    ErrorInfo(ErrorCode code, std::string&& message): code_(code), message_(std::move(message)) {}
+    ErrorInfo(const ErrorInfo& other)            = default;
+    ErrorInfo(ErrorInfo&& other)                 = default;
+    ErrorInfo& operator=(const ErrorInfo& other) = default;
+    ErrorInfo& operator=(ErrorInfo&& other)      = default;
 
     const std::string& ToString() const {
         return message_;


### PR DESCRIPTION
## Summary

This change makes GenerateStream output readiness event-driven and thread-safe. It replaces the output queue’s polling-based wait with a single stream-level synchronization domain for consumer-visible state.

- Replace `NormalGenerateStream`'s `SynchronizedQueue` with a mutex-protected `std::deque`.
- Use one consumer condition variable for output, errors, cancellation, timeout, completion, and PD handoff (`NeedRemoteGenerate`).
- Make `nextOutput()` the sole blocking consumer API and remove `waitForRemoteGenerate()`.

## Design

`nextOutput()` now evaluates output availability, terminal events, errors, and the request deadline under the same mutex that protects publication. Predicate-based waits eliminate the previous check-then-wait gap and fixed one-second wake-up delay. A steady-clock deadline reports timeout through the normal state-machine event path.

The result order remains unchanged: errors take precedence over queued output, while final output is drained before normal completion is returned. PD separation uses the same readiness path rather than a separate wait primitive.

## Lifecycle boundaries

Consumer readiness is separated from committed stream lifecycle transitions. Scheduler-owned `moveToNext()` remains responsible for state commits, cache-resource actions, and scheduler-visible lifecycle changes at safe engine-step boundaries.

Synchronous gRPC cancellation remains detected after `nextOutput()` wakes; prompt cancellation publication through async gRPC is intentionally out of scope.

## Coverage

Adds focused stream and RPC tests alongside API-server coverage for readiness, completion/error handling, and PD-related behavior.