### PR TITLE
feat: support Qwen3.5 dense MTP

### DIFF
--- a/rtp_llm/frontend/tokenizer_factory/tokenizers/qwen_tokenizer.py
+++ b/rtp_llm/frontend/tokenizer_factory/tokenizers/qwen_tokenizer.py
@@ -232,6 +232,7 @@ register_tokenizer(
         "qwen_3",
         "qwen_3_tool",
         "qwen35_dense",
+        "qwen35_dense_mtp",
         "qwen35_moe",
         "qwen35_moe_mtp",
     ],

--- a/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
@@ -8,10 +8,10 @@ from rtp_llm.models.hybrid_kv_cache import build_hybrid_kv_cache_spec_descs
 from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next, Qwen35Dense, Qwen35Moe
 from rtp_llm.models.qwen3_next.qwen3_next_weight import (
     Qwen3NextWeight,
-    Qwen35DenseWeight,
+    build_qwen35_dense_ffn_weights,
     plus_one,
 )
-from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
+from rtp_llm.ops import HybridAttentionType, KVCacheSpecType, RopeStyle
 from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
 
 
@@ -81,20 +81,30 @@ class Qwen35MoeMTPWeight(Qwen3NextMTPWeight):
 
 class Qwen35DenseMTPWeight(Qwen35MoeMTPWeight):
     def _create_ffn_weight(self) -> List[WeightModule]:
-        return Qwen35DenseWeight._create_ffn_weight(self)
+        return build_qwen35_dense_ffn_weights(
+            self.prefix, self._align_size, self.ffn_config
+        )
 
 
-class Qwen3NextMTP(Qwen3Next):
+class Qwen3NextMTPMixin:
+    _mtp_moe_layer_index = (0,)
+    _mtp_use_base_rope = False
+
     @classmethod
     def _create_config(cls, ckpt_path: str) -> ModelConfig:
         config = super()._create_config(ckpt_path)
-        # mtp model attention is mqa, not linear
+        # MTP layers always use full MQA, even when the target layer at the same
+        # index uses linear attention.
         config.hybrid_attention_config.hybrid_attention_types = [
             HybridAttentionType.NONE
         ]
-        config.moe_layer_index = [0]
+        config.moe_layer_index = list(cls._mtp_moe_layer_index)
         config.num_layers = 1
         config.is_mtp = True
+        if cls._mtp_use_base_rope:
+            # Draft MTP consumes text tokens only. Plain RoPE keeps the
+            # PyFlashinfer prefill CUDA graph implementation eligible.
+            config.attn_config.rope_config.style = RopeStyle.Base
         return config
 
     @classmethod
@@ -123,102 +133,24 @@ class Qwen3NextMTP(Qwen3Next):
             device_resource_config=self.device_resource_config,
         )
 
+
+class Qwen3NextMTP(Qwen3NextMTPMixin, Qwen3Next):
     @staticmethod
     def get_weight_cls():
         return Qwen3NextMTPWeight
 
 
-class Qwen35MoeMTP(Qwen35Moe):
-    @classmethod
-    def _create_config(cls, ckpt_path: str) -> ModelConfig:
-        config = super()._create_config(ckpt_path)
-        # mtp model attention is mqa, not linear
-        config.hybrid_attention_config.hybrid_attention_types = [
-            HybridAttentionType.NONE
-        ]
-        config.moe_layer_index = [0]
-        config.num_layers = 1
-        config.is_mtp = True
-        # Draft MTP consumes text tokens only (no vision tokens), so MRoPE's 3D
-        # position encoding is unnecessary. Falling back to plain RoPE keeps the
-        # PyFlashinfer prefill impl eligible (it filters out MRoPE), which is the
-        # only impl in the registry that handles prefill CUDA graph correctly.
-        config.attn_config.rope_config.style = 1
-        return config
-
-    @classmethod
-    def _post_build_model_config(cls, model_config: ModelConfig) -> None:
-        model_config.kv_cache_spec_descs = build_hybrid_kv_cache_spec_descs(
-            [HybridAttentionType.NONE],
-            KVCacheSpecType.MHA,
-        )
-
-    def _create_python_model(self) -> Optional[Any]:
-        from rtp_llm.models_py.model_desc.qwen3_next_mtp import Qwen3NextMTPModel
-
-        model_config = self.model_config
-        parallelism_config = self.parallelism_config
-        fmha_config = self.fmha_config
-        py_hw_kernel_config = self.hw_kernel_config
-        moe_config = self.moe_config
-        self.py_model = Qwen3NextMTPModel(
-            model_config,
-            parallelism_config,
-            self.weight,
-            max_generate_batch_size=self.max_generate_batch_size,
-            moe_config=moe_config,
-            fmha_config=fmha_config,
-            py_hw_kernel_config=py_hw_kernel_config,
-            device_resource_config=self.device_resource_config,
-        )
+class Qwen35MoeMTP(Qwen3NextMTPMixin, Qwen35Moe):
+    _mtp_use_base_rope = True
 
     @staticmethod
     def get_weight_cls():
         return Qwen35MoeMTPWeight
 
 
