### PR TITLE
Develop/hengcang/newloader qwen3 vl dense

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -226,6 +226,7 @@ py_library(
         ":torchvision",
         ":protobuf",
         ":pyOpenSSL",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
     ] + select({
         "@//:using_arm": [],
 	    "@//:using_rocm": ["pyrsmi", "amdsmi"],

--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -227,6 +227,7 @@ py_library(
         ":protobuf",
         ":pyOpenSSL",
         "//rtp_llm/models_py:qwen2_vl_vision_loader",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
     ] + select({
         "@//:using_arm": [],
 	    "@//:using_rocm": ["pyrsmi", "amdsmi"],

--- a/rtp_llm/config/model_config.py
+++ b/rtp_llm/config/model_config.py
@@ -73,6 +73,7 @@ class ModelConfig(CppModelConfig):
         "phy2log_path",
         "lora_infos",
         "headwise_config",
+        "use_new_loader",
     }
 
     # Known C++ ModelConfig members (from ModelConfig.h)
@@ -545,6 +546,7 @@ class ModelConfig(CppModelConfig):
         self.render_config: Optional[Any] = None  # RenderConfig for renderer factory
         self.mm_related_params = VitParameters()
         self.quant_config = None
+        self.use_new_loader: bool = False
 
     def apply_override_args(self, json_model_override_args: str) -> None:
         """Apply model override arguments to ModelConfig.

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Optional, Type, Union
 
 import torch
+
 from rtp_llm.config.generate_config import GenerateConfig
 from rtp_llm.config.kv_cache_config import KVCacheConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -29,6 +30,7 @@ from rtp_llm.ops import (
     ParallelismConfig,
 )
 from rtp_llm.utils.database import CkptDatabase
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 from rtp_llm.utils.time_util import timer_wrapper
 
 
@@ -318,9 +320,7 @@ class BaseModel(object):
             self.custom_module.init(self.weight)
 
     def _use_new_loader(self) -> bool:
-        return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
-            getattr(self.model_config, "use_new_loader", False)
-        )
+        return is_new_loader_enabled(self.model_config)
 
     def _new_loader_quant_type(self) -> str:
         quant_config = getattr(self.model_config, "quant_config", None)

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -77,31 +77,40 @@ class QWen3_VL(QwenV3):
             [config_json["vision_start_token_id"], config_json["vision_end_token_id"]]
         ]
 
-        config_json = config_json["text_config"]
-        config.inter_size = config_json["intermediate_size"]
-        config.attn_config.head_num = config_json["num_attention_heads"]
-        config.attn_config.kv_head_num = config_json.get(
+        vision_config = config_json.get("vision_config")
+        if not isinstance(vision_config, dict):
+            raise ValueError("Qwen3-VL config.json must contain vision_config")
+        config.mm_related_params.config.update(vision_config)
+
+        text_config = config_json.get("text_config")
+        if not isinstance(text_config, dict):
+            raise ValueError("Qwen3-VL config.json must contain text_config")
+        config.inter_size = text_config["intermediate_size"]
+        config.attn_config.head_num = text_config["num_attention_heads"]
+        config.attn_config.kv_head_num = text_config.get(
             "num_key_value_heads", config.attn_config.head_num
         )
         config.attn_config.size_per_head = (
-            int(config_json.get("head_dim"))
-            if "head_dim" in config_json
-            else config_json["hidden_size"] // config.attn_config.head_num
+            int(text_config["head_dim"])
+            if "head_dim" in text_config
+            else text_config["hidden_size"] // config.attn_config.head_num
         )
-        if config_json.get("hidden_size") is not None:
-            config.hidden_size = config_json["hidden_size"]
-        config.num_layers = config_json["num_hidden_layers"]
-        config.attn_config.rope_config.base = config_json.get(
+        if text_config.get("hidden_size") is not None:
+            config.hidden_size = text_config["hidden_size"]
+        config.num_layers = text_config["num_hidden_layers"]
+        config.attn_config.rope_config.base = text_config.get(
             "rope_theta", config.attn_config.rope_config.base
         )
-        config.vocab_size = config_json["vocab_size"]
+        config.vocab_size = text_config["vocab_size"]
         config.attn_config.rope_config.dim = config.attn_config.size_per_head
-        config.layernorm_eps = config_json.get("rms_norm_eps", 1e-06)
-        config.tie_word_embeddings = config_json.get("tie_word_embeddings", False)
-        config.config_dtype = config_json.get("torch_dtype", None)
+        config.layernorm_eps = text_config.get("rms_norm_eps", 1e-06)
+        config.tie_word_embeddings = text_config.get("tie_word_embeddings", False)
+        config.config_dtype = text_config.get(
+            "dtype", text_config.get("torch_dtype", None)
+        )
 
         config.attn_config.rope_config.style = 7
-        mrope_section = config_json["rope_scaling"].get("mrope_section", [16, 24, 24])
+        mrope_section = text_config["rope_scaling"].get("mrope_section", [16, 24, 24])
         config.attn_config.rope_config.index_factor = len(mrope_section)
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -141,6 +141,7 @@ py_library(
         "new_models/qwen3/*.py",
         "new_models/qwen3_moe/*.py",
         "new_models/qwen3_next/*.py",
+        "new_models/qwen3_vl/*.py",
         "quant_methods/*.py",
     ]),
     deps = [
@@ -171,6 +172,25 @@ py_library(
         "new_models/__init__.py",
         "new_models/qwen2_vl/__init__.py",
         "new_models/qwen2_vl/vision.py",
+    ],
+    deps = [
+        ":new_loader_core",
+        "//rtp_llm:torch",
+        "//rtp_llm:utils",
+    ] + select({
+        "@//:using_cuda12_9_x86": flashattn,
+        "@//:using_cuda12_arm": flashattn,
+        "//conditions:default": [],
+    }),
+    visibility = ["//rtp_llm:__subpackages__"],
+)
+
+py_library(
+    name = "qwen3_vl_vision_loader",
+    srcs = [
+        "new_models/__init__.py",
+        "new_models/qwen3_vl/__init__.py",
+        "new_models/qwen3_vl/vision.py",
     ],
     deps = [
         ":new_loader_core",

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -126,6 +126,7 @@ py_library(
         "new_models/*.py",
         "new_models/qwen2/*.py",
         "new_models/qwen2_moe/*.py",
+        "new_models/qwen2_vl/*.py",
         "new_models/qwen3/*.py",
         "new_models/qwen3_moe/*.py",
         "new_models/qwen3_next/*.py",
@@ -150,6 +151,30 @@ py_library(
         "//:th_transformer_config",
     ],
     visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "qwen2_vl_vision_loader",
+    srcs = [
+        "__init__.py",
+        "model_loader.py",
+        "module_base.py",
+        "new_models/__init__.py",
+        "new_models/qwen2_vl/__init__.py",
+        "new_models/qwen2_vl/vision.py",
+        "registry.py",
+        "weight_mapper.py",
+    ],
+    deps = [
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm:utils",
+    ] + select({
+        "@//:using_cuda12_9_x86": flashattn,
+        "@//:using_cuda12_arm": flashattn,
+        "//conditions:default": [],
+    }),
+    visibility = ["//rtp_llm:__subpackages__"],
 )
 
 py_library(

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -113,14 +113,25 @@ py_library(
 )
 
 py_library(
-    name = "new_weight_loader",
+    name = "new_loader_core",
     srcs = [
         "__init__.py",
         "model_loader.py",
-        "model_desc/module_base.py",
         "module_base.py",
         "registry.py",
         "weight_mapper.py",
+    ],
+    deps = [
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "new_weight_loader",
+    srcs = [
+        "model_desc/module_base.py",
     ] + glob([
         "layers/*.py",
         "new_models/*.py",
@@ -133,6 +144,7 @@ py_library(
         "quant_methods/*.py",
     ]),
     deps = [
+        ":new_loader_core",
         ":kernels",
         ":modules",
         "//rtp_llm:_ft_pickler",
@@ -156,17 +168,12 @@ py_library(
 py_library(
     name = "qwen2_vl_vision_loader",
     srcs = [
-        "__init__.py",
-        "model_loader.py",
-        "module_base.py",
         "new_models/__init__.py",
         "new_models/qwen2_vl/__init__.py",
         "new_models/qwen2_vl/vision.py",
-        "registry.py",
-        "weight_mapper.py",
     ],
     deps = [
-        "//rtp_llm:safetensors",
+        ":new_loader_core",
         "//rtp_llm:torch",
         "//rtp_llm:utils",
     ] + select({

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -81,26 +81,77 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     params.prefill_runtime_max_prefix_len      = max_prefix_len;
     params.prefill_runtime_seq_len_with_prefix = params.max_seq_len + max_prefix_len;
 
+    const bool captured_position_ids = params.position_ids.defined() && params.position_ids.numel() > 0;
+    const bool replay_position_ids =
+        attn_inputs.combo_position_ids.defined() && attn_inputs.combo_position_ids.numel() > 0;
+    if (captured_position_ids || replay_position_ids) {
+        if (!captured_position_ids || !replay_position_ids) {
+            throw std::runtime_error("prepare_in_place requires combo_position_ids in both capture and replay inputs");
+        }
+        if (params.position_ids.data_ptr() != attn_inputs.combo_position_ids.data_ptr()) {
+            copyTensorExactInPlace(params.position_ids, attn_inputs.combo_position_ids, "combo_position_ids");
+        }
+    }
+
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
+static void validateMropePositionIds(const RopeConfig&    rope_config,
+                                     const torch::Tensor& position_ids,
+                                     int64_t              expected_tokens,
+                                     const char*          where) {
+    if (rope_config.style != RopeStyle::Mrope) {
+        return;
+    }
+
+    TORCH_CHECK(rope_config.index_factor == 3,
+                where,
+                ": RopeStyle::Mrope requires index_factor == 3, got ",
+                rope_config.index_factor);
+    const int mrope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
+    TORCH_CHECK(rope_config.mrope_dim1 > 0 && rope_config.mrope_dim2 > 0 && rope_config.mrope_dim3 > 0
+                    && mrope_dim * 2 == rope_config.dim,
+                where,
+                ": invalid Mrope sections [",
+                rope_config.mrope_dim1,
+                ", ",
+                rope_config.mrope_dim2,
+                ", ",
+                rope_config.mrope_dim3,
+                "] for rope dim ",
+                rope_config.dim);
+    TORCH_CHECK(position_ids.defined() && position_ids.numel() > 0,
+                where,
+                ": RopeStyle::Mrope requires non-empty combo_position_ids");
+    TORCH_CHECK(position_ids.scalar_type() == at::kInt,
+                where,
+                ": combo_position_ids must be int32, got ",
+                position_ids.scalar_type());
+    TORCH_CHECK(position_ids.is_cuda(), where, ": combo_position_ids must be on the ROCm device");
+    TORCH_CHECK(position_ids.is_contiguous(), where, ": combo_position_ids must be contiguous");
+    TORCH_CHECK(position_ids.numel() % rope_config.index_factor == 0,
+                where,
+                ": combo_position_ids numel (",
+                position_ids.numel(),
+                ") must be divisible by index_factor (",
+                rope_config.index_factor,
+                ")");
+    if (expected_tokens >= 0) {
+        TORCH_CHECK(position_ids.numel() == expected_tokens * rope_config.index_factor,
+                    where,
+                    ": combo_position_ids numel mismatch: expected ",
+                    expected_tokens * rope_config.index_factor,
+                    " for ",
+                    expected_tokens,
+                    " tokens and index_factor ",
+                    rope_config.index_factor,
+                    ", got ",
+                    position_ids.numel());
     }
 }
 
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCachePrefillOpBase(attn_configs) {}
@@ -144,14 +195,21 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
         attn_params->prefix_lengths = attn_inputs.prefix_lengths;
     }
     attn_params->kv_block_array.cache_type = attn_configs_.kv_cache_dtype;
-    attn_params->position_ids = attn_inputs.combo_position_ids;
+    attn_params->position_ids              = attn_inputs.combo_position_ids;
 
-// Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
-    if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
-        attn_params->position_ids =
-            attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
+    // MRoPE position IDs originate on the host in the normal engine. Keep a
+    // contiguous device tensor because the fused kernel indexes the flattened
+    // token-major [token, axis] layout directly.
+    if (attn_params->position_ids.defined()) {
+        if (!attn_params->position_ids.is_cuda()) {
+            attn_params->position_ids =
+                attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true);
+        }
+        attn_params->position_ids = attn_params->position_ids.contiguous();
     }
-    
+    validateMropePositionIds(
+        attn_configs_.rope_config, attn_params->position_ids, -1, "FusedRopeKVCachePrefillOp::prepare");
+
     int max_prefix_length = 0;
     if (has_prefix && attn_params->prefix_lengths.defined() && attn_params->prefix_lengths.numel() > 0) {
         max_prefix_length = attn_params->prefix_lengths.max().item<int32_t>();
@@ -174,6 +232,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
     const int max_prefix_length =
         params->prefill_runtime_max_prefix_len >= 0 ? params->prefill_runtime_max_prefix_len : 0;
     const int seq_len_with_prefix = seq_len + max_prefix_length;
+    validateMropePositionIds(
+        attn_configs_.rope_config, params->position_ids, token_num, "FusedRopeKVCachePrefillOp::forward");
 
     const int  q_output_token_num = (use_paged_fmha && pad_query) ? batch_size * seq_len : token_num;
     const bool paged_fp8          = use_paged_fmha && attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
@@ -352,9 +412,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 }
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCacheDecodeOpBase(attn_configs) {}
@@ -392,11 +450,15 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     attn_params->prefix_lengths            = attn_inputs.prefix_lengths;
     attn_params->padding_offset            = attn_inputs.padding_offset;
     attn_params->position_ids              = attn_inputs.combo_position_ids;
-    // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
-    if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
-        attn_params->position_ids =
-            attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
+    if (attn_params->position_ids.defined()) {
+        if (!attn_params->position_ids.is_cuda()) {
+            attn_params->position_ids =
+                attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true);
+        }
+        attn_params->position_ids = attn_params->position_ids.contiguous();
     }
+    validateMropePositionIds(
+        attn_configs_.rope_config, attn_params->position_ids, -1, "FusedRopeKVCacheDecodeOp::prepare");
 
     if (attn_inputs.kv_cache_kernel_block_id_device.defined()
         && attn_inputs.kv_cache_kernel_block_id_device.numel() > 0) {
@@ -426,6 +488,8 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
     const int     batch_size        = params->sequence_lengths.size(0);
     torch::Tensor q_output          = torch::empty({token_num, local_head_num, size_per_head},
                                           torch::TensorOptions(qkv.dtype()).device(qkv.device()));
+    validateMropePositionIds(
+        attn_configs_.rope_config, params->position_ids, token_num, "FusedRopeKVCacheDecodeOp::forward");
 
     PrefixPromptBatchWeightsParam prefix_prompt_param;
     prefix_prompt_param.kv_block_array = kv_block_array;

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple
 
-import rtp_llm.models_py.weight_mapper as weight_mapper
 import torch
 import torch.nn as nn
+
+import rtp_llm.models_py.weight_mapper as weight_mapper
 from rtp_llm.models_py.module_base import RtpModule, collect_loaded_tensor_ids
 from rtp_llm.models_py.registry import get_model_class, list_models
 
@@ -341,10 +342,12 @@ class NewModelLoader:
         model: RtpModule,
     ) -> Optional[Callable[[str], bool]]:
         model_filter = model.checkpoint_weight_name_filter()
-        if model_filter is not None and not callable(model_filter):
+        if model_filter is not None and (
+            not callable(model_filter) or isinstance(model_filter, nn.Module)
+        ):
             raise TypeError(
                 f"{type(model).__name__}.checkpoint_weight_name_filter() must "
-                "return a callable or None"
+                "return a callable function or None, not an nn.Module"
             )
         return model_filter
 

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -24,6 +24,16 @@ _STACKED_EXPERT_RE = re.compile(
 )
 
 
+def _require_callable_name_filter(
+    model_filter: Optional[Callable[[str], bool]], label: str
+) -> Optional[Callable[[str], bool]]:
+    if isinstance(model_filter, nn.Module):
+        raise TypeError(f"{label} must be callable or None, not an nn.Module")
+    if model_filter is not None and not callable(model_filter):
+        raise TypeError(f"{label} must be callable or None")
+    return model_filter
+
+
 class _ExpertRangeFilter:
     """Select only this EP rank's per-expert checkpoint tensors."""
 
@@ -341,25 +351,17 @@ class NewModelLoader:
     def _model_checkpoint_name_filter(
         model: RtpModule,
     ) -> Optional[Callable[[str], bool]]:
-        model_filter = model.checkpoint_weight_name_filter()
-        if model_filter is not None and (
-            not callable(model_filter) or isinstance(model_filter, nn.Module)
-        ):
-            raise TypeError(
-                f"{type(model).__name__}.checkpoint_weight_name_filter() must "
-                "return a callable function or None, not an nn.Module"
-            )
-        return model_filter
+        return _require_callable_name_filter(
+            model.checkpoint_weight_name_filter(),
+            f"{type(model).__name__}.checkpoint_weight_name_filter() return value",
+        )
 
     @staticmethod
     def _checkpoint_name_filter(
         model_filter: Optional[Callable[[str], bool]],
         expert_filter: Optional[_ExpertRangeFilter],
     ) -> Optional[Callable[[str], bool]]:
-        if model_filter is not None and (
-            not callable(model_filter) or isinstance(model_filter, nn.Module)
-        ):
-            raise TypeError("model_filter must be callable or None")
+        model_filter = _require_callable_name_filter(model_filter, "model_filter")
         if model_filter is None and expert_filter is None:
             return None
 
@@ -517,7 +519,8 @@ class NewModelLoader:
             )
         started = time.time()
         expert_filter = self._expert_filter()
-        model_filter = self._model_checkpoint_name_filter(model)
+        model_filter = model.checkpoint_weight_name_filter()
+        name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         selected_files = weight_mapper.select_safetensor_files(
             self._resolved_model_path(), checkpoint_files, model_filter
         )
@@ -527,7 +530,6 @@ class NewModelLoader:
                 len(selected_files),
                 len(checkpoint_files),
             )
-        name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         model.load_weights(
             weight_mapper.get_all_weights(
                 selected_files,

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -339,8 +339,12 @@ class NewModelLoader:
             raise TypeError(
                 f"model_config num_experts must be an integer, got {num_experts!r}"
             )
-        if num_experts <= 0:
-            raise ValueError("EP loading requires model_config.num_experts")
+        if num_experts < 0:
+            raise ValueError(
+                f"model_config num_experts must be non-negative, got {num_experts}"
+            )
+        if num_experts == 0:
+            return None
         return _ExpertRangeFilter(
             num_experts,
             self.load_config.ep_size,
@@ -376,8 +380,12 @@ class NewModelLoader:
 
         return should_load
 
-    def _validate_ep_checkpoint_format(self, checkpoint_files) -> None:
-        if self.load_config.ep_size == 1:
+    def _validate_ep_checkpoint_format(
+        self,
+        checkpoint_files,
+        expert_filter: Optional[_ExpertRangeFilter],
+    ) -> None:
+        if expert_filter is None:
             return
         unsupported = [
             path
@@ -508,7 +516,8 @@ class NewModelLoader:
         if method != NewLoaderLoadMethod.SCRATCH:
             raise RuntimeError(f"Resolved unsupported load method: {method}")
         checkpoint_files = self._checkpoint_files()
-        self._validate_ep_checkpoint_format(checkpoint_files)
+        expert_filter = self._expert_filter()
+        self._validate_ep_checkpoint_format(checkpoint_files, expert_filter)
         model = self._create_model()
         if weight_mapper.is_rank_local_checkpoint(checkpoint_files) and not bool(
             getattr(model, "supports_rank_local_checkpoint", False)
@@ -518,7 +527,6 @@ class NewModelLoader:
                 "checkpoints; use a global HF checkpoint"
             )
         started = time.time()
-        expert_filter = self._expert_filter()
         model_filter = model.checkpoint_weight_name_filter()
         name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         selected_files = weight_mapper.select_safetensor_files(

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -113,6 +113,22 @@ def _make_rope_attn_configs(
     return cfg
 
 
+def _make_mrope_attn_configs(
+    head_num: int,
+    head_num_kv: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    mrope_section=(16, 24, 24),
+):
+    """Qwen3-VL-style MRoPE configuration for the real ROCm fused op."""
+    cfg = _make_rope_attn_configs(head_num, head_num_kv, head_dim, dtype)
+    rope = cfg.rope_config
+    rope.style = RopeStyle.Mrope
+    rope.index_factor = 3
+    rope.mrope_dim1, rope.mrope_dim2, rope.mrope_dim3 = mrope_section
+    return cfg
+
+
 def _make_rope_prefill_inputs(
     input_lengths: List[int], device: torch.device, dtype: torch.dtype
 ):
@@ -171,6 +187,38 @@ def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int])
         cos_b = cos.unsqueeze(1)
         sin_b = sin.unsqueeze(1)
         return torch.cat([lo * cos_b - hi * sin_b, hi * cos_b + lo * sin_b], dim=-1)
+
+    return rot(q).to(q.dtype), rot(k).to(k.dtype)
+
+
+def _apply_mrope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    mrope_section=(16, 24, 24),
+):
+    """Torch reference for token-major three-axis Qwen3-VL MRoPE."""
+    head_dim = q.shape[-1]
+    half = head_dim // 2
+    if sum(mrope_section) != half:
+        raise ValueError("MRoPE sections must cover half of the head dimension")
+
+    axis_by_pair = torch.repeat_interleave(
+        torch.arange(3, device=q.device),
+        torch.tensor(mrope_section, device=q.device),
+    )
+    positions = position_ids.to(device=q.device, dtype=torch.float32)
+    pair_positions = positions[:, axis_by_pair]
+    inv_freq = 10000 ** (
+        -2.0 * torch.arange(half, dtype=torch.float32, device=q.device) / head_dim
+    )
+    angle = pair_positions * inv_freq.unsqueeze(0)
+    cos = torch.cos(angle).unsqueeze(1)
+    sin = torch.sin(angle).unsqueeze(1)
+
+    def rot(x):
+        lo, hi = x[..., :half], x[..., half:]
+        return torch.cat([lo * cos - hi * sin, hi * cos + lo * sin], dim=-1)
 
     return rot(q).to(q.dtype), rot(k).to(k.dtype)
 
@@ -1256,6 +1304,135 @@ class TestAiterPrefillImplNoKvRopeRealOp(unittest.TestCase):
 
     def test_nonasm_no_kv_rope_real_op_matches_reference(self):
         self._check_real_no_kv_rope_path(AiterPrefillImplNonAsm)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
+    """Numerical and validation coverage for Qwen3-VL MRoPE position IDs."""
+
+    def setUp(self):
+        torch.manual_seed(2)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_mrope_matches_reference(self, impl_cls):
+        input_lengths = [3, 2]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 128
+        cfg = _make_mrope_attn_configs(
+            head_num, head_num_kv, head_dim, dtype=self.dtype
+        )
+        attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        position_ids = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 4, 7],
+                [2, 5, 8],
+                [0, 0, 0],
+                [3, 6, 9],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        attn_inputs.combo_position_ids = position_ids.flatten()
+        impl = impl_cls(cfg, attn_inputs)
+
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+
+        actual_q, actual_k, actual_v = impl.rope_kvcache_impl.forward(
+            qkv, None, impl.rope_params
+        )
+        ref_q, ref_k = _apply_mrope(q, k, position_ids)
+        ref_k_padded, ref_v_padded = _pad_kv(ref_k, v, attn_inputs.cu_kv_seqlens_device)
+
+        torch.testing.assert_close(actual_q, ref_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, ref_k_padded, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_v, ref_v_padded, atol=1e-2, rtol=1e-2)
+
+    def test_asm_mrope_uses_all_three_position_axes(self):
+        self._check_mrope_matches_reference(AiterPrefillImplAsm)
+
+    def test_nonasm_mrope_uses_all_three_position_axes(self):
+        self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
+
+    def test_prepare_in_place_refreshes_mrope_position_ids(self):
+        input_lengths = [3, 2]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 128
+        cfg = _make_mrope_attn_configs(
+            head_num, head_num_kv, head_dim, dtype=self.dtype
+        )
+        attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        first_position_ids = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [0, 0, 0],
+                [1, 1, 1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        attn_inputs.combo_position_ids = first_position_ids.flatten()
+        impl = AiterPrefillImplAsm(cfg, attn_inputs)
+
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+        first_q, _, _ = impl.rope_kvcache_impl.forward(qkv, None, impl.rope_params)
+
+        replay_inputs = _make_rope_prefill_inputs(
+            input_lengths, self.device, self.dtype
+        )
+        replay_position_ids = torch.tensor(
+            [
+                [0, 3, 6],
+                [1, 4, 7],
+                [2, 5, 8],
+                [0, 2, 4],
+                [1, 3, 5],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        replay_inputs.combo_position_ids = replay_position_ids.flatten()
+        impl.rope_params.prepare_in_place(replay_inputs)
+        replay_q, _, _ = impl.rope_kvcache_impl.forward(qkv, None, impl.rope_params)
+        expected_q, _ = _apply_mrope(q, k, replay_position_ids)
+
+        self.assertFalse(torch.equal(first_q, replay_q))
+        torch.testing.assert_close(replay_q, expected_q, atol=1e-2, rtol=1e-2)
+
+    def test_mrope_missing_position_ids_fails_during_prepare(self):
+        cfg = _make_mrope_attn_configs(4, 2, 128, dtype=self.dtype)
+        attn_inputs = _make_rope_prefill_inputs([2], self.device, self.dtype)
+        with self.assertRaisesRegex(
+            RuntimeError, "requires non-empty combo_position_ids"
+        ):
+            AiterPrefillImplAsm(cfg, attn_inputs)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_loader_test/foundation_test.py
+++ b/rtp_llm/models_py/new_loader_test/foundation_test.py
@@ -9,6 +9,8 @@ from unittest import mock
 
 import torch
 import torch.nn as nn
+from safetensors.torch import save_file
+
 from rtp_llm.models_py.model_loader import (
     NewLoaderConfig,
     NewLoaderLoadMethod,
@@ -25,7 +27,6 @@ from rtp_llm.models_py.weight_mapper import (
     get_all_weights,
     select_safetensor_files,
 )
-from safetensors.torch import save_file
 
 
 class _Block(RtpModule):
@@ -102,6 +103,20 @@ class FoundationLoaderTest(unittest.TestCase):
     def test_combined_checkpoint_filter_rejects_model_instances(self):
         with self.assertRaisesRegex(TypeError, "model_filter must be callable"):
             NewModelLoader._checkpoint_name_filter(RtpModule(), None)
+
+    def test_model_filter_rejects_module_before_shard_preselection(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_weights(), os.path.join(model_path, "model.safetensors"))
+            with mock.patch.object(
+                _FoundationModel,
+                "checkpoint_weight_name_filter",
+                return_value=RtpModule(),
+            ), mock.patch(
+                "rtp_llm.models_py.model_loader.weight_mapper.select_safetensor_files"
+            ) as select_files:
+                with self.assertRaisesRegex(TypeError, "not an nn.Module"):
+                    self._loader(model_path).load()
+                select_files.assert_not_called()
 
     def test_staged_modules_move_and_postprocess_one_at_a_time(self):
         events = []

--- a/rtp_llm/models_py/new_models/qwen2_vl/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen2-VL newloader language and vision implementations."""

--- a/rtp_llm/models_py/new_models/qwen2_vl/model.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/model.py
@@ -1,0 +1,10 @@
+from typing import Callable
+
+from rtp_llm.models_py.new_models.qwen2.language import Qwen2ForCausalLM
+
+
+class Qwen2VLForCausalLM(Qwen2ForCausalLM):
+    """Qwen2-VL language runtime with vision tensors filtered before loading."""
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: not name.startswith("visual.")

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
@@ -10,6 +10,15 @@ py_test(
 )
 
 py_test(
+    name = "test_qwen2_vl_vision_loader_import",
+    srcs = ["test_qwen2_vl_vision_loader_import.py"],
+    deps = [
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)
+
+py_test(
     name = "test_qwen2_vl_gpu",
     srcs = ["test_qwen2_vl_gpu.py"],
     exec_properties = {

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/BUILD
@@ -1,0 +1,43 @@
+py_test(
+    name = "test_qwen2_vl_load",
+    srcs = ["test_qwen2_vl_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen2_vl_gpu",
+    srcs = ["test_qwen2_vl_gpu.py"],
+    exec_properties = {
+        "gpu": "H20",
+        "gpu_count": "1",
+    },
+    tags = ["H20"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen2_vl_rocm",
+    srcs = ["test_qwen2_vl_gpu.py"],
+    main = "test_qwen2_vl_gpu.py",
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "1",
+    },
+    tags = ["rocm"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
@@ -1,0 +1,71 @@
+import tempfile
+import unittest
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+    Qwen2VLForVisionEmbedding,
+    _resolve_flash_attn_varlen,
+    load_qwen2_vl_vision,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "embed_dim": 8,
+        "hidden_size": 6,
+        "hidden_act": "quick_gelu",
+        "mlp_ratio": 2.0,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 1,
+    }
+
+
+class Qwen2VLVisionGpuTest(unittest.TestCase):
+    def test_real_newloader_gpu_forward_matches_cpu_reference(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+        if torch.version.hip is None:
+            self.assertIsNotNone(_resolve_flash_attn_varlen())
+
+        torch.manual_seed(11)
+        config = _vision_config()
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 32).reshape(8, 4)
+        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected = source(pixel_values, grid_thw)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    name: tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            visual = load_qwen2_vl_vision(
+                vision_config=config,
+                model_path=model_path,
+                compute_dtype=torch.float16,
+                device="cuda:0",
+            )
+
+        self.assertFalse(visual.training)
+        self.assertEqual(visual.device, torch.device("cuda:0"))
+        with torch.inference_mode():
+            actual = visual(pixel_values.cuda(), grid_thw.cuda()).float().cpu()
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_gpu.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 from safetensors.torch import save_file
@@ -23,7 +24,7 @@ def _vision_config():
         "in_channels": 1,
         "patch_size": 2,
         "spatial_merge_size": 2,
-        "temporal_patch_size": 1,
+        "temporal_patch_size": 2,
     }
 
 
@@ -32,7 +33,13 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("A CUDA or ROCm accelerator is required")
         if torch.version.hip is None:
-            self.assertIsNotNone(_resolve_flash_attn_varlen())
+            self.assertIsNotNone(
+                _resolve_flash_attn_varlen(),
+                (
+                    f"flash-attn unavailable on {torch.cuda.get_device_name(0)} "
+                    f"with capability {torch.cuda.get_device_capability(0)}"
+                ),
+            )
 
         torch.manual_seed(11)
         config = _vision_config()
@@ -40,8 +47,8 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
             {"model_type": "qwen2_vl_vision", "vision_config": config},
             NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
         ).eval()
-        pixel_values = torch.linspace(-1.0, 1.0, 32).reshape(8, 4)
-        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
         with torch.inference_mode():
             expected = source(pixel_values, grid_thw)
 
@@ -65,6 +72,29 @@ class Qwen2VLVisionGpuTest(unittest.TestCase):
         with torch.inference_mode():
             actual = visual(pixel_values.cuda(), grid_thw.cuda()).float().cpu()
         torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+    def test_fp32_accelerator_forward_uses_sdpa_fallback(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        config = _vision_config()
+        model = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cuda:0"),
+        ).cuda()
+        pixel_values = torch.linspace(-1.0, 1.0, 128, device="cuda").reshape(16, 8)
+        grid_thw = torch.tensor(
+            [[2, 2, 2], [1, 4, 2]], dtype=torch.int64, device="cuda"
+        )
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen2_vl.vision."
+            "_resolve_flash_attn_varlen",
+            side_effect=AssertionError("FP32 must not resolve flash attention"),
+        ):
+            with torch.inference_mode():
+                output = model(pixel_values, grid_thw)
+        self.assertTrue(torch.isfinite(output).all())
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_load.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_load.py
@@ -1,0 +1,278 @@
+import tempfile
+import types
+import unittest
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen2_vl.model import Qwen2VLForCausalLM
+from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+
+def _parallelism():
+    return types.SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+        get_attn_tp_size=lambda: 1,
+        get_attn_tp_rank=lambda: 0,
+        get_ffn_tp_size=lambda: 1,
+        get_ffn_tp_rank=lambda: 0,
+    )
+
+
+def _load_config() -> NewLoaderConfig:
+    return NewLoaderConfig(
+        compute_dtype=torch.float32,
+        device="cpu",
+        quant_config=QuantizationConfig("none"),
+        parallelism_config=_parallelism(),
+    )
+
+
+def _language_config():
+    return types.SimpleNamespace(
+        model_type="qwen2_vl",
+        num_layers=1,
+        vocab_size=8,
+        hidden_size=4,
+        inter_size=4,
+        attn_config=types.SimpleNamespace(
+            head_num=2,
+            kv_head_num=1,
+            size_per_head=2,
+        ),
+        layernorm_eps=1e-6,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=True,
+    )
+
+
+def _language_weights():
+    return {
+        "model.embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(
+            8, 4
+        ),
+        "model.layers.0.input_layernorm.weight": torch.ones(4),
+        "model.layers.0.self_attn.q_proj.weight": torch.arange(
+            16, dtype=torch.float32
+        ).reshape(4, 4),
+        "model.layers.0.self_attn.k_proj.weight": torch.arange(
+            8, dtype=torch.float32
+        ).reshape(2, 4),
+        "model.layers.0.self_attn.v_proj.weight": torch.arange(
+            8, 16, dtype=torch.float32
+        ).reshape(2, 4),
+        "model.layers.0.self_attn.q_proj.bias": torch.full((4,), 0.5),
+        "model.layers.0.self_attn.k_proj.bias": torch.full((2,), -0.25),
+        "model.layers.0.self_attn.v_proj.bias": torch.full((2,), 0.75),
+        "model.layers.0.self_attn.o_proj.weight": torch.eye(4),
+        "model.layers.0.post_attention_layernorm.weight": torch.ones(4),
+        "model.layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+        "model.layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+        "model.layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+        "model.norm.weight": torch.ones(4),
+    }
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "embed_dim": 8,
+        "hidden_size": 6,
+        "hidden_act": "quick_gelu",
+        "mlp_ratio": 2.0,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 1,
+    }
+
+
+def _vision_model_config():
+    return {
+        "model_type": "qwen2_vl_vision",
+        "vision_config": _vision_config(),
+    }
+
+
+def _manual_vision_forward(model, pixel_values):
+    visual = model.visual
+    patch = visual.patch_embed
+    hidden = F.conv3d(
+        pixel_values.reshape(-1, 1, 1, 2, 2),
+        patch.proj.weight,
+        stride=(1, 2, 2),
+    ).reshape(-1, 8)
+
+    block = visual.blocks[0]
+    normed = F.layer_norm(
+        hidden,
+        (8,),
+        block.norm1.weight,
+        block.norm1.bias,
+        block.norm1.eps,
+    )
+    qkv = F.linear(normed, block.attn.qkv.weight, block.attn.qkv.bias)
+    q, k, v = qkv.reshape(8, 3, 2, 4).permute(1, 0, 2, 3).unbind(0)
+    positions = torch.tensor(
+        [[0, 0], [0, 1], [1, 0], [1, 1]] * 2,
+        dtype=torch.float32,
+    )
+    cos = positions.cos().unsqueeze(1).repeat(1, 1, 2)
+    sin = positions.sin().unsqueeze(1).repeat(1, 1, 2)
+
+    def rotate_half(tensor):
+        first, second = tensor.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    q = q * cos + rotate_half(q) * sin
+    k = k * cos + rotate_half(k) * sin
+    attention_outputs = []
+    for start in (0, 4):
+        end = start + 4
+        attention = F.scaled_dot_product_attention(
+            q[start:end].transpose(0, 1).unsqueeze(0),
+            k[start:end].transpose(0, 1).unsqueeze(0),
+            v[start:end].transpose(0, 1).unsqueeze(0),
+            dropout_p=0.0,
+        )
+        attention_outputs.append(attention.squeeze(0).transpose(0, 1))
+    attention = torch.cat(attention_outputs).reshape(8, 8)
+    hidden = hidden + F.linear(attention, block.attn.proj.weight, block.attn.proj.bias)
+    normed = F.layer_norm(
+        hidden,
+        (8,),
+        block.norm2.weight,
+        block.norm2.bias,
+        block.norm2.eps,
+    )
+    mlp_hidden = F.linear(normed, block.mlp.fc1.weight, block.mlp.fc1.bias)
+    mlp_hidden = mlp_hidden * torch.sigmoid(1.702 * mlp_hidden)
+    hidden = hidden + F.linear(mlp_hidden, block.mlp.fc2.weight, block.mlp.fc2.bias)
+
+    merger = visual.merger
+    merged = F.layer_norm(
+        hidden,
+        (8,),
+        merger.ln_q.weight,
+        merger.ln_q.bias,
+        merger.ln_q.eps,
+    ).reshape(-1, 32)
+    merged = F.gelu(F.linear(merged, merger.mlp[0].weight, merger.mlp[0].bias))
+    return F.linear(merged, merger.mlp[2].weight, merger.mlp[2].bias)
+
+
+class Qwen2VLNewLoaderTest(unittest.TestCase):
+    def test_language_loader_filters_visual_tensors_before_dispatch(self):
+        weights = _language_weights()
+        weights["visual.not_a_language_weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen2VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertNotIn("visual", dict(model.named_modules()))
+
+    def test_vision_loader_streams_only_visual_weights_and_matches_reference(self):
+        torch.manual_seed(7)
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+        }
+        weights["model.unused_language_weight"] = torch.ones(3)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config=_vision_model_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        for name, expected in source.state_dict().items():
+            torch.testing.assert_close(loaded.state_dict()[name], expected)
+        pixel_values = torch.arange(32, dtype=torch.float32).reshape(8, 4) / 31
+        grid_thw = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            actual = loaded(pixel_values, grid_thw)
+            expected = _manual_vision_forward(loaded, pixel_values)
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-5)
+
+    def test_vision_loader_rejects_unknown_visual_tensor(self):
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+        }
+        weights["visual.blocks.0.attn.typo.weight"] = torch.ones(1)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_loader_rejects_missing_required_tensor(self):
+        source = Qwen2VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = {
+            name: tensor.detach().clone()
+            for name, tensor in source.state_dict().items()
+            if name != "visual.blocks.0.attn.qkv.weight"
+        }
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "attn.qkv.weight"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_forward_rejects_inconsistent_grid(self):
+        model = Qwen2VLForVisionEmbedding(_vision_model_config(), _load_config())
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            model(torch.zeros(0, 4), torch.empty((0, 3), dtype=torch.int64))
+        with self.assertRaisesRegex(ValueError, "describes 4"):
+            model(torch.zeros(3, 4), torch.tensor([[1, 2, 2]]))
+        with self.assertRaisesRegex(ValueError, "spatial_merge_size"):
+            model(torch.zeros(6, 4), torch.tensor([[1, 2, 3]]))
+        with self.assertRaisesRegex(TypeError, "integer dtype"):
+            model(torch.zeros(4, 4), torch.tensor([[1.0, 2.0, 2.0]]))
+
+    def test_vision_config_rejects_invalid_rotary_head_dimension(self):
+        config = _vision_config()
+        config["embed_dim"] = 12
+        with self.assertRaisesRegex(ValueError, "head_dim=6 must be divisible by 4"):
+            Qwen2VLForVisionEmbedding(
+                {"model_type": "qwen2_vl_vision", "vision_config": config},
+                _load_config(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_vision_loader_import.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/test/test_qwen2_vl_vision_loader_import.py
@@ -1,0 +1,46 @@
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+    Qwen2VLForVisionEmbedding,
+    load_qwen2_vl_vision,
+)
+
+
+class Qwen2VLVisionLoaderImportTest(unittest.TestCase):
+    def test_public_vision_loader_target_loads_checkpoint_on_cpu(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+        }
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(source.state_dict(), f"{model_path}/pytorch_model.bin")
+            loaded = load_qwen2_vl_vision(
+                vision_config=vision_config,
+                model_path=model_path,
+                compute_dtype=torch.float32,
+                device="cpu",
+            )
+
+        self.assertEqual(loaded.device, torch.device("cpu"))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(loaded.state_dict()[name], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen2_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/vision.py
@@ -1,0 +1,508 @@
+import logging
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from itertools import accumulate
+from numbers import Real
+from typing import Any, Callable, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rtp_llm.models_py.model_loader import (
+    NewLoaderConfig,
+    NewLoaderLoadMethod,
+    NewModelLoader,
+)
+from rtp_llm.models_py.module_base import RtpModule
+
+logger = logging.getLogger(__name__)
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class Qwen2VLVisionConfig:
+    depth: int
+    embed_dim: int
+    hidden_size: int
+    hidden_act: str
+    mlp_ratio: float
+    num_heads: int
+    in_channels: int
+    patch_size: int
+    spatial_merge_size: int
+    temporal_patch_size: int
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any]) -> "Qwen2VLVisionConfig":
+        if not isinstance(config, Mapping):
+            raise TypeError("vision_config must be a mapping")
+        hidden_act = config.get("hidden_act", "quick_gelu")
+        if not isinstance(hidden_act, str):
+            raise TypeError("vision hidden_act must be a string")
+        mlp_ratio = config.get("mlp_ratio", 4.0)
+        if isinstance(mlp_ratio, bool) or not isinstance(mlp_ratio, Real):
+            raise TypeError("vision mlp_ratio must be a real number")
+        result = cls(
+            depth=_positive_int(config.get("depth", 32), "vision depth"),
+            embed_dim=_positive_int(config.get("embed_dim", 1280), "vision embed_dim"),
+            hidden_size=_positive_int(
+                config.get("hidden_size", 3584), "vision hidden_size"
+            ),
+            hidden_act=hidden_act,
+            mlp_ratio=float(mlp_ratio),
+            num_heads=_positive_int(config.get("num_heads", 16), "vision num_heads"),
+            in_channels=_positive_int(
+                config.get("in_chans", config.get("in_channels", 3)),
+                "vision in_channels",
+            ),
+            patch_size=_positive_int(config.get("patch_size", 14), "vision patch_size"),
+            spatial_merge_size=_positive_int(
+                config.get("spatial_merge_size", 2),
+                "vision spatial_merge_size",
+            ),
+            temporal_patch_size=_positive_int(
+                config.get("temporal_patch_size", 2),
+                "vision temporal_patch_size",
+            ),
+        )
+        if result.embed_dim % result.num_heads != 0:
+            raise ValueError(
+                f"vision embed_dim={result.embed_dim} must be divisible by "
+                f"num_heads={result.num_heads}"
+            )
+        head_dim = result.embed_dim // result.num_heads
+        if head_dim % 4 != 0:
+            raise ValueError(
+                f"vision head_dim={head_dim} must be divisible by 4 for 2D rotary "
+                "embedding"
+            )
+        if not math.isfinite(result.mlp_ratio) or result.mlp_ratio <= 0:
+            raise ValueError(
+                f"vision mlp_ratio must be finite and positive, got {result.mlp_ratio}"
+            )
+        if result.hidden_act not in {"gelu", "gelu_new", "quick_gelu"}:
+            raise ValueError(
+                f"Unsupported Qwen2-VL vision activation {result.hidden_act!r}"
+            )
+        return result
+
+
+class Qwen2VisionPatchEmbed(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.embed_dim = config.embed_dim
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        kernel_size = (
+            config.temporal_patch_size,
+            config.patch_size,
+            config.patch_size,
+        )
+        self.proj = nn.Conv3d(
+            config.in_channels,
+            config.embed_dim,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=False,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        expected_width = (
+            self.in_channels
+            * self.temporal_patch_size
+            * self.patch_size
+            * self.patch_size
+        )
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != expected_width:
+            raise ValueError(
+                "Qwen2-VL pixel values must have shape "
+                f"[num_patches, {expected_width}], got {tuple(hidden_states.shape)}"
+            )
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=self.proj.weight.dtype))
+        return hidden_states.reshape(-1, self.embed_dim)
+
+
+class Qwen2VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(
+            seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+        )
+        return torch.outer(seq, self.inv_freq)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    first, second = x.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_vision_rotary(
+    q: torch.Tensor, k: torch.Tensor, freqs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    original_q_dtype = q.dtype
+    original_k_dtype = k.dtype
+    cos = freqs.cos().unsqueeze(1).repeat(1, 1, 2).float()
+    sin = freqs.sin().unsqueeze(1).repeat(1, 1, 2).float()
+    q_float = q.float()
+    k_float = k.float()
+    q = (q_float * cos) + (_rotate_half(q_float) * sin)
+    k = (k_float * cos) + (_rotate_half(k_float) * sin)
+    return q.to(original_q_dtype), k.to(original_k_dtype)
+
+
+_FLASH_ATTN_VARLEN: Optional[Callable[..., torch.Tensor]] = None
+_FLASH_ATTN_RESOLVED = False
+
+
+def _resolve_flash_attn_varlen() -> Optional[Callable[..., torch.Tensor]]:
+    global _FLASH_ATTN_RESOLVED, _FLASH_ATTN_VARLEN
+    if _FLASH_ATTN_RESOLVED:
+        return _FLASH_ATTN_VARLEN
+    _FLASH_ATTN_RESOLVED = True
+    try:
+        from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+
+        if can_use_flash_attn():
+            from flash_attn import flash_attn_varlen_func
+
+            _FLASH_ATTN_VARLEN = flash_attn_varlen_func
+    except (ImportError, OSError) as exc:
+        logger.info("Qwen2-VL vision flash attention is unavailable: %s", exc)
+    return _FLASH_ATTN_VARLEN
+
+
+class Qwen2VisionAttention(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.num_heads = config.num_heads
+        self.head_dim = config.embed_dim // config.num_heads
+        self.qkv = nn.Linear(
+            config.embed_dim,
+            3 * config.embed_dim,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.proj = nn.Linear(
+            config.embed_dim,
+            config.embed_dim,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states).reshape(
+            seq_length, 3, self.num_heads, self.head_dim
+        )
+        q, k, v = qkv.permute(1, 0, 2, 3).unbind(0)
+        q, k = _apply_vision_rotary(q, k, rotary_pos_emb)
+
+        flash_attn_varlen = (
+            _resolve_flash_attn_varlen() if hidden_states.is_cuda else None
+        )
+        if flash_attn_varlen is not None:
+            output = flash_attn_varlen(
+                q,
+                k,
+                v,
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+            ).reshape(seq_length, -1)
+        else:
+            q_chunks = torch.split(q, segment_lengths, dim=0)
+            k_chunks = torch.split(k, segment_lengths, dim=0)
+            v_chunks = torch.split(v, segment_lengths, dim=0)
+            outputs = []
+            for q_chunk, k_chunk, v_chunk in zip(q_chunks, k_chunks, v_chunks):
+                output = F.scaled_dot_product_attention(
+                    q_chunk.transpose(0, 1).unsqueeze(0),
+                    k_chunk.transpose(0, 1).unsqueeze(0),
+                    v_chunk.transpose(0, 1).unsqueeze(0),
+                    dropout_p=0.0,
+                )
+                outputs.append(output.squeeze(0).transpose(0, 1))
+            output = torch.cat(outputs, dim=0).reshape(seq_length, -1)
+        return self.proj(output)
+
+
+def _apply_activation(x: torch.Tensor, name: str) -> torch.Tensor:
+    if name == "quick_gelu":
+        return x * torch.sigmoid(1.702 * x)
+    if name == "gelu_new":
+        return F.gelu(x, approximate="tanh")
+    return F.gelu(x)
+
+
+class Qwen2VisionMLP(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        intermediate_size = int(config.embed_dim * config.mlp_ratio)
+        if intermediate_size <= 0:
+            raise ValueError("Qwen2-VL vision MLP has an invalid intermediate size")
+        self.hidden_act = config.hidden_act
+        self.fc1 = nn.Linear(
+            config.embed_dim, intermediate_size, bias=True, dtype=params_dtype
+        )
+        self.fc2 = nn.Linear(
+            intermediate_size, config.embed_dim, bias=True, dtype=params_dtype
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(_apply_activation(self.fc1(x), self.hidden_act))
+
+
+class Qwen2VisionBlock(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.norm2 = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.attn = Qwen2VisionAttention(config, params_dtype)
+        self.mlp = Qwen2VisionMLP(config, params_dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens,
+            rotary_pos_emb,
+            segment_lengths,
+            max_seqlen,
+        )
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+class Qwen2VisionPatchMerger(RtpModule):
+    def __init__(self, config: Qwen2VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.hidden_size = config.embed_dim * (config.spatial_merge_size**2)
+        self.ln_q = nn.LayerNorm(config.embed_dim, eps=1e-6, dtype=params_dtype)
+        self.mlp = nn.Sequential(
+            nn.Linear(
+                self.hidden_size,
+                self.hidden_size,
+                bias=True,
+                dtype=params_dtype,
+            ),
+            nn.GELU(),
+            nn.Linear(
+                self.hidden_size,
+                config.hidden_size,
+                bias=True,
+                dtype=params_dtype,
+            ),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.ln_q(hidden_states).reshape(-1, self.hidden_size)
+        return self.mlp(hidden_states)
+
+
+class Qwen2VisionTransformer(RtpModule):
+    def __init__(self, vision_config: Mapping[str, Any], params_dtype: torch.dtype):
+        super().__init__()
+        config = Qwen2VLVisionConfig.from_mapping(vision_config)
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_embed = Qwen2VisionPatchEmbed(config, params_dtype)
+        head_dim = config.embed_dim // config.num_heads
+        self.rotary_pos_emb = Qwen2VisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [Qwen2VisionBlock(config, params_dtype) for _ in range(config.depth)]
+        )
+        self.merger = Qwen2VisionPatchMerger(config, params_dtype)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def get_dtype(self) -> torch.dtype:
+        return self.dtype
+
+    def get_device(self) -> torch.device:
+        return self.device
+
+    def _rotary_positions(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        position_ids = []
+        merge_size = self.spatial_merge_size
+        for t, h, w in grid_values:
+            if t <= 0 or h <= 0 or w <= 0:
+                raise ValueError(f"grid_thw values must be positive, got {(t, h, w)}")
+            if h % merge_size or w % merge_size:
+                raise ValueError(
+                    f"grid ({t}, {h}, {w}) must align to spatial_merge_size="
+                    f"{merge_size}"
+                )
+            h_positions = torch.arange(h).unsqueeze(1).expand(-1, w)
+            h_positions = (
+                h_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            w_positions = torch.arange(w).unsqueeze(0).expand(h, -1)
+            w_positions = (
+                w_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            position_ids.append(
+                torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
+            )
+        indices = torch.cat(position_ids, dim=0).to(self.device)
+        max_grid_size = max(max(h, w) for _, h, w in grid_values)
+        return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+            raise ValueError(
+                f"grid_thw must have shape [num_items, 3], got {tuple(grid_thw.shape)}"
+            )
+        if grid_thw.shape[0] == 0:
+            raise ValueError("grid_thw must describe at least one image or video")
+        if (
+            grid_thw.dtype == torch.bool
+            or grid_thw.is_floating_point()
+            or grid_thw.is_complex()
+        ):
+            raise TypeError("grid_thw must use an integer dtype")
+        if hidden_states.device != grid_thw.device:
+            raise ValueError(
+                "pixel_values and grid_thw must be on the same device, got "
+                f"{hidden_states.device} and {grid_thw.device}"
+            )
+        if hidden_states.device != self.device:
+            raise ValueError(
+                f"pixel_values must be on the vision model device {self.device}, "
+                f"got {hidden_states.device}"
+            )
+        grid_values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
+        rotary_pos_emb = self._rotary_positions(grid_values)
+        expected_patches = sum(t * h * w for t, h, w in grid_values)
+        if hidden_states.shape[0] != expected_patches:
+            raise ValueError(
+                f"pixel_values contain {hidden_states.shape[0]} patches, but "
+                f"grid_thw describes {expected_patches}"
+            )
+        hidden_states = self.patch_embed(hidden_states)
+        segment_lengths = tuple(h * w for t, h, w in grid_values for _ in range(t))
+        max_seqlen = max(segment_lengths)
+        cu_seqlens = torch.tensor(
+            (0, *accumulate(segment_lengths)),
+            device=hidden_states.device,
+            dtype=torch.int32,
+        )
+        for block in self.blocks:
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens,
+                rotary_pos_emb,
+                segment_lengths,
+                max_seqlen,
+            )
+        return self.merger(hidden_states)
+
+
+def _vision_config_from_model(
+    model_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if not isinstance(model_config, Mapping):
+        raise TypeError("qwen2_vl_vision model_config must be a mapping")
+    vision_config = model_config.get("vision_config")
+    if not isinstance(vision_config, Mapping):
+        raise TypeError("qwen2_vl_vision requires model_config.vision_config")
+    return vision_config
+
+
+class Qwen2VLForVisionEmbedding(RtpModule):
+    def __init__(self, model_config: Mapping[str, Any], load_config: NewLoaderConfig):
+        super().__init__()
+        if load_config.tp_size != 1 or load_config.tp_rank != 0:
+            raise ValueError("Qwen2-VL vision newloader is single-rank and replicated")
+        self.visual = Qwen2VisionTransformer(
+            _vision_config_from_model(model_config), load_config.compute_dtype
+        )
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("visual.")
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        return self.visual(hidden_states, grid_thw)
+
+
+def load_qwen2_vl_vision(
+    vision_config: Mapping[str, Any],
+    model_path: str,
+    compute_dtype: torch.dtype,
+    device: str,
+) -> Qwen2VisionTransformer:
+    model_config = {
+        "model_type": "qwen2_vl_vision",
+        "model_path": model_path,
+        "vision_config": dict(vision_config),
+    }
+    load_config = NewLoaderConfig(
+        compute_dtype=compute_dtype,
+        device=device,
+        load_method=NewLoaderLoadMethod.SCRATCH,
+    )
+    loader = NewModelLoader(
+        model_config=model_config,
+        load_config=load_config,
+        model_path=model_path,
+    )
+    with torch.device("cpu"):
+        model = loader.load()
+    return model.visual

--- a/rtp_llm/models_py/new_models/qwen2_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen2_vl/vision.py
@@ -157,12 +157,13 @@ def _rotate_half(x: torch.Tensor) -> torch.Tensor:
 
 
 def _apply_vision_rotary(
-    q: torch.Tensor, k: torch.Tensor, freqs: torch.Tensor
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     original_q_dtype = q.dtype
     original_k_dtype = k.dtype
-    cos = freqs.cos().unsqueeze(1).repeat(1, 1, 2).float()
-    sin = freqs.sin().unsqueeze(1).repeat(1, 1, 2).float()
     q_float = q.float()
     k_float = k.float()
     q = (q_float * cos) + (_rotate_half(q_float) * sin)
@@ -213,7 +214,8 @@ class Qwen2VisionAttention(RtpModule):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
         segment_lengths: tuple[int, ...],
         max_seqlen: int,
     ) -> torch.Tensor:
@@ -222,10 +224,12 @@ class Qwen2VisionAttention(RtpModule):
             seq_length, 3, self.num_heads, self.head_dim
         )
         q, k, v = qkv.permute(1, 0, 2, 3).unbind(0)
-        q, k = _apply_vision_rotary(q, k, rotary_pos_emb)
+        q, k = _apply_vision_rotary(q, k, rotary_cos, rotary_sin)
 
         flash_attn_varlen = (
-            _resolve_flash_attn_varlen() if hidden_states.is_cuda else None
+            _resolve_flash_attn_varlen()
+            if q.is_cuda and q.dtype in (torch.float16, torch.bfloat16)
+            else None
         )
         if flash_attn_varlen is not None:
             output = flash_attn_varlen(
@@ -292,14 +296,16 @@ class Qwen2VisionBlock(RtpModule):
         self,
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        rotary_pos_emb: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
         segment_lengths: tuple[int, ...],
         max_seqlen: int,
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
             cu_seqlens,
-            rotary_pos_emb,
+            rotary_cos,
+            rotary_sin,
             segment_lengths,
             max_seqlen,
         )
@@ -372,7 +378,7 @@ class Qwen2VisionTransformer(RtpModule):
                     f"grid ({t}, {h}, {w}) must align to spatial_merge_size="
                     f"{merge_size}"
                 )
-            h_positions = torch.arange(h).unsqueeze(1).expand(-1, w)
+            h_positions = torch.arange(h, device=self.device).unsqueeze(1).expand(-1, w)
             h_positions = (
                 h_positions.reshape(
                     h // merge_size,
@@ -383,7 +389,7 @@ class Qwen2VisionTransformer(RtpModule):
                 .permute(0, 2, 1, 3)
                 .flatten()
             )
-            w_positions = torch.arange(w).unsqueeze(0).expand(h, -1)
+            w_positions = torch.arange(w, device=self.device).unsqueeze(0).expand(h, -1)
             w_positions = (
                 w_positions.reshape(
                     h // merge_size,
@@ -397,7 +403,7 @@ class Qwen2VisionTransformer(RtpModule):
             position_ids.append(
                 torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
             )
-        indices = torch.cat(position_ids, dim=0).to(self.device)
+        indices = torch.cat(position_ids, dim=0)
         max_grid_size = max(max(h, w) for _, h, w in grid_values)
         return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
 
@@ -428,6 +434,8 @@ class Qwen2VisionTransformer(RtpModule):
             )
         grid_values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
         rotary_pos_emb = self._rotary_positions(grid_values)
+        rotary_cos = rotary_pos_emb.cos().unsqueeze(1).repeat(1, 1, 2).float()
+        rotary_sin = rotary_pos_emb.sin().unsqueeze(1).repeat(1, 1, 2).float()
         expected_patches = sum(t * h * w for t, h, w in grid_values)
         if hidden_states.shape[0] != expected_patches:
             raise ValueError(
@@ -446,7 +454,8 @@ class Qwen2VisionTransformer(RtpModule):
             hidden_states = block(
                 hidden_states,
                 cu_seqlens,
-                rotary_pos_emb,
+                rotary_cos,
+                rotary_sin,
                 segment_lengths,
                 max_seqlen,
             )

--- a/rtp_llm/models_py/new_models/qwen3_vl/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/__init__.py
@@ -1,0 +1,13 @@
+"""Qwen3-VL newloader language and vision implementations."""
+
+from typing import Any
+
+__all__ = ["Qwen3VLForCausalLM"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "Qwen3VLForCausalLM":
+        from rtp_llm.models_py.new_models.qwen3_vl.model import Qwen3VLForCausalLM
+
+        return Qwen3VLForCausalLM
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rtp_llm/models_py/new_models/qwen3_vl/model.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/model.py
@@ -1,0 +1,92 @@
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+
+from rtp_llm.models_py.modules import (
+    MultimodalDeepstackInjector,
+    MultimodalEmbeddingInjector,
+    reshape_extra_input_to_deepstack,
+)
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
+from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+
+
+class Qwen3VLForCausalLM(Qwen3ForCausalLM):
+    """Qwen3-VL text runtime with multimodal feature injection."""
+
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.language_model.": ""},
+    )
+
+    def __init__(self, model_config: Any, load_config: Any):
+        super().__init__(model_config, load_config)
+        self.multimodal_embedding_injector = MultimodalEmbeddingInjector()
+        self.multimodal_deepstack_injector = MultimodalDeepstackInjector()
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("model.language_model.") or name.startswith(
+            "lm_head."
+        )
+
+    def load_weights(
+        self, weights: Iterator[tuple[str, torch.Tensor]] | dict[str, torch.Tensor]
+    ) -> None:
+        iterator = weights.items() if isinstance(weights, dict) else weights
+        super().load_weights(self.WEIGHTS_MAPPER.apply(iterator))
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids = inputs.input_ids
+        text_tokens_mask = inputs.embedding_inputs.text_tokens_mask
+        if text_tokens_mask is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            text_mask = text_tokens_mask.to(device=input_ids.device, dtype=torch.bool)
+            safe_input_ids = torch.where(text_mask, input_ids, 0)
+            hidden_states = self.embed_tokens(safe_input_ids)
+            hidden_states = hidden_states * text_mask.unsqueeze(-1)
+
+        multimodal_inputs = inputs.multimodal_inputs
+        mm_features = multimodal_inputs.multimodal_features
+        mm_feature_locs = multimodal_inputs.mm_features_locs
+        mm_extra_input = multimodal_inputs.mm_extra_input
+        mm_deepstack_embeds = (
+            reshape_extra_input_to_deepstack(mm_extra_input, mm_features)
+            if mm_extra_input
+            else []
+        )
+        hidden_states = self.multimodal_embedding_injector(
+            hidden_states, mm_features, mm_feature_locs
+        )
+
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+
+        cpu_locs = (
+            mm_feature_locs.to(device="cpu", dtype=torch.long).view(-1).tolist()
+            if mm_deepstack_embeds and mm_feature_locs is not None
+            else []
+        )
+        for layer_id, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, layer_id)
+            hidden_states = layer(
+                hidden_states,
+                fmha_impl,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(layer_id) if self.kv_cache else None
+                ),
+            )
+            hidden_states = self.multimodal_deepstack_injector(
+                hidden_states,
+                mm_deepstack_embeds,
+                cpu_locs,
+                layer_id,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)
+
+
+__all__ = ["Qwen3VLForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/BUILD
@@ -1,0 +1,52 @@
+py_test(
+    name = "test_qwen3_vl_load",
+    srcs = ["test_qwen3_vl_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_vision_loader_import",
+    srcs = ["test_qwen3_vl_vision_loader_import.py"],
+    deps = [
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_gpu",
+    srcs = ["test_qwen3_vl_gpu.py"],
+    exec_properties = {
+        "gpu": "H20",
+        "gpu_count": "1",
+    },
+    tags = ["H20"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_rocm",
+    srcs = ["test_qwen3_vl_gpu.py"],
+    main = "test_qwen3_vl_gpu.py",
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "1",
+    },
+    tags = ["rocm"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
@@ -1,0 +1,204 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+    Qwen3VLForVisionEmbedding,
+    _resolve_flash_attn_varlen,
+    load_qwen3_vl_vision,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+def _reference_interpolated_position_embeddings(visual, grid_values):
+    index_lists = [[], [], [], []]
+    weight_lists = [[], [], [], []]
+    for _, height, width in grid_values:
+        height_indexes = torch.linspace(0, visual.num_grid_per_side - 1, height)
+        width_indexes = torch.linspace(0, visual.num_grid_per_side - 1, width)
+        height_floor = height_indexes.int()
+        width_floor = width_indexes.int()
+        height_ceil = (height_floor + 1).clip(max=visual.num_grid_per_side - 1)
+        width_ceil = (width_floor + 1).clip(max=visual.num_grid_per_side - 1)
+        delta_height = height_indexes - height_floor
+        delta_width = width_indexes - width_floor
+        base_height = height_floor * visual.num_grid_per_side
+        base_height_ceil = height_ceil * visual.num_grid_per_side
+
+        indexes = (
+            (base_height[:, None] + width_floor[None]).flatten(),
+            (base_height[:, None] + width_ceil[None]).flatten(),
+            (base_height_ceil[:, None] + width_floor[None]).flatten(),
+            (base_height_ceil[:, None] + width_ceil[None]).flatten(),
+        )
+        weights = (
+            ((1 - delta_height)[:, None] * (1 - delta_width)[None]).flatten(),
+            ((1 - delta_height)[:, None] * delta_width[None]).flatten(),
+            (delta_height[:, None] * (1 - delta_width)[None]).flatten(),
+            (delta_height[:, None] * delta_width[None]).flatten(),
+        )
+        for index in range(4):
+            index_lists[index].extend(indexes[index].tolist())
+            weight_lists[index].extend(weights[index].tolist())
+
+    index_tensor = torch.tensor(index_lists, dtype=torch.long, device=visual.device)
+    weight_tensor = torch.tensor(weight_lists, dtype=visual.dtype, device=visual.device)
+    weighted = visual.pos_embed(index_tensor) * weight_tensor[:, :, None]
+    interpolated = weighted[0] + weighted[1] + weighted[2] + weighted[3]
+    reduction_order = weighted.sum(dim=0)
+
+    def reorder(position_embeddings):
+        outputs = []
+        offset = 0
+        merge_size = visual.spatial_merge_size
+        for frames, height, width in grid_values:
+            spatial_size = height * width
+            item = position_embeddings[offset : offset + spatial_size]
+            offset += spatial_size
+            outputs.append(
+                item.repeat(frames, 1)
+                .reshape(
+                    frames,
+                    height // merge_size,
+                    merge_size,
+                    width // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+        return torch.cat(outputs)
+
+    return reorder(interpolated), reorder(reduction_order)
+
+
+class Qwen3VLVisionGpuTest(unittest.TestCase):
+    def test_bf16_position_interpolation_matches_reference_addition_order(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        torch.manual_seed(29)
+        visual = (
+            Qwen3VLForVisionEmbedding(
+                {
+                    "model_type": "qwen3_vl_vision",
+                    "vision_config": _vision_config(),
+                },
+                NewLoaderConfig(compute_dtype=torch.bfloat16, device="cuda:0"),
+            )
+            .cuda()
+            .eval()
+            .visual
+        )
+        grid_values = [(1, 6, 10)]
+        with torch.inference_mode():
+            actual = visual._interpolated_position_embeddings(grid_values)
+            expected, reduction_order = _reference_interpolated_position_embeddings(
+                visual, grid_values
+            )
+
+        self.assertTrue(torch.equal(actual, expected))
+        self.assertFalse(torch.equal(reduction_order, expected))
+
+    def test_real_newloader_gpu_forward_matches_cpu_reference(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+        if torch.version.hip is None:
+            self.assertIsNotNone(_resolve_flash_attn_varlen())
+
+        torch.manual_seed(11)
+        config = _vision_config()
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 64).reshape(8, 8)
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected_output, expected_deepstack = source(pixel_values, grid_thw)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            visual = load_qwen3_vl_vision(
+                vision_config=config,
+                model_path=model_path,
+                compute_dtype=torch.float16,
+                device="cuda:0",
+            )
+
+        self.assertFalse(visual.training)
+        self.assertEqual(visual.device, torch.device("cuda:0"))
+        with torch.inference_mode():
+            actual_output, actual_deepstack = visual(
+                pixel_values.cuda(), grid_thw.cuda()
+            )
+        torch.testing.assert_close(
+            actual_output.float().cpu(),
+            expected_output,
+            atol=2e-2,
+            rtol=2e-2,
+        )
+        self.assertEqual(len(actual_deepstack), len(expected_deepstack))
+        torch.testing.assert_close(
+            actual_deepstack[0].float().cpu(),
+            expected_deepstack[0],
+            atol=2e-2,
+            rtol=2e-2,
+        )
+
+    def test_fp32_accelerator_forward_uses_sdpa_fallback(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        config = _vision_config()
+        model = (
+            Qwen3VLForVisionEmbedding(
+                {"model_type": "qwen3_vl_vision", "vision_config": config},
+                NewLoaderConfig(compute_dtype=torch.float32, device="cuda:0"),
+            )
+            .cuda()
+            .eval()
+        )
+        pixel_values = torch.linspace(-1.0, 1.0, 64, device="cuda").reshape(8, 8)
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64, device="cuda")
+
+        with patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.vision._resolve_flash_attn_varlen",
+            side_effect=AssertionError("FP32 must not resolve flash-attention"),
+        ):
+            with torch.inference_mode():
+                output, deepstack = model(pixel_values, grid_thw)
+
+        self.assertEqual(output.device.type, "cuda")
+        self.assertEqual(len(deepstack), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
@@ -1,0 +1,451 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen3_vl import (
+    Qwen3VLForCausalLM as ExportedQwen3VLForCausalLM,
+)
+from rtp_llm.models_py.new_models.qwen3_vl.model import Qwen3VLForCausalLM
+from rtp_llm.models_py.new_models.qwen3_vl.vision import Qwen3VLForVisionEmbedding
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+
+def _parallelism(ep_size=1):
+    return types.SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=ep_size,
+        ep_rank=0,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+        get_attn_tp_size=lambda: 1,
+        get_attn_tp_rank=lambda: 0,
+        get_ffn_tp_size=lambda: 1,
+        get_ffn_tp_rank=lambda: 0,
+    )
+
+
+def _load_config(dtype=torch.float32, ep_size=1) -> NewLoaderConfig:
+    return NewLoaderConfig(
+        compute_dtype=dtype,
+        device="cpu",
+        quant_config=QuantizationConfig("none"),
+        parallelism_config=_parallelism(ep_size),
+        ep_size=ep_size,
+        ep_rank=0,
+    )
+
+
+def _language_config():
+    return types.SimpleNamespace(
+        model_type="qwen3_vl",
+        num_layers=1,
+        vocab_size=8,
+        hidden_size=4,
+        inter_size=4,
+        attn_config=types.SimpleNamespace(
+            head_num=2,
+            kv_head_num=1,
+            size_per_head=2,
+        ),
+        layernorm_eps=1e-6,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=True,
+        expert_num=0,
+    )
+
+
+def _language_weights():
+    prefix = "model.language_model."
+    return {
+        prefix
+        + "embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(8, 4),
+        prefix + "layers.0.input_layernorm.weight": torch.ones(4),
+        prefix
+        + "layers.0.self_attn.q_proj.weight": torch.arange(
+            16, dtype=torch.float32
+        ).reshape(4, 4),
+        prefix
+        + "layers.0.self_attn.k_proj.weight": torch.arange(
+            8, dtype=torch.float32
+        ).reshape(2, 4),
+        prefix
+        + "layers.0.self_attn.v_proj.weight": torch.arange(
+            8, 16, dtype=torch.float32
+        ).reshape(2, 4),
+        prefix + "layers.0.self_attn.q_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.k_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.o_proj.weight": torch.eye(4),
+        prefix + "layers.0.post_attention_layernorm.weight": torch.ones(4),
+        prefix + "layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+        prefix + "layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+        prefix + "layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+        prefix + "norm.weight": torch.ones(4),
+    }
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+def _vision_model_config():
+    return {
+        "model_type": "qwen3_vl_vision",
+        "vision_config": _vision_config(),
+    }
+
+
+def _manual_merger(merger, hidden_states):
+    if merger.use_postshuffle_norm:
+        hidden_states = F.layer_norm(
+            hidden_states.reshape(-1, 32),
+            (32,),
+            merger.norm.weight,
+            merger.norm.bias,
+            merger.norm.eps,
+        )
+    else:
+        hidden_states = F.layer_norm(
+            hidden_states,
+            (8,),
+            merger.norm.weight,
+            merger.norm.bias,
+            merger.norm.eps,
+        ).reshape(-1, 32)
+    hidden_states = F.gelu(
+        F.linear(
+            hidden_states,
+            merger.linear_fc1.weight,
+            merger.linear_fc1.bias,
+        )
+    )
+    return F.linear(
+        hidden_states,
+        merger.linear_fc2.weight,
+        merger.linear_fc2.bias,
+    )
+
+
+def _manual_vision_forward(model, pixel_values):
+    visual = model.visual
+    hidden_states = F.conv3d(
+        pixel_values.reshape(-1, 1, 2, 2, 2),
+        visual.patch_embed.proj.weight,
+        visual.patch_embed.proj.bias,
+        stride=(2, 2, 2),
+    ).reshape(-1, 8)
+    position_indexes = torch.tensor([0, 3, 12, 15] * 2)
+    hidden_states = hidden_states + visual.pos_embed(position_indexes)
+
+    block = visual.blocks[0]
+    normed = F.layer_norm(
+        hidden_states,
+        (8,),
+        block.norm1.weight,
+        block.norm1.bias,
+        block.norm1.eps,
+    )
+    qkv = F.linear(normed, block.attn.qkv.weight, block.attn.qkv.bias)
+    query, key, value = qkv.reshape(8, 3, 2, 4).permute(1, 0, 2, 3).unbind(0)
+    positions = torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]] * 2)
+    cos = positions.cos().unsqueeze(1).repeat(1, 1, 2)
+    sin = positions.sin().unsqueeze(1).repeat(1, 1, 2)
+
+    def rotate_half(tensor):
+        first, second = tensor.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    query = query * cos + rotate_half(query) * sin
+    key = key * cos + rotate_half(key) * sin
+    attention_outputs = []
+    for start in (0, 4):
+        end = start + 4
+        attention = F.scaled_dot_product_attention(
+            query[start:end].transpose(0, 1).unsqueeze(0),
+            key[start:end].transpose(0, 1).unsqueeze(0),
+            value[start:end].transpose(0, 1).unsqueeze(0),
+            dropout_p=0.0,
+        )
+        attention_outputs.append(attention.squeeze(0).transpose(0, 1))
+    attention = torch.cat(attention_outputs).reshape(8, 8)
+    hidden_states = hidden_states + F.linear(
+        attention,
+        block.attn.proj.weight,
+        block.attn.proj.bias,
+    )
+
+    normed = F.layer_norm(
+        hidden_states,
+        (8,),
+        block.norm2.weight,
+        block.norm2.bias,
+        block.norm2.eps,
+    )
+    mlp = F.gelu(
+        F.linear(normed, block.mlp.linear_fc1.weight, block.mlp.linear_fc1.bias),
+        approximate="tanh",
+    )
+    hidden_states = hidden_states + F.linear(
+        mlp,
+        block.mlp.linear_fc2.weight,
+        block.mlp.linear_fc2.bias,
+    )
+    return (
+        _manual_merger(visual.merger, hidden_states),
+        [_manual_merger(visual.deepstack_merger_list[0], hidden_states)],
+    )
+
+
+def _vision_checkpoint(model):
+    return {
+        f"model.{name}": tensor.detach().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
+class Qwen3VLNewLoaderTest(unittest.TestCase):
+    def test_package_export_resolves_language_model_lazily(self):
+        self.assertIs(ExportedQwen3VLForCausalLM, Qwen3VLForCausalLM)
+
+    def test_language_loader_filters_visual_tensors_before_dispatch(self):
+        weights = _language_weights()
+        weights["model.visual.not_a_language_weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen3VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertNotIn("visual", dict(model.named_modules()))
+
+    def test_unknown_language_tensor_is_not_silently_ignored(self):
+        weights = _language_weights()
+        weights["model.language_model.layers.0.typo.weight"] = torch.ones(1)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_language_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_missing_language_tensor_is_not_silently_ignored(self):
+        weights = _language_weights()
+        del weights["model.language_model.layers.0.self_attn.q_proj.weight"]
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, r"qkv_proj.*weight"):
+                NewModelLoader(
+                    model_config=_language_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_dense_language_ignores_runtime_ep_topology(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_language_weights(), f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(ep_size=2),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen3VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+
+    def test_language_forward_handles_text_only_input(self):
+        class IdentityLayer(torch.nn.Module):
+            def forward(self, hidden_states, fmha_impl, kv_cache=None):
+                return hidden_states
+
+        model = Qwen3VLForCausalLM.__new__(Qwen3VLForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        model.layers = torch.nn.ModuleList([IdentityLayer()])
+        model.norm = torch.nn.Identity()
+        model.kv_cache = None
+        model.multimodal_embedding_injector = (
+            lambda hidden_states, features, locations: hidden_states
+        )
+        model.multimodal_deepstack_injector = (
+            lambda hidden_states, deepstack, locations, layer_id: hidden_states
+        )
+        input_ids = torch.tensor([1, 2, 3])
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            embedding_inputs=types.SimpleNamespace(text_tokens_mask=None),
+            multimodal_inputs=types.SimpleNamespace(
+                multimodal_features=[],
+                mm_features_locs=torch.empty(0, dtype=torch.long),
+                mm_extra_input=[],
+            ),
+            attention_inputs=object(),
+        )
+        fmha_impl = types.SimpleNamespace(fmha_params=None)
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.model." "select_block_map_for_layer"
+        ):
+            outputs = model(inputs, fmha_impl)
+
+        torch.testing.assert_close(outputs.hidden_states, model.embed_tokens(input_ids))
+
+    def test_vision_loader_matches_independent_cpu_reference(self):
+        torch.manual_seed(7)
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        weights["model.language_model.unused.weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config=_vision_model_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        pixel_values = torch.arange(64, dtype=torch.float32).reshape(8, 8) / 63
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            actual_output, actual_deepstack = loaded(pixel_values, grid_thw)
+            expected_output, expected_deepstack = _manual_vision_forward(
+                loaded, pixel_values
+            )
+        torch.testing.assert_close(actual_output, expected_output, atol=1e-6, rtol=1e-5)
+        self.assertEqual(len(actual_deepstack), 1)
+        torch.testing.assert_close(
+            actual_deepstack[0], expected_deepstack[0], atol=1e-6, rtol=1e-5
+        )
+
+    def test_vision_loader_rejects_unknown_and_missing_tensors(self):
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        with tempfile.TemporaryDirectory() as model_path:
+            unexpected = dict(weights)
+            unexpected["model.visual.blocks.0.attn.typo.weight"] = torch.ones(1)
+            save_file(unexpected, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+        with tempfile.TemporaryDirectory() as model_path:
+            missing = dict(weights)
+            del missing["model.visual.blocks.0.attn.qkv.weight"]
+            save_file(missing, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "attn.qkv.weight"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_forward_handles_video_and_heterogeneous_grids(self):
+        torch.manual_seed(13)
+        model = Qwen3VLForVisionEmbedding(_vision_model_config(), _load_config()).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            combined, combined_deepstack = model(pixel_values, grid_thw)
+            first, first_deepstack = model(pixel_values[:8], grid_thw[:1])
+            second, second_deepstack = model(pixel_values[8:], grid_thw[1:])
+
+        torch.testing.assert_close(
+            combined, torch.cat((first, second)), atol=1e-6, rtol=1e-5
+        )
+        self.assertEqual(len(combined_deepstack), 1)
+        torch.testing.assert_close(
+            combined_deepstack[0],
+            torch.cat((first_deepstack[0], second_deepstack[0])),
+            atol=1e-6,
+            rtol=1e-5,
+        )
+
+    def test_vision_forward_rejects_invalid_grid_and_patch_count(self):
+        model = Qwen3VLForVisionEmbedding(_vision_model_config(), _load_config()).eval()
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            model(torch.zeros(0, 8), torch.empty((0, 3), dtype=torch.int64))
+        with self.assertRaisesRegex(ValueError, "align"):
+            model(torch.zeros(6, 8), torch.tensor([[1, 2, 3]]))
+        with self.assertRaisesRegex(ValueError, "describes 4"):
+            model(torch.zeros(3, 8), torch.tensor([[1, 2, 2]]))
+        with self.assertRaisesRegex(TypeError, "integer dtype"):
+            model(torch.zeros(4, 8), torch.tensor([[1.0, 2.0, 2.0]]))
+
+    def test_vision_loader_matches_legacy_fp16_staging_for_runtime_dtypes(self):
+        torch.manual_seed(19)
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        key = "model.visual.blocks.0.attn.qkv.weight"
+        weights[key] = torch.linspace(
+            -0.0001,
+            0.0001,
+            weights[key].numel(),
+            dtype=torch.float32,
+        ).reshape_as(weights[key])
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            for runtime_dtype in (
+                torch.float16,
+                torch.bfloat16,
+                torch.float32,
+            ):
+                with self.subTest(runtime_dtype=runtime_dtype):
+                    loaded = NewModelLoader(
+                        model_config=_vision_model_config(),
+                        load_config=_load_config(runtime_dtype),
+                        model_path=model_path,
+                    ).load()
+                    expected = weights[key].to(torch.float16).to(runtime_dtype)
+                    torch.testing.assert_close(
+                        loaded.visual.blocks[0].attn.qkv.weight,
+                        expected,
+                    )
+                    if runtime_dtype == torch.bfloat16:
+                        self.assertFalse(
+                            torch.equal(expected, weights[key].to(torch.bfloat16))
+                        )
+                    before = loaded.visual.blocks[0].attn.qkv.weight.detach().clone()
+                    loaded.visual.process_weights_after_loading()
+                    torch.testing.assert_close(
+                        loaded.visual.blocks[0].attn.qkv.weight,
+                        before,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_vision_loader_import.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_vision_loader_import.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+    Qwen3VLForVisionEmbedding,
+    load_qwen3_vl_vision,
+)
+
+
+class Qwen3VLVisionLoaderImportTest(unittest.TestCase):
+    def test_public_vision_loader_target_loads_checkpoint_on_cpu(self):
+        vision_config = {
+            "depth": 1,
+            "hidden_size": 8,
+            "hidden_act": "gelu_pytorch_tanh",
+            "intermediate_size": 16,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "out_hidden_size": 6,
+            "num_position_embeddings": 16,
+            "deepstack_visual_indexes": [0],
+        }
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(
+                {
+                    f"model.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/pytorch_model.bin",
+            )
+            loaded = load_qwen3_vl_vision(
+                vision_config=vision_config,
+                model_path=model_path,
+                compute_dtype=torch.float32,
+                device="cpu",
+            )
+
+        self.assertEqual(loaded.device, torch.device("cpu"))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                loaded.state_dict()[name],
+                expected.to(torch.float16).to(torch.float32),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/vision.py
@@ -1,0 +1,686 @@
+import logging
+import math
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import accumulate
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rtp_llm.models_py.model_loader import (
+    NewLoaderConfig,
+    NewLoaderLoadMethod,
+    NewModelLoader,
+)
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+
+logger = logging.getLogger(__name__)
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class Qwen3VLVisionConfig:
+    depth: int
+    hidden_size: int
+    hidden_act: str
+    intermediate_size: int
+    num_heads: int
+    in_channels: int
+    patch_size: int
+    spatial_merge_size: int
+    temporal_patch_size: int
+    out_hidden_size: int
+    num_position_embeddings: int
+    deepstack_visual_indexes: tuple[int, ...]
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any]) -> "Qwen3VLVisionConfig":
+        if not isinstance(config, Mapping):
+            raise TypeError("vision_config must be a mapping")
+        hidden_act = config.get("hidden_act", "gelu_pytorch_tanh")
+        if not isinstance(hidden_act, str):
+            raise TypeError("vision hidden_act must be a string")
+        raw_indexes = config.get("deepstack_visual_indexes", (5, 11, 17))
+        if not isinstance(raw_indexes, Sequence) or isinstance(
+            raw_indexes, (str, bytes)
+        ):
+            raise TypeError("deepstack_visual_indexes must be a sequence of integers")
+        indexes = tuple(raw_indexes)
+        if any(
+            isinstance(index, bool) or not isinstance(index, int) for index in indexes
+        ):
+            raise TypeError("deepstack_visual_indexes must contain only integers")
+
+        result = cls(
+            depth=_positive_int(config.get("depth", 24), "vision depth"),
+            hidden_size=_positive_int(
+                config.get("hidden_size", 1024), "vision hidden_size"
+            ),
+            hidden_act=hidden_act,
+            intermediate_size=_positive_int(
+                config.get("intermediate_size", 4096),
+                "vision intermediate_size",
+            ),
+            num_heads=_positive_int(config.get("num_heads", 16), "vision num_heads"),
+            in_channels=_positive_int(
+                config.get("in_channels", 3), "vision in_channels"
+            ),
+            patch_size=_positive_int(config.get("patch_size", 16), "vision patch_size"),
+            spatial_merge_size=_positive_int(
+                config.get("spatial_merge_size", 2),
+                "vision spatial_merge_size",
+            ),
+            temporal_patch_size=_positive_int(
+                config.get("temporal_patch_size", 2),
+                "vision temporal_patch_size",
+            ),
+            out_hidden_size=_positive_int(
+                config.get("out_hidden_size", 2560),
+                "vision out_hidden_size",
+            ),
+            num_position_embeddings=_positive_int(
+                config.get("num_position_embeddings", 2304),
+                "vision num_position_embeddings",
+            ),
+            deepstack_visual_indexes=indexes,
+        )
+        if result.hidden_size % result.num_heads:
+            raise ValueError(
+                f"vision hidden_size={result.hidden_size} must be divisible by "
+                f"num_heads={result.num_heads}"
+            )
+        head_dim = result.hidden_size // result.num_heads
+        if head_dim % 4:
+            raise ValueError(
+                f"vision head_dim={head_dim} must be divisible by 4 for 2D rotary "
+                "embedding"
+            )
+        grid_side = math.isqrt(result.num_position_embeddings)
+        if grid_side * grid_side != result.num_position_embeddings:
+            raise ValueError("num_position_embeddings must form a square grid")
+        if len(set(indexes)) != len(indexes):
+            raise ValueError("deepstack_visual_indexes must not contain duplicates")
+        if any(index < 0 or index >= result.depth for index in indexes):
+            raise ValueError(
+                "deepstack_visual_indexes must refer to existing vision blocks"
+            )
+        if result.hidden_act not in {"gelu", "gelu_pytorch_tanh"}:
+            raise ValueError(
+                f"Unsupported Qwen3-VL vision activation {result.hidden_act!r}"
+            )
+        return result
+
+
+class Qwen3VisionPatchEmbed(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.hidden_size = config.hidden_size
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        kernel_size = (
+            config.temporal_patch_size,
+            config.patch_size,
+            config.patch_size,
+        )
+        self.proj = nn.Conv3d(
+            config.in_channels,
+            config.hidden_size,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        expected_width = (
+            self.in_channels
+            * self.temporal_patch_size
+            * self.patch_size
+            * self.patch_size
+        )
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != expected_width:
+            raise ValueError(
+                "Qwen3-VL pixel values must have shape "
+                f"[num_patches, {expected_width}], got {tuple(hidden_states.shape)}"
+            )
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=self.proj.weight.dtype))
+        return hidden_states.reshape(-1, self.hidden_size)
+
+
+class Qwen3VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        positions = torch.arange(
+            seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+        )
+        return torch.outer(positions, self.inv_freq)
+
+
+def _rotate_half(tensor: torch.Tensor) -> torch.Tensor:
+    first, second = tensor.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_vision_rotary(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query_dtype = query.dtype
+    key_dtype = key.dtype
+    query = query.float()
+    key = key.float()
+    query = (query * cos) + (_rotate_half(query) * sin)
+    key = (key * cos) + (_rotate_half(key) * sin)
+    return query.to(query_dtype), key.to(key_dtype)
+
+
+_FLASH_ATTN_VARLEN: Optional[Callable[..., torch.Tensor]] = None
+_FLASH_ATTN_RESOLVED = False
+
+
+def _resolve_flash_attn_varlen() -> Optional[Callable[..., torch.Tensor]]:
+    global _FLASH_ATTN_RESOLVED, _FLASH_ATTN_VARLEN
+    if _FLASH_ATTN_RESOLVED:
+        return _FLASH_ATTN_VARLEN
+    _FLASH_ATTN_RESOLVED = True
+    try:
+        from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+
+        if can_use_flash_attn():
+            from flash_attn import flash_attn_varlen_func
+
+            _FLASH_ATTN_VARLEN = flash_attn_varlen_func
+    except (ImportError, OSError) as exc:
+        logger.info("Qwen3-VL vision flash attention is unavailable: %s", exc)
+    return _FLASH_ATTN_VARLEN
+
+
+class Qwen3VisionAttention(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.num_heads = config.num_heads
+        self.head_dim = config.hidden_size // config.num_heads
+        self.qkv = nn.Linear(
+            config.hidden_size,
+            3 * config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.proj = nn.Linear(
+            config.hidden_size,
+            config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states).reshape(
+            seq_length, 3, self.num_heads, self.head_dim
+        )
+        query, key, value = qkv.permute(1, 0, 2, 3).unbind(0)
+        query, key = _apply_vision_rotary(query, key, rotary_cos, rotary_sin)
+
+        flash_attn_varlen = (
+            _resolve_flash_attn_varlen()
+            if query.is_cuda and query.dtype in (torch.float16, torch.bfloat16)
+            else None
+        )
+        if flash_attn_varlen is not None:
+            output = flash_attn_varlen(
+                query,
+                key,
+                value,
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+            ).reshape(seq_length, -1)
+        else:
+            query_chunks = torch.split(query, segment_lengths, dim=0)
+            key_chunks = torch.split(key, segment_lengths, dim=0)
+            value_chunks = torch.split(value, segment_lengths, dim=0)
+            outputs = []
+            for query_chunk, key_chunk, value_chunk in zip(
+                query_chunks, key_chunks, value_chunks
+            ):
+                output = F.scaled_dot_product_attention(
+                    query_chunk.transpose(0, 1).unsqueeze(0),
+                    key_chunk.transpose(0, 1).unsqueeze(0),
+                    value_chunk.transpose(0, 1).unsqueeze(0),
+                    dropout_p=0.0,
+                )
+                outputs.append(output.squeeze(0).transpose(0, 1))
+            output = torch.cat(outputs, dim=0).reshape(seq_length, -1)
+        return self.proj(output)
+
+
+class Qwen3VisionMLP(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.hidden_act = config.hidden_act
+        self.linear_fc1 = nn.Linear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.linear_fc2 = nn.Linear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_fc1(hidden_states)
+        hidden_states = F.gelu(
+            hidden_states,
+            approximate="tanh" if self.hidden_act == "gelu_pytorch_tanh" else "none",
+        )
+        return self.linear_fc2(hidden_states)
+
+
+class Qwen3VisionBlock(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6, dtype=params_dtype)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6, dtype=params_dtype)
+        self.attn = Qwen3VisionAttention(config, params_dtype)
+        self.mlp = Qwen3VisionMLP(config, params_dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens,
+            rotary_cos,
+            rotary_sin,
+            segment_lengths,
+            max_seqlen,
+        )
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+class Qwen3VisionPatchMerger(RtpModule):
+    def __init__(
+        self,
+        config: Qwen3VLVisionConfig,
+        params_dtype: torch.dtype,
+        use_postshuffle_norm: bool,
+    ):
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = use_postshuffle_norm
+        norm_size = self.hidden_size if use_postshuffle_norm else config.hidden_size
+        self.norm = nn.LayerNorm(norm_size, eps=1e-6, dtype=params_dtype)
+        self.linear_fc1 = nn.Linear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.linear_fc2 = nn.Linear(
+            self.hidden_size,
+            config.out_hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_postshuffle_norm:
+            hidden_states = self.norm(hidden_states.reshape(-1, self.hidden_size))
+        else:
+            hidden_states = self.norm(hidden_states).reshape(-1, self.hidden_size)
+        hidden_states = F.gelu(self.linear_fc1(hidden_states))
+        return self.linear_fc2(hidden_states)
+
+
+class Qwen3VLVisionTransformer(RtpModule):
+    def __init__(self, vision_config: Mapping[str, Any], params_dtype: torch.dtype):
+        super().__init__()
+        config = Qwen3VLVisionConfig.from_mapping(vision_config)
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+        self.num_grid_per_side = math.isqrt(config.num_position_embeddings)
+        self.deepstack_visual_indexes = config.deepstack_visual_indexes
+
+        self.patch_embed = Qwen3VisionPatchEmbed(config, params_dtype)
+        self.pos_embed = nn.Embedding(
+            config.num_position_embeddings,
+            config.hidden_size,
+            dtype=params_dtype,
+        )
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Qwen3VisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [Qwen3VisionBlock(config, params_dtype) for _ in range(config.depth)]
+        )
+        self.merger = Qwen3VisionPatchMerger(
+            config, params_dtype, use_postshuffle_norm=False
+        )
+        self.deepstack_merger_list = nn.ModuleList(
+            [
+                Qwen3VisionPatchMerger(config, params_dtype, use_postshuffle_norm=True)
+                for _ in self.deepstack_visual_indexes
+            ]
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def get_dtype(self) -> torch.dtype:
+        return self.dtype
+
+    def get_device(self) -> torch.device:
+        return self.device
+
+    def _grid_values(self, grid_thw: torch.Tensor) -> list[tuple[int, int, int]]:
+        if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+            raise ValueError(
+                f"grid_thw must have shape [num_items, 3], got {tuple(grid_thw.shape)}"
+            )
+        if grid_thw.shape[0] == 0:
+            raise ValueError("grid_thw must describe at least one image or video")
+        if (
+            grid_thw.dtype == torch.bool
+            or grid_thw.is_floating_point()
+            or grid_thw.is_complex()
+        ):
+            raise TypeError("grid_thw must use an integer dtype")
+        if grid_thw.device != self.device:
+            raise ValueError(
+                f"grid_thw must be on the vision model device {self.device}, "
+                f"got {grid_thw.device}"
+            )
+
+        values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
+        for value in values:
+            t, h, w = value
+            if t <= 0 or h <= 0 or w <= 0:
+                raise ValueError(f"grid_thw values must be positive, got {value}")
+            if h % self.spatial_merge_size or w % self.spatial_merge_size:
+                raise ValueError(
+                    f"grid {value} must align to spatial_merge_size="
+                    f"{self.spatial_merge_size}"
+                )
+        return values
+
+    def _rotary_positions(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        position_ids = []
+        merge_size = self.spatial_merge_size
+        for t, h, w in grid_values:
+            h_positions = torch.arange(h, device=self.device).unsqueeze(1).expand(-1, w)
+            h_positions = (
+                h_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            w_positions = torch.arange(w, device=self.device).unsqueeze(0).expand(h, -1)
+            w_positions = (
+                w_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            position_ids.append(
+                torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
+            )
+        indices = torch.cat(position_ids, dim=0)
+        max_grid_size = max(max(h, w) for _, h, w in grid_values)
+        return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
+
+    def _interpolated_position_embeddings(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        index_lists: list[list[int]] = [[], [], [], []]
+        weight_lists: list[list[float]] = [[], [], [], []]
+        for _, h, w in grid_values:
+            h_indexes = torch.linspace(0, self.num_grid_per_side - 1, h)
+            w_indexes = torch.linspace(0, self.num_grid_per_side - 1, w)
+            h_floor = h_indexes.int()
+            w_floor = w_indexes.int()
+            h_ceil = (h_floor + 1).clip(max=self.num_grid_per_side - 1)
+            w_ceil = (w_floor + 1).clip(max=self.num_grid_per_side - 1)
+            delta_h = h_indexes - h_floor
+            delta_w = w_indexes - w_floor
+            base_h = h_floor * self.num_grid_per_side
+            base_h_ceil = h_ceil * self.num_grid_per_side
+
+            indexes = (
+                (base_h[:, None] + w_floor[None]).flatten(),
+                (base_h[:, None] + w_ceil[None]).flatten(),
+                (base_h_ceil[:, None] + w_floor[None]).flatten(),
+                (base_h_ceil[:, None] + w_ceil[None]).flatten(),
+            )
+            weights = (
+                ((1 - delta_h)[:, None] * (1 - delta_w)[None]).flatten(),
+                ((1 - delta_h)[:, None] * delta_w[None]).flatten(),
+                (delta_h[:, None] * (1 - delta_w)[None]).flatten(),
+                (delta_h[:, None] * delta_w[None]).flatten(),
+            )
+            for index in range(4):
+                index_lists[index].extend(indexes[index].tolist())
+                weight_lists[index].extend(weights[index].tolist())
+
+        index_tensor = torch.tensor(index_lists, dtype=torch.long, device=self.device)
+        weight_tensor = torch.tensor(weight_lists, dtype=self.dtype, device=self.device)
+        position_embeddings = self.pos_embed(index_tensor) * weight_tensor[:, :, None]
+        interpolated = (
+            position_embeddings[0]
+            + position_embeddings[1]
+            + position_embeddings[2]
+            + position_embeddings[3]
+        )
+        spatial_sizes = [h * w for _, h, w in grid_values]
+        spatial_embeddings = interpolated.split(spatial_sizes)
+
+        outputs = []
+        merge_size = self.spatial_merge_size
+        for position_embedding, (t, h, w) in zip(spatial_embeddings, grid_values):
+            position_embedding = position_embedding.repeat(t, 1)
+            position_embedding = (
+                position_embedding.reshape(
+                    t,
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            outputs.append(position_embedding)
+        return torch.cat(outputs)
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        if hidden_states.device != self.device:
+            raise ValueError(
+                f"pixel_values must be on the vision model device {self.device}, "
+                f"got {hidden_states.device}"
+            )
+        grid_values = self._grid_values(grid_thw)
+        expected_patches = sum(t * h * w for t, h, w in grid_values)
+        if hidden_states.shape[0] != expected_patches:
+            raise ValueError(
+                f"pixel_values contain {hidden_states.shape[0]} patches, but "
+                f"grid_thw describes {expected_patches}"
+            )
+
+        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = hidden_states + self._interpolated_position_embeddings(
+            grid_values
+        )
+        rotary_pos_emb = self._rotary_positions(grid_values)
+        rotary_cos = rotary_pos_emb.cos().unsqueeze(1).repeat(1, 1, 2).float()
+        rotary_sin = rotary_pos_emb.sin().unsqueeze(1).repeat(1, 1, 2).float()
+        segment_lengths = tuple(h * w for t, h, w in grid_values for _ in range(t))
+        max_seqlen = max(segment_lengths)
+        cu_seqlens = torch.tensor(
+            (0, *accumulate(segment_lengths)),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        deepstack_features = []
+        deepstack_index_map = {
+            layer_index: merger_index
+            for merger_index, layer_index in enumerate(self.deepstack_visual_indexes)
+        }
+        for layer_index, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens,
+                rotary_cos,
+                rotary_sin,
+                segment_lengths,
+                max_seqlen,
+            )
+            merger_index = deepstack_index_map.get(layer_index)
+            if merger_index is not None:
+                deepstack_features.append(
+                    self.deepstack_merger_list[merger_index](hidden_states)
+                )
+        return self.merger(hidden_states), deepstack_features
+
+
+def _vision_config_from_model(
+    model_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if not isinstance(model_config, Mapping):
+        raise TypeError("qwen3_vl_vision model_config must be a mapping")
+    vision_config = model_config.get("vision_config")
+    if not isinstance(vision_config, Mapping):
+        raise TypeError("qwen3_vl_vision requires model_config.vision_config")
+    return vision_config
+
+
+class Qwen3VLForVisionEmbedding(RtpModule):
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.visual.": "visual."},
+    )
+
+    def __init__(self, model_config: Mapping[str, Any], load_config: NewLoaderConfig):
+        super().__init__()
+        if load_config.tp_size != 1 or load_config.tp_rank != 0:
+            raise ValueError("Qwen3-VL vision newloader is single-rank and replicated")
+        self.visual = Qwen3VLVisionTransformer(
+            _vision_config_from_model(model_config), load_config.compute_dtype
+        )
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("model.visual.")
+
+    def load_weights(
+        self, weights: Iterator[tuple[str, torch.Tensor]] | dict[str, torch.Tensor]
+    ) -> None:
+        iterator = weights.items() if isinstance(weights, dict) else weights
+
+        def legacy_compatible_weights():
+            target_dtype = self.visual.dtype
+            for name, tensor in iterator:
+                if tensor.is_floating_point():
+                    # The established Qwen3-VL vision path stages every checkpoint
+                    # tensor through FP16 before converting it to the runtime dtype.
+                    # Preserve that numerical contract so newloader and legacy
+                    # inference produce the same BF16/FP32 features and tokens.
+                    tensor = tensor.to(torch.float16).to(target_dtype)
+                yield name, tensor
+
+        super().load_weights(self.WEIGHTS_MAPPER.apply(legacy_compatible_weights()))
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        return self.visual(hidden_states, grid_thw)
+
+
+def load_qwen3_vl_vision(
+    vision_config: Mapping[str, Any],
+    model_path: str,
+    compute_dtype: torch.dtype,
+    device: str,
+) -> Qwen3VLVisionTransformer:
+    model_config = {
+        "model_type": "qwen3_vl_vision",
+        "model_path": model_path,
+        "vision_config": dict(vision_config),
+    }
+    load_config = NewLoaderConfig(
+        compute_dtype=compute_dtype,
+        device=device,
+        load_method=NewLoaderLoadMethod.SCRATCH,
+    )
+    loader = NewModelLoader(
+        model_config=model_config,
+        load_config=load_config,
+        model_path=model_path,
+    )
+    with torch.device("cpu"):
+        model = loader.load()
+    return model.visual
+
+
+__all__ = [
+    "Qwen3VLForVisionEmbedding",
+    "Qwen3VLVisionTransformer",
+    "load_qwen3_vl_vision",
+]

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -158,3 +158,13 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen2_moe",
     "Qwen2MoeForCausalLM",
 )
+register_lazy_model(
+    "qwen2_vl",
+    "rtp_llm.models_py.new_models.qwen2_vl.model",
+    "Qwen2VLForCausalLM",
+)
+register_lazy_model(
+    "qwen2_vl_vision",
+    "rtp_llm.models_py.new_models.qwen2_vl.vision",
+    "Qwen2VLForVisionEmbedding",
+)

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -168,3 +168,13 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen2_vl.vision",
     "Qwen2VLForVisionEmbedding",
 )
+register_lazy_model(
+    "qwen3_vl",
+    "rtp_llm.models_py.new_models.qwen3_vl",
+    "Qwen3VLForCausalLM",
+)
+register_lazy_model(
+    "qwen3_vl_vision",
+    "rtp_llm.models_py.new_models.qwen3_vl.vision",
+    "Qwen3VLForVisionEmbedding",
+)

--- a/rtp_llm/multimodal/multimodal_mixin_factory.py
+++ b/rtp_llm/multimodal/multimodal_mixin_factory.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -10,6 +11,12 @@ from rtp_llm.multimodal.multimodal_mixin_register import (
 )
 from rtp_llm.multimodal.multimodal_mixins import BaseMultiModalMixin
 from rtp_llm.ops import TaskType
+
+
+def _new_loader_requested(model_config: ModelConfig) -> bool:
+    return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
+        getattr(model_config, "use_new_loader", False)
+    )
 
 
 class MultimodalMixinFactory:
@@ -31,6 +38,7 @@ class MultimodalMixinFactory:
             engine_config.load_config.load_method,
             vit_config,
             model_config.ckpt_path,
+            use_new_loader=_new_loader_requested(model_config),
         )
 
     @staticmethod

--- a/rtp_llm/multimodal/multimodal_mixin_factory.py
+++ b/rtp_llm/multimodal/multimodal_mixin_factory.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from rtp_llm.config.engine_config import EngineConfig
 from rtp_llm.config.model_config import ModelConfig
@@ -11,12 +10,7 @@ from rtp_llm.multimodal.multimodal_mixin_register import (
 )
 from rtp_llm.multimodal.multimodal_mixins import BaseMultiModalMixin
 from rtp_llm.ops import TaskType
-
-
-def _new_loader_requested(model_config: ModelConfig) -> bool:
-    return os.environ.get("USE_NEW_LOADER", "0") == "1" or bool(
-        getattr(model_config, "use_new_loader", False)
-    )
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 
 
 class MultimodalMixinFactory:
@@ -38,7 +32,7 @@ class MultimodalMixinFactory:
             engine_config.load_config.load_method,
             vit_config,
             model_config.ckpt_path,
-            use_new_loader=_new_loader_requested(model_config),
+            use_new_loader=is_new_loader_enabled(model_config),
         )
 
     @staticmethod

--- a/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/base_multimodal_mixin.py
@@ -89,12 +89,17 @@ class BaseMultiModalMixin:
         load_method: LoadMethod,
         vit_config: VitConfig,
         ckpt_path: str,
+        use_new_loader: bool = False,
     ) -> None:
         self.compute_dtype = compute_dtype
+        self.device = device
         self.mm_related_params = mm_related_params
         self.vit_config = vit_config
         self.load_method = load_method
         self.ckpt_path = ckpt_path
+        if not isinstance(use_new_loader, bool):
+            raise TypeError("use_new_loader must be a bool")
+        self.use_new_loader = use_new_loader
 
         with torch.device(device):
             torch_default_dtype = torch.get_default_dtype()

--- a/rtp_llm/multimodal/multimodal_mixins/qwen2_vl/qwen2_vl_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen2_vl/qwen2_vl_mixin.py
@@ -109,15 +109,17 @@ class Qwen2_VLVitWeight(BaseVitWeights):
 
 
 class Qwen2_VLImageEmbedding(MultiModalEmbeddingInterface):
-    def __init__(self, mm_related_params: VitParameters):
+    def __init__(self, mm_related_params: VitParameters, visual=None):
         self.mm_related_params = mm_related_params
         self.image_processor = Qwen2VLImageProcessor.from_pretrained(
             mm_related_params.config["ckpt_path"]
         )
 
-        self.visual = Qwen2VisionTransformerPretrainedModel(
-            mm_related_params.config
-        ).share_memory()
+        if visual is None:
+            visual = Qwen2VisionTransformerPretrainedModel(
+                mm_related_params.config
+            ).share_memory()
+        self.visual = visual
         self.spatial_merge_size = mm_related_params.config.get("spatial_merge_size", 2)
 
     @property
@@ -325,6 +327,21 @@ class Qwen2_VLImageEmbedding(MultiModalEmbeddingInterface):
 
 class Qwen2_VLMixin(BaseMultiModalMixin):
     def _init_multimodal(self):
+        if self.use_new_loader:
+            from rtp_llm.models_py.new_models.qwen2_vl.vision import (
+                load_qwen2_vl_vision,
+            )
+
+            visual = load_qwen2_vl_vision(
+                vision_config=self.mm_related_params.config,
+                model_path=self.ckpt_path,
+                compute_dtype=self.compute_dtype,
+                device=self.device,
+            )
+            self.mm_part = Qwen2_VLImageEmbedding(self.mm_related_params, visual=visual)
+            self.mm_related_params.vit_weights = None
+            return
+
         self.mm_part = Qwen2_VLImageEmbedding(self.mm_related_params)
         self.mm_related_params.vit_weights = Qwen2_VLVitWeight(
             {"vit": self.mm_part.visual}

--- a/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
@@ -6,12 +6,7 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.library as tl
 from PIL import Image
-from transformers import (
-    AutoProcessor,
-    Qwen2VLImageProcessor,
-    Qwen3VLConfig,
-    Qwen3VLVisionModel,
-)
+from transformers import AutoProcessor, Qwen3VLConfig, Qwen3VLVisionModel
 
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.metrics.kmonitor_metric_reporter import GaugeMetrics
@@ -52,17 +47,39 @@ if not hasattr(tl, "wrap_triton"):
 
 
 class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
-    def __init__(self, mm_related_params: VitParameters):
+    def __init__(self, mm_related_params: VitParameters, visual=None):
         self.mm_processor = AutoProcessor.from_pretrained(
             mm_related_params.config["ckpt_path"]
         )
-        self.mm_processor.image_processor = Qwen2VLImageProcessor.from_pretrained(
-            mm_related_params.config["ckpt_path"]
-        )
-        config_hf = Qwen3VLConfig.from_pretrained(mm_related_params.config["ckpt_path"])
-        config_hf.vision_config._attn_implementation = default_attn_impl
-        self.visual = Qwen3VLVisionModel._from_config(config_hf.vision_config)
+        self._uses_new_loader_vision = visual is not None
+        if visual is None:
+            config_hf = Qwen3VLConfig.from_pretrained(
+                mm_related_params.config["ckpt_path"]
+            )
+            config_hf.vision_config._attn_implementation = default_attn_impl
+            visual = Qwen3VLVisionModel._from_config(config_hf.vision_config)
+        self.visual = visual
         self.spatial_merge_size = self.visual.spatial_merge_size
+
+    @staticmethod
+    def _unpack_vision_output(vision_output):
+        if isinstance(vision_output, tuple):
+            if len(vision_output) != 2:
+                raise ValueError(
+                    "Qwen3-VL vision tuple output must contain embeddings and "
+                    f"deepstack features, got {len(vision_output)} values"
+                )
+            embeds, deepstack_embeds = vision_output
+        else:
+            embeds = vision_output.pooler_output
+            deepstack_embeds = vision_output.deepstack_features
+        if not isinstance(embeds, torch.Tensor):
+            raise TypeError("Qwen3-VL vision embeddings must be a tensor")
+        if not isinstance(deepstack_embeds, (list, tuple)):
+            raise TypeError("Qwen3-VL deepstack features must be a sequence")
+        if not all(isinstance(item, torch.Tensor) for item in deepstack_embeds):
+            raise TypeError("Qwen3-VL deepstack features must contain only tensors")
+        return embeds, deepstack_embeds
 
     @property
     def _data_type(self):
@@ -168,7 +185,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
                 )
             return res["pixel_values_videos"], res["video_grid_thw"]
         else:
-            raise Exception("unknown mm url type")
+            raise ValueError(f"unknown mm url type: {mm_type}")
 
     def get_preprocess_params(self):
         return {
@@ -181,8 +198,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
         pixel_values = data[0].to(self._device).to(self._data_type)
         grid_thw = data[1].to(self._device)
         vision_output = self.visual(pixel_values, grid_thw=grid_thw)
-        embeds = vision_output.pooler_output
-        deepstack_embeds = vision_output.deepstack_features
+        embeds, deepstack_embeds = self._unpack_vision_output(vision_output)
         split_sizes = (grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
         embeds = torch.split(embeds, split_sizes)
         pos_id = self.get_position_ids(grid_thw)[0]
@@ -208,8 +224,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
         )
         grid_thw = torch.concat(grid_thw_list, dim=0).to(self._device)
         vision_output = self.visual(pixel_values, grid_thw=grid_thw)
-        embeds = vision_output.pooler_output
-        deepstack_embeds = vision_output.deepstack_features
+        embeds, deepstack_embeds = self._unpack_vision_output(vision_output)
         split_sizes = (grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
         embeds = torch.split(embeds, split_sizes)
         pos_id = self.get_position_ids(grid_thw)
@@ -230,6 +245,21 @@ class Qwen3VLVitWeight(BaseVitWeights):
 
 class Qwen3_VLMixin(Qwen2_5_VLMixin):
     def _init_multimodal(self):
+        if self.use_new_loader:
+            from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+                load_qwen3_vl_vision,
+            )
+
+            visual = load_qwen3_vl_vision(
+                vision_config=self.mm_related_params.config,
+                model_path=self.ckpt_path,
+                compute_dtype=self.compute_dtype,
+                device=self.device,
+            )
+            self.mm_part = Qwen3_VLImageEmbedding(self.mm_related_params, visual=visual)
+            self.mm_related_params.vit_weights = None
+            return
+
         self.mm_part = Qwen3_VLImageEmbedding(self.mm_related_params)
         self.mm_related_params.vit_weights = Qwen3VLVitWeight(
             {"vit": self.mm_part.visual}

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -91,3 +91,17 @@ py_test(
         "//rtp_llm/models_py:qwen2_vl_vision_loader",
     ],
 )
+
+py_test(
+    name = "qwen3_vl_newloader_routing_test",
+    srcs = ["qwen3_vl_newloader_routing_test.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:multimodal",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:testlib",
+        "//rtp_llm:torch",
+        "//rtp_llm/model_loader:loader",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -77,3 +77,17 @@ py_test(
         "//rtp_llm:testlib",
     ],
 )
+
+py_test(
+    name = "qwen2_vl_newloader_routing_test",
+    srcs = ["qwen2_vl_newloader_routing_test.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:multimodal",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:testlib",
+        "//rtp_llm:torch",
+        "//rtp_llm/model_loader:loader",
+        "//rtp_llm/models_py:qwen2_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
@@ -8,28 +8,35 @@ from safetensors.torch import save_file
 
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.model_loader.load_config import LoadMethod
-from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
-from rtp_llm.multimodal.multimodal_mixin_factory import _new_loader_requested
 from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.modeling_qwen2_vl import (
     Qwen2VisionTransformerPretrainedModel,
+    VisionSdpaAttention,
 )
 from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin import (
     Qwen2_VLImageEmbedding,
     Qwen2_VLMixin,
 )
+from rtp_llm.utils.new_loader import is_new_loader_enabled
 
 
 class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
     def test_newloader_switch_matches_language_loader_semantics(self):
         model_config = types.SimpleNamespace(use_new_loader=False)
         with mock.patch.dict("os.environ", {}, clear=True):
-            self.assertFalse(_new_loader_requested(model_config))
+            self.assertFalse(is_new_loader_enabled(model_config))
             model_config.use_new_loader = True
-            self.assertTrue(_new_loader_requested(model_config))
+            self.assertTrue(is_new_loader_enabled(model_config))
         model_config.use_new_loader = False
         with mock.patch.dict("os.environ", {"USE_NEW_LOADER": "1"}, clear=True):
-            self.assertTrue(_new_loader_requested(model_config))
+            self.assertTrue(is_new_loader_enabled(model_config))
+        del model_config.use_new_loader
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(is_new_loader_enabled(model_config))
+        model_config.use_new_loader = "1"
+        with self.assertRaisesRegex(TypeError, "use_new_loader must be a bool"):
+            is_new_loader_enabled(model_config)
 
     def test_qwen2_vl_mixin_uses_standalone_newloader_vision(self):
         vision_config = {
@@ -132,6 +139,54 @@ class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
                 atol=2e-4,
                 rtol=1e-3,
             )
+
+    def test_new_vision_matches_legacy_video_and_hf_checkpoint_layout(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+        }
+        torch.manual_seed(23)
+        legacy = Qwen2VisionTransformerPretrainedModel(vision_config).eval()
+        for block in legacy.blocks:
+            sdpa = VisionSdpaAttention(vision_config["embed_dim"], num_heads=2)
+            sdpa.load_state_dict(block.attn.state_dict())
+            block.attn = sdpa
+
+        checkpoint = {
+            f"visual.{name}": tensor.detach().clone()
+            for name, tensor in legacy.state_dict().items()
+        }
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(checkpoint, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config={
+                    "model_type": "qwen2_vl_vision",
+                    "vision_config": vision_config,
+                },
+                load_config=NewLoaderConfig(
+                    compute_dtype=torch.float32,
+                    device="cpu",
+                ),
+                model_path=model_path,
+            ).load()
+
+        for name, expected in legacy.state_dict().items():
+            torch.testing.assert_close(loaded.visual.state_dict()[name], expected)
+
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected = legacy(pixel_values, grid_thw)
+            actual = loaded(pixel_values, grid_thw)
+        torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-5)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen2_vl_newloader_routing_test.py
@@ -1,0 +1,138 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.config.py_config_modules import VitConfig
+from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen2_vl.vision import Qwen2VLForVisionEmbedding
+from rtp_llm.multimodal.multimodal_mixin_factory import _new_loader_requested
+from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.modeling_qwen2_vl import (
+    Qwen2VisionTransformerPretrainedModel,
+)
+from rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin import (
+    Qwen2_VLImageEmbedding,
+    Qwen2_VLMixin,
+)
+
+
+class Qwen2VLNewLoaderRoutingTest(unittest.TestCase):
+    def test_newloader_switch_matches_language_loader_semantics(self):
+        model_config = types.SimpleNamespace(use_new_loader=False)
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(_new_loader_requested(model_config))
+            model_config.use_new_loader = True
+            self.assertTrue(_new_loader_requested(model_config))
+        model_config.use_new_loader = False
+        with mock.patch.dict("os.environ", {"USE_NEW_LOADER": "1"}, clear=True):
+            self.assertTrue(_new_loader_requested(model_config))
+
+    def test_qwen2_vl_mixin_uses_standalone_newloader_vision(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 1,
+        }
+        source = Qwen2VLForVisionEmbedding(
+            {"model_type": "qwen2_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    name: tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=object(),
+            )
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin."
+                "Qwen2VLImageProcessor.from_pretrained",
+                return_value=object(),
+            ):
+                mixin = Qwen2_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                    use_new_loader=True,
+                )
+
+        self.assertIsInstance(mixin.mm_part, Qwen2_VLImageEmbedding)
+        self.assertIsNone(mm_related_params.vit_weights)
+        self.assertNotIn("mm_mixin_loader", vars(mixin))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name], expected
+            )
+
+    def test_default_route_preserves_legacy_qwen2_vl_loader(self):
+        vision_config = {
+            "depth": 1,
+            "embed_dim": 8,
+            "hidden_size": 6,
+            "hidden_act": "quick_gelu",
+            "mlp_ratio": 2.0,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 1,
+        }
+        source = Qwen2VisionTransformerPretrainedModel(vision_config).eval()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"visual.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=None,
+            )
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen2_vl.qwen2_vl_mixin."
+                "Qwen2VLImageProcessor.from_pretrained",
+                return_value=object(),
+            ):
+                mixin = Qwen2_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                )
+
+        self.assertIn("mm_mixin_loader", vars(mixin))
+        self.assertIsNotNone(mm_related_params.vit_weights)
+        for name, expected in source.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name],
+                expected,
+                atol=2e-4,
+                rtol=1e-3,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
@@ -1,0 +1,175 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+from safetensors.torch import save_file
+from transformers import Qwen3VLVisionModel
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
+
+from rtp_llm.config.py_config_modules import VitConfig
+from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen3_vl.vision import Qwen3VLForVisionEmbedding
+from rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin import (
+    Qwen3_VLImageEmbedding,
+    Qwen3_VLMixin,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+class Qwen3VLNewLoaderRoutingTest(unittest.TestCase):
+    def test_qwen3_vl_mixin_uses_standalone_newloader_vision(self):
+        vision_config = _vision_config()
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.{name}": tensor.detach().to(torch.float16)
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=object(),
+            )
+            processor = types.SimpleNamespace(image_processor=None)
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+                "AutoProcessor.from_pretrained",
+                return_value=processor,
+            ):
+                mixin = Qwen3_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                    use_new_loader=True,
+                )
+
+        self.assertIsInstance(mixin.mm_part, Qwen3_VLImageEmbedding)
+        self.assertTrue(mixin.mm_part._uses_new_loader_vision)
+        self.assertIsNone(mixin.mm_part.mm_processor.image_processor)
+        self.assertIsNone(mm_related_params.vit_weights)
+        self.assertNotIn("mm_mixin_loader", vars(mixin))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name],
+                expected.to(torch.float16).to(torch.float32),
+            )
+
+    def test_default_route_keeps_legacy_vision_loader(self):
+        visual = torch.nn.Identity()
+        visual.spatial_merge_size = 2
+        visual.patch_size = 16
+        config = types.SimpleNamespace(
+            vision_config=types.SimpleNamespace(_attn_implementation=None)
+        )
+        mm_related_params = types.SimpleNamespace(
+            config={"ckpt_path": "/tmp/model"},
+            vit_weights=None,
+        )
+        processor = types.SimpleNamespace(image_processor=None)
+        with mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "AutoProcessor.from_pretrained",
+            return_value=processor,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLConfig.from_pretrained",
+            return_value=config,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLVisionModel._from_config",
+            return_value=visual,
+        ):
+            mixin = Qwen3_VLMixin.__new__(Qwen3_VLMixin)
+            mixin.compute_dtype = torch.float32
+            mixin.device = "cpu"
+            mixin.mm_related_params = mm_related_params
+            mixin.vit_config = VitConfig()
+            mixin.load_method = LoadMethod.SCRATCH
+            mixin.ckpt_path = "/tmp/model"
+            mixin.use_new_loader = False
+            mixin._init_multimodal()
+
+        self.assertFalse(mixin.mm_part._uses_new_loader_vision)
+        self.assertIsNone(mixin.mm_part.mm_processor.image_processor)
+        self.assertIsNotNone(mm_related_params.vit_weights)
+
+    def test_newloader_vision_matches_transformers_reference(self):
+        vision_config = _vision_config()
+        reference_config = Qwen3VLVisionConfig(**vision_config)
+        reference_config._attn_implementation = "sdpa"
+        torch.manual_seed(23)
+        reference = Qwen3VLVisionModel(reference_config).eval()
+        checkpoint_state = {
+            name: tensor.detach().to(torch.float16)
+            for name, tensor in reference.state_dict().items()
+        }
+        reference.load_state_dict(checkpoint_state)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.visual.{name}": tensor
+                    for name, tensor in checkpoint_state.items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            actual = NewModelLoader(
+                model_config={
+                    "model_type": "qwen3_vl_vision",
+                    "vision_config": vision_config,
+                },
+                load_config=NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+                model_path=model_path,
+            ).load()
+
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected_output, expected_deepstack = (
+                Qwen3_VLImageEmbedding._unpack_vision_output(
+                    reference(pixel_values, grid_thw)
+                )
+            )
+            actual_output, actual_deepstack = (
+                Qwen3_VLImageEmbedding._unpack_vision_output(
+                    actual(pixel_values, grid_thw)
+                )
+            )
+
+        torch.testing.assert_close(actual_output, expected_output)
+        self.assertEqual(len(actual_deepstack), len(expected_deepstack))
+        for actual_feature, expected_feature in zip(
+            actual_deepstack, expected_deepstack
+        ):
+            torch.testing.assert_close(actual_feature, expected_feature)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -557,6 +557,10 @@ def h20_oss_suites():
                     "llm": "--act_type BF16 --use_local 1 --tp_size 2 --reuse_cache 1",
                     "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1"
                 },
+                envs = {
+                    "llm": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                    "vit": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                },
                 gpu_type=["H20"],
                 data=native.glob(['data/model/llava/*.jpg']),
             ),

--- a/rtp_llm/utils/new_loader.py
+++ b/rtp_llm/utils/new_loader.py
@@ -1,0 +1,17 @@
+import os
+from typing import Protocol
+
+
+class NewLoaderConfigSource(Protocol):
+    use_new_loader: bool
+
+
+def is_new_loader_enabled(model_config: NewLoaderConfigSource) -> bool:
+    """Return the single process/model decision used by all loader entry points."""
+    try:
+        configured = model_config.use_new_loader
+    except AttributeError:
+        configured = False
+    if not isinstance(configured, bool):
+        raise TypeError("model_config.use_new_loader must be a bool")
+    return os.environ.get("USE_NEW_LOADER", "0") == "1" or configured


### PR DESCRIPTION
  ## Summary

  Add clean newloader support for Qwen3-VL Dense, covering both the language model and vision transformer.

  ## Changes

  - Add Qwen3-VL Dense language newloader implementation.
  - Add standalone Qwen3-VL vision newloader and lazy registry entries.
  - Add strict checkpoint filtering and prefix mapping for:
    - `model.language_model.*`
    - `model.visual.*`
    - `lm_head.*`
  - Support TP=2 language loading while keeping the vision model replicated.
  - Preserve dense-model behavior when `expert_num=0`, without applying EP expert filtering.
  - Route Qwen3-VL LLM and ViT through `USE_NEW_LOADER=1` with `LOAD_METHOD=scratch`.
  - Keep the legacy vision route compatible.
  - Support image, video, heterogeneous grids, DeepStack injection, cache reuse, and text-only requests.
  - Add independent BUILD ownership/import target for the vision loader.
  - Enable ROCm fused MRoPE with strict `combo_position_ids` validation and graph replay refresh.

  ## Numerical Compatibility Fixes

  Two numerical differences were found and fixed during real-checkpoint comparison:

  1. Position interpolation must use the same fixed addition order as Transformers:

     `p0 + p1 + p2 + p3`

     Using `sum(dim=0)` changes BF16 rounding and the error is amplified through the 24 vision layers.

  2. Vision checkpoint weights must preserve the established conversion path:

     checkpoint dtype → FP16 → runtime dtype

     Direct checkpoint-to-BF16/FP32 conversion produces different vision features.

  After these fixes, newloader and the legacy Transformers vision implementation are element-wise identical for all checkpoint weights, all 24 vision blocks, final embeddings, and DeepStack features.

  ## Validation

  H20:

  - `foundation_test`
  - `test_qwen3_moe_load`
  - `test_qwen3_vl_load`
  - `test_qwen3_vl_vision_loader_import`
  - `test_qwen3_vl_gpu`
  - `qwen3_vl_newloader_routing_test`
  - Full Qwen3-VL all-newloader smoke:
    - 2/2 requests passed
    - `compare diff count=0`
    - TP=2
    - image tokens: 2752
    - cache reuse verified

  ROCm:

  - Corresponding focused tests passed: 6/6
  - ROCm fused MRoPE tests passed: 41/41
  - Real-checkpoint legacy/newloader vision comparison:
    - 315 state tensors: exact
    - 24 vision blocks: exact
    - final embeddings: exact
    - 3 DeepStack tensors: exact
  - End-to-end generation completed successfully with MRoPE enabled.

  Static checks:

  - Black
  - isort
  - clang-format
  - py_compile
  - `git diff --check`
  - pre-commit hooks