### PR TITLE
test: add e2e cache UT/smoke tests

### DIFF
--- a/rtp_llm/cpp/cache/smoke/BUILD
+++ b/rtp_llm/cpp/cache/smoke/BUILD
@@ -1,0 +1,58 @@
+load("//:def.bzl", "cc_test_wrapper", "copts")
+load("//bazel:arch_select.bzl", "torch_deps")
+load("//bazel:device_defs.bzl", "device_impl_target")
+
+cc_test = cc_test_wrapper
+
+test_copts = [
+    "-fno-access-control",
+] + copts()
+
+common_deps = [
+    "//rtp_llm/cpp/cache",
+    "//rtp_llm/cpp/cache/test:cache_config_test_utils",
+    "//rtp_llm/cpp/config:config_modules",
+    "//rtp_llm/cpp/metrics:metrics",
+    "//rtp_llm/cpp/utils:core_utils",
+    "//rtp_llm/models_py/bindings/core:exec_ops_test_lib",
+    "@com_google_googletest//:gtest",
+    "@havenask//aios/autil:log",
+] + device_impl_target() + torch_deps()
+
+cc_test(
+    name = "cache_lifecycle_smoke_test",
+    srcs = [
+        "CacheLifecycleSmokeTest.cc",
+        "CacheSmokeMain.cc",
+        "CacheSmokeTestUtils.h",
+    ],
+    copts = test_copts,
+    deps = common_deps,
+    env = {},
+    exec_properties = {"gpu": "H20"},
+)
+
+cc_test(
+    name = "cache_pd_smoke_test",
+    srcs = [
+        "CachePDSmokeTest.cc",
+        "CacheSmokeMain.cc",
+        "CacheSmokeTestUtils.h",
+    ],
+    copts = test_copts,
+    deps = common_deps + [
+        "//rtp_llm/cpp/cache/connector/p2p:connector",
+        "//rtp_llm/cpp/utils:time_util",
+        "@havenask//aios/autil:net",
+    ],
+    env = {},
+    exec_properties = {"gpu": "H20"},
+)
+
+test_suite(
+    name = "cache_framework_smoke",
+    tests = [
+        ":cache_lifecycle_smoke_test",
+        ":cache_pd_smoke_test",
+    ],
+)