-class Qwen35DenseMTP(Qwen35Dense):
-    @classmethod
-    def _create_config(cls, ckpt_path: str) -> ModelConfig:
-        config = super()._create_config(ckpt_path)
-        # The MTP layer always uses full MQA, even when the target layer at the
-        # same index uses linear attention.
-        config.hybrid_attention_config.hybrid_attention_types = [
-            HybridAttentionType.NONE
-        ]
-        config.moe_layer_index = []
-        config.num_layers = 1
-        config.is_mtp = True
-        # Draft MTP receives text tokens only, so plain RoPE is sufficient and
-        # keeps the prefill CUDA graph implementation eligible.
-        config.attn_config.rope_config.style = 1
-        return config
-
-    @classmethod
-    def _post_build_model_config(cls, model_config: ModelConfig) -> None:
-        model_config.kv_cache_spec_descs = build_hybrid_kv_cache_spec_descs(
-            [HybridAttentionType.NONE],
-            KVCacheSpecType.MHA,
-        )
-
-    def _create_python_model(self) -> Optional[Any]:
-        from rtp_llm.models_py.model_desc.qwen3_next_mtp import Qwen3NextMTPModel
-
-        model_config = self.model_config
-        parallelism_config = self.parallelism_config
-        fmha_config = self.fmha_config
-        py_hw_kernel_config = self.hw_kernel_config
-        moe_config = self.moe_config
-        self.py_model = Qwen3NextMTPModel(
-            model_config,
-            parallelism_config,
-            self.weight,
-            max_generate_batch_size=self.max_generate_batch_size,
-            moe_config=moe_config,
-            fmha_config=fmha_config,
-            py_hw_kernel_config=py_hw_kernel_config,
-            device_resource_config=self.device_resource_config,
-        )
+class Qwen35DenseMTP(Qwen3NextMTPMixin, Qwen35Dense):
+    _mtp_moe_layer_index = ()
+    _mtp_use_base_rope = True
 
     @staticmethod
     def get_weight_cls():

--- a/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_mtp.py
@@ -5,8 +5,12 @@ from rtp_llm.model_factory_register import register_model
 from rtp_llm.model_loader.model_weight_info import ModelWeightInfo
 from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
 from rtp_llm.models.hybrid_kv_cache import build_hybrid_kv_cache_spec_descs
-from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next, Qwen35Moe
-from rtp_llm.models.qwen3_next.qwen3_next_weight import Qwen3NextWeight, plus_one
+from rtp_llm.models.qwen3_next.qwen3_next import Qwen3Next, Qwen35Dense, Qwen35Moe
+from rtp_llm.models.qwen3_next.qwen3_next_weight import (
+    Qwen3NextWeight,
+    Qwen35DenseWeight,
+    plus_one,
+)
 from rtp_llm.ops import HybridAttentionType, KVCacheSpecType
 from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity, transpose
 
@@ -73,6 +77,11 @@ class Qwen35MoeMTPWeight(Qwen3NextMTPWeight):
     def __init__(self, *args: List[Any], **kwargs: Dict[str, Any]):
         super().__init__(*args, **kwargs)
         self.model_prefix = "model.language_model."
+
+
+class Qwen35DenseMTPWeight(Qwen35MoeMTPWeight):
+    def _create_ffn_weight(self) -> List[WeightModule]:
+        return Qwen35DenseWeight._create_ffn_weight(self)
 
 
 class Qwen3NextMTP(Qwen3Next):
