### PR TITLE
fix(rocm): reuse TP communicator for HIPGraph capture

### DIFF
--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -38,6 +38,18 @@ _parallelism_config: Optional[ParallelismConfig] = None
 _initialized: bool = False  # Track if we've initialized (to prevent double init)
 
 
+def _set_current_device_from_local_rank(parallelism_config: ParallelismConfig) -> None:
+    if not rocm_rccl.is_available_runtime() or not torch.cuda.is_available():
+        return
+    local_rank = int(parallelism_config.local_rank)
+    device_count = torch.cuda.device_count()
+    if local_rank < 0 or local_rank >= device_count:
+        raise RuntimeError(
+            f"local_rank {local_rank} exceeds available CUDA/HIP device count {device_count}"
+        )
+    torch.cuda.set_device(local_rank)
+
+
 def init_distributed_environment(
     parallelism_config: ParallelismConfig,
     nccl_comm_config: NcclCommConfig,
@@ -61,6 +73,8 @@ def init_distributed_environment(
         RuntimeError: If already initialized and not destroyed
     """
     global _group_map, _parallelism_config, _initialized
+
+    _set_current_device_from_local_rank(parallelism_config)
 
     # Check if already initialized (and not destroyed)
     if _initialized and torch.distributed.is_initialized():

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -662,7 +662,10 @@ def reduce_scatter(input_tensor: torch.Tensor, group: Group) -> torch.Tensor:
         dtype=input_tensor.dtype,
     )
     torch.distributed.reduce_scatter_tensor(
-        output_tensor, input_tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
+        output_tensor,
+        input_tensor,
+        op=torch.distributed.ReduceOp.SUM,
+        group=process_group,
     )
     return output_tensor
 

--- a/rtp_llm/models_py/distributed/rocm_rccl.py
+++ b/rtp_llm/models_py/distributed/rocm_rccl.py
@@ -204,7 +204,9 @@ def _get_rccl_runtime(
         raise RuntimeError(
             "RCCL library is not available for HIPGraph capture collectives"
         )
-    if (_rccl_comm is None or _rccl_comm.value is None) and not _is_hipgraph_capture_active():
+    if (
+        _rccl_comm is None or _rccl_comm.value is None
+    ) and not _is_hipgraph_capture_active():
         _ensure_rccl_comm_from_process_group(process_group)
     if _rccl_comm is None or _rccl_comm.value is None:
         raise RuntimeError(
@@ -270,6 +272,7 @@ def set_hipgraph_capture_nccl_comm(
         return
     _pre_init_trtllm_allreduce()
 
+
 def _pre_init_trtllm_allreduce(
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
 ) -> None:
@@ -287,6 +290,7 @@ def _pre_init_trtllm_allreduce(
         from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
             ensure_trtllm_comm_initialized,
         )
+
         if not torch.distributed.is_initialized():
             return
         if tp_group is None:
@@ -296,6 +300,7 @@ def _pre_init_trtllm_allreduce(
         logging.info("Pre-init trtllm_allreduce succeeded (device_id=%s)", device_id)
     except Exception as exc:
         logging.warning("Pre-init trtllm_allreduce failed (non-fatal): %s", exc)
+
 
 def _warmup_rccl_collectives(
     lib: ctypes.CDLL, comm: ctypes.c_void_p, world_size: int
@@ -310,23 +315,30 @@ def _warmup_rccl_collectives(
         nccl_float = _get_nccl_dtype(dummy_in)
 
         res = lib.ncclAllGather(
-            dummy_in.data_ptr(), ag_out.data_ptr(),
-            dummy_in.numel(), nccl_float, comm, stream,
+            dummy_in.data_ptr(),
+            ag_out.data_ptr(),
+            dummy_in.numel(),
+            nccl_float,
+            comm,
+            stream,
         )
         if res != _NCCL_SUCCESS:
             logging.warning("RCCL AllGather warmup returned error %d", res)
 
         res = lib.ncclAllReduce(
-            ar_out.data_ptr(), ar_out.data_ptr(),
-            ar_out.numel(), nccl_float, _NCCL_SUM, comm, stream,
+            ar_out.data_ptr(),
+            ar_out.data_ptr(),
+            ar_out.numel(),
+            nccl_float,
+            _NCCL_SUM,
+            comm,
+            stream,
         )
         if res != _NCCL_SUCCESS:
             logging.warning("RCCL AllReduce warmup returned error %d", res)
 
         torch.cuda.synchronize(device)
-        logging.info(
-            "RCCL collective warmup succeeded (world_size=%d)", world_size
-        )
+        logging.info("RCCL collective warmup succeeded (world_size=%d)", world_size)
     except Exception as e:
         logging.warning("RCCL collective warmup failed (non-fatal): %s", e)
 
@@ -468,11 +480,7 @@ def finish_hipgraph_capture_session() -> None:
 
 
 def should_use_hipgraph_capture_rccl(is_tp_group: bool) -> bool:
-    return (
-        _is_rocm_runtime
-        and is_tp_group
-        and _is_hipgraph_capture_active()
-    )
+    return _is_rocm_runtime and is_tp_group and _is_hipgraph_capture_active()
 
 
 def ensure_tp_rccl_comm_for_capture(is_tp_group: bool) -> None:
@@ -494,16 +502,22 @@ def _is_hidden_size_supported_for_trtllm(hidden_size: int) -> bool:
         from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
             ALLREDUCE_SUPPORTED_HIDDEN_SIZES,
         )
+
         return hidden_size in ALLREDUCE_SUPPORTED_HIDDEN_SIZES
     except Exception:
         return False
 
+
 def _is_trtllm_allreduce_ready() -> bool:
     try:
-        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import is_trt_allreduce_ready
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
+            is_trt_allreduce_ready,
+        )
+
         return is_trt_allreduce_ready()
     except ImportError:
         return False
+
 
 _trtllm_fallback_warned: bool = False
 
@@ -523,8 +537,11 @@ def hipgraph_capture_all_reduce(
         try:
             from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
                 _trtllm_comm_manager,
+            )
+            from rtp_llm.models_py.modules.base.rocm.trt_allreduce import (
                 allreduce as trtllm_allreduce,
             )
+
             # Size guard: fall through to NCCL when input exceeds the
             # workspace `data_` capacity. Without this check,
             # CommWorkspace::get_comm_data's gpuMemcpyAsync would write
@@ -544,7 +561,8 @@ def hipgraph_capture_all_reduce(
             if not _trtllm_fallback_warned:
                 logging.warning(
                     "trtllm_allreduce import failed in graph capture mode, "
-                    "fallback to ncclAllReduce (further warnings suppressed): %s", exc,
+                    "fallback to ncclAllReduce (further warnings suppressed): %s",
+                    exc,
                 )
                 _trtllm_fallback_warned = True
         except RuntimeError as exc:
@@ -552,7 +570,8 @@ def hipgraph_capture_all_reduce(
                 logging.warning(
                     "trtllm_allreduce failed in graph capture mode, "
                     "fallback to ncclAllReduce (further warnings suppressed): %s",
-                    exc, exc_info=True,
+                    exc,
+                    exc_info=True,
                 )
                 _trtllm_fallback_warned = True
 

--- a/rtp_llm/models_py/distributed/rocm_rccl.py
+++ b/rtp_llm/models_py/distributed/rocm_rccl.py
@@ -175,9 +175,19 @@ def _ensure_rccl_comm_from_process_group(
         return True
     try:
         comm_ptr = int(process_group._comm_ptr())
-    except Exception as e:
-        logging.warning("Failed to fetch NCCL comm from process group: %s", e)
-        return False
+    except Exception as process_group_error:
+        try:
+            backend = process_group._get_backend(
+                torch.device("cuda", torch.cuda.current_device())
+            )
+            comm_ptr = int(backend._comm_ptr())
+        except Exception as backend_error:
+            logging.warning(
+                "Failed to fetch NCCL comm from process group: %s; backend fallback: %s",
+                process_group_error,
+                backend_error,
+            )
+            return False
     if comm_ptr == 0:
         return False
     lib = _load_rccl()
@@ -421,8 +431,10 @@ def prepare_hipgraph_capture_rccl_comm_if_needed(
         return
     if parallelism_config.tp_size <= 1:
         return
-    # IMPORTANT: bootstrap must happen before graph capture begins.
-    bootstrap_hipgraph_capture_rccl_comm_from_tp_group(tp_group)
+
+    if not _ensure_rccl_comm_from_process_group(tp_group):
+        # IMPORTANT: bootstrap must happen before graph capture begins.
+        bootstrap_hipgraph_capture_rccl_comm_from_tp_group(tp_group)
     # Pre-initialize trt_allreduce with the correct TP group so that
     # hipgraph_capture_all_reduce can use it during graph capture.
     _pre_init_trtllm_allreduce(tp_group)

--- a/rtp_llm/models_py/distributed/test/collective_torch_hipgraph_unit_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_hipgraph_unit_test.py
@@ -17,6 +17,7 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
         self._orig_rccl_comm = hr._rccl_comm
         self._orig_rccl_world_size = hr._rccl_world_size
         self._orig_rccl_lib = hr._rccl_lib
+        self._orig_rccl_comm_owned_by_python = hr._rccl_comm_owned_by_python
         self._orig_cache = dict(hr._hipgraph_allgather_outputs)
         hr._hipgraph_allgather_outputs.clear()
 
@@ -25,8 +26,70 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
         hr._rccl_comm = self._orig_rccl_comm
         hr._rccl_world_size = self._orig_rccl_world_size
         hr._rccl_lib = self._orig_rccl_lib
+        hr._rccl_comm_owned_by_python = self._orig_rccl_comm_owned_by_python
         hr._hipgraph_allgather_outputs.clear()
         hr._hipgraph_allgather_outputs.update(self._orig_cache)
+
+    def test_set_current_device_is_rocm_only(self):
+        config = SimpleNamespace(local_rank=1)
+        with patch.object(hr, "is_available_runtime", return_value=False), patch(
+            "torch.cuda.is_available", return_value=True
+        ), patch("torch.cuda.set_device") as set_device:
+            ct._set_current_device_from_local_rank(config)
+
+        set_device.assert_not_called()
+
+    def test_set_current_device_from_valid_rocm_local_rank(self):
+        config = SimpleNamespace(local_rank=1)
+        with patch.object(hr, "is_available_runtime", return_value=True), patch(
+            "torch.cuda.is_available", return_value=True
+        ), patch("torch.cuda.device_count", return_value=2), patch(
+            "torch.cuda.set_device"
+        ) as set_device:
+            ct._set_current_device_from_local_rank(config)
+
+        set_device.assert_called_once_with(1)
+
+    def test_set_current_device_rejects_invalid_rocm_local_rank(self):
+        with patch.object(hr, "is_available_runtime", return_value=True), patch(
+            "torch.cuda.is_available", return_value=True
+        ), patch("torch.cuda.device_count", return_value=2), patch(
+            "torch.cuda.set_device"
+        ) as set_device:
+            for local_rank in (-1, 2):
+                with self.subTest(local_rank=local_rank), self.assertRaisesRegex(
+                    RuntimeError, "local_rank.*device count"
+                ):
+                    ct._set_current_device_from_local_rank(
+                        SimpleNamespace(local_rank=local_rank)
+                    )
+
+        set_device.assert_not_called()
+
+    def test_ensure_rccl_comm_uses_device_backend_fallback(self):
+        hr._rccl_comm = None
+        hr._rccl_world_size = 1
+        hr._rccl_comm_owned_by_python = False
+        backend = unittest.mock.MagicMock()
+        backend._comm_ptr.return_value = 456
+        process_group = unittest.mock.MagicMock()
+        process_group._comm_ptr.side_effect = RuntimeError("direct API unavailable")
+        process_group._get_backend.return_value = backend
+        fake_lib = object()
+
+        with patch("torch.cuda.current_device", return_value=1), patch.object(
+            hr, "_load_rccl", return_value=fake_lib
+        ), patch.object(hr, "_setup_rccl_api") as setup_api, patch(
+            "torch.distributed.get_world_size", return_value=2
+        ):
+            self.assertTrue(hr._ensure_rccl_comm_from_process_group(process_group))
+
+        process_group._get_backend.assert_called_once_with(torch.device("cuda", 1))
+        backend._comm_ptr.assert_called_once_with()
+        setup_api.assert_called_once_with(fake_lib)
+        self.assertEqual(hr._rccl_comm.value, 456)
+        self.assertEqual(hr._rccl_world_size, 2)
+        self.assertFalse(hr._rccl_comm_owned_by_python)
 
     def test_should_use_hipgraph_capture_rccl(self):
         hr._is_rocm_runtime = True
@@ -125,12 +188,36 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
         parallelism_config = SimpleNamespace(tp_size=2, world_size=2)
         tp_group = object()
         with patch.object(
+            hr, "_ensure_rccl_comm_from_process_group", return_value=False
+        ), patch.object(
             hr, "bootstrap_hipgraph_capture_rccl_comm_from_tp_group"
-        ) as bootstrap:
+        ) as bootstrap, patch.object(
+            hr, "_pre_init_trtllm_allreduce"
+        ) as pre_init:
             hr.prepare_hipgraph_capture_rccl_comm_if_needed(
                 parallelism_config, tp_group
             )
         bootstrap.assert_called_once_with(tp_group)
+        pre_init.assert_called_once_with(tp_group)
+
+    def test_prepare_hipgraph_capture_reuses_native_process_group_comm(self):
+        hr._is_rocm_runtime = True
+        parallelism_config = SimpleNamespace(tp_size=2, world_size=2)
+        tp_group = object()
+        with patch.object(
+            hr, "_ensure_rccl_comm_from_process_group", return_value=True
+        ) as ensure, patch.object(
+            hr, "bootstrap_hipgraph_capture_rccl_comm_from_tp_group"
+        ) as bootstrap, patch.object(
+            hr, "_pre_init_trtllm_allreduce"
+        ) as pre_init:
+            hr.prepare_hipgraph_capture_rccl_comm_if_needed(
+                parallelism_config, tp_group
+            )
+
+        ensure.assert_called_once_with(tp_group)
+        bootstrap.assert_not_called()
+        pre_init.assert_called_once_with(tp_group)
 
     def test_all_gather_fail_fast_when_capture_has_no_rccl_comm(self):
         hr._is_rocm_runtime = True

--- a/rtp_llm/models_py/distributed/test/collective_torch_hipgraph_unit_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_hipgraph_unit_test.py
@@ -232,9 +232,12 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
 
         tensor = torch.zeros((4,), dtype=torch.float16)
         mock_group = object()
-        with patch.object(hr, "_is_hipgraph_capture_active", return_value=True), \
-             patch("torch.cuda.current_stream") as mock_stream, \
-             patch("rtp_llm.models_py.distributed.collective_torch._get_group", return_value=mock_group):
+        with patch.object(hr, "_is_hipgraph_capture_active", return_value=True), patch(
+            "torch.cuda.current_stream"
+        ) as mock_stream, patch(
+            "rtp_llm.models_py.distributed.collective_torch._get_group",
+            return_value=mock_group,
+        ):
             mock_stream.return_value.cuda_stream = 0
             result = ct.all_reduce(tensor, ct.Group.TP)
 
@@ -251,9 +254,12 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
 
         tensor = torch.zeros((2, 4), dtype=torch.bfloat16)
         mock_group = object()
-        with patch.object(hr, "_is_hipgraph_capture_active", return_value=True), \
-             patch("torch.cuda.current_stream") as mock_stream, \
-             patch("rtp_llm.models_py.distributed.collective_torch._get_group", return_value=mock_group):
+        with patch.object(hr, "_is_hipgraph_capture_active", return_value=True), patch(
+            "torch.cuda.current_stream"
+        ) as mock_stream, patch(
+            "rtp_llm.models_py.distributed.collective_torch._get_group",
+            return_value=mock_group,
+        ):
             mock_stream.return_value.cuda_stream = 0
             out = ct.all_gather(tensor, ct.Group.TP)
 
@@ -353,7 +359,10 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
             consume_capture=mock_consume,
             has_pending_capture=mock_has_pending,
         )
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module}):
+        with patch.dict(
+            "sys.modules",
+            {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module},
+        ):
             hr.finish_hipgraph_capture_session()
 
         mock_has_pending.assert_called_once()
@@ -367,7 +376,10 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
             consume_capture=mock_consume,
             has_pending_capture=mock_has_pending,
         )
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module}):
+        with patch.dict(
+            "sys.modules",
+            {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module},
+        ):
             hr.finish_hipgraph_capture_session()
 
         mock_has_pending.assert_called_once()
@@ -375,19 +387,26 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
 
     def test_finish_session_propagates_consume_error(self):
         """Runtime errors from consume_capture() propagate (not silenced)."""
-        mock_consume = unittest.mock.MagicMock(side_effect=RuntimeError("barrier timeout"))
+        mock_consume = unittest.mock.MagicMock(
+            side_effect=RuntimeError("barrier timeout")
+        )
         mock_has_pending = unittest.mock.MagicMock(return_value=True)
         fake_module = SimpleNamespace(
             consume_capture=mock_consume,
             has_pending_capture=mock_has_pending,
         )
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module}):
+        with patch.dict(
+            "sys.modules",
+            {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module},
+        ):
             with self.assertRaises(RuntimeError):
                 hr.finish_hipgraph_capture_session()
 
     def test_finish_session_tolerates_import_error(self):
         """ImportError (trt_allreduce unavailable) is silently handled."""
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": None}):
+        with patch.dict(
+            "sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": None}
+        ):
             hr.finish_hipgraph_capture_session()
 
     # ------------------------------------------------------------------
@@ -404,7 +423,9 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
 
         fake_dist_env = SimpleNamespace(max_size_in_bytes=max_size_in_bytes)
         fake_comm_manager = SimpleNamespace(dist_env=fake_dist_env)
-        fake_allreduce = unittest.mock.MagicMock(side_effect=lambda **kw: kw["allreduce_in"])
+        fake_allreduce = unittest.mock.MagicMock(
+            side_effect=lambda **kw: kw["allreduce_in"]
+        )
         fake_module = SimpleNamespace(
             _trtllm_comm_manager=fake_comm_manager,
             allreduce=fake_allreduce,
@@ -421,10 +442,16 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
         tensor = torch.zeros((512,), dtype=torch.float16)
         process_group = object()
 
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module}), \
-             patch.object(hr, "_is_hidden_size_supported_for_trtllm", return_value=True), \
-             patch.object(hr, "_is_trtllm_allreduce_ready", return_value=True), \
-             patch("torch.cuda.current_device", return_value=0):
+        with patch.dict(
+            "sys.modules",
+            {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module},
+        ), patch.object(
+            hr, "_is_hidden_size_supported_for_trtllm", return_value=True
+        ), patch.object(
+            hr, "_is_trtllm_allreduce_ready", return_value=True
+        ), patch(
+            "torch.cuda.current_device", return_value=0
+        ):
             result = hr.hipgraph_capture_all_reduce(tensor, process_group)
 
         fake_allreduce.assert_called_once()
@@ -438,10 +465,16 @@ class TestCollectiveTorchHipGraphUnit(unittest.TestCase):
         tensor = torch.zeros((1024,), dtype=torch.float16)
         process_group = object()
 
-        with patch.dict("sys.modules", {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module}), \
-             patch.object(hr, "_is_hidden_size_supported_for_trtllm", return_value=True), \
-             patch.object(hr, "_is_trtllm_allreduce_ready", return_value=True), \
-             patch("torch.cuda.current_stream") as mock_stream:
+        with patch.dict(
+            "sys.modules",
+            {"rtp_llm.models_py.modules.base.rocm.trt_allreduce": fake_module},
+        ), patch.object(
+            hr, "_is_hidden_size_supported_for_trtllm", return_value=True
+        ), patch.object(
+            hr, "_is_trtllm_allreduce_ready", return_value=True
+        ), patch(
+            "torch.cuda.current_stream"
+        ) as mock_stream:
             mock_stream.return_value.cuda_stream = 0
             result = hr.hipgraph_capture_all_reduce(tensor, process_group)
 

--- a/rtp_llm/models_py/modules/base/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/base/rocm/test/BUILD
@@ -84,12 +84,13 @@ py_test(
     srcs = ["test_trt_allreduce_graph_replay.py"],
     deps = [
         "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
         "//rtp_llm/models_py/modules/base/rocm:trt_allreduce",
     ],
     timeout = "moderate",
-    env = {"GPU_COUNT": "2"},
+    env = {"GPU_COUNT": "4"},
     tags = ["rocm"],
-    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'4'},
 )
 
 py_test(

--- a/rtp_llm/models_py/modules/base/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/base/rocm/test/BUILD
@@ -103,4 +103,3 @@ py_test(
     tags = ["rocm"],
     exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
 )
-

--- a/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
@@ -13,23 +13,35 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
-warnings.filterwarnings("ignore", message="barrier.*using the device under current context")
+warnings.filterwarnings(
+    "ignore", message="barrier.*using the device under current context"
+)
 warnings.filterwarnings("ignore", message="Guessing device ID based on global rank")
 
 REPLAY_ROUNDS = 60
 
 
 def _setup(rank, world_size, port):
-    os.environ.update(MASTER_ADDR="localhost", MASTER_PORT=str(port),
-                      RANK=str(rank), WORLD_SIZE=str(world_size))
+    os.environ.update(
+        MASTER_ADDR="localhost",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
     torch.cuda.set_device(rank)
-    dist.init_process_group("nccl", init_method="env://", world_size=world_size,
-                            rank=rank, device_id=torch.device(f"cuda:{rank}"))
+    dist.init_process_group(
+        "nccl",
+        init_method="env://",
+        world_size=world_size,
+        rank=rank,
+        device_id=torch.device(f"cuda:{rank}"),
+    )
 
 
 def _teardown():
     try:
-        dist.barrier(); torch.cuda.synchronize()
+        dist.barrier()
+        torch.cuda.synchronize()
     except Exception:
         pass
     try:
@@ -40,24 +52,28 @@ def _teardown():
 
 def _free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0)); return s.getsockname()[1]
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 def _launch(fn, world_size=2, timeout=180, **kw):
     port = _free_port()
     procs = []
     for r in range(world_size):
-        p = mp.Process(target=fn, args=(r, world_size, port), kwargs=kw, name=f"rank-{r}")
-        p.start(); procs.append(p)
+        p = mp.Process(
+            target=fn, args=(r, world_size, port), kwargs=kw, name=f"rank-{r}"
+        )
+        p.start()
+        procs.append(p)
     try:
         for p in procs:
             p.join(timeout=timeout)
             if p.exitcode is None:
                 raise RuntimeError(
-                    f"{p.name} timed out after {timeout}s (still running)")
+                    f"{p.name} timed out after {timeout}s (still running)"
+                )
             if p.exitcode != 0:
-                raise RuntimeError(
-                    f"{p.name} exited with code {p.exitcode}")
+                raise RuntimeError(f"{p.name} exited with code {p.exitcode}")
     finally:
         for p in procs:
             if p.is_alive():
@@ -79,30 +95,39 @@ def _worker_graph_pure_allreduce(rank, world_size, port, num_replays):
         torch.manual_seed(42 + rank)
         inp = torch.randn(8, 4096, dtype=torch.bfloat16, device=dev)
 
-        ref = inp.clone(); dist.all_reduce(ref)
+        ref = inp.clone()
+        dist.all_reduce(ref)
 
         s = torch.cuda.Stream(device=dev)
         with torch.cuda.stream(s):
-            env.allreduce_op(inp.clone(), torch.empty_like(inp)); s.synchronize()
+            env.allreduce_op(inp.clone(), torch.empty_like(inp))
+            s.synchronize()
             g = torch.cuda.CUDAGraph()
             g_in, g_out = inp.clone(), torch.empty_like(inp)
             with torch.cuda.graph(g, stream=s):
                 env.allreduce_op(g_in, g_out)
-        s.synchronize(); env.consume_capture_if_needed()
+        s.synchronize()
+        env.consume_capture_if_needed()
 
         for i in range(num_replays):
-            g_in.copy_(inp); g.replay(); s.synchronize()
+            g_in.copy_(inp)
+            g.replay()
+            s.synchronize()
             diff = (g_out - ref).abs().max().item()
             ref_max = ref.abs().max().item()
             rel = diff / ref_max if ref_max > 0 else 0
-            assert rel < 1e-2 or diff < 1e-3, \
-                f"[Rank {rank}] replay {i}: rel={rel:.4e} abs={diff:.4e}"
+            assert (
+                rel < 1e-2 or diff < 1e-3
+            ), f"[Rank {rank}] replay {i}: rel={rel:.4e} abs={diff:.4e}"
 
         if rank == 0:
             print(f"  [graph_pure_allreduce] {num_replays} replays passed")
     except Exception as e:
         print(f"[Rank {rank}] FAILED: {e}", file=sys.stderr)
-        import traceback; traceback.print_exc(); raise
+        import traceback
+
+        traceback.print_exc()
+        raise
     finally:
         _teardown()
 
@@ -122,7 +147,8 @@ def _worker_graph_fused_rmsnorm(rank, world_size, port, num_replays):
         eps = 1e-6
 
         ref_res, ref_norm, _ = env.allreduce_add_rms_native(
-            ar_in.clone(), res_in.clone(), w, eps)
+            ar_in.clone(), res_in.clone(), w, eps
+        )
 
         s = torch.cuda.Stream(device=dev)
         with torch.cuda.stream(s):
@@ -132,26 +158,36 @@ def _worker_graph_fused_rmsnorm(rank, world_size, port, num_replays):
             g_ar, g_res = ar_in.clone(), res_in.clone()
             with torch.cuda.graph(g, stream=s):
                 g_res_out, g_norm_out, _ = env.allreduce_add_rms_fused(
-                    g_ar, g_res, w, eps)
-        s.synchronize(); env.consume_capture_if_needed()
+                    g_ar, g_res, w, eps
+                )
+        s.synchronize()
+        env.consume_capture_if_needed()
 
         for i in range(num_replays):
-            g_ar.copy_(ar_in); g_res.copy_(res_in)
-            g.replay(); s.synchronize()
+            g_ar.copy_(ar_in)
+            g_res.copy_(res_in)
+            g.replay()
+            s.synchronize()
 
-            for name, got, want in [("residual", g_res_out, ref_res),
-                                    ("norm", g_norm_out, ref_norm)]:
+            for name, got, want in [
+                ("residual", g_res_out, ref_res),
+                ("norm", g_norm_out, ref_norm),
+            ]:
                 diff = (got - want).abs().max().item()
                 mx = want.abs().max().item()
                 rel = diff / mx if mx > 0 else 0
-                assert rel < 1e-2 or diff < 1e-3, \
-                    f"[Rank {rank}] replay {i} {name}: rel={rel:.4e} abs={diff:.4e}"
+                assert (
+                    rel < 1e-2 or diff < 1e-3
+                ), f"[Rank {rank}] replay {i} {name}: rel={rel:.4e} abs={diff:.4e}"
 
         if rank == 0:
             print(f"  [graph_fused_rmsnorm] {num_replays} replays passed")
     except Exception as e:
         print(f"[Rank {rank}] FAILED: {e}", file=sys.stderr)
-        import traceback; traceback.print_exc(); raise
+        import traceback
+
+        traceback.print_exc()
+        raise
     finally:
         _teardown()
 

--- a/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
@@ -192,6 +192,134 @@ def _worker_graph_fused_rmsnorm(rank, world_size, port, num_replays):
         _teardown()
 
 
+def _worker_collective_torch_tp_capture(rank, world_size, port, num_replays):
+    """Exercise the production TP group and native ProcessGroup communicator."""
+    capture_state_checker = None
+    collective_torch = None
+    graph = None
+
+    try:
+        _setup(rank, world_size, port)
+
+        from rtp_llm.models_py.distributed import collective_torch, rocm_rccl
+        from rtp_llm.ops import NcclCommConfig, ParallelismConfig
+
+        # Prove that externally initialized torch.distributed callers are rebound
+        # to their configured local ROCm device before TP groups are created.
+        torch.cuda.set_device((rank + 1) % world_size)
+        parallelism_config = ParallelismConfig()
+        parallelism_config.world_rank = rank
+        parallelism_config.world_size = world_size
+        parallelism_config.local_rank = rank
+        parallelism_config.tp_size = 2
+        parallelism_config.dp_size = world_size // parallelism_config.tp_size
+        nccl_comm_config = NcclCommConfig(
+            nccl_ip="127.0.0.1",
+            tp_nccl_port=port + 9,
+            dp_tp_nccl_port=port + 1,
+            ffn_tp_nccl_port=port + 6,
+        )
+        collective_torch.init_distributed_environment(
+            parallelism_config,
+            nccl_comm_config=nccl_comm_config,
+            nccl_init_port=port,
+            backend="nccl",
+            timeout=60,
+        )
+
+        assert torch.cuda.current_device() == rank
+        tp_group = collective_torch._get_group(collective_torch.Group.TP)
+        tp_ranks = dist.get_process_group_ranks(tp_group)
+        assert len(tp_ranks) == parallelism_config.tp_size
+        assert parallelism_config.dp_size > 1
+        assert rocm_rccl._rccl_comm is not None
+        assert rocm_rccl._rccl_comm.value is not None
+        assert rocm_rccl._rccl_world_size == parallelism_config.tp_size
+        assert not rocm_rccl._rccl_comm_owned_by_python
+
+        device = torch.device(f"cuda:{rank}")
+        # Warm up the real TP ProcessGroup before stream capture.
+        warmup = torch.full((2, 7), rank + 1, dtype=torch.float32, device=device)
+        dist.all_reduce(warmup, group=tp_group)
+        warmup_gather = torch.empty(
+            (parallelism_config.tp_size * 2, 7),
+            dtype=torch.float32,
+            device=device,
+        )
+        dist.all_gather_into_tensor(warmup_gather, warmup, group=tp_group)
+        torch.cuda.synchronize(device)
+
+        graph_stream = torch.cuda.Stream(device=device)
+        graph = torch.cuda.CUDAGraph()
+        graph_allreduce_input = torch.empty((2, 7), dtype=torch.float32, device=device)
+        graph_allgather_input = torch.empty((2, 7), dtype=torch.float32, device=device)
+
+        # The production capture-state flag is normally owned by C++ graph
+        # orchestration. This integration test controls only that flag while
+        # exercising the real Python dispatch, RCCL communicator, and kernels.
+        capture_state_checker = rocm_rccl._is_hipgraph_capture_active
+        rocm_rccl._is_hipgraph_capture_active = lambda: True
+        with torch.cuda.stream(graph_stream):
+            with torch.cuda.graph(graph, stream=graph_stream):
+                graph_allreduce_output = collective_torch.all_reduce(
+                    graph_allreduce_input, collective_torch.Group.TP
+                )
+                graph_allgather_output = collective_torch.all_gather(
+                    graph_allgather_input, collective_torch.Group.TP
+                )
+        graph_stream.synchronize()
+
+        for replay in range(num_replays):
+            with torch.cuda.stream(graph_stream):
+                graph_allreduce_input.fill_(rank + replay + 1)
+                graph_allgather_input.fill_(rank + replay * 10)
+                graph.replay()
+            graph_stream.synchronize()
+
+            expected_sum = sum(tp_rank + replay + 1 for tp_rank in tp_ranks)
+            expected_gather = torch.cat(
+                [
+                    torch.full(
+                        (2, 7),
+                        tp_rank + replay * 10,
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    for tp_rank in tp_ranks
+                ]
+            )
+            torch.testing.assert_close(
+                graph_allreduce_output,
+                torch.full_like(graph_allreduce_output, expected_sum),
+            )
+            torch.testing.assert_close(graph_allgather_output, expected_gather)
+
+        if rank == 0:
+            print(
+                "  [collective_torch_tp_capture] "
+                f"dp={parallelism_config.dp_size} tp={parallelism_config.tp_size} "
+                f"{num_replays} replays passed"
+            )
+    except Exception as e:
+        print(f"[Rank {rank}] FAILED: {e}", file=sys.stderr)
+        import traceback
+
+        traceback.print_exc()
+        raise
+    finally:
+        # A captured raw RCCL operation retains the ProcessGroup communicator.
+        # Destroy the graph before collective_torch tears that communicator down.
+        if graph is not None:
+            graph.reset()
+        if capture_state_checker is not None:
+            from rtp_llm.models_py.distributed import rocm_rccl
+
+            rocm_rccl._is_hipgraph_capture_active = capture_state_checker
+        if collective_torch is not None and dist.is_initialized():
+            collective_torch.destroy_distributed_environment()
+        _teardown()
+
+
 class TestTrtAllReduceGraphReplay(unittest.TestCase):
 
     def setUp(self):
@@ -209,6 +337,15 @@ class TestTrtAllReduceGraphReplay(unittest.TestCase):
 
     def test_graph_replay_fused_rmsnorm(self):
         _launch(_worker_graph_fused_rmsnorm, num_replays=REPLAY_ROUNDS)
+
+    def test_collective_torch_tp_capture_with_dp_and_external_init(self):
+        if torch.cuda.device_count() < 4:
+            self.skipTest("Need >= 4 GPUs for dp_size=2 and tp_size=2")
+        _launch(
+            _worker_collective_torch_tp_capture,
+            world_size=4,
+            num_replays=3,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Bind each ROCm worker to its configured local rank before distributed initialization, including when `torch.distributed` was initialized externally.
- Reuse the native RCCL communicator from the TP ProcessGroup for HIPGraph capture, with backend-pointer lookup and the existing Python bootstrap path as fallbacks.
- Pre-initialize TRT-LLM allreduce with the correct TP group before capture.
- Add unit coverage and a four-GPU `dp_size=2`, `tp_size=2` graph replay test for TP allreduce and all-gather.
- Reset the captured `CUDAGraph` before ProcessGroup teardown so raw RCCL graph nodes do not retain the communicator and hang cleanup.

CUDA behavior is unchanged; the functional path is gated to ROCm.

## Testing

- `//rtp_llm/models_py/distributed/test:collective_torch_hipgraph_unit_test` — passed in 24.1s
- `//rtp_llm/models_py/modules/base/rocm/test:test_trt_allreduce_graph_replay` — passed in 53.4s
- Focused four-GPU regression — passed; one test ran in 16.579s
- Pre-commit hooks — passed