--- a/rtp_llm/cpp/cache/smoke/CacheLifecycleSmokeTest.cc
+++ b/rtp_llm/cpp/cache/smoke/CacheLifecycleSmokeTest.cc
@@ -1,0 +1,260 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <set>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/SharedBlockCache.h"
+#include "rtp_llm/cpp/cache/smoke/CacheSmokeTestUtils.h"
+
+namespace rtp_llm::test {
+
+class CacheLifecycleSmokeTest: public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        initCacheSmokeRuntime();
+    }
+};
+
+TEST_F(CacheLifecycleSmokeTest, PoolInitAllocateCopyRecycle) {
+    const auto     config = makeCacheSmokeConfig();
+    KVCacheManager manager(config);
+    ASSERT_TRUE(manager.init());
+
+    const size_t baseline_free = manager.freeBlocksNum();
+    EXPECT_EQ(manager.totalBlocksNum(), config.block_num - 1);
+    EXPECT_EQ(baseline_free, config.block_num - 1);
+
+    const auto layout = manager.allLayerCacheBase();
+    ASSERT_EQ(layout.groups().size(), 1u);
+    const auto& group_layout = layout.group("default");
+    ASSERT_EQ(group_layout.size(), config.layer_num);
+    for (const auto& layer : group_layout.layers()) {
+        EXPECT_TRUE(layer.kv_addr.defined());
+        EXPECT_GT(layer.kv_addr.numel(), 0);
+        EXPECT_TRUE(layer.kv_scale_addr.defined());
+        EXPECT_GT(layer.kv_scale_addr.numel(), 0);
+    }
+
+    auto       token_ids = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/8));
+    auto       resource  = makeCacheSmokeResource(config, makeCacheKeys(/*begin=*/100, /*count=*/2));
+    MallocInfo malloc_info{resource, token_ids};
+    malloc_info.reuse_cache         = false;
+    malloc_info.enable_device_cache = false;
+    ASSERT_TRUE(manager.malloc(malloc_info).success);
+    ASSERT_EQ(resource->blocksNum(0, 0), 2);
+
+    const auto released_blocks = resource->blocks(0, 0);
+    ASSERT_EQ(std::set<BlockIdxType>(released_blocks.begin(), released_blocks.end()).size(), 2u);
+    const auto src_block = released_blocks[0];
+    const auto dst_block = released_blocks[1];
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        ASSERT_NO_FATAL_FAILURE(
+            fillBlockInfos(managerBlockInfos(manager, layer_id, src_block), static_cast<uint8_t>(41 + layer_id * 19)));
+        ASSERT_NO_FATAL_FAILURE(fillBlockInfos(managerBlockInfos(manager, layer_id, dst_block), /*seed=*/0));
+    }
+
+    manager.blockCopy(src_block, dst_block);
+    synchronizeCacheSmokeDevice();
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        const auto src_infos = managerBlockInfos(manager, layer_id, src_block);
+        const auto dst_infos = managerBlockInfos(manager, layer_id, dst_block);
+        ASSERT_FALSE(src_infos.empty());
+        ASSERT_FALSE(dst_infos.empty());
+        ASSERT_EQ(src_infos.size(), dst_infos.size());
+        for (size_t buffer_id = 0; buffer_id < src_infos.size(); ++buffer_id) {
+            const auto src_bytes = readBlockInfoBytes(src_infos[buffer_id]);
+            ASSERT_GT(src_bytes.size(), 1u);
+            EXPECT_EQ(src_bytes[0], static_cast<uint8_t>(41 + layer_id * 19 + buffer_id));
+            EXPECT_EQ(src_bytes[1], static_cast<uint8_t>(42 + layer_id * 19 + buffer_id));
+            EXPECT_EQ(src_bytes, readBlockInfoBytes(dst_infos[buffer_id]));
+        }
+    }
+
+    manager.free(FreeInfo{resource, token_ids});
+    EXPECT_EQ(manager.freeBlocksNum(), baseline_free);
+    EXPECT_EQ(resource->curBlocksNum(), 0);
+
+    auto       next_tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1000, /*count=*/4));
+    auto       next_resource = makeCacheSmokeResource(config, makeCacheKeys(/*begin=*/1000, /*count=*/1));
+    MallocInfo next_malloc{next_resource, next_tokens};
+    next_malloc.reuse_cache         = false;
+    next_malloc.enable_device_cache = false;
+    ASSERT_TRUE(manager.malloc(next_malloc).success);
+    ASSERT_EQ(next_resource->blocksNum(0, 0), 1);
+    manager.free(FreeInfo{next_resource, next_tokens});
+    EXPECT_EQ(manager.freeBlocksNum(), baseline_free);
+}
+
+TEST_F(CacheLifecycleSmokeTest, PrefixReusePreservesBlockIdentityAndPayload) {
+    const auto config    = makeCacheSmokeConfig();
+    auto       allocator = makeCacheSmokeAllocator(config, /*enable_prefix_cache=*/true);
+    ASSERT_TRUE(allocator->init());
+    const size_t baseline_free = allocator->freeBlocksNum();
+
+    const auto seed_keys     = makeCacheKeys(/*begin=*/200, /*count=*/4);
+    auto       seed_tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/16));
+    auto       seed_resource = makeCacheSmokeResource(config, seed_keys);
+    ASSERT_TRUE(allocateCacheSmokeResource(allocator, seed_resource, seed_tokens).success);
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*allocator, seed_resource->cacheResource(0), /*seed=*/17));
+
+    const auto                                     seed_blocks = seed_resource->blocks(0, 0);
+    std::vector<std::vector<std::vector<uint8_t>>> expected_payload(config.layer_num);
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        expected_payload[static_cast<size_t>(layer_id)].resize(seed_blocks.size());
+        for (size_t block_pos = 0; block_pos < seed_blocks.size(); ++block_pos) {
+            const auto infos = allocatorBlockInfos(*allocator, layer_id, seed_blocks[block_pos]);
+            ASSERT_FALSE(infos.empty());
+            for (const auto& info : infos) {
+                auto bytes = readBlockInfoBytes(info);
+                expected_payload[static_cast<size_t>(layer_id)][block_pos].insert(
+                    expected_payload[static_cast<size_t>(layer_id)][block_pos].end(), bytes.begin(), bytes.end());
+            }
+        }
+    }
+
+    allocator->insertIntoCache(InsertInfo{seed_resource, seed_tokens, /*is_resident=*/false});
+    allocator->free(FreeInfo{seed_resource, seed_tokens});
+
+    auto hit_keys = seed_keys;
+    hit_keys.push_back(999);
+    auto hit_tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/20));
+    auto hit_resource = makeCacheSmokeResource(config, hit_keys);
+    auto hit_result   = allocateCacheSmokeResource(allocator, hit_resource, hit_tokens, /*enable_device_cache=*/true);
+    ASSERT_TRUE(hit_result.success);
+    EXPECT_EQ(hit_result.reuse_len, 16);
+    EXPECT_EQ(hit_resource->cacheResource(0).deviceReuseBlockNum(), seed_blocks.size());
+    ASSERT_EQ(hit_resource->blocksNum(0, 0), 5);
+    EXPECT_TRUE(std::equal(seed_blocks.begin(), seed_blocks.end(), hit_resource->blocks(0, 0).begin()));
+
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        for (size_t block_pos = 0; block_pos < seed_blocks.size(); ++block_pos) {
+            std::vector<uint8_t> actual;
+            const auto infos = allocatorBlockInfos(*allocator, layer_id, hit_resource->blocks(0, 0)[block_pos]);
+            ASSERT_FALSE(infos.empty());
+            for (const auto& info : infos) {
+                auto bytes = readBlockInfoBytes(info);
+                actual.insert(actual.end(), bytes.begin(), bytes.end());
+            }
+            EXPECT_EQ(actual, expected_payload[static_cast<size_t>(layer_id)][block_pos]);
+        }
+    }
+
+    allocator->free(FreeInfo{hit_resource, hit_tokens});
+    drainAllocatorCache(allocator);
+    EXPECT_EQ(allocator->freeBlocksNum(), baseline_free);
+    EXPECT_EQ(allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(allocator->blockCacheRefBlocksNum(), 0u);
+}
+
+TEST_F(CacheLifecycleSmokeTest, PressureEvictsOldestPrefixAndRecoversPool) {
+    const auto config    = makeCacheSmokeConfig(/*block_num=*/8);
+    auto       allocator = makeCacheSmokeAllocator(config, /*enable_prefix_cache=*/true);
+    ASSERT_TRUE(allocator->init());
+    const size_t baseline_free = allocator->freeBlocksNum();
+    const auto   cache         = allocator->sharedBlockCache();
+    ASSERT_NE(cache, nullptr);
+
+    auto cache_request = [&](CacheKeyType key_begin, int32_t token_begin) {
+        auto keys     = makeCacheKeys(key_begin, /*count=*/3);
+        auto tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(token_begin, /*count=*/12));
+        auto resource = makeCacheSmokeResource(config, keys);
+        EXPECT_TRUE(allocateCacheSmokeResource(allocator, resource, tokens).success);
+        allocator->insertIntoCache(InsertInfo{resource, tokens, /*is_resident=*/false});
+        allocator->free(FreeInfo{resource, tokens});
+    };
+
+    cache_request(/*key_begin=*/10, /*token_begin=*/1);
+    cache_request(/*key_begin=*/20, /*token_begin=*/100);
+    EXPECT_EQ(allocator->freeBlocksNum(), 1u);
+    ASSERT_TRUE(cache->contains(10));
+    ASSERT_TRUE(cache->contains(20));
+
+    auto pressure_tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1000, /*count=*/12));
+    auto pressure_resource = makeCacheSmokeResource(config, makeCacheKeys(/*begin=*/30, /*count=*/3));
+    ASSERT_TRUE(allocateCacheSmokeResource(allocator, pressure_resource, pressure_tokens).success);
+
+    EXPECT_FALSE(cache->contains(10));
+    EXPECT_TRUE(cache->contains(20));
+    allocator->free(FreeInfo{pressure_resource, pressure_tokens});
+    drainAllocatorCache(allocator);
+
+    EXPECT_EQ(allocator->freeBlocksNum(), baseline_free);
+    EXPECT_EQ(allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(allocator->blockCacheRefBlocksNum(), 0u);
+}
+
+TEST_F(CacheLifecycleSmokeTest, FailedAllocationRollsBackAllReferences) {
+    const auto config    = makeCacheSmokeConfig(/*block_num=*/5);
+    auto       allocator = makeCacheSmokeAllocator(config, /*enable_prefix_cache=*/true);
+    ASSERT_TRUE(allocator->init());
+
+    const size_t baseline_free      = allocator->freeBlocksNum();
+    const size_t baseline_available = allocator->availableBlocksNum();
+    auto         tokens             = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/20));
+    auto         resource           = makeCacheSmokeResource(config, makeCacheKeys(/*begin=*/500, /*count=*/5));
+
+    EXPECT_FALSE(allocateCacheSmokeResource(allocator, resource, tokens).success);
+    EXPECT_EQ(resource->curBlocksNum(), 0);
+    EXPECT_EQ(allocator->freeBlocksNum(), baseline_free);
+    EXPECT_EQ(allocator->availableBlocksNum(), baseline_available);
+    EXPECT_EQ(allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(allocator->blockCacheRefBlocksNum(), 0u);
+}
+
+TEST_F(CacheLifecycleSmokeTest, MultiTypeGroupsAllocateTaggedCopyRecycle) {
+    const auto config    = makeMultiGroupCacheSmokeConfig();
+    auto       allocator = makeCacheSmokeAllocatorForConfig(config, /*enable_prefix_cache=*/false);
+    ASSERT_TRUE(allocator->init());
+    auto* hybrid = dynamic_cast<HybridPoolKVCacheAllocator*>(allocator.get());
+    ASSERT_NE(hybrid, nullptr);
+    ASSERT_EQ(hybrid->groupBlockPools().size(), 5u);
+    const auto baseline = snapshotCacheSmokePools(*hybrid);
+
+    auto tokens   = makeCacheSmokeTokenIds(config, makeTokenRange(1, 20));
+    auto resource = makeCacheSmokeResource(config, makeCacheKeys(800, 5));
+    ASSERT_TRUE(allocateCacheSmokeResource(allocator, resource, tokens, /*enable_device_cache=*/true).success);
+    auto& batch_resource = resource->cacheResource(0);
+    ASSERT_EQ(batch_resource.layerNum(), 3);
+    EXPECT_EQ(batch_resource.groupTagsForLayer(0), (std::vector<std::string>{"shared_full", "layer0_linear"}));
+    EXPECT_EQ(batch_resource.groupTagsForLayer(1),
+              (std::vector<std::string>{"shared_full", "layer1_swa", "layer1_full"}));
+    EXPECT_EQ(batch_resource.groupTagsForLayer(2), (std::vector<std::string>{"shared_full", "layer2_linear"}));
+    for (int layer = 0; layer < 3; ++layer) {
+        for (const auto& tag : batch_resource.groupTagsForLayer(layer)) {
+            const auto& blocks = resource->blocksForLayer(0, layer, tag);
+            EXPECT_EQ(blocks.size(), 5u) << "layer=" << layer << " tag=" << tag;
+            const auto valid =
+                std::count_if(blocks.begin(), blocks.end(), [](BlockIdxType b) { return !isNullBlockIdx(b); });
+            if (tag == "layer1_swa") {
+                EXPECT_GE(valid, 2);
+            } else {
+                EXPECT_EQ(valid, 5);
+            }
+        }
+    }
+
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*allocator, resource->cacheResource(0), 37));
+    const auto shared0 = resource->blocksForLayer(0, 0, "shared_full");
+    EXPECT_EQ(shared0, resource->blocksForLayer(0, 1, "shared_full"));
+    ASSERT_GE(shared0.size(), 2u);
+    auto source              = shared0[0];
+    auto target              = shared0[1];
+    auto source_infos        = allocatorBlockInfos(*allocator, 0, "shared_full", source);
+    auto target_infos        = allocatorBlockInfos(*allocator, 0, "shared_full", target);
+    auto linear_target_infos = allocatorBlockInfos(*allocator, 0, "layer0_linear", target);
+    ASSERT_FALSE(source_infos.empty());
+    ASSERT_FALSE(target_infos.empty());
+    ASSERT_FALSE(linear_target_infos.empty());
+    const auto untouched = readBlockInfoBytes(linear_target_infos[0]);
+    allocator->blockBatchCopyByTag({TaggedBlockIdPair{"shared_full", source, target}});
+    synchronizeCacheSmokeDevice();
+    EXPECT_EQ(readBlockInfoBytes(source_infos[0]), readBlockInfoBytes(target_infos[0]));
+    EXPECT_EQ(untouched, readBlockInfoBytes(linear_target_infos[0]));
+
+    allocator->free(FreeInfo{resource, tokens});
+    ASSERT_NO_FATAL_FAILURE(expectCacheSmokePoolsEqual(*hybrid, baseline));
+}
+
+}  // namespace rtp_llm::test

