### PR TITLE
fix: release speculative prefill model buffers

### DIFF
--- a/bazel/device_defs.bzl
+++ b/bazel/device_defs.bzl
@@ -1,19 +1,38 @@
 load("@arch_config//:arch_select.bzl", "torch_deps")
 
 
+def cuda_test_envs():
+    return {
+        "TEST_USING_DEVICE": "CUDA",
+        "LD_PRELOAD": "libtorch_cpu.so",
+    }
+
+def rocm_test_envs():
+    return {
+        "TEST_USING_DEVICE": "ROCM",
+    }
+
 def device_test_envs():
     return select({
-        "@//:using_cuda": {
-            "TEST_USING_DEVICE": "CUDA",
-            "LD_PRELOAD": "libtorch_cpu.so",
-        },
-        "@//:using_rocm": {
-            "TEST_USING_DEVICE": "ROCM",
-        },
-        "//conditions:default": {
-            "TEST_USING_DEVICE": "CUDA",
-            "LD_PRELOAD": "libtorch_cpu.so",
-        },
+        "@//:using_cuda": cuda_test_envs(),
+        "@//:using_rocm": rocm_test_envs(),
+        "//conditions:default": cuda_test_envs(),
+    })
+
+def device_runtime_deps():
+    return select({
+        "@//:using_cuda": [
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [
+            "@local_config_cuda//cuda:cuda_headers",
+            "@local_config_cuda//cuda:cudart",
+        ],
     })
 
 def device_impl_target():
@@ -21,5 +40,8 @@ def device_impl_target():
         "@//:using_cuda": [
             "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
         ],
+        # ROCm has no equivalent Python-op registration target. Tests using this
+        # helper exercise the C++ device path without a static op registry.
+        "@//:using_rocm": [],
         "//conditions:default": [],
     })

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -24,6 +24,17 @@
 
 namespace rtp_llm {
 
+void MtpExecutor::releaseAllModelBuffers() {
+    // Keep every model forwarded by this executor registered here. Their host
+    // buffers back asynchronous H2D copies and may only be released at the
+    // executor's synchronization-safe points, not at the next forward entry.
+    model_->releaseBuffers();
+    draft_model_->releaseBuffers();
+    if (sp_prefill_draft_model_) {
+        sp_prefill_draft_model_->releaseBuffers();
+    }
+}
+
 GptModelOutputs MtpExecutor::forwardModel(ModelBase* model, const GptModelInputs& inputs, ModelInputsModelRole role) {
     RTP_LLM_CHECK_WITH_INFO(model != nullptr, "model is null before forward");
     if (model_inputs_logger_) {
@@ -355,8 +366,7 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
     metrics_collector.not_skip = true;
 
     // release model input before forward
-    model_->releaseBuffers();
-    draft_model_->releaseBuffers();
+    releaseAllModelBuffers();
 
     // target model prefill
     {
@@ -399,8 +409,7 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
 
     if (!isTpRank0() || warm_up_ || streams.size() == 0 || model_input.is_fake_stream) {
         cudaSyncAndCheck();
-        model_->releaseBuffers();
-        draft_model_->releaseBuffers();
+        releaseAllModelBuffers();
         return absl::OkStatus();
     }
 
@@ -436,8 +445,7 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
                                                      {std::move(draft_model_output), std::move(draft_sampler_output)});
         RTP_LLM_LOG_DEBUG("dispatch done");
 
-        model_->releaseBuffers();
-        draft_model_->releaseBuffers();
+        releaseAllModelBuffers();
 
         return result;
     }
@@ -589,8 +597,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     }
 
     // release hold buffers before draft model forward
-    draft_model_->releaseBuffers();
-    model_->releaseBuffers();
+    releaseAllModelBuffers();
 
     if (propose_step_ > 1) {
         RTP_LLM_LOG_DEBUG("[MTP decode] draftModelDecode start");
@@ -691,8 +698,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
 
     if (!isTpRank0() || warm_up_ || streams.size() == 0 || model_input.is_fake_stream) {
         cudaSyncAndCheck();
-        draft_model_->releaseBuffers();
-        model_->releaseBuffers();
+        releaseAllModelBuffers();
         return absl::OkStatus();
     }
 
@@ -735,8 +741,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
             stream->getSPOutputBuffer()->tensors_holder.clear();
         }
 
-        draft_model_->releaseBuffers();
-        model_->releaseBuffers();
+        releaseAllModelBuffers();
 
         return result;
     }