@@ -168,5 +177,54 @@ class Qwen35MoeMTP(Qwen35Moe):
         return Qwen35MoeMTPWeight
 
 
+class Qwen35DenseMTP(Qwen35Dense):
+    @classmethod
+    def _create_config(cls, ckpt_path: str) -> ModelConfig:
+        config = super()._create_config(ckpt_path)
+        # The MTP layer always uses full MQA, even when the target layer at the
+        # same index uses linear attention.
+        config.hybrid_attention_config.hybrid_attention_types = [
+            HybridAttentionType.NONE
+        ]
+        config.moe_layer_index = []
+        config.num_layers = 1
+        config.is_mtp = True
+        # Draft MTP receives text tokens only, so plain RoPE is sufficient and
+        # keeps the prefill CUDA graph implementation eligible.
+        config.attn_config.rope_config.style = 1
+        return config
+
+    @classmethod
+    def _post_build_model_config(cls, model_config: ModelConfig) -> None:
+        model_config.kv_cache_spec_descs = build_hybrid_kv_cache_spec_descs(
+            [HybridAttentionType.NONE],
+            KVCacheSpecType.MHA,
+        )
+
+    def _create_python_model(self) -> Optional[Any]:
+        from rtp_llm.models_py.model_desc.qwen3_next_mtp import Qwen3NextMTPModel
+
+        model_config = self.model_config
+        parallelism_config = self.parallelism_config
+        fmha_config = self.fmha_config
+        py_hw_kernel_config = self.hw_kernel_config
+        moe_config = self.moe_config
+        self.py_model = Qwen3NextMTPModel(
+            model_config,
+            parallelism_config,
+            self.weight,
+            max_generate_batch_size=self.max_generate_batch_size,
+            moe_config=moe_config,
+            fmha_config=fmha_config,
+            py_hw_kernel_config=py_hw_kernel_config,
+            device_resource_config=self.device_resource_config,
+        )
+
+    @staticmethod
+    def get_weight_cls():
+        return Qwen35DenseMTPWeight
+
+
 register_model("qwen3_next_mtp", Qwen3NextMTP, ["Qwen3NextMTPForCausalLM"])
 register_model("qwen35_moe_mtp", Qwen35MoeMTP, ["Qwen35MoeMTPForCausalLM"])
+register_model("qwen35_dense_mtp", Qwen35DenseMTP)

--- a/rtp_llm/models/qwen3_next/qwen3_next_weight.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next_weight.py
@@ -649,6 +649,68 @@ class Qwen35MoeWeight(Qwen3NextBaseWeight):
         )
 
 
+def build_qwen35_dense_ffn_weights(
+    prefix: str, align_size: int, ffn_config: FfnConfig
+) -> List[WeightModule]:
+    return [
+        FfnWeight(
+            sub_weights=[
+                FfnAtomicWeight(
+                    W.ffn_w1,
+                    [
+                        CkptWeightInfo(
+                            prefix + "layers.{i}.mlp.gate_proj.weight",
+                            identity,
+                        )
+                    ],
+                    functools.partial(transpose_pad, align_size=align_size, dim=0),
+                    config=ffn_config,
+                    lora_a_process_func=transpose,
+                    lora_b_process_func=functools.partial(
+                        transpose_pad, align_size=align_size, dim=0
+                    ),
+                    lora_a_split_func=sp_id,
+                    lora_b_split_func=sp_neg1,
+                ),
+                FfnAtomicWeight(
+                    W.ffn_w3,
+                    [
+                        CkptWeightInfo(
+                            prefix + "layers.{i}.mlp.up_proj.weight", identity
+                        )
+                    ],
+                    functools.partial(transpose_pad, align_size=align_size, dim=0),
+                    config=ffn_config,
+                    lora_a_process_func=transpose,
+                    lora_b_process_func=functools.partial(
+                        transpose_pad, align_size=align_size, dim=0
+                    ),
+                    lora_a_split_func=sp_id,
+                    lora_b_split_func=sp_neg1,
+                ),
+                FfnAtomicWeight(
+                    W.ffn_w2,
+                    [
+                        CkptWeightInfo(
+                            prefix + "layers.{i}.mlp.down_proj.weight",
+                            identity,
+                        )
+                    ],
+                    functools.partial(transpose_pad, align_size=align_size, dim=1),
+                    config=ffn_config,
+                    lora_a_process_func=functools.partial(
+                        transpose_pad, align_size=align_size, dim=1
+                    ),
+                    lora_b_process_func=transpose,
+                    lora_a_split_func=sp_0,
+                    lora_b_split_func=sp_id,
+                ),
+            ],
+            config=ffn_config,
+        ),
+    ]
+
+
 class Qwen35DenseWeight(Qwen35MoeWeight):
     """Qwen3.5 Dense weight loading (dynamic prefix detection, separate weight format, stacked support)."""
 