--- a/rtp_llm/cpp/cache/smoke/CachePDSmokeTest.cc
+++ b/rtp_llm/cpp/cache/smoke/CachePDSmokeTest.cc
@@ -1,0 +1,379 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <initializer_list>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "autil/NetUtil.h"
+#include "rtp_llm/cpp/cache/connector/p2p/LayerBlockConverterImpl.h"
+#include "rtp_llm/cpp/cache/connector/p2p/LayerCacheBufferUtil.h"
+#include "rtp_llm/cpp/cache/connector/p2p/P2PConnectorWorker.h"
+#include "rtp_llm/cpp/cache/smoke/CacheSmokeTestUtils.h"
+#include "rtp_llm/cpp/utils/Logger.h"
+#include "rtp_llm/cpp/utils/TimeUtil.h"
+
+namespace rtp_llm::test {
+
+namespace {
+
+constexpr int kEndpointInitAttempts = 10;
+
+struct PdEndpoint {
+    explicit PdEndpoint(const CacheConfig& config, int64_t tp_size = 1, int64_t tp_rank = 0):
+        allocator(makeCacheSmokeAllocatorForConfig(config, /*enable_prefix_cache=*/false)),
+        layer_all_num(config.layer_all_num),
+        tp_size(tp_size),
+        tp_rank(tp_rank) {}
+
+    bool init(std::initializer_list<uint32_t> excluded_ports = {}) {
+        if (!allocator->init()) {
+            return false;
+        }
+        converter = std::make_shared<LayerBlockConverterImpl>(allocator);
+
+        std::set<uint32_t> attempted_ports(excluded_ports);
+        for (int attempt = 0; attempt < kEndpointInitAttempts; ++attempt) {
+            uint32_t candidate_port = 0;
+            do {
+                candidate_port = autil::NetUtil::randomPort();
+            } while (!attempted_ports.insert(candidate_port).second);
+
+            P2PConnectorWorkerConfig worker_config;
+            // Hermetic smoke uses TCP. Production RDMA requires separate validation on an RDMA-enabled host.
+            worker_config.transfer_backend_config.cache_store_rdma_mode           = false;
+            worker_config.transfer_backend_config.cache_store_listen_port         = candidate_port;
+            worker_config.transfer_backend_config.messager_io_thread_count        = 1;
+            worker_config.transfer_backend_config.messager_worker_thread_count    = 1;
+            worker_config.transfer_backend_config.rdma_transfer_wait_timeout_ms   = 5000;
+            worker_config.transfer_backend_config.transfer_wait_check_interval_us = 1000;
+            worker_config.tp_size                                                 = tp_size;
+            worker_config.tp_rank                                                 = tp_rank;
+            worker_config.layer_all_num                                           = layer_all_num;
+            worker_config.p2p_read_steal_before_deadline_ms                       = 250;
+            worker_config.p2p_read_return_before_deadline_ms                      = 100;
+
+            auto candidate_worker = std::make_unique<P2PConnectorWorker>(worker_config, converter, nullptr);
+            if (candidate_worker->init(/*store_wait_timeout_ms=*/5000)) {
+                port   = candidate_port;
+                worker = std::move(candidate_worker);
+                return true;
+            }
+            RTP_LLM_LOG_WARNING("cache PD smoke endpoint init failed, port=%u, attempt=%d/%d",
+                                candidate_port,
+                                attempt + 1,
+                                kEndpointInitAttempts);
+        }
+        return false;
+    }
+
+    KVCacheAllocatorPtr                  allocator;
+    std::shared_ptr<LayerBlockConverter> converter;
+    std::unique_ptr<P2PConnectorWorker>  worker;
+    uint32_t                             port{0};
+    uint32_t                             layer_all_num;
+    int64_t                              tp_size;
+    int64_t                              tp_rank;
+};
+
+}  // namespace
+
+class CachePDSmokeTest: public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        initCacheSmokeRuntime();
+    }
+};
+
+TEST_F(CachePDSmokeTest, WorkerTcpRoundTripPreservesPayloadAndConnectorLifetime) {
+    const auto config = makeCacheSmokeConfig(/*block_num=*/8, DataType::TYPE_INT8);
+
+    PdEndpoint prefill(config);
+    PdEndpoint decode(config);
+    ASSERT_TRUE(prefill.init());
+    ASSERT_TRUE(decode.init({prefill.port}));
+
+    const size_t prefill_baseline_free = prefill.allocator->freeBlocksNum();
+    const size_t decode_baseline_free  = decode.allocator->freeBlocksNum();
+    const auto   cache_keys            = makeCacheKeys(/*begin=*/700, /*count=*/3);
+    auto         tokens                = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/12));
+    auto         prefill_batch         = makeCacheSmokeResource(config, cache_keys);
+    auto         decode_batch          = makeCacheSmokeResource(config, cache_keys);
+
+    ASSERT_TRUE(allocateCacheSmokeResource(prefill.allocator, prefill_batch, tokens).success);
+    ASSERT_TRUE(allocateCacheSmokeResource(decode.allocator, decode_batch, tokens).success);
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*prefill.allocator, prefill_batch->cacheResource(0), /*seed=*/53));
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*decode.allocator, decode_batch->cacheResource(0), /*seed=*/0));
+
+    auto prefill_hold =
+        prefill.allocator->incrKVCacheRef(prefill_batch->cacheResource(0), cache_keys, /*is_connector=*/true);
+    auto decode_hold =
+        decode.allocator->incrKVCacheRef(decode_batch->cacheResource(0), cache_keys, /*is_connector=*/true);
+    ASSERT_NE(prefill_hold, nullptr);
+    ASSERT_NE(decode_hold, nullptr);
+
+    prefill.allocator->free(FreeInfo{prefill_batch, tokens});
+    decode.allocator->free(FreeInfo{decode_batch, tokens});
+    EXPECT_EQ(prefill.allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(prefill.allocator->connectorRefBlocksNum(), cache_keys.size());
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), cache_keys.size());
+    EXPECT_EQ(prefill.allocator->freeBlocksNum(), prefill_baseline_free - cache_keys.size());
+    EXPECT_EQ(decode.allocator->freeBlocksNum(), decode_baseline_free - cache_keys.size());
+
+    const int64_t     request_id     = 9001;
+    const std::string unique_key     = "cache-smoke-pd-9001";
+    const int64_t     deadline_ms    = currentTimeMs() + 10000;
+    auto              decode_buffers = LayerCacheBufferUtil::convert(*decode_hold,
+                                                        /*batch_id=*/0,
+                                                        /*start_block_idx=*/0,
+                                                        /*block_count=*/-1,
+                                                        /*cp_rank=*/0,
+                                                        /*cp_size=*/1);
+    ASSERT_EQ(decode_buffers.size(), config.layer_num);
+
+    auto decode_result_future = std::async(std::launch::async, [&]() {
+        return decode.worker->read(request_id, unique_key, deadline_ms, decode_buffers, /*remote_tp_size=*/1);
+    });
+
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        ASSERT_TRUE(prefill.worker->writeByLayer(layer_id, prefill_hold, request_id, std::nullopt));
+    }
+
+    const auto send_result =
+        prefill.worker->sendKVCache(request_id, unique_key, deadline_ms, {{"127.0.0.1", decode.port}});
+    ASSERT_TRUE(send_result.ok()) << send_result.ToString();
+    ASSERT_EQ(decode_result_future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    const auto decode_result = decode_result_future.get();
+    ASSERT_TRUE(decode_result.ok()) << decode_result.ToString();
+
+    ASSERT_NO_FATAL_FAILURE(
+        expectAllocatorResourcesEqual(*prefill.allocator, *prefill_hold, *decode.allocator, *decode_hold));
+
+    prefill_hold.reset();
+    decode_hold.reset();
+    EXPECT_EQ(prefill.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(prefill.allocator->freeBlocksNum(), prefill_baseline_free);
+    EXPECT_EQ(decode.allocator->freeBlocksNum(), decode_baseline_free);
+    EXPECT_EQ(prefill.allocator->availableBlocksNum(), prefill_baseline_free);
+    EXPECT_EQ(decode.allocator->availableBlocksNum(), decode_baseline_free);
+}
+
+TEST_F(CachePDSmokeTest, WorkerTcpReadTimeoutReleasesConnectorHoldAndRestoresPool) {
+    const auto config = makeCacheSmokeConfig(/*block_num=*/8, DataType::TYPE_INT8);
+    PdEndpoint decode(config);
+    ASSERT_TRUE(decode.init());
+
+    const size_t baseline_free      = decode.allocator->freeBlocksNum();
+    const size_t baseline_available = decode.allocator->availableBlocksNum();
+    const auto   cache_keys         = makeCacheKeys(/*begin=*/750, /*count=*/2);
+    auto         tokens             = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/8));
+    auto         decode_batch       = makeCacheSmokeResource(config, cache_keys);
+    ASSERT_TRUE(allocateCacheSmokeResource(decode.allocator, decode_batch, tokens).success);
+
+    auto decode_hold =
+        decode.allocator->incrKVCacheRef(decode_batch->cacheResource(0), cache_keys, /*is_connector=*/true);
+    ASSERT_NE(decode_hold, nullptr);
+    decode.allocator->free(FreeInfo{decode_batch, tokens});
+    EXPECT_EQ(decode.allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), cache_keys.size());
+    EXPECT_EQ(decode.allocator->freeBlocksNum(), baseline_free - cache_keys.size());
+
+    auto decode_buffers = LayerCacheBufferUtil::convert(*decode_hold, /*batch_id=*/0);
+    ASSERT_EQ(decode_buffers.size(), config.layer_num);
+    const auto read_result = decode.worker->read(/*request_id=*/9051,
+                                                 /*unique_key=*/"cache-smoke-pd-timeout-9051",
+                                                 /*deadline_ms=*/currentTimeMs() + 500,
+                                                 decode_buffers,
+                                                 /*remote_tp_size=*/1);
+    EXPECT_TRUE(read_result.hasError());
+    EXPECT_EQ(decode.allocator->requestRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), cache_keys.size());
+
+    decode_hold.reset();
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->freeBlocksNum(), baseline_free);
+    EXPECT_EQ(decode.allocator->availableBlocksNum(), baseline_available);
+}
+
+TEST_F(CachePDSmokeTest, WorkerTcp2P1DRoundTripAssemblesDecodePartitions) {
+    constexpr int64_t kPrefillTpSize = 2;
+    const auto        prefill_config = makeSimpleMhaCacheConfig(/*layer_num=*/2,
+                                                         /*block_num=*/8,
+                                                         /*tokens_per_block=*/4,
+                                                         DataType::TYPE_FP16,
+                                                         /*local_head_num_kv=*/1,
+                                                         /*size_per_head=*/8);
+    const auto        decode_config  = makeSimpleMhaCacheConfig(/*layer_num=*/2,
+                                                        /*block_num=*/8,
+                                                        /*tokens_per_block=*/4,
+                                                        DataType::TYPE_FP16,
+                                                        /*local_head_num_kv=*/2,
+                                                        /*size_per_head=*/8);
+
+    PdEndpoint prefill_rank0(prefill_config, kPrefillTpSize, /*tp_rank=*/0);
+    PdEndpoint prefill_rank1(prefill_config, kPrefillTpSize, /*tp_rank=*/1);
+    PdEndpoint decode(decode_config);
+    ASSERT_TRUE(prefill_rank0.init());
+    ASSERT_TRUE(prefill_rank1.init({prefill_rank0.port}));
+    ASSERT_TRUE(decode.init({prefill_rank0.port, prefill_rank1.port}));
+
+    const size_t prefill_rank0_baseline_free = prefill_rank0.allocator->freeBlocksNum();
+    const size_t prefill_rank1_baseline_free = prefill_rank1.allocator->freeBlocksNum();
+    const size_t decode_baseline_free        = decode.allocator->freeBlocksNum();
+    const auto   cache_keys                  = makeCacheKeys(/*begin=*/800, /*count=*/3);
+    auto         tokens = makeCacheSmokeTokenIds(prefill_config, makeTokenRange(/*begin=*/1, /*count=*/12));
+    auto         prefill_rank0_batch = makeCacheSmokeResource(prefill_config, cache_keys);
+    auto         prefill_rank1_batch = makeCacheSmokeResource(prefill_config, cache_keys);
+    auto         decode_batch        = makeCacheSmokeResource(decode_config, cache_keys);
+
+    ASSERT_TRUE(allocateCacheSmokeResource(prefill_rank0.allocator, prefill_rank0_batch, tokens).success);
+    ASSERT_TRUE(allocateCacheSmokeResource(prefill_rank1.allocator, prefill_rank1_batch, tokens).success);
+    ASSERT_TRUE(allocateCacheSmokeResource(decode.allocator, decode_batch, tokens).success);
+    ASSERT_NO_FATAL_FAILURE(
+        fillAllocatorResource(*prefill_rank0.allocator, prefill_rank0_batch->cacheResource(0), /*seed=*/29));
+    ASSERT_NO_FATAL_FAILURE(
+        fillAllocatorResource(*prefill_rank1.allocator, prefill_rank1_batch->cacheResource(0), /*seed=*/137));
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*decode.allocator, decode_batch->cacheResource(0), /*seed=*/0));
+
+    auto prefill_rank0_hold = prefill_rank0.allocator->incrKVCacheRef(prefill_rank0_batch->cacheResource(0),
+                                                                      cache_keys,
+                                                                      /*is_connector=*/true);
+    auto prefill_rank1_hold = prefill_rank1.allocator->incrKVCacheRef(prefill_rank1_batch->cacheResource(0),
+                                                                      cache_keys,
+                                                                      /*is_connector=*/true);
+    auto decode_hold =
+        decode.allocator->incrKVCacheRef(decode_batch->cacheResource(0), cache_keys, /*is_connector=*/true);
+    ASSERT_NE(prefill_rank0_hold, nullptr);
+    ASSERT_NE(prefill_rank1_hold, nullptr);
+    ASSERT_NE(decode_hold, nullptr);
+
+    prefill_rank0.allocator->free(FreeInfo{prefill_rank0_batch, tokens});
+    prefill_rank1.allocator->free(FreeInfo{prefill_rank1_batch, tokens});
+    decode.allocator->free(FreeInfo{decode_batch, tokens});
+
+    const int64_t     request_id     = 9201;
+    const std::string unique_key     = "cache-smoke-pd-2p1d-9201";
+    const int64_t     deadline_ms    = currentTimeMs() + 10000;
+    auto              decode_buffers = LayerCacheBufferUtil::convert(*decode_hold, /*batch_id=*/0);
+    ASSERT_EQ(decode_buffers.size(), decode_config.layer_num);
+
+    auto decode_result_future = std::async(std::launch::async, [&]() {
+        return decode.worker->read(
+            request_id, unique_key, deadline_ms, decode_buffers, /*remote_tp_size=*/kPrefillTpSize);
+    });
+
+    for (int layer_id = 0; layer_id < static_cast<int>(prefill_config.layer_num); ++layer_id) {
+        ASSERT_TRUE(prefill_rank0.worker->writeByLayer(layer_id, prefill_rank0_hold, request_id, std::nullopt));
+        ASSERT_TRUE(prefill_rank1.worker->writeByLayer(layer_id, prefill_rank1_hold, request_id, std::nullopt));
+    }
+
+    const std::vector<std::pair<std::string, uint32_t>> decode_servers = {{"127.0.0.1", decode.port}};
+    auto prefill_rank0_send_future                                     = std::async(std::launch::async, [&]() {
+        return prefill_rank0.worker->sendKVCache(request_id, unique_key, deadline_ms, decode_servers);
+    });
+    auto prefill_rank1_send_future                                     = std::async(std::launch::async, [&]() {
+        return prefill_rank1.worker->sendKVCache(request_id, unique_key, deadline_ms, decode_servers);
+    });
+
+    ASSERT_EQ(prefill_rank0_send_future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    ASSERT_EQ(prefill_rank1_send_future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    const auto prefill_rank0_send_result = prefill_rank0_send_future.get();
+    const auto prefill_rank1_send_result = prefill_rank1_send_future.get();
+    ASSERT_TRUE(prefill_rank0_send_result.ok()) << prefill_rank0_send_result.ToString();
+    ASSERT_TRUE(prefill_rank1_send_result.ok()) << prefill_rank1_send_result.ToString();
+    ASSERT_EQ(decode_result_future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    const auto decode_result = decode_result_future.get();
+    ASSERT_TRUE(decode_result.ok()) << decode_result.ToString();
+
+    ASSERT_NO_FATAL_FAILURE(expectAllocatorResourcePartitionsEqual(*prefill_rank0.allocator,
+                                                                   *prefill_rank0_hold,
+                                                                   /*src_partition_count=*/1,
+                                                                   /*src_partition_id=*/0,
+                                                                   *decode.allocator,
+                                                                   *decode_hold,
+                                                                   /*dst_partition_count=*/2,
+                                                                   /*dst_partition_id=*/0));
+    ASSERT_NO_FATAL_FAILURE(expectAllocatorResourcePartitionsEqual(*prefill_rank1.allocator,
+                                                                   *prefill_rank1_hold,
+                                                                   /*src_partition_count=*/1,
+                                                                   /*src_partition_id=*/0,
+                                                                   *decode.allocator,
+                                                                   *decode_hold,
+                                                                   /*dst_partition_count=*/2,
+                                                                   /*dst_partition_id=*/1));
+
+    prefill_rank0_hold.reset();
+    prefill_rank1_hold.reset();
+    decode_hold.reset();
+    EXPECT_EQ(prefill_rank0.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(prefill_rank1.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(decode.allocator->connectorRefBlocksNum(), 0u);
+    EXPECT_EQ(prefill_rank0.allocator->freeBlocksNum(), prefill_rank0_baseline_free);
+    EXPECT_EQ(prefill_rank1.allocator->freeBlocksNum(), prefill_rank1_baseline_free);
+    EXPECT_EQ(decode.allocator->freeBlocksNum(), decode_baseline_free);
+    EXPECT_EQ(prefill_rank0.allocator->availableBlocksNum(), prefill_rank0_baseline_free);
+    EXPECT_EQ(prefill_rank1.allocator->availableBlocksNum(), prefill_rank1_baseline_free);
+    EXPECT_EQ(decode.allocator->availableBlocksNum(), decode_baseline_free);
+}
+
+TEST_F(CachePDSmokeTest, MultiTypeGroupsTcpRoundTripPreservesLayerTags) {
+    const auto config = makeMultiGroupCacheSmokeConfig();
+    PdEndpoint prefill(config);
+    PdEndpoint decode(config);
+    ASSERT_TRUE(prefill.init());
+    ASSERT_TRUE(decode.init({prefill.port}));
+    auto* prefill_hybrid = dynamic_cast<HybridPoolKVCacheAllocator*>(prefill.allocator.get());
+    auto* decode_hybrid  = dynamic_cast<HybridPoolKVCacheAllocator*>(decode.allocator.get());
+    ASSERT_NE(prefill_hybrid, nullptr);
+    ASSERT_NE(decode_hybrid, nullptr);
+    const auto prefill_baseline = snapshotCacheSmokePools(*prefill_hybrid);
+    const auto decode_baseline  = snapshotCacheSmokePools(*decode_hybrid);
+    const auto keys             = makeCacheKeys(/*begin=*/900, /*count=*/5);
+    auto       tokens           = makeCacheSmokeTokenIds(config, makeTokenRange(/*begin=*/1, /*count=*/20));
+    auto       prefill_batch    = makeCacheSmokeResource(config, keys);
+    auto       decode_batch     = makeCacheSmokeResource(config, keys);
+    ASSERT_TRUE(
+        allocateCacheSmokeResource(prefill.allocator, prefill_batch, tokens, /*enable_device_cache=*/true).success);
+    ASSERT_TRUE(
+        allocateCacheSmokeResource(decode.allocator, decode_batch, tokens, /*enable_device_cache=*/true).success);
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*prefill.allocator, prefill_batch->cacheResource(0), /*seed=*/71));
+    ASSERT_NO_FATAL_FAILURE(fillAllocatorResource(*decode.allocator, decode_batch->cacheResource(0), /*seed=*/0));
+    auto prefill_hold = prefill.allocator->incrKVCacheRef(prefill_batch->cacheResource(0), keys, /*is_connector=*/true);
+    auto decode_hold  = decode.allocator->incrKVCacheRef(decode_batch->cacheResource(0), keys, /*is_connector=*/true);
+    ASSERT_NE(prefill_hold, nullptr);
+    ASSERT_NE(decode_hold, nullptr);
+    prefill.allocator->free(FreeInfo{prefill_batch, tokens});
+    decode.allocator->free(FreeInfo{decode_batch, tokens});
+    auto buffers = LayerCacheBufferUtil::convert(*decode_hold, /*batch_id=*/0);
+    // Layer-tag buffers: layer 0 has 2 groups, layer 1 has 3, and layer 2 has 2.
+    ASSERT_EQ(buffers.size(), 7u);
+    const int64_t     request_id           = 9101;
+    const std::string unique_key           = "cache-smoke-multi";
+    const int64_t     deadline_ms          = currentTimeMs() + 10000;
+    auto              decode_result_future = std::async(std::launch::async, [&]() {
+        return decode.worker->read(request_id, unique_key, deadline_ms, buffers, /*remote_tp_size=*/1);
+    });
+    for (int layer_id = 0; layer_id < static_cast<int>(config.layer_num); ++layer_id) {
+        ASSERT_TRUE(prefill.worker->writeByLayer(layer_id, prefill_hold, request_id, std::nullopt));
+    }
+    const auto send_result =
+        prefill.worker->sendKVCache(request_id, unique_key, deadline_ms, {{"127.0.0.1", decode.port}});
+    ASSERT_TRUE(send_result.ok()) << send_result.ToString();
+    ASSERT_EQ(decode_result_future.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    const auto decode_result = decode_result_future.get();
+    ASSERT_TRUE(decode_result.ok()) << decode_result.ToString();
+    ASSERT_NO_FATAL_FAILURE(
+        expectAllocatorResourcesEqual(*prefill.allocator, *prefill_hold, *decode.allocator, *decode_hold));
+    prefill_hold.reset();
+    decode_hold.reset();
+    ASSERT_NO_FATAL_FAILURE(expectCacheSmokePoolsEqual(*prefill_hybrid, prefill_baseline));
+    ASSERT_NO_FATAL_FAILURE(expectCacheSmokePoolsEqual(*decode_hybrid, decode_baseline));
+}
+
+}  // namespace rtp_llm::test

--- a/rtp_llm/cpp/cache/smoke/CacheSmokeMain.cc
+++ b/rtp_llm/cpp/cache/smoke/CacheSmokeMain.cc
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "autil/Log.h"
+#include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
+
+namespace {
+
+const std::string kCacheSmokeLogConfig = R"conf(
+alog.rootLogger=INFO, cacheSmokeAppender
+alog.max_msg_len=4096
+alog.appender.cacheSmokeAppender=ConsoleAppender
+alog.appender.cacheSmokeAppender.flush=true
+alog.appender.cacheSmokeAppender.layout=PatternLayout
+alog.appender.cacheSmokeAppender.layout.LogPattern=[%%d] [%%l] [%%t,%%F -- %%f():%%n] [%%m]
+alog.logger.arpc=WARN
+alog.logger.kmonitor=WARN
+)conf";
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    rtp_llm::initKmonitorFactory();
+    AUTIL_LOG_CONFIG_FROM_STRING(kCacheSmokeLogConfig.c_str());
+    ::testing::InitGoogleTest(&argc, argv);
+    const int result = RUN_ALL_TESTS();
+    rtp_llm::stopKmonitorFactory();
+    return result;
+}

--- a/rtp_llm/cpp/cache/smoke/CacheSmokeTestUtils.h
+++ b/rtp_llm/cpp/cache/smoke/CacheSmokeTestUtils.h
@@ -1,0 +1,363 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <c10/cuda/CUDAStream.h>
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include "rtp_llm/cpp/cache/BatchKVCacheResource.h"
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/HybridPoolKVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/KVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/KVCacheManager.h"
+#include "rtp_llm/cpp/cache/SingleTypeKVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
+#include "rtp_llm/cpp/engine_base/stream/CompleteTokenIds.h"
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm::test {
+
+inline void initCacheSmokeRuntime() {
+    if (!isRuntimeInitialized()) {
+        initRuntime(/*device_id=*/0,
+                    /*trace_memory=*/false,
+                    /*enable_comm_overlap=*/false,
+                    MlaOpsType::AUTO);
+    }
+}
+
+inline CacheConfig makeCacheSmokeConfig(int block_num = 8, DataType dtype = DataType::TYPE_INT8) {
+    return makeSimpleMhaCacheConfig(/*layer_num=*/2,
+                                    block_num,
+                                    /*tokens_per_block=*/4,
+                                    dtype,
+                                    /*local_head_num_kv=*/2,
+                                    /*size_per_head=*/8);
+}
+
+inline CacheConfig makeMultiGroupCacheSmokeConfig() {
+    constexpr uint32_t kBlockNum       = 10;
+    constexpr uint32_t kTokensPerBlock = 4;
+
+    CacheConfig config;
+    config.dtype                       = DataType::TYPE_FP16;
+    config.layer_num                   = 3;
+    config.layer_all_num               = 3;
+    config.block_num                   = kBlockNum;
+    config.seq_size_per_block          = kTokensPerBlock;
+    config.kernel_seq_size_per_block   = kTokensPerBlock;
+    config.linear_step                 = 1;
+    config.use_independent_block_pools = true;
+
+    const std::vector<std::string> tags = {
+        "shared_full", "layer0_linear", "layer1_swa", "layer1_full", "layer2_linear"};
+    std::vector<KVCacheSpecPtr> specs = {
+        makeResolvedMhaSpec(config.dtype, 1, 2, kTokensPerBlock, tags[0]),
+        makeResolvedLinearSpec(config.dtype, 1, 1, 2, 2, 2, kTokensPerBlock, config.dtype, config.dtype, tags[1]),
+        makeResolvedMhaSpec(config.dtype, 1, 2, kTokensPerBlock, tags[2]),
+        makeResolvedMhaSpec(config.dtype, 1, 2, kTokensPerBlock, tags[3]),
+        makeResolvedLinearSpec(config.dtype, 1, 1, 2, 2, 2, kTokensPerBlock, config.dtype, config.dtype, tags[4]),
+    };
+    const std::vector<std::vector<int>> layers_by_group = {{0, 1, 2}, {0}, {1}, {1}, {2}};
+    const std::vector<CacheGroupType>   group_types     = {
+        CacheGroupType::FULL,
+        CacheGroupType::LINEAR,
+        CacheGroupType::SWA,
+        CacheGroupType::FULL,
+        CacheGroupType::LINEAR,
+    };
+    config.fromGroupedSpecs(specs, layers_by_group, group_types, tags);
+
+    std::vector<uint32_t> block_nums(specs.size(), kBlockNum);
+    std::vector<size_t>   kv_strides;
+    std::vector<size_t>   scale_strides;
+    kv_strides.reserve(specs.size());
+    scale_strides.reserve(specs.size());
+    for (const auto& spec : specs) {
+        kv_strides.push_back(spec->block_size_bytes());
+        scale_strides.push_back(spec->scale_block_size_bytes());
+    }
+    config.setGroupBlockLayout(block_nums, kv_strides, scale_strides);
+
+    // This isolated smoke config intentionally avoids the production creator. Independent pools consume the
+    // per-group layout stored in topology, so keep the hand-built layout tied directly to each group's spec.
+    const auto configured_block_nums    = config.groupBlockNumsSnapshot();
+    const auto configured_kv_strides    = config.groupKvBlockStrideBytesSnapshot();
+    const auto configured_scale_strides = config.groupKvScaleStrideBytesSnapshot();
+    RTP_LLM_CHECK_WITH_INFO(configured_block_nums == block_nums, "multi-group smoke block counts are inconsistent");
+    RTP_LLM_CHECK_WITH_INFO(configured_kv_strides == kv_strides, "multi-group smoke KV strides are inconsistent");
+    RTP_LLM_CHECK_WITH_INFO(configured_scale_strides == scale_strides,
+                            "multi-group smoke scale strides are inconsistent");
+    for (size_t gid = 0; gid < specs.size(); ++gid) {
+        const auto& configured_spec = config.specForGroup(gid);
+        RTP_LLM_CHECK_WITH_INFO(configured_spec != nullptr, "multi-group smoke spec is null for gid=%zu", gid);
+        RTP_LLM_CHECK_WITH_INFO(configured_spec->block_size_bytes() == configured_kv_strides[gid],
+                                "multi-group smoke KV stride mismatch for gid=%zu",
+                                gid);
+        RTP_LLM_CHECK_WITH_INFO(configured_spec->scale_block_size_bytes() == configured_scale_strides[gid],
+                                "multi-group smoke scale stride mismatch for gid=%zu",
+                                gid);
+    }
+
+    finalizeTestCacheConfigLayout(config,
+                                  static_cast<size_t>(config.layer_all_num),
+                                  *std::max_element(kv_strides.begin(), kv_strides.end()),
+                                  *std::max_element(scale_strides.begin(), scale_strides.end()));
+    return config;
+}
+
+inline CompleteTokenIdsPtr makeCacheSmokeTokenIds(const CacheConfig& config, const std::vector<int32_t>& tokens) {
+    auto complete_token_ids = std::make_shared<CompleteTokenIds>(
+        /*batch_size=*/1, /*beam_width=*/1, tokens.size() + 32, config.seq_size_per_block);
+    auto input_ids = torch::from_blob(const_cast<int32_t*>(tokens.data()),
+                                      {static_cast<int64_t>(tokens.size())},
+                                      torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU))
+                         .clone();
+    auto generate_input             = std::make_shared<GenerateInput>();
+    generate_input->input_ids       = std::move(input_ids);
+    generate_input->generate_config = std::make_shared<GenerateConfig>();
+    complete_token_ids->init(generate_input);
+    complete_token_ids->setSeqLength(static_cast<int>(tokens.size()));
+    return complete_token_ids;
+}
+
+inline std::vector<int32_t> makeTokenRange(int32_t begin, int count) {
+    std::vector<int32_t> tokens(static_cast<size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        tokens[static_cast<size_t>(i)] = begin + i;
+    }
+    return tokens;
+}
+
+inline CacheKeysType makeCacheKeys(CacheKeyType begin, int count) {
+    CacheKeysType keys(static_cast<size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        keys[static_cast<size_t>(i)] = begin + i;
+    }
+    return keys;
+}
+
+inline BatchKVCacheResourcePtr makeCacheSmokeResource(const CacheConfig& config, const CacheKeysType& cache_keys) {
+    auto resource = std::make_shared<BatchKVCacheResource>();
+    resource->resetBatchSize(1);
+    resource->initGroups(config.topologyPtr());
+    resource->setBatchCacheKeys(/*batch_id=*/0, cache_keys);
+    return resource;
+}
+
+inline MallocResult allocateCacheSmokeResource(const KVCacheAllocatorPtr&     allocator,
+                                               const BatchKVCacheResourcePtr& resource,
+                                               const CompleteTokenIdsPtr&     token_ids,
+                                               bool                           enable_device_cache = false) {
+    MallocInfo malloc_info{resource, token_ids};
+    malloc_info.reuse_cache         = enable_device_cache;
+    malloc_info.enable_device_cache = enable_device_cache;
+    return allocator->malloc(malloc_info);
+}
+
+inline torch::Tensor byteTensorForBlockInfo(const BlockInfo& info) {
+    auto options = torch::TensorOptions().dtype(torch::kUInt8);
+    if (info.is_cuda) {
+        options = options.device(torch::Device(torch::kCUDA, info.device_index));
+    } else {
+        options = options.device(torch::kCPU);
+    }
+    return torch::from_blob(info.addr, {static_cast<int64_t>(info.size_bytes)}, options);
+}
+
+inline void synchronizeCacheSmokeDevice() {
+    at::cuda::getCurrentCUDAStream().synchronize();
+}
+
+inline void fillBlockInfos(const std::vector<BlockInfo>& infos, uint8_t seed) {
+    ASSERT_FALSE(infos.empty());
+    for (size_t i = 0; i < infos.size(); ++i) {
+        ASSERT_NE(infos[i].addr, nullptr);
+        ASSERT_GT(infos[i].size_bytes, 0u);
+        auto bytes   = byteTensorForBlockInfo(infos[i]);
+        auto pattern = torch::arange(static_cast<int64_t>(infos[i].size_bytes),
+                                     torch::TensorOptions().dtype(torch::kInt64).device(bytes.device()));
+        pattern =
+            torch::remainder(pattern + static_cast<int64_t>(seed) + static_cast<int64_t>(i), 256).to(torch::kUInt8);
+        bytes.copy_(pattern);
+    }
+    synchronizeCacheSmokeDevice();
+}
+
+inline std::vector<uint8_t> readBlockInfoBytes(const BlockInfo& info) {
+    auto cpu = byteTensorForBlockInfo(info).cpu();
+    synchronizeCacheSmokeDevice();
+    std::vector<uint8_t> bytes(info.size_bytes);
+    std::memcpy(bytes.data(), cpu.data_ptr(), info.size_bytes);
+    return bytes;
+}
+
+inline std::vector<BlockInfo> allocatorBlockInfos(const KVCacheAllocator& allocator,
+                                                  int                     layer_id,
+                                                  const std::string&      tag,
+                                                  BlockIdxType            block_id,
+                                                  int                     partition_count,
+                                                  int                     partition_id) {
+    return allocator.convertIndexToBufferByTag(layer_id, tag, block_id, partition_count, partition_id);
+}
+
+inline std::vector<BlockInfo>
+allocatorBlockInfos(const KVCacheAllocator& allocator, int layer_id, const std::string& tag, BlockIdxType block_id) {
+    return allocatorBlockInfos(allocator, layer_id, tag, block_id, /*partition_count=*/1, /*partition_id=*/0);
+}
+
+inline std::vector<BlockInfo>
+allocatorBlockInfos(const KVCacheAllocator& allocator, int layer_id, BlockIdxType block_id) {
+    return allocatorBlockInfos(allocator, layer_id, "default", block_id);
+}
+
+inline std::vector<BlockInfo> managerBlockInfos(const KVCacheManager& manager, int layer_id, BlockIdxType block_id) {
+    return manager.convertIndexToBufferByTag(
+        block_id, layer_id, /*tag=*/"default", /*partition_count=*/1, /*partition_id=*/0);
+}
+
+inline void fillAllocatorResource(const KVCacheAllocator& allocator, const KVCacheResource& resource, uint8_t seed) {
+    for (int layer_id = 0; layer_id < resource.layerNum(); ++layer_id) {
+        const auto& tags = resource.groupTagsForLayer(layer_id);
+        for (size_t group_pos = 0; group_pos < tags.size(); ++group_pos) {
+            const auto& blocks = resource.blocksForLayer(layer_id, tags[group_pos]);
+            for (size_t block_pos = 0; block_pos < blocks.size(); ++block_pos) {
+                if (isNullBlockIdx(blocks[block_pos])) {
+                    continue;
+                }
+                ASSERT_NO_FATAL_FAILURE(
+                    fillBlockInfos(allocatorBlockInfos(allocator, layer_id, tags[group_pos], blocks[block_pos]),
+                                   static_cast<uint8_t>(seed + layer_id * 31 + group_pos * 17 + block_pos * 7)));
+            }
+        }
+    }
+}
+
+inline void expectAllocatorResourcePartitionsEqual(const KVCacheAllocator& src_allocator,
+                                                   const KVCacheResource&  src_resource,
+                                                   int                     src_partition_count,
+                                                   int                     src_partition_id,
+                                                   const KVCacheAllocator& dst_allocator,
+                                                   const KVCacheResource&  dst_resource,
+                                                   int                     dst_partition_count,
+                                                   int                     dst_partition_id) {
+    ASSERT_GT(src_partition_count, 0);
+    ASSERT_GE(src_partition_id, 0);
+    ASSERT_LT(src_partition_id, src_partition_count);
+    ASSERT_GT(dst_partition_count, 0);
+    ASSERT_GE(dst_partition_id, 0);
+    ASSERT_LT(dst_partition_id, dst_partition_count);
+    ASSERT_EQ(src_resource.layerNum(), dst_resource.layerNum());
+    ASSERT_EQ(src_resource.cacheKeys(), dst_resource.cacheKeys());
+    for (int layer_id = 0; layer_id < src_resource.layerNum(); ++layer_id) {
+        ASSERT_EQ(src_resource.groupTagsForLayer(layer_id), dst_resource.groupTagsForLayer(layer_id));
+        for (const auto& tag : src_resource.groupTagsForLayer(layer_id)) {
+            const auto& src_blocks = src_resource.blocksForLayer(layer_id, tag);
+            const auto& dst_blocks = dst_resource.blocksForLayer(layer_id, tag);
+            ASSERT_EQ(src_blocks.size(), dst_blocks.size()) << "layer=" << layer_id << " tag=" << tag;
+            for (size_t block_pos = 0; block_pos < src_blocks.size(); ++block_pos) {
+                ASSERT_EQ(isNullBlockIdx(src_blocks[block_pos]), isNullBlockIdx(dst_blocks[block_pos]))
+                    << "layer=" << layer_id << " tag=" << tag << " block_pos=" << block_pos;
+                if (isNullBlockIdx(src_blocks[block_pos])) {
+                    continue;
+                }
+                auto src_infos = allocatorBlockInfos(
+                    src_allocator, layer_id, tag, src_blocks[block_pos], src_partition_count, src_partition_id);
+                auto dst_infos = allocatorBlockInfos(
+                    dst_allocator, layer_id, tag, dst_blocks[block_pos], dst_partition_count, dst_partition_id);
+                ASSERT_FALSE(src_infos.empty()) << "layer=" << layer_id << " tag=" << tag << " block_pos=" << block_pos;
+                ASSERT_FALSE(dst_infos.empty()) << "layer=" << layer_id << " tag=" << tag << " block_pos=" << block_pos;
+                ASSERT_EQ(src_infos.size(), dst_infos.size())
+                    << "layer=" << layer_id << " tag=" << tag << " block_pos=" << block_pos;
+                for (size_t buffer_id = 0; buffer_id < src_infos.size(); ++buffer_id) {
+                    EXPECT_EQ(readBlockInfoBytes(src_infos[buffer_id]), readBlockInfoBytes(dst_infos[buffer_id]))
+                        << "layer=" << layer_id << " tag=" << tag << " block_pos=" << block_pos
+                        << " buffer_id=" << buffer_id;
+                }
+            }
+        }
+    }
+}
+
+inline void expectAllocatorResourcesEqual(const KVCacheAllocator& src_allocator,
+                                          const KVCacheResource&  src_resource,
+                                          const KVCacheAllocator& dst_allocator,
+                                          const KVCacheResource&  dst_resource) {
+    ASSERT_NO_FATAL_FAILURE(expectAllocatorResourcePartitionsEqual(src_allocator,
+                                                                   src_resource,
+                                                                   /*src_partition_count=*/1,
+                                                                   /*src_partition_id=*/0,
+                                                                   dst_allocator,
+                                                                   dst_resource,
+                                                                   /*dst_partition_count=*/1,
+                                                                   /*dst_partition_id=*/0));
+}
+
+inline void drainAllocatorCache(const KVCacheAllocatorPtr& allocator) {
+    while (auto evicted = allocator->popBlocksFromCache(allocator->totalBlocksNum())) {
+        allocator->blockCacheFree(evicted);
+    }
+}
+
+inline SingleTypeKVCacheAllocatorPtr makeCacheSmokeAllocator(const CacheConfig& config, bool enable_prefix_cache) {
+    auto allocator = std::make_shared<SingleTypeKVCacheAllocator>(config);
+    if (enable_prefix_cache) {
+        allocator->setSharedBlockCache(std::make_shared<SharedBlockCache>());
+    }
+    return allocator;
+}
+
+inline KVCacheAllocatorPtr makeCacheSmokeAllocatorForConfig(const CacheConfig& config, bool enable_prefix_cache) {
+    KVCacheAllocatorPtr allocator;
+    if (config.use_independent_block_pools) {
+        allocator = std::make_shared<HybridPoolKVCacheAllocator>(config);
+    } else {
+        allocator = std::make_shared<SingleTypeKVCacheAllocator>(config);
+    }
+    if (enable_prefix_cache) {
+        allocator->setSharedBlockCache(std::make_shared<SharedBlockCache>());
+    }
+    return allocator;
+}
+
+struct CacheSmokePoolCounters {
+    size_t free_blocks;
+    size_t available_blocks;
+    size_t request_refs;
+    size_t block_cache_refs;
+    size_t connector_refs;
+};
+
+inline std::vector<CacheSmokePoolCounters> snapshotCacheSmokePools(const HybridPoolKVCacheAllocator& allocator) {
+    std::vector<CacheSmokePoolCounters> counters;
+    counters.reserve(allocator.groupBlockPools().size());
+    for (const auto& pool : allocator.groupBlockPools()) {
+        counters.push_back({pool->freeBlocksNum(),
+                            pool->availableBlocksNum(),
+                            pool->requestRefBlocksNum(),
+                            pool->blockCacheRefBlocksNum(),
+                            pool->connectorRefBlocksNum()});
+    }
+    return counters;
+}
+
+inline void expectCacheSmokePoolsEqual(const HybridPoolKVCacheAllocator&          allocator,
+                                       const std::vector<CacheSmokePoolCounters>& expected) {
+    ASSERT_EQ(allocator.groupBlockPools().size(), expected.size());
+    for (size_t gid = 0; gid < expected.size(); ++gid) {
+        const auto& pool = allocator.groupBlockPools()[gid];
+        EXPECT_EQ(pool->freeBlocksNum(), expected[gid].free_blocks) << "gid=" << gid;
+        EXPECT_EQ(pool->availableBlocksNum(), expected[gid].available_blocks) << "gid=" << gid;
+        EXPECT_EQ(pool->requestRefBlocksNum(), expected[gid].request_refs) << "gid=" << gid;
+        EXPECT_EQ(pool->blockCacheRefBlocksNum(), expected[gid].block_cache_refs) << "gid=" << gid;
+        EXPECT_EQ(pool->connectorRefBlocksNum(), expected[gid].connector_refs) << "gid=" << gid;
+    }
+}
+
+}  // namespace rtp_llm::test

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rtp_llm/cpp/cache/CacheConfig.h"
@@ -435,6 +436,36 @@ inline KVCacheSpecPtr makeLinearSpec(const std::string& tag,
     return SpecBuilder::build(desc, ctx);
 }
 
