### PR TITLE
feat(loader): add Qwen2-VL newloader path

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -226,6 +226,7 @@ py_library(
         ":torchvision",
         ":protobuf",
         ":pyOpenSSL",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
     ] + select({
         "@//:using_arm": [],
 	    "@//:using_rocm": ["pyrsmi", "amdsmi"],

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -73,6 +73,7 @@ class ModelConfig(CppModelConfig):
         "phy2log_path",
         "lora_infos",
         "headwise_config",
+        "use_new_loader",
     }
 
     # Known C++ ModelConfig members (from ModelConfig.h)
@@ -545,6 +546,7 @@ class ModelConfig(CppModelConfig):
         self.render_config: Optional[Any] = None  # RenderConfig for renderer factory
         self.mm_related_params = VitParameters()
         self.quant_config = None
+        self.use_new_loader: bool = False
 
     def apply_override_args(self, json_model_override_args: str) -> None:
         """Apply model override arguments to ModelConfig.

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Optional, Type, Union
 
 import torch
+
 from rtp_llm.config.generate_config import GenerateConfig
 from rtp_llm.config.kv_cache_config import KVCacheConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -29,6 +30,7 @@ from rtp_llm.ops import (
     ParallelismConfig,
 )
 from rtp_llm.utils.database import CkptDatabase
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 from rtp_llm.utils.time_util import timer_wrapper
 
 
@@ -318,9 +320,7 @@ class BaseModel(object):
             self.custom_module.init(self.weight)
 
     def _use_new_loader(self) -> bool:
-        return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
-            getattr(self.model_config, "use_new_loader", False)
-        )
+        return is_new_loader_enabled(self.model_config)
 
     def _new_loader_quant_type(self) -> str:
         quant_config = getattr(self.model_config, "quant_config", None)

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -126,6 +126,7 @@ py_library(
         "new_models/*.py",
         "new_models/qwen2/*.py",
         "new_models/qwen2_moe/*.py",
+        "new_models/qwen2_vl/*.py",
         "new_models/qwen3/*.py",
         "new_models/qwen3_moe/*.py",
         "new_models/qwen3_next/*.py",
@@ -150,6 +151,30 @@ py_library(
         "//:th_transformer_config",
     ],
     visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "qwen2_vl_vision_loader",
+    srcs = [
+        "__init__.py",
+        "model_loader.py",
+        "module_base.py",
+        "new_models/__init__.py",
+        "new_models/qwen2_vl/__init__.py",
+        "new_models/qwen2_vl/vision.py",
+        "registry.py",
+        "weight_mapper.py",
+    ],
+    deps = [
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm:utils",
+    ] + select({
+        "@//:using_cuda12_9_x86": flashattn,
+        "@//:using_cuda12_arm": flashattn,
+        "//conditions:default": [],
+    }),
+    visibility = ["//rtp_llm:__subpackages__"],
 )
 
 py_library(

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -113,14 +113,25 @@ py_library(
 )
 
 py_library(
-    name = "new_weight_loader",
+    name = "new_loader_core",
     srcs = [
         "__init__.py",
         "model_loader.py",
-        "model_desc/module_base.py",
         "module_base.py",
         "registry.py",
         "weight_mapper.py",
+    ],
+    deps = [
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "new_weight_loader",
+    srcs = [
+        "model_desc/module_base.py",
     ] + glob([
         "layers/*.py",
         "new_models/*.py",
@@ -133,6 +144,7 @@ py_library(
         "quant_methods/*.py",
     ]),
     deps = [
+        ":new_loader_core",
         ":kernels",
         ":modules",
         "//rtp_llm:_ft_pickler",
@@ -156,17 +168,12 @@ py_library(
 py_library(
     name = "qwen2_vl_vision_loader",
     srcs = [
-        "__init__.py",
-        "model_loader.py",
-        "module_base.py",
         "new_models/__init__.py",
         "new_models/qwen2_vl/__init__.py",
         "new_models/qwen2_vl/vision.py",
-        "registry.py",
-        "weight_mapper.py",
     ],
     deps = [
-        "//rtp_llm:safetensors",
+        ":new_loader_core",
         "//rtp_llm:torch",
         "//rtp_llm:utils",
     ] + select({

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple
 
-import rtp_llm.models_py.weight_mapper as weight_mapper
 import torch
 import torch.nn as nn
+
+import rtp_llm.models_py.weight_mapper as weight_mapper
 from rtp_llm.models_py.module_base import RtpModule, collect_loaded_tensor_ids
 from rtp_llm.models_py.registry import get_model_class, list_models
 
@@ -341,10 +342,12 @@ class NewModelLoader:
         model: RtpModule,
     ) -> Optional[Callable[[str], bool]]:
         model_filter = model.checkpoint_weight_name_filter()
-        if model_filter is not None and not callable(model_filter):
+        if model_filter is not None and (
+            not callable(model_filter) or isinstance(model_filter, nn.Module)
+        ):
             raise TypeError(
                 f"{type(model).__name__}.checkpoint_weight_name_filter() must "
-                "return a callable or None"
+                "return a callable function or None, not an nn.Module"
             )
         return model_filter
 

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -24,6 +24,16 @@ _STACKED_EXPERT_RE = re.compile(
 )
 
 
+def _require_callable_name_filter(
+    model_filter: Optional[Callable[[str], bool]], label: str
+) -> Optional[Callable[[str], bool]]:
+    if isinstance(model_filter, nn.Module):
+        raise TypeError(f"{label} must be callable or None, not an nn.Module")
+    if model_filter is not None and not callable(model_filter):
+        raise TypeError(f"{label} must be callable or None")
+    return model_filter
+
+
 class _ExpertRangeFilter:
     """Select only this EP rank's per-expert checkpoint tensors."""
 
@@ -341,25 +351,17 @@ class NewModelLoader:
     def _model_checkpoint_name_filter(
         model: RtpModule,
     ) -> Optional[Callable[[str], bool]]:
-        model_filter = model.checkpoint_weight_name_filter()
-        if model_filter is not None and (
-            not callable(model_filter) or isinstance(model_filter, nn.Module)
-        ):
-            raise TypeError(
-                f"{type(model).__name__}.checkpoint_weight_name_filter() must "
-                "return a callable function or None, not an nn.Module"
-            )
-        return model_filter
+        return _require_callable_name_filter(
+            model.checkpoint_weight_name_filter(),
+            f"{type(model).__name__}.checkpoint_weight_name_filter() return value",
+        )
 
     @staticmethod
     def _checkpoint_name_filter(
         model_filter: Optional[Callable[[str], bool]],
         expert_filter: Optional[_ExpertRangeFilter],
     ) -> Optional[Callable[[str], bool]]:
-        if model_filter is not None and (
-            not callable(model_filter) or isinstance(model_filter, nn.Module)
-        ):
-            raise TypeError("model_filter must be callable or None")
+        model_filter = _require_callable_name_filter(model_filter, "model_filter")
         if model_filter is None and expert_filter is None:
             return None
 
@@ -517,7 +519,8 @@ class NewModelLoader:
             )
         started = time.time()
         expert_filter = self._expert_filter()