@@ -826,9 +831,6 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
                                    std::vector<torch::Tensor>& draft_probs_list,
                                    torch::Tensor&              draft_token_ids_t) {
     RTP_LLM_PROFILE_SCOPE_DYNAMIC("executor.mtp.draft_model_decode(batch_size=%zu)", model_input.combo_tokens.size(0));
-
-    // clear host buffers holder
-    buffer_holder_.release();
 
     const auto& mtp_cache_cfg = cache_manager_->getMTPModuleCacheConfig(0);
     applyCacheStrideToModelInput(model_input, mtp_cache_cfg);

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
@@ -27,24 +27,6 @@ struct MtpMetricsCollector {
     bool not_skip = false;
 };
 
-class MtpBufferHolder {
-public:
-    void hold(const GptModelInputs& model_input) {
-        tensor_holder_.push_back(model_input.combo_tokens);
-        tensor_holder_.push_back(model_input.input_lengths);
-        tensor_holder_.push_back(model_input.sequence_lengths);
-        tensor_holder_.push_back(model_input.lm_output_indexes);
-        tensor_holder_.push_back(model_input.prefix_lengths);
-    }
-
-    void release() {
-        tensor_holder_.clear();
-    }
-
-private:
-    std::vector<torch::Tensor> tensor_holder_;
-};
-
 class MtpExecutor: public Executor {
 public:
     explicit MtpExecutor(const EngineInitParams&                        params,
@@ -63,6 +45,10 @@ public:
 
     void setDraftModel(std::unique_ptr<ModelBase> model) {
         draft_model_ = std::move(model);
+    }
+
+    void setSpPrefillDraftModel(std::shared_ptr<ModelBase> model) {
+        sp_prefill_draft_model_ = std::move(model);
     }
 
     void setBatchProcessor(std::unique_ptr<MtpBatchStreamProcessor> processor) {
@@ -110,6 +96,8 @@ protected:
                         std::list<GenerateStreamPtr>&       decode_streams);
 
 private:
+    void releaseAllModelBuffers();
+
     GptModelOutputs forwardModel(ModelBase* model, const GptModelInputs& inputs, ModelInputsModelRole role);
 
     std::unique_ptr<ModelBase>               model_;
@@ -134,9 +122,6 @@ private:
     std::shared_ptr<ModelBase>                       sp_prefill_draft_model_;
     std::unique_ptr<speculative::SpeculativeSampler> speculative_sampler_;
     std::unique_ptr<speculative::FastTopKSampler>    fast_topk_sampler_;
-
-    // holder for host buffers to avoid early free before H2D copy kernel execution
-    MtpBufferHolder buffer_holder_;
 
     bool     warm_up_;
     RoleType role_type_;

--- a/rtp_llm/cpp/normal_engine/speculative/test/BUILD
+++ b/rtp_llm/cpp/normal_engine/speculative/test/BUILD
@@ -1,11 +1,21 @@
 load("//:def.bzl", "cc_test_wrapper", "copts")
 load("@arch_config//:arch_select.bzl", "torch_deps")
+load(
+    "//bazel:device_defs.bzl",
+    "cuda_test_envs",
+    "device_impl_target",
+    "device_runtime_deps",
+    "rocm_test_envs",
+)
 
 cc_test = cc_test_wrapper
 
 test_copts = [
     "-fno-access-control",
 ] + copts()
+
+# This test stays CUDA-only because it directly exercises the CUDA op
+# implementation. The executor regression below has dedicated CUDA/ROCm targets.
 
 cc_test(
     name = "mtp_batch_stream_processor_test",
@@ -33,28 +43,38 @@ cc_test(
     exec_properties = {'gpu':'H20'},
 )
 
+mtp_executor_test_srcs = glob([
+    "MtpExecutorTest.cc",
+])
+
+mtp_executor_test_deps = [
+    "//rtp_llm/cpp/testing:device_test_utils",
+    "//rtp_llm/cpp/cache:cache",
+    "//rtp_llm/cpp/normal_engine:normal_engine",
+    "//rtp_llm/cpp/models:models",
+    "//rtp_llm/cpp/config:config_modules",
+    "//rtp_llm/cpp/normal_engine/test:mock_engine",
+    "@com_google_googletest//:gtest",
+    "@com_google_googletest//:gtest_main",
+] + device_runtime_deps() + device_impl_target()
+
 cc_test(
     name = "mtp_executor_test",
-    srcs = glob([
-        "MtpExecutorTest.cc",
-    ]),
+    srcs = mtp_executor_test_srcs,
     data = [],
     copts = test_copts,
-    deps = [
-        "//rtp_llm/cpp/testing:device_test_utils",
-        "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
-        "//rtp_llm/cpp/cache:cache",
-        "//rtp_llm/cpp/normal_engine:normal_engine",
-        "//rtp_llm/cpp/models:models",
-        "//rtp_llm/cpp/config:config_modules",
-        "//rtp_llm/cpp/normal_engine/test:mock_engine",
-        "@com_google_googletest//:gtest",
-        "@com_google_googletest//:gtest_main",
-        "@local_config_cuda//cuda:cuda_headers",
-        "@local_config_cuda//cuda:cudart",
-    ],
-    env = {
-        "TEST_USING_DEVICE": "CUDA",
-    },
-    exec_properties = {'gpu':'H20'},
+    deps = mtp_executor_test_deps,
+    env = cuda_test_envs(),
+    exec_properties = {"gpu": "H20"},
+)
+
+cc_test(
+    name = "mtp_executor_rocm_test",
+    srcs = mtp_executor_test_srcs,
+    data = [],
+    copts = test_copts,
+    deps = mtp_executor_test_deps,
+    env = rocm_test_envs(),
+    exec_properties = {"gpu": "MI308X-ROCM7"},
+    tags = ["rocm"],
 )

--- a/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/MtpExecutorTest.cc
@@ -6,7 +6,6 @@
 #include "rtp_llm/cpp/cache/CacheConfigCreator.h"
 #include "rtp_llm/cpp/cache/test/CacheConfigTestUtils.h"
 
-#define private public
 #include "rtp_llm/cpp/normal_engine/speculative/MtpBatchStreamProcessor.h"
 #include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
 #include "rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h"
@@ -130,6 +129,14 @@ public:
         return forward_count_;
     }
 
+    void releaseBuffers() override {
+        ++release_count_;
+    }
+
+    size_t releaseCount() const {
+        return release_count_;
+    }
+
     void checkTensorField(const char* name, const torch::Tensor& actual, const torch::Tensor& expected) {
         RTP_LLM_LOG_INFO("check %s", name);
         checkTensorEqual(actual, expected);
@@ -158,6 +165,7 @@ private:
     TestDataHolder<GptModelInputs>  input_holder;
     TestDataHolder<GptModelOutputs> output_holder;
     size_t                          forward_count_ = 0;
+    size_t                          release_count_ = 0;
 };
 
 class FakeFastTopKSampler: public spec::FastTopKSampler {
@@ -251,10 +259,23 @@ private:
     TestDataHolder<SamplerOutput> output_holder;
 };
 
+class TestableMtpExecutor: public MtpExecutor {
+public:
+    using MtpExecutor::MtpExecutor;
+
+    void draftModelDecodeForTest(GptModelInputs&             model_input,
+                                 const StreamGroups&         stream_groups,
+                                 std::vector<torch::Tensor>& draft_probs_list,
+                                 torch::Tensor&              draft_token_ids_t) {
+        draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t);
+    }
+};
+
 struct MtpExecutorComponents {
-    std::unique_ptr<MtpExecutor>            executor;
+    std::unique_ptr<TestableMtpExecutor>    executor;
     std::unique_ptr<FakeModel>              fake_target_model;
     std::unique_ptr<FakeModel>              fake_draft_model;
+    std::shared_ptr<FakeModel>              fake_sp_prefill_draft_model;
     std::unique_ptr<FakeFastTopKSampler>    fake_fast_topk_sampler;
     std::unique_ptr<FakeSpeculativeSampler> fake_speculative_sampler;
     std::unique_ptr<FakeSampler>            fake_sampler;
@@ -396,7 +417,7 @@ public:
         cache_manager->init();
 
         // Create MtpExecutor
-        auto executor = std::make_unique<MtpExecutor>(params, propose_params, cache_manager);
+        auto executor = std::make_unique<TestableMtpExecutor>(params, propose_params, cache_manager);
 
         // Create fake models
         GptModelInitParams target_model_params(
@@ -415,22 +436,24 @@ public:
              params.model_id,
              params.parallelism_config});
 
-        auto fake_target_model        = std::make_unique<FakeModel>(target_model_params);
-        auto fake_draft_model         = std::make_unique<FakeModel>(draft_model_params);
-        auto fake_fast_topk_sampler   = std::make_unique<FakeFastTopKSampler>();
-        auto fake_speculative_sampler = std::make_unique<FakeSpeculativeSampler>(sp_config.gen_num_per_cycle);
-        auto fake_sampler             = std::make_unique<FakeSampler>(SamplerInitParams{});
+        auto fake_target_model           = std::make_unique<FakeModel>(target_model_params);
+        auto fake_draft_model            = std::make_unique<FakeModel>(draft_model_params);
+        auto fake_sp_prefill_draft_model = std::make_shared<FakeModel>(draft_model_params);
+        auto fake_fast_topk_sampler      = std::make_unique<FakeFastTopKSampler>();
+        auto fake_speculative_sampler    = std::make_unique<FakeSpeculativeSampler>(sp_config.gen_num_per_cycle);
+        auto fake_sampler                = std::make_unique<FakeSampler>(SamplerInitParams{});
 
         MtpExecutorComponents components;
-        components.executor                 = std::move(executor);
-        components.fake_target_model        = std::move(fake_target_model);
-        components.fake_draft_model         = std::move(fake_draft_model);
-        components.fake_fast_topk_sampler   = std::move(fake_fast_topk_sampler);
-        components.fake_speculative_sampler = std::move(fake_speculative_sampler);
-        components.fake_sampler             = std::move(fake_sampler);
-        components.model_config             = model_config;
-        components.runtime_config           = runtime_config;
-        components.resource_context         = resource_context;
+        components.executor                    = std::move(executor);
+        components.fake_target_model           = std::move(fake_target_model);
+        components.fake_draft_model            = std::move(fake_draft_model);
+        components.fake_sp_prefill_draft_model = std::move(fake_sp_prefill_draft_model);
+        components.fake_fast_topk_sampler      = std::move(fake_fast_topk_sampler);
+        components.fake_speculative_sampler    = std::move(fake_speculative_sampler);
+        components.fake_sampler                = std::move(fake_sampler);
+        components.model_config                = model_config;
+        components.runtime_config              = runtime_config;
+        components.resource_context            = resource_context;
 
         return components;
     }
@@ -440,9 +463,11 @@ public:
                          std::unique_ptr<FakeModel>              fake_draft_model,
                          std::unique_ptr<FakeFastTopKSampler>    fake_fast_topk_sampler,
                          std::unique_ptr<FakeSpeculativeSampler> fake_speculative_sampler,
-                         std::unique_ptr<FakeSampler>            fake_sampler) {
+                         std::unique_ptr<FakeSampler>            fake_sampler,
+                         std::shared_ptr<FakeModel>              fake_sp_prefill_draft_model = nullptr) {
         executor->setTargetModel(std::move(fake_target_model));
         executor->setDraftModel(std::move(fake_draft_model));
+        executor->setSpPrefillDraftModel(std::move(fake_sp_prefill_draft_model));
         executor->setFastTopKSampler(std::move(fake_fast_topk_sampler));
         executor->setSpeculativeSampler(std::move(fake_speculative_sampler));
         executor->setSampler(std::move(fake_sampler));
@@ -510,17 +535,25 @@ TEST_F(MtpExecutorTest, testSingleBatchPrefill) {
     components.fake_fast_topk_sampler->setInputs({draft_output.logits});
     components.fake_fast_topk_sampler->setOutputs({fast_topk_sampler_output});
 
+    auto* target_model           = components.fake_target_model.get();
+    auto* draft_model            = components.fake_draft_model.get();
+    auto* sp_prefill_draft_model = components.fake_sp_prefill_draft_model.get();
+
     // Replace models with fake models
     setupFakeModels(components.executor.get(),
                     std::move(components.fake_target_model),
                     std::move(components.fake_draft_model),
                     std::move(components.fake_fast_topk_sampler),
                     std::move(components.fake_speculative_sampler),
-                    std::move(components.fake_sampler));
+                    std::move(components.fake_sampler),
+                    std::move(components.fake_sp_prefill_draft_model));
 
     // Verify executor was created successfully
     auto status = components.executor->process({stream1});
     ASSERT_TRUE(status.ok());
+    EXPECT_EQ(target_model->releaseCount(), 2);
+    EXPECT_EQ(draft_model->releaseCount(), 2);
+    EXPECT_EQ(sp_prefill_draft_model->releaseCount(), 2);
 
     // check stream result
     checkOutput(stream1, {0, 1, 2, 3, 1}, {1, 2}, {0.0, 0.0, 1.0, 0.0}, {0.17, 0.18});
@@ -669,8 +702,10 @@ TEST_F(MtpExecutorTest, testSingleBatchDecode) {
     next_draft_input.lm_output_indexes  = torch::tensor({2}, torch::kInt32);
     next_draft_input.last_hidden_states = torch::tensor({0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.06f}).reshape({3, 2});
 
-    components.fake_draft_model->setInputs({draft_input_1, draft_input_2, draft_input_3, next_draft_input});
-    components.fake_draft_model->setOutputs({draft_output_1, draft_output_2, draft_output_3, next_draft_output});
+    components.fake_draft_model->setInputs({draft_input_1, draft_input_2, draft_input_3});
+    components.fake_draft_model->setOutputs({draft_output_1, draft_output_2, draft_output_3});
+    components.fake_sp_prefill_draft_model->setInputs({next_draft_input});
+    components.fake_sp_prefill_draft_model->setOutputs({next_draft_output});
 
     // set fake model outputs
     auto target_input              = GptModelInputs{};
@@ -738,9 +773,9 @@ TEST_F(MtpExecutorTest, testSingleBatchDecode) {
     components.fake_speculative_sampler->setInputs({draft_spec_sample_input, target_spec_sample_input});
     components.fake_speculative_sampler->setOutputs({speculative_sampler_output});
 
-    // A single active draft model must execute every proposal step, even
-    // though the init plan retains one physical slot per configured module.
-    auto* active_draft_model = components.fake_draft_model.get();
+    auto* target_model           = components.fake_target_model.get();
+    auto* active_draft_model     = components.fake_draft_model.get();
+    auto* sp_prefill_draft_model = components.fake_sp_prefill_draft_model.get();
 
     // Replace models with fake models
     setupFakeModels(components.executor.get(),
@@ -748,12 +783,17 @@ TEST_F(MtpExecutorTest, testSingleBatchDecode) {
                     std::move(components.fake_draft_model),
                     std::move(components.fake_fast_topk_sampler),
                     std::move(components.fake_speculative_sampler),
-                    std::move(components.fake_sampler));
+                    std::move(components.fake_sampler),
+                    std::move(components.fake_sp_prefill_draft_model));
 
     // Verify executor was created successfully
     auto status = components.executor->process({stream1});
     ASSERT_TRUE(status.ok());
-    EXPECT_EQ(active_draft_model->forwardCount(), propose_step);
+    EXPECT_EQ(active_draft_model->forwardCount(), propose_step - 1);
+    EXPECT_EQ(sp_prefill_draft_model->forwardCount(), 1);
+    EXPECT_EQ(target_model->releaseCount(), 2);
+    EXPECT_EQ(active_draft_model->releaseCount(), 2);
+    EXPECT_EQ(sp_prefill_draft_model->releaseCount(), 2);
 
     // check stream result
     checkOutput(stream1, {0, 1, 2, 3, 2, 0}, {0, 1}, {0.0, 1.0, 0.0, 0.0}, {0.3, 0.33});
@@ -1028,7 +1068,7 @@ TEST_F(MtpExecutorTest, testDraftModelDecodeExpandsTargetVerifyPositionIds) {
 
     std::vector<torch::Tensor> draft_probs_list;
     torch::Tensor              draft_token_ids_t;
-    components.executor->draftModelDecode(model_input, stream_groups, draft_probs_list, draft_token_ids_t);
+    components.executor->draftModelDecodeForTest(model_input, stream_groups, draft_probs_list, draft_token_ids_t);
 
     EXPECT_EQ((std::vector<int>{10, 11, 12, 13, 14, 20, 21, 22, 23, 24}), toVec<int>(model_input.combo_tokens));
     EXPECT_EQ((std::vector<int>{5, 5}), toVec<int>(model_input.input_lengths));

--- a/rtp_llm/cpp/normal_engine/test/BUILD
+++ b/rtp_llm/cpp/normal_engine/test/BUILD
@@ -1,5 +1,6 @@
 load("//:def.bzl", "cc_test_wrapper", "copts")
 load("@arch_config//:arch_select.bzl", "torch_deps")
+load("//bazel:device_defs.bzl", "device_impl_target", "device_runtime_deps")
 
 cc_test = cc_test_wrapper
 
@@ -18,16 +19,13 @@ cc_library(
     copts = test_copts,
     deps =  [
         "//rtp_llm/cpp/testing:device_test_utils",
-        "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
         "//rtp_llm/cpp/normal_engine:normal_engine",
         "//rtp_llm/cpp/models:models",
         "//rtp_llm/cpp/config:config_modules",
         "//rtp_llm/cpp/engine_base:weights_converter",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@local_config_cuda//cuda:cuda_headers",
-        "@local_config_cuda//cuda:cudart",
-    ] + torch_deps(),
+    ] + torch_deps() + device_runtime_deps() + device_impl_target(),
     alwayslink = 1,
     visibility = ["//visibility:public"],
 )

--- a/rtp_llm/cpp/normal_engine/test/MockEngine.h
+++ b/rtp_llm/cpp/normal_engine/test/MockEngine.h
@@ -4,7 +4,6 @@
 #include <c10/util/Half.h>
 #include <cstring>
 #include <memory>
-#include <cuda_fp16.h>
 #include "c10/util/intrusive_ptr.h"
 #include "torch/all.h"
 


### PR DESCRIPTION
## Summary

- Release sp_prefill_draft_model_ buffers at all three MTP decode cleanup boundaries.
- Prevent the graph-only speculative-prefill draft model from retaining per-decode host/pinned input tensors and accumulating kernel file objects.
- Preserve MTP speculative decoding and CUDA/HIP graph capture; no broad pinned-buffer rewrite is included.

## Background

The MI308X MTP service reproduced host-wide ENFILE growth with graph-enabled speculative decoding while process FD counts stayed flat. The graph-only sp_prefill_draft_model_ is a PyWrappedModel with a ModelBufferHolder, but its holder was not released; the target and regular draft models already performed this cleanup.

## Validation

- ROCm Bazel target //rtp_llm/cpp/normal_engine/speculative/test:mtp_executor_rocm_test passed after a full rebuild (5/5 GTests; invocation be6cf678-fb20-42bb-863d-34a6455d4e18; elapsed 67.384s), and pre-commit passed.
- With MTP and graph enabled, 40 sequential requests generated 20,480 tokens; all returned HTTP 200 with 512 tokens.
- A rank/thread-scoped kernel file-object trace showed balanced allocation/free pointers and zero outstanding RTP-LLM-owned objects after a short cleanup grace period.

A production-equivalent multi-hour soak, followed by the normal CI and canary workflow, remains recommended.