### PR TITLE
Develop/hengcang/newloader qwen3 next mtp

### DIFF
--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -7,10 +7,9 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple
 
+import rtp_llm.models_py.weight_mapper as weight_mapper
 import torch
 import torch.nn as nn
-
-import rtp_llm.models_py.weight_mapper as weight_mapper
 from rtp_llm.models_py.module_base import RtpModule, collect_loaded_tensor_ids
 from rtp_llm.models_py.registry import get_model_class, list_models
 
@@ -338,8 +337,8 @@ class NewModelLoader:
         )
 
     @staticmethod
-    def _checkpoint_name_filter(
-        model: RtpModule, expert_filter: Optional[_ExpertRangeFilter]
+    def _model_checkpoint_name_filter(
+        model: RtpModule,
     ) -> Optional[Callable[[str], bool]]:
         model_filter = model.checkpoint_weight_name_filter()
         if model_filter is not None and not callable(model_filter):
@@ -347,6 +346,13 @@ class NewModelLoader:
                 f"{type(model).__name__}.checkpoint_weight_name_filter() must "
                 "return a callable or None"
             )
+        return model_filter
+
+    @staticmethod
+    def _checkpoint_name_filter(
+        model_filter: Optional[Callable[[str], bool]],
+        expert_filter: Optional[_ExpertRangeFilter],
+    ) -> Optional[Callable[[str], bool]]:
         if model_filter is None and expert_filter is None:
             return None
 
@@ -504,10 +510,20 @@ class NewModelLoader:
             )
         started = time.time()
         expert_filter = self._expert_filter()
-        name_filter = self._checkpoint_name_filter(model, expert_filter)
+        model_filter = self._model_checkpoint_name_filter(model)
+        selected_files = weight_mapper.select_safetensor_files(
+            self._resolved_model_path(), checkpoint_files, model_filter
+        )
+        if len(selected_files) != len(checkpoint_files):
+            logger.info(
+                "Model checkpoint filter selected %d/%d shards",
+                len(selected_files),
+                len(checkpoint_files),
+            )
+        name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         model.load_weights(
             weight_mapper.get_all_weights(
-                checkpoint_files,
+                selected_files,
                 device="cpu",
                 name_filter=name_filter,
                 safetensor_slice_expander=expert_filter,

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -353,6 +353,10 @@ class NewModelLoader:
         model_filter: Optional[Callable[[str], bool]],
         expert_filter: Optional[_ExpertRangeFilter],
     ) -> Optional[Callable[[str], bool]]:
+        if model_filter is not None and (
+            not callable(model_filter) or isinstance(model_filter, nn.Module)
+        ):
+            raise TypeError("model_filter must be callable or None")
         if model_filter is None and expert_filter is None:
             return None
 

--- a/rtp_llm/models_py/new_loader_test/foundation_test.py
+++ b/rtp_llm/models_py/new_loader_test/foundation_test.py
@@ -99,6 +99,10 @@ class FoundationLoaderTest(unittest.TestCase):
                     self._loader(model_path).load()
                 move.assert_not_called()
 
+    def test_combined_checkpoint_filter_rejects_model_instances(self):
+        with self.assertRaisesRegex(TypeError, "model_filter must be callable"):
+            NewModelLoader._checkpoint_name_filter(RtpModule(), None)
+
     def test_staged_modules_move_and_postprocess_one_at_a_time(self):
         events = []
 
@@ -523,6 +527,31 @@ class FoundationLoaderTest(unittest.TestCase):
                 ),
                 [draft],
             )
+
+    def test_model_filter_without_matches_fails(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            shard = os.path.join(model_path, "model.safetensors")
+            save_file({"main.weight": torch.ones(1)}, shard)
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump(
+                    {"weight_map": {"main.weight": os.path.basename(shard)}}, handle
+                )
+
+            with self.assertRaisesRegex(ValueError, "did not match"):
+                select_safetensor_files(
+                    model_path,
+                    [shard],
+                    lambda name: name.startswith("draft."),
+                )
+
+    def test_model_filter_preserves_non_safetensors_files(self):
+        files = ["pytorch_model.bin", "extra.pt"]
+        self.assertEqual(
+            select_safetensor_files("unused", files, lambda name: False),
+            files,
+        )
 
     def test_model_filter_rejects_index_shard_outside_discovered_set(self):
         with tempfile.TemporaryDirectory() as model_path:

--- a/rtp_llm/models_py/new_loader_test/foundation_test.py
+++ b/rtp_llm/models_py/new_loader_test/foundation_test.py
@@ -20,7 +20,11 @@ from rtp_llm.models_py.registry import (
     register_lazy_model,
     register_model,
 )
-from rtp_llm.models_py.weight_mapper import discover_ckpt_files, get_all_weights
+from rtp_llm.models_py.weight_mapper import (
+    discover_ckpt_files,
+    get_all_weights,
+    select_safetensor_files,
+)
 from safetensors.torch import save_file
 
 
@@ -478,6 +482,113 @@ class FoundationLoaderTest(unittest.TestCase):
                 discover_ckpt_files(model_path),
                 [os.path.realpath(shard1), os.path.realpath(shard2)],
             )
