### PR TITLE
Develop/hengcang/newloader deepseek v3

### DIFF
--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -149,9 +149,14 @@ class LoadConfig:
     def __init__(self):
         self.load_method: str = "auto"
         self.force_cpu_load_weights: bool = False
+        self.keep_mla_checkpoint_weights: bool = False
 
     def to_string(self):
-        return f"load_method: {self.load_method}\nforce_cpu_load_weights: {self.force_cpu_load_weights}"
+        return (
+            f"load_method: {self.load_method}\n"
+            f"force_cpu_load_weights: {self.force_cpu_load_weights}\n"
+            f"keep_mla_checkpoint_weights: {self.keep_mla_checkpoint_weights}"
+        )
 
 
 class RenderConfig:

--- a/rtp_llm/cpp/cache/BUILD
+++ b/rtp_llm/cpp/cache/BUILD
@@ -78,6 +78,18 @@ cc_library(
 )
 
 cc_library(
+    name = "block_pool_config",
+    hdrs = [
+        "BlockPoolConfig.h",
+        "BlockPoolConfigHelper.h",
+        "MemoryLayoutConfig.h",
+    ],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [":cache_types"],
+)
+
+cc_library(
     name = "block_pool",
     srcs = [
         "BlockCache.cc",
@@ -87,15 +99,13 @@ cc_library(
     hdrs = [
         "BlockCache.h",
         "BlockPool.h",
-        "BlockPoolConfig.h",
-        "BlockPoolConfigHelper.h",
         "BlockRefCounter.h",
         "MemoryLayoutStrategy.h",
-        "MemoryLayoutConfig.h",
     ],
     copts = copts(),
     visibility = ["//visibility:public"],
     deps = [
+        ":block_pool_config",
         ":cache_types",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/cpp/disaggregate/cache_store",

--- a/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
+++ b/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
@@ -46,9 +46,8 @@ public:
         for (size_t i = 0; i < cache_config.mtp_sub_configs.size(); ++i) {
             const auto& mtp_sub_config = cache_config.mtp_sub_configs[i];
             RTP_LLM_CHECK_WITH_INFO(mtp_sub_config != nullptr, "mtp_sub_configs[%zu] is null", i);
-            RTP_LLM_CHECK_WITH_INFO(mtp_sub_config->groupNums() > 0,
-                                    "MTP module %zu cache groups must not be empty",
-                                    i);
+            RTP_LLM_CHECK_WITH_INFO(
+                mtp_sub_config->groupNums() > 0, "MTP module %zu cache groups must not be empty", i);
 
             const auto mtp_layer_num = mtp_sub_config->layer_num;
 
@@ -60,16 +59,22 @@ public:
                 }
             }
             const auto& mtp_spec = mtp_sub_config->specForGroup(real_mtp_gid);
+            // Sparse attention stores the quantized indexer K cache in the
+            // scale pool. Its stride is an explicit CacheConfig override and
+            // therefore is not represented by the MLA spec's scale size.
+            const auto mtp_scale_stride_bytes =
+                mtp_sub_config->is_sparse ? mtp_sub_config->kv_scale_stride_bytes : mtp_spec->scale_block_size_bytes();
             // MTP block size may differ from the main model. Use the real
             // MTP group that owns a layer; target-aligned placeholder groups
             // must not affect the sub-model memory layout.
-            MemoryLayoutConfig mtp_layout = createMemoryLayoutConfig(false,
-                                                                     mtp_layer_num,
-                                                                     mtp_spec->block_size_bytes(),
-                                                                     mtp_spec->scale_block_size_bytes(),
-                                                                     mtp_spec,
-                                                                     cache_config,
-                                                                     mtp_sub_config->localKvHeadNumForGroup(real_mtp_gid));
+            MemoryLayoutConfig mtp_layout =
+                createMemoryLayoutConfig(false,
+                                         mtp_layer_num,
+                                         mtp_spec->block_size_bytes(),
+                                         mtp_scale_stride_bytes,
+                                         mtp_spec,
+                                         *mtp_sub_config,
+                                         mtp_sub_config->localKvHeadNumForGroup(real_mtp_gid));
 
             mtp_layout.kv_cache_offset_bytes = current_offset;
             RTP_LLM_LOG_INFO("mtp_layout.kv_block_pool_size_bytes = %ld", mtp_layout.kv_block_pool_size_bytes);
@@ -143,9 +148,9 @@ private:
         cfg.local_head_num_kv       = local_kv_head_num;
         cfg.enable_hybrid_attention = enable_hybrid_attention;
         // Scale 3D layout for MLA and indexer; KV 3D only for MLA (concat_and_cache_mla)
-        cfg.is_mla             = cache_config.use_mla || cache_config.is_sparse;
-        cfg.use_mla            = cache_config.use_mla;
-        cfg.seq_size_per_block = static_cast<size_t>(cache_config.seq_size_per_block);
+        cfg.is_mla                     = cache_config.use_mla || cache_config.is_sparse;
+        cfg.use_mla                    = cache_config.use_mla;
+        cfg.seq_size_per_block         = static_cast<size_t>(cache_config.seq_size_per_block);
         cfg.kernel_blocks_per_kv_block = cache_config.kernelBlocksPerKvBlock();
 
         cfg.kv_block_pool_size_bytes =

--- a/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
+++ b/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
@@ -67,17 +67,19 @@ public:
                                     "MTP module %zu has no cache group containing layers",
                                     i);
             const auto& mtp_spec = mtp_sub_config->specForGroup(real_mtp_gid);
-            // CacheConfig is the canonical physical-layout source. This is
-            // especially important for sparse MLA, whose indexer cache lives
-            // in the scale pool and is not represented by the logical spec.
-            const auto mtp_scale_stride_bytes = mtp_sub_config->kv_scale_stride_bytes;
-            // MTP block size may differ from the main model. Use the real
-            // MTP group that owns a layer; target-aligned placeholder groups
-            // must not affect the sub-model memory layout.
+            // The selected group owns the physical KV stride, including any
+            // hybrid padding. Sparse MLA is the exception for scale storage:
+            // its indexer cache is not represented by MLAKVCacheSpec (whose
+            // scale size is zero), so SingleConfigCreator records that
+            // physical stride on CacheConfig instead.
+            const auto         mtp_kv_stride_bytes    = mtp_sub_config->kvBlockStrideBytesForGroup(real_mtp_gid);
+            const auto         mtp_scale_stride_bytes = mtp_sub_config->is_sparse ?
+                                                            mtp_sub_config->kv_scale_stride_bytes :
+                                                            mtp_sub_config->kvScaleStrideBytesForGroup(real_mtp_gid);
             MemoryLayoutConfig mtp_layout =
                 createMemoryLayoutConfig(false,
                                          mtp_layer_num,
-                                         mtp_spec->block_size_bytes(),
+                                         mtp_kv_stride_bytes,
                                          mtp_scale_stride_bytes,
                                          mtp_spec,
                                          *mtp_sub_config,

--- a/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
+++ b/rtp_llm/cpp/cache/BlockPoolConfigHelper.h
@@ -48,22 +48,29 @@ public:
             RTP_LLM_CHECK_WITH_INFO(mtp_sub_config != nullptr, "mtp_sub_configs[%zu] is null", i);
             RTP_LLM_CHECK_WITH_INFO(
                 mtp_sub_config->groupNums() > 0, "MTP module %zu cache groups must not be empty", i);
+            RTP_LLM_CHECK_WITH_INFO(mtp_sub_config->block_num == cache_config.block_num,
+                                    "MTP module %zu block_num=%u must match main block_num=%u",
+                                    i,
+                                    mtp_sub_config->block_num,
+                                    cache_config.block_num);
 
             const auto mtp_layer_num = mtp_sub_config->layer_num;
 
-            size_t real_mtp_gid = 0;
+            size_t real_mtp_gid = static_cast<size_t>(mtp_sub_config->groupNums());
             for (size_t gid = 0; gid < static_cast<size_t>(mtp_sub_config->groupNums()); ++gid) {
                 if (!mtp_sub_config->layerIdsForGroup(gid).empty()) {
                     real_mtp_gid = gid;
                     break;
                 }
             }
+            RTP_LLM_CHECK_WITH_INFO(real_mtp_gid < static_cast<size_t>(mtp_sub_config->groupNums()),
+                                    "MTP module %zu has no cache group containing layers",
+                                    i);
             const auto& mtp_spec = mtp_sub_config->specForGroup(real_mtp_gid);
-            // Sparse attention stores the quantized indexer K cache in the
-            // scale pool. Its stride is an explicit CacheConfig override and
-            // therefore is not represented by the MLA spec's scale size.
-            const auto mtp_scale_stride_bytes =
-                mtp_sub_config->is_sparse ? mtp_sub_config->kv_scale_stride_bytes : mtp_spec->scale_block_size_bytes();
+            // CacheConfig is the canonical physical-layout source. This is
+            // especially important for sparse MLA, whose indexer cache lives
+            // in the scale pool and is not represented by the logical spec.
+            const auto mtp_scale_stride_bytes = mtp_sub_config->kv_scale_stride_bytes;
             // MTP block size may differ from the main model. Use the real
             // MTP group that owns a layer; target-aligned placeholder groups
             // must not affect the sub-model memory layout.
@@ -126,13 +133,13 @@ public:
     }
 
 private:
-    static MemoryLayoutConfig createMemoryLayoutConfig(bool           enable_hybrid_attention,
-                                                       uint32_t       layer_num,
-                                                       size_t         kv_block_stride_bytes,
-                                                       size_t         kv_scale_stride_bytes,
-                                                       KVCacheSpecPtr spec,
-                                                       CacheConfig    cache_config,
-                                                       uint32_t       local_kv_head_num) {
+    static MemoryLayoutConfig createMemoryLayoutConfig(bool               enable_hybrid_attention,
+                                                       uint32_t           layer_num,
+                                                       size_t             kv_block_stride_bytes,
+                                                       size_t             kv_scale_stride_bytes,
+                                                       KVCacheSpecPtr     spec,
+                                                       const CacheConfig& cache_config,
+                                                       uint32_t           local_kv_head_num) {
         MemoryLayoutConfig cfg;
         cfg.layer_num             = layer_num;
         cfg.block_num             = cache_config.block_num;

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -63,6 +63,7 @@ cc_test(
     srcs = ["BlockPoolConfigHelperTest.cc"],
     copts = test_copts,
     deps = [
+        ":cache_config_test_utils",
         "//rtp_llm/cpp/cache:block_pool_config",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -58,6 +58,17 @@ cc_library(
     ] + torch_deps(),
 )
 
+cc_test(
+    name = "block_pool_config_helper_test",
+    srcs = ["BlockPoolConfigHelperTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:block_pool_config",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_binary(
     name = "cache_config_creator_py_test",
     linkshared = 1,

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -68,6 +68,8 @@ cc_test(
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
+    env = {},
+    exec_properties = {"gpu": "H20"},
 )
 
 cc_binary(

--- a/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
+++ b/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 
 #include "rtp_llm/cpp/cache/BlockPoolConfigHelper.h"
 #include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
@@ -10,58 +11,35 @@ namespace rtp_llm {
 namespace test {
 namespace {
 
-CacheConfig makeMlaCacheConfig(uint32_t layer_num,
-                               uint32_t block_num,
-                               uint32_t kernel_tokens_per_block,
-                               bool     sparse,
-                               size_t   config_scale_stride_bytes,
-                               size_t   group_scale_stride_bytes) {
-    constexpr uint32_t kSeqSizePerBlock = 4;
-    auto spec = makeMlaSpec("default", kSeqSizePerBlock, DataType::TYPE_BF16, /*kv_lora_rank=*/4, /*rope_head_dim=*/4);
-
-    CacheConfig config;
-    config.dtype                     = DataType::TYPE_BF16;
-    config.layer_num                 = layer_num;
-    config.layer_all_num             = layer_num;
-    config.use_mla                   = true;
-    config.is_sparse                 = sparse;
-    config.block_num                 = block_num;
-    config.seq_size_per_block        = kSeqSizePerBlock;
-    config.kernel_seq_size_per_block = kernel_tokens_per_block;
-    config.kv_block_stride_bytes     = spec->block_size_bytes();
-    config.kv_scale_stride_bytes     = config_scale_stride_bytes;
-
-    GroupBase group;
-    group.spec                  = spec;
-    group.policy                = defaultCacheGroupPolicy(CacheGroupType::FULL);
-    group.local_kv_head_num     = 1;
-    group.kv_block_stride_bytes = config.kv_block_stride_bytes;
-    group.kv_scale_stride_bytes = group_scale_stride_bytes;
-    for (uint32_t layer_id = 0; layer_id < layer_num; ++layer_id) {
-        group.layer_ids.push_back(static_cast<int>(layer_id));
-    }
-    config.groups.push_back(std::move(group));
-    return config;
+CacheConfig makeSparseMlaConfig(uint32_t layer_num,
+                                uint32_t block_num,
+                                size_t   tokens_per_block,
+                                size_t   kernel_tokens_per_block,
+                                size_t   scale_stride_bytes) {
+    return makeSimpleMlaCacheConfig(static_cast<int>(layer_num),
+                                    static_cast<int>(block_num),
+                                    tokens_per_block,
+                                    DataType::TYPE_BF16,
+                                    /*sparse=*/true,
+                                    scale_stride_bytes,
+                                    kernel_tokens_per_block);
 }
 
-TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeConfigAndScaleStride) {
-    auto score_config   = makeMlaCacheConfig(/*layer_num=*/2,
-                                           /*block_num=*/4,
-                                           /*kernel_tokens_per_block=*/4,
-                                           /*sparse=*/true,
-                                           /*config_scale_stride_bytes=*/32,
-                                           /*group_scale_stride_bytes=*/16);
-    auto propose_config = std::make_shared<CacheConfig>(makeMlaCacheConfig(/*layer_num=*/1,
-                                                                           /*block_num=*/3,
-                                                                           /*kernel_tokens_per_block=*/2,
-                                                                           /*sparse=*/true,
-                                                                           /*config_scale_stride_bytes=*/128,
-                                                                           /*group_scale_stride_bytes=*/24));
+TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeTopologyAndScaleStride) {
+    auto score_config   = makeSparseMlaConfig(/*layer_num=*/2,
+                                            /*block_num=*/4,
+                                            /*tokens_per_block=*/4,
+                                            /*kernel_tokens_per_block=*/4,
+                                            /*scale_stride_bytes=*/32);
+    auto propose_config = std::make_shared<CacheConfig>(makeSparseMlaConfig(/*layer_num=*/1,
+                                                                            /*block_num=*/4,
+                                                                            /*tokens_per_block=*/4,
+                                                                            /*kernel_tokens_per_block=*/2,
+                                                                            /*scale_stride_bytes=*/128));
     score_config.mtp_sub_configs.push_back(propose_config);
 
     ASSERT_EQ(propose_config->specForGroup(0)->block_size_bytes(), 64u);
     ASSERT_EQ(propose_config->specForGroup(0)->scale_block_size_bytes(), 0u);
-    ASSERT_NE(propose_config->kv_scale_stride_bytes, propose_config->groups[0].kv_scale_stride_bytes);
 
     const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
     ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
@@ -70,47 +48,116 @@ TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeConfigAndScaleStride)
     EXPECT_EQ(main_layout.block_num, 4u);
     EXPECT_EQ(main_layout.kv_cache_offset_bytes, 0u);
     EXPECT_EQ(main_layout.kv_block_pool_size_bytes, 2u * 4u * 64u);
-    EXPECT_EQ(main_layout.kv_scale_offset_bytes, 2u * 4u * 64u);
+    EXPECT_EQ(main_layout.kv_scale_offset_bytes, 512u);
     EXPECT_EQ(main_layout.kv_scale_pool_size_bytes, 2u * 4u * 32u);
 
     const auto& mtp_layout = pool_config.memory_layouts[1];
     EXPECT_TRUE(mtp_layout.is_mla);
     EXPECT_TRUE(mtp_layout.hasScale());
-    EXPECT_EQ(mtp_layout.block_num, 3u);
+    EXPECT_EQ(mtp_layout.block_num, 4u);
+    EXPECT_EQ(mtp_layout.layer_num, 1u);
+    EXPECT_EQ(mtp_layout.seq_size_per_block, 4u);
     EXPECT_EQ(mtp_layout.kernel_blocks_per_kv_block, 2u);
-    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->kv_scale_stride_bytes);
+    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, 128u);
     EXPECT_EQ(mtp_layout.kv_cache_offset_bytes, 768u);
-    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 3u * 64u);
-    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, 960u);
-    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 1u * 3u * 128u);
-    EXPECT_EQ(pool_config.total_size_bytes, 1344u);
+    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 4u * 64u);
+    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, 1024u);
+    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 1u * 4u * 128u);
+    EXPECT_EQ(pool_config.total_size_bytes, 1536u);
 }
 
-TEST(BlockPoolConfigHelperTest, MTPNonSparseUsesSpecScaleAndNoScalePool) {
-    auto score_config   = makeMlaCacheConfig(/*layer_num=*/2,
-                                           /*block_num=*/4,
-                                           /*kernel_tokens_per_block=*/4,
-                                           /*sparse=*/true,
-                                           /*config_scale_stride_bytes=*/32,
-                                           /*group_scale_stride_bytes=*/16);
-    auto propose_config = std::make_shared<CacheConfig>(makeMlaCacheConfig(/*layer_num=*/1,
-                                                                           /*block_num=*/3,
-                                                                           /*kernel_tokens_per_block=*/2,
-                                                                           /*sparse=*/false,
-                                                                           /*config_scale_stride_bytes=*/128,
-                                                                           /*group_scale_stride_bytes=*/24));
+TEST(BlockPoolConfigHelperTest, MTPNonSparseUsesNonzeroPhysicalScaleStride) {
+    auto score_config   = makeSparseMlaConfig(/*layer_num=*/2,
+                                            /*block_num=*/4,
+                                            /*tokens_per_block=*/4,
+                                            /*kernel_tokens_per_block=*/4,
+                                            /*scale_stride_bytes=*/32);
+    auto propose_config = std::make_shared<CacheConfig>(makeSimpleMhaCacheConfig(/*layer_num=*/1,
+                                                                                 /*block_num=*/4,
+                                                                                 /*tokens_per_block=*/4,
+                                                                                 DataType::TYPE_INT8,
+                                                                                 /*local_head_num_kv=*/1,
+                                                                                 /*size_per_head=*/2));
     score_config.mtp_sub_configs.push_back(propose_config);
 
+    ASSERT_EQ(propose_config->specForGroup(0)->block_size_bytes(), 16u);
+    ASSERT_EQ(propose_config->specForGroup(0)->scale_block_size_bytes(), 32u);
     const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
     ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
+
     const auto& mtp_layout = pool_config.memory_layouts[1];
-    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->specForGroup(0)->scale_block_size_bytes());
-    EXPECT_FALSE(mtp_layout.hasScale());
+    EXPECT_FALSE(mtp_layout.is_mla);
+    EXPECT_TRUE(mtp_layout.hasScale());
+    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, 32u);
     EXPECT_EQ(mtp_layout.kv_cache_offset_bytes, 768u);
-    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 3u * 64u);
-    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, mtp_layout.kv_cache_offset_bytes + mtp_layout.kv_block_pool_size_bytes);
-    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 0u);
+    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 4u * 16u);
+    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, 832u);
+    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 1u * 4u * 32u);
     EXPECT_EQ(pool_config.total_size_bytes, 960u);
+}
+
+TEST(BlockPoolConfigHelperTest, MTPSelectsRealGroupAndAccumulatesMultipleOffsets) {
+    auto score_config = makeSparseMlaConfig(/*layer_num=*/2,
+                                            /*block_num=*/4,
+                                            /*tokens_per_block=*/4,
+                                            /*kernel_tokens_per_block=*/4,
+                                            /*scale_stride_bytes=*/32);
+    auto first        = std::make_shared<CacheConfig>(makeSparseMlaConfig(/*layer_num=*/1,
+                                                                   /*block_num=*/4,
+                                                                   /*tokens_per_block=*/4,
+                                                                   /*kernel_tokens_per_block=*/2,
+                                                                   /*scale_stride_bytes=*/128));
+
+    auto second      = std::make_shared<CacheConfig>(makeSparseMlaConfig(/*layer_num=*/2,
+                                                                    /*block_num=*/4,
+                                                                    /*tokens_per_block=*/8,
+                                                                    /*kernel_tokens_per_block=*/2,
+                                                                    /*scale_stride_bytes=*/64));
+    auto placeholder = makeMhaSpec("placeholder", 8, DataType::TYPE_BF16, 1, 1);
+    auto real_spec   = second->specForGroup(0);
+    second->fromGroupedSpecs({placeholder, real_spec},
+                             {{}, {0, 1}},
+                             {CacheGroupType::FULL, CacheGroupType::FULL},
+                             {"placeholder", "default"});
+
+    score_config.mtp_sub_configs = {first, second};
+    const auto pool_config       = BlockPoolConfigHelper::createConfig(score_config);
+    ASSERT_EQ(pool_config.memory_layouts.size(), 3u);
+
+    const auto& first_layout  = pool_config.memory_layouts[1];
+    const auto& second_layout = pool_config.memory_layouts[2];
+    EXPECT_EQ(first_layout.kv_cache_offset_bytes, 768u);
+    EXPECT_EQ(first_layout.kv_scale_offset_bytes, 1024u);
+    EXPECT_EQ(second_layout.kv_cache_offset_bytes, 1536u);
+    EXPECT_EQ(second_layout.kv_block_stride_bytes, real_spec->block_size_bytes());
+    EXPECT_EQ(second_layout.local_head_num_kv, 1u);
+    EXPECT_EQ(second_layout.layer_num, 2u);
+    EXPECT_EQ(second_layout.seq_size_per_block, 8u);
+    EXPECT_EQ(second_layout.kernel_blocks_per_kv_block, 4u);
+    EXPECT_EQ(second_layout.kv_block_pool_size_bytes, 2u * 4u * 128u);
+    EXPECT_EQ(second_layout.kv_scale_offset_bytes, 2560u);
+    EXPECT_EQ(second_layout.kv_scale_pool_size_bytes, 2u * 4u * 64u);
+    EXPECT_EQ(pool_config.total_size_bytes, 3072u);
+}
+
+TEST(BlockPoolConfigHelperTest, RejectsNullMTPSubConfig) {
+    auto score_config = makeSparseMlaConfig(2, 4, 4, 4, 32);
+    score_config.mtp_sub_configs.push_back(nullptr);
+    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
+}
+
+TEST(BlockPoolConfigHelperTest, RejectsMTPSubConfigWithoutGroups) {
+    auto score_config            = makeSparseMlaConfig(2, 4, 4, 4, 32);
+    auto empty                   = std::make_shared<CacheConfig>();
+    score_config.mtp_sub_configs = {empty};
+    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
+}
+
+TEST(BlockPoolConfigHelperTest, RejectsMTPSubConfigWithMismatchedBlockNum) {
+    auto score_config            = makeSparseMlaConfig(2, 4, 4, 4, 32);
+    auto mismatched              = std::make_shared<CacheConfig>(makeSparseMlaConfig(1, 3, 4, 2, 128));
+    score_config.mtp_sub_configs = {mismatched};
+    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
 }
 
 }  // namespace

--- a/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
+++ b/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
@@ -25,6 +25,16 @@ CacheConfig makeSparseMlaConfig(uint32_t layer_num,
                                     kernel_tokens_per_block);
 }
 
+template<typename Fn>
+void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
+    try {
+        fn();
+        FAIL() << "expected std::runtime_error containing: " << expected;
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find(expected), std::string::npos) << error.what();
+    }
+}
+
 TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeTopologyAndScaleStride) {
     auto score_config   = makeSparseMlaConfig(/*layer_num=*/2,
                                             /*block_num=*/4,
@@ -119,6 +129,9 @@ TEST(BlockPoolConfigHelperTest, MTPSelectsRealGroupAndAccumulatesMultipleOffsets
                              {{}, {0, 1}},
                              {CacheGroupType::FULL, CacheGroupType::FULL},
                              {"placeholder", "default"});
+    const size_t placeholder_kv_stride = 256;
+    const size_t real_kv_stride        = 192;
+    second->setGroupBlockLayout({4, 4}, {placeholder_kv_stride, real_kv_stride}, {0, 64});
 
     score_config.mtp_sub_configs = {first, second};
     const auto pool_config       = BlockPoolConfigHelper::createConfig(score_config);
@@ -129,35 +142,68 @@ TEST(BlockPoolConfigHelperTest, MTPSelectsRealGroupAndAccumulatesMultipleOffsets
     EXPECT_EQ(first_layout.kv_cache_offset_bytes, 768u);
     EXPECT_EQ(first_layout.kv_scale_offset_bytes, 1024u);
     EXPECT_EQ(second_layout.kv_cache_offset_bytes, 1536u);
-    EXPECT_EQ(second_layout.kv_block_stride_bytes, real_spec->block_size_bytes());
+    EXPECT_GT(placeholder_kv_stride, real_kv_stride);
+    EXPECT_NE(real_kv_stride, real_spec->block_size_bytes());
+    EXPECT_EQ(second_layout.kv_block_stride_bytes, real_kv_stride);
     EXPECT_EQ(second_layout.local_head_num_kv, 1u);
     EXPECT_EQ(second_layout.layer_num, 2u);
     EXPECT_EQ(second_layout.seq_size_per_block, 8u);
     EXPECT_EQ(second_layout.kernel_blocks_per_kv_block, 4u);
-    EXPECT_EQ(second_layout.kv_block_pool_size_bytes, 2u * 4u * 128u);
-    EXPECT_EQ(second_layout.kv_scale_offset_bytes, 2560u);
+    EXPECT_EQ(second_layout.kv_block_pool_size_bytes, 2u * 4u * 192u);
+    EXPECT_EQ(second_layout.kv_scale_offset_bytes, 3072u);
     EXPECT_EQ(second_layout.kv_scale_pool_size_bytes, 2u * 4u * 64u);
-    EXPECT_EQ(pool_config.total_size_bytes, 3072u);
+    EXPECT_EQ(pool_config.total_size_bytes, 3584u);
 }
 
 TEST(BlockPoolConfigHelperTest, RejectsNullMTPSubConfig) {
     auto score_config = makeSparseMlaConfig(2, 4, 4, 4, 32);
     score_config.mtp_sub_configs.push_back(nullptr);
-    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
+    expectRuntimeErrorContains([&score_config] { BlockPoolConfigHelper::createConfig(score_config); }, "is null");
 }
 
 TEST(BlockPoolConfigHelperTest, RejectsMTPSubConfigWithoutGroups) {
     auto score_config            = makeSparseMlaConfig(2, 4, 4, 4, 32);
     auto empty                   = std::make_shared<CacheConfig>();
     score_config.mtp_sub_configs = {empty};
-    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
+    expectRuntimeErrorContains([&score_config] { BlockPoolConfigHelper::createConfig(score_config); },
+                               "cache groups must not be empty");
 }
 
 TEST(BlockPoolConfigHelperTest, RejectsMTPSubConfigWithMismatchedBlockNum) {
     auto score_config            = makeSparseMlaConfig(2, 4, 4, 4, 32);
     auto mismatched              = std::make_shared<CacheConfig>(makeSparseMlaConfig(1, 3, 4, 2, 128));
     score_config.mtp_sub_configs = {mismatched};
-    EXPECT_THROW(BlockPoolConfigHelper::createConfig(score_config), std::runtime_error);
+    expectRuntimeErrorContains([&score_config] { BlockPoolConfigHelper::createConfig(score_config); },
+                               "must match main block_num");
+}
+
+TEST(BlockPoolConfigHelperTest, RejectsMTPSubConfigWithoutLayerOwningGroup) {
+    auto score_config = makeSparseMlaConfig(2, 4, 4, 4, 32);
+    auto no_layers    = std::make_shared<CacheConfig>(makeSparseMlaConfig(1, 4, 4, 2, 128));
+    no_layers->setLayerIdsForGroup(0, {});
+    score_config.mtp_sub_configs = {no_layers};
+    expectRuntimeErrorContains([&score_config] { BlockPoolConfigHelper::createConfig(score_config); },
+                               "no cache group containing layers");
+}
+
+TEST(BlockPoolConfigHelperTest, MTPWithoutScaleKeepsContiguousOffsets) {
+    auto score_config            = makeSparseMlaConfig(2, 4, 4, 4, 32);
+    auto no_scale                = std::make_shared<CacheConfig>(makeSimpleMlaCacheConfig(
+        /*layer_num=*/1,
+        /*block_num=*/4,
+        /*tokens_per_block=*/4,
+        DataType::TYPE_BF16,
+        /*sparse=*/false));
+    score_config.mtp_sub_configs = {no_scale};
+
+    const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
+    ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
+    const auto& mtp_layout = pool_config.memory_layouts[1];
+    EXPECT_FALSE(mtp_layout.hasScale());
+    EXPECT_EQ(mtp_layout.kv_cache_offset_bytes, 768u);
+    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 4u * 64u);
+    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, mtp_layout.kv_cache_offset_bytes + mtp_layout.kv_block_pool_size_bytes);
+    EXPECT_EQ(pool_config.total_size_bytes, 1024u);
 }
 
 }  // namespace

--- a/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
+++ b/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "rtp_llm/cpp/cache/BlockPoolConfigHelper.h"
+
+namespace rtp_llm {
+namespace test {
+namespace {
+
+class FixedMLASpec final: public KVCacheSpec {
+public:
+    explicit FixedMLASpec(size_t block_size_bytes): block_size_bytes_(block_size_bytes) {
+        type               = KVCacheSpecType::MultiHeadLatentAttention;
+        tag                = "default";
+        seq_size_per_block = 4;
+    }
+
+    size_t block_size() const override {
+        return block_size_bytes_ / 2;
+    }
+
+    size_t k_block_size() const override {
+        return block_size() - v_block_size();
+    }
+
+    size_t v_block_size() const override {
+        return 4;
+    }
+
+    size_t block_size_bytes() const override {
+        return block_size_bytes_;
+    }
+
+    size_t k_block_size_bytes() const override {
+        return block_size_bytes_ - v_block_size_bytes();
+    }
+
+    size_t v_block_size_bytes() const override {
+        return 8;
+    }
+
+    DataType memoryLayoutDType() const override {
+        return DataType::TYPE_BF16;
+    }
+
+    KVCacheSpecPtr clone() const override {
+        return std::make_shared<FixedMLASpec>(*this);
+    }
+
+    std::string debugString(size_t) const override {
+        return "FixedMLASpec";
+    }
+
+private:
+    size_t block_size_bytes_;
+};
+
+CacheConfig makeCacheConfig(uint32_t layer_num, bool sparse, size_t scale_stride_bytes) {
+    CacheConfig config;
+    config.dtype                     = DataType::TYPE_BF16;
+    config.layer_num                 = layer_num;
+    config.layer_all_num             = layer_num;
+    config.use_mla                   = true;
+    config.is_sparse                 = sparse;
+    config.block_num                 = 4;
+    config.seq_size_per_block        = 4;
+    config.kernel_seq_size_per_block = 4;
+    config.kv_block_stride_bytes     = 64;
+    config.kv_scale_stride_bytes     = scale_stride_bytes;
+
+    GroupBase group;
+    group.spec                  = std::make_shared<FixedMLASpec>(config.kv_block_stride_bytes);
+    group.policy                = defaultCacheGroupPolicy(CacheGroupType::FULL);
+    group.local_kv_head_num     = 1;
+    group.kv_block_stride_bytes = config.kv_block_stride_bytes;
+    group.kv_scale_stride_bytes = config.kv_scale_stride_bytes;
+    for (uint32_t layer_id = 0; layer_id < layer_num; ++layer_id) {
+        group.layer_ids.push_back(static_cast<int>(layer_id));
+    }
+    config.groups.push_back(std::move(group));
+    return config;
+}
+
+TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeScaleStride) {
+    auto score_config = makeCacheConfig(/*layer_num=*/2, /*sparse=*/true, /*scale_stride_bytes=*/32);
+    auto propose_config =
+        std::make_shared<CacheConfig>(makeCacheConfig(/*layer_num=*/1, /*sparse=*/true, /*scale_stride_bytes=*/128));
+    score_config.mtp_sub_configs.push_back(propose_config);
+
+    ASSERT_TRUE(propose_config->is_sparse);
+    ASSERT_EQ(propose_config->specForGroup(0)->scale_block_size_bytes(), 0u);
+    ASSERT_GT(propose_config->kv_scale_stride_bytes, 0u);
+
+    const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
+    ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
+    const auto& mtp_layout = pool_config.memory_layouts[1];
+    EXPECT_TRUE(mtp_layout.is_mla);
+    EXPECT_TRUE(mtp_layout.hasScale());
+    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->kv_scale_stride_bytes);
+    EXPECT_GT(mtp_layout.kv_scale_pool_size_bytes, 0u);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
+++ b/rtp_llm/cpp/cache/test/BlockPoolConfigHelperTest.cc
@@ -2,81 +2,41 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 
 #include "rtp_llm/cpp/cache/BlockPoolConfigHelper.h"
+#include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
 
 namespace rtp_llm {
 namespace test {
 namespace {
 
-class FixedMLASpec final: public KVCacheSpec {
-public:
-    explicit FixedMLASpec(size_t block_size_bytes): block_size_bytes_(block_size_bytes) {
-        type               = KVCacheSpecType::MultiHeadLatentAttention;
-        tag                = "default";
-        seq_size_per_block = 4;
-    }
+CacheConfig makeMlaCacheConfig(uint32_t layer_num,
+                               uint32_t block_num,
+                               uint32_t kernel_tokens_per_block,
+                               bool     sparse,
+                               size_t   config_scale_stride_bytes,
+                               size_t   group_scale_stride_bytes) {
+    constexpr uint32_t kSeqSizePerBlock = 4;
+    auto spec = makeMlaSpec("default", kSeqSizePerBlock, DataType::TYPE_BF16, /*kv_lora_rank=*/4, /*rope_head_dim=*/4);
 
-    size_t block_size() const override {
-        return block_size_bytes_ / 2;
-    }
-
-    size_t k_block_size() const override {
-        return block_size() - v_block_size();
-    }
-
-    size_t v_block_size() const override {
-        return 4;
-    }
-
-    size_t block_size_bytes() const override {
-        return block_size_bytes_;
-    }
-
-    size_t k_block_size_bytes() const override {
-        return block_size_bytes_ - v_block_size_bytes();
-    }
-
-    size_t v_block_size_bytes() const override {
-        return 8;
-    }
-
-    DataType memoryLayoutDType() const override {
-        return DataType::TYPE_BF16;
-    }
-
-    KVCacheSpecPtr clone() const override {
-        return std::make_shared<FixedMLASpec>(*this);
-    }
-
-    std::string debugString(size_t) const override {
-        return "FixedMLASpec";
-    }
-
-private:
-    size_t block_size_bytes_;
-};
-
-CacheConfig makeCacheConfig(uint32_t layer_num, bool sparse, size_t scale_stride_bytes) {
     CacheConfig config;
     config.dtype                     = DataType::TYPE_BF16;
     config.layer_num                 = layer_num;
     config.layer_all_num             = layer_num;
     config.use_mla                   = true;
     config.is_sparse                 = sparse;
-    config.block_num                 = 4;
-    config.seq_size_per_block        = 4;
-    config.kernel_seq_size_per_block = 4;
-    config.kv_block_stride_bytes     = 64;
-    config.kv_scale_stride_bytes     = scale_stride_bytes;
+    config.block_num                 = block_num;
+    config.seq_size_per_block        = kSeqSizePerBlock;
+    config.kernel_seq_size_per_block = kernel_tokens_per_block;
+    config.kv_block_stride_bytes     = spec->block_size_bytes();
+    config.kv_scale_stride_bytes     = config_scale_stride_bytes;
 
     GroupBase group;
-    group.spec                  = std::make_shared<FixedMLASpec>(config.kv_block_stride_bytes);
+    group.spec                  = spec;
     group.policy                = defaultCacheGroupPolicy(CacheGroupType::FULL);
     group.local_kv_head_num     = 1;
     group.kv_block_stride_bytes = config.kv_block_stride_bytes;
-    group.kv_scale_stride_bytes = config.kv_scale_stride_bytes;
+    group.kv_scale_stride_bytes = group_scale_stride_bytes;
     for (uint32_t layer_id = 0; layer_id < layer_num; ++layer_id) {
         group.layer_ids.push_back(static_cast<int>(layer_id));
     }
@@ -84,23 +44,73 @@ CacheConfig makeCacheConfig(uint32_t layer_num, bool sparse, size_t scale_stride
     return config;
 }
 
-TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeScaleStride) {
-    auto score_config = makeCacheConfig(/*layer_num=*/2, /*sparse=*/true, /*scale_stride_bytes=*/32);
-    auto propose_config =
-        std::make_shared<CacheConfig>(makeCacheConfig(/*layer_num=*/1, /*sparse=*/true, /*scale_stride_bytes=*/128));
+TEST(BlockPoolConfigHelperTest, MTPSparseIndexerUsesProposeConfigAndScaleStride) {
+    auto score_config   = makeMlaCacheConfig(/*layer_num=*/2,
+                                           /*block_num=*/4,
+                                           /*kernel_tokens_per_block=*/4,
+                                           /*sparse=*/true,
+                                           /*config_scale_stride_bytes=*/32,
+                                           /*group_scale_stride_bytes=*/16);
+    auto propose_config = std::make_shared<CacheConfig>(makeMlaCacheConfig(/*layer_num=*/1,
+                                                                           /*block_num=*/3,
+                                                                           /*kernel_tokens_per_block=*/2,
+                                                                           /*sparse=*/true,
+                                                                           /*config_scale_stride_bytes=*/128,
+                                                                           /*group_scale_stride_bytes=*/24));
     score_config.mtp_sub_configs.push_back(propose_config);
 
-    ASSERT_TRUE(propose_config->is_sparse);
+    ASSERT_EQ(propose_config->specForGroup(0)->block_size_bytes(), 64u);
     ASSERT_EQ(propose_config->specForGroup(0)->scale_block_size_bytes(), 0u);
-    ASSERT_GT(propose_config->kv_scale_stride_bytes, 0u);
+    ASSERT_NE(propose_config->kv_scale_stride_bytes, propose_config->groups[0].kv_scale_stride_bytes);
+
+    const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
+    ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
+
+    const auto& main_layout = pool_config.memory_layouts[0];
+    EXPECT_EQ(main_layout.block_num, 4u);
+    EXPECT_EQ(main_layout.kv_cache_offset_bytes, 0u);
+    EXPECT_EQ(main_layout.kv_block_pool_size_bytes, 2u * 4u * 64u);
+    EXPECT_EQ(main_layout.kv_scale_offset_bytes, 2u * 4u * 64u);
+    EXPECT_EQ(main_layout.kv_scale_pool_size_bytes, 2u * 4u * 32u);
+
+    const auto& mtp_layout = pool_config.memory_layouts[1];
+    EXPECT_TRUE(mtp_layout.is_mla);
+    EXPECT_TRUE(mtp_layout.hasScale());
+    EXPECT_EQ(mtp_layout.block_num, 3u);
+    EXPECT_EQ(mtp_layout.kernel_blocks_per_kv_block, 2u);
+    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->kv_scale_stride_bytes);
+    EXPECT_EQ(mtp_layout.kv_cache_offset_bytes, 768u);
+    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 3u * 64u);
+    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, 960u);
+    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 1u * 3u * 128u);
+    EXPECT_EQ(pool_config.total_size_bytes, 1344u);
+}
+
+TEST(BlockPoolConfigHelperTest, MTPNonSparseUsesSpecScaleAndNoScalePool) {
+    auto score_config   = makeMlaCacheConfig(/*layer_num=*/2,
+                                           /*block_num=*/4,
+                                           /*kernel_tokens_per_block=*/4,
+                                           /*sparse=*/true,
+                                           /*config_scale_stride_bytes=*/32,
+                                           /*group_scale_stride_bytes=*/16);
+    auto propose_config = std::make_shared<CacheConfig>(makeMlaCacheConfig(/*layer_num=*/1,
+                                                                           /*block_num=*/3,
+                                                                           /*kernel_tokens_per_block=*/2,
+                                                                           /*sparse=*/false,
+                                                                           /*config_scale_stride_bytes=*/128,
+                                                                           /*group_scale_stride_bytes=*/24));
+    score_config.mtp_sub_configs.push_back(propose_config);
 
     const auto pool_config = BlockPoolConfigHelper::createConfig(score_config);
     ASSERT_EQ(pool_config.memory_layouts.size(), 2u);
     const auto& mtp_layout = pool_config.memory_layouts[1];
-    EXPECT_TRUE(mtp_layout.is_mla);
-    EXPECT_TRUE(mtp_layout.hasScale());
-    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->kv_scale_stride_bytes);
-    EXPECT_GT(mtp_layout.kv_scale_pool_size_bytes, 0u);
+    EXPECT_EQ(mtp_layout.kv_scale_stride_bytes, propose_config->specForGroup(0)->scale_block_size_bytes());
+    EXPECT_FALSE(mtp_layout.hasScale());
+    EXPECT_EQ(mtp_layout.kv_cache_offset_bytes, 768u);
+    EXPECT_EQ(mtp_layout.kv_block_pool_size_bytes, 1u * 3u * 64u);
+    EXPECT_EQ(mtp_layout.kv_scale_offset_bytes, mtp_layout.kv_cache_offset_bytes + mtp_layout.kv_block_pool_size_bytes);
+    EXPECT_EQ(mtp_layout.kv_scale_pool_size_bytes, 0u);
+    EXPECT_EQ(pool_config.total_size_bytes, 960u);
 }
 
 }  // namespace

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -157,7 +157,6 @@ inline CacheConfig makeSimpleMlaCacheConfig(int               layer_num,
     config.kv_scale_stride_bytes = kv_scale_stride_bytes == 0 ? spec->scale_block_size_bytes() : kv_scale_stride_bytes;
     config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
     config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-
     const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
     config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
                                               static_cast<int>(per_layer_stride_bytes));

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -126,6 +126,44 @@ inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
     return config;
 }
 
+inline CacheConfig makeSimpleMlaCacheConfig(int               layer_num,
+                                            int               block_num,
+                                            size_t            tokens_per_block,
+                                            rtp_llm::DataType dtype,
+                                            bool              sparse                  = false,
+                                            size_t            kv_scale_stride_bytes   = 0,
+                                            size_t            kernel_tokens_per_block = 0,
+                                            uint32_t          kv_lora_rank            = 4,
+                                            uint32_t          rope_head_dim           = 4) {
+    CacheConfig config;
+    config.dtype                     = dtype;
+    config.layer_num                 = static_cast<uint32_t>(layer_num);
+    config.layer_all_num             = static_cast<uint32_t>(layer_num);
+    config.block_num                 = static_cast<uint32_t>(block_num);
+    config.seq_size_per_block        = tokens_per_block;
+    config.kernel_seq_size_per_block = kernel_tokens_per_block == 0 ? tokens_per_block : kernel_tokens_per_block;
+    config.use_mla                   = true;
+    config.is_sparse                 = sparse;
+
+    auto             spec = makeMlaSpec("default", tokens_per_block, dtype, kv_lora_rank, rope_head_dim);
+    std::vector<int> layer_ids(layer_num);
+    for (int i = 0; i < layer_num; ++i) {
+        layer_ids[i] = i;
+    }
+    config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::FULL}, {"default"});
+
+    config.kv_block_stride_bytes = spec->block_size_bytes();
+    config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
+    config.kv_scale_stride_bytes = kv_scale_stride_bytes == 0 ? spec->scale_block_size_bytes() : kv_scale_stride_bytes;
+    config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
+    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
+
+    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
+    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
+                                              static_cast<int>(per_layer_stride_bytes));
+    return config;
+}
+
 inline CacheConfig makeSimpleLinearCacheConfig(int               layer_num,
                                                int               block_num,
                                                size_t            tokens_per_block,

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -38,6 +38,31 @@ inline KVCacheSpecPtr makeMhaSpec(const std::string& tag,
     return SpecBuilder::build(desc, ctx);
 }
 
+inline KVCacheSpecPtr makeMlaSpec(const std::string& tag,
+                                  size_t             tokens_per_block,
+                                  rtp_llm::DataType  dtype,
+                                  uint32_t           kv_lora_rank,
+                                  uint32_t           rope_head_dim) {
+    AttentionConfigs attn_config;
+    attn_config.kv_lora_rank  = kv_lora_rank;
+    attn_config.rope_head_dim = rope_head_dim;
+
+    ParallelismConfig parallelism_config;
+    parallelism_config.tp_size = 1;
+
+    KVCacheSpecDesc desc;
+    desc.tag        = tag;
+    desc.cache_type = KVCacheSpecType::MultiHeadLatentAttention;
+    desc.dtype      = dtype;
+
+    SpecBuildContext ctx;
+    ctx.dtype              = dtype;
+    ctx.seq_size_per_block = static_cast<uint32_t>(tokens_per_block);
+    ctx.attn_config        = &attn_config;
+    ctx.parallelism_config = &parallelism_config;
+    return SpecBuilder::build(desc, ctx);
+}
+
 inline KVCacheSpecPtr makeLinearSpec(const std::string& tag,
                                      size_t             tokens_per_block,
                                      rtp_llm::DataType  dtype,

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -92,6 +92,9 @@ class ModelFactory:
             merge_lora=merge_lora,
             device_resource_config=engine_config.device_resource_config,
             force_cpu_load_weights=engine_config.load_config.force_cpu_load_weights,
+            keep_mla_checkpoint_weights=(
+                engine_config.load_config.keep_mla_checkpoint_weights
+            ),
         )
         return model
 
@@ -160,6 +163,9 @@ class ModelFactory:
                 device_resource_config=engine_config.device_resource_config,
                 vit_config=None,  # Propose model doesn't need vit_config
                 merge_lora=False,  # Propose model doesn't need merge_lora
+                keep_mla_checkpoint_weights=(
+                    engine_config.load_config.keep_mla_checkpoint_weights
+                ),
             )
             logging.info(f"create propose model {engine_config.sp_config.type}")
             return ProposeModel(sp_type, gen_num_per_circle, gpt_model)

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -58,6 +58,7 @@ class BaseModel(object):
         merge_lora: bool,
         device_resource_config: Optional[DeviceResourceConfig],
         force_cpu_load_weights: bool = False,
+        keep_mla_checkpoint_weights: bool = False,
     ) -> None:
         """Initialize BaseModel with independent configuration objects.
         Args:
@@ -84,6 +85,7 @@ class BaseModel(object):
         self.merge_lora = merge_lora
         self.device_resource_config = device_resource_config
         self.force_cpu_load_weights = force_cpu_load_weights
+        self.keep_mla_checkpoint_weights = keep_mla_checkpoint_weights
         self.weight = None
         self.weight_manager = None
 
@@ -271,10 +273,8 @@ class BaseModel(object):
             merge_lora=merge_lora,
             device_resource_config=device_resource_config,
             force_cpu_load_weights=force_cpu_load_weights,
+            keep_mla_checkpoint_weights=keep_mla_checkpoint_weights,
         )
-        if not isinstance(keep_mla_checkpoint_weights, bool):
-            raise TypeError("keep_mla_checkpoint_weights must be a bool")
-        model.keep_mla_checkpoint_weights = keep_mla_checkpoint_weights
 
         import os
 

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -240,6 +240,7 @@ class BaseModel(object):
         merge_lora: bool,
         device_resource_config: DeviceResourceConfig,
         force_cpu_load_weights: bool = False,
+        keep_mla_checkpoint_weights: bool = False,
         skip_python_model: bool = False,
     ) -> "BaseModel":
         """Create model from independent configuration objects.
@@ -254,6 +255,7 @@ class BaseModel(object):
             max_generate_batch_size: Maximum batch size for generation
             merge_lora: Whether to merge LoRA weights
             device_resource_config: DeviceResourceConfig for device resource configuration
+            keep_mla_checkpoint_weights: Keep superseded MLA checkpoint tensors for debugging
         """
         # All metadata is in model_config
         model = cls(
@@ -270,6 +272,9 @@ class BaseModel(object):
             device_resource_config=device_resource_config,
             force_cpu_load_weights=force_cpu_load_weights,
         )
+        if not isinstance(keep_mla_checkpoint_weights, bool):
+            raise TypeError("keep_mla_checkpoint_weights must be a bool")
+        model.keep_mla_checkpoint_weights = keep_mla_checkpoint_weights
 
         import os
 
@@ -429,6 +434,7 @@ class BaseModel(object):
             moe_config=getattr(self, "moe_config", None),
             fmha_config=self.fmha_config,
             device_resource_config=self.device_resource_config,
+            keep_mla_checkpoint_weights=self.keep_mla_checkpoint_weights,
         )
         loader = NewModelLoader(
             model_config=self.model_config,

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -135,6 +135,9 @@ py_library(
     ] + glob([
         "layers/*.py",
         "new_models/*.py",
+        "new_models/deepseek_v3/*.py",
+        "new_models/deepseek_v3_mtp/*.py",
+        "new_models/mtp/*.py",
         "new_models/qwen2/*.py",
         "new_models/qwen2_moe/*.py",
         "new_models/qwen2_vl/*.py",

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -41,10 +41,6 @@ def _copy_checked(target: torch.Tensor, source: torch.Tensor, label: str) -> Non
 
 class LinearBase(RtpModule):
 
-    # FP8 per-block (DeepSeek-style) quantization block size, used when
-    # TP-slicing / shard-merging `weight_scale_inv` block grids.
-    _FP8_BLOCK = 128
-
     def __init__(
         self,
         input_size: int,
@@ -140,12 +136,9 @@ class LinearBase(RtpModule):
         if name == "weight":
             self._main_weight_loaded = True
 
-    def _fp8_scale_block_size(self) -> tuple[int, int]:
-        return self.quant_config.fp8_block_size
-
     def fp8_scale_block_size(self) -> tuple[int, int]:
         """Public validated FP8 block layout for derived runtime weights."""
-        return self._fp8_scale_block_size()
+        return self.quant_config.fp8_block_size
 
     @staticmethod
     def _ceil_div(x: int, y: int) -> int:
@@ -232,7 +225,7 @@ class ColumnParallelLinear(LinearBase):
                     tensor = self._split_weight(tensor, dim=0)
             elif param_name == "weight_scale_inv":
                 if self.tp_size > 1:
-                    block_n, _ = self._fp8_scale_block_size()
+                    block_n, _ = self.fp8_scale_block_size()
                     start_row = self.tp_rank * self.output_size_per_partition
                     if (
                         start_row % block_n != 0
@@ -365,7 +358,7 @@ class RowParallelLinear(LinearBase):
                     tensor = self._split_weight(tensor, dim=-1)
             elif param_name == "weight_scale_inv":
                 if self.tp_size > 1:
-                    _, block_k = self._fp8_scale_block_size()
+                    _, block_k = self.fp8_scale_block_size()
                     start_column = self.tp_rank * self.input_size_per_partition
                     if (
                         start_column % block_k != 0
@@ -485,7 +478,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
                 if shard_id < 0:
                     if param_name == "weight_scale_inv" and tensor.shape != param.shape:
-                        block_n, _ = self._fp8_scale_block_size()
+                        block_n, _ = self.fp8_scale_block_size()
                         global_shard_rows = shard_size * self.tp_size
                         if global_shard_rows % block_n or shard_size % block_n:
                             raise ValueError(
@@ -544,7 +537,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     # shard (gate/up) ships its own grid; place this shard's
                     # block-rows at its block offset. shard_size is in weight
                     # rows, so convert through the quant config's N block.
-                    block_n, _ = self._fp8_scale_block_size()
+                    block_n, _ = self.fp8_scale_block_size()
                     start_row = self.tp_rank * shard_size
                     if start_row % block_n != 0 or shard_size % block_n != 0:
                         raise ValueError(
@@ -964,7 +957,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                         )
                         self._record_fused_parameter_loaded(param_name)
                     elif param_name == "weight_scale_inv":
-                        block_n, _ = self._fp8_scale_block_size()
+                        block_n, _ = self.fp8_scale_block_size()
                         q_rows = self.num_heads * self.head_dim
                         kv_rows = self.num_kv_heads * self.head_dim
                         if q_rows % block_n or kv_rows % block_n:
@@ -1064,7 +1057,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             # FP8 per-block grid for this q/k/v shard: TP-slice along the
             # output(head)-block dim, then place at the shard's block offset
             # in the merged [total_blocks, in_blocks] grid.
-            block_n, _ = self._fp8_scale_block_size()
+            block_n, _ = self.fp8_scale_block_size()
             rank = self.tp_rank if qkv_key == "q" else self.kv_head_rank
             self._ensure_parameter_shard_not_loaded(param_name, qkv_key)
             if self.tp_size > 1:

--- a/rtp_llm/models_py/layers/linear.py
+++ b/rtp_llm/models_py/layers/linear.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 
 import torch
 import torch.nn as nn
+
 from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.module_base import RtpModule, copy_weight_
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
@@ -139,16 +140,12 @@ class LinearBase(RtpModule):
         if name == "weight":
             self._main_weight_loaded = True
 
-    def _fp8_scale_block_size(self):
-        value = getattr(
-            self.quant_config, "weight_block_size", [self._FP8_BLOCK, self._FP8_BLOCK]
-        )
-        if not isinstance(value, (list, tuple)) or len(value) != 2:
-            raise ValueError(f"Invalid FP8 weight_block_size {value!r}")
-        block_n, block_k = value
-        _require_positive_int(block_n, "FP8 output block size")
-        _require_positive_int(block_k, "FP8 input block size")
-        return block_n, block_k
+    def _fp8_scale_block_size(self) -> tuple[int, int]:
+        return self.quant_config.fp8_block_size
+
+    def fp8_scale_block_size(self) -> tuple[int, int]:
+        """Public validated FP8 block layout for derived runtime weights."""
+        return self._fp8_scale_block_size()
 
     @staticmethod
     def _ceil_div(x: int, y: int) -> int:

--- a/rtp_llm/models_py/layers/moe_experts.py
+++ b/rtp_llm/models_py/layers/moe_experts.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+
 from rtp_llm.device import get_current_device
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.modules import FusedMoeFactory
@@ -921,6 +922,15 @@ class BaseMoEExperts(RtpModule):
     # ------------------------------------------------------------------ #
     #  Forward
     # ------------------------------------------------------------------ #
+
+    @property
+    def topk_ids_dtype(self) -> torch.dtype:
+        if self.fused_moe is None:
+            raise RuntimeError(
+                "Fused MoE executor is not initialized; complete weight loading "
+                "and post-load processing before reading topk_ids_dtype"
+            )
+        return self.fused_moe.topk_ids_dtype
 
     def forward(
         self,

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -186,6 +186,20 @@ class NewLoaderConfig:
                 raise ValueError(
                     f"Invalid {prefix} partition: rank={rank}, size={size}"
                 )
+            if prefix in ("attn_tp", "ffn_tp"):
+                if size not in (1, self.tp_size):
+                    raise ValueError(
+                        f"{size_name}={size} must be either 1 or the physical "
+                        f"tp_size={self.tp_size}; independent TP subgroups are "
+                        "not supported by Group.TP collectives"
+                    )
+                expected_rank = 0 if size == 1 else self.tp_rank
+                if rank != expected_rank:
+                    raise ValueError(
+                        f"{rank_name}={rank} does not match the supported "
+                        f"{prefix} topology: expected rank={expected_rank} for "
+                        f"size={size}"
+                    )
         if self.ep_size <= 0 or not 0 <= self.ep_rank < self.ep_size:
             raise ValueError(
                 f"Invalid EP partition: rank={self.ep_rank}, size={self.ep_size}"

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -137,6 +137,7 @@ class NewLoaderConfig:
     ffn_tp_rank: Optional[int] = None
     lm_head_tp_size: Optional[int] = None
     lm_head_tp_rank: Optional[int] = None
+    keep_mla_checkpoint_weights: bool = False
 
     def __post_init__(self) -> None:
         if isinstance(self.load_method, str):
@@ -206,6 +207,8 @@ class NewLoaderConfig:
             )
         if not isinstance(self.compute_dtype, torch.dtype):
             raise TypeError("compute_dtype must be a torch.dtype")
+        if not isinstance(self.keep_mla_checkpoint_weights, bool):
+            raise TypeError("keep_mla_checkpoint_weights must be a bool")
         _validate_runtime_device(self.device, "device")
         if self.parallelism_config is not None:
             for prefix in ("tp", "ep"):
@@ -503,11 +506,15 @@ class NewModelLoader:
                 try:
                     validator(loaded_tensor_ids)
                 except Exception as exc:
-                    qualified_name = module_name or "<root>"
-                    raise RuntimeError(
-                        f"Weight validation failed for {qualified_name} "
-                        f"({type(module).__name__}): {exc}"
-                    ) from exc
+                    context = (
+                        f"Weight validation failed for {module_name} "
+                        f"({type(module).__name__})"
+                    )
+                    if exc.args:
+                        exc.args = (f"{context}: {exc.args[0]}", *exc.args[1:])
+                    else:
+                        exc.args = (context,)
+                    raise
 
     @staticmethod
     def _run_post_load_hooks(model: nn.Module) -> None:

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -488,7 +488,7 @@ class NewModelLoader:
                     )
                 try:
                     validator(loaded_tensor_ids)
-                except RuntimeError as exc:
+                except Exception as exc:
                     qualified_name = module_name or "<root>"
                     raise RuntimeError(
                         f"Weight validation failed for {qualified_name} "

--- a/rtp_llm/models_py/model_loader.py
+++ b/rtp_llm/models_py/model_loader.py
@@ -472,7 +472,7 @@ class NewModelLoader:
             )
         root_validator(loaded_tensor_ids)
 
-        for module in model.modules():
+        for module_name, module in model.named_modules():
             if module is model:
                 continue
             custom_loader = getattr(type(module), "load_weights", None)
@@ -486,7 +486,14 @@ class NewModelLoader:
                         f"Custom weight loader {type(module).__name__}.load_weights() "
                         "must define validate_weights_loaded()"
                     )
-                validator(loaded_tensor_ids)
+                try:
+                    validator(loaded_tensor_ids)
+                except RuntimeError as exc:
+                    qualified_name = module_name or "<root>"
+                    raise RuntimeError(
+                        f"Weight validation failed for {qualified_name} "
+                        f"({type(module).__name__}): {exc}"
+                    ) from exc
 
     @staticmethod
     def _run_post_load_hooks(model: nn.Module) -> None:

--- a/rtp_llm/models_py/modules/base/cuda/indexer_op.py
+++ b/rtp_llm/models_py/modules/base/cuda/indexer_op.py
@@ -110,14 +110,22 @@ class IndexerOp(nn.Module):
         self.scale_fmt = scale_fmt
         self.is_neox_style = is_neox_style
 
-    def _validated_cos_sin_cache(self) -> Optional[torch.Tensor]:
-        cache = self.cos_sin_cache
-        if cache is not None and cache.dtype != torch.float32:
-            raise RuntimeError(
-                "IndexerOp cos_sin_cache dtype changed after construction: "
-                f"expected torch.float32, got {cache.dtype}"
+    def _apply(self, fn, recurse: bool = True):
+        source_cos_sin_cache = self.cos_sin_cache
+        result = super()._apply(fn, recurse)
+        if (
+            source_cos_sin_cache is not None
+            and self.cos_sin_cache is not None
+            and self.cos_sin_cache.dtype != torch.float32
+        ):
+            # RoPE kernels require an FP32 cache. Module.to(dtype=...) should
+            # still migrate its device, but must not silently lower precision
+            # or round the original FP32 values through the requested dtype.
+            self.cos_sin_cache = source_cos_sin_cache.to(
+                device=self.cos_sin_cache.device,
+                dtype=torch.float32,
             )
-        return cache
+        return result
 
     def apply_rope_and_rotate_q_k(
         self,
@@ -141,7 +149,7 @@ class IndexerOp(nn.Module):
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
         # Apply RoPE (same as vllm indexer rope)
-        cos_sin_cache = self._validated_cos_sin_cache()
+        cos_sin_cache = self.cos_sin_cache
         if cos_sin_cache is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=q_pe,
@@ -186,7 +194,7 @@ class IndexerOp(nn.Module):
         q_pe = q[:, :, : self.index_head_dim - self.rope_head_dim]
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
-        cos_sin_cache = self._validated_cos_sin_cache()
+        cos_sin_cache = self.cos_sin_cache
         if cos_sin_cache is not None and full_rope_pos_ids is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=q_pe,
@@ -222,7 +230,7 @@ class IndexerOp(nn.Module):
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
         # Apply RoPE (same as vllm indexer rope)
-        cos_sin_cache = self._validated_cos_sin_cache()
+        cos_sin_cache = self.cos_sin_cache
         if cos_sin_cache is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=k_pe.unsqueeze(1),

--- a/rtp_llm/models_py/modules/base/cuda/indexer_op.py
+++ b/rtp_llm/models_py/modules/base/cuda/indexer_op.py
@@ -99,7 +99,7 @@ class IndexerOp(nn.Module):
         self.index_head_dim = index_head_dim
         self.index_topk = index_topk
         self.rope_head_dim = rope_head_dim
-        self.cos_sin_cache = cos_sin_cache
+        self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
         self.blocksize = blocksize
         self.block_size = block_size
         self.scale_fmt = scale_fmt
@@ -603,9 +603,12 @@ class IndexerOp(nn.Module):
 
         if total_local_ids.size(0) > 0:
             topk = run_part_logits_topk(
-                q0, weights_sq0,
-                precomputed_ks, precomputed_ke,
-                precomputed_lengths, precomputed_topk_off,
+                q0,
+                weights_sq0,
+                precomputed_ks,
+                precomputed_ke,
+                precomputed_lengths,
+                precomputed_topk_off,
             )
         else:
             topk = None

--- a/rtp_llm/models_py/modules/base/cuda/indexer_op.py
+++ b/rtp_llm/models_py/modules/base/cuda/indexer_op.py
@@ -99,11 +99,25 @@ class IndexerOp(nn.Module):
         self.index_head_dim = index_head_dim
         self.index_topk = index_topk
         self.rope_head_dim = rope_head_dim
+        if cos_sin_cache is not None and cos_sin_cache.dtype != torch.float32:
+            raise TypeError(
+                "IndexerOp cos_sin_cache must use torch.float32, got "
+                f"{cos_sin_cache.dtype}"
+            )
         self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
         self.blocksize = blocksize
         self.block_size = block_size
         self.scale_fmt = scale_fmt
         self.is_neox_style = is_neox_style
+
+    def _validated_cos_sin_cache(self) -> Optional[torch.Tensor]:
+        cache = self.cos_sin_cache
+        if cache is not None and cache.dtype != torch.float32:
+            raise RuntimeError(
+                "IndexerOp cos_sin_cache dtype changed after construction: "
+                f"expected torch.float32, got {cache.dtype}"
+            )
+        return cache
 
     def apply_rope_and_rotate_q_k(
         self,
@@ -127,13 +141,14 @@ class IndexerOp(nn.Module):
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
         # Apply RoPE (same as vllm indexer rope)
-        if self.cos_sin_cache is not None:
+        cos_sin_cache = self._validated_cos_sin_cache()
+        if cos_sin_cache is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=q_pe,
                 k=k_pe.unsqueeze(1),
                 q_rope=q_pe,
                 k_rope=k_pe.unsqueeze(1),
-                cos_sin_cache=self.cos_sin_cache,
+                cos_sin_cache=cos_sin_cache,
                 pos_ids=positions,
                 interleave=not self.is_neox_style,
             )
@@ -171,13 +186,14 @@ class IndexerOp(nn.Module):
         q_pe = q[:, :, : self.index_head_dim - self.rope_head_dim]
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
-        if self.cos_sin_cache is not None and full_rope_pos_ids is not None:
+        cos_sin_cache = self._validated_cos_sin_cache()
+        if cos_sin_cache is not None and full_rope_pos_ids is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=q_pe,
                 k=k_pe.unsqueeze(1),
                 q_rope=q_pe,
                 k_rope=k_pe.unsqueeze(1),
-                cos_sin_cache=self.cos_sin_cache,
+                cos_sin_cache=cos_sin_cache,
                 pos_ids=full_rope_pos_ids,
                 interleave=not self.is_neox_style,
             )
@@ -206,13 +222,14 @@ class IndexerOp(nn.Module):
         k_pe = k[:, : self.index_head_dim - self.rope_head_dim]
 
         # Apply RoPE (same as vllm indexer rope)
-        if self.cos_sin_cache is not None:
+        cos_sin_cache = self._validated_cos_sin_cache()
+        if cos_sin_cache is not None:
             rope._apply_rope_pos_ids_cos_sin_cache(
                 q=k_pe.unsqueeze(1),
                 k=k_pe.unsqueeze(1),
                 q_rope=k_pe.unsqueeze(1),
                 k_rope=k_pe.unsqueeze(1),
-                cos_sin_cache=self.cos_sin_cache,
+                cos_sin_cache=cos_sin_cache,
                 pos_ids=positions,
                 interleave=not self.is_neox_style,
             )

--- a/rtp_llm/models_py/modules/base/cuda/indexer_op.py
+++ b/rtp_llm/models_py/modules/base/cuda/indexer_op.py
@@ -99,16 +99,24 @@ class IndexerOp(nn.Module):
         self.index_head_dim = index_head_dim
         self.index_topk = index_topk
         self.rope_head_dim = rope_head_dim
-        if cos_sin_cache is not None and cos_sin_cache.dtype != torch.float32:
-            raise TypeError(
-                "IndexerOp cos_sin_cache must use torch.float32, got "
-                f"{cos_sin_cache.dtype}"
-            )
-        self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
+        self.register_buffer("cos_sin_cache", None, persistent=False)
+        if cos_sin_cache is not None:
+            self.bind_rope_cache(cos_sin_cache)
         self.blocksize = blocksize
         self.block_size = block_size
         self.scale_fmt = scale_fmt
         self.is_neox_style = is_neox_style
+
+    def bind_rope_cache(self, cos_sin_cache: torch.Tensor) -> None:
+        """Bind the canonical FP32 RoPE cache tracked by the owning model."""
+        if not isinstance(cos_sin_cache, torch.Tensor):
+            raise TypeError("IndexerOp cos_sin_cache must be a torch.Tensor")
+        if cos_sin_cache.dtype != torch.float32:
+            raise TypeError(
+                "IndexerOp cos_sin_cache must use torch.float32, got "
+                f"{cos_sin_cache.dtype}"
+            )
+        self.cos_sin_cache = cos_sin_cache
 
     def _apply(self, fn, recurse: bool = True):
         source_cos_sin_cache = self.cos_sin_cache

--- a/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
@@ -1,0 +1,8 @@
+from .language import DeepSeekV32ForCausalLM
+
+# DeepSeekV32ForCausalLM also serves as the new-loader implementation for
+# deepseek2, deepseek3, deepseek_v31, and glm_5.  All four are architectural
+# variants of the same MLA + MoE family and are handled by the same class
+# via config-driven parameterisation in _extract_config_values.
+
+__all__ = ["DeepSeekV32ForCausalLM"]

--- a/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
@@ -1,8 +1,8 @@
 from .language import DeepSeekV32ForCausalLM
 
 # DeepSeekV32ForCausalLM also serves as the new-loader implementation for
-# deepseek2, deepseek3, deepseek_v31, and glm_5.  All four are architectural
-# variants of the same MLA + MoE family and are handled by the same class
-# via config-driven parameterisation in _extract_config_values.
+# deepseek2, deepseek3, deepseek_v31, deepseek_v32, glm_5, and kimi_k2. These
+# are architectural variants of the same MLA + MoE family and are handled by
+# the same class via config-driven parameterisation in _extract_config_values.
 
 __all__ = ["DeepSeekV32ForCausalLM"]

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -41,12 +41,20 @@ from rtp_llm.utils.model_weight import W
 class _CudaRuntimeFusedFp8Linear(nn.Module):
     """CUDA-only fused view over independently loaded FP8 projections."""
 
-    def __init__(self, weight: torch.Tensor, weight_scale: torch.Tensor):
+    def __init__(
+        self,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        block_size: tuple[int, int],
+    ):
         super().__init__()
+        if len(block_size) != 2 or any(size <= 0 for size in block_size):
+            raise ValueError(f"invalid FP8 block size {block_size!r}")
         self.register_buffer("weight", weight.contiguous(), persistent=False)
         self.register_buffer(
             "weight_scale", weight_scale.contiguous(), persistent=False
         )
+        self.block_size = block_size
         self._fp8_logical_output_size = weight.shape[0]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -54,7 +62,7 @@ class _CudaRuntimeFusedFp8Linear(nn.Module):
         scale_ue8m0 = self.weight_scale.dtype == torch.int32
         qinput, input_scales = _resolve_sgl_per_token_group_quant()(
             input_2d,
-            group_size=128,
+            group_size=self.block_size[1],
             eps=1e-4,
             column_major_scales=True,
             scale_tma_aligned=True,
@@ -87,7 +95,7 @@ def _rounded_fp8_values(weight: torch.Tensor) -> torch.Tensor:
 def _dequant_fp8_to_bf16(
     weight: torch.Tensor,
     scale: torch.Tensor,
-    block_size: tuple[int, int] = (128, 128),
+    block_size: tuple[int, int],
 ) -> torch.Tensor:
     """Dequantize per-tensor, per-channel, or per-block FP8 to BF16."""
     n, k = weight.shape
@@ -451,6 +459,7 @@ class DeepSeekV32MlaAttention(RtpModule):
             self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
                 fused_a_weight,
                 fused_a_scale,
+                self.q_a_proj.fp8_scale_block_size(),
             )
             self._fused_qkv_a_w = fused_a_weight
         else:
@@ -475,7 +484,9 @@ class DeepSeekV32MlaAttention(RtpModule):
                     fused_a_weight, fused_a_scale
                 )
                 self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
-                    fused_a_weight, fused_a_scale
+                    fused_a_weight,
+                    fused_a_scale,
+                    self.q_a_proj.fp8_scale_block_size(),
                 )
                 self._fused_qkv_a_w = fused_a_weight
             else:
@@ -626,6 +637,8 @@ class DeepSeekV32MlaAttention(RtpModule):
             if self._fused_qkv_a_runtime is not None:
                 fused_qkv_a = self._fused_qkv_a_runtime(hidden_states)
             else:
+                if self._fused_qkv_a_w is None:
+                    raise RuntimeError("process_weights_after_loading() must run first")
                 fused_qkv_a = torch.nn.functional.linear(
                     hidden_states, self._fused_qkv_a_w
                 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -281,6 +281,10 @@ class DeepSeekV32MlaAttention(RtpModule):
         self.layer_idx = layer_idx
         self.tp_size = tp_size
         self.quant_config = quant_config
+        self._online_fp8 = (
+            quant_config is not None and quant_config.quant_type == "fp8_block_online"
+        )
+        self._checkpoint_weights_released = False
 
         # The checkpoint stores the A projections as FP8 per-block tensors.
         # Preserve their scale parameters during streaming load. Postprocessing
@@ -357,12 +361,19 @@ class DeepSeekV32MlaAttention(RtpModule):
         # Each head contributes (nope+v) contiguous rows, so a plain column
         # split lands whole heads on each rank; self.num_heads (= num_heads //
         # tp_size) then matches the loaded weight in the kc/vc derivation below.
+        # Online FP8 leaves are quantized one at a time before parent post-load
+        # hooks run. Keep kv_b in the checkpoint dtype until this attention
+        # module has derived the exact kc/vc decode views; process_weights then
+        # creates a separate FP8 runtime view for prefill on CUDA.
+        kv_b_quant_config = (
+            QuantizationConfig(quant_type="none") if self._online_fp8 else quant_config
+        )
         self.kv_b_proj = ColumnParallelLinear(
             input_size=kv_lora_rank,
             output_size=num_heads * (nope_head_dim + v_head_dim),
             tp_size=tp_size,
             tp_rank=tp_rank,
-            quant_config=quant_config,
+            quant_config=kv_b_quant_config,
             prefix="kv_b_proj",
             bias=False,
             params_dtype=params_dtype,
@@ -385,11 +396,18 @@ class DeepSeekV32MlaAttention(RtpModule):
         self.register_buffer("_fused_qkv_a_s", None, persistent=False)
         self._fused_qkv_a_runtime: Optional[nn.Module] = None
         self.register_buffer("_kv_b_w", None, persistent=False)
+        self.register_buffer("_kv_b_runtime_w", None, persistent=False)
+        self.register_buffer("_kv_b_runtime_s", None, persistent=False)
         self.register_buffer("_kc_w", None, persistent=False)
         self.register_buffer("_vc_w", None, persistent=False)
         self.indexer: Optional[nn.Module] = None
 
     def load_weights(self, weights):
+        if self._checkpoint_weights_released:
+            raise RuntimeError(
+                "MLA checkpoint weights were released after runtime layout "
+                "construction; rebuild the model before loading new weights"
+            )
         if self.q_lora_rank == 0:
             items = weights.items() if isinstance(weights, dict) else weights
             weights = {
@@ -488,19 +506,33 @@ class DeepSeekV32MlaAttention(RtpModule):
             .contiguous()
             .view(self.kv_lora_rank, head_num, nope + v_head)
         )
-        # _kv_b_w: [kv_lora_rank, head_num * (nope + v_head)] — transposed kv_b
-        # for FlashInfer prefill (matches legacy DeepSeekV2's `transpose` rule).
-        # Decode/absorb paths use _kc_w / _vc_w instead.
-        kv_b_scale = _fp8_scale_parameter(self.kv_b_proj)
-        self._kv_b_w = (
-            None
-            if kv_b_scale is not None
-            else t.view(self.kv_lora_rank, head_num * (nope + v_head)).contiguous()
-        )
         # _kc_w shape: [head_num, nope, kv_lora_rank]
         self._kc_w = t[:, :, :nope].permute(1, 2, 0).contiguous()
         # _vc_w shape: [head_num, kv_lora_rank, v_head]
         self._vc_w = t[:, :, nope:].transpose(0, 1).contiguous()
+        # _kv_b_w: [kv_lora_rank, head_num * (nope + v_head)] — transposed kv_b
+        # for BF16 FlashInfer prefill. Decode/absorb always consumes the exact
+        # BF16 checkpoint-derived kc/vc views above. CUDA online-FP8 builds a
+        # separate quantized prefill view only after those derivations.
+        kv_b_scale = _fp8_scale_parameter(self.kv_b_proj)
+        if self._online_fp8 and not is_hip:
+            from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
+
+            runtime_weight, runtime_scale = per_block_cast_to_fp8(
+                kv_b_w,
+                use_ue8m0=False,
+            )
+            (
+                self._kv_b_runtime_w,
+                self._kv_b_runtime_s,
+            ) = _prepare_fused_fp8_runtime_weight(runtime_weight, runtime_scale)
+            self._kv_b_w = None
+        else:
+            self._kv_b_w = (
+                None
+                if kv_b_scale is not None
+                else t.view(self.kv_lora_rank, head_num * (nope + v_head)).contiguous()
+            )
 
     def _build_mla_kernel_weights(self) -> Dict[str, torch.Tensor]:
         """Assemble the W.* dict that MlaImplBase expects at forward time."""
@@ -558,7 +590,17 @@ class DeepSeekV32MlaAttention(RtpModule):
         # absorb/decode paths.
         kv_b_weight = self.kv_b_proj.weight.data
         kv_b_scale = _fp8_scale_parameter(self.kv_b_proj)
-        if kv_b_scale is not None:
+        if self._kv_b_runtime_w is not None:
+            if self._kv_b_runtime_s is None:
+                raise RuntimeError("online-FP8 MLA kv_b runtime scale is missing")
+            (
+                weights[W.mla_kv_b_w],
+                weights[W.mla_kv_b_s],
+            ) = _kernel_fp8_weight_and_scale(
+                self._kv_b_runtime_w,
+                self._kv_b_runtime_s,
+            )
+        elif kv_b_scale is not None:
             (
                 weights[W.mla_kv_b_w],
                 weights[W.mla_kv_b_s],
@@ -580,18 +622,21 @@ class DeepSeekV32MlaAttention(RtpModule):
         NewModelLoader validation and every child quantization post-load hook
         must finish before this method runs. The top-level model therefore
         calls it only after `_build_mla_kernel_weights()` has captured the
-        runtime tensors consumed by attention factories.
+        runtime tensors consumed by attention factories. This transition is
+        intentionally irreversible: weight refresh requires rebuilding the
+        module so checkpoint-shaped parameters and quantization state exist.
         """
         if self._fused_qkv_a_w is None:
             raise RuntimeError("MLA runtime weights must be built before release")
         parameter_names = ("weight", "weight_scale", "weight_scale_inv")
         _release_parameter_storage(self.q_a_proj, parameter_names)
         _release_parameter_storage(self.kv_a_proj_with_mqa, parameter_names)
-        # BF16 prefill consumes the transposed `_kv_b_w` copy. FP8 prefill
-        # consumes kv_b_proj weight/scale directly through the kernel layout,
-        # so that storage must remain live.
+        # BF16 and online-FP8 prefill consume derived runtime copies.
+        # Pre-quantized FP8 consumes kv_b_proj weight/scale directly through
+        # the kernel layout, so only that checkpoint storage must remain live.
         if _fp8_scale_parameter(self.kv_b_proj) is None:
             _release_parameter_storage(self.kv_b_proj, parameter_names)
+        self._checkpoint_weights_released = True
 
     def _run_sparse_indexer(
         self,

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -19,7 +19,6 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 
-from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
 from rtp_llm.models_py.layers.norm import RMSNorm
 from rtp_llm.models_py.module_base import RtpModule
@@ -45,7 +44,6 @@ class _CudaRuntimeFusedFp8Linear(nn.Module):
             "weight_scale", weight_scale.contiguous(), persistent=False
         )
         self._fp8_logical_output_size = weight.shape[0]
-        self.prefix = "fused_qkv_a_runtime"
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         input_2d = x.view(-1, x.shape[-1]).contiguous()
@@ -268,6 +266,7 @@ class DeepSeekV32MlaAttention(RtpModule):
         quant_config: Optional[QuantizationConfig] = None,
         params_dtype: torch.dtype = torch.bfloat16,
         layernorm_eps: float = 1e-6,
+        prefix: str = "self_attn",
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -316,7 +315,7 @@ class DeepSeekV32MlaAttention(RtpModule):
             tp_size=q_a_tp_size,
             tp_rank=q_a_tp_rank,
             quant_config=a_proj_quant_config,
-            prefix="q_a_proj" if q_lora_rank > 0 else "q_proj",
+            prefix=f"{prefix}.q_a_proj" if q_lora_rank > 0 else f"{prefix}.q_proj",
             bias=False,
             params_dtype=params_dtype,
         )
@@ -328,7 +327,7 @@ class DeepSeekV32MlaAttention(RtpModule):
             tp_size=1,
             tp_rank=0,
             quant_config=a_proj_quant_config,
-            prefix="kv_a_proj_with_mqa",
+            prefix=f"{prefix}.kv_a_proj_with_mqa",
             bias=False,
             params_dtype=params_dtype,
         )
@@ -348,7 +347,7 @@ class DeepSeekV32MlaAttention(RtpModule):
                 tp_size=tp_size,
                 tp_rank=tp_rank,
                 quant_config=quant_config,
-                prefix="q_b_proj",
+                prefix=f"{prefix}.q_b_proj",
                 bias=False,
                 params_dtype=params_dtype,
             )
@@ -374,7 +373,7 @@ class DeepSeekV32MlaAttention(RtpModule):
             tp_size=tp_size,
             tp_rank=tp_rank,
             quant_config=kv_b_quant_config,
-            prefix="kv_b_proj",
+            prefix=f"{prefix}.kv_b_proj",
             bias=False,
             params_dtype=params_dtype,
         )
@@ -385,9 +384,9 @@ class DeepSeekV32MlaAttention(RtpModule):
             tp_size=tp_size,
             tp_rank=tp_rank,
             quant_config=quant_config,
-            prefix="o_proj",
+            prefix=f"{prefix}.o_proj",
             bias=False,
-            reduce_output=False,
+            reduce_output=True,
             params_dtype=params_dtype,
         )
 
@@ -692,6 +691,4 @@ class DeepSeekV32MlaAttention(RtpModule):
                 device=hidden_states.device,
             )
         attn_output = self.o_proj(attn_output)
-        if self.tp_size > 1:
-            attn_output = all_reduce(attn_output, group=Group.TP)
         return attn_output

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -1,0 +1,586 @@
+"""
+MLA attention for DeepSeek V3.2, new-loader style.
+
+Key design decisions:
+  - __init__ creates independent nn.Module submodules named with HF ckpt keys
+    (q_a_proj, kv_a_proj_with_mqa, q_a_layernorm, kv_a_layernorm, q_b_proj, o_proj).
+    HF weights flow through RtpModule.load_weights directly into nn.Parameter.
+  - process_weights_after_loading() fuses q_a_proj + kv_a_proj_with_mqa into
+    _fused_qkv_a_w (following Qwen3Experts pattern), and stacks q_b_proj
+    + kv_b_proj split into _fused_qkv_b_w.
+  - _build_mla_kernel_weights() assembles the W.* layout that MlaImplBase
+    factory expects at forward time.
+  - forward() mirrors MlaAttention.forward() exactly; the Indexer is a
+    separate submodule built by the DecoderLayer when is_sparse is True.
+"""
+
+import math
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
+from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
+from rtp_llm.models_py.layers.norm import RMSNorm
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules.factory.attention.attn_factory import MlaImplBase
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.quant_methods.fp8 import (
+    _resolve_fp8_gemm_nt,
+    _resolve_sgl_per_token_group_quant,
+)
+from rtp_llm.ops.compute_ops import LayerKVCache
+from rtp_llm.utils.model_weight import W
+
+
+class _CudaRuntimeFusedFp8Linear(nn.Module):
+    """CUDA-only fused view over independently loaded FP8 projections."""
+
+    def __init__(self, weight: torch.Tensor, weight_scale: torch.Tensor):
+        super().__init__()
+        self.register_buffer("weight", weight.contiguous(), persistent=False)
+        self.register_buffer(
+            "weight_scale", weight_scale.contiguous(), persistent=False
+        )
+        self._fp8_logical_output_size = weight.shape[0]
+        self.prefix = "fused_qkv_a_runtime"
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_2d = x.view(-1, x.shape[-1]).contiguous()
+        qinput, input_scales = _resolve_sgl_per_token_group_quant()(
+            input_2d,
+            group_size=128,
+            eps=1e-4,
+            column_major_scales=True,
+            scale_tma_aligned=True,
+            scale_ue8m0=False,
+        )
+        output = torch.empty(
+            input_2d.shape[0],
+            self.weight.shape[0],
+            dtype=torch.bfloat16,
+            device=input_2d.device,
+        )
+        _resolve_fp8_gemm_nt()(
+            (qinput, input_scales),
+            (self.weight, self.weight_scale),
+            output,
+            c=None,
+            disable_ue8m0_cast=True,
+        )
+        return output.view(*x.shape[:-1], self.weight.shape[0])
+
+
+def _rounded_fp8_values(weight: torch.Tensor) -> torch.Tensor:
+    # The legacy MLA kc/vc derivation loads both the FP8 codes and block
+    # scales through the model compute dtype before dequantization.  Preserve
+    # that rounding only for these kernel-facing BF16 views; the projection
+    # modules themselves keep the original FP8 weight and FP32 scale.
+    return weight.to(torch.bfloat16).to(torch.float32)
+
+
+def _dequant_fp8_to_bf16(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: tuple[int, int] = (128, 128),
+) -> torch.Tensor:
+    """Dequantize per-tensor, per-channel, or per-block FP8 to BF16."""
+    n, k = weight.shape
+    w = _rounded_fp8_values(weight)
+    s = scale.to(torch.bfloat16).to(torch.float32)
+    if s.numel() == 1:
+        return (w * s.reshape(1, 1)).to(torch.bfloat16)
+    if s.dim() == 1 and s.shape[0] == n:
+        return (w * s.reshape(n, 1)).to(torch.bfloat16)
+    if s.dim() == 2 and tuple(s.shape) == (n, 1):
+        return (w * s).to(torch.bfloat16)
+    if s.dim() == 2 and tuple(s.shape) == (1, n):
+        return (w * s.t()).to(torch.bfloat16)
+    if s.dim() != 2:
+        raise ValueError(
+            f"Unsupported FP8 scale shape {tuple(scale.shape)} for "
+            f"weight {tuple(weight.shape)}"
+        )
+
+    block_n, block_k = block_size
+    expected = (math.ceil(n / block_n), math.ceil(k / block_k))
+    if tuple(s.shape) != expected:
+        raise ValueError(
+            f"FP8 block scale shape must be {expected} for weight "
+            f"{tuple(weight.shape)}, got {tuple(scale.shape)}"
+        )
+    s = s.repeat_interleave(block_n, dim=0).repeat_interleave(block_k, dim=1)
+    s = s[:n, :k]
+    return (w * s).to(torch.bfloat16)
+
+
+def _fp8_block_size(linear: nn.Module) -> tuple[int, int]:
+    quant_config = getattr(linear, "quant_config", None)
+    value = getattr(quant_config, "weight_block_size", (128, 128))
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"Invalid FP8 weight_block_size {value!r}")
+    block_n, block_k = value
+    if any(
+        isinstance(item, bool) or not isinstance(item, int) or item <= 0
+        for item in (block_n, block_k)
+    ):
+        raise ValueError(f"Invalid FP8 weight_block_size {value!r}")
+    return block_n, block_k
+
+
+def _is_fp8_block_scale(linear: nn.Module, scale: torch.Tensor) -> bool:
+    if scale.dim() != 2:
+        return False
+    block_n, block_k = _fp8_block_size(linear)
+    expected = (
+        math.ceil(linear.weight.shape[0] / block_n),
+        math.ceil(linear.weight.shape[1] / block_k),
+    )
+    return tuple(scale.shape) == expected
+
+
+def _linear_weight_bf16(linear: nn.Module) -> torch.Tensor:
+    """Return a linear's weight as bf16, dequantizing it when it is FP8.
+
+    Used by the MLA post-load derivations (fused qkv-a, kc/vc) which run
+    through torch.cat / torch.bmm — neither supports fp8 — even though the
+    forward projections themselves keep running the fp8 weights via DeepGEMM.
+    Called from the attention module's post-load hook, which fires before the
+    child linears' own hook (parent-before-child), so the scale is still under
+    `weight_scale_inv`; `weight_scale` is checked too for robustness.
+    """
+    w = linear.weight.data
+    fp8_dtypes = (torch.float8_e4m3fn,)
+    if hasattr(torch, "float8_e4m3fnuz"):
+        fp8_dtypes += (torch.float8_e4m3fnuz,)
+    if w.dtype not in fp8_dtypes:
+        return w
+    scale = getattr(linear, "weight_scale_inv", None)
+    if scale is None:
+        scale = getattr(linear, "weight_scale", None)
+    if scale is None:
+        raise RuntimeError(
+            f"fp8 linear missing block scale: {getattr(linear, 'prefix', '?')}"
+        )
+    return _dequant_fp8_to_bf16(w, scale.data, _fp8_block_size(linear))
+
+
+class DeepSeekV32MlaAttention(RtpModule):
+    """MLA attention for DeepSeek V3.2, new-loader style.
+
+    HF ckpt keys consumed (per layer):
+      model.layers.{i}.self_attn.q_a_proj.weight          → q_a_proj
+      model.layers.{i}.self_attn.kv_a_proj_with_mqa.weight → kv_a_proj_with_mqa
+      model.layers.{i}.self_attn.q_a_layernorm.weight      → q_a_layernorm
+      model.layers.{i}.self_attn.kv_a_layernorm.weight     → kv_a_layernorm
+      model.layers.{i}.self_attn.q_b_proj.weight           → q_b_proj
+      model.layers.{i}.self_attn.kv_b_proj.weight          → kv_b_proj
+      model.layers.{i}.self_attn.o_proj.weight             → o_proj
+
+    process_weights_after_loading fuses q_a_proj + kv_a_proj_with_mqa into
+    _fused_qkv_a_w, copies q_b_proj into _fused_qkv_b_w, and splits
+    kv_b_proj into _kc_w (nope half) and _vc_w (v half) using the same
+    transpose+slice formula as the legacy loader.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        nope_head_dim: int,
+        rope_head_dim: int,
+        v_head_dim: int,
+        layer_idx: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.bfloat16,
+        layernorm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads // tp_size
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.nope_head_dim = nope_head_dim
+        self.rope_head_dim = rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_head_dim = nope_head_dim + rope_head_dim
+        self.layer_idx = layer_idx
+        self.tp_size = tp_size
+        self.quant_config = quant_config
+        self.softmax_scale = self.q_head_dim ** (-0.5)
+
+        # The checkpoint stores the A projections as FP8 per-block tensors.
+        # Preserve their scale parameters during streaming load. Postprocessing
+        # builds BF16 kernel views while forward keeps the fused FP8 execution.
+        # An unquantized allocation would silently drop weight_scale_inv and
+        # cast the raw FP8 codes to BF16 without applying their scales.
+        # Legacy MLA keeps A projections in BF16 for runtime/on-the-fly FP8.
+        # Pre-quantized checkpoints still need their stored FP8 scales preserved.
+        a_proj_quant_config = (
+            quant_config
+            if quant_config is not None
+            and not quant_config.quant_type.endswith("_online")
+            else QuantizationConfig(quant_type="none")
+        )
+
+        # --- Independent submodules matching HF ckpt names ---
+        # q_a_proj is either the LoRA down-projection (hidden -> q_lora_rank)
+        # or, when q_lora_rank == 0, the direct query projection
+        # (hidden -> num_heads * q_head_dim). The LoRA down-projection is
+        # replicated, while direct Q is sharded by head across TP ranks.
+        q_a_output_size = (
+            q_lora_rank if q_lora_rank > 0 else num_heads * self.q_head_dim
+        )
+        q_a_tp_size = 1 if q_lora_rank > 0 else tp_size
+        q_a_tp_rank = 0 if q_lora_rank > 0 else tp_rank
+        self.q_a_proj = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=q_a_output_size,
+            tp_size=q_a_tp_size,
+            tp_rank=q_a_tp_rank,
+            quant_config=a_proj_quant_config,
+            prefix="q_a_proj" if q_lora_rank > 0 else "q_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        # kv_a_proj_with_mqa: hidden → (kv_lora_rank + rope_head_dim).
+        # MQA shared kv latent + k_pe — REPLICATED across TP ranks (tp_size=1).
+        self.kv_a_proj_with_mqa = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=kv_lora_rank + rope_head_dim,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=a_proj_quant_config,
+            prefix="kv_a_proj_with_mqa",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        self.q_a_layernorm = (
+            RMSNorm(q_lora_rank, eps=layernorm_eps, params_dtype=params_dtype)
+            if q_lora_rank > 0
+            else None
+        )
+        self.kv_a_layernorm = RMSNorm(
+            kv_lora_rank, eps=layernorm_eps, params_dtype=params_dtype
+        )
+        # q_b_proj: q_lora_rank → num_heads * q_head_dim
+        # It is unused when q_lora_rank == 0. Keep the empty [N, 0] placeholder
+        # unquantized so online FP8 methods do not launch a CUDA kernel with a
+        # zero-sized input dimension.
+        q_b_quant_config = quant_config if q_lora_rank > 0 else a_proj_quant_config
+        self.q_b_proj = (
+            ColumnParallelLinear(
+                input_size=q_lora_rank,
+                output_size=num_heads * self.q_head_dim,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+                quant_config=q_b_quant_config,
+                prefix="q_b_proj",
+                bias=False,
+                params_dtype=params_dtype,
+            )
+            if q_lora_rank > 0
+            else None
+        )
+        # kv_b_proj: kv_lora_rank → num_heads * (nope_head_dim + v_head_dim).
+        # Per-head k_nope / v up-projection — SHARDED by head along the output
+        # dim (column parallel), matching the legacy loader's head_num split.
+        # Each head contributes (nope+v) contiguous rows, so a plain column
+        # split lands whole heads on each rank; self.num_heads (= num_heads //
+        # tp_size) then matches the loaded weight in the kc/vc derivation below.
+        self.kv_b_proj = ColumnParallelLinear(
+            input_size=kv_lora_rank,
+            output_size=num_heads * (nope_head_dim + v_head_dim),
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="kv_b_proj",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        # o_proj: num_heads * v_head_dim → hidden
+        self.o_proj = RowParallelLinear(
+            input_size=num_heads * v_head_dim,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="o_proj",
+            bias=False,
+            reduce_output=False,
+            params_dtype=params_dtype,
+        )
+
+        # --- Fused weights (built after loading) ---
+        self.register_buffer("_fused_qkv_a_w", None, persistent=False)
+        self._fused_qkv_a_runtime: Optional[nn.Module] = None
+        self.register_buffer("_fused_qkv_b_w", None, persistent=False)
+        self.register_buffer("_kv_b_w", None, persistent=False)
+        self.register_buffer("_kc_w", None, persistent=False)
+        self.register_buffer("_vc_w", None, persistent=False)
+
+    def load_weights(self, weights):
+        if self.q_lora_rank == 0:
+            items = weights.items() if isinstance(weights, dict) else weights
+            weights = {
+                (
+                    "q_a_proj." + name[len("q_proj.") :]
+                    if name.startswith("q_proj.")
+                    else name
+                ): tensor
+                for name, tensor in items
+            }
+        return super().load_weights(weights)
+
+    def process_weights_after_loading(self):
+        """Fuse q_a_proj + kv_a_proj_with_mqa into a single _fused_qkv_a_w.
+
+        Also collect q_b_proj weight into _fused_qkv_b_w, and split
+        kv_b_proj into _kc_w (nope) and _vc_w (v) using the same formula
+        as the legacy loader's transpose_slice_k / transpose_slice_v
+        (utils/model_weight.py).
+        """
+        # These derivations run through torch.cat / torch.bmm, which do not
+        # support fp8, so dequantize the (possibly fp8-per-block) weights to
+        # bf16 here. The forward projections still execute the fp8 weights via
+        # the linear's DeepGEMM apply — this only affects the kc/vc + fused
+        # views consumed by the MLA kernel.
+        q_a_scale = getattr(self.q_a_proj, "weight_scale_inv", None)
+        kv_a_scale = getattr(self.kv_a_proj_with_mqa, "weight_scale_inv", None)
+        is_hip = getattr(torch.version, "hip", None) is not None
+        block_n, _ = _fp8_block_size(self.q_a_proj)
+        fused_a_block_aligned = self.q_a_proj.weight.shape[0] % block_n == 0
+        if (
+            q_a_scale is not None
+            and kv_a_scale is not None
+            and not is_hip
+            and fused_a_block_aligned
+            and _is_fp8_block_scale(self.q_a_proj, q_a_scale)
+            and _is_fp8_block_scale(self.kv_a_proj_with_mqa, kv_a_scale)
+        ):
+            self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
+                torch.cat(
+                    [
+                        self.q_a_proj.weight.detach(),
+                        self.kv_a_proj_with_mqa.weight.detach(),
+                    ],
+                    dim=0,
+                ),
+                torch.cat(
+                    [q_a_scale.detach(), kv_a_scale.detach()],
+                    dim=0,
+                ),
+            )
+
+        q_a_w = _linear_weight_bf16(self.q_a_proj)
+        kv_a_w = _linear_weight_bf16(self.kv_a_proj_with_mqa)
+        if (
+            self._fused_qkv_a_runtime is None
+            and not is_hip
+            and self.quant_config is not None
+            and self.quant_config.quant_type == "fp8_block_online"
+        ):
+            from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
+
+            fused_a_fp8, fused_a_scale = per_block_cast_to_fp8(
+                torch.cat([q_a_w, kv_a_w], dim=0),
+                use_ue8m0=False,
+            )
+            self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
+                fused_a_fp8, fused_a_scale
+            )
+        self._fused_qkv_a_w = torch.cat([q_a_w, kv_a_w], dim=0).contiguous()
+        if self.q_lora_rank > 0:
+            if self.q_b_proj is None:
+                raise RuntimeError("q_b_proj is required when q_lora_rank is positive")
+            # q_b_proj weight: [num_heads * q_head_dim, q_lora_rank]
+            self._fused_qkv_b_w = _linear_weight_bf16(self.q_b_proj).clone()
+
+        # kv_b_proj weight: [num_heads * (nope + v_head), kv_lora_rank].
+        # Reshape to [kv_lora_rank, num_heads, nope+v_head] then slice.
+        kv_b_w = _linear_weight_bf16(self.kv_b_proj)
+        head_num = self.num_heads
+        nope = self.nope_head_dim
+        v_head = self.v_head_dim
+        t = (
+            kv_b_w.transpose(0, 1)
+            .contiguous()
+            .view(self.kv_lora_rank, head_num, nope + v_head)
+        )
+        # _kv_b_w: [kv_lora_rank, head_num * (nope + v_head)] — transposed kv_b
+        # for FlashInfer prefill (matches legacy DeepSeekV2's `transpose` rule).
+        # Decode/absorb paths use _kc_w / _vc_w instead.
+        self._kv_b_w = t.view(
+            self.kv_lora_rank, head_num * (nope + v_head)
+        ).contiguous()
+        # _kc_w shape: [head_num, nope, kv_lora_rank]
+        self._kc_w = t[:, :, :nope].permute(1, 2, 0).contiguous()
+        # _vc_w shape: [head_num, kv_lora_rank, v_head]
+        self._vc_w = t[:, :, nope:].transpose(0, 1).contiguous()
+
+    def _build_mla_kernel_weights(self) -> Dict[str, torch.Tensor]:
+        """Assemble the W.* dict that MlaImplBase expects at forward time."""
+        if self._fused_qkv_a_w is None:
+            raise RuntimeError(
+                "process_weights_after_loading() must be called before "
+                "_build_mla_kernel_weights()"
+            )
+        weights: Dict[str, torch.Tensor] = {}
+        if self.q_lora_rank > 0:
+            if self._fused_qkv_b_w is None or self.q_a_layernorm is None:
+                raise RuntimeError("incomplete MLA Q-LoRA runtime layout")
+            weights[W.mla_fusedqkrope_w] = self._fused_qkv_a_w
+            weights[W.mla_q_b_w] = self._fused_qkv_b_w
+            weights[W.mla_q_a_ln_gamma] = self.q_a_layernorm.weight.data
+        else:
+            weights[W.mla_fusedqkrope_no_lora_w] = self._fused_qkv_a_w
+        weights[W.mla_kv_a_ln_gamma] = self.kv_a_layernorm.weight.data
+        o_weight = self.o_proj.weight.data
+        if hasattr(self.o_proj, "weight_scale"):
+            o_scale = self.o_proj.weight_scale.data
+            weights[W.attn_o_w] = (
+                o_weight.reshape(o_weight.shape[1], o_weight.shape[0])
+                if o_scale.dim() == 2
+                else o_weight
+            )
+            weights[W.attn_o_s] = (
+                o_scale.reshape(o_scale.shape[1], o_scale.shape[0])
+                if o_scale.dim() == 2
+                else o_scale
+            )
+        else:
+            # BF16 LinearFactory consumes the legacy [input, output] layout.
+            # Keep a transpose view so GEMM observes the correct stride.
+            weights[W.attn_o_w] = o_weight.t()
+
+        # Prefill consumes kv_b through the attention factory. Preserve the
+        # FP8 weight/scale pair so it selects the same block-quantized linear
+        # as the legacy loader; kc/vc remain dequantized derived views for the
+        # absorb/decode paths.
+        kv_b_weight = self.kv_b_proj.weight.data
+        if hasattr(self.kv_b_proj, "weight_scale"):
+            kv_b_scale = self.kv_b_proj.weight_scale.data
+            weights[W.mla_kv_b_w] = (
+                kv_b_weight.reshape(kv_b_weight.shape[1], kv_b_weight.shape[0])
+                if kv_b_scale.dim() == 2
+                else kv_b_weight
+            )
+            weights[W.mla_kv_b_s] = (
+                kv_b_scale.reshape(kv_b_scale.shape[1], kv_b_scale.shape[0])
+                if kv_b_scale.dim() == 2
+                else kv_b_scale
+            )
+        else:
+            weights[W.mla_kv_b_w] = self._kv_b_w
+        weights[W.mla_kc] = self._kc_w
+        weights[W.mla_vc] = self._vc_w
+        return weights
+
+    def _run_sparse_indexer(
+        self,
+        hidden_states: torch.Tensor,
+        q_c: Optional[torch.Tensor],
+        q_view: torch.Tensor,
+        kv_cache: Optional[LayerKVCache],
+        fmha_impl: MlaImplBase,
+    ) -> Optional[torch.Tensor]:
+        """Compute sparse top-k indices via the Indexer submodule.
+
+        Mirrors legacy MlaAttention._run_sparse_indexer
+        (modules/hybrid/mla_attention.py).  Returns None for dense layers
+        (indexer not attached) so fmha_impl.forward gets a None and dense
+        backends short-circuit; sparse backends require non-None.
+        """
+        indexer = getattr(self, "indexer", None)
+        if indexer is None:
+            return None
+        q_for_indexer = q_c if self.q_lora_rank > 0 else q_view
+        return indexer(
+            hidden_states,
+            q_for_indexer,
+            kv_cache,
+            fmha_impl.fmha_params,
+            fmha_impl.attn_inputs,
+            use_fast_path=not fmha_impl.is_sparse(),
+            cp_params=fmha_impl.cp_params,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fmha_impl: MlaImplBase,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        q_c = None
+
+        if self.q_lora_rank > 0:
+            # The legacy path executes q_a + kv_a as one FP8 GEMM. Keep the
+            # checkpoint-facing modules independent, but use their fused
+            # runtime view so activation quantization and accumulation match.
+            if self._fused_qkv_a_runtime is not None:
+                fused_qkv_a = self._fused_qkv_a_runtime(hidden_states)
+            else:
+                fused_qkv_a = torch.nn.functional.linear(
+                    hidden_states, self._fused_qkv_a_w
+                )
+            q, kv_a = torch.split(
+                fused_qkv_a,
+                [self.q_lora_rank, self.kv_lora_rank + self.rope_head_dim],
+                dim=-1,
+            )
+            # split: q_a, then kv_a+rope
+            compressed_kv = kv_a[..., : self.kv_lora_rank]
+            k_pe = kv_a[..., self.kv_lora_rank :]
+            # q_a layernorm
+            if self.q_a_layernorm is None or self.q_b_proj is None:
+                raise RuntimeError("incomplete MLA Q-LoRA modules")
+            q_c = self.q_a_layernorm(q.contiguous())
+            # q_b projection
+            q = self.q_b_proj(q_c)
+        else:
+            # Match the legacy no-LoRA path's single fused BF16 projection.
+            if self._fused_qkv_a_w is None:
+                raise RuntimeError("process_weights_after_loading() must run first")
+            fused_qkv = torch.nn.functional.linear(hidden_states, self._fused_qkv_a_w)
+            q_offset = self.num_heads * self.q_head_dim
+            q_output, kv_output = torch.split(
+                fused_qkv,
+                [q_offset, self.kv_lora_rank + self.rope_head_dim],
+                dim=-1,
+            )
+            compressed_kv = kv_output[..., : self.kv_lora_rank]
+            k_pe = kv_output[..., self.kv_lora_rank :]
+            q = q_output
+
+        q_view = q.reshape(-1, self.num_heads, self.q_head_dim)
+
+        # kv_a layernorm
+        compressed_kv = self.kv_a_layernorm(compressed_kv.contiguous())
+
+        # Sparse Indexer (DSA) — runs only when self.indexer is attached
+        # (DecoderLayer sets self.indexer when is_sparse=True).
+        topk_indices = self._run_sparse_indexer(
+            hidden_states, q_c, q_view, kv_cache, fmha_impl
+        )
+        attn_output = fmha_impl.forward(
+            q_view, compressed_kv, k_pe, kv_cache, self.layer_idx, topk_indices
+        )
+
+        if attn_output is not None and attn_output.numel() != 0:
+            attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        else:
+            attn_output = torch.zeros(
+                (*input_shape, self.num_heads * self.v_head_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+        attn_output = self.o_proj(attn_output)
+        if self.tp_size > 1:
+            attn_output = all_reduce(attn_output, group=Group.TP)
+        return attn_output

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -6,8 +6,7 @@ Key design decisions:
     (q_a_proj, kv_a_proj_with_mqa, q_a_layernorm, kv_a_layernorm, q_b_proj, o_proj).
     HF weights flow through RtpModule.load_weights directly into nn.Parameter.
   - process_weights_after_loading() fuses q_a_proj + kv_a_proj_with_mqa into
-    _fused_qkv_a_w (following Qwen3Experts pattern), and stacks q_b_proj
-    + kv_b_proj split into _fused_qkv_b_w.
+    _fused_qkv_a_w and splits kv_b_proj into the absorb/decode views.
   - _build_mla_kernel_weights() assembles the W.* layout that MlaImplBase
     factory expects at forward time.
   - forward() mirrors MlaAttention.forward() exactly; the Indexer is a
@@ -28,7 +27,9 @@ from rtp_llm.models_py.modules.factory.attention.attn_factory import MlaImplBase
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.quant_methods.fp8 import (
     _resolve_fp8_gemm_nt,
+    _resolve_requant_weight_ue8m0,
     _resolve_sgl_per_token_group_quant,
+    is_deep_gemm_e8m0_used,
 )
 from rtp_llm.ops.compute_ops import LayerKVCache
 from rtp_llm.utils.model_weight import W
@@ -48,13 +49,14 @@ class _CudaRuntimeFusedFp8Linear(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         input_2d = x.view(-1, x.shape[-1]).contiguous()
+        scale_ue8m0 = self.weight_scale.dtype == torch.int32
         qinput, input_scales = _resolve_sgl_per_token_group_quant()(
             input_2d,
             group_size=128,
             eps=1e-4,
             column_major_scales=True,
             scale_tma_aligned=True,
-            scale_ue8m0=False,
+            scale_ue8m0=scale_ue8m0,
         )
         output = torch.empty(
             input_2d.shape[0],
@@ -67,7 +69,7 @@ class _CudaRuntimeFusedFp8Linear(nn.Module):
             (self.weight, self.weight_scale),
             output,
             c=None,
-            disable_ue8m0_cast=True,
+            disable_ue8m0_cast=not scale_ue8m0,
         )
         return output.view(*x.shape[:-1], self.weight.shape[0])
 
@@ -166,6 +168,43 @@ def _linear_weight_bf16(linear: nn.Module) -> torch.Tensor:
     return _dequant_fp8_to_bf16(w, scale.data, _fp8_block_size(linear))
 
 
+def _kernel_fp8_weight_and_scale(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the layout consumed by the legacy LinearFactory.
+
+    FP32 block scales use the historical flattened-transpose view. DeepGEMM
+    UE8M0 postprocessing instead stores an already runtime-ready ``[N, K]``
+    weight and packed int32 ``[N, ceil(K / 512)]`` scales; reshaping either
+    tensor would corrupt that contract.
+    """
+    if scale.dtype == torch.int32:
+        return weight, scale
+    if scale.dim() == 2:
+        return (
+            weight.reshape(weight.shape[1], weight.shape[0]),
+            scale.reshape(scale.shape[1], scale.shape[0]),
+        )
+    return weight, scale
+
+
+def _prepare_fused_fp8_runtime_weight(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply the same UE8M0 conversion as the child FP8 linear hook.
+
+    RtpModule post-load hooks visit this attention module before its child
+    projections.  The fused QKV-A runtime view must therefore perform the
+    device-specific conversion itself instead of caching the checkpoint's
+    pre-requantized FP32 block scales.
+    """
+    if is_deep_gemm_e8m0_used(weight.device):
+        return _resolve_requant_weight_ue8m0()(weight, scale)
+    return weight, scale
+
+
 class DeepSeekV32MlaAttention(RtpModule):
     """MLA attention for DeepSeek V3.2, new-loader style.
 
@@ -179,9 +218,8 @@ class DeepSeekV32MlaAttention(RtpModule):
       model.layers.{i}.self_attn.o_proj.weight             → o_proj
 
     process_weights_after_loading fuses q_a_proj + kv_a_proj_with_mqa into
-    _fused_qkv_a_w, copies q_b_proj into _fused_qkv_b_w, and splits
-    kv_b_proj into _kc_w (nope half) and _vc_w (v half) using the same
-    transpose+slice formula as the legacy loader.
+    _fused_qkv_a_w and splits kv_b_proj into _kc_w (nope half) and _vc_w
+    (v half) using the same transpose+slice formula as the legacy loader.
     """
 
     def __init__(
@@ -318,11 +356,12 @@ class DeepSeekV32MlaAttention(RtpModule):
 
         # --- Fused weights (built after loading) ---
         self.register_buffer("_fused_qkv_a_w", None, persistent=False)
+        self.register_buffer("_fused_qkv_a_s", None, persistent=False)
         self._fused_qkv_a_runtime: Optional[nn.Module] = None
-        self.register_buffer("_fused_qkv_b_w", None, persistent=False)
         self.register_buffer("_kv_b_w", None, persistent=False)
         self.register_buffer("_kc_w", None, persistent=False)
         self.register_buffer("_vc_w", None, persistent=False)
+        self.indexer: Optional[nn.Module] = None
 
     def load_weights(self, weights):
         if self.q_lora_rank == 0:
@@ -340,10 +379,10 @@ class DeepSeekV32MlaAttention(RtpModule):
     def process_weights_after_loading(self):
         """Fuse q_a_proj + kv_a_proj_with_mqa into a single _fused_qkv_a_w.
 
-        Also collect q_b_proj weight into _fused_qkv_b_w, and split
-        kv_b_proj into _kc_w (nope) and _vc_w (v) using the same formula
-        as the legacy loader's transpose_slice_k / transpose_slice_v
-        (utils/model_weight.py).
+        Also split kv_b_proj into _kc_w (nope) and _vc_w (v) using the same
+        formula as the legacy loader's transpose_slice_k / transpose_slice_v
+        (utils/model_weight.py). q_b_proj stays in its quantized linear module;
+        _build_mla_kernel_weights creates only a view over that storage.
         """
         # These derivations run through torch.cat / torch.bmm, which do not
         # support fp8, so dequantize the (possibly fp8-per-block) weights to
@@ -356,14 +395,15 @@ class DeepSeekV32MlaAttention(RtpModule):
         block_n, _ = _fp8_block_size(self.q_a_proj)
         fused_a_block_aligned = self.q_a_proj.weight.shape[0] % block_n == 0
         if (
-            q_a_scale is not None
+            self.q_lora_rank > 0
+            and q_a_scale is not None
             and kv_a_scale is not None
             and not is_hip
             and fused_a_block_aligned
             and _is_fp8_block_scale(self.q_a_proj, q_a_scale)
             and _is_fp8_block_scale(self.kv_a_proj_with_mqa, kv_a_scale)
         ):
-            self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
+            fused_a_weight, fused_a_scale = _prepare_fused_fp8_runtime_weight(
                 torch.cat(
                     [
                         self.q_a_proj.weight.detach(),
@@ -376,30 +416,40 @@ class DeepSeekV32MlaAttention(RtpModule):
                     dim=0,
                 ),
             )
-
-        q_a_w = _linear_weight_bf16(self.q_a_proj)
-        kv_a_w = _linear_weight_bf16(self.kv_a_proj_with_mqa)
-        if (
-            self._fused_qkv_a_runtime is None
-            and not is_hip
-            and self.quant_config is not None
-            and self.quant_config.quant_type == "fp8_block_online"
-        ):
-            from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
-
-            fused_a_fp8, fused_a_scale = per_block_cast_to_fp8(
-                torch.cat([q_a_w, kv_a_w], dim=0),
-                use_ue8m0=False,
-            )
             self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
-                fused_a_fp8, fused_a_scale
+                fused_a_weight,
+                fused_a_scale,
             )
-        self._fused_qkv_a_w = torch.cat([q_a_w, kv_a_w], dim=0).contiguous()
-        if self.q_lora_rank > 0:
-            if self.q_b_proj is None:
-                raise RuntimeError("q_b_proj is required when q_lora_rank is positive")
-            # q_b_proj weight: [num_heads * q_head_dim, q_lora_rank]
-            self._fused_qkv_b_w = _linear_weight_bf16(self.q_b_proj).clone()
+            self._fused_qkv_a_w = fused_a_weight
+            self._fused_qkv_a_s = fused_a_scale
+        else:
+            q_a_w = _linear_weight_bf16(self.q_a_proj)
+            kv_a_w = _linear_weight_bf16(self.kv_a_proj_with_mqa)
+            fused_a_bf16 = torch.cat([q_a_w, kv_a_w], dim=0).contiguous()
+            if (
+                self.q_lora_rank > 0
+                and not is_hip
+                and self.quant_config is not None
+                and self.quant_config.quant_type == "fp8_block_online"
+            ):
+                from rtp_llm.models_py.kernels.cuda.fp8_quant import (
+                    per_block_cast_to_fp8,
+                )
+
+                fused_a_weight, fused_a_scale = per_block_cast_to_fp8(
+                    fused_a_bf16,
+                    use_ue8m0=False,
+                )
+                fused_a_weight, fused_a_scale = _prepare_fused_fp8_runtime_weight(
+                    fused_a_weight, fused_a_scale
+                )
+                self._fused_qkv_a_runtime = _CudaRuntimeFusedFp8Linear(
+                    fused_a_weight, fused_a_scale
+                )
+                self._fused_qkv_a_w = fused_a_weight
+                self._fused_qkv_a_s = fused_a_scale
+            else:
+                self._fused_qkv_a_w = fused_a_bf16
 
         # kv_b_proj weight: [num_heads * (nope + v_head), kv_lora_rank].
         # Reshape to [kv_lora_rank, num_heads, nope+v_head] then slice.
@@ -432,26 +482,41 @@ class DeepSeekV32MlaAttention(RtpModule):
             )
         weights: Dict[str, torch.Tensor] = {}
         if self.q_lora_rank > 0:
-            if self._fused_qkv_b_w is None or self.q_a_layernorm is None:
+            if self.q_b_proj is None or self.q_a_layernorm is None:
                 raise RuntimeError("incomplete MLA Q-LoRA runtime layout")
-            weights[W.mla_fusedqkrope_w] = self._fused_qkv_a_w
-            weights[W.mla_q_b_w] = self._fused_qkv_b_w
+            if self._fused_qkv_a_s is not None:
+                (
+                    weights[W.mla_fusedqkrope_w],
+                    weights[W.mla_fusedqkrope_s],
+                ) = _kernel_fp8_weight_and_scale(
+                    self._fused_qkv_a_w,
+                    self._fused_qkv_a_s,
+                )
+            else:
+                weights[W.mla_fusedqkrope_w] = self._fused_qkv_a_w.t()
+
+            q_b_weight = self.q_b_proj.weight.data
+            if hasattr(self.q_b_proj, "weight_scale"):
+                q_b_scale = self.q_b_proj.weight_scale.data
+                (
+                    weights[W.mla_q_b_w],
+                    weights[W.mla_q_b_s],
+                ) = _kernel_fp8_weight_and_scale(q_b_weight, q_b_scale)
+            else:
+                weights[W.mla_q_b_w] = q_b_weight.t()
             weights[W.mla_q_a_ln_gamma] = self.q_a_layernorm.weight.data
         else:
-            weights[W.mla_fusedqkrope_no_lora_w] = self._fused_qkv_a_w
+            weights[W.mla_fusedqkrope_no_lora_w] = self._fused_qkv_a_w.t()
         weights[W.mla_kv_a_ln_gamma] = self.kv_a_layernorm.weight.data
         o_weight = self.o_proj.weight.data
         if hasattr(self.o_proj, "weight_scale"):
             o_scale = self.o_proj.weight_scale.data
-            weights[W.attn_o_w] = (
-                o_weight.reshape(o_weight.shape[1], o_weight.shape[0])
-                if o_scale.dim() == 2
-                else o_weight
-            )
-            weights[W.attn_o_s] = (
-                o_scale.reshape(o_scale.shape[1], o_scale.shape[0])
-                if o_scale.dim() == 2
-                else o_scale
+            (
+                weights[W.attn_o_w],
+                weights[W.attn_o_s],
+            ) = _kernel_fp8_weight_and_scale(
+                o_weight,
+                o_scale,
             )
         else:
             # BF16 LinearFactory consumes the legacy [input, output] layout.
@@ -465,15 +530,12 @@ class DeepSeekV32MlaAttention(RtpModule):
         kv_b_weight = self.kv_b_proj.weight.data
         if hasattr(self.kv_b_proj, "weight_scale"):
             kv_b_scale = self.kv_b_proj.weight_scale.data
-            weights[W.mla_kv_b_w] = (
-                kv_b_weight.reshape(kv_b_weight.shape[1], kv_b_weight.shape[0])
-                if kv_b_scale.dim() == 2
-                else kv_b_weight
-            )
-            weights[W.mla_kv_b_s] = (
-                kv_b_scale.reshape(kv_b_scale.shape[1], kv_b_scale.shape[0])
-                if kv_b_scale.dim() == 2
-                else kv_b_scale
+            (
+                weights[W.mla_kv_b_w],
+                weights[W.mla_kv_b_s],
+            ) = _kernel_fp8_weight_and_scale(
+                kv_b_weight,
+                kv_b_scale,
             )
         else:
             weights[W.mla_kv_b_w] = self._kv_b_w
@@ -496,11 +558,10 @@ class DeepSeekV32MlaAttention(RtpModule):
         (indexer not attached) so fmha_impl.forward gets a None and dense
         backends short-circuit; sparse backends require non-None.
         """
-        indexer = getattr(self, "indexer", None)
-        if indexer is None:
+        if self.indexer is None:
             return None
         q_for_indexer = q_c if self.q_lora_rank > 0 else q_view
-        return indexer(
+        return self.indexer(
             hidden_states,
             q_for_indexer,
             kv_cache,

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -7,14 +7,14 @@ Key design decisions:
     HF weights flow through RtpModule.load_weights directly into nn.Parameter.
   - process_weights_after_loading() fuses q_a_proj + kv_a_proj_with_mqa into
     _fused_qkv_a_w and splits kv_b_proj into the absorb/decode views.
-  - _build_mla_kernel_weights() assembles the W.* layout that MlaImplBase
-    factory expects at forward time.
+  - _build_mla_kernel_weights() exposes only the kv_b/kc/vc tensors consumed
+    by the MLA backend; Q and O projections execute through this module.
   - forward() mirrors MlaAttention.forward() exactly; the Indexer is a
     separate submodule built by the DecoderLayer when is_sparse is True.
 """
 
 import math
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -393,7 +393,6 @@ class DeepSeekV32MlaAttention(RtpModule):
 
         # --- Fused weights (built after loading) ---
         self.register_buffer("_fused_qkv_a_w", None, persistent=False)
-        self.register_buffer("_fused_qkv_a_s", None, persistent=False)
         self._fused_qkv_a_runtime: Optional[nn.Module] = None
         self.register_buffer("_kv_b_w", None, persistent=False)
         self.register_buffer("_kv_b_runtime_w", None, persistent=False)
@@ -465,7 +464,6 @@ class DeepSeekV32MlaAttention(RtpModule):
                 fused_a_scale,
             )
             self._fused_qkv_a_w = fused_a_weight
-            self._fused_qkv_a_s = fused_a_scale
         else:
             q_a_w = _linear_weight_bf16(self.q_a_proj)
             kv_a_w = _linear_weight_bf16(self.kv_a_proj_with_mqa)
@@ -491,7 +489,6 @@ class DeepSeekV32MlaAttention(RtpModule):
                     fused_a_weight, fused_a_scale
                 )
                 self._fused_qkv_a_w = fused_a_weight
-                self._fused_qkv_a_s = fused_a_scale
             else:
                 self._fused_qkv_a_w = fused_a_bf16
 
@@ -535,55 +532,13 @@ class DeepSeekV32MlaAttention(RtpModule):
             )
 
     def _build_mla_kernel_weights(self) -> Dict[str, torch.Tensor]:
-        """Assemble the W.* dict that MlaImplBase expects at forward time."""
+        """Expose only the kv_b/kc/vc tensors consumed by MLA factories."""
         if self._fused_qkv_a_w is None:
             raise RuntimeError(
                 "process_weights_after_loading() must be called before "
                 "_build_mla_kernel_weights()"
             )
         weights: Dict[str, torch.Tensor] = {}
-        if self.q_lora_rank > 0:
-            if self.q_b_proj is None or self.q_a_layernorm is None:
-                raise RuntimeError("incomplete MLA Q-LoRA runtime layout")
-            if self._fused_qkv_a_s is not None:
-                (
-                    weights[W.mla_fusedqkrope_w],
-                    weights[W.mla_fusedqkrope_s],
-                ) = _kernel_fp8_weight_and_scale(
-                    self._fused_qkv_a_w,
-                    self._fused_qkv_a_s,
-                )
-            else:
-                weights[W.mla_fusedqkrope_w] = self._fused_qkv_a_w.t()
-
-            q_b_weight = self.q_b_proj.weight.data
-            q_b_scale = _fp8_scale_parameter(self.q_b_proj)
-            if q_b_scale is not None:
-                (
-                    weights[W.mla_q_b_w],
-                    weights[W.mla_q_b_s],
-                ) = _kernel_fp8_weight_and_scale(q_b_weight, q_b_scale.data)
-            else:
-                weights[W.mla_q_b_w] = q_b_weight.t()
-            weights[W.mla_q_a_ln_gamma] = self.q_a_layernorm.weight.data
-        else:
-            weights[W.mla_fusedqkrope_no_lora_w] = self._fused_qkv_a_w.t()
-        weights[W.mla_kv_a_ln_gamma] = self.kv_a_layernorm.weight.data
-        o_weight = self.o_proj.weight.data
-        o_scale = _fp8_scale_parameter(self.o_proj)
-        if o_scale is not None:
-            (
-                weights[W.attn_o_w],
-                weights[W.attn_o_s],
-            ) = _kernel_fp8_weight_and_scale(
-                o_weight,
-                o_scale.data,
-            )
-        else:
-            # BF16 LinearFactory consumes the legacy [input, output] layout.
-            # Keep a transpose view so GEMM observes the correct stride.
-            weights[W.attn_o_w] = o_weight.t()
-
         # Prefill consumes kv_b through the attention factory. Preserve the
         # FP8 weight/scale pair so it selects the same block-quantized linear
         # as the legacy loader; kc/vc remain dequantized derived views for the

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -158,14 +158,26 @@ def _linear_weight_bf16(linear: nn.Module) -> torch.Tensor:
         fp8_dtypes += (torch.float8_e4m3fnuz,)
     if w.dtype not in fp8_dtypes:
         return w
-    scale = getattr(linear, "weight_scale_inv", None)
+    scale = _fp8_scale_parameter(linear)
     if scale is None:
-        scale = getattr(linear, "weight_scale", None)
-    if scale is None:
-        raise RuntimeError(
-            f"fp8 linear missing block scale: {getattr(linear, 'prefix', '?')}"
-        )
+        raise RuntimeError(f"fp8 linear {type(linear).__name__} is missing block scale")
     return _dequant_fp8_to_bf16(w, scale.data, _fp8_block_size(linear))
+
+
+def _fp8_scale_parameter(linear: nn.Module) -> Optional[nn.Parameter]:
+    """Return the registered pre- or post-hook FP8 block scale.
+
+    Fp8BlockLinearMethod deliberately renames the registered parameter from
+    ``weight_scale_inv`` to ``weight_scale`` in its post-load hook. The MLA
+    parent hook runs before child hooks, while kernel views are built after
+    them, so both lifecycle states are part of the quant-method contract.
+    Keep that dynamic protocol isolated here instead of scattering
+    hasattr/getattr control flow across the attention implementation.
+    """
+    scale = linear._parameters.get("weight_scale")
+    if scale is None:
+        scale = linear._parameters.get("weight_scale_inv")
+    return scale
 
 
 def _kernel_fp8_weight_and_scale(
@@ -250,7 +262,6 @@ class DeepSeekV32MlaAttention(RtpModule):
         self.layer_idx = layer_idx
         self.tp_size = tp_size
         self.quant_config = quant_config
-        self.softmax_scale = self.q_head_dim ** (-0.5)
 
         # The checkpoint stores the A projections as FP8 per-block tensors.
         # Preserve their scale parameters during streaming load. Postprocessing
@@ -389,9 +400,9 @@ class DeepSeekV32MlaAttention(RtpModule):
         # bf16 here. The forward projections still execute the fp8 weights via
         # the linear's DeepGEMM apply — this only affects the kc/vc + fused
         # views consumed by the MLA kernel.
-        q_a_scale = getattr(self.q_a_proj, "weight_scale_inv", None)
-        kv_a_scale = getattr(self.kv_a_proj_with_mqa, "weight_scale_inv", None)
-        is_hip = getattr(torch.version, "hip", None) is not None
+        q_a_scale = _fp8_scale_parameter(self.q_a_proj)
+        kv_a_scale = _fp8_scale_parameter(self.kv_a_proj_with_mqa)
+        is_hip = torch.version.hip is not None
         block_n, _ = _fp8_block_size(self.q_a_proj)
         fused_a_block_aligned = self.q_a_proj.weight.shape[0] % block_n == 0
         if (
@@ -465,9 +476,12 @@ class DeepSeekV32MlaAttention(RtpModule):
         # _kv_b_w: [kv_lora_rank, head_num * (nope + v_head)] — transposed kv_b
         # for FlashInfer prefill (matches legacy DeepSeekV2's `transpose` rule).
         # Decode/absorb paths use _kc_w / _vc_w instead.
-        self._kv_b_w = t.view(
-            self.kv_lora_rank, head_num * (nope + v_head)
-        ).contiguous()
+        kv_b_scale = _fp8_scale_parameter(self.kv_b_proj)
+        self._kv_b_w = (
+            None
+            if kv_b_scale is not None
+            else t.view(self.kv_lora_rank, head_num * (nope + v_head)).contiguous()
+        )
         # _kc_w shape: [head_num, nope, kv_lora_rank]
         self._kc_w = t[:, :, :nope].permute(1, 2, 0).contiguous()
         # _vc_w shape: [head_num, kv_lora_rank, v_head]
@@ -496,12 +510,12 @@ class DeepSeekV32MlaAttention(RtpModule):
                 weights[W.mla_fusedqkrope_w] = self._fused_qkv_a_w.t()
 
             q_b_weight = self.q_b_proj.weight.data
-            if hasattr(self.q_b_proj, "weight_scale"):
-                q_b_scale = self.q_b_proj.weight_scale.data
+            q_b_scale = _fp8_scale_parameter(self.q_b_proj)
+            if q_b_scale is not None:
                 (
                     weights[W.mla_q_b_w],
                     weights[W.mla_q_b_s],
-                ) = _kernel_fp8_weight_and_scale(q_b_weight, q_b_scale)
+                ) = _kernel_fp8_weight_and_scale(q_b_weight, q_b_scale.data)
             else:
                 weights[W.mla_q_b_w] = q_b_weight.t()
             weights[W.mla_q_a_ln_gamma] = self.q_a_layernorm.weight.data
@@ -509,14 +523,14 @@ class DeepSeekV32MlaAttention(RtpModule):
             weights[W.mla_fusedqkrope_no_lora_w] = self._fused_qkv_a_w.t()
         weights[W.mla_kv_a_ln_gamma] = self.kv_a_layernorm.weight.data
         o_weight = self.o_proj.weight.data
-        if hasattr(self.o_proj, "weight_scale"):
-            o_scale = self.o_proj.weight_scale.data
+        o_scale = _fp8_scale_parameter(self.o_proj)
+        if o_scale is not None:
             (
                 weights[W.attn_o_w],
                 weights[W.attn_o_s],
             ) = _kernel_fp8_weight_and_scale(
                 o_weight,
-                o_scale,
+                o_scale.data,
             )
         else:
             # BF16 LinearFactory consumes the legacy [input, output] layout.
@@ -528,16 +542,18 @@ class DeepSeekV32MlaAttention(RtpModule):
         # as the legacy loader; kc/vc remain dequantized derived views for the
         # absorb/decode paths.
         kv_b_weight = self.kv_b_proj.weight.data
-        if hasattr(self.kv_b_proj, "weight_scale"):
-            kv_b_scale = self.kv_b_proj.weight_scale.data
+        kv_b_scale = _fp8_scale_parameter(self.kv_b_proj)
+        if kv_b_scale is not None:
             (
                 weights[W.mla_kv_b_w],
                 weights[W.mla_kv_b_s],
             ) = _kernel_fp8_weight_and_scale(
                 kv_b_weight,
-                kv_b_scale,
+                kv_b_scale.data,
             )
         else:
+            if self._kv_b_w is None:
+                raise RuntimeError("BF16 MLA kv_b runtime view was not constructed")
             weights[W.mla_kv_b_w] = self._kv_b_w
         weights[W.mla_kc] = self._kc_w
         weights[W.mla_vc] = self._vc_w

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -19,7 +19,11 @@ from typing import Dict, Optional
 import torch
 import torch.nn as nn
 
-from rtp_llm.models_py.layers.linear import ColumnParallelLinear, RowParallelLinear
+from rtp_llm.models_py.layers.linear import (
+    ColumnParallelLinear,
+    LinearBase,
+    RowParallelLinear,
+)
 from rtp_llm.models_py.layers.norm import RMSNorm
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.modules.factory.attention.attn_factory import MlaImplBase
@@ -115,24 +119,10 @@ def _dequant_fp8_to_bf16(
     return (w * s).to(torch.bfloat16)
 
 
-def _fp8_block_size(linear: nn.Module) -> tuple[int, int]:
-    quant_config = getattr(linear, "quant_config", None)
-    value = getattr(quant_config, "weight_block_size", (128, 128))
-    if not isinstance(value, (list, tuple)) or len(value) != 2:
-        raise ValueError(f"Invalid FP8 weight_block_size {value!r}")
-    block_n, block_k = value
-    if any(
-        isinstance(item, bool) or not isinstance(item, int) or item <= 0
-        for item in (block_n, block_k)
-    ):
-        raise ValueError(f"Invalid FP8 weight_block_size {value!r}")
-    return block_n, block_k
-
-
-def _is_fp8_block_scale(linear: nn.Module, scale: torch.Tensor) -> bool:
+def _is_fp8_block_scale(linear: LinearBase, scale: torch.Tensor) -> bool:
     if scale.dim() != 2:
         return False
-    block_n, block_k = _fp8_block_size(linear)
+    block_n, block_k = linear.fp8_scale_block_size()
     expected = (
         math.ceil(linear.weight.shape[0] / block_n),
         math.ceil(linear.weight.shape[1] / block_k),
@@ -140,7 +130,7 @@ def _is_fp8_block_scale(linear: nn.Module, scale: torch.Tensor) -> bool:
     return tuple(scale.shape) == expected
 
 
-def _linear_weight_bf16(linear: nn.Module) -> torch.Tensor:
+def _linear_weight_bf16(linear: LinearBase) -> torch.Tensor:
     """Return a linear's weight as bf16, dequantizing it when it is FP8.
 
     Used by the MLA post-load derivations (fused qkv-a, kc/vc) which run
@@ -159,10 +149,10 @@ def _linear_weight_bf16(linear: nn.Module) -> torch.Tensor:
     scale = _fp8_scale_parameter(linear)
     if scale is None:
         raise RuntimeError(f"fp8 linear {type(linear).__name__} is missing block scale")
-    return _dequant_fp8_to_bf16(w, scale.data, _fp8_block_size(linear))
+    return _dequant_fp8_to_bf16(w, scale.data, linear.fp8_scale_block_size())
 
 
-def _fp8_scale_parameter(linear: nn.Module) -> Optional[nn.Parameter]:
+def _fp8_scale_parameter(linear: LinearBase) -> Optional[nn.Parameter]:
     """Return the registered pre- or post-hook FP8 block scale.
 
     Fp8BlockLinearMethod deliberately renames the registered parameter from
@@ -434,7 +424,7 @@ class DeepSeekV32MlaAttention(RtpModule):
         q_a_scale = _fp8_scale_parameter(self.q_a_proj)
         kv_a_scale = _fp8_scale_parameter(self.kv_a_proj_with_mqa)
         is_hip = torch.version.hip is not None
-        block_n, _ = _fp8_block_size(self.q_a_proj)
+        block_n, _ = self.q_a_proj.fp8_scale_block_size()
         fused_a_block_aligned = self.q_a_proj.weight.shape[0] % block_n == 0
         if (
             self.q_lora_rank > 0

--- a/rtp_llm/models_py/new_models/deepseek_v3/attention.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/attention.py
@@ -180,6 +180,25 @@ def _fp8_scale_parameter(linear: nn.Module) -> Optional[nn.Parameter]:
     return scale
 
 
+def _release_parameter_storage(
+    module: nn.Module,
+    parameter_names: tuple[str, ...],
+) -> None:
+    """Replace checkpoint-only parameters with zero-sized device tensors."""
+    parameters = dict(module.named_parameters(recurse=False))
+    for name in parameter_names:
+        parameter = parameters.get(name)
+        if parameter is None:
+            continue
+        module.register_parameter(
+            name,
+            nn.Parameter(
+                parameter.detach().new_empty(0),
+                requires_grad=False,
+            ),
+        )
+
+
 def _kernel_fp8_weight_and_scale(
     weight: torch.Tensor,
     scale: torch.Tensor,
@@ -317,18 +336,14 @@ class DeepSeekV32MlaAttention(RtpModule):
         self.kv_a_layernorm = RMSNorm(
             kv_lora_rank, eps=layernorm_eps, params_dtype=params_dtype
         )
-        # q_b_proj: q_lora_rank → num_heads * q_head_dim
-        # It is unused when q_lora_rank == 0. Keep the empty [N, 0] placeholder
-        # unquantized so online FP8 methods do not launch a CUDA kernel with a
-        # zero-sized input dimension.
-        q_b_quant_config = quant_config if q_lora_rank > 0 else a_proj_quant_config
+        # q_b_proj exists only for Q-LoRA checkpoints.
         self.q_b_proj = (
             ColumnParallelLinear(
                 input_size=q_lora_rank,
                 output_size=num_heads * self.q_head_dim,
                 tp_size=tp_size,
                 tp_rank=tp_rank,
-                quant_config=q_b_quant_config,
+                quant_config=quant_config,
                 prefix="q_b_proj",
                 bias=False,
                 params_dtype=params_dtype,
@@ -558,6 +573,25 @@ class DeepSeekV32MlaAttention(RtpModule):
         weights[W.mla_kc] = self._kc_w
         weights[W.mla_vc] = self._vc_w
         return weights
+
+    def release_checkpoint_only_weights(self) -> None:
+        """Free projection parameters superseded by MLA runtime views.
+
+        NewModelLoader validation and every child quantization post-load hook
+        must finish before this method runs. The top-level model therefore
+        calls it only after `_build_mla_kernel_weights()` has captured the
+        runtime tensors consumed by attention factories.
+        """
+        if self._fused_qkv_a_w is None:
+            raise RuntimeError("MLA runtime weights must be built before release")
+        parameter_names = ("weight", "weight_scale", "weight_scale_inv")
+        _release_parameter_storage(self.q_a_proj, parameter_names)
+        _release_parameter_storage(self.kv_a_proj_with_mqa, parameter_names)
+        # BF16 prefill consumes the transposed `_kv_b_w` copy. FP8 prefill
+        # consumes kv_b_proj weight/scale directly through the kernel layout,
+        # so that storage must remain live.
+        if _fp8_scale_parameter(self.kv_b_proj) is None:
+            _release_parameter_storage(self.kv_b_proj, parameter_names)
 
     def _run_sparse_indexer(
         self,

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -26,11 +26,12 @@ from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.modules import AttnImplFactory
 from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
 from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops import MlaOpsType
 from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
 from rtp_llm.utils.model_weight import W
 
 from .model import DeepSeekV32DecoderLayer
-from .moe import _normalize_topk_method
+from .moe import normalize_topk_method
 from .rotary_embedding import DeepseekV3RotaryEmbedding, DeepseekV3YarnRotaryEmbedding
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,93 @@ def _build_mla_runtime_layout(
 #  RoPE helpers (mirrors DeepSeekV2._create_rope_w)
 # ------------------------------------------------------------------ #
 
+_YARN_REQUIRED_KEYS = (
+    "factor",
+    "original_max_position_embeddings",
+    "mscale",
+    "mscale_all_dim",
+)
+_YARN_TYPES = {"yarn", "deepseek_yarn"}
+
+
+def _rope_type(config: dict) -> Optional[str]:
+    rope_type = config.get("rope_type", config.get("type"))
+    if rope_type is None:
+        return None
+    if not isinstance(rope_type, str):
+        raise TypeError(f"DeepSeek rope_type must be a string, got {rope_type!r}")
+    return rope_type.strip().lower()
+
+
+def _resolve_yarn_parameters(config_json: dict) -> Optional[dict]:
+    """Resolve legacy rope_scaling and Transformers rope_parameters safely."""
+    rope_scaling = config_json.get("rope_scaling")
+    rope_parameters = config_json.get("rope_parameters", {})
+    if rope_scaling is not None and not isinstance(rope_scaling, dict):
+        raise TypeError("DeepSeek rope_scaling must be a dictionary")
+    if not isinstance(rope_parameters, dict):
+        raise TypeError("DeepSeek rope_parameters must be a dictionary")
+
+    parameter_type = _rope_type(rope_parameters)
+    parameter_has_scaling = parameter_type in _YARN_TYPES or any(
+        key in rope_parameters for key in _YARN_REQUIRED_KEYS
+    )
+    if (
+        parameter_has_scaling
+        and parameter_type is not None
+        and parameter_type not in _YARN_TYPES
+    ):
+        raise ValueError(
+            f"unsupported DeepSeek rope_parameters rope_type={parameter_type!r}"
+        )
+
+    if rope_scaling is None:
+        yarn = rope_parameters if parameter_has_scaling else None
+    else:
+        scaling_type = _rope_type(rope_scaling)
+        if scaling_type is not None and scaling_type not in _YARN_TYPES:
+            raise ValueError(
+                f"unsupported DeepSeek rope_scaling rope_type={scaling_type!r}"
+            )
+        yarn = rope_scaling
+        if parameter_has_scaling:
+            for key in _YARN_REQUIRED_KEYS:
+                if (
+                    key in rope_scaling
+                    and key in rope_parameters
+                    and rope_scaling[key] != rope_parameters[key]
+                ):
+                    raise ValueError(
+                        "conflicting DeepSeek RoPE scaling values for "
+                        f"{key}: rope_scaling={rope_scaling[key]!r}, "
+                        f"rope_parameters={rope_parameters[key]!r}"
+                    )
+
+    if yarn is None:
+        return None
+    missing = [key for key in _YARN_REQUIRED_KEYS if key not in yarn]
+    if missing:
+        raise ValueError(f"DeepSeek YaRN configuration is missing keys: {missing}")
+    factor = yarn["factor"]
+    original_max = yarn["original_max_position_embeddings"]
+    for name, value in (
+        ("factor", factor),
+        ("mscale", yarn["mscale"]),
+        ("mscale_all_dim", yarn["mscale_all_dim"]),
+    ):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+            raise ValueError(f"DeepSeek YaRN {name} must be positive, got {value!r}")
+    if (
+        isinstance(original_max, bool)
+        or not isinstance(original_max, int)
+        or original_max <= 0
+    ):
+        raise ValueError(
+            "DeepSeek YaRN original_max_position_embeddings must be a "
+            f"positive integer, got {original_max!r}"
+        )
+    return yarn
+
 
 def _build_rope_cache(
     config_json: dict,
@@ -87,11 +175,18 @@ def _build_rope_cache(
 
     Returns [cos|sin] concatenated, shape [max_seq_len, rope_head_dim], float32.
     """
-    rope_scaling = config_json.get("rope_scaling")
     rope_parameters = config_json.get("rope_parameters", {})
+    if not isinstance(rope_parameters, dict):
+        raise TypeError("DeepSeek rope_parameters must be a dictionary")
     rope_theta = rope_parameters.get(
         "rope_theta", config_json.get("rope_theta", 10000.0)
     )
+    if (
+        isinstance(rope_theta, bool)
+        or not isinstance(rope_theta, (int, float))
+        or rope_theta <= 0
+    ):
+        raise ValueError(f"DeepSeek rope_theta must be positive, got {rope_theta!r}")
     rope_head_dim = config_json.get(
         "qk_rope_head_dim", config_json.get("rope_head_dim")
     )
@@ -106,9 +201,9 @@ def _build_rope_cache(
             f"got {rope_head_dim!r}"
         )
 
-    has_yarn = rope_scaling is not None
+    yarn_parameters = _resolve_yarn_parameters(config_json)
 
-    if not has_yarn:
+    if yarn_parameters is None:
         rotary_emb = DeepseekV3RotaryEmbedding(
             dim=rope_head_dim,
             max_position_embeddings=max_seq_len,
@@ -122,14 +217,14 @@ def _build_rope_cache(
             rope_head_dim,
             max_seq_len,
             rope_theta,
-            scaling_factor=rope_scaling["factor"],
-            original_max_position_embeddings=rope_scaling[
+            scaling_factor=yarn_parameters["factor"],
+            original_max_position_embeddings=yarn_parameters[
                 "original_max_position_embeddings"
             ],
-            beta_fast=float(rope_scaling.get("beta_fast", 32)),
-            beta_slow=float(rope_scaling.get("beta_slow", 1)),
-            mscale=rope_scaling["mscale"],
-            mscale_all_dim=rope_scaling["mscale_all_dim"],
+            beta_fast=float(yarn_parameters.get("beta_fast", 32)),
+            beta_slow=float(yarn_parameters.get("beta_slow", 1)),
+            mscale=yarn_parameters["mscale"],
+            mscale_all_dim=yarn_parameters["mscale_all_dim"],
         )
 
     half_rope_dim = rope_head_dim // 2
@@ -253,6 +348,18 @@ def _extract_config_values(
         indexer_head_num = _get(model_config, "index_n_heads", 64)
         indexer_topk = _get(model_config, "index_topk", 2048)
 
+    if attn_config is not None:
+        use_mla = _bool_value(
+            _get(attn_config, "use_mla", False),
+            "attn_config.use_mla",
+        )
+        mla_ops_type = _get(model_config, "mla_ops_type", None)
+        if not use_mla or mla_ops_type == MlaOpsType.MHA:
+            raise ValueError(
+                "DeepSeek newloader requires an MLA attention backend; "
+                "the legacy expanded-MHA fallback is not supported"
+            )
+
     rms_norm_eps = _positive_float(
         _get(
             model_config,
@@ -362,7 +469,7 @@ def _extract_config_values(
             "routed_scaling_factor", routed_scaling_factor
         )
     topk_method = config_json.get("topk_method", "greedy") if config_json else "greedy"
-    topk_method = _normalize_topk_method(topk_method)
+    topk_method = normalize_topk_method(topk_method)
     # has_e_score_correction is not a ModelConfig field — the legacy loader
     # detects it from ckpt key presence on the weight class side. Derive it
     # here from config.json's topk_method ("noaux_tc" => correction bias).

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -625,6 +625,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
+        self._mla_kernel_layout: Optional[MlaKernelWeightLayout] = None
 
         # Resolve ckpt_path from model_config.ckpt_path (C++ pybind attribute).
         ckpt_path = ""
@@ -759,7 +760,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
         Called from initialize() once all child post-load hooks have run, and
         also kept as a lazy fallback in forward() for direct-execution paths.
         """
-        if getattr(self, "_mla_kernel_layout", None) is not None:
+        if self._mla_kernel_layout is not None:
             return
         self._mla_kernel_layout = MlaKernelWeightLayout(
             [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -71,18 +71,41 @@ def build_mla_runtime_layout(
     )
 
 
-def keep_mla_checkpoint_weights() -> bool:
-    """Return whether debugging requested retention of superseded weights."""
-    value = os.environ.get("RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS", "0")
-    if value not in {"0", "1"}:
-        raise ValueError(
-            "RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS must be either '0' or '1'"
-        )
-    return value == "1"
-
-
 class MlaRuntimeLayoutMixin:
     """Shared MLA runtime-layout lifecycle for score and MTP models."""
+
+    def _apply(self, fn, recurse: bool = True):
+        source_cos_sin_cache = self.cos_sin_cache
+        result = super()._apply(fn, recurse)
+        # The score/MTP model and every sparse IndexerOp intentionally share
+        # one RoPE cache. RtpModule restores aliases after recursively applying
+        # ``fn``; because the top-level registration is the alias master, a
+        # model-wide ``to(dtype=...)`` can otherwise overwrite the IndexerOp's
+        # local FP32 correction with a lower-precision cache. Re-establish the
+        # kernel contract once, after alias restoration, and bind every
+        # consumer to that canonical tensor.
+        cos_sin_cache = self.cos_sin_cache
+        if cos_sin_cache.dtype != torch.float32:
+            # Use the pre-conversion FP32 values and only adopt the target
+            # device. Casting the already-lowered tensor back to FP32 would
+            # preserve its dtype but irreversibly keep BF16/FP16 rounding.
+            cos_sin_cache = source_cos_sin_cache.to(
+                device=cos_sin_cache.device,
+                dtype=torch.float32,
+            )
+        self.cos_sin_cache = cos_sin_cache
+        for layer in self.layers:
+            indexer = layer.self_attn.indexer
+            if indexer is not None:
+                indexer.indexer_op.cos_sin_cache = cos_sin_cache
+        if self._mla_kernel_layout is not None:
+            # The runtime layout is a lightweight non-Module view, so refresh
+            # all of its tensor references after a post-initialize migration.
+            self._mla_kernel_layout = build_mla_runtime_layout(
+                self.layers,
+                cos_sin_cache,
+            )
+        return result
 
     def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
         return {
@@ -817,7 +840,7 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
-        self._keep_mla_checkpoint_weights = keep_mla_checkpoint_weights()
+        self._keep_mla_checkpoint_weights = load_config.keep_mla_checkpoint_weights
         self._mla_kernel_layout: Optional[MlaKernelWeightLayout] = None
 
         ckpt_path = checkpoint_path(model_config)

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -97,7 +97,7 @@ class MlaRuntimeLayoutMixin:
         for layer in self.layers:
             indexer = layer.self_attn.indexer
             if indexer is not None:
-                indexer.indexer_op.cos_sin_cache = cos_sin_cache
+                indexer.bind_rope_cache(cos_sin_cache)
         if self._mla_kernel_layout is not None:
             # The runtime layout is a lightweight non-Module view, so refresh
             # all of its tensor references after a post-initialize migration.
@@ -119,7 +119,12 @@ class MlaRuntimeLayoutMixin:
         if not ok:
             return ok
         self._ensure_mla_kernel_layout()
-        if not self._keep_mla_checkpoint_weights:
+        if self._keep_mla_checkpoint_weights:
+            logger.info(
+                "Keeping DeepSeek MLA checkpoint-only weights for debugging; "
+                "GPU memory usage will be higher"
+            )
+        else:
             for layer in self.layers:
                 layer.self_attn.release_checkpoint_only_weights()
         return ok
@@ -804,12 +809,7 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
         def _track(it):
             nonlocal has_lm_head
             for name, tensor in it:
-                if (
-                    name == "lm_head.weight"
-                    or name.startswith("lm_head.")
-                    or name == "model.lm_head.weight"
-                    or name.startswith("model.lm_head.")
-                ):
+                if name.startswith(("lm_head.", "model.lm_head.")):
                     has_lm_head = True
                 yield name, tensor
 
@@ -828,9 +828,9 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
         model_config: Any,
         load_config: Any,
     ):
-        parallelism_config = getattr(load_config, "parallelism_config", None)
-        fmha_config = getattr(load_config, "fmha_config", None)
-        device_resource_config = getattr(load_config, "device_resource_config", None)
+        parallelism_config = load_config.parallelism_config
+        fmha_config = load_config.fmha_config
+        device_resource_config = load_config.device_resource_config
 
         super().__init__(
             config=model_config,
@@ -861,12 +861,8 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
         self.tie_word_embeddings = cfg["tie_word_embeddings"]
 
         # --- RoPE cache: read config.json directly for full rope fields ---
-        device = torch.device(getattr(load_config, "device", "cuda"))
-        cos_sin_cache = build_rope_cache(
-            config_json if config_json else cfg,
-            cfg["max_seq_len"],
-            device,
-        )
+        device = torch.device(load_config.device)
+        cos_sin_cache = build_rope_cache(config_json, cfg["max_seq_len"], device)
         self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
 
         # --- Embedding ---

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -30,6 +30,7 @@ from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
 from rtp_llm.utils.model_weight import W
 
 from .model import DeepSeekV32DecoderLayer
+from .moe import _normalize_topk_method
 from .rotary_embedding import DeepseekV3RotaryEmbedding, DeepseekV3YarnRotaryEmbedding
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,21 @@ class MlaKernelWeightLayout:
         if name == W.rope_cos_sin_cache:
             return self._cos_sin_cache
         return None
+
+
+def _build_mla_runtime_layout(
+    layers: nn.ModuleList,
+    cos_sin_cache: torch.Tensor,
+) -> MlaKernelWeightLayout:
+    """Capture MLA runtime tensors, then free superseded checkpoint storage."""
+    attentions = [layer.self_attn for layer in layers]
+    layout = MlaKernelWeightLayout(
+        [attention._build_mla_kernel_weights() for attention in attentions],
+        cos_sin_cache,
+    )
+    for attention in attentions:
+        attention.release_checkpoint_only_weights()
+    return layout
 
 
 # ------------------------------------------------------------------ #
@@ -184,7 +200,9 @@ def _partition(load_config: Any, prefix: str) -> tuple[int, int]:
 
 
 def _extract_config_values(
-    model_config: Any, load_config: Any, config_json: dict = None
+    model_config: Any,
+    load_config: Any,
+    config_json: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Read config from either ModelConfig (C++ pybind) or HF dict.
 
@@ -344,10 +362,7 @@ def _extract_config_values(
             "routed_scaling_factor", routed_scaling_factor
         )
     topk_method = config_json.get("topk_method", "greedy") if config_json else "greedy"
-    if topk_method == "gready":
-        topk_method = "greedy"
-    if topk_method not in {"greedy", "group_limited_greedy", "noaux_tc"}:
-        raise ValueError(f"unsupported topk_method={topk_method!r}")
+    topk_method = _normalize_topk_method(topk_method)
     # has_e_score_correction is not a ModelConfig field — the legacy loader
     # detects it from ckpt key presence on the weight class side. Derive it
     # here from config.json's topk_method ("noaux_tc" => correction bias).
@@ -762,8 +777,8 @@ class DeepSeekV32ForCausalLM(GptModelBase):
         """
         if self._mla_kernel_layout is not None:
             return
-        self._mla_kernel_layout = MlaKernelWeightLayout(
-            [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],
+        self._mla_kernel_layout = _build_mla_runtime_layout(
+            self.layers,
             self.cos_sin_cache,
         )
 

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -59,19 +59,65 @@ class MlaKernelWeightLayout:
         return None
 
 
-def _build_mla_runtime_layout(
+def build_mla_runtime_layout(
     layers: nn.ModuleList,
     cos_sin_cache: torch.Tensor,
 ) -> MlaKernelWeightLayout:
-    """Capture MLA runtime tensors, then free superseded checkpoint storage."""
+    """Capture MLA runtime tensor views without mutating checkpoint storage."""
     attentions = [layer.self_attn for layer in layers]
-    layout = MlaKernelWeightLayout(
+    return MlaKernelWeightLayout(
         [attention._build_mla_kernel_weights() for attention in attentions],
         cos_sin_cache,
     )
-    for attention in attentions:
-        attention.release_checkpoint_only_weights()
-    return layout
+
+
+def keep_mla_checkpoint_weights() -> bool:
+    """Return whether debugging requested retention of superseded weights."""
+    value = os.environ.get("RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS", "0")
+    if value not in {"0", "1"}:
+        raise ValueError(
+            "RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS must be either '0' or '1'"
+        )
+    return value == "1"
+
+
+class MlaRuntimeLayoutMixin:
+    """Shared MLA runtime-layout lifecycle for score and MTP models."""
+
+    def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def initialize(self, init_resource):
+        ok = super().initialize(init_resource)
+        self._ensure_mla_kernel_layout()
+        if not keep_mla_checkpoint_weights():
+            for layer in self.layers:
+                layer.self_attn.release_checkpoint_only_weights()
+        return ok
+
+    def _ensure_mla_kernel_layout(self) -> None:
+        if self._mla_kernel_layout is None:
+            self._mla_kernel_layout = build_mla_runtime_layout(
+                self.layers,
+                self.cos_sin_cache,
+            )
+
+    def prepare_fmha_impl(
+        self, inputs: PyModelInputs, is_cuda_graph: bool = False
+    ) -> Any:
+        self._ensure_mla_kernel_layout()
+        return AttnImplFactory.get_fmha_impl(
+            self.config,
+            self.parallelism_config,
+            self._mla_kernel_layout,
+            inputs.attention_inputs,
+            self.fmha_config,
+            is_cuda_graph,
+        )
 
 
 # ------------------------------------------------------------------ #
@@ -147,13 +193,24 @@ def _resolve_yarn_parameters(config_json: dict) -> Optional[dict]:
         raise ValueError(f"DeepSeek YaRN configuration is missing keys: {missing}")
     factor = yarn["factor"]
     original_max = yarn["original_max_position_embeddings"]
-    for name, value in (
-        ("factor", factor),
-        ("mscale", yarn["mscale"]),
-        ("mscale_all_dim", yarn["mscale_all_dim"]),
+    if (
+        isinstance(factor, bool)
+        or not isinstance(factor, (int, float))
+        or not math.isfinite(float(factor))
+        or factor <= 0
     ):
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
-            raise ValueError(f"DeepSeek YaRN {name} must be positive, got {value!r}")
+        raise ValueError(f"DeepSeek YaRN factor must be positive, got {factor!r}")
+    for name in ("mscale", "mscale_all_dim"):
+        value = yarn[name]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or value < 0
+        ):
+            raise ValueError(
+                f"DeepSeek YaRN {name} must be non-negative, got {value!r}"
+            )
     if (
         isinstance(original_max, bool)
         or not isinstance(original_max, int)
@@ -166,7 +223,7 @@ def _resolve_yarn_parameters(config_json: dict) -> Optional[dict]:
     return yarn
 
 
-def _build_rope_cache(
+def build_rope_cache(
     config_json: dict,
     max_seq_len: int,
     device: torch.device,
@@ -237,7 +294,7 @@ def _build_rope_cache(
     )
 
 
-def _read_config_json(ckpt_path: str) -> Dict[str, Any]:
+def read_config_json(ckpt_path: str) -> Dict[str, Any]:
     """Read config.json from ckpt path, return empty dict if not found."""
     if not ckpt_path:
         return {}
@@ -251,13 +308,26 @@ def _read_config_json(ckpt_path: str) -> Dict[str, Any]:
     return payload
 
 
-def _positive_int(value: Any, name: str) -> int:
+def checkpoint_path(model_config: Any) -> str:
+    value = (
+        model_config.get("ckpt_path", "")
+        if isinstance(model_config, dict)
+        else getattr(model_config, "ckpt_path", "")
+    )
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise TypeError(f"model_config.ckpt_path must be a string, got {value!r}")
+    return value
+
+
+def positive_int(value: Any, name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise ValueError(f"{name} must be a positive integer, got {value!r}")
     return value
 
 
-def _nonnegative_int(value: Any, name: str) -> int:
+def nonnegative_int(value: Any, name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
     return value
@@ -283,7 +353,7 @@ def _bool_value(value: Any, name: str) -> bool:
 def _partition(load_config: Any, prefix: str) -> tuple[int, int]:
     size = getattr(load_config, f"{prefix}_size", None)
     rank = getattr(load_config, f"{prefix}_rank", None)
-    size = _positive_int(size, f"{prefix}_size")
+    size = positive_int(size, f"{prefix}_size")
     if isinstance(rank, bool) or not isinstance(rank, int) or not 0 <= rank < size:
         raise ValueError(f"invalid {prefix} partition: rank={rank!r}, size={size}")
     return size, rank
@@ -294,7 +364,7 @@ def _partition(load_config: Any, prefix: str) -> tuple[int, int]:
 # ------------------------------------------------------------------ #
 
 
-def _extract_config_values(
+def extract_config_values(
     model_config: Any,
     load_config: Any,
     config_json: Optional[Dict[str, Any]] = None,
@@ -311,8 +381,17 @@ def _extract_config_values(
             return obj.get(name, default)
         return getattr(obj, name, default)
 
-    hidden_size = _positive_int(_get(model_config, "hidden_size", 7168), "hidden_size")
-    num_layers = _positive_int(
+    eplb_config = _get(model_config, "eplb_config", None)
+    enable_eplb = _get(eplb_config, "enable_eplb", False)
+    if callable(enable_eplb):
+        enable_eplb = enable_eplb()
+    if not isinstance(enable_eplb, bool):
+        raise TypeError("eplb_config.enable_eplb must be a bool")
+    if enable_eplb:
+        raise ValueError("EPLB is not supported by the DeepSeek newloader path")
+
+    hidden_size = positive_int(_get(model_config, "hidden_size", 7168), "hidden_size")
+    num_layers = positive_int(
         _get(
             model_config,
             "num_layers",
@@ -320,8 +399,8 @@ def _extract_config_values(
         ),
         "num_layers",
     )
-    vocab_size = _positive_int(_get(model_config, "vocab_size", 102400), "vocab_size")
-    max_seq_len = _positive_int(_get(model_config, "max_seq_len", 8192), "max_seq_len")
+    vocab_size = positive_int(_get(model_config, "vocab_size", 102400), "vocab_size")
+    max_seq_len = positive_int(_get(model_config, "max_seq_len", 8192), "max_seq_len")
 
     # Attention config
     attn_config = _get(model_config, "attn_config", None)
@@ -389,18 +468,17 @@ def _extract_config_values(
     n_shared_experts = _get(model_config, "n_shared_experts", 1)
     if config_json:
         n_shared_experts = config_json.get("n_shared_experts", n_shared_experts)
-    n_shared_experts = _nonnegative_int(n_shared_experts, "n_shared_experts")
+    n_shared_experts = nonnegative_int(n_shared_experts, "n_shared_experts")
     shared_expert_intermediate_size = _get(
         model_config,
         "shared_expert_intermediate_size",
         None,
     )
-    if shared_expert_intermediate_size is None and config_json:
+    if shared_expert_intermediate_size in (None, 0) and config_json:
         shared_expert_intermediate_size = config_json.get(
-            "shared_expert_intermediate_size",
-            n_shared_experts * moe_intermediate_size,
+            "shared_expert_intermediate_size"
         )
-    if shared_expert_intermediate_size is None:
+    if shared_expert_intermediate_size in (None, 0):
         shared_expert_intermediate_size = n_shared_experts * moe_intermediate_size
 
     # NOTE: model_config.inter_size is overridden by the old-loader to
@@ -429,10 +507,10 @@ def _extract_config_values(
         first_k_dense_replace = _get(model_config, "first_k_dense_replace", 1)
     if moe_layer_freq is None:
         moe_layer_freq = _get(model_config, "moe_layer_freq", 1)
-    first_k_dense_replace = _nonnegative_int(
+    first_k_dense_replace = nonnegative_int(
         first_k_dense_replace, "first_k_dense_replace"
     )
-    moe_layer_freq = _positive_int(moe_layer_freq, "moe_layer_freq")
+    moe_layer_freq = positive_int(moe_layer_freq, "moe_layer_freq")
     moe_layer_index = [
         i
         for i in range(num_layers)
@@ -480,20 +558,8 @@ def _extract_config_values(
         has_e_score_correction, "has_e_score_correction"
     )
 
-    # Rope interleave style.
-    # The old loader sets these on model_config.attn_config.rope_config
-    # (is_neox_style / indexer_is_neox_style), NOT as direct attributes on
-    # model_config.  So _get(model_config, "rope_interleave", ...) returns the
-    # default.  Read from config_json to get the raw value — this matters for
-    # GLM-5 which may set rope_interleave=False / indexer_rope_interleave=True.
-    rope_interleave = _get(model_config, "rope_interleave", None)
-    if rope_interleave is None and config_json:
-        rope_interleave = config_json.get("rope_interleave", True)
-    if rope_interleave is None:
-        rope_interleave = True
-    rope_interleave = _bool_value(rope_interleave, "rope_interleave")
-    is_neox_style = not rope_interleave
-
+    # Only the sparse indexer consumes an interleave flag. MLA RoPE itself is
+    # applied by the backend and does not read a model-level is_neox_style.
     indexer_rope_interleave = _get(model_config, "indexer_rope_interleave", None)
     if indexer_rope_interleave is None and config_json:
         indexer_rope_interleave = config_json.get("indexer_rope_interleave", False)
@@ -528,20 +594,27 @@ def _extract_config_values(
         "config.json tie_word_embeddings",
     )
     tie_word_embeddings = model_tie_word_embeddings or checkpoint_tie_word_embeddings
+    if tie_word_embeddings and (
+        attn_tp_size != lm_head_tp_size or attn_tp_rank != lm_head_tp_rank
+    ):
+        raise ValueError(
+            "tied DeepSeek embeddings require matching attention and LM-head "
+            "TP partitions"
+        )
     moe_config = getattr(load_config, "moe_config", None)
 
     # Kernel tokens per block
     blocksize = _get(model_config, "kernel_tokens_per_block", 64)
     if attn_config is not None:
         blocksize = _get(attn_config, "kernel_tokens_per_block", blocksize)
-    blocksize = _positive_int(blocksize, "kernel_tokens_per_block")
+    blocksize = positive_int(blocksize, "kernel_tokens_per_block")
 
-    q_lora_rank = _nonnegative_int(q_lora_rank, "q_lora_rank")
-    kv_lora_rank = _positive_int(kv_lora_rank, "kv_lora_rank")
-    num_heads = _positive_int(num_heads, "num_attention_heads")
-    nope_head_dim = _positive_int(nope_head_dim, "qk_nope_head_dim")
-    rope_head_dim = _positive_int(rope_head_dim, "qk_rope_head_dim")
-    v_head_dim = _positive_int(v_head_dim, "v_head_dim")
+    q_lora_rank = nonnegative_int(q_lora_rank, "q_lora_rank")
+    kv_lora_rank = positive_int(kv_lora_rank, "kv_lora_rank")
+    num_heads = positive_int(num_heads, "num_attention_heads")
+    nope_head_dim = positive_int(nope_head_dim, "qk_nope_head_dim")
+    rope_head_dim = positive_int(rope_head_dim, "qk_rope_head_dim")
+    v_head_dim = positive_int(v_head_dim, "v_head_dim")
     if rope_head_dim % 2:
         raise ValueError("qk_rope_head_dim must be even")
     if num_heads % attn_tp_size:
@@ -550,17 +623,13 @@ def _extract_config_values(
             f"attn_tp_size={attn_tp_size}"
         )
     is_sparse = _bool_value(is_sparse, "is_sparse")
-    dense_intermediate_size = _positive_int(
-        dense_intermediate_size, "intermediate_size"
-    )
-    moe_intermediate_size = _positive_int(
-        moe_intermediate_size, "moe_intermediate_size"
-    )
-    shared_expert_intermediate_size = _nonnegative_int(
+    dense_intermediate_size = positive_int(dense_intermediate_size, "intermediate_size")
+    moe_intermediate_size = positive_int(moe_intermediate_size, "moe_intermediate_size")
+    shared_expert_intermediate_size = nonnegative_int(
         shared_expert_intermediate_size, "shared_expert_intermediate_size"
     )
-    num_experts = _nonnegative_int(num_experts, "num_experts")
-    top_k = _nonnegative_int(top_k, "num_experts_per_tok")
+    num_experts = nonnegative_int(num_experts, "num_experts")
+    top_k = nonnegative_int(top_k, "num_experts_per_tok")
     if moe_layer_index:
         if num_experts == 0:
             raise ValueError("DeepSeek MoE layers require a positive expert count")
@@ -575,17 +644,17 @@ def _extract_config_values(
     if is_sparse:
         if q_lora_rank == 0:
             raise ValueError("DeepSeek sparse indexer requires q_lora_rank > 0")
-        indexer_head_dim = _positive_int(indexer_head_dim, "index_head_dim")
-        indexer_head_num = _positive_int(indexer_head_num, "index_n_heads")
-        indexer_topk = _positive_int(indexer_topk, "index_topk")
-    scoring_func = _nonnegative_int(scoring_func, "scoring_func")
+        indexer_head_dim = positive_int(indexer_head_dim, "index_head_dim")
+        indexer_head_num = positive_int(indexer_head_num, "index_n_heads")
+        indexer_topk = positive_int(indexer_topk, "index_topk")
+    scoring_func = nonnegative_int(scoring_func, "scoring_func")
     if scoring_func not in (0, 1):
         raise ValueError(f"unsupported scoring_func={scoring_func}")
     routed_scaling_factor = _positive_float(
         routed_scaling_factor, "routed_scaling_factor"
     )
-    n_group = _positive_int(n_group, "n_group")
-    topk_group = _positive_int(topk_group, "topk_group")
+    n_group = positive_int(n_group, "n_group")
+    topk_group = positive_int(topk_group, "topk_group")
     if topk_group > n_group:
         raise ValueError(f"topk_group={topk_group} exceeds n_group={n_group}")
     if moe_layer_index and topk_method in {"group_limited_greedy", "noaux_tc"}:
@@ -629,7 +698,6 @@ def _extract_config_values(
         indexer_head_dim=indexer_head_dim,
         indexer_head_num=indexer_head_num,
         indexer_topk=indexer_topk,
-        is_neox_style=is_neox_style,
         indexer_is_neox_style=indexer_is_neox_style,
         blocksize=blocksize,
         tp_size=attn_tp_size,
@@ -657,7 +725,7 @@ def _extract_config_values(
 # ------------------------------------------------------------------ #
 
 
-class DeepSeekV32ForCausalLM(GptModelBase):
+class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
     """Config-driven DeepSeek MLA/MoE implementation for newloader.
 
     WEIGHTS_MAPPER only strips "model." prefix.  All submodule names match
@@ -698,7 +766,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
         ``language_config`` section into the top-level dict so that
         _extract_config_values can find MLA / MoE fields).
         """
-        return _read_config_json(ckpt_path)
+        return read_config_json(ckpt_path)
 
     def load_weights(self, weights):
         if isinstance(weights, dict):
@@ -749,10 +817,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
         )
         self._mla_kernel_layout: Optional[MlaKernelWeightLayout] = None
 
-        # Resolve ckpt_path from model_config.ckpt_path (C++ pybind attribute).
-        ckpt_path = ""
-        if hasattr(model_config, "ckpt_path") and model_config.ckpt_path:
-            ckpt_path = model_config.ckpt_path
+        ckpt_path = checkpoint_path(model_config)
 
         # Read config.json early — _extract_config_values needs it to
         # resolve fields that old-loader's _create_config overwrites on
@@ -766,12 +831,12 @@ class DeepSeekV32ForCausalLM(GptModelBase):
                 "MLA, RoPE, MoE, and dense-layer topology"
             )
 
-        cfg = _extract_config_values(model_config, load_config, config_json)
+        cfg = extract_config_values(model_config, load_config, config_json)
         self.tie_word_embeddings = cfg["tie_word_embeddings"]
 
         # --- RoPE cache: read config.json directly for full rope fields ---
         device = torch.device(getattr(load_config, "device", "cuda"))
-        cos_sin_cache = _build_rope_cache(
+        cos_sin_cache = build_rope_cache(
             config_json if config_json else cfg,
             cfg["max_seq_len"],
             device,
@@ -852,54 +917,6 @@ class DeepSeekV32ForCausalLM(GptModelBase):
             tp_size=cfg["lm_head_tp_size"],
             tp_rank=cfg["lm_head_tp_rank"],
             params_dtype=cfg["lm_head_params_dtype"],
-        )
-
-    def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
-        return {
-            "embedding": self.embed_tokens.weight,
-            "final_layernorm.gamma": self.norm.weight,
-            "lm_head": self.lm_head.weight,
-        }
-
-    def initialize(self, init_resource):
-        """Build the MLA kernel layout after all post-load hooks have run.
-
-        Called by C++ PyWrappedModel after weight loading +
-        process_weights_after_loading completes, before any prepare_fmha_impl /
-        forward.  By this point every self_attn module has _fused_qkv_a_w /
-        _kc_w / _vc_w populated, so the W.* kernel views are ready.
-        """
-        ok = super().initialize(init_resource)
-        self._ensure_mla_kernel_layout()
-        return ok
-
-    def _ensure_mla_kernel_layout(self) -> None:
-        """Reconstruct only the W.* tensor views required by MLA kernels.
-
-        Cannot run inside __init__ (params not loaded yet) or inside
-        process_weights_after_loading (parent hook fires before children's,
-        so layer.self_attn._fused_qkv_a_w etc. would still be None).
-        Called from initialize() once all child post-load hooks have run, and
-        also kept as a lazy fallback in forward() for direct-execution paths.
-        """
-        if self._mla_kernel_layout is not None:
-            return
-        self._mla_kernel_layout = _build_mla_runtime_layout(
-            self.layers,
-            self.cos_sin_cache,
-        )
-
-    def prepare_fmha_impl(
-        self, inputs: PyModelInputs, is_cuda_graph: bool = False
-    ) -> Any:
-        self._ensure_mla_kernel_layout()
-        return AttnImplFactory.get_fmha_impl(
-            self.config,
-            self.parallelism_config,
-            self._mla_kernel_layout,
-            inputs.attention_inputs,
-            self.fmha_config,
-            is_cuda_graph,
         )
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -324,12 +324,17 @@ def _extract_config_values(
         model_config, "has_moe_norm", _get(model_config, "norm_topk_prob", None)
     )
     if config_json:
-        if n_group is None:
-            n_group = config_json.get("n_group", 1)
-        if topk_group is None:
-            topk_group = config_json.get("topk_group", 1)
-        if has_moe_norm is None:
-            has_moe_norm = config_json.get("norm_topk_prob", False)
+        raw_scoring_func = config_json.get("scoring_func")
+        if raw_scoring_func is not None:
+            if raw_scoring_func == "softmax":
+                scoring_func = 0
+            elif raw_scoring_func == "sigmoid":
+                scoring_func = 1
+            else:
+                raise ValueError(f"unsupported scoring_func={raw_scoring_func!r}")
+        n_group = config_json.get("n_group", n_group)
+        topk_group = config_json.get("topk_group", topk_group)
+        has_moe_norm = config_json.get("norm_topk_prob", has_moe_norm)
     n_group = n_group if n_group is not None else 1
     topk_group = topk_group if topk_group is not None else 1
     has_moe_norm = has_moe_norm if has_moe_norm is not None else False
@@ -338,12 +343,17 @@ def _extract_config_values(
         routed_scaling_factor = config_json.get(
             "routed_scaling_factor", routed_scaling_factor
         )
+    topk_method = config_json.get("topk_method", "greedy") if config_json else "greedy"
+    if topk_method == "gready":
+        topk_method = "greedy"
+    if topk_method not in {"greedy", "group_limited_greedy", "noaux_tc"}:
+        raise ValueError(f"unsupported topk_method={topk_method!r}")
     # has_e_score_correction is not a ModelConfig field — the legacy loader
     # detects it from ckpt key presence on the weight class side. Derive it
     # here from config.json's topk_method ("noaux_tc" => correction bias).
     has_e_score_correction = _get(model_config, "has_e_score_correction", False)
     if not has_e_score_correction and config_json:
-        has_e_score_correction = config_json.get("topk_method") == "noaux_tc"
+        has_e_score_correction = topk_method == "noaux_tc"
     has_e_score_correction = _bool_value(
         has_e_score_correction, "has_e_score_correction"
     )
@@ -456,7 +466,7 @@ def _extract_config_values(
     topk_group = _positive_int(topk_group, "topk_group")
     if topk_group > n_group:
         raise ValueError(f"topk_group={topk_group} exceeds n_group={n_group}")
-    if moe_layer_index and has_e_score_correction:
+    if moe_layer_index and topk_method in {"group_limited_greedy", "noaux_tc"}:
         if num_experts % n_group:
             raise ValueError(
                 f"num_experts={num_experts} must be divisible by " f"n_group={n_group}"
@@ -490,6 +500,7 @@ def _extract_config_values(
         routed_scaling_factor=routed_scaling_factor,
         n_group=n_group,
         topk_group=topk_group,
+        topk_method=topk_method,
         has_moe_norm=has_moe_norm,
         has_e_score_correction=has_e_score_correction,
         is_sparse=is_sparse,
@@ -636,7 +647,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
         self.tie_word_embeddings = cfg["tie_word_embeddings"]
 
         # --- RoPE cache: read config.json directly for full rope fields ---
-        device = torch.device("cuda")
+        device = torch.device(getattr(load_config, "device", "cuda"))
         cos_sin_cache = _build_rope_cache(
             config_json if config_json else cfg,
             cfg["max_seq_len"],
@@ -691,6 +702,7 @@ class DeepSeekV32ForCausalLM(GptModelBase):
                 routed_scaling_factor=cfg["routed_scaling_factor"],
                 n_group=cfg["n_group"],
                 topk_group=cfg["topk_group"],
+                topk_method=cfg["topk_method"],
                 has_moe_norm=cfg["has_moe_norm"],
                 correction_bias=cfg["has_e_score_correction"],
                 is_sparse=cfg["is_sparse"],

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -1,0 +1,787 @@
+"""
+DeepSeek MLA/MoE language models for newloader.
+
+Top-level model: DeepSeekV32ForCausalLM
+  - load_weights() applies WEIGHTS_MAPPER (prefix_mapping={"model.": ""})
+    then delegates to RtpModule's streaming dispatch via super().
+  - __init__ builds all submodules with HF-compatible names.
+  - process_weights_after_loading() fuses QKV projections and KV cache
+    projections (kc/vc from kv_b).
+  - RoPE cos/sin cache is computed on-the-fly from config.
+"""
+
+import json
+import logging
+import math
+import os
+from collections.abc import Callable
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.norm import RMSResNorm
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.modules import AttnImplFactory
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
+from rtp_llm.models_py.weight_mapper import WeightsMapper
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+from rtp_llm.utils.model_weight import W
+
+from .model import DeepSeekV32DecoderLayer
+from .rotary_embedding import DeepseekV3RotaryEmbedding, DeepseekV3YarnRotaryEmbedding
+
+logger = logging.getLogger(__name__)
+
+
+class MlaKernelWeightLayout:
+    """Minimal W.* layout consumed by MLA kernels.
+
+    The tensors remain owned by the new-loader modules.  This object only
+    provides the legacy internal names required by the attention kernels; it
+    is not involved in checkpoint mapping or weight loading.
+    """
+
+    def __init__(
+        self,
+        layer_weights: list[Dict[str, torch.Tensor]],
+        cos_sin_cache: torch.Tensor,
+    ) -> None:
+        self.weights = layer_weights
+        self._cos_sin_cache = cos_sin_cache
+
+    def get_global_weight_or_none(self, name: str) -> Optional[torch.Tensor]:
+        if name == W.rope_cos_sin_cache:
+            return self._cos_sin_cache
+        return None
+
+
+# ------------------------------------------------------------------ #
+#  RoPE helpers (mirrors DeepSeekV2._create_rope_w)
+# ------------------------------------------------------------------ #
+
+
+def _build_rope_cache(
+    config_json: dict,
+    max_seq_len: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build RoPE cos/sin cache from config.json + max_seq_len.
+
+    Returns [cos|sin] concatenated, shape [max_seq_len, rope_head_dim], float32.
+    """
+    rope_scaling = config_json.get("rope_scaling")
+    rope_parameters = config_json.get("rope_parameters", {})
+    rope_theta = rope_parameters.get(
+        "rope_theta", config_json.get("rope_theta", 10000.0)
+    )
+    rope_head_dim = config_json.get(
+        "qk_rope_head_dim", config_json.get("rope_head_dim")
+    )
+    if (
+        isinstance(rope_head_dim, bool)
+        or not isinstance(rope_head_dim, int)
+        or rope_head_dim <= 0
+        or rope_head_dim % 2
+    ):
+        raise ValueError(
+            "DeepSeek RoPE head dimension must be a positive even integer, "
+            f"got {rope_head_dim!r}"
+        )
+
+    has_yarn = rope_scaling is not None
+
+    if not has_yarn:
+        rotary_emb = DeepseekV3RotaryEmbedding(
+            dim=rope_head_dim,
+            max_position_embeddings=max_seq_len,
+            base=rope_theta,
+            device=device,
+        )
+    else:
+        # Match the legacy loader's CPU sin/cos evaluation exactly, then move
+        # the finished cache to CUDA before the indexer captures its reference.
+        rotary_emb = DeepseekV3YarnRotaryEmbedding(
+            rope_head_dim,
+            max_seq_len,
+            rope_theta,
+            scaling_factor=rope_scaling["factor"],
+            original_max_position_embeddings=rope_scaling[
+                "original_max_position_embeddings"
+            ],
+            beta_fast=float(rope_scaling.get("beta_fast", 32)),
+            beta_slow=float(rope_scaling.get("beta_slow", 1)),
+            mscale=rope_scaling["mscale"],
+            mscale_all_dim=rope_scaling["mscale_all_dim"],
+        )
+
+    half_rope_dim = rope_head_dim // 2
+    cos_cache = rotary_emb.cos_cached[:, :half_rope_dim]
+    sin_cache = rotary_emb.sin_cached[:, :half_rope_dim]
+    return (
+        torch.cat([cos_cache, sin_cache], dim=-1)
+        .contiguous()
+        .to(device=device, dtype=torch.float32)
+    )
+
+
+def _read_config_json(ckpt_path: str) -> Dict[str, Any]:
+    """Read config.json from ckpt path, return empty dict if not found."""
+    if not ckpt_path:
+        return {}
+    config_path = os.path.join(ckpt_path, "config.json")
+    if not os.path.exists(config_path):
+        return {}
+    with open(config_path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError(f"{config_path} must contain a JSON object")
+    return payload
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return value
+
+
+def _nonnegative_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+    return value
+
+
+def _positive_float(value: Any, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) <= 0
+    ):
+        raise ValueError(f"{name} must be finite and positive, got {value!r}")
+    return float(value)
+
+
+def _bool_value(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{name} must be a bool, got {value!r}")
+    return value
+
+
+def _partition(load_config: Any, prefix: str) -> tuple[int, int]:
+    size = getattr(load_config, f"{prefix}_size", None)
+    rank = getattr(load_config, f"{prefix}_rank", None)
+    size = _positive_int(size, f"{prefix}_size")
+    if isinstance(rank, bool) or not isinstance(rank, int) or not 0 <= rank < size:
+        raise ValueError(f"invalid {prefix} partition: rank={rank!r}, size={size}")
+    return size, rank
+
+
+# ------------------------------------------------------------------ #
+#  Config extraction (mirrors DeepSeekV2._from_hf)
+# ------------------------------------------------------------------ #
+
+
+def _extract_config_values(
+    model_config: Any, load_config: Any, config_json: dict = None
+) -> Dict[str, Any]:
+    """Read config from either ModelConfig (C++ pybind) or HF dict.
+
+    config_json is the raw config.json dict; used to resolve fields that
+    the old-loader's _create_config overwrites on model_config (e.g.
+    inter_size -> n_shared_experts * moe_intermediate_size).
+    """
+
+    def _get(obj, name, default=None):
+        if isinstance(obj, dict):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+
+    hidden_size = _positive_int(_get(model_config, "hidden_size", 7168), "hidden_size")
+    num_layers = _positive_int(
+        _get(
+            model_config,
+            "num_layers",
+            _get(model_config, "num_hidden_layers", 4),
+        ),
+        "num_layers",
+    )
+    vocab_size = _positive_int(_get(model_config, "vocab_size", 102400), "vocab_size")
+    max_seq_len = _positive_int(_get(model_config, "max_seq_len", 8192), "max_seq_len")
+
+    # Attention config
+    attn_config = _get(model_config, "attn_config", None)
+    if attn_config is not None:
+        num_heads = _get(attn_config, "head_num", 128)
+        q_lora_rank = _get(attn_config, "q_lora_rank", 1536)
+        kv_lora_rank = _get(attn_config, "kv_lora_rank", 512)
+        nope_head_dim = _get(attn_config, "nope_head_dim", 128)
+        rope_head_dim = _get(attn_config, "rope_head_dim", 64)
+        v_head_dim = _get(attn_config, "v_head_dim", 128)
+        is_sparse = _get(attn_config, "is_sparse", False)
+        indexer_head_dim = _get(attn_config, "indexer_head_dim", 128)
+        indexer_head_num = _get(attn_config, "indexer_head_num", 64)
+        indexer_topk = _get(attn_config, "indexer_topk", 2048)
+    else:
+        num_heads = _get(model_config, "num_attention_heads", 128)
+        q_lora_rank = _get(model_config, "q_lora_rank", 1536)
+        kv_lora_rank = _get(model_config, "kv_lora_rank", 512)
+        nope_head_dim = _get(model_config, "qk_nope_head_dim", 128)
+        rope_head_dim = _get(model_config, "qk_rope_head_dim", 64)
+        v_head_dim = _get(model_config, "v_head_dim", 128)
+        is_sparse = _get(model_config, "is_sparse", False)
+        indexer_head_dim = _get(model_config, "index_head_dim", 128)
+        indexer_head_num = _get(model_config, "index_n_heads", 64)
+        indexer_topk = _get(model_config, "index_topk", 2048)
+
+    rms_norm_eps = _positive_float(
+        _get(
+            model_config,
+            "rms_norm_eps",
+            _get(model_config, "layernorm_eps", 1e-6),
+        ),
+        "rms_norm_eps",
+    )
+
+    # MoE config
+    num_experts = _get(
+        model_config, "expert_num", _get(model_config, "n_routed_experts", 256)
+    )
+    top_k = _get(model_config, "moe_k", _get(model_config, "num_experts_per_tok", 8))
+    # ModelConfig.moe_inter_size defaults to 0 and the legacy DeepSeek
+    # loader never overwrites it — reading model_config first would yield
+    # 0, breaking the expert buffer shapes. Prefer config.json's
+    # moe_intermediate_size, fall through to the default only if absent.
+    moe_intermediate_size = None
+    if config_json:
+        moe_intermediate_size = config_json.get("moe_intermediate_size")
+    if not moe_intermediate_size:
+        mc_moe = _get(model_config, "moe_inter_size", 0) or _get(
+            model_config, "moe_intermediate_size", 0
+        )
+        moe_intermediate_size = mc_moe or 2048
+    n_shared_experts = _get(model_config, "n_shared_experts", 1)
+    if config_json:
+        n_shared_experts = config_json.get("n_shared_experts", n_shared_experts)
+    n_shared_experts = _nonnegative_int(n_shared_experts, "n_shared_experts")
+    shared_expert_intermediate_size = _get(
+        model_config,
+        "shared_expert_intermediate_size",
+        None,
+    )
+    if shared_expert_intermediate_size is None and config_json:
+        shared_expert_intermediate_size = config_json.get(
+            "shared_expert_intermediate_size",
+            n_shared_experts * moe_intermediate_size,
+        )
+    if shared_expert_intermediate_size is None:
+        shared_expert_intermediate_size = n_shared_experts * moe_intermediate_size
+
+    # NOTE: model_config.inter_size is overridden by the old-loader to
+    # n_shared_experts * moe_intermediate_size.  Read the real dense FFN
+    # width from config_json (HF ckpt) when available.
+    dense_intermediate_size = None
+    if config_json:
+        dense_intermediate_size = config_json.get("intermediate_size")
+    if dense_intermediate_size is None:
+        dense_intermediate_size = _get(
+            model_config,
+            "intermediate_size",
+            _get(model_config, "inter_size", 18432),
+        )
+
+    # first_k_dense_replace / moe_layer_freq are not propagated onto
+    # ModelConfig by the legacy loader either — read from config.json,
+    # falling back only as a last resort. Wrong values here mismap dense
+    # vs MoE layers and routes dense ckpt tensors into MoEBlock.
+    first_k_dense_replace = None
+    moe_layer_freq = None
+    if config_json:
+        first_k_dense_replace = config_json.get("first_k_dense_replace")
+        moe_layer_freq = config_json.get("moe_layer_freq")
+    if first_k_dense_replace is None:
+        first_k_dense_replace = _get(model_config, "first_k_dense_replace", 1)
+    if moe_layer_freq is None:
+        moe_layer_freq = _get(model_config, "moe_layer_freq", 1)
+    first_k_dense_replace = _nonnegative_int(
+        first_k_dense_replace, "first_k_dense_replace"
+    )
+    moe_layer_freq = _positive_int(moe_layer_freq, "moe_layer_freq")
+    moe_layer_index = [
+        i
+        for i in range(num_layers)
+        if i >= first_k_dense_replace and i % moe_layer_freq == 0
+    ]
+
+    scoring_func = _get(model_config, "scoring_func", 1)  # 0=softmax, 1=sigmoid
+    routed_scaling_factor = _get(model_config, "routed_scaling_factor", 1.0)
+    n_group = _get(model_config, "moe_n_group", _get(model_config, "n_group", None))
+    topk_group = _get(
+        model_config, "moe_topk_group", _get(model_config, "topk_group", None)
+    )
+    has_moe_norm = _get(
+        model_config, "has_moe_norm", _get(model_config, "norm_topk_prob", None)
+    )
+    if config_json:
+        if n_group is None:
+            n_group = config_json.get("n_group", 1)
+        if topk_group is None:
+            topk_group = config_json.get("topk_group", 1)
+        if has_moe_norm is None:
+            has_moe_norm = config_json.get("norm_topk_prob", False)
+    n_group = n_group if n_group is not None else 1
+    topk_group = topk_group if topk_group is not None else 1
+    has_moe_norm = has_moe_norm if has_moe_norm is not None else False
+    has_moe_norm = _bool_value(has_moe_norm, "norm_topk_prob")
+    if config_json:
+        routed_scaling_factor = config_json.get(
+            "routed_scaling_factor", routed_scaling_factor
+        )
+    # has_e_score_correction is not a ModelConfig field — the legacy loader
+    # detects it from ckpt key presence on the weight class side. Derive it
+    # here from config.json's topk_method ("noaux_tc" => correction bias).
+    has_e_score_correction = _get(model_config, "has_e_score_correction", False)
+    if not has_e_score_correction and config_json:
+        has_e_score_correction = config_json.get("topk_method") == "noaux_tc"
+    has_e_score_correction = _bool_value(
+        has_e_score_correction, "has_e_score_correction"
+    )
+
+    # Rope interleave style.
+    # The old loader sets these on model_config.attn_config.rope_config
+    # (is_neox_style / indexer_is_neox_style), NOT as direct attributes on
+    # model_config.  So _get(model_config, "rope_interleave", ...) returns the
+    # default.  Read from config_json to get the raw value — this matters for
+    # GLM-5 which may set rope_interleave=False / indexer_rope_interleave=True.
+    rope_interleave = _get(model_config, "rope_interleave", None)
+    if rope_interleave is None and config_json:
+        rope_interleave = config_json.get("rope_interleave", True)
+    if rope_interleave is None:
+        rope_interleave = True
+    rope_interleave = _bool_value(rope_interleave, "rope_interleave")
+    is_neox_style = not rope_interleave
+
+    indexer_rope_interleave = _get(model_config, "indexer_rope_interleave", None)
+    if indexer_rope_interleave is None and config_json:
+        indexer_rope_interleave = config_json.get("indexer_rope_interleave", False)
+    if indexer_rope_interleave is None:
+        indexer_rope_interleave = False
+    indexer_rope_interleave = _bool_value(
+        indexer_rope_interleave, "indexer_rope_interleave"
+    )
+    indexer_is_neox_style = not indexer_rope_interleave
+
+    # Parallelism. Attention may be replicated under context parallelism while
+    # FFN weights remain sharded across the physical TP group.
+    parallelism_config = getattr(load_config, "parallelism_config", None)
+    attn_tp_size, attn_tp_rank = _partition(load_config, "attn_tp")
+    ffn_tp_size, ffn_tp_rank = _partition(load_config, "ffn_tp")
+    lm_head_tp_size, lm_head_tp_rank = _partition(load_config, "lm_head_tp")
+    ep_size, ep_rank = _partition(load_config, "ep")
+    quant_config = getattr(load_config, "quant_config", None)
+    params_dtype = getattr(load_config, "compute_dtype", torch.bfloat16)
+    if not isinstance(params_dtype, torch.dtype):
+        raise TypeError(f"compute_dtype must be torch.dtype, got {params_dtype!r}")
+    enable_fp32_lm_head = _bool_value(
+        _get(model_config, "enable_fp32_lm_head", True),
+        "enable_fp32_lm_head",
+    )
+    model_tie_word_embeddings = _bool_value(
+        _get(model_config, "tie_word_embeddings", False),
+        "model_config.tie_word_embeddings",
+    )
+    checkpoint_tie_word_embeddings = _bool_value(
+        (config_json or {}).get("tie_word_embeddings", False),
+        "config.json tie_word_embeddings",
+    )
+    tie_word_embeddings = model_tie_word_embeddings or checkpoint_tie_word_embeddings
+    moe_config = getattr(load_config, "moe_config", None)
+
+    # Kernel tokens per block
+    blocksize = _get(model_config, "kernel_tokens_per_block", 64)
+    if attn_config is not None:
+        blocksize = _get(attn_config, "kernel_tokens_per_block", blocksize)
+    blocksize = _positive_int(blocksize, "kernel_tokens_per_block")
+
+    q_lora_rank = _nonnegative_int(q_lora_rank, "q_lora_rank")
+    kv_lora_rank = _positive_int(kv_lora_rank, "kv_lora_rank")
+    num_heads = _positive_int(num_heads, "num_attention_heads")
+    nope_head_dim = _positive_int(nope_head_dim, "qk_nope_head_dim")
+    rope_head_dim = _positive_int(rope_head_dim, "qk_rope_head_dim")
+    v_head_dim = _positive_int(v_head_dim, "v_head_dim")
+    if rope_head_dim % 2:
+        raise ValueError("qk_rope_head_dim must be even")
+    if num_heads % attn_tp_size:
+        raise ValueError(
+            f"num_attention_heads={num_heads} must be divisible by "
+            f"attn_tp_size={attn_tp_size}"
+        )
+    is_sparse = _bool_value(is_sparse, "is_sparse")
+    dense_intermediate_size = _positive_int(
+        dense_intermediate_size, "intermediate_size"
+    )
+    moe_intermediate_size = _positive_int(
+        moe_intermediate_size, "moe_intermediate_size"
+    )
+    shared_expert_intermediate_size = _nonnegative_int(
+        shared_expert_intermediate_size, "shared_expert_intermediate_size"
+    )
+    num_experts = _nonnegative_int(num_experts, "num_experts")
+    top_k = _nonnegative_int(top_k, "num_experts_per_tok")
+    if moe_layer_index:
+        if num_experts == 0:
+            raise ValueError("DeepSeek MoE layers require a positive expert count")
+        if not 0 < top_k <= num_experts:
+            raise ValueError(
+                f"num_experts_per_tok={top_k} must be in [1, {num_experts}]"
+            )
+        if num_experts % ep_size:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by ep_size={ep_size}"
+            )
+    if is_sparse:
+        if q_lora_rank == 0:
+            raise ValueError("DeepSeek sparse indexer requires q_lora_rank > 0")
+        indexer_head_dim = _positive_int(indexer_head_dim, "index_head_dim")
+        indexer_head_num = _positive_int(indexer_head_num, "index_n_heads")
+        indexer_topk = _positive_int(indexer_topk, "index_topk")
+    scoring_func = _nonnegative_int(scoring_func, "scoring_func")
+    if scoring_func not in (0, 1):
+        raise ValueError(f"unsupported scoring_func={scoring_func}")
+    routed_scaling_factor = _positive_float(
+        routed_scaling_factor, "routed_scaling_factor"
+    )
+    n_group = _positive_int(n_group, "n_group")
+    topk_group = _positive_int(topk_group, "topk_group")
+    if topk_group > n_group:
+        raise ValueError(f"topk_group={topk_group} exceeds n_group={n_group}")
+    if moe_layer_index and has_e_score_correction:
+        if num_experts % n_group:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by " f"n_group={n_group}"
+            )
+        selected_expert_capacity = topk_group * (num_experts // n_group)
+        if top_k > selected_expert_capacity:
+            raise ValueError(
+                f"num_experts_per_tok={top_k} exceeds grouped routing "
+                f"capacity={selected_expert_capacity}"
+            )
+
+    return dict(
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        num_layers=num_layers,
+        vocab_size=vocab_size,
+        max_seq_len=max_seq_len,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=kv_lora_rank,
+        nope_head_dim=nope_head_dim,
+        rope_head_dim=rope_head_dim,
+        v_head_dim=v_head_dim,
+        rms_norm_eps=rms_norm_eps,
+        num_experts=num_experts,
+        top_k=top_k,
+        moe_intermediate_size=moe_intermediate_size,
+        shared_expert_intermediate_size=shared_expert_intermediate_size,
+        dense_intermediate_size=dense_intermediate_size,
+        moe_layer_index=moe_layer_index,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+        n_group=n_group,
+        topk_group=topk_group,
+        has_moe_norm=has_moe_norm,
+        has_e_score_correction=has_e_score_correction,
+        is_sparse=is_sparse,
+        indexer_head_dim=indexer_head_dim,
+        indexer_head_num=indexer_head_num,
+        indexer_topk=indexer_topk,
+        is_neox_style=is_neox_style,
+        indexer_is_neox_style=indexer_is_neox_style,
+        blocksize=blocksize,
+        tp_size=attn_tp_size,
+        tp_rank=attn_tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_tp_rank=attn_tp_rank,
+        ffn_tp_size=ffn_tp_size,
+        ffn_tp_rank=ffn_tp_rank,
+        lm_head_tp_size=lm_head_tp_size,
+        lm_head_tp_rank=lm_head_tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+        quant_config=quant_config,
+        params_dtype=params_dtype,
+        lm_head_params_dtype=torch.float32 if enable_fp32_lm_head else params_dtype,
+        tie_word_embeddings=tie_word_embeddings,
+        model_config=model_config,
+        parallelism_config=parallelism_config,
+        moe_config=moe_config,
+    )
+
+
+# ------------------------------------------------------------------ #
+#  Top-level model
+# ------------------------------------------------------------------ #
+
+
+class DeepSeekV32ForCausalLM(GptModelBase):
+    """Config-driven DeepSeek MLA/MoE implementation for newloader.
+
+    WEIGHTS_MAPPER only strips "model." prefix.  All submodule names match
+    HF ckpt keys directly, so RtpModule.load_weights can dispatch weights
+    without any fusion-time mapping.
+    """
+
+    WEIGHTS_MAPPER = WeightsMapper(prefix_mapping={"model.": ""})
+
+    @staticmethod
+    def _checkpoint_layer_index(name: str) -> Optional[int]:
+        prefix = "model.layers."
+        if not name.startswith(prefix):
+            return None
+        layer_text, separator, _ = name[len(prefix) :].partition(".")
+        if not separator or not layer_text.isdigit():
+            return None
+        return int(layer_text)
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        num_layers = len(self.layers)
+
+        def should_load(name: str) -> bool:
+            if name.startswith("model.layers."):
+                layer_idx = self._checkpoint_layer_index(name)
+                if layer_idx is None:
+                    return True
+                return layer_idx < num_layers
+            return name.startswith(("model.", "lm_head."))
+
+        return should_load
+
+    @staticmethod
+    def _read_config_json(ckpt_path: str) -> Dict[str, Any]:
+        """Read config.json from ckpt path.
+
+        Overridable by subclasses (e.g. DeepSeek VL V2 merges the nested
+        ``language_config`` section into the top-level dict so that
+        _extract_config_values can find MLA / MoE fields).
+        """
+        return _read_config_json(ckpt_path)
+
+    def load_weights(self, weights):
+        if isinstance(weights, dict):
+            weights_iter = iter(weights.items())
+        else:
+            weights_iter = weights
+
+        has_lm_head = False
+
+        def _track(it):
+            nonlocal has_lm_head
+            for name, tensor in it:
+                if (
+                    name == "lm_head.weight"
+                    or name.startswith("lm_head.")
+                    or name == "model.lm_head.weight"
+                    or name.startswith("model.lm_head.")
+                ):
+                    has_lm_head = True
+                yield name, tensor
+
+        mapped_iter = self.WEIGHTS_MAPPER.apply(_track(weights_iter))
+        super().load_weights(mapped_iter)
+
+        if not has_lm_head and self.tie_word_embeddings:
+            logger.info(
+                "[DeepSeekV32] lm_head.weight not found in ckpt; "
+                "tying lm_head to embed_tokens"
+            )
+            self.lm_head._copy_local_tied_weight(self.embed_tokens.weight.data)
+
+    def __init__(
+        self,
+        model_config: Any,
+        load_config: Any,
+    ):
+        parallelism_config = getattr(load_config, "parallelism_config", None)
+        fmha_config = getattr(load_config, "fmha_config", None)
+        device_resource_config = getattr(load_config, "device_resource_config", None)
+
+        super().__init__(
+            config=model_config,
+            parallelism_config=parallelism_config,
+            weight=None,
+            max_generate_batch_size=0,
+            fmha_config=fmha_config,
+            device_resource_config=device_resource_config,
+        )
+
+        # Resolve ckpt_path from model_config.ckpt_path (C++ pybind attribute).
+        ckpt_path = ""
+        if hasattr(model_config, "ckpt_path") and model_config.ckpt_path:
+            ckpt_path = model_config.ckpt_path
+
+        # Read config.json early — _extract_config_values needs it to
+        # resolve fields that old-loader's _create_config overwrites on
+        # model_config (e.g. inter_size).
+        # _read_config_json is overridable so multimodal variants (e.g.
+        # DeepSeek VL V2 can merge nested sub-configs into the top level.
+        config_json = self._read_config_json(ckpt_path)
+        if not config_json:
+            raise FileNotFoundError(
+                "DeepSeek newloader requires checkpoint config.json to preserve "
+                "MLA, RoPE, MoE, and dense-layer topology"
+            )
+
+        cfg = _extract_config_values(model_config, load_config, config_json)
+        self.tie_word_embeddings = cfg["tie_word_embeddings"]
+
+        # --- RoPE cache: read config.json directly for full rope fields ---
+        device = torch.device("cuda")
+        cos_sin_cache = _build_rope_cache(
+            config_json if config_json else cfg,
+            cfg["max_seq_len"],
+            device,
+        )
+        self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
+
+        # --- Embedding ---
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size=cfg["vocab_size"],
+            embedding_dim=cfg["hidden_size"],
+            tp_size=cfg["tp_size"],
+            tp_rank=cfg["tp_rank"],
+            params_dtype=cfg["params_dtype"],
+        )
+
+        # --- Decoder layers ---
+        moe_layer_set = set(cfg["moe_layer_index"])
+        self.layers = nn.ModuleList()
+
+        for i in range(cfg["num_layers"]):
+            is_moe = i in moe_layer_set
+            layer = DeepSeekV32DecoderLayer(
+                hidden_size=cfg["hidden_size"],
+                num_heads=cfg["num_heads"],
+                q_lora_rank=cfg["q_lora_rank"],
+                kv_lora_rank=cfg["kv_lora_rank"],
+                nope_head_dim=cfg["nope_head_dim"],
+                rope_head_dim=cfg["rope_head_dim"],
+                v_head_dim=cfg["v_head_dim"],
+                layer_idx=i,
+                attn_tp_size=cfg["attn_tp_size"],
+                attn_tp_rank=cfg["attn_tp_rank"],
+                ffn_tp_size=cfg["ffn_tp_size"],
+                ffn_tp_rank=cfg["ffn_tp_rank"],
+                ep_size=cfg["ep_size"],
+                ep_rank=cfg["ep_rank"],
+                params_dtype=cfg["params_dtype"],
+                layernorm_eps=cfg["rms_norm_eps"],
+                quant_config=cfg["quant_config"],
+                model_config=cfg["model_config"],
+                parallelism_config=cfg["parallelism_config"],
+                moe_config=cfg["moe_config"],
+                is_moe_layer=is_moe,
+                dense_intermediate_size=cfg["dense_intermediate_size"],
+                moe_intermediate_size=cfg["moe_intermediate_size"],
+                num_experts=cfg["num_experts"],
+                top_k=cfg["top_k"],
+                shared_expert_intermediate_size=cfg["shared_expert_intermediate_size"],
+                has_shared_expert=True,
+                scoring_func=cfg["scoring_func"],
+                routed_scaling_factor=cfg["routed_scaling_factor"],
+                n_group=cfg["n_group"],
+                topk_group=cfg["topk_group"],
+                has_moe_norm=cfg["has_moe_norm"],
+                correction_bias=cfg["has_e_score_correction"],
+                is_sparse=cfg["is_sparse"],
+                index_n_heads=cfg["indexer_head_num"],
+                index_head_dim=cfg["indexer_head_dim"],
+                index_topk=cfg["indexer_topk"],
+                indexer_is_neox_style=cfg["indexer_is_neox_style"],
+                cos_sin_cache=cos_sin_cache,
+                blocksize=cfg["blocksize"],
+            )
+            self.layers.append(layer)
+
+        # --- Final norm ---
+        self.norm = RMSResNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+
+        # --- LM head ---
+        self.lm_head = ParallelLMHead(
+            vocab_size=cfg["vocab_size"],
+            hidden_size=cfg["hidden_size"],
+            tp_size=cfg["lm_head_tp_size"],
+            tp_rank=cfg["lm_head_tp_rank"],
+            params_dtype=cfg["lm_head_params_dtype"],
+        )
+
+    def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def initialize(self, init_resource):
+        """Build the MLA kernel layout after all post-load hooks have run.
+
+        Called by C++ PyWrappedModel after weight loading +
+        process_weights_after_loading completes, before any prepare_fmha_impl /
+        forward.  By this point every self_attn module has _fused_qkv_a_w /
+        _kc_w / _vc_w populated, so the W.* kernel views are ready.
+        """
+        ok = super().initialize(init_resource)
+        self._ensure_mla_kernel_layout()
+        return ok
+
+    def _ensure_mla_kernel_layout(self) -> None:
+        """Reconstruct only the W.* tensor views required by MLA kernels.
+
+        Cannot run inside __init__ (params not loaded yet) or inside
+        process_weights_after_loading (parent hook fires before children's,
+        so layer.self_attn._fused_qkv_a_w etc. would still be None).
+        Called from initialize() once all child post-load hooks have run, and
+        also kept as a lazy fallback in forward() for direct-execution paths.
+        """
+        if getattr(self, "_mla_kernel_layout", None) is not None:
+            return
+        self._mla_kernel_layout = MlaKernelWeightLayout(
+            [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],
+            self.cos_sin_cache,
+        )
+
+    def prepare_fmha_impl(
+        self, inputs: PyModelInputs, is_cuda_graph: bool = False
+    ) -> Any:
+        self._ensure_mla_kernel_layout()
+        return AttnImplFactory.get_fmha_impl(
+            self.config,
+            self.parallelism_config,
+            self._mla_kernel_layout,
+            inputs.attention_inputs,
+            self.fmha_config,
+            is_cuda_graph,
+        )
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        if inputs.attention_inputs is None:
+            raise ValueError("DeepSeek forward requires attention_inputs")
+        input_ids = inputs.input_ids
+        hidden_states = self.embed_tokens(input_ids)
+        residual = torch.zeros_like(hidden_states)
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+        for i, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, i)
+            hidden_states, residual = layer(
+                hidden_states,
+                residual,
+                fmha_impl,
+                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -93,8 +93,10 @@ class MlaRuntimeLayoutMixin:
 
     def initialize(self, init_resource):
         ok = super().initialize(init_resource)
+        if not ok:
+            return ok
         self._ensure_mla_kernel_layout()
-        if not keep_mla_checkpoint_weights():
+        if not self._keep_mla_checkpoint_weights:
             for layer in self.layers:
                 layer.self_attn.release_checkpoint_only_weights()
         return ok
@@ -815,6 +817,7 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
+        self._keep_mla_checkpoint_weights = keep_mla_checkpoint_weights()
         self._mla_kernel_layout: Optional[MlaKernelWeightLayout] = None
 
         ckpt_path = checkpoint_path(model_config)
@@ -885,7 +888,7 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
                 num_experts=cfg["num_experts"],
                 top_k=cfg["top_k"],
                 shared_expert_intermediate_size=cfg["shared_expert_intermediate_size"],
-                has_shared_expert=True,
+                has_shared_expert=cfg["shared_expert_intermediate_size"] > 0,
                 scoring_func=cfg["scoring_func"],
                 routed_scaling_factor=cfg["routed_scaling_factor"],
                 n_group=cfg["n_group"],
@@ -900,6 +903,7 @@ class DeepSeekV32ForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
                 indexer_is_neox_style=cfg["indexer_is_neox_style"],
                 cos_sin_cache=cos_sin_cache,
                 blocksize=cfg["blocksize"],
+                prefix=f"layers.{i}",
             )
             self.layers.append(layer)
 

--- a/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
@@ -1,0 +1,159 @@
+"""Dense and shared-expert MLP used by DeepSeek newloader models."""
+
+import math
+from typing import Optional
+
+import torch
+
+from rtp_llm.models_py.layers.linear import (
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules.base import FusedSiluAndMul
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+
+_FP8_BLOCK_QUANT_TYPES = {
+    "fp8_block",
+    "fp8_block_online",
+    "fp8_per_block",
+}
+
+
+def _uses_fp8_block_quant(quant_config: Optional[QuantizationConfig]) -> bool:
+    quant_type = str(getattr(quant_config, "quant_type", "none")).lower()
+    return quant_type in _FP8_BLOCK_QUANT_TYPES
+
+
+def _pad_dimension(
+    tensor: torch.Tensor,
+    *,
+    dim: int,
+    expected_size: int,
+    padded_size: int,
+    label: str,
+) -> torch.Tensor:
+    current_size = tensor.shape[dim]
+    if current_size == padded_size:
+        return tensor
+    if current_size != expected_size:
+        raise ValueError(
+            f"{label} dimension {dim} must be {expected_size} or "
+            f"{padded_size}, got {current_size}"
+        )
+
+    pad_shape = list(tensor.shape)
+    pad_shape[dim] = padded_size - expected_size
+    padding = torch.zeros(pad_shape, dtype=torch.float32, device=tensor.device).to(
+        tensor.dtype
+    )
+    if str(tensor.dtype).startswith("torch.float8_"):
+        padded = torch.cat(
+            (tensor.view(torch.uint8), padding.view(torch.uint8)), dim=dim
+        ).view(tensor.dtype)
+    else:
+        padded = torch.cat((tensor, padding), dim=dim)
+    return padded.contiguous()
+
+
+class DeepSeekV32MLP(RtpModule):
+    """SiLU-gated MLP with TP-safe FP8 padding and reduction semantics."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.bfloat16,
+        reduce_output: bool = True,
+    ):
+        super().__init__()
+        self.intermediate_size = intermediate_size
+        self.padded_intermediate_size = intermediate_size
+        self.fp8_block_size = None
+        if _uses_fp8_block_quant(quant_config):
+            block_n, block_k = getattr(quant_config, "weight_block_size", [128, 128])
+            alignment = math.lcm(tp_size * block_n, tp_size * block_k)
+            self.padded_intermediate_size = (
+                (intermediate_size + alignment - 1) // alignment * alignment
+            )
+            self.fp8_block_size = (block_n, block_k)
+
+        self.act_fn = FusedSiluAndMul()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=2 * self.padded_intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="gate_up_proj",
+            bias=False,
+            shard_names=["gate_proj", "up_proj"],
+            params_dtype=params_dtype,
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=self.padded_intermediate_size,
+            output_size=hidden_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            quant_config=quant_config,
+            prefix="down_proj",
+            bias=False,
+            reduce_output=reduce_output,
+            params_dtype=params_dtype,
+        )
+
+    def _pad_checkpoint_tensor(self, name: str, tensor: torch.Tensor) -> torch.Tensor:
+        if self.padded_intermediate_size == self.intermediate_size:
+            return tensor
+
+        if name in ("gate_proj.weight", "up_proj.weight"):
+            return _pad_dimension(
+                tensor,
+                dim=0,
+                expected_size=self.intermediate_size,
+                padded_size=self.padded_intermediate_size,
+                label=name,
+            )
+        if name == "down_proj.weight":
+            return _pad_dimension(
+                tensor,
+                dim=1,
+                expected_size=self.intermediate_size,
+                padded_size=self.padded_intermediate_size,
+                label=name,
+            )
+        if self.fp8_block_size is None:
+            return tensor
+
+        block_n, block_k = self.fp8_block_size
+        if name in (
+            "gate_proj.weight_scale_inv",
+            "up_proj.weight_scale_inv",
+        ):
+            return _pad_dimension(
+                tensor,
+                dim=0,
+                expected_size=math.ceil(self.intermediate_size / block_n),
+                padded_size=self.padded_intermediate_size // block_n,
+                label=name,
+            )
+        if name == "down_proj.weight_scale_inv":
+            return _pad_dimension(
+                tensor,
+                dim=1,
+                expected_size=math.ceil(self.intermediate_size / block_k),
+                padded_size=self.padded_intermediate_size // block_k,
+                label=name,
+            )
+        return tensor
+
+    def load_weights(self, weights) -> None:
+        items = weights.items() if isinstance(weights, dict) else weights
+        for name, tensor in items:
+            super().load_weights({name: self._pad_checkpoint_tensor(name, tensor)})
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_up_proj(x)))

--- a/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
@@ -68,6 +68,7 @@ class DeepSeekV32MLP(RtpModule):
         quant_config: Optional[QuantizationConfig] = None,
         params_dtype: torch.dtype = torch.bfloat16,
         reduce_output: bool = True,
+        prefix: str = "mlp",
     ):
         super().__init__()
         self.intermediate_size = intermediate_size
@@ -88,7 +89,7 @@ class DeepSeekV32MLP(RtpModule):
             tp_size=tp_size,
             tp_rank=tp_rank,
             quant_config=quant_config,
-            prefix="gate_up_proj",
+            prefix=f"{prefix}.gate_up_proj",
             bias=False,
             shard_names=["gate_proj", "up_proj"],
             params_dtype=params_dtype,
@@ -99,7 +100,7 @@ class DeepSeekV32MLP(RtpModule):
             tp_size=tp_size,
             tp_rank=tp_rank,
             quant_config=quant_config,
-            prefix="down_proj",
+            prefix=f"{prefix}.down_proj",
             bias=False,
             reduce_output=reduce_output,
             params_dtype=params_dtype,

--- a/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/mlp.py
@@ -21,7 +21,7 @@ _FP8_BLOCK_QUANT_TYPES = {
 
 
 def _uses_fp8_block_quant(quant_config: Optional[QuantizationConfig]) -> bool:
-    quant_type = str(getattr(quant_config, "quant_type", "none")).lower()
+    quant_type = "none" if quant_config is None else quant_config.quant_type.lower()
     return quant_type in _FP8_BLOCK_QUANT_TYPES
 
 
@@ -74,8 +74,8 @@ class DeepSeekV32MLP(RtpModule):
         self.intermediate_size = intermediate_size
         self.padded_intermediate_size = intermediate_size
         self.fp8_block_size = None
-        if _uses_fp8_block_quant(quant_config):
-            block_n, block_k = getattr(quant_config, "weight_block_size", [128, 128])
+        if quant_config is not None and _uses_fp8_block_quant(quant_config):
+            block_n, block_k = quant_config.fp8_block_size
             alignment = math.lcm(tp_size * block_n, tp_size * block_k)
             self.padded_intermediate_size = (
                 (intermediate_size + alignment - 1) // alignment * alignment
@@ -127,8 +127,9 @@ class DeepSeekV32MLP(RtpModule):
                 label=name,
             )
         if self.fp8_block_size is None:
-            return tensor
-
+            raise RuntimeError(
+                "padded DeepSeek MLP weights require an FP8 block layout"
+            )
         block_n, block_k = self.fp8_block_size
         if name in (
             "gate_proj.weight_scale_inv",

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -1,0 +1,435 @@
+"""
+DecoderLayer for DeepSeek V3.2, new-loader style.
+
+Orchestrates:
+  - Pre-norm → MLA attention (with optional sparse Indexer) → post-norm → FFN
+  - FFN is either a dense MLP (first K layers) or a MoE block (remaining layers).
+  - Indexer is a stateful submodule with HF ckpt keys:
+      model.layers.{i}.self_attn.indexer.wq_b.weight
+      model.layers.{i}.self_attn.indexer.wk.weight
+      model.layers.{i}.self_attn.indexer.k_norm.weight
+      model.layers.{i}.self_attn.indexer.k_norm.bias
+      model.layers.{i}.self_attn.indexer.weights_proj.weight
+"""
+
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.layers.linear import ColumnParallelLinear
+from rtp_llm.models_py.layers.norm import RMSNorm, RMSResNorm
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules import IndexerOp
+from rtp_llm.models_py.modules.factory.attention.attn_factory import MlaImplBase
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.ops.compute_ops import LayerKVCache
+from rtp_llm.utils.model_weight import W
+
+from .attention import DeepSeekV32MlaAttention
+from .mlp import DeepSeekV32MLP
+from .moe import DeepSeekV32MoEBlock
+
+
+class DeepSeekV32Indexer(RtpModule):
+    """Sparse Indexer for DeepSeek V3.2 DSA, new-loader style.
+
+    HF ckpt keys (per layer):
+      model.layers.{i}.self_attn.indexer.wq_b.weight
+      model.layers.{i}.self_attn.indexer.wk.weight
+      model.layers.{i}.self_attn.indexer.k_norm.weight
+      model.layers.{i}.self_attn.indexer.k_norm.bias
+      model.layers.{i}.self_attn.indexer.weights_proj.weight
+    """
+
+    def __init__(
+        self,
+        index_n_heads: int,
+        index_head_dim: int,
+        index_topk: int,
+        rope_head_dim: int,
+        hidden_size: int,
+        q_lora_rank: int,
+        layer_idx: int,
+        layernorm_eps: float,
+        blocksize: int,
+        is_neox_style: bool,
+        tp_size: int = 1,
+        tp_rank: int = 0,
+        quant_config: Optional[QuantizationConfig] = None,
+        params_dtype: torch.dtype = torch.bfloat16,
+        cos_sin_cache: Optional[torch.Tensor] = None,
+        parallelism_config: Any = None,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.index_n_heads = index_n_heads
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.rope_head_dim = rope_head_dim
+        self.block_size = 128
+        self.head_kv = 1
+        self.scale_fmt = "none"
+        self.softmax_scale = index_head_dim**-0.5
+        self.weights_scale = index_n_heads**-0.5
+        self.blocksize = blocksize
+        self.indexer_size = index_head_dim / 2 + index_head_dim / 128 * 2
+        self.is_neox_style = is_neox_style
+        self.parallelism_config = parallelism_config
+
+        # wq_b: q_lora_rank → index_n_heads * index_head_dim
+        self.wq_b = ColumnParallelLinear(
+            input_size=q_lora_rank,
+            output_size=index_n_heads * index_head_dim,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=quant_config,
+            prefix="wq_b",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        # wk: hidden_size → index_head_dim. The HF Indexer is MQA-style for
+        # the key path: a single shared k vector of size `index_head_dim`,
+        # not n_heads independent keys. ckpt shape is [head_dim, hidden].
+        self.wk = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=index_head_dim,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=quant_config,
+            prefix="wk",
+            bias=False,
+            params_dtype=params_dtype,
+        )
+        # HF Indexer applies k_norm per-head over `index_head_dim`, not over
+        # the full `index_n_heads * index_head_dim` flat feature. The ckpt
+        # bias/weight tensors are sized `index_head_dim`.
+        self.k_norm = nn.LayerNorm(
+            index_head_dim,
+            eps=layernorm_eps,
+            elementwise_affine=True,
+            bias=True,
+            dtype=params_dtype,
+        )
+        # weights_proj: hidden_size → index_n_heads
+        self.weights_proj = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=index_n_heads,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=None,
+            prefix="weights_proj",
+            bias=False,
+            params_dtype=torch.float32,
+        )
+
+        self.cos_sin_cache = cos_sin_cache
+
+        self.indexer_op = IndexerOp(
+            index_n_heads=index_n_heads,
+            index_head_dim=index_head_dim,
+            index_topk=index_topk,
+            rope_head_dim=rope_head_dim,
+            cos_sin_cache=cos_sin_cache,
+            blocksize=blocksize,
+            block_size=self.block_size,
+            scale_fmt=self.scale_fmt,
+            is_neox_style=is_neox_style,
+        )
+
+    def _prefill_cp_enabled(self) -> bool:
+        if self.parallelism_config is None:
+            return False
+        return self.parallelism_config.prefill_cp_config.is_enabled()
+
+    def _is_sparse_prefill_cp(self, attention_inputs: Any) -> bool:
+        return bool(attention_inputs.is_prefill) and self._prefill_cp_enabled()
+
+    @staticmethod
+    def _require_cp_params(cp_params: Optional[Any]) -> Any:
+        if cp_params is None:
+            raise ValueError("cp_params are required when sparse prefill CP is enabled")
+        return cp_params
+
+    def _get_logits_head_gate(
+        self, x: torch.Tensor, q_scale: torch.Tensor
+    ) -> torch.Tensor:
+        x = x.float()
+        weights = self.weights_proj(x)
+        scale = self.softmax_scale * self.weights_scale
+        weights = weights.unsqueeze(-1) * q_scale * scale
+        return weights
+
+    def _get_q_k_bf16(
+        self,
+        q_lora: torch.Tensor,
+        x: torch.Tensor,
+        flashmla_params: Any,
+        cp_params: Optional[Any],
+    ):
+        q = self.wq_b(q_lora)
+        q = q.view(-1, self.index_n_heads, self.index_head_dim)
+
+        k = self.wk(x)
+        k = self.k_norm(k)
+
+        if self._prefill_cp_enabled():
+            cp_params = self._require_cp_params(cp_params)
+            query, key = self.indexer_op.apply_rope_and_rotate_q_k_cp(
+                q,
+                k,
+                cp_params.full_rope_pos_ids,
+            )
+        else:
+            positions = flashmla_params.positions_d
+            query, key = self.indexer_op.apply_rope_and_rotate_q_k(q, k, positions)
+
+        return query, key
+
+    def _get_k_bf16(self, x: torch.Tensor, flashmla_params: Any) -> torch.Tensor:
+        k = self.wk(x)
+        k = self.k_norm(k)
+        return self.indexer_op.apply_rope_and_rotate_k(k, flashmla_params.positions_d)
+
+    def _quantize_q_k(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        kv_cache,
+        fmha_params: Any,
+        attention_inputs: Any,
+        cp_params: Optional[Any],
+    ):
+        if self._is_sparse_prefill_cp(attention_inputs):
+            cp_params = self._require_cp_params(cp_params)
+            return self.indexer_op.quant_q_k_cp(
+                query,
+                key,
+                kv_cache,
+                fmha_params.slot_mapping,
+                cp_params.kv_restore_unpad_indices,
+            )
+        return self.indexer_op.quant_q_k(query, key, kv_cache, fmha_params.slot_mapping)
+
+    def _compute_topk(
+        self,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        kv_cache,
+        fmha_params: Any,
+        attention_inputs: Any,
+        cp_params: Optional[Any],
+    ) -> torch.Tensor:
+        if not attention_inputs.is_prefill:
+            return self.indexer_op._get_topk_paged(
+                q_fp8, weights, kv_cache, fmha_params, attention_inputs
+            )
+        if self._prefill_cp_enabled():
+            cp_params = self._require_cp_params(cp_params)
+            return self.indexer_op._get_topk_ragged_cp(
+                q_fp8,
+                weights,
+                kv_cache,
+                fmha_params,
+                attention_inputs,
+                cp_params.total_local_ids,
+                cp_params.cu_kv_seqlens_global,
+                cp_params.total_kv_len,
+                cp_params.precomputed_ks,
+                cp_params.precomputed_ke,
+                cp_params.precomputed_lengths,
+                cp_params.precomputed_topk_off,
+            )
+        return self.indexer_op._get_topk_ragged(
+            q_fp8, weights, kv_cache, fmha_params, attention_inputs
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        q_lora: torch.Tensor,
+        kv_cache,
+        fmha_params: Any,
+        attention_inputs: Any,
+        use_fast_path: bool,
+        cp_params: Any = None,
+    ) -> Optional[torch.Tensor]:
+        if use_fast_path:
+            key = self._get_k_bf16(hidden_states, fmha_params)
+            self.indexer_op.quant_k_only(key, kv_cache, fmha_params.slot_mapping)
+            return None
+
+        if self._is_sparse_prefill_cp(attention_inputs):
+            self._require_cp_params(cp_params)
+
+        query, key = self._get_q_k_bf16(q_lora, hidden_states, fmha_params, cp_params)
+        q_fp8, q_scale = self._quantize_q_k(
+            query, key, kv_cache, fmha_params, attention_inputs, cp_params
+        )
+        weights = self._get_logits_head_gate(hidden_states, q_scale)
+        return self._compute_topk(
+            q_fp8, weights, kv_cache, fmha_params, attention_inputs, cp_params
+        )
+
+
+class DeepSeekV32DecoderLayer(RtpModule):
+    """Single decoder layer: MLA attention + FFN (dense or MoE)."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        nope_head_dim: int,
+        rope_head_dim: int,
+        v_head_dim: int,
+        layer_idx: int,
+        attn_tp_size: int,
+        attn_tp_rank: int,
+        ffn_tp_size: int,
+        ffn_tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        params_dtype: torch.dtype,
+        layernorm_eps: float,
+        quant_config: Optional[QuantizationConfig],
+        model_config: Any,
+        parallelism_config: Any,
+        moe_config: Any,
+        # --- FFN config ---
+        is_moe_layer: bool = False,
+        dense_intermediate_size: int = 0,
+        moe_intermediate_size: int = 0,
+        num_experts: int = 0,
+        top_k: int = 0,
+        shared_expert_intermediate_size: int = 0,
+        has_shared_expert: bool = True,
+        scoring_func: int = 1,
+        routed_scaling_factor: float = 1.0,
+        n_group: int = 1,
+        topk_group: int = 1,
+        has_moe_norm: bool = False,
+        correction_bias: bool = False,
+        # --- Indexer config ---
+        is_sparse: bool = False,
+        index_n_heads: int = 0,
+        index_head_dim: int = 0,
+        index_topk: int = 0,
+        indexer_is_neox_style: bool = False,
+        cos_sin_cache: Optional[torch.Tensor] = None,
+        blocksize: int = 64,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_sparse = is_sparse
+        self.q_lora_rank = q_lora_rank
+
+        self.input_layernorm = RMSResNorm(
+            hidden_size, eps=layernorm_eps, params_dtype=params_dtype
+        )
+        self.self_attn = DeepSeekV32MlaAttention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=kv_lora_rank,
+            nope_head_dim=nope_head_dim,
+            rope_head_dim=rope_head_dim,
+            v_head_dim=v_head_dim,
+            layer_idx=layer_idx,
+            tp_size=attn_tp_size,
+            tp_rank=attn_tp_rank,
+            quant_config=quant_config,
+            params_dtype=params_dtype,
+            layernorm_eps=layernorm_eps,
+        )
+        self.post_attention_layernorm = RMSResNorm(
+            hidden_size, eps=layernorm_eps, params_dtype=params_dtype
+        )
+
+        if is_moe_layer:
+            self.mlp = DeepSeekV32MoEBlock(
+                hidden_size=hidden_size,
+                moe_intermediate_size=moe_intermediate_size,
+                num_experts=num_experts,
+                top_k=top_k,
+                layer_idx=layer_idx,
+                tp_size=ffn_tp_size,
+                tp_rank=ffn_tp_rank,
+                ep_size=ep_size,
+                ep_rank=ep_rank,
+                model_config=model_config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config,
+                quant_config=quant_config,
+                params_dtype=params_dtype,
+                has_shared_expert=has_shared_expert,
+                shared_expert_intermediate_size=shared_expert_intermediate_size,
+                scoring_func=scoring_func,
+                routed_scaling_factor=routed_scaling_factor,
+                n_group=n_group,
+                topk_group=topk_group,
+                has_moe_norm=has_moe_norm,
+                correction_bias=correction_bias,
+            )
+        else:
+            self.mlp = DeepSeekV32MLP(
+                hidden_size=hidden_size,
+                intermediate_size=dense_intermediate_size,
+                tp_size=ffn_tp_size,
+                tp_rank=ffn_tp_rank,
+                quant_config=quant_config,
+                params_dtype=params_dtype,
+            )
+
+        # Register the indexer as a *child of self_attn*, not of this layer,
+        # so HF ckpt keys `model.layers.{i}.self_attn.indexer.{wq_b,wk,...}`
+        # route correctly via the streaming dispatch.  self_attn.forward
+        # invokes self.indexer internally (see attention.py
+        # DeepSeekV32MlaAttention._run_sparse_indexer); the `self.indexer`
+        # property here is just a convenience accessor for callers that
+        # want to reach the indexer from the layer level.
+        if is_sparse:
+            self.self_attn.indexer = DeepSeekV32Indexer(
+                index_n_heads=index_n_heads,
+                index_head_dim=index_head_dim,
+                index_topk=index_topk,
+                rope_head_dim=rope_head_dim,
+                hidden_size=hidden_size,
+                q_lora_rank=q_lora_rank,
+                layer_idx=layer_idx,
+                layernorm_eps=layernorm_eps,
+                blocksize=blocksize,
+                is_neox_style=indexer_is_neox_style,
+                tp_size=attn_tp_size,
+                tp_rank=attn_tp_rank,
+                quant_config=quant_config,
+                params_dtype=params_dtype,
+                cos_sin_cache=cos_sin_cache,
+                parallelism_config=parallelism_config,
+            )
+        else:
+            self.self_attn.indexer = None
+
+    @property
+    def indexer(self):
+        return getattr(self.self_attn, "indexer", None)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        fmha_impl: Any,
+        kv_cache: Optional[LayerKVCache] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        # self_attn.forward owns the sparse Indexer call internally,
+        # mirroring legacy MlaAttention (modules/hybrid/mla_attention.py).
+        attn_output = self.self_attn(hidden_states, fmha_impl, kv_cache)
+        hidden_states = attn_output
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -309,6 +309,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
         routed_scaling_factor: float = 1.0,
         n_group: int = 1,
         topk_group: int = 1,
+        topk_method: str = "greedy",
         has_moe_norm: bool = False,
         correction_bias: bool = False,
         # --- Indexer config ---
@@ -369,6 +370,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
                 routed_scaling_factor=routed_scaling_factor,
                 n_group=n_group,
                 topk_group=topk_group,
+                topk_method=topk_method,
                 has_moe_norm=has_moe_norm,
                 correction_bias=correction_bias,
             )

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -34,6 +34,12 @@ from .moe import DeepSeekV32MoEBlock
 class DeepSeekV32Indexer(RtpModule):
     """Sparse Indexer for DeepSeek V3.2 DSA, new-loader style.
 
+    The forward orchestration mirrors ``modules/hybrid/indexer.py::Indexer``.
+    Projection ownership differs deliberately: this class owns independently
+    loadable RtpModule children, while the legacy implementation consumes a
+    W.* dictionary. Keep algorithm changes synchronized with that reference;
+    both paths are exercised by the sparse-indexer GPU parity/smoke coverage.
+
     HF ckpt keys (per layer):
       model.layers.{i}.self_attn.indexer.wq_b.weight
       model.layers.{i}.self_attn.indexer.wk.weight
@@ -54,8 +60,6 @@ class DeepSeekV32Indexer(RtpModule):
         layernorm_eps: float,
         blocksize: int,
         is_neox_style: bool,
-        tp_size: int = 1,
-        tp_rank: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         params_dtype: torch.dtype = torch.bfloat16,
         cos_sin_cache: Optional[torch.Tensor] = None,
@@ -403,8 +407,6 @@ class DeepSeekV32DecoderLayer(RtpModule):
                 layernorm_eps=layernorm_eps,
                 blocksize=blocksize,
                 is_neox_style=indexer_is_neox_style,
-                tp_size=attn_tp_size,
-                tp_rank=attn_tp_rank,
                 quant_config=quant_config,
                 params_dtype=params_dtype,
                 cos_sin_cache=cos_sin_cache,
@@ -415,7 +417,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
 
     @property
     def indexer(self):
-        return getattr(self.self_attn, "indexer", None)
+        return self.self_attn.indexer
 
     def forward(
         self,

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -138,6 +138,9 @@ class DeepSeekV32Indexer(RtpModule):
             is_neox_style=is_neox_style,
         )
 
+    def bind_rope_cache(self, cos_sin_cache: torch.Tensor) -> None:
+        self.indexer_op.bind_rope_cache(cos_sin_cache)
+
     def _prefill_cp_enabled(self) -> bool:
         if self.parallelism_config is None:
             return False

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -38,7 +38,7 @@ class DeepSeekV32Indexer(RtpModule):
     Projection ownership differs deliberately: this class owns independently
     loadable RtpModule children, while the legacy implementation consumes a
     W.* dictionary. Keep algorithm changes synchronized with that reference;
-    both paths are exercised by the sparse-indexer GPU parity/smoke coverage.
+    the integrated sparse path is covered by the DeepSeek/GLM GPU smoke.
 
     HF ckpt keys (per layer):
       model.layers.{i}.self_attn.indexer.wq_b.weight
@@ -77,7 +77,6 @@ class DeepSeekV32Indexer(RtpModule):
         self.softmax_scale = index_head_dim**-0.5
         self.weights_scale = index_n_heads**-0.5
         self.blocksize = blocksize
-        self.indexer_size = index_head_dim / 2 + index_head_dim / 128 * 2
         self.is_neox_style = is_neox_style
         self.parallelism_config = parallelism_config
 

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -18,13 +18,12 @@ import torch
 import torch.nn as nn
 
 from rtp_llm.models_py.layers.linear import ColumnParallelLinear
-from rtp_llm.models_py.layers.norm import RMSNorm, RMSResNorm
+from rtp_llm.models_py.layers.norm import RMSResNorm
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.modules import IndexerOp
 from rtp_llm.models_py.modules.factory.attention.attn_factory import MlaImplBase
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.ops.compute_ops import LayerKVCache
-from rtp_llm.utils.model_weight import W
 
 from .attention import DeepSeekV32MlaAttention
 from .mlp import DeepSeekV32MLP
@@ -125,8 +124,6 @@ class DeepSeekV32Indexer(RtpModule):
             bias=False,
             params_dtype=torch.float32,
         )
-
-        self.cos_sin_cache = cos_sin_cache
 
         self.indexer_op = IndexerOp(
             index_n_heads=index_n_heads,
@@ -422,7 +419,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
         self,
         hidden_states: torch.Tensor,
         residual: torch.Tensor,
-        fmha_impl: Any,
+        fmha_impl: MlaImplBase,
         kv_cache: Optional[LayerKVCache] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         hidden_states, residual = self.input_layernorm(hidden_states, residual)

--- a/rtp_llm/models_py/new_models/deepseek_v3/model.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/model.py
@@ -63,6 +63,7 @@ class DeepSeekV32Indexer(RtpModule):
         params_dtype: torch.dtype = torch.bfloat16,
         cos_sin_cache: Optional[torch.Tensor] = None,
         parallelism_config: Any = None,
+        prefix: str = "self_attn.indexer",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -86,7 +87,7 @@ class DeepSeekV32Indexer(RtpModule):
             tp_size=1,
             tp_rank=0,
             quant_config=quant_config,
-            prefix="wq_b",
+            prefix=f"{prefix}.wq_b",
             bias=False,
             params_dtype=params_dtype,
         )
@@ -99,7 +100,7 @@ class DeepSeekV32Indexer(RtpModule):
             tp_size=1,
             tp_rank=0,
             quant_config=quant_config,
-            prefix="wk",
+            prefix=f"{prefix}.wk",
             bias=False,
             params_dtype=params_dtype,
         )
@@ -120,7 +121,7 @@ class DeepSeekV32Indexer(RtpModule):
             tp_size=1,
             tp_rank=0,
             quant_config=None,
-            prefix="weights_proj",
+            prefix=f"{prefix}.weights_proj",
             bias=False,
             params_dtype=torch.float32,
         )
@@ -320,6 +321,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
         indexer_is_neox_style: bool = False,
         cos_sin_cache: Optional[torch.Tensor] = None,
         blocksize: int = 64,
+        prefix: str = "layer",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -343,6 +345,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
             quant_config=quant_config,
             params_dtype=params_dtype,
             layernorm_eps=layernorm_eps,
+            prefix=f"{prefix}.self_attn",
         )
         self.post_attention_layernorm = RMSResNorm(
             hidden_size, eps=layernorm_eps, params_dtype=params_dtype
@@ -373,6 +376,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
                 topk_method=topk_method,
                 has_moe_norm=has_moe_norm,
                 correction_bias=correction_bias,
+                prefix=f"{prefix}.mlp",
             )
         else:
             self.mlp = DeepSeekV32MLP(
@@ -382,6 +386,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
                 tp_rank=ffn_tp_rank,
                 quant_config=quant_config,
                 params_dtype=params_dtype,
+                prefix=f"{prefix}.mlp",
             )
 
         # Register the indexer as a *child of self_attn*, not of this layer,
@@ -407,6 +412,7 @@ class DeepSeekV32DecoderLayer(RtpModule):
                 params_dtype=params_dtype,
                 cos_sin_cache=cos_sin_cache,
                 parallelism_config=parallelism_config,
+                prefix=f"{prefix}.self_attn.indexer",
             )
         else:
             self.self_attn.indexer = None

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -17,13 +17,153 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
 from rtp_llm.models_py.module_base import RtpModule
-from rtp_llm.models_py.modules import GroupTopK, SelectTopk
+from rtp_llm.models_py.modules import FakeBalanceExpert, GroupTopK, SelectTopk
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 
 from .mlp import DeepSeekV32MLP
+
+
+def _select_deepseek_topk(
+    router_logits_fp32: torch.Tensor,
+    *,
+    top_k: int,
+    scoring_func: int,
+    n_group: int,
+    topk_group: int,
+    group_limited: bool,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference-correct DeepSeek-V2 routing for the non-noaux path."""
+    if router_logits_fp32.dim() != 2:
+        raise ValueError(
+            "router logits must have shape [tokens, experts], got "
+            f"{tuple(router_logits_fp32.shape)}"
+        )
+    num_experts = router_logits_fp32.shape[-1]
+    if n_group <= 0 or num_experts % n_group:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by n_group={n_group}"
+        )
+    if not 0 < topk_group <= n_group:
+        raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
+    group_size = num_experts // n_group
+    selected_capacity = topk_group * group_size if group_limited else num_experts
+    if not 0 < top_k <= selected_capacity:
+        raise ValueError(
+            f"top_k={top_k} exceeds selected-group capacity " f"{selected_capacity}"
+        )
+
+    if scoring_func == 0:
+        scores = torch.softmax(router_logits_fp32, dim=-1)
+    elif scoring_func == 1:
+        scores = torch.sigmoid(router_logits_fp32)
+    else:
+        raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
+
+    candidate_scores = scores
+    if group_limited:
+        group_scores = scores.view(-1, n_group, group_size).amax(dim=-1)
+        selected_groups = torch.topk(
+            group_scores,
+            k=topk_group,
+            dim=-1,
+            sorted=False,
+        ).indices
+        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+        group_mask.scatter_(1, selected_groups, True)
+        expert_mask = (
+            group_mask.unsqueeze(-1).expand(-1, -1, group_size).reshape_as(scores)
+        )
+        candidate_scores = scores.masked_fill(~expert_mask, float("-inf"))
+
+    topk_weights, topk_ids = torch.topk(
+        candidate_scores,
+        k=top_k,
+        dim=-1,
+        sorted=False,
+    )
+    if renormalize and top_k > 1:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            1e-20
+        )
+    return topk_weights * routed_scaling_factor, topk_ids
+
+
+def _select_deepseek_noaux_topk(
+    router_logits_fp32: torch.Tensor,
+    correction_bias: torch.Tensor,
+    *,
+    top_k: int,
+    n_group: int,
+    topk_group: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference DeepSeek-V3 noaux_tc routing used when GroupTopK is unavailable."""
+    if router_logits_fp32.dim() != 2:
+        raise ValueError(
+            "router logits must have shape [tokens, experts], got "
+            f"{tuple(router_logits_fp32.shape)}"
+        )
+    num_experts = router_logits_fp32.shape[-1]
+    if correction_bias.shape != (num_experts,):
+        raise ValueError(
+            "correction_bias must have shape [experts], got "
+            f"{tuple(correction_bias.shape)} for {num_experts} experts"
+        )
+    if n_group <= 0 or num_experts % n_group:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by n_group={n_group}"
+        )
+    if not 0 < topk_group <= n_group:
+        raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
+    group_size = num_experts // n_group
+    selected_capacity = topk_group * group_size
+    if not 0 < top_k <= selected_capacity:
+        raise ValueError(
+            f"top_k={top_k} exceeds selected-group capacity {selected_capacity}"
+        )
+
+    scores = torch.sigmoid(router_logits_fp32)
+    scores_for_choice = scores + correction_bias
+    grouped_scores = scores_for_choice.view(-1, n_group, group_size)
+    group_scores = torch.topk(
+        grouped_scores,
+        k=min(2, group_size),
+        dim=-1,
+        sorted=False,
+    ).values.sum(dim=-1)
+    selected_groups = torch.topk(
+        group_scores,
+        k=topk_group,
+        dim=-1,
+        sorted=False,
+    ).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+    group_mask.scatter_(1, selected_groups, True)
+    expert_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(-1, -1, group_size)
+        .reshape_as(scores_for_choice)
+    )
+    candidate_scores = scores_for_choice.masked_fill(~expert_mask, float("-inf"))
+    topk_ids = torch.topk(
+        candidate_scores,
+        k=top_k,
+        dim=-1,
+        sorted=False,
+    ).indices
+    topk_weights = scores.gather(1, topk_ids)
+    if renormalize and top_k > 1:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            1e-20
+        )
+    return topk_weights * routed_scaling_factor, topk_ids
 
 
 class DeepSeekV32Experts(BaseMoEExperts):
@@ -103,10 +243,44 @@ class DeepSeekV32MoEBlock(RtpModule):
         routed_scaling_factor: float = 1.0,
         n_group: int = 1,
         topk_group: int = 1,
+        topk_method: str = "greedy",
         has_moe_norm: bool = False,
         correction_bias: bool = False,
     ):
         super().__init__()
+        fake_balance_expert = (
+            False if moe_config is None else moe_config.fake_balance_expert
+        )
+        if not isinstance(fake_balance_expert, bool):
+            raise TypeError("moe_config.fake_balance_expert must be a bool")
+        if scoring_func not in (0, 1):
+            raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
+        if topk_method == "gready":
+            topk_method = "greedy"
+        if topk_method not in {"greedy", "group_limited_greedy", "noaux_tc"}:
+            raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}")
+        if correction_bias != (topk_method == "noaux_tc"):
+            raise ValueError(
+                "correction_bias must be enabled exactly for noaux_tc routing"
+            )
+        if correction_bias and scoring_func != 1:
+            raise ValueError("noaux_tc routing requires sigmoid scoring")
+        if num_experts % n_group:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by n_group={n_group}"
+            )
+        if not 0 < topk_group <= n_group:
+            raise ValueError(
+                f"topk_group={topk_group} must be in [1, n_group={n_group}]"
+            )
+        grouped = topk_method in {"group_limited_greedy", "noaux_tc"}
+        selected_capacity = (
+            topk_group * (num_experts // n_group) if grouped else num_experts
+        )
+        if not 0 < top_k <= selected_capacity:
+            raise ValueError(
+                f"top_k={top_k} exceeds selected-group capacity " f"{selected_capacity}"
+            )
         self.tp_size = tp_size
         self.ep_size = ep_size
         self.top_k = top_k
@@ -117,7 +291,14 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.topk_group = topk_group
         self.has_moe_norm = has_moe_norm
         self.correction_bias = correction_bias
-        self.num_experts = num_experts
+        self.group_limited = topk_method == "group_limited_greedy"
+        self._use_fast_select_topk = (
+            get_device_type() == DeviceType.Cuda
+            and not correction_bias
+            and scoring_func == 0
+            and not self.group_limited
+            and routed_scaling_factor == 1.0
+        )
 
         # Router gate: hidden → num_experts (not TP-sharded, small).
         # Custom wrapper owns `weight` AND `e_score_correction_bias` so the
@@ -129,8 +310,26 @@ class DeepSeekV32MoEBlock(RtpModule):
             has_correction_bias=correction_bias,
             params_dtype=params_dtype,
         )
-        self.select_topk = SelectTopk(config=model_config)
-        self.group_topk = GroupTopK() if correction_bias else None
+        self.select_topk = (
+            SelectTopk(config=model_config) if self._use_fast_select_topk else None
+        )
+        # GroupTopK is a CUDA-only fused op. ROCm and CPU use the exact
+        # reference algorithm below instead of failing during construction.
+        self._use_fast_group_topk = (
+            correction_bias and get_device_type() == DeviceType.Cuda
+        )
+        self.group_topk = GroupTopK() if self._use_fast_group_topk else None
+        self.fake_balance_expert = (
+            FakeBalanceExpert(
+                expert_num=num_experts,
+                moe_k=top_k,
+                dp_rank=parallelism_config.dp_rank,
+                dp_size=parallelism_config.dp_size,
+                ep_size=ep_size,
+            )
+            if fake_balance_expert
+            else None
+        )
 
         # Routed experts
         self.experts = DeepSeekV32Experts(
@@ -167,6 +366,13 @@ class DeepSeekV32MoEBlock(RtpModule):
             self.shared_experts = None
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.experts.fused_moe is None:
+            raise RuntimeError("DeepSeek fused MoE runtime is not initialized")
+        if hidden_states.dim() != 2:
+            raise ValueError(
+                "DeepSeek MoE expects a two-dimensional token matrix, got "
+                f"{tuple(hidden_states.shape)}"
+            )
         num_tokens = hidden_states.shape[0]
         router_logits = self.gate(hidden_states)
         router_logits_fp32 = router_logits.float()
@@ -176,11 +382,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             dtype=torch.float32,
             device=hidden_states.device,
         )
-        topk_ids_dtype = (
-            self.experts.fused_moe.topk_ids_dtype
-            if self.experts.fused_moe is not None
-            else torch.int32
-        )
+        topk_ids_dtype = self.experts.fused_moe.topk_ids_dtype
         topk_ids = torch.empty(
             (num_tokens, self.top_k),
             dtype=topk_ids_dtype,
@@ -188,21 +390,55 @@ class DeepSeekV32MoEBlock(RtpModule):
         )
 
         if self.correction_bias:
-            if self.group_topk is None:
-                raise RuntimeError("DeepSeek grouped top-k router is not initialized")
-            self.group_topk(
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                scores=router_logits_fp32,
-                correction_bias=self.gate.e_score_correction_bias,
-                n_group=self.n_group,
-                topk_group=self.topk_group,
-                topk=self.top_k,
-                renormalize=self.has_moe_norm,
-                routed_scaling_factor=self.routed_scaling_factor,
-            )
+            if self._use_fast_group_topk and router_logits_fp32.is_cuda:
+                if self.group_topk is None:
+                    raise RuntimeError(
+                        "DeepSeek grouped top-k router is not initialized"
+                    )
+                self.group_topk(
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    scores=router_logits_fp32,
+                    correction_bias=self.gate.e_score_correction_bias,
+                    n_group=self.n_group,
+                    topk_group=self.topk_group,
+                    topk=self.top_k,
+                    renormalize=self.has_moe_norm,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                )
+            else:
+                selected_weights, selected_ids = _select_deepseek_noaux_topk(
+                    router_logits_fp32,
+                    self.gate.e_score_correction_bias,
+                    top_k=self.top_k,
+                    n_group=self.n_group,
+                    topk_group=self.topk_group,
+                    renormalize=self.has_moe_norm,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                )
+                topk_weights.copy_(selected_weights)
+                topk_ids.copy_(selected_ids)
         else:
-            self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+            if self._use_fast_select_topk and router_logits_fp32.is_cuda:
+                if self.select_topk is None:
+                    raise RuntimeError("DeepSeek fast top-k router is not initialized")
+                self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+            else:
+                selected_weights, selected_ids = _select_deepseek_topk(
+                    router_logits_fp32,
+                    top_k=self.top_k,
+                    scoring_func=self.scoring_func,
+                    n_group=self.n_group,
+                    topk_group=self.topk_group,
+                    group_limited=self.group_limited,
+                    renormalize=self.has_moe_norm,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                )
+                topk_weights.copy_(selected_weights)
+                topk_ids.copy_(selected_ids)
+
+        if self.fake_balance_expert is not None:
+            self.fake_balance_expert(topk_ids, topk_weights)
 
         experts_output = self.experts(hidden_states, topk_weights, topk_ids)
 

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -2,10 +2,7 @@
 MoE layers for DeepSeek V3.2, new-loader style.
 
 Key design:
-  - DeepSeekV32Experts extends BaseMoEExperts for the routed experts.
-    HF ckpt provides per-expert weights (gate_proj, up_proj, down_proj) which
-    BaseMoEExperts handles with its own EP/TP streaming load_weights override
-    (taking precedence over RtpModule's default via normal Python MRO).
+  - BaseMoEExperts owns the routed experts and their EP/TP loading contract.
   - DeepSeekV32MoEBlock wraps gate + SelectTopk(/GroupTopK) + experts + shared_expert.
     Mirrors GenericMoeLayer.forward but with new-loader submodules.
   - Shared expert reuses the common TP/FP8-safe DeepSeek MLP.
@@ -19,7 +16,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from rtp_llm.device.device_type import DeviceType, get_device_type
-from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.modules import FakeBalanceExpert, GroupTopK, SelectTopk
@@ -72,15 +68,17 @@ def _validate_routing_args(
     topk_group: int,
     grouped: bool,
 ) -> None:
+    if not 0 < top_k <= num_experts:
+        raise ValueError(f"top_k={top_k} must be in [1, {num_experts}]")
+    if not grouped:
+        return
     if n_group <= 0 or num_experts % n_group:
         raise ValueError(
             f"num_experts={num_experts} must be divisible by n_group={n_group}"
         )
     if not 0 < topk_group <= n_group:
         raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
-    selected_capacity = (
-        topk_group * (num_experts // n_group) if grouped else num_experts
-    )
+    selected_capacity = topk_group * (num_experts // n_group)
     if not 0 < top_k <= selected_capacity:
         raise ValueError(
             f"top_k={top_k} exceeds selected-group capacity {selected_capacity}"
@@ -118,8 +116,6 @@ def _select_deepseek_topk(
         topk_group=topk_group,
         grouped=group_limited,
     )
-    group_size = num_experts // n_group
-
     if scoring_func == 0:
         scores = torch.softmax(router_logits_fp32, dim=-1)
     elif scoring_func == 1:
@@ -129,6 +125,7 @@ def _select_deepseek_topk(
 
     candidate_scores = scores
     if group_limited:
+        group_size = num_experts // n_group
         group_scores = scores.view(-1, n_group, group_size).amax(dim=-1)
         candidate_scores = _mask_scores_by_group(
             scores,
@@ -212,20 +209,6 @@ def _select_deepseek_noaux_topk(
     return topk_weights * routed_scaling_factor, topk_ids
 
 
-class DeepSeekV32Experts(BaseMoEExperts):
-    """Routed experts for DeepSeek V3.2.
-
-    Inherits everything from BaseMoEExperts:
-      - EP/TP expert loading via _dispatch_weight / _dispatch_scale
-      - FP8/FP4 scale fusion in process_weights_after_loading
-      - _build_weights_dict → FusedMoeFactory
-
-    Quantization is driven by LoadConfig. Already-quantized FP8-per-block
-    checkpoints resolve through BaseMoEExperts' shared ``fp8_block`` mapping;
-    plain BF16/FP16 checkpoints use the unquantized path.
-    """
-
-
 class DeepSeekV32MoeGate(RtpModule):
     """Router gate that owns both `weight` and `e_score_correction_bias`.
 
@@ -297,9 +280,12 @@ class DeepSeekV32MoEBlock(RtpModule):
         correction_bias: bool = False,
     ):
         super().__init__()
-        fake_balance_expert = (
-            False if moe_config is None else moe_config.fake_balance_expert
-        )
+        if moe_config is None:
+            fake_balance_expert = False
+        elif isinstance(moe_config, dict):
+            fake_balance_expert = moe_config.get("fake_balance_expert", False)
+        else:
+            fake_balance_expert = getattr(moe_config, "fake_balance_expert", False)
         if not isinstance(fake_balance_expert, bool):
             raise TypeError("moe_config.fake_balance_expert must be a bool")
         if scoring_func not in (0, 1):
@@ -319,10 +305,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             topk_group=topk_group,
             grouped=grouped,
         )
-        self.tp_size = tp_size
-        self.ep_size = ep_size
         self.top_k = top_k
-        self.has_shared_expert = has_shared_expert
         self.scoring_func = scoring_func
         self.routed_scaling_factor = routed_scaling_factor
         self.n_group = n_group
@@ -330,11 +313,25 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.has_moe_norm = has_moe_norm
         self.correction_bias = correction_bias
         self.group_limited = topk_method == "group_limited_greedy"
+
+        def config_value(name: str, default: Any) -> Any:
+            if isinstance(model_config, dict):
+                return model_config.get(name, default)
+            return getattr(model_config, name, default)
+
         routing_config = {
-            "hidden_size": (model_config.hidden_size, hidden_size),
-            "expert_num": (model_config.expert_num, num_experts),
-            "moe_k": (model_config.moe_k, top_k),
-            "has_moe_norm": (model_config.has_moe_norm, has_moe_norm),
+            "hidden_size": (config_value("hidden_size", hidden_size), hidden_size),
+            "expert_num": (config_value("expert_num", num_experts), num_experts),
+            "moe_k": (config_value("moe_k", top_k), top_k),
+            "has_moe_norm": (
+                config_value("has_moe_norm", has_moe_norm),
+                has_moe_norm,
+            ),
+            "moe_n_group": (config_value("moe_n_group", n_group), n_group),
+            "moe_topk_group": (
+                config_value("moe_topk_group", topk_group),
+                topk_group,
+            ),
         }
         mismatches = [
             f"{name}=ModelConfig({actual!r})/constructor({expected!r})"
@@ -352,6 +349,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             and scoring_func == 0
             and not self.group_limited
             and routed_scaling_factor == 1.0
+            and not (top_k == 1 and has_moe_norm)
         )
         # SelectTopk and FusedMoe both consume ModelConfig. The equality check
         # above keeps their sizing/normalization contract identical to the
@@ -384,18 +382,19 @@ class DeepSeekV32MoEBlock(RtpModule):
             and not self._use_fast_select_topk
             and not self._use_fast_group_topk
         ):
-            logger.info(
-                "DeepSeek layer %d uses reference PyTorch MoE routing "
-                "(method=%s scoring_func=%d groups=%d/%d scaling=%s "
-                "renormalize=%s)",
-                layer_idx,
-                topk_method,
-                scoring_func,
-                topk_group,
-                n_group,
-                routed_scaling_factor,
-                has_moe_norm,
-            )
+            if layer_idx == 0:
+                logger.info(
+                    "DeepSeek layer %d uses reference PyTorch MoE routing "
+                    "(method=%s scoring_func=%d groups=%d/%d scaling=%s "
+                    "renormalize=%s)",
+                    layer_idx,
+                    topk_method,
+                    scoring_func,
+                    topk_group,
+                    n_group,
+                    routed_scaling_factor,
+                    has_moe_norm,
+                )
         if fake_balance_expert:
             if parallelism_config is None:
                 raise ValueError(
@@ -414,7 +413,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             self.fake_balance_expert = None
 
         # Routed experts
-        self.experts = DeepSeekV32Experts(
+        self.experts = BaseMoEExperts(
             num_experts=num_experts,
             top_k=top_k,
             hidden_size=hidden_size,
@@ -442,7 +441,7 @@ class DeepSeekV32MoEBlock(RtpModule):
                 tp_rank=tp_rank,
                 quant_config=quant_config,
                 params_dtype=params_dtype,
-                reduce_output=False,
+                reduce_output=True,
             )
         else:
             self.shared_experts = None
@@ -472,12 +471,17 @@ class DeepSeekV32MoEBlock(RtpModule):
         )
 
         if self.correction_bias:
-            if self._use_fast_group_topk and router_logits_fp32.is_cuda:
-                if self.group_topk is None:
+            if self._use_fast_group_topk:
+                if not router_logits_fp32.is_cuda:
                     raise RuntimeError(
-                        "DeepSeek grouped top-k router is not initialized"
+                        "DeepSeek CUDA grouped top-k router received a CPU tensor"
                     )
-                self.group_topk(
+                group_topk = self.group_topk
+                if group_topk is None:
+                    raise RuntimeError(
+                        "DeepSeek CUDA grouped top-k router is not initialized"
+                    )
+                group_topk(
                     topk_weights=topk_weights,
                     topk_ids=topk_ids,
                     scores=router_logits_fp32,
@@ -501,10 +505,15 @@ class DeepSeekV32MoEBlock(RtpModule):
                 topk_weights.copy_(selected_weights)
                 topk_ids.copy_(selected_ids)
         else:
-            if self._use_fast_select_topk and router_logits_fp32.is_cuda:
-                if self.select_topk is None:
-                    raise RuntimeError("DeepSeek fast top-k router is not initialized")
-                self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+            if self._use_fast_select_topk:
+                if not router_logits_fp32.is_cuda:
+                    raise RuntimeError(
+                        "DeepSeek CUDA top-k router received a CPU tensor"
+                    )
+                select_topk = self.select_topk
+                if select_topk is None:
+                    raise RuntimeError("DeepSeek CUDA top-k router is not initialized")
+                select_topk(router_logits_fp32, topk_ids, topk_weights)
             else:
                 selected_weights, selected_ids = _select_deepseek_topk(
                     router_logits_fp32,
@@ -526,8 +535,6 @@ class DeepSeekV32MoEBlock(RtpModule):
 
         if self.shared_experts is not None:
             shared_output = self.shared_experts(hidden_states)
-            if self.tp_size > 1:
-                shared_output = all_reduce(shared_output, group=Group.TP)
             experts_output = experts_output + shared_output
 
         return experts_output

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -1,0 +1,215 @@
+"""
+MoE layers for DeepSeek V3.2, new-loader style.
+
+Key design:
+  - DeepSeekV32Experts extends BaseMoEExperts for the routed experts.
+    HF ckpt provides per-expert weights (gate_proj, up_proj, down_proj) which
+    BaseMoEExperts handles with its own EP/TP streaming load_weights override
+    (taking precedence over RtpModule's default via normal Python MRO).
+  - DeepSeekV32MoEBlock wraps gate + SelectTopk(/GroupTopK) + experts + shared_expert.
+    Mirrors GenericMoeLayer.forward but with new-loader submodules.
+  - Shared expert reuses the common TP/FP8-safe DeepSeek MLP.
+"""
+
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
+from rtp_llm.models_py.layers.moe_experts import BaseMoEExperts
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules import GroupTopK, SelectTopk
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+
+from .mlp import DeepSeekV32MLP
+
+
+class DeepSeekV32Experts(BaseMoEExperts):
+    """Routed experts for DeepSeek V3.2.
+
+    Inherits everything from BaseMoEExperts:
+      - EP/TP expert loading via _dispatch_weight / _dispatch_scale
+      - FP8/FP4 scale fusion in process_weights_after_loading
+      - _build_weights_dict → FusedMoeFactory
+
+    Quantization is driven by LoadConfig. Already-quantized FP8-per-block
+    checkpoints resolve through BaseMoEExperts' shared ``fp8_block`` mapping;
+    plain BF16/FP16 checkpoints use the unquantized path.
+    """
+
+
+class DeepSeekV32MoeGate(RtpModule):
+    """Router gate that owns both `weight` and `e_score_correction_bias`.
+
+    Matches HF ckpt keys:
+      model.layers.{i}.mlp.gate.weight                  -> weight
+      model.layers.{i}.mlp.gate.e_score_correction_bias -> e_score_correction_bias
+
+    Not TP-sharded (num_experts is small relative to hidden dim).
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_experts: int,
+        has_correction_bias: bool,
+        params_dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(num_experts, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        if has_correction_bias:
+            self.e_score_correction_bias = nn.Parameter(
+                torch.empty(num_experts, dtype=torch.float32),
+                requires_grad=False,
+            )
+        else:
+            self.register_parameter("e_score_correction_bias", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight, None)
+
+
+class DeepSeekV32MoEBlock(RtpModule):
+    """Full MoE block: gate + router + routed experts + shared expert.
+
+    Mirrors GenericMoeLayer.forward: routing → FusedMoe → (optional) shared expert.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        moe_intermediate_size: int,
+        num_experts: int,
+        top_k: int,
+        layer_idx: int,
+        tp_size: int,
+        tp_rank: int,
+        ep_size: int,
+        ep_rank: int,
+        model_config: Any,
+        parallelism_config: Any,
+        moe_config: Any,
+        quant_config: Optional[QuantizationConfig],
+        params_dtype: torch.dtype,
+        # Config fields for GroupTopK (DeepSeek V3 style)
+        has_shared_expert: bool = True,
+        shared_expert_intermediate_size: int = 0,
+        scoring_func: int = 1,  # 0=softmax, 1=sigmoid
+        routed_scaling_factor: float = 1.0,
+        n_group: int = 1,
+        topk_group: int = 1,
+        has_moe_norm: bool = False,
+        correction_bias: bool = False,
+    ):
+        super().__init__()
+        self.tp_size = tp_size
+        self.ep_size = ep_size
+        self.top_k = top_k
+        self.has_shared_expert = has_shared_expert
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.has_moe_norm = has_moe_norm
+        self.correction_bias = correction_bias
+        self.num_experts = num_experts
+
+        # Router gate: hidden → num_experts (not TP-sharded, small).
+        # Custom wrapper owns `weight` AND `e_score_correction_bias` so the
+        # HF key model.layers.{i}.mlp.gate.e_score_correction_bias loads
+        # cleanly via streaming dispatch.
+        self.gate = DeepSeekV32MoeGate(
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            has_correction_bias=correction_bias,
+            params_dtype=params_dtype,
+        )
+        self.select_topk = SelectTopk(config=model_config)
+        self.group_topk = GroupTopK() if correction_bias else None
+
+        # Routed experts
+        self.experts = DeepSeekV32Experts(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            moe_intermediate_size=moe_intermediate_size,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            params_dtype=params_dtype,
+            model_config=model_config,
+            parallelism_config=parallelism_config,
+            moe_config=moe_config,
+            quant_config=quant_config,
+            layer_idx=layer_idx,
+        )
+
+        # Shared expert. HF key is `mlp.shared_experts.{gate,up,down}_proj`
+        # (PLURAL). DeepSeek-V3.2 has no shared-expert gating — the routed
+        # MoE output is summed directly with shared_experts(hidden_states).
+        if has_shared_expert and shared_expert_intermediate_size > 0:
+            self.shared_experts = DeepSeekV32MLP(
+                hidden_size=hidden_size,
+                intermediate_size=shared_expert_intermediate_size,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+                quant_config=quant_config,
+                params_dtype=params_dtype,
+                reduce_output=False,
+            )
+        else:
+            self.shared_experts = None
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        num_tokens = hidden_states.shape[0]
+        router_logits = self.gate(hidden_states)
+        router_logits_fp32 = router_logits.float()
+
+        topk_weights = torch.empty(
+            (num_tokens, self.top_k),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        topk_ids_dtype = (
+            self.experts.fused_moe.topk_ids_dtype
+            if self.experts.fused_moe is not None
+            else torch.int32
+        )
+        topk_ids = torch.empty(
+            (num_tokens, self.top_k),
+            dtype=topk_ids_dtype,
+            device=hidden_states.device,
+        )
+
+        if self.correction_bias:
+            if self.group_topk is None:
+                raise RuntimeError("DeepSeek grouped top-k router is not initialized")
+            self.group_topk(
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                scores=router_logits_fp32,
+                correction_bias=self.gate.e_score_correction_bias,
+                n_group=self.n_group,
+                topk_group=self.topk_group,
+                topk=self.top_k,
+                renormalize=self.has_moe_norm,
+                routed_scaling_factor=self.routed_scaling_factor,
+            )
+        else:
+            self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+
+        experts_output = self.experts(hidden_states, topk_weights, topk_ids)
+
+        if self.shared_experts is not None:
+            shared_output = self.shared_experts(hidden_states)
+            if self.tp_size > 1:
+                shared_output = all_reduce(shared_output, group=Group.TP)
+            experts_output = experts_output + shared_output
+
+        return experts_output

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -9,6 +9,8 @@ Key design:
 """
 
 import logging
+import math
+from enum import Enum, IntEnum
 from typing import Any, Optional
 
 import torch
@@ -23,17 +25,30 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 
 from .mlp import DeepSeekV32MLP
 
-_VALID_TOPK_METHODS = {"greedy", "group_limited_greedy", "noaux_tc"}
 logger = logging.getLogger(__name__)
 
 
-def normalize_topk_method(topk_method: str) -> str:
+class ScoringFunc(IntEnum):
+    SOFTMAX = 0
+    SIGMOID = 1
+
+
+class TopKMethod(str, Enum):
+    GREEDY = "greedy"
+    GROUP_LIMITED_GREEDY = "group_limited_greedy"
+    NOAUX_TC = "noaux_tc"
+
+
+def normalize_topk_method(topk_method: str | TopKMethod) -> TopKMethod:
+    if isinstance(topk_method, TopKMethod):
+        return topk_method
     if not isinstance(topk_method, str):
         raise TypeError(f"topk_method must be a string, got {topk_method!r}")
     normalized = "greedy" if topk_method == "gready" else topk_method
-    if normalized not in _VALID_TOPK_METHODS:
-        raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}")
-    return normalized
+    try:
+        return TopKMethod(normalized)
+    except ValueError as exc:
+        raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}") from exc
 
 
 def _mask_scores_by_group(
@@ -52,12 +67,11 @@ def _mask_scores_by_group(
     ).indices
     group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
     group_mask.scatter_(1, selected_groups, True)
-    expert_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(-1, -1, group_size)
-        .reshape_as(scores_for_choice)
-    )
-    return scores_for_choice.masked_fill(~expert_mask, float("-inf"))
+    grouped_scores = scores_for_choice.view(-1, n_group, group_size)
+    return grouped_scores.masked_fill(
+        ~group_mask.unsqueeze(-1),
+        float("-inf"),
+    ).view_as(scores_for_choice)
 
 
 def _validate_routing_args(
@@ -89,12 +103,13 @@ def _select_deepseek_topk(
     router_logits_fp32: torch.Tensor,
     *,
     top_k: int,
-    scoring_func: int,
+    scoring_func: int | ScoringFunc,
     n_group: int,
     topk_group: int,
     group_limited: bool,
     renormalize: bool,
     routed_scaling_factor: float,
+    validate: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Reference-correct DeepSeek-V2 routing for the non-noaux path.
 
@@ -109,19 +124,19 @@ def _select_deepseek_topk(
             f"{tuple(router_logits_fp32.shape)}"
         )
     num_experts = router_logits_fp32.shape[-1]
-    _validate_routing_args(
-        num_experts=num_experts,
-        top_k=top_k,
-        n_group=n_group,
-        topk_group=topk_group,
-        grouped=group_limited,
-    )
-    if scoring_func == 0:
+    if validate:
+        _validate_routing_args(
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            grouped=group_limited,
+        )
+    scoring_func = ScoringFunc(scoring_func)
+    if scoring_func == ScoringFunc.SOFTMAX:
         scores = torch.softmax(router_logits_fp32, dim=-1)
-    elif scoring_func == 1:
+    elif scoring_func == ScoringFunc.SIGMOID:
         scores = torch.sigmoid(router_logits_fp32)
-    else:
-        raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
 
     candidate_scores = scores
     if group_limited:
@@ -158,6 +173,7 @@ def _select_deepseek_noaux_topk(
     topk_group: int,
     renormalize: bool,
     routed_scaling_factor: float,
+    validate: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Reference DeepSeek-V3 noaux_tc routing used when GroupTopK is unavailable."""
     if router_logits_fp32.dim() != 2:
@@ -166,18 +182,19 @@ def _select_deepseek_noaux_topk(
             f"{tuple(router_logits_fp32.shape)}"
         )
     num_experts = router_logits_fp32.shape[-1]
-    if correction_bias.shape != (num_experts,):
+    if validate and correction_bias.shape != (num_experts,):
         raise ValueError(
             "correction_bias must have shape [experts], got "
             f"{tuple(correction_bias.shape)} for {num_experts} experts"
         )
-    _validate_routing_args(
-        num_experts=num_experts,
-        top_k=top_k,
-        n_group=n_group,
-        topk_group=topk_group,
-        grouped=True,
-    )
+    if validate:
+        _validate_routing_args(
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            grouped=True,
+        )
     group_size = num_experts // n_group
 
     scores = torch.sigmoid(router_logits_fp32)
@@ -271,11 +288,11 @@ class DeepSeekV32MoEBlock(RtpModule):
         # Config fields for GroupTopK (DeepSeek V3 style)
         has_shared_expert: bool = True,
         shared_expert_intermediate_size: int = 0,
-        scoring_func: int = 1,  # 0=softmax, 1=sigmoid
+        scoring_func: int | ScoringFunc = ScoringFunc.SIGMOID,
         routed_scaling_factor: float = 1.0,
         n_group: int = 1,
         topk_group: int = 1,
-        topk_method: str = "greedy",
+        topk_method: str | TopKMethod = TopKMethod.GREEDY,
         has_moe_norm: bool = False,
         correction_bias: bool = False,
         prefix: str = "mlp",
@@ -283,22 +300,27 @@ class DeepSeekV32MoEBlock(RtpModule):
         super().__init__()
         if moe_config is None:
             fake_balance_expert = False
-        elif isinstance(moe_config, dict):
-            fake_balance_expert = moe_config.get("fake_balance_expert", False)
         else:
-            fake_balance_expert = getattr(moe_config, "fake_balance_expert", False)
+            fake_balance_expert = moe_config.fake_balance_expert
         if not isinstance(fake_balance_expert, bool):
             raise TypeError("moe_config.fake_balance_expert must be a bool")
-        if scoring_func not in (0, 1):
-            raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
+        try:
+            scoring_func = ScoringFunc(scoring_func)
+        except ValueError as exc:
+            raise ValueError(
+                f"unsupported DeepSeek scoring_func={scoring_func}"
+            ) from exc
         topk_method = normalize_topk_method(topk_method)
-        if correction_bias != (topk_method == "noaux_tc"):
+        if correction_bias != (topk_method == TopKMethod.NOAUX_TC):
             raise ValueError(
                 "correction_bias must be enabled exactly for noaux_tc routing"
             )
-        if correction_bias and scoring_func != 1:
+        if correction_bias and scoring_func != ScoringFunc.SIGMOID:
             raise ValueError("noaux_tc routing requires sigmoid scoring")
-        grouped = topk_method in {"group_limited_greedy", "noaux_tc"}
+        grouped = topk_method in {
+            TopKMethod.GROUP_LIMITED_GREEDY,
+            TopKMethod.NOAUX_TC,
+        }
         _validate_routing_args(
             num_experts=num_experts,
             top_k=top_k,
@@ -313,7 +335,7 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.topk_group = topk_group
         self.has_moe_norm = has_moe_norm
         self.correction_bias = correction_bias
-        self.group_limited = topk_method == "group_limited_greedy"
+        self.group_limited = topk_method == TopKMethod.GROUP_LIMITED_GREEDY
 
         routing_config = {
             "hidden_size": (model_config.hidden_size, hidden_size),
@@ -328,11 +350,23 @@ class DeepSeekV32MoEBlock(RtpModule):
                 model_config.moe_topk_group,
                 topk_group,
             ),
+            "scoring_func": (
+                ScoringFunc(model_config.scoring_func),
+                scoring_func,
+            ),
+            "routed_scaling_factor": (
+                float(model_config.routed_scaling_factor),
+                float(routed_scaling_factor),
+            ),
         }
         mismatches = [
             f"{name}=ModelConfig({actual!r})/constructor({expected!r})"
             for name, (actual, expected) in routing_config.items()
-            if actual != expected
+            if not (
+                math.isclose(actual, expected, rel_tol=0.0, abs_tol=1e-12)
+                if name == "routed_scaling_factor"
+                else actual == expected
+            )
         ]
         if mismatches:
             raise ValueError(
@@ -343,7 +377,7 @@ class DeepSeekV32MoEBlock(RtpModule):
         fast_select_topk_candidate = (
             device_type == DeviceType.Cuda
             and not correction_bias
-            and scoring_func == 0
+            and scoring_func == ScoringFunc.SOFTMAX
             and not self.group_limited
             and routed_scaling_factor == 1.0
             and not (top_k == 1 and has_moe_norm)
@@ -379,7 +413,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             and not self._use_fast_group_topk
             and layer_idx == 0
         ):
-            logger.info(
+            logger.warning(
                 "DeepSeek layer %d uses reference PyTorch MoE routing "
                 "(device=%s method=%s scoring_func=%d groups=%d/%d scaling=%s "
                 "renormalize=%s)",
@@ -452,28 +486,14 @@ class DeepSeekV32MoEBlock(RtpModule):
             self.shared_experts = None
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        if self.experts.fused_moe is None:
-            raise RuntimeError("DeepSeek fused MoE runtime is not initialized")
         if hidden_states.dim() != 2:
             raise ValueError(
                 "DeepSeek MoE expects a two-dimensional token matrix, got "
                 f"{tuple(hidden_states.shape)}"
             )
-        num_tokens = hidden_states.shape[0]
         router_logits = self.gate(hidden_states)
         router_logits_fp32 = router_logits.float()
-
-        topk_weights = torch.empty(
-            (num_tokens, self.top_k),
-            dtype=torch.float32,
-            device=hidden_states.device,
-        )
-        topk_ids_dtype = self.experts.fused_moe.topk_ids_dtype
-        topk_ids = torch.empty(
-            (num_tokens, self.top_k),
-            dtype=topk_ids_dtype,
-            device=hidden_states.device,
-        )
+        topk_ids_dtype = self.experts.topk_ids_dtype
 
         if self.correction_bias:
             if self._use_fast_group_topk:
@@ -481,12 +501,17 @@ class DeepSeekV32MoEBlock(RtpModule):
                     raise RuntimeError(
                         "DeepSeek CUDA grouped top-k router received a CPU tensor"
                     )
-                group_topk = self.group_topk
-                if group_topk is None:
-                    raise RuntimeError(
-                        "DeepSeek CUDA grouped top-k router is not initialized"
-                    )
-                group_topk(
+                topk_weights = torch.empty(
+                    (hidden_states.shape[0], self.top_k),
+                    dtype=torch.float32,
+                    device=hidden_states.device,
+                )
+                topk_ids = torch.empty(
+                    (hidden_states.shape[0], self.top_k),
+                    dtype=topk_ids_dtype,
+                    device=hidden_states.device,
+                )
+                self.group_topk(
                     topk_weights=topk_weights,
                     topk_ids=topk_ids,
                     scores=router_logits_fp32,
@@ -506,19 +531,27 @@ class DeepSeekV32MoEBlock(RtpModule):
                     topk_group=self.topk_group,
                     renormalize=self.has_moe_norm,
                     routed_scaling_factor=self.routed_scaling_factor,
+                    validate=False,
                 )
-                topk_weights.copy_(selected_weights)
-                topk_ids.copy_(selected_ids)
+                topk_weights = selected_weights
+                topk_ids = selected_ids.to(dtype=topk_ids_dtype)
         else:
             if self._use_fast_select_topk:
                 if not router_logits_fp32.is_cuda:
                     raise RuntimeError(
                         "DeepSeek CUDA top-k router received a CPU tensor"
                     )
-                select_topk = self.select_topk
-                if select_topk is None:
-                    raise RuntimeError("DeepSeek CUDA top-k router is not initialized")
-                select_topk(router_logits_fp32, topk_ids, topk_weights)
+                topk_weights = torch.empty(
+                    (hidden_states.shape[0], self.top_k),
+                    dtype=torch.float32,
+                    device=hidden_states.device,
+                )
+                topk_ids = torch.empty(
+                    (hidden_states.shape[0], self.top_k),
+                    dtype=topk_ids_dtype,
+                    device=hidden_states.device,
+                )
+                self.select_topk(router_logits_fp32, topk_ids, topk_weights)
             else:
                 selected_weights, selected_ids = _select_deepseek_topk(
                     router_logits_fp32,
@@ -529,9 +562,10 @@ class DeepSeekV32MoEBlock(RtpModule):
                     group_limited=self.group_limited,
                     renormalize=self.has_moe_norm,
                     routed_scaling_factor=self.routed_scaling_factor,
+                    validate=False,
                 )
-                topk_weights.copy_(selected_weights)
-                topk_ids.copy_(selected_ids)
+                topk_weights = selected_weights
+                topk_ids = selected_ids.to(dtype=topk_ids_dtype)
 
         if self.fake_balance_expert is not None:
             self.fake_balance_expert(topk_ids, topk_weights)

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -137,6 +137,8 @@ def _select_deepseek_topk(
         scores = torch.softmax(router_logits_fp32, dim=-1)
     elif scoring_func == ScoringFunc.SIGMOID:
         scores = torch.sigmoid(router_logits_fp32)
+    else:
+        raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func!r}")
 
     candidate_scores = scores
     if group_limited:
@@ -268,6 +270,8 @@ class DeepSeekV32MoEBlock(RtpModule):
 
     Mirrors GenericMoeLayer.forward: routing → FusedMoe → (optional) shared expert.
     """
+
+    _reference_router_warning_emitted = False
 
     def __init__(
         self,
@@ -405,13 +409,15 @@ class DeepSeekV32MoEBlock(RtpModule):
         self._use_fast_group_topk = (
             correction_bias
             and device_type == DeviceType.Cuda
+            and n_group <= 32
+            and top_k <= 32
             and not (top_k == 1 and has_moe_norm)
         )
         self.group_topk = GroupTopK() if self._use_fast_group_topk else None
         if (
             not self._use_fast_select_topk
             and not self._use_fast_group_topk
-            and layer_idx == 0
+            and not type(self)._reference_router_warning_emitted
         ):
             logger.warning(
                 "DeepSeek layer %d uses reference PyTorch MoE routing "
@@ -426,6 +432,7 @@ class DeepSeekV32MoEBlock(RtpModule):
                 routed_scaling_factor,
                 has_moe_norm,
             )
+            type(self)._reference_router_warning_emitted = True
         if fake_balance_expert:
             if parallelism_config is None:
                 raise ValueError(

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -278,6 +278,7 @@ class DeepSeekV32MoEBlock(RtpModule):
         topk_method: str = "greedy",
         has_moe_norm: bool = False,
         correction_bias: bool = False,
+        prefix: str = "mlp",
     ):
         super().__init__()
         if moe_config is None:
@@ -314,22 +315,17 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.correction_bias = correction_bias
         self.group_limited = topk_method == "group_limited_greedy"
 
-        def config_value(name: str, default: Any) -> Any:
-            if isinstance(model_config, dict):
-                return model_config.get(name, default)
-            return getattr(model_config, name, default)
-
         routing_config = {
-            "hidden_size": (config_value("hidden_size", hidden_size), hidden_size),
-            "expert_num": (config_value("expert_num", num_experts), num_experts),
-            "moe_k": (config_value("moe_k", top_k), top_k),
+            "hidden_size": (model_config.hidden_size, hidden_size),
+            "expert_num": (model_config.expert_num, num_experts),
+            "moe_k": (model_config.moe_k, top_k),
             "has_moe_norm": (
-                config_value("has_moe_norm", has_moe_norm),
+                model_config.has_moe_norm,
                 has_moe_norm,
             ),
-            "moe_n_group": (config_value("moe_n_group", n_group), n_group),
+            "moe_n_group": (model_config.moe_n_group, n_group),
             "moe_topk_group": (
-                config_value("moe_topk_group", topk_group),
+                model_config.moe_topk_group,
                 topk_group,
             ),
         }
@@ -343,8 +339,9 @@ class DeepSeekV32MoEBlock(RtpModule):
                 f"DeepSeek routing config mismatch at layer {layer_idx}: "
                 + ", ".join(mismatches)
             )
+        device_type = get_device_type()
         fast_select_topk_candidate = (
-            get_device_type() == DeviceType.Cuda
+            device_type == DeviceType.Cuda
             and not correction_bias
             and scoring_func == 0
             and not self.group_limited
@@ -373,34 +370,34 @@ class DeepSeekV32MoEBlock(RtpModule):
         # reference algorithm below instead of failing during construction.
         self._use_fast_group_topk = (
             correction_bias
-            and get_device_type() == DeviceType.Cuda
+            and device_type == DeviceType.Cuda
             and not (top_k == 1 and has_moe_norm)
         )
         self.group_topk = GroupTopK() if self._use_fast_group_topk else None
         if (
-            get_device_type() == DeviceType.Cuda
-            and not self._use_fast_select_topk
+            not self._use_fast_select_topk
             and not self._use_fast_group_topk
+            and layer_idx == 0
         ):
-            if layer_idx == 0:
-                logger.info(
-                    "DeepSeek layer %d uses reference PyTorch MoE routing "
-                    "(method=%s scoring_func=%d groups=%d/%d scaling=%s "
-                    "renormalize=%s)",
-                    layer_idx,
-                    topk_method,
-                    scoring_func,
-                    topk_group,
-                    n_group,
-                    routed_scaling_factor,
-                    has_moe_norm,
-                )
+            logger.info(
+                "DeepSeek layer %d uses reference PyTorch MoE routing "
+                "(device=%s method=%s scoring_func=%d groups=%d/%d scaling=%s "
+                "renormalize=%s)",
+                layer_idx,
+                device_type,
+                topk_method,
+                scoring_func,
+                topk_group,
+                n_group,
+                routed_scaling_factor,
+                has_moe_norm,
+            )
         if fake_balance_expert:
             if parallelism_config is None:
                 raise ValueError(
                     "fake_balance_expert requires a complete parallelism_config"
                 )
-            if get_device_type() != DeviceType.Cuda:
+            if device_type != DeviceType.Cuda:
                 raise RuntimeError("fake_balance_expert is supported only on CUDA")
             self.fake_balance_expert = FakeBalanceExpert(
                 expert_num=num_experts,
@@ -411,6 +408,12 @@ class DeepSeekV32MoEBlock(RtpModule):
             )
         else:
             self.fake_balance_expert = None
+
+        if has_shared_expert != (shared_expert_intermediate_size > 0):
+            raise ValueError(
+                "has_shared_expert must match whether "
+                "shared_expert_intermediate_size is positive"
+            )
 
         # Routed experts
         self.experts = BaseMoEExperts(
@@ -428,12 +431,13 @@ class DeepSeekV32MoEBlock(RtpModule):
             moe_config=moe_config,
             quant_config=quant_config,
             layer_idx=layer_idx,
+            prefix=f"{prefix}.experts",
         )
 
         # Shared expert. HF key is `mlp.shared_experts.{gate,up,down}_proj`
         # (PLURAL). DeepSeek-V3.2 has no shared-expert gating — the routed
         # MoE output is summed directly with shared_experts(hidden_states).
-        if has_shared_expert and shared_expert_intermediate_size > 0:
+        if has_shared_expert:
             self.shared_experts = DeepSeekV32MLP(
                 hidden_size=hidden_size,
                 intermediate_size=shared_expert_intermediate_size,
@@ -442,6 +446,7 @@ class DeepSeekV32MoEBlock(RtpModule):
                 quant_config=quant_config,
                 params_dtype=params_dtype,
                 reduce_output=True,
+                prefix=f"{prefix}.shared_experts",
             )
         else:
             self.shared_experts = None

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -26,6 +26,17 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 
 from .mlp import DeepSeekV32MLP
 
+_VALID_TOPK_METHODS = {"greedy", "group_limited_greedy", "noaux_tc"}
+
+
+def _normalize_topk_method(topk_method: str) -> str:
+    if not isinstance(topk_method, str):
+        raise TypeError(f"topk_method must be a string, got {topk_method!r}")
+    normalized = "greedy" if topk_method == "gready" else topk_method
+    if normalized not in _VALID_TOPK_METHODS:
+        raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}")
+    return normalized
+
 
 def _validate_routing_args(
     *,
@@ -61,7 +72,13 @@ def _select_deepseek_topk(
     renormalize: bool,
     routed_scaling_factor: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Reference-correct DeepSeek-V2 routing for the non-noaux path."""
+    """Reference-correct DeepSeek-V2 routing for the non-noaux path.
+
+    DeepSeek-V2 normalizes top-k weights *or* applies routed scaling. Public
+    V2 configurations do not combine non-unit scaling with normalization, but
+    keeping the reference branch explicit avoids silently adopting V3 noaux
+    semantics for a future V2 variant.
+    """
     if router_logits_fp32.dim() != 2:
         raise ValueError(
             "router logits must have shape [tokens, experts], got "
@@ -110,7 +127,9 @@ def _select_deepseek_topk(
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
             1e-20
         )
-    return topk_weights * routed_scaling_factor, topk_ids
+    else:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights, topk_ids
 
 
 def _select_deepseek_noaux_topk(
@@ -273,10 +292,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             raise TypeError("moe_config.fake_balance_expert must be a bool")
         if scoring_func not in (0, 1):
             raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
-        if topk_method == "gready":
-            topk_method = "greedy"
-        if topk_method not in {"greedy", "group_limited_greedy", "noaux_tc"}:
-            raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}")
+        topk_method = _normalize_topk_method(topk_method)
         if correction_bias != (topk_method == "noaux_tc"):
             raise ValueError(
                 "correction_bias must be enabled exactly for noaux_tc routing"
@@ -302,6 +318,22 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.has_moe_norm = has_moe_norm
         self.correction_bias = correction_bias
         self.group_limited = topk_method == "group_limited_greedy"
+        routing_config = {
+            "hidden_size": (model_config.hidden_size, hidden_size),
+            "expert_num": (model_config.expert_num, num_experts),
+            "moe_k": (model_config.moe_k, top_k),
+            "has_moe_norm": (model_config.has_moe_norm, has_moe_norm),
+        }
+        mismatches = [
+            f"{name}=ModelConfig({actual!r})/constructor({expected!r})"
+            for name, (actual, expected) in routing_config.items()
+            if actual != expected
+        ]
+        if mismatches:
+            raise ValueError(
+                f"DeepSeek routing config mismatch at layer {layer_idx}: "
+                + ", ".join(mismatches)
+            )
         fast_select_topk_candidate = (
             get_device_type() == DeviceType.Cuda
             and not correction_bias
@@ -309,16 +341,10 @@ class DeepSeekV32MoEBlock(RtpModule):
             and not self.group_limited
             and routed_scaling_factor == 1.0
         )
-        # SelectTopk reads these values from the pybind ModelConfig while the
-        # reference path uses the canonical config.json-derived constructor
-        # values above. A stale ModelConfig must never size or normalize the
-        # fused output with a different contract; safely use the reference
-        # implementation when either source disagrees.
-        self._use_fast_select_topk = fast_select_topk_candidate and (
-            model_config.expert_num == num_experts
-            and model_config.moe_k == top_k
-            and model_config.has_moe_norm == has_moe_norm
-        )
+        # SelectTopk and FusedMoe both consume ModelConfig. The equality check
+        # above keeps their sizing/normalization contract identical to the
+        # canonical config.json-derived constructor arguments.
+        self._use_fast_select_topk = fast_select_topk_candidate
 
         # Router gate: hidden → num_experts (not TP-sharded, small).
         # Custom wrapper owns `weight` AND `e_score_correction_bias` so the
@@ -339,17 +365,22 @@ class DeepSeekV32MoEBlock(RtpModule):
             correction_bias and get_device_type() == DeviceType.Cuda
         )
         self.group_topk = GroupTopK() if self._use_fast_group_topk else None
-        self.fake_balance_expert = (
-            FakeBalanceExpert(
+        if fake_balance_expert:
+            if parallelism_config is None:
+                raise ValueError(
+                    "fake_balance_expert requires a complete parallelism_config"
+                )
+            if get_device_type() != DeviceType.Cuda:
+                raise RuntimeError("fake_balance_expert is supported only on CUDA")
+            self.fake_balance_expert = FakeBalanceExpert(
                 expert_num=num_experts,
                 moe_k=top_k,
                 dp_rank=parallelism_config.dp_rank,
                 dp_size=parallelism_config.dp_size,
                 ep_size=ep_size,
             )
-            if fake_balance_expert
-            else None
-        )
+        else:
+            self.fake_balance_expert = None
 
         # Routed experts
         self.experts = DeepSeekV32Experts(

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -27,6 +27,29 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from .mlp import DeepSeekV32MLP
 
 
+def _validate_routing_args(
+    *,
+    num_experts: int,
+    top_k: int,
+    n_group: int,
+    topk_group: int,
+    grouped: bool,
+) -> None:
+    if n_group <= 0 or num_experts % n_group:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by n_group={n_group}"
+        )
+    if not 0 < topk_group <= n_group:
+        raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
+    selected_capacity = (
+        topk_group * (num_experts // n_group) if grouped else num_experts
+    )
+    if not 0 < top_k <= selected_capacity:
+        raise ValueError(
+            f"top_k={top_k} exceeds selected-group capacity {selected_capacity}"
+        )
+
+
 def _select_deepseek_topk(
     router_logits_fp32: torch.Tensor,
     *,
@@ -45,18 +68,14 @@ def _select_deepseek_topk(
             f"{tuple(router_logits_fp32.shape)}"
         )
     num_experts = router_logits_fp32.shape[-1]
-    if n_group <= 0 or num_experts % n_group:
-        raise ValueError(
-            f"num_experts={num_experts} must be divisible by n_group={n_group}"
-        )
-    if not 0 < topk_group <= n_group:
-        raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
+    _validate_routing_args(
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        grouped=group_limited,
+    )
     group_size = num_experts // n_group
-    selected_capacity = topk_group * group_size if group_limited else num_experts
-    if not 0 < top_k <= selected_capacity:
-        raise ValueError(
-            f"top_k={top_k} exceeds selected-group capacity " f"{selected_capacity}"
-        )
 
     if scoring_func == 0:
         scores = torch.softmax(router_logits_fp32, dim=-1)
@@ -116,18 +135,14 @@ def _select_deepseek_noaux_topk(
             "correction_bias must have shape [experts], got "
             f"{tuple(correction_bias.shape)} for {num_experts} experts"
         )
-    if n_group <= 0 or num_experts % n_group:
-        raise ValueError(
-            f"num_experts={num_experts} must be divisible by n_group={n_group}"
-        )
-    if not 0 < topk_group <= n_group:
-        raise ValueError(f"topk_group={topk_group} must be in [1, n_group={n_group}]")
+    _validate_routing_args(
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        grouped=True,
+    )
     group_size = num_experts // n_group
-    selected_capacity = topk_group * group_size
-    if not 0 < top_k <= selected_capacity:
-        raise ValueError(
-            f"top_k={top_k} exceeds selected-group capacity {selected_capacity}"
-        )
 
     scores = torch.sigmoid(router_logits_fp32)
     scores_for_choice = scores + correction_bias
@@ -211,6 +226,9 @@ class DeepSeekV32MoeGate(RtpModule):
             self.register_parameter("e_score_correction_bias", None)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Keep the gate GEMM in the model dtype to match GenericMoeLayer and
+        # avoid materializing a full FP32 gate-weight copy on every layer and
+        # forward. Routing itself consumes FP32 logits below.
         return F.linear(x, self.weight, None)
 
 
@@ -265,22 +283,14 @@ class DeepSeekV32MoEBlock(RtpModule):
             )
         if correction_bias and scoring_func != 1:
             raise ValueError("noaux_tc routing requires sigmoid scoring")
-        if num_experts % n_group:
-            raise ValueError(
-                f"num_experts={num_experts} must be divisible by n_group={n_group}"
-            )
-        if not 0 < topk_group <= n_group:
-            raise ValueError(
-                f"topk_group={topk_group} must be in [1, n_group={n_group}]"
-            )
         grouped = topk_method in {"group_limited_greedy", "noaux_tc"}
-        selected_capacity = (
-            topk_group * (num_experts // n_group) if grouped else num_experts
+        _validate_routing_args(
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            grouped=grouped,
         )
-        if not 0 < top_k <= selected_capacity:
-            raise ValueError(
-                f"top_k={top_k} exceeds selected-group capacity " f"{selected_capacity}"
-            )
         self.tp_size = tp_size
         self.ep_size = ep_size
         self.top_k = top_k
@@ -292,12 +302,22 @@ class DeepSeekV32MoEBlock(RtpModule):
         self.has_moe_norm = has_moe_norm
         self.correction_bias = correction_bias
         self.group_limited = topk_method == "group_limited_greedy"
-        self._use_fast_select_topk = (
+        fast_select_topk_candidate = (
             get_device_type() == DeviceType.Cuda
             and not correction_bias
             and scoring_func == 0
             and not self.group_limited
             and routed_scaling_factor == 1.0
+        )
+        # SelectTopk reads these values from the pybind ModelConfig while the
+        # reference path uses the canonical config.json-derived constructor
+        # values above. A stale ModelConfig must never size or normalize the
+        # fused output with a different contract; safely use the reference
+        # implementation when either source disagrees.
+        self._use_fast_select_topk = fast_select_topk_candidate and (
+            model_config.expert_num == num_experts
+            and model_config.moe_k == top_k
+            and model_config.has_moe_norm == has_moe_norm
         )
 
         # Router gate: hidden → num_experts (not TP-sharded, small).

--- a/rtp_llm/models_py/new_models/deepseek_v3/moe.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/moe.py
@@ -11,6 +11,7 @@ Key design:
   - Shared expert reuses the common TP/FP8-safe DeepSeek MLP.
 """
 
+import logging
 from typing import Any, Optional
 
 import torch
@@ -27,15 +28,40 @@ from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from .mlp import DeepSeekV32MLP
 
 _VALID_TOPK_METHODS = {"greedy", "group_limited_greedy", "noaux_tc"}
+logger = logging.getLogger(__name__)
 
 
-def _normalize_topk_method(topk_method: str) -> str:
+def normalize_topk_method(topk_method: str) -> str:
     if not isinstance(topk_method, str):
         raise TypeError(f"topk_method must be a string, got {topk_method!r}")
     normalized = "greedy" if topk_method == "gready" else topk_method
     if normalized not in _VALID_TOPK_METHODS:
         raise ValueError(f"unsupported DeepSeek topk_method={topk_method!r}")
     return normalized
+
+
+def _mask_scores_by_group(
+    scores_for_choice: torch.Tensor,
+    group_scores: torch.Tensor,
+    n_group: int,
+    topk_group: int,
+) -> torch.Tensor:
+    """Mask experts outside the selected routing groups."""
+    group_size = scores_for_choice.shape[-1] // n_group
+    selected_groups = torch.topk(
+        group_scores,
+        k=topk_group,
+        dim=-1,
+        sorted=False,
+    ).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+    group_mask.scatter_(1, selected_groups, True)
+    expert_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(-1, -1, group_size)
+        .reshape_as(scores_for_choice)
+    )
+    return scores_for_choice.masked_fill(~expert_mask, float("-inf"))
 
 
 def _validate_routing_args(
@@ -104,18 +130,12 @@ def _select_deepseek_topk(
     candidate_scores = scores
     if group_limited:
         group_scores = scores.view(-1, n_group, group_size).amax(dim=-1)
-        selected_groups = torch.topk(
+        candidate_scores = _mask_scores_by_group(
+            scores,
             group_scores,
-            k=topk_group,
-            dim=-1,
-            sorted=False,
-        ).indices
-        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
-        group_mask.scatter_(1, selected_groups, True)
-        expert_mask = (
-            group_mask.unsqueeze(-1).expand(-1, -1, group_size).reshape_as(scores)
+            n_group,
+            topk_group,
         )
-        candidate_scores = scores.masked_fill(~expert_mask, float("-inf"))
 
     topk_weights, topk_ids = torch.topk(
         candidate_scores,
@@ -172,20 +192,12 @@ def _select_deepseek_noaux_topk(
         dim=-1,
         sorted=False,
     ).values.sum(dim=-1)
-    selected_groups = torch.topk(
+    candidate_scores = _mask_scores_by_group(
+        scores_for_choice,
         group_scores,
-        k=topk_group,
-        dim=-1,
-        sorted=False,
-    ).indices
-    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
-    group_mask.scatter_(1, selected_groups, True)
-    expert_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(-1, -1, group_size)
-        .reshape_as(scores_for_choice)
+        n_group,
+        topk_group,
     )
-    candidate_scores = scores_for_choice.masked_fill(~expert_mask, float("-inf"))
     topk_ids = torch.topk(
         candidate_scores,
         k=top_k,
@@ -292,7 +304,7 @@ class DeepSeekV32MoEBlock(RtpModule):
             raise TypeError("moe_config.fake_balance_expert must be a bool")
         if scoring_func not in (0, 1):
             raise ValueError(f"unsupported DeepSeek scoring_func={scoring_func}")
-        topk_method = _normalize_topk_method(topk_method)
+        topk_method = normalize_topk_method(topk_method)
         if correction_bias != (topk_method == "noaux_tc"):
             raise ValueError(
                 "correction_bias must be enabled exactly for noaux_tc routing"
@@ -362,9 +374,28 @@ class DeepSeekV32MoEBlock(RtpModule):
         # GroupTopK is a CUDA-only fused op. ROCm and CPU use the exact
         # reference algorithm below instead of failing during construction.
         self._use_fast_group_topk = (
-            correction_bias and get_device_type() == DeviceType.Cuda
+            correction_bias
+            and get_device_type() == DeviceType.Cuda
+            and not (top_k == 1 and has_moe_norm)
         )
         self.group_topk = GroupTopK() if self._use_fast_group_topk else None
+        if (
+            get_device_type() == DeviceType.Cuda
+            and not self._use_fast_select_topk
+            and not self._use_fast_group_topk
+        ):
+            logger.info(
+                "DeepSeek layer %d uses reference PyTorch MoE routing "
+                "(method=%s scoring_func=%d groups=%d/%d scaling=%s "
+                "renormalize=%s)",
+                layer_idx,
+                topk_method,
+                scoring_func,
+                topk_group,
+                n_group,
+                routed_scaling_factor,
+                has_moe_norm,
+            )
         if fake_balance_expert:
             if parallelism_config is None:
                 raise ValueError(

--- a/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
@@ -27,14 +27,13 @@ class DeepseekV3RotaryEmbedding(nn.Module):
             device=self.inv_freq.device,
             dtype=torch.get_default_dtype(),
         )
-        self.max_seq_lencached = None
 
     def _set_cos_sin_cache(
         self, seq_len: int, device: torch.device, dtype: torch.dtype
     ) -> None:
-        self.max_seq_lencached = seq_len
+        self.max_seq_len_cached = seq_len
         t = torch.arange(
-            self.max_seq_lencached,
+            self.max_seq_len_cached,
             device=device,
             dtype=self.inv_freq.dtype,
         )
@@ -46,7 +45,7 @@ class DeepseekV3RotaryEmbedding(nn.Module):
     def forward(
         self, x: torch.Tensor, seq_len: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.max_seq_lencached is None or seq_len > self.max_seq_lencached:
+        if seq_len > self.max_seq_len_cached:
             self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
         return (
             self.cos_cached[:seq_len].to(dtype=x.dtype),
@@ -123,7 +122,7 @@ class DeepseekV3YarnRotaryEmbedding(DeepseekV3RotaryEmbedding):
     def _set_cos_sin_cache(
         self, seq_len: int, device: torch.device, dtype: torch.dtype
     ) -> None:
-        self.max_seq_lencached = seq_len
+        self.max_seq_len_cached = seq_len
         dim = self.dim
         freq_extra = 1.0 / (
             self.base

--- a/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
@@ -1,0 +1,165 @@
+import math
+
+import torch
+from torch import nn
+
+
+class DeepseekV3RotaryEmbedding(nn.Module):
+    """DeepSeek rotary cache used by the newloader MLA adapter."""
+
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int = 2048,
+        base: float = 10000,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        inv_freq = 1.0 / (
+            self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._set_cos_sin_cache(
+            seq_len=max_position_embeddings,
+            device=self.inv_freq.device,
+            dtype=torch.get_default_dtype(),
+        )
+        self.max_seq_lencached = None
+
+    def _set_cos_sin_cache(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        self.max_seq_lencached = seq_len
+        t = torch.arange(
+            self.max_seq_lencached,
+            device=device,
+            dtype=self.inv_freq.dtype,
+        )
+        freqs = torch.outer(t, self.inv_freq.to(t.device))
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos().to(dtype), persistent=False)
+        self.register_buffer("sin_cached", emb.sin().to(dtype), persistent=False)
+
+    def forward(
+        self, x: torch.Tensor, seq_len: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.max_seq_lencached is None or seq_len > self.max_seq_lencached:
+            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+        return (
+            self.cos_cached[:seq_len].to(dtype=x.dtype),
+            self.sin_cached[:seq_len].to(dtype=x.dtype),
+        )
+
+
+def _yarn_find_correction_dim(
+    num_rotations: float,
+    dim: int,
+    base: float,
+    max_position_embeddings: int,
+) -> float:
+    return (dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi))) / (
+        2 * math.log(base)
+    )
+
+
+def _yarn_find_correction_range(
+    low_rot: float,
+    high_rot: float,
+    dim: int,
+    base: float,
+    max_position_embeddings: int,
+) -> tuple[int, int]:
+    low = math.floor(
+        _yarn_find_correction_dim(low_rot, dim, base, max_position_embeddings)
+    )
+    high = math.ceil(
+        _yarn_find_correction_dim(high_rot, dim, base, max_position_embeddings)
+    )
+    return max(low, 0), min(high, dim - 1)
+
+
+def _yarn_get_mscale(scale: float, mscale: float) -> float:
+    if scale <= 1:
+        return 1.0
+    return 0.1 * mscale * math.log(scale) + 1.0
+
+
+def _yarn_linear_ramp_mask(minimum: int, maximum: int, dim: int) -> torch.Tensor:
+    if minimum == maximum:
+        maximum += 0.001
+    linear_func = (torch.arange(dim, dtype=torch.float32) - minimum) / (
+        maximum - minimum
+    )
+    return torch.clamp(linear_func, 0, 1)
+
+
+class DeepseekV3YarnRotaryEmbedding(DeepseekV3RotaryEmbedding):
+    """DeepSeek YaRN rotary cache with legacy numerical ordering preserved."""
+
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int = 2048,
+        base: float = 10000,
+        device: torch.device | None = None,
+        scaling_factor: float = 1.0,
+        original_max_position_embeddings: int = 4096,
+        beta_fast: float = 32,
+        beta_slow: float = 1,
+        mscale: float = 1,
+        mscale_all_dim: float = 0,
+    ) -> None:
+        self.scaling_factor = scaling_factor
+        self.original_max_position_embeddings = original_max_position_embeddings
+        self.beta_fast = beta_fast
+        self.beta_slow = beta_slow
+        self.mscale = mscale
+        self.mscale_all_dim = mscale_all_dim
+        super().__init__(dim, max_position_embeddings, base, device)
+
+    def _set_cos_sin_cache(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        self.max_seq_lencached = seq_len
+        dim = self.dim
+        freq_extra = 1.0 / (
+            self.base
+            ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        )
+        freq_inter = 1.0 / (
+            self.scaling_factor
+            * self.base
+            ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        )
+        low, high = _yarn_find_correction_range(
+            self.beta_fast,
+            self.beta_slow,
+            dim,
+            self.base,
+            self.original_max_position_embeddings,
+        )
+        inv_freq_mask = 1.0 - _yarn_linear_ramp_mask(low, high, dim // 2).to(
+            device=device, dtype=torch.float32
+        )
+        inv_freq = freq_inter * (1 - inv_freq_mask) + freq_extra * inv_freq_mask
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        t = torch.arange(seq_len, device=device, dtype=torch.float32)
+        freqs = torch.outer(t, inv_freq)
+        yarn_mscale = float(
+            _yarn_get_mscale(self.scaling_factor, self.mscale)
+            / _yarn_get_mscale(self.scaling_factor, self.mscale_all_dim)
+        )
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer(
+            "cos_cached",
+            (emb.cos() * yarn_mscale).to(dtype),
+            persistent=False,
+        )
+        self.register_buffer(
+            "sin_cached",
+            (emb.sin() * yarn_mscale).to(dtype),
+            persistent=False,
+        )

--- a/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/rotary_embedding.py
@@ -19,13 +19,17 @@ class DeepseekV3RotaryEmbedding(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.base = base
         inv_freq = 1.0 / (
-            self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim)
+            self.base
+            ** (
+                torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                / self.dim
+            )
         )
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self._set_cos_sin_cache(
             seq_len=max_position_embeddings,
             device=self.inv_freq.device,
-            dtype=torch.get_default_dtype(),
+            dtype=torch.float32,
         )
 
     def _set_cos_sin_cache(
@@ -46,7 +50,11 @@ class DeepseekV3RotaryEmbedding(nn.Module):
         self, x: torch.Tensor, seq_len: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if seq_len > self.max_seq_len_cached:
-            self._set_cos_sin_cache(seq_len=seq_len, device=x.device, dtype=x.dtype)
+            self._set_cos_sin_cache(
+                seq_len=seq_len,
+                device=x.device,
+                dtype=torch.float32,
+            )
         return (
             self.cos_cached[:seq_len].to(dtype=x.dtype),
             self.sin_cached[:seq_len].to(dtype=x.dtype),

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -2,7 +2,12 @@ py_test(
     name = "test_deepseek_newloader",
     srcs = ["test_deepseek_newloader.py"],
     deps = [
+        "//rtp_llm:config",
+        "//rtp_llm:device",
+        "//rtp_llm:ops",
+        "//rtp_llm:safetensors",
         "//rtp_llm:torch",
+        "//rtp_llm:utils",
         "//rtp_llm/models_py:new_weight_loader",
     ],
 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -1,4 +1,4 @@
-deepseek_test_deps = [
+deepseek_cpu_test_deps = [
     "//rtp_llm:aiohttp",
     "//rtp_llm:config",
     "//rtp_llm:device",
@@ -19,33 +19,47 @@ deepseek_test_deps = [
     "//conditions:default": [],
 })
 
+deepseek_gpu_test_deps = [
+    "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    "//rtp_llm/models_py:new_weight_loader",
+]
+
 py_test(
     name = "test_deepseek_newloader",
     srcs = ["test_deepseek_newloader.py"],
-    main = "test_deepseek_newloader.py",
-    deps = deepseek_test_deps,
+    data = [
+        "//:rtp_compute_ops",
+        "//:th_transformer_config",
+    ],
+    deps = deepseek_cpu_test_deps,
 )
 
 py_test(
     name = "test_deepseek_newloader_gpu",
-    srcs = ["test_deepseek_newloader.py"],
-    main = "test_deepseek_newloader.py",
+    srcs = [
+        "test_deepseek_newloader.py",
+        "test_deepseek_newloader_gpu.py",
+    ],
+    main = "test_deepseek_newloader_gpu.py",
     exec_properties = {
         "gpu": "H20",
         "gpu_count": "1",
     },
     tags = ["H20"],
-    deps = deepseek_test_deps,
+    deps = deepseek_gpu_test_deps,
 )
 
 py_test(
     name = "test_deepseek_newloader_rocm_gpu",
-    srcs = ["test_deepseek_newloader.py"],
-    main = "test_deepseek_newloader.py",
+    srcs = [
+        "test_deepseek_newloader.py",
+        "test_deepseek_newloader_gpu.py",
+    ],
+    main = "test_deepseek_newloader_gpu.py",
     exec_properties = {
         "gpu": "MI308X-ROCM7",
         "gpu_count": "1",
     },
     tags = ["rocm"],
-    deps = deepseek_test_deps,
+    deps = deepseek_gpu_test_deps,
 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -4,6 +4,5 @@ py_test(
     deps = [
         "//rtp_llm:torch",
         "//rtp_llm/models_py:new_weight_loader",
-        "//rtp_llm/models_py/standalone:py_standalone_testlib",
     ],
 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -1,12 +1,23 @@
 deepseek_test_deps = [
+    "//rtp_llm:aiohttp",
     "//rtp_llm:config",
     "//rtp_llm:device",
+    "//rtp_llm:fastapi",
     "//rtp_llm:ops",
+    "//rtp_llm:psutil",
+    "//rtp_llm:pydantic",
     "//rtp_llm:safetensors",
     "//rtp_llm:torch",
+    "//rtp_llm:transformers",
     "//rtp_llm:utils",
     "//rtp_llm/models_py:new_weight_loader",
-]
+] + select({
+    "@//:using_rocm": [
+        "//rtp_llm:aiter",
+        "//rtp_llm:triton",
+    ],
+    "//conditions:default": [],
+})
 
 py_test(
     name = "test_deepseek_newloader",
@@ -18,12 +29,6 @@ py_test(
     name = "test_deepseek_newloader_gpu",
     srcs = ["test_deepseek_newloader.py"],
     main = "test_deepseek_newloader.py",
-    args = [
-        "DeepSeekNewloaderTest.test_moe_cuda_noaux_router_matches_reference",
-        "DeepSeekNewloaderTest.test_moe_cuda_fast_select_topk_matches_reference",
-        "DeepSeekNewloaderTest.test_mla_online_fused_fp8_projection_matches_bf16_reference",
-        "DeepSeekNewloaderTest.test_mla_prequantized_fp8_kernel_views_execute_numerically",
-    ],
     exec_properties = {
         "gpu": "H20",
         "gpu_count": "1",
@@ -36,9 +41,6 @@ py_test(
     name = "test_deepseek_newloader_rocm_gpu",
     srcs = ["test_deepseek_newloader.py"],
     main = "test_deepseek_newloader.py",
-    args = [
-        "DeepSeekNewloaderTest.test_moe_rocm_noaux_reference_router_matches_expected",
-    ],
     exec_properties = {
         "gpu": "MI308X-ROCM7",
         "gpu_count": "1",

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -1,13 +1,51 @@
+deepseek_test_deps = [
+    "//rtp_llm:config",
+    "//rtp_llm:device",
+    "//rtp_llm:ops",
+    "//rtp_llm:safetensors",
+    "//rtp_llm:torch",
+    "//rtp_llm:utils",
+    "//rtp_llm/models_py:new_weight_loader",
+]
+
 py_test(
     name = "test_deepseek_newloader",
     srcs = ["test_deepseek_newloader.py"],
-    deps = [
-        "//rtp_llm:config",
-        "//rtp_llm:device",
-        "//rtp_llm:ops",
-        "//rtp_llm:safetensors",
-        "//rtp_llm:torch",
-        "//rtp_llm:utils",
-        "//rtp_llm/models_py:new_weight_loader",
+    deps = deepseek_test_deps,
+)
+
+py_test(
+    name = "test_deepseek_newloader_gpu",
+    srcs = ["test_deepseek_newloader.py"],
+    main = "test_deepseek_newloader.py",
+    args = [
+        "DeepSeekNewloaderTest.test_moe_cuda_noaux_router_matches_reference",
+        "DeepSeekNewloaderTest.test_moe_cuda_fast_select_topk_matches_reference",
+        "DeepSeekNewloaderTest.test_mla_online_fused_fp8_projection_matches_bf16_reference",
+        "DeepSeekNewloaderTest.test_mla_prequantized_fp8_kernel_views_execute_numerically",
     ],
+    exec_properties = {
+        "gpu": "H20",
+        "gpu_count": "1",
+    },
+    tags = ["gpu"],
+    deps = deepseek_test_deps,
+)
+
+py_test(
+    name = "test_deepseek_newloader_rocm_gpu",
+    srcs = ["test_deepseek_newloader.py"],
+    main = "test_deepseek_newloader.py",
+    args = [
+        "DeepSeekNewloaderTest.test_moe_rocm_noaux_reference_router_matches_expected",
+    ],
+    exec_properties = {
+        "gpu": "MI308X-ROCM7",
+        "gpu_count": "1",
+    },
+    tags = [
+        "gpu",
+        "rocm",
+    ],
+    deps = deepseek_test_deps,
 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -1,0 +1,9 @@
+py_test(
+    name = "test_deepseek_newloader",
+    srcs = ["test_deepseek_newloader.py"],
+    deps = [
+        "//rtp_llm:torch",
+        "//rtp_llm/models_py:new_weight_loader",
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+)

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/BUILD
@@ -22,6 +22,7 @@ deepseek_test_deps = [
 py_test(
     name = "test_deepseek_newloader",
     srcs = ["test_deepseek_newloader.py"],
+    main = "test_deepseek_newloader.py",
     deps = deepseek_test_deps,
 )
 
@@ -33,7 +34,7 @@ py_test(
         "gpu": "H20",
         "gpu_count": "1",
     },
-    tags = ["gpu"],
+    tags = ["H20"],
     deps = deepseek_test_deps,
 )
 
@@ -45,9 +46,6 @@ py_test(
         "gpu": "MI308X-ROCM7",
         "gpu_count": "1",
     },
-    tags = [
-        "gpu",
-        "rocm",
-    ],
+    tags = ["rocm"],
     deps = deepseek_test_deps,
 )

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from safetensors.torch import save_file
 
 from rtp_llm.config.model_config import ModelConfig
-from rtp_llm.device.device_type import DeviceType, get_device_type
+from rtp_llm.device.device_type import DeviceType, get_device_type, is_cuda, is_hip
 from rtp_llm.models_py.distributed.collective_torch import Group
 from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.module_base import RtpModule
@@ -22,6 +22,7 @@ from rtp_llm.models_py.new_models.deepseek_v3.attention import (
 )
 from rtp_llm.models_py.new_models.deepseek_v3.language import (
     DeepSeekV32ForCausalLM,
+    MlaRuntimeLayoutMixin,
     build_rope_cache,
     extract_config_values,
 )
@@ -128,6 +129,8 @@ def _router_model_config(
     has_moe_norm=False,
     moe_n_group=1,
     moe_topk_group=1,
+    scoring_func=1,
+    routed_scaling_factor=1.0,
 ):
     config = ModelConfig()
     config.attn_config.head_num = 1
@@ -141,6 +144,8 @@ def _router_model_config(
     config.has_moe_norm = has_moe_norm
     config.moe_n_group = moe_n_group
     config.moe_topk_group = moe_topk_group
+    config.scoring_func = scoring_func
+    config.routed_scaling_factor = routed_scaling_factor
     config.quant_config = None
     return config
 
@@ -188,33 +193,44 @@ def _manual_noaux_reference(
     renormalize,
     routed_scaling_factor,
 ):
-    """Independent HF-style reference for forward/router integration tests."""
-    scores = logits.float().sigmoid()
-    scores_for_choice = scores + correction_bias
-    group_size = scores.shape[-1] // n_group
-    grouped_scores = scores_for_choice.view(-1, n_group, group_size)
-    group_scores = grouped_scores.topk(
-        min(2, group_size), dim=-1, sorted=False
-    ).values.sum(dim=-1)
-    selected_groups = group_scores.topk(topk_group, dim=-1, sorted=False).indices
-    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
-    group_mask.scatter_(1, selected_groups, True)
-    expert_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(-1, -1, group_size)
-        .reshape_as(scores_for_choice)
-    )
-    topk_ids = (
-        scores_for_choice.masked_fill(~expert_mask, float("-inf"))
-        .topk(top_k, dim=-1, sorted=False)
-        .indices
-    )
-    topk_weights = scores.gather(1, topk_ids)
-    if renormalize and top_k > 1:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
-            1e-20
+    """Scalar reference intentionally independent of the vectorized router."""
+    scores = logits.float().sigmoid().tolist()
+    biases = correction_bias.float().tolist()
+    group_size = len(biases) // n_group
+    all_weights = []
+    all_ids = []
+    for token_scores in scores:
+        choice_scores = [score + bias for score, bias in zip(token_scores, biases)]
+        group_scores = []
+        for group_id in range(n_group):
+            begin = group_id * group_size
+            group_values = choice_scores[begin : begin + group_size]
+            group_scores.append(sum(sorted(group_values, reverse=True)[:2]))
+        selected_groups = set(
+            sorted(range(n_group), key=group_scores.__getitem__, reverse=True)[
+                :topk_group
+            ]
         )
-    return topk_weights * routed_scaling_factor, topk_ids
+        candidates = [
+            expert_id
+            for expert_id in range(len(token_scores))
+            if expert_id // group_size in selected_groups
+        ]
+        selected_experts = sorted(
+            candidates,
+            key=choice_scores.__getitem__,
+            reverse=True,
+        )[:top_k]
+        token_weights = [token_scores[expert_id] for expert_id in selected_experts]
+        if renormalize and top_k > 1:
+            denominator = max(sum(token_weights), 1e-20)
+            token_weights = [weight / denominator for weight in token_weights]
+        all_ids.append(selected_experts)
+        all_weights.append([weight * routed_scaling_factor for weight in token_weights])
+    return (
+        torch.tensor(all_weights, dtype=torch.float32, device=logits.device),
+        torch.tensor(all_ids, dtype=torch.int64, device=logits.device),
+    )
 
 
 def _dense_checkpoint_weights():
@@ -522,6 +538,42 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             DeepSeekV32MTPForCausalLM,
         )
 
+    def test_registry_aliases_complete_a_real_checkpoint_load(self):
+        weights = _dense_checkpoint_weights()
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            with open(
+                f"{checkpoint_path}/config.json",
+                "w",
+                encoding="utf-8",
+            ) as config_file:
+                json.dump(_dense_loader_config_json(), config_file)
+            save_file(weights, f"{checkpoint_path}/model.safetensors")
+
+            for model_type in (
+                "deepseek2",
+                "deepseek3",
+                "deepseek_v31",
+                "deepseek_v32",
+                "glm_5",
+                "kimi_k2",
+            ):
+                with self.subTest(model_type=model_type):
+                    model_config = _dense_loader_model_config(checkpoint_path)
+                    model_config.model_type = model_type
+                    model = NewModelLoader(
+                        model_config=model_config,
+                        load_config=NewLoaderConfig(
+                            compute_dtype=torch.float32,
+                            device="cpu",
+                        ),
+                        model_path=checkpoint_path,
+                    ).load()
+                    self.assertIsInstance(model, DeepSeekV32ForCausalLM)
+                    torch.testing.assert_close(
+                        model.embed_tokens.weight,
+                        weights["model.embed_tokens.weight"],
+                    )
+
     def test_new_model_loader_safetensors_forward_matches_reference(self):
         weights = _dense_checkpoint_weights()
         with tempfile.TemporaryDirectory() as checkpoint_path:
@@ -626,7 +678,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         torch.testing.assert_close(outputs.hidden_states, expected)
 
-    def test_weight_validation_wraps_non_runtime_errors_with_module_name(self):
+    def test_weight_validation_preserves_error_type_and_adds_module_context(self):
         class ValueErrorLoader(RtpModule):
             def load_weights(self, weights):
                 del weights
@@ -638,8 +690,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         root = RtpModule()
         root.child = ValueErrorLoader()
         with self.assertRaisesRegex(
-            RuntimeError,
-            r"Weight validation failed for child .*invalid child state",
+            ValueError,
+            "Weight validation failed for child.*invalid child state",
         ):
             NewModelLoader._validate_loaded_weights(root)
 
@@ -1112,7 +1164,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         "IndexerOp is not implemented on ROCm",
     )
     def test_sparse_indexer_rope_cache_is_a_device_tracked_buffer(self):
-        cache = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        cache = torch.linspace(-0.97, 0.91, 32, dtype=torch.float32).reshape(8, 4)
         with torch.device("cpu"):
             indexer = DeepSeekV32Indexer(
                 index_n_heads=1,
@@ -1132,10 +1184,62 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             dict(indexer.indexer_op.named_buffers())["cos_sin_cache"],
             indexer.indexer_op.cos_sin_cache,
         )
-        indexer.indexer_op.to(dtype=torch.float64)
-        self.assertEqual(indexer.indexer_op.cos_sin_cache.dtype, torch.float64)
-        with self.assertRaisesRegex(RuntimeError, "expected torch.float32"):
-            indexer.indexer_op._validated_cos_sin_cache()
+        indexer.indexer_op.to(dtype=torch.bfloat16)
+        self.assertEqual(indexer.indexer_op.cos_sin_cache.dtype, torch.float32)
+        torch.testing.assert_close(
+            indexer.indexer_op.cos_sin_cache,
+            cache,
+            rtol=0,
+            atol=0,
+        )
+
+    def test_model_dtype_migration_preserves_shared_fp32_rope_cache(self):
+        cache = torch.linspace(-0.97, 0.91, 16, dtype=torch.float32).reshape(4, 4)
+        # A plain consumer isolates the top-level alias-restoration contract;
+        # the real CUDA IndexerOp's standalone _apply behavior is covered by
+        # test_sparse_indexer_rope_cache_is_a_device_tracked_buffer above.
+        indexer_op = torch.nn.Module()
+        indexer_op.register_buffer("cos_sin_cache", cache, persistent=False)
+        indexer = torch.nn.Module()
+        indexer.indexer_op = indexer_op
+        attention = torch.nn.Module()
+        attention.indexer = indexer
+        layer = torch.nn.Module()
+        layer.self_attn = attention
+
+        class CacheOwner(MlaRuntimeLayoutMixin, RtpModule):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cos_sin_cache", cache, persistent=False)
+                self.layers = torch.nn.ModuleList([layer])
+                self._mla_kernel_layout = None
+
+        owner = CacheOwner().to(dtype=torch.bfloat16)
+        self.assertEqual(owner.cos_sin_cache.dtype, torch.float32)
+        self.assertIs(
+            owner.layers[0].self_attn.indexer.indexer_op.cos_sin_cache,
+            owner.cos_sin_cache,
+        )
+        torch.testing.assert_close(owner.cos_sin_cache, cache, rtol=0, atol=0)
+
+    def test_rotary_cache_is_fp32_even_when_default_dtype_is_bfloat16(self):
+        original_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.bfloat16)
+            cache = build_rope_cache(
+                {"qk_rope_head_dim": 4, "rope_theta": 10000.0},
+                max_seq_len=16,
+                device=torch.device("cpu"),
+            )
+        finally:
+            torch.set_default_dtype(original_dtype)
+        reference = build_rope_cache(
+            {"qk_rope_head_dim": 4, "rope_theta": 10000.0},
+            max_seq_len=16,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(cache.dtype, torch.float32)
+        torch.testing.assert_close(cache, reference, rtol=0, atol=0)
 
     def test_linear_prefixes_preserve_layer_qualified_quantization_rules(self):
         quant_config = QuantizationConfig(
@@ -1310,13 +1414,17 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(attention.o_proj.reduce_output)
 
     def test_mla_fp8_derived_weights_support_tensor_and_channel_scales(self):
+        class Fp8LinearStub(torch.nn.Module):
+            def fp8_scale_block_size(self) -> tuple[int, int]:
+                return (128, 128)
+
         weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float8_e4m3fn)
         for scale in (
             torch.tensor([0.5], dtype=torch.float32),
             torch.tensor([[0.5], [2.0]], dtype=torch.float32),
         ):
             with self.subTest(scale_shape=tuple(scale.shape)):
-                linear = torch.nn.Module()
+                linear = Fp8LinearStub()
                 linear.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
                 linear.weight_scale = torch.nn.Parameter(
                     scale.clone(), requires_grad=False
@@ -1544,29 +1652,29 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             routed_scaling_factor=2.5,
         )
 
+        expected_weights, expected_ids = _manual_noaux_reference(
+            logits,
+            correction_bias,
+            top_k=2,
+            n_group=4,
+            topk_group=2,
+            renormalize=True,
+            routed_scaling_factor=2.5,
+        )
+        actual_order = ids.argsort(dim=-1)
+        expected_order = expected_ids.argsort(dim=-1)
+        self.assertTrue(
+            torch.equal(
+                ids.gather(1, actual_order),
+                expected_ids.gather(1, expected_order),
+            )
+        )
+        torch.testing.assert_close(
+            weights.gather(1, actual_order),
+            expected_weights.gather(1, expected_order),
+        )
         scores = logits.sigmoid()
         choice_scores = scores + correction_bias
-        grouped = choice_scores.view(2, 4, 2)
-        group_scores = grouped.topk(2, dim=-1, sorted=False).values.sum(dim=-1)
-        selected_groups = group_scores.topk(2, dim=-1, sorted=False).indices
-        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
-        group_mask.scatter_(1, selected_groups, True)
-        expert_mask = (
-            group_mask.unsqueeze(-1).expand(-1, -1, 2).reshape_as(choice_scores)
-        )
-        expected_ids = (
-            choice_scores.masked_fill(~expert_mask, float("-inf"))
-            .topk(2, dim=-1, sorted=False)
-            .indices
-        )
-        expected_weights = scores.gather(1, expected_ids)
-        expected_weights = (
-            expected_weights
-            / expected_weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
-            * 2.5
-        )
-        self.assertTrue(torch.equal(ids, expected_ids))
-        self.assertTrue(torch.equal(weights, expected_weights))
         self.assertFalse(
             torch.equal(
                 weights,
@@ -1574,6 +1682,25 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 / choice_scores.gather(1, ids).sum(dim=-1, keepdim=True)
                 * 2.5,
             )
+        )
+
+    def test_noaux_router_matches_hand_computed_golden(self):
+        probabilities = torch.tensor([[0.5, 0.75, 0.25, 0.6]], dtype=torch.float32)
+        logits = torch.logit(probabilities)
+        weights, ids = _select_deepseek_noaux_topk(
+            logits,
+            torch.tensor([0.0, 0.0, 1.0, 1.0]),
+            top_k=2,
+            n_group=2,
+            topk_group=1,
+            renormalize=False,
+            routed_scaling_factor=2.0,
+        )
+        order = ids.argsort(dim=-1)
+        self.assertTrue(torch.equal(ids.gather(1, order), torch.tensor([[2, 3]])))
+        torch.testing.assert_close(
+            weights.gather(1, order),
+            torch.tensor([[0.5, 1.2]]),
         )
 
     def test_noaux_router_device_selection_is_explicit(self):
@@ -1618,9 +1745,9 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     topk_method="noaux_tc",
                     correction_bias=True,
                 )
-            self.assertEqual(block._use_fast_group_topk, expect_fast)
-            self.assertEqual(block.group_topk is not None, expect_fast)
-            self.assertEqual(group_topk.call_count, int(expect_fast))
+                self.assertEqual(block._use_fast_group_topk, expect_fast)
+                self.assertEqual(block.group_topk is not None, expect_fast)
+                self.assertEqual(group_topk.call_count, int(expect_fast))
 
     def test_noaux_top1_normalization_uses_reference_path_on_cuda(self):
         with (
@@ -1687,7 +1814,11 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=_router_model_config(moe_k=1, has_moe_norm=True),
+                model_config=_router_model_config(
+                    moe_k=1,
+                    has_moe_norm=True,
+                    scoring_func=0,
+                ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -1708,7 +1839,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
     def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
         parallelism_config = _single_rank_parallelism_config()
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
-        model_config = _router_model_config()
+        model_config = _router_model_config(scoring_func=0)
         with (
             mock.patch(
                 "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
@@ -1748,12 +1879,23 @@ class DeepSeekNewloaderTest(unittest.TestCase):
 
     def test_moe_rejects_model_config_routing_mismatch(self):
         mismatch_configs = {
-            "hidden_size": _router_model_config(hidden_size=16),
-            "expert_num": _router_model_config(expert_num=8),
-            "moe_k": _router_model_config(moe_k=1),
-            "has_moe_norm": _router_model_config(has_moe_norm=True),
-            "moe_n_group": _router_model_config(moe_n_group=2),
-            "moe_topk_group": _router_model_config(moe_topk_group=2),
+            "hidden_size": _router_model_config(hidden_size=16, scoring_func=0),
+            "expert_num": _router_model_config(expert_num=8, scoring_func=0),
+            "moe_k": _router_model_config(moe_k=1, scoring_func=0),
+            "has_moe_norm": _router_model_config(
+                has_moe_norm=True,
+                scoring_func=0,
+            ),
+            "moe_n_group": _router_model_config(moe_n_group=2, scoring_func=0),
+            "moe_topk_group": _router_model_config(
+                moe_topk_group=2,
+                scoring_func=0,
+            ),
+            "scoring_func": _router_model_config(scoring_func=1),
+            "routed_scaling_factor": _router_model_config(
+                scoring_func=0,
+                routed_scaling_factor=2.0,
+            ),
         }
         with (
             mock.patch(
@@ -1823,6 +1965,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     has_moe_norm=True,
                     moe_n_group=2,
                     moe_topk_group=1,
+                    routed_scaling_factor=2.0,
                 ),
                 parallelism_config=parallelism_config,
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -1842,6 +1985,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int64)
+                self.topk_ids_dtype = torch.int64
                 self.weights = None
                 self.ids = None
 
@@ -1899,7 +2043,11 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             tp_rank=0,
             ep_size=1,
             ep_rank=0,
-            model_config=_router_model_config(hidden_size=4),
+            model_config=_router_model_config(
+                hidden_size=4,
+                scoring_func=0,
+                routed_scaling_factor=2.0,
+            ),
             parallelism_config=_single_rank_parallelism_config(),
             quant_config=None,
             params_dtype=torch.float32,
@@ -1957,11 +2105,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "two-dimensional"):
             block(torch.zeros(1, 2, 4))
 
-    @unittest.skipUnless(
-        get_device_type() == DeviceType.Cuda,
-        "CUDA GroupTopK is required",
-    )
-    def test_moe_cuda_noaux_router_matches_reference(self):
+    @unittest.skipUnless(is_cuda(), "CUDA GroupTopK is required")
+    def _gpu_moe_cuda_noaux_router_matches_reference(self):
         with torch.device("cuda"):
             block = DeepSeekV32MoEBlock(
                 hidden_size=4,
@@ -1979,6 +2124,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     has_moe_norm=True,
                     moe_n_group=4,
                     moe_topk_group=2,
+                    routed_scaling_factor=2.5,
                 ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -1999,6 +2145,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.topk_ids_dtype = torch.int32
                 self.weights = None
                 self.ids = None
 
@@ -2062,11 +2209,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(torch.allclose(actual_weights, expected_weights, atol=1e-6))
         self.assertTrue(torch.equal(output, hidden_states))
 
-    @unittest.skipUnless(
-        get_device_type() == DeviceType.Cuda,
-        "CUDA SelectTopk is required",
-    )
-    def test_moe_cuda_fast_select_topk_matches_reference(self):
+    @unittest.skipUnless(is_cuda(), "CUDA SelectTopk is required")
+    def _gpu_moe_cuda_fast_select_topk_matches_reference(self):
         model_config = ModelConfig()
         model_config.attn_config.head_num = 1
         model_config.attn_config.size_per_head = 128
@@ -2077,6 +2221,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         model_config.expert_num = 8
         model_config.moe_k = 2
         model_config.has_moe_norm = True
+        model_config.scoring_func = 0
+        model_config.routed_scaling_factor = 1.0
+        model_config.moe_n_group = 1
+        model_config.moe_topk_group = 1
         with torch.device("cuda"):
             block = DeepSeekV32MoEBlock(
                 hidden_size=4,
@@ -2108,6 +2256,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.topk_ids_dtype = torch.int32
                 self.weights = None
                 self.ids = None
 
@@ -2151,11 +2300,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(torch.equal(actual_ids, expected_ids))
         torch.testing.assert_close(actual_weights, expected_weights)
 
-    @unittest.skipUnless(
-        get_device_type() == DeviceType.ROCm,
-        "ROCm is required",
-    )
-    def test_moe_rocm_noaux_reference_router_matches_expected(self):
+    @unittest.skipUnless(is_hip(), "ROCm is required")
+    def _gpu_moe_rocm_noaux_reference_router_matches_expected(self):
         with torch.device("cuda"):
             block = DeepSeekV32MoEBlock(
                 hidden_size=4,
@@ -2173,6 +2319,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     has_moe_norm=True,
                     moe_n_group=4,
                     moe_topk_group=2,
+                    routed_scaling_factor=2.5,
                 ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -2194,6 +2341,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.topk_ids_dtype = torch.int32
                 self.weights = None
                 self.ids = None
 
@@ -2294,12 +2442,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             (128 + 128 + 2, 128),
         )
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
-    @unittest.skipIf(
-        torch.version.hip is not None,
-        "online fused FP8 A projection is CUDA-only",
-    )
-    def test_mla_online_fp8_uses_models_py_quantizer(self):
+    @unittest.skipUnless(is_cuda(), "requires a CUDA GPU")
+    def _gpu_mla_online_fp8_uses_models_py_quantizer(self):
         with torch.device("cuda"):
             attention = DeepSeekV32MlaAttention(
                 hidden_size=128,
@@ -2323,12 +2467,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             (128 + 128 + 2, 128),
         )
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a ROCm GPU")
-    @unittest.skipUnless(
-        torch.version.hip is not None,
-        "ROCm online-FP8 fallback is required",
-    )
-    def test_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views(self):
+    @unittest.skipUnless(is_hip(), "requires a ROCm GPU")
+    def _gpu_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views(self):
         device = torch.device("cuda")
         with torch.device(device):
             attention = DeepSeekV32MlaAttention(
@@ -2371,12 +2511,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(torch.equal(kernel_weights[W.mla_kv_b_w], expected_kv_b))
         self.assertNotIn(W.mla_kv_b_s, kernel_weights)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
-    @unittest.skipIf(
-        torch.version.hip is not None,
-        "DeepGEMM fused FP8 projection is CUDA-only",
-    )
-    def test_mla_online_fused_fp8_projection_matches_bf16_reference(self):
+    @unittest.skipUnless(is_cuda(), "requires a CUDA GPU")
+    def _gpu_mla_online_fused_fp8_projection_matches_bf16_reference(self):
         device = torch.device("cuda")
         with torch.device(device):
             attention = DeepSeekV32MlaAttention(
@@ -2430,12 +2566,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertLess(float(relative_rmse), 0.05)
         self.assertGreater(float(cosine), 0.998)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
-    @unittest.skipIf(
-        torch.version.hip is not None,
-        "CUDA online-FP8 kv_b runtime is required",
-    )
-    def test_mla_online_fp8_kc_vc_use_bf16_checkpoint_source(self):
+    @unittest.skipUnless(is_cuda(), "requires a CUDA GPU")
+    def _gpu_mla_online_fp8_kc_vc_use_bf16_checkpoint_source(self):
         from rtp_llm.models_py.modules.factory import LinearFactory
 
         device = torch.device("cuda")
@@ -2508,12 +2640,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertLess(float(relative_rmse), 0.05)
         self.assertGreater(float(cosine), 0.998)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
-    @unittest.skipIf(
-        torch.version.hip is not None,
-        "CUDA DeepGEMM pre-quantized FP8 projection is required",
-    )
-    def test_mla_prequantized_fp8_kernel_views_execute_numerically(self):
+    @unittest.skipUnless(is_cuda(), "requires a CUDA GPU")
+    def _gpu_mla_prequantized_fp8_kernel_views_execute_numerically(self):
         from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
         from rtp_llm.models_py.modules.factory import LinearFactory
 
@@ -2726,8 +2854,29 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             self.assertFalse(model.initialize(None))
         ensure_layout.assert_not_called()
 
+    def test_keep_mla_checkpoint_weights_is_typed_and_prevents_release(self):
+        with self.assertRaisesRegex(TypeError, "keep_mla_checkpoint_weights"):
+            NewLoaderConfig(keep_mla_checkpoint_weights=1)
+
+        model = _uninitialized_model(DeepSeekV32ForCausalLM)
+        model._mla_kernel_layout = None
+        model._keep_mla_checkpoint_weights = True
+        attention = mock.Mock()
+        model.layers = [types.SimpleNamespace(self_attn=attention)]
+        with (
+            mock.patch(
+                "rtp_llm.models_py.model_desc.module_base.GptModelBase.initialize",
+                return_value=True,
+            ),
+            mock.patch.object(model, "_ensure_mla_kernel_layout") as ensure_layout,
+        ):
+            self.assertTrue(model.initialize(None))
+        ensure_layout.assert_called_once_with()
+        attention.release_checkpoint_only_weights.assert_not_called()
+
     def test_mtp_block_rejects_inconsistent_inputs(self):
         block = MTPBlock(hidden_size=4, params_dtype=torch.float32)
+        self.assertEqual(block.fc.prefix, "mtp_block.fc")
         with self.assertRaisesRegex(ValueError, "shape mismatch"):
             block(torch.zeros(2, 4), torch.zeros(1, 4))
         with self.assertRaisesRegex(TypeError, "share a dtype"):

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -6,9 +6,14 @@ import unittest
 from unittest import mock
 
 import torch
+import torch.nn.functional as F
+from safetensors.torch import save_file
 
+from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.device.device_type import DeviceType, get_device_type
-from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
+from rtp_llm.models_py.module_base import RtpModule
+from rtp_llm.models_py.modules.factory import LinearFactory
 from rtp_llm.models_py.new_models.deepseek_v3.attention import (
     DeepSeekV32MlaAttention,
     _kernel_fp8_weight_and_scale,
@@ -37,6 +42,8 @@ from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
 from rtp_llm.models_py.new_models.mtp import MTPBlock
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.registry import get_model_class
+from rtp_llm.ops import ParallelismConfig
+from rtp_llm.ops.compute_ops import PyAttentionInputs, PyModelInputs
 from rtp_llm.utils.model_weight import W
 
 
@@ -108,6 +115,158 @@ def _load_config():
         compute_dtype=torch.float32,
         device="cpu",
     )
+
+
+def _router_model_config(
+    *,
+    expert_num=4,
+    moe_k=2,
+    has_moe_norm=False,
+):
+    return types.SimpleNamespace(
+        quant_config=None,
+        expert_num=expert_num,
+        moe_k=moe_k,
+        has_moe_norm=has_moe_norm,
+    )
+
+
+def _dense_loader_model_config(checkpoint_path):
+    config = _model_config()
+    config.ckpt_path = checkpoint_path
+    config.num_layers = 1
+    config.expert_num = 0
+    config.moe_k = 0
+    config.tie_word_embeddings = True
+    return config
+
+
+def _dense_loader_config_json():
+    config = _raw_config()
+    config.update(
+        {
+            "num_hidden_layers": 1,
+            "num_nextn_predict_layers": 0,
+            "first_k_dense_replace": 1,
+            "n_shared_experts": 0,
+            "tie_word_embeddings": True,
+        }
+    )
+    return config
+
+
+def _dense_checkpoint_weights():
+    def values(shape, offset):
+        count = math.prod(shape)
+        return (
+            torch.arange(offset, offset + count, dtype=torch.float32).reshape(shape)
+            / max(count, 1)
+            - 0.5
+        )
+
+    return {
+        "model.embed_tokens.weight": values((16, 8), 0),
+        "model.layers.0.input_layernorm.weight": values((8,), 3) + 1.0,
+        "model.layers.0.self_attn.q_a_proj.weight": values((4, 8), 5),
+        "model.layers.0.self_attn.q_a_layernorm.weight": values((4,), 7) + 1.0,
+        "model.layers.0.self_attn.q_b_proj.weight": values((16, 4), 11),
+        "model.layers.0.self_attn.kv_a_proj_with_mqa.weight": values((6, 8), 13),
+        "model.layers.0.self_attn.kv_a_layernorm.weight": values((4,), 17) + 1.0,
+        "model.layers.0.self_attn.kv_b_proj.weight": values((16, 4), 19),
+        "model.layers.0.self_attn.o_proj.weight": values((8, 8), 23),
+        "model.layers.0.post_attention_layernorm.weight": values((8,), 29) + 1.0,
+        "model.layers.0.mlp.gate_proj.weight": values((16, 8), 31),
+        "model.layers.0.mlp.up_proj.weight": values((16, 8), 37),
+        "model.layers.0.mlp.down_proj.weight": values((8, 16), 41),
+        "model.norm.weight": values((8,), 43) + 1.0,
+    }
+
+
+def _mtp_loader_model_config(checkpoint_path):
+    config = _model_config()
+    config.model_type = "deepseek-v3-mtp"
+    config.ckpt_path = checkpoint_path
+    config.num_layers = 1
+    config.expert_num = 2
+    config.moe_k = 1
+    config.data_type = "fp32"
+    config.activation_type = "SiGLU"
+    # The test intentionally loads CPU tensors.  Preserve their layout while
+    # still executing the real MoE post-load validation/factory hook; device
+    # shuffling is covered by the GPU loader/smoke suites.
+    config.exported_device = types.SimpleNamespace(
+        shuffle_moe_weight=lambda tensor, data_type, name: tensor,
+    )
+    return config
+
+
+def _single_rank_parallelism_config():
+    config = ParallelismConfig()
+    config.tp_size = 1
+    config.tp_rank = 0
+    config.ep_size = 1
+    config.ep_rank = 0
+    config.dp_size = 1
+    config.dp_rank = 0
+    config.world_size = 1
+    config.world_rank = 0
+    config.local_rank = 0
+    config.local_world_size = 1
+    return config
+
+
+def _mtp_loader_config_json():
+    config = _raw_config()
+    config.update(
+        {
+            "num_hidden_layers": 1,
+            "num_nextn_predict_layers": 1,
+            "n_shared_experts": 1,
+            "n_group": 1,
+            "topk_group": 1,
+        }
+    )
+    return config
+
+
+def _mtp_checkpoint_weights():
+    def values(shape, offset):
+        count = math.prod(shape)
+        return (
+            torch.arange(offset, offset + count, dtype=torch.float32).reshape(shape)
+            / max(count, 1)
+            - 0.5
+        )
+
+    prefix = "model.layers.1."
+    weights = {
+        prefix + "embed_tokens.weight": values((16, 8), 0),
+        prefix + "enorm.weight": values((8,), 3) + 1.0,
+        prefix + "hnorm.weight": values((8,), 5) + 1.0,
+        prefix + "eh_proj.weight": values((8, 16), 7),
+        prefix + "input_layernorm.weight": values((8,), 11) + 1.0,
+        prefix + "self_attn.q_a_proj.weight": values((4, 8), 13),
+        prefix + "self_attn.q_a_layernorm.weight": values((4,), 17) + 1.0,
+        prefix + "self_attn.q_b_proj.weight": values((16, 4), 19),
+        prefix + "self_attn.kv_a_proj_with_mqa.weight": values((6, 8), 23),
+        prefix + "self_attn.kv_a_layernorm.weight": values((4,), 29) + 1.0,
+        prefix + "self_attn.kv_b_proj.weight": values((16, 4), 31),
+        prefix + "self_attn.o_proj.weight": values((8, 8), 37),
+        prefix + "post_attention_layernorm.weight": values((8,), 41) + 1.0,
+        prefix + "mlp.gate.weight": values((2, 8), 43),
+        prefix + "mlp.shared_experts.gate_proj.weight": values((8, 8), 47),
+        prefix + "mlp.shared_experts.up_proj.weight": values((8, 8), 53),
+        prefix + "mlp.shared_experts.down_proj.weight": values((8, 8), 59),
+        prefix + "shared_head.norm.weight": values((8,), 61) + 1.0,
+        prefix + "shared_head.head.weight": values((16, 8), 67),
+    }
+    for expert_id in range(2):
+        expert_prefix = prefix + f"mlp.experts.{expert_id}."
+        offset = 71 + expert_id * 17
+        weights[expert_prefix + "gate_proj.weight"] = values((8, 8), offset)
+        weights[expert_prefix + "up_proj.weight"] = values((8, 8), offset + 3)
+        weights[expert_prefix + "down_proj.weight"] = values((8, 8), offset + 5)
+    return weights
 
 
 def _uninitialized_model(model_type, *, layer_count=0, checkpoint_prefix=None):
@@ -223,6 +382,162 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             get_model_class("deepseek-v3-mtp"),
             DeepSeekV32MTPForCausalLM,
         )
+
+    def test_new_model_loader_safetensors_forward_matches_reference(self):
+        weights = _dense_checkpoint_weights()
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            with open(
+                f"{checkpoint_path}/config.json",
+                "w",
+                encoding="utf-8",
+            ) as config_file:
+                json.dump(_dense_loader_config_json(), config_file)
+            save_file(weights, f"{checkpoint_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_dense_loader_model_config(checkpoint_path),
+                load_config=NewLoaderConfig(
+                    tp_size=1,
+                    tp_rank=0,
+                    ep_size=1,
+                    ep_rank=0,
+                    compute_dtype=torch.float32,
+                    device="cpu",
+                ),
+                model_path=checkpoint_path,
+            ).load()
+
+        self.assertIsInstance(model, DeepSeekV32ForCausalLM)
+        self.assertFalse(model.training)
+        torch.testing.assert_close(
+            model.lm_head.weight,
+            model.embed_tokens.weight,
+        )
+        self.assertIsNone(model._mla_kernel_layout)
+        model._ensure_mla_kernel_layout()
+        self.assertIsNotNone(model._mla_kernel_layout)
+
+        class TorchSiluAndMul(torch.nn.Module):
+            @staticmethod
+            def forward(gate_up):
+                gate, up = gate_up.chunk(2, dim=-1)
+                return F.silu(gate) * up
+
+        # The production activation is a CUDA/HIP kernel and does not dispatch
+        # FP32 CPU tensors. Keep this loader/forward parity test CPU-runnable;
+        # GPU activation dispatch is covered by the focused GPU suites.
+        model.layers[0].mlp.act_fn = TorchSiluAndMul()
+
+        class ZeroAttention:
+            fmha_params = None
+
+            @staticmethod
+            def forward(q_view, compressed_kv, k_pe, kv_cache, layer_idx, topk):
+                del compressed_kv, k_pe, kv_cache, layer_idx, topk
+                return torch.zeros(
+                    (*q_view.shape[:-1], 2),
+                    dtype=q_view.dtype,
+                    device=q_view.device,
+                )
+
+        input_ids = torch.tensor([0, 3, 7], dtype=torch.int32)
+        inputs = PyModelInputs(
+            input_ids=input_ids,
+            attention_inputs=PyAttentionInputs(),
+        )
+        with mock.patch(
+            "rtp_llm.models_py.new_models.deepseek_v3.language."
+            "select_block_map_for_layer"
+        ) as select_block_map:
+            outputs = model(inputs, fmha_impl=ZeroAttention())
+        select_block_map.assert_called_once_with(inputs.attention_inputs, 0)
+
+        def rms_norm(x, weight):
+            normalized = x * torch.rsqrt(x.square().mean(dim=-1, keepdim=True) + 1e-6)
+            return normalized * weight
+
+        residual = F.embedding(
+            input_ids.long(),
+            weights["model.embed_tokens.weight"],
+        )
+        mlp_input = rms_norm(
+            residual,
+            weights["model.layers.0.post_attention_layernorm.weight"],
+        )
+        gate = F.linear(
+            mlp_input,
+            weights["model.layers.0.mlp.gate_proj.weight"],
+        )
+        up = F.linear(
+            mlp_input,
+            weights["model.layers.0.mlp.up_proj.weight"],
+        )
+        mlp_output = F.linear(
+            F.silu(gate) * up,
+            weights["model.layers.0.mlp.down_proj.weight"],
+        )
+        expected = rms_norm(
+            residual + mlp_output,
+            weights["model.norm.weight"],
+        )
+        torch.testing.assert_close(outputs.hidden_states, expected)
+
+    def test_weight_validation_wraps_non_runtime_errors_with_module_name(self):
+        class ValueErrorLoader(RtpModule):
+            def load_weights(self, weights):
+                del weights
+
+            def validate_weights_loaded(self, loaded_tensor_ids):
+                del loaded_tensor_ids
+                raise ValueError("invalid child state")
+
+        root = RtpModule()
+        root.child = ValueErrorLoader()
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Weight validation failed for child .*invalid child state",
+        ):
+            NewModelLoader._validate_loaded_weights(root)
+
+    def test_mtp_new_model_loader_reads_only_appended_draft_weights(self):
+        weights = _mtp_checkpoint_weights()
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            with open(
+                f"{checkpoint_path}/config.json",
+                "w",
+                encoding="utf-8",
+            ) as config_file:
+                json.dump(_mtp_loader_config_json(), config_file)
+            save_file(weights, f"{checkpoint_path}/model.safetensors")
+            model = NewModelLoader(
+                model_config=_mtp_loader_model_config(checkpoint_path),
+                load_config=NewLoaderConfig(
+                    tp_size=1,
+                    tp_rank=0,
+                    ep_size=1,
+                    ep_rank=0,
+                    compute_dtype=torch.float32,
+                    device="cpu",
+                    parallelism_config=_single_rank_parallelism_config(),
+                ),
+                model_path=checkpoint_path,
+            ).load()
+
+        self.assertIsInstance(model, DeepSeekV32MTPForCausalLM)
+        self.assertEqual(model._checkpoint_prefix, "model.layers.1.")
+        self.assertFalse(model.training)
+        torch.testing.assert_close(
+            model.embed_tokens.weight,
+            weights["model.layers.1.embed_tokens.weight"],
+        )
+        torch.testing.assert_close(
+            model.mtp_block.fc.weight,
+            weights["model.layers.1.eh_proj.weight"],
+        )
+        torch.testing.assert_close(
+            model.lm_head.weight,
+            weights["model.layers.1.shared_head.head.weight"],
+        )
+        self.assertIsNotNone(model.layers[0].mlp.experts.fused_moe)
 
     def test_rotary_cache_is_valid_immediately_after_construction(self):
         rotary = DeepseekV3RotaryEmbedding(
@@ -623,6 +938,18 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             layer_idx=0,
             params_dtype=torch.float32,
         )
+        # LinearFactory allocates parameters with torch.empty.  Initialize
+        # them deterministically so this layout assertion cannot depend on
+        # allocator contents (in particular, NaNs make torch.equal(x, x)
+        # return False).
+        with torch.no_grad():
+            for parameter_index, parameter in enumerate(attention.parameters()):
+                values = torch.arange(
+                    parameter.numel(),
+                    dtype=parameter.dtype,
+                    device=parameter.device,
+                ).reshape_as(parameter)
+                parameter.copy_(values + parameter_index)
         attention.process_weights_after_loading()
         weights = attention._build_mla_kernel_weights()
 
@@ -806,45 +1133,59 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             )
         )
 
-    def test_noaux_router_constructs_without_cuda_group_topk(self):
+    def test_noaux_router_device_selection_is_explicit(self):
         parallelism_config = types.SimpleNamespace(
             dp_rank=0,
             dp_size=1,
         )
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
-        model_config = types.SimpleNamespace(quant_config=None)
-        with torch.device("cpu"):
-            block = DeepSeekV32MoEBlock(
-                hidden_size=8,
-                moe_intermediate_size=4,
-                num_experts=4,
-                top_k=2,
-                layer_idx=0,
-                tp_size=1,
-                tp_rank=0,
-                ep_size=1,
-                ep_rank=0,
-                model_config=model_config,
-                parallelism_config=parallelism_config,
-                moe_config=moe_config,
-                quant_config=None,
-                params_dtype=torch.float32,
-                has_shared_expert=False,
-                scoring_func=1,
-                routed_scaling_factor=1.0,
-                n_group=2,
-                topk_group=1,
-                topk_method="noaux_tc",
-                correction_bias=True,
-            )
-        expect_fast_group_topk = get_device_type() == DeviceType.Cuda
-        self.assertEqual(block._use_fast_group_topk, expect_fast_group_topk)
-        self.assertEqual(block.group_topk is not None, expect_fast_group_topk)
+        model_config = _router_model_config()
+        for device_type, expect_fast in (
+            (DeviceType.Cuda, True),
+            (DeviceType.ROCm, False),
+        ):
+            with (
+                self.subTest(device_type=device_type),
+                mock.patch(
+                    "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                    return_value=device_type,
+                ),
+                mock.patch(
+                    "rtp_llm.models_py.new_models.deepseek_v3.moe.GroupTopK"
+                ) as group_topk,
+                torch.device("cpu"),
+            ):
+                block = DeepSeekV32MoEBlock(
+                    hidden_size=8,
+                    moe_intermediate_size=4,
+                    num_experts=4,
+                    top_k=2,
+                    layer_idx=0,
+                    tp_size=1,
+                    tp_rank=0,
+                    ep_size=1,
+                    ep_rank=0,
+                    model_config=model_config,
+                    parallelism_config=parallelism_config,
+                    moe_config=moe_config,
+                    quant_config=None,
+                    params_dtype=torch.float32,
+                    has_shared_expert=False,
+                    scoring_func=1,
+                    routed_scaling_factor=1.0,
+                    n_group=2,
+                    topk_group=1,
+                    topk_method="noaux_tc",
+                    correction_bias=True,
+                )
+            self.assertEqual(block._use_fast_group_topk, expect_fast)
+            self.assertEqual(block.group_topk is not None, expect_fast)
+            self.assertEqual(group_topk.call_count, int(expect_fast))
 
     def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
         parallelism_config = types.SimpleNamespace(dp_rank=0, dp_size=1)
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
-        model_config = types.SimpleNamespace(quant_config=None)
+        model_config = _router_model_config()
         with (
             mock.patch(
                 "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
@@ -882,6 +1223,46 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIsNone(block.select_topk)
         select_topk.assert_not_called()
 
+    def test_fast_select_topk_falls_back_on_model_config_mismatch(self):
+        model_config = _router_model_config(has_moe_norm=True)
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.Cuda,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.SelectTopk"
+            ) as select_topk,
+            torch.device("cpu"),
+        ):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=4,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=model_config,
+                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=0,
+                routed_scaling_factor=1.0,
+                n_group=1,
+                topk_group=1,
+                topk_method="greedy",
+                has_moe_norm=False,
+                correction_bias=False,
+            )
+        self.assertFalse(block._use_fast_select_topk)
+        self.assertIsNone(block.select_topk)
+        select_topk.assert_not_called()
+
     def test_moe_forward_uses_reference_noaux_routing_on_cpu(self):
         parallelism_config = types.SimpleNamespace(
             dp_rank=0,
@@ -898,7 +1279,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=types.SimpleNamespace(quant_config=None),
+                model_config=_router_model_config(has_moe_norm=True),
                 parallelism_config=parallelism_config,
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -974,7 +1355,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             tp_rank=0,
             ep_size=1,
             ep_rank=0,
-            model_config=types.SimpleNamespace(quant_config=None),
+            model_config=_router_model_config(),
             parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
             quant_config=None,
             params_dtype=torch.float32,
@@ -1016,7 +1397,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=types.SimpleNamespace(quant_config=None),
+                model_config=_router_model_config(
+                    expert_num=8,
+                    has_moe_norm=True,
+                ),
                 parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -1100,6 +1484,97 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(torch.equal(output, hidden_states))
 
     @unittest.skipUnless(
+        get_device_type() == DeviceType.Cuda,
+        "CUDA SelectTopk is required",
+    )
+    def test_moe_cuda_fast_select_topk_matches_reference(self):
+        model_config = ModelConfig()
+        model_config.attn_config.head_num = 1
+        model_config.attn_config.size_per_head = 128
+        model_config.num_layers = 1
+        model_config.max_seq_len = 1
+        model_config.vocab_size = 16
+        model_config.expert_num = 8
+        model_config.moe_k = 2
+        model_config.has_moe_norm = True
+        with torch.device("cuda"):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=4,
+                moe_intermediate_size=2,
+                num_experts=8,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=model_config,
+                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=0,
+                routed_scaling_factor=1.0,
+                n_group=1,
+                topk_group=1,
+                topk_method="greedy",
+                has_moe_norm=True,
+                correction_bias=False,
+            )
+        self.assertTrue(block._use_fast_select_topk)
+
+        class CapturingExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.weights = None
+                self.ids = None
+
+            def forward(self, hidden_states, topk_weights, topk_ids):
+                self.weights = topk_weights.clone()
+                self.ids = topk_ids.clone()
+                return hidden_states
+
+        capturing_experts = CapturingExperts()
+        block.experts = capturing_experts
+        generator = torch.Generator(device="cuda").manual_seed(20260728)
+        hidden_states = torch.randn(
+            (17, 4),
+            generator=generator,
+            device="cuda",
+        )
+        with torch.no_grad():
+            block.gate.weight.copy_(
+                torch.randn(
+                    block.gate.weight.shape,
+                    generator=generator,
+                    device="cuda",
+                )
+            )
+
+        expected_weights, expected_ids = _select_deepseek_topk(
+            block.gate(hidden_states).float(),
+            top_k=2,
+            scoring_func=0,
+            n_group=1,
+            topk_group=1,
+            group_limited=False,
+            renormalize=True,
+            routed_scaling_factor=1.0,
+        )
+        block(hidden_states)
+
+        actual_order = capturing_experts.ids.argsort(dim=-1)
+        expected_order = expected_ids.argsort(dim=-1)
+        actual_ids = capturing_experts.ids.gather(1, actual_order)
+        expected_ids = expected_ids.gather(1, expected_order).to(actual_ids.dtype)
+        actual_weights = capturing_experts.weights.gather(1, actual_order)
+        expected_weights = expected_weights.gather(1, expected_order)
+        self.assertTrue(torch.equal(actual_ids, expected_ids))
+        torch.testing.assert_close(actual_weights, expected_weights)
+
+    @unittest.skipUnless(
         get_device_type() == DeviceType.ROCm,
         "ROCm is required",
     )
@@ -1115,7 +1590,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=types.SimpleNamespace(quant_config=None),
+                model_config=_router_model_config(
+                    expert_num=8,
+                    has_moe_norm=True,
+                ),
                 parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -1237,7 +1715,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        getattr(torch.version, "hip", None) is not None,
+        torch.version.hip is not None,
         "online fused FP8 A projection is CUDA-only",
     )
     def test_mla_online_fp8_uses_models_py_quantizer(self):
@@ -1266,7 +1744,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
     @unittest.skipIf(
-        getattr(torch.version, "hip", None) is not None,
+        torch.version.hip is not None,
         "DeepGEMM fused FP8 projection is CUDA-only",
     )
     def test_mla_online_fused_fp8_projection_matches_bf16_reference(self):
@@ -1322,6 +1800,102 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         self.assertLess(float(relative_rmse), 0.05)
         self.assertGreater(float(cosine), 0.998)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
+    @unittest.skipIf(
+        torch.version.hip is not None,
+        "CUDA DeepGEMM pre-quantized FP8 projection is required",
+    )
+    def test_mla_prequantized_fp8_kernel_views_execute_numerically(self):
+        from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
+
+        device = torch.device("cuda")
+        quant_config = QuantizationConfig("FP8_PER_BLOCK")
+        with torch.device(device):
+            attention = DeepSeekV32MlaAttention(
+                hidden_size=128,
+                num_heads=2,
+                q_lora_rank=128,
+                kv_lora_rank=128,
+                nope_head_dim=64,
+                rope_head_dim=128,
+                v_head_dim=64,
+                layer_idx=0,
+                quant_config=quant_config,
+                params_dtype=torch.bfloat16,
+            )
+
+        generator = torch.Generator(device=device).manual_seed(20260728)
+        reference_weights = {}
+        for name, linear in (
+            ("q_a", attention.q_a_proj),
+            ("kv_a", attention.kv_a_proj_with_mqa),
+            ("q_b", attention.q_b_proj),
+            ("kv_b", attention.kv_b_proj),
+            ("o", attention.o_proj),
+        ):
+            reference = torch.randn(
+                linear.weight.shape,
+                generator=generator,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            fp8_weight, scale = per_block_cast_to_fp8(
+                reference,
+                use_ue8m0=False,
+            )
+            linear.weight.data.copy_(fp8_weight)
+            linear.weight_scale_inv.data.copy_(scale)
+            reference_weights[name] = reference
+
+        NewModelLoader._run_post_load_hooks(attention)
+        kernel_weights = attention._build_mla_kernel_weights()
+        self.assertIsNone(attention._kv_b_w)
+
+        fused_reference = torch.cat(
+            [reference_weights["q_a"], reference_weights["kv_a"]],
+            dim=0,
+        )
+        cases = (
+            (
+                W.mla_fusedqkrope_w,
+                W.mla_fusedqkrope_s,
+                fused_reference,
+            ),
+            (W.mla_q_b_w, W.mla_q_b_s, reference_weights["q_b"]),
+            (W.mla_kv_b_w, W.mla_kv_b_s, reference_weights["kv_b"]),
+            (W.attn_o_w, W.attn_o_s, reference_weights["o"]),
+        )
+        runtime_quant_config = types.SimpleNamespace(get_method=lambda: "FP8_PER_BLOCK")
+        for weight_key, scale_key, reference in cases:
+            with self.subTest(weight_key=weight_key):
+                linear = LinearFactory.create_linear_from_weights(
+                    kernel_weights,
+                    weight_key,
+                    scale_key,
+                    None,
+                    quant_config=runtime_quant_config,
+                )
+                x = torch.randn(
+                    (11, reference.shape[1]),
+                    generator=generator,
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+                actual = linear(x)
+                expected = F.linear(x, reference)
+                difference = actual.float() - expected.float()
+                relative_rmse = (
+                    difference.square().mean().sqrt()
+                    / expected.float().square().mean().sqrt()
+                )
+                cosine = F.cosine_similarity(
+                    actual.float().flatten(),
+                    expected.float().flatten(),
+                    dim=0,
+                )
+                self.assertLess(float(relative_rmse), 0.05)
+                self.assertGreater(float(cosine), 0.998)
 
     def test_mlp_tp_reduction_is_owned_by_row_parallel_linear(self):
         dense = DeepSeekV32MLP(

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -26,7 +26,10 @@ from rtp_llm.models_py.new_models.deepseek_v3.language import (
     extract_config_values,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.mlp import DeepSeekV32MLP
-from rtp_llm.models_py.new_models.deepseek_v3.model import DeepSeekV32Indexer
+from rtp_llm.models_py.new_models.deepseek_v3.model import (
+    DeepSeekV32DecoderLayer,
+    DeepSeekV32Indexer,
+)
 from rtp_llm.models_py.new_models.deepseek_v3.moe import (
     DeepSeekV32MoEBlock,
     _select_deepseek_noaux_topk,
@@ -930,8 +933,9 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             extract_config_values(config, _load_config(), _raw_config())
 
     def test_zero_explicit_shared_expert_width_uses_checkpoint_topology(self):
-        config = {"shared_expert_intermediate_size": 0}
-        cfg = extract_config_values(config, _load_config(), _raw_config())
+        raw = _raw_config()
+        raw["shared_expert_intermediate_size"] = 0
+        cfg = extract_config_values(_model_config(), _load_config(), raw)
         self.assertEqual(cfg["shared_expert_intermediate_size"], 8)
 
     def test_new_loader_rejects_unsupported_attention_and_ffn_tp_groups(self):
@@ -1103,6 +1107,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIs(fake_op.calls[-1][1], kv_cache)
         self.assertIs(fake_op.calls[-1][2], attention_inputs)
 
+    @unittest.skipIf(
+        get_device_type() == DeviceType.ROCm,
+        "IndexerOp is not implemented on ROCm",
+    )
     def test_sparse_indexer_rope_cache_is_a_device_tracked_buffer(self):
         cache = torch.arange(32, dtype=torch.float32).reshape(8, 4)
         with torch.device("cpu"):
@@ -1126,6 +1134,76 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         indexer.indexer_op.to(dtype=torch.float64)
         self.assertEqual(indexer.indexer_op.cos_sin_cache.dtype, torch.float64)
+        with self.assertRaisesRegex(RuntimeError, "expected torch.float32"):
+            indexer.indexer_op._validated_cos_sin_cache()
+
+    def test_linear_prefixes_preserve_layer_qualified_quantization_rules(self):
+        quant_config = QuantizationConfig(
+            "FP8_PER_BLOCK",
+            ignored_layers=[
+                "model.layers.3.self_attn.o_proj",
+                "model.layers.3.mlp.down_proj",
+            ],
+        )
+        layer = DeepSeekV32DecoderLayer(
+            hidden_size=128,
+            num_heads=2,
+            q_lora_rank=128,
+            kv_lora_rank=128,
+            nope_head_dim=64,
+            rope_head_dim=64,
+            v_head_dim=64,
+            layer_idx=3,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+            ffn_tp_size=1,
+            ffn_tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            params_dtype=torch.bfloat16,
+            layernorm_eps=1e-6,
+            quant_config=quant_config,
+            model_config=_router_model_config(hidden_size=128),
+            parallelism_config=None,
+            moe_config=None,
+            is_moe_layer=False,
+            dense_intermediate_size=128,
+            prefix="layers.3",
+        )
+        self.assertEqual(layer.self_attn.q_a_proj.prefix, "layers.3.self_attn.q_a_proj")
+        self.assertEqual(layer.self_attn.o_proj.prefix, "layers.3.self_attn.o_proj")
+        self.assertEqual(layer.mlp.gate_up_proj.prefix, "layers.3.mlp.gate_up_proj")
+        self.assertEqual(layer.mlp.down_proj.prefix, "layers.3.mlp.down_proj")
+        self.assertTrue(quant_config.is_layer_ignored(layer.self_attn.o_proj.prefix))
+        self.assertTrue(quant_config.is_layer_ignored(layer.mlp.down_proj.prefix))
+
+        fake_indexer_op = torch.nn.Identity()
+        with mock.patch(
+            "rtp_llm.models_py.new_models.deepseek_v3.model.IndexerOp",
+            return_value=fake_indexer_op,
+        ):
+            indexer = DeepSeekV32Indexer(
+                index_n_heads=1,
+                index_head_dim=2,
+                index_topk=1,
+                rope_head_dim=2,
+                hidden_size=2,
+                q_lora_rank=2,
+                layer_idx=3,
+                layernorm_eps=1e-6,
+                blocksize=64,
+                is_neox_style=False,
+                params_dtype=torch.float32,
+                prefix="layers.3.self_attn.indexer",
+            )
+        self.assertEqual(
+            indexer.wq_b.prefix,
+            "layers.3.self_attn.indexer.wq_b",
+        )
+        self.assertEqual(
+            indexer.weights_proj.prefix,
+            "layers.3.self_attn.indexer.weights_proj",
+        )
 
     def test_grouped_router_rejects_invalid_expert_partition(self):
         raw = _raw_config()
@@ -1169,7 +1247,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertTrue(derived.isdisjoint(dict(attention.named_parameters())))
         self.assertTrue(derived.isdisjoint(attention.state_dict()))
 
-    def test_no_q_lora_tp2_forward_uses_rank_local_heads(self):
+    def test_no_q_lora_tp2_forward_uses_row_parallel_reduction(self):
         attention = DeepSeekV32MlaAttention(
             hidden_size=8,
             num_heads=4,
@@ -1205,7 +1283,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         fmha_impl = ZeroFmha()
         hidden_states = torch.randn(3, 8)
         with mock.patch(
-            "rtp_llm.models_py.new_models.deepseek_v3.attention.all_reduce",
+            "rtp_llm.models_py.layers.linear.all_reduce",
             side_effect=lambda tensor, group: tensor,
         ) as reduce_mock:
             output = attention(hidden_states, fmha_impl)
@@ -1215,7 +1293,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         reduce_mock.assert_called_once()
         self.assertIs(reduce_mock.call_args.kwargs["group"], Group.TP)
 
-    def test_mla_output_projection_defers_tp_reduction_to_attention(self):
+    def test_mla_output_projection_owns_tp_reduction(self):
         attention = DeepSeekV32MlaAttention(
             hidden_size=8,
             num_heads=2,
@@ -1229,7 +1307,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             tp_rank=0,
             params_dtype=torch.float32,
         )
-        self.assertFalse(attention.o_proj.reduce_output)
+        self.assertTrue(attention.o_proj.reduce_output)
 
     def test_mla_fp8_derived_weights_support_tensor_and_channel_scales(self):
         weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float8_e4m3fn)
@@ -1861,6 +1939,14 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             DeepSeekV32MoEBlock(
                 moe_config=types.SimpleNamespace(fake_balance_expert=True),
                 **kwargs,
+            )
+
+        mismatched_shared = dict(kwargs)
+        mismatched_shared["has_shared_expert"] = True
+        with self.assertRaisesRegex(ValueError, "has_shared_expert"):
+            DeepSeekV32MoEBlock(
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                **mismatched_shared,
             )
 
         block = DeepSeekV32MoEBlock(
@@ -2625,6 +2711,20 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 )
                 self.assertIs(view["embedding"], model.embed_tokens.weight)
                 self.assertIs(view["lm_head"], model.lm_head.weight)
+
+    def test_initialize_failure_does_not_build_layout_or_release_weights(self):
+        model = _uninitialized_model(DeepSeekV32ForCausalLM)
+        model._mla_kernel_layout = None
+        model._keep_mla_checkpoint_weights = False
+        with (
+            mock.patch(
+                "rtp_llm.models_py.model_desc.module_base.GptModelBase.initialize",
+                return_value=False,
+            ),
+            mock.patch.object(model, "_ensure_mla_kernel_layout") as ensure_layout,
+        ):
+            self.assertFalse(model.initialize(None))
+        ensure_layout.assert_not_called()
 
     def test_mtp_block_rejects_inconsistent_inputs(self):
         block = MTPBlock(hidden_size=4, params_dtype=torch.float32)

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -22,8 +22,8 @@ from rtp_llm.models_py.new_models.deepseek_v3.attention import (
 )
 from rtp_llm.models_py.new_models.deepseek_v3.language import (
     DeepSeekV32ForCausalLM,
-    _build_rope_cache,
-    _extract_config_values,
+    build_rope_cache,
+    extract_config_values,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.mlp import DeepSeekV32MLP
 from rtp_llm.models_py.new_models.deepseek_v3.model import DeepSeekV32Indexer
@@ -43,7 +43,7 @@ from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
 from rtp_llm.models_py.new_models.mtp import MTPBlock
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.registry import get_model_class
-from rtp_llm.ops import ParallelismConfig
+from rtp_llm.ops import EplbMode, ParallelismConfig
 from rtp_llm.ops.compute_ops import PyAttentionInputs, PyModelInputs
 from rtp_llm.utils.model_weight import W
 
@@ -123,6 +123,8 @@ def _router_model_config(
     expert_num=4,
     moe_k=2,
     has_moe_norm=False,
+    moe_n_group=1,
+    moe_topk_group=1,
 ):
     config = ModelConfig()
     config.attn_config.head_num = 1
@@ -134,6 +136,8 @@ def _router_model_config(
     config.expert_num = expert_num
     config.moe_k = moe_k
     config.has_moe_norm = has_moe_norm
+    config.moe_n_group = moe_n_group
+    config.moe_topk_group = moe_topk_group
     config.quant_config = None
     return config
 
@@ -171,6 +175,45 @@ def _deterministic_values(shape, offset):
     )
 
 
+def _manual_noaux_reference(
+    logits,
+    correction_bias,
+    *,
+    top_k,
+    n_group,
+    topk_group,
+    renormalize,
+    routed_scaling_factor,
+):
+    """Independent HF-style reference for forward/router integration tests."""
+    scores = logits.float().sigmoid()
+    scores_for_choice = scores + correction_bias
+    group_size = scores.shape[-1] // n_group
+    grouped_scores = scores_for_choice.view(-1, n_group, group_size)
+    group_scores = grouped_scores.topk(
+        min(2, group_size), dim=-1, sorted=False
+    ).values.sum(dim=-1)
+    selected_groups = group_scores.topk(topk_group, dim=-1, sorted=False).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+    group_mask.scatter_(1, selected_groups, True)
+    expert_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(-1, -1, group_size)
+        .reshape_as(scores_for_choice)
+    )
+    topk_ids = (
+        scores_for_choice.masked_fill(~expert_mask, float("-inf"))
+        .topk(top_k, dim=-1, sorted=False)
+        .indices
+    )
+    topk_weights = scores.gather(1, topk_ids)
+    if renormalize and top_k > 1:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            1e-20
+        )
+    return topk_weights * routed_scaling_factor, topk_ids
+
+
 def _dense_checkpoint_weights():
     values = _deterministic_values
     return {
@@ -198,6 +241,8 @@ def _mtp_loader_model_config(checkpoint_path):
     config.num_layers = 1
     config.expert_num = 2
     config.moe_k = 1
+    config.moe_n_group = 1
+    config.moe_topk_group = 1
     config.data_type = "fp32"
     config.activation_type = "SiGLU"
     return config
@@ -282,7 +327,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         max_seq_len = 32
         rope_dim = 8
         base = 10000.0
-        plain = _build_rope_cache(
+        plain = build_rope_cache(
             {"qk_rope_head_dim": rope_dim, "rope_theta": base},
             max_seq_len,
             torch.device("cpu"),
@@ -302,7 +347,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         beta_slow = 1.0
         mscale = 1.0
         mscale_all_dim = 1.0
-        yarn = _build_rope_cache(
+        yarn = build_rope_cache(
             {
                 "qk_rope_head_dim": rope_dim,
                 "rope_theta": base,
@@ -363,7 +408,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             )
         )
 
-        rope_parameters_yarn = _build_rope_cache(
+        rope_parameters_yarn = build_rope_cache(
             {
                 "qk_rope_head_dim": rope_dim,
                 "rope_parameters": {
@@ -382,10 +427,38 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(rope_parameters_yarn, yarn))
 
+        zero_all_dim = build_rope_cache(
+            {
+                "qk_rope_head_dim": rope_dim,
+                "rope_theta": base,
+                "rope_scaling": {
+                    "factor": factor,
+                    "original_max_position_embeddings": original_max,
+                    "beta_fast": beta_fast,
+                    "beta_slow": beta_slow,
+                    "mscale": mscale,
+                    "mscale_all_dim": 0.0,
+                },
+            },
+            max_seq_len,
+            torch.device("cpu"),
+        )
+        zero_all_dim_scale = yarn_mscale(mscale)
+        torch.testing.assert_close(
+            zero_all_dim,
+            torch.cat(
+                [
+                    yarn_freqs.cos() * zero_all_dim_scale,
+                    yarn_freqs.sin() * zero_all_dim_scale,
+                ],
+                dim=-1,
+            ),
+        )
+
     def test_rope_cache_rejects_ambiguous_or_incomplete_scaling(self):
         base_config = {"qk_rope_head_dim": 8}
         with self.assertRaisesRegex(ValueError, "unsupported.*rope_type"):
-            _build_rope_cache(
+            build_rope_cache(
                 {
                     **base_config,
                     "rope_parameters": {
@@ -397,7 +470,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 torch.device("cpu"),
             )
         with self.assertRaisesRegex(ValueError, "missing keys"):
-            _build_rope_cache(
+            build_rope_cache(
                 {
                     **base_config,
                     "rope_parameters": {
@@ -409,7 +482,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 torch.device("cpu"),
             )
         with self.assertRaisesRegex(ValueError, "conflicting"):
-            _build_rope_cache(
+            build_rope_cache(
                 {
                     **base_config,
                     "rope_scaling": {
@@ -478,12 +551,12 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIsNone(model._mla_kernel_layout)
         model._ensure_mla_kernel_layout()
         self.assertIsNotNone(model._mla_kernel_layout)
-        self.assertEqual(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
-        self.assertEqual(
+        self.assertGreater(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
+        self.assertGreater(
             model.layers[0].self_attn.kv_a_proj_with_mqa.weight.numel(),
             0,
         )
-        self.assertEqual(model.layers[0].self_attn.kv_b_proj.weight.numel(), 0)
+        self.assertGreater(model.layers[0].self_attn.kv_b_proj.weight.numel(), 0)
 
         class TorchSiluAndMul(torch.nn.Module):
             @staticmethod
@@ -618,8 +691,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         self.assertIsNotNone(model.layers[0].mlp.experts.fused_moe)
         model._ensure_mla_kernel_layout()
-        self.assertEqual(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
-        self.assertEqual(
+        self.assertGreater(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
+        self.assertGreater(
             model.layers[0].self_attn.kv_a_proj_with_mqa.weight.numel(),
             0,
         )
@@ -836,13 +909,30 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             )
 
     def test_config_keeps_attention_and_ffn_topologies_distinct(self):
-        cfg = _extract_config_values(_model_config(), _load_config(), _raw_config())
+        cfg = extract_config_values(_model_config(), _load_config(), _raw_config())
         self.assertEqual((cfg["attn_tp_size"], cfg["attn_tp_rank"]), (1, 0))
         self.assertEqual((cfg["ffn_tp_size"], cfg["ffn_tp_rank"]), (2, 1))
         self.assertEqual((cfg["lm_head_tp_size"], cfg["lm_head_tp_rank"]), (2, 1))
         self.assertEqual((cfg["ep_size"], cfg["ep_rank"]), (2, 1))
         self.assertEqual(cfg["moe_layer_index"], [3])
         self.assertEqual(cfg["topk_method"], "greedy")
+
+    def test_config_rejects_eplb_before_module_construction(self):
+        config = _model_config()
+        config.eplb_config.eplb_mode = EplbMode.EPLB
+        with self.assertRaisesRegex(ValueError, "EPLB is not supported"):
+            extract_config_values(config, _load_config(), _raw_config())
+
+    def test_tied_embeddings_require_matching_tp_partitions(self):
+        config = _model_config()
+        config.tie_word_embeddings = True
+        with self.assertRaisesRegex(ValueError, "matching attention and LM-head"):
+            extract_config_values(config, _load_config(), _raw_config())
+
+    def test_zero_explicit_shared_expert_width_uses_checkpoint_topology(self):
+        config = {"shared_expert_intermediate_size": 0}
+        cfg = extract_config_values(config, _load_config(), _raw_config())
+        self.assertEqual(cfg["shared_expert_intermediate_size"], 8)
 
     def test_new_loader_rejects_unsupported_attention_and_ffn_tp_groups(self):
         with self.assertRaisesRegex(ValueError, "independent TP subgroups"):
@@ -882,7 +972,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 "topk_method": "group_limited_greedy",
             }
         )
-        cfg = _extract_config_values(_model_config(), _load_config(), raw)
+        cfg = extract_config_values(_model_config(), _load_config(), raw)
         self.assertEqual(cfg["scoring_func"], 0)
         self.assertEqual(cfg["routed_scaling_factor"], 2.5)
         self.assertEqual(cfg["n_group"], 4)
@@ -892,7 +982,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
 
     def test_sparse_indexer_rejects_no_q_lora(self):
         with self.assertRaisesRegex(ValueError, "requires q_lora_rank"):
-            _extract_config_values(
+            extract_config_values(
                 _model_config(sparse=True, q_lora_rank=0),
                 _load_config(),
                 _raw_config(),
@@ -902,7 +992,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         config = _model_config()
         config.mla_ops_type = "MHA"
         with self.assertRaisesRegex(ValueError, "requires an MLA attention backend"):
-            _extract_config_values(config, _load_config(), _raw_config())
+            extract_config_values(config, _load_config(), _raw_config())
 
     def test_sparse_indexer_fast_and_sparse_call_sequences(self):
         class FakeIndexerOp(torch.nn.Module):
@@ -1013,6 +1103,30 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIs(fake_op.calls[-1][1], kv_cache)
         self.assertIs(fake_op.calls[-1][2], attention_inputs)
 
+    def test_sparse_indexer_rope_cache_is_a_device_tracked_buffer(self):
+        cache = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+        with torch.device("cpu"):
+            indexer = DeepSeekV32Indexer(
+                index_n_heads=1,
+                index_head_dim=2,
+                index_topk=1,
+                rope_head_dim=2,
+                hidden_size=2,
+                q_lora_rank=2,
+                layer_idx=0,
+                layernorm_eps=1e-6,
+                blocksize=64,
+                is_neox_style=False,
+                params_dtype=torch.float32,
+                cos_sin_cache=cache,
+            )
+        self.assertIs(
+            dict(indexer.indexer_op.named_buffers())["cos_sin_cache"],
+            indexer.indexer_op.cos_sin_cache,
+        )
+        indexer.indexer_op.to(dtype=torch.float64)
+        self.assertEqual(indexer.indexer_op.cos_sin_cache.dtype, torch.float64)
+
     def test_grouped_router_rejects_invalid_expert_partition(self):
         raw = _raw_config()
         raw.update(
@@ -1023,7 +1137,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             }
         )
         with self.assertRaisesRegex(ValueError, "divisible by n_group"):
-            _extract_config_values(_model_config(), _load_config(), raw)
+            extract_config_values(_model_config(), _load_config(), raw)
 
     def test_no_q_lora_has_no_empty_checkpoint_parameters(self):
         attention = DeepSeekV32MlaAttention(
@@ -1198,7 +1312,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIs(runtime_weight, weight)
         self.assertIs(runtime_scale, scale)
 
-    def test_mla_bf16_kernel_views_match_legacy_orientation(self):
+    def test_mla_bf16_kernel_layout_contains_only_backend_consumers(self):
         attention = DeepSeekV32MlaAttention(
             hidden_size=8,
             num_heads=2,
@@ -1226,26 +1340,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         weights = attention._build_mla_kernel_weights()
 
         self.assertFalse(hasattr(attention, "_fused_qkv_b_w"))
-        self.assertEqual(
-            tuple(weights[W.mla_fusedqkrope_w].shape),
-            (8, 4 + 4 + 2),
-        )
-        self.assertEqual(
-            tuple(weights[W.mla_q_b_w].shape),
-            (4, 2 * (2 + 2)),
-        )
-        self.assertTrue(
-            torch.equal(
-                weights[W.mla_fusedqkrope_w],
-                attention._fused_qkv_a_w.t(),
-            )
-        )
-        self.assertTrue(
-            torch.equal(weights[W.mla_q_b_w], attention.q_b_proj.weight.t())
-        )
-        self.assertNotIn(W.mla_fusedqkrope_s, weights)
-        self.assertNotIn(W.mla_q_b_s, weights)
-        fused_qkv_a_ptr = weights[W.mla_fusedqkrope_w].data_ptr()
+        self.assertEqual(set(weights), {W.mla_kv_b_w, W.mla_kc, W.mla_vc})
         kv_b_ptr = weights[W.mla_kv_b_w].data_ptr()
         attention.release_checkpoint_only_weights()
         self.assertEqual(attention.q_a_proj.weight.numel(), 0)
@@ -1253,12 +1348,11 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertEqual(attention.kv_b_proj.weight.numel(), 0)
         self.assertGreater(attention.q_b_proj.weight.numel(), 0)
         self.assertGreater(attention.o_proj.weight.numel(), 0)
-        self.assertEqual(weights[W.mla_fusedqkrope_w].data_ptr(), fused_qkv_a_ptr)
         self.assertEqual(weights[W.mla_kv_b_w].data_ptr(), kv_b_ptr)
         with self.assertRaisesRegex(RuntimeError, "rebuild the model"):
             attention.load_weights({})
 
-    def test_mla_fp8_kernel_views_keep_scales_without_bf16_qb_copy(self):
+    def test_mla_fp8_kernel_layout_keeps_only_kv_b_scale(self):
         attention = DeepSeekV32MlaAttention(
             hidden_size=128,
             num_heads=2,
@@ -1276,9 +1370,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             128,
             dtype=torch.float8_e4m3fn,
         )
-        fused_scale = torch.ones(3, 1, dtype=torch.float32)
         attention._fused_qkv_a_w = fused_weight
-        attention._fused_qkv_a_s = fused_scale
         del attention.q_b_proj.weight_scale_inv
         attention.q_b_proj.register_parameter(
             "weight_scale",
@@ -1294,22 +1386,9 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         weights = attention._build_mla_kernel_weights()
 
         self.assertEqual(
-            tuple(weights[W.mla_fusedqkrope_w].shape),
-            (128, 320),
+            set(weights),
+            {W.mla_kv_b_w, W.mla_kv_b_s, W.mla_kc, W.mla_vc},
         )
-        self.assertEqual(
-            tuple(weights[W.mla_fusedqkrope_s].shape),
-            (1, 3),
-        )
-        self.assertEqual(
-            tuple(weights[W.mla_q_b_w].shape),
-            (128, 256),
-        )
-        self.assertEqual(
-            tuple(weights[W.mla_q_b_s].shape),
-            (1, 2),
-        )
-        self.assertEqual(weights[W.mla_q_b_w].dtype, torch.float8_e4m3fn)
         attention.release_checkpoint_only_weights()
         self.assertEqual(attention.q_a_proj.weight.numel(), 0)
         self.assertEqual(attention.kv_a_proj_with_mqa.weight.numel(), 0)
@@ -1422,7 +1501,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
     def test_noaux_router_device_selection_is_explicit(self):
         parallelism_config = _single_rank_parallelism_config()
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
-        model_config = _router_model_config()
+        model_config = _router_model_config(moe_n_group=2, moe_topk_group=1)
         for device_type, expect_fast in (
             (DeviceType.Cuda, True),
             (DeviceType.ROCm, False),
@@ -1486,7 +1565,12 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=_router_model_config(moe_k=1, has_moe_norm=True),
+                model_config=_router_model_config(
+                    moe_k=1,
+                    has_moe_norm=True,
+                    moe_n_group=2,
+                    moe_topk_group=1,
+                ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -1503,6 +1587,45 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertFalse(block._use_fast_group_topk)
         self.assertIsNone(block.group_topk)
         group_topk.assert_not_called()
+
+    def test_greedy_top1_normalization_uses_reference_path_on_cuda(self):
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.Cuda,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.SelectTopk"
+            ) as select_topk,
+            torch.device("cpu"),
+        ):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=4,
+                top_k=1,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=_router_model_config(moe_k=1, has_moe_norm=True),
+                parallelism_config=_single_rank_parallelism_config(),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=0,
+                routed_scaling_factor=1.0,
+                n_group=1,
+                topk_group=1,
+                topk_method="greedy",
+                has_moe_norm=True,
+                correction_bias=False,
+            )
+        self.assertFalse(block._use_fast_select_topk)
+        self.assertIsNone(block.select_topk)
+        select_topk.assert_not_called()
 
     def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
         parallelism_config = _single_rank_parallelism_config()
@@ -1551,6 +1674,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             "expert_num": _router_model_config(expert_num=8),
             "moe_k": _router_model_config(moe_k=1),
             "has_moe_norm": _router_model_config(has_moe_norm=True),
+            "moe_n_group": _router_model_config(moe_n_group=2),
+            "moe_topk_group": _router_model_config(moe_topk_group=2),
         }
         with (
             mock.patch(
@@ -1598,7 +1723,13 @@ class DeepSeekNewloaderTest(unittest.TestCase):
 
     def test_moe_forward_uses_reference_noaux_routing_on_cpu(self):
         parallelism_config = _single_rank_parallelism_config()
-        with torch.device("cpu"):
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.ROCm,
+            ),
+            torch.device("cpu"),
+        ):
             block = DeepSeekV32MoEBlock(
                 hidden_size=4,
                 moe_intermediate_size=2,
@@ -1612,6 +1743,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 model_config=_router_model_config(
                     hidden_size=4,
                     has_moe_norm=True,
+                    moe_n_group=2,
+                    moe_topk_group=1,
                 ),
                 parallelism_config=parallelism_config,
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -1657,7 +1790,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 torch.tensor([0.1, -0.2, 0.3, -0.4])
             )
 
-        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+        expected_weights, expected_ids = _manual_noaux_reference(
             block.gate(hidden_states).float(),
             block.gate.e_score_correction_bias,
             top_k=2,
@@ -1758,6 +1891,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     hidden_size=4,
                     expert_num=8,
                     has_moe_norm=True,
+                    moe_n_group=4,
+                    moe_topk_group=2,
                 ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -1820,7 +1955,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             )
 
         router_logits = block.gate(hidden_states).float()
-        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+        expected_weights, expected_ids = _manual_noaux_reference(
             router_logits,
             block.gate.e_score_correction_bias,
             top_k=2,
@@ -1912,16 +2047,13 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 )
             )
 
-        expected_weights, expected_ids = _select_deepseek_topk(
-            block.gate(hidden_states).float(),
-            top_k=2,
-            scoring_func=0,
-            n_group=1,
-            topk_group=1,
-            group_limited=False,
-            renormalize=True,
-            routed_scaling_factor=1.0,
+        expected_weights, expected_ids = (
+            block.gate(hidden_states)
+            .float()
+            .softmax(dim=-1)
+            .topk(2, dim=-1, sorted=False)
         )
+        expected_weights = expected_weights / expected_weights.sum(dim=-1, keepdim=True)
         block(hidden_states)
 
         actual_order = capturing_experts.ids.argsort(dim=-1)
@@ -1953,6 +2085,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     hidden_size=4,
                     expert_num=8,
                     has_moe_norm=True,
+                    moe_n_group=4,
+                    moe_topk_group=2,
                 ),
                 parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
@@ -2011,7 +2145,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 torch.linspace(-0.2, 0.2, 8, device="cuda")
             )
 
-        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+        expected_weights, expected_ids = _manual_noaux_reference(
             block.gate(hidden_states).float(),
             block.gate.e_score_correction_bias,
             top_k=2,
@@ -2098,7 +2232,6 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         attention.process_weights_after_loading()
         self.assertIsNotNone(attention._fused_qkv_a_runtime)
         self.assertEqual(attention._fused_qkv_a_w.dtype, torch.float8_e4m3fn)
-        self.assertIsNotNone(attention._fused_qkv_a_s)
         self.assertEqual(
             tuple(attention._fused_qkv_a_runtime.weight.shape),
             (128 + 128 + 2, 128),
@@ -2341,20 +2474,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         kernel_weights = attention._build_mla_kernel_weights()
         self.assertIsNone(attention._kv_b_w)
 
-        fused_reference = torch.cat(
-            [reference_weights["q_a"], reference_weights["kv_a"]],
-            dim=0,
-        )
-        cases = (
-            (
-                W.mla_fusedqkrope_w,
-                W.mla_fusedqkrope_s,
-                fused_reference,
-            ),
-            (W.mla_q_b_w, W.mla_q_b_s, reference_weights["q_b"]),
-            (W.mla_kv_b_w, W.mla_kv_b_s, reference_weights["kv_b"]),
-            (W.attn_o_w, W.attn_o_s, reference_weights["o"]),
-        )
+        cases = ((W.mla_kv_b_w, W.mla_kv_b_s, reference_weights["kv_b"]),)
         runtime_quant_config = types.SimpleNamespace(get_method=lambda: "FP8_PER_BLOCK")
         for weight_key, scale_key, reference in cases:
             with self.subTest(weight_key=weight_key):
@@ -2515,6 +2635,32 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 torch.zeros(2, 4, dtype=torch.float32),
                 torch.zeros(2, 4, dtype=torch.float64),
             )
+
+    def test_mtp_block_concat_order_is_numerically_explicit(self):
+        inputs_embeds = torch.tensor([[1.0, 2.0]])
+        last_hidden_states = torch.tensor([[3.0, 5.0]])
+        projection = torch.tensor(
+            [
+                [1.0, 10.0, 100.0, 1000.0],
+                [-2.0, 3.0, -5.0, 7.0],
+            ]
+        )
+        for reverse_concat, expected_concat in (
+            (False, torch.tensor([[1.0, 2.0, 3.0, 5.0]])),
+            (True, torch.tensor([[3.0, 5.0, 1.0, 2.0]])),
+        ):
+            with self.subTest(reverse_concat=reverse_concat):
+                block = MTPBlock(
+                    hidden_size=2,
+                    reverse_concat=reverse_concat,
+                    params_dtype=torch.float32,
+                )
+                block.e_norm = torch.nn.Identity()
+                block.h_norm = torch.nn.Identity()
+                block.fc.weight.data.copy_(projection)
+                actual = block(inputs_embeds, last_hidden_states)
+                expected = F.linear(expected_concat, projection)
+                torch.testing.assert_close(actual, expected)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -16,6 +16,7 @@ from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.deepseek_v3.attention import (
     DeepSeekV32MlaAttention,
+    _CudaRuntimeFusedFp8Linear,
     _kernel_fp8_weight_and_scale,
     _linear_weight_bf16,
     _prepare_fused_fp8_runtime_weight,
@@ -1184,24 +1185,37 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             dict(indexer.indexer_op.named_buffers())["cos_sin_cache"],
             indexer.indexer_op.cos_sin_cache,
         )
+        rebound_cache = cache + 0.25
+        indexer.bind_rope_cache(rebound_cache)
+        self.assertIs(indexer.indexer_op.cos_sin_cache, rebound_cache)
+        with self.assertRaisesRegex(TypeError, "must use torch.float32"):
+            indexer.bind_rope_cache(rebound_cache.to(torch.bfloat16))
         indexer.indexer_op.to(dtype=torch.bfloat16)
         self.assertEqual(indexer.indexer_op.cos_sin_cache.dtype, torch.float32)
         torch.testing.assert_close(
             indexer.indexer_op.cos_sin_cache,
-            cache,
+            rebound_cache,
             rtol=0,
             atol=0,
         )
 
     def test_model_dtype_migration_preserves_shared_fp32_rope_cache(self):
         cache = torch.linspace(-0.97, 0.91, 16, dtype=torch.float32).reshape(4, 4)
+
         # A plain consumer isolates the top-level alias-restoration contract;
         # the real CUDA IndexerOp's standalone _apply behavior is covered by
         # test_sparse_indexer_rope_cache_is_a_device_tracked_buffer above.
-        indexer_op = torch.nn.Module()
-        indexer_op.register_buffer("cos_sin_cache", cache, persistent=False)
-        indexer = torch.nn.Module()
-        indexer.indexer_op = indexer_op
+        class CacheConsumer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cos_sin_cache", cache, persistent=False)
+
+            def bind_rope_cache(self, rope_cache):
+                if rope_cache.dtype != torch.float32:
+                    raise TypeError("RoPE cache must remain FP32")
+                self.cos_sin_cache = rope_cache
+
+        indexer = CacheConsumer()
         attention = torch.nn.Module()
         attention.indexer = indexer
         layer = torch.nn.Module()
@@ -1217,7 +1231,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         owner = CacheOwner().to(dtype=torch.bfloat16)
         self.assertEqual(owner.cos_sin_cache.dtype, torch.float32)
         self.assertIs(
-            owner.layers[0].self_attn.indexer.indexer_op.cos_sin_cache,
+            owner.layers[0].self_attn.indexer.cos_sin_cache,
             owner.cos_sin_cache,
         )
         torch.testing.assert_close(owner.cos_sin_cache, cache, rtol=0, atol=0)
@@ -1436,6 +1450,36 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     torch.bfloat16
                 )
                 self.assertTrue(torch.equal(_linear_weight_bf16(linear), expected))
+
+    def test_mla_fused_fp8_runtime_uses_configured_input_group_size(self):
+        runtime = _CudaRuntimeFusedFp8Linear(
+            torch.ones(4, 4),
+            torch.ones(2, 1),
+            (2, 4),
+        )
+        quantized = torch.zeros(1, 4)
+        input_scales = torch.ones(1, 1)
+        quantizer = mock.Mock(return_value=(quantized, input_scales))
+
+        def fake_gemm(_a, _b, output, **_kwargs):
+            output.zero_()
+
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.attention."
+                "_resolve_sgl_per_token_group_quant",
+                return_value=quantizer,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.attention."
+                "_resolve_fp8_gemm_nt",
+                return_value=fake_gemm,
+            ),
+        ):
+            output = runtime(torch.ones(1, 4))
+
+        self.assertEqual(tuple(output.shape), (1, 4))
+        self.assertEqual(quantizer.call_args.kwargs["group_size"], 4)
 
     def test_mla_kernel_fp8_layout_preserves_ue8m0_contract(self):
         weight = torch.arange(24, dtype=torch.float32).reshape(6, 4)
@@ -1787,6 +1831,48 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 topk_group=1,
                 topk_method="noaux_tc",
                 has_moe_norm=True,
+                correction_bias=True,
+            )
+        self.assertFalse(block._use_fast_group_topk)
+        self.assertIsNone(block.group_topk)
+        group_topk.assert_not_called()
+
+    def test_noaux_router_exceeding_warp_capacity_uses_reference_path(self):
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.Cuda,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.GroupTopK"
+            ) as group_topk,
+            torch.device("cpu"),
+        ):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=64,
+                top_k=2,
+                layer_idx=3,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=_router_model_config(
+                    expert_num=64,
+                    moe_n_group=64,
+                    moe_topk_group=2,
+                ),
+                parallelism_config=_single_rank_parallelism_config(),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=1.0,
+                n_group=64,
+                topk_group=2,
+                topk_method="noaux_tc",
                 correction_bias=True,
             )
         self.assertFalse(block._use_fast_group_topk)

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -1,13 +1,19 @@
+import json
 import math
+import tempfile
 import types
 import unittest
+from unittest import mock
 
 import torch
 
+from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.model_loader import NewLoaderConfig
 from rtp_llm.models_py.new_models.deepseek_v3.attention import (
     DeepSeekV32MlaAttention,
+    _kernel_fp8_weight_and_scale,
     _linear_weight_bf16,
+    _prepare_fused_fp8_runtime_weight,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.language import (
     DeepSeekV32ForCausalLM,
@@ -15,6 +21,14 @@ from rtp_llm.models_py.new_models.deepseek_v3.language import (
     _extract_config_values,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.mlp import DeepSeekV32MLP
+from rtp_llm.models_py.new_models.deepseek_v3.moe import (
+    DeepSeekV32MoEBlock,
+    _select_deepseek_noaux_topk,
+    _select_deepseek_topk,
+)
+from rtp_llm.models_py.new_models.deepseek_v3.rotary_embedding import (
+    DeepseekV3RotaryEmbedding,
+)
 from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
     DeepSeekV32MTPForCausalLM,
     _draft_checkpoint_layer,
@@ -23,6 +37,7 @@ from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
 from rtp_llm.models_py.new_models.mtp import MTPBlock
 from rtp_llm.models_py.quant_methods.base import QuantizationConfig
 from rtp_llm.models_py.registry import get_model_class
+from rtp_llm.utils.model_weight import W
 
 
 def _model_config(*, sparse=False, q_lora_rank=4):
@@ -200,6 +215,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             "deepseek_v31",
             "deepseek_v32",
             "glm_5",
+            "kimi_k2",
         ):
             with self.subTest(model_type=model_type):
                 self.assertIs(get_model_class(model_type), DeepSeekV32ForCausalLM)
@@ -207,6 +223,17 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             get_model_class("deepseek-v3-mtp"),
             DeepSeekV32MTPForCausalLM,
         )
+
+    def test_rotary_cache_is_valid_immediately_after_construction(self):
+        rotary = DeepseekV3RotaryEmbedding(
+            dim=8,
+            max_position_embeddings=16,
+            device=torch.device("cpu"),
+        )
+        cache_ptr = rotary.cos_cached.data_ptr()
+        self.assertEqual(rotary.max_seq_len_cached, 16)
+        rotary(torch.zeros(1, 8), seq_len=8)
+        self.assertEqual(rotary.cos_cached.data_ptr(), cache_ptr)
 
     def test_core_filter_excludes_appended_draft_and_unrelated_tensors(self):
         model = _uninitialized_model(DeepSeekV32ForCausalLM, layer_count=4)
@@ -265,6 +292,30 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     "num_nextn_predict_layers": 2,
                 }
             )
+
+    def test_mtp_real_constructor_uses_appended_layer_from_full_checkpoint(self):
+        config_json = _raw_config()
+        model_config = _model_config()
+        # ModelFactory creates the draft config from the full checkpoint, so
+        # this remains the main-model layer count at construction time.
+        model_config.num_layers = config_json["num_hidden_layers"]
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            model_config.ckpt_path = checkpoint_path
+            with open(
+                f"{checkpoint_path}/config.json", "w", encoding="utf-8"
+            ) as config_file:
+                json.dump(config_json, config_file)
+            with torch.device("cpu"):
+                model = DeepSeekV32MTPForCausalLM(
+                    model_config,
+                    _load_config(),
+                )
+
+        self.assertEqual(model._checkpoint_layer, 4)
+        self.assertEqual(model._checkpoint_prefix, "model.layers.4.")
+        self.assertEqual(model.layer_num, 1)
+        self.assertEqual(len(model.layers), 1)
+        self.assertEqual(model.cos_sin_cache.device.type, "cpu")
 
     def test_mtp_filter_is_exact_and_rank_invariant(self):
         model = _uninitialized_model(
@@ -391,6 +442,27 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertEqual((cfg["lm_head_tp_size"], cfg["lm_head_tp_rank"]), (2, 1))
         self.assertEqual((cfg["ep_size"], cfg["ep_rank"]), (2, 1))
         self.assertEqual(cfg["moe_layer_index"], [3])
+        self.assertEqual(cfg["topk_method"], "greedy")
+
+    def test_raw_router_config_is_canonical(self):
+        raw = _raw_config()
+        raw.update(
+            {
+                "scoring_func": "softmax",
+                "routed_scaling_factor": 2.5,
+                "n_group": 4,
+                "topk_group": 2,
+                "norm_topk_prob": False,
+                "topk_method": "group_limited_greedy",
+            }
+        )
+        cfg = _extract_config_values(_model_config(), _load_config(), raw)
+        self.assertEqual(cfg["scoring_func"], 0)
+        self.assertEqual(cfg["routed_scaling_factor"], 2.5)
+        self.assertEqual(cfg["n_group"], 4)
+        self.assertEqual(cfg["topk_group"], 2)
+        self.assertFalse(cfg["has_moe_norm"])
+        self.assertEqual(cfg["topk_method"], "group_limited_greedy")
 
     def test_sparse_indexer_rejects_no_q_lora(self):
         with self.assertRaisesRegex(ValueError, "requires q_lora_rank"):
@@ -404,14 +476,13 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         raw = _raw_config()
         raw.update(
             {
+                "n_group": 3,
                 "topk_method": "noaux_tc",
                 "topk_group": 1,
             }
         )
-        model_config = _model_config()
-        model_config.moe_n_group = 3
         with self.assertRaisesRegex(ValueError, "divisible by n_group"):
-            _extract_config_values(model_config, _load_config(), raw)
+            _extract_config_values(_model_config(), _load_config(), raw)
 
     def test_no_q_lora_has_no_empty_checkpoint_parameters(self):
         attention = DeepSeekV32MlaAttention(
@@ -478,6 +549,642 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                     torch.bfloat16
                 )
                 self.assertTrue(torch.equal(_linear_weight_bf16(linear), expected))
+
+    def test_mla_kernel_fp8_layout_preserves_ue8m0_contract(self):
+        weight = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+        fp32_scale = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+        normal_weight, normal_scale = _kernel_fp8_weight_and_scale(weight, fp32_scale)
+        self.assertEqual(tuple(normal_weight.shape), (4, 6))
+        self.assertEqual(tuple(normal_scale.shape), (2, 3))
+        self.assertEqual(normal_weight.data_ptr(), weight.data_ptr())
+        self.assertEqual(normal_scale.data_ptr(), fp32_scale.data_ptr())
+
+        ue8m0_scale = torch.ones(6, 1, dtype=torch.int32)
+        ue8m0_weight, preserved_scale = _kernel_fp8_weight_and_scale(
+            weight, ue8m0_scale
+        )
+        self.assertIs(ue8m0_weight, weight)
+        self.assertIs(preserved_scale, ue8m0_scale)
+        self.assertEqual(tuple(ue8m0_weight.shape), (6, 4))
+        self.assertEqual(tuple(preserved_scale.shape), (6, 1))
+
+    def test_mla_fused_runtime_requants_before_child_post_load(self):
+        weight = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+        scale = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+        requant_weight = weight + 1
+        requant_scale = torch.ones(6, 1, dtype=torch.int32)
+        requant = mock.Mock(return_value=(requant_weight, requant_scale))
+
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.attention."
+                "is_deep_gemm_e8m0_used",
+                return_value=True,
+            ) as e8m0_used,
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.attention."
+                "_resolve_requant_weight_ue8m0",
+                return_value=requant,
+            ),
+        ):
+            runtime_weight, runtime_scale = _prepare_fused_fp8_runtime_weight(
+                weight, scale
+            )
+
+        e8m0_used.assert_called_once_with(weight.device)
+        requant.assert_called_once_with(weight, scale)
+        self.assertIs(runtime_weight, requant_weight)
+        self.assertIs(runtime_scale, requant_scale)
+        self.assertEqual(runtime_scale.dtype, torch.int32)
+
+    def test_mla_fused_runtime_keeps_standard_block_scales(self):
+        weight = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+        scale = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+        with mock.patch(
+            "rtp_llm.models_py.new_models.deepseek_v3.attention."
+            "is_deep_gemm_e8m0_used",
+            return_value=False,
+        ):
+            runtime_weight, runtime_scale = _prepare_fused_fp8_runtime_weight(
+                weight, scale
+            )
+        self.assertIs(runtime_weight, weight)
+        self.assertIs(runtime_scale, scale)
+
+    def test_mla_bf16_kernel_views_match_legacy_orientation(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=8,
+            num_heads=2,
+            q_lora_rank=4,
+            kv_lora_rank=4,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            params_dtype=torch.float32,
+        )
+        attention.process_weights_after_loading()
+        weights = attention._build_mla_kernel_weights()
+
+        self.assertFalse(hasattr(attention, "_fused_qkv_b_w"))
+        self.assertEqual(
+            tuple(weights[W.mla_fusedqkrope_w].shape),
+            (8, 4 + 4 + 2),
+        )
+        self.assertEqual(
+            tuple(weights[W.mla_q_b_w].shape),
+            (4, 2 * (2 + 2)),
+        )
+        self.assertTrue(
+            torch.equal(
+                weights[W.mla_fusedqkrope_w],
+                attention._fused_qkv_a_w.t(),
+            )
+        )
+        self.assertTrue(
+            torch.equal(weights[W.mla_q_b_w], attention.q_b_proj.weight.t())
+        )
+        self.assertNotIn(W.mla_fusedqkrope_s, weights)
+        self.assertNotIn(W.mla_q_b_s, weights)
+
+    def test_mla_fp8_kernel_views_keep_scales_without_bf16_qb_copy(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=128,
+            num_heads=2,
+            q_lora_rank=128,
+            kv_lora_rank=128,
+            nope_head_dim=64,
+            rope_head_dim=64,
+            v_head_dim=64,
+            layer_idx=0,
+            quant_config=QuantizationConfig("FP8_PER_BLOCK"),
+            params_dtype=torch.bfloat16,
+        )
+        fused_weight = torch.zeros(
+            128 + 128 + 64,
+            128,
+            dtype=torch.float8_e4m3fn,
+        )
+        fused_scale = torch.ones(3, 1, dtype=torch.float32)
+        attention._fused_qkv_a_w = fused_weight
+        attention._fused_qkv_a_s = fused_scale
+        del attention.q_b_proj.weight_scale_inv
+        attention.q_b_proj.register_parameter(
+            "weight_scale",
+            torch.nn.Parameter(
+                torch.ones(2, 1, dtype=torch.float32),
+                requires_grad=False,
+            ),
+        )
+        attention._kv_b_w = torch.empty(128, 256)
+        attention._kc_w = torch.empty(2, 64, 128)
+        attention._vc_w = torch.empty(2, 128, 64)
+
+        weights = attention._build_mla_kernel_weights()
+
+        self.assertEqual(
+            tuple(weights[W.mla_fusedqkrope_w].shape),
+            (128, 320),
+        )
+        self.assertEqual(
+            tuple(weights[W.mla_fusedqkrope_s].shape),
+            (1, 3),
+        )
+        self.assertEqual(
+            tuple(weights[W.mla_q_b_w].shape),
+            (128, 256),
+        )
+        self.assertEqual(
+            tuple(weights[W.mla_q_b_s].shape),
+            (1, 2),
+        )
+        self.assertEqual(weights[W.mla_q_b_w].dtype, torch.float8_e4m3fn)
+
+    def test_non_noaux_router_preserves_scoring_grouping_and_scaling(self):
+        logits = torch.tensor(
+            [
+                [1.0, 2.0, -1.0, 0.0],
+                [-2.0, -1.0, 3.0, 2.0],
+            ],
+            dtype=torch.float32,
+        )
+        weights, ids = _select_deepseek_topk(
+            logits,
+            top_k=2,
+            scoring_func=1,
+            n_group=2,
+            topk_group=1,
+            group_limited=True,
+            renormalize=True,
+            routed_scaling_factor=2.5,
+        )
+        scores = logits.sigmoid()
+        group_scores = scores.view(2, 2, 2).amax(dim=-1)
+        selected_groups = group_scores.topk(1, dim=-1, sorted=False).indices
+        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+        group_mask.scatter_(1, selected_groups, True)
+        masked = scores.masked_fill(
+            ~group_mask.unsqueeze(-1).expand(-1, -1, 2).reshape_as(scores),
+            float("-inf"),
+        )
+        expected_weights, expected_ids = masked.topk(2, dim=-1, sorted=False)
+        expected_weights = (
+            expected_weights
+            / expected_weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+            * 2.5
+        )
+        self.assertTrue(torch.equal(ids, expected_ids))
+        self.assertTrue(torch.equal(weights, expected_weights))
+
+        softmax_weights, softmax_ids = _select_deepseek_topk(
+            logits,
+            top_k=2,
+            scoring_func=0,
+            n_group=2,
+            topk_group=1,
+            group_limited=False,
+            renormalize=False,
+            routed_scaling_factor=1.5,
+        )
+        reference_weights, reference_ids = logits.softmax(dim=-1).topk(
+            2, dim=-1, sorted=False
+        )
+        self.assertTrue(torch.equal(softmax_ids, reference_ids))
+        self.assertTrue(torch.equal(softmax_weights, reference_weights * 1.5))
+
+    def test_noaux_router_uses_bias_only_for_selection(self):
+        logits = torch.tensor(
+            [
+                [2.0, 1.0, 0.0, -1.0, -2.0, 3.0, 0.5, -0.5],
+                [-1.0, 0.0, 1.0, 2.0, 3.0, -2.0, -0.5, 0.5],
+            ],
+            dtype=torch.float32,
+        )
+        correction_bias = torch.tensor(
+            [-0.3, 0.2, 0.1, -0.2, 0.4, -0.4, 0.3, -0.1],
+            dtype=torch.float32,
+        )
+        weights, ids = _select_deepseek_noaux_topk(
+            logits,
+            correction_bias,
+            top_k=2,
+            n_group=4,
+            topk_group=2,
+            renormalize=True,
+            routed_scaling_factor=2.5,
+        )
+
+        scores = logits.sigmoid()
+        choice_scores = scores + correction_bias
+        grouped = choice_scores.view(2, 4, 2)
+        group_scores = grouped.topk(2, dim=-1, sorted=False).values.sum(dim=-1)
+        selected_groups = group_scores.topk(2, dim=-1, sorted=False).indices
+        group_mask = torch.zeros_like(group_scores, dtype=torch.bool)
+        group_mask.scatter_(1, selected_groups, True)
+        expert_mask = (
+            group_mask.unsqueeze(-1).expand(-1, -1, 2).reshape_as(choice_scores)
+        )
+        expected_ids = (
+            choice_scores.masked_fill(~expert_mask, float("-inf"))
+            .topk(2, dim=-1, sorted=False)
+            .indices
+        )
+        expected_weights = scores.gather(1, expected_ids)
+        expected_weights = (
+            expected_weights
+            / expected_weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+            * 2.5
+        )
+        self.assertTrue(torch.equal(ids, expected_ids))
+        self.assertTrue(torch.equal(weights, expected_weights))
+        self.assertFalse(
+            torch.equal(
+                weights,
+                choice_scores.gather(1, ids)
+                / choice_scores.gather(1, ids).sum(dim=-1, keepdim=True)
+                * 2.5,
+            )
+        )
+
+    def test_noaux_router_constructs_without_cuda_group_topk(self):
+        parallelism_config = types.SimpleNamespace(
+            dp_rank=0,
+            dp_size=1,
+        )
+        moe_config = types.SimpleNamespace(fake_balance_expert=False)
+        model_config = types.SimpleNamespace(quant_config=None)
+        with torch.device("cpu"):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=4,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=model_config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config,
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=1.0,
+                n_group=2,
+                topk_group=1,
+                topk_method="noaux_tc",
+                correction_bias=True,
+            )
+        expect_fast_group_topk = get_device_type() == DeviceType.Cuda
+        self.assertEqual(block._use_fast_group_topk, expect_fast_group_topk)
+        self.assertEqual(block.group_topk is not None, expect_fast_group_topk)
+
+    def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
+        parallelism_config = types.SimpleNamespace(dp_rank=0, dp_size=1)
+        moe_config = types.SimpleNamespace(fake_balance_expert=False)
+        model_config = types.SimpleNamespace(quant_config=None)
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.ROCm,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.SelectTopk"
+            ) as select_topk,
+            torch.device("cpu"),
+        ):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=4,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=model_config,
+                parallelism_config=parallelism_config,
+                moe_config=moe_config,
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=0,
+                routed_scaling_factor=1.0,
+                n_group=1,
+                topk_group=1,
+                topk_method="greedy",
+                correction_bias=False,
+            )
+        self.assertFalse(block._use_fast_select_topk)
+        self.assertIsNone(block.select_topk)
+        select_topk.assert_not_called()
+
+    def test_moe_forward_uses_reference_noaux_routing_on_cpu(self):
+        parallelism_config = types.SimpleNamespace(
+            dp_rank=0,
+            dp_size=1,
+        )
+        with torch.device("cpu"):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=4,
+                moe_intermediate_size=2,
+                num_experts=4,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=types.SimpleNamespace(quant_config=None),
+                parallelism_config=parallelism_config,
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=2.0,
+                n_group=2,
+                topk_group=1,
+                topk_method="noaux_tc",
+                has_moe_norm=True,
+                correction_bias=True,
+            )
+
+        class CapturingExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int64)
+                self.weights = None
+                self.ids = None
+
+            def forward(self, hidden_states, topk_weights, topk_ids):
+                self.weights = topk_weights.clone()
+                self.ids = topk_ids.clone()
+                return hidden_states + topk_weights.sum(dim=-1, keepdim=True)
+
+        capturing_experts = CapturingExperts()
+        block.experts = capturing_experts
+        hidden_states = torch.tensor([[1.0, 0.5, -1.0, 2.0], [-0.5, 1.5, 0.25, -1.0]])
+        with torch.no_grad():
+            block.gate.weight.copy_(
+                torch.tensor(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ]
+                )
+            )
+            block.gate.e_score_correction_bias.copy_(
+                torch.tensor([0.1, -0.2, 0.3, -0.4])
+            )
+
+        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+            block.gate(hidden_states).float(),
+            block.gate.e_score_correction_bias,
+            top_k=2,
+            n_group=2,
+            topk_group=1,
+            renormalize=True,
+            routed_scaling_factor=2.0,
+        )
+        output = block(hidden_states)
+
+        self.assertTrue(torch.equal(capturing_experts.ids, expected_ids))
+        self.assertTrue(torch.equal(capturing_experts.weights, expected_weights))
+        self.assertTrue(
+            torch.equal(
+                output,
+                hidden_states + expected_weights.sum(dim=-1, keepdim=True),
+            )
+        )
+
+    def test_moe_rejects_invalid_fake_balance_and_input_rank(self):
+        kwargs = dict(
+            hidden_size=4,
+            moe_intermediate_size=2,
+            num_experts=4,
+            top_k=2,
+            layer_idx=0,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            model_config=types.SimpleNamespace(quant_config=None),
+            parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+            quant_config=None,
+            params_dtype=torch.float32,
+            has_shared_expert=False,
+            scoring_func=0,
+            routed_scaling_factor=2.0,
+            n_group=1,
+            topk_group=1,
+            topk_method="greedy",
+            correction_bias=False,
+        )
+        with self.assertRaisesRegex(TypeError, "fake_balance_expert"):
+            DeepSeekV32MoEBlock(
+                moe_config=types.SimpleNamespace(fake_balance_expert=1),
+                **kwargs,
+            )
+
+        block = DeepSeekV32MoEBlock(
+            moe_config=types.SimpleNamespace(fake_balance_expert=False),
+            **kwargs,
+        )
+        block.experts.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int64)
+        with self.assertRaisesRegex(ValueError, "two-dimensional"):
+            block(torch.zeros(1, 2, 4))
+
+    @unittest.skipUnless(
+        get_device_type() == DeviceType.Cuda,
+        "CUDA GroupTopK is required",
+    )
+    def test_moe_cuda_noaux_router_matches_reference(self):
+        with torch.device("cuda"):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=4,
+                moe_intermediate_size=2,
+                num_experts=8,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=types.SimpleNamespace(quant_config=None),
+                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=2.5,
+                n_group=4,
+                topk_group=2,
+                topk_method="noaux_tc",
+                has_moe_norm=True,
+                correction_bias=True,
+            )
+        self.assertTrue(block._use_fast_group_topk)
+
+        class CapturingExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.weights = None
+                self.ids = None
+
+            def forward(self, hidden_states, topk_weights, topk_ids):
+                self.weights = topk_weights.clone()
+                self.ids = topk_ids.clone()
+                return hidden_states
+
+        capturing_experts = CapturingExperts()
+        block.experts = capturing_experts
+        hidden_states = torch.tensor(
+            [
+                [1.0, 0.5, -1.0, 2.0],
+                [-0.5, 1.5, 0.25, -1.0],
+                [0.75, -0.25, 1.25, 0.5],
+            ],
+            device="cuda",
+        )
+        with torch.no_grad():
+            block.gate.weight.copy_(
+                torch.tensor(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                        [0.5, -0.5, 0.25, 0.0],
+                        [-0.25, 0.75, 0.0, 0.5],
+                        [0.0, 0.25, 0.75, -0.5],
+                        [0.5, 0.0, -0.25, 0.75],
+                    ],
+                    device="cuda",
+                )
+            )
+            block.gate.e_score_correction_bias.copy_(
+                torch.tensor(
+                    [0.1, -0.2, 0.3, -0.4, 0.05, 0.15, -0.1, 0.2],
+                    device="cuda",
+                )
+            )
+
+        router_logits = block.gate(hidden_states).float()
+        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+            router_logits,
+            block.gate.e_score_correction_bias,
+            top_k=2,
+            n_group=4,
+            topk_group=2,
+            renormalize=True,
+            routed_scaling_factor=2.5,
+        )
+        output = block(hidden_states)
+
+        actual_order = capturing_experts.ids.argsort(dim=-1)
+        expected_order = expected_ids.argsort(dim=-1)
+        actual_ids = capturing_experts.ids.gather(1, actual_order)
+        expected_ids = expected_ids.gather(1, expected_order).to(actual_ids.dtype)
+        actual_weights = capturing_experts.weights.gather(1, actual_order)
+        expected_weights = expected_weights.gather(1, expected_order)
+        self.assertTrue(torch.equal(actual_ids, expected_ids))
+        self.assertTrue(torch.allclose(actual_weights, expected_weights, atol=1e-6))
+        self.assertTrue(torch.equal(output, hidden_states))
+
+    @unittest.skipUnless(
+        get_device_type() == DeviceType.ROCm,
+        "ROCm is required",
+    )
+    def test_moe_rocm_noaux_reference_router_matches_expected(self):
+        with torch.device("cuda"):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=4,
+                moe_intermediate_size=2,
+                num_experts=8,
+                top_k=2,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=types.SimpleNamespace(quant_config=None),
+                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=2.5,
+                n_group=4,
+                topk_group=2,
+                topk_method="noaux_tc",
+                has_moe_norm=True,
+                correction_bias=True,
+            )
+        self.assertFalse(block._use_fast_group_topk)
+        self.assertIsNone(block.group_topk)
+
+        class CapturingExperts(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fused_moe = types.SimpleNamespace(topk_ids_dtype=torch.int32)
+                self.weights = None
+                self.ids = None
+
+            def forward(self, hidden_states, topk_weights, topk_ids):
+                self.weights = topk_weights.clone()
+                self.ids = topk_ids.clone()
+                return hidden_states
+
+        capturing_experts = CapturingExperts()
+        block.experts = capturing_experts
+        hidden_states = torch.tensor(
+            [
+                [1.0, 0.5, -1.0, 2.0],
+                [-0.5, 1.5, 0.25, -1.0],
+            ],
+            device="cuda",
+        )
+        with torch.no_grad():
+            block.gate.weight.copy_(
+                torch.tensor(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                        [1.0, 1.0, 0.0, 0.0],
+                        [0.0, 1.0, 1.0, 0.0],
+                        [0.0, 0.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 1.0],
+                    ],
+                    device="cuda",
+                )
+            )
+            block.gate.e_score_correction_bias.copy_(
+                torch.linspace(-0.2, 0.2, 8, device="cuda")
+            )
+
+        expected_weights, expected_ids = _select_deepseek_noaux_topk(
+            block.gate(hidden_states).float(),
+            block.gate.e_score_correction_bias,
+            top_k=2,
+            n_group=4,
+            topk_group=2,
+            renormalize=True,
+            routed_scaling_factor=2.5,
+        )
+        block(hidden_states)
+        self.assertTrue(torch.equal(capturing_experts.ids, expected_ids))
+        torch.testing.assert_close(capturing_experts.weights, expected_weights)
 
     def test_mla_misaligned_fp8_a_projection_uses_bf16_fallback(self):
         attention = DeepSeekV32MlaAttention(
@@ -550,10 +1257,71 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             parameter.data.zero_()
         attention.process_weights_after_loading()
         self.assertIsNotNone(attention._fused_qkv_a_runtime)
+        self.assertEqual(attention._fused_qkv_a_w.dtype, torch.float8_e4m3fn)
+        self.assertIsNotNone(attention._fused_qkv_a_s)
         self.assertEqual(
             tuple(attention._fused_qkv_a_runtime.weight.shape),
             (128 + 128 + 2, 128),
         )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
+    @unittest.skipIf(
+        getattr(torch.version, "hip", None) is not None,
+        "DeepGEMM fused FP8 projection is CUDA-only",
+    )
+    def test_mla_online_fused_fp8_projection_matches_bf16_reference(self):
+        device = torch.device("cuda")
+        with torch.device(device):
+            attention = DeepSeekV32MlaAttention(
+                hidden_size=128,
+                num_heads=2,
+                q_lora_rank=128,
+                kv_lora_rank=128,
+                nope_head_dim=64,
+                rope_head_dim=128,
+                v_head_dim=64,
+                layer_idx=0,
+                quant_config=QuantizationConfig("fp8_block_online"),
+                params_dtype=torch.bfloat16,
+            )
+        generator = torch.Generator(device=device).manual_seed(20260727)
+        q_a_weight = torch.randn(
+            attention.q_a_proj.weight.shape,
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        kv_a_weight = torch.randn(
+            attention.kv_a_proj_with_mqa.weight.shape,
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        attention.q_a_proj.weight.data.copy_(q_a_weight)
+        attention.kv_a_proj_with_mqa.weight.data.copy_(kv_a_weight)
+        reference_weight = torch.cat([q_a_weight, kv_a_weight], dim=0)
+
+        attention.process_weights_after_loading()
+        self.assertIsNotNone(attention._fused_qkv_a_runtime)
+        x = torch.randn(
+            (7, 128),
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        actual = attention._fused_qkv_a_runtime(x)
+        expected = torch.nn.functional.linear(x, reference_weight)
+        difference = actual.float() - expected.float()
+        relative_rmse = (
+            difference.square().mean().sqrt() / expected.float().square().mean().sqrt()
+        )
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.float().flatten(),
+            expected.float().flatten(),
+            dim=0,
+        )
+        self.assertLess(float(relative_rmse), 0.05)
+        self.assertGreater(float(cosine), 0.998)
 
     def test_mlp_tp_reduction_is_owned_by_row_parallel_linear(self):
         dense = DeepSeekV32MLP(

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -11,9 +11,9 @@ from safetensors.torch import save_file
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.device.device_type import DeviceType, get_device_type
+from rtp_llm.models_py.distributed.collective_torch import Group
 from rtp_llm.models_py.model_loader import NewLoaderConfig, NewModelLoader
 from rtp_llm.models_py.module_base import RtpModule
-from rtp_llm.models_py.modules.factory import LinearFactory
 from rtp_llm.models_py.new_models.deepseek_v3.attention import (
     DeepSeekV32MlaAttention,
     _kernel_fp8_weight_and_scale,
@@ -26,6 +26,7 @@ from rtp_llm.models_py.new_models.deepseek_v3.language import (
     _extract_config_values,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.mlp import DeepSeekV32MLP
+from rtp_llm.models_py.new_models.deepseek_v3.model import DeepSeekV32Indexer
 from rtp_llm.models_py.new_models.deepseek_v3.moe import (
     DeepSeekV32MoEBlock,
     _select_deepseek_noaux_topk,
@@ -48,36 +49,35 @@ from rtp_llm.utils.model_weight import W
 
 
 def _model_config(*, sparse=False, q_lora_rank=4):
-    return types.SimpleNamespace(
-        model_type="deepseek3",
-        hidden_size=8,
-        num_layers=4,
-        vocab_size=16,
-        max_seq_len=128,
-        rms_norm_eps=1e-6,
-        expert_num=8,
-        moe_k=2,
-        scoring_func=1,
-        routed_scaling_factor=1.0,
-        moe_n_group=2,
-        moe_topk_group=1,
-        has_moe_norm=True,
-        enable_fp32_lm_head=False,
-        tie_word_embeddings=False,
-        attn_config=types.SimpleNamespace(
-            head_num=4,
-            q_lora_rank=q_lora_rank,
-            kv_lora_rank=4,
-            nope_head_dim=2,
-            rope_head_dim=2,
-            v_head_dim=2,
-            is_sparse=sparse,
-            indexer_head_dim=4,
-            indexer_head_num=2,
-            indexer_topk=8,
-            kernel_tokens_per_block=64,
-        ),
-    )
+    config = ModelConfig()
+    config.model_type = "deepseek3"
+    config.hidden_size = 8
+    config.num_layers = 4
+    config.vocab_size = 16
+    config.max_seq_len = 128
+    config.layernorm_eps = 1e-6
+    config.expert_num = 8
+    config.moe_k = 2
+    config.scoring_func = 1
+    config.routed_scaling_factor = 1.0
+    config.moe_n_group = 2
+    config.moe_topk_group = 1
+    config.has_moe_norm = True
+    config.enable_fp32_lm_head = False
+    config.tie_word_embeddings = False
+    config.attn_config.head_num = 4
+    config.attn_config.q_lora_rank = q_lora_rank
+    config.attn_config.kv_lora_rank = 4
+    config.attn_config.nope_head_dim = 2
+    config.attn_config.rope_head_dim = 2
+    config.attn_config.v_head_dim = 2
+    config.attn_config.use_mla = True
+    config.attn_config.is_sparse = sparse
+    config.attn_config.indexer_head_dim = 4
+    config.attn_config.indexer_head_num = 2
+    config.attn_config.indexer_topk = 8
+    config.attn_config.kernel_tokens_per_block = 64
+    return config
 
 
 def _raw_config():
@@ -162,15 +162,17 @@ def _dense_loader_config_json():
     return config
 
 
-def _dense_checkpoint_weights():
-    def values(shape, offset):
-        count = math.prod(shape)
-        return (
-            torch.arange(offset, offset + count, dtype=torch.float32).reshape(shape)
-            / max(count, 1)
-            - 0.5
-        )
+def _deterministic_values(shape, offset):
+    count = math.prod(shape)
+    return (
+        torch.arange(offset, offset + count, dtype=torch.float32).reshape(shape)
+        / max(count, 1)
+        - 0.5
+    )
 
+
+def _dense_checkpoint_weights():
+    values = _deterministic_values
     return {
         "model.embed_tokens.weight": values((16, 8), 0),
         "model.layers.0.input_layernorm.weight": values((8,), 3) + 1.0,
@@ -198,12 +200,6 @@ def _mtp_loader_model_config(checkpoint_path):
     config.moe_k = 1
     config.data_type = "fp32"
     config.activation_type = "SiGLU"
-    # The test intentionally loads CPU tensors.  Preserve their layout while
-    # still executing the real MoE post-load validation/factory hook; device
-    # shuffling is covered by the GPU loader/smoke suites.
-    config.exported_device = types.SimpleNamespace(
-        shuffle_moe_weight=lambda tensor, data_type, name: tensor,
-    )
     return config
 
 
@@ -237,14 +233,7 @@ def _mtp_loader_config_json():
 
 
 def _mtp_checkpoint_weights():
-    def values(shape, offset):
-        count = math.prod(shape)
-        return (
-            torch.arange(offset, offset + count, dtype=torch.float32).reshape(shape)
-            / max(count, 1)
-            - 0.5
-        )
-
+    values = _deterministic_values
     prefix = "model.layers.1."
     weights = {
         prefix + "embed_tokens.weight": values((16, 8), 0),
@@ -373,6 +362,73 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 ),
             )
         )
+
+        rope_parameters_yarn = _build_rope_cache(
+            {
+                "qk_rope_head_dim": rope_dim,
+                "rope_parameters": {
+                    "rope_type": "yarn",
+                    "rope_theta": base,
+                    "factor": factor,
+                    "original_max_position_embeddings": original_max,
+                    "beta_fast": beta_fast,
+                    "beta_slow": beta_slow,
+                    "mscale": mscale,
+                    "mscale_all_dim": mscale_all_dim,
+                },
+            },
+            max_seq_len,
+            torch.device("cpu"),
+        )
+        self.assertTrue(torch.equal(rope_parameters_yarn, yarn))
+
+    def test_rope_cache_rejects_ambiguous_or_incomplete_scaling(self):
+        base_config = {"qk_rope_head_dim": 8}
+        with self.assertRaisesRegex(ValueError, "unsupported.*rope_type"):
+            _build_rope_cache(
+                {
+                    **base_config,
+                    "rope_parameters": {
+                        "rope_type": "linear",
+                        "factor": 2.0,
+                    },
+                },
+                32,
+                torch.device("cpu"),
+            )
+        with self.assertRaisesRegex(ValueError, "missing keys"):
+            _build_rope_cache(
+                {
+                    **base_config,
+                    "rope_parameters": {
+                        "rope_type": "yarn",
+                        "factor": 2.0,
+                    },
+                },
+                32,
+                torch.device("cpu"),
+            )
+        with self.assertRaisesRegex(ValueError, "conflicting"):
+            _build_rope_cache(
+                {
+                    **base_config,
+                    "rope_scaling": {
+                        "factor": 2.0,
+                        "original_max_position_embeddings": 16,
+                        "mscale": 1.0,
+                        "mscale_all_dim": 1.0,
+                    },
+                    "rope_parameters": {
+                        "rope_type": "yarn",
+                        "factor": 4.0,
+                        "original_max_position_embeddings": 16,
+                        "mscale": 1.0,
+                        "mscale_all_dim": 1.0,
+                    },
+                },
+                32,
+                torch.device("cpu"),
+            )
 
     def test_registry_aliases_are_typed(self):
         for model_type in (
@@ -513,6 +569,12 @@ class DeepSeekNewloaderTest(unittest.TestCase):
 
     def test_mtp_new_model_loader_reads_only_appended_draft_weights(self):
         weights = _mtp_checkpoint_weights()
+        # The test intentionally loads CPU tensors. Preserve their layout while
+        # still executing the real MoE post-load validation/factory hook; device
+        # shuffling is covered by the GPU loader/smoke suites.
+        cpu_device = types.SimpleNamespace(
+            shuffle_moe_weight=lambda tensor, data_type, name: tensor,
+        )
         with tempfile.TemporaryDirectory() as checkpoint_path:
             with open(
                 f"{checkpoint_path}/config.json",
@@ -521,19 +583,23 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             ) as config_file:
                 json.dump(_mtp_loader_config_json(), config_file)
             save_file(weights, f"{checkpoint_path}/model.safetensors")
-            model = NewModelLoader(
-                model_config=_mtp_loader_model_config(checkpoint_path),
-                load_config=NewLoaderConfig(
-                    tp_size=1,
-                    tp_rank=0,
-                    ep_size=1,
-                    ep_rank=0,
-                    compute_dtype=torch.float32,
-                    device="cpu",
-                    parallelism_config=_single_rank_parallelism_config(),
-                ),
-                model_path=checkpoint_path,
-            ).load()
+            with mock.patch(
+                "rtp_llm.models_py.layers.moe_experts.get_current_device",
+                return_value=cpu_device,
+            ):
+                model = NewModelLoader(
+                    model_config=_mtp_loader_model_config(checkpoint_path),
+                    load_config=NewLoaderConfig(
+                        tp_size=1,
+                        tp_rank=0,
+                        ep_size=1,
+                        ep_rank=0,
+                        compute_dtype=torch.float32,
+                        device="cpu",
+                        parallelism_config=_single_rank_parallelism_config(),
+                    ),
+                    model_path=checkpoint_path,
+                ).load()
 
         self.assertIsInstance(model, DeepSeekV32MTPForCausalLM)
         self.assertEqual(model._checkpoint_prefix, "model.layers.1.")
@@ -778,6 +844,32 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertEqual(cfg["moe_layer_index"], [3])
         self.assertEqual(cfg["topk_method"], "greedy")
 
+    def test_new_loader_rejects_unsupported_attention_and_ffn_tp_groups(self):
+        with self.assertRaisesRegex(ValueError, "independent TP subgroups"):
+            NewLoaderConfig(
+                tp_size=4,
+                tp_rank=2,
+                attn_tp_size=2,
+                attn_tp_rank=1,
+            )
+        with self.assertRaisesRegex(ValueError, "expected rank=2"):
+            NewLoaderConfig(
+                tp_size=4,
+                tp_rank=2,
+                ffn_tp_size=4,
+                ffn_tp_rank=1,
+            )
+        config = NewLoaderConfig(
+            tp_size=4,
+            tp_rank=2,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+            ffn_tp_size=4,
+            ffn_tp_rank=2,
+        )
+        self.assertEqual((config.attn_tp_size, config.attn_tp_rank), (1, 0))
+        self.assertEqual((config.ffn_tp_size, config.ffn_tp_rank), (4, 2))
+
     def test_raw_router_config_is_canonical(self):
         raw = _raw_config()
         raw.update(
@@ -805,6 +897,121 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 _load_config(),
                 _raw_config(),
             )
+
+    def test_config_rejects_legacy_expanded_mha_fallback(self):
+        config = _model_config()
+        config.mla_ops_type = "MHA"
+        with self.assertRaisesRegex(ValueError, "requires an MLA attention backend"):
+            _extract_config_values(config, _load_config(), _raw_config())
+
+    def test_sparse_indexer_fast_and_sparse_call_sequences(self):
+        class FakeIndexerOp(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = []
+
+            def apply_rope_and_rotate_k(self, key, positions):
+                self.calls.append(("rotate_k", positions))
+                return key + 1
+
+            def quant_k_only(self, key, kv_cache, slot_mapping):
+                self.calls.append(("quant_k_only", key, kv_cache, slot_mapping))
+
+            def apply_rope_and_rotate_q_k(self, query, key, positions):
+                self.calls.append(("rotate_q_k", positions))
+                return query + 2, key + 3
+
+            def quant_q_k(self, query, key, kv_cache, slot_mapping):
+                self.calls.append(("quant_q_k", kv_cache, slot_mapping))
+                q_scale = torch.ones(
+                    query.shape[0],
+                    query.shape[1],
+                    1,
+                    dtype=query.dtype,
+                )
+                return query, q_scale
+
+            def _get_topk_ragged(
+                self,
+                q_fp8,
+                weights,
+                kv_cache,
+                fmha_params,
+                attention_inputs,
+            ):
+                self.calls.append(("topk_ragged", kv_cache, attention_inputs))
+                return torch.tensor([[1], [0]], dtype=torch.int32)
+
+        fake_op = FakeIndexerOp()
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.model.IndexerOp",
+                return_value=fake_op,
+            ),
+            torch.device("cpu"),
+        ):
+            indexer = DeepSeekV32Indexer(
+                index_n_heads=1,
+                index_head_dim=2,
+                index_topk=1,
+                rope_head_dim=2,
+                hidden_size=2,
+                q_lora_rank=2,
+                layer_idx=0,
+                layernorm_eps=1e-6,
+                blocksize=64,
+                is_neox_style=False,
+                params_dtype=torch.float32,
+            )
+        indexer.wq_b = torch.nn.Identity()
+        indexer.wk = torch.nn.Identity()
+        indexer.k_norm = torch.nn.Identity()
+        indexer.weights_proj = torch.nn.Linear(2, 1, bias=False)
+        indexer.weights_proj.weight.data.fill_(1.0)
+
+        hidden_states = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        q_lora = torch.tensor([[0.5, 1.5], [2.5, 3.5]])
+        positions = torch.tensor([0, 1], dtype=torch.int32)
+        slot_mapping = torch.tensor([4, 5], dtype=torch.int32)
+        fmha_params = types.SimpleNamespace(
+            positions_d=positions,
+            slot_mapping=slot_mapping,
+        )
+        kv_cache = object()
+
+        result = indexer(
+            hidden_states,
+            q_lora,
+            kv_cache,
+            fmha_params,
+            types.SimpleNamespace(is_prefill=False),
+            use_fast_path=True,
+        )
+        self.assertIsNone(result)
+        self.assertEqual(
+            [call[0] for call in fake_op.calls], ["rotate_k", "quant_k_only"]
+        )
+        self.assertIs(fake_op.calls[1][2], kv_cache)
+
+        fake_op.calls.clear()
+        attention_inputs = types.SimpleNamespace(is_prefill=True)
+        result = indexer(
+            hidden_states,
+            q_lora,
+            kv_cache,
+            fmha_params,
+            attention_inputs,
+            use_fast_path=False,
+        )
+        self.assertTrue(
+            torch.equal(result, torch.tensor([[1], [0]], dtype=torch.int32))
+        )
+        self.assertEqual(
+            [call[0] for call in fake_op.calls],
+            ["rotate_q_k", "quant_q_k", "topk_ragged"],
+        )
+        self.assertIs(fake_op.calls[-1][1], kv_cache)
+        self.assertIs(fake_op.calls[-1][2], attention_inputs)
 
     def test_grouped_router_rejects_invalid_expert_partition(self):
         raw = _raw_config()
@@ -847,6 +1054,52 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         }
         self.assertTrue(derived.isdisjoint(dict(attention.named_parameters())))
         self.assertTrue(derived.isdisjoint(attention.state_dict()))
+
+    def test_no_q_lora_tp2_forward_uses_rank_local_heads(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=8,
+            num_heads=4,
+            q_lora_rank=0,
+            kv_lora_rank=4,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            tp_size=2,
+            tp_rank=1,
+            params_dtype=torch.float32,
+        )
+        for parameter in attention.parameters():
+            parameter.data.zero_()
+        attention.kv_a_layernorm.weight.data.fill_(1.0)
+        attention.process_weights_after_loading()
+
+        class ZeroFmha:
+            def forward(self, q, compressed_kv, k_pe, *args):
+                self.shapes = (
+                    tuple(q.shape),
+                    tuple(compressed_kv.shape),
+                    tuple(k_pe.shape),
+                )
+                return torch.zeros(
+                    q.shape[0],
+                    q.shape[1] * 2,
+                    dtype=q.dtype,
+                    device=q.device,
+                )
+
+        fmha_impl = ZeroFmha()
+        hidden_states = torch.randn(3, 8)
+        with mock.patch(
+            "rtp_llm.models_py.new_models.deepseek_v3.attention.all_reduce",
+            side_effect=lambda tensor, group: tensor,
+        ) as reduce_mock:
+            output = attention(hidden_states, fmha_impl)
+
+        self.assertEqual(fmha_impl.shapes, ((3, 2, 4), (3, 4), (3, 2)))
+        self.assertEqual(tuple(output.shape), (3, 8))
+        reduce_mock.assert_called_once()
+        self.assertIs(reduce_mock.call_args.kwargs["group"], Group.TP)
 
     def test_mla_output_projection_defers_tp_reduction_to_attention(self):
         attention = DeepSeekV32MlaAttention(
@@ -1002,6 +1255,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertGreater(attention.o_proj.weight.numel(), 0)
         self.assertEqual(weights[W.mla_fusedqkrope_w].data_ptr(), fused_qkv_a_ptr)
         self.assertEqual(weights[W.mla_kv_b_w].data_ptr(), kv_b_ptr)
+        with self.assertRaisesRegex(RuntimeError, "rebuild the model"):
+            attention.load_weights({})
 
     def test_mla_fp8_kernel_views_keep_scales_without_bf16_qb_copy(self):
         attention = DeepSeekV32MlaAttention(
@@ -1209,6 +1464,45 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             self.assertEqual(block._use_fast_group_topk, expect_fast)
             self.assertEqual(block.group_topk is not None, expect_fast)
             self.assertEqual(group_topk.call_count, int(expect_fast))
+
+    def test_noaux_top1_normalization_uses_reference_path_on_cuda(self):
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.Cuda,
+            ),
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.GroupTopK"
+            ) as group_topk,
+            torch.device("cpu"),
+        ):
+            block = DeepSeekV32MoEBlock(
+                hidden_size=8,
+                moe_intermediate_size=4,
+                num_experts=4,
+                top_k=1,
+                layer_idx=0,
+                tp_size=1,
+                tp_rank=0,
+                ep_size=1,
+                ep_rank=0,
+                model_config=_router_model_config(moe_k=1, has_moe_norm=True),
+                parallelism_config=_single_rank_parallelism_config(),
+                moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                quant_config=None,
+                params_dtype=torch.float32,
+                has_shared_expert=False,
+                scoring_func=1,
+                routed_scaling_factor=1.0,
+                n_group=2,
+                topk_group=1,
+                topk_method="noaux_tc",
+                has_moe_norm=True,
+                correction_bias=True,
+            )
+        self.assertFalse(block._use_fast_group_topk)
+        self.assertIsNone(block.group_topk)
+        group_topk.assert_not_called()
 
     def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
         parallelism_config = _single_rank_parallelism_config()
@@ -1780,23 +2074,25 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             (128 + 128 + 2, 128),
         )
 
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
     @unittest.skipIf(
         torch.version.hip is not None,
         "online fused FP8 A projection is CUDA-only",
     )
     def test_mla_online_fp8_uses_models_py_quantizer(self):
-        attention = DeepSeekV32MlaAttention(
-            hidden_size=128,
-            num_heads=2,
-            q_lora_rank=128,
-            kv_lora_rank=128,
-            nope_head_dim=2,
-            rope_head_dim=2,
-            v_head_dim=2,
-            layer_idx=0,
-            quant_config=QuantizationConfig("fp8_block_online"),
-            params_dtype=torch.bfloat16,
-        )
+        with torch.device("cuda"):
+            attention = DeepSeekV32MlaAttention(
+                hidden_size=128,
+                num_heads=2,
+                q_lora_rank=128,
+                kv_lora_rank=128,
+                nope_head_dim=2,
+                rope_head_dim=2,
+                v_head_dim=2,
+                layer_idx=0,
+                quant_config=QuantizationConfig("fp8_block_online"),
+                params_dtype=torch.bfloat16,
+            )
         for parameter in attention.parameters():
             parameter.data.zero_()
         attention.process_weights_after_loading()
@@ -1807,6 +2103,54 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             tuple(attention._fused_qkv_a_runtime.weight.shape),
             (128 + 128 + 2, 128),
         )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a ROCm GPU")
+    @unittest.skipUnless(
+        torch.version.hip is not None,
+        "ROCm online-FP8 fallback is required",
+    )
+    def test_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views(self):
+        device = torch.device("cuda")
+        with torch.device(device):
+            attention = DeepSeekV32MlaAttention(
+                hidden_size=128,
+                num_heads=2,
+                q_lora_rank=128,
+                kv_lora_rank=128,
+                nope_head_dim=64,
+                rope_head_dim=128,
+                v_head_dim=64,
+                layer_idx=0,
+                quant_config=QuantizationConfig("fp8_block_online"),
+                params_dtype=torch.bfloat16,
+            )
+        with torch.no_grad():
+            for parameter in attention.parameters():
+                parameter.zero_()
+            checkpoint_weight = torch.arange(
+                attention.kv_b_proj.weight.numel(),
+                device=device,
+                dtype=torch.float32,
+            ).reshape_as(attention.kv_b_proj.weight)
+            checkpoint_weight = (checkpoint_weight.remainder(97) - 48).to(
+                torch.bfloat16
+            )
+            attention.kv_b_proj.weight.copy_(checkpoint_weight)
+        expected_kv_b = checkpoint_weight.t().contiguous()
+
+        NewModelLoader._validate_runtime_backends(attention, "cuda")
+        NewModelLoader._migrate_staged_modules(attention, "cuda")
+        attention.to(device)
+        NewModelLoader._run_post_load_hooks(attention)
+
+        self.assertIsNone(attention._fused_qkv_a_runtime)
+        self.assertEqual(attention._fused_qkv_a_w.dtype, torch.bfloat16)
+        self.assertIsNone(attention._kv_b_runtime_w)
+        self.assertIsNone(attention._kv_b_runtime_s)
+        self.assertTrue(torch.equal(attention._kv_b_w, expected_kv_b))
+        kernel_weights = attention._build_mla_kernel_weights()
+        self.assertTrue(torch.equal(kernel_weights[W.mla_kv_b_w], expected_kv_b))
+        self.assertNotIn(W.mla_kv_b_s, kernel_weights)
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
     @unittest.skipIf(
@@ -1870,10 +2214,89 @@ class DeepSeekNewloaderTest(unittest.TestCase):
     @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
     @unittest.skipIf(
         torch.version.hip is not None,
+        "CUDA online-FP8 kv_b runtime is required",
+    )
+    def test_mla_online_fp8_kc_vc_use_bf16_checkpoint_source(self):
+        from rtp_llm.models_py.modules.factory import LinearFactory
+
+        device = torch.device("cuda")
+        with torch.device(device):
+            attention = DeepSeekV32MlaAttention(
+                hidden_size=128,
+                num_heads=2,
+                q_lora_rank=128,
+                kv_lora_rank=128,
+                nope_head_dim=64,
+                rope_head_dim=128,
+                v_head_dim=64,
+                layer_idx=0,
+                quant_config=QuantizationConfig("fp8_block_online"),
+                params_dtype=torch.bfloat16,
+            )
+        generator = torch.Generator(device=device).manual_seed(20260730)
+        checkpoint_weight = torch.randn(
+            attention.kv_b_proj.weight.shape,
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        attention.kv_b_proj.weight.data.copy_(checkpoint_weight)
+        expected = checkpoint_weight.transpose(0, 1).contiguous().view(128, 2, 128)
+
+        attention.process_weights_after_loading()
+
+        self.assertTrue(
+            torch.equal(
+                attention._kc_w,
+                expected[:, :, :64].permute(1, 2, 0).contiguous(),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                attention._vc_w,
+                expected[:, :, 64:].transpose(0, 1).contiguous(),
+            )
+        )
+        self.assertIsNone(attention._kv_b_w)
+        self.assertIsNotNone(attention._kv_b_runtime_w)
+        self.assertIsNotNone(attention._kv_b_runtime_s)
+
+        kernel_weights = attention._build_mla_kernel_weights()
+        linear = LinearFactory.create_linear_from_weights(
+            kernel_weights,
+            W.mla_kv_b_w,
+            W.mla_kv_b_s,
+            None,
+            quant_config=types.SimpleNamespace(get_method=lambda: "FP8_PER_BLOCK"),
+        )
+        x = torch.randn(
+            (11, checkpoint_weight.shape[1]),
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        actual = linear(x)
+        reference = F.linear(x, checkpoint_weight)
+        difference = actual.float() - reference.float()
+        relative_rmse = (
+            difference.square().mean().sqrt() / reference.float().square().mean().sqrt()
+        )
+        cosine = F.cosine_similarity(
+            actual.float().flatten(),
+            reference.float().flatten(),
+            dim=0,
+        )
+        self.assertLess(float(relative_rmse), 0.05)
+        self.assertGreater(float(cosine), 0.998)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA GPU")
+    @unittest.skipIf(
+        torch.version.hip is not None,
         "CUDA DeepGEMM pre-quantized FP8 projection is required",
     )
     def test_mla_prequantized_fp8_kernel_views_execute_numerically(self):
         from rtp_llm.models_py.kernels.cuda.fp8_quant import per_block_cast_to_fp8
+        from rtp_llm.models_py.modules.factory import LinearFactory
 
         device = torch.device("cuda")
         quant_config = QuantizationConfig("FP8_PER_BLOCK")

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -119,16 +119,23 @@ def _load_config():
 
 def _router_model_config(
     *,
+    hidden_size=8,
     expert_num=4,
     moe_k=2,
     has_moe_norm=False,
 ):
-    return types.SimpleNamespace(
-        quant_config=None,
-        expert_num=expert_num,
-        moe_k=moe_k,
-        has_moe_norm=has_moe_norm,
-    )
+    config = ModelConfig()
+    config.attn_config.head_num = 1
+    config.attn_config.size_per_head = 128
+    config.num_layers = 1
+    config.max_seq_len = 128
+    config.vocab_size = 16
+    config.hidden_size = hidden_size
+    config.expert_num = expert_num
+    config.moe_k = moe_k
+    config.has_moe_norm = has_moe_norm
+    config.quant_config = None
+    return config
 
 
 def _dense_loader_model_config(checkpoint_path):
@@ -415,6 +422,12 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIsNone(model._mla_kernel_layout)
         model._ensure_mla_kernel_layout()
         self.assertIsNotNone(model._mla_kernel_layout)
+        self.assertEqual(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
+        self.assertEqual(
+            model.layers[0].self_attn.kv_a_proj_with_mqa.weight.numel(),
+            0,
+        )
+        self.assertEqual(model.layers[0].self_attn.kv_b_proj.weight.numel(), 0)
 
         class TorchSiluAndMul(torch.nn.Module):
             @staticmethod
@@ -538,6 +551,12 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             weights["model.layers.1.shared_head.head.weight"],
         )
         self.assertIsNotNone(model.layers[0].mlp.experts.fused_moe)
+        model._ensure_mla_kernel_layout()
+        self.assertEqual(model.layers[0].self_attn.q_a_proj.weight.numel(), 0)
+        self.assertEqual(
+            model.layers[0].self_attn.kv_a_proj_with_mqa.weight.numel(),
+            0,
+        )
 
     def test_rotary_cache_is_valid_immediately_after_construction(self):
         rotary = DeepseekV3RotaryEmbedding(
@@ -973,6 +992,16 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
         self.assertNotIn(W.mla_fusedqkrope_s, weights)
         self.assertNotIn(W.mla_q_b_s, weights)
+        fused_qkv_a_ptr = weights[W.mla_fusedqkrope_w].data_ptr()
+        kv_b_ptr = weights[W.mla_kv_b_w].data_ptr()
+        attention.release_checkpoint_only_weights()
+        self.assertEqual(attention.q_a_proj.weight.numel(), 0)
+        self.assertEqual(attention.kv_a_proj_with_mqa.weight.numel(), 0)
+        self.assertEqual(attention.kv_b_proj.weight.numel(), 0)
+        self.assertGreater(attention.q_b_proj.weight.numel(), 0)
+        self.assertGreater(attention.o_proj.weight.numel(), 0)
+        self.assertEqual(weights[W.mla_fusedqkrope_w].data_ptr(), fused_qkv_a_ptr)
+        self.assertEqual(weights[W.mla_kv_b_w].data_ptr(), kv_b_ptr)
 
     def test_mla_fp8_kernel_views_keep_scales_without_bf16_qb_copy(self):
         attention = DeepSeekV32MlaAttention(
@@ -1026,6 +1055,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             (1, 2),
         )
         self.assertEqual(weights[W.mla_q_b_w].dtype, torch.float8_e4m3fn)
+        attention.release_checkpoint_only_weights()
+        self.assertEqual(attention.q_a_proj.weight.numel(), 0)
+        self.assertEqual(attention.kv_a_proj_with_mqa.weight.numel(), 0)
+        self.assertGreater(attention.kv_b_proj.weight.numel(), 0)
 
     def test_non_noaux_router_preserves_scoring_grouping_and_scaling(self):
         logits = torch.tensor(
@@ -1055,11 +1088,9 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             float("-inf"),
         )
         expected_weights, expected_ids = masked.topk(2, dim=-1, sorted=False)
-        expected_weights = (
-            expected_weights
-            / expected_weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
-            * 2.5
-        )
+        expected_weights = expected_weights / expected_weights.sum(
+            dim=-1, keepdim=True
+        ).clamp_min(1e-20)
         self.assertTrue(torch.equal(ids, expected_ids))
         self.assertTrue(torch.equal(weights, expected_weights))
 
@@ -1134,10 +1165,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         )
 
     def test_noaux_router_device_selection_is_explicit(self):
-        parallelism_config = types.SimpleNamespace(
-            dp_rank=0,
-            dp_size=1,
-        )
+        parallelism_config = _single_rank_parallelism_config()
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
         model_config = _router_model_config()
         for device_type, expect_fast in (
@@ -1183,7 +1211,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             self.assertEqual(group_topk.call_count, int(expect_fast))
 
     def test_non_noaux_router_avoids_cuda_select_topk_on_other_devices(self):
-        parallelism_config = types.SimpleNamespace(dp_rank=0, dp_size=1)
+        parallelism_config = _single_rank_parallelism_config()
         moe_config = types.SimpleNamespace(fake_balance_expert=False)
         model_config = _router_model_config()
         with (
@@ -1223,8 +1251,13 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         self.assertIsNone(block.select_topk)
         select_topk.assert_not_called()
 
-    def test_fast_select_topk_falls_back_on_model_config_mismatch(self):
-        model_config = _router_model_config(has_moe_norm=True)
+    def test_moe_rejects_model_config_routing_mismatch(self):
+        mismatch_configs = {
+            "hidden_size": _router_model_config(hidden_size=16),
+            "expert_num": _router_model_config(expert_num=8),
+            "moe_k": _router_model_config(moe_k=1),
+            "has_moe_norm": _router_model_config(has_moe_norm=True),
+        }
         with (
             mock.patch(
                 "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
@@ -1235,39 +1268,42 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             ) as select_topk,
             torch.device("cpu"),
         ):
-            block = DeepSeekV32MoEBlock(
-                hidden_size=8,
-                moe_intermediate_size=4,
-                num_experts=4,
-                top_k=2,
-                layer_idx=0,
-                tp_size=1,
-                tp_rank=0,
-                ep_size=1,
-                ep_rank=0,
-                model_config=model_config,
-                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
-                moe_config=types.SimpleNamespace(fake_balance_expert=False),
-                quant_config=None,
-                params_dtype=torch.float32,
-                has_shared_expert=False,
-                scoring_func=0,
-                routed_scaling_factor=1.0,
-                n_group=1,
-                topk_group=1,
-                topk_method="greedy",
-                has_moe_norm=False,
-                correction_bias=False,
-            )
-        self.assertFalse(block._use_fast_select_topk)
-        self.assertIsNone(block.select_topk)
+            for field, model_config in mismatch_configs.items():
+                with (
+                    self.subTest(field=field),
+                    self.assertRaisesRegex(
+                        ValueError,
+                        field,
+                    ),
+                ):
+                    DeepSeekV32MoEBlock(
+                        hidden_size=8,
+                        moe_intermediate_size=4,
+                        num_experts=4,
+                        top_k=2,
+                        layer_idx=0,
+                        tp_size=1,
+                        tp_rank=0,
+                        ep_size=1,
+                        ep_rank=0,
+                        model_config=model_config,
+                        parallelism_config=_single_rank_parallelism_config(),
+                        moe_config=types.SimpleNamespace(fake_balance_expert=False),
+                        quant_config=None,
+                        params_dtype=torch.float32,
+                        has_shared_expert=False,
+                        scoring_func=0,
+                        routed_scaling_factor=1.0,
+                        n_group=1,
+                        topk_group=1,
+                        topk_method="greedy",
+                        has_moe_norm=False,
+                        correction_bias=False,
+                    )
         select_topk.assert_not_called()
 
     def test_moe_forward_uses_reference_noaux_routing_on_cpu(self):
-        parallelism_config = types.SimpleNamespace(
-            dp_rank=0,
-            dp_size=1,
-        )
+        parallelism_config = _single_rank_parallelism_config()
         with torch.device("cpu"):
             block = DeepSeekV32MoEBlock(
                 hidden_size=4,
@@ -1279,7 +1315,10 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 tp_rank=0,
                 ep_size=1,
                 ep_rank=0,
-                model_config=_router_model_config(has_moe_norm=True),
+                model_config=_router_model_config(
+                    hidden_size=4,
+                    has_moe_norm=True,
+                ),
                 parallelism_config=parallelism_config,
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
@@ -1355,8 +1394,8 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             tp_rank=0,
             ep_size=1,
             ep_rank=0,
-            model_config=_router_model_config(),
-            parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+            model_config=_router_model_config(hidden_size=4),
+            parallelism_config=_single_rank_parallelism_config(),
             quant_config=None,
             params_dtype=torch.float32,
             has_shared_expert=False,
@@ -1370,6 +1409,30 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "fake_balance_expert"):
             DeepSeekV32MoEBlock(
                 moe_config=types.SimpleNamespace(fake_balance_expert=1),
+                **kwargs,
+            )
+        no_parallelism = dict(kwargs)
+        no_parallelism["parallelism_config"] = None
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.Cuda,
+            ),
+            self.assertRaisesRegex(ValueError, "parallelism_config"),
+        ):
+            DeepSeekV32MoEBlock(
+                moe_config=types.SimpleNamespace(fake_balance_expert=True),
+                **no_parallelism,
+            )
+        with (
+            mock.patch(
+                "rtp_llm.models_py.new_models.deepseek_v3.moe.get_device_type",
+                return_value=DeviceType.ROCm,
+            ),
+            self.assertRaisesRegex(RuntimeError, "only on CUDA"),
+        ):
+            DeepSeekV32MoEBlock(
+                moe_config=types.SimpleNamespace(fake_balance_expert=True),
                 **kwargs,
             )
 
@@ -1398,10 +1461,11 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 ep_size=1,
                 ep_rank=0,
                 model_config=_router_model_config(
+                    hidden_size=4,
                     expert_num=8,
                     has_moe_norm=True,
                 ),
-                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
                 params_dtype=torch.float32,
@@ -1494,6 +1558,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
         model_config.num_layers = 1
         model_config.max_seq_len = 1
         model_config.vocab_size = 16
+        model_config.hidden_size = 4
         model_config.expert_num = 8
         model_config.moe_k = 2
         model_config.has_moe_norm = True
@@ -1509,7 +1574,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 ep_size=1,
                 ep_rank=0,
                 model_config=model_config,
-                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
                 params_dtype=torch.float32,
@@ -1591,10 +1656,11 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 ep_size=1,
                 ep_rank=0,
                 model_config=_router_model_config(
+                    hidden_size=4,
                     expert_num=8,
                     has_moe_norm=True,
                 ),
-                parallelism_config=types.SimpleNamespace(dp_rank=0, dp_size=1),
+                parallelism_config=_single_rank_parallelism_config(),
                 moe_config=types.SimpleNamespace(fake_balance_expert=False),
                 quant_config=None,
                 params_dtype=torch.float32,

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -1,0 +1,690 @@
+import math
+import types
+import unittest
+
+import torch
+
+from rtp_llm.models_py.model_loader import NewLoaderConfig
+from rtp_llm.models_py.new_models.deepseek_v3.attention import (
+    DeepSeekV32MlaAttention,
+    _linear_weight_bf16,
+)
+from rtp_llm.models_py.new_models.deepseek_v3.language import (
+    DeepSeekV32ForCausalLM,
+    _build_rope_cache,
+    _extract_config_values,
+)
+from rtp_llm.models_py.new_models.deepseek_v3.mlp import DeepSeekV32MLP
+from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
+    DeepSeekV32MTPForCausalLM,
+    _draft_checkpoint_layer,
+    _remap_key,
+)
+from rtp_llm.models_py.new_models.mtp import MTPBlock
+from rtp_llm.models_py.quant_methods.base import QuantizationConfig
+from rtp_llm.models_py.registry import get_model_class
+
+
+def _model_config(*, sparse=False, q_lora_rank=4):
+    return types.SimpleNamespace(
+        model_type="deepseek3",
+        hidden_size=8,
+        num_layers=4,
+        vocab_size=16,
+        max_seq_len=128,
+        rms_norm_eps=1e-6,
+        expert_num=8,
+        moe_k=2,
+        scoring_func=1,
+        routed_scaling_factor=1.0,
+        moe_n_group=2,
+        moe_topk_group=1,
+        has_moe_norm=True,
+        enable_fp32_lm_head=False,
+        tie_word_embeddings=False,
+        attn_config=types.SimpleNamespace(
+            head_num=4,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=4,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            is_sparse=sparse,
+            indexer_head_dim=4,
+            indexer_head_num=2,
+            indexer_topk=8,
+            kernel_tokens_per_block=64,
+        ),
+    )
+
+
+def _raw_config():
+    return {
+        "architectures": ["DeepseekV3ForCausalLM"],
+        "num_hidden_layers": 4,
+        "num_nextn_predict_layers": 1,
+        "intermediate_size": 16,
+        "moe_intermediate_size": 8,
+        "n_shared_experts": 1,
+        "first_k_dense_replace": 3,
+        "moe_layer_freq": 1,
+        "n_group": 2,
+        "topk_group": 1,
+        "norm_topk_prob": True,
+        "topk_method": "greedy",
+        "rope_interleave": True,
+        "indexer_rope_interleave": False,
+        "qk_rope_head_dim": 2,
+    }
+
+
+def _load_config():
+    return NewLoaderConfig(
+        tp_size=2,
+        tp_rank=1,
+        ep_size=2,
+        ep_rank=1,
+        attn_tp_size=1,
+        attn_tp_rank=0,
+        ffn_tp_size=2,
+        ffn_tp_rank=1,
+        lm_head_tp_size=2,
+        lm_head_tp_rank=1,
+        compute_dtype=torch.float32,
+        device="cpu",
+    )
+
+
+def _uninitialized_model(model_type, *, layer_count=0, checkpoint_prefix=None):
+    model = object.__new__(model_type)
+    torch.nn.Module.__init__(model)
+    if layer_count:
+        model.layers = torch.nn.ModuleList(
+            [torch.nn.Identity() for _ in range(layer_count)]
+        )
+    if checkpoint_prefix is not None:
+        model._checkpoint_prefix = checkpoint_prefix
+    return model
+
+
+class DeepSeekNewloaderTest(unittest.TestCase):
+    def test_local_rope_cache_preserves_reference_numerics(self):
+        max_seq_len = 32
+        rope_dim = 8
+        base = 10000.0
+        plain = _build_rope_cache(
+            {"qk_rope_head_dim": rope_dim, "rope_theta": base},
+            max_seq_len,
+            torch.device("cpu"),
+        )
+        inv_freq = 1.0 / (base ** (torch.arange(0, rope_dim, 2).float() / rope_dim))
+        freqs = torch.outer(torch.arange(max_seq_len, dtype=inv_freq.dtype), inv_freq)
+        self.assertTrue(
+            torch.equal(
+                plain,
+                torch.cat([freqs.cos(), freqs.sin()], dim=-1),
+            )
+        )
+
+        factor = 8.0
+        original_max = 16
+        beta_fast = 32.0
+        beta_slow = 1.0
+        mscale = 1.0
+        mscale_all_dim = 1.0
+        yarn = _build_rope_cache(
+            {
+                "qk_rope_head_dim": rope_dim,
+                "rope_theta": base,
+                "rope_scaling": {
+                    "factor": factor,
+                    "original_max_position_embeddings": original_max,
+                    "beta_fast": beta_fast,
+                    "beta_slow": beta_slow,
+                    "mscale": mscale,
+                    "mscale_all_dim": mscale_all_dim,
+                },
+            },
+            max_seq_len,
+            torch.device("cpu"),
+        )
+        freq_extra = 1.0 / (
+            base ** (torch.arange(0, rope_dim, 2, dtype=torch.float32) / rope_dim)
+        )
+        freq_inter = freq_extra / factor
+
+        def correction_dim(num_rotations):
+            return (
+                rope_dim * math.log(original_max / (num_rotations * 2 * math.pi))
+            ) / (2 * math.log(base))
+
+        low = max(math.floor(correction_dim(beta_fast)), 0)
+        high = min(math.ceil(correction_dim(beta_slow)), rope_dim - 1)
+        if low == high:
+            high += 0.001
+        ramp = torch.clamp(
+            (torch.arange(rope_dim // 2, dtype=torch.float32) - low) / (high - low),
+            0,
+            1,
+        )
+        mask = 1.0 - ramp
+        yarn_inv_freq = freq_inter * (1 - mask) + freq_extra * mask
+        yarn_freqs = torch.outer(
+            torch.arange(max_seq_len, dtype=torch.float32),
+            yarn_inv_freq,
+        )
+
+        def yarn_mscale(value):
+            if factor <= 1:
+                return 1.0
+            return 0.1 * value * math.log(factor) + 1.0
+
+        scale = yarn_mscale(mscale) / yarn_mscale(mscale_all_dim)
+        self.assertTrue(
+            torch.equal(
+                yarn,
+                torch.cat(
+                    [
+                        yarn_freqs.cos() * scale,
+                        yarn_freqs.sin() * scale,
+                    ],
+                    dim=-1,
+                ),
+            )
+        )
+
+    def test_registry_aliases_are_typed(self):
+        for model_type in (
+            "deepseek2",
+            "deepseek3",
+            "deepseek_v31",
+            "deepseek_v32",
+            "glm_5",
+        ):
+            with self.subTest(model_type=model_type):
+                self.assertIs(get_model_class(model_type), DeepSeekV32ForCausalLM)
+        self.assertIs(
+            get_model_class("deepseek-v3-mtp"),
+            DeepSeekV32MTPForCausalLM,
+        )
+
+    def test_core_filter_excludes_appended_draft_and_unrelated_tensors(self):
+        model = _uninitialized_model(DeepSeekV32ForCausalLM, layer_count=4)
+        should_load = model.checkpoint_weight_name_filter()
+        accepted = (
+            "model.embed_tokens.weight",
+            "model.layers.0.self_attn.q_a_proj.weight",
+            "model.layers.3.mlp.experts.7.down_proj.weight",
+            "model.layers.bad.weight",
+            "model.norm.weight",
+            "model.unknown.weight",
+            "model.visual.weight",
+            "lm_head.weight",
+        )
+        rejected = (
+            "model.layers.4.self_attn.q_a_proj.weight",
+            "model.layers.40.self_attn.q_a_proj.weight",
+            "mtp.layers.0.weight",
+        )
+        for name in accepted:
+            with self.subTest(name=name):
+                self.assertTrue(should_load(name))
+        for name in rejected:
+            with self.subTest(name=name):
+                self.assertFalse(should_load(name))
+
+    def test_mtp_prefix_supports_standalone_and_full_checkpoints(self):
+        standalone = {
+            "architectures": ["DeepseekV3ForCausalLMNextN"],
+            "num_hidden_layers": 1,
+            "num_nextn_predict_layers": 1,
+        }
+        self.assertEqual(_draft_checkpoint_layer(standalone), 0)
+        with self.assertRaisesRegex(ValueError, "at most one draft"):
+            _draft_checkpoint_layer(
+                {
+                    "architectures": ["DeepseekV3ForCausalLMNextN"],
+                    "num_hidden_layers": 1,
+                    "num_nextn_predict_layers": 2,
+                }
+            )
+        self.assertEqual(_draft_checkpoint_layer(_raw_config()), 4)
+        with self.assertRaisesRegex(ValueError, "exactly one appended"):
+            _draft_checkpoint_layer(
+                {
+                    "architectures": ["DeepseekV3ForCausalLM"],
+                    "num_hidden_layers": 4,
+                    "num_nextn_predict_layers": 0,
+                }
+            )
+        with self.assertRaisesRegex(ValueError, "exactly one appended"):
+            _draft_checkpoint_layer(
+                {
+                    "architectures": ["DeepseekV3ForCausalLM"],
+                    "num_hidden_layers": 4,
+                    "num_nextn_predict_layers": 2,
+                }
+            )
+
+    def test_mtp_filter_is_exact_and_rank_invariant(self):
+        model = _uninitialized_model(
+            DeepSeekV32MTPForCausalLM,
+            checkpoint_prefix="model.layers.4.",
+        )
+        should_load = model.checkpoint_weight_name_filter()
+        self.assertTrue(should_load("model.layers.4.embed_tokens.weight"))
+        self.assertTrue(should_load("model.layers.4.mlp.experts.7.gate_proj.weight"))
+        self.assertFalse(should_load("model.layers.3.embed_tokens.weight"))
+        self.assertFalse(should_load("model.layers.40.embed_tokens.weight"))
+        self.assertFalse(should_load("model.layers.4."))
+        self.assertFalse(should_load("lm_head.weight"))
+
+    def test_mtp_key_remap_is_explicit(self):
+        expected = {
+            "embed_tokens.weight": "embed_tokens.weight",
+            "shared_head.head.weight": "lm_head.weight",
+            "shared_head.norm.weight": "norm.weight",
+            "enorm.weight": "mtp_block.e_norm.weight",
+            "hnorm.weight": "mtp_block.h_norm.weight",
+            "eh_proj.weight": "mtp_block.fc.weight",
+            "self_attn.q_a_proj.weight": "layers.0.self_attn.q_a_proj.weight",
+            "mlp.gate.weight": "layers.0.mlp.gate.weight",
+        }
+        for name, remapped in expected.items():
+            with self.subTest(name=name):
+                self.assertEqual(_remap_key(name), remapped)
+
+    def test_mtp_load_weights_maps_real_modules_and_rejects_extra_tensors(self):
+        model = _uninitialized_model(
+            DeepSeekV32MTPForCausalLM,
+            checkpoint_prefix="model.layers.4.",
+        )
+        model.embed_tokens = torch.nn.Embedding(3, 2)
+        model.lm_head = torch.nn.Linear(2, 3, bias=False)
+        model.norm = torch.nn.LayerNorm(2, elementwise_affine=True, bias=False)
+        model.mtp_block = MTPBlock(hidden_size=2, params_dtype=torch.float32)
+
+        layer = torch.nn.Module()
+        layer.self_attn = torch.nn.Module()
+        layer.self_attn.q_a_proj = torch.nn.Linear(2, 2, bias=False)
+        model.layers = torch.nn.ModuleList([layer])
+
+        values = {
+            "model.layers.4.embed_tokens.weight": torch.arange(
+                6, dtype=torch.float32
+            ).reshape(3, 2),
+            "model.layers.4.shared_head.head.weight": torch.arange(
+                6, 12, dtype=torch.float32
+            ).reshape(3, 2),
+            "model.layers.4.shared_head.norm.weight": torch.tensor([12.0, 13.0]),
+            "model.layers.4.enorm.weight": torch.tensor([14.0, 15.0]),
+            "model.layers.4.hnorm.weight": torch.tensor([16.0, 17.0]),
+            "model.layers.4.eh_proj.weight": torch.arange(
+                18, 26, dtype=torch.float32
+            ).reshape(2, 4),
+            "model.layers.4.self_attn.q_a_proj.weight": torch.arange(
+                26, 30, dtype=torch.float32
+            ).reshape(2, 2),
+        }
+        model.load_weights(values)
+
+        self.assertTrue(
+            torch.equal(
+                model.embed_tokens.weight,
+                values["model.layers.4.embed_tokens.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.lm_head.weight,
+                values["model.layers.4.shared_head.head.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.norm.weight,
+                values["model.layers.4.shared_head.norm.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.mtp_block.e_norm.weight,
+                values["model.layers.4.enorm.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.mtp_block.h_norm.weight,
+                values["model.layers.4.hnorm.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.mtp_block.fc.weight,
+                values["model.layers.4.eh_proj.weight"],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                model.layers[0].self_attn.q_a_proj.weight,
+                values["model.layers.4.self_attn.q_a_proj.weight"],
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "non-draft"):
+            model.load_weights(
+                {
+                    "model.layers.3.embed_tokens.weight": torch.zeros(
+                        3, 2, dtype=torch.float32
+                    )
+                }
+            )
+        with self.assertRaisesRegex(RuntimeError, "could not dispatch"):
+            model.load_weights(
+                {"model.layers.4.unknown.weight": torch.zeros(1, dtype=torch.float32)}
+            )
+
+    def test_config_keeps_attention_and_ffn_topologies_distinct(self):
+        cfg = _extract_config_values(_model_config(), _load_config(), _raw_config())
+        self.assertEqual((cfg["attn_tp_size"], cfg["attn_tp_rank"]), (1, 0))
+        self.assertEqual((cfg["ffn_tp_size"], cfg["ffn_tp_rank"]), (2, 1))
+        self.assertEqual((cfg["lm_head_tp_size"], cfg["lm_head_tp_rank"]), (2, 1))
+        self.assertEqual((cfg["ep_size"], cfg["ep_rank"]), (2, 1))
+        self.assertEqual(cfg["moe_layer_index"], [3])
+
+    def test_sparse_indexer_rejects_no_q_lora(self):
+        with self.assertRaisesRegex(ValueError, "requires q_lora_rank"):
+            _extract_config_values(
+                _model_config(sparse=True, q_lora_rank=0),
+                _load_config(),
+                _raw_config(),
+            )
+
+    def test_grouped_router_rejects_invalid_expert_partition(self):
+        raw = _raw_config()
+        raw.update(
+            {
+                "topk_method": "noaux_tc",
+                "topk_group": 1,
+            }
+        )
+        model_config = _model_config()
+        model_config.moe_n_group = 3
+        with self.assertRaisesRegex(ValueError, "divisible by n_group"):
+            _extract_config_values(model_config, _load_config(), raw)
+
+    def test_no_q_lora_has_no_empty_checkpoint_parameters(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=8,
+            num_heads=2,
+            q_lora_rank=0,
+            kv_lora_rank=4,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            params_dtype=torch.float32,
+        )
+        self.assertIsNone(attention.q_a_layernorm)
+        self.assertIsNone(attention.q_b_proj)
+        self.assertFalse(
+            any(
+                name.startswith("q_b_proj.") for name, _ in attention.named_parameters()
+            )
+        )
+        attention.process_weights_after_loading()
+        derived = {
+            "_fused_qkv_a_w",
+            "_fused_qkv_b_w",
+            "_kv_b_w",
+            "_kc_w",
+            "_vc_w",
+        }
+        self.assertTrue(derived.isdisjoint(dict(attention.named_parameters())))
+        self.assertTrue(derived.isdisjoint(attention.state_dict()))
+
+    def test_mla_output_projection_defers_tp_reduction_to_attention(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=8,
+            num_heads=2,
+            q_lora_rank=4,
+            kv_lora_rank=4,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            tp_size=2,
+            tp_rank=0,
+            params_dtype=torch.float32,
+        )
+        self.assertFalse(attention.o_proj.reduce_output)
+
+    def test_mla_fp8_derived_weights_support_tensor_and_channel_scales(self):
+        weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float8_e4m3fn)
+        for scale in (
+            torch.tensor([0.5], dtype=torch.float32),
+            torch.tensor([[0.5], [2.0]], dtype=torch.float32),
+        ):
+            with self.subTest(scale_shape=tuple(scale.shape)):
+                linear = torch.nn.Module()
+                linear.weight = torch.nn.Parameter(weight.clone(), requires_grad=False)
+                linear.weight_scale = torch.nn.Parameter(
+                    scale.clone(), requires_grad=False
+                )
+                expected_scale = scale.to(torch.bfloat16).float()
+                if expected_scale.numel() == 1:
+                    expected_scale = expected_scale.reshape(1, 1)
+                expected = (weight.to(torch.bfloat16).float() * expected_scale).to(
+                    torch.bfloat16
+                )
+                self.assertTrue(torch.equal(_linear_weight_bf16(linear), expected))
+
+    def test_mla_misaligned_fp8_a_projection_uses_bf16_fallback(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=128,
+            num_heads=2,
+            q_lora_rank=129,
+            kv_lora_rank=128,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            quant_config=QuantizationConfig("FP8_PER_BLOCK"),
+            params_dtype=torch.bfloat16,
+        )
+        for parameter in attention.parameters():
+            parameter.data.zero_()
+        attention.process_weights_after_loading()
+        self.assertIsNone(attention._fused_qkv_a_runtime)
+        self.assertEqual(
+            tuple(attention._fused_qkv_a_w.shape),
+            (129 + 128 + 2, 128),
+        )
+
+    def test_mla_non_block_fp8_scales_use_bf16_fallback(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=128,
+            num_heads=2,
+            q_lora_rank=128,
+            kv_lora_rank=128,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            quant_config=QuantizationConfig("FP8_PER_BLOCK"),
+            params_dtype=torch.bfloat16,
+        )
+        for parameter in attention.parameters():
+            parameter.data.zero_()
+        attention.q_a_proj.weight_scale_inv = torch.nn.Parameter(
+            torch.ones(1, dtype=torch.float32), requires_grad=False
+        )
+        attention.kv_a_proj_with_mqa.weight_scale_inv = torch.nn.Parameter(
+            torch.ones(1, dtype=torch.float32), requires_grad=False
+        )
+        attention.process_weights_after_loading()
+        self.assertIsNone(attention._fused_qkv_a_runtime)
+        self.assertEqual(
+            tuple(attention._fused_qkv_a_w.shape),
+            (128 + 128 + 2, 128),
+        )
+
+    @unittest.skipIf(
+        getattr(torch.version, "hip", None) is not None,
+        "online fused FP8 A projection is CUDA-only",
+    )
+    def test_mla_online_fp8_uses_models_py_quantizer(self):
+        attention = DeepSeekV32MlaAttention(
+            hidden_size=128,
+            num_heads=2,
+            q_lora_rank=128,
+            kv_lora_rank=128,
+            nope_head_dim=2,
+            rope_head_dim=2,
+            v_head_dim=2,
+            layer_idx=0,
+            quant_config=QuantizationConfig("fp8_block_online"),
+            params_dtype=torch.bfloat16,
+        )
+        for parameter in attention.parameters():
+            parameter.data.zero_()
+        attention.process_weights_after_loading()
+        self.assertIsNotNone(attention._fused_qkv_a_runtime)
+        self.assertEqual(
+            tuple(attention._fused_qkv_a_runtime.weight.shape),
+            (128 + 128 + 2, 128),
+        )
+
+    def test_mlp_tp_reduction_is_owned_by_row_parallel_linear(self):
+        dense = DeepSeekV32MLP(
+            hidden_size=4,
+            intermediate_size=4,
+            tp_size=2,
+            tp_rank=0,
+            params_dtype=torch.float32,
+            reduce_output=True,
+        )
+        shared = DeepSeekV32MLP(
+            hidden_size=4,
+            intermediate_size=4,
+            tp_size=2,
+            tp_rank=0,
+            params_dtype=torch.float32,
+            reduce_output=False,
+        )
+        self.assertTrue(dense.down_proj.reduce_output)
+        self.assertFalse(shared.down_proj.reduce_output)
+
+    def test_fp8_mlp_pads_weights_and_scales_before_tp_split(self):
+        hidden_size = 128
+        intermediate_size = 257
+        block_size = 128
+        mlp = DeepSeekV32MLP(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            tp_size=2,
+            tp_rank=1,
+            quant_config=QuantizationConfig("FP8_PER_BLOCK"),
+            params_dtype=torch.bfloat16,
+        )
+        self.assertEqual(mlp.padded_intermediate_size, 512)
+
+        gate = (
+            torch.arange(intermediate_size * hidden_size, dtype=torch.float32)
+            .reshape(intermediate_size, hidden_size)
+            .remainder(17)
+            .sub(8)
+            .to(torch.float8_e4m3fn)
+        )
+        up = (
+            torch.arange(intermediate_size * hidden_size, dtype=torch.float32)
+            .reshape(intermediate_size, hidden_size)
+            .remainder(13)
+            .sub(6)
+            .to(torch.float8_e4m3fn)
+        )
+        down = (
+            torch.arange(hidden_size * intermediate_size, dtype=torch.float32)
+            .reshape(hidden_size, intermediate_size)
+            .remainder(11)
+            .sub(5)
+            .to(torch.float8_e4m3fn)
+        )
+        scale_blocks = (intermediate_size + block_size - 1) // block_size
+        gate_scale = torch.arange(1, scale_blocks + 1, dtype=torch.float32).reshape(
+            scale_blocks, 1
+        )
+        up_scale = gate_scale + 10
+        down_scale = gate_scale.t() + 20
+
+        mlp.load_weights(
+            {
+                "gate_proj.weight": gate,
+                "gate_proj.weight_scale_inv": gate_scale,
+                "up_proj.weight": up,
+                "up_proj.weight_scale_inv": up_scale,
+                "down_proj.weight": down,
+                "down_proj.weight_scale_inv": down_scale,
+            }
+        )
+
+        expected_gate = torch.zeros(256, hidden_size, dtype=torch.float8_e4m3fn)
+        expected_gate[0] = gate[-1]
+        expected_up = torch.zeros(256, hidden_size, dtype=torch.float8_e4m3fn)
+        expected_up[0] = up[-1]
+        self.assertTrue(torch.equal(mlp.gate_up_proj.weight[:256], expected_gate))
+        self.assertTrue(torch.equal(mlp.gate_up_proj.weight[256:], expected_up))
+
+        expected_down = torch.zeros(hidden_size, 256, dtype=torch.float8_e4m3fn)
+        expected_down[:, 0] = down[:, -1]
+        self.assertTrue(torch.equal(mlp.down_proj.weight, expected_down))
+
+        expected_gate_scale = torch.tensor([[3.0], [0.0]])
+        expected_up_scale = torch.tensor([[13.0], [0.0]])
+        self.assertTrue(
+            torch.equal(
+                mlp.gate_up_proj.weight_scale_inv[:2],
+                expected_gate_scale,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                mlp.gate_up_proj.weight_scale_inv[2:],
+                expected_up_scale,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                mlp.down_proj.weight_scale_inv,
+                torch.tensor([[23.0, 0.0]]),
+            )
+        )
+
+    def test_runtime_weight_view_exports_only_runtime_globals(self):
+        for model_type in (DeepSeekV32ForCausalLM, DeepSeekV32MTPForCausalLM):
+            with self.subTest(model_type=model_type.__name__):
+                model = _uninitialized_model(model_type)
+                model.embed_tokens = torch.nn.Embedding(4, 2)
+                model.norm = torch.nn.LayerNorm(2)
+                model.lm_head = torch.nn.Linear(2, 4, bias=False)
+                view = model.runtime_weight_view()
+                self.assertEqual(
+                    set(view),
+                    {"embedding", "final_layernorm.gamma", "lm_head"},
+                )
+                self.assertIs(view["embedding"], model.embed_tokens.weight)
+                self.assertIs(view["lm_head"], model.lm_head.weight)
+
+    def test_mtp_block_rejects_inconsistent_inputs(self):
+        block = MTPBlock(hidden_size=4, params_dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "shape mismatch"):
+            block(torch.zeros(2, 4), torch.zeros(1, 4))
+        with self.assertRaisesRegex(TypeError, "share a dtype"):
+            block(
+                torch.zeros(2, 4, dtype=torch.float32),
+                torch.zeros(2, 4, dtype=torch.float64),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader_gpu.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader_gpu.py
@@ -6,34 +6,24 @@ not repeat the CPU loader/configuration suite.
 
 import unittest
 
+# Bazel puts the main script's directory on sys.path. Keep this deliberate
+# sibling import: the fully qualified path executes deepseek_v3/__init__.py
+# before the shared test module initializes its imports, which makes the ROCm
+# lane eagerly import CUDA-only flashinfer modules and fail during collection.
 from test_deepseek_newloader import DeepSeekNewloaderTest as _SharedTests
 
 
 class DeepSeekNewloaderGpuTest(unittest.TestCase):
-    test_moe_cuda_noaux_router_matches_reference = (
-        _SharedTests._gpu_moe_cuda_noaux_router_matches_reference
-    )
-    test_moe_cuda_fast_select_topk_matches_reference = (
-        _SharedTests._gpu_moe_cuda_fast_select_topk_matches_reference
-    )
-    test_moe_rocm_noaux_reference_router_matches_expected = (
-        _SharedTests._gpu_moe_rocm_noaux_reference_router_matches_expected
-    )
-    test_mla_online_fp8_uses_models_py_quantizer = (
-        _SharedTests._gpu_mla_online_fp8_uses_models_py_quantizer
-    )
-    test_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views = (
-        _SharedTests._gpu_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views
-    )
-    test_mla_online_fused_fp8_projection_matches_bf16_reference = (
-        _SharedTests._gpu_mla_online_fused_fp8_projection_matches_bf16_reference
-    )
-    test_mla_online_fp8_kc_vc_use_bf16_checkpoint_source = (
-        _SharedTests._gpu_mla_online_fp8_kc_vc_use_bf16_checkpoint_source
-    )
-    test_mla_prequantized_fp8_kernel_views_execute_numerically = (
-        _SharedTests._gpu_mla_prequantized_fp8_kernel_views_execute_numerically
-    )
+    pass
+
+
+for _name in dir(_SharedTests):
+    if _name.startswith("_gpu_"):
+        setattr(
+            DeepSeekNewloaderGpuTest,
+            _name.replace("_gpu_", "test_", 1),
+            getattr(_SharedTests, _name),
+        )
 
 
 del _SharedTests

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader_gpu.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader_gpu.py
@@ -1,0 +1,43 @@
+"""Device-only DeepSeek newloader numerical tests.
+
+Only these cases are exported by the GPU targets, so CUDA and ROCm lanes do
+not repeat the CPU loader/configuration suite.
+"""
+
+import unittest
+
+from test_deepseek_newloader import DeepSeekNewloaderTest as _SharedTests
+
+
+class DeepSeekNewloaderGpuTest(unittest.TestCase):
+    test_moe_cuda_noaux_router_matches_reference = (
+        _SharedTests._gpu_moe_cuda_noaux_router_matches_reference
+    )
+    test_moe_cuda_fast_select_topk_matches_reference = (
+        _SharedTests._gpu_moe_cuda_fast_select_topk_matches_reference
+    )
+    test_moe_rocm_noaux_reference_router_matches_expected = (
+        _SharedTests._gpu_moe_rocm_noaux_reference_router_matches_expected
+    )
+    test_mla_online_fp8_uses_models_py_quantizer = (
+        _SharedTests._gpu_mla_online_fp8_uses_models_py_quantizer
+    )
+    test_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views = (
+        _SharedTests._gpu_mla_online_fp8_rocm_keeps_exact_bf16_kv_b_views
+    )
+    test_mla_online_fused_fp8_projection_matches_bf16_reference = (
+        _SharedTests._gpu_mla_online_fused_fp8_projection_matches_bf16_reference
+    )
+    test_mla_online_fp8_kc_vc_use_bf16_checkpoint_source = (
+        _SharedTests._gpu_mla_online_fp8_kc_vc_use_bf16_checkpoint_source
+    )
+    test_mla_prequantized_fp8_kernel_views_execute_numerically = (
+        _SharedTests._gpu_mla_prequantized_fp8_kernel_views_execute_numerically
+    )
+
+
+del _SharedTests
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/__init__.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/__init__.py
@@ -1,0 +1,5 @@
+from rtp_llm.models_py.new_models.deepseek_v3_mtp.language import (
+    DeepSeekV32MTPForCausalLM,
+)
+
+__all__ = ["DeepSeekV32MTPForCausalLM"]

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -28,7 +28,7 @@ from rtp_llm.models_py.layers.norm import RMSResNorm
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.modules import AttnImplFactory
 from rtp_llm.models_py.new_models.deepseek_v3.language import (
-    MlaKernelWeightLayout,
+    _build_mla_runtime_layout,
     _build_rope_cache,
     _extract_config_values,
     _nonnegative_int,
@@ -304,8 +304,8 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
         """Reconstruct only the W.* tensor views required by MLA kernels."""
         if self._mla_kernel_layout is not None:
             return
-        self._mla_kernel_layout = MlaKernelWeightLayout(
-            [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],
+        self._mla_kernel_layout = _build_mla_runtime_layout(
+            self.layers,
             self.cos_sin_cache,
         )
 

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -172,12 +172,14 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
                 "DeepSeek MTP newloader requires checkpoint config.json"
             )
         cfg = _extract_config_values(model_config, load_config, config_json)
+        self._checkpoint_layer = _draft_checkpoint_layer(config_json)
+        self._checkpoint_prefix = f"model.layers.{self._checkpoint_layer}."
 
-        if cfg["num_layers"] != 1:
-            raise ValueError(
-                "DeepSeek MTP runtime config must expose exactly one draft layer, "
-                f"got num_layers={cfg['num_layers']}"
-            )
+        # The engine builds the draft ModelConfig from the full checkpoint, so
+        # model_config.num_layers still describes all main-model layers.  This
+        # class represents exactly the single appended MTP layer selected above.
+        cfg["num_layers"] = 1
+        self.layer_num = 1
         if cfg["num_experts"] <= 0 or not 0 < cfg["top_k"] <= cfg["num_experts"]:
             raise ValueError(
                 "DeepSeek MTP requires routed experts with "
@@ -188,14 +190,12 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
                 f"num_experts={cfg['num_experts']} must be divisible by "
                 f"ep_size={cfg['ep_size']}"
             )
-        self._checkpoint_layer = _draft_checkpoint_layer(config_json)
-        self._checkpoint_prefix = f"model.layers.{self._checkpoint_layer}."
 
         # The single draft layer always uses the routed/shared MoE path.
         cfg["moe_layer_index"] = [0]
 
         # --- RoPE cache ---
-        device = torch.device("cuda")
+        device = torch.device(getattr(load_config, "device", "cuda"))
         cos_sin_cache = _build_rope_cache(
             config_json if config_json else cfg,
             cfg["max_seq_len"],
@@ -257,6 +257,7 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
             routed_scaling_factor=cfg["routed_scaling_factor"],
             n_group=cfg["n_group"],
             topk_group=cfg["topk_group"],
+            topk_method=cfg["topk_method"],
             has_moe_norm=cfg["has_moe_norm"],
             correction_bias=cfg["has_e_score_correction"],
             is_sparse=cfg["is_sparse"],

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -31,6 +31,7 @@ from rtp_llm.models_py.new_models.deepseek_v3.language import (
     build_rope_cache,
     checkpoint_path,
     extract_config_values,
+    keep_mla_checkpoint_weights,
     nonnegative_int,
     positive_int,
     read_config_json,
@@ -160,6 +161,7 @@ class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
+        self._keep_mla_checkpoint_weights = keep_mla_checkpoint_weights()
         self._mla_kernel_layout = None
 
         ckpt_path = checkpoint_path(model_config)
@@ -250,7 +252,7 @@ class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             num_experts=cfg["num_experts"],
             top_k=cfg["top_k"],
             shared_expert_intermediate_size=cfg["shared_expert_intermediate_size"],
-            has_shared_expert=True,
+            has_shared_expert=cfg["shared_expert_intermediate_size"] > 0,
             scoring_func=cfg["scoring_func"],
             routed_scaling_factor=cfg["routed_scaling_factor"],
             n_group=cfg["n_group"],
@@ -265,6 +267,7 @@ class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             indexer_is_neox_style=cfg["indexer_is_neox_style"],
             cos_sin_cache=cos_sin_cache,
             blocksize=cfg["blocksize"],
+            prefix="layers.0",
         )
         self.layers.append(layer)
 

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -31,7 +31,6 @@ from rtp_llm.models_py.new_models.deepseek_v3.language import (
     build_rope_cache,
     checkpoint_path,
     extract_config_values,
-    keep_mla_checkpoint_weights,
     nonnegative_int,
     positive_int,
     read_config_json,
@@ -161,7 +160,7 @@ class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
-        self._keep_mla_checkpoint_weights = keep_mla_checkpoint_weights()
+        self._keep_mla_checkpoint_weights = load_config.keep_mla_checkpoint_weights
         self._mla_kernel_layout = None
 
         ckpt_path = checkpoint_path(model_config)
@@ -221,6 +220,7 @@ class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
             reverse_concat=True,
             bias=False,
             params_dtype=cfg["params_dtype"],
+            prefix="mtp_block",
         )
 
         # --- Single MoE decoder layer ---

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -160,6 +160,7 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
             fmha_config=fmha_config,
             device_resource_config=device_resource_config,
         )
+        self._mla_kernel_layout = None
 
         # Resolve ckpt_path
         ckpt_path = ""
@@ -301,7 +302,7 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
 
     def _ensure_mla_kernel_layout(self) -> None:
         """Reconstruct only the W.* tensor views required by MLA kernels."""
-        if getattr(self, "_mla_kernel_layout", None) is not None:
+        if self._mla_kernel_layout is not None:
             return
         self._mla_kernel_layout = MlaKernelWeightLayout(
             [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -1,0 +1,352 @@
+"""
+DeepSeek V3 MTP (Multi-Token Prediction) draft head for new-loader.
+
+Top-level model: DeepSeekV32MTPForCausalLM
+  - Standalone draft checkpoints use "model.layers.0.".
+  - Full checkpoints use the appended "model.layers.{num_hidden_layers}.".
+  - load_weights() strips the selected draft prefix and remaps keys:
+      embed_tokens.weight        -> embed_tokens.weight
+      shared_head.head.weight    -> lm_head.weight
+      shared_head.norm.weight    -> norm.weight
+      enorm.weight               -> mtp_block.e_norm.weight
+      hnorm.weight               -> mtp_block.h_norm.weight
+      eh_proj.weight             -> mtp_block.fc.weight
+      self_attn.*                -> layers.0.self_attn.*
+      mlp.*                      -> layers.0.mlp.*
+      input_layernorm.*          -> layers.0.input_layernorm.*
+      post_attention_layernorm.* -> layers.0.post_attention_layernorm.*
+"""
+
+from collections.abc import Callable
+from typing import Any, Dict
+
+import torch
+import torch.nn as nn
+
+from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
+from rtp_llm.models_py.layers.norm import RMSResNorm
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+from rtp_llm.models_py.modules import AttnImplFactory
+from rtp_llm.models_py.new_models.deepseek_v3.language import (
+    MlaKernelWeightLayout,
+    _build_rope_cache,
+    _extract_config_values,
+    _nonnegative_int,
+    _positive_int,
+    _read_config_json,
+)
+from rtp_llm.models_py.new_models.deepseek_v3.model import DeepSeekV32DecoderLayer
+from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
+from rtp_llm.models_py.new_models.mtp import MTPBlock
+from rtp_llm.ops.compute_ops import PyModelInputs, PyModelOutputs
+
+# ------------------------------------------------------------------ #
+#  Key remapping helpers
+# ------------------------------------------------------------------ #
+
+# After the selected draft-layer prefix is stripped, these are the remaining
+# key prefixes / full names that need to be renamed to match submodule paths.
+_LAYER_PREFIXES = (
+    "self_attn.",
+    "mlp.",
+    "input_layernorm.",
+    "post_attention_layernorm.",
+)
+
+_KEY_REMAP = {
+    "shared_head.head.weight": "lm_head.weight",
+    "shared_head.norm.weight": "norm.weight",
+    "enorm.weight": "mtp_block.e_norm.weight",
+    "hnorm.weight": "mtp_block.h_norm.weight",
+}
+
+_EH_PROJ_KEY = "eh_proj.weight"
+_EH_PROJ_MAPPED = "mtp_block.fc.weight"
+
+
+def _remap_key(name: str) -> str:
+    """Remap a stripped HF key to the submodule key used in this model."""
+    if name == _EH_PROJ_KEY:
+        return _EH_PROJ_MAPPED
+
+    # simple renames
+    if name in _KEY_REMAP:
+        return _KEY_REMAP[name]
+
+    # layer-level weights: prepend "layers.0."
+    for prefix in _LAYER_PREFIXES:
+        if name.startswith(prefix):
+            return "layers.0." + name
+
+    # embed_tokens.weight and anything else: pass through unchanged
+    return name
+
+
+def _draft_checkpoint_layer(config_json: Dict[str, Any]) -> int:
+    """Resolve the one draft layer without guessing from checkpoint order."""
+    architectures = config_json.get("architectures", [])
+    if not isinstance(architectures, list) or not all(
+        isinstance(name, str) for name in architectures
+    ):
+        raise TypeError("config.json architectures must be a list of strings")
+    nextn_layers = _nonnegative_int(
+        config_json.get("num_nextn_predict_layers", 0),
+        "num_nextn_predict_layers",
+    )
+    if any(name.endswith("ForCausalLMNextN") for name in architectures):
+        if nextn_layers > 1:
+            raise ValueError(
+                "DeepSeek standalone MTP checkpoints must contain at most "
+                f"one draft layer, got num_nextn_predict_layers={nextn_layers}"
+            )
+        return 0
+
+    if nextn_layers != 1:
+        raise ValueError(
+            "DeepSeek full-model checkpoints must contain exactly one "
+            "appended MTP "
+            f"layer, got num_nextn_predict_layers={nextn_layers}"
+        )
+    return _positive_int(config_json.get("num_hidden_layers"), "num_hidden_layers")
+
+
+# ------------------------------------------------------------------ #
+#  Top-level model
+# ------------------------------------------------------------------ #
+
+
+class DeepSeekV32MTPForCausalLM(GptModelBase):
+    """DeepSeek V3 MTP draft head for new-loader.
+
+    Single-layer MoE decoder + MTPBlock projection.
+    """
+
+    def checkpoint_weight_name_filter(self) -> Callable[[str], bool]:
+        prefix = self._checkpoint_prefix
+        return lambda name: name.startswith(prefix) and len(name) > len(prefix)
+
+    def load_weights(self, weights):
+        if isinstance(weights, dict):
+            weights_iter = iter(weights.items())
+        else:
+            weights_iter = weights
+
+        def _mapped(it):
+            for name, tensor in it:
+                if not name.startswith(self._checkpoint_prefix):
+                    raise RuntimeError(
+                        "DeepSeek MTP received a non-draft checkpoint tensor: "
+                        f"{name!r}"
+                    )
+                stripped_name = name[len(self._checkpoint_prefix) :]
+                yield _remap_key(stripped_name), tensor
+
+        super().load_weights(_mapped(weights_iter))
+
+    def __init__(
+        self,
+        model_config: Any,
+        load_config: Any,
+    ):
+        parallelism_config = getattr(load_config, "parallelism_config", None)
+        fmha_config = getattr(load_config, "fmha_config", None)
+        device_resource_config = getattr(load_config, "device_resource_config", None)
+
+        super().__init__(
+            config=model_config,
+            parallelism_config=parallelism_config,
+            weight=None,
+            max_generate_batch_size=0,
+            fmha_config=fmha_config,
+            device_resource_config=device_resource_config,
+        )
+
+        # Resolve ckpt_path
+        ckpt_path = ""
+        if hasattr(model_config, "ckpt_path") and model_config.ckpt_path:
+            ckpt_path = model_config.ckpt_path
+
+        config_json = _read_config_json(ckpt_path)
+        if not config_json:
+            raise FileNotFoundError(
+                "DeepSeek MTP newloader requires checkpoint config.json"
+            )
+        cfg = _extract_config_values(model_config, load_config, config_json)
+
+        if cfg["num_layers"] != 1:
+            raise ValueError(
+                "DeepSeek MTP runtime config must expose exactly one draft layer, "
+                f"got num_layers={cfg['num_layers']}"
+            )
+        if cfg["num_experts"] <= 0 or not 0 < cfg["top_k"] <= cfg["num_experts"]:
+            raise ValueError(
+                "DeepSeek MTP requires routed experts with "
+                f"top_k={cfg['top_k']} and num_experts={cfg['num_experts']}"
+            )
+        if cfg["num_experts"] % cfg["ep_size"]:
+            raise ValueError(
+                f"num_experts={cfg['num_experts']} must be divisible by "
+                f"ep_size={cfg['ep_size']}"
+            )
+        self._checkpoint_layer = _draft_checkpoint_layer(config_json)
+        self._checkpoint_prefix = f"model.layers.{self._checkpoint_layer}."
+
+        # The single draft layer always uses the routed/shared MoE path.
+        cfg["moe_layer_index"] = [0]
+
+        # --- RoPE cache ---
+        device = torch.device("cuda")
+        cos_sin_cache = _build_rope_cache(
+            config_json if config_json else cfg,
+            cfg["max_seq_len"],
+            device,
+        )
+        self.register_buffer("cos_sin_cache", cos_sin_cache, persistent=False)
+
+        # --- Embedding ---
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size=cfg["vocab_size"],
+            embedding_dim=cfg["hidden_size"],
+            tp_size=cfg["attn_tp_size"],
+            tp_rank=cfg["attn_tp_rank"],
+            params_dtype=cfg["params_dtype"],
+        )
+
+        # --- MTP projection block (reverse_concat=True for DeepSeek style) ---
+        # HF ckpt names: enorm.weight -> e_norm, hnorm.weight -> h_norm,
+        # eh_proj.weight -> fc (mapped in load_weights above)
+        self.mtp_block = MTPBlock(
+            hidden_size=cfg["hidden_size"],
+            rms_norm_eps=cfg["rms_norm_eps"],
+            reverse_concat=True,
+            bias=False,
+            params_dtype=cfg["params_dtype"],
+        )
+
+        # --- Single MoE decoder layer ---
+        self.layers = nn.ModuleList()
+        layer = DeepSeekV32DecoderLayer(
+            hidden_size=cfg["hidden_size"],
+            num_heads=cfg["num_heads"],
+            q_lora_rank=cfg["q_lora_rank"],
+            kv_lora_rank=cfg["kv_lora_rank"],
+            nope_head_dim=cfg["nope_head_dim"],
+            rope_head_dim=cfg["rope_head_dim"],
+            v_head_dim=cfg["v_head_dim"],
+            layer_idx=0,
+            attn_tp_size=cfg["attn_tp_size"],
+            attn_tp_rank=cfg["attn_tp_rank"],
+            ffn_tp_size=cfg["ffn_tp_size"],
+            ffn_tp_rank=cfg["ffn_tp_rank"],
+            ep_size=cfg["ep_size"],
+            ep_rank=cfg["ep_rank"],
+            params_dtype=cfg["params_dtype"],
+            layernorm_eps=cfg["rms_norm_eps"],
+            quant_config=cfg["quant_config"],
+            model_config=cfg["model_config"],
+            parallelism_config=cfg["parallelism_config"],
+            moe_config=cfg["moe_config"],
+            is_moe_layer=True,
+            dense_intermediate_size=cfg["dense_intermediate_size"],
+            moe_intermediate_size=cfg["moe_intermediate_size"],
+            num_experts=cfg["num_experts"],
+            top_k=cfg["top_k"],
+            shared_expert_intermediate_size=cfg["shared_expert_intermediate_size"],
+            has_shared_expert=True,
+            scoring_func=cfg["scoring_func"],
+            routed_scaling_factor=cfg["routed_scaling_factor"],
+            n_group=cfg["n_group"],
+            topk_group=cfg["topk_group"],
+            has_moe_norm=cfg["has_moe_norm"],
+            correction_bias=cfg["has_e_score_correction"],
+            is_sparse=cfg["is_sparse"],
+            index_n_heads=cfg["indexer_head_num"],
+            index_head_dim=cfg["indexer_head_dim"],
+            index_topk=cfg["indexer_topk"],
+            indexer_is_neox_style=cfg["indexer_is_neox_style"],
+            cos_sin_cache=cos_sin_cache,
+            blocksize=cfg["blocksize"],
+        )
+        self.layers.append(layer)
+
+        # --- Final norm (from shared_head.norm) ---
+        self.norm = RMSResNorm(
+            cfg["hidden_size"],
+            eps=cfg["rms_norm_eps"],
+            params_dtype=cfg["params_dtype"],
+        )
+
+        # --- LM head (from shared_head.head) ---
+        self.lm_head = ParallelLMHead(
+            vocab_size=cfg["vocab_size"],
+            hidden_size=cfg["hidden_size"],
+            tp_size=cfg["lm_head_tp_size"],
+            tp_rank=cfg["lm_head_tp_rank"],
+            params_dtype=cfg["lm_head_params_dtype"],
+        )
+
+    def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
+        return {
+            "embedding": self.embed_tokens.weight,
+            "final_layernorm.gamma": self.norm.weight,
+            "lm_head": self.lm_head.weight,
+        }
+
+    def initialize(self, init_resource):
+        """Build the MLA kernel layout after all post-load hooks have run."""
+        ok = super().initialize(init_resource)
+        self._ensure_mla_kernel_layout()
+        return ok
+
+    def _ensure_mla_kernel_layout(self) -> None:
+        """Reconstruct only the W.* tensor views required by MLA kernels."""
+        if getattr(self, "_mla_kernel_layout", None) is not None:
+            return
+        self._mla_kernel_layout = MlaKernelWeightLayout(
+            [layer.self_attn._build_mla_kernel_weights() for layer in self.layers],
+            self.cos_sin_cache,
+        )
+
+    def prepare_fmha_impl(
+        self, inputs: PyModelInputs, is_cuda_graph: bool = False
+    ) -> Any:
+        self._ensure_mla_kernel_layout()
+        return AttnImplFactory.get_fmha_impl(
+            self.config,
+            self.parallelism_config,
+            self._mla_kernel_layout,
+            inputs.attention_inputs,
+            self.fmha_config,
+            is_cuda_graph,
+        )
+
+    def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
+        if inputs.input_hiddens is None:
+            raise ValueError("DeepSeek MTP requires input_hiddens")
+        if inputs.attention_inputs is None:
+            raise ValueError("DeepSeek MTP requires attention_inputs")
+        # inputs_embeds from current token ids
+        inputs_embeds = self.embed_tokens(inputs.input_ids)
+        if inputs.input_hiddens.shape != inputs_embeds.shape:
+            raise ValueError(
+                "DeepSeek MTP input_hiddens must match token embeddings: "
+                f"{tuple(inputs.input_hiddens.shape)} != {tuple(inputs_embeds.shape)}"
+            )
+        # MTP block: combine embed with last hidden states from the main model
+        hidden_states = self.mtp_block(inputs_embeds, inputs.input_hiddens)
+        residual = torch.zeros_like(hidden_states)
+
+        if fmha_impl is None:
+            fmha_impl = self.prepare_fmha_impl(inputs)
+
+        for i, layer in enumerate(self.layers):
+            select_block_map_for_layer(inputs.attention_inputs, i)
+            hidden_states, residual = layer(
+                hidden_states,
+                residual,
+                fmha_impl,
+                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return PyModelOutputs(hidden_states, fmha_impl.fmha_params)

--- a/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3_mtp/language.py
@@ -26,14 +26,14 @@ import torch.nn as nn
 from rtp_llm.models_py.layers.embedding import ParallelLMHead, VocabParallelEmbedding
 from rtp_llm.models_py.layers.norm import RMSResNorm
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
-from rtp_llm.models_py.modules import AttnImplFactory
 from rtp_llm.models_py.new_models.deepseek_v3.language import (
-    _build_mla_runtime_layout,
-    _build_rope_cache,
-    _extract_config_values,
-    _nonnegative_int,
-    _positive_int,
-    _read_config_json,
+    MlaRuntimeLayoutMixin,
+    build_rope_cache,
+    checkpoint_path,
+    extract_config_values,
+    nonnegative_int,
+    positive_int,
+    read_config_json,
 )
 from rtp_llm.models_py.new_models.deepseek_v3.model import DeepSeekV32DecoderLayer
 from rtp_llm.models_py.new_models.model_base import select_block_map_for_layer
@@ -89,7 +89,7 @@ def _draft_checkpoint_layer(config_json: Dict[str, Any]) -> int:
         isinstance(name, str) for name in architectures
     ):
         raise TypeError("config.json architectures must be a list of strings")
-    nextn_layers = _nonnegative_int(
+    nextn_layers = nonnegative_int(
         config_json.get("num_nextn_predict_layers", 0),
         "num_nextn_predict_layers",
     )
@@ -107,7 +107,7 @@ def _draft_checkpoint_layer(config_json: Dict[str, Any]) -> int:
             "appended MTP "
             f"layer, got num_nextn_predict_layers={nextn_layers}"
         )
-    return _positive_int(config_json.get("num_hidden_layers"), "num_hidden_layers")
+    return positive_int(config_json.get("num_hidden_layers"), "num_hidden_layers")
 
 
 # ------------------------------------------------------------------ #
@@ -115,7 +115,7 @@ def _draft_checkpoint_layer(config_json: Dict[str, Any]) -> int:
 # ------------------------------------------------------------------ #
 
 
-class DeepSeekV32MTPForCausalLM(GptModelBase):
+class DeepSeekV32MTPForCausalLM(MlaRuntimeLayoutMixin, GptModelBase):
     """DeepSeek V3 MTP draft head for new-loader.
 
     Single-layer MoE decoder + MTPBlock projection.
@@ -162,17 +162,14 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
         )
         self._mla_kernel_layout = None
 
-        # Resolve ckpt_path
-        ckpt_path = ""
-        if hasattr(model_config, "ckpt_path") and model_config.ckpt_path:
-            ckpt_path = model_config.ckpt_path
+        ckpt_path = checkpoint_path(model_config)
 
-        config_json = _read_config_json(ckpt_path)
+        config_json = read_config_json(ckpt_path)
         if not config_json:
             raise FileNotFoundError(
                 "DeepSeek MTP newloader requires checkpoint config.json"
             )
-        cfg = _extract_config_values(model_config, load_config, config_json)
+        cfg = extract_config_values(model_config, load_config, config_json)
         self._checkpoint_layer = _draft_checkpoint_layer(config_json)
         self._checkpoint_prefix = f"model.layers.{self._checkpoint_layer}."
 
@@ -197,7 +194,7 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
 
         # --- RoPE cache ---
         device = torch.device(getattr(load_config, "device", "cuda"))
-        cos_sin_cache = _build_rope_cache(
+        cos_sin_cache = build_rope_cache(
             config_json if config_json else cfg,
             cfg["max_seq_len"],
             device,
@@ -285,41 +282,6 @@ class DeepSeekV32MTPForCausalLM(GptModelBase):
             tp_size=cfg["lm_head_tp_size"],
             tp_rank=cfg["lm_head_tp_rank"],
             params_dtype=cfg["lm_head_params_dtype"],
-        )
-
-    def runtime_weight_view(self) -> Dict[str, torch.Tensor]:
-        return {
-            "embedding": self.embed_tokens.weight,
-            "final_layernorm.gamma": self.norm.weight,
-            "lm_head": self.lm_head.weight,
-        }
-
-    def initialize(self, init_resource):
-        """Build the MLA kernel layout after all post-load hooks have run."""
-        ok = super().initialize(init_resource)
-        self._ensure_mla_kernel_layout()
-        return ok
-
-    def _ensure_mla_kernel_layout(self) -> None:
-        """Reconstruct only the W.* tensor views required by MLA kernels."""
-        if self._mla_kernel_layout is not None:
-            return
-        self._mla_kernel_layout = _build_mla_runtime_layout(
-            self.layers,
-            self.cos_sin_cache,
-        )
-
-    def prepare_fmha_impl(
-        self, inputs: PyModelInputs, is_cuda_graph: bool = False
-    ) -> Any:
-        self._ensure_mla_kernel_layout()
-        return AttnImplFactory.get_fmha_impl(
-            self.config,
-            self.parallelism_config,
-            self._mla_kernel_layout,
-            inputs.attention_inputs,
-            self.fmha_config,
-            is_cuda_graph,
         )
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:

--- a/rtp_llm/models_py/new_models/mtp/__init__.py
+++ b/rtp_llm/models_py/new_models/mtp/__init__.py
@@ -1,0 +1,3 @@
+from rtp_llm.models_py.new_models.mtp.mtp_block import MTPBlock
+
+__all__ = ["MTPBlock"]

--- a/rtp_llm/models_py/new_models/mtp/mtp_block.py
+++ b/rtp_llm/models_py/new_models/mtp/mtp_block.py
@@ -1,0 +1,59 @@
+"""MTP (Multi-Token Prediction) block for new-loader models."""
+
+import torch
+
+from rtp_llm.models_py.layers.linear import ColumnParallelLinear
+from rtp_llm.models_py.layers.norm import RMSNorm
+from rtp_llm.models_py.module_base import RtpModule
+
+
+class MTPBlock(RtpModule):
+    """Multi-Token Prediction block.
+
+    Flow: embed_norm(inputs_embeds) + hidden_norm(last_hidden_states) -> concat -> fc -> output.
+    reverse_concat=True: [h_norm, e_norm] (DeepSeek V3 style)
+    reverse_concat=False: [e_norm, h_norm] (Qwen style)
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        rms_norm_eps: float = 1e-6,
+        reverse_concat: bool = False,
+        bias: bool = False,
+        params_dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        self.reverse_concat = reverse_concat
+        self.e_norm = RMSNorm(hidden_size, eps=rms_norm_eps, params_dtype=params_dtype)
+        self.h_norm = RMSNorm(hidden_size, eps=rms_norm_eps, params_dtype=params_dtype)
+        self.fc = ColumnParallelLinear(
+            input_size=hidden_size * 2,
+            output_size=hidden_size,
+            tp_size=1,
+            tp_rank=0,
+            quant_config=None,
+            prefix="fc",
+            bias=bias,
+            params_dtype=params_dtype,
+        )
+
+    def forward(
+        self, inputs_embeds: torch.Tensor, last_hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        if inputs_embeds.shape != last_hidden_states.shape:
+            raise ValueError(
+                "MTP embedding/hidden shape mismatch: "
+                f"{tuple(inputs_embeds.shape)} != {tuple(last_hidden_states.shape)}"
+            )
+        if inputs_embeds.device != last_hidden_states.device:
+            raise ValueError("MTP embedding and hidden states must share a device")
+        if inputs_embeds.dtype != last_hidden_states.dtype:
+            raise TypeError("MTP embedding and hidden states must share a dtype")
+        e_norm = self.e_norm(inputs_embeds)
+        h_norm = self.h_norm(last_hidden_states)
+        if self.reverse_concat:
+            concat = torch.cat([h_norm, e_norm], dim=-1)
+        else:
+            concat = torch.cat([e_norm, h_norm], dim=-1)
+        return self.fc(concat)

--- a/rtp_llm/models_py/new_models/mtp/mtp_block.py
+++ b/rtp_llm/models_py/new_models/mtp/mtp_block.py
@@ -22,6 +22,7 @@ class MTPBlock(RtpModule):
         reverse_concat: bool = False,
         bias: bool = False,
         params_dtype: torch.dtype = torch.bfloat16,
+        prefix: str = "mtp_block",
     ):
         super().__init__()
         self.reverse_concat = reverse_concat
@@ -33,7 +34,7 @@ class MTPBlock(RtpModule):
             tp_size=1,
             tp_rank=0,
             quant_config=None,
-            prefix="fc",
+            prefix=f"{prefix}.fc",
             bias=bias,
             params_dtype=params_dtype,
         )

--- a/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
+++ b/rtp_llm/models_py/new_models/qwen3/test/test_qwen3_base_model_integration.py
@@ -6,6 +6,8 @@ import unittest
 from unittest.mock import patch
 
 import torch
+from safetensors.torch import save_file
+
 from rtp_llm.config.quant_config import QuantizationConfig as SourceQuantizationConfig
 from rtp_llm.model_loader.load_config import LoadMethod
 from rtp_llm.models.base_model import BaseModel
@@ -13,7 +15,6 @@ from rtp_llm.models_py.model_desc.module_base import GptModelBase
 from rtp_llm.models_py.module_base import RtpModule
 from rtp_llm.models_py.new_models.qwen3.language import Qwen3ForCausalLM
 from rtp_llm.models_py.quant_methods.unquantized import UnquantizedLinearMethod
-from safetensors.torch import save_file
 
 
 def _model_config():
@@ -32,9 +33,35 @@ def _model_config():
         enable_fp32_lm_head=False,
         tie_word_embeddings=True,
         compute_dtype=torch.float32,
+        generate_env_config=None,
         lora_infos={},
         quant_config=types.SimpleNamespace(get_runtime_method_key=lambda: "none"),
     )
+
+
+def _base_model(config, hw_kernel_config=None):
+    if hw_kernel_config is None:
+        hw_kernel_config = types.SimpleNamespace(enable_cuda_graph=False)
+    kv_cache_config = types.SimpleNamespace(
+        multi_task_prompt=False,
+        multi_task_prompt_str="",
+    )
+    with patch.object(BaseModel, "load_tokenizer", return_value=None):
+        model = BaseModel(
+            model_config=config,
+            parallelism_config=_parallelism_config(),
+            hw_kernel_config=hw_kernel_config,
+            kv_cache_config=kv_cache_config,
+            fmha_config=None,
+            moe_config=None,
+            max_generate_batch_size=0,
+            load_method=LoadMethod.SCRATCH,
+            vit_config=None,
+            merge_lora=False,
+            device_resource_config=None,
+        )
+    model.tokenizer = None
+    return model
 
 
 def _parallelism_config():
@@ -168,15 +195,8 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
         ]
         excluded = "model.layers.0.mlp.down_proj"
         config = _model_config()
-        base_model = object.__new__(BaseModel)
-        base_model.model_config = config
-        base_model.parallelism_config = _parallelism_config()
-        base_model.force_cpu_load_weights = False
-        base_model.load_method = LoadMethod.SCRATCH
-        base_model.fmha_config = None
-        base_model.device_resource_config = None
-        base_model.tokenizer = None
-        base_model.hw_kernel_config = types.SimpleNamespace(enable_cuda_graph=False)
+        base_model = _base_model(config)
+        self.assertFalse(base_model.keep_mla_checkpoint_weights)
 
         with tempfile.TemporaryDirectory() as model_path:
             with open(f"{model_path}/config.json", "w") as output:
@@ -276,19 +296,11 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
                 config = _model_config()
                 config.quant_config = source_config
                 config.ckpt_path = model_path
-                base_model = object.__new__(BaseModel)
-                base_model.model_config = config
-                base_model.parallelism_config = _parallelism_config()
-                base_model.force_cpu_load_weights = False
-                base_model.load_method = LoadMethod.SCRATCH
-                base_model.fmha_config = None
-                base_model.device_resource_config = None
-                base_model.tokenizer = None
                 hw_kernel_config = types.SimpleNamespace(
                     enable_cuda_graph=False,
                     use_swizzleA=True,
                 )
-                base_model.hw_kernel_config = hw_kernel_config
+                base_model = _base_model(config, hw_kernel_config)
 
                 with patch.object(
                     BaseModel, "_get_device_str", return_value="cpu"
@@ -350,15 +362,7 @@ class Qwen3BaseModelIntegrationTest(unittest.TestCase):
 
     def test_base_model_entry_loads_registered_qwen_runtime(self):
         config = _model_config()
-        base_model = object.__new__(BaseModel)
-        base_model.model_config = config
-        base_model.parallelism_config = _parallelism_config()
-        base_model.force_cpu_load_weights = False
-        base_model.load_method = LoadMethod.SCRATCH
-        base_model.fmha_config = None
-        base_model.device_resource_config = None
-        base_model.tokenizer = None
-        base_model.hw_kernel_config = types.SimpleNamespace(enable_cuda_graph=False)
+        base_model = _base_model(config)
 
         with tempfile.TemporaryDirectory() as model_path:
             config.ckpt_path = model_path

--- a/rtp_llm/models_py/quant_methods/base.py
+++ b/rtp_llm/models_py/quant_methods/base.py
@@ -1,7 +1,7 @@
 import fnmatch
 import re
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Type
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 import torch
 
@@ -174,6 +174,11 @@ class QuantizationConfig:
         )
         self.activation_dynamic = self._activation_dynamic(source_config)
         self.weight_block_size = self._weight_block_size(self.quant_type, source_config)
+
+    @property
+    def fp8_block_size(self) -> Tuple[int, int]:
+        """Return the validated output/input FP8 block dimensions."""
+        return self.weight_block_size[0], self.weight_block_size[1]
 
     @staticmethod
     def _normalize_ignored(values: Iterable[str]) -> List[str]:

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -183,3 +183,20 @@ register_lazy_model(
     "rtp_llm.models_py.new_models.qwen3_vl.vision",
     "Qwen3VLForVisionEmbedding",
 )
+for _deepseek_model_type in (
+    "deepseek2",
+    "deepseek3",
+    "deepseek_v31",
+    "deepseek_v32",
+    "glm_5",
+):
+    register_lazy_model(
+        _deepseek_model_type,
+        "rtp_llm.models_py.new_models.deepseek_v3",
+        "DeepSeekV32ForCausalLM",
+    )
+register_lazy_model(
+    "deepseek-v3-mtp",
+    "rtp_llm.models_py.new_models.deepseek_v3_mtp",
+    "DeepSeekV32MTPForCausalLM",
+)

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -189,6 +189,7 @@ for _deepseek_model_type in (
     "deepseek_v31",
     "deepseek_v32",
     "glm_5",
+    "kimi_k2",
 ):
     register_lazy_model(
         _deepseek_model_type,

--- a/rtp_llm/server/server_args/load_group_args.py
+++ b/rtp_llm/server/server_args/load_group_args.py
@@ -22,3 +22,11 @@ def init_load_group_args(parser, load_config, model_args):
         default=False,
         help="强制在CPU上加载权重，用于显存不足的场景",
     )
+    load_group.add_argument(
+        "--keep_mla_checkpoint_weights",
+        env_name="RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS",
+        bind_to=(load_config, "keep_mla_checkpoint_weights"),
+        type=str2bool,
+        default=False,
+        help="保留已转换为运行时布局的 MLA checkpoint 权重，用于调试",
+    )

--- a/rtp_llm/server/server_args/load_group_args.py
+++ b/rtp_llm/server/server_args/load_group_args.py
@@ -24,9 +24,12 @@ def init_load_group_args(parser, load_config, model_args):
     )
     load_group.add_argument(
         "--keep_mla_checkpoint_weights",
-        env_name="RTP_LLM_KEEP_MLA_CHECKPOINT_WEIGHTS",
+        env_name="KEEP_MLA_CHECKPOINT_WEIGHTS",
         bind_to=(load_config, "keep_mla_checkpoint_weights"),
         type=str2bool,
         default=False,
-        help="保留已转换为运行时布局的 MLA checkpoint 权重，用于调试",
+        help=(
+            "仅对 DeepSeek MLA newloader 生效：保留已转换为运行时布局的 "
+            "checkpoint 权重。会增加显存占用并减少 KV cache 可用块，仅用于调试"
+        ),
     )

--- a/rtp_llm/server/server_args/test/server_args_test.py
+++ b/rtp_llm/server/server_args/test/server_args_test.py
@@ -32,6 +32,7 @@ class ServerArgsSetTest(TestCase):
         os.environ["MAX_CONTEXT_BATCH_SIZE"] = "32"
         os.environ["WARM_UP"] = "1"
         os.environ["MAX_SEQ_LEN"] = "4096"
+        os.environ["KEEP_MLA_CHECKPOINT_WEIGHTS"] = "1"
 
         sys.argv = ["prog"]
 
@@ -62,6 +63,7 @@ class ServerArgsSetTest(TestCase):
 
         # Verify runtime_config (warm_up is now in RuntimeConfig)
         self.assertEqual(py_env_configs.runtime_config.warm_up, True)  # bool in C++
+        self.assertTrue(py_env_configs.load_config.keep_mla_checkpoint_weights)
         # Note: max_seq_len is in ModelConfig, not RuntimeConfig or EngineConfig
         # It will be set when ModelConfig is created from model_args
 
@@ -87,6 +89,8 @@ class ServerArgsSetTest(TestCase):
             "64",
             "--warm_up",
             "0",
+            "--keep_mla_checkpoint_weights",
+            "True",
             "--cache_store_rdma_io_thread_count",
             "4",
             "--cache_store_rdma_worker_thread_count",
@@ -124,6 +128,7 @@ class ServerArgsSetTest(TestCase):
 
         # Verify runtime_config (warm_up is now in RuntimeConfig)
         self.assertEqual(py_env_configs.runtime_config.warm_up, False)  # bool in C++
+        self.assertTrue(py_env_configs.load_config.keep_mla_checkpoint_weights)
         # Note: max_seq_len is in ModelConfig, not RuntimeConfig or EngineConfig
         # It will be set when ModelConfig is created from model_args
 

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -16,6 +16,20 @@ def h20_oss_suites():
                 envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
                 gpu_type=["H20"],
             ),
+            smoke_test(
+                name="h20_deepseek_v32_newloader_cudagraph_deepep_tp2",
+                task_info="data/model/deepseek_v32_4layers/v32_fp8_q_r_h20_cuda_graph.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 1 --reserver_runtime_mem_mb 20000 --tp_size 2 --world_size 2 --dp_size 1 --fp8_kv_cache 1 --use_deepep_moe 1 --use_deepep_low_latency 1",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="h20_deepseek_v32_mtp_newloader",
+                task_info="data/model/deepseek_v32_4layers/v32_fp8_q_r_h20.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp --sp_act_type BF16 --sp_min_token_match 2 --sp_max_token_match 2",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
+                gpu_type=["H20"],
+            ),
         ],
     )
 

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -4,8 +4,10 @@ def h20_oss_suites():
     # H20 (SM9x) — Architecture-grouped suites
     # ============================================================================
 
-    # Qwen3 dense newloader production boundary: public server startup, TP2,
-    # prefill/decode, final logits, and CUDA Graph replay.
+    # Newloader production boundaries for Qwen3 dense and DeepSeek V3.2.
+    # DeepSeek score-model coverage includes MLA, FP8 KV, TP2, DeepEP, and
+    # CUDA Graph; MTP is kept as a separate TP1 non-graph smoke to fit the
+    # H20 memory envelope while still exercising score+draft loading/decoding.
     native.test_suite(
         name = "smoke_h20_newloader",
         tests = [

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -6,8 +6,8 @@ def h20_oss_suites():
 
     # Newloader production boundaries for Qwen3 dense and DeepSeek V3.2.
     # DeepSeek score-model coverage includes MLA, FP8 KV, TP2, DeepEP, and
-    # CUDA Graph; MTP is kept as a separate TP1 non-graph smoke to fit the
-    # H20 memory envelope while still exercising score+draft loading/decoding.
+    # CUDA Graph; MTP uses the four-layer checkpoint for score and the extracted
+    # layer-61 checkpoint for draft, so both assets match their actual layouts.
     native.test_suite(
         name = "smoke_h20_newloader",
         tests = [
@@ -28,7 +28,7 @@ def h20_oss_suites():
             smoke_test(
                 name="h20_deepseek_v32_mtp_newloader",
                 task_info="data/model/deepseek_v32_4layers/v32_fp8_q_r_h20.json",
-                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp --sp_act_type BF16 --sp_min_token_match 2 --sp_max_token_match 2",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --reserver_runtime_mem_mb 20000 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp-MTP --sp_act_type BF16 --sp_min_token_match 2 --sp_max_token_match 2",
                 envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
                 gpu_type=["H20"],
             ),

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -28,7 +28,7 @@ def h20_oss_suites():
             smoke_test(
                 name="h20_deepseek_v32_mtp_newloader",
                 task_info="data/model/deepseek_v32_4layers/v32_fp8_q_r_h20.json",
-                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --reserver_runtime_mem_mb 20000 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp-MTP --sp_act_type BF16 --sp_min_token_match 2 --sp_max_token_match 2",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --reserver_runtime_mem_mb 20000 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp-MTP --sp_act_type BF16",
                 envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
                 gpu_type=["H20"],
             ),


### PR DESCRIPTION
  ## Summary

  Add a clean newloader implementation for the DeepSeek V3 MLA/MoE family, including:

  - DeepSeek V3 / V3.1 / V3.2
  - DeepSeek V3 MTP draft model
  - GLM-5 through the same config-driven MLA/MoE implementation

  ## Key changes

  - Add config-driven DeepSeek MLA attention, dense MLP, routed/shared MoE, sparse indexer, and model forward path.
  - Add standalone and appended DeepSeek MTP checkpoint loading.
  - Ensure MTP draft rank loads only the exact draft layer instead of materializing the complete main model.
  - Add strict checkpoint prefix, layer-range, missing/unknown/extra tensor validation.
  - Fix TP reduction ownership to avoid duplicate all-reduce in MLA and shared-expert paths.
  - Support TP-safe FP8 block padding for weights and scale tensors.
  - Support per-tensor, per-channel, and per-block FP8 MLA derived weights with safe BF16 fallback.
  - Preserve DeepSeek/GLM RoPE and YaRN numerical behavior in the newloader package.
  - Register DeepSeek and GLM model aliases in the newloader registry.
  - Add focused coverage for MTP mapping, TP/EP invariants, FP8 layouts, RoPE numerics, filtering, and failure boundaries.

  The production implementation does not depend on `ModelWeightInfo`,
  `CustomAtomicWeight`, old loader/model modules, or direct compute-op SO imports.
  `W.*` is used only as the runtime tensor-key adapter required by the existing
  MLA kernel factory, not for checkpoint loading or ownership.

  ## Validation

  ### H20

  - `//rtp_llm/models_py/new_models/deepseek_v3/test:test_deepseek_newloader`
    - 20/20 passed
  - Foundation CPU/GPU tests passed
  - Unquantized and FP8 loader regression tests passed
  - MLA attention, reuse-cache, and indexer GPU tests passed
  - GLM-5 local-checkpoint smoke:
    - total count: 1
    - success count: 1
    - compare diff count: 0
  - DeepSeek TP=2 local checkpoint loading reached only the expected missing final
    norm from the intentionally incomplete four-layer checkpoint; no routing,
    sharding, expert, or tensor-shape errors were found.

  All model validation used local checkpoints; no NAS model path was used.

  ### ROCm / MI308X

  - Focused DeepSeek newloader test:
    - 19 passed
    - 1 CUDA-only online-FP8 test skipped
  - The local GLM-5 checkpoint was copied and SHA256-verified successfully.
  - End-to-end GLM-5 ROCm smoke is currently blocked by the existing platform
    limitation: `IndexerOp is not implemented for ROCm`.
    The ROCm suite currently contains no DeepSeek/GLM sparse-indexer smoke case.

  ## Static checks

  - Black passed
  - isort passed
  - Python 3.10 `py_compile` passed
  - Full pre-commit hooks passed
  - `git diff --check` passed
  - No old-loader/model imports, direct SO imports, or NAS paths in the submitted
    production code