@@ -656,62 +718,6 @@ class Qwen35DenseWeight(Qwen35MoeWeight):
         super().__init__(*args, **kwargs)
 
     def _create_ffn_weight(self) -> List[WeightModule]:
-        align_size = self._align_size
-        ffn_config: FfnConfig = self.ffn_config
-        return [
-            FfnWeight(
-                sub_weights=[
-                    FfnAtomicWeight(
-                        W.ffn_w1,
-                        [
-                            CkptWeightInfo(
-                                self.prefix + "layers.{i}.mlp.gate_proj.weight",
-                                identity,
-                            )
-                        ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
-                        config=ffn_config,
-                        lora_a_process_func=transpose,
-                        lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
-                        ),
-                        lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
-                    ),
-                    FfnAtomicWeight(
-                        W.ffn_w3,
-                        [
-                            CkptWeightInfo(
-                                self.prefix + "layers.{i}.mlp.up_proj.weight", identity
-                            )
-                        ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=0),
-                        config=ffn_config,
-                        lora_a_process_func=transpose,
-                        lora_b_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=0
-                        ),
-                        lora_a_split_func=sp_id,
-                        lora_b_split_func=sp_neg1,
-                    ),
-                    FfnAtomicWeight(
-                        W.ffn_w2,
-                        [
-                            CkptWeightInfo(
-                                self.prefix + "layers.{i}.mlp.down_proj.weight",
-                                identity,
-                            )
-                        ],
-                        functools.partial(transpose_pad, align_size=align_size, dim=1),
-                        config=ffn_config,
-                        lora_a_process_func=functools.partial(
-                            transpose_pad, align_size=align_size, dim=1
-                        ),
-                        lora_b_process_func=transpose,
-                        lora_a_split_func=sp_0,
-                        lora_b_split_func=sp_id,
-                    ),
-                ],
-                config=ffn_config,
-            ),
-        ]
+        return build_qwen35_dense_ffn_weights(
+            self.prefix, self._align_size, self.ffn_config
+        )

--- a/rtp_llm/models/qwen3_next/test/BUILD
+++ b/rtp_llm/models/qwen3_next/test/BUILD
@@ -1,0 +1,6 @@
+py_test(
+    name = "qwen3_next_mtp_test",
+    srcs = ["qwen3_next_mtp_test.py"],
+    deps = ["//rtp_llm:testlib"],
+    exec_properties = {"gpu": "H20"},
+)