-        model_filter = self._model_checkpoint_name_filter(model)
+        model_filter = model.checkpoint_weight_name_filter()
+        name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         selected_files = weight_mapper.select_safetensor_files(
             self._resolved_model_path(), checkpoint_files, model_filter
         )
@@ -527,7 +530,6 @@ class NewModelLoader:
                 len(selected_files),
                 len(checkpoint_files),
             )
-        name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         model.load_weights(
             weight_mapper.get_all_weights(
                 selected_files,

--- a/rtp_llm/models_py/new_loader_test/foundation_test.py
+++ b/rtp_llm/models_py/new_loader_test/foundation_test.py
@@ -9,6 +9,8 @@ from unittest import mock
 
 import torch
 import torch.nn as nn
+from safetensors.torch import save_file
+
 from rtp_llm.models_py.model_loader import (
     NewLoaderConfig,
     NewLoaderLoadMethod,
@@ -25,7 +27,6 @@ from rtp_llm.models_py.weight_mapper import (
     get_all_weights,
     select_safetensor_files,
 )
-from safetensors.torch import save_file
 
 
 class _Block(RtpModule):
@@ -102,6 +103,20 @@ class FoundationLoaderTest(unittest.TestCase):
     def test_combined_checkpoint_filter_rejects_model_instances(self):
         with self.assertRaisesRegex(TypeError, "model_filter must be callable"):
             NewModelLoader._checkpoint_name_filter(RtpModule(), None)
+
+    def test_model_filter_rejects_module_before_shard_preselection(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_weights(), os.path.join(model_path, "model.safetensors"))
+            with mock.patch.object(
+                _FoundationModel,
+                "checkpoint_weight_name_filter",
+                return_value=RtpModule(),
+            ), mock.patch(
+                "rtp_llm.models_py.model_loader.weight_mapper.select_safetensor_files"
+            ) as select_files:
+                with self.assertRaisesRegex(TypeError, "not an nn.Module"):
+                    self._loader(model_path).load()
+                select_files.assert_not_called()
 
     def test_staged_modules_move_and_postprocess_one_at_a_time(self):
         events = []

--- a/rtp_llm/models_py/new_models/qwen2_vl/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen2-VL newloader language and vision implementations."""

--- a/rtp_llm/models_py/new_models/qwen2_vl/model.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/model.py
@@ -1,0 +1,10 @@
+from typing import Callable
+
+from rtp_llm.models_py.new_models.qwen2.language import Qwen2ForCausalLM
+
+
+class Qwen2VLForCausalLM(Qwen2ForCausalLM):
+    """Qwen2-VL language runtime with vision tensors filtered before loading."""
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: not name.startswith("visual.")

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
@@ -10,6 +10,15 @@ py_test(
 )
 
 py_test(
+    name = "test_qwen2_vl_vision_loader_import",
+    srcs = ["test_qwen2_vl_vision_loader_import.py"],
+    deps = [
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)
+
+py_test(
     name = "test_qwen2_vl_gpu",
     srcs = ["test_qwen2_vl_gpu.py"],
     exec_properties = {

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
@@ -1,0 +1,43 @@
+py_test(
+    name = "test_qwen2_vl_load",
+    srcs = ["test_qwen2_vl_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen2_vl_gpu",
+    srcs = ["test_qwen2_vl_gpu.py"],
+    exec_properties = {
+        "gpu": "H20",
+        "gpu_count": "1",
+    },
+    tags = ["H20"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen2_vl_rocm",
+    srcs = ["test_qwen2_vl_gpu.py"],
+    main = "test_qwen2_vl_gpu.py",
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "1",
+    },
+    tags = ["rocm"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
@@ -1,0 +1,71 @@
+import tempfile
+import unittest
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+    Qwen2VLForVisionEmbedding,
+    _resolve_flash_attn_varlen,
+    load_qwen2_vl_vision,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "embed_dim": 8,
+        "hidden_size": 6,
+        "hidden_act": "quick_gelu",
+        "mlp_ratio": 2.0,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 1,
+    }
+
+
+class Qwen2VLVisionGpuTest(unittest.TestCase):
+    def test_real_newloader_gpu_forward_matches_cpu_reference(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+        if torch.version.hip is None:
+            self.assertIsNotNone(_resolve_flash_attn_varlen())
+
+        torch.manual_seed(11)
+        config = _vision_config()
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 32).reshape(8, 4)
+        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected = source(pixel_values, grid_thw)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    name: tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            visual = load_qwen2_vl_vision(
+                vision_config=config,
+                model_path=model_path,
+                compute_dtype=torch.float16,
+                device="cuda:0",
+            )
+
+        self.assertFalse(visual.training)
+        self.assertEqual(visual.device, torch.device("cuda:0"))
+        with torch.inference_mode():
+            actual = visual(pixel_values.cuda(), grid_thw.cuda()).float().cpu()
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 from safetensors.torch import save_file
@@ -23,7 +24,7 @@ def _vision_config():
         "in_channels": 1,
         "patch_size": 2,
         "spatial_merge_size": 2,
-        "temporal_patch_size": 1,
+        "temporal_patch_size": 2,
     }
 
 
@@ -32,7 +33,13 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("A CUDA or ROCm accelerator is required")
         if torch.version.hip is None:
-            self.assertIsNotNone(_resolve_flash_attn_varlen())
+            self.assertIsNotNone(
+                _resolve_flash_attn_varlen(),
+                (
+                    f"flash-attn unavailable on {torch.cuda.get_device_name(0)} "
+                    f"with capability {torch.cuda.get_device_capability(0)}"
+                ),
+            )
 
         torch.manual_seed(11)
         config = _vision_config()
@@ -40,8 +47,8 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
             {"model_type": "qwen2_vl_vision", "vision_config": config},
             NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
         ).eval()
-        pixel_values = torch.linspace(-1.0, 1.0, 32).reshape(8, 4)
-        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
         with torch.inference_mode():
             expected = source(pixel_values, grid_thw)
 
@@ -65,6 +72,29 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
         with torch.inference_mode():
             actual = visual(pixel_values.cuda(), grid_thw.cuda()).float().cpu()
         torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+    def test_fp32_accelerator_forward_uses_sdpa_fallback(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        config = _vision_config()
+        model = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cuda:0"),
+        ).cuda()
+        pixel_values = torch.linspace(-1.0, 1.0, 128, device="cuda").reshape(16, 8)
+        grid_thw = torch.tensor(
+            [[2, 2, 2], [1, 4, 2]], dtype=torch.int64, device="cuda"
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen2_vl.vision."
+            "_resolve_flash_attn_varlen",
+            side_effect=AssertionError("FP32 must not resolve flash attention"),
+        ):
+            with torch.inference_mode():
+                output = model(pixel_values, grid_thw)
+        self.assertTrue(torch.isfinite(output).all())
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_load.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_load.py
@@ -1,0 +1,278 @@
+import tempfile
+import types
+import unittest
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen2_vl.model import Qwen2VLForCausalLM
+from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+
+def _parallelism():
+    return types.SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+        get_attn_tp_size=lambda: 1,
+        get_attn_tp_rank=lambda: 0,
+        get_ffn_tp_size=lambda: 1,
+        get_ffn_tp_rank=lambda: 0,
+    )
+
+
+def _load_config() -> NewLoaderConfig:
+    return NewLoaderConfig(
+        compute_dtype=torch.float32,
+        device="cpu",
+        quant_config=QuantizationConfig("none"),
+        parallelism_config=_parallelism(),
+    )
+
+
+def _language_config():
+    return types.SimpleNamespace(
+        model_type="qwen2_vl",
+        num_layers=1,
+        vocab_size=8,
+        hidden_size=4,
+        inter_size=4,
+        attn_config=types.SimpleNamespace(
+            head_num=2,
+            kv_head_num=1,
+            size_per_head=2,
+        ),
+        layernorm_eps=1e-6,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=True,
+    )
+
+
+def _language_weights():
+    return {
+        "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+            8, 4
+        ),
+        "model.layers.0.input_layernorm.weight": torch.ones(4),
+        "model.layers.0.self_attn.q_proj.weight": torch.arange(
+            16, dtype=torch.float32
+        ).reshape(4, 4),
+        "model.layers.0.self_attn.k_proj.weight": torch.arange(
+            8, dtype=torch.float32
+        ).reshape(2, 4),
+        "model.layers.0.self_attn.v_proj.weight": torch.arange(
+            8, 16, dtype=torch.float32
+        ).reshape(2, 4),
+        "model.layers.0.self_attn.q_proj.bias": torch.full((4,), 0.5),
+        "model.layers.0.self_attn.k_proj.bias": torch.full((2,), -0.25),
+        "model.layers.0.self_attn.v_proj.bias": torch.full((2,), 0.75),
+        "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+        "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+        "model.layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+        "model.layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+        "model.layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+        "model.norm.weight": torch.ones(4),
+    }
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "embed_dim": 8,
+        "hidden_size": 6,
+        "hidden_act": "quick_gelu",
+        "mlp_ratio": 2.0,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 1,
+    }
+
+
+def _vision_model_config():
+    return {
+        "model_type": "qwen2_vl_vision",
+        "vision_config": _vision_config(),
+    }
+
+
+def _manual_vision_forward(model, pixel_values):
+    visual = model.visual
+    patch = visual.patch_embed
+    hidden = F.conv3d(
+        pixel_values.reshape(-1, 1, 1, 2, 2),
+        patch.proj.weight,
+        stride=(1, 2, 2),
+    ).reshape(-1, 8)
+
+    block = visual.blocks[0]
+    normed = F.layer_norm(
+        hidden,
+        (8,),
+        block.norm1.weight,
+        block.norm1.bias,
+        block.norm1.eps,
+    )
+    qkv = F.linear(normed, block.attn.qkv.weight, block.attn.qkv.bias)
+    q, k, v = qkv.reshape(8, 3, 2, 4).permute(1, 0, 2, 3).unbind(0)
+    positions = torch.tensor(
+        [[0, 0], [0, 1], [1, 0], [1, 1]] * 2,
+        dtype=torch.float32,
+    )
+    cos = positions.cos().unsqueeze(1).repeat(1, 1, 2)
+    sin = positions.sin().unsqueeze(1).repeat(1, 1, 2)
+
+    def rotate_half(tensor):
+        first, second = tensor.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    q = q * cos + rotate_half(q) * sin
+    k = k * cos + rotate_half(k) * sin
+    attention_outputs = []
+    for start in (0, 4):
+        end = start + 4
+        attention = F.scaled_dot_product_attention(
+            q[start:end].transpose(0, 1).unsqueeze(0),
+            k[start:end].transpose(0, 1).unsqueeze(0),
+            v[start:end].transpose(0, 1).unsqueeze(0),
+            dropout_p=0.0,
+        )
+        attention_outputs.append(attention.squeeze(0).transpose(0, 1))
+    attention = torch.cat(attention_outputs).reshape(8, 8)
+    hidden = hidden + F.linear(attention, block.attn.proj.weight, block.attn.proj.bias)
+    normed = F.layer_norm(
+        hidden,
+        (8,),
+        block.norm2.weight,
+        block.norm2.bias,
+        block.norm2.eps,
+    )
+    mlp_hidden = F.linear(normed, block.mlp.fc1.weight, block.mlp.fc1.bias)
+    mlp_hidden = mlp_hidden * torch.sigmoid(1.702 * mlp_hidden)
+    hidden = hidden + F.linear(mlp_hidden, block.mlp.fc2.weight, block.mlp.fc2.bias)
+
+    merger = visual.merger
+    merged = F.layer_norm(
+        hidden,
+        (8,),
+        merger.ln_q.weight,
+        merger.ln_q.bias,
+        merger.ln_q.eps,
+    ).reshape(-1, 32)
+    merged = F.gelu(F.linear(merged, merger.mlp[0].weight, merger.mlp[0].bias))
+    return F.linear(merged, merger.mlp[2].weight, merger.mlp[2].bias)
+
+
+class Qwen2VLNewLoaderTest(unittest.TestCase):
+    def test_language_loader_filters_visual_tensors_before_dispatch(self):
+        weights = _language_weights()
+        weights["visual.not_a_language_weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen2VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertNotIn("visual", dict(model.named_modules()))
+
+    def test_vision_loader_streams_only_visual_weights_and_matches_reference(self):
+        torch.manual_seed(7)
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+        }
+        weights["model.unused_language_weight"] = torch.ones(3)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config=_vision_model_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        for name, expected in source.state_dict().items():
+            torch.testing.assert_close(loaded.state_dict()[name], expected)
+        pixel_values = torch.arange(32, dtype=torch.float32).reshape(8, 4) / 31
+        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            actual = loaded(pixel_values, grid_thw)
+            expected = _manual_vision_forward(loaded, pixel_values)
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-5)
+
+    def test_vision_loader_rejects_unknown_visual_tensor(self):
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+        }
+        weights["visual.blocks.0.attn.typo.weight"] = torch.ones(1)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_loader_rejects_missing_required_tensor(self):
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+            if name != "visual.blocks.0.attn.qkv.weight"
+        }
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "attn.qkv.weight"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_forward_rejects_inconsistent_grid(self):
+        model = Qwen2VLForVisionEmbedding(_vision_model_config(), _load_config())
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            model(torch.zeros(0, 4), torch.empty((0, 3), dtype=torch.int64))
+        with self.assertRaisesRegex(ValueError, "describes 4"):
+            model(torch.zeros(3, 4), torch.tensor([[1, 2, 2]]))
+        with self.assertRaisesRegex(ValueError, "spatial_merge_size"):
+            model(torch.zeros(6, 4), torch.tensor([[1, 2, 3]]))
+        with self.assertRaisesRegex(TypeError, "integer dtype"):
+            model(torch.zeros(4, 4), torch.tensor([[1.0, 2.0, 2.0]]))
+
+    def test_vision_config_rejects_invalid_rotary_head_dimension(self):
+        config = _vision_config()
+        config["embed_dim"] = 12
+        with self.assertRaisesRegex(ValueError, "head_dim=6 must be divisible by 4"):
+            Qwen2VLForVisionEmbedding(
+                {"model_type": "qwen2_vl_vision", "vision_config": config},
+                _load_config(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_vision_loader_import.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_vision_loader_import.py
@@ -1,0 +1,46 @@
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+    Qwen2VLForVisionEmbedding,
+    load_qwen2_vl_vision,
+)
+
+
+class Qwen2VLVisionLoaderImportTest(unittest.TestCase):
+    def test_public_vision_loader_target_loads_checkpoint_on_cpu(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+        }
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(source.state_dict(), f"{model_path}/pytorch_model.bin")
+            loaded = load_qwen2_vl_vision(
+                vision_config=vision_config,
+                model_path=model_path,
+                compute_dtype=torch.float32,
+                device="cpu",
+            )
+
+        self.assertEqual(loaded.device, torch.device("cpu"))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(loaded.state_dict()[name], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/vision.py
@@ -1,0 +1,508 @@
+import logging
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from itertools import accumulate
+from numbers import Real
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rtp_llm.models_py.model_loader import (
+    NewLoaderConfig,
+    NewLoaderLoadMethod,
+    NewModelLoader,
+)
+from rtp_llm.models_py.module_base import RtpModule
+
+logger = logging.getLogger(__name__)
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class Qwen2VLVisionConfig:
+    depth: int
+    embed_dim: int
+    hidden_size: int
+    hidden_act: str
+    mlp_ratio: float
+    num_heads: int
+    in_channels: int
+    patch_size: int
+    spatial_merge_size: int
+    temporal_patch_size: int
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any]) -> "Qwen2VLVisionConfig":
+        if not isinstance(config, Mapping):
+            raise TypeError("vision_config must be a mapping")
+        hidden_act = config.get("hidden_act", "quick_gelu")
+        if not isinstance(hidden_act, str):
+            raise TypeError("vision hidden_act must be a string")
+        mlp_ratio = config.get("mlp_ratio", 4.0)
+        if isinstance(mlp_ratio, bool) or not isinstance(mlp_ratio, Real):
+            raise TypeError("vision mlp_ratio must be a real number")
+        result = cls(
+            depth=_positive_int(config.get("depth", 32), "vision depth"),
+            embed_dim=_positive_int(config.get("embed_dim", 1280), "vision embed_dim"),
+            hidden_size=_positive_int(
+                config.get("hidden_size", 3584), "vision hidden_size"
+            ),
+            hidden_act=hidden_act,
+            mlp_ratio=float(mlp_ratio),
+            num_heads=_positive_int(config.get("num_heads", 16), "vision num_heads"),
+            in_channels=_positive_int(
+                config.get("in_chans", config.get("in_channels", 3)),
+                "vision in_channels",
+            ),
+            patch_size=_positive_int(config.get("patch_size", 14), "vision patch_size"),
+            spatial_merge_size=_positive_int(
+                config.get("spatial_merge_size", 2),
+                "vision spatial_merge_size",
+            ),
+            temporal_patch_size=_positive_int(
+                config.get("temporal_patch_size", 2),
+                "vision temporal_patch_size",
+            ),
+        )
+        if result.embed_dim % result.num_heads != 0:
+            raise ValueError(
+                f"vision embed_dim={result.embed_dim} must be divisible by "
+                f"num_heads={result.num_heads}"
+            )
+        head_dim = result.embed_dim // result.num_heads
+        if head_dim % 4 != 0:
+            raise ValueError(
+                f"vision head_dim={head_dim} must be divisible by 4 for 2D rotary "
+                "embedding"
+            )
+        if not math.isfinite(result.mlp_ratio) or result.mlp_ratio <= 0:
+            raise ValueError(
+                f"vision mlp_ratio must be finite and positive, got {result.mlp_ratio}"
+            )
+        if result.hidden_act not in {"gelu", "gelu_new", "quick_gelu"}:
+            raise ValueError(
+                f"Unsupported Qwen2-VL vision activation {result.hidden_act!r}"
+            )
+        return result
+
+
+class Qwen2VisionPatchEmbed(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.embed_dim = config.embed_dim
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        kernel_size = (
+            config.temporal_patch_size,
+            config.patch_size,
+            config.patch_size,
+        )
+        self.proj = nn.Conv3d(
+            config.in_channels,
+            config.embed_dim,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=False,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        expected_width = (
+            self.in_channels
+            * self.temporal_patch_size
+            * self.patch_size
+            * self.patch_size
+        )
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != expected_width:
+            raise ValueError(
+                "Qwen2-VL pixel values must have shape "
+                f"[num_patches, {expected_width}], got {tuple(hidden_states.shape)}"
+            )
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=self.proj.weight.dtype))
+        return hidden_states.reshape(-1, self.embed_dim)
+
+
+class Qwen2VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(
+            seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+        )
+        return torch.outer(seq, self.inv_freq)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    first, second = x.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_vision_rotary(
+    q: torch.Tensor, k: torch.Tensor, freqs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    original_q_dtype = q.dtype
+    original_k_dtype = k.dtype
+    cos = freqs.cos().unsqueeze(1).repeat(1, 1, 2).float()
+    sin = freqs.sin().unsqueeze(1).repeat(1, 1, 2).float()
+    q_float = q.float()
+    k_float = k.float()
+    q = (q_float * cos) + (_rotate_half(q_float) * sin)
+    k = (k_float * cos) + (_rotate_half(k_float) * sin)
+    return q.to(original_q_dtype), k.to(original_k_dtype)
+
+
+_FLASH_ATTN_VARLEN: Optional[Callable[..., torch.Tensor]] = None
+_FLASH_ATTN_RESOLVED = False
+
+
+def _resolve_flash_attn_varlen() -> Optional[Callable[..., torch.Tensor]]:
+    global _FLASH_ATTN_RESOLVED, _FLASH_ATTN_VARLEN
+    if _FLASH_ATTN_RESOLVED:
+        return _FLASH_ATTN_VARLEN
+    _FLASH_ATTN_RESOLVED = True
+    try:
+        from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+
+        if can_use_flash_attn():
+            from flash_attn import flash_attn_varlen_func
+
+            _FLASH_ATTN_VARLEN = flash_attn_varlen_func
+    except (ImportError, OSError) as exc:
+        logger.info("Qwen2-VL vision flash attention is unavailable: %s", exc)
+    return _FLASH_ATTN_VARLEN
+
+
+class Qwen2VisionAttention(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.num_heads = config.num_heads
+        self.head_dim = config.embed_dim // config.num_heads
+        self.qkv = nn.Linear(
+            config.embed_dim,
+            3 * config.embed_dim,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.proj = nn.Linear(
+            config.embed_dim,
+            config.embed_dim,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states).reshape(
+            seq_length, 3, self.num_heads, self.head_dim
+        )
+        q, k, v = qkv.permute(1, 0, 2, 3).unbind(0)
+        q, k = _apply_vision_rotary(q, k, rotary_pos_emb)
+
+        flash_attn_varlen = (
+            _resolve_flash_attn_varlen() if hidden_states.is_cuda else None
+        )
+        if flash_attn_varlen is not None:
+            output = flash_attn_varlen(
+                q,
+                k,
+                v,
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+            ).reshape(seq_length, -1)
+        else:
+            q_chunks = torch.split(q, segment_lengths, dim=0)
+            k_chunks = torch.split(k, segment_lengths, dim=0)
+            v_chunks = torch.split(v, segment_lengths, dim=0)
+            outputs = []
+            for q_chunk, k_chunk, v_chunk in zip(q_chunks, k_chunks, v_chunks):
+                output = F.scaled_dot_product_attention(
+                    q_chunk.transpose(0, 1).unsqueeze(0),
+                    k_chunk.transpose(0, 1).unsqueeze(0),
+                    v_chunk.transpose(0, 1).unsqueeze(0),
+                    dropout_p=0.0,
+                )
+                outputs.append(output.squeeze(0).transpose(0, 1))
+            output = torch.cat(outputs, dim=0).reshape(seq_length, -1)
+        return self.proj(output)
+
+
+def _apply_activation(x: torch.Tensor, name: str) -> torch.Tensor:
+    if name == "quick_gelu":
+        return x * torch.sigmoid(1.702 * x)
+    if name == "gelu_new":
+        return F.gelu(x, approximate="tanh")
+    return F.gelu(x)
+
+
+class Qwen2VisionMLP(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        intermediate_size = int(config.embed_dim * config.mlp_ratio)
+        if intermediate_size <= 0:
+            raise ValueError("Qwen2-VL vision MLP has an invalid intermediate size")
+        self.hidden_act = config.hidden_act
+        self.fc1 = nn.Linear(
+            config.embed_dim, intermediate_size, bias=True, dtype=params_dtype
+        )
+        self.fc2 = nn.Linear(
+            intermediate_size, config.embed_dim, bias=True, dtype=params_dtype
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(_apply_activation(self.fc1(x), self.hidden_act))
+
+
+class Qwen2VisionBlock(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.norm2 = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.attn = Qwen2VisionAttention(config, params_dtype)
+        self.mlp = Qwen2VisionMLP(config, params_dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens,
+            rotary_pos_emb,
+            segment_lengths,
+            max_seqlen,
+        )
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+class Qwen2VisionPatchMerger(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.hidden_size = config.embed_dim * (config.spatial_merge_size**2)
+        self.ln_q = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.mlp = nn.Sequential(
+            nn.Linear(
+                self.hidden_size,
+                self.hidden_size,
+                bias=True,
+                dtype=params_dtype,
+            ),
+            nn.GELU(),
+            nn.Linear(
+                self.hidden_size,
+                config.hidden_size,
+                bias=True,
+                dtype=params_dtype,
+            ),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.ln_q(hidden_states).reshape(-1, self.hidden_size)
+        return self.mlp(hidden_states)
+
+
+class Qwen2VisionTransformer(RtpModule):
+    def __init__(self, vision_config: Mapping[str, Any], params_dtype: torch.dtype):
+        super().__init__()
+        config = Qwen2VLVisionConfig.from_mapping(vision_config)
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_embed = Qwen2VisionPatchEmbed(config, params_dtype)
+        head_dim = config.embed_dim // config.num_heads
+        self.rotary_pos_emb = Qwen2VisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [Qwen2VisionBlock(config, params_dtype) for _ in range(config.depth)]
+        )
+        self.merger = Qwen2VisionPatchMerger(config, params_dtype)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def get_dtype(self) -> torch.dtype:
+        return self.dtype
+
+    def get_device(self) -> torch.device:
+        return self.device
+
+    def _rotary_positions(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        position_ids = []
+        merge_size = self.spatial_merge_size
+        for t, h, w in grid_values:
+            if t <= 0 or h <= 0 or w <= 0:
+                raise ValueError(f"grid_thw values must be positive, got {(t, h, w)}")
+            if h % merge_size or w % merge_size:
+                raise ValueError(
+                    f"grid ({t}, {h}, {w}) must align to spatial_merge_size="
+                    f"{merge_size}"
+                )
+            h_positions = torch.arange(h).unsqueeze(1).expand(-1, w)
+            h_positions = (
+                h_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            w_positions = torch.arange(w).unsqueeze(0).expand(h, -1)
+            w_positions = (
+                w_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            position_ids.append(
+                torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
+            )
+        indices = torch.cat(position_ids, dim=0).to(self.device)
+        max_grid_size = max(max(h, w) for _, h, w in grid_values)
+        return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+            raise ValueError(
+                f"grid_thw must have shape [num_items, 3], got {tuple(grid_thw.shape)}"
+            )
+        if grid_thw.shape[0] == 0:
+            raise ValueError("grid_thw must describe at least one image or video")
+        if (
+            grid_thw.dtype == torch.bool
+            or grid_thw.is_floating_point()
+            or grid_thw.is_complex()
+        ):
+            raise TypeError("grid_thw must use an integer dtype")
+        if hidden_states.device != grid_thw.device:
+            raise ValueError(
+                "pixel_values and grid_thw must be on the same device, got "
+                f"{hidden_states.device} and {grid_thw.device}"
+            )
+        if hidden_states.device != self.device:
+            raise ValueError(
+                f"pixel_values must be on the vision model device {self.device}, "
+                f"got {hidden_states.device}"
+            )
+        grid_values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
+        rotary_pos_emb = self._rotary_positions(grid_values)
+        expected_patches = sum(t * h * w for t, h, w in grid_values)
+        if hidden_states.shape[0] != expected_patches:
+            raise ValueError(
+                f"pixel_values contain {hidden_states.shape[0]} patches, but "
+                f"grid_thw describes {expected_patches}"
+            )
+        hidden_states = self.patch_embed(hidden_states)
+        segment_lengths = tuple(h * w for t, h, w in grid_values for _ in range(t))
+        max_seqlen = max(segment_lengths)
+        cu_seqlens = torch.tensor(
+            (0, *accumulate(segment_lengths)),
+            device=hidden_states.device,
+            dtype=torch.int32,
+        )
+        for block in self.blocks:
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens,
+                rotary_pos_emb,
+                segment_lengths,
+                max_seqlen,
+            )
+        return self.merger(hidden_states)
+
+
+def _vision_config_from_model(
+    model_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if not isinstance(model_config, Mapping):
+        raise TypeError("qwen2_vl_vision model_config must be a mapping")
+    vision_config = model_config.get("vision_config")
+    if not isinstance(vision_config, Mapping):
+        raise TypeError("qwen2_vl_vision requires model_config.vision_config")
+    return vision_config
+
+
+class Qwen2VLForVisionEmbedding(RtpModule):
+    def __init__(self, model_config: Mapping[str, Any], load_config: NewLoaderConfig):
+        super().__init__()
+        if load_config.tp_size != 1 or load_config.tp_rank != 0:
+            raise ValueError("Qwen2-VL vision newloader is single-rank and replicated")
+        self.visual = Qwen2VisionTransformer(
+            _vision_config_from_model(model_config), load_config.compute_dtype
+        )
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("visual.")
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        return self.visual(hidden_states, grid_thw)
+
+
+def load_qwen2_vl_vision(
+    vision_config: Mapping[str, Any],
+    model_path: str,
+    compute_dtype: torch.dtype,
+    device: str,
+) -> Qwen2VisionTransformer:
+    model_config = {
+        "model_type": "qwen2_vl_vision",
+        "model_path": model_path,
+        "vision_config": dict(vision_config),
+    }
+    load_config = NewLoaderConfig(
+        compute_dtype=compute_dtype,
+        device=device,
+        load_method=NewLoaderLoadMethod.SCRATCH,
+    )
+    loader = NewModelLoader(
+        model_config=model_config,
+        load_config=load_config,
+        model_path=model_path,
+    )
+    with torch.device("cpu"):
+        model = loader.load()
+    return model.visual

--- a/rtp_llm/models_py/new_models/qwen2_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/vision.py
@@ -157,12 +157,13 @@ def _rotate_half(x: torch.Tensor) -> torch.Tensor:
 
 
 def _apply_vision_rotary(
-    q: torch.Tensor, k: torch.Tensor, freqs: torch.Tensor
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     original_q_dtype = q.dtype
     original_k_dtype = k.dtype
-    cos = freqs.cos().unsqueeze(1).repeat(1, 1, 2).float()
-    sin = freqs.sin().unsqueeze(1).repeat(1, 1, 2).float()
     q_float = q.float()
     k_float = k.float()
     q = (q_float * cos) + (_rotate_half(q_float) * sin)
@@ -213,7 +214,8 @@ class Qwen2VisionAttention(RtpModule):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
         segment_lengths: tuple[int, ...],
         max_seqlen: int,
     ) -> torch.Tensor:
@@ -222,10 +224,12 @@ class Qwen2VisionAttention(RtpModule):
             seq_length, 3, self.num_heads, self.head_dim
         )
         q, k, v = qkv.permute(1, 0, 2, 3).unbind(0)
-        q, k = _apply_vision_rotary(q, k, rotary_pos_emb)
+        q, k = _apply_vision_rotary(q, k, rotary_cos, rotary_sin)
 
         flash_attn_varlen = (
-            _resolve_flash_attn_varlen() if hidden_states.is_cuda else None
+            _resolve_flash_attn_varlen()
+            if q.is_cuda and q.dtype in (torch.float16, torch.bfloat16)
+            else None
         )
         if flash_attn_varlen is not None:
             output = flash_attn_varlen(
@@ -292,14 +296,16 @@ class Qwen2VisionBlock(RtpModule):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
         segment_lengths: tuple[int, ...],
         max_seqlen: int,
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens,
-            rotary_pos_emb,
+            rotary_cos,
+            rotary_sin,
             segment_lengths,
             max_seqlen,
         )
@@ -372,7 +378,7 @@ class Qwen2VisionTransformer(RtpModule):
                     f"grid ({t}, {h}, {w}) must align to spatial_merge_size="
                     f"{merge_size}"
                 )
-            h_positions = torch.arange(h).unsqueeze(1).expand(-1, w)
+            h_positions = torch.arange(h, device=self.device).unsqueeze(1).expand(-1, w)
             h_positions = (
                 h_positions.reshape(
                     h // merge_size,
@@ -383,7 +389,7 @@ class Qwen2VisionTransformer(RtpModule):
                 .permute(0, 2, 1, 3)
                 .flatten()
             )
-            w_positions = torch.arange(w).unsqueeze(0).expand(h, -1)
+            w_positions = torch.arange(w, device=self.device).unsqueeze(0).expand(h, -1)
             w_positions = (
                 w_positions.reshape(
                     h // merge_size,
@@ -397,7 +403,7 @@ class Qwen2VisionTransformer(RtpModule):
             position_ids.append(
                 torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
             )
-        indices = torch.cat(position_ids, dim=0).to(self.device)
+        indices = torch.cat(position_ids, dim=0)
         max_grid_size = max(max(h, w) for _, h, w in grid_values)
         return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
 
@@ -428,6 +434,8 @@ class Qwen2VisionTransformer(RtpModule):
             )
         grid_values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
         rotary_pos_emb = self._rotary_positions(grid_values)
+        rotary_cos = rotary_pos_emb.cos().unsqueeze(1).repeat(1, 1, 2).float()
+        rotary_sin = rotary_pos_emb.sin().unsqueeze(1).repeat(1, 1, 2).float()
         expected_patches = sum(t * h * w for t, h, w in grid_values)
         if hidden_states.shape[0] != expected_patches:
             raise ValueError(
@@ -446,7 +454,8 @@ class Qwen2VisionTransformer(RtpModule):
             hidden_states = block(
                 hidden_states,
                 cu_seqlens,
-                rotary_pos_emb,
+                rotary_cos,
+                rotary_sin,
                 segment_lengths,
                 max_seqlen,
             )

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -158,3 +158,13 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen2_moe",
     "Qwen2MoeForCausalLM",
 )
+register_lazy_model(
+    "qwen2_vl",
+    "rtp_llm.models_py.new_models.qwen2_vl.model",
+    "Qwen2VLForCausalLM",
+)
+register_lazy_model(
+    "qwen2_vl_vision",
+    "rtp_llm.models_py.new_models.qwen2_vl.vision",
+    "Qwen2VLForVisionEmbedding",
+)

--- a/rtp_llm/multimodal/multimodal_mixin_factory.py
+++ b/rtp_llm/multimodal/multimodal_mixin_factory.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -10,6 +11,12 @@ from rtp_llm.multimodal.multimodal_mixin_register import (
 )
 from rtp_llm.multimodal.multimodal_mixins import BaseMultiModalMixin
 from rtp_llm.ops import TaskType
+
+
+def _new_loader_requested(model_config: ModelConfig) -> bool:
+    return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
+        getattr(model_config, "use_new_loader", False)
+    )
 
 
 class MultimodalMixinFactory:
@@ -31,6 +38,7 @@ class MultimodalMixinFactory:
             engine_config.load_config.load_method,
             vit_config,
             model_config.ckpt_path,
+            use_new_loader=_new_loader_requested(model_config),
         )
 
     @staticmethod

--- a/rtp_llm/multimodal/multimodal_mixin_factory.py
+++ b/rtp_llm/multimodal/multimodal_mixin_factory.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -11,12 +10,7 @@ from rtp_llm.multimodal.multimodal_mixin_register import (
 )
 from rtp_llm.multimodal.multimodal_mixins import BaseMultiModalMixin
 from rtp_llm.ops import TaskType
-
-
-def _new_loader_requested(model_config: ModelConfig) -> bool:
-    return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
-        getattr(model_config, "use_new_loader", False)
-    )
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 
 
 class MultimodalMixinFactory:
@@ -38,7 +32,7 @@ class MultimodalMixinFactory:
             engine_config.load_config.load_method,
             vit_config,
             model_config.ckpt_path,
-            use_new_loader=_new_loader_requested(model_config),
+            use_new_loader=is_new_loader_enabled(model_config),
         )
 
     @staticmethod

--- a/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
@@ -89,12 +89,17 @@ class BaseMultiModalMixin:
         load_method: LoadMethod,
         vit_config: VitConfig,
         ckpt_path: str,
+        use_new_loader: bool = False,
     ) -> None:
         self.compute_dtype = compute_dtype
+        self.device = device
         self.mm_related_params = mm_related_params
         self.vit_config = vit_config
         self.load_method = load_method
         self.ckpt_path = ckpt_path
+        if not isinstance(use_new_loader, bool):
+            raise TypeError("use_new_loader must be a bool")
+        self.use_new_loader = use_new_loader
 
         with torch.device(device):
             torch_default_dtype = torch.get_default_dtype()

--- a/rtp_llm/multimodal/multimodal_mixins/qwen2_vl/qwen2_vl_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen2_vl/qwen2_vl_mixin.py
@@ -109,15 +109,17 @@ class Qwen2_VLVitWeight(BaseVitWeights):
 
 
 class Qwen2_VLImageEmbedding(MultiModalEmbeddingInterface):
-    def __init__(self, mm_related_params: VitParameters):
+    def __init__(self, mm_related_params: VitParameters, visual=None):
         self.mm_related_params = mm_related_params
         self.image_processor = Qwen2VLImageProcessor.from_pretrained(
             mm_related_params.config["ckpt_path"]
         )
 
-        self.visual = Qwen2VisionTransformerPretrainedModel(
-            mm_related_params.config
-        ).share_memory()
+        if visual is None:
+            visual = Qwen2VisionTransformerPretrainedModel(
+                mm_related_params.config
+            ).share_memory()
+        self.visual = visual
         self.spatial_merge_size = mm_related_params.config.get("spatial_merge_size", 2)
 
     @property
@@ -325,6 +327,21 @@ class Qwen2_VLImageEmbedding(MultiModalEmbeddingInterface):
 
 class Qwen2_VLMixin(BaseMultiModalMixin):
     def _init_multimodal(self):
+        if self.use_new_loader:
+            from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+                load_qwen2_vl_vision,
+            )
+
+            visual = load_qwen2_vl_vision(
+                vision_config=self.mm_related_params.config,
+                model_path=self.ckpt_path,
+                compute_dtype=self.compute_dtype,
+                device=self.device,
+            )
+            self.mm_part = Qwen2_VLImageEmbedding(self.mm_related_params, visual=visual)
+            self.mm_related_params.vit_weights = None
+            return
+
         self.mm_part = Qwen2_VLImageEmbedding(self.mm_related_params)
         self.mm_related_params.vit_weights = Qwen2_VLVitWeight(
             {"vit": self.mm_part.visual}

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -77,3 +77,17 @@ py_test(
         "//rtp_llm:testlib",
     ],
 )
+
+py_test(
+    name = "qwen2_vl_newloader_routing_test",
+    srcs = ["qwen2_vl_newloader_routing_test.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:multimodal",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:testlib",
+        "//rtp_llm:torch",
+        "//rtp_llm/model_loader:loader",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
@@ -8,28 +8,35 @@ from safetensors.torch import save_file
 
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.model_loader.load_config import LoadMethod
-from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
-from rtp_llm.multimodal.multimodal_mixin_factory import _new_loader_requested
 from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.modeling_qwen2_vl import (
     Qwen2VisionTransformerPretrainedModel,
+    VisionSdpaAttention,
 )
 from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin import (
     Qwen2_VLImageEmbedding,
     Qwen2_VLMixin,
 )
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 
 
 class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
     def test_newloader_switch_matches_language_loader_semantics(self):
         model_config = types.SimpleNamespace(use_new_loader=False)
         with mock.patch.dict("os.environ", {}, clear=True):
-            self.assertFalse(_new_loader_requested(model_config))
+            self.assertFalse(is_new_loader_enabled(model_config))
             model_config.use_new_loader = True
-            self.assertTrue(_new_loader_requested(model_config))
+            self.assertTrue(is_new_loader_enabled(model_config))
         model_config.use_new_loader = False
         with mock.patch.dict("os.environ", {"USE_NEW_LOADER": "1"}, clear=True):
-            self.assertTrue(_new_loader_requested(model_config))
+            self.assertTrue(is_new_loader_enabled(model_config))
+        del model_config.use_new_loader
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(is_new_loader_enabled(model_config))
+        model_config.use_new_loader = "1"
+        with self.assertRaisesRegex(TypeError, "use_new_loader must be a bool"):
+            is_new_loader_enabled(model_config)
 
     def test_qwen2_vl_mixin_uses_standalone_newloader_vision(self):
         vision_config = {
@@ -132,6 +139,54 @@ class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
                 atol=2e-4,
                 rtol=1e-3,
             )
+
+    def test_new_vision_matches_legacy_video_and_hf_checkpoint_layout(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+        }
+        torch.manual_seed(23)
+        legacy = Qwen2VisionTransformerPretrainedModel(vision_config).eval()
+        for block in legacy.blocks:
+            sdpa = VisionSdpaAttention(vision_config["embed_dim"], num_heads=2)
+            sdpa.load_state_dict(block.attn.state_dict())
+            block.attn = sdpa
+
+        checkpoint = {
+            f"visual.{name}": tensor.detach().clone()
+            for name, tensor in legacy.state_dict().items()
+        }
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(checkpoint, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config={
+                    "model_type": "qwen2_vl_vision",
+                    "vision_config": vision_config,
+                },
+                load_config=NewLoaderConfig(
+                    compute_dtype=torch.float32,
+                    device="cpu",
+                ),
+                model_path=model_path,
+            ).load()
+
+        for name, expected in legacy.state_dict().items():
+            torch.testing.assert_close(loaded.visual.state_dict()[name], expected)
+
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected = legacy(pixel_values, grid_thw)
+            actual = loaded(pixel_values, grid_thw)
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-5)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
@@ -1,0 +1,138 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.config.py_config_modules import VitConfig
+from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
+from rtp_llm.multimodal.multimodal_mixin_factory import _new_loader_requested
+from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.modeling_qwen2_vl import (
+    Qwen2VisionTransformerPretrainedModel,
+)
+from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin import (
+    Qwen2_VLImageEmbedding,
+    Qwen2_VLMixin,
+)
+
+
+class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
+    def test_newloader_switch_matches_language_loader_semantics(self):
+        model_config = types.SimpleNamespace(use_new_loader=False)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(_new_loader_requested(model_config))
+            model_config.use_new_loader = True
+            self.assertTrue(_new_loader_requested(model_config))
+        model_config.use_new_loader = False
+        with mock.patch.dict("os.environ", {"USE_NEW_LOADER": "1"}, clear=True):
+            self.assertTrue(_new_loader_requested(model_config))
+
+    def test_qwen2_vl_mixin_uses_standalone_newloader_vision(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 1,
+        }
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    name: tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=object(),
+            )
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin."
+                "Qwen2VLImageProcessor.from_pretrained",
+                return_value=object(),
+            ):
+                mixin = Qwen2_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                    use_new_loader=True,
+                )
+
+        self.assertIsInstance(mixin.mm_part, Qwen2_VLImageEmbedding)
+        self.assertIsNone(mm_related_params.vit_weights)
+        self.assertNotIn("mm_mixin_loader", vars(mixin))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name], expected
+            )
+
+    def test_default_route_preserves_legacy_qwen2_vl_loader(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 1,
+        }
+        source = Qwen2VisionTransformerPretrainedModel(vision_config).eval()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"visual.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=None,
+            )
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin."
+                "Qwen2VLImageProcessor.from_pretrained",
+                return_value=object(),
+            ):
+                mixin = Qwen2_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                )
+
+        self.assertIn("mm_mixin_loader", vars(mixin))
+        self.assertIsNotNone(mm_related_params.vit_weights)
+        for name, expected in source.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name],
+                expected,
+                atol=2e-4,
+                rtol=1e-3,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/utils/new_loader.py
+++ b/rtp_llm/utils/new_loader.py
@@ -1,0 +1,17 @@
+import os
+from typing import Protocol
+
+
+class NewLoaderConfigSource(Protocol):
+    use_new_loader: bool
+
+
+def is_new_loader_enabled(model_config: NewLoaderConfigSource) -> bool:
+    """Return the single process/model decision used by all loader entry points."""
+    try:
+        configured = model_config.use_new_loader
+    except AttributeError:
+        configured = False
+    if not isinstance(configured, bool):
+        raise TypeError("model_config.use_new_loader must be a bool")
+    return os.environ.get("USE_NEW_LOADER", "0") == "1" or configured


### PR DESCRIPTION
  ## Summary

  - Add Qwen2-VL language and standalone vision support to the newloader path.
  - Implement the vision encoder with `RtpModule`, including patch embedding, 2D RoPE, varlen attention, MLP, and patch merger.
  - Filter language and vision checkpoint tensors before materialization.
  - Route Qwen2-VL multimodal loading through newloader when `USE_NEW_LOADER=1`.
  - Preserve the existing legacy multimodal loading path by default.
  - Reject invalid module-based checkpoint filters before shard preselection.
  - Add explicit H20 and MI308X ROCm GPU coverage.

  ## Loading flow

  - The language model uses the existing Qwen2 newloader runtime and excludes `visual.*` tensors.
  - The vision model is constructed independently and loads only `visual.*` tensors through the scratch newloader path.
  - Weight completeness is validated before device migration and post-load processing.
  - The implementation does not depend on `ModelWeightInfo`, `CustomAtomicWeight`, or `CustomGlobalWeight`.

  ## Validation

  - Foundation loader tests
  - Qwen2 dense regression tests
  - Qwen2-VL loading and CPU numerical reference tests
  - Qwen2-VL multimodal routing tests
  - Full multimodal package test suite
  - H20 flash-attention GPU numerical test
  - MI308X ROCm SDPA GPU numerical test
  - Black, isort, pre-commit, and `git diff --check`