### PR TITLE
fix(cache): map default MTP group to compatible full group

### DIFF
--- a/rtp_llm/cpp/cache/CacheConfig.cc
+++ b/rtp_llm/cpp/cache/CacheConfig.cc
@@ -1,8 +1,11 @@
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 
 #include <algorithm>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+
+#include "rtp_llm/cpp/utils/Logger.h"
 
 namespace rtp_llm {
 
@@ -14,6 +17,31 @@ CacheGroupType groupTypeForSpec(const KVCacheSpec& spec) {
 
 bool isFullAttentionSpec(KVCacheSpecType type) {
     return type == KVCacheSpecType::MultiHeadAttention || type == KVCacheSpecType::MultiHeadLatentAttention;
+}
+
+std::string targetGroupSummary(const CacheConfig& target_config) {
+    std::ostringstream os;
+    os << '[';
+    for (size_t target_gid = 0; target_gid < static_cast<size_t>(target_config.groupNums()); ++target_gid) {
+        if (target_gid > 0) {
+            os << ", ";
+        }
+        const auto& group = target_config.topology().groupById(target_gid);
+        os << "{tag=" << group.tag << ", group_type=" << cacheGroupTypeName(group.policy.group_type);
+        if (group.spec != nullptr) {
+            os << ", spec_type=" << static_cast<int>(group.spec->type)
+               << ", dtype=" << static_cast<int>(group.spec->memoryLayoutDType())
+               << ", block_size_bytes=" << group.spec->block_size_bytes()
+               << ", scale_block_size_bytes=" << group.spec->scale_block_size_bytes();
+        } else {
+            os << ", spec=null";
+        }
+        os << ", seq_size_per_block=" << group.seq_size_per_block
+           << ", kv_block_stride_bytes=" << group.kv_block_stride_bytes
+           << ", kv_scale_stride_bytes=" << group.kv_scale_stride_bytes << '}';
+    }
+    os << ']';
+    return os.str();
 }
 
 size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const CacheConfig& propose_config) {
@@ -37,19 +65,41 @@ size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const Cache
     std::vector<size_t> candidates;
     for (size_t target_gid = 0; target_gid < static_cast<size_t>(target_config.groupNums()); ++target_gid) {
         const auto& target_group = target_config.topology().groupById(target_gid);
+        // The aliased draft layer uses its own MTP memory layout. Group-tag APIs still expose it as the target
+        // group, however, so both logical block granularity and physical block shape must remain compatible.
         if (target_group.policy.group_type == source_group.policy.group_type && target_group.spec != nullptr
             && target_group.spec->type == source_group.spec->type
-            && target_group.seq_size_per_block == source_group.seq_size_per_block) {
+            && target_group.spec->memoryLayoutDType() == source_group.spec->memoryLayoutDType()
+            && target_group.spec->block_size_bytes() == source_group.spec->block_size_bytes()
+            && target_group.spec->scale_block_size_bytes() == source_group.spec->scale_block_size_bytes()
+            && target_group.seq_size_per_block == source_group.seq_size_per_block
+            && target_group.kv_block_stride_bytes == source_group.kv_block_stride_bytes
+            && target_group.kv_scale_stride_bytes == source_group.kv_scale_stride_bytes) {
             candidates.push_back(target_gid);
         }
     }
 
+    const auto target_summary = targetGroupSummary(target_config);
+    RTP_LLM_CHECK_WITH_INFO(!candidates.empty(),
+                            "CacheConfig::mergeMTPModule no compatible target group for sole propose tag=default: "
+                            "source_spec_type=%d source_dtype=%d source_seq_size_per_block=%zu "
+                            "source_block_size_bytes=%zu source_scale_block_size_bytes=%zu "
+                            "source_kv_block_stride_bytes=%zu source_kv_scale_stride_bytes=%zu target_groups=%s",
+                            static_cast<int>(source_group.spec->type),
+                            static_cast<int>(source_group.spec->memoryLayoutDType()),
+                            source_group.seq_size_per_block,
+                            source_group.spec->block_size_bytes(),
+                            source_group.spec->scale_block_size_bytes(),
+                            source_group.kv_block_stride_bytes,
+                            source_group.kv_scale_stride_bytes,
+                            target_summary.c_str());
     RTP_LLM_CHECK_WITH_INFO(candidates.size() <= 1,
                             "CacheConfig::mergeMTPModule ambiguous default FULL group mapping: "
-                            "compatible target groups=%zu spec_type=%d",
+                            "compatible target groups=%zu spec_type=%d target_groups=%s",
                             candidates.size(),
-                            static_cast<int>(source_group.spec->type));
-    return candidates.empty() ? invalid_gid : candidates.front();
+                            static_cast<int>(source_group.spec->type),
+                            target_summary.c_str());
+    return candidates.front();
 }
 
 }  // namespace
@@ -234,6 +284,16 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
         GroupBase sub_group = source_group;
         sub_group.layer_ids.clear();
         if (uses_default_alias) {
+            RTP_LLM_LOG_INFO("CacheConfig::mergeMTPModule aliases propose tag=default to target tag=%s: "
+                             "module=%d spec_type=%d dtype=%d seq_size_per_block=%zu "
+                             "kv_block_stride_bytes=%zu kv_scale_stride_bytes=%zu",
+                             tag.c_str(),
+                             module_index,
+                             static_cast<int>(source_group.spec->type),
+                             static_cast<int>(source_group.spec->memoryLayoutDType()),
+                             source_group.seq_size_per_block,
+                             source_group.kv_block_stride_bytes,
+                             source_group.kv_scale_stride_bytes);
             auto aliased_spec = source_group.spec->clone();
             aliased_spec->tag = tag;
             sub_group.tag     = tag;

--- a/rtp_llm/cpp/cache/CacheConfig.cc
+++ b/rtp_llm/cpp/cache/CacheConfig.cc
@@ -1,6 +1,7 @@
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 
 #include <algorithm>
+#include <optional>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -17,6 +18,20 @@ CacheGroupType groupTypeForSpec(const KVCacheSpec& spec) {
 
 bool isFullAttentionSpec(KVCacheSpecType type) {
     return type == KVCacheSpecType::MultiHeadAttention || type == KVCacheSpecType::MultiHeadLatentAttention;
+}
+
+std::string cacheGroupPolicySummary(const CacheGroupPolicy& policy) {
+    std::ostringstream os;
+    os << "{group_type=" << cacheGroupTypeName(policy.group_type) << ", prefix_reuse=" << policy.enable_prefix_reuse
+       << ", evict=" << static_cast<int>(policy.evict_policy) << ", reservable=" << policy.reservable
+       << ", explicit_block_num=" << policy.explicit_block_num
+       << ", charge_to_paged_budget=" << policy.charge_to_paged_budget
+       << ", memory_placement=" << static_cast<int>(policy.memory_placement)
+       << ", active_tail_blocks=" << policy.active_tail_blocks
+       << ", validate_tail_blocks=" << policy.validate_tail_blocks
+       << ", cp_mapping=" << static_cast<int>(policy.cp_mapping) << ", cp_slice=" << static_cast<int>(policy.cp_slice)
+       << '}';
+    return os.str();
 }
 
 std::string targetGroupSummary(const CacheConfig& target_config) {
@@ -38,28 +53,28 @@ std::string targetGroupSummary(const CacheConfig& target_config) {
         }
         os << ", seq_size_per_block=" << group.seq_size_per_block
            << ", kv_block_stride_bytes=" << group.kv_block_stride_bytes
-           << ", kv_scale_stride_bytes=" << group.kv_scale_stride_bytes << '}';
+           << ", kv_scale_stride_bytes=" << group.kv_scale_stride_bytes
+           << ", policy=" << cacheGroupPolicySummary(group.policy) << '}';
     }
     os << ']';
     return os.str();
 }
 
