### PR TITLE
feat: support rocm interleaved mrope graph replay

### DIFF
--- a/rtp_llm/cpp/cuda_graph/BUILD
+++ b/rtp_llm/cpp/cuda_graph/BUILD
@@ -11,6 +11,13 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "combo_position_ids_validation",
+    hdrs = ["combo_position_ids_validation.h"],
+    deps = torch_deps(),
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "cuda_graph_srcs",
     srcs = [
@@ -27,6 +34,7 @@ filegroup(
     name = "cuda_graph_hdrs",
     srcs = [
         "cuda_graph_base.h",
+        "combo_position_ids_validation.h",
         "cuda_graph_device_shims.h",
         "cuda_graph_utils.h",
         "cuda_graph_runner.h",
@@ -65,6 +73,7 @@ cc_library(
     ],
     deps = torch_deps() + [
         ":cuda_graph_base",
+        ":combo_position_ids_validation",
         ":cuda_graph_hdrs_lib",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/cpp/utils:core_utils",

--- a/rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h
+++ b/rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstddef>
+
+#include <torch/torch.h>
+
+namespace rtp_llm {
+
+inline bool validateComboPositionIdsForReplay(int                  position_id_len_factor,
+                                              int                  token_count,
+                                              const torch::Tensor& position_ids,
+                                              const torch::Tensor& captured_position_ids,
+                                              size_t&              copy_numel) {
+    copy_numel = 0;
+    if (position_id_len_factor <= 0) {
+        return true;
+    }
+
+    if (!position_ids.defined() || !position_ids.has_storage() || position_ids.numel() <= 0
+        || !captured_position_ids.defined() || !captured_position_ids.has_storage()
+        || captured_position_ids.numel() <= 0) {
+        return false;
+    }
+    if (position_ids.scalar_type() != torch::kInt32 || captured_position_ids.scalar_type() != torch::kInt32
+        || !position_ids.is_contiguous() || !captured_position_ids.is_contiguous()
+        || position_ids.numel() % position_id_len_factor != 0) {
+        return false;
+    }
+
+    if (token_count <= 0) {
+        return false;
+    }
+    copy_numel = static_cast<size_t>(token_count) * static_cast<size_t>(position_id_len_factor);
+    return static_cast<size_t>(position_ids.numel()) >= copy_numel
+           && static_cast<size_t>(captured_position_ids.numel()) >= copy_numel;
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -1,4 +1,5 @@
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_runner.h"
+#include "rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h"
 
 #include <algorithm>
 #include <cstring>
@@ -194,6 +195,21 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
                              py_model_inputs_.attention_inputs.kv_cache_kernel_block_id_device);
     }
 
+    if (position_id_len_factor_ > 0) {
+        size_t copy_numel = 0;
+        RTP_LLM_CHECK_WITH_INFO(
+            validateComboPositionIds(inputs, state, py_model_inputs_.combo_position_ids, copy_numel),
+            "invalid combo_position_ids before CUDA graph replay: factor=%d, src_numel=%lld, dst_numel=%lld",
+            position_id_len_factor_,
+            inputs.combo_position_ids.defined() ? static_cast<long long>(inputs.combo_position_ids.numel()) : -1LL,
+            py_model_inputs_.combo_position_ids.defined() ?
+                static_cast<long long>(py_model_inputs_.combo_position_ids.numel()) :
+                -1LL);
+        optimizedCopyAsync(inputs.combo_position_ids,
+                           py_model_inputs_.combo_position_ids,
+                           copy_numel * inputs.combo_position_ids.element_size());
+    }
+
     if (!is_prefill_cuda_graph_mode_) {
         // D2D copies — collected for single batched kernel launch
         tryAddD2DCopy(inputs.attention_inputs.sequence_lengths_plus_1_device,
@@ -202,21 +218,6 @@ void CudaGraphRunner::prepareInputs(const PyModelInputs& inputs, CudaGraphState&
         tryAddD2DCopy(inputs.attention_inputs.decode_cu_seqlens_device,
                       py_model_inputs_.attention_inputs.decode_cu_seqlens_device,
                       (state.current_batch_size + 1) * sizeof(int));
-
-        if (inputs.combo_position_ids.defined() && inputs.combo_position_ids.numel() > 0
-            && inputs.combo_position_ids.has_storage()) {
-            if (!py_model_inputs_.combo_position_ids.defined()) {
-                RTP_LLM_LOG_WARNING("combo_position_ids not defined in graph but present in input, skipping copy");
-            } else {
-                const size_t copy_size   = inputs.combo_position_ids.numel() * sizeof(int);
-                const size_t target_size = py_model_inputs_.combo_position_ids.numel() * sizeof(int);
-                RTP_LLM_CHECK_WITH_INFO(target_size >= copy_size,
-                                        "combo_position_ids target tensor size (%zu) is smaller than needed (%zu)",
-                                        target_size,
-                                        copy_size);
-                optimizedCopyAsync(inputs.combo_position_ids, py_model_inputs_.combo_position_ids, copy_size);
-            }
-        }
     } else {
         // D2D copy
         if (inputs.bert_embedding_inputs.position_encoding.numel() > 0) {
@@ -421,6 +422,38 @@ bool CudaGraphRunner::tryGetRealGraphDecodeBatchSize(const PyModelInputs& inputs
     return true;
 }
 
+bool CudaGraphRunner::validateComboPositionIds(const PyModelInputs&  inputs,
+                                               const CudaGraphState& state,
+                                               const torch::Tensor&  captured_position_ids,
+                                               size_t&               copy_numel) const {
+    const int token_count = is_prefill_cuda_graph_mode_ ? state.current_seq_len : state.seq_len_sum;
+    return validateComboPositionIdsForReplay(
+        position_id_len_factor_, token_count, inputs.combo_position_ids, captured_position_ids, copy_numel);
+}
+
+bool CudaGraphRunner::canReplaySelectedGraph(const PyModelInputs& inputs, const CudaGraphState& state) const {
+    const int  graph_key = is_prefill_cuda_graph_mode_ ? state.current_real_graph_seq_len : state.current_real_graph_bs;
+    const auto graph_it  = graph_instances_.find(graph_key);
+    if (graph_it == graph_instances_.end()) {
+        RTP_LLM_LOG_WARNING("CUDA graph key %d was not captured, fallback to normal run", graph_key);
+        return false;
+    }
+
+    size_t      copy_numel            = 0;
+    const auto& captured_position_ids = graph_it->second.mem_hold_.py_model_inputs_.combo_position_ids;
+    if (!validateComboPositionIds(inputs, state, captured_position_ids, copy_numel)) {
+        RTP_LLM_LOG_WARNING(
+            "combo_position_ids are incompatible with CUDA graph key %d: factor=%d, src_numel=%lld, "
+            "dst_numel=%lld; fallback to normal run",
+            graph_key,
+            position_id_len_factor_,
+            inputs.combo_position_ids.defined() ? static_cast<long long>(inputs.combo_position_ids.numel()) : -1LL,
+            captured_position_ids.defined() ? static_cast<long long>(captured_position_ids.numel()) : -1LL);
+        return false;
+    }
+    return true;
+}
+
 bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state) {
     RTP_LLM_PROFILE_SCOPE("cuda_graph.canRun");
     if (kv_cache_group_tags_.size() > 1) {
@@ -449,7 +482,7 @@ bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state)
         if (inputs.attention_inputs.is_target_verify) {
             // Target-verify must also respect captured decode range.
             // Otherwise we may replay an uncaptured graph key.
-            return tryGetRealGraphDecodeBatchSize(inputs, state);
+            return tryGetRealGraphDecodeBatchSize(inputs, state) && canReplaySelectedGraph(inputs, state);
         }
         return false;
     }
@@ -469,7 +502,7 @@ bool CudaGraphRunner::canRun(const PyModelInputs& inputs, CudaGraphState& state)
             return false;
         }
     }
-    return true;
+    return canReplaySelectedGraph(inputs, state);
 }
 
 void CudaGraphRunner::initKernelInternalMemory() {
@@ -519,8 +552,7 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     // (non-Mrope models pay zero memory and the captured graph never references it).
     if (position_id_len_factor_ > 0) {
         inputs.combo_position_ids =
-            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cpu_int32_);
-        inputs.combo_position_ids                  = inputs.combo_position_ids.pin_memory();
+            torch::ones({int(max_bs_) * num_tokens_per_bs_ * position_id_len_factor_}, options_cuda_int32_);
         inputs.attention_inputs.combo_position_ids = inputs.combo_position_ids;
     }
 
@@ -556,7 +588,8 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     inputs.attention_inputs.padding_offset = inputs.attention_inputs.padding_offset.pin_memory();
     inputs.attention_inputs.dtype          = model_data_type_;
     inputs.attention_inputs.is_s_padded    = true;
-    inputs.attention_inputs.sequence_lengths_plus_1_device = torch::zeros({int(max_bs_)}, options_cuda_int32_);
+    auto sequence_lengths_plus_1           = inputs.attention_inputs.sequence_lengths.add(1).pin_memory();
+    inputs.attention_inputs.sequence_lengths_plus_1_device = sequence_lengths_plus_1.cuda();
     // Step=1 is intentional: when num_tokens_per_bs_ > 1 (target verify), is_prefill is set to true
     // so the factory selects PREFILL impls (which use cu_seqlens, not decode_cu_seqlens).
     // XQADecodeImpl/XQAWrapper (the consumers of decode_cu_seqlens_host) are never reached in that path.
@@ -686,7 +719,15 @@ void CudaGraphRunner::initCapture() {
         // get real output data type (params already prepared in attn impl __init__/create_params)
         auto attn_pyobj = py_attn_pyobj_method_(capture_mem_hold_.py_model_inputs_, true);
         RTP_LLM_LOG_INFO("initCapture forward for output datatype start");
-        py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        try {
+            py_forward_method_(capture_mem_hold_.py_model_inputs_, attn_pyobj);
+        } catch (const py::error_already_set& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with Python exception: %s", e.what());
+            throw;
+        } catch (const std::exception& e) {
+            RTP_LLM_LOG_ERROR("initCapture forward for output datatype failed with C++ exception: %s", e.what());
+            throw;
+        }
         RTP_LLM_LOG_INFO("initCapture forward for output datatype end");
         output = torch::zeros({max_num_token_, hidden_size_}, options_cuda_float_);
         capture_mem_hold_.setHiddenStates(output);

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
@@ -115,6 +115,11 @@ private:
     bool tryGetRealGraphDecodeBatchSize(const PyModelInputs& inputs, CudaGraphState& state);
     /// Select graph key for prefill; false if capture_range_ empty or seq_len above max captured (lower_bound hit end).
     bool                    tryGetRealGraphPrefillSeqLen(const PyModelInputs& inputs, CudaGraphState& state);
+    bool                    validateComboPositionIds(const PyModelInputs&  inputs,
+                                                     const CudaGraphState& state,
+                                                     const torch::Tensor&  captured_position_ids,
+                                                     size_t&               copy_numel) const;
+    bool                    canReplaySelectedGraph(const PyModelInputs& inputs, const CudaGraphState& state) const;
     void                    initCaptureAttentionInputs(PyModelInputs& inputs, int max_bs, int num_tokens_per_bs);
     void                    initCaptureBertEmbeddingInputs(PyModelInputs& inputs, int max_bs, int max_num_token);
     void                    initCaptureAttentionInputsPost();

--- a/rtp_llm/cpp/cuda_graph/tests/BUILD
+++ b/rtp_llm/cpp/cuda_graph/tests/BUILD
@@ -1,6 +1,16 @@
 load("//:def.bzl", "copts")
 load("@arch_config//:arch_select.bzl", "torch_deps")
 
+cc_test(
+    name = "combo_position_ids_validation_test",
+    srcs = ["combo_position_ids_validation_test.cc"],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/cpp/cuda_graph:combo_position_ids_validation",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps(),
+)
+
 cc_library(
     name = "test_cuda_graph_runner_libs",
     srcs = [

--- a/rtp_llm/cpp/cuda_graph/tests/combo_position_ids_validation_test.cc
+++ b/rtp_llm/cpp/cuda_graph/tests/combo_position_ids_validation_test.cc
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "rtp_llm/cpp/cuda_graph/combo_position_ids_validation.h"
+
+namespace rtp_llm {
+namespace {
+
+TEST(ComboPositionIdsValidationTest, AcceptsExactSourceAndDestinationSizes) {
+    const auto options = torch::TensorOptions().dtype(torch::kInt32);
+    const auto src     = torch::zeros({6}, options);
+    const auto dst     = torch::zeros({6}, options);
+    size_t     copy_numel;
+
+    EXPECT_TRUE(validateComboPositionIdsForReplay(3, 2, src, dst, copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+}
+
+TEST(ComboPositionIdsValidationTest, RejectsTooSmallSourceOrDestination) {
+    const auto options = torch::TensorOptions().dtype(torch::kInt32);
+    size_t     copy_numel;
+
+    EXPECT_FALSE(
+        validateComboPositionIdsForReplay(3, 2, torch::zeros({3}, options), torch::zeros({6}, options), copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+    EXPECT_FALSE(
+        validateComboPositionIdsForReplay(3, 2, torch::zeros({6}, options), torch::zeros({3}, options), copy_numel));
+    EXPECT_EQ(copy_numel, 6);
+}
+
+TEST(ComboPositionIdsValidationTest, RejectsInvalidTensorContracts) {
+    const auto int_options = torch::TensorOptions().dtype(torch::kInt32);
+    const auto valid       = torch::zeros({6}, int_options);
+    size_t     copy_numel;
+
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::Tensor(), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({6}, torch::kInt64), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({2, 3}, int_options).t(), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 2, torch::zeros({5}, int_options), valid, copy_numel));
+    EXPECT_FALSE(validateComboPositionIdsForReplay(3, 0, valid, valid, copy_numel));
+}
+
+TEST(ComboPositionIdsValidationTest, DisabledFactorNeedsNoPositionIds) {
+    size_t copy_numel = 1;
+    EXPECT_TRUE(validateComboPositionIdsForReplay(0, 0, torch::Tensor(), torch::Tensor(), copy_numel));
+    EXPECT_EQ(copy_numel, 0);
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/model_utils/RopeConfig.cc
+++ b/rtp_llm/cpp/model_utils/RopeConfig.cc
@@ -19,8 +19,8 @@ std::string RopeConfig::DebugRopeConfigStr() const {
     oss << "  mrope_dim1: " << mrope_dim1 << std::endl;
     oss << "  mrope_dim2: " << mrope_dim2 << std::endl;
     oss << "  mrope_dim3: " << mrope_dim3 << std::endl;
+    oss << "  mrope_interleaved: " << mrope_interleaved << std::endl;
     return oss.str();
 }
 
 }  // namespace rtp_llm
-

--- a/rtp_llm/cpp/model_utils/RopeConfig.h
+++ b/rtp_llm/cpp/model_utils/RopeConfig.h
@@ -34,6 +34,7 @@ struct RopeConfig {
     int   mrope_dim1            = 0;
     int   mrope_dim2            = 0;
     int   mrope_dim3            = 0;
+    bool  mrope_interleaved     = false;
     bool  is_neox_style         = true;
     bool  indexer_is_neox_style = true;
 

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1426,6 +1426,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("mrope_dim1", &RopeConfig::mrope_dim1)
         .def_readwrite("mrope_dim2", &RopeConfig::mrope_dim2)
         .def_readwrite("mrope_dim3", &RopeConfig::mrope_dim3)
+        .def_readwrite("mrope_interleaved", &RopeConfig::mrope_interleaved)
         .def_readwrite("is_neox_style", &RopeConfig::is_neox_style)
         .def_readwrite("indexer_is_neox_style", &RopeConfig::indexer_is_neox_style);
 

--- a/rtp_llm/models/qwen2_vl.py
+++ b/rtp_llm/models/qwen2_vl.py
@@ -259,6 +259,9 @@ class QWen2_VL(QWen_VL):
         rope_config.mrope_dim1 = mrope_section[0]
         rope_config.mrope_dim2 = mrope_section[1]
         rope_config.mrope_dim3 = mrope_section[2]
+        rope_config.mrope_interleaved = config_json.get("rope_scaling", {}).get(
+            "mrope_interleaved", False
+        )
         rope_config.dim = 128
 
     @staticmethod

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -11,10 +11,7 @@ from rtp_llm.models.qwen3_next.qwen3_next_weight import (
     Qwen35DenseWeight,
     Qwen35MoeWeight,
 )
-from rtp_llm.ops import (
-    KVCacheSpecType,
-    HybridAttentionType,
-)
+from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
 
 
 class Qwen3NextBase(BaseModel):
@@ -200,9 +197,11 @@ class Qwen35Moe(Qwen3NextBase):
     @classmethod
     def _parse_rope_config(cls, config_json: dict, config: ModelConfig):
         rope_parameters = config_json["rope_parameters"]
-        # TODO@xieshui support mrope in cuda graph and reopen config
-        mrope_interleaved = rope_parameters["mrope_interleaved"]
-        assert mrope_interleaved, "mrope_interleaved should be True"
+        mrope_interleaved = rope_parameters.get("mrope_interleaved", True)
+        if not mrope_interleaved:
+            raise ValueError(
+                "Qwen3Next requires rope_parameters.mrope_interleaved to be true"
+            )
         config.attn_config.rope_config.style = 7
         config.attn_config.rope_config.base = rope_parameters["rope_theta"]
         config.partial_rotary_factor = rope_parameters["partial_rotary_factor"]
@@ -214,6 +213,7 @@ class Qwen35Moe(Qwen3NextBase):
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = mrope_interleaved
         config.mm_model_config.mm_position_ids_style = 2
 
     @classmethod
@@ -233,10 +233,11 @@ class Qwen35Moe(Qwen3NextBase):
         moe_config = self.moe_config
         max_generate_batch_size = self.max_generate_batch_size
 
+        from rtp_llm.device.device_type import is_hip
         from rtp_llm.models_py.utils.arch import is_cuda
 
-        if not is_cuda():
-            raise RuntimeError("Qwen3Next is only supported in cuda arch")
+        if not is_cuda() and not is_hip():
+            raise RuntimeError("Qwen3Next is only supported in cuda/rocm arch")
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -101,11 +101,16 @@ class QWen3_VL(QwenV3):
         config.config_dtype = config_json.get("torch_dtype", None)
 
         config.attn_config.rope_config.style = 7
-        mrope_section = config_json["rope_scaling"].get("mrope_section", [16, 24, 24])
+        # Qwen3-VL interleaves T/H/W rotary pairs; the model default for a
+        # 128-dim rotary region is 24/20/20 (64 pairs total).
+        mrope_section = config_json["rope_scaling"].get("mrope_section", [24, 20, 20])
         config.attn_config.rope_config.index_factor = len(mrope_section)
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]
         config.attn_config.rope_config.mrope_dim3 = mrope_section[2]
+        config.attn_config.rope_config.mrope_interleaved = config_json[
+            "rope_scaling"
+        ].get("mrope_interleaved", True)
         config.mm_model_config.mm_position_ids_style = 2
 
         config.mm_related_params.config["ckpt_path"] = config.ckpt_path

--- a/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
+++ b/rtp_llm/models_py/bindings/common/kernels/rotary_position_embedding.h
@@ -1015,7 +1015,7 @@ __device__ inline void context_rope(RopeConfig    rope_config,
         input_len = input_len + prefix_prompt_length;
         seqidx    = seqidx + prefix_prompt_length;
     }
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         seqidx = position_id;
     }
 
@@ -1046,7 +1046,7 @@ __device__ inline void attention_rope(RopeConfig rope_config,
         prefix_prompt_length = 0;
     }
 
-    if (position_id > 0) {
+    if (position_id > 0 || (position_id == 0 && rope_config.style == RopeStyle::Mrope)) {
         tlength = position_id;
     }
 

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -12,6 +12,58 @@
 
 namespace rtp_llm {
 
+namespace {
+
+void validateMropeConfig(const AttentionConfigs& attn_configs) {
+    const RopeConfig& rope_config = attn_configs.rope_config;
+    if (rope_config.style != RopeStyle::Mrope) {
+        return;
+    }
+    if (!rope_config.mrope_interleaved) {
+        throw std::runtime_error("ROCm FusedRopeKVCache does not support MRoPE with mrope_interleaved=false. "
+                                 "Use mrope_interleaved=true or disable the fused rope path.");
+    }
+    if (rope_config.index_factor != 3) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE requires index_factor=3, got "
+                                 + std::to_string(rope_config.index_factor));
+    }
+    if (rope_config.dim <= 0 || rope_config.dim % 2 != 0) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE requires a positive even rope dim, got "
+                                 + std::to_string(rope_config.dim));
+    }
+    if (rope_config.dim > attn_configs.size_per_head) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE rope dim exceeds size_per_head: rope dim="
+                                 + std::to_string(rope_config.dim)
+                                 + ", size_per_head=" + std::to_string(attn_configs.size_per_head));
+    }
+    if (rope_config.mrope_dim1 < 0 || rope_config.mrope_dim2 < 0 || rope_config.mrope_dim3 < 0) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE sections must be non-negative");
+    }
+
+    const int64_t section_sum = static_cast<int64_t>(rope_config.mrope_dim1)
+                                + static_cast<int64_t>(rope_config.mrope_dim2)
+                                + static_cast<int64_t>(rope_config.mrope_dim3);
+    const int rotary_pair_count = rope_config.dim / 2;
+    if (section_sum != rotary_pair_count) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE section sum must equal rope dim / 2: got "
+                                 + std::to_string(section_sum) + ", expected " + std::to_string(rotary_pair_count));
+    }
+
+    // Qwen3/3.5 interleaves pair indices as T,H,W,T,H,W,... and leaves
+    // unclaimed H/W slots on the temporal axis. Each requested section must
+    // therefore fit the number of corresponding slots in the rotary region.
+    const int max_height_pairs = (rotary_pair_count + 1) / 3;
+    const int max_width_pairs  = rotary_pair_count / 3;
+    if (rope_config.mrope_dim2 > max_height_pairs || rope_config.mrope_dim3 > max_width_pairs) {
+        throw std::runtime_error("ROCm FusedRopeKVCache MRoPE sections exceed interleaved H/W capacity: H="
+                                 + std::to_string(rope_config.mrope_dim2) + " (max " + std::to_string(max_height_pairs)
+                                 + "), W=" + std::to_string(rope_config.mrope_dim3) + " (max "
+                                 + std::to_string(max_width_pairs) + ")");
+    }
+}
+
+}  // namespace
+
 static at::ScalarType get_fp8_dtype() {
     hipDeviceProp_t prop;
     int             device_id = 0;
@@ -84,22 +136,9 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
-    }
-}
-
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
+    validateMropeConfig(attn_configs_);
 }
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
@@ -144,14 +183,29 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
         attn_params->prefix_lengths = attn_inputs.prefix_lengths;
     }
     attn_params->kv_block_array.cache_type = attn_configs_.kv_cache_dtype;