--- a/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
+++ b/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
@@ -1,0 +1,93 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from rtp_llm.model_factory_register import _model_factory
+from rtp_llm.model_loader.ffn_weight import FfnWeight, MoeWeight
+from rtp_llm.models.qwen3_next.qwen3_next_mtp import (
+    Qwen35DenseMTP,
+    Qwen35DenseMTPWeight,
+)
+from rtp_llm.ops import HybridAttentionType, RopeStyle
+
+
+class Qwen35DenseMTPTest(unittest.TestCase):
+    def test_dense_mtp_config_and_registration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "config.json").write_text(json.dumps(self._config()))
+
+            config = Qwen35DenseMTP.create_config(temp_dir)
+
+        self.assertIs(_model_factory["qwen35_dense_mtp"], Qwen35DenseMTP)
+        self.assertEqual(config.num_layers, 1)
+        self.assertTrue(config.is_mtp)
+        self.assertEqual(config.moe_style, 0)
+        self.assertEqual(list(config.moe_layer_index), [])
+        self.assertEqual(
+            list(config.hybrid_attention_config.hybrid_attention_types),
+            [HybridAttentionType.NONE],
+        )
+        self.assertEqual(config.attn_config.rope_config.style, RopeStyle.Base)
+        self.assertEqual(len(config.kv_cache_spec_descs), 1)
+
+    def test_dense_mtp_uses_dense_ffn_checkpoint_keys(self):
+        weight = object.__new__(Qwen35DenseMTPWeight)
+        weight.prefix = "mtp."
+        weight._align_size = 0
+        weight._is_gated_activation = True
+
+        modules = weight._create_ffn_weight()
+
+        self.assertEqual(len(modules), 1)
+        self.assertIsInstance(modules[0], FfnWeight)
+        self.assertNotIsInstance(modules[0], MoeWeight)
+        ffn = modules[0]
+        checkpoint_keys = {
+            info.name
+            for atomic_weight in (ffn.origin_w1, ffn.origin_w3, ffn.w2)
+            for info in atomic_weight.weights
+        }
+        self.assertEqual(
+            checkpoint_keys,
+            {
+                "mtp.layers.{i}.mlp.gate_proj.weight",
+                "mtp.layers.{i}.mlp.up_proj.weight",
+                "mtp.layers.{i}.mlp.down_proj.weight",
+            },
+        )
+
+    @staticmethod
+    def _config():
+        return {
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+            "text_config": {
+                "num_attention_heads": 24,
+                "num_key_value_heads": 4,
+                "head_dim": 256,
+                "num_hidden_layers": 64,
+                "hidden_size": 5120,
+                "vocab_size": 248320,
+                "max_position_embeddings": 262144,
+                "rms_norm_eps": 1e-6,
+                "intermediate_size": 17408,
+                "full_attention_interval": 4,
+                "linear_conv_kernel_dim": 4,
+                "linear_key_head_dim": 128,
+                "linear_num_key_heads": 16,
+                "linear_num_value_heads": 48,
+                "linear_value_head_dim": 128,
+                "rope_parameters": {
+                    "mrope_interleaved": True,
+                    "mrope_section": [11, 11, 10],
+                    "rope_theta": 10000000,
+                    "partial_rotary_factor": 0.25,
+                },
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
+++ b/rtp_llm/models/qwen3_next/test/qwen3_next_mtp_test.py
@@ -3,13 +3,23 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from rtp_llm.config.kv_cache_config import KVCacheConfig
 from rtp_llm.model_factory_register import _model_factory
 from rtp_llm.model_loader.ffn_weight import FfnWeight, MoeWeight
 from rtp_llm.models.qwen3_next.qwen3_next_mtp import (
     Qwen35DenseMTP,
     Qwen35DenseMTPWeight,
 )
-from rtp_llm.ops import HybridAttentionType, RopeStyle
+from rtp_llm.multimodal.multimodal_mixin_register import get_multimodal_mixin_cls
+from rtp_llm.multimodal.multimodal_mixins.qwen3_5_moe.qwen3_5_moe_mixin import (
+    Qwen3_5MoeMixin,
+)
+from rtp_llm.ops import (
+    HWKernelConfig,
+    HybridAttentionType,
+    ParallelismConfig,
+    RopeStyle,
+)
 
 
 class Qwen35DenseMTPTest(unittest.TestCase):
@@ -32,13 +42,20 @@ class Qwen35DenseMTPTest(unittest.TestCase):
         self.assertEqual(len(config.kv_cache_spec_descs), 1)
 
     def test_dense_mtp_uses_dense_ffn_checkpoint_keys(self):
-        weight = object.__new__(Qwen35DenseMTPWeight)
-        weight.prefix = "mtp."
-        weight._align_size = 0
-        weight._is_gated_activation = True
+        with tempfile.TemporaryDirectory() as temp_dir:
+            Path(temp_dir, "config.json").write_text(json.dumps(self._config()))
+            config = Qwen35DenseMTP.create_config(temp_dir)
+            weight = Qwen35DenseMTPWeight(
+                model_config=config,
+                parallelism_config=ParallelismConfig(),
+                hw_kernel_config=HWKernelConfig(),
+                kv_cache_config=KVCacheConfig(),
+            )
 
         modules = weight._create_ffn_weight()
 
+        self.assertEqual(weight.prefix, "mtp.")
+        self.assertEqual(weight.model_prefix, "model.language_model.")
         self.assertEqual(len(modules), 1)
         self.assertIsInstance(modules[0], FfnWeight)
         self.assertNotIsInstance(modules[0], MoeWeight)
@@ -55,6 +72,11 @@ class Qwen35DenseMTPTest(unittest.TestCase):
                 "mtp.layers.{i}.mlp.up_proj.weight",
                 "mtp.layers.{i}.mlp.down_proj.weight",
             },
+        )
+
+    def test_dense_mtp_uses_qwen35_multimodal_mixin(self):
+        self.assertIs(
+            get_multimodal_mixin_cls("qwen35_dense_mtp"), Qwen3_5MoeMixin
         )
 
     @staticmethod