+inline void setTestTopologyLocalKvHeadNum(CacheConfig& config, uint32_t local_head_num_kv) {
+    RTP_LLM_CHECK_WITH_INFO(local_head_num_kv > 0, "local_head_num_kv must be > 0");
+    auto groups = config.topology().groups();
+    auto layers = config.topology().layers();
+    RTP_LLM_CHECK_WITH_INFO(!groups.empty(), "test cache topology must contain at least one group");
+    for (auto& group : groups) {
+        group.local_kv_head_num = local_head_num_kv;
+    }
+    config.setTopology(std::move(groups), std::move(layers));
+}
+
+inline void finalizeTestCacheConfigLayout(CacheConfig& config,
+                                          size_t       layout_layer_num,
+                                          size_t       kv_block_stride_bytes,
+                                          size_t       kv_scale_stride_bytes) {
+    RTP_LLM_CHECK_WITH_INFO(config.layer_all_num > 0, "test cache config must contain at least one layer");
+    RTP_LLM_CHECK_WITH_INFO(layout_layer_num > 0, "test cache layout must contain at least one layer");
+    RTP_LLM_CHECK_WITH_INFO(kv_block_stride_bytes > 0, "test cache KV block stride must be > 0");
+
+    config.kv_block_stride_bytes = kv_block_stride_bytes;
+    config.kv_scale_stride_bytes = kv_scale_stride_bytes;
+    config.kv_block_size_bytes   = layout_layer_num * config.kv_block_stride_bytes;
+    config.kv_scale_size_bytes   = layout_layer_num * config.kv_scale_stride_bytes;
+    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
+
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
+}
+
 inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
                                             int               block_num,
                                             size_t            tokens_per_block,