-    attn_params->position_ids = attn_inputs.combo_position_ids;
+    attn_params->position_ids              = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error("MRoPE prefill requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num    = int(attn_inputs.input_lengths.sum().item<int64_t>());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error("MRoPE prefill combo_position_ids too small: got "
+                                     + std::to_string(attn_params->position_ids.numel()) + ", expected at least "
+                                     + std::to_string(min_expected) + " (token_num=" + std::to_string(token_num)
+                                     + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
 
-// Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
+    // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
         attn_params->position_ids =
             attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
     }
-    
+
     int max_prefix_length = 0;
     if (has_prefix && attn_params->prefix_lengths.defined() && attn_params->prefix_lengths.numel() > 0) {
         max_prefix_length = attn_params->prefix_lengths.max().item<int32_t>();
@@ -353,7 +407,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
     attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
+    validateMropeConfig(attn_configs_);
 }
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
@@ -392,6 +446,21 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     attn_params->prefix_lengths            = attn_inputs.prefix_lengths;
     attn_params->padding_offset            = attn_inputs.padding_offset;
     attn_params->position_ids              = attn_inputs.combo_position_ids;
+    // MRoPE requires combo_position_ids with index_factor axes
+    if (attn_configs_.rope_config.style == RopeStyle::Mrope) {
+        int expected_factor = attn_configs_.rope_config.index_factor;
+        if (!attn_params->position_ids.defined() || attn_params->position_ids.numel() == 0) {
+            throw std::runtime_error("MRoPE requires combo_position_ids but it is undefined or empty");
+        }
+        int token_num    = int(attn_inputs.sequence_lengths.numel());
+        int min_expected = token_num * expected_factor;
+        if (attn_params->position_ids.numel() < min_expected) {
+            throw std::runtime_error("MRoPE combo_position_ids too small: got "
+                                     + std::to_string(attn_params->position_ids.numel()) + ", expected at least "
+                                     + std::to_string(min_expected) + " (token_num=" + std::to_string(token_num)
+                                     + ", index_factor=" + std::to_string(expected_factor) + ")");
+        }
+    }
     // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
     if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
         attn_params->position_ids =

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -101,6 +101,33 @@ inline __device__ type_out* reinterpret_ptr(void* ptr, size_t offset) {
     return reinterpret_cast<type_out*>(reinterpret_cast<type_in*>(ptr) + offset);
 }
 
