### PR TITLE
Develop/hengcang/newloader qwen3 vl moe

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -227,6 +227,7 @@ py_library(
         ":protobuf",
         ":pyOpenSSL",
         "//rtp_llm/models_py:qwen2_vl_vision_loader",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
     ] + select({
         "@//:using_arm": [],
 	    "@//:using_rocm": ["pyrsmi", "amdsmi"],

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -77,31 +77,40 @@ class QWen3_VL(QwenV3):
             [config_json["vision_start_token_id"], config_json["vision_end_token_id"]]
         ]
 
-        config_json = config_json["text_config"]
-        config.inter_size = config_json["intermediate_size"]
-        config.attn_config.head_num = config_json["num_attention_heads"]
-        config.attn_config.kv_head_num = config_json.get(
+        vision_config = config_json.get("vision_config")
+        if not isinstance(vision_config, dict):
+            raise ValueError("Qwen3-VL config.json must contain vision_config")
+        config.mm_related_params.config.update(vision_config)
+
+        text_config = config_json.get("text_config")
+        if not isinstance(text_config, dict):
+            raise ValueError("Qwen3-VL config.json must contain text_config")
+        config.inter_size = text_config["intermediate_size"]
+        config.attn_config.head_num = text_config["num_attention_heads"]
+        config.attn_config.kv_head_num = text_config.get(
             "num_key_value_heads", config.attn_config.head_num
         )
         config.attn_config.size_per_head = (
-            int(config_json.get("head_dim"))
-            if "head_dim" in config_json
-            else config_json["hidden_size"] // config.attn_config.head_num
+            int(text_config["head_dim"])
+            if "head_dim" in text_config
+            else text_config["hidden_size"] // config.attn_config.head_num
         )
-        if config_json.get("hidden_size") is not None:
-            config.hidden_size = config_json["hidden_size"]
-        config.num_layers = config_json["num_hidden_layers"]
-        config.attn_config.rope_config.base = config_json.get(
+        if text_config.get("hidden_size") is not None:
+            config.hidden_size = text_config["hidden_size"]
+        config.num_layers = text_config["num_hidden_layers"]
+        config.attn_config.rope_config.base = text_config.get(
             "rope_theta", config.attn_config.rope_config.base
         )
-        config.vocab_size = config_json["vocab_size"]
+        config.vocab_size = text_config["vocab_size"]
         config.attn_config.rope_config.dim = config.attn_config.size_per_head
-        config.layernorm_eps = config_json.get("rms_norm_eps", 1e-06)
-        config.tie_word_embeddings = config_json.get("tie_word_embeddings", False)
-        config.config_dtype = config_json.get("torch_dtype", None)
+        config.layernorm_eps = text_config.get("rms_norm_eps", 1e-06)
+        config.tie_word_embeddings = text_config.get("tie_word_embeddings", False)
+        config.config_dtype = text_config.get(
+            "dtype", text_config.get("torch_dtype", None)
+        )
 
         config.attn_config.rope_config.style = 7
-        mrope_section = config_json["rope_scaling"].get("mrope_section", [16, 24, 24])
+        mrope_section = text_config["rope_scaling"].get("mrope_section", [16, 24, 24])
         config.attn_config.rope_config.index_factor = len(mrope_section)
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]

--- a/rtp_llm/models/qwen3_vl.py
+++ b/rtp_llm/models/qwen3_vl.py
@@ -2,22 +2,10 @@ import json
 import os
 from typing import Any, Dict, List, Optional
 
-import torch
-import torch.library as tl
-from PIL import Image
-from transformers import AutoProcessor, Qwen3VLConfig, Qwen3VLVisionModel
-
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.models.qwen_v3 import QwenV3, QWenV3Weight
-
-if not hasattr(tl, "wrap_triton"):
-
-    def wrap_triton(fn):
-        return fn
-
-    tl.wrap_triton = wrap_triton
 
 
 class QWen3_VL(QwenV3):
@@ -105,12 +93,37 @@ class QWen3_VL(QwenV3):
         config.attn_config.rope_config.dim = config.attn_config.size_per_head
         config.layernorm_eps = text_config.get("rms_norm_eps", 1e-06)
         config.tie_word_embeddings = text_config.get("tie_word_embeddings", False)
-        config.config_dtype = text_config.get(
-            "dtype", text_config.get("torch_dtype", None)
-        )
+        config.config_dtype = text_config.get("dtype")
+        if config.config_dtype is None:
+            config.config_dtype = text_config.get("torch_dtype")
+
+        rope_scaling = text_config.get("rope_scaling")
+        if not isinstance(rope_scaling, dict):
+            raise ValueError(
+                "Qwen3-VL config.json text_config must contain rope_scaling"
+            )
+        mrope_section = rope_scaling.get("mrope_section", [16, 24, 24])
+        if (
+            not isinstance(mrope_section, (list, tuple))
+            or len(mrope_section) != 3
+            or any(
+                isinstance(section, bool)
+                or not isinstance(section, int)
+                or section <= 0
+                for section in mrope_section
+            )
+        ):
+            raise ValueError(
+                "Qwen3-VL text_config.rope_scaling.mrope_section must contain "
+                "three positive integers"
+            )
+        if sum(mrope_section) * 2 != config.attn_config.size_per_head:
+            raise ValueError(
+                "Qwen3-VL text_config.rope_scaling.mrope_section must cover "
+                "half of head_dim"
+            )
 
         config.attn_config.rope_config.style = 7
-        mrope_section = text_config["rope_scaling"].get("mrope_section", [16, 24, 24])
         config.attn_config.rope_config.index_factor = len(mrope_section)
         config.attn_config.rope_config.mrope_dim1 = mrope_section[0]
         config.attn_config.rope_config.mrope_dim2 = mrope_section[1]

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -141,6 +141,7 @@ py_library(
         "new_models/qwen3/*.py",
         "new_models/qwen3_moe/*.py",
         "new_models/qwen3_next/*.py",
+        "new_models/qwen3_vl/*.py",
         "quant_methods/*.py",
     ]),
     deps = [
@@ -171,6 +172,25 @@ py_library(
         "new_models/__init__.py",
         "new_models/qwen2_vl/__init__.py",
         "new_models/qwen2_vl/vision.py",
+    ],
+    deps = [
+        ":new_loader_core",
+        "//rtp_llm:torch",
+        "//rtp_llm:utils",
+    ] + select({
+        "@//:using_cuda12_9_x86": flashattn,
+        "@//:using_cuda12_arm": flashattn,
+        "//conditions:default": [],
+    }),
+    visibility = ["//rtp_llm:__subpackages__"],
+)
+
+py_library(
+    name = "qwen3_vl_vision_loader",
+    srcs = [
+        "new_models/__init__.py",
+        "new_models/qwen3_vl/__init__.py",
+        "new_models/qwen3_vl/vision.py",
     ],
     deps = [
         ":new_loader_core",

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -142,6 +142,7 @@ py_library(
         "new_models/qwen3_moe/*.py",
         "new_models/qwen3_next/*.py",
         "new_models/qwen3_vl/*.py",
+        "new_models/qwen3_vl_moe/*.py",
         "quant_methods/*.py",
     ]),
     deps = [

--- a/rtp_llm/models_py/bindings/rocm/CKAttnUtils.h
+++ b/rtp_llm/models_py/bindings/rocm/CKAttnUtils.h
@@ -3,6 +3,7 @@
 #include "rtp_llm/models_py/bindings/common/kernels/kv_cache/kv_cache_utils.h"
 #include "rtp_llm/models_py/bindings/common/kernels/kv_cache_kernels.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/model_utils/RopeConfig.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/models_py/bindings/core/Types.h"
 #include "rtp_llm/models_py/bindings/core/OpData.h"
@@ -16,6 +17,7 @@ namespace rtp_llm {
 
 struct CKAttn {
     KVBlockArray  kv_block_array;
+    RopeConfig    rope_config;
     torch::Tensor kv_cache_offset;
 
     torch::Tensor kv_cache_block_id_device;

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -81,26 +81,77 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     params.prefill_runtime_max_prefix_len      = max_prefix_len;
     params.prefill_runtime_seq_len_with_prefix = params.max_seq_len + max_prefix_len;
 
+    const bool captured_position_ids = params.position_ids.defined() && params.position_ids.numel() > 0;
+    const bool replay_position_ids =
+        attn_inputs.combo_position_ids.defined() && attn_inputs.combo_position_ids.numel() > 0;
+    if (captured_position_ids || replay_position_ids) {
+        if (!captured_position_ids || !replay_position_ids) {
+            throw std::runtime_error("prepare_in_place requires combo_position_ids in both capture and replay inputs");
+        }
+        if (params.position_ids.data_ptr() != attn_inputs.combo_position_ids.data_ptr()) {
+            copyTensorExactInPlace(params.position_ids, attn_inputs.combo_position_ids, "combo_position_ids");
+        }
+    }
+
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
 
-static void rejectMropeWithoutPositionIds(const RopeConfig& rope_config, const char* where) {
-    // ROCm prefill/decode dispatch always passes position_ids=nullptr (combo_position_ids
-    // is not plumbed through this path yet). Mrope needs real per-axis position ids — without
-    // them the kernel silently uses position_id=-1, producing wrong RoPE positions.
-    if (rope_config.style == RopeStyle::Mrope) {
-        throw std::runtime_error(std::string(where)
-                                 + ": RopeStyle::Mrope requires combo_position_ids, but ROCm "
-                                   "fused RoPE+KV-cache path does not plumb position_ids yet. "
-                                   "Run this model on the CUDA path or extend this op to accept "
-                                   "position_ids before enabling Mrope.");
+static void validateMropePositionIds(const RopeConfig&    rope_config,
+                                     const torch::Tensor& position_ids,
+                                     int64_t              expected_tokens,
+                                     const char*          where) {
+    if (rope_config.style != RopeStyle::Mrope) {
+        return;
+    }
+
+    TORCH_CHECK(rope_config.index_factor == 3,
+                where,
+                ": RopeStyle::Mrope requires index_factor == 3, got ",
+                rope_config.index_factor);
+    const int mrope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
+    TORCH_CHECK(rope_config.mrope_dim1 > 0 && rope_config.mrope_dim2 > 0 && rope_config.mrope_dim3 > 0
+                    && mrope_dim * 2 == rope_config.dim,
+                where,
+                ": invalid Mrope sections [",
+                rope_config.mrope_dim1,
+                ", ",
+                rope_config.mrope_dim2,
+                ", ",
+                rope_config.mrope_dim3,
+                "] for rope dim ",
+                rope_config.dim);
+    TORCH_CHECK(position_ids.defined() && position_ids.numel() > 0,
+                where,
+                ": RopeStyle::Mrope requires non-empty combo_position_ids");
+    TORCH_CHECK(position_ids.scalar_type() == at::kInt,
+                where,
+                ": combo_position_ids must be int32, got ",
+                position_ids.scalar_type());
+    TORCH_CHECK(position_ids.is_cuda(), where, ": combo_position_ids must be on the ROCm device");
+    TORCH_CHECK(position_ids.is_contiguous(), where, ": combo_position_ids must be contiguous");
+    TORCH_CHECK(position_ids.numel() % rope_config.index_factor == 0,
+                where,
+                ": combo_position_ids numel (",
+                position_ids.numel(),
+                ") must be divisible by index_factor (",
+                rope_config.index_factor,
+                ")");
+    if (expected_tokens >= 0) {
+        TORCH_CHECK(position_ids.numel() == expected_tokens * rope_config.index_factor,
+                    where,
+                    ": combo_position_ids numel mismatch: expected ",
+                    expected_tokens * rope_config.index_factor,
+                    " for ",
+                    expected_tokens,
+                    " tokens and index_factor ",
+                    rope_config.index_factor,
+                    ", got ",
+                    position_ids.numel());
     }
 }
 
 FusedRopeKVCachePrefillOpBase::FusedRopeKVCachePrefillOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCachePrefillOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCachePrefillOpAsm::FusedRopeKVCachePrefillOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCachePrefillOpBase(attn_configs) {}
@@ -144,14 +195,21 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
         attn_params->prefix_lengths = attn_inputs.prefix_lengths;
     }
     attn_params->kv_block_array.cache_type = attn_configs_.kv_cache_dtype;
-    attn_params->position_ids = attn_inputs.combo_position_ids;
+    attn_params->position_ids              = attn_inputs.combo_position_ids;
 
-// Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
-    if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
-        attn_params->position_ids =
-            attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
+    // MRoPE position IDs originate on the host in the normal engine. Keep a
+    // contiguous device tensor because the fused kernel indexes the flattened
+    // token-major [token, axis] layout directly.
+    if (attn_params->position_ids.defined()) {
+        if (!attn_params->position_ids.is_cuda()) {
+            attn_params->position_ids =
+                attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true);
+        }
+        attn_params->position_ids = attn_params->position_ids.contiguous();
     }
-    
+    validateMropePositionIds(
+        attn_configs_.rope_config, attn_params->position_ids, -1, "FusedRopeKVCachePrefillOp::prepare");
+
     int max_prefix_length = 0;
     if (has_prefix && attn_params->prefix_lengths.defined() && attn_params->prefix_lengths.numel() > 0) {
         max_prefix_length = attn_params->prefix_lengths.max().item<int32_t>();
@@ -174,6 +232,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
     const int max_prefix_length =
         params->prefill_runtime_max_prefix_len >= 0 ? params->prefill_runtime_max_prefix_len : 0;
     const int seq_len_with_prefix = seq_len + max_prefix_length;
+    validateMropePositionIds(
+        attn_configs_.rope_config, params->position_ids, token_num, "FusedRopeKVCachePrefillOp::forward");
 
     const int  q_output_token_num = (use_paged_fmha && pad_query) ? batch_size * seq_len : token_num;
     const bool paged_fp8          = use_paged_fmha && attn_configs_.kv_cache_dtype == KvCacheDataType::FP8;
@@ -352,9 +412,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
 }
 
 FusedRopeKVCacheDecodeOpBase::FusedRopeKVCacheDecodeOpBase(const AttentionConfigs& attn_configs):
-    attn_configs_(attn_configs) {
-    rejectMropeWithoutPositionIds(attn_configs.rope_config, "FusedRopeKVCacheDecodeOp");
-}
+    attn_configs_(attn_configs) {}
 
 FusedRopeKVCacheDecodeOpAsm::FusedRopeKVCacheDecodeOpAsm(const AttentionConfigs& attn_configs):
     FusedRopeKVCacheDecodeOpBase(attn_configs) {}
@@ -392,11 +450,15 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     attn_params->prefix_lengths            = attn_inputs.prefix_lengths;
     attn_params->padding_offset            = attn_inputs.padding_offset;
     attn_params->position_ids              = attn_inputs.combo_position_ids;
-    // Ensure position_ids is on CUDA device (e.g., MROPE position_ids may be on CPU)
-    if (attn_params->position_ids.defined() && !attn_params->position_ids.is_cuda()) {
-        attn_params->position_ids =
-            attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true).contiguous();
+    if (attn_params->position_ids.defined()) {
+        if (!attn_params->position_ids.is_cuda()) {
+            attn_params->position_ids =
+                attn_params->position_ids.to(torch::kCUDA, /*non_blocking=*/false, /*copy=*/true);
+        }
+        attn_params->position_ids = attn_params->position_ids.contiguous();
     }
+    validateMropePositionIds(
+        attn_configs_.rope_config, attn_params->position_ids, -1, "FusedRopeKVCacheDecodeOp::prepare");
 
     if (attn_inputs.kv_cache_kernel_block_id_device.defined()
         && attn_inputs.kv_cache_kernel_block_id_device.numel() > 0) {
@@ -426,6 +488,8 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
     const int     batch_size        = params->sequence_lengths.size(0);
     torch::Tensor q_output          = torch::empty({token_num, local_head_num, size_per_head},
                                           torch::TensorOptions(qkv.dtype()).device(qkv.device()));
+    validateMropePositionIds(
+        attn_configs_.rope_config, params->position_ids, token_num, "FusedRopeKVCacheDecodeOp::forward");
 
     PrefixPromptBatchWeightsParam prefix_prompt_param;
     prefix_prompt_param.kv_block_array = kv_block_array;

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -24,26 +24,26 @@ static at::ScalarType get_fp8_dtype() {
     return torch::kFloat8_e4m3fnuz;  // gfx942 and default
 }
 
+static void
+validateMropePositionIds(const RopeConfig&, const torch::Tensor&, int64_t, const char*, bool require_device = true);
+
 static void copyTensorExactInPlace(torch::Tensor& dst, const torch::Tensor& src, const char* name) {
-    if (!src.defined()) {
-        throw std::runtime_error(std::string("prepare_in_place expects defined tensor: ") + name);
-    }
+    TORCH_CHECK(src.defined(), "prepare_in_place expects defined tensor: ", name);
     torch::Tensor src_flat = src.contiguous().reshape({-1});
     if (!dst.defined()) {
         dst = src_flat.clone();
         return;
     }
     torch::Tensor dst_flat = dst.reshape({-1});
-    if (dst_flat.numel() != src_flat.numel()) {
-        throw std::runtime_error(std::string("prepare_in_place tensor size mismatch for ") + name + ": capture="
-                                 + std::to_string(dst_flat.numel()) + ", replay=" + std::to_string(src_flat.numel()));
-    }
+    TORCH_CHECK(dst_flat.numel() == src_flat.numel(),
+                "prepare_in_place tensor size mismatch for ",
+                name,
+                ": capture=",
+                dst_flat.numel(),
+                ", replay=",
+                src_flat.numel());
 
-    torch::Tensor src_match = src_flat;
-    if (src_match.scalar_type() != dst.scalar_type() || src_match.device() != dst.device()) {
-        src_match = src_match.to(dst.options(), true, false);
-    }
-    dst_flat.copy_(src_match, true);
+    dst_flat.copy_(src_flat, /*non_blocking=*/true);
 }
 
 void updateKvCacheOffset(CKAttn& params, const torch::Tensor& kv_cache_block_id_device) {
@@ -85,12 +85,17 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     const bool replay_position_ids =
         attn_inputs.combo_position_ids.defined() && attn_inputs.combo_position_ids.numel() > 0;
     if (captured_position_ids || replay_position_ids) {
-        if (!captured_position_ids || !replay_position_ids) {
-            throw std::runtime_error("prepare_in_place requires combo_position_ids in both capture and replay inputs");
+        TORCH_CHECK(captured_position_ids && replay_position_ids,
+                    "prepare_in_place requires combo_position_ids in both capture and replay inputs");
+        torch::Tensor replay_ids = attn_inputs.combo_position_ids.contiguous();
+        validateMropePositionIds(params.rope_config, replay_ids, -1, "prepare_in_place", false);
+        if (params.position_ids.data_ptr() != replay_ids.data_ptr()) {
+            // CUDA graph inputs allocate combo_position_ids as pinned host
+            // memory. Copy directly into the persistent device capture buffer
+            // on the current stream; avoid a synchronous per-replay .to().
+            copyTensorExactInPlace(params.position_ids, replay_ids, "combo_position_ids");
         }
-        if (params.position_ids.data_ptr() != attn_inputs.combo_position_ids.data_ptr()) {
-            copyTensorExactInPlace(params.position_ids, attn_inputs.combo_position_ids, "combo_position_ids");
-        }
+        validateMropePositionIds(params.rope_config, params.position_ids, -1, "prepare_in_place");
     }
 
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
@@ -99,7 +104,8 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
 static void validateMropePositionIds(const RopeConfig&    rope_config,
                                      const torch::Tensor& position_ids,
                                      int64_t              expected_tokens,
-                                     const char*          where) {
+                                     const char*          where,
+                                     bool                 require_device) {
     if (rope_config.style != RopeStyle::Mrope) {
         return;
     }
@@ -127,7 +133,7 @@ static void validateMropePositionIds(const RopeConfig&    rope_config,
                 where,
                 ": combo_position_ids must be int32, got ",
                 position_ids.scalar_type());
-    TORCH_CHECK(position_ids.is_cuda(), where, ": combo_position_ids must be on the ROCm device");
+    TORCH_CHECK(!require_device || position_ids.is_cuda(), where, ": combo_position_ids must be on the ROCm device");
     TORCH_CHECK(position_ids.is_contiguous(), where, ": combo_position_ids must be contiguous");
     TORCH_CHECK(position_ids.numel() % rope_config.index_factor == 0,
                 where,
@@ -177,6 +183,7 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
     } else {
         attn_params = std::make_shared<CKAttn>();
     }
+    attn_params->rope_config    = attn_configs_.rope_config;
     attn_params->attn_type      = torchDTypeToDataType(attn_inputs.dtype);
     attn_params->cu_seqlens     = attn_inputs.cu_seqlens_device;
     attn_params->cu_kv_seqlens  = attn_inputs.cu_kv_seqlens_device;
@@ -325,16 +332,12 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
     }
 
     int *padding_offset = nullptr, *position_ids = nullptr;
-    if (params->padding_offset.defined()) {
+    if (params->padding_offset.defined() && params->padding_offset.numel() > 0) {
         padding_offset = params->padding_offset.data_ptr<int>();
     }
     if (params->position_ids.defined()) {
         position_ids = params->position_ids.data_ptr<int>();
     }
-
-    auto    rope_cache = getRopeCacheOnce(attn_configs_.rope_config, attn_configs_.max_seq_len, false);
-    float2* rope_cache_ptr =
-        rope_cache.used && rope_cache.data.defined() ? static_cast<float2*>(rope_cache.data.data_ptr()) : nullptr;
 
     if (use_asm()) {
         DISPATCH_CUDA_FUNCTION_DATA_TYPE(
@@ -349,7 +352,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
                         (use_fmha_fp8 && qkv_buf_fp8.defined() ? qkv_buf_fp8.data_ptr() : nullptr),
             position_ids,
             nullptr,  // qkv_bias
-            params->padding_offset.data_ptr<int>(),
+            padding_offset,
             params->cu_seqlens.data_ptr<int>(),
             batch_size,
             seq_len,
@@ -382,7 +385,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FusedRopeKVCachePrefillO
                         (use_fmha_fp8 && qkv_buf_fp8.defined() ? qkv_buf_fp8.data_ptr() : nullptr),
             position_ids,
             nullptr,
-            params->padding_offset.data_ptr<int>(),
+            padding_offset,
             params->cu_seqlens.data_ptr<int>(),
             batch_size,
             seq_len,
@@ -440,6 +443,7 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
     }
 
     attn_params                            = CKAttnPtr(params, (CKAttn*)params.get());
+    attn_params->rope_config               = attn_configs_.rope_config;
     attn_params->decode_plan               = true;
     attn_params->attn_type                 = torchDTypeToDataType(attn_inputs.dtype);
     attn_params->cu_seqlens                = attn_inputs.cu_seqlens_device;
@@ -471,9 +475,7 @@ CKAttnPtr FusedRopeKVCacheDecodeOpBase::prepare(torch_ext::PyAttentionInputs att
 torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&                   qkv,
                                                     std::optional<torch_ext::LayerKVCache> kv_cache,
                                                     const CKAttnPtr&                       params) {
-    // Check that kv_cache is provided
-    // (CUDA version uses RTP_LLM_CHECK_WITH_INFO, use assert or similar if not available)
-    assert(kv_cache.has_value() && "decode should have kv cache.");
+    TORCH_CHECK(kv_cache.has_value(), "FusedRopeKVCacheDecodeOp::forward: decode should have kv cache");
 
     auto kv_block_array            = params->kv_block_array;
     kv_block_array.mPrimaryPoolPtr = kv_cache.value().kv_cache_base.data_ptr();

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -120,6 +120,24 @@ inline __device__ void convert_to_fp8(__hip_fp8x2_e4m3_fnuz* v, const uint32_t u
     *v                              = *reinterpret_cast<const __hip_fp8x2_e4m3_fnuz*>(&raw_fp8x2);
 }
 
+inline __device__ int get_rope_position_id(const RopeConfig& rope_config,
+                                           const int*        position_ids,
+                                           const int         token_idx,
+                                           const int         rotary_pair_idx) {
+    if (position_ids == nullptr) {
+        return -1;
+    }
+    int position_axis = 0;
+    if (rope_config.style == RopeStyle::Mrope) {
+        const int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
+        const int pair_idx = rotary_pair_idx % rope_dim;
+        position_axis      = pair_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2 ?
+                                 2 :
+                                 (pair_idx >= rope_config.mrope_dim1 ? 1 : 0);
+    }
+    return position_ids[token_idx * rope_config.index_factor + position_axis];
+}
+
 template<typename T, typename Tcache, bool PREFIX_PROMPT, bool USE_PAGED_FMHA, RopeStyle ROPE_STYLE>
 __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                            q_buf,
                                                               T*                            k_buf,
@@ -215,19 +233,7 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel_v1(T*                
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
+    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
     const int pre_len   = cu_seqlens[batch_idx];
     const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
@@ -849,19 +855,7 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel(T*                   
             v      = add(v, v_bias);
         }
     }
-    int position_id = -1;
-    if (rope_config.style == RopeStyle::Mrope && position_ids) {
-        int rope_dim = rope_config.mrope_dim1 + rope_config.mrope_dim2 + rope_config.mrope_dim3;
-        int now_idx = tidx % rope_dim, now_dim = 0;
-        if (now_idx >= rope_config.mrope_dim1 + rope_config.mrope_dim2) {
-            now_dim = 2;
-        } else if (now_idx >= rope_config.mrope_dim1) {
-            now_dim = 1;
-        }
-        position_id = position_ids[token_idx * rope_config.index_factor + now_dim];
-    } else if (position_ids) {
-        position_id = position_ids[token_idx * rope_config.index_factor];
-    }
+    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
     const int pre_len   = cu_seqlens[batch_idx];
     const int input_len = cu_seqlens[batch_idx + 1] - pre_len;
     context_rope<T, Vec_t, ROPE_STYLE>(rope_config,
@@ -1200,7 +1194,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    const int  position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;
@@ -1360,7 +1354,7 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
 
     // refer to the implementation of hipify decode attention
     const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = position_ids == nullptr ? -1 : position_ids[token_idx * rope_config.index_factor];
+    const int  position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
     const int timestep  = tlength;

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -339,8 +339,12 @@ class NewModelLoader:
             raise TypeError(
                 f"model_config num_experts must be an integer, got {num_experts!r}"
             )
-        if num_experts <= 0:
-            raise ValueError("EP loading requires model_config.num_experts")
+        if num_experts < 0:
+            raise ValueError(
+                f"model_config num_experts must be non-negative, got {num_experts}"
+            )
+        if num_experts == 0:
+            return None
         return _ExpertRangeFilter(
             num_experts,
             self.load_config.ep_size,
@@ -376,8 +380,12 @@ class NewModelLoader:
 
         return should_load
 
-    def _validate_ep_checkpoint_format(self, checkpoint_files) -> None:
-        if self.load_config.ep_size == 1:
+    def _validate_ep_checkpoint_format(
+        self,
+        checkpoint_files,
+        expert_filter: Optional[_ExpertRangeFilter],
+    ) -> None:
+        if expert_filter is None:
             return
         unsupported = [
             path
@@ -508,7 +516,8 @@ class NewModelLoader:
         if method != NewLoaderLoadMethod.SCRATCH:
             raise RuntimeError(f"Resolved unsupported load method: {method}")
         checkpoint_files = self._checkpoint_files()
-        self._validate_ep_checkpoint_format(checkpoint_files)
+        expert_filter = self._expert_filter()
+        self._validate_ep_checkpoint_format(checkpoint_files, expert_filter)
         model = self._create_model()
         if weight_mapper.is_rank_local_checkpoint(checkpoint_files) and not bool(
             getattr(model, "supports_rank_local_checkpoint", False)
@@ -518,7 +527,6 @@ class NewModelLoader:
                 "checkpoints; use a global HF checkpoint"
             )
         started = time.time()
-        expert_filter = self._expert_filter()
         model_filter = model.checkpoint_weight_name_filter()
         name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         selected_files = weight_mapper.select_safetensor_files(

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -344,6 +344,46 @@ class NewModelLoader:
                 f"model_config num_experts must be non-negative, got {num_experts}"
             )
         if num_experts == 0:
+            model_type = (
+                self.model_config.get("model_type", "")
+                if isinstance(self.model_config, dict)
+                else getattr(self.model_config, "model_type", "")
+            )
+            moe_top_k = (
+                self.model_config.get(
+                    "moe_k", self.model_config.get("num_experts_per_tok", 0)
+                )
+                if isinstance(self.model_config, dict)
+                else getattr(self.model_config, "moe_k", 0)
+            )
+            moe_style = (
+                self.model_config.get("moe_style", 0)
+                if isinstance(self.model_config, dict)
+                else getattr(self.model_config, "moe_style", 0)
+            )
+            for name, value in (("moe_k", moe_top_k), ("moe_style", moe_style)):
+                if isinstance(value, bool) or not isinstance(value, int):
+                    raise TypeError(
+                        f"model_config {name} must be an integer, got {value!r}"
+                    )
+                if value < 0:
+                    raise ValueError(
+                        f"model_config {name} must be non-negative, got {value}"
+                    )
+            if "moe" in str(model_type).lower() or moe_top_k > 0 or moe_style > 0:
+                raise ValueError(
+                    "EP is configured for a MoE model "
+                    f"(model_type={model_type!r}, moe_k={moe_top_k}, "
+                    f"moe_style={moe_style}), but "
+                    "model_config reports zero experts"
+                )
+            logger.warning(
+                "EP size %d is configured, but model_config reports zero experts; "
+                "model_type=%r and zero moe_k/moe_style markers identify a dense "
+                "model, so expert checkpoint filtering is disabled",
+                self.load_config.ep_size,
+                model_type,
+            )
             return None
         return _ExpertRangeFilter(
             num_experts,
@@ -527,7 +567,7 @@ class NewModelLoader:
                 "checkpoints; use a global HF checkpoint"
             )
         started = time.time()
-        model_filter = model.checkpoint_weight_name_filter()
+        model_filter = self._model_checkpoint_name_filter(model)
         name_filter = self._checkpoint_name_filter(model_filter, expert_filter)
         selected_files = weight_mapper.select_safetensor_files(
             self._resolved_model_path(), checkpoint_files, model_filter

--- a/rtp_llm/models_py/modules/base/common/multimodal_embedding.py
+++ b/rtp_llm/models_py/modules/base/common/multimodal_embedding.py
@@ -15,11 +15,30 @@ def reshape_extra_input_to_deepstack(
     layers is derived from the element count. This is the model-specific inverse of the
     flatten done in the qwen3-vl producer.
     """
+    if len(extra_input) != len(multimodal_features):
+        raise ValueError(
+            f"extra_input has {len(extra_input)} entries but "
+            f"multimodal_features has {len(multimodal_features)}"
+        )
+
     deepstack: List[torch.Tensor] = []
-    for flat, feature in zip(extra_input, multimodal_features):
+    for index, (flat, feature) in enumerate(zip(extra_input, multimodal_features)):
+        if flat.dim() != 1:
+            raise ValueError(f"extra_input[{index}] must be a flat 1-D tensor")
+        if feature.dim() != 2 or feature.size(0) == 0 or feature.size(1) == 0:
+            raise ValueError(
+                f"multimodal_features[{index}] must have non-empty shape "
+                "[tokens, hidden]"
+            )
         tokens = feature.size(0)
         hidden = feature.size(-1)
-        layers = flat.numel() // (tokens * hidden)
+        values_per_layer = tokens * hidden
+        if flat.numel() == 0 or flat.numel() % values_per_layer:
+            raise ValueError(
+                f"extra_input[{index}] has {flat.numel()} values, which cannot "
+                f"be reshaped using feature shape [{tokens}, {hidden}]"
+            )
+        layers = flat.numel() // values_per_layer
         deepstack.append(flat.reshape(layers, tokens, hidden))
     return deepstack
 

--- a/rtp_llm/models_py/modules/base/common/test/BUILD
+++ b/rtp_llm/models_py/modules/base/common/test/BUILD
@@ -20,3 +20,9 @@ py_test (
     env = test_envs,
     exec_properties = {'gpu':'H20'},
 )
+
+py_test(
+    name = "multimodal_embedding_prefix_cache_test",
+    srcs = ["multimodal_embedding_prefix_cache_test.py"],
+    deps = py_test_deps,
+)

--- a/rtp_llm/models_py/modules/base/common/test/multimodal_embedding_prefix_cache_test.py
+++ b/rtp_llm/models_py/modules/base/common/test/multimodal_embedding_prefix_cache_test.py
@@ -1,0 +1,81 @@
+from unittest import TestCase, main
+
+import torch
+
+from rtp_llm.models_py.modules.base.common.multimodal_embedding import (
+    MultimodalDeepstackInjector,
+    MultimodalEmbeddingInjector,
+)
+
+
+class MultimodalPrefixCacheInjectorTest(TestCase):
+    def test_mixed_cached_and_uncached_features_remain_independent(self):
+        embeddings = torch.arange(20, dtype=torch.float32).reshape(10, 2)
+        first = torch.arange(8, dtype=torch.float32).reshape(4, 2) + 100
+        second = torch.arange(6, dtype=torch.float32).reshape(3, 2) + 200
+        locations = torch.tensor([-2, 4], dtype=torch.int32)
+
+        expected_embeddings = embeddings.clone()
+        expected_embeddings[:2] = first[2:]
+        expected_embeddings[4:7] = second
+        actual_embeddings = MultimodalEmbeddingInjector()(
+            embeddings.clone(), [first, second], locations
+        )
+        torch.testing.assert_close(actual_embeddings, expected_embeddings)
+
+        hidden = embeddings.clone()
+        first_stack = torch.stack((first, first + 10))
+        second_stack = torch.stack((second, second + 10))
+        expected_hidden = hidden.clone()
+        expected_hidden[:2] += first_stack[1, 2:]
+        expected_hidden[4:7] += second_stack[1]
+        actual_hidden = MultimodalDeepstackInjector()(
+            hidden, [first_stack, second_stack], locations, layer_id=1
+        )
+        torch.testing.assert_close(actual_hidden, expected_hidden)
+
+    def test_embedding_injector_drops_cached_feature_prefix_on_cpu(self):
+        embeddings = torch.arange(18, dtype=torch.float32).reshape(6, 3)
+        feature = torch.arange(12, dtype=torch.float32).reshape(4, 3) + 100
+        injector = MultimodalEmbeddingInjector()
+
+        for cached_rows in (2, 4, 6):
+            with self.subTest(cached_rows=cached_rows):
+                expected = embeddings.clone()
+                if cached_rows < feature.size(0):
+                    tail = feature[cached_rows:]
+                    expected[: tail.size(0)] = tail
+
+                actual = injector(
+                    embeddings.clone(),
+                    [feature],
+                    torch.tensor([-cached_rows], dtype=torch.int32),
+                )
+                torch.testing.assert_close(actual, expected)
+                self.assertEqual(actual.device.type, "cpu")
+
+    def test_deepstack_injector_drops_cached_feature_prefix_on_cpu(self):
+        hidden = torch.arange(18, dtype=torch.float32).reshape(6, 3)
+        stack = torch.arange(24, dtype=torch.float32).reshape(2, 4, 3) + 100
+        injector = MultimodalDeepstackInjector()
+        layer_id = 1
+
+        for cached_rows in (2, 4, 6):
+            with self.subTest(cached_rows=cached_rows):
+                expected = hidden.clone()
+                if cached_rows < stack.size(1):
+                    tail = stack[layer_id, cached_rows:]
+                    expected[: tail.size(0)] += tail
+
+                actual = injector(
+                    hidden.clone(),
+                    [stack],
+                    torch.tensor([-cached_rows], dtype=torch.int32),
+                    layer_id,
+                )
+                torch.testing.assert_close(actual, expected)
+                self.assertEqual(actual.device.type, "cpu")
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/base/common/test/multimodal_embedding_test.py
+++ b/rtp_llm/models_py/modules/base/common/test/multimodal_embedding_test.py
@@ -119,6 +119,27 @@ class MultimodalEmbeddingTest(TestCase):
             ):
                 self._run_deepstack_embedding_test(*params)
 
+    def test_partial_prefix_cache_moves_cpu_features_to_cuda(self):
+        embeddings = torch.zeros(5, 3, device="cuda", dtype=torch.float32)
+        feature = torch.arange(12, device="cpu", dtype=torch.float32).reshape(4, 3)
+        output = MultimodalEmbeddingInjector().cuda()(
+            embeddings, [feature], torch.tensor([-2], device="cuda")
+        )
+        expected = torch.zeros_like(embeddings)
+        expected[:2] = feature[2:].cuda()
+        self.assertEqual(output.device.type, "cuda")
+        torch.testing.assert_close(output, expected)
+
+        hidden = torch.zeros(5, 3, device="cuda", dtype=torch.float32)
+        deepstack = torch.arange(24, device="cpu", dtype=torch.float32).reshape(2, 4, 3)
+        output = MultimodalDeepstackInjector().cuda()(
+            hidden, [deepstack], torch.tensor([-1], device="cuda"), layer_id=1
+        )
+        expected = torch.zeros_like(hidden)
+        expected[:3] = deepstack[1, 1:].cuda()
+        self.assertEqual(output.device.type, "cuda")
+        torch.testing.assert_close(output, expected)
+
 
 if __name__ == "__main__":
     main()

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -113,6 +113,22 @@ def _make_rope_attn_configs(
     return cfg
 
 
+def _make_mrope_attn_configs(
+    head_num: int,
+    head_num_kv: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    mrope_section=(16, 24, 24),
+):
+    """Qwen3-VL-style MRoPE configuration for the real ROCm fused op."""
+    cfg = _make_rope_attn_configs(head_num, head_num_kv, head_dim, dtype)
+    rope = cfg.rope_config
+    rope.style = RopeStyle.Mrope
+    rope.index_factor = 3
+    rope.mrope_dim1, rope.mrope_dim2, rope.mrope_dim3 = mrope_section
+    return cfg
+
+
 def _make_rope_prefill_inputs(
     input_lengths: List[int], device: torch.device, dtype: torch.dtype
 ):
@@ -171,6 +187,38 @@ def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int])
         cos_b = cos.unsqueeze(1)
         sin_b = sin.unsqueeze(1)
         return torch.cat([lo * cos_b - hi * sin_b, hi * cos_b + lo * sin_b], dim=-1)
+
+    return rot(q).to(q.dtype), rot(k).to(k.dtype)
+
+
+def _apply_mrope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    mrope_section=(16, 24, 24),
+):
+    """Torch reference for token-major three-axis Qwen3-VL MRoPE."""
+    head_dim = q.shape[-1]
+    half = head_dim // 2
+    if sum(mrope_section) != half:
+        raise ValueError("MRoPE sections must cover half of the head dimension")
+
+    axis_by_pair = torch.repeat_interleave(
+        torch.arange(3, device=q.device),
+        torch.tensor(mrope_section, device=q.device),
+    )
+    positions = position_ids.to(device=q.device, dtype=torch.float32)
+    pair_positions = positions[:, axis_by_pair]
+    inv_freq = 10000 ** (
+        -2.0 * torch.arange(half, dtype=torch.float32, device=q.device) / head_dim
+    )
+    angle = pair_positions * inv_freq.unsqueeze(0)
+    cos = torch.cos(angle).unsqueeze(1)
+    sin = torch.sin(angle).unsqueeze(1)
+
+    def rot(x):
+        lo, hi = x[..., :half], x[..., half:]
+        return torch.cat([lo * cos - hi * sin, hi * cos + lo * sin], dim=-1)
 
     return rot(q).to(q.dtype), rot(k).to(k.dtype)
 
@@ -1256,6 +1304,135 @@ class TestAiterPrefillImplNoKvRopeRealOp(unittest.TestCase):
 
     def test_nonasm_no_kv_rope_real_op_matches_reference(self):
         self._check_real_no_kv_rope_path(AiterPrefillImplNonAsm)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
+    """Numerical and validation coverage for Qwen3-VL MRoPE position IDs."""
+
+    def setUp(self):
+        torch.manual_seed(2)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_mrope_matches_reference(self, impl_cls):
+        input_lengths = [3, 2]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 128
+        cfg = _make_mrope_attn_configs(
+            head_num, head_num_kv, head_dim, dtype=self.dtype
+        )
+        attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        position_ids = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 4, 7],
+                [2, 5, 8],
+                [0, 0, 0],
+                [3, 6, 9],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        attn_inputs.combo_position_ids = position_ids.flatten()
+        impl = impl_cls(cfg, attn_inputs)
+
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+
+        actual_q, actual_k, actual_v = impl.rope_kvcache_impl.forward(
+            qkv, None, impl.rope_params
+        )
+        ref_q, ref_k = _apply_mrope(q, k, position_ids)
+        ref_k_padded, ref_v_padded = _pad_kv(ref_k, v, attn_inputs.cu_kv_seqlens_device)
+
+        torch.testing.assert_close(actual_q, ref_q, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_k, ref_k_padded, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual_v, ref_v_padded, atol=1e-2, rtol=1e-2)
+
+    def test_asm_mrope_uses_all_three_position_axes(self):
+        self._check_mrope_matches_reference(AiterPrefillImplAsm)
+
+    def test_nonasm_mrope_uses_all_three_position_axes(self):
+        self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
+
+    def test_prepare_in_place_refreshes_mrope_position_ids(self):
+        input_lengths = [3, 2]
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 128
+        cfg = _make_mrope_attn_configs(
+            head_num, head_num_kv, head_dim, dtype=self.dtype
+        )
+        attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        first_position_ids = torch.tensor(
+            [
+                [0, 0, 0],
+                [1, 1, 1],
+                [2, 2, 2],
+                [0, 0, 0],
+                [1, 1, 1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        attn_inputs.combo_position_ids = first_position_ids.flatten()
+        impl = AiterPrefillImplAsm(cfg, attn_inputs)
+
+        total_tokens = sum(input_lengths)
+        q = torch.randn(
+            total_tokens, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            total_tokens, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+        first_q, _, _ = impl.rope_kvcache_impl.forward(qkv, None, impl.rope_params)
+
+        replay_inputs = _make_rope_prefill_inputs(
+            input_lengths, self.device, self.dtype
+        )
+        replay_position_ids = torch.tensor(
+            [
+                [0, 3, 6],
+                [1, 4, 7],
+                [2, 5, 8],
+                [0, 2, 4],
+                [1, 3, 5],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        replay_inputs.combo_position_ids = replay_position_ids.flatten()
+        impl.rope_params.prepare_in_place(replay_inputs)
+        replay_q, _, _ = impl.rope_kvcache_impl.forward(qkv, None, impl.rope_params)
+        expected_q, _ = _apply_mrope(q, k, replay_position_ids)
+
+        self.assertFalse(torch.equal(first_q, replay_q))
+        torch.testing.assert_close(replay_q, expected_q, atol=1e-2, rtol=1e-2)
+
+    def test_mrope_missing_position_ids_fails_during_prepare(self):
+        cfg = _make_mrope_attn_configs(4, 2, 128, dtype=self.dtype)
+        attn_inputs = _make_rope_prefill_inputs([2], self.device, self.dtype)
+        with self.assertRaisesRegex(
+            RuntimeError, "requires non-empty combo_position_ids"
+        ):
+            AiterPrefillImplAsm(cfg, attn_inputs)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -50,7 +50,12 @@ try:
         RopeConfig,
         RopeStyle,
     )
-    from rtp_llm.ops.compute_ops import get_typemeta
+    from rtp_llm.ops.compute_ops import (
+        FusedRopeKVCacheDecodeOpAsm,
+        FusedRopeKVCacheDecodeOpNonAsm,
+        LayerKVCache,
+        get_typemeta,
+    )
 
     _OPS_IMPORTABLE = True
 except ImportError:
@@ -163,6 +168,58 @@ def _make_rope_prefill_inputs(
         padding_offset, dtype=torch.int32, device=device
     )
     return attn_inputs
+
+
+def _make_mrope_decode_inputs(
+    sequence_lengths: List[int],
+    position_ids: torch.Tensor,
+    device: torch.device,
+    dtype: torch.dtype,
+    tokens_per_block: int = 16,
+):
+    """Build one-token-per-sequence inputs for the real ROCm decode RoPE op."""
+    batch_size = len(sequence_lengths)
+    attn_inputs = PyAttentionInputs()
+    attn_inputs.is_prefill = False
+    attn_inputs.dtype = get_typemeta(torch.empty(1, dtype=dtype))
+    attn_inputs.input_lengths = torch.ones(
+        batch_size, dtype=torch.int32, device="cpu"
+    ).pin_memory()
+    attn_inputs.sequence_lengths = torch.tensor(
+        sequence_lengths, dtype=torch.int32, device="cpu"
+    ).pin_memory()
+    attn_inputs.prefix_lengths = torch.zeros(
+        batch_size, dtype=torch.int32, device="cpu"
+    )
+    attn_inputs.padding_offset = torch.zeros(
+        batch_size, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_seqlens_device = torch.arange(
+        batch_size + 1, dtype=torch.int32, device=device
+    )
+    attn_inputs.cu_kv_seqlens_device = torch.tensor(
+        [0] + [sum(sequence_lengths[:idx]) + idx for idx in range(1, batch_size + 1)],
+        dtype=torch.int32,
+        device=device,
+    )
+    max_blocks = max(
+        (sequence_length + 1 + tokens_per_block - 1) // tokens_per_block
+        for sequence_length in sequence_lengths
+    )
+    block_table = torch.zeros((batch_size, max_blocks), dtype=torch.int32, device="cpu")
+    next_block = 0
+    for batch_idx, sequence_length in enumerate(sequence_lengths):
+        block_count = (sequence_length + 1 + tokens_per_block - 1) // tokens_per_block
+        block_table[batch_idx, :block_count] = torch.arange(
+            next_block, next_block + block_count, dtype=torch.int32
+        )
+        next_block += block_count
+    attn_inputs.kv_cache_kernel_block_id = block_table
+    attn_inputs.kv_cache_kernel_block_id_device = block_table.to(device)
+    attn_inputs.combo_position_ids = (
+        position_ids.to(device=device, dtype=torch.int32).contiguous().view(-1)
+    )
+    return attn_inputs, next_block
 
 
 def _apply_base_rope(q: torch.Tensor, k: torch.Tensor, input_lengths: List[int]):
@@ -1317,7 +1374,9 @@ class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
         self.device = torch.device("cuda")
         self.dtype = torch.bfloat16
 
-    def _check_mrope_matches_reference(self, impl_cls):
+    def _check_mrope_matches_reference(
+        self, impl_cls, *, define_padding_offset: bool = True
+    ):
         input_lengths = [3, 2]
         head_num = 4
         head_num_kv = 2
@@ -1326,6 +1385,8 @@ class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
             head_num, head_num_kv, head_dim, dtype=self.dtype
         )
         attn_inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        if not define_padding_offset:
+            attn_inputs.padding_offset = torch.Tensor()
         position_ids = torch.tensor(
             [
                 [0, 0, 0],
@@ -1368,7 +1429,15 @@ class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
     def test_nonasm_mrope_uses_all_three_position_axes(self):
         self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
 
+    def test_asm_mrope_accepts_undefined_padding_offset(self):
+        self._check_mrope_matches_reference(
+            AiterPrefillImplAsm, define_padding_offset=False
+        )
+
     def test_prepare_in_place_refreshes_mrope_position_ids(self):
+        # This covers the persistent-buffer refresh used before graph replay.
+        # It does not perform a real graph capture/replay; that remains an
+        # engine-level integration coverage boundary.
         input_lengths = [3, 2]
         head_num = 4
         head_num_kv = 2
@@ -1426,6 +1495,27 @@ class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
         self.assertFalse(torch.equal(first_q, replay_q))
         torch.testing.assert_close(replay_q, expected_q, atol=1e-2, rtol=1e-2)
 
+    def test_prepare_in_place_rejects_invalid_mrope_position_ids(self):
+        cfg = _make_mrope_attn_configs(4, 2, 128, dtype=self.dtype)
+        capture_inputs = _make_rope_prefill_inputs([2], self.device, self.dtype)
+        capture_inputs.combo_position_ids = torch.tensor(
+            [[0, 0, 0], [1, 1, 1]],
+            dtype=torch.int32,
+            device=self.device,
+        ).flatten()
+        impl = AiterPrefillImplAsm(cfg, capture_inputs)
+
+        replay_inputs = _make_rope_prefill_inputs([2], self.device, self.dtype)
+        replay_inputs.combo_position_ids = torch.tensor(
+            [[0, 0, 0], [1, 1, 1]],
+            dtype=torch.float32,
+            device=self.device,
+        ).flatten()
+        with self.assertRaisesRegex(
+            RuntimeError, "prepare_in_place: combo_position_ids must be int32"
+        ):
+            impl.rope_params.prepare_in_place(replay_inputs)
+
     def test_mrope_missing_position_ids_fails_during_prepare(self):
         cfg = _make_mrope_attn_configs(4, 2, 128, dtype=self.dtype)
         attn_inputs = _make_rope_prefill_inputs([2], self.device, self.dtype)
@@ -1433,6 +1523,115 @@ class TestAiterPrefillImplMropeRealOp(unittest.TestCase):
             RuntimeError, "requires non-empty combo_position_ids"
         ):
             AiterPrefillImplAsm(cfg, attn_inputs)
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention operators")
+class TestRocmDecodeMropeRealOp(unittest.TestCase):
+    """Numerical coverage for the distinct ROCm decode MRoPE kernels."""
+
+    def setUp(self):
+        torch.manual_seed(3)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def _check_decode_matches_reference(
+        self,
+        op_cls,
+        sequence_lengths: List[int],
+        position_ids: torch.Tensor,
+    ):
+        head_num = 4
+        head_num_kv = 2
+        head_dim = 128
+        tokens_per_block = 16
+        cfg = _make_mrope_attn_configs(
+            head_num, head_num_kv, head_dim, dtype=self.dtype
+        )
+        cfg.max_seq_len = 64
+        attn_inputs, block_count = _make_mrope_decode_inputs(
+            sequence_lengths,
+            position_ids,
+            self.device,
+            self.dtype,
+            tokens_per_block,
+        )
+        op = op_cls(cfg)
+        params = op.prepare(attn_inputs)
+        token_num = len(sequence_lengths)
+        q = torch.randn(
+            token_num, head_num, head_dim, dtype=self.dtype, device=self.device
+        )
+        k = torch.randn(
+            token_num, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        v = torch.randn(
+            token_num, head_num_kv, head_dim, dtype=self.dtype, device=self.device
+        )
+        qkv = _pack_qkv(q, k, v)
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.zeros(
+            block_count,
+            2,
+            head_num_kv,
+            tokens_per_block,
+            head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+        actual_q = op.forward(qkv, kv_cache, params)
+        expected_q, _ = _apply_mrope(q, k, position_ids)
+        torch.testing.assert_close(actual_q, expected_q, atol=1e-2, rtol=1e-2)
+
+    def test_asm_single_sequence_uses_all_three_position_axes(self):
+        self._check_decode_matches_reference(
+            FusedRopeKVCacheDecodeOpAsm,
+            [3],
+            torch.tensor([[2, 5, 7]], dtype=torch.int32),
+        )
+
+    def test_nonasm_single_sequence_uses_all_three_position_axes(self):
+        self._check_decode_matches_reference(
+            FusedRopeKVCacheDecodeOpNonAsm,
+            [3],
+            torch.tensor([[2, 5, 7]], dtype=torch.int32),
+        )
+
+    def test_asm_multi_sequence_uses_token_major_position_ids(self):
+        self._check_decode_matches_reference(
+            FusedRopeKVCacheDecodeOpAsm,
+            [3, 5],
+            torch.tensor([[2, 5, 7], [4, 1, 9]], dtype=torch.int32),
+        )
+
+    def test_nonasm_multi_sequence_uses_token_major_position_ids(self):
+        self._check_decode_matches_reference(
+            FusedRopeKVCacheDecodeOpNonAsm,
+            [3, 5],
+            torch.tensor([[2, 5, 7], [4, 1, 9]], dtype=torch.int32),
+        )
+
+    def test_decode_without_kv_cache_fails_in_release_builds(self):
+        cfg = _make_mrope_attn_configs(4, 2, 128, dtype=self.dtype)
+        cfg.max_seq_len = 64
+        attn_inputs, _ = _make_mrope_decode_inputs(
+            [3],
+            torch.tensor([[2, 5, 7]], dtype=torch.int32),
+            self.device,
+            self.dtype,
+        )
+        op = FusedRopeKVCacheDecodeOpAsm(cfg)
+        params = op.prepare(attn_inputs)
+        qkv = torch.randn(
+            1,
+            4 * 128 + 2 * 2 * 128,
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "decode should have kv cache"):
+            op.forward(qkv, None, params)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_models/qwen3_vl/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/__init__.py
@@ -1,0 +1,13 @@
+"""Qwen3-VL newloader language and vision implementations."""
+
+from typing import Any
+
+__all__ = ["Qwen3VLForCausalLM"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "Qwen3VLForCausalLM":
+        from rtp_llm.models_py.new_models.qwen3_vl.model import Qwen3VLForCausalLM
+
+        return Qwen3VLForCausalLM
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rtp_llm/models_py/new_models/qwen3_vl/model.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/model.py
@@ -1,0 +1,92 @@
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+
+from rtp_llm.models_py.modules import (
+    MultimodalDeepstackInjector,
+    MultimodalEmbeddingInjector,
+    reshape_extra_input_to_deepstack,
+)
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
+from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+
+
+class Qwen3VLForCausalLM(Qwen3ForCausalLM):
+    """Qwen3-VL text runtime with multimodal feature injection."""
+
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.language_model.": ""},
+    )
+
+    def __init__(self, model_config: Any, load_config: Any):
+        super().__init__(model_config, load_config)
+        self.multimodal_embedding_injector = MultimodalEmbeddingInjector()
+        self.multimodal_deepstack_injector = MultimodalDeepstackInjector()
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("model.language_model.") or name.startswith(
+            "lm_head."
+        )
+
+    def load_weights(
+        self, weights: Iterator[tuple[str, torch.Tensor]] | dict[str, torch.Tensor]
+    ) -> None:
+        iterator = weights.items() if isinstance(weights, dict) else weights
+        super().load_weights(self.WEIGHTS_MAPPER.apply(iterator))
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids = inputs.input_ids
+        text_tokens_mask = inputs.embedding_inputs.text_tokens_mask
+        if text_tokens_mask is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            text_mask = text_tokens_mask.to(device=input_ids.device, dtype=torch.bool)
+            safe_input_ids = torch.where(text_mask, input_ids, 0)
+            hidden_states = self.embed_tokens(safe_input_ids)
+            hidden_states = hidden_states * text_mask.unsqueeze(-1)
+
+        multimodal_inputs = inputs.multimodal_inputs
+        mm_features = multimodal_inputs.multimodal_features
+        mm_feature_locs = multimodal_inputs.mm_features_locs
+        mm_extra_input = multimodal_inputs.mm_extra_input
+        mm_deepstack_embeds = (
+            reshape_extra_input_to_deepstack(mm_extra_input, mm_features)
+            if mm_extra_input
+            else []
+        )
+        hidden_states = self.multimodal_embedding_injector(
+            hidden_states, mm_features, mm_feature_locs
+        )
+
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+
+        cpu_locs = (
+            mm_feature_locs.to(device="cpu", dtype=torch.long).view(-1).tolist()
+            if mm_deepstack_embeds and mm_feature_locs is not None
+            else []
+        )
+        for layer_id, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, layer_id)
+            hidden_states = layer(
+                hidden_states,
+                fmha_impl,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(layer_id) if self.kv_cache else None
+                ),
+            )
+            hidden_states = self.multimodal_deepstack_injector(
+                hidden_states,
+                mm_deepstack_embeds,
+                cpu_locs,
+                layer_id,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)
+
+
+__all__ = ["Qwen3VLForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/BUILD
@@ -1,0 +1,52 @@
+py_test(
+    name = "test_qwen3_vl_load",
+    srcs = ["test_qwen3_vl_load.py"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_vision_loader_import",
+    srcs = ["test_qwen3_vl_vision_loader_import.py"],
+    deps = [
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_gpu",
+    srcs = ["test_qwen3_vl_gpu.py"],
+    exec_properties = {
+        "gpu": "H20",
+        "gpu_count": "1",
+    },
+    tags = ["H20"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)
+
+py_test(
+    name = "test_qwen3_vl_rocm",
+    srcs = ["test_qwen3_vl_gpu.py"],
+    main = "test_qwen3_vl_gpu.py",
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "1",
+    },
+    tags = ["rocm"],
+    deps = [
+        "//rtp_llm:numpy",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
@@ -1,0 +1,204 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+    Qwen3VLForVisionEmbedding,
+    _resolve_flash_attn_varlen,
+    load_qwen3_vl_vision,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+def _reference_interpolated_position_embeddings(visual, grid_values):
+    index_lists = [[], [], [], []]
+    weight_lists = [[], [], [], []]
+    for _, height, width in grid_values:
+        height_indexes = torch.linspace(0, visual.num_grid_per_side - 1, height)
+        width_indexes = torch.linspace(0, visual.num_grid_per_side - 1, width)
+        height_floor = height_indexes.int()
+        width_floor = width_indexes.int()
+        height_ceil = (height_floor + 1).clip(max=visual.num_grid_per_side - 1)
+        width_ceil = (width_floor + 1).clip(max=visual.num_grid_per_side - 1)
+        delta_height = height_indexes - height_floor
+        delta_width = width_indexes - width_floor
+        base_height = height_floor * visual.num_grid_per_side
+        base_height_ceil = height_ceil * visual.num_grid_per_side
+
+        indexes = (
+            (base_height[:, None] + width_floor[None]).flatten(),
+            (base_height[:, None] + width_ceil[None]).flatten(),
+            (base_height_ceil[:, None] + width_floor[None]).flatten(),
+            (base_height_ceil[:, None] + width_ceil[None]).flatten(),
+        )
+        weights = (
+            ((1 - delta_height)[:, None] * (1 - delta_width)[None]).flatten(),
+            ((1 - delta_height)[:, None] * delta_width[None]).flatten(),
+            (delta_height[:, None] * (1 - delta_width)[None]).flatten(),
+            (delta_height[:, None] * delta_width[None]).flatten(),
+        )
+        for index in range(4):
+            index_lists[index].extend(indexes[index].tolist())
+            weight_lists[index].extend(weights[index].tolist())
+
+    index_tensor = torch.tensor(index_lists, dtype=torch.long, device=visual.device)
+    weight_tensor = torch.tensor(weight_lists, dtype=visual.dtype, device=visual.device)
+    weighted = visual.pos_embed(index_tensor) * weight_tensor[:, :, None]
+    interpolated = weighted[0] + weighted[1] + weighted[2] + weighted[3]
+    reduction_order = weighted.sum(dim=0)
+
+    def reorder(position_embeddings):
+        outputs = []
+        offset = 0
+        merge_size = visual.spatial_merge_size
+        for frames, height, width in grid_values:
+            spatial_size = height * width
+            item = position_embeddings[offset : offset + spatial_size]
+            offset += spatial_size
+            outputs.append(
+                item.repeat(frames, 1)
+                .reshape(
+                    frames,
+                    height // merge_size,
+                    merge_size,
+                    width // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+        return torch.cat(outputs)
+
+    return reorder(interpolated), reorder(reduction_order)
+
+
+class Qwen3VLVisionGpuTest(unittest.TestCase):
+    def test_bf16_position_interpolation_matches_reference_addition_order(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        torch.manual_seed(29)
+        visual = (
+            Qwen3VLForVisionEmbedding(
+                {
+                    "model_type": "qwen3_vl_vision",
+                    "vision_config": _vision_config(),
+                },
+                NewLoaderConfig(compute_dtype=torch.bfloat16, device="cuda:0"),
+            )
+            .cuda()
+            .eval()
+            .visual
+        )
+        grid_values = [(1, 6, 10)]
+        with torch.inference_mode():
+            actual = visual._interpolated_position_embeddings(grid_values)
+            expected, reduction_order = _reference_interpolated_position_embeddings(
+                visual, grid_values
+            )
+
+        self.assertTrue(torch.equal(actual, expected))
+        self.assertFalse(torch.equal(reduction_order, expected))
+
+    def test_real_newloader_gpu_forward_matches_cpu_reference(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+        if torch.version.hip is None:
+            self.assertIsNotNone(_resolve_flash_attn_varlen())
+
+        torch.manual_seed(11)
+        config = _vision_config()
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 64).reshape(8, 8)
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected_output, expected_deepstack = source(pixel_values, grid_thw)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            visual = load_qwen3_vl_vision(
+                vision_config=config,
+                model_path=model_path,
+                compute_dtype=torch.float16,
+                device="cuda:0",
+            )
+
+        self.assertFalse(visual.training)
+        self.assertEqual(visual.device, torch.device("cuda:0"))
+        with torch.inference_mode():
+            actual_output, actual_deepstack = visual(
+                pixel_values.cuda(), grid_thw.cuda()
+            )
+        torch.testing.assert_close(
+            actual_output.float().cpu(),
+            expected_output,
+            atol=2e-2,
+            rtol=2e-2,
+        )
+        self.assertEqual(len(actual_deepstack), len(expected_deepstack))
+        torch.testing.assert_close(
+            actual_deepstack[0].float().cpu(),
+            expected_deepstack[0],
+            atol=2e-2,
+            rtol=2e-2,
+        )
+
+    def test_fp32_accelerator_forward_uses_sdpa_fallback(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        config = _vision_config()
+        model = (
+            Qwen3VLForVisionEmbedding(
+                {"model_type": "qwen3_vl_vision", "vision_config": config},
+                NewLoaderConfig(compute_dtype=torch.float32, device="cuda:0"),
+            )
+            .cuda()
+            .eval()
+        )
+        pixel_values = torch.linspace(-1.0, 1.0, 64, device="cuda").reshape(8, 8)
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64, device="cuda")
+
+        with patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.vision._resolve_flash_attn_varlen",
+            side_effect=AssertionError("FP32 must not resolve flash-attention"),
+        ):
+            with torch.inference_mode():
+                output, deepstack = model(pixel_values, grid_thw)
+
+        self.assertEqual(output.device.type, "cuda")
+        self.assertEqual(len(deepstack), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_gpu.py
@@ -7,6 +7,7 @@ from safetensors.torch import save_file
 
 from rtp_llm.models_py.model_loader import NewLoaderConfig
 from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+    Qwen3VisionRotaryEmbedding,
     Qwen3VLForVisionEmbedding,
     _resolve_flash_attn_varlen,
     load_qwen3_vl_vision,
@@ -94,6 +95,18 @@ def _reference_interpolated_position_embeddings(visual, grid_values):
 
 
 class Qwen3VLVisionGpuTest(unittest.TestCase):
+    def test_rotary_uses_runtime_device_numerics_after_cpu_construction(self):
+        if not torch.cuda.is_available():
+            self.skipTest("A CUDA or ROCm accelerator is required")
+
+        cpu_constructed = Qwen3VisionRotaryEmbedding(32).to("cuda:0")
+        with torch.device("cuda:0"):
+            device_constructed = Qwen3VisionRotaryEmbedding(32)
+
+        actual = cpu_constructed(128)
+        expected = device_constructed(128)
+        self.assertTrue(torch.equal(actual, expected))
+
     def test_bf16_position_interpolation_matches_reference_addition_order(self):
         if not torch.cuda.is_available():
             self.skipTest("A CUDA or ROCm accelerator is required")

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
@@ -61,6 +61,8 @@ def _language_config():
         enable_fp32_lm_head=False,
         tie_word_embeddings=True,
         expert_num=0,
+        moe_k=0,
+        moe_style=0,
     )
 
 
@@ -271,14 +273,50 @@ class Qwen3VLNewLoaderTest(unittest.TestCase):
     def test_dense_language_ignores_runtime_ep_topology(self):
         with tempfile.TemporaryDirectory() as model_path:
             save_file(_language_weights(), f"{model_path}/model.safetensors")
-            model = NewModelLoader(
-                model_config=_language_config(),
-                load_config=_load_config(ep_size=2),
-                model_path=model_path,
-            ).load()
+            with self.assertLogs(
+                "rtp_llm.models_py.model_loader", level="WARNING"
+            ) as logs:
+                model = NewModelLoader(
+                    model_config=_language_config(),
+                    load_config=_load_config(ep_size=2),
+                    model_path=model_path,
+                ).load()
 
         self.assertIsInstance(model, Qwen3VLForCausalLM)
         torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertTrue(
+            any("identify a dense model" in message for message in logs.output)
+        )
+        self.assertTrue(
+            any("model_type='qwen3_vl'" in message for message in logs.output)
+        )
+
+    def test_ep_rejects_zero_experts_when_moe_markers_are_enabled(self):
+        config = _language_config()
+        config.moe_k = 1
+        config.moe_style = 1
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_language_weights(), f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(ValueError, "MoE model.*zero experts"):
+                NewModelLoader(
+                    model_config=config,
+                    load_config=_load_config(ep_size=2),
+                    model_path=model_path,
+                ).load()
+
+    def test_ep_rejects_known_moe_model_type_with_zero_experts(self):
+        config = _language_config()
+        config.model_type = "qwen3_vl_moe"
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_language_weights(), f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(
+                ValueError, "model_type='qwen3_vl_moe'.*zero experts"
+            ):
+                NewModelLoader(
+                    model_config=config,
+                    load_config=_load_config(ep_size=2),
+                    model_path=model_path,
+                ).load()
 
     def test_language_forward_handles_text_only_input(self):
         class IdentityLayer(torch.nn.Module):
@@ -316,6 +354,85 @@ class Qwen3VLNewLoaderTest(unittest.TestCase):
             outputs = model(inputs, fmha_impl)
 
         torch.testing.assert_close(outputs.hidden_states, model.embed_tokens(input_ids))
+
+    def test_language_forward_injects_multimodal_features_and_deepstack(self):
+        class IdentityLayer(torch.nn.Module):
+            def forward(self, hidden_states, fmha_impl, kv_cache=None):
+                return hidden_states
+
+        class EmbeddingInjector:
+            def __init__(self):
+                self.input_at_mm_location = None
+
+            def __call__(self, hidden_states, features, locations):
+                loc = int(locations.item())
+                self.input_at_mm_location = hidden_states[loc].clone()
+                output = hidden_states.clone()
+                output[loc] = features[0]
+                return output
+
+        class DeepstackInjector:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, hidden_states, deepstack, locations, layer_id):
+                self.calls.append((tuple(locations), layer_id))
+                output = hidden_states.clone()
+                output[locations[0]] += deepstack[layer_id]
+                return output
+
+        model = Qwen3VLForCausalLM.__new__(Qwen3VLForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        with torch.no_grad():
+            model.embed_tokens.weight.copy_(
+                torch.arange(32, dtype=torch.float32).reshape(8, 4)
+            )
+        model.layers = torch.nn.ModuleList([IdentityLayer(), IdentityLayer()])
+        model.norm = torch.nn.Identity()
+        model.kv_cache = None
+        embedding_injector = EmbeddingInjector()
+        deepstack_injector = DeepstackInjector()
+        model.multimodal_embedding_injector = embedding_injector
+        model.multimodal_deepstack_injector = deepstack_injector
+
+        input_ids = torch.tensor([1, 99, 2])
+        text_mask = torch.tensor([True, False, True])
+        mm_feature = torch.tensor([10.0, 20.0, 30.0, 40.0])
+        mm_feature_locs = torch.tensor([1])
+        deepstack = [
+            torch.tensor([1.0, 2.0, 3.0, 4.0]),
+            torch.tensor([5.0, 6.0, 7.0, 8.0]),
+        ]
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            embedding_inputs=types.SimpleNamespace(text_tokens_mask=text_mask),
+            multimodal_inputs=types.SimpleNamespace(
+                multimodal_features=[mm_feature],
+                mm_features_locs=mm_feature_locs,
+                mm_extra_input=[object()],
+            ),
+            attention_inputs=object(),
+        )
+        fmha_impl = types.SimpleNamespace(fmha_params=None)
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.model."
+            "reshape_extra_input_to_deepstack",
+            return_value=deepstack,
+        ), mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.model." "select_block_map_for_layer"
+        ) as select_block_map:
+            outputs = model(inputs, fmha_impl)
+
+        torch.testing.assert_close(
+            embedding_injector.input_at_mm_location, torch.zeros(4)
+        )
+        expected = model.embed_tokens(torch.tensor([1, 0, 2])).detach()
+        expected[1] = mm_feature + deepstack[0] + deepstack[1]
+        torch.testing.assert_close(outputs.hidden_states, expected)
+        self.assertEqual(deepstack_injector.calls, [((1,), 0), ((1,), 1)])
+        self.assertEqual(select_block_map.call_count, 2)
 
     def test_vision_loader_matches_independent_cpu_reference(self):
         torch.manual_seed(7)
@@ -404,6 +521,13 @@ class Qwen3VLNewLoaderTest(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "integer dtype"):
             model(torch.zeros(4, 8), torch.tensor([[1.0, 2.0, 2.0]]))
 
+    def test_vision_config_rejects_empty_deepstack_indexes(self):
+        config = _vision_model_config()
+        config["vision_config"] = dict(config["vision_config"])
+        config["vision_config"]["deepstack_visual_indexes"] = []
+        with self.assertRaisesRegex(ValueError, "at least one layer"):
+            Qwen3VLForVisionEmbedding(config, _load_config())
+
     def test_vision_loader_matches_legacy_fp16_staging_for_runtime_dtypes(self):
         torch.manual_seed(19)
         source = Qwen3VLForVisionEmbedding(
@@ -445,6 +569,22 @@ class Qwen3VLNewLoaderTest(unittest.TestCase):
                         loaded.visual.blocks[0].attn.qkv.weight,
                         before,
                     )
+
+    def test_vision_loader_rejects_fp16_staging_overflow(self):
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        key = "model.visual.blocks.0.attn.qkv.weight"
+        weights[key] = torch.full_like(weights[key], 70000, dtype=torch.bfloat16)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(ValueError, "FP16-compatible range"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(torch.bfloat16),
+                    model_path=model_path,
+                ).load()
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_load.py
@@ -1,0 +1,451 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen3_vl import (
+    Qwen3VLForCausalLM as ExportedQwen3VLForCausalLM,
+)
+from rtp_llm.models_py.new_models.qwen3_vl.model import Qwen3VLForCausalLM
+from rtp_llm.models_py.new_models.qwen3_vl.vision import Qwen3VLForVisionEmbedding
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+
+
+def _parallelism(ep_size=1):
+    return types.SimpleNamespace(
+        tp_size=1,
+        tp_rank=0,
+        ep_size=ep_size,
+        ep_rank=0,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+        get_attn_tp_size=lambda: 1,
+        get_attn_tp_rank=lambda: 0,
+        get_ffn_tp_size=lambda: 1,
+        get_ffn_tp_rank=lambda: 0,
+    )
+
+
+def _load_config(dtype=torch.float32, ep_size=1) -> NewLoaderConfig:
+    return NewLoaderConfig(
+        compute_dtype=dtype,
+        device="cpu",
+        quant_config=QuantizationConfig("none"),
+        parallelism_config=_parallelism(ep_size),
+        ep_size=ep_size,
+        ep_rank=0,
+    )
+
+
+def _language_config():
+    return types.SimpleNamespace(
+        model_type="qwen3_vl",
+        num_layers=1,
+        vocab_size=8,
+        hidden_size=4,
+        inter_size=4,
+        attn_config=types.SimpleNamespace(
+            head_num=2,
+            kv_head_num=1,
+            size_per_head=2,
+        ),
+        layernorm_eps=1e-6,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=True,
+        expert_num=0,
+    )
+
+
+def _language_weights():
+    prefix = "model.language_model."
+    return {
+        prefix
+        + "embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(8, 4),
+        prefix + "layers.0.input_layernorm.weight": torch.ones(4),
+        prefix
+        + "layers.0.self_attn.q_proj.weight": torch.arange(
+            16, dtype=torch.float32
+        ).reshape(4, 4),
+        prefix
+        + "layers.0.self_attn.k_proj.weight": torch.arange(
+            8, dtype=torch.float32
+        ).reshape(2, 4),
+        prefix
+        + "layers.0.self_attn.v_proj.weight": torch.arange(
+            8, 16, dtype=torch.float32
+        ).reshape(2, 4),
+        prefix + "layers.0.self_attn.q_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.k_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.o_proj.weight": torch.eye(4),
+        prefix + "layers.0.post_attention_layernorm.weight": torch.ones(4),
+        prefix + "layers.0.mlp.gate_proj.weight": torch.ones(4, 4),
+        prefix + "layers.0.mlp.up_proj.weight": torch.full((4, 4), 2.0),
+        prefix + "layers.0.mlp.down_proj.weight": torch.ones(4, 4),
+        prefix + "norm.weight": torch.ones(4),
+    }
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+def _vision_model_config():
+    return {
+        "model_type": "qwen3_vl_vision",
+        "vision_config": _vision_config(),
+    }
+
+
+def _manual_merger(merger, hidden_states):
+    if merger.use_postshuffle_norm:
+        hidden_states = F.layer_norm(
+            hidden_states.reshape(-1, 32),
+            (32,),
+            merger.norm.weight,
+            merger.norm.bias,
+            merger.norm.eps,
+        )
+    else:
+        hidden_states = F.layer_norm(
+            hidden_states,
+            (8,),
+            merger.norm.weight,
+            merger.norm.bias,
+            merger.norm.eps,
+        ).reshape(-1, 32)
+    hidden_states = F.gelu(
+        F.linear(
+            hidden_states,
+            merger.linear_fc1.weight,
+            merger.linear_fc1.bias,
+        )
+    )
+    return F.linear(
+        hidden_states,
+        merger.linear_fc2.weight,
+        merger.linear_fc2.bias,
+    )
+
+
+def _manual_vision_forward(model, pixel_values):
+    visual = model.visual
+    hidden_states = F.conv3d(
+        pixel_values.reshape(-1, 1, 2, 2, 2),
+        visual.patch_embed.proj.weight,
+        visual.patch_embed.proj.bias,
+        stride=(2, 2, 2),
+    ).reshape(-1, 8)
+    position_indexes = torch.tensor([0, 3, 12, 15] * 2)
+    hidden_states = hidden_states + visual.pos_embed(position_indexes)
+
+    block = visual.blocks[0]
+    normed = F.layer_norm(
+        hidden_states,
+        (8,),
+        block.norm1.weight,
+        block.norm1.bias,
+        block.norm1.eps,
+    )
+    qkv = F.linear(normed, block.attn.qkv.weight, block.attn.qkv.bias)
+    query, key, value = qkv.reshape(8, 3, 2, 4).permute(1, 0, 2, 3).unbind(0)
+    positions = torch.tensor([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]] * 2)
+    cos = positions.cos().unsqueeze(1).repeat(1, 1, 2)
+    sin = positions.sin().unsqueeze(1).repeat(1, 1, 2)
+
+    def rotate_half(tensor):
+        first, second = tensor.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    query = query * cos + rotate_half(query) * sin
+    key = key * cos + rotate_half(key) * sin
+    attention_outputs = []
+    for start in (0, 4):
+        end = start + 4
+        attention = F.scaled_dot_product_attention(
+            query[start:end].transpose(0, 1).unsqueeze(0),
+            key[start:end].transpose(0, 1).unsqueeze(0),
+            value[start:end].transpose(0, 1).unsqueeze(0),
+            dropout_p=0.0,
+        )
+        attention_outputs.append(attention.squeeze(0).transpose(0, 1))
+    attention = torch.cat(attention_outputs).reshape(8, 8)
+    hidden_states = hidden_states + F.linear(
+        attention,
+        block.attn.proj.weight,
+        block.attn.proj.bias,
+    )
+
+    normed = F.layer_norm(
+        hidden_states,
+        (8,),
+        block.norm2.weight,
+        block.norm2.bias,
+        block.norm2.eps,
+    )
+    mlp = F.gelu(
+        F.linear(normed, block.mlp.linear_fc1.weight, block.mlp.linear_fc1.bias),
+        approximate="tanh",
+    )
+    hidden_states = hidden_states + F.linear(
+        mlp,
+        block.mlp.linear_fc2.weight,
+        block.mlp.linear_fc2.bias,
+    )
+    return (
+        _manual_merger(visual.merger, hidden_states),
+        [_manual_merger(visual.deepstack_merger_list[0], hidden_states)],
+    )
+
+
+def _vision_checkpoint(model):
+    return {
+        f"model.{name}": tensor.detach().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
+class Qwen3VLNewLoaderTest(unittest.TestCase):
+    def test_package_export_resolves_language_model_lazily(self):
+        self.assertIs(ExportedQwen3VLForCausalLM, Qwen3VLForCausalLM)
+
+    def test_language_loader_filters_visual_tensors_before_dispatch(self):
+        weights = _language_weights()
+        weights["model.visual.not_a_language_weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen3VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+        self.assertNotIn("visual", dict(model.named_modules()))
+
+    def test_unknown_language_tensor_is_not_silently_ignored(self):
+        weights = _language_weights()
+        weights["model.language_model.layers.0.typo.weight"] = torch.ones(1)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_language_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_missing_language_tensor_is_not_silently_ignored(self):
+        weights = _language_weights()
+        del weights["model.language_model.layers.0.self_attn.q_proj.weight"]
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, r"qkv_proj.*weight"):
+                NewModelLoader(
+                    model_config=_language_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_dense_language_ignores_runtime_ep_topology(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(_language_weights(), f"{model_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_language_config(),
+                load_config=_load_config(ep_size=2),
+                model_path=model_path,
+            ).load()
+
+        self.assertIsInstance(model, Qwen3VLForCausalLM)
+        torch.testing.assert_close(model.lm_head.weight, model.embed_tokens.weight)
+
+    def test_language_forward_handles_text_only_input(self):
+        class IdentityLayer(torch.nn.Module):
+            def forward(self, hidden_states, fmha_impl, kv_cache=None):
+                return hidden_states
+
+        model = Qwen3VLForCausalLM.__new__(Qwen3VLForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        model.layers = torch.nn.ModuleList([IdentityLayer()])
+        model.norm = torch.nn.Identity()
+        model.kv_cache = None
+        model.multimodal_embedding_injector = (
+            lambda hidden_states, features, locations: hidden_states
+        )
+        model.multimodal_deepstack_injector = (
+            lambda hidden_states, deepstack, locations, layer_id: hidden_states
+        )
+        input_ids = torch.tensor([1, 2, 3])
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            embedding_inputs=types.SimpleNamespace(text_tokens_mask=None),
+            multimodal_inputs=types.SimpleNamespace(
+                multimodal_features=[],
+                mm_features_locs=torch.empty(0, dtype=torch.long),
+                mm_extra_input=[],
+            ),
+            attention_inputs=object(),
+        )
+        fmha_impl = types.SimpleNamespace(fmha_params=None)
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl.model." "select_block_map_for_layer"
+        ):
+            outputs = model(inputs, fmha_impl)
+
+        torch.testing.assert_close(outputs.hidden_states, model.embed_tokens(input_ids))
+
+    def test_vision_loader_matches_independent_cpu_reference(self):
+        torch.manual_seed(7)
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        weights["model.language_model.unused.weight"] = torch.ones(3)
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            loaded = NewModelLoader(
+                model_config=_vision_model_config(),
+                load_config=_load_config(),
+                model_path=model_path,
+            ).load()
+
+        pixel_values = torch.arange(64, dtype=torch.float32).reshape(8, 8) / 63
+        grid_thw = torch.tensor([[2, 2, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            actual_output, actual_deepstack = loaded(pixel_values, grid_thw)
+            expected_output, expected_deepstack = _manual_vision_forward(
+                loaded, pixel_values
+            )
+        torch.testing.assert_close(actual_output, expected_output, atol=1e-6, rtol=1e-5)
+        self.assertEqual(len(actual_deepstack), 1)
+        torch.testing.assert_close(
+            actual_deepstack[0], expected_deepstack[0], atol=1e-6, rtol=1e-5
+        )
+
+    def test_vision_loader_rejects_unknown_and_missing_tensors(self):
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        with tempfile.TemporaryDirectory() as model_path:
+            unexpected = dict(weights)
+            unexpected["model.visual.blocks.0.attn.typo.weight"] = torch.ones(1)
+            save_file(unexpected, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "typo"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+        with tempfile.TemporaryDirectory() as model_path:
+            missing = dict(weights)
+            del missing["model.visual.blocks.0.attn.qkv.weight"]
+            save_file(missing, f"{model_path}/model.safetensors")
+            with self.assertRaisesRegex(RuntimeError, "attn.qkv.weight"):
+                NewModelLoader(
+                    model_config=_vision_model_config(),
+                    load_config=_load_config(),
+                    model_path=model_path,
+                ).load()
+
+    def test_vision_forward_handles_video_and_heterogeneous_grids(self):
+        torch.manual_seed(13)
+        model = Qwen3VLForVisionEmbedding(_vision_model_config(), _load_config()).eval()
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            combined, combined_deepstack = model(pixel_values, grid_thw)
+            first, first_deepstack = model(pixel_values[:8], grid_thw[:1])
+            second, second_deepstack = model(pixel_values[8:], grid_thw[1:])
+
+        torch.testing.assert_close(
+            combined, torch.cat((first, second)), atol=1e-6, rtol=1e-5
+        )
+        self.assertEqual(len(combined_deepstack), 1)
+        torch.testing.assert_close(
+            combined_deepstack[0],
+            torch.cat((first_deepstack[0], second_deepstack[0])),
+            atol=1e-6,
+            rtol=1e-5,
+        )
+
+    def test_vision_forward_rejects_invalid_grid_and_patch_count(self):
+        model = Qwen3VLForVisionEmbedding(_vision_model_config(), _load_config()).eval()
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            model(torch.zeros(0, 8), torch.empty((0, 3), dtype=torch.int64))
+        with self.assertRaisesRegex(ValueError, "align"):
+            model(torch.zeros(6, 8), torch.tensor([[1, 2, 3]]))
+        with self.assertRaisesRegex(ValueError, "describes 4"):
+            model(torch.zeros(3, 8), torch.tensor([[1, 2, 2]]))
+        with self.assertRaisesRegex(TypeError, "integer dtype"):
+            model(torch.zeros(4, 8), torch.tensor([[1.0, 2.0, 2.0]]))
+
+    def test_vision_loader_matches_legacy_fp16_staging_for_runtime_dtypes(self):
+        torch.manual_seed(19)
+        source = Qwen3VLForVisionEmbedding(
+            _vision_model_config(), _load_config()
+        ).eval()
+        weights = _vision_checkpoint(source)
+        key = "model.visual.blocks.0.attn.qkv.weight"
+        weights[key] = torch.linspace(
+            -0.0001,
+            0.0001,
+            weights[key].numel(),
+            dtype=torch.float32,
+        ).reshape_as(weights[key])
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(weights, f"{model_path}/model.safetensors")
+            for runtime_dtype in (
+                torch.float16,
+                torch.bfloat16,
+                torch.float32,
+            ):
+                with self.subTest(runtime_dtype=runtime_dtype):
+                    loaded = NewModelLoader(
+                        model_config=_vision_model_config(),
+                        load_config=_load_config(runtime_dtype),
+                        model_path=model_path,
+                    ).load()
+                    expected = weights[key].to(torch.float16).to(runtime_dtype)
+                    torch.testing.assert_close(
+                        loaded.visual.blocks[0].attn.qkv.weight,
+                        expected,
+                    )
+                    if runtime_dtype == torch.bfloat16:
+                        self.assertFalse(
+                            torch.equal(expected, weights[key].to(torch.bfloat16))
+                        )
+                    before = loaded.visual.blocks[0].attn.qkv.weight.detach().clone()
+                    loaded.visual.process_weights_after_loading()
+                    torch.testing.assert_close(
+                        loaded.visual.blocks[0].attn.qkv.weight,
+                        before,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_vision_loader_import.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/test/test_qwen3_vl_vision_loader_import.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+    Qwen3VLForVisionEmbedding,
+    load_qwen3_vl_vision,
+)
+
+
+class Qwen3VLVisionLoaderImportTest(unittest.TestCase):
+    def test_public_vision_loader_target_loads_checkpoint_on_cpu(self):
+        vision_config = {
+            "depth": 1,
+            "hidden_size": 8,
+            "hidden_act": "gelu_pytorch_tanh",
+            "intermediate_size": 16,
+            "num_heads": 2,
+            "in_channels": 1,
+            "patch_size": 2,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "out_hidden_size": 6,
+            "num_position_embeddings": 16,
+            "deepstack_visual_indexes": [0],
+        }
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        )
+        with tempfile.TemporaryDirectory() as model_path:
+            torch.save(
+                {
+                    f"model.{name}": tensor.detach().clone()
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/pytorch_model.bin",
+            )
+            loaded = load_qwen3_vl_vision(
+                vision_config=vision_config,
+                model_path=model_path,
+                compute_dtype=torch.float32,
+                device="cpu",
+            )
+
+        self.assertEqual(loaded.device, torch.device("cpu"))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                loaded.state_dict()[name],
+                expected.to(torch.float16).to(torch.float32),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/qwen3_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/vision.py
@@ -1,0 +1,686 @@
+import logging
+import math
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import accumulate
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rtp_llm.models_py.model_loader import (
+    NewLoaderConfig,
+    NewLoaderLoadMethod,
+    NewModelLoader,
+)
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+
+logger = logging.getLogger(__name__)
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class Qwen3VLVisionConfig:
+    depth: int
+    hidden_size: int
+    hidden_act: str
+    intermediate_size: int
+    num_heads: int
+    in_channels: int
+    patch_size: int
+    spatial_merge_size: int
+    temporal_patch_size: int
+    out_hidden_size: int
+    num_position_embeddings: int
+    deepstack_visual_indexes: tuple[int, ...]
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, Any]) -> "Qwen3VLVisionConfig":
+        if not isinstance(config, Mapping):
+            raise TypeError("vision_config must be a mapping")
+        hidden_act = config.get("hidden_act", "gelu_pytorch_tanh")
+        if not isinstance(hidden_act, str):
+            raise TypeError("vision hidden_act must be a string")
+        raw_indexes = config.get("deepstack_visual_indexes", (5, 11, 17))
+        if not isinstance(raw_indexes, Sequence) or isinstance(
+            raw_indexes, (str, bytes)
+        ):
+            raise TypeError("deepstack_visual_indexes must be a sequence of integers")
+        indexes = tuple(raw_indexes)
+        if any(
+            isinstance(index, bool) or not isinstance(index, int) for index in indexes
+        ):
+            raise TypeError("deepstack_visual_indexes must contain only integers")
+
+        result = cls(
+            depth=_positive_int(config.get("depth", 24), "vision depth"),
+            hidden_size=_positive_int(
+                config.get("hidden_size", 1024), "vision hidden_size"
+            ),
+            hidden_act=hidden_act,
+            intermediate_size=_positive_int(
+                config.get("intermediate_size", 4096),
+                "vision intermediate_size",
+            ),
+            num_heads=_positive_int(config.get("num_heads", 16), "vision num_heads"),
+            in_channels=_positive_int(
+                config.get("in_channels", 3), "vision in_channels"
+            ),
+            patch_size=_positive_int(config.get("patch_size", 16), "vision patch_size"),
+            spatial_merge_size=_positive_int(
+                config.get("spatial_merge_size", 2),
+                "vision spatial_merge_size",
+            ),
+            temporal_patch_size=_positive_int(
+                config.get("temporal_patch_size", 2),
+                "vision temporal_patch_size",
+            ),
+            out_hidden_size=_positive_int(
+                config.get("out_hidden_size", 2560),
+                "vision out_hidden_size",
+            ),
+            num_position_embeddings=_positive_int(
+                config.get("num_position_embeddings", 2304),
+                "vision num_position_embeddings",
+            ),
+            deepstack_visual_indexes=indexes,
+        )
+        if result.hidden_size % result.num_heads:
+            raise ValueError(
+                f"vision hidden_size={result.hidden_size} must be divisible by "
+                f"num_heads={result.num_heads}"
+            )
+        head_dim = result.hidden_size // result.num_heads
+        if head_dim % 4:
+            raise ValueError(
+                f"vision head_dim={head_dim} must be divisible by 4 for 2D rotary "
+                "embedding"
+            )
+        grid_side = math.isqrt(result.num_position_embeddings)
+        if grid_side * grid_side != result.num_position_embeddings:
+            raise ValueError("num_position_embeddings must form a square grid")
+        if len(set(indexes)) != len(indexes):
+            raise ValueError("deepstack_visual_indexes must not contain duplicates")
+        if any(index < 0 or index >= result.depth for index in indexes):
+            raise ValueError(
+                "deepstack_visual_indexes must refer to existing vision blocks"
+            )
+        if result.hidden_act not in {"gelu", "gelu_pytorch_tanh"}:
+            raise ValueError(
+                f"Unsupported Qwen3-VL vision activation {result.hidden_act!r}"
+            )
+        return result
+
+
+class Qwen3VisionPatchEmbed(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.in_channels = config.in_channels
+        self.hidden_size = config.hidden_size
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        kernel_size = (
+            config.temporal_patch_size,
+            config.patch_size,
+            config.patch_size,
+        )
+        self.proj = nn.Conv3d(
+            config.in_channels,
+            config.hidden_size,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        expected_width = (
+            self.in_channels
+            * self.temporal_patch_size
+            * self.patch_size
+            * self.patch_size
+        )
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != expected_width:
+            raise ValueError(
+                "Qwen3-VL pixel values must have shape "
+                f"[num_patches, {expected_width}], got {tuple(hidden_states.shape)}"
+            )
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=self.proj.weight.dtype))
+        return hidden_states.reshape(-1, self.hidden_size)
+
+
+class Qwen3VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        positions = torch.arange(
+            seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
+        )
+        return torch.outer(positions, self.inv_freq)
+
+
+def _rotate_half(tensor: torch.Tensor) -> torch.Tensor:
+    first, second = tensor.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_vision_rotary(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query_dtype = query.dtype
+    key_dtype = key.dtype
+    query = query.float()
+    key = key.float()
+    query = (query * cos) + (_rotate_half(query) * sin)
+    key = (key * cos) + (_rotate_half(key) * sin)
+    return query.to(query_dtype), key.to(key_dtype)
+
+
+_FLASH_ATTN_VARLEN: Optional[Callable[..., torch.Tensor]] = None
+_FLASH_ATTN_RESOLVED = False
+
+
+def _resolve_flash_attn_varlen() -> Optional[Callable[..., torch.Tensor]]:
+    global _FLASH_ATTN_RESOLVED, _FLASH_ATTN_VARLEN
+    if _FLASH_ATTN_RESOLVED:
+        return _FLASH_ATTN_VARLEN
+    _FLASH_ATTN_RESOLVED = True
+    try:
+        from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+
+        if can_use_flash_attn():
+            from flash_attn import flash_attn_varlen_func
+
+            _FLASH_ATTN_VARLEN = flash_attn_varlen_func
+    except (ImportError, OSError) as exc:
+        logger.info("Qwen3-VL vision flash attention is unavailable: %s", exc)
+    return _FLASH_ATTN_VARLEN
+
+
+class Qwen3VisionAttention(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.num_heads = config.num_heads
+        self.head_dim = config.hidden_size // config.num_heads
+        self.qkv = nn.Linear(
+            config.hidden_size,
+            3 * config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.proj = nn.Linear(
+            config.hidden_size,
+            config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        qkv = self.qkv(hidden_states).reshape(
+            seq_length, 3, self.num_heads, self.head_dim
+        )
+        query, key, value = qkv.permute(1, 0, 2, 3).unbind(0)
+        query, key = _apply_vision_rotary(query, key, rotary_cos, rotary_sin)
+
+        flash_attn_varlen = (
+            _resolve_flash_attn_varlen()
+            if query.is_cuda and query.dtype in (torch.float16, torch.bfloat16)
+            else None
+        )
+        if flash_attn_varlen is not None:
+            output = flash_attn_varlen(
+                query,
+                key,
+                value,
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+            ).reshape(seq_length, -1)
+        else:
+            query_chunks = torch.split(query, segment_lengths, dim=0)
+            key_chunks = torch.split(key, segment_lengths, dim=0)
+            value_chunks = torch.split(value, segment_lengths, dim=0)
+            outputs = []
+            for query_chunk, key_chunk, value_chunk in zip(
+                query_chunks, key_chunks, value_chunks
+            ):
+                output = F.scaled_dot_product_attention(
+                    query_chunk.transpose(0, 1).unsqueeze(0),
+                    key_chunk.transpose(0, 1).unsqueeze(0),
+                    value_chunk.transpose(0, 1).unsqueeze(0),
+                    dropout_p=0.0,
+                )
+                outputs.append(output.squeeze(0).transpose(0, 1))
+            output = torch.cat(outputs, dim=0).reshape(seq_length, -1)
+        return self.proj(output)
+
+
+class Qwen3VisionMLP(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.hidden_act = config.hidden_act
+        self.linear_fc1 = nn.Linear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.linear_fc2 = nn.Linear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_fc1(hidden_states)
+        hidden_states = F.gelu(
+            hidden_states,
+            approximate="tanh" if self.hidden_act == "gelu_pytorch_tanh" else "none",
+        )
+        return self.linear_fc2(hidden_states)
+
+
+class Qwen3VisionBlock(RtpModule):
+    def __init__(self, config: Qwen3VLVisionConfig, params_dtype: torch.dtype):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=1e-6, dtype=params_dtype)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=1e-6, dtype=params_dtype)
+        self.attn = Qwen3VisionAttention(config, params_dtype)
+        self.mlp = Qwen3VisionMLP(config, params_dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_cos: torch.Tensor,
+        rotary_sin: torch.Tensor,
+        segment_lengths: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens,
+            rotary_cos,
+            rotary_sin,
+            segment_lengths,
+            max_seqlen,
+        )
+        return hidden_states + self.mlp(self.norm2(hidden_states))
+
+
+class Qwen3VisionPatchMerger(RtpModule):
+    def __init__(
+        self,
+        config: Qwen3VLVisionConfig,
+        params_dtype: torch.dtype,
+        use_postshuffle_norm: bool,
+    ):
+        super().__init__()
+        self.hidden_size = config.hidden_size * (config.spatial_merge_size**2)
+        self.use_postshuffle_norm = use_postshuffle_norm
+        norm_size = self.hidden_size if use_postshuffle_norm else config.hidden_size
+        self.norm = nn.LayerNorm(norm_size, eps=1e-6, dtype=params_dtype)
+        self.linear_fc1 = nn.Linear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+        self.linear_fc2 = nn.Linear(
+            self.hidden_size,
+            config.out_hidden_size,
+            bias=True,
+            dtype=params_dtype,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_postshuffle_norm:
+            hidden_states = self.norm(hidden_states.reshape(-1, self.hidden_size))
+        else:
+            hidden_states = self.norm(hidden_states).reshape(-1, self.hidden_size)
+        hidden_states = F.gelu(self.linear_fc1(hidden_states))
+        return self.linear_fc2(hidden_states)
+
+
+class Qwen3VLVisionTransformer(RtpModule):
+    def __init__(self, vision_config: Mapping[str, Any], params_dtype: torch.dtype):
+        super().__init__()
+        config = Qwen3VLVisionConfig.from_mapping(vision_config)
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+        self.num_grid_per_side = math.isqrt(config.num_position_embeddings)
+        self.deepstack_visual_indexes = config.deepstack_visual_indexes
+
+        self.patch_embed = Qwen3VisionPatchEmbed(config, params_dtype)
+        self.pos_embed = nn.Embedding(
+            config.num_position_embeddings,
+            config.hidden_size,
+            dtype=params_dtype,
+        )
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Qwen3VisionRotaryEmbedding(head_dim // 2)
+        self.blocks = nn.ModuleList(
+            [Qwen3VisionBlock(config, params_dtype) for _ in range(config.depth)]
+        )
+        self.merger = Qwen3VisionPatchMerger(
+            config, params_dtype, use_postshuffle_norm=False
+        )
+        self.deepstack_merger_list = nn.ModuleList(
+            [
+                Qwen3VisionPatchMerger(config, params_dtype, use_postshuffle_norm=True)
+                for _ in self.deepstack_visual_indexes
+            ]
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def get_dtype(self) -> torch.dtype:
+        return self.dtype
+
+    def get_device(self) -> torch.device:
+        return self.device
+
+    def _grid_values(self, grid_thw: torch.Tensor) -> list[tuple[int, int, int]]:
+        if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+            raise ValueError(
+                f"grid_thw must have shape [num_items, 3], got {tuple(grid_thw.shape)}"
+            )
+        if grid_thw.shape[0] == 0:
+            raise ValueError("grid_thw must describe at least one image or video")
+        if (
+            grid_thw.dtype == torch.bool
+            or grid_thw.is_floating_point()
+            or grid_thw.is_complex()
+        ):
+            raise TypeError("grid_thw must use an integer dtype")
+        if grid_thw.device != self.device:
+            raise ValueError(
+                f"grid_thw must be on the vision model device {self.device}, "
+                f"got {grid_thw.device}"
+            )
+
+        values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
+        for value in values:
+            t, h, w = value
+            if t <= 0 or h <= 0 or w <= 0:
+                raise ValueError(f"grid_thw values must be positive, got {value}")
+            if h % self.spatial_merge_size or w % self.spatial_merge_size:
+                raise ValueError(
+                    f"grid {value} must align to spatial_merge_size="
+                    f"{self.spatial_merge_size}"
+                )
+        return values
+
+    def _rotary_positions(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        position_ids = []
+        merge_size = self.spatial_merge_size
+        for t, h, w in grid_values:
+            h_positions = torch.arange(h, device=self.device).unsqueeze(1).expand(-1, w)
+            h_positions = (
+                h_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            w_positions = torch.arange(w, device=self.device).unsqueeze(0).expand(h, -1)
+            w_positions = (
+                w_positions.reshape(
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            position_ids.append(
+                torch.stack((h_positions, w_positions), dim=-1).repeat(t, 1)
+            )
+        indices = torch.cat(position_ids, dim=0)
+        max_grid_size = max(max(h, w) for _, h, w in grid_values)
+        return self.rotary_pos_emb(max_grid_size)[indices].flatten(1)
+
+    def _interpolated_position_embeddings(
+        self, grid_values: list[tuple[int, int, int]]
+    ) -> torch.Tensor:
+        index_lists: list[list[int]] = [[], [], [], []]
+        weight_lists: list[list[float]] = [[], [], [], []]
+        for _, h, w in grid_values:
+            h_indexes = torch.linspace(0, self.num_grid_per_side - 1, h)
+            w_indexes = torch.linspace(0, self.num_grid_per_side - 1, w)
+            h_floor = h_indexes.int()
+            w_floor = w_indexes.int()
+            h_ceil = (h_floor + 1).clip(max=self.num_grid_per_side - 1)
+            w_ceil = (w_floor + 1).clip(max=self.num_grid_per_side - 1)
+            delta_h = h_indexes - h_floor
+            delta_w = w_indexes - w_floor
+            base_h = h_floor * self.num_grid_per_side
+            base_h_ceil = h_ceil * self.num_grid_per_side
+
+            indexes = (
+                (base_h[:, None] + w_floor[None]).flatten(),
+                (base_h[:, None] + w_ceil[None]).flatten(),
+                (base_h_ceil[:, None] + w_floor[None]).flatten(),
+                (base_h_ceil[:, None] + w_ceil[None]).flatten(),
+            )
+            weights = (
+                ((1 - delta_h)[:, None] * (1 - delta_w)[None]).flatten(),
+                ((1 - delta_h)[:, None] * delta_w[None]).flatten(),
+                (delta_h[:, None] * (1 - delta_w)[None]).flatten(),
+                (delta_h[:, None] * delta_w[None]).flatten(),
+            )
+            for index in range(4):
+                index_lists[index].extend(indexes[index].tolist())
+                weight_lists[index].extend(weights[index].tolist())
+
+        index_tensor = torch.tensor(index_lists, dtype=torch.long, device=self.device)
+        weight_tensor = torch.tensor(weight_lists, dtype=self.dtype, device=self.device)
+        position_embeddings = self.pos_embed(index_tensor) * weight_tensor[:, :, None]
+        interpolated = (
+            position_embeddings[0]
+            + position_embeddings[1]
+            + position_embeddings[2]
+            + position_embeddings[3]
+        )
+        spatial_sizes = [h * w for _, h, w in grid_values]
+        spatial_embeddings = interpolated.split(spatial_sizes)
+
+        outputs = []
+        merge_size = self.spatial_merge_size
+        for position_embedding, (t, h, w) in zip(spatial_embeddings, grid_values):
+            position_embedding = position_embedding.repeat(t, 1)
+            position_embedding = (
+                position_embedding.reshape(
+                    t,
+                    h // merge_size,
+                    merge_size,
+                    w // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            outputs.append(position_embedding)
+        return torch.cat(outputs)
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        if hidden_states.device != self.device:
+            raise ValueError(
+                f"pixel_values must be on the vision model device {self.device}, "
+                f"got {hidden_states.device}"
+            )
+        grid_values = self._grid_values(grid_thw)
+        expected_patches = sum(t * h * w for t, h, w in grid_values)
+        if hidden_states.shape[0] != expected_patches:
+            raise ValueError(
+                f"pixel_values contain {hidden_states.shape[0]} patches, but "
+                f"grid_thw describes {expected_patches}"
+            )
+
+        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = hidden_states + self._interpolated_position_embeddings(
+            grid_values
+        )
+        rotary_pos_emb = self._rotary_positions(grid_values)
+        rotary_cos = rotary_pos_emb.cos().unsqueeze(1).repeat(1, 1, 2).float()
+        rotary_sin = rotary_pos_emb.sin().unsqueeze(1).repeat(1, 1, 2).float()
+        segment_lengths = tuple(h * w for t, h, w in grid_values for _ in range(t))
+        max_seqlen = max(segment_lengths)
+        cu_seqlens = torch.tensor(
+            (0, *accumulate(segment_lengths)),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        deepstack_features = []
+        deepstack_index_map = {
+            layer_index: merger_index
+            for merger_index, layer_index in enumerate(self.deepstack_visual_indexes)
+        }
+        for layer_index, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens,
+                rotary_cos,
+                rotary_sin,
+                segment_lengths,
+                max_seqlen,
+            )
+            merger_index = deepstack_index_map.get(layer_index)
+            if merger_index is not None:
+                deepstack_features.append(
+                    self.deepstack_merger_list[merger_index](hidden_states)
+                )
+        return self.merger(hidden_states), deepstack_features
+
+
+def _vision_config_from_model(
+    model_config: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if not isinstance(model_config, Mapping):
+        raise TypeError("qwen3_vl_vision model_config must be a mapping")
+    vision_config = model_config.get("vision_config")
+    if not isinstance(vision_config, Mapping):
+        raise TypeError("qwen3_vl_vision requires model_config.vision_config")
+    return vision_config
+
+
+class Qwen3VLForVisionEmbedding(RtpModule):
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.visual.": "visual."},
+    )
+
+    def __init__(self, model_config: Mapping[str, Any], load_config: NewLoaderConfig):
+        super().__init__()
+        if load_config.tp_size != 1 or load_config.tp_rank != 0:
+            raise ValueError("Qwen3-VL vision newloader is single-rank and replicated")
+        self.visual = Qwen3VLVisionTransformer(
+            _vision_config_from_model(model_config), load_config.compute_dtype
+        )
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("model.visual.")
+
+    def load_weights(
+        self, weights: Iterator[tuple[str, torch.Tensor]] | dict[str, torch.Tensor]
+    ) -> None:
+        iterator = weights.items() if isinstance(weights, dict) else weights
+
+        def legacy_compatible_weights():
+            target_dtype = self.visual.dtype
+            for name, tensor in iterator:
+                if tensor.is_floating_point():
+                    # The established Qwen3-VL vision path stages every checkpoint
+                    # tensor through FP16 before converting it to the runtime dtype.
+                    # Preserve that numerical contract so newloader and legacy
+                    # inference produce the same BF16/FP32 features and tokens.
+                    tensor = tensor.to(torch.float16).to(target_dtype)
+                yield name, tensor
+
+        super().load_weights(self.WEIGHTS_MAPPER.apply(legacy_compatible_weights()))
+
+    def forward(
+        self, hidden_states: torch.Tensor, grid_thw: torch.Tensor
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        return self.visual(hidden_states, grid_thw)
+
+
+def load_qwen3_vl_vision(
+    vision_config: Mapping[str, Any],
+    model_path: str,
+    compute_dtype: torch.dtype,
+    device: str,
+) -> Qwen3VLVisionTransformer:
+    model_config = {
+        "model_type": "qwen3_vl_vision",
+        "model_path": model_path,
+        "vision_config": dict(vision_config),
+    }
+    load_config = NewLoaderConfig(
+        compute_dtype=compute_dtype,
+        device=device,
+        load_method=NewLoaderLoadMethod.SCRATCH,
+    )
+    loader = NewModelLoader(
+        model_config=model_config,
+        load_config=load_config,
+        model_path=model_path,
+    )
+    with torch.device("cpu"):
+        model = loader.load()
+    return model.visual
+
+
+__all__ = [
+    "Qwen3VLForVisionEmbedding",
+    "Qwen3VLVisionTransformer",
+    "load_qwen3_vl_vision",
+]

--- a/rtp_llm/models_py/new_models/qwen3_vl/vision.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl/vision.py
@@ -54,6 +54,8 @@ class Qwen3VLVisionConfig:
         ):
             raise TypeError("deepstack_visual_indexes must be a sequence of integers")
         indexes = tuple(raw_indexes)
+        if not indexes:
+            raise ValueError("deepstack_visual_indexes must contain at least one layer")
         if any(
             isinstance(index, bool) or not isinstance(index, int) for index in indexes
         ):
@@ -166,14 +168,34 @@ class Qwen3VisionPatchEmbed(RtpModule):
 class Qwen3VisionRotaryEmbedding(nn.Module):
     def __init__(self, dim: int, theta: float = 10000.0):
         super().__init__()
+        self.dim = dim
+        self.theta = theta
         inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def forward(self, seqlen: int) -> torch.Tensor:
+        # Match Transformers' device-context construction. CPU and accelerator
+        # pow implementations can differ by one ULP (notably on ROCm), so a
+        # buffer computed on CPU and later moved is not numerically equivalent
+        # to constructing the legacy vision module on its runtime device.
+        inv_freq = 1.0 / (
+            self.theta
+            ** (
+                torch.arange(
+                    0,
+                    self.dim,
+                    2,
+                    device=self.inv_freq.device,
+                    dtype=torch.float,
+                )
+                / self.dim
+            )
+        )
+        inv_freq = inv_freq.to(self.inv_freq.dtype)
         positions = torch.arange(
             seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype
         )
-        return torch.outer(positions, self.inv_freq)
+        return torch.outer(positions, inv_freq)
 
 
 def _rotate_half(tensor: torch.Tensor) -> torch.Tensor:
@@ -438,6 +460,8 @@ class Qwen3VLVisionTransformer(RtpModule):
                 f"got {grid_thw.device}"
             )
 
+        # Materialize only the three shape scalars per item for validation and
+        # control flow. Per-patch interpolation stays tensorized below.
         values = [tuple(int(value) for value in row) for row in grid_thw.tolist()]
         for value in values:
             t, h, w = value
@@ -488,8 +512,8 @@ class Qwen3VLVisionTransformer(RtpModule):
     def _interpolated_position_embeddings(
         self, grid_values: list[tuple[int, int, int]]
     ) -> torch.Tensor:
-        index_lists: list[list[int]] = [[], [], [], []]
-        weight_lists: list[list[float]] = [[], [], [], []]
+        index_tensors: list[list[torch.Tensor]] = [[], [], [], []]
+        weight_tensors: list[list[torch.Tensor]] = [[], [], [], []]
         for _, h, w in grid_values:
             h_indexes = torch.linspace(0, self.num_grid_per_side - 1, h)
             w_indexes = torch.linspace(0, self.num_grid_per_side - 1, w)
@@ -515,11 +539,18 @@ class Qwen3VLVisionTransformer(RtpModule):
                 (delta_h[:, None] * delta_w[None]).flatten(),
             )
             for index in range(4):
-                index_lists[index].extend(indexes[index].tolist())
-                weight_lists[index].extend(weights[index].tolist())
+                index_tensors[index].append(indexes[index])
+                weight_tensors[index].append(weights[index])
 
-        index_tensor = torch.tensor(index_lists, dtype=torch.long, device=self.device)
-        weight_tensor = torch.tensor(weight_lists, dtype=self.dtype, device=self.device)
+        # Keep the Transformers-compatible CPU interpolation arithmetic, but
+        # concatenate tensors directly instead of synchronizing through
+        # per-element Python lists. Transfer each compact table only once.
+        index_tensor = torch.stack([torch.cat(values) for values in index_tensors]).to(
+            device=self.device, dtype=torch.long
+        )
+        weight_tensor = torch.stack(
+            [torch.cat(values) for values in weight_tensors]
+        ).to(device=self.device, dtype=self.dtype)
         position_embeddings = self.pos_embed(index_tensor) * weight_tensor[:, :, None]
         interpolated = (
             position_embeddings[0]
@@ -642,6 +673,19 @@ class Qwen3VLForVisionEmbedding(RtpModule):
                     # tensor through FP16 before converting it to the runtime dtype.
                     # Preserve that numerical contract so newloader and legacy
                     # inference produce the same BF16/FP32 features and tokens.
+                    if (
+                        target_dtype != torch.float16
+                        and tensor.dtype
+                        in (torch.bfloat16, torch.float32, torch.float64)
+                        and tensor.numel()
+                        and tensor.detach().abs().amax().item()
+                        > torch.finfo(torch.float16).max
+                    ):
+                        raise ValueError(
+                            f"Qwen3-VL vision weight {name!r} exceeds the "
+                            "FP16-compatible range required by the legacy "
+                            "staging contract"
+                        )
                     tensor = tensor.to(torch.float16).to(target_dtype)
                 yield name, tensor
 

--- a/rtp_llm/models_py/new_models/qwen3_vl_moe/__init__.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl_moe/__init__.py
@@ -1,0 +1,15 @@
+"""Qwen3-VL MoE newloader language implementation."""
+
+from typing import Any
+
+__all__ = ["Qwen3VLMoeForCausalLM"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "Qwen3VLMoeForCausalLM":
+        from rtp_llm.models_py.new_models.qwen3_vl_moe.model import (
+            Qwen3VLMoeForCausalLM,
+        )
+
+        return Qwen3VLMoeForCausalLM
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rtp_llm/models_py/new_models/qwen3_vl_moe/model.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl_moe/model.py
@@ -1,0 +1,88 @@
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from rtp_llm.models_py.modules import (
+    MultimodalDeepstackInjector,
+    MultimodalEmbeddingInjector,
+    reshape_extra_input_to_deepstack,
+)
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
+from rtp_llm.models_py.new_models.qwen3_moe.language import Qwen3MoeForCausalLM
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+
+
+class Qwen3VLMoeForCausalLM(Qwen3MoeForCausalLM):
+    """Qwen3-VL MoE text runtime with multimodal feature injection."""
+
+    WEIGHTS_MAPPER = WeightsMapper(
+        prefix_mapping={"model.language_model.": ""},
+    )
+
+    def __init__(self, model_config: Any, load_config: Any):
+        super().__init__(model_config, load_config)
+        self.multimodal_embedding_injector = MultimodalEmbeddingInjector()
+        self.multimodal_deepstack_injector = MultimodalDeepstackInjector()
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        return lambda name: name.startswith("model.language_model.") or name.startswith(
+            "lm_head."
+        )
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        input_ids = inputs.input_ids
+        text_tokens_mask = inputs.embedding_inputs.text_tokens_mask
+        if text_tokens_mask is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            text_mask = text_tokens_mask.to(device=input_ids.device, dtype=torch.bool)
+            safe_input_ids = torch.where(text_mask, input_ids, 0)
+            hidden_states = self.embed_tokens(safe_input_ids)
+            hidden_states = hidden_states * text_mask.unsqueeze(-1)
+
+        multimodal_inputs = inputs.multimodal_inputs
+        mm_features = multimodal_inputs.multimodal_features
+        mm_feature_locs = multimodal_inputs.mm_features_locs
+        mm_extra_input = multimodal_inputs.mm_extra_input
+        mm_deepstack_embeds = (
+            reshape_extra_input_to_deepstack(mm_extra_input, mm_features)
+            if mm_extra_input
+            else []
+        )
+        hidden_states = self.multimodal_embedding_injector(
+            hidden_states, mm_features, mm_feature_locs
+        )
+
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+
+        cpu_locs = (
+            mm_feature_locs.to(device="cpu", dtype=torch.long).view(-1).tolist()
+            if mm_deepstack_embeds and mm_feature_locs is not None
+            else []
+        )
+        residual = torch.zeros_like(hidden_states)
+        for layer_id, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, layer_id)
+            hidden_states, residual = layer(
+                hidden_states,
+                residual,
+                fmha_impl,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(layer_id) if self.kv_cache else None
+                ),
+            )
+            hidden_states = self.multimodal_deepstack_injector(
+                hidden_states,
+                mm_deepstack_embeds,
+                cpu_locs,
+                layer_id,
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)
+
+
+__all__ = ["Qwen3VLMoeForCausalLM"]

--- a/rtp_llm/models_py/new_models/qwen3_vl_moe/test/BUILD
+++ b/rtp_llm/models_py/new_models/qwen3_vl_moe/test/BUILD
@@ -1,0 +1,9 @@
+py_test(
+    name = "test_qwen3_vl_moe_load",
+    srcs = ["test_qwen3_vl_moe_load.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+    ],
+)

--- a/rtp_llm/models_py/new_models/qwen3_vl_moe/test/test_qwen3_vl_moe_load.py
+++ b/rtp_llm/models_py/new_models/qwen3_vl_moe/test/test_qwen3_vl_moe_load.py
@@ -1,0 +1,318 @@
+import types
+import unittest
+from unittest import mock
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.model_loader import (
+    NewLoaderConfig,
+    NewModelLoader,
+    _ExpertRangeFilter,
+)
+from rtp_llm.models_py.modules import (
+    MultimodalDeepstackInjector,
+    MultimodalEmbeddingInjector,
+)
+from rtp_llm.models_py.new_models.qwen3_vl_moe import (
+    Qwen3VLMoeForCausalLM as ExportedQwen3VLMoeForCausalLM,
+)
+from rtp_llm.models_py.new_models.qwen3_vl_moe.model import Qwen3VLMoeForCausalLM
+from rtp_llm.models_py.quant_methods import QuantizationConfig
+from rtp_llm.models_py.registry import get_model_class
+
+
+def _parallelism(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0):
+    return types.SimpleNamespace(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        dp_size=1,
+        dp_rank=0,
+        world_size=max(tp_size, ep_size),
+        local_rank=tp_rank,
+        get_attn_tp_size=lambda: tp_size,
+        get_attn_tp_rank=lambda: tp_rank,
+        get_ffn_tp_size=lambda: tp_size,
+        get_ffn_tp_rank=lambda: tp_rank,
+        prefill_cp_config=types.SimpleNamespace(
+            is_enabled=lambda: False,
+            is_prefill_enabled=lambda: False,
+        ),
+        ffn_disaggregate_config=types.SimpleNamespace(enable_ffn_disaggregate=False),
+    )
+
+
+def _moe_config():
+    return types.SimpleNamespace(
+        ll_num_max_token=1,
+        masked_max_token_num=1,
+        moe_strategy=0,
+        use_mori_ep=False,
+        use_deepep_moe=False,
+        use_deepep_low_latency=False,
+        use_all_gather=True,
+        fake_balance_expert=False,
+    )
+
+
+def _model_config(num_experts=2, tie_word_embeddings=False):
+    config = ModelConfig()
+    config.model_type = "qwen3_vl_moe"
+    config.num_layers = 1
+    config.vocab_size = 8
+    config.hidden_size = 4
+    config.inter_size = 0
+    config.expert_num = num_experts
+    config.moe_inter_size = 3
+    config.moe_k = 1
+    config.moe_topk_group = 1
+    config.attn_config.head_num = 2
+    config.attn_config.kv_head_num = 1
+    config.attn_config.size_per_head = 2
+    config.layernorm_eps = 1e-6
+    config.enable_fp32_lm_head = False
+    config.tie_word_embeddings = tie_word_embeddings
+    config.data_type = "fp32"
+    config.quant_config = None
+    config.activation_type = "SiGLU"
+    return config
+
+
+def _load_config(tp_size=1, tp_rank=0, ep_size=1, ep_rank=0):
+    return NewLoaderConfig(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        compute_dtype=torch.float32,
+        device="cpu",
+        quant_config=QuantizationConfig("none"),
+        parallelism_config=_parallelism(tp_size, tp_rank, ep_size, ep_rank),
+        moe_config=_moe_config(),
+    )
+
+
+def _weights(num_experts=2):
+    prefix = "model.language_model."
+    weights = {
+        prefix
+        + "embed_tokens.weight": torch.arange(32, dtype=torch.float32).reshape(8, 4),
+        prefix + "layers.0.input_layernorm.weight": torch.ones(4),
+        prefix + "layers.0.self_attn.q_proj.weight": torch.ones(4, 4),
+        prefix + "layers.0.self_attn.k_proj.weight": torch.ones(2, 4),
+        prefix + "layers.0.self_attn.v_proj.weight": torch.ones(2, 4),
+        prefix + "layers.0.self_attn.q_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.k_norm.weight": torch.ones(2),
+        prefix + "layers.0.self_attn.o_proj.weight": torch.eye(4),
+        prefix + "layers.0.post_attention_layernorm.weight": torch.ones(4),
+        prefix + "layers.0.mlp.gate.weight": torch.ones(num_experts, 4),
+        prefix
+        + "layers.0.mlp.experts.gate_up_proj": torch.arange(
+            num_experts * 6 * 4, dtype=torch.float32
+        ).reshape(num_experts, 6, 4),
+        prefix
+        + "layers.0.mlp.experts.down_proj": torch.arange(
+            num_experts * 4 * 3, dtype=torch.float32
+        ).reshape(num_experts, 4, 3),
+        prefix + "norm.weight": torch.ones(4),
+        "lm_head.weight": torch.arange(32, dtype=torch.float32).reshape(8, 4),
+    }
+    return weights
+
+
+class Qwen3VLMoeNewLoaderTest(unittest.TestCase):
+    def test_package_export_and_registry_resolve_language_model(self):
+        self.assertIs(ExportedQwen3VLMoeForCausalLM, Qwen3VLMoeForCausalLM)
+        self.assertIs(get_model_class("qwen3_vl_moe"), Qwen3VLMoeForCausalLM)
+
+    def test_prefixed_stacked_checkpoint_loads_complete_model(self):
+        model = Qwen3VLMoeForCausalLM(_model_config(), _load_config())
+        checkpoint = _weights()
+        checkpoint["model.visual.unused.weight"] = torch.ones(1)
+        name_filter = model.checkpoint_weight_name_filter()
+        model.load_weights(
+            (name, tensor) for name, tensor in checkpoint.items() if name_filter(name)
+        )
+        NewModelLoader._validate_loaded_weights(model)
+
+        self.assertEqual(model.layers[0].mlp.experts._loaded_count, 6)
+        torch.testing.assert_close(
+            model.lm_head.weight,
+            checkpoint["lm_head.weight"],
+        )
+
+    def test_unknown_and_missing_language_tensors_are_not_ignored(self):
+        model = Qwen3VLMoeForCausalLM(_model_config(), _load_config())
+        unknown = _weights()
+        unknown["model.language_model.layers.0.typo.weight"] = torch.ones(1)
+        with self.assertRaisesRegex(RuntimeError, "typo"):
+            model.load_weights(unknown)
+
+        model = Qwen3VLMoeForCausalLM(_model_config(), _load_config())
+        missing = _weights()
+        del missing["model.language_model.layers.0.self_attn.q_proj.weight"]
+        model.load_weights(missing)
+        with self.assertRaisesRegex(RuntimeError, r"qkv_proj.*weight"):
+            NewModelLoader._validate_loaded_weights(model)
+
+    def test_ep_expands_only_prefixed_language_experts(self):
+        model = Qwen3VLMoeForCausalLM(
+            _model_config(num_experts=4),
+            _load_config(ep_size=2, ep_rank=1),
+        )
+        model_filter = model.checkpoint_weight_name_filter()
+        expert_filter = _ExpertRangeFilter(4, 2, 1)
+        combined_filter = NewModelLoader._checkpoint_name_filter(
+            model_filter, expert_filter
+        )
+        checkpoint_name = "model.language_model.layers.0.mlp.experts.gate_up_proj"
+
+        self.assertTrue(combined_filter(checkpoint_name))
+        self.assertTrue(expert_filter.handles_safetensor(checkpoint_name))
+        expanded = expert_filter.expand_safetensor(checkpoint_name, (4, 6, 4))
+        self.assertEqual(
+            [
+                (model.WEIGHTS_MAPPER.map_name(name), expert_id)
+                for name, expert_id in expanded
+            ],
+            [
+                ("layers.0.mlp.experts.2.gate_up_proj.weight", 2),
+                ("layers.0.mlp.experts.3.gate_up_proj.weight", 3),
+            ],
+        )
+        self.assertFalse(
+            combined_filter("model.visual.layers.0.mlp.experts.gate_up_proj")
+        )
+
+    def test_tp_and_ep_owners_follow_moe_topology(self):
+        model = Qwen3VLMoeForCausalLM(
+            _model_config(num_experts=4),
+            _load_config(tp_size=2, tp_rank=1, ep_size=2, ep_rank=1),
+        )
+
+        self.assertEqual(
+            (model.embed_tokens.tp_size, model.embed_tokens.tp_rank), (2, 1)
+        )
+        self.assertEqual(
+            (
+                model.layers[0].self_attn.qkv_proj.tp_size,
+                model.layers[0].self_attn.qkv_proj.tp_rank,
+            ),
+            (2, 1),
+        )
+        experts = model.layers[0].mlp.experts
+        self.assertEqual(
+            (experts.moe_expert_tp_size, experts.moe_expert_tp_rank), (1, 0)
+        )
+        self.assertEqual((experts.ep_size, experts.ep_rank), (2, 1))
+
+    def test_forward_masks_image_token_ids_and_preserves_residual_contract(self):
+        class ResidualLayer(torch.nn.Module):
+            def __init__(self, hidden_delta, residual_delta):
+                super().__init__()
+                self.hidden_delta = hidden_delta
+                self.residual_delta = residual_delta
+
+            def forward(self, hidden_states, residual, fmha_impl, kv_cache=None):
+                return (
+                    hidden_states + self.hidden_delta,
+                    residual + self.residual_delta,
+                )
+
+        class FinalNorm(torch.nn.Module):
+            def forward(self, hidden_states, residual):
+                return hidden_states + residual, residual
+
+        model = Qwen3VLMoeForCausalLM.__new__(Qwen3VLMoeForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        model.embed_tokens.weight.data.copy_(
+            torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        )
+        model.multimodal_embedding_injector = MultimodalEmbeddingInjector()
+        model.multimodal_deepstack_injector = MultimodalDeepstackInjector()
+        model.layers = torch.nn.ModuleList(
+            [ResidualLayer(1.0, 10.0), ResidualLayer(2.0, 20.0)]
+        )
+        model.norm = FinalNorm()
+        model.kv_cache = None
+
+        input_ids = torch.tensor([1, 100, 2])
+        image_feature = torch.full((1, 4), 50.0)
+        deepstack = torch.stack((torch.full((1, 4), 100.0), torch.full((1, 4), 200.0)))
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            embedding_inputs=types.SimpleNamespace(
+                text_tokens_mask=torch.tensor([True, False, True])
+            ),
+            multimodal_inputs=types.SimpleNamespace(
+                multimodal_features=[image_feature],
+                mm_features_locs=torch.tensor([1]),
+                mm_extra_input=[deepstack.flatten()],
+            ),
+            attention_inputs=object(),
+        )
+        fmha_impl = types.SimpleNamespace(fmha_params=None)
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl_moe.model."
+            "select_block_map_for_layer"
+        ) as select_block:
+            output = model(inputs, fmha_impl)
+
+        expected = model.embed_tokens(torch.tensor([1, 0, 2]))
+        expected[1] = image_feature[0]
+        expected = expected + 1.0
+        expected[1] += 100.0
+        expected = expected + 2.0
+        expected[1] += 200.0
+        expected = expected + 30.0
+        torch.testing.assert_close(output.hidden_states, expected)
+        self.assertEqual(
+            [call.args for call in select_block.call_args_list],
+            [(inputs.attention_inputs, 0), (inputs.attention_inputs, 1)],
+        )
+
+    def test_forward_handles_text_only_input(self):
+        class IdentityLayer(torch.nn.Module):
+            def forward(self, hidden_states, residual, fmha_impl, kv_cache=None):
+                return hidden_states, residual
+
+        class FinalNorm(torch.nn.Module):
+            def forward(self, hidden_states, residual):
+                return hidden_states + residual, residual
+
+        model = Qwen3VLMoeForCausalLM.__new__(Qwen3VLMoeForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.embed_tokens = torch.nn.Embedding(8, 4)
+        model.multimodal_embedding_injector = MultimodalEmbeddingInjector()
+        model.multimodal_deepstack_injector = MultimodalDeepstackInjector()
+        model.layers = torch.nn.ModuleList([IdentityLayer()])
+        model.norm = FinalNorm()
+        model.kv_cache = None
+        input_ids = torch.tensor([1, 2, 3])
+        inputs = types.SimpleNamespace(
+            input_ids=input_ids,
+            embedding_inputs=types.SimpleNamespace(text_tokens_mask=None),
+            multimodal_inputs=types.SimpleNamespace(
+                multimodal_features=[],
+                mm_features_locs=torch.empty(0, dtype=torch.long),
+                mm_extra_input=[],
+            ),
+            attention_inputs=object(),
+        )
+        fmha_impl = types.SimpleNamespace(fmha_params=None)
+
+        with mock.patch(
+            "rtp_llm.models_py.new_models.qwen3_vl_moe.model."
+            "select_block_map_for_layer"
+        ):
+            output = model(inputs, fmha_impl)
+
+        torch.testing.assert_close(output.hidden_states, model.embed_tokens(input_ids))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -168,3 +168,13 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen2_vl.vision",
     "Qwen2VLForVisionEmbedding",
 )
+register_lazy_model(
+    "qwen3_vl",
+    "rtp_llm.models_py.new_models.qwen3_vl",
+    "Qwen3VLForCausalLM",
+)
+register_lazy_model(
+    "qwen3_vl_vision",
+    "rtp_llm.models_py.new_models.qwen3_vl.vision",
+    "Qwen3VLForVisionEmbedding",
+)

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -174,6 +174,11 @@ register_lazy_model(
     "Qwen3VLForCausalLM",
 )
 register_lazy_model(
+    "qwen3_vl_moe",
+    "rtp_llm.models_py.new_models.qwen3_vl_moe",
+    "Qwen3VLMoeForCausalLM",
+)
+register_lazy_model(
     "qwen3_vl_vision",
     "rtp_llm.models_py.new_models.qwen3_vl.vision",
     "Qwen3VLForVisionEmbedding",

--- a/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
@@ -6,12 +6,7 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch.library as tl
 from PIL import Image
-from transformers import (
-    AutoProcessor,
-    Qwen2VLImageProcessor,
-    Qwen3VLConfig,
-    Qwen3VLVisionModel,
-)
+from transformers import AutoProcessor, Qwen3VLConfig, Qwen3VLVisionModel
 
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.metrics.kmonitor_metric_reporter import GaugeMetrics
@@ -52,17 +47,39 @@ if not hasattr(tl, "wrap_triton"):
 
 
 class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
-    def __init__(self, mm_related_params: VitParameters):
+    def __init__(self, mm_related_params: VitParameters, visual=None):
         self.mm_processor = AutoProcessor.from_pretrained(
             mm_related_params.config["ckpt_path"]
         )
-        self.mm_processor.image_processor = Qwen2VLImageProcessor.from_pretrained(
-            mm_related_params.config["ckpt_path"]
-        )
-        config_hf = Qwen3VLConfig.from_pretrained(mm_related_params.config["ckpt_path"])
-        config_hf.vision_config._attn_implementation = default_attn_impl
-        self.visual = Qwen3VLVisionModel._from_config(config_hf.vision_config)
+        self._uses_new_loader_vision = visual is not None
+        if visual is None:
+            config_hf = Qwen3VLConfig.from_pretrained(
+                mm_related_params.config["ckpt_path"]
+            )
+            config_hf.vision_config._attn_implementation = default_attn_impl
+            visual = Qwen3VLVisionModel._from_config(config_hf.vision_config)
+        self.visual = visual
         self.spatial_merge_size = self.visual.spatial_merge_size
+
+    @staticmethod
+    def _unpack_vision_output(vision_output):
+        if isinstance(vision_output, tuple):
+            if len(vision_output) != 2:
+                raise ValueError(
+                    "Qwen3-VL vision tuple output must contain embeddings and "
+                    f"deepstack features, got {len(vision_output)} values"
+                )
+            embeds, deepstack_embeds = vision_output
+        else:
+            embeds = vision_output.pooler_output
+            deepstack_embeds = vision_output.deepstack_features
+        if not isinstance(embeds, torch.Tensor):
+            raise TypeError("Qwen3-VL vision embeddings must be a tensor")
+        if not isinstance(deepstack_embeds, (list, tuple)):
+            raise TypeError("Qwen3-VL deepstack features must be a sequence")
+        if not all(isinstance(item, torch.Tensor) for item in deepstack_embeds):
+            raise TypeError("Qwen3-VL deepstack features must contain only tensors")
+        return embeds, deepstack_embeds
 
     @property
     def _data_type(self):
@@ -168,7 +185,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
                 )
             return res["pixel_values_videos"], res["video_grid_thw"]
         else:
-            raise Exception("unknown mm url type")
+            raise ValueError(f"unknown mm url type: {mm_type}")
 
     def get_preprocess_params(self):
         return {
@@ -181,8 +198,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
         pixel_values = data[0].to(self._device).to(self._data_type)
         grid_thw = data[1].to(self._device)
         vision_output = self.visual(pixel_values, grid_thw=grid_thw)
-        embeds = vision_output.pooler_output
-        deepstack_embeds = vision_output.deepstack_features
+        embeds, deepstack_embeds = self._unpack_vision_output(vision_output)
         split_sizes = (grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
         embeds = torch.split(embeds, split_sizes)
         pos_id = self.get_position_ids(grid_thw)[0]
@@ -208,8 +224,7 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
         )
         grid_thw = torch.concat(grid_thw_list, dim=0).to(self._device)
         vision_output = self.visual(pixel_values, grid_thw=grid_thw)
-        embeds = vision_output.pooler_output
-        deepstack_embeds = vision_output.deepstack_features
+        embeds, deepstack_embeds = self._unpack_vision_output(vision_output)
         split_sizes = (grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
         embeds = torch.split(embeds, split_sizes)
         pos_id = self.get_position_ids(grid_thw)
@@ -230,6 +245,21 @@ class Qwen3VLVitWeight(BaseVitWeights):
 
 class Qwen3_VLMixin(Qwen2_5_VLMixin):
     def _init_multimodal(self):
+        if self.use_new_loader:
+            from rtp_llm.models_py.new_models.qwen3_vl.vision import (
+                load_qwen3_vl_vision,
+            )
+
+            visual = load_qwen3_vl_vision(
+                vision_config=self.mm_related_params.config,
+                model_path=self.ckpt_path,
+                compute_dtype=self.compute_dtype,
+                device=self.device,
+            )
+            self.mm_part = Qwen3_VLImageEmbedding(self.mm_related_params, visual=visual)
+            self.mm_related_params.vit_weights = None
+            return
+
         self.mm_part = Qwen3_VLImageEmbedding(self.mm_related_params)
         self.mm_related_params.vit_weights = Qwen3VLVitWeight(
             {"vit": self.mm_part.visual}

--- a/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen3_vl_mixin.py
@@ -4,7 +4,6 @@ import os
 from typing import Any, Dict, List, Optional
 
 import torch
-import torch.library as tl
 from PIL import Image
 from transformers import AutoProcessor, Qwen3VLConfig, Qwen3VLVisionModel
 
@@ -28,6 +27,7 @@ from rtp_llm.multimodal.vit_metrics import (
 from rtp_llm.ops import MMPreprocessConfig, MultimodalInput
 from rtp_llm.utils.base_model_datatypes import MMUrlType
 from rtp_llm.utils.flash_attn_utils import can_use_flash_attn
+from rtp_llm.utils.torch_compat import ensure_torch_library_wrap_triton
 
 default_attn_impl = "sdpa"
 try:
@@ -38,21 +38,21 @@ except Exception as e:
         f"initialize flash_attn failed, exception {e}, using sdpa attention in qwen2.5 vl vit"
     )
 
-if not hasattr(tl, "wrap_triton"):
-
-    def wrap_triton(fn):
-        return fn
-
-    tl.wrap_triton = wrap_triton
-
 
 class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
     def __init__(self, mm_related_params: VitParameters, visual=None):
+        # Some supported Torch releases do not expose wrap_triton. Initialize
+        # that process-wide compatibility only when Qwen3-VL vision is created,
+        # rather than as an import-time side effect.
+        ensure_torch_library_wrap_triton()
         self.mm_processor = AutoProcessor.from_pretrained(
             mm_related_params.config["ckpt_path"]
         )
         self._uses_new_loader_vision = visual is not None
         if visual is None:
+            # Keep AutoProcessor's native Qwen3-VL image processor. The old
+            # forced Qwen2-VL override changes the image grid for Qwen3-VL
+            # checkpoints (950 instead of 2752 tokens for the smoke image).
             config_hf = Qwen3VLConfig.from_pretrained(
                 mm_related_params.config["ckpt_path"]
             )
@@ -77,6 +77,8 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
             raise TypeError("Qwen3-VL vision embeddings must be a tensor")
         if not isinstance(deepstack_embeds, (list, tuple)):
             raise TypeError("Qwen3-VL deepstack features must be a sequence")
+        if not deepstack_embeds:
+            raise ValueError("Qwen3-VL deepstack features must not be empty")
         if not all(isinstance(item, torch.Tensor) for item in deepstack_embeds):
             raise TypeError("Qwen3-VL deepstack features must contain only tensors")
         return embeds, deepstack_embeds
@@ -211,12 +213,23 @@ class Qwen3_VLImageEmbedding(Qwen2_5_VLImageEmbedding):
     def batched_embedding(
         self, data_list: List[Any], mm_types: List[MMUrlType], **kwargs
     ):
-        if not all(mm_type == MMUrlType.IMAGE for mm_type in mm_types):
-            return super().batched_embedding(data_list, mm_types, **kwargs)
+        if len(data_list) != len(mm_types):
+            raise ValueError(
+                f"data_list has {len(data_list)} entries but mm_types has "
+                f"{len(mm_types)}"
+            )
+        if not data_list:
+            return []
+        supported_types = {MMUrlType.DEFAULT, MMUrlType.IMAGE, MMUrlType.VIDEO}
+        for index, mm_type in enumerate(mm_types):
+            if mm_type not in supported_types:
+                raise ValueError(
+                    f"unsupported mm_types[{index}] for Qwen3-VL batching: {mm_type}"
+                )
         res_list = []
         pixel_values_list = []
         grid_thw_list = []
-        for data, mm_type in zip(data_list, mm_types):
+        for data in data_list:
             pixel_values_list.append(data[0])
             grid_thw_list.append(data[1])
         pixel_values = (
@@ -270,5 +283,4 @@ class Qwen3_VLMixin(Qwen2_5_VLMixin):
         return Qwen3_VLImageEmbedding(mm_related_params).visual
 
 
-register_multimodal_mixin(["qwen3_vl"], Qwen3_VLMixin)
-register_multimodal_mixin(["qwen3_vl_moe"], Qwen3_VLMixin)
+register_multimodal_mixin(["qwen3_vl", "qwen3_vl_moe"], Qwen3_VLMixin)

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -98,6 +98,7 @@ py_test(
     deps = [
         "//rtp_llm:config",
         "//rtp_llm:multimodal",
+        "//rtp_llm:models",
         "//rtp_llm:safetensors",
         "//rtp_llm:testlib",
         "//rtp_llm:torch",

--- a/rtp_llm/multimodal/test/BUILD
+++ b/rtp_llm/multimodal/test/BUILD
@@ -91,3 +91,17 @@ py_test(
         "//rtp_llm/models_py:qwen2_vl_vision_loader",
     ],
 )
+
+py_test(
+    name = "qwen3_vl_newloader_routing_test",
+    srcs = ["qwen3_vl_newloader_routing_test.py"],
+    deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:multimodal",
+        "//rtp_llm:safetensors",
+        "//rtp_llm:testlib",
+        "//rtp_llm:torch",
+        "//rtp_llm/model_loader:loader",
+        "//rtp_llm/models_py:qwen3_vl_vision_loader",
+    ],
+)

--- a/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
@@ -1,0 +1,175 @@
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import torch
+from safetensors.torch import save_file
+from transformers import Qwen3VLVisionModel
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
+
+from rtp_llm.config.py_config_modules import VitConfig
+from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.new_models.qwen3_vl.vision import Qwen3VLForVisionEmbedding
+from rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin import (
+    Qwen3_VLImageEmbedding,
+    Qwen3_VLMixin,
+)
+
+
+def _vision_config():
+    return {
+        "depth": 1,
+        "hidden_size": 8,
+        "hidden_act": "gelu_pytorch_tanh",
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "in_channels": 1,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 2,
+        "out_hidden_size": 6,
+        "num_position_embeddings": 16,
+        "deepstack_visual_indexes": [0],
+    }
+
+
+class Qwen3VLNewLoaderRoutingTest(unittest.TestCase):
+    def test_qwen3_vl_mixin_uses_standalone_newloader_vision(self):
+        vision_config = _vision_config()
+        source = Qwen3VLForVisionEmbedding(
+            {"model_type": "qwen3_vl_vision", "vision_config": vision_config},
+            NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+        ).eval()
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.{name}": tensor.detach().to(torch.float16)
+                    for name, tensor in source.state_dict().items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            mm_related_params = types.SimpleNamespace(
+                config={**vision_config, "ckpt_path": model_path},
+                vit_weights=object(),
+            )
+            processor = types.SimpleNamespace(image_processor=None)
+            with mock.patch(
+                "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+                "AutoProcessor.from_pretrained",
+                return_value=processor,
+            ):
+                mixin = Qwen3_VLMixin(
+                    torch.float32,
+                    "cpu",
+                    mm_related_params,
+                    LoadMethod.SCRATCH,
+                    VitConfig(),
+                    model_path,
+                    use_new_loader=True,
+                )
+
+        self.assertIsInstance(mixin.mm_part, Qwen3_VLImageEmbedding)
+        self.assertTrue(mixin.mm_part._uses_new_loader_vision)
+        self.assertIsNone(mixin.mm_part.mm_processor.image_processor)
+        self.assertIsNone(mm_related_params.vit_weights)
+        self.assertNotIn("mm_mixin_loader", vars(mixin))
+        for name, expected in source.visual.state_dict().items():
+            torch.testing.assert_close(
+                mixin.mm_part.visual.state_dict()[name],
+                expected.to(torch.float16).to(torch.float32),
+            )
+
+    def test_default_route_keeps_legacy_vision_loader(self):
+        visual = torch.nn.Identity()
+        visual.spatial_merge_size = 2
+        visual.patch_size = 16
+        config = types.SimpleNamespace(
+            vision_config=types.SimpleNamespace(_attn_implementation=None)
+        )
+        mm_related_params = types.SimpleNamespace(
+            config={"ckpt_path": "/tmp/model"},
+            vit_weights=None,
+        )
+        processor = types.SimpleNamespace(image_processor=None)
+        with mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "AutoProcessor.from_pretrained",
+            return_value=processor,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLConfig.from_pretrained",
+            return_value=config,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLVisionModel._from_config",
+            return_value=visual,
+        ):
+            mixin = Qwen3_VLMixin.__new__(Qwen3_VLMixin)
+            mixin.compute_dtype = torch.float32
+            mixin.device = "cpu"
+            mixin.mm_related_params = mm_related_params
+            mixin.vit_config = VitConfig()
+            mixin.load_method = LoadMethod.SCRATCH
+            mixin.ckpt_path = "/tmp/model"
+            mixin.use_new_loader = False
+            mixin._init_multimodal()
+
+        self.assertFalse(mixin.mm_part._uses_new_loader_vision)
+        self.assertIsNone(mixin.mm_part.mm_processor.image_processor)
+        self.assertIsNotNone(mm_related_params.vit_weights)
+
+    def test_newloader_vision_matches_transformers_reference(self):
+        vision_config = _vision_config()
+        reference_config = Qwen3VLVisionConfig(**vision_config)
+        reference_config._attn_implementation = "sdpa"
+        torch.manual_seed(23)
+        reference = Qwen3VLVisionModel(reference_config).eval()
+        checkpoint_state = {
+            name: tensor.detach().to(torch.float16)
+            for name, tensor in reference.state_dict().items()
+        }
+        reference.load_state_dict(checkpoint_state)
+
+        with tempfile.TemporaryDirectory() as model_path:
+            save_file(
+                {
+                    f"model.visual.{name}": tensor
+                    for name, tensor in checkpoint_state.items()
+                },
+                f"{model_path}/model.safetensors",
+            )
+            actual = NewModelLoader(
+                model_config={
+                    "model_type": "qwen3_vl_vision",
+                    "vision_config": vision_config,
+                },
+                load_config=NewLoaderConfig(compute_dtype=torch.float32, device="cpu"),
+                model_path=model_path,
+            ).load()
+
+        pixel_values = torch.linspace(-1.0, 1.0, 128).reshape(16, 8)
+        grid_thw = torch.tensor([[2, 2, 2], [1, 4, 2]], dtype=torch.int64)
+        with torch.inference_mode():
+            expected_output, expected_deepstack = (
+                Qwen3_VLImageEmbedding._unpack_vision_output(
+                    reference(pixel_values, grid_thw)
+                )
+            )
+            actual_output, actual_deepstack = (
+                Qwen3_VLImageEmbedding._unpack_vision_output(
+                    actual(pixel_values, grid_thw)
+                )
+            )
+
+        torch.testing.assert_close(actual_output, expected_output)
+        self.assertEqual(len(actual_deepstack), len(expected_deepstack))
+        for actual_feature, expected_feature in zip(
+            actual_deepstack, expected_deepstack
+        ):
+            torch.testing.assert_close(actual_feature, expected_feature)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
+++ b/rtp_llm/multimodal/test/qwen3_vl_newloader_routing_test.py
@@ -4,18 +4,26 @@ import unittest
 from unittest import mock
 
 import torch
+from PIL import Image
 from safetensors.torch import save_file
-from transformers import Qwen3VLVisionModel
+from transformers import Qwen2VLImageProcessor, Qwen3VLVisionModel
 from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
 
+from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.config.py_config_modules import VitConfig
 from rtp_llm.model_loader.load_config import LoadMethod
+from rtp_llm.models.qwen3_vl import QWen3_VL
 from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.modules.base.common.multimodal_embedding import (
+    reshape_extra_input_to_deepstack,
+)
 from rtp_llm.models_py.new_models.qwen3_vl.vision import Qwen3VLForVisionEmbedding
+from rtp_llm.multimodal.multimodal_mixin_register import get_multimodal_mixin_cls
 from rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin import (
     Qwen3_VLImageEmbedding,
     Qwen3_VLMixin,
 )
+from rtp_llm.utils.base_model_datatypes import MMUrlType
 
 
 def _vision_config():
@@ -32,6 +40,29 @@ def _vision_config():
         "out_hidden_size": 6,
         "num_position_embeddings": 16,
         "deepstack_visual_indexes": [0],
+    }
+
+
+def _model_config_json():
+    return {
+        "vision_start_token_id": 1,
+        "vision_end_token_id": 2,
+        "vision_config": {
+            "hidden_size": 8,
+            "spatial_merge_size": 2,
+        },
+        "text_config": {
+            "intermediate_size": 512,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 128,
+            "hidden_size": 256,
+            "num_hidden_layers": 2,
+            "vocab_size": 64,
+            "rope_scaling": {"mrope_section": [16, 24, 24]},
+            "dtype": "bfloat16",
+            "torch_dtype": "float16",
+        },
     }
 
 
@@ -119,6 +150,209 @@ class Qwen3VLNewLoaderRoutingTest(unittest.TestCase):
         self.assertFalse(mixin.mm_part._uses_new_loader_vision)
         self.assertIsNone(mixin.mm_part.mm_processor.image_processor)
         self.assertIsNotNone(mm_related_params.vit_weights)
+
+    def test_both_routes_preserve_the_native_auto_processor(self):
+        def image_processor():
+            return Qwen2VLImageProcessor(
+                min_pixels=16,
+                max_pixels=64,
+                patch_size=2,
+                temporal_patch_size=2,
+                merge_size=2,
+            )
+
+        newloader_processor = types.SimpleNamespace(image_processor=image_processor())
+        legacy_processor = types.SimpleNamespace(image_processor=image_processor())
+        visual = torch.nn.Identity()
+        visual.spatial_merge_size = 2
+        visual.patch_size = 16
+        mm_related_params = types.SimpleNamespace(
+            config={"ckpt_path": "/tmp/model"},
+            vit_weights=None,
+        )
+        config = types.SimpleNamespace(
+            vision_config=types.SimpleNamespace(_attn_implementation=None)
+        )
+
+        with mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "AutoProcessor.from_pretrained",
+            return_value=newloader_processor,
+        ):
+            newloader_embedding = Qwen3_VLImageEmbedding(
+                mm_related_params, visual=visual
+            )
+        with mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "AutoProcessor.from_pretrained",
+            return_value=legacy_processor,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLConfig.from_pretrained",
+            return_value=config,
+        ), mock.patch(
+            "rtp_llm.multimodal.multimodal_mixins.qwen3_vl_mixin."
+            "Qwen3VLVisionModel._from_config",
+            return_value=visual,
+        ):
+            legacy_embedding = Qwen3_VLImageEmbedding(mm_related_params)
+
+        self.assertIs(newloader_embedding.mm_processor, newloader_processor)
+        self.assertIs(legacy_embedding.mm_processor, legacy_processor)
+        self.assertIs(
+            newloader_embedding.mm_processor.image_processor,
+            newloader_processor.image_processor,
+        )
+        self.assertIs(
+            legacy_embedding.mm_processor.image_processor,
+            legacy_processor.image_processor,
+        )
+        image = Image.new("RGB", (8, 8), color=(32, 64, 128))
+        newloader_output = newloader_embedding.mm_processor.image_processor(
+            image, return_tensors="pt", do_resize=True
+        )
+        legacy_output = legacy_embedding.mm_processor.image_processor(
+            image, return_tensors="pt", do_resize=True
+        )
+        torch.testing.assert_close(
+            newloader_output["pixel_values"], legacy_output["pixel_values"]
+        )
+        torch.testing.assert_close(
+            newloader_output["image_grid_thw"], legacy_output["image_grid_thw"]
+        )
+
+    def test_qwen3_vl_moe_reuses_shared_vision_routes(self):
+        self.assertIs(get_multimodal_mixin_cls("qwen3_vl"), Qwen3_VLMixin)
+        self.assertIs(get_multimodal_mixin_cls("qwen3_vl_moe"), Qwen3_VLMixin)
+
+    def test_batched_image_video_deepstack_roundtrip_matches_single_item(self):
+        class FakeVisual:
+            dtype = torch.float32
+            device = torch.device("cpu")
+            patch_size = 1
+            spatial_merge_size = 1
+
+            def __call__(self, pixel_values, grid_thw):
+                outputs = []
+                offset = 0
+                for grid in grid_thw:
+                    token_count = int(grid.prod().item())
+                    values = pixel_values[offset : offset + token_count, :1]
+                    outputs.append(torch.cat((values, values + 1, values + 2), dim=1))
+                    offset += token_count
+                embeddings = torch.cat(outputs)
+                return embeddings, [embeddings + 10, embeddings + 20]
+
+        embedding = Qwen3_VLImageEmbedding.__new__(Qwen3_VLImageEmbedding)
+        embedding.visual = FakeVisual()
+        embedding.spatial_merge_size = 1
+        image_data = [
+            (
+                torch.tensor([[1.0], [2.0]]),
+                torch.tensor([[1, 1, 2]], dtype=torch.int64),
+            ),
+            (
+                torch.tensor([[3.0], [4.0], [5.0]]),
+                torch.tensor([[1, 1, 3]], dtype=torch.int64),
+            ),
+        ]
+        video_data = (
+            torch.tensor([[6.0], [7.0], [8.0], [9.0]]),
+            torch.tensor([[2, 1, 2]], dtype=torch.int64),
+        )
+
+        cases = (
+            ("images", image_data, [MMUrlType.IMAGE, MMUrlType.IMAGE]),
+            ("video", [video_data], [MMUrlType.VIDEO]),
+            (
+                "mixed",
+                [image_data[0], video_data],
+                [MMUrlType.IMAGE, MMUrlType.VIDEO],
+            ),
+        )
+        for name, data_list, mm_types in cases:
+            with self.subTest(name=name):
+                batched = embedding.batched_embedding(data_list, mm_types)
+                singles = [embedding.embedding(data) for data in data_list]
+                for actual, expected in zip(batched, singles):
+                    torch.testing.assert_close(actual[0], expected[0])
+                    torch.testing.assert_close(actual[1], expected[1])
+                    torch.testing.assert_close(actual[2], expected[2])
+
+                restored = reshape_extra_input_to_deepstack(
+                    [item[2] for item in batched],
+                    [item[0] for item in batched],
+                )
+                for expected, deepstack in zip(singles, restored):
+                    torch.testing.assert_close(
+                        deepstack,
+                        expected[2].reshape(
+                            2, expected[0].size(0), expected[0].size(1)
+                        ),
+                    )
+
+        self.assertEqual(embedding.batched_embedding([], []), [])
+        with self.assertRaisesRegex(ValueError, "data_list has 2 entries"):
+            embedding.batched_embedding(image_data, [MMUrlType.IMAGE])
+        with self.assertRaisesRegex(ValueError, "unsupported mm_types"):
+            embedding.batched_embedding([image_data[0]], [MMUrlType.AUDIO])
+
+    def test_deepstack_transport_rejects_malformed_inputs(self):
+        feature = torch.zeros(2, 3)
+        with self.assertRaisesRegex(ValueError, "extra_input has 0 entries"):
+            reshape_extra_input_to_deepstack([], [feature])
+        with self.assertRaisesRegex(ValueError, "flat 1-D"):
+            reshape_extra_input_to_deepstack([torch.zeros(2, 3)], [feature])
+        with self.assertRaisesRegex(ValueError, "non-empty shape"):
+            reshape_extra_input_to_deepstack([torch.zeros(6)], [torch.empty(0, 3)])
+        with self.assertRaisesRegex(ValueError, "cannot be reshaped"):
+            reshape_extra_input_to_deepstack([torch.zeros(5)], [feature])
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            Qwen3_VLImageEmbedding._unpack_vision_output((torch.zeros(1, 3), []))
+
+    def test_config_json_requires_typed_vision_and_text_sections(self):
+        for missing, message in (
+            ("vision_config", "vision_config"),
+            ("text_config", "text_config"),
+        ):
+            with self.subTest(missing=missing):
+                config_json = _model_config_json()
+                del config_json[missing]
+                with self.assertRaisesRegex(ValueError, message):
+                    QWen3_VL._from_config_json(ModelConfig(), config_json)
+
+    def test_config_json_propagates_vision_and_dtype(self):
+        config = ModelConfig()
+        config.ckpt_path = "/tmp/qwen3-vl"
+        config_json = _model_config_json()
+        QWen3_VL._from_config_json(config, config_json)
+
+        self.assertEqual(config.config_dtype, "bfloat16")
+        self.assertEqual(config.mm_related_params.config["hidden_size"], 8)
+        self.assertEqual(config.mm_related_params.config["ckpt_path"], "/tmp/qwen3-vl")
+        self.assertEqual(config.attn_config.rope_config.index_factor, 3)
+
+        fallback_config = ModelConfig()
+        fallback_json = _model_config_json()
+        fallback_json["text_config"]["dtype"] = None
+        QWen3_VL._from_config_json(fallback_config, fallback_json)
+        self.assertEqual(fallback_config.config_dtype, "float16")
+
+    def test_config_json_rejects_missing_or_invalid_mrope_sections(self):
+        config_json = _model_config_json()
+        del config_json["text_config"]["rope_scaling"]
+        with self.assertRaisesRegex(ValueError, "rope_scaling"):
+            QWen3_VL._from_config_json(ModelConfig(), config_json)
+
+        config_json = _model_config_json()
+        config_json["text_config"]["rope_scaling"]["mrope_section"] = [16, 24]
+        with self.assertRaisesRegex(ValueError, "three positive integers"):
+            QWen3_VL._from_config_json(ModelConfig(), config_json)
+
+        config_json = _model_config_json()
+        config_json["text_config"]["rope_scaling"]["mrope_section"] = [16, 24, 23]
+        with self.assertRaisesRegex(ValueError, "half of head_dim"):
+            QWen3_VL._from_config_json(ModelConfig(), config_json)
 
     def test_newloader_vision_matches_transformers_reference(self):
         vision_config = _vision_config()

--- a/rtp_llm/test/smoke/data/model/qwen_vl/q_r_3_rocm.json
+++ b/rtp_llm/test/smoke/data/model/qwen_vl/q_r_3_rocm.json
@@ -1,0 +1,114 @@
+{
+    "model_type": "qwen3_vl",
+    "model_path": "/mnt/nas1/hf/Qwen3-VL-4B-Instruct/",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen3-VL-4B-Instruct/",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data/model/qwen_vl/1.jpeg"
+                                }
+                            },
+                            {
+                                "type": "text",
+                                "text": "Describe this image."
+                            }
+                        ]
+                    }
+                ],
+                "extra_configs": {
+                    "add_vision_id": false
+                },
+                "max_tokens": 100,
+                "temperature": 0.0,
+                "top_p": 0.01
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1705334081,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "This is a heartwarming, sun-drenched photograph capturing a tender moment between a woman and her dog on a beach at sunset.\n\n**Key Elements:**\n\n- **The Subjects:** A woman with long dark hair, wearing a plaid shirt and dark pants, is sitting on the sand. She is smiling warmly as she gives a high-five to a large, light-colored Labrador Retriever. The dog, wearing a colorful harness, is sitting upright and reaching its paw up to meet hers.",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 2766,
+                    "total_tokens": 2866,
+                    "completion_tokens": 100,
+                    "prompt_tokens_details": {
+                        "image_tokens": 2752
+                    }
+                }
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "data/model/qwen_vl/1.jpeg"
+                                }
+                            },
+                            {
+                                "type": "text",
+                                "text": "Describe this image."
+                            }
+                        ]
+                    }
+                ],
+                "extra_configs": {
+                    "add_vision_id": false
+                },
+                "max_tokens": 100,
+                "temperature": 0.0,
+                "top_p": 0.01
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1705334081,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "This is a heartwarming, sun-drenched photograph capturing a tender moment between a woman and her dog on a beach at sunset.\n\n**Key Elements:**\n\n- **The Subjects:** A woman with long dark hair, wearing a plaid shirt and dark pants, is sitting on the sand. She is smiling warmly as she gives a high-five to a large, light-colored Labrador Retriever. The dog, wearing a colorful harness, is sitting upright and reaching its paw up to meet hers.",
+                            "partial": false
+                        },
+                        "finish_reason": "length"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 2766,
+                    "total_tokens": 2866,
+                    "completion_tokens": 100,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 2752,
+                        "image_tokens": 2752
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -557,6 +557,10 @@ def h20_oss_suites():
                     "llm": "--act_type BF16 --use_local 1 --tp_size 2 --reuse_cache 1",
                     "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1"
                 },
+                envs = {
+                    "llm": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                    "vit": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                },
                 gpu_type=["H20"],
                 data=native.glob(['data/model/llava/*.jpg']),
             ),

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -567,7 +567,14 @@ def h20_oss_suites():
             smoke_test(
                 name="qwen3_vl_moe",
                 task_info="data/model/qwen_vl/q_r_3_moe.json",
-                smoke_args = "--act_type BF16 --use_local 1 --enable_xqa off",
+                smoke_args = {
+                    "llm": "--act_type BF16 --use_local 1 --enable_xqa off --tp_size 2",
+                    "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1"
+                },
+                envs = {
+                    "llm": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                    "vit": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                },
                 gpu_type=["H20"],
                 data=native.glob(['data/model/llava/*']),
             ),

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -557,6 +557,16 @@ def h20_oss_suites():
                     "llm": "--act_type BF16 --use_local 1 --tp_size 2 --reuse_cache 1",
                     "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1"
                 },
+                gpu_type=["H20"],
+                data=native.glob(['data/model/llava/*.jpg']),
+            ),
+            smoke_test(
+                name="qwen3_vl_newloader",
+                task_info="data/model/qwen_vl/q_r_3.json",
+                smoke_args = {
+                    "llm": "--act_type BF16 --use_local 1 --tp_size 2 --reuse_cache 1",
+                    "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1"
+                },
                 envs = {
                     "llm": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
                     "vit": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
@@ -566,6 +576,14 @@ def h20_oss_suites():
             ),
             smoke_test(
                 name="qwen3_vl_moe",
+                task_info="data/model/qwen_vl/q_r_3_moe.json",
+                smoke_args = "--act_type BF16 --use_local 1 --enable_xqa off --tp_size 2",
+                envs = ["USE_NEW_LOADER=0", "LOAD_METHOD=scratch"],
+                gpu_type=["H20"],
+                data=native.glob(['data/model/llava/*']),
+            ),
+            smoke_test(
+                name="qwen3_vl_moe_newloader",
                 task_info="data/model/qwen_vl/q_r_3_moe.json",
                 smoke_args = {
                     "llm": "--act_type BF16 --use_local 1 --enable_xqa off --tp_size 2",

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -73,6 +73,27 @@ def rocm_oss_suites():
         ],
     )
 
+    # ROCm VL (Qwen3-VL newloader, including fused MRoPE prefill/decode)
+    native.test_suite(
+        name = "smoke_rocm_vl",
+        tests = [
+            smoke_test(
+                name = "rocm_qwen3_vl_newloader",
+                task_info = "data/model/qwen_vl/q_r_3_rocm.json",
+                smoke_args = {
+                    "llm": "--act_type BF16 --use_local 1 --tp_size 2 --reuse_cache 1 --use_asm_pa 1 --use_aiter_pa 1 --seq_size_per_block 16",
+                    "vit": "--act_type BF16 --use_local 1 --use_local_preprocess 1",
+                },
+                envs = {
+                    "llm": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                    "vit": ["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
+                },
+                gpu_type = ["MI308X-ROCM7"],
+                data = native.glob(["data/model/llava/*.jpg"]),
+            ),
+        ],
+    )
+
 
     # ROCm MoE (Qwen3-30B MoE)
     native.test_suite(

--- a/rtp_llm/utils/torch_compat.py
+++ b/rtp_llm/utils/torch_compat.py
@@ -1,0 +1,24 @@
+import logging
+
+import torch.library as torch_library
+
+logger = logging.getLogger(__name__)
+_wrap_triton_fallback_logged = False
+
+
+def ensure_torch_library_wrap_triton() -> None:
+    """Install the identity fallback required by older supported Torch releases."""
+    global _wrap_triton_fallback_logged
+
+    if not hasattr(torch_library, "wrap_triton"):
+
+        def wrap_triton(fn):
+            return fn
+
+        torch_library.wrap_triton = wrap_triton
+        if not _wrap_triton_fallback_logged:
+            logger.warning(
+                "torch.library.wrap_triton is unavailable; using the identity "
+                "compatibility fallback"
+            )
+            _wrap_triton_fallback_logged = True


### PR DESCRIPTION
 ## Summary

  Add a clean newloader implementation for Qwen3-VL MoE.

  Built on top of the Qwen3-VL dense newloader support from #1216.

  ## Changes

  - Add `Qwen3VLMoeForCausalLM` based on the Qwen3 MoE newloader runtime.
  - Load prefixed Qwen3-VL MoE language weights directly from:
    - `model.language_model.*`
    - `lm_head.*`
  - Support stacked expert checkpoints, TP/EP ownership, expert filtering, tied/untied LM head, and strict missing/unknown tensor validation.
  - Preserve the Qwen3 MoE residual contract while injecting:
    - multimodal embeddings
    - per-layer deepstack embeddings
    - text-only inputs
  - Register `qwen3_vl_moe` in the new model registry and BUILD dependency closure.
  - Reuse the shared Qwen3-VL vision newloader for both `qwen3_vl` and `qwen3_vl_moe`.
  - Cover image, video, mixed batches, heterogeneous grids, deepstack transport, and prefix-cache reuse.
  - Preserve the existing legacy Qwen3-VL MoE smoke and add a separate all-newloader smoke target.
  - Sync the latest reviewed fixes from #1216.

  The implementation does not depend on `ModelWeightInfo`, `CustomAtomicWeight`, or the legacy loader weight layout.

  ## Processor compatibility

  The removal of the forced `Qwen2VLImageProcessor` override is intentional.

  For Qwen3-VL checkpoints, the native Qwen3-VL processor produces the correct 2752 image tokens for the smoke image. The old forced Qwen2-VL processor produced an incompatible 950-token grid.

  Both the legacy and newloader Qwen3-VL MoE routes were validated with the native processor.

  ## Validation

  ### H20 focused tests

  All passed:

  - `foundation_test`
  - `test_qwen3_moe_load`
  - `test_qwen3_vl_moe_load`
  - `test_qwen3_vl_load`
  - `test_qwen3_vl_vision_loader_import`
  - `test_qwen3_vl_gpu`
  - `qwen3_vl_newloader_routing_test`
  - `multimodal_embedding_test`

  ### H20 end-to-end smoke

  Using only the local `Qwen3-VL-30B-A3B-Instruct` checkpoint:

  - Legacy Qwen3-VL MoE, TP=2, scratch: 2/2 passed, compare diff count = 0
  - All-newloader Qwen3-VL MoE, TP=2, scratch: 2/2 passed, compare diff count = 0
  - Image and video cases both passed
  - Image token count: 2752

  ### ROCm

  All available focused tests passed:

  - `foundation_test`
  - `test_qwen3_moe_load`
  - `test_qwen3_vl_moe_load`
  - `test_qwen3_vl_gpu`
  - `qwen3_vl_newloader_routing_test`

  ROCm end-to-end MoE smoke was not run because the ROCm host does not have a local Qwen3-VL MoE checkpoint. No NAS checkpoint was used.

  ### Static checks

  - Black: passed
  - isort: passed
  - pre-commit: passed
  - `git diff --check`: passed