-size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const CacheConfig& propose_config) {
-    constexpr size_t invalid_gid = std::numeric_limits<size_t>::max();
+std::optional<size_t> resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const CacheConfig& propose_config) {
     if (propose_config.groupNums() != 1 || propose_config.tagForGroup(0) != "default") {
-        return invalid_gid;
+        return std::nullopt;
     }
 
     for (size_t target_gid = 0; target_gid < static_cast<size_t>(target_config.groupNums()); ++target_gid) {
         if (target_config.tagForGroup(target_gid) == "default") {
-            return invalid_gid;  // Exact tag matching remains authoritative.
+            return std::nullopt;  // Exact tag matching remains authoritative.
         }
     }
 
     const auto& source_group = propose_config.topology().groupById(0);
     if (source_group.policy.group_type != CacheGroupType::FULL || source_group.spec == nullptr
         || !isFullAttentionSpec(source_group.spec->type)) {
-        return invalid_gid;
+        return std::nullopt;
     }
 
     std::vector<size_t> candidates;
@@ -67,7 +82,7 @@ size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const Cache
         const auto& target_group = target_config.topology().groupById(target_gid);
         // The aliased draft layer uses its own MTP memory layout. Group-tag APIs still expose it as the target
         // group, however, so both logical block granularity and physical block shape must remain compatible.
-        if (target_group.policy.group_type == source_group.policy.group_type && target_group.spec != nullptr
+        if (CacheConfig::samePolicy(target_group.policy, source_group.policy) && target_group.spec != nullptr
             && target_group.spec->type == source_group.spec->type
             && target_group.spec->memoryLayoutDType() == source_group.spec->memoryLayoutDType()
             && target_group.spec->block_size_bytes() == source_group.spec->block_size_bytes()
@@ -79,26 +94,32 @@ size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const Cache
         }
     }
 
-    const auto target_summary = targetGroupSummary(target_config);
-    RTP_LLM_CHECK_WITH_INFO(!candidates.empty(),
-                            "CacheConfig::mergeMTPModule no compatible target group for sole propose tag=default: "
-                            "source_spec_type=%d source_dtype=%d source_seq_size_per_block=%zu "
-                            "source_block_size_bytes=%zu source_scale_block_size_bytes=%zu "
-                            "source_kv_block_stride_bytes=%zu source_kv_scale_stride_bytes=%zu target_groups=%s",
-                            static_cast<int>(source_group.spec->type),
-                            static_cast<int>(source_group.spec->memoryLayoutDType()),
-                            source_group.seq_size_per_block,
-                            source_group.spec->block_size_bytes(),
-                            source_group.spec->scale_block_size_bytes(),
-                            source_group.kv_block_stride_bytes,
-                            source_group.kv_scale_stride_bytes,
-                            target_summary.c_str());
-    RTP_LLM_CHECK_WITH_INFO(candidates.size() <= 1,
-                            "CacheConfig::mergeMTPModule ambiguous default FULL group mapping: "
-                            "compatible target groups=%zu spec_type=%d target_groups=%s",
-                            candidates.size(),
-                            static_cast<int>(source_group.spec->type),
-                            target_summary.c_str());
+    if (candidates.empty()) {
+        const auto target_summary = targetGroupSummary(target_config);
+        const auto source_policy  = cacheGroupPolicySummary(source_group.policy);
+        RTP_LLM_FAIL("CacheConfig::mergeMTPModule no compatible target group for sole propose tag=default: "
+                     "source_spec_type=%d source_dtype=%d source_seq_size_per_block=%zu "
+                     "source_block_size_bytes=%zu source_scale_block_size_bytes=%zu "
+                     "source_kv_block_stride_bytes=%zu source_kv_scale_stride_bytes=%zu "
+                     "source_policy=%s target_groups=%s",
+                     static_cast<int>(source_group.spec->type),
+                     static_cast<int>(source_group.spec->memoryLayoutDType()),
+                     source_group.seq_size_per_block,
+                     source_group.spec->block_size_bytes(),
+                     source_group.spec->scale_block_size_bytes(),
+                     source_group.kv_block_stride_bytes,
+                     source_group.kv_scale_stride_bytes,
+                     source_policy.c_str(),
+                     target_summary.c_str());
+    }
+    if (candidates.size() > 1) {
+        const auto target_summary = targetGroupSummary(target_config);
+        RTP_LLM_FAIL("CacheConfig::mergeMTPModule ambiguous default FULL group mapping: "
+                     "compatible target groups=%zu spec_type=%d target_groups=%s",
+                     candidates.size(),
+                     static_cast<int>(source_group.spec->type),
+                     target_summary.c_str());
+    }
     return candidates.front();
 }
 
@@ -232,8 +253,7 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
     for (size_t gid = 0; gid < propose_config.topology().groups().size(); ++gid) {
         propose_gid_by_tag.emplace(propose_config.tagForGroup(gid), gid);
     }
-    const size_t     default_alias_target_gid = resolveDefaultMTPGroupAlias(*this, propose_config);
-    constexpr size_t invalid_gid              = std::numeric_limits<size_t>::max();
+    const auto default_alias_target_gid = resolveDefaultMTPGroupAlias(*this, propose_config);
 
     std::vector<GroupBase> sub_groups;
     std::vector<LayerBase> sub_layers(static_cast<size_t>(mtp_layer_num));
@@ -244,23 +264,35 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
         const auto  propose_it      = propose_gid_by_tag.find(tag);
         const bool  has_exact_group = propose_it != propose_gid_by_tag.end();
         const bool  uses_default_alias =
