### PR TITLE
perf(cache): replace O(N*G) slot simulation with O(1) closed-form pea…

### DIFF
--- a/rtp_llm/cpp/cache/LinearKVCacheGroup.cc
+++ b/rtp_llm/cpp/cache/LinearKVCacheGroup.cc
@@ -40,6 +40,108 @@ int estimatePeakFromSlotCosts(std::vector<int> block_costs,
     return peak_blocks;
 }
 
+int countLinearStepHits(int begin, int end, int linear_step) {
+    begin = std::max(begin, 0);
+    end   = std::max(end, begin);
+    if (linear_step <= 0) return 0;
+    return end / linear_step - begin / linear_step;
+}
+
+// Number of slots in [begin, end) that would be freed by removeSkippedBlocks.
+// With reuse disabled every materialized slot is freed; with reuse enabled only non-step-hit slots are freed.
+int countFreedSlots(int begin, int end, bool enable_reuse_cache, int linear_step) {
+    begin = std::max(begin, 0);
+    end   = std::max(end, begin);
+    const int slots = end - begin;
+    return enable_reuse_cache ? slots - countLinearStepHits(begin, end, linear_step) : slots;
+}
+
+// Materialized slot count in [begin, end) for an initial allocation of seq_slots slots with M materialized tail
+// blocks. With reuse enabled, step hits and the last M sequence slots are materialized; with reuse disabled only
+// the last M sequence slots are.
+int countMaterializedSlots(int begin, int end, int seq_slots, int M, bool enable_reuse_cache, int linear_step) {
+    begin = std::max(begin, 0);
+    end   = std::max(end, begin);
+    if (end <= begin || seq_slots <= 0) return 0;
+
+    const int tail_begin = std::max(0, seq_slots - M);
+    const int tail_end   = std::min(end, seq_slots);
+    if (enable_reuse_cache) {
+        return countLinearStepHits(begin, end, linear_step)
+               + countFreedSlots(std::max(begin, tail_begin), tail_end, true, linear_step);
+    }
+    return std::max(0, tail_end - std::max(begin, tail_begin));
+}
+
+// Closed-form peak block count for a fresh batch under the continue-cleanup behavior.
+//
+// After each append, removeSkippedBlocks walks the entire [0, cleanup_end] range (skipping nulls) and frees every
+// non-step-hit materialized slot. This means the layout reaches maximal sparsity after the first cleanup, and
+// each subsequent cleanup frees at most one newly aged-out slot. Physical block count is therefore non-decreasing
+// across steps, and the peak is at the last append:
+//
+//   peak = initial_materialized + batch_size * growth - freed_before_last_cleanup
+//
+// where freed_before_last_cleanup counts non-step-hit (or all, if reuse disabled) materialized slots in the union
+// of all cleanup ranges before the final append, computed via integer division in O(1).
+int estimateInitialPeakFromSlotCounts(int  common_slots,
+                                      int  seq_slots,
+                                      int  final_seq_slots,
+                                      int  reserve_step,
+                                      bool enable_reuse_cache,
+                                      int  linear_step,
+                                      int  target_batch_size,
+                                      int  materialized_tail,
+                                      int  retained_tail) {
+    const int batch_size   = std::max(target_batch_size, 1);
+    const int step         = std::max(1, linear_step);
+    const int M            = std::max(1, materialized_tail);
+    const int R            = std::max(2, retained_tail);
+    const int reserve_slots = reserve_step > 0 ? reserve_step - 1 : 0;
+    const int initial_slots = seq_slots + reserve_slots;
+    const int final_slots   = final_seq_slots + reserve_slots;
+    const int actual_initial = std::max(initial_slots, common_slots);
+    const int growth        = std::max(final_slots - actual_initial, 0);
+
+    const int common_mat  = countMaterializedSlots(0, common_slots, common_slots, M, enable_reuse_cache, step);
+    const int private_mat = countMaterializedSlots(common_slots, seq_slots, seq_slots, M, enable_reuse_cache, step);
+    const int private_reserve = std::max(0, initial_slots - std::max(seq_slots, common_slots));
+    const int initial_physical = common_mat + batch_size * (private_mat + private_reserve);
+
+    if (growth == 0) {
+        return initial_physical;
+    }
+
+    // cleanup_end at step k-1 (the last cleanup before the peak measurement at step k=growth).
+    int cleanup_end_last = actual_initial + growth - R - 2 - reserve_step;
+
+    int freed = 0;
+    if (growth > 1 && cleanup_end_last >= 0) {
+        // Common tail slots (shared, cost 1).
+        int cbegin = std::max(0, common_slots - M);
+        int cend   = std::min(common_slots, cleanup_end_last + 1);
+        freed += countFreedSlots(cbegin, cend, enable_reuse_cache, step);
+
+        // Private tail slots (per-sequence, cost batch_size).
+        int pbegin = std::max(common_slots, seq_slots - M);
+        int pend   = std::min(seq_slots, cleanup_end_last + 1);
+        freed += batch_size * countFreedSlots(pbegin, pend, enable_reuse_cache, step);
+
+        // Private reserve slots (per-sequence, cost batch_size).
+        int rbegin = std::max(seq_slots, common_slots);
+        int rend   = std::min(initial_slots, cleanup_end_last + 1);
+        freed += batch_size * countFreedSlots(rbegin, rend, enable_reuse_cache, step);
+
+        // Growth slots (per-sequence, cost batch_size).
+        int gbegin = actual_initial;
+        int gend   = std::min(actual_initial + growth, cleanup_end_last + 1);
+        freed += batch_size * countFreedSlots(gbegin, gend, enable_reuse_cache, step);
+    }
+
+    const int peak = initial_physical + batch_size * growth - freed;
+    return std::max(peak, initial_physical + batch_size);
+}
+
 }  // namespace
 
 void LinearKVCacheGroup::filterValidBlocks(const BlockIndicesType& in, BlockIndicesType& out) const {
@@ -90,24 +192,30 @@ int LinearKVCacheGroup::estimatePeakNeedBlocks(int                     seq_len,
     const int step              = std::max(1, linear_step_);
     const int current_seq_slots = (seq_len + seqSizePerBlock() - 1) / seqSizePerBlock();
     const int final_seq_slots   = (seq_len + remaining_tokens + seqSizePerBlock() - 1) / seqSizePerBlock();
-    const int extra_blocks      = reserve_step ? reserve_step - 1 : 0;
-    const int total_slots       = final_seq_slots + extra_blocks;
+
+    if (current_block_indices.empty()) {
+        return estimateInitialPeakFromSlotCounts(/*common_slots=*/0,
+                                                 current_seq_slots,
+                                                 final_seq_slots,
+                                                 reserve_step,
+                                                 enable_reuse_cache,
+                                                 step,
+                                                 /*target_batch_size=*/1,
+                                                 materializedTailBlockCount(),
+                                                 retainedTailBlockCount());
+    }
+
+    const int extra_blocks = reserve_step ? reserve_step - 1 : 0;
+    const int total_slots  = final_seq_slots + extra_blocks;
 
     std::vector<int> block_costs;
     block_costs.reserve(std::max(total_slots, static_cast<int>(current_block_indices.size())));
 
     int current_physical_blocks = 0;
-    if (!current_block_indices.empty()) {
-        for (const auto block_index : current_block_indices) {
-            const bool allocated = !isNullBlockIdx(block_index);
-            block_costs.push_back(allocated ? 1 : 0);
-            current_physical_blocks += allocated;
-        }
-    } else {
-        const int initial_slots = current_seq_slots + extra_blocks;
-        for (int i = 0; i < initial_slots; ++i) {
-            block_costs.push_back(shouldMaterializeBlock(i, seq_len, reserve_step, enable_reuse_cache) ? 1 : 0);
-        }
+    for (const auto block_index : current_block_indices) {
+        const bool allocated = !isNullBlockIdx(block_index);
+        block_costs.push_back(allocated ? 1 : 0);
+        current_physical_blocks += allocated;
     }
 
     const int peak_blocks = estimatePeakFromSlotCosts(
@@ -121,34 +229,18 @@ int LinearKVCacheGroup::estimateInitialBatchPeakNeedBlocks(int  seq_len,
                                                            int  reserve_step,
                                                            bool enable_reuse_cache,
                                                            int  target_batch_size) const {
-    const int  step       = std::max(1, linear_step_);
-    const int  batch_size = std::max(target_batch_size, 1);
-    const auto seq_slots  = [&](int length) { return (length + seqSizePerBlock() - 1) / seqSizePerBlock(); };
+    const int step = std::max(1, linear_step_);
+    const auto seq_slots = [&](int length) { return (length + seqSizePerBlock() - 1) / seqSizePerBlock(); };
 
-    const int        common_slots   = seq_slots(common_seq_len);
-    const int        initial_slots  = seq_slots(seq_len);
-    const int        reserve_blocks = reserve_step > 0 ? reserve_step - 1 : 0;
-    const int        initial_total  = initial_slots + reserve_blocks;
-    const int        final_total    = seq_slots(seq_len + remaining_tokens) + reserve_blocks;
-    std::vector<int> block_costs;
-    block_costs.reserve(static_cast<size_t>(std::max(initial_total, final_total)));
-
-    for (int slot = 0; slot < common_slots; ++slot) {
-        block_costs.push_back(shouldMaterializeBlock(slot, common_seq_len, 0, enable_reuse_cache) ? 1 : 0);
-    }
-
-    // initMalloc's incrMalloc phase appends the whole prompt suffix without sparse cleanup.
-    for (int slot = common_slots; slot < initial_total; ++slot) {
-        block_costs.push_back(shouldMaterializeBlock(slot, seq_len, reserve_step, enable_reuse_cache) ? batch_size : 0);
-    }
-
-    return estimatePeakFromSlotCosts(std::move(block_costs),
-                                     final_total,
-                                     batch_size,
-                                     reserve_step,
-                                     retainedTailBlockCount(),
-                                     enable_reuse_cache,
-                                     step);
+    return estimateInitialPeakFromSlotCounts(seq_slots(common_seq_len),
+                                             seq_slots(seq_len),
+                                             seq_slots(seq_len + remaining_tokens),
+                                             reserve_step,
+                                             enable_reuse_cache,
+                                             step,
+                                             target_batch_size,
+                                             materializedTailBlockCount(),
+                                             retainedTailBlockCount());
 }
 
 NeedBlocksInfo LinearKVCacheGroup::getNeedBlocks(

--- a/rtp_llm/cpp/cache/test/BlockPoolTestHelper.h
+++ b/rtp_llm/cpp/cache/test/BlockPoolTestHelper.h
@@ -102,9 +102,10 @@ inline BlockPoolConfig createTestConfig(size_t            k_block_stride_bytes =
                                         size_t            v_scale_stride_bytes = 0,
                                         rtp_llm::DataType dtype                = rtp_llm::DataType::TYPE_FP16,
                                         uint32_t          local_head_num_kv    = 1,
-                                        uint32_t          seq_size_per_block   = 1) {
+                                        uint32_t          seq_size_per_block   = 1,
+                                        uint32_t          block_num            = 10) {
     constexpr uint32_t kLayerNum = 4;
-    constexpr uint32_t kBlockNum = 10;
+    const uint32_t     kBlockNum = block_num;
 
     auto spec = createTestKvCacheSpec(
         kLayerNum, dtype, local_head_num_kv, seq_size_per_block, k_block_stride_bytes, v_block_stride_bytes);
@@ -142,6 +143,13 @@ inline void createDevice() {
 BlockPoolPtr createBlockPool() {
     createDevice();
     auto config     = createTestConfig();
+    auto block_pool = std::make_shared<BlockPool>(config);
+    return block_pool;
+}
+
+BlockPoolPtr createBlockPoolWithSize(uint32_t block_num) {
+    createDevice();
+    auto config     = createTestConfig(512, 512, 0, 0, rtp_llm::DataType::TYPE_FP16, 1, 1, block_num);
     auto block_pool = std::make_shared<BlockPool>(config);
     return block_pool;
 }

--- a/rtp_llm/cpp/cache/test/LinearKVCacheGroupTest.cc
+++ b/rtp_llm/cpp/cache/test/LinearKVCacheGroupTest.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "rtp_llm/cpp/cache/SharedBlockCache.h"
@@ -676,6 +678,184 @@ TEST_F(LinearKVCacheGroupTest, InsertIntoCacheWithEmptyInputsIsNoop) {
     group.insertIntoCache(CacheKeysType{}, BlockIndicesType{1, 2}, /*is_resident=*/false);
     group.insertIntoCache(CacheKeysType{100, 101}, BlockIndicesType{}, /*is_resident=*/false);
     EXPECT_EQ(shared_cache->size(), 0u);
+}
+
+// ---- Oracle helpers: independent reimplementation of the slot-cost simulation ----
+
+static bool oracleShouldMaterialize(int pos, int seq_slots, int M, int reserve_step, bool reuse, int step) {
+    const int  reserve_slots = reserve_step > 0 ? reserve_step - 1 : 0;
+    const int  total_slots    = seq_slots + reserve_slots;
+    const bool is_seq_tail    = (seq_slots > 0) && (pos >= std::max(0, seq_slots - M)) && (pos < seq_slots);
+    const bool is_reserve     = (reserve_step > 0) && (pos >= seq_slots) && (pos < total_slots);
+    const bool step_hit       = (step > 0) && ((pos + 1) % step == 0);
+    return is_reserve || (reuse ? (step_hit || is_seq_tail) : is_seq_tail);
+}
+
+static int oracleEstimateInitialBatchPeak(int common_slots, int seq_slots, int final_seq_slots,
+                                          int reserve_step, bool reuse, int step,
+                                          int M, int R, int batch_size) {
+    const int reserve_slots  = reserve_step > 0 ? reserve_step - 1 : 0;
+    const int initial_slots  = seq_slots + reserve_slots;
+    const int final_slots    = final_seq_slots + reserve_slots;
+
+    std::vector<int> costs;
+    costs.reserve(static_cast<size_t>(std::max(final_slots, 0)));
+    for (int pos = 0; pos < common_slots; ++pos) {
+        costs.push_back(oracleShouldMaterialize(pos, common_slots, M, 0, reuse, step) ? 1 : 0);
+    }
+    for (int pos = common_slots; pos < initial_slots; ++pos) {
+        costs.push_back(oracleShouldMaterialize(pos, seq_slots, M, reserve_step, reuse, step) ? batch_size : 0);
+    }
+
+    int physical = std::accumulate(costs.begin(), costs.end(), 0);
+    int peak     = physical;
+
+    while (static_cast<int>(costs.size()) < final_slots) {
+        costs.push_back(batch_size);
+        physical += batch_size;
+        peak = std::max(peak, physical);
+
+        for (int slot = static_cast<int>(costs.size()) - R - 1 - reserve_step; slot >= 0; --slot) {
+            auto& cost = costs[static_cast<size_t>(slot)];
+            if (cost == 0) {
+                continue;
+            }
+            if (reuse && step > 0 && (slot + 1) % step == 0) {
+                continue;
+            }
+            physical -= cost;
+            cost = 0;
+        }
+    }
+    return peak;
+}
+
+static int countPhysicalBlocks(const BlockIds& blocks) {
+    int count = 0;
+    for (auto b : blocks.blocks()) {
+        if (!isNullBlockIdx(b)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+// ---- Closed-form vs. oracle simulation ----
+
+TEST_F(LinearKVCacheGroupTest, ClosedFormPeakEstimatesExactlyMatchSlotSimulation) {
+    for (int block_size : {1, 4}) {
+        auto block_pool = createBlockPoolWithSize(4096);
+        ASSERT_TRUE(block_pool->init());
+
+        for (int linear_step : {1, 2, 3, 5}) {
+            for (uint32_t configured_tail : {0u, 1u, 2u}) {
+                auto policy               = defaultCacheGroupPolicy(CacheGroupType::LINEAR);
+                policy.active_tail_blocks = configured_tail;
+                auto spec                 = makeTestLinearSpec(block_size);
+                LinearKVCacheGroup group({}, spec, block_pool, 0, linear_step, nullptr, nullptr, policy);
+                ASSERT_TRUE(group.init());
+
+                const int M = std::max(1, static_cast<int>(configured_tail));
+                const int R = std::max(2, M);
+
+                for (bool reuse : {false, true}) {
+                    for (int reserve_step : {0, 1, 2}) {
+                        for (int common_seq : {0, 3, 10}) {
+                            for (int seq_len : {1, 10, 20}) {
+                                for (int remaining : {0, 5, 20}) {
+                                    for (int batch : {1, 2, 4}) {
+                                        SCOPED_TRACE(testing::Message()
+                                                     << "bs=" << block_size << " step=" << linear_step
+                                                     << " reuse=" << reuse << " reserve=" << reserve_step
+                                                     << " tail=" << configured_tail << " common=" << common_seq
+                                                     << " seq=" << seq_len << " remaining=" << remaining
+                                                     << " batch=" << batch);
+
+                                        const int common_slots = (common_seq + block_size - 1) / block_size;
+                                        const int seq_slots    = (seq_len + block_size - 1) / block_size;
+                                        const int final_slots  = (seq_len + remaining + block_size - 1) / block_size;
+
+                                        const int oracle = oracleEstimateInitialBatchPeak(
+                                            common_slots, seq_slots, final_slots,
+                                            reserve_step, reuse, linear_step, M, R, batch);
+                                        const int estimate = group.estimateInitialBatchPeakNeedBlocks(
+                                            seq_len, common_seq, remaining,
+                                            reserve_step, reuse, batch);
+                                        EXPECT_EQ(estimate, oracle);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_F(LinearKVCacheGroupTest, ClosedFormPeakEstimatesMatchSimulationAtLargeScale) {
+    auto block_pool = createBlockPoolWithSize(65536);
+    ASSERT_TRUE(block_pool->init());
+
+    for (int linear_step : {1, 7, 13, 64}) {
+        for (bool reuse : {false, true}) {
+            for (int reserve_step : {0, 1, 4}) {
+                auto spec  = makeTestLinearSpec(1);
+                LinearKVCacheGroup group({}, spec, block_pool, 0, linear_step);
+                ASSERT_TRUE(group.init());
+
+                const int M = 1, R = 2;
+                const int common = 50, seq_len = 500, remaining = 1000, batch = 4;
+
+                const int oracle = oracleEstimateInitialBatchPeak(
+                    common, seq_len, seq_len + remaining,
+                    reserve_step, reuse, linear_step, M, R, batch);
+                const int estimate = group.estimateInitialBatchPeakNeedBlocks(
+                    seq_len, common, remaining, reserve_step, reuse, batch);
+
+                SCOPED_TRACE(testing::Message()
+                             << "step=" << linear_step << " reuse=" << reuse << " reserve=" << reserve_step);
+                EXPECT_EQ(estimate, oracle);
+            }
+        }
+    }
+}
+
+TEST_F(LinearKVCacheGroupTest, EstimateMatchesRealAllocatorPeak) {
+    for (int linear_step : {1, 2, 3, 5}) {
+        for (bool reuse : {false, true}) {
+            for (int reserve_step : {0, 1, 2}) {
+                auto block_pool = createBlockPoolWithSize(512);
+                ASSERT_TRUE(block_pool->init());
+
+                auto spec  = makeTestLinearSpec(1);
+                LinearKVCacheGroup group({}, spec, block_pool, 0, linear_step);
+                ASSERT_TRUE(group.init());
+
+                const int initial_seq_len = 10;
+                const int remaining       = 60;
+
+                const int estimate = group.estimatePeakNeedBlocks(
+                    initial_seq_len, {}, remaining, reserve_step, reuse);
+
+                BlockIds blocks;
+                ASSERT_TRUE(group.malloc(blocks, initial_seq_len, reuse, reserve_step));
+                int peak = countPhysicalBlocks(blocks);
+
+                int seq_len = initial_seq_len;
+                while (seq_len < initial_seq_len + remaining) {
+                    ++seq_len;
+                    ASSERT_TRUE(group.malloc(blocks, seq_len, reuse, reserve_step));
+                    peak = std::max(peak, countPhysicalBlocks(blocks));
+                    group.removeSkippedBlocks(blocks, reuse, reserve_step);
+                }
+
+                SCOPED_TRACE(testing::Message()
+                             << "step=" << linear_step << " reuse=" << reuse << " reserve=" << reserve_step);
+                EXPECT_EQ(estimate, peak);
+            }
+        }
+    }
 }
 
 }  // namespace test


### PR DESCRIPTION
LinearKVCacheGroup's estimateInitialBatchPeakNeedBlocks and the empty-indices path of estimatePeakNeedBlocks previously ran an O(N*G) slot-by-slot simulation to predict peak block usage. Replace with an O(1) closed-form formula that exploits the continue-cleanup invariant: physical block count is non-decreasing across decode steps, so the peak equals the last append minus freed-before-last.

Fixes two correctness issues uncovered by oracle-simulation and real-allocator sweep tests:
- countMaterializedSlots double-counted positions that are both step hits and tail blocks when reuse is enabled
- estimateInitialPeakFromSlotCounts mishandled common_slots > seq_slots (common prefix longer than the sequence), over-counting reserve slots and growth

Adds three test cases:
- ClosedFormPeakEstimatesExactlyMatchSlotSimulation: ~12k parameter combinations verified against independent O(N) oracle simulation
- ClosedFormPeakEstimatesMatchSimulationAtLargeScale: 1000-token growth verified at scale
- EstimateMatchesRealAllocatorPeak: estimate verified against actual malloc + removeSkippedBlocks peak for single-sequence decode