@@ -456,16 +487,10 @@ inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
         layer_ids[i] = i;
     }
     config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::FULL}, {"default"});
+    setTestTopologyLocalKvHeadNum(config, local_head_num_kv);
 
-    config.kv_block_stride_bytes = spec->block_size_bytes();
-    config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
-    config.kv_scale_stride_bytes = spec->scale_block_size_bytes();
-    config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
-    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-
-    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
-    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
-                                              static_cast<int>(per_layer_stride_bytes));
+    finalizeTestCacheConfigLayout(
+        config, static_cast<size_t>(layer_num), spec->block_size_bytes(), spec->scale_block_size_bytes());
 
     return config;
 }
@@ -491,16 +516,10 @@ inline CacheConfig makeSimpleLinearCacheConfig(int               layer_num,
         layer_ids[i] = i;
     }
     config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::LINEAR}, {"linear"});
+    setTestTopologyLocalKvHeadNum(config, local_head_num_kv);
 
-    config.kv_block_stride_bytes = spec->block_size_bytes();
-    config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
-    config.kv_scale_stride_bytes = spec->scale_block_size_bytes();
-    config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
-    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-
-    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
-    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
-                                              static_cast<int>(per_layer_stride_bytes));
+    finalizeTestCacheConfigLayout(
+        config, static_cast<size_t>(layer_num), spec->block_size_bytes(), spec->scale_block_size_bytes());
 
     return config;
 }