-            !has_exact_group && default_alias_target_gid != invalid_gid && target_gid == default_alias_target_gid;
-        const bool   has_propose_group = has_exact_group || uses_default_alias;
-        const auto&  source_config     = has_propose_group ? propose_config : *this;
-        const size_t source_gid        = has_exact_group ? propose_it->second : uses_default_alias ? 0 : target_gid;
-        const auto&  source_group      = source_config.topology().groupById(source_gid);
+            !has_exact_group && default_alias_target_gid.has_value() && target_gid == *default_alias_target_gid;
+
+        const CacheConfig* source_config = this;
+        size_t             source_gid    = target_gid;
+        if (has_exact_group) {
+            source_config = &propose_config;
+            source_gid    = propose_it->second;
+        } else if (uses_default_alias) {
+            source_config = &propose_config;
+            source_gid    = 0;
+        }
+        const bool  has_propose_group = has_exact_group || uses_default_alias;
+        const auto& source_group      = source_config->topology().groupById(source_gid);
 
         if (has_propose_group) {
             RTP_LLM_CHECK_WITH_INFO(
                 source_group.layer_ids.size() == static_cast<size_t>(mtp_layer_num),
-                "CacheConfig::mergeMTPModule tag=%s must cover every module layer, got=%zu expected=%u",
+                "CacheConfig::mergeMTPModule source_tag=%s target_tag=%s must cover every module layer, "
+                "got=%zu expected=%u",
+                source_group.tag.c_str(),
                 tag.c_str(),
                 source_group.layer_ids.size(),
                 mtp_layer_num);
             for (size_t local_layer_id = 0; local_layer_id < source_group.layer_ids.size(); ++local_layer_id) {
                 RTP_LLM_CHECK_WITH_INFO(
                     source_group.layer_ids[local_layer_id] == static_cast<int>(local_layer_id),
-                    "CacheConfig::mergeMTPModule tag=%s source layers must be ordered 0..%u, index=%zu value=%d",
+                    "CacheConfig::mergeMTPModule source_tag=%s target_tag=%s source layers must be ordered 0..%u, "
+                    "index=%zu value=%d",
+                    source_group.tag.c_str(),
                     tag.c_str(),
                     mtp_layer_num - 1,
                     local_layer_id,
@@ -270,8 +302,10 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
             const size_t expected_existing_layers =
                 static_cast<size_t>(group_layer_num) + static_cast<size_t>(module_index) * mtp_layer_num;
             RTP_LLM_CHECK_WITH_INFO(target_groups[target_gid].layer_ids.size() == expected_existing_layers,
-                                    "CacheConfig::mergeMTPModule tag=%s gid=%zu physical group alignment mismatch: "
+                                    "CacheConfig::mergeMTPModule source_tag=%s target_tag=%s gid=%zu "
+                                    "physical group alignment mismatch: "
                                     "existing_layers=%zu expected=%zu module=%d group_layer_num=%d module_layers=%u",
+                                    source_group.tag.c_str(),
                                     tag.c_str(),
                                     target_gid,
                                     target_groups[target_gid].layer_ids.size(),

--- a/rtp_llm/cpp/cache/CacheConfig.cc
+++ b/rtp_llm/cpp/cache/CacheConfig.cc
@@ -12,6 +12,46 @@ CacheGroupType groupTypeForSpec(const KVCacheSpec& spec) {
     return spec.type == KVCacheSpecType::LinearAttention ? CacheGroupType::LINEAR : CacheGroupType::FULL;
 }
 
+bool isFullAttentionSpec(KVCacheSpecType type) {
+    return type == KVCacheSpecType::MultiHeadAttention || type == KVCacheSpecType::MultiHeadLatentAttention;
+}
+
+size_t resolveDefaultMTPGroupAlias(const CacheConfig& target_config, const CacheConfig& propose_config) {
+    constexpr size_t invalid_gid = std::numeric_limits<size_t>::max();
+    if (propose_config.groupNums() != 1 || propose_config.tagForGroup(0) != "default") {
+        return invalid_gid;
+    }
+
+    for (size_t target_gid = 0; target_gid < static_cast<size_t>(target_config.groupNums()); ++target_gid) {
+        if (target_config.tagForGroup(target_gid) == "default") {
+            return invalid_gid;  // Exact tag matching remains authoritative.
+        }
+    }
+
+    const auto& source_group = propose_config.topology().groupById(0);
+    if (source_group.policy.group_type != CacheGroupType::FULL || source_group.spec == nullptr
+        || !isFullAttentionSpec(source_group.spec->type)) {
+        return invalid_gid;
+    }
+
+    std::vector<size_t> candidates;
+    for (size_t target_gid = 0; target_gid < static_cast<size_t>(target_config.groupNums()); ++target_gid) {
+        const auto& target_group = target_config.topology().groupById(target_gid);
+        if (target_group.policy.group_type == source_group.policy.group_type && target_group.spec != nullptr
+            && target_group.spec->type == source_group.spec->type
+            && target_group.seq_size_per_block == source_group.seq_size_per_block) {
+            candidates.push_back(target_gid);
+        }
+    }
+
+    RTP_LLM_CHECK_WITH_INFO(candidates.size() <= 1,
+                            "CacheConfig::mergeMTPModule ambiguous default FULL group mapping: "
+                            "compatible target groups=%zu spec_type=%d",
+                            candidates.size(),
+                            static_cast<int>(source_group.spec->type));
+    return candidates.empty() ? invalid_gid : candidates.front();
+}
+
 }  // namespace
 
 bool CacheConfig::samePolicy(const CacheGroupPolicy& lhs, const CacheGroupPolicy& rhs) {
@@ -142,17 +182,22 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
     for (size_t gid = 0; gid < propose_config.topology().groups().size(); ++gid) {
         propose_gid_by_tag.emplace(propose_config.tagForGroup(gid), gid);
     }
+    const size_t     default_alias_target_gid = resolveDefaultMTPGroupAlias(*this, propose_config);
+    constexpr size_t invalid_gid              = std::numeric_limits<size_t>::max();
 
     std::vector<GroupBase> sub_groups;
     std::vector<LayerBase> sub_layers(static_cast<size_t>(mtp_layer_num));
     sub_groups.reserve(target_group_num);
 
     for (size_t target_gid = 0; target_gid < target_group_num; ++target_gid) {
-        const auto&  tag               = tagForGroup(target_gid);
-        const auto   propose_it        = propose_gid_by_tag.find(tag);
-        const bool   has_propose_group = propose_it != propose_gid_by_tag.end();
+        const auto& tag             = tagForGroup(target_gid);
+        const auto  propose_it      = propose_gid_by_tag.find(tag);
+        const bool  has_exact_group = propose_it != propose_gid_by_tag.end();
+        const bool  uses_default_alias =
+            !has_exact_group && default_alias_target_gid != invalid_gid && target_gid == default_alias_target_gid;
+        const bool   has_propose_group = has_exact_group || uses_default_alias;
         const auto&  source_config     = has_propose_group ? propose_config : *this;
-        const size_t source_gid        = has_propose_group ? propose_it->second : target_gid;
+        const size_t source_gid        = has_exact_group ? propose_it->second : uses_default_alias ? 0 : target_gid;
         const auto&  source_group      = source_config.topology().groupById(source_gid);
 
         if (has_propose_group) {
@@ -188,6 +233,12 @@ CacheConfig::mergeMTPModule(const CacheConfig& propose_config, int module_index,
 
         GroupBase sub_group = source_group;
         sub_group.layer_ids.clear();
+        if (uses_default_alias) {
+            auto aliased_spec = source_group.spec->clone();
+            aliased_spec->tag = tag;
+            sub_group.tag     = tag;
+            sub_group.spec    = std::move(aliased_spec);
+        }
 
         if (!has_propose_group) {
             sub_groups.push_back(std::move(sub_group));

--- a/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
+++ b/rtp_llm/cpp/cache/test/CacheConfigTestUtils.h
@@ -435,27 +435,19 @@ inline KVCacheSpecPtr makeLinearSpec(const std::string& tag,
     return SpecBuilder::build(desc, ctx);
 }
 
-inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
-                                            int               block_num,
-                                            size_t            tokens_per_block,
-                                            rtp_llm::DataType dtype,
-                                            uint32_t          local_head_num_kv = 1,
-                                            uint32_t          size_per_head     = 1) {
+inline CacheConfig
+makeSingleGroupCacheConfig(KVCacheSpecPtr spec, CacheGroupType group_type, int layer_num, int block_num) {
     CacheConfig config;
-    config.dtype                     = dtype;
+    config.dtype                     = spec->memoryLayoutDType();
     config.layer_num                 = static_cast<uint32_t>(layer_num);
     config.layer_all_num             = static_cast<uint32_t>(layer_num);
     config.block_num                 = static_cast<uint32_t>(block_num);
-    config.seq_size_per_block        = tokens_per_block;
-    config.kernel_seq_size_per_block = tokens_per_block;
+    config.seq_size_per_block        = spec->seq_size_per_block;
+    config.kernel_seq_size_per_block = spec->seq_size_per_block;
 
-    auto spec = makeMhaSpec("default", tokens_per_block, dtype, local_head_num_kv, size_per_head);
-
-    std::vector<int> layer_ids(layer_num);
-    for (int i = 0; i < layer_num; ++i) {
-        layer_ids[i] = i;
-    }
-    config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::FULL}, {"default"});
+    std::vector<int> layer_ids(static_cast<size_t>(layer_num));
+    std::iota(layer_ids.begin(), layer_ids.end(), 0);
+    config.fromGroupedSpecs({spec}, {layer_ids}, {group_type}, {spec->tag});
 
     config.kv_block_stride_bytes = spec->block_size_bytes();
     config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
@@ -466,8 +458,23 @@ inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
     const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
     config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
                                               static_cast<int>(per_layer_stride_bytes));
-
     return config;
+}
+
+inline CacheConfig makeSingleLayerCacheConfig(KVCacheSpecPtr spec, CacheGroupType group_type, int block_num = 4) {
+    auto config            = makeSingleGroupCacheConfig(std::move(spec), group_type, /*layer_num=*/1, block_num);
+    config.group_layer_num = 1;
+    return config;
+}
+
+inline CacheConfig makeSimpleMhaCacheConfig(int               layer_num,
+                                            int               block_num,
+                                            size_t            tokens_per_block,
+                                            rtp_llm::DataType dtype,
+                                            uint32_t          local_head_num_kv = 1,
+                                            uint32_t          size_per_head     = 1) {
+    auto spec = makeMhaSpec("default", tokens_per_block, dtype, local_head_num_kv, size_per_head);
+    return makeSingleGroupCacheConfig(std::move(spec), CacheGroupType::FULL, layer_num, block_num);
 }
 
 inline CacheConfig makeSimpleLinearCacheConfig(int               layer_num,
@@ -476,33 +483,8 @@ inline CacheConfig makeSimpleLinearCacheConfig(int               layer_num,
                                                rtp_llm::DataType dtype,
                                                uint32_t          local_head_num_kv = 1,
                                                uint32_t          size_per_head     = 1) {
-    CacheConfig config;
-    config.dtype                     = dtype;
-    config.layer_num                 = static_cast<uint32_t>(layer_num);
-    config.layer_all_num             = static_cast<uint32_t>(layer_num);
-    config.block_num                 = static_cast<uint32_t>(block_num);
-    config.seq_size_per_block        = tokens_per_block;
-    config.kernel_seq_size_per_block = tokens_per_block;
-
     auto spec = makeLinearSpec("linear", tokens_per_block, dtype, local_head_num_kv, size_per_head);
-
-    std::vector<int> layer_ids(layer_num);
-    for (int i = 0; i < layer_num; ++i) {
-        layer_ids[i] = i;
-    }
-    config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::LINEAR}, {"linear"});
-
-    config.kv_block_stride_bytes = spec->block_size_bytes();
-    config.kv_block_size_bytes   = static_cast<size_t>(layer_num) * config.kv_block_stride_bytes;
-    config.kv_scale_stride_bytes = spec->scale_block_size_bytes();
-    config.kv_scale_size_bytes   = static_cast<size_t>(layer_num) * config.kv_scale_stride_bytes;
-    config.block_size_bytes      = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-
-    const size_t per_layer_stride_bytes = config.kv_block_stride_bytes + config.kv_scale_stride_bytes;
-    config.layer_to_block_stride_bytes.assign(static_cast<size_t>(config.layer_all_num),
-                                              static_cast<int>(per_layer_stride_bytes));
-
-    return config;
+    return makeSingleGroupCacheConfig(std::move(spec), CacheGroupType::LINEAR, layer_num, block_num);
 }
 
 inline CacheConfig makeSimpleHybridMhaCacheConfig(int               layer_num,

--- a/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
@@ -52,6 +52,26 @@ static ModelConfig makeTinyModelConfig(uint32_t num_layers) {
     return cfg;
 }
 
+static CacheConfig makeSingleLayerCacheConfig(KVCacheSpecPtr spec, CacheGroupType group_type) {
+    CacheConfig config;
+    config.dtype                     = spec->memoryLayoutDType();
+    config.layer_num                 = 1;
+    config.layer_all_num             = 1;
+    config.group_layer_num           = 1;
+    config.block_num                 = 4;
+    config.seq_size_per_block        = spec->seq_size_per_block;
+    config.kernel_seq_size_per_block = spec->seq_size_per_block;
+    config.fromGroupedSpecs({spec}, {{0}}, {group_type}, {spec->tag});
+
+    config.kv_block_stride_bytes       = spec->block_size_bytes();
+    config.kv_block_size_bytes         = spec->block_size_bytes();
+    config.kv_scale_stride_bytes       = spec->scale_block_size_bytes();
+    config.kv_scale_size_bytes         = spec->scale_block_size_bytes();
+    config.block_size_bytes            = config.kv_block_size_bytes + config.kv_scale_size_bytes;
+    config.layer_to_block_stride_bytes = {static_cast<int>(config.block_size_bytes)};
+    return config;
+}
+
 static KVCacheSpecPtr makeLinearSpecWithGlobalHeads(uint32_t key_heads, uint32_t value_heads, uint32_t tp) {
     LinearAttentionConfig linear_config;
     linear_config.linear_conv_kernel_dim = 2;
@@ -102,7 +122,9 @@ static void setHybridLayerDescsWithTags(ModelConfig&                            
     }
 }
 
-static CacheConfig makeTinyHybridMtpConfigByCreateSpConfig() {
+static CacheConfig makeTinyHybridMtpConfigByCreateSpConfig(SpeculativeType    sp_type     = SP_TYPE_MTP,
+                                                           const std::string& propose_tag = "full",
+                                                           int64_t            gen_num     = 2) {
     auto score_model_cfg   = makeTinyModelConfig(/*num_layers=*/4);
     auto propose_model_cfg = makeTinyModelConfig(/*num_layers=*/1);
 
@@ -116,6 +138,7 @@ static CacheConfig makeTinyHybridMtpConfigByCreateSpConfig() {
     score_model_cfg.linear_attention_config.linear_value_head_dim  = 8;
     score_model_cfg.linear_attention_config.linear_num_key_heads   = 2;
     score_model_cfg.linear_attention_config.linear_num_value_heads = 2;
+    propose_model_cfg.kv_cache_spec_descs[0][0].tag                = propose_tag;
 
     ParallelismConfig parallelism_cfg;
     parallelism_cfg.tp_size = 1;
@@ -125,8 +148,8 @@ static CacheConfig makeTinyHybridMtpConfigByCreateSpConfig() {
     kv_cache_cfg.test_block_num = 8;
 
     SpeculativeExecutionConfig sp_cfg;
-    sp_cfg.type              = SP_TYPE_MTP;
-    sp_cfg.gen_num_per_cycle = 2;
+    sp_cfg.type              = sp_type;
+    sp_cfg.gen_num_per_cycle = gen_num;
 
     return CacheConfigCreator::createSpConfig(score_model_cfg,
                                               propose_model_cfg,
@@ -136,7 +159,7 @@ static CacheConfig makeTinyHybridMtpConfigByCreateSpConfig() {
                                               sp_cfg,
                                               /*warm_up_result=*/std::nullopt,
                                               /*is_mtp=*/true,
-                                              /*is_eagle=*/false);
+                                              /*is_eagle=*/sp_type == SP_TYPE_EAGLE);
 }
 
 static CompleteTokenIdsPtr makeCompleteTokenIds(int batch_size, int seq_length, int seq_size_per_block) {
@@ -494,41 +517,7 @@ TEST_F(HybridTypeKVCacheAllocatorTest, ConvertToGlobalLayerIdHybridWithMtpSubCon
 }
 
 TEST_F(HybridTypeKVCacheAllocatorTest, EagleMapsSoleDefaultFullDraftGroupToUniqueFullTargetGroup) {
-    auto score_model_cfg   = makeTinyModelConfig(/*num_layers=*/4);
-    auto propose_model_cfg = makeTinyModelConfig(/*num_layers=*/1);
-
-    setHybridLayerDescs(score_model_cfg,
-                        {HybridAttentionType::LINEAR,
-                         HybridAttentionType::LINEAR,
-                         HybridAttentionType::NONE,
-                         HybridAttentionType::NONE});
-    score_model_cfg.linear_attention_config.linear_conv_kernel_dim = 2;
-    score_model_cfg.linear_attention_config.linear_key_head_dim    = 8;
-    score_model_cfg.linear_attention_config.linear_value_head_dim  = 8;
-    score_model_cfg.linear_attention_config.linear_num_key_heads   = 2;
-    score_model_cfg.linear_attention_config.linear_num_value_heads = 2;
-    propose_model_cfg.kv_cache_spec_descs[0][0].tag                = "default";
-
-    ParallelismConfig parallelism_cfg;
-    parallelism_cfg.tp_size = 1;
-
-    RuntimeConfig runtime_cfg;
-    KVCacheConfig kv_cache_cfg;
-    kv_cache_cfg.test_block_num = 8;
-
-    SpeculativeExecutionConfig sp_cfg;
-    sp_cfg.type              = SP_TYPE_EAGLE;
-    sp_cfg.gen_num_per_cycle = 2;
-
-    auto config = CacheConfigCreator::createSpConfig(score_model_cfg,
-                                                     propose_model_cfg,
-                                                     parallelism_cfg,
-                                                     runtime_cfg,
-                                                     kv_cache_cfg,
-                                                     sp_cfg,
-                                                     /*warm_up_result=*/std::nullopt,
-                                                     /*is_mtp=*/true,
-                                                     /*is_eagle=*/true);
+    auto config = makeTinyHybridMtpConfigByCreateSpConfig(SP_TYPE_EAGLE, "default");
 
     ASSERT_EQ(config.mtp_sub_configs.size(), 1u);
     const auto& sub_config = config.mtp_sub_configs[0];
@@ -549,6 +538,23 @@ TEST_F(HybridTypeKVCacheAllocatorTest, EagleMapsSoleDefaultFullDraftGroupToUniqu
     const auto layout = manager->getMTPModuleGroupedCacheLayerLayout(0);
     EXPECT_TRUE(layout.at("full", 0).kv_addr.defined());
     EXPECT_TRUE(layout.group("linear").empty());
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MtpMapsDefaultFullDraftGroupForEveryModule) {
+    auto config = makeTinyHybridMtpConfigByCreateSpConfig(SP_TYPE_MTP, "default", /*gen_num=*/2);
+
+    ASSERT_EQ(config.mtp_sub_configs.size(), 2u);
+    const auto full_gid   = static_cast<size_t>(config.groupIdForTag("full"));
+    const auto linear_gid = static_cast<size_t>(config.groupIdForTag("linear"));
+    EXPECT_EQ(config.layerIdsForGroup(full_gid), std::vector<int>({2, 3, 4, 5}));
+    for (size_t module_index = 0; module_index < config.mtp_sub_configs.size(); ++module_index) {
+        const auto& sub_config = config.mtp_sub_configs[module_index];
+        ASSERT_NE(sub_config, nullptr);
+        EXPECT_EQ(sub_config->groupTagsSnapshot(), config.groupTagsSnapshot());
+        EXPECT_EQ(sub_config->layerIdsForGroup(full_gid), std::vector<int>({0}));
+        EXPECT_TRUE(sub_config->layerIdsForGroup(linear_gid).empty());
+        EXPECT_EQ(config.groupIdForLayerTag(static_cast<int>(4 + module_index), "full"), static_cast<int>(full_gid));
+    }
 }
 
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsAmbiguousDefaultFullGroupAlias) {
@@ -580,8 +586,105 @@ TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpDoesNotAliasDefaultFullGroupToLin
     auto propose_config = makeSimpleMhaCacheConfig(
         /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/4, rtp_llm::DataType::TYPE_FP16);
 
-    EXPECT_THROW(main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1),
-                 std::runtime_error);
+    try {
+        main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+        FAIL() << "expected a default FULL group without a compatible target to be rejected";
+    } catch (const std::runtime_error& e) {
+        const std::string message = e.what();
+        EXPECT_NE(message.find("no compatible target group for sole propose tag=default"), std::string::npos);
+        EXPECT_NE(message.find("tag=linear"), std::string::npos);
+    }
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsIncompatibleDefaultFullGroupAlias) {
+    const auto expect_no_compatible_alias = [](CacheConfig target_config, const CacheConfig& propose_config) {
+        try {
+            target_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+            FAIL() << "expected an incompatible default FULL group alias to be rejected";
+        } catch (const std::runtime_error& e) {
+            const std::string message = e.what();
+            EXPECT_NE(message.find("no compatible target group for sole propose tag=default"), std::string::npos);
+            EXPECT_NE(message.find("target_groups=[{tag=full"), std::string::npos);
+        }
+    };
+
+    auto target = makeSingleLayerCacheConfig(
+        makeMhaSpec("full", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
+        CacheGroupType::FULL);
+    auto different_tokens = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                                   /*tokens_per_block=*/8,
+                                                                   DataType::TYPE_FP16,
+                                                                   /*local_head_num_kv=*/1,
+                                                                   /*size_per_head=*/1),
+                                                       CacheGroupType::FULL);
+    expect_no_compatible_alias(target, different_tokens);
+
+    auto different_geometry = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                                     /*tokens_per_block=*/4,
+                                                                     DataType::TYPE_FP16,
+                                                                     /*local_head_num_kv=*/2,
+                                                                     /*size_per_head=*/1),
+                                                         CacheGroupType::FULL);
+    expect_no_compatible_alias(target, different_geometry);
+
+    auto mla_target  = makeSingleLayerCacheConfig(makeResolvedMlaSpec(DataType::TYPE_FP16,
+                                                                     /*kv_lora_rank=*/1,
+                                                                     /*rope_head_dim=*/1,
+                                                                     /*seq_size_per_block=*/4,
+                                                                     "full"),
+                                                 CacheGroupType::FULL);
+    auto mha_propose = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                              /*tokens_per_block=*/4,
+                                                              DataType::TYPE_FP16,
+                                                              /*local_head_num_kv=*/1,
+                                                              /*size_per_head=*/1),
+                                                  CacheGroupType::FULL);
+    expect_no_compatible_alias(mla_target, mha_propose);
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpPrefersExactDefaultGroupMatch) {
+    auto main_config    = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                              /*tokens_per_block=*/4,
+                                                              DataType::TYPE_FP16,
+                                                              /*local_head_num_kv=*/1,
+                                                              /*size_per_head=*/1),
+                                                  CacheGroupType::FULL);
+    auto propose_config = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                                 /*tokens_per_block=*/4,
+                                                                 DataType::TYPE_FP16,
+                                                                 /*local_head_num_kv=*/1,
+                                                                 /*size_per_head=*/1),
+                                                     CacheGroupType::FULL);
+
+    const auto sub_config = main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+    ASSERT_NE(sub_config, nullptr);
+    EXPECT_EQ(sub_config->groupTagsSnapshot(), std::vector<std::string>({"default"}));
+    EXPECT_EQ(sub_config->layerIdsForGroup(0), std::vector<int>({0}));
+    EXPECT_EQ(main_config.layerIdsForGroup(0), std::vector<int>({0, 1}));
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpDoesNotAliasMultiGroupProposeConfig) {
+    auto main_config = makeSingleLayerCacheConfig(
+        makeMhaSpec("full", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
+        CacheGroupType::FULL);
+
+    CacheConfig propose_config;
+    propose_config.layer_num       = 1;
+    propose_config.layer_all_num   = 1;
+    propose_config.group_layer_num = 1;
+    propose_config.fromGroupedSpecs(
+        {makeMhaSpec("default", 4, DataType::TYPE_FP16, 1, 1), makeMhaSpec("aux", 4, DataType::TYPE_FP16, 1, 1)},
+        {{0}, {0}},
+        {CacheGroupType::FULL, CacheGroupType::FULL},
+        {"default", "aux"});
+    propose_config.layer_to_block_stride_bytes = {1};
+
+    try {
+        main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+        FAIL() << "expected a multi-group propose config not to use the default alias";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("missing group mapping for sub layer 0"), std::string::npos);
+    }
 }
 
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsShortTargetGroup) {

--- a/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
@@ -52,26 +52,6 @@ static ModelConfig makeTinyModelConfig(uint32_t num_layers) {
     return cfg;
 }
 
-static CacheConfig makeSingleLayerCacheConfig(KVCacheSpecPtr spec, CacheGroupType group_type) {
-    CacheConfig config;
-    config.dtype                     = spec->memoryLayoutDType();
-    config.layer_num                 = 1;
-    config.layer_all_num             = 1;
-    config.group_layer_num           = 1;
-    config.block_num                 = 4;
-    config.seq_size_per_block        = spec->seq_size_per_block;
-    config.kernel_seq_size_per_block = spec->seq_size_per_block;
-    config.fromGroupedSpecs({spec}, {{0}}, {group_type}, {spec->tag});
-
-    config.kv_block_stride_bytes       = spec->block_size_bytes();
-    config.kv_block_size_bytes         = spec->block_size_bytes();
-    config.kv_scale_stride_bytes       = spec->scale_block_size_bytes();
-    config.kv_scale_size_bytes         = spec->scale_block_size_bytes();
-    config.block_size_bytes            = config.kv_block_size_bytes + config.kv_scale_size_bytes;
-    config.layer_to_block_stride_bytes = {static_cast<int>(config.block_size_bytes)};
-    return config;
-}
-
 static KVCacheSpecPtr makeLinearSpecWithGlobalHeads(uint32_t key_heads, uint32_t value_heads, uint32_t tp) {
     LinearAttentionConfig linear_config;
     linear_config.linear_conv_kernel_dim = 2;
@@ -557,6 +537,29 @@ TEST_F(HybridTypeKVCacheAllocatorTest, MtpMapsDefaultFullDraftGroupForEveryModul
     }
 }
 
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpAliasesCompatibleDefaultMlaGroup) {
+    auto main_config    = makeSingleLayerCacheConfig(makeResolvedMlaSpec(DataType::TYPE_FP16,
+                                                                      /*kv_lora_rank=*/1,
+                                                                      /*rope_head_dim=*/1,
+                                                                      /*seq_size_per_block=*/4,
+                                                                      "full"),
+                                                  CacheGroupType::FULL);
+    auto propose_config = makeSingleLayerCacheConfig(makeResolvedMlaSpec(DataType::TYPE_FP16,
+                                                                         /*kv_lora_rank=*/1,
+                                                                         /*rope_head_dim=*/1,
+                                                                         /*seq_size_per_block=*/4,
+                                                                         "default"),
+                                                     CacheGroupType::FULL);
+
+    const auto sub_config = main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+    ASSERT_NE(sub_config, nullptr);
+    EXPECT_EQ(sub_config->groupTagsSnapshot(), std::vector<std::string>({"full"}));
+    EXPECT_EQ(sub_config->specForGroup(0)->type, KVCacheSpecType::MultiHeadLatentAttention);
+    EXPECT_EQ(sub_config->specForGroup(0)->tag, "full");
+    EXPECT_EQ(sub_config->layerIdsForGroup(0), std::vector<int>({0}));
+    EXPECT_EQ(main_config.layerIdsForGroup(0), std::vector<int>({0, 1}));
+}
+
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsAmbiguousDefaultFullGroupAlias) {
     CacheConfig main_config;
     main_config.layer_num       = 2;
@@ -611,7 +614,13 @@ TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsIncompatibleDefaultFullGro
     auto target = makeSingleLayerCacheConfig(
         makeMhaSpec("full", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
         CacheGroupType::FULL);
-    auto different_tokens = makeSingleLayerCacheConfig(makeMhaSpec("default",
+    auto compatible_propose = makeSingleLayerCacheConfig(makeMhaSpec("default",
+                                                                     /*tokens_per_block=*/4,
+                                                                     DataType::TYPE_FP16,
+                                                                     /*local_head_num_kv=*/1,
+                                                                     /*size_per_head=*/1),
+                                                         CacheGroupType::FULL);
+    auto different_tokens   = makeSingleLayerCacheConfig(makeMhaSpec("default",
                                                                    /*tokens_per_block=*/8,
                                                                    DataType::TYPE_FP16,
                                                                    /*local_head_num_kv=*/1,
@@ -627,28 +636,40 @@ TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsIncompatibleDefaultFullGro
                                                          CacheGroupType::FULL);
     expect_no_compatible_alias(target, different_geometry);
 
-    auto mla_target  = makeSingleLayerCacheConfig(makeResolvedMlaSpec(DataType::TYPE_FP16,
+    auto mla_target = makeSingleLayerCacheConfig(makeResolvedMlaSpec(DataType::TYPE_FP16,
                                                                      /*kv_lora_rank=*/1,
                                                                      /*rope_head_dim=*/1,
                                                                      /*seq_size_per_block=*/4,
                                                                      "full"),
                                                  CacheGroupType::FULL);
-    auto mha_propose = makeSingleLayerCacheConfig(makeMhaSpec("default",
-                                                              /*tokens_per_block=*/4,
-                                                              DataType::TYPE_FP16,
-                                                              /*local_head_num_kv=*/1,
-                                                              /*size_per_head=*/1),
-                                                  CacheGroupType::FULL);
-    expect_no_compatible_alias(mla_target, mha_propose);
+    expect_no_compatible_alias(mla_target, compatible_propose);
+
+    auto different_group_stride = compatible_propose;
+    different_group_stride.setGroupBlockLayout({different_group_stride.blockNumForGroup(0)},
+                                               {different_group_stride.kvBlockStrideBytesForGroup(0) + 1},
+                                               {different_group_stride.kvScaleStrideBytesForGroup(0)});
+    expect_no_compatible_alias(target, different_group_stride);
+
+    auto target_with_different_policy    = target;
+    auto target_policy                   = target_with_different_policy.topology().groupById(0).policy;
+    target_policy.explicit_block_num     = 2;
+    target_policy.charge_to_paged_budget = true;
+    target_with_different_policy.setGroupPolicies({target_policy});
+    expect_no_compatible_alias(target_with_different_policy, compatible_propose);
 }
 
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpPrefersExactDefaultGroupMatch) {
-    auto main_config    = makeSingleLayerCacheConfig(makeMhaSpec("default",
-                                                              /*tokens_per_block=*/4,
-                                                              DataType::TYPE_FP16,
-                                                              /*local_head_num_kv=*/1,
-                                                              /*size_per_head=*/1),
-                                                  CacheGroupType::FULL);
+    CacheConfig main_config;
+    main_config.layer_num       = 2;
+    main_config.layer_all_num   = 2;
+    main_config.group_layer_num = 1;
+    main_config.fromGroupedSpecs(
+        {makeMhaSpec("default", 4, DataType::TYPE_FP16, 1, 1), makeMhaSpec("aux", 4, DataType::TYPE_FP16, 1, 1)},
+        {{0}, {1}},
+        {CacheGroupType::FULL, CacheGroupType::FULL},
+        {"default", "aux"});
+    main_config.layer_to_block_stride_bytes.assign(3, 1);
+
     auto propose_config = makeSingleLayerCacheConfig(makeMhaSpec("default",
                                                                  /*tokens_per_block=*/4,
                                                                  DataType::TYPE_FP16,
@@ -656,11 +677,56 @@ TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpPrefersExactDefaultGroupMatch) {
                                                                  /*size_per_head=*/1),
                                                      CacheGroupType::FULL);
 
-    const auto sub_config = main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+    const auto sub_config = main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/2);
     ASSERT_NE(sub_config, nullptr);
-    EXPECT_EQ(sub_config->groupTagsSnapshot(), std::vector<std::string>({"default"}));
-    EXPECT_EQ(sub_config->layerIdsForGroup(0), std::vector<int>({0}));
-    EXPECT_EQ(main_config.layerIdsForGroup(0), std::vector<int>({0, 1}));
+    EXPECT_EQ(sub_config->groupTagsSnapshot(), std::vector<std::string>({"default", "aux"}));
+    const auto default_gid = static_cast<size_t>(main_config.groupIdForTag("default"));
+    const auto aux_gid     = static_cast<size_t>(main_config.groupIdForTag("aux"));
+    EXPECT_EQ(sub_config->layerIdsForGroup(default_gid), std::vector<int>({0}));
+    EXPECT_TRUE(sub_config->layerIdsForGroup(aux_gid).empty());
+    EXPECT_EQ(main_config.layerIdsForGroup(default_gid), std::vector<int>({0, 2}));
+    EXPECT_EQ(main_config.layerIdsForGroup(aux_gid), std::vector<int>({1}));
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpDoesNotAliasDefaultLinearProposeGroup) {
+    auto main_config = makeSingleLayerCacheConfig(
+        makeMhaSpec("full", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
+        CacheGroupType::FULL);
+    auto propose_config = makeSingleLayerCacheConfig(
+        makeLinearSpec(
+            "default", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
+        CacheGroupType::LINEAR);
+
+    try {
+        main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1);
+        FAIL() << "expected a default Linear propose group not to use the FULL alias";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("missing group mapping for sub layer 0"), std::string::npos);
+    }
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpAliasErrorIdentifiesSourceAndTargetTags) {
+    auto main_config = makeSingleGroupCacheConfig(
+        makeMhaSpec("full", /*tokens_per_block=*/4, DataType::TYPE_FP16, /*local_head_num_kv=*/1, /*size_per_head=*/1),
+        CacheGroupType::FULL,
+        /*layer_num=*/2,
+        /*block_num=*/4);
+    main_config.group_layer_num = 2;
+    auto propose_config         = makeSimpleMhaCacheConfig(
+        /*layer_num=*/2, /*block_num=*/4, /*tokens_per_block=*/4, DataType::TYPE_FP16);
+    auto propose_groups         = propose_config.topology().groups();
+    auto propose_layers         = propose_config.topology().layers();
+    propose_groups[0].layer_ids = {1, 0};
+    propose_config.setTopology(std::move(propose_groups), std::move(propose_layers));
+
+    try {
+        main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/2);
+        FAIL() << "expected reordered aliased source layers to be rejected";
+    } catch (const std::runtime_error& e) {
+        const std::string message = e.what();
+        EXPECT_NE(message.find("source_tag=default"), std::string::npos);
+        EXPECT_NE(message.find("target_tag=full"), std::string::npos);
+    }
 }
 
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpDoesNotAliasMultiGroupProposeConfig) {

--- a/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
+++ b/rtp_llm/cpp/cache/test/HybridTypeKVCacheAllocatorTest.cc
@@ -493,6 +493,97 @@ TEST_F(HybridTypeKVCacheAllocatorTest, ConvertToGlobalLayerIdHybridWithMtpSubCon
               std::numeric_limits<uint32_t>::max());
 }
 
+TEST_F(HybridTypeKVCacheAllocatorTest, EagleMapsSoleDefaultFullDraftGroupToUniqueFullTargetGroup) {
+    auto score_model_cfg   = makeTinyModelConfig(/*num_layers=*/4);
+    auto propose_model_cfg = makeTinyModelConfig(/*num_layers=*/1);
+
+    setHybridLayerDescs(score_model_cfg,
+                        {HybridAttentionType::LINEAR,
+                         HybridAttentionType::LINEAR,
+                         HybridAttentionType::NONE,
+                         HybridAttentionType::NONE});
+    score_model_cfg.linear_attention_config.linear_conv_kernel_dim = 2;
+    score_model_cfg.linear_attention_config.linear_key_head_dim    = 8;
+    score_model_cfg.linear_attention_config.linear_value_head_dim  = 8;
+    score_model_cfg.linear_attention_config.linear_num_key_heads   = 2;
+    score_model_cfg.linear_attention_config.linear_num_value_heads = 2;
+    propose_model_cfg.kv_cache_spec_descs[0][0].tag                = "default";
+
+    ParallelismConfig parallelism_cfg;
+    parallelism_cfg.tp_size = 1;
+
+    RuntimeConfig runtime_cfg;
+    KVCacheConfig kv_cache_cfg;
+    kv_cache_cfg.test_block_num = 8;
+
+    SpeculativeExecutionConfig sp_cfg;
+    sp_cfg.type              = SP_TYPE_EAGLE;
+    sp_cfg.gen_num_per_cycle = 2;
+
+    auto config = CacheConfigCreator::createSpConfig(score_model_cfg,
+                                                     propose_model_cfg,
+                                                     parallelism_cfg,
+                                                     runtime_cfg,
+                                                     kv_cache_cfg,
+                                                     sp_cfg,
+                                                     /*warm_up_result=*/std::nullopt,
+                                                     /*is_mtp=*/true,
+                                                     /*is_eagle=*/true);
+
+    ASSERT_EQ(config.mtp_sub_configs.size(), 1u);
+    const auto& sub_config = config.mtp_sub_configs[0];
+    ASSERT_NE(sub_config, nullptr);
+    EXPECT_EQ(sub_config->groupTagsSnapshot(), config.groupTagsSnapshot());
+
+    const auto full_gid = static_cast<size_t>(config.groupIdForTag("full"));
+    EXPECT_EQ(sub_config->groupIdForLayerTag(0, "full"), static_cast<int>(full_gid));
+    EXPECT_EQ(sub_config->layerIdsForGroup(full_gid), std::vector<int>({0}));
+    EXPECT_EQ(sub_config->specForGroup(full_gid)->tag, "full");
+    EXPECT_EQ(sub_config->specForGroup(full_gid)->type, KVCacheSpecType::MultiHeadAttention);
+
+    const auto linear_gid = static_cast<size_t>(config.groupIdForTag("linear"));
+    EXPECT_TRUE(sub_config->layerIdsForGroup(linear_gid).empty());
+
+    auto manager = std::make_shared<KVCacheManager>(config);
+    ASSERT_TRUE(manager->init());
+    const auto layout = manager->getMTPModuleGroupedCacheLayerLayout(0);
+    EXPECT_TRUE(layout.at("full", 0).kv_addr.defined());
+    EXPECT_TRUE(layout.group("linear").empty());
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsAmbiguousDefaultFullGroupAlias) {
+    CacheConfig main_config;
+    main_config.layer_num       = 2;
+    main_config.layer_all_num   = 2;
+    main_config.group_layer_num = 1;
+    main_config.fromGroupedSpecs(
+        {makeMhaSpec("full0", 4, DataType::TYPE_FP16, 1, 1), makeMhaSpec("full1", 4, DataType::TYPE_FP16, 1, 1)},
+        {{0}, {1}},
+        {CacheGroupType::FULL, CacheGroupType::FULL},
+        {"full0", "full1"});
+    main_config.layer_to_block_stride_bytes.assign(3, 1);
+
+    auto propose_config = makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/4, rtp_llm::DataType::TYPE_FP16);
+
+    try {
+        main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/2);
+        FAIL() << "expected an ambiguous default FULL group mapping to be rejected";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("ambiguous default FULL group mapping"), std::string::npos);
+    }
+}
+
+TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpDoesNotAliasDefaultFullGroupToLinearTarget) {
+    auto main_config = makeSimpleLinearCacheConfig(
+        /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/4, rtp_llm::DataType::TYPE_FP16);
+    auto propose_config = makeSimpleMhaCacheConfig(
+        /*layer_num=*/1, /*block_num=*/4, /*tokens_per_block=*/4, rtp_llm::DataType::TYPE_FP16);
+
+    EXPECT_THROW(main_config.mergeMTPModule(propose_config, /*module_index=*/0, /*main_layer_num=*/1),
+                 std::runtime_error);
+}
+
 TEST_F(HybridTypeKVCacheAllocatorTest, MergeMtpRejectsShortTargetGroup) {
     CacheConfig main_config;
     main_config.layer_num       = 5;


### PR DESCRIPTION
## Summary

- resolve a sole legacy default FULL MHA/MLA draft cache group to the unique compatible target FULL group
- preserve exact tag matching and reject ambiguous or type-incompatible aliases
- cover the Qwen35 hybrid score plus Qwen2 MTP Eagle path through KVCacheManager layout initialization

## Testing

- bazelisk test //rtp_llm/cpp/cache/test:hybrid_kv_cache_allocator_test --config=cuda12_9 --config=compat --config=sm9x --test_output=errors