### PR TITLE
fix(pd): propagate reuse blocks and add ROCm Qwen3.5 FP8 smoke

### DIFF
--- a/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/DecodeRpcServer.cc
@@ -323,6 +323,7 @@ BroadcastLoadRequestPB DecodeRpcServer::constructRemoteLoadRequestForMla(
             }
         }
     }
+    request.set_reuse_block_size(load_context.reuse_block_size);
     request.set_timeout_ms(load_context.timeout_ms);
     return request;
 }
@@ -385,6 +386,7 @@ BroadcastLoadRequestPB DecodeRpcServer::constructRemoteLoadRequest(const LoadKVC
             }
         }
     }
+    request.set_reuse_block_size(load_context.reuse_block_size);
     request.set_timeout_ms(load_context.timeout_ms);
     return request;
 }


### PR DESCRIPTION
## Summary
- fix TP>1 decode RPCs so every remote worker receives `reuse_block_size`
- keep reuse units consistent across ordinary, CP-sharded, and compact fixed-block cache tables
- add focused CPU coverage for request construction, invalid reuse fallback, CP/compact planning, tail policies, and tagged group rows
- add a dedicated Qwen3.5 FP8 ROCm PD-separation smoke on MI308X

## Reuse semantics and rollout
`BroadcastLoadRequestPB.reuse_block_size` remains wire field 7 and is expressed in global logical blocks (`reuse_length / seq_size_per_block`). Cache load/store planners convert it to CP page units where required. Negative or out-of-range values conservatively fall back to a full transfer instead of silently producing an empty plan.

Decode and worker processes for one service must be rolled out from the same build. The existing `--reuse_cache 0` / `REUSE_CACHE=0` switch is the operational rollback: it makes the generated reuse length zero and restores the previous full-load behavior without a protocol change.

## Validation
- focused cache planner and DecodeRpcServer unit tests
- ROCm golden regenerated and replay-validated on MI308X (gfx942, ROCm 7)

## Coverage boundaries
The ROCm smoke intentionally covers single-host local TCP PD with the attention backend defaults pinned explicitly. It does not cover cross-host RDMA, CUDA graph, or a non-zero reuse hit: its short prompt is below the 1024-token logical block size. Non-zero reuse and CP compact conversion are covered by zero-GPU planner tests; broader end-to-end variants should remain separate to avoid adding another four-GPU gate to this PR.