+
+    def test_model_filter_preselects_only_matching_index_shards(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            shard_names = [
+                f"model-{index:05d}-of-00004.safetensors" for index in range(1, 5)
+            ]
+            shard_paths = [os.path.join(model_path, name) for name in shard_names]
+            tensor_names = ["main.weight", "draft.embed", "draft.layer", "other.weight"]
+            for path, name in zip(shard_paths, tensor_names):
+                save_file({name: torch.ones(1)}, path)
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump({"weight_map": dict(zip(tensor_names, shard_names))}, handle)
+
+            with mock.patch(
+                "safetensors.safe_open",
+                side_effect=AssertionError("indexed selection opened shard headers"),
+            ):
+                selected = select_safetensor_files(
+                    model_path,
+                    shard_paths,
+                    lambda name: name.startswith("draft."),
+                )
+
+            self.assertEqual(selected, shard_paths[1:3])
+
+    def test_model_filter_without_index_falls_back_to_headers(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            main = os.path.join(model_path, "model-00001-of-00002.safetensors")
+            draft = os.path.join(model_path, "model-00002-of-00002.safetensors")
+            save_file({"main.weight": torch.ones(1)}, main)
+            save_file({"draft.weight": torch.ones(1)}, draft)
+            self.assertEqual(
+                select_safetensor_files(
+                    model_path,
+                    [main, draft],
+                    lambda name: name.startswith("draft."),
+                ),
+                [draft],
+            )
+
+    def test_model_filter_rejects_index_shard_outside_discovered_set(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            discovered = os.path.join(model_path, "model-00001-of-00002.safetensors")
+            undiscovered = os.path.join(model_path, "model-00002-of-00002.safetensors")
+            save_file({"main.weight": torch.ones(1)}, discovered)
+            save_file({"draft.weight": torch.ones(1)}, undiscovered)
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump(
+                    {"weight_map": {"draft.weight": os.path.basename(undiscovered)}},
+                    handle,
+                )
+            with self.assertRaisesRegex(ValueError, "undiscovered shard"):
+                select_safetensor_files(
+                    model_path,
+                    [discovered],
+                    lambda name: name.startswith("draft."),
+                )
+
+    def test_model_filter_allows_discovered_external_blob_symlink(self):
+        with tempfile.TemporaryDirectory() as temp_root:
+            model_path = os.path.join(temp_root, "snapshot")
+            blob_path = os.path.join(temp_root, "blob.safetensors")
+            os.mkdir(model_path)
+            save_file({"draft.weight": torch.ones(1)}, blob_path)
+            shard = os.path.join(model_path, "model-00001-of-00001.safetensors")
+            os.symlink(blob_path, shard)
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump(
+                    {"weight_map": {"draft.weight": os.path.basename(shard)}},
+                    handle,
+                )
+
+            self.assertEqual(
+                select_safetensor_files(
+                    model_path,
+                    [shard],
+                    lambda name: name.startswith("draft."),
+                ),
+                [shard],
+            )
+
+    def test_model_filter_rejects_parent_path_even_if_discovered(self):
+        with tempfile.TemporaryDirectory() as temp_root:
+            model_path = os.path.join(temp_root, "snapshot")
+            outside = os.path.join(temp_root, "outside.safetensors")
+            os.mkdir(model_path)
+            save_file({"draft.weight": torch.ones(1)}, outside)
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump(
+                    {"weight_map": {"draft.weight": "../outside.safetensors"}},
+                    handle,
+                )
+
+            with self.assertRaisesRegex(ValueError, "outside model directory"):
+                select_safetensor_files(
+                    model_path,
+                    [outside],
+                    lambda name: name.startswith("draft."),
+                )
 
     def test_pytorch_index_excludes_training_and_adapter_files(self):
         with tempfile.TemporaryDirectory() as model_path:

--- a/rtp_llm/models_py/new_models/qwen3_moe/test/test_qwen3_moe_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_moe/test/test_qwen3_moe_load.py
@@ -219,7 +219,8 @@ class MoEWeightDispatchTest(unittest.TestCase):
                 weight_mapper.get_all_weights(
                     ["model.safetensors"],
                     name_filter=NewModelLoader._checkpoint_name_filter(
-                        RtpModule(), rank_one
+                        NewModelLoader._model_checkpoint_name_filter(RtpModule()),
+                        rank_one,
                     ),
                     safetensor_slice_expander=rank_one,
                 )

--- a/rtp_llm/models_py/new_models/qwen3_next/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen3_next/__init__.py
@@ -1,3 +1,11 @@
-from rtp_llm.models_py.new_models.qwen3_next.language import Qwen3NextForCausalLM
+from rtp_llm.models_py.new_models.qwen3_next.language import (
+    Qwen3NextForCausalLM,
+    Qwen3NextMTPForCausalLM,
+    Qwen35MoeMTPForCausalLM,
+)
 
-__all__ = ["Qwen3NextForCausalLM"]
+__all__ = [
+    "Qwen3NextForCausalLM",
+    "Qwen3NextMTPForCausalLM",
+    "Qwen35MoeMTPForCausalLM",
+]

--- a/rtp_llm/models_py/new_models/qwen3_next/language.py
+++ b/rtp_llm/models_py/new_models/qwen3_next/language.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
-
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
@@ -16,7 +15,7 @@ from rtp_llm.models_py.layers.linear import (
     MergedColumnParallelLinear,
     RowParallelLinear,
 )
-from rtp_llm.models_py.layers.norm import RMSResNorm
+from rtp_llm.models_py.layers.norm import RMSNorm, RMSResNorm
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.module_base import RtpModule, copy_weight_
 from rtp_llm.models_py.modules import FakeBalanceExpert, SelectTopk
@@ -225,7 +224,10 @@ def _validate_partition(size: Any, rank: Any, name: str) -> Tuple[int, int]:
 
 
 def _extract_config_values(
-    model_config: ModelConfig, load_config: Any
+    model_config: ModelConfig,
+    load_config: Any,
+    *,
+    expects_mtp: bool = False,
 ) -> Dict[str, Any]:
     """Validate the typed runtime configuration used by Qwen3-Next."""
     if not isinstance(model_config, ModelConfig):
@@ -333,8 +335,12 @@ def _extract_config_values(
         raise ValueError(f"Invalid moe_layer_index {moe_layer_index!r}")
     has_moe_norm = _config_bool(model_config, "has_moe_norm", True)
     tie_word_embeddings = _config_bool(model_config, "tie_word_embeddings", False)
-    if _config_bool(model_config, "is_mtp", False):
-        raise ValueError("MTP is not part of the Qwen3-Next core newloader slice")
+    if not isinstance(expects_mtp, bool):
+        raise TypeError("expects_mtp must be a bool")
+    is_mtp = _config_bool(model_config, "is_mtp", False)
+    if is_mtp != expects_mtp:
+        expected = "MTP" if expects_mtp else "core"
+        raise ValueError(f"{expected} Qwen3-Next loader received is_mtp={is_mtp}")
 
     tp_size, tp_rank = _validate_partition(
         required_config_value(load_config, "tp_size"),
@@ -1729,6 +1735,8 @@ class Qwen3NextDecoderLayer(RtpModule):
 class Qwen3NextForCausalLM(GptModelBase):
     """Qwen3-Next Dense + Linear Attention (prefix model.)."""
 
+    _expects_mtp = False
+
     WEIGHTS_MAPPER = WeightsMapper(
         prefix_mapping={
             "model.language_model.": "",
@@ -1806,7 +1814,13 @@ class Qwen3NextForCausalLM(GptModelBase):
             return False
         # Standard norm weights: input_layernorm, post_attention_layernorm,
         # q_norm, k_norm, final norm — all use plus_one (gemma_rms_norm).
-        return name.endswith("norm.weight")
+        return name.endswith(
+            (
+                "norm.weight",
+                "pre_fc_norm_embedding.weight",
+                "pre_fc_norm_hidden.weight",
+            )
+        )
 
     @staticmethod
     def _split_q_gate_yield(
@@ -1855,7 +1869,9 @@ class Qwen3NextForCausalLM(GptModelBase):
         yield gate_name, gate_part
 
     def __init__(self, model_config: ModelConfig, load_config: Any):
-        cfg = _extract_config_values(model_config, load_config)
+        cfg = _extract_config_values(
+            model_config, load_config, expects_mtp=self._expects_mtp
+        )
         parallelism_config = cfg["parallelism_config"]
         fmha_config = getattr(load_config, "fmha_config", None)
         device_resource_config = getattr(load_config, "device_resource_config", None)
@@ -1933,3 +1949,113 @@ class Qwen3NextForCausalLM(GptModelBase):
             )
         hidden_states, residual = self.norm(hidden_states, residual)
         return PyModelOutputs(hidden_states, fmha_impl.fmha_params)
+
+
+class Qwen3NextMTPForCausalLM(Qwen3NextForCausalLM):
+    """Single-layer Qwen3-Next draft model backed by ``mtp.*`` weights."""
+
+    _expects_mtp = True
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={
+            "model.language_model.": "",
+            "model.": "",
+            "mtp.": "",
+        }
+    )
+    _EMBEDDING_WEIGHT_NAMES = frozenset(
+        {
+            "model.embed_tokens.weight",
+            "model.language_model.embed_tokens.weight",
+        }
+    )
+
+    @classmethod
+    def _is_mtp_checkpoint_weight(cls, name: str) -> bool:
+        return (
+            (name.startswith("mtp.") and len(name) > len("mtp."))
+            or name == "lm_head.weight"
+            or name in cls._EMBEDDING_WEIGHT_NAMES
+        )
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return self._is_mtp_checkpoint_weight
+
+    def __init__(self, model_config: ModelConfig, load_config: Any):
+        super().__init__(model_config, load_config)
+        cfg = self._cfg
+        if cfg["num_layers"] != 1:
+            raise ValueError(
+                f"Qwen3-Next MTP requires exactly one layer, got {cfg['num_layers']}"
+            )
+        if cfg["hybrid_types"] != [HybridAttentionType.NONE]:
+            raise ValueError("Qwen3-Next MTP requires one standard-attention layer")
+        if cfg["moe_layer_index"] != [0]:
+            raise ValueError("Qwen3-Next MTP requires MoE layer index [0]")
+
+        self.pre_fc_norm_embedding = RMSNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.pre_fc_norm_hidden = RMSNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+        self.fc = ColumnParallelLinear(
+            input_size=cfg["hidden_size"] * 2,
+            output_size=cfg["hidden_size"],
+            tp_size=1,
+            tp_rank=0,
+            quant_config=None,
+            prefix="fc",
+            bias=False,
+            params_dtype=cfg["params_dtype"],
+        )
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        inputs_embeds = self.embed_tokens(inputs.input_ids)
+        last_hidden_states = inputs.input_hiddens
+        if last_hidden_states is None:
+            raise ValueError("Qwen3-Next MTP requires input_hiddens")
+        if last_hidden_states.shape != inputs_embeds.shape:
+            raise ValueError(
+                "Qwen3-Next MTP input_hiddens must match token embeddings: "
+                f"{tuple(last_hidden_states.shape)} != {tuple(inputs_embeds.shape)}"
+            )
+        hidden_states = self.fc(
+            torch.cat(
+                [
+                    self.pre_fc_norm_embedding(inputs_embeds),
+                    self.pre_fc_norm_hidden(last_hidden_states),
+                ],
+                dim=-1,
+            )
+        )
+
+        if inputs.attention_inputs is None:
+            raise ValueError("Qwen3-Next MTP requires attention inputs")
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+        residual = torch.zeros_like(hidden_states)
+        # The draft layer is standard attention. Empty typed metadata also avoids
+        # allocating linear-attention prefill state during CUDA graph capture.
+        attn_meta = Qwen3NextMetadata()
+        for index, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, index)
+            hidden_states, residual = layer(
+                hidden_states,
+                residual,
+                fmha_impl,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(index) if self.kv_cache else None
+                ),
+                attention_inputs=inputs.attention_inputs,
+                attn_meta=attn_meta,
+            )
+        hidden_states, residual = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)
+
+
+class Qwen35MoeMTPForCausalLM(Qwen3NextMTPForCausalLM):
+    """Qwen3.5 MoE MTP alias with the same runtime layout."""

--- a/rtp_llm/models_py/new_models/qwen3_next/test/test_qwen3_next_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_next/test/test_qwen3_next_load.py
@@ -1,16 +1,19 @@
+import json
 import os
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 import torch
-
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.new_models.qwen3_next.language import (
     Qwen3NextForCausalLM,
     Qwen3NextGatedDeltaNet,
     Qwen3NextMetadata,
+    Qwen3NextMTPForCausalLM,
+    Qwen35MoeMTPForCausalLM,
     _build_qwen3_next_metadata,
     reorder_ba,
     reorder_qkvz,
@@ -19,6 +22,7 @@ from rtp_llm.models_py.new_models.qwen3_next.language import (
 from rtp_llm.models_py.quant_methods import QuantizationConfig
 from rtp_llm.models_py.registry import get_model_class
 from rtp_llm.ops import DataType, HybridAttentionType
+from safetensors.torch import save_file
 
 
 def _parallelism(
@@ -198,9 +202,157 @@ def _moe_weights():
     return weights
 
 
+def _mtp_config(model_type="qwen35_moe_mtp"):
+    config = _config(tie=False)
+    config.model_type = model_type
+    config.is_mtp = True
+    config.moe_layer_index = [0]
+    config.hybrid_attention_config.hybrid_attention_types = [HybridAttentionType.NONE]
+    return config
+
+
+def _mtp_weights(embedding_prefix="model.language_model."):
+    weights = {}
+    for name, tensor in _moe_weights().items():
+        if name == "model.embed_tokens.weight":
+            weights[f"{embedding_prefix}embed_tokens.weight"] = tensor
+        elif name.startswith("model."):
+            weights[f"mtp.{name[len('model.'):]}"] = tensor
+        else:
+            weights[name] = tensor
+    weights.update(
+        {
+            "lm_head.weight": torch.full((8, 4), 3.0),
+            "mtp.pre_fc_norm_embedding.weight": torch.ones(4),
+            "mtp.pre_fc_norm_hidden.weight": torch.ones(4),
+            "mtp.fc.weight": torch.arange(32, dtype=torch.float32).reshape(4, 8),
+        }
+    )
+    return weights
+
+
 class Qwen3NextLoadTest(unittest.TestCase):
     def test_production_model_type_alias_uses_qwen3_next_newloader(self):
         self.assertIs(get_model_class("qwen35_moe"), Qwen3NextForCausalLM)
+
+    def test_mtp_model_type_aliases_use_typed_draft_models(self):
+        self.assertIs(get_model_class("qwen3_next_mtp"), Qwen3NextMTPForCausalLM)
+        self.assertIs(get_model_class("qwen35_moe_mtp"), Qwen35MoeMTPForCausalLM)
+
+    def test_mtp_filter_is_exact_and_rank_invariant(self):
+        accepted = (
+            "mtp.layers.0.self_attn.q_proj.weight",
+            "mtp.pre_fc_norm_embedding.weight",
+            "model.embed_tokens.weight",
+            "model.language_model.embed_tokens.weight",
+            "lm_head.weight",
+        )
+        rejected = (
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.language_model.layers.0.mlp.gate.weight",
+            "model.visual.embed_tokens.weight",
+            "model.embed_tokens.weight_scale",
+            "lm_head.bias",
+            "mtp.",
+        )
+        for name in accepted:
+            with self.subTest(name=name):
+                self.assertTrue(Qwen3NextMTPForCausalLM._is_mtp_checkpoint_weight(name))
+        for name in rejected:
+            with self.subTest(name=name):
+                self.assertFalse(
+                    Qwen3NextMTPForCausalLM._is_mtp_checkpoint_weight(name)
+                )
+
+    def test_real_mtp_tree_loads_draft_only_weights(self):
+        model = Qwen35MoeMTPForCausalLM(_mtp_config(), _load_config())
+        model.load_weights(_mtp_weights())
+        NewModelLoader._validate_loaded_weights(model)
+
+        self.assertEqual(len(model.layers), 1)
+        self.assertNotIn("linear_attn", model.layers[0]._modules)
+        self.assertIsNotNone(model.layers[0].mlp.select_topk)
+        torch.testing.assert_close(
+            model.pre_fc_norm_embedding.weight, torch.full((4,), 2.0)
+        )
+        torch.testing.assert_close(
+            model.pre_fc_norm_hidden.weight, torch.full((4,), 2.0)
+        )
+        torch.testing.assert_close(
+            model.fc.weight,
+            torch.arange(32, dtype=torch.float32).reshape(4, 8),
+        )
+        torch.testing.assert_close(model.norm.weight, torch.full((4,), 2.0))
+
+    def test_new_loader_preselects_mtp_shard_before_materialization(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            main_name = "model-00001-of-00002.safetensors"
+            draft_name = "model-00002-of-00002.safetensors"
+            main_path = os.path.join(model_path, main_name)
+            draft_path = os.path.join(model_path, draft_name)
+            with open(main_path, "wb") as handle:
+                handle.write(b"not a safetensors file")
+            draft_weights = _mtp_weights()
+            save_file(draft_weights, draft_path)
+            weight_map = {"model.visual.unused": main_name}
+            weight_map.update({name: draft_name for name in draft_weights})
+            with open(
+                os.path.join(model_path, "model.safetensors.index.json"), "w"
+            ) as handle:
+                json.dump({"weight_map": weight_map}, handle)
+
+            with mock.patch(
+                "rtp_llm.models_py.layers.moe_experts.BaseMoEExperts."
+                "_maybe_build_fused_moe"
+            ):
+                model = NewModelLoader(
+                    _mtp_config(), _load_config(), model_path=model_path
+                ).load()
+
+        NewModelLoader._validate_loaded_weights(model)
+        self.assertEqual(len(model.layers), 1)
+
+    def test_qwen3_next_mtp_embedding_prefix_loads(self):
+        model = Qwen3NextMTPForCausalLM(_mtp_config("qwen3_next_mtp"), _load_config())
+        model.load_weights(_mtp_weights("model."))
+        NewModelLoader._validate_loaded_weights(model)
+
+    def test_mtp_unknown_checkpoint_tensor_fails(self):
+        model = Qwen35MoeMTPForCausalLM(_mtp_config(), _load_config())
+        weights = _mtp_weights()
+        weights["mtp.layers.0.self_attn.q_projj.weight"] = torch.ones(4, 4)
+        with self.assertRaisesRegex(RuntimeError, "q_projj"):
+            model.load_weights(weights)
+
+    def test_core_and_mtp_configs_cannot_cross_model_boundaries(self):
+        with self.assertRaisesRegex(ValueError, "MTP.*is_mtp=False"):
+            Qwen3NextMTPForCausalLM(_config(), _load_config())
+        config = _mtp_config()
+        with self.assertRaisesRegex(ValueError, "core.*is_mtp=True"):
+            Qwen3NextForCausalLM(config, _load_config())
+
+    def test_mtp_rejects_unsupported_layer_topology(self):
+        multi_layer = _mtp_config()
+        multi_layer.num_layers = 2
+        multi_layer.moe_layer_index = [0, 1]
+        multi_layer.hybrid_attention_config.hybrid_attention_types = [
+            HybridAttentionType.NONE,
+            HybridAttentionType.NONE,
+        ]
+        with self.assertRaisesRegex(ValueError, "exactly one layer"):
+            Qwen3NextMTPForCausalLM(multi_layer, _load_config())
+
+        linear_attention = _mtp_config()
+        linear_attention.hybrid_attention_config.hybrid_attention_types = [
+            HybridAttentionType.LINEAR
+        ]
+        with self.assertRaisesRegex(ValueError, "standard-attention"):
+            Qwen3NextMTPForCausalLM(linear_attention, _load_config())
+
+        dense_layer = _mtp_config()
+        dense_layer.moe_layer_index = []
+        with self.assertRaisesRegex(ValueError, "MoE layer index"):
+            Qwen3NextMTPForCausalLM(dense_layer, _load_config())
 
     def test_qwen35_language_model_prefix_maps_to_runtime_root(self):
         self.assertEqual(
@@ -346,7 +498,7 @@ class Qwen3NextLoadTest(unittest.TestCase):
 
         config = _config()
         config.is_mtp = True
-        with self.assertRaisesRegex(ValueError, "MTP is not part"):
+        with self.assertRaisesRegex(ValueError, "core.*is_mtp=True"):
             Qwen3NextForCausalLM(config, _load_config())
 
     def test_q_gate_per_channel_scale_accepts_vector_layout(self):

--- a/rtp_llm/models_py/new_models/qwen3_next/test/test_qwen3_next_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_next/test/test_qwen3_next_load.py
@@ -284,6 +284,68 @@ class Qwen3NextLoadTest(unittest.TestCase):
         )
         torch.testing.assert_close(model.norm.weight, torch.full((4,), 2.0))
 
+    def test_mtp_forward_rejects_missing_and_mismatched_hidden_states(self):
+        model = Qwen35MoeMTPForCausalLM(_mtp_config(), _load_config())
+        model.load_weights(_mtp_weights())
+        input_ids = torch.tensor([0, 1], dtype=torch.int64)
+        attention_inputs = types.SimpleNamespace()
+
+        for input_hiddens, message in (
+            (None, "requires input_hiddens"),
+            (torch.zeros(1, 4), "must match token embeddings"),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                model.forward(
+                    types.SimpleNamespace(
+                        input_ids=input_ids,
+                        input_hiddens=input_hiddens,
+                        attention_inputs=attention_inputs,
+                    )
+                )
+
+    def test_mtp_forward_projects_normalized_embedding_and_hidden_state(self):
+        class PassLayer(torch.nn.Module):
+            def forward(self, hidden_states, residual, fmha_impl, **kwargs):
+                return hidden_states, residual
+
+        class PassNorm(torch.nn.Module):
+            def forward(self, hidden_states, residual):
+                return hidden_states, residual
+
+        model = Qwen35MoeMTPForCausalLM(_mtp_config(), _load_config())
+        model.load_weights(_mtp_weights())
+        input_ids = torch.tensor([0, 1], dtype=torch.int64)
+        input_hiddens = torch.arange(8, dtype=torch.float32).reshape(2, 4) + 1
+        input_embeds = model.embed_tokens(input_ids)
+        expected = model.fc(
+            torch.cat(
+                [
+                    model.pre_fc_norm_embedding(input_embeds),
+                    model.pre_fc_norm_hidden(input_hiddens),
+                ],
+                dim=-1,
+            )
+        )
+        model.layers = torch.nn.ModuleList([PassLayer()])
+        model.norm = PassNorm()
+        model.kv_cache = None
+        fmha_impl = types.SimpleNamespace(fmha_params="mtp-fmha")
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            input_hiddens=input_hiddens,
+            attention_inputs=types.SimpleNamespace(),
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_next.language."
+            "select_block_map_for_layer"
+        ):
+            outputs = model.forward(inputs, fmha_impl=fmha_impl)
+
+        torch.testing.assert_close(outputs.hidden_states, expected)
+
     def test_new_loader_preselects_mtp_shard_before_materialization(self):
         with tempfile.TemporaryDirectory() as model_path:
             main_name = "model-00001-of-00002.safetensors"

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -129,6 +129,16 @@ register_lazy_model(
     "Qwen3NextForCausalLM",
 )
 register_lazy_model(
+    "qwen3_next_mtp",
+    "rtp_llm.models_py.new_models.qwen3_next",
+    "Qwen3NextMTPForCausalLM",
+)
+register_lazy_model(
+    "qwen35_moe_mtp",
+    "rtp_llm.models_py.new_models.qwen3_next",
+    "Qwen35MoeMTPForCausalLM",
+)
+register_lazy_model(
     "qwen_2",
     "rtp_llm.models_py.new_models.qwen2",
     "Qwen2ForCausalLM",

--- a/rtp_llm/models_py/weight_mapper.py
+++ b/rtp_llm/models_py/weight_mapper.py
@@ -188,6 +188,64 @@ def get_all_weights(
             yield name, tensor
 
 
+def _read_checkpoint_index(
+    model_path: str, index_name: str
+) -> Optional[Tuple[str, Mapping[str, object]]]:
+    index_path = os.path.join(model_path, index_name)
+    if not os.path.isfile(index_path):
+        return None
+    try:
+        with open(index_path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Failed to read checkpoint index {index_path}: {exc}"
+        ) from exc
+    weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"Checkpoint index {index_path} has no non-empty weight_map")
+    return index_path, weight_map
+
+
+def _resolve_index_shard_path(
+    model_root: str,
+    index_path: str,
+    shard_name: object,
+    expected_suffix: str,
+) -> str:
+    if not isinstance(shard_name, str) or not shard_name.endswith(expected_suffix):
+        raise ValueError(
+            f"Checkpoint index {index_path} contains invalid shard {shard_name!r}"
+        )
+    path_parts = re.split(r"[\\/]", shard_name)
+    if os.path.isabs(shard_name) or ntpath.isabs(shard_name) or os.pardir in path_parts:
+        raise ValueError(
+            f"Checkpoint index {index_path} references a path outside model "
+            f"directory: {shard_name!r}"
+        )
+
+    normalized_name = os.path.normpath(shard_name)
+    shard_path = os.path.join(model_root, normalized_name)
+    try:
+        inside_model = os.path.commonpath([model_root, shard_path]) == model_root
+    except ValueError:
+        inside_model = False
+    if not inside_model:
+        raise ValueError(
+            f"Checkpoint index {index_path} references a path outside model "
+            f"directory: {shard_name!r}"
+        )
+    if not _is_model_weight_file(normalized_name, allow_consolidated=True):
+        raise ValueError(
+            f"Checkpoint index {index_path} references non-model file {shard_name!r}"
+        )
+    if not os.path.isfile(shard_path):
+        raise FileNotFoundError(
+            f"Checkpoint index {index_path} references missing shard {shard_name!r}"
+        )
+    return shard_path
+
+
 def select_safetensor_files(
     model_path: str,
     checkpoint_files: Sequence[str],
@@ -208,65 +266,38 @@ def select_safetensor_files(
         return files
 
     discovered = {os.path.realpath(path): path for path in files}
-    index_path = os.path.join(model_path, _SAFETENSORS_INDEX)
     selected_identities = set()
-    if os.path.isfile(index_path):
-        try:
-            with open(index_path, encoding="utf-8") as handle:
-                payload = json.load(handle)
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ValueError(
-                f"Failed to read checkpoint index {index_path}: {exc}"
-            ) from exc
-        weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
-        if not isinstance(weight_map, dict) or not weight_map:
-            raise ValueError(
-                f"Checkpoint index {index_path} has no non-empty weight_map"
-            )
-
+    index = _read_checkpoint_index(model_path, _SAFETENSORS_INDEX)
+    if index is not None:
+        index_path, weight_map = index
         model_root = os.path.realpath(model_path)
+        shard_identities = {}
         for name, shard_name in weight_map.items():
             if not isinstance(name, str):
                 raise ValueError(
                     f"Checkpoint index {index_path} contains non-string tensor name"
                 )
-            if not name_filter(name):
-                continue
             if not isinstance(shard_name, str):
                 raise ValueError(
                     f"Checkpoint index {index_path} contains invalid shard "
-                    f"{shard_name!r} for tensor {name!r}"
+                    f"{shard_name!r}"
                 )
-            path_parts = re.split(r"[\\/]", shard_name)
-            if (
-                os.path.isabs(shard_name)
-                or ntpath.isabs(shard_name)
-                or os.pardir in path_parts
-            ):
-                raise ValueError(
-                    f"Checkpoint index {index_path} references a path outside "
-                    f"model directory: {shard_name!r}"
+            if shard_name not in shard_identities:
+                shard_path = _resolve_index_shard_path(
+                    model_root,
+                    index_path,
+                    shard_name,
+                    ".safetensors",
                 )
-            normalized_name = os.path.normpath(shard_name)
-            shard_path = os.path.join(model_root, normalized_name)
-            try:
-                inside_model = (
-                    os.path.commonpath([model_root, shard_path]) == model_root
-                )
-            except ValueError:
-                inside_model = False
-            if not inside_model:
-                raise ValueError(
-                    f"Checkpoint index {index_path} references a path outside "
-                    f"model directory: {shard_name!r}"
-                )
-            identity = os.path.realpath(shard_path)
-            if identity not in discovered:
-                raise ValueError(
-                    f"Checkpoint index {index_path} selected undiscovered shard "
-                    f"{shard_name!r} for tensor {name!r}"
-                )
-            selected_identities.add(identity)
+                shard_identities[shard_name] = os.path.realpath(shard_path)
+            identity = shard_identities[shard_name]
+            if name_filter(name):
+                if identity not in discovered:
+                    raise ValueError(
+                        f"Checkpoint index {index_path} references undiscovered shard "
+                        f"{shard_name!r}"
+                    )
+                selected_identities.add(identity)
     else:
         from safetensors import safe_open
 
@@ -282,61 +313,22 @@ def select_safetensor_files(
 
 
 def _files_from_index(model_path: str, index_name: str) -> Optional[List[str]]:
-    index_path = os.path.join(model_path, index_name)
-    if not os.path.isfile(index_path):
+    index = _read_checkpoint_index(model_path, index_name)
+    if index is None:
         return None
-    try:
-        with open(index_path, encoding="utf-8") as handle:
-            payload = json.load(handle)
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(
-            f"Failed to read checkpoint index {index_path}: {exc}"
-        ) from exc
-    weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
-    if not isinstance(weight_map, dict) or not weight_map:
-        raise ValueError(f"Checkpoint index {index_path} has no non-empty weight_map")
+    index_path, weight_map = index
 
     expected_suffix = ".safetensors" if index_name == _SAFETENSORS_INDEX else ".bin"
     model_root = os.path.realpath(model_path)
     files = []
     seen = set()
     for shard_name in weight_map.values():
-        if not isinstance(shard_name, str) or not shard_name.endswith(expected_suffix):
-            raise ValueError(
-                f"Checkpoint index {index_path} contains invalid shard {shard_name!r}"
-            )
-        # Validate index text lexically. A symlink already present under model_root
-        # is a trusted filesystem entry and may point to a content-addressed blob.
-        path_parts = re.split(r"[\\/]", shard_name)
-        if (
-            os.path.isabs(shard_name)
-            or ntpath.isabs(shard_name)
-            or os.pardir in path_parts
-        ):
-            raise ValueError(
-                f"Checkpoint index {index_path} references a path outside model directory: "
-                f"{shard_name!r}"
-            )
-
-        normalized_name = os.path.normpath(shard_name)
-        shard_path = os.path.join(model_root, normalized_name)
-        try:
-            inside_model = os.path.commonpath([model_root, shard_path]) == model_root
-        except ValueError:
-            inside_model = False
-        if not inside_model:
-            raise ValueError(
-                f"Checkpoint index {index_path} references a path outside model directory: "
-                f"{shard_name!r}"
-            )
-        if not _is_model_weight_file(normalized_name, allow_consolidated=True):
-            raise ValueError(
-                f"Checkpoint index {index_path} references non-model file {shard_name!r}"
-            )
-        if not os.path.isfile(shard_path):
-            raise FileNotFoundError(
-                f"Checkpoint index {index_path} references missing shard {shard_name!r}"
-            )
+        shard_path = _resolve_index_shard_path(
+            model_root,
+            index_path,
+            shard_name,
+            expected_suffix,
+        )
         shard_identity = os.path.realpath(shard_path)
         if shard_identity not in seen:
             seen.add(shard_identity)

--- a/rtp_llm/models_py/weight_mapper.py
+++ b/rtp_llm/models_py/weight_mapper.py
@@ -188,6 +188,99 @@ def get_all_weights(
             yield name, tensor
 
 
+def select_safetensor_files(
+    model_path: str,
+    checkpoint_files: Sequence[str],
+    name_filter: Optional[Callable[[str], bool]],
+) -> List[str]:
+    """Select shards containing at least one accepted checkpoint tensor.
+
+    The model predicate must be rank-invariant. Rank-specific expert slicing is
+    intentionally applied later so a future collective loader cannot diverge
+    across ranks while opening shards.
+    """
+    files = list(checkpoint_files)
+    if name_filter is None or not files:
+        return files
+    if not callable(name_filter):
+        raise TypeError("name_filter must be callable")
+    if not all(path.lower().endswith(".safetensors") for path in files):
+        return files
+
+    discovered = {os.path.realpath(path): path for path in files}
+    index_path = os.path.join(model_path, _SAFETENSORS_INDEX)
+    selected_identities = set()
+    if os.path.isfile(index_path):
+        try:
+            with open(index_path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"Failed to read checkpoint index {index_path}: {exc}"
+            ) from exc
+        weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise ValueError(
+                f"Checkpoint index {index_path} has no non-empty weight_map"
+            )
+
+        model_root = os.path.realpath(model_path)
+        for name, shard_name in weight_map.items():
+            if not isinstance(name, str):
+                raise ValueError(
+                    f"Checkpoint index {index_path} contains non-string tensor name"
+                )
+            if not name_filter(name):
+                continue
+            if not isinstance(shard_name, str):
+                raise ValueError(
+                    f"Checkpoint index {index_path} contains invalid shard "
+                    f"{shard_name!r} for tensor {name!r}"
+                )
+            path_parts = re.split(r"[\\/]", shard_name)
+            if (
+                os.path.isabs(shard_name)
+                or ntpath.isabs(shard_name)
+                or os.pardir in path_parts
+            ):
+                raise ValueError(
+                    f"Checkpoint index {index_path} references a path outside "
+                    f"model directory: {shard_name!r}"
+                )
+            normalized_name = os.path.normpath(shard_name)
+            shard_path = os.path.join(model_root, normalized_name)
+            try:
+                inside_model = (
+                    os.path.commonpath([model_root, shard_path]) == model_root
+                )
+            except ValueError:
+                inside_model = False
+            if not inside_model:
+                raise ValueError(
+                    f"Checkpoint index {index_path} references a path outside "
+                    f"model directory: {shard_name!r}"
+                )
+            identity = os.path.realpath(shard_path)
+            if identity not in discovered:
+                raise ValueError(
+                    f"Checkpoint index {index_path} selected undiscovered shard "
+                    f"{shard_name!r} for tensor {name!r}"
+                )
+            selected_identities.add(identity)
+    else:
+        from safetensors import safe_open
+
+        for path in files:
+            with safe_open(path, framework="pt", device="cpu") as handle:
+                if any(name_filter(name) for name in handle.keys()):
+                    selected_identities.add(os.path.realpath(path))
+
+    selected = [path for path in files if os.path.realpath(path) in selected_identities]
+    if not selected:
+        raise ValueError("Checkpoint filter did not match any safetensors shard")
+    return selected
+
+
 def _files_from_index(model_path: str, index_name: str) -> Optional[List[str]]:
     index_path = os.path.join(model_path, index_name)
     if not os.path.isfile(index_path):

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -328,6 +328,10 @@ def h20_oss_suites():
                 name="next_mtp_basic",
                 task_info="data/model/qwen3_next/q_r_next_fp8_tp2_mtp.json",
                 smoke_args="--act_type BF16 --seq_size_per_block 2048 --tp_size 2 --max_seq_len 12800 --reserver_runtime_mem_mb 10000 --sp_model_type qwen35_moe_mtp --gen_num_per_cycle 4 --sp_type eagle --sp_checkpoint_path /mnt/nas1/hf/Qwen3.5-35B-A3B-FP8 --sp_act_type bf16",
+                envs=[
+                    "LOAD_METHOD=scratch",
+                    "USE_NEW_LOADER=1",
+                ],
                 gpu_type=["H20"],
             ),
             smoke_test(


### PR DESCRIPTION
## Summary

  Add Qwen3-Next/Qwen3.5 MoE MTP draft-model support to the newloader path.

   ## Changes

  - Register `qwen3_next_mtp` and `qwen35_moe_mtp` newloader models.
  - Implement the single-layer MTP runtime using the existing `GptModelBase`/`RtpModule` lifecycle.
  - Load `mtp.*`, embedding, and LM-head tensors through exact checkpoint-name filtering.
  - Validate MTP/core model boundaries and reject unsupported layer topologies.
  - Add index-based safetensors shard preselection before tensor materialization.
  - Keep model-level shard selection rank-invariant; apply EP filtering later at tensor iteration.
  - Enable `USE_NEW_LOADER=1` with scratch loading for `next_mtp_basic`.
  - Add path traversal, external blob symlink, unknown tensor, prefix mapping, topology, and load-integrity coverage.

  This implementation does not use `ModelWeightInfo`, `CustomAtomicWeight`, or the legacy weight-loading lifecycle. It does not enable fastsafetensors in this PR.

  ## Loading Optimization

  For the tested Qwen3.5 MTP checkpoint, the draft loader selects only the 3 required shards out of 14 instead of materializing the complete checkpoint.

  Observed draft loading time:

  - `LoadWeight`: 0.93s / 1.10s
  - `LoadModel`: 3.65s / 3.36s

  ## Validation

  - Bazel focused tests: 2/2 targets passed
  - Python tests: 90/90 passed
  - H20 TP=2 MTP smoke with a local FP8 checkpoint:
    - 3/3 requests passed
    - golden output diff: 0
    - selected shards: 3/14
    - exit code: 0
  - Black, isort, py_compile, and `git diff --check` passed