@@ -559,16 +578,12 @@ inline CacheConfig makeSimpleHybridMhaCacheConfig(int               layer_num,
         layers_by_group.push_back(std::move(group_layers));
     }
     config.fromGroupedSpecs(specs, layers_by_group, types, tags);
+    setTestTopologyLocalKvHeadNum(config, local_head_num_kv);
 
-    config.kv_block_stride_bytes = std::max(full_spec->block_size_bytes(), linear_spec->block_size_bytes());
-    config.kv_block_size_bytes   = static_cast<size_t>(config.group_layer_num) * config.kv_block_stride_bytes;
-    config.kv_scale_stride_bytes = full_spec->scale_block_size_bytes();
-    config.kv_scale_size_bytes   = static_cast<size_t>(config.group_layer_num) * config.kv_scale_stride_bytes;
-    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-
-    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
-    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
-                                              static_cast<int>(per_layer_stride_bytes));
+    finalizeTestCacheConfigLayout(config,
+                                  static_cast<size_t>(config.group_layer_num),
+                                  std::max(full_spec->block_size_bytes(), linear_spec->block_size_bytes()),
+                                  full_spec->scale_block_size_bytes());
     return config;
 }
 

--- a/rtp_llm/cpp/cache/test/KVCacheManagerTest.cc
+++ b/rtp_llm/cpp/cache/test/KVCacheManagerTest.cc
@@ -300,6 +300,38 @@ TEST_F(KVCacheManagerTest, WarmupConfigSmoke) {
     EXPECT_EQ(cache_manager->freeBlocksNum(), 0);
 }
 
