### PR TITLE
fix: use int64 offsets in long-prefill triton kernels

### DIFF
--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -686,7 +686,15 @@ void CudaGraphRunner::initCapture() {
         // get real output data type (params already prepared in attn impl __init__/create_params)
         auto attn_pyobj = py_attn_pyobj_method_(capture_mem_hold_.py_model_inputs_, true);
         RTP_LLM_LOG_INFO("initCapture forward for output datatype start");
-        py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        try {
+            py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        } catch (const py::error_already_set& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with Python exception: %s", e.what());
+            throw;
+        } catch (const std::exception& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with C++ exception: %s", e.what());
+            throw;
+        }
         RTP_LLM_LOG_INFO("initCapture forward for output datatype end");
         output = torch::zeros({max_num_token_, hidden_size_}, options_cuda_float_);
         capture_mem_hold_.setHiddenStates(output);

--- a/rtp_llm/models_py/triton_kernels/causal_conv1d/causal_conv1d.py
+++ b/rtp_llm/models_py/triton_kernels/causal_conv1d/causal_conv1d.py
@@ -91,7 +91,7 @@ def prepare_causal_conv1d_metadata(
     )
 
 
-@triton.jit(do_not_specialize=["max_block_size"])
+@triton.jit(do_not_specialize=["stride_block_map"])
 def _causal_conv1d_fwd_kernel(  # continuous batching
     # Pointers to matrices
     x_ptr,  # (dim, cu_seqlen) holding `batch` of actual sequences + padded sequences
@@ -107,7 +107,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     # Matrix dimensions
     batch: tl.int32,  # actually padded_batch
     dim: tl.constexpr,
-    max_block_size: tl.int32,
+    stride_block_map: tl.int64,
     # Strides
     stride_x_seq: tl.constexpr,  # stride to get to next sequence,
     stride_x_dim: tl.constexpr,  # stride to get to next feature-value,
@@ -179,7 +179,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         if HAS_CACHE and prefix_length > 0:
             init_state_block_pos = (prefix_length - 1) // SEQ_SIZE_PER_BLOCK
             init_state_block_idx = tl.load(
-                block_map_ptr + idx_seq * max_block_size + init_state_block_pos
+                block_map_ptr + idx_seq * stride_block_map + init_state_block_pos
             ).to(tl.int64)
             tl.device_assert(
                 init_state_block_idx >= 0,
@@ -353,13 +353,13 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         if write_to_block:
             write_page_idx = tl.load(
                 block_map_ptr
-                + idx_seq * max_block_size
+                + idx_seq * stride_block_map
                 + dest_idx // SEQ_SIZE_PER_BLOCK
             ).to(tl.int64)
 
         if write_to_block and write_page_idx >= 0:
             # tl.device_print("idx_seq:", idx_seq)
-            # tl.device_print("max_block_size:", max_block_size)
+            # tl.device_print("stride_block_map:", stride_block_map)
             # tl.device_print("dest_idx:", dest_idx)
             # tl.device_print("SEQ_SIZE_PER_BLOCK:", SEQ_SIZE_PER_BLOCK)
 
@@ -539,7 +539,7 @@ def causal_conv1d_fn(
     stride_istate_seq = 0
     stride_istate_dim = 0
     stride_istate_token = 0
-    max_block_size = block_map.size(1) if block_map is not None else 0
+    stride_block_map = block_map.stride(0) if block_map is not None else 0
     if conv_states is not None:
         # extensions to support vLLM:
         # 1. conv_states is used to replaced initial_states
@@ -605,7 +605,7 @@ def causal_conv1d_fn(
         # Matrix dimensions
         padded_batch,
         dim,
-        max_block_size,
+        stride_block_map,
         # stride
         stride_x_seq,
         stride_x_dim,
@@ -644,7 +644,7 @@ def _causal_conv1d_update_kernel(
     conv_state_ptr,
     cache_seqlens_ptr,  # circular buffer
     block_map_ptr,
-    stride_block_map: tl.int32,
+    stride_block_map: tl.int64,
     sequence_lengths_ptr,
     query_start_loc_ptr,  # (batch + 1)
     o_ptr,  # (batch, dim, seqlen)
@@ -1039,7 +1039,7 @@ def causal_conv1d_update(
     # when speculative, we load (width - 2) token from conv_state and (seqlen) token from x, then store them in different block
     np2_statelen_total = triton.next_power_of_2(state_len - 1 + seqlen)
 
-    stride_block_map = block_map.size(1) if block_map is not None else 0
+    stride_block_map = block_map.stride(0) if block_map is not None else 0
 
     def grid(META):
         return (

--- a/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_decode.py
+++ b/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_decode.py
@@ -93,9 +93,10 @@ class TestCausalConv1dUpdate(unittest.TestCase):
                 ]
                 max_block_num = max(block_nums)
                 total_block_num = sum(block_nums)
-                block_map = torch.zeros(
-                    [batch, max_block_num], dtype=torch.int32, device=device
+                block_map_storage = torch.zeros(
+                    [batch, max_block_num + 1], dtype=torch.int32, device=device
                 )
+                block_map = block_map_storage[:, :max_block_num]
                 offset = 0
                 for i in range(batch):
                     block_map[i, : block_nums[i]] = torch.arange(

--- a/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_prefill.py
+++ b/rtp_llm/models_py/triton_kernels/causal_conv1d/test/test_casual_conv1d_prefill.py
@@ -163,9 +163,12 @@ class TestCausalConv1dPrefill(unittest.TestCase):
 
             # 对齐成二维tensor，右边补-1
             max_blocks = max(block_num) if block_num else 0
-            block_indices_tensor = torch.full(
-                (batch, max_blocks), -1, device=device, dtype=torch.int32
+            # Match CUDA graph replay, where the active block table is a
+            # narrow view backed by a wider persistent allocation.
+            block_indices_storage = torch.full(
+                (batch, max_blocks + 1), -1, device=device, dtype=torch.int32
             )
+            block_indices_tensor = block_indices_storage[:, :max_blocks]
             for i, indices in enumerate(block_indices_list):
                 block_indices_tensor[i, : len(indices)] = indices
 
@@ -278,9 +281,10 @@ class TestCausalConv1dPrefill(unittest.TestCase):
                 offset += block_num[i]
             # 对齐成二维tensor，右边补-1
             max_blocks = max(block_num) if block_num else 0
-            block_indices_tensor = torch.full(
-                (batch, max_blocks), -1, device=device, dtype=torch.int32
+            block_indices_storage = torch.full(
+                (batch, max_blocks + 1), -1, device=device, dtype=torch.int32
             )
+            block_indices_tensor = block_indices_storage[:, :max_blocks]
             for i, indices in enumerate(block_indices_list):
                 block_indices_tensor[i, : len(indices)] = indices
 

--- a/rtp_llm/models_py/triton_kernels/common/offset.py
+++ b/rtp_llm/models_py/triton_kernels/common/offset.py
@@ -1,0 +1,8 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def linear_offset_64(index, stride):
+    """Compute a linear element offset without overflowing int32."""
+    return index.to(tl.int64) * stride

--- a/rtp_llm/models_py/triton_kernels/common/offset.py
+++ b/rtp_llm/models_py/triton_kernels/common/offset.py
@@ -5,4 +5,7 @@ import triton.language as tl
 @triton.jit
 def linear_offset_64(index, stride):
     """Compute a linear element offset without overflowing int32."""
-    return index.to(tl.int64) * stride
+    # tl.cast handles both runtime tensors and compile-time scalar values. The
+    # latter occur for static loop induction variables in chunk kernels and do
+    # not consistently provide Tensor.to() across Triton versions.
+    return tl.cast(index, tl.int64) * stride

--- a/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
+++ b/rtp_llm/models_py/triton_kernels/common/scatter_qkv.py
@@ -10,6 +10,8 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
+
 
 @triton.jit
 def _scatter_qkv_kernel(
@@ -24,12 +26,12 @@ def _scatter_qkv_kernel(
     BLK_V: tl.constexpr,
 ):
     row = tl.program_id(0)
-    src = row * stride_src_row
+    src = linear_offset_64(row, stride_src_row)
 
     offs_qk = tl.arange(0, BLK_QK)
     mask_qk = offs_qk < K_DIM
-    q_dst = row * K_DIM + offs_qk
-    k_dst = row * K_DIM + offs_qk
+    q_dst = linear_offset_64(row, K_DIM) + offs_qk
+    k_dst = linear_offset_64(row, K_DIM) + offs_qk
     tl.store(
         q_ptr + q_dst, tl.load(src_ptr + src + offs_qk, mask=mask_qk), mask=mask_qk
     )
@@ -41,7 +43,7 @@ def _scatter_qkv_kernel(
 
     offs_v = tl.arange(0, BLK_V)
     mask_v = offs_v < V_DIM
-    v_dst = row * V_DIM + offs_v
+    v_dst = linear_offset_64(row, V_DIM) + offs_v
     tl.store(
         v_ptr + v_dst,
         tl.load(src_ptr + src + 2 * K_DIM + offs_v, mask=mask_v),

--- a/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
+++ b/rtp_llm/models_py/triton_kernels/common/test/scatter_qkv_test.py
@@ -1,8 +1,16 @@
 import unittest
 
 import torch
+import triton
+import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.common.scatter_qkv import scatter_qkv
+
+
+@triton.jit
+def _linear_offset_test_kernel(output, row, stride):
+    tl.store(output, linear_offset_64(row, stride))
 
 
 def _split_view_baseline(
@@ -78,6 +86,15 @@ class TestScatterQKV(unittest.TestCase):
         for M in (2047, 2048, 2049):
             with self.subTest(M=M):
                 self._assert_equivalent(M, 8, 16, 128, 128, torch.bfloat16)
+
+    def test_large_packed_prefill_offset_uses_int64(self) -> None:
+        """Cover Qwen3.5 TP1/TP2 rows where row * qkv_stride exceeds INT32_MAX."""
+        output = torch.empty(1, dtype=torch.int64, device=self.device)
+        for row, stride in ((209716, 10240), (419431, 5120), (524288, 4096)):
+            with self.subTest(row=row, stride=stride):
+                _linear_offset_test_kernel[(1,)](output, row, stride)
+                self.assertEqual(output.item(), row * stride)
+                self.assertGreater(output.item(), torch.iinfo(torch.int32).max)
 
     def test_dtypes(self) -> None:
         """bf16 is the production dtype; fp16/fp32 should also work."""

--- a/rtp_llm/models_py/triton_kernels/fla/block.py
+++ b/rtp_llm/models_py/triton_kernels/fla/block.py
@@ -6,13 +6,13 @@ from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 
 
-@triton.jit(do_not_specialize=["max_block_size"])
+@triton.jit(do_not_specialize=["block_map_stride_b"])
 def load_initial_state_from_block_map_kernel(
     prefix_lengths: tl.tensor,
     block_map: tl.tensor,
     conv_states: tl.tensor,
     initial_states: tl.tensor,
-    max_block_size: tl.int32,
+    block_map_stride_b: tl.int64,
     HEAD_NUM: tl.constexpr,
     V: tl.constexpr,
     K: tl.constexpr,
@@ -34,7 +34,7 @@ def load_initial_state_from_block_map_kernel(
     block_offset = tl.where(is_zero, 0, (prefix - 1) // SEQ_SIZE_PER_BLOCK)
 
     block_idx = tl.where(
-        is_zero, 0, tl.load(block_map + i_b * max_block_size + block_offset)
+        is_zero, 0, tl.load(block_map + i_b * block_map_stride_b + block_offset)
     ).to(tl.int64)
 
     p_out = tl.make_block_ptr(
@@ -72,7 +72,7 @@ def load_initial_state_from_block_map(
     seq_size_per_block: int,
     block_v: int = 64,
 ):
-    batch, max_block_size = block_map.shape
+    batch = block_map.shape[0]
     _, head_num, v, k = conv_states.shape
     assert prefix_lengths.shape[0] == batch
 
@@ -85,7 +85,7 @@ def load_initial_state_from_block_map(
         block_map,
         conv_states,
         initial_states,
-        max_block_size,
+        block_map.stride(0),
         HEAD_NUM=head_num,
         V=v,
         K=k,
@@ -104,14 +104,14 @@ def _store_ssm_state_block(
     v_offset,
     block_map: tl.tensor,
     ssm_states: tl.tensor,
-    max_block_size: tl.int32,
+    block_map_stride_b: tl.int64,
     SSM_PER_HEAD: tl.constexpr,
     V: tl.constexpr,
     K: tl.constexpr,
     BLOCK_V: tl.constexpr,
     CONV_STRIDE_TOKEN: tl.constexpr,
 ):
-    block_idx = tl.load(block_map + batch * max_block_size + dest_block_pos).to(
+    block_idx = tl.load(block_map + batch * block_map_stride_b + dest_block_pos).to(
         tl.int64
     )
 
@@ -146,7 +146,7 @@ def _store_ssm_state_block(
         )
 
 
-@triton.jit(do_not_specialize=["max_block_size"])
+@triton.jit(do_not_specialize=["block_map_stride_b"])
 def store_ssm_state_to_block_map_kernel(
     chunk_indices: tl.tensor,
     h: tl.tensor,
@@ -155,7 +155,7 @@ def store_ssm_state_to_block_map_kernel(
     cu_seqlens: tl.tensor,
     block_map: tl.tensor,
     ssm_states: tl.tensor,
-    max_block_size: tl.int32,
+    block_map_stride_b: tl.int64,
     HEAD_NUM: tl.constexpr,
     V: tl.constexpr,
     K: tl.constexpr,
@@ -195,7 +195,7 @@ def store_ssm_state_to_block_map_kernel(
             v_offset,
             block_map,
             ssm_states,
-            max_block_size,
+            block_map_stride_b,
             SSM_PER_HEAD,
             V,
             K,
@@ -219,7 +219,7 @@ def store_ssm_state_to_block_map_kernel(
             v_offset,
             block_map,
             ssm_states,
-            max_block_size,
+            block_map_stride_b,
             SSM_PER_HEAD,
             V,
             K,
@@ -247,7 +247,7 @@ def store_ssm_state_to_block_map(
     chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     _, head_num, v, k = ssm_states.shape
     chunk_num = chunk_indices.shape[0]
-    max_block_size = block_map.shape[1]
+    block_map_stride_b = block_map.stride(0)
     grid = (chunk_num, head_num, triton.cdiv(v, block_v))
     token_stride_ssm_state = ssm_states.stride(0)
     store_ssm_state_to_block_map_kernel[grid](
@@ -258,7 +258,7 @@ def store_ssm_state_to_block_map(
         cu_seqlens,
         block_map,
         ssm_states,
-        max_block_size,
+        block_map_stride_b,
         HEAD_NUM=head_num,
         V=v,
         K=k,

--- a/rtp_llm/models_py/triton_kernels/fla/block.py
+++ b/rtp_llm/models_py/triton_kernels/fla/block.py
@@ -2,6 +2,7 @@ import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla.index import prepare_chunk_indices
 
 
@@ -94,6 +95,57 @@ def load_initial_state_from_block_map(
     )
 
 
+@triton.jit
+def _store_ssm_state_block(
+    source_ptr,
+    dest_block_pos,
+    batch,
+    i_h,
+    v_offset,
+    block_map: tl.tensor,
+    ssm_states: tl.tensor,
+    max_block_size: tl.int32,
+    SSM_PER_HEAD: tl.constexpr,
+    V: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+    CONV_STRIDE_TOKEN: tl.constexpr,
+):
+    block_idx = tl.load(block_map + batch * max_block_size + dest_block_pos).to(
+        tl.int64
+    )
+
+    if block_idx > 0:
+        dest_ptr = (
+            ssm_states
+            + linear_offset_64(block_idx, CONV_STRIDE_TOKEN)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
+
+        p_in = tl.make_block_ptr(
+            source_ptr,
+            (V, K),
+            (K, 1),
+            (v_offset, 0),
+            (BLOCK_V, K),
+            (1, 0),
+        )
+        p_out = tl.make_block_ptr(
+            dest_ptr,
+            (V, K),
+            (K, 1),
+            (v_offset, 0),
+            (BLOCK_V, K),
+            (1, 0),
+        )
+
+        tl.store(
+            p_out,
+            tl.load(p_in, boundary_check=(0, 1)).to(ssm_states.dtype.element_ty),
+            boundary_check=(0, 1),
+        )
+
+
 @triton.jit(do_not_specialize=["max_block_size"])
 def store_ssm_state_to_block_map_kernel(
     chunk_indices: tl.tensor,
@@ -126,56 +178,54 @@ def store_ssm_state_to_block_map_kernel(
     eos = tl.load(cu_seqlens + batch + 1).to(tl.int32)
     input_len = eos - bos
 
-    should_write = False
-    dest_block_pos = 0
-    source_ptr = final_states
-
-    # last chunk always record to final states
+    # Keep source pointers branch-local. Triton 3.7 cannot canonicalize a
+    # pointer phi whose branches use different offset widths.
     if (chunk + 1) * CHUNK_SIZE >= input_len:
-        source_ptr = final_states + batch * SSM_PER_BATCH + i_h * SSM_PER_HEAD
+        source_ptr = (
+            final_states
+            + linear_offset_64(batch, SSM_PER_BATCH)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
         dest_block_pos = (prefix + input_len - 1) // SEQ_SIZE_PER_BLOCK
-        should_write = True
+        _store_ssm_state_block(
+            source_ptr,
+            dest_block_pos,
+            batch,
+            i_h,
+            v_offset,
+            block_map,
+            ssm_states,
+            max_block_size,
+            SSM_PER_HEAD,
+            V,
+            K,
+            BLOCK_V,
+            CONV_STRIDE_TOKEN,
+        )
     elif chunk > 0 and (chunk + 1) * CHUNK_SIZE % SEQ_SIZE_PER_BLOCK == 0:
+        source_ptr = (
+            h
+            + linear_offset_64(i_c + 1, SSM_PER_BATCH)
+            + linear_offset_64(i_h, SSM_PER_HEAD)
+        )
         dest_block_pos = (
             prefix + chunk * CHUNK_SIZE + CHUNK_SIZE - 1
         ) // SEQ_SIZE_PER_BLOCK
-        source_ptr = h + (i_c + 1) * SSM_PER_BATCH + i_h * SSM_PER_HEAD
-        should_write = True
-
-    if not should_write:
-        return
-
-    block_idx = tl.load(block_map + batch * max_block_size + dest_block_pos).to(
-        tl.int64
-    )
-
-    if block_idx <= 0:
-        return
-
-    dest_ptr = ssm_states + block_idx * CONV_STRIDE_TOKEN + i_h * SSM_PER_HEAD
-
-    p_in = tl.make_block_ptr(
-        source_ptr,
-        (V, K),
-        (K, 1),
-        (v_offset, 0),
-        (BLOCK_V, K),
-        (1, 0),
-    )
-    p_out = tl.make_block_ptr(
-        dest_ptr,
-        (V, K),
-        (K, 1),
-        (v_offset, 0),
-        (BLOCK_V, K),
-        (1, 0),
-    )
-
-    tl.store(
-        p_out,
-        tl.load(p_in, boundary_check=(0, 1)).to(ssm_states.dtype.element_ty),
-        boundary_check=(0, 1),
-    )
+        _store_ssm_state_block(
+            source_ptr,
+            dest_block_pos,
+            batch,
+            i_h,
+            v_offset,
+            block_map,
+            ssm_states,
+            max_block_size,
+            SSM_PER_HEAD,
+            V,
+            K,
+            BLOCK_V,
+            CONV_STRIDE_TOKEN,
+        )
 
 
 def store_ssm_state_to_block_map(

--- a/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
+++ b/rtp_llm/models_py/triton_kernels/fla/chunk_delta_h.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 
+import logging
 from typing import Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla.index import (
     prepare_chunk_indices,
     prepare_chunk_offsets,
@@ -20,7 +22,6 @@ from rtp_llm.models_py.triton_kernels.fla.utils import (
     is_nvidia_hopper,
 )
 
-import logging
 logger = logging.getLogger(__name__)
 
 # TODO(V-first migration): Gluon CDNA4 chunk-h path is disabled until the mfma
@@ -107,20 +108,20 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         b_h4 = tl.zeros([BV, 64], dtype=tl.float32)
 
     # calculate offset
-    h += ((boh * H + i_h) * K * V).to(tl.int64)
-    v += ((bos * H + i_h) * V).to(tl.int64)
-    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
-    w += ((bos * H + i_h) * K).to(tl.int64)
+    h += linear_offset_64(boh, H * K * V) + linear_offset_64(i_h, K * V)
+    v += linear_offset_64(bos, H * V) + linear_offset_64(i_h, V)
+    k += linear_offset_64(bos, Hg * K) + linear_offset_64(i_h // (H // Hg), K)
+    w += linear_offset_64(bos, H * K) + linear_offset_64(i_h, K)
     if SAVE_NEW_VALUE:
-        v_new += ((bos * H + i_h) * V).to(tl.int64)
+        v_new += linear_offset_64(bos, H * V) + linear_offset_64(i_h, V)
     stride_v = H * V
     stride_h = H * K * V
     stride_k = Hg * K
     stride_w = H * K
     if USE_INITIAL_STATE:
-        h0 = h0 + i_nh * K * V
+        h0 += linear_offset_64(i_nh, K * V)
     if STORE_FINAL_STATE:
-        ht = ht + i_nh * K * V
+        ht += linear_offset_64(i_nh, K * V)
 
     # load initial state — V-first view: (V, K) + strides (K, 1)
     if USE_INITIAL_STATE:
@@ -144,23 +145,24 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # main recurrence
     for i_t in range(NT):
+        h_chunk = h + linear_offset_64(i_t, stride_h)
         p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
+            h_chunk, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0)
         )
         tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:
             p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 64), (BV, 64), (1, 0)
             )
             tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
         if K > 128:
             p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 128), (BV, 64), (1, 0)
             )
             tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
         if K > 192:
             p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
+                h_chunk, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
             )
             tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
 
@@ -201,17 +203,15 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
+            g_base = g + linear_offset_64(bos, H) + i_h
+            g_last = g_base + linear_offset_64(last_idx, H)
             if IS_LOG2:
                 # AMD path: g is in log2 domain (RCP_LN2-scaled cumsum upstream).
                 # The fp32 promotions, int64 index and m_t mask are robustness
                 # tweaks added together with the log2 rewrite for MI355X/MI308X.
                 m_t = (i_t * BT + tl.arange(0, BT)) < T
-                b_g_last = tl.load(g + (bos * H + last_idx * H + i_h).to(tl.int64)).to(
-                    tl.float32
-                )
-                p_g = tl.make_block_ptr(
-                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-                )
+                b_g_last = tl.load(g_last).to(tl.float32)
+                p_g = tl.make_block_ptr(g_base, (T,), (H,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
                 b_v = b_v * tl.where(m_t, exp2(b_g_last - b_g), 0)[:, None]
                 b_g_last = exp2(b_g_last)
@@ -219,10 +219,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 # NVIDIA path: g is in natural-log domain. Keep the original
                 # exp/safe_exp formulation and integer indexing for bit-level
                 # parity with the pre-optimization implementation.
-                b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-                p_g = tl.make_block_ptr(
-                    g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-                )
+                b_g_last = tl.load(g_last)
+                p_g = tl.make_block_ptr(g_base, (T,), (H,), (i_t * BT,), (BT,), (0,))
                 b_g = tl.load(p_g, boundary_check=(0,))
                 b_v = b_v * safe_exp(b_g_last - b_g)[:, None]
                 b_g_last = exp(b_g_last)
@@ -235,9 +233,11 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 b_h4 = b_h4 * b_g_last
 
         if USE_GK:
+            gk_base = gk + linear_offset_64(bos, H * K) + linear_offset_64(i_h, K)
+            gk_last = gk_base + linear_offset_64(last_idx, H * K)
             o_k1 = tl.arange(0, 64)
             b_gk_last1 = tl.load(
-                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                gk_last + o_k1,
                 mask=(o_k1 < K),
                 other=0.0,
             )
@@ -249,7 +249,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 64:
                 o_k2 = 64 + o_k1
                 b_gk_last2 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,
+                    gk_last + o_k2,
                     mask=(o_k2 < K),
                     other=0.0,
                 )
@@ -260,7 +260,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 128:
                 o_k3 = 128 + o_k1
                 b_gk_last3 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    gk_last + o_k3,
                     mask=(o_k3 < K),
                     other=0.0,
                 )
@@ -271,7 +271,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             if K > 192:
                 o_k4 = 192 + o_k1
                 b_gk_last4 = tl.load(
-                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,
+                    gk_last + o_k4,
                     mask=(o_k4 < K),
                     other=0.0,
                 )

--- a/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
+++ b/rtp_llm/models_py/triton_kernels/fla/fused_recurrent.py
@@ -42,7 +42,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     cu_seqlens,
     block_map,
     sequence_lengths,
-    max_block_size: tl.int32,
+    block_map_stride_b: tl.int64,
     scale,
     N,  # num of sequences
     T,  # num of tokens
@@ -118,7 +118,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         if IS_CONTINUOUS_BATCHING:
             load_block_offset = cal_block_idx(sequence_length - 1, SEQ_SIZE_PER_BLOCK)
             read_block_id = tl.load(
-                block_map + i_n * max_block_size + load_block_offset
+                block_map + i_n * block_map_stride_b + load_block_offset
             ).to(tl.int64)
             if read_block_id <= 0:
                 return
@@ -159,7 +159,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
                 cal_block_idx(sequence_length, SEQ_SIZE_PER_BLOCK) + i_t
             )
             write_block_id = tl.load(
-                block_map + i_n * max_block_size + write_block_offset
+                block_map + i_n * block_map_stride_b + write_block_offset
             ).to(tl.int64)
             p_ht = ht + write_block_id * stride_final_state_token
         else:
@@ -217,10 +217,10 @@ def fused_recurrent_gated_delta_rule_fwd(
         q.stride(3) == 1 and k.stride(3) == 1 and v.stride(3) == 1
     ), "stride_qd, stride_kd, stride_vd must be 1"
 
-    max_block_size = 0
+    block_map_stride_b = 0
     if block_map is not None:
         assert block_map.ndim == 2, "block_map must be a 2D tensor"
-        max_block_size = block_map.shape[1]
+        block_map_stride_b = block_map.stride(0)
 
     grid = (NK, NV, N * HV)
     fused_recurrent_gated_delta_rule_fwd_kernel[grid](
@@ -235,7 +235,7 @@ def fused_recurrent_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens,
         block_map=block_map,
         sequence_lengths=sequence_lengths,
-        max_block_size=max_block_size,
+        block_map_stride_b=block_map_stride_b,
         scale=scale,
         N=N,
         T=T,

--- a/rtp_llm/models_py/triton_kernels/fla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/fla/test/BUILD
@@ -39,6 +39,26 @@ py_test(
 )
 
 py_test(
+    name = "test_gdn_block_prefill_rocm",
+    srcs = ["test_gdn_block_prefill.py"],
+    main = "test_gdn_block_prefill.py",
+    deps = ["//rtp_llm/models_py/triton_kernels:fla"] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
+    visibility = ["//visibility:public"],
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7'},
+)
+
+py_test(
+    name = "test_gdn_decode_rocm",
+    srcs = ["test_gdn_decode.py"],
+    main = "test_gdn_decode.py",
+    deps = ["//rtp_llm/models_py/triton_kernels:fla"] + [":triton", ":torch", ":numpy", ":einops", ":packaging"],
+    visibility = ["//visibility:public"],
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7'},
+)
+
+py_test(
     name = "test_chunk_prefill",
     srcs = [
         "test_chunk_prefill.py"

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
@@ -5,7 +5,10 @@ import unittest
 from typing import List
 
 import torch
+import triton
+import triton.language as tl
 
+from rtp_llm.models_py.triton_kernels.common.offset import linear_offset_64
 from rtp_llm.models_py.triton_kernels.fla import (
     load_initial_state_from_block_map,
     store_ssm_state_to_block_map,
@@ -21,7 +24,24 @@ SSM_STATE_DTYPES = [torch.bfloat16, torch.float32]
 INTERMEDIATE_DTYPE = torch.float32
 
 
+@triton.jit
+def _linear_offset_test_kernel(output, index, stride):
+    tl.store(output, linear_offset_64(index, stride))
+
+
 class BlockTest(unittest.TestCase):
+    def test_large_chunk_state_offset_uses_int64(self):
+        output = torch.empty(1, dtype=torch.int64, device="cuda")
+        cases = [
+            (8192, 16 * 128 * 128),
+            (4096, 32 * 128 * 128),
+        ]
+        for chunk_index, ssm_per_chunk in cases:
+            with self.subTest(chunk_index=chunk_index, ssm_per_chunk=ssm_per_chunk):
+                _linear_offset_test_kernel[(1,)](output, chunk_index, ssm_per_chunk)
+                self.assertEqual(output.item(), chunk_index * ssm_per_chunk)
+                self.assertEqual(output.item(), 1 << 31)
+
     def test_load_initial_state_from_block_map(self):
         device = torch.device("cuda")
         head_nums = [1, 4, 8, 16]

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_block_prefill.py
@@ -29,6 +29,11 @@ def _linear_offset_test_kernel(output, index, stride):
     tl.store(output, linear_offset_64(index, stride))
 
 
+@triton.jit
+def _constexpr_linear_offset_test_kernel(output, stride):
+    tl.store(output, linear_offset_64(8192, stride))
+
+
 class BlockTest(unittest.TestCase):
     def test_large_chunk_state_offset_uses_int64(self):
         output = torch.empty(1, dtype=torch.int64, device="cuda")
@@ -42,6 +47,9 @@ class BlockTest(unittest.TestCase):
                 self.assertEqual(output.item(), chunk_index * ssm_per_chunk)
                 self.assertEqual(output.item(), 1 << 31)
 
+        _constexpr_linear_offset_test_kernel[(1,)](output, 16 * 128 * 128)
+        self.assertEqual(output.item(), 1 << 31)
+
     def test_load_initial_state_from_block_map(self):
         device = torch.device("cuda")
         head_nums = [1, 4, 8, 16]
@@ -51,7 +59,11 @@ class BlockTest(unittest.TestCase):
         seq_size_per_block = 16
 
         def test_one_case(
-            k_size: int, head_num: int, bs: int, ssm_state_dtype: torch.dtype
+            k_size: int,
+            head_num: int,
+            bs: int,
+            ssm_state_dtype: torch.dtype,
+            use_narrow_block_map: bool = False,
         ):
             logging.info(
                 f"test_load_initial_state_from_block_map: k_size={k_size} head_num={head_num} bs={bs} "
@@ -86,7 +98,8 @@ class BlockTest(unittest.TestCase):
             )
 
             max_block_num = max(block_num)
-            block_map = torch.ones([bs, max_block_num], dtype=torch.int32)
+            storage_width = max_block_num + int(use_narrow_block_map)
+            block_map = torch.ones([bs, storage_width], dtype=torch.int32)
             offset = 0
             for i in range(bs):
                 block_map[i, : block_num[i]] = torch.arange(
@@ -94,6 +107,8 @@ class BlockTest(unittest.TestCase):
                 )
                 offset += block_num[i]
             block_map = block_map.to(device)
+            if use_narrow_block_map:
+                block_map = block_map[:, :max_block_num]
             prefix_length_t = torch.tensor(
                 prefix_length, device=device, dtype=torch.int32
             )
@@ -121,6 +136,7 @@ class BlockTest(unittest.TestCase):
                 for head_num in head_nums:
                     for bs in batch_size:
                         test_one_case(k_size, head_num, bs, ssm_state_dtype)
+        test_one_case(128, 4, 4, torch.float32, use_narrow_block_map=True)
 
     def test_store_ssm_state_to_block_map(self):
         device = torch.device("cuda")
@@ -138,6 +154,7 @@ class BlockTest(unittest.TestCase):
             prefix_lengths: List[int],
             input_lengths: List[int],
             ssm_state_dtype: torch.dtype,
+            use_narrow_block_map: bool = False,
         ):
             logging.info(
                 f"test_store_ssm_state_to_block_map: k_size={k_size} head_num={head_num} bs={bs} "
@@ -152,7 +169,9 @@ class BlockTest(unittest.TestCase):
             ]
             total_block_num = sum(block_num)
             total_chunk_size = sum(chunk_lengths)
-            block_map = torch.ones([bs, max(block_num)], dtype=torch.int32)
+            map_width = max(block_num)
+            storage_width = map_width + int(use_narrow_block_map)
+            block_map = torch.ones([bs, storage_width], dtype=torch.int32)
             offset = 0
             for i in range(bs):
                 block_map[i, : block_num[i]] = torch.arange(
@@ -196,6 +215,8 @@ class BlockTest(unittest.TestCase):
                 cu_seq_len.append(cu_seq_len[-1] + length)
             cu_seq_len = torch.tensor(cu_seq_len, device=device, dtype=torch.int32)
             block_map_gpu = block_map.to(device)
+            if use_narrow_block_map:
+                block_map_gpu = block_map_gpu[:, :map_width]
             store_ssm_state_to_block_map(
                 h,
                 final_states,
@@ -241,29 +262,36 @@ class BlockTest(unittest.TestCase):
                             prefix_lengths = [
                                 random.randint(1, 10) * seq_size_per_block
                             ]
-                            input_lengths = [
-                                random.randint(10, 1024) for _ in range(bs)
-                            ]
-                            _test_one_case(
-                                k_size,
-                                head_num,
-                                bs,
-                                prefix_lengths,
-                                input_lengths,
-                                ssm_state_dtype,
-                            )
-                            input_lengths = [
-                                random.randint(1, 10) * seq_size_per_block
-                                for _ in range(bs)
-                            ]
-                            _test_one_case(
-                                k_size,
-                                head_num,
-                                bs,
-                                prefix_lengths,
-                                input_lengths,
-                                ssm_state_dtype,
-                            )
+                        input_lengths = [random.randint(10, 1024) for _ in range(bs)]
+                        _test_one_case(
+                            k_size,
+                            head_num,
+                            bs,
+                            prefix_lengths,
+                            input_lengths,
+                            ssm_state_dtype,
+                        )
+                        input_lengths = [
+                            random.randint(1, 10) * seq_size_per_block
+                            for _ in range(bs)
+                        ]
+                        _test_one_case(
+                            k_size,
+                            head_num,
+                            bs,
+                            prefix_lengths,
+                            input_lengths,
+                            ssm_state_dtype,
+                        )
+        _test_one_case(
+            128,
+            4,
+            4,
+            [128, 256, 384, 0],
+            [64, 128, 192, 256],
+            torch.float32,
+            use_narrow_block_map=True,
+        )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
@@ -62,7 +62,7 @@ def recurrent_gated_delta_rule_ref(
     return o, hs
 
 
-def test_fused_recurrent_continuous_batching(
+def _run_fused_recurrent_continuous_batching(
     B: int,
     S: int,
     H: int,
@@ -177,10 +177,10 @@ def test_fused_recurrent_narrow_block_map_view():
         dtype=torch.bfloat16,
         sequence_lengths=[10, 11, 12, 13],
     )
-    contiguous_output, contiguous_cache = test_fused_recurrent_continuous_batching(
+    contiguous_output, contiguous_cache = _run_fused_recurrent_continuous_batching(
         **kwargs
     )
-    narrow_output, narrow_cache = test_fused_recurrent_continuous_batching(
+    narrow_output, narrow_cache = _run_fused_recurrent_continuous_batching(
         **kwargs, use_narrow_block_map=True
     )
     assert_close("narrow output", contiguous_output, narrow_output, 0.0)
@@ -196,6 +196,7 @@ if __name__ == "__main__":
     for bs in [1, 2, 4, 8, 16, 32, 64]:
         for seq in [1, 2, 4]:
             logging.info(f"Testing with batch size: {bs}, sequence length: {seq}")
-            test_fused_recurrent_continuous_batching(
+            _run_fused_recurrent_continuous_batching(
                 bs, seq, H, HV, D, scale, gate_logit_normalizer, torch.bfloat16
             )
+    test_fused_recurrent_narrow_block_map_view()

--- a/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
+++ b/rtp_llm/models_py/triton_kernels/fla/test/test_gdn_decode.py
@@ -71,6 +71,8 @@ def test_fused_recurrent_continuous_batching(
     scale: float,
     gate_logit_normalizer: float,
     dtype: torch.dtype,
+    sequence_lengths: List[int] = None,
+    use_narrow_block_map: bool = False,
 ):
     device = "cuda"
     torch.manual_seed(42)
@@ -100,12 +102,13 @@ def test_fused_recurrent_continuous_batching(
     )
 
     seq_size_per_block = 128
-    sequence_lengths = [random.randint(10, 1024) for _ in range(B)]
+    sequence_lengths = sequence_lengths or [random.randint(10, 1024) for _ in range(B)]
     block_num = [
         math.ceil(sequence_lengths[i] / seq_size_per_block) + (S - 1) for i in range(B)
     ]
     total_block_num = sum(block_num) + 1
-    block_map = torch.zeros([B, total_block_num], dtype=torch.int32)
+    block_map_width = 2 if use_narrow_block_map else total_block_num
+    block_map = torch.zeros([B, block_map_width], dtype=torch.int32)
     offset = 1
     for i in range(B):
         # start from 1 to avoid treated as padding batch in kernel
@@ -114,6 +117,10 @@ def test_fused_recurrent_continuous_batching(
         )
         offset += block_num[i]
     block_map = block_map.to(device)
+    if use_narrow_block_map:
+        # Preserve the production shape while retaining the padded row stride.
+        # The kernel must use stride(0), not shape[1], to address this view.
+        block_map = block_map[:, :1]
     load_block_offset = [(x - 2) // seq_size_per_block for x in sequence_lengths]
     # ssm_cache is the kernel's V-first (..., V, K) cache (see refactor commit
     # 5f271c1b). h0 above comes from recurrent_gated_delta_rule_ref which still
@@ -155,6 +162,29 @@ def test_fused_recurrent_continuous_batching(
                 int(block_map[bs, write_block_offset[bs] + seq])
             ].transpose(-1, -2)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+    return tri.detach().clone(), ssm_cache.detach().clone()
+
+
+def test_fused_recurrent_narrow_block_map_view():
+    kwargs = dict(
+        B=4,
+        S=1,
+        H=16,
+        HV=32,
+        D=128,
+        scale=1,
+        gate_logit_normalizer=0.1,
+        dtype=torch.bfloat16,
+        sequence_lengths=[10, 11, 12, 13],
+    )
+    contiguous_output, contiguous_cache = test_fused_recurrent_continuous_batching(
+        **kwargs
+    )
+    narrow_output, narrow_cache = test_fused_recurrent_continuous_batching(
+        **kwargs, use_narrow_block_map=True
+    )
+    assert_close("narrow output", contiguous_output, narrow_output, 0.0)
+    assert_close("narrow cache", contiguous_cache, narrow_cache, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  - Prevent int32 pointer-offset overflow in scatter-QKV and FLA kernels.
  - Correct FLA addressing for non-contiguous `block_map` views.
  - Add long-offset and `block_map[:, :1]` numerical tests.