--- a/rtp_llm/multimodal/multimodal_mixins/qwen3_5_moe/qwen3_5_moe_mixin.py
+++ b/rtp_llm/multimodal/multimodal_mixins/qwen3_5_moe/qwen3_5_moe_mixin.py
@@ -188,4 +188,5 @@ class Qwen3_5MoeMixin(Qwen3_VLMixin):
 
 register_multimodal_mixin(["qwen35_moe"], Qwen3_5MoeMixin)
 register_multimodal_mixin(["qwen35_dense"], Qwen3_5MoeMixin)
+register_multimodal_mixin(["qwen35_dense_mtp"], Qwen3_5MoeMixin)
 register_multimodal_mixin(["qwen35_moe_mtp"], Qwen3_5MoeMixin)

--- a/rtp_llm/openai/renderers/qwen35_renderer.py
+++ b/rtp_llm/openai/renderers/qwen35_renderer.py
@@ -43,4 +43,5 @@ class Qwen35Renderer(Qwen3CoderRenderer, Qwen2VLRenderer):
 
 register_renderer("qwen35_moe", Qwen35Renderer)
 register_renderer("qwen35_dense", Qwen35Renderer)
+register_renderer("qwen35_dense_mtp", Qwen35Renderer)
 register_renderer("qwen35_moe_mtp", Qwen35Renderer)

--- a/rtp_llm/test/template_test.py
+++ b/rtp_llm/test/template_test.py
@@ -337,6 +337,9 @@ class TemplateTest(TestCase):
     def test_qwen35_moe_mtp_uses_qwen35_renderer(self):
         assert _renderer_factory["qwen35_moe_mtp"] is Qwen35Renderer
 
+    def test_qwen35_dense_mtp_uses_qwen35_renderer(self):
+        assert _renderer_factory["qwen35_dense_mtp"] is Qwen35Renderer
+
     def test_qwen35_passes_chat_template_kwargs_to_template(self):
         tokenizer = _Qwen35DefaultTemplateTokenizer()
         renderer = Qwen35Renderer(

--- a/rtp_llm/test/tokenizer_test/qwen2_tokenizer_test.py
+++ b/rtp_llm/test/tokenizer_test/qwen2_tokenizer_test.py
@@ -25,7 +25,12 @@ class AllFakeModelTest(TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             tokenizer_path = self._create_qwen35_tokenizer(Path(temp_dir))
 
-            for model_type in ["qwen35_dense", "qwen35_moe", "qwen35_moe_mtp"]:
+            for model_type in [
+                "qwen35_dense",
+                "qwen35_dense_mtp",
+                "qwen35_moe",
+                "qwen35_moe_mtp",
+            ]:
                 with self.subTest(model_type=model_type):
                     tokenizer = TokenizerFactory.create(
                         str(tokenizer_path), str(tokenizer_path), model_type


### PR DESCRIPTION
## Summary

- add the Qwen3.5 dense MTP model, configuration, Python-model path, and dense FFN checkpoint mapping
- register Qwen3.5 dense MTP with the tokenizer, multimodal mixin, and renderer integrations
- share MTP configuration/model creation across Qwen3 Next variants and use an explicit dense FFN weight builder
- cover real weight construction, checkpoint keys, model configuration, multimodal/renderer registration, and tokenizer creation

## Testing

- `bazelisk test --config=sm9x --config=cuda12_9 //rtp_llm/models/qwen3_next/test:qwen3_next_mtp_test //rtp_llm/test:template_test //rtp_llm/test/tokenizer_test:qwen2_tokenizer_test --test_output=errors`

## Follow-up

- End-to-end model smoke coverage is intentionally deferred to a follow-up; this PR uses focused config, weight-construction, and registration tests in the meantime.