+TEST_F(KVCacheManagerTest, SimpleConfigHelpersPropagateLocalKvHeadNumToEveryGroup) {
+    constexpr uint32_t kLocalKvHeadNum       = 3;
+    const auto         expect_local_kv_heads = [=](const CacheConfig& config, size_t expected_group_count) {
+        EXPECT_EQ(config.topology().groups().size(), expected_group_count);
+        for (const auto& group : config.topology().groups()) {
+            EXPECT_EQ(group.local_kv_head_num, kLocalKvHeadNum) << "tag=" << group.tag;
+        }
+    };
+
+    const auto mha = makeSimpleMhaCacheConfig(/*layer_num=*/2,
+                                              /*block_num=*/4,
+                                              /*tokens_per_block=*/2,
+                                              rtp_llm::DataType::TYPE_FP16,
+                                              kLocalKvHeadNum);
+    expect_local_kv_heads(mha, /*expected_group_count=*/1);
+
+    const auto linear = makeSimpleLinearCacheConfig(/*layer_num=*/2,
+                                                    /*block_num=*/4,
+                                                    /*tokens_per_block=*/2,
+                                                    rtp_llm::DataType::TYPE_FP16,
+                                                    kLocalKvHeadNum);
+    expect_local_kv_heads(linear, /*expected_group_count=*/1);
+
+    const auto hybrid = makeSimpleHybridMhaCacheConfig(/*layer_num=*/6,
+                                                       /*block_num=*/4,
+                                                       /*tokens_per_block=*/2,
+                                                       rtp_llm::DataType::TYPE_FP16,
+                                                       /*group_layer_num=*/2,
+                                                       kLocalKvHeadNum);
+    expect_local_kv_heads(hybrid, /*expected_group_count=*/3);
+}
+
 TEST_F(KVCacheManagerTest, InitRejectsSingleLinearGroup) {
     auto cache_config = makeSimpleLinearCacheConfig(
         /*layer_num=*/2, /*block_num=*/4, /*tokens_per_block=*/2, rtp_llm::DataType::TYPE_BF16);


### PR DESCRIPTION
## Summary

- Add standalone KV cache lifecycle and PD smoke targets without changing production cache or P2P APIs.
- Keep MHA, Linear, and Hybrid simple cache-config helpers consistent by propagating `local_kv_head_num` to every topology group, with focused multi-group coverage.
- Exercise a 3-layer, 5-group hybrid topology across FULL, LINEAR, and SWA groups, including tag-aware allocation, block-copy isolation, prefix reuse, release/reallocation, and per-pool recycling.
- Make smoke helpers derive token blocks from `CacheConfig::seq_size_per_block`, validate per-group layout and stride contracts, and guard block-info access with fatal assertions.
- Cover TCP PD round-trip, read timeout without a prefill sender, connector reference release, TP>1 2P1D shard aggregation, bounded endpoint initialization retries, and resource-count recovery.

## Validation

Validated in a CUDA 12.9 GPU environment with the daily remote cache and GPU lock:

- `//rtp_llm/cpp/cache/test:kv_cache_manager_test`
- `//rtp_llm/cpp/cache/test:single_type_kv_cache_allocator_test`
- `//rtp_llm/cpp/cache/test:hybrid_kv_cache_allocator_test`
- `//rtp_llm/cpp/cache/test:memory_connector_test`
- `//rtp_llm/cpp/cache/test:p2p_connector_worker_test`
- `//rtp_llm/cpp/cache/smoke:cache_pd_smoke_test`
- `//rtp_llm/cpp/cache/smoke:cache_framework_smoke --runs_per_test=3`
- Pre-commit checks for all changed source files

The complete PR diff passes the code-review checklist with no P0–P3 findings.

## Residual Risk

The hermetic PD smoke uses TCP. The real RDMA transport path still requires validation in an RDMA-enabled environment.