+__device__ __forceinline__ int get_mrope_position_dim(const RopeConfig& rope_config, const int tidx) {
+    // Vec_t<T> contains one rotary pair after RotaryHalfRead, so tidx is
+    // the frequency-pair index. Qwen3/3.5 assigns H/W to interleaved slots
+    // and keeps all remaining slots on the temporal axis. The host validates
+    // that the three section counts sum to rope_config.dim / 2 and fit these
+    // interleaved slots before launching the kernel.
+    if (tidx % 3 == 1 && tidx < rope_config.mrope_dim2 * 3) {
+        return 1;
+    }
+    if (tidx % 3 == 2 && tidx < rope_config.mrope_dim3 * 3) {
+        return 2;
+    }
+    return 0;
+}
+
+__device__ __forceinline__ int
+get_rope_position_id(const RopeConfig& rope_config, const int* position_ids, const int token_idx, const int tidx) {
+    if (!position_ids) {
+        return -1;
+    }
+    if (rope_config.style == RopeStyle::Mrope) {
+        const int now_dim = get_mrope_position_dim(rope_config, tidx);
+        return position_ids[token_idx * rope_config.index_factor + now_dim];
+    }
+    return position_ids[token_idx * rope_config.index_factor];
+}
+
 inline __device__ void convert_to_fp8(__hip_fp8x2_e4m3_fnuz* v, const amd_bfloat162 u) {
     __hip_bfloat162_raw   raw_bf16  = *reinterpret_cast<const __hip_bfloat162_raw*>(&u);
     __hip_fp8x2_storage_t raw_fp8x2 = __hip_cvt_bfloat16raw2_to_fp8x2(raw_bf16, __HIP_SATFINITE, __HIP_E4M3_FNUZ);
@@ -215,21 +242,9 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
-    const int pre_len   = cu_seqlens[batch_idx];
-    const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
+    int       position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    const int pre_len     = cu_seqlens[batch_idx];
+    const int input_len   = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                        q,
                                        k,
@@ -385,21 +400,27 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
 // V3 must match its caller's layout or the FMHA reader will see garbage V.
 // =====================================================================================
 template<bool V_VEC_LAYOUT>
-__global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
-    __nv_bfloat16*                 q_buf,
-    __nv_bfloat16*                 k_buf,
-    __nv_bfloat16*                 v_buf,
-    const __nv_bfloat16*           QKV,
-    const __nv_bfloat16* __restrict qkv_bias,
-    const int*           __restrict padding_offset,
-    const float2*        __restrict cos_sin_cache,
-    PrefixPromptBatchWeightsParam   param,
-    int token_num, int head_num, int head_num_kv, int head_dim, int seq_len,
-    int rot_dim, float rope_base, float rope_scale,
-    bool store_kv, bool store_cache) {
-    constexpr int VEC = 8;
-    constexpr int K_TOK = 4;
-    extern __shared__ __nv_bfloat16 smem[];   // [K_TOK][head_dim] BF16
+__global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(__nv_bfloat16*       q_buf,
+                                                                 __nv_bfloat16*       k_buf,
+                                                                 __nv_bfloat16*       v_buf,
+                                                                 const __nv_bfloat16* QKV,
+                                                                 const __nv_bfloat16* __restrict qkv_bias,
+                                                                 const int* __restrict padding_offset,
+                                                                 const float2* __restrict cos_sin_cache,
+                                                                 PrefixPromptBatchWeightsParam param,
+                                                                 int                           token_num,
+                                                                 int                           head_num,
+                                                                 int                           head_num_kv,
+                                                                 int                           head_dim,
+                                                                 int                           seq_len,
+                                                                 int                           rot_dim,
+                                                                 float                         rope_base,
+                                                                 float                         rope_scale,
+                                                                 bool                          store_kv,
+                                                                 bool                          store_cache) {
+    constexpr int                   VEC   = 8;
+    constexpr int                   K_TOK = 4;
+    extern __shared__ __nv_bfloat16 smem[];  // [K_TOK][head_dim] BF16
 
     const int tok_local = threadIdx.y;
     const int token_idx = blockIdx.x * K_TOK + tok_local;
@@ -425,21 +446,21 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
     const int  d_part  = is_lo ? (d + half_r) : (d - half_r);
     const int  rope_d  = is_lo ? d : d_part;
 
-    const int  token_padding_offset = padding_offset ? padding_offset[safe_token_idx] : 0;
-    const int  tgt_token_idx = safe_token_idx + token_padding_offset;
-    const int  batch_idx = tgt_token_idx / seq_len;
-    const int  dst_kv_seq_idx = tgt_token_idx % seq_len;
+    const int token_padding_offset = padding_offset ? padding_offset[safe_token_idx] : 0;
+    const int tgt_token_idx        = safe_token_idx + token_padding_offset;
+    const int batch_idx            = tgt_token_idx / seq_len;
+    const int dst_kv_seq_idx       = tgt_token_idx % seq_len;
     // V3 dispatch guard enforces prefix==0, so batch-local seq_idx is the
     // absolute RoPE position — no external position_ids needed.
-    const int  pos_id = dst_kv_seq_idx;
+    const int pos_id = dst_kv_seq_idx;
 
-    const int n      = head_num    * head_dim;
-    const int kv_n   = head_num_kv * head_dim;
-    const int hidden = n + 2 * kv_n;
+    const int n       = head_num * head_dim;
+    const int kv_n    = head_num_kv * head_dim;
+    const int hidden  = n + 2 * kv_n;
     const int row_off = safe_token_idx * hidden;
 
-    auto load8  = [](const __nv_bfloat16* p) { return *reinterpret_cast<const int4*>(p); };
-    auto store8 = [](__nv_bfloat16* p, int4 v) { *reinterpret_cast<int4*>(p) = v; };
+    auto           load8    = [](const __nv_bfloat16* p) { return *reinterpret_cast<const int4*>(p); };
+    auto           store8   = [](__nv_bfloat16* p, int4 v) { *reinterpret_cast<int4*>(p) = v; };
     __nv_bfloat16* smem_row = smem + tok_local * head_dim;
 
     // ---- inv_freq (per thread, shared across all heads) ----
@@ -449,49 +470,52 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
     // (__powf ~6 ULP, __sincosf ~2-3 ULP) drift enough across many layers/heads
     // to flip greedy decoding at marginal logit positions (observed regression
     // in Eagle speculative decoding on Qwen2-14B).
-    float inv_freq_lo[VEC/2], inv_freq_hi[VEC/2];
+    float inv_freq_lo[VEC / 2], inv_freq_hi[VEC / 2];
     if (in_rope && !cos_sin_cache) {
         const float inv_rot_dim = 1.0f / float(rot_dim);
-        #pragma unroll
-        for (int i = 0; i < VEC/2; ++i) {
-            inv_freq_lo[i] = powf(rope_base, -float(2 * (rope_d + 2*i))     * inv_rot_dim);
-            inv_freq_hi[i] = powf(rope_base, -float(2 * (rope_d + 2*i + 1)) * inv_rot_dim);
+#pragma unroll
+        for (int i = 0; i < VEC / 2; ++i) {
+            inv_freq_lo[i] = powf(rope_base, -float(2 * (rope_d + 2 * i)) * inv_rot_dim);
+            inv_freq_hi[i] = powf(rope_base, -float(2 * (rope_d + 2 * i + 1)) * inv_rot_dim);
         }
     }
 
     // ---- cs_lo/cs_hi (per token, shared across all heads of this block) ----
-    float2 cs_lo[VEC/2], cs_hi[VEC/2];
+    float2 cs_lo[VEC / 2], cs_hi[VEC / 2];
     if (in_rope) {
-        #pragma unroll
-        for (int i = 0; i < VEC/2; ++i) {
+#pragma unroll
+        for (int i = 0; i < VEC / 2; ++i) {
             if (cos_sin_cache) {
-                cs_lo[i] = cos_sin_cache[pos_id * half_r + rope_d + 2*i];
-                cs_hi[i] = cos_sin_cache[pos_id * half_r + rope_d + 2*i + 1];
+                cs_lo[i] = cos_sin_cache[pos_id * half_r + rope_d + 2 * i];
+                cs_hi[i] = cos_sin_cache[pos_id * half_r + rope_d + 2 * i + 1];
             } else {
                 // Compute angle in float, but evaluate sincos in double to
                 // match V1 (rotary_position_embedding.h:340 declares
                 // `double sin_i, cos_i;` for ROCm before calling sincos).
-                float angle0 = float(pos_id) * inv_freq_lo[i] / rope_scale;
-                float angle1 = float(pos_id) * inv_freq_hi[i] / rope_scale;
+                float  angle0 = float(pos_id) * inv_freq_lo[i] / rope_scale;
+                float  angle1 = float(pos_id) * inv_freq_hi[i] / rope_scale;
                 double s0, c0, s1, c1;
                 sincos((double)angle0, &s0, &c0);
                 sincos((double)angle1, &s1, &c1);
-                cs_lo[i].x = (float)c0; cs_lo[i].y = (float)s0;
-                cs_hi[i].x = (float)c1; cs_hi[i].y = (float)s1;
+                cs_lo[i].x = (float)c0;
+                cs_lo[i].y = (float)s0;
+                cs_hi[i].x = (float)c1;
+                cs_hi[i].y = (float)s1;
             }
         }
     }
 
     // ---- Process all Q heads ----
     for (int h = 0; h < head_num; ++h) {
-        const int q_off = h * head_dim;
-        int4 q_pack = load8(&QKV[row_off + q_off + d]);
-        auto* q2 = reinterpret_cast<__nv_bfloat162*>(&q_pack);
+        const int q_off  = h * head_dim;
+        int4      q_pack = load8(&QKV[row_off + q_off + d]);
+        auto*     q2     = reinterpret_cast<__nv_bfloat162*>(&q_pack);
         if (qkv_bias) {
-            int4 qb_pack = load8(&qkv_bias[q_off + d]);
-            auto* qb2 = reinterpret_cast<__nv_bfloat162*>(&qb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) q2[i] = __hadd2(q2[i], qb2[i]);
+            int4  qb_pack = load8(&qkv_bias[q_off + d]);
+            auto* qb2     = reinterpret_cast<__nv_bfloat162*>(&qb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                q2[i] = __hadd2(q2[i], qb2[i]);
         }
         // Partner exchange via smem. Only rotary-region threads (in_rope=true)
         // need to read their partner; passthrough threads still write so the
@@ -500,82 +524,82 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
         __syncthreads();
         int4 q_out_pack = q_pack;  // passthrough default
         if (in_rope) {
-            int4 q_partner_pack = load8(&smem_row[d_part]);
-            auto* qp2 = reinterpret_cast<__nv_bfloat162*>(&q_partner_pack);
-            auto* qo2 = reinterpret_cast<__nv_bfloat162*>(&q_out_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) {
+            int4  q_partner_pack = load8(&smem_row[d_part]);
+            auto* qp2            = reinterpret_cast<__nv_bfloat162*>(&q_partner_pack);
+            auto* qo2            = reinterpret_cast<__nv_bfloat162*>(&q_out_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i) {
                 float2 cs0 = cs_lo[i], cs1 = cs_hi[i];
-                float s0 = __bfloat162float(__low2bfloat16(q2[i]));
-                float s1 = __bfloat162float(__high2bfloat16(q2[i]));
-                float p0 = __bfloat162float(__low2bfloat16(qp2[i]));
-                float p1 = __bfloat162float(__high2bfloat16(qp2[i]));
-                float o0 = is_lo ? (s0*cs0.x - p0*cs0.y) : (s0*cs0.x + p0*cs0.y);
-                float o1 = is_lo ? (s1*cs1.x - p1*cs1.y) : (s1*cs1.x + p1*cs1.y);
-                qo2[i] = __floats2bfloat162_rn(o0, o1);
+                float  s0 = __bfloat162float(__low2bfloat16(q2[i]));
+                float  s1 = __bfloat162float(__high2bfloat16(q2[i]));
+                float  p0 = __bfloat162float(__low2bfloat16(qp2[i]));
+                float  p1 = __bfloat162float(__high2bfloat16(qp2[i]));
+                float  o0 = is_lo ? (s0 * cs0.x - p0 * cs0.y) : (s0 * cs0.x + p0 * cs0.y);
+                float  o1 = is_lo ? (s1 * cs1.x - p1 * cs1.y) : (s1 * cs1.x + p1 * cs1.y);
+                qo2[i]    = __floats2bfloat162_rn(o0, o1);
             }
         }
         if (active) {
             store8(&q_buf[(size_t)token_idx * n + q_off + d], q_out_pack);
         }
-        __syncthreads();   // before next head reuses smem
+        __syncthreads();  // before next head reuses smem
     }
 
     // ---- Process all K, V heads ----
-    KVBlockArray kv_block_array;
+    KVBlockArray   kv_block_array;
     __nv_bfloat16 *k_cache = nullptr, *v_cache = nullptr;
     if (store_cache && active) {
         kv_block_array = param.kv_block_array;
-        k_cache = reinterpret_cast<__nv_bfloat16*>(
-            kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
-        v_cache = reinterpret_cast<__nv_bfloat16*>(
-            kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
+        k_cache        = reinterpret_cast<__nv_bfloat16*>(kv_block_array.getKBlockPtr(batch_idx, dst_kv_seq_idx));
+        v_cache        = reinterpret_cast<__nv_bfloat16*>(kv_block_array.getVBlockPtr(batch_idx, dst_kv_seq_idx));
     }
     for (int h = 0; h < head_num_kv; ++h) {
         const int k_off = n + h * head_dim;
         const int v_off = n + kv_n + h * head_dim;
 
         // K
-        int4 k_pack = load8(&QKV[row_off + k_off + d]);
-        auto* k2 = reinterpret_cast<__nv_bfloat162*>(&k_pack);
+        int4  k_pack = load8(&QKV[row_off + k_off + d]);
+        auto* k2     = reinterpret_cast<__nv_bfloat162*>(&k_pack);
         if (qkv_bias) {
-            int4 kb_pack = load8(&qkv_bias[k_off + d]);
-            auto* kb2 = reinterpret_cast<__nv_bfloat162*>(&kb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) k2[i] = __hadd2(k2[i], kb2[i]);
+            int4  kb_pack = load8(&qkv_bias[k_off + d]);
+            auto* kb2     = reinterpret_cast<__nv_bfloat162*>(&kb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                k2[i] = __hadd2(k2[i], kb2[i]);
         }
         store8(&smem_row[d], k_pack);
         __syncthreads();
         int4 k_out_pack = k_pack;  // passthrough default
         if (in_rope) {
-            int4 k_partner_pack = load8(&smem_row[d_part]);
-            auto* kp2 = reinterpret_cast<__nv_bfloat162*>(&k_partner_pack);
-            auto* ko2 = reinterpret_cast<__nv_bfloat162*>(&k_out_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) {
+            int4  k_partner_pack = load8(&smem_row[d_part]);
+            auto* kp2            = reinterpret_cast<__nv_bfloat162*>(&k_partner_pack);
+            auto* ko2            = reinterpret_cast<__nv_bfloat162*>(&k_out_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i) {
                 float2 cs0 = cs_lo[i], cs1 = cs_hi[i];
-                float s0 = __bfloat162float(__low2bfloat16(k2[i]));
-                float s1 = __bfloat162float(__high2bfloat16(k2[i]));
-                float p0 = __bfloat162float(__low2bfloat16(kp2[i]));
-                float p1 = __bfloat162float(__high2bfloat16(kp2[i]));
-                float o0 = is_lo ? (s0*cs0.x - p0*cs0.y) : (s0*cs0.x + p0*cs0.y);
-                float o1 = is_lo ? (s1*cs1.x - p1*cs1.y) : (s1*cs1.x + p1*cs1.y);
-                ko2[i] = __floats2bfloat162_rn(o0, o1);
+                float  s0 = __bfloat162float(__low2bfloat16(k2[i]));
+                float  s1 = __bfloat162float(__high2bfloat16(k2[i]));
+                float  p0 = __bfloat162float(__low2bfloat16(kp2[i]));
+                float  p1 = __bfloat162float(__high2bfloat16(kp2[i]));
+                float  o0 = is_lo ? (s0 * cs0.x - p0 * cs0.y) : (s0 * cs0.x + p0 * cs0.y);
+                float  o1 = is_lo ? (s1 * cs1.x - p1 * cs1.y) : (s1 * cs1.x + p1 * cs1.y);
+                ko2[i]    = __floats2bfloat162_rn(o0, o1);
             }
         }
         if (active && store_kv) {
             store8(&k_buf[(size_t)token_idx * kv_n + h * head_dim + d], k_out_pack);
         }
-        __syncthreads();   // before next iteration uses smem
+        __syncthreads();  // before next iteration uses smem
 
         // V (no RoPE)
-        int4 v_pack = load8(&QKV[row_off + v_off + d]);
-        auto* v2 = reinterpret_cast<__nv_bfloat162*>(&v_pack);
+        int4  v_pack = load8(&QKV[row_off + v_off + d]);
+        auto* v2     = reinterpret_cast<__nv_bfloat162*>(&v_pack);
         if (qkv_bias) {
-            int4 vb_pack = load8(&qkv_bias[v_off + d]);
-            auto* vb2 = reinterpret_cast<__nv_bfloat162*>(&vb_pack);
-            #pragma unroll
-            for (int i = 0; i < VEC/2; ++i) v2[i] = __hadd2(v2[i], vb2[i]);
+            int4  vb_pack = load8(&qkv_bias[v_off + d]);
+            auto* vb2     = reinterpret_cast<__nv_bfloat162*>(&vb_pack);
+#pragma unroll
+            for (int i = 0; i < VEC / 2; ++i)
+                v2[i] = __hadd2(v2[i], vb2[i]);
         }
         if (active && store_kv) {
             store8(&v_buf[(size_t)token_idx * kv_n + h * head_dim + d], v_pack);
@@ -583,17 +607,15 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
 
         // Cache write
         if (store_cache && active) {
-            const int inK = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(
-                dst_kv_seq_idx, h, head_dim, d);
+            const int inK = kv_block_array.getKLocalIdx<KvCacheDataType::BASE>(dst_kv_seq_idx, h, head_dim, d);
             *reinterpret_cast<int4*>(&k_cache[inK]) = k_out_pack;
-            const __nv_bfloat16* v_src = reinterpret_cast<const __nv_bfloat16*>(&v_pack);
-            #pragma unroll
+            const __nv_bfloat16* v_src              = reinterpret_cast<const __nv_bfloat16*>(&v_pack);
+#pragma unroll
             for (int vi = 0; vi < VEC; ++vi) {
-                const int inV = V_VEC_LAYOUT
-                    ? kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(
-                          dst_kv_seq_idx, h, head_dim, d + vi)
-                    : kv_block_array.getVLocalIdx(
-                          dst_kv_seq_idx, h, head_dim, d + vi);
+                const int inV =
+                    V_VEC_LAYOUT ?
+                        kv_block_array.getVLocalIdx<KvCacheDataType::BASE>(dst_kv_seq_idx, h, head_dim, d + vi) :
+                        kv_block_array.getVLocalIdx(dst_kv_seq_idx, h, head_dim, d + vi);
                 v_cache[inV] = v_src[vi];
             }
         }
@@ -603,46 +625,105 @@ __global__ void add_fusedQKV_bias_transpose_prefill_v3_all_heads(
 // Compile-time dispatcher: only BF16 specialization actually launches v3.
 template<typename T>
 struct V3OptKernelDispatch {
-    static bool try_launch(T*, T*, T*, const T*, const T*,
-                           const int*, const float2*,
+    static bool try_launch(T*,
+                           T*,
+                           T*,
+                           const T*,
+                           const T*,
+                           const int*,
+                           const float2*,
                            PrefixPromptBatchWeightsParam&,
-                           int, int, int, int, int, int, float, float, bool, bool, bool, cudaStream_t) {
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           float,
+                           float,
+                           bool,
+                           bool,
+                           bool,
+                           cudaStream_t) {
         return false;
     }
 };
 template<>
 struct V3OptKernelDispatch<__nv_bfloat16> {
-    static bool try_launch(__nv_bfloat16* q_buf, __nv_bfloat16* k_buf, __nv_bfloat16* v_buf,
-                           const __nv_bfloat16* QKV, const __nv_bfloat16* qkv_bias,
-                           const int* padding_offset, const float2* cos_sin_cache,
+    static bool try_launch(__nv_bfloat16*                 q_buf,
+                           __nv_bfloat16*                 k_buf,
+                           __nv_bfloat16*                 v_buf,
+                           const __nv_bfloat16*           QKV,
+                           const __nv_bfloat16*           qkv_bias,
+                           const int*                     padding_offset,
+                           const float2*                  cos_sin_cache,
                            PrefixPromptBatchWeightsParam& param,
-                           int token_num, int head_num, int head_num_kv, int head_dim, int seq_len,
-                           int rot_dim, float rope_base, float rope_scale,
-                           bool store_kv, bool store_cache, bool v_vec_layout, cudaStream_t stream) {
+                           int                            token_num,
+                           int                            head_num,
+                           int                            head_num_kv,
+                           int                            head_dim,
+                           int                            seq_len,
+                           int                            rot_dim,
+                           float                          rope_base,
+                           float                          rope_scale,
+                           bool                           store_kv,
+                           bool                           store_cache,
+                           bool                           v_vec_layout,
+                           cudaStream_t                   stream) {
         constexpr int VEC = 8, K_TOK = 4;
-        if (head_dim % VEC != 0) return false;
-        if (head_dim % 2 != 0) return false;
+        if (head_dim % VEC != 0)
+            return false;
+        if (head_dim % 2 != 0)
+            return false;
         // Partial rotary requires rot_dim aligned to VEC*2 so each thread is
         // either fully in the rotary region or fully passthrough, and the
         // partner index (rope_d ± half_r) stays inside the rotary region.
-        if (rot_dim % (VEC * 2) != 0) return false;
-        if (rot_dim > head_dim) return false;
+        if (rot_dim % (VEC * 2) != 0)
+            return false;
+        if (rot_dim > head_dim)
+            return false;
         dim3 block(head_dim / VEC, K_TOK);
         // v3: one block per token-chunk, iterates ALL heads inside
-        dim3 grid((token_num + K_TOK - 1) / K_TOK, 1);
+        dim3   grid((token_num + K_TOK - 1) / K_TOK, 1);
         size_t smem = K_TOK * head_dim * sizeof(__nv_bfloat16);
         if (v_vec_layout) {
-            add_fusedQKV_bias_transpose_prefill_v3_all_heads<true>
-                <<<grid, block, smem, stream>>>(
-                    q_buf, k_buf, v_buf, QKV, qkv_bias, padding_offset, cos_sin_cache,
-                    param, token_num, head_num, head_num_kv, head_dim, seq_len,
-                    rot_dim, rope_base, rope_scale, store_kv, store_cache);
+            add_fusedQKV_bias_transpose_prefill_v3_all_heads<true><<<grid, block, smem, stream>>>(q_buf,
+                                                                                                  k_buf,
+                                                                                                  v_buf,
+                                                                                                  QKV,
+                                                                                                  qkv_bias,
+                                                                                                  padding_offset,
+                                                                                                  cos_sin_cache,
+                                                                                                  param,
+                                                                                                  token_num,
+                                                                                                  head_num,
+                                                                                                  head_num_kv,
+                                                                                                  head_dim,
+                                                                                                  seq_len,
+                                                                                                  rot_dim,
+                                                                                                  rope_base,
+                                                                                                  rope_scale,
+                                                                                                  store_kv,
+                                                                                                  store_cache);
         } else {
-            add_fusedQKV_bias_transpose_prefill_v3_all_heads<false>
-                <<<grid, block, smem, stream>>>(
-                    q_buf, k_buf, v_buf, QKV, qkv_bias, padding_offset, cos_sin_cache,
-                    param, token_num, head_num, head_num_kv, head_dim, seq_len,
-                    rot_dim, rope_base, rope_scale, store_kv, store_cache);
+            add_fusedQKV_bias_transpose_prefill_v3_all_heads<false><<<grid, block, smem, stream>>>(q_buf,
+                                                                                                   k_buf,
+                                                                                                   v_buf,
+                                                                                                   QKV,
+                                                                                                   qkv_bias,
+                                                                                                   padding_offset,
+                                                                                                   cos_sin_cache,
+                                                                                                   param,
+                                                                                                   token_num,
+                                                                                                   head_num,
+                                                                                                   head_num_kv,
+                                                                                                   head_dim,
+                                                                                                   seq_len,
+                                                                                                   rot_dim,
+                                                                                                   rope_base,
+                                                                                                   rope_scale,
+                                                                                                   store_kv,
+                                                                                                   store_cache);
         }
         return true;
     }
@@ -676,7 +757,7 @@ void invokeAddFusedQKVBiasTransposePrefillV1(T*                             q_bu
                                              const bool                     store_cache,
                                              const float2*                  cos_sin_cache,
                                              cudaStream_t                   stream) {
-    auto&  param = *param_ptr;
+    auto& param = *param_ptr;
 
     // ---- v3 fast path (default ON) ----
     // Hand-tuned BF16 kernel: vec=8 + 4 tokens/block + smem partner exchange + cos/sin
@@ -692,27 +773,36 @@ void invokeAddFusedQKVBiasTransposePrefillV1(T*                             q_bu
     // in BHSD ([batch, head_kv, seq, dim]) layout, while V3 uses THD ([token,
     // head_kv, dim]). Production NonAsm uses store_kv=false (K/V only flow into
     // paged cache), so V3 fires by writing only to the paged cache.
-    if (use_paged_fmha
-        && param.max_prefix_prompt_length == 0
-        && store_q && !store_qkv && !store_kv && store_cache
+    if (use_paged_fmha && param.max_prefix_prompt_length == 0 && store_q && !store_qkv && !store_kv && store_cache
         && rope_config.style == RopeStyle::Base
         && rope_config.dim <= size_per_head  // partial rotary supported (rot_dim<=head_dim)
-        && rope_config.scale == 1.0f  // V3 scale path lacks precision tests; fall back to V1
-        && !use_logn_attn
-        && QuantizedQKV == nullptr
+        && rope_config.scale == 1.0f         // V3 scale path lacks precision tests; fall back to V1
+        && !use_logn_attn && QuantizedQKV == nullptr
         && qkv_bias == nullptr  // bias path is implemented but untested; fall back
         && param.kv_block_array.cache_type == KvCacheDataType::BASE) {
         // V1 invoker (NonAsm path) writes V cache in non-templated layout
         // [numHeads, dimsPerHead, mTokensPerBlock]. Pass v_vec_layout=false so
         // V3's V cache write matches what the NonAsm CK FMHA reader expects.
-        if (V3OptKernelDispatch<T>::try_launch(q_buf, k_buf, v_buf, QKV, qkv_bias,
-                                                padding_offset, cos_sin_cache,
-                                                param,
-                                                token_num, head_num, head_num_kv, size_per_head,
-                                                seq_len,
-                                                rope_config.dim, rope_config.base, rope_config.scale,
-                                                store_kv, store_cache, /*v_vec_layout=*/false,
-                                                stream)) {
+        if (V3OptKernelDispatch<T>::try_launch(q_buf,
+                                               k_buf,
+                                               v_buf,
+                                               QKV,
+                                               qkv_bias,
+                                               padding_offset,
+                                               cos_sin_cache,
+                                               param,
+                                               token_num,
+                                               head_num,
+                                               head_num_kv,
+                                               size_per_head,
+                                               seq_len,
+                                               rope_config.dim,
+                                               rope_config.base,
+                                               rope_config.scale,
+                                               store_kv,
+                                               store_cache,
+                                               /*v_vec_layout=*/false,
+                                               stream)) {
             return;
         }
     }
@@ -849,21 +939,9 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel(T*                   
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
-    const int pre_len   = cu_seqlens[batch_idx];
-    const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
+    int       position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    const int pre_len     = cu_seqlens[batch_idx];
+    const int input_len   = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                        q,
                                        k,
@@ -1027,7 +1105,7 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
                                            const float2*                  cos_sin_cache,
                                            const bool                     pad_query,
                                            cudaStream_t                   stream) {
-    auto&  param = *param_ptr;
+    auto& param = *param_ptr;
 
     // ---- v3 fast path (default ON, ASM-side invoker) ----
     // Mirrors the V3 dispatch in invokeAddFusedQKVBiasTransposePrefillV1. Required
@@ -1044,15 +1122,10 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
     // store_kv is excluded because the in-tree ASM kernel writes packed K/V in
     // BHSD layout while V3 uses THD; in production store_kv=false anyway, so
     // V3 only writes to the paged cache.
-    if (use_paged_fmha
-        && !pad_query
-        && param.max_prefix_prompt_length == 0
-        && store_q && !store_qkv && !store_kv && store_cache
-        && rope_config.style == RopeStyle::Base
+    if (use_paged_fmha && !pad_query && param.max_prefix_prompt_length == 0 && store_q && !store_qkv && !store_kv
+        && store_cache && rope_config.style == RopeStyle::Base
         && rope_config.dim <= size_per_head  // partial rotary supported
-        && rope_config.scale == 1.0f
-        && !use_logn_attn
-        && QuantizedQKV == nullptr
+        && rope_config.scale == 1.0f && !use_logn_attn && QuantizedQKV == nullptr
         && qkv_bias == nullptr  // bias path is implemented but untested; fall back
         && param.kv_block_array.cache_type == KvCacheDataType::BASE) {
         // ASM invoker writes V cache via getVLocalIdx<KvCacheDataType::BASE>
@@ -1060,14 +1133,26 @@ void invokeAddFusedQKVBiasTransposePrefill(T*                             q_buf,
         // Pass v_vec_layout=true so V3 produces the layout the ASM-flash FMHA
         // reader expects — using the V1-style flat layout here corrupts V cache
         // and yields garbage attention output (root cause of the precision bug).
-        if (V3OptKernelDispatch<T>::try_launch(q_buf, k_buf, v_buf, QKV, qkv_bias,
-                                                padding_offset, cos_sin_cache,
-                                                param,
-                                                token_num, head_num, head_num_kv, size_per_head,
-                                                seq_len,
-                                                rope_config.dim, rope_config.base, rope_config.scale,
-                                                store_kv, store_cache, /*v_vec_layout=*/true,
-                                                stream)) {
+        if (V3OptKernelDispatch<T>::try_launch(q_buf,
+                                               k_buf,
+                                               v_buf,
+                                               QKV,
+                                               qkv_bias,
+                                               padding_offset,
+                                               cos_sin_cache,
+                                               param,
+                                               token_num,
+                                               head_num,
+                                               head_num_kv,
+                                               size_per_head,
+                                               seq_len,
+                                               rope_config.dim,
+                                               rope_config.base,
+                                               rope_config.scale,
+                                               store_kv,
+                                               store_cache,
+                                               /*v_vec_layout=*/true,
+                                               stream)) {
             return;
         }
     }
@@ -1200,7 +1285,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int        position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;
@@ -1360,7 +1445,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    int        position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -399,6 +399,17 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
 
 
 class Qwen3NextGatedDeltaNetDecode(Qwen3NextGatedDeltaNetBase):
+    def _get_fla_block_map(self, attn_inputs: PyAttentionInputs) -> torch.Tensor:
+        block_map = attn_inputs.kv_cache_kernel_block_id_device
+        if (
+            attn_inputs.is_cuda_graph
+            and block_map is not None
+            and block_map.ndim == 2
+            and block_map.shape[1] > 1
+        ):
+            return block_map[:, :1]
+        return block_map
+
     def _conv1d(
         self,
         mixed_qkv: torch.Tensor,
@@ -473,7 +484,7 @@ class Qwen3NextGatedDeltaNetDecode(Qwen3NextGatedDeltaNetBase):
             scale=None,
             initial_state=ssm_states,
             inplace_final_state=True,
-            block_map=attn_inputs.kv_cache_kernel_block_id_device,
+            block_map=self._get_fla_block_map(attn_inputs),
             seq_size_per_block=seq_size_per_block,
             sequence_lengths=attn_inputs.sequence_lengths_plus_1_device,
             use_qk_l2norm_in_kernel=True,

--- a/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
+++ b/rtp_llm/models_py/model_desc/test/attention_input_routing_test.py
@@ -8,6 +8,7 @@ from torch import nn
 from rtp_llm.models_py.model_desc.block_map import get_group_tags_for_layers
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.model_desc.qwen3_next import (
+    Qwen3NextGatedDeltaNetDecode,
     Qwen3NextMetadata,
     _maybe_write_cp_cache_store,
     _write_cp_cache_store,
@@ -36,6 +37,30 @@ class RoutingModel(GptModelBase):
 
 
 class AttentionInputRoutingTest(unittest.TestCase):
+    def test_qwen3_next_cuda_graph_uses_narrow_block_map_view(self):
+        block_map = torch.arange(12, dtype=torch.int32).reshape(3, 4)
+        attention_inputs = SimpleNamespace(
+            is_cuda_graph=True,
+            kv_cache_kernel_block_id_device=block_map,
+        )
+        decode = object.__new__(Qwen3NextGatedDeltaNetDecode)
+
+        narrowed = decode._get_fla_block_map(attention_inputs)
+
+        self.assertEqual(narrowed.shape, (3, 1))
+        self.assertEqual(narrowed.stride(0), block_map.stride(0))
+        self.assertEqual(narrowed[:, 0].tolist(), [0, 4, 8])
+
+    def test_qwen3_next_non_graph_keeps_full_block_map(self):
+        block_map = torch.arange(12, dtype=torch.int32).reshape(3, 4)
+        attention_inputs = SimpleNamespace(
+            is_cuda_graph=False,
+            kv_cache_kernel_block_id_device=block_map,
+        )
+        decode = object.__new__(Qwen3NextGatedDeltaNetDecode)
+
+        self.assertIs(decode._get_fla_block_map(attention_inputs), block_map)
+
     def test_cp_cache_store_uses_each_layer_tag_metadata(self):
         expected = {}
         layer_inputs = {}

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -16,7 +16,13 @@ from rtp_llm.models_py.modules.factory.attention.rocm_impl._attn_utils import (
     split_raw_qkv,
     unpad_kv_vectorized,
 )
-from rtp_llm.ops import AttentionConfigs, FMHAType, KvCacheDataType, ParallelismConfig
+from rtp_llm.ops import (
+    AttentionConfigs,
+    FMHAType,
+    KvCacheDataType,
+    ParallelismConfig,
+    RopeStyle,
+)
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOpAsm,
     FusedRopeKVCacheDecodeOpNonAsm,
@@ -27,6 +33,14 @@ from rtp_llm.ops.compute_ops import (
     PyAttentionInputs,
     paged_attention_atrex,
 )
+
+
+def _mrope_interleaved_supported(attn_configs: AttentionConfigs) -> bool:
+    """Return whether ROCm fused RoPE supports the configured MRoPE layout."""
+    return not (
+        attn_configs.rope_config.style == RopeStyle.Mrope
+        and not attn_configs.rope_config.mrope_interleaved
+    )
 
 
 # Pure Python implementation of FMHAParams
@@ -1397,7 +1411,7 @@ class AiterPrefillImplAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1457,7 +1471,7 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1716,7 +1730,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1763,7 +1777,7 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,
@@ -1809,7 +1823,7 @@ class AiterDecodeImplTriton(AiterDecodeImplBase):
     def support(
         cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
     ) -> bool:
-        return True
+        return _mrope_interleaved_supported(attn_configs)
 
     def forward(
         self,

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -20,7 +20,7 @@ on the rest of the fleet.
 
 import math
 import unittest
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import torch
 import torch.nn.functional as F
@@ -50,7 +50,14 @@ try:
         RopeConfig,
         RopeStyle,
     )
-    from rtp_llm.ops.compute_ops import get_typemeta
+    from rtp_llm.ops.compute_ops import (
+        FusedRopeKVCacheDecodeOpAsm,
+        FusedRopeKVCacheDecodeOpNonAsm,
+        FusedRopeKVCachePrefillOpAsm,
+        FusedRopeKVCachePrefillOpNonAsm,
+        LayerKVCache,
+        get_typemeta,
+    )
 
     _OPS_IMPORTABLE = True
 except ImportError:
@@ -113,6 +120,28 @@ def _make_rope_attn_configs(
     return cfg
 
 
+def _make_mrope_attn_configs(
+    head_num: int,
+    head_num_kv: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    rope_dim: int = 64,
+    mrope_sections: Sequence[int] = (11, 11, 10),
+    tokens_per_block: int = 16,
+):
+    cfg = _make_rope_attn_configs(
+        head_num, head_num_kv, head_dim, dtype, tokens_per_block
+    )
+    cfg.rope_config.style = RopeStyle.Mrope
+    cfg.rope_config.dim = rope_dim
+    cfg.rope_config.index_factor = 3
+    cfg.rope_config.mrope_dim1 = mrope_sections[0]
+    cfg.rope_config.mrope_dim2 = mrope_sections[1]
+    cfg.rope_config.mrope_dim3 = mrope_sections[2]
+    cfg.rope_config.mrope_interleaved = True
+    return cfg
+
+
 def _make_rope_prefill_inputs(
     input_lengths: List[int], device: torch.device, dtype: torch.dtype
 ):
@@ -149,6 +178,125 @@ def _make_rope_prefill_inputs(
     return attn_inputs
 
 
+def _make_mrope_prefill_inputs(
+    input_lengths: List[int], device: torch.device, dtype: torch.dtype
+):
+    attn_inputs = _make_rope_prefill_inputs(input_lengths, device, dtype)
+    total_tokens = sum(input_lengths)
+    position_ids = torch.zeros(total_tokens, 3, dtype=torch.int32, device=device)
+    cursor = 0
+    for seq_len in input_lengths:
+        positions = torch.arange(seq_len, dtype=torch.int32, device=device)
+        position_ids[cursor : cursor + seq_len, 0] = positions
+        position_ids[cursor : cursor + seq_len, 1] = positions // 2
+        position_ids[cursor : cursor + seq_len, 2] = positions % 3
+        cursor += seq_len
+    attn_inputs.combo_position_ids = position_ids.contiguous()
+    return attn_inputs
+
+
+def _make_mrope_decode_inputs(
+    sequence_lengths: List[int],
+    position_ids: torch.Tensor,
+    device: torch.device,
+    dtype: torch.dtype,
+    tokens_per_block: int = 16,
+):
+    """Build one-token-per-request decode inputs and an isolated block table."""
+    batch_size = len(sequence_lengths)
+    attn_inputs = PyAttentionInputs()
+    attn_inputs.is_prefill = False
+    attn_inputs.dtype = get_typemeta(torch.zeros([1], dtype=dtype))
+    attn_inputs.sequence_lengths = torch.tensor(
+        sequence_lengths, dtype=torch.int32, device=device
+    )
+    attn_inputs.input_lengths = torch.ones(batch_size, dtype=torch.int32, device=device)
+    # Empty is the production no-prefix representation. A nonempty CUDA tensor
+    # would make decode forward call .max().item() during graph capture.
+    attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32)
+    attn_inputs.padding_offset = torch.zeros(
+        batch_size, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_seqlens_device = torch.arange(
+        batch_size + 1, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_kv_seqlens_device = attn_inputs.cu_seqlens_device
+    attn_inputs.combo_position_ids = position_ids.contiguous()
+
+    block_counts = [
+        (seq_len + 1 + tokens_per_block - 1) // tokens_per_block
+        for seq_len in sequence_lengths
+    ]
+    max_blocks = max(block_counts)
+    block_table = torch.zeros(batch_size, max_blocks, dtype=torch.int32)
+    per_batch_block_ids = []
+    next_block = 0
+    for batch_idx, block_count in enumerate(block_counts):
+        block_ids = list(range(next_block, next_block + block_count))
+        per_batch_block_ids.append(block_ids)
+        block_table[batch_idx, :block_count] = torch.tensor(
+            block_ids, dtype=torch.int32
+        )
+        next_block += block_count
+    attn_inputs.kv_cache_kernel_block_id = block_table
+    attn_inputs.kv_cache_kernel_block_id_device = block_table.to(device)
+    return attn_inputs, per_batch_block_ids, next_block
+
+
+def _alloc_decode_kv_cache(
+    num_blocks: int,
+    head_num_kv: int,
+    tokens_per_block: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+):
+    pool = torch.zeros(
+        [num_blocks, 2, head_num_kv, tokens_per_block, head_dim],
+        dtype=dtype,
+        device=device,
+    )
+    layer_cache = LayerKVCache()
+    layer_cache.kv_cache_base = pool
+    return layer_cache, pool
+
+
+def _read_decode_k_from_pool(
+    pool: torch.Tensor,
+    per_batch_block_ids: List[List[int]],
+    sequence_lengths: List[int],
+    head_num_kv: int,
+    head_dim: int,
+    tokens_per_block: int,
+):
+    """Read the K written at each request's decode position."""
+    vector_size = 16 // pool.element_size()
+    result = torch.empty(
+        len(sequence_lengths),
+        head_num_kv,
+        head_dim,
+        dtype=pool.dtype,
+        device=pool.device,
+    )
+    for batch_idx, sequence_length in enumerate(sequence_lengths):
+        block_id = per_batch_block_ids[batch_idx][sequence_length // tokens_per_block]
+        local_position = sequence_length % tokens_per_block
+        k_kernel = (
+            pool[block_id, 0]
+            .contiguous()
+            .view(
+                head_num_kv,
+                head_dim // vector_size,
+                tokens_per_block,
+                vector_size,
+            )
+        )
+        result[batch_idx] = k_kernel.permute(0, 2, 1, 3).reshape(
+            head_num_kv, tokens_per_block, head_dim
+        )[:, local_position, :]
+    return result
+
+
 def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int]):
     """Torch reference for base RoPE (style=Base, base=10000) — matches the
     RopeConfig produced by _make_rope_attn_configs. Used to validate the C++
@@ -171,6 +319,47 @@ def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int])
         cos_b = cos.unsqueeze(1)
         sin_b = sin.unsqueeze(1)
         return torch.cat([lo * cos_b - hi * sin_b, hi * cos_b + lo * sin_b], dim=-1)
+
+    return rot(q).to(q.dtype), rot(k).to(k.dtype)
+
+
+def _apply_mrope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    mrope_sections: Sequence[int],
+    rope_dim: int,
+):
+    """Independent Qwen3/3.5 interleaved-MRoPE reference."""
+    head_dim = q.shape[-1]
+    assert 0 < rope_dim <= head_dim and rope_dim % 2 == 0
+    rotary_pairs = rope_dim // 2
+    assert len(mrope_sections) == 3
+    assert sum(mrope_sections) == rotary_pairs
+
+    # Match the model contract: start with temporal frequencies, then replace
+    # H/W slots at offsets 1/2 in the THW interleaving.
+    axes = torch.zeros(rotary_pairs, dtype=torch.long, device=q.device)
+    axes[1 : 3 * mrope_sections[1] : 3] = 1
+    axes[2 : 3 * mrope_sections[2] : 3] = 2
+    assert int((axes == 1).sum()) == mrope_sections[1]
+    assert int((axes == 2).sum()) == mrope_sections[2]
+    positions = position_ids[:, axes].to(torch.float32)
+    inv_freq = 10000 ** (
+        -2.0
+        * torch.arange(rotary_pairs, dtype=torch.float32, device=q.device)
+        / rope_dim
+    )
+    angle = positions * inv_freq.unsqueeze(0)
+    cos = torch.cos(angle).unsqueeze(1)
+    sin = torch.sin(angle).unsqueeze(1)
+
+    def rot(x):
+        x_float = x.float()
+        lo = x_float[..., :rotary_pairs]
+        hi = x_float[..., rotary_pairs:rope_dim]
+        tail = x_float[..., rope_dim:]
+        return torch.cat([lo * cos - hi * sin, hi * cos + lo * sin, tail], dim=-1)
 
     return rot(q).to(q.dtype), rot(k).to(k.dtype)
 
@@ -1256,6 +1445,284 @@ class TestAiterPrefillImplNoKvRopeRealOp(unittest.TestCase):
 
     def test_nonasm_no_kv_rope_real_op_matches_reference(self):
         self._check_real_no_kv_rope_path(AiterPrefillImplNonAsm)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestFusedRopeKVCacheMropeContract(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(2)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.head_num = 4
+        self.head_num_kv = 2
+        self.head_dim = 256
+        self.rope_dim = 64
+        self.sections = (11, 11, 10)
+        self.tokens_per_block = 16
+
+    def _make_config(self):
+        return _make_mrope_attn_configs(
+            head_num=self.head_num,
+            head_num_kv=self.head_num_kv,
+            head_dim=self.head_dim,
+            dtype=self.dtype,
+            rope_dim=self.rope_dim,
+            mrope_sections=self.sections,
+            tokens_per_block=self.tokens_per_block,
+        )
+
+    def test_prefill_and_decode_reject_section_sum_mismatch(self):
+        op_classes = (
+            FusedRopeKVCachePrefillOpAsm,
+            FusedRopeKVCachePrefillOpNonAsm,
+            FusedRopeKVCacheDecodeOpAsm,
+            FusedRopeKVCacheDecodeOpNonAsm,
+        )
+        for op_class in op_classes:
+            cfg = self._make_config()
+            cfg.rope_config.mrope_dim3 += 1
+            with self.subTest(op_class=op_class.__name__):
+                with self.assertRaisesRegex(RuntimeError, "section sum"):
+                    op_class(cfg)
+
+    def test_rejects_invalid_axis_count_and_interleaved_capacity(self):
+        cfg = self._make_config()
+        cfg.rope_config.index_factor = 4
+        with self.assertRaisesRegex(RuntimeError, "index_factor=3"):
+            FusedRopeKVCacheDecodeOpAsm(cfg)
+
+        # Although 12+12+8 is 32 pairs, H=12 cannot fit the 11 H slots in a
+        # 32-pair THW-interleaved region. This is why the review's proposed
+        # contiguous 12/12/8 fix is not valid for mrope_interleaved=true.
+        cfg = _make_mrope_attn_configs(
+            self.head_num,
+            self.head_num_kv,
+            self.head_dim,
+            self.dtype,
+            rope_dim=self.rope_dim,
+            mrope_sections=(12, 12, 8),
+        )
+        with self.assertRaisesRegex(RuntimeError, "interleaved H/W capacity"):
+            FusedRopeKVCachePrefillOpAsm(cfg)
+
+    def _build_decode_case(self, op_class):
+        sequence_lengths = [5, 3]
+        position_ids = torch.tensor(
+            [[5, 2, 1], [3, 7, 2]], dtype=torch.int32, device=self.device
+        )
+        attn_inputs, per_batch_block_ids, num_blocks = _make_mrope_decode_inputs(
+            sequence_lengths,
+            position_ids,
+            self.device,
+            self.dtype,
+            self.tokens_per_block,
+        )
+        cfg = self._make_config()
+        op = op_class(cfg)
+        params = op.prepare(attn_inputs)
+        layer_cache, pool = _alloc_decode_kv_cache(
+            num_blocks,
+            self.head_num_kv,
+            self.tokens_per_block,
+            self.head_dim,
+            self.dtype,
+            self.device,
+        )
+        q = torch.randn(
+            len(sequence_lengths),
+            self.head_num,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        k = torch.randn(
+            len(sequence_lengths),
+            self.head_num_kv,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        v = torch.randn_like(k)
+        return (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        )
+
+    def _assert_decode_matches_reference(self, op_class):
+        (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        ) = self._build_decode_case(op_class)
+
+        actual_q = op.forward(_pack_qkv(q, k, v), layer_cache, params)
+        expected_q, expected_k = _apply_mrope(
+            q,
+            k,
+            attn_inputs.combo_position_ids,
+            self.sections,
+            self.rope_dim,
+        )
+        actual_k = _read_decode_k_from_pool(
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            self.head_num_kv,
+            self.head_dim,
+            self.tokens_per_block,
+        )
+        torch.testing.assert_close(actual_q, expected_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, expected_k, atol=1e-2, rtol=1e-2)
+
+    def test_asm_decode_q_and_k_cache_match_reference(self):
+        self._assert_decode_matches_reference(FusedRopeKVCacheDecodeOpAsm)
+
+    def test_nonasm_decode_q_and_k_cache_match_reference(self):
+        self._assert_decode_matches_reference(FusedRopeKVCacheDecodeOpNonAsm)
+
+    def _assert_cuda_graph_replay_uses_new_position_ids(self, op_class):
+        (
+            op,
+            params,
+            attn_inputs,
+            layer_cache,
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            q,
+            k,
+            v,
+        ) = self._build_decode_case(op_class)
+        qkv = _pack_qkv(q, k, v)
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            op.forward(qkv, layer_cache, params)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        pool.zero_()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured_q = op.forward(qkv, layer_cache, params)
+
+        replay_position_ids = torch.tensor(
+            [[9, 1, 6], [4, 8, 2]], dtype=torch.int32, device=self.device
+        )
+        attn_inputs.combo_position_ids.copy_(replay_position_ids)
+        pool.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected_q, expected_k = _apply_mrope(
+            q,
+            k,
+            replay_position_ids,
+            self.sections,
+            self.rope_dim,
+        )
+        actual_k = _read_decode_k_from_pool(
+            pool,
+            per_batch_block_ids,
+            sequence_lengths,
+            self.head_num_kv,
+            self.head_dim,
+            self.tokens_per_block,
+        )
+        torch.testing.assert_close(captured_q, expected_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, expected_k, atol=1e-2, rtol=1e-2)
+
+    def test_asm_cuda_graph_replay_uses_new_position_ids(self):
+        self._assert_cuda_graph_replay_uses_new_position_ids(
+            FusedRopeKVCacheDecodeOpAsm
+        )
+
+    def test_nonasm_cuda_graph_replay_uses_new_position_ids(self):
+        self._assert_cuda_graph_replay_uses_new_position_ids(
+            FusedRopeKVCacheDecodeOpNonAsm
+        )
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplMropePositionIds(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(1)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_mrope_matches_reference(self, impl_cls):
+        input_lengths = [5, 3]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 256
+        rope_dim = 64
+        mrope_sections = (11, 11, 10)
+        cfg = _make_mrope_attn_configs(
+            head_num=head_num,
+            head_num_kv=head_num_kv,
+            head_dim=head_dim,
+            dtype=self.dtype,
+            rope_dim=rope_dim,
+            mrope_sections=mrope_sections,
+        )
+        attn_inputs = _make_mrope_prefill_inputs(input_lengths, self.device, self.dtype)
+
+        impl = impl_cls(cfg, attn_inputs)
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+
+        actual = impl.forward(_pack_qkv(q, k, v), kv_cache=None, layer_idx=0)
+        q_rope, k_rope = _apply_mrope(
+            q,
+            k,
+            attn_inputs.combo_position_ids,
+            mrope_sections,
+            rope_dim,
+        )
+        ref = _sdpa_reference(
+            q_rope,
+            k_rope,
+            v,
+            attn_inputs.cu_seqlens_device,
+            attn_inputs.cu_kv_seqlens_device,
+            causal=True,
+        )
+
+        self.assertTrue(impl.rope_params.position_ids.defined())
+        self.assertEqual(tuple(impl.rope_params.position_ids.shape), (8, 3))
+        torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
+
+    def test_asm_mrope_matches_reference(self):
+        self._check_mrope_matches_reference(AiterPrefillImplAsm)
+
+    def test_nonasm_mrope_matches_reference(self):
+        self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1468,6 +1468,7 @@ class RopeConfig:
     mrope_dim1: int
     mrope_dim2: int
     mrope_dim3: int
+    mrope_interleaved: bool
     mscale: float
     offset: int
     scale: float

--- a/rtp_llm/test/kv_cache_specs_test.py
+++ b/rtp_llm/test/kv_cache_specs_test.py
@@ -4,8 +4,10 @@ from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.models.deepseek_v2 import DeepSeekV3Mtp
 from rtp_llm.models.hybrid_kv_cache import calculate_hybrid_group_layer_num
 from rtp_llm.models.kimi_linear.kimi_linear import KimiLinear
+from rtp_llm.models.qwen2_vl import QWen2_VL
 from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next
 from rtp_llm.models.qwen3_next.qwen3_next_mtp import Qwen3NextMTP
+from rtp_llm.models.qwen3_vl import QWen3_VL
 from rtp_llm.models.qwen_v2 import QwenV2MTP
 from rtp_llm.ops import HybridAttentionType, KVCacheSpecDesc, KVCacheSpecType
 
@@ -67,7 +69,9 @@ class HybridKVCacheSpecTest(TestCase):
 
         self.assertEqual(len(config.kv_cache_spec_descs), 1)
         self.assertEqual(config.kv_cache_spec_descs[0][0].tag, "full")
-        self.assertEqual(config.kv_cache_spec_descs[0][0].cache_type, KVCacheSpecType.MHA)
+        self.assertEqual(
+            config.kv_cache_spec_descs[0][0].cache_type, KVCacheSpecType.MHA
+        )
 
     def test_calculate_group_layer_num_uses_full_count_fallback(self):
         self.assertEqual(calculate_hybrid_group_layer_num(30, 10), 10)
@@ -92,6 +96,101 @@ class HybridKVCacheSpecTest(TestCase):
         self.assertEqual(tags[11], "full")
         self.assertEqual(tags[12], "linear0")
         self.assertEqual(tags[13], "linear1")
+
+    def test_qwen3_next_defaults_missing_mrope_interleaved_to_true(self):
+        config = ModelConfig()
+        config.attn_config.size_per_head = 256
+        rope_parameters = {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+            "mrope_section": [11, 11, 10],
+        }
+
+        Qwen3Next._parse_rope_config({"rope_parameters": rope_parameters}, config)
+
+        self.assertTrue(config.attn_config.rope_config.mrope_interleaved)
+
+    def test_qwen3_next_rejects_non_interleaved_mrope(self):
+        config = ModelConfig()
+        config.attn_config.size_per_head = 256
+        rope_parameters = {
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+            "mrope_section": [11, 11, 10],
+            "mrope_interleaved": False,
+        }
+
+        with self.assertRaisesRegex(ValueError, "Qwen3Next requires.*true"):
+            Qwen3Next._parse_rope_config({"rope_parameters": rope_parameters}, config)
+
+    def test_qwen3_vl_defaults_to_interleaved_mrope_sections(self):
+        config = ModelConfig()
+        QWen3_VL._from_config_json(
+            config,
+            {
+                "vision_start_token_id": 1,
+                "vision_end_token_id": 2,
+                "text_config": {
+                    "intermediate_size": 256,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "head_dim": 128,
+                    "hidden_size": 256,
+                    "num_hidden_layers": 2,
+                    "vocab_size": 1024,
+                    "rope_scaling": {},
+                },
+            },
+        )
+
+        rope_config = config.attn_config.rope_config
+        self.assertTrue(rope_config.mrope_interleaved)
+        self.assertEqual(rope_config.index_factor, 3)
+        self.assertEqual(
+            [
+                rope_config.mrope_dim1,
+                rope_config.mrope_dim2,
+                rope_config.mrope_dim3,
+            ],
+            [24, 20, 20],
+        )
+        self.assertEqual(
+            rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3,
+            rope_config.dim // 2,
+        )
+
+    def test_qwen2_vl_parses_explicit_mrope_layout(self):
+        config = ModelConfig()
+        QWen2_VL._from_hf(
+            config,
+            {
+                "vocab_size": 1024,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "hidden_size": 256,
+                "head_dim": 128,
+                "num_hidden_layers": 2,
+                "intermediate_size": 256,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 1_000_000,
+                "rope_scaling": {
+                    "mrope_section": [20, 22, 22],
+                    "mrope_interleaved": True,
+                },
+            },
+        )
+
+        rope_config = config.attn_config.rope_config
+        self.assertTrue(rope_config.mrope_interleaved)
+        self.assertEqual(rope_config.index_factor, 3)
+        self.assertEqual(
+            [
+                rope_config.mrope_dim1,
+                rope_config.mrope_dim2,
+                rope_config.mrope_dim3,
+            ],
+            [20, 22, 22],
+        )
 
     def test_kimi_linear_uses_contiguous_tags_across_hybrid_cycles(self):
         tags = self._kimi_post_build_tags(

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -62,6 +62,7 @@ test_suite(
         ":smoke_rocm_basic",
         ":smoke_rocm_dense",
         ":smoke_rocm_moe",
+        ":smoke_rocm_qwen35_mrope_cg",
         ":smoke_rocm_eagle",
         ":smoke_rocm_pd",
         ":smoke_rocm_embedding",

--- a/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm.json
+++ b/rtp_llm/test/smoke/data/model/qwen35/qwen35_bf16_rocm.json
@@ -1,0 +1,41 @@
+{
+    "model_type": "qwen35_moe",
+    "model_path": "/mnt/nas1/hf/Qwen3.5-35B-A3B",
+    "query_result": [
+        {
+            "query": {
+                "prompt_batch": [
+                    "$prompt:s1",
+                    "$prompt:s1",
+                    "$prompt:s1"
+                ],
+                "generate_config": {
+                    "max_new_tokens": 10,
+                    "top_k": 1
+                }
+            },
+            "result": {
+                "response_batch": [
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    },
+                    {
+                        "response": "\n\nThe CAP theorem, also known as Brewer's",
+                        "response_alternatives": [
+                            "\n\nThe CAP Theorem, also known as Brewer"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -88,6 +88,19 @@ def rocm_oss_suites():
         ],
     )
 
+    # Minimal Qwen3.5 coverage for interleaved MRoPE CUDA Graph replay.
+    native.test_suite(
+        name = "smoke_rocm_qwen35_mrope_cg",
+        tests = [
+            smoke_test(
+                name="rocm_qwen35_bf16_mrope_cg",
+                task_info="data/model/qwen35/qwen35_bf16_rocm.json",
+                smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+        ],
+    )
+
 
     # ROCm Eagle (Qwen2-14B + draft)
     native.test_suite(


### PR DESCRIPTION
 - Add ROCm interleaved MRoPE support for Qwen VL and Qwen3.5.
  - Support safe combo-position-ID capture and CUDA Graph replay.
  - Add focused numerical tests and one minimal Qwen3.5 ROCm graph smoke case.