### PR TITLE
perf(dash_sc): reduce frontend stream overhead

### DIFF
--- a/docs/backend/DashSc-gRPC.md
+++ b/docs/backend/DashSc-gRPC.md
@@ -147,6 +147,6 @@ bazel test //rtp_llm/dash_sc/test:proxy_servicer_test
 bazel test //rtp_llm/dash_sc/test:access_log_test
 ```
 
-`codec_test` 覆盖请求解析、`SamplingParams` / `DashScRequestControls` 以及 `build_stream_response_from_generate_outputs`；
+`codec_test` 覆盖请求解析、`SamplingParams` / `DashScRequestControls`、`ParsedInputIds` 以及 `StreamResponseBuilder`；
 `inference_servicer_test` 覆盖 `iter_real_model_stream_infer`（mock `run_enqueue_sync`）、`DashScInferenceServicer.ModelStreamInfer` 与缺 `input_ids` 错误路径；
 `proxy_servicer_test` 覆盖 gRPC proxy 转发、下游异常和流关闭路径。

--- a/rtp_llm/dash_sc/codec.py
+++ b/rtp_llm/dash_sc/codec.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import torch
+
 from rtp_llm.dash_sc.proto import predict_v2_pb2
 from rtp_llm.dash_sc.structural_tag import (
     DashScStructuralTagError,
@@ -28,6 +30,7 @@ from rtp_llm.utils.base_model_datatypes import GenerateOutput, GenerateOutputs
 if TYPE_CHECKING:
     from rtp_llm.config.generate_config import GenerateConfig
 
+_INT32_MIN = -2_147_483_648
 _INT32_MAX = 2_147_483_647
 _DEFAULT_MAX_NEW_TOKENS = 32000
 
@@ -117,6 +120,10 @@ DASH_ERROR_INTERNAL = DashErrorSpec(
 
 class DashScParameterError(ValueError):
     """Explicit user-parameter parse/validation error for dash-sc gRPC."""
+
+
+class DashScInputIdsError(RuntimeError):
+    """Input IDs cannot be represented by the engine's INT32 tensor."""
 
 
 # ----------------------------------------------------------------------------
@@ -749,6 +756,12 @@ class SamplingParams:
 # ----------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class ParsedInputIds:
+    values: list[int]
+    tensor: torch.Tensor
+
+
 def parse_input_ids_from_request(
     request: predict_v2_pb2.ModelInferRequest,
 ) -> list[int] | None:
@@ -760,6 +773,27 @@ def parse_input_ids_from_request(
     if inp is None or raw is None:
         return None
     return _parse_int_tensor_flat(inp, raw)
+
+
+def _parse_input_ids_for_inference(request) -> ParsedInputIds | None:
+    inp, raw = _find_input_raw(request, "input_ids")
+    if inp is None or raw is None:
+        return None
+    values = _parse_int_tensor_flat(inp, raw)
+    if values is None:
+        return None
+    if inp.datatype == "INT32":
+        tensor = torch.frombuffer(bytearray(raw), dtype=torch.int32)
+    elif inp.datatype == "INT64":
+        tensor = torch.frombuffer(bytearray(raw), dtype=torch.int64)
+        if tensor.numel():
+            min_value, max_value = torch.aminmax(tensor)
+            if min_value.item() < _INT32_MIN or max_value.item() > _INT32_MAX:
+                raise DashScInputIdsError("input_ids value is outside the INT32 range")
+        tensor = tensor.to(torch.int32)
+    else:
+        return None
+    return ParsedInputIds(values=values, tensor=tensor)
 
 
 def parse_sampling_params(
@@ -962,9 +996,13 @@ def parse_request_controls(
 
 def parse_dash_sc_grpc_request(
     request: predict_v2_pb2.ModelInferRequest,
-) -> tuple[list[int] | None, SamplingParams | None, DashScRequestControls | None]:
+) -> tuple[
+    ParsedInputIds | None,
+    SamplingParams | None,
+    DashScRequestControls | None,
+]:
     """Parse one ``ModelInferRequest`` into ids, sampling, and request controls."""
-    ids = parse_input_ids_from_request(request)
+    ids = _parse_input_ids_for_inference(request)
     if ids is None:
         return None, None, None
     ds_attrs = parse_ds_header_attributes(request)
@@ -986,7 +1024,10 @@ def _token_ids_list_from_generate_output(out_py: GenerateOutput) -> list[int]:
         t = out_py.output_ids
         if t.dim() > 1:
             t = t[0]
-        ids = t.cpu().int().tolist()
+        t = t.cpu()
+        if t.is_floating_point():
+            t = t.int()
+        ids = t.tolist()
     return ids
 
 
@@ -1168,80 +1209,210 @@ def _append_aux_info_metrics_outputs(
     _append_prompt_cache_usage_parameters(infer, input_len, reuse_len)
 
 
-def build_stream_response_from_generate_outputs(
-    dash_sc_request_id: str,
-    model_name: str,
-    go: GenerateOutputs,
-    request_log_tag: str,
-    request_input_ids: list[int] | None = None,
-    return_input_ids: bool = False,
-    is_streaming: bool = True,
-    generate_config: GenerateConfig | None = None,
-    eos_token_id: int | None = None,
-    max_token_id: int | None = None,
-    generate_think_token_num: int | None = None,
-    finish_reason_override: int | None = None,
-    _request_shape: list[int] | None = None,
-    *,
-    stream_finished: bool | None = None,
-    token_ids: list[int] | None = None,
-) -> predict_v2_pb2.ModelStreamInferResponse:
-    """Build ``ModelStreamInferResponse`` from one ``GenerateOutputs`` chunk.
+class StreamResponseBuilder:
+    """Request-scoped protobuf builder with a cached static response template.
 
-    ``stream_finished``: if provided, overrides ``out_py.finished`` for the wire
-    ``finished`` / ``finish_reason`` fields. Use when the servicer knows the gRPC
-    stream is not done yet (e.g. phase-2 will follow).
-
-    ``token_ids``: if provided, overrides the generated_ids from ``out_py``.
-    Use when the servicer rewrites the token payload (e.g. injecting </think>).
+    A streaming response repeats the same tensor descriptors, request identity,
+    generation limits, and most parameters for every chunk. Construct them once,
+    then clone the protobuf and patch only values that can change per frame.
     """
-    del _request_shape  # reserved for future shape alignment
-    if not go.generate_outputs:
-        raise ValueError(
-            "build_stream_response_from_generate_outputs expects non-empty go.generate_outputs"
+
+    __slots__ = (
+        "_dash_sc_request_id",
+        "_model_name",
+        "_request_log_tag",
+        "_request_input_ids",
+        "_return_input_ids",
+        "_is_streaming",
+        "_generate_config",
+        "_eos_token_id",
+        "_max_token_id",
+        "_template",
+        "_generated_index",
+        "_finish_index",
+        "_finished_index",
+        "_prompt_index",
+        "_cached_index",
+        "_template_finish_reason",
+        "_template_finished",
+        "_template_prompt_tokens",
+        "_template_cached_tokens",
+        "_template_think_token_num",
+    )
+
+    def __init__(
+        self,
+        *,
+        dash_sc_request_id: str,
+        model_name: str,
+        request_log_tag: str,
+        request_input_ids: list[int] | None = None,
+        return_input_ids: bool = False,
+        is_streaming: bool = True,
+        generate_config: GenerateConfig | None = None,
+        eos_token_id: int | None = None,
+        max_token_id: int | None = None,
+    ) -> None:
+        self._dash_sc_request_id = dash_sc_request_id
+        self._model_name = model_name
+        self._request_log_tag = request_log_tag
+        self._request_input_ids = request_input_ids
+        self._return_input_ids = return_input_ids
+        self._is_streaming = is_streaming
+        self._generate_config = generate_config
+        self._eos_token_id = eos_token_id
+        self._max_token_id = max_token_id
+        self._template: predict_v2_pb2.ModelStreamInferResponse | None = None
+        self._generated_index = -1
+        self._finish_index = -1
+        self._finished_index = -1
+        self._prompt_index = -1
+        self._cached_index = -1
+        self._template_finish_reason: int | None = None
+        self._template_finished: bool | None = None
+        self._template_prompt_tokens: int | None = None
+        self._template_cached_tokens: int | None = None
+        self._template_think_token_num: int | None = None
+
+    def build(
+        self,
+        go: GenerateOutputs,
+        *,
+        generate_think_token_num: int | None = None,
+        finish_reason_override: int | None = None,
+        stream_finished: bool | None = None,
+        token_ids: list[int] | None = None,
+    ) -> predict_v2_pb2.ModelStreamInferResponse:
+        if not go.generate_outputs:
+            raise ValueError("StreamResponseBuilder.build expects non-empty outputs")
+        out_py = go.generate_outputs[0]
+        generated_ids = (
+            token_ids
+            if token_ids is not None
+            else _token_ids_list_from_generate_output(out_py)
         )
-    stream_resp = predict_v2_pb2.ModelStreamInferResponse()
-    infer = stream_resp.infer_response
-    infer.id = dash_sc_request_id
-    infer.model_name = model_name
+        finished = stream_finished if stream_finished is not None else out_py.finished
+        finish_reason = (
+            finish_reason_override
+            if finish_reason_override is not None
+            else LLMFinishReason.STOP if finished else LLMFinishReason.STREAMING
+        )
+        aux_info = getattr(out_py, "aux_info", None)
+        prompt_tokens = (
+            int(aux_info.input_len)
+            if aux_info is not None
+            else len(self._request_input_ids or [])
+        )
+        cached_tokens = int(aux_info.reuse_len) if aux_info is not None else 0
 
-    out_py = go.generate_outputs[0]
-    finished = stream_finished if stream_finished is not None else out_py.finished
-    generated_ids = (
-        token_ids
-        if token_ids is not None
-        else _token_ids_list_from_generate_output(out_py)
-    )
+        if self._template is None:
+            response = predict_v2_pb2.ModelStreamInferResponse()
+            infer = response.infer_response
+            infer.id = self._dash_sc_request_id
+            infer.model_name = self._model_name
+            if self._return_input_ids and self._request_input_ids is not None:
+                _append_prompt_token_ids_output(infer, self._request_input_ids)
+            _append_generated_ids_output(infer, generated_ids)
+            _append_finish_reason_output(infer, finished, finish_reason_override)
+            _append_finished_output(infer, finished)
+            _append_aux_info_metrics_outputs(
+                infer,
+                out_py,
+                prompt_token_fallback=len(self._request_input_ids or []),
+            )
+            infer.parameters["incremental_output"].int64_param = (
+                1 if self._is_streaming else 0
+            )
+            _append_dashllm_limit_parameters(
+                infer,
+                generate_config=self._generate_config,
+                eos_token_id=self._eos_token_id,
+                max_token_id=self._max_token_id,
+                generate_think_token_num=generate_think_token_num,
+            )
+            self._template = predict_v2_pb2.ModelStreamInferResponse()
+            self._template.CopyFrom(response)
+            output_indexes = {
+                output.name: index
+                for index, output in enumerate(response.infer_response.outputs)
+            }
+            self._generated_index = output_indexes["generated_ids"]
+            self._finish_index = output_indexes["finish_reason"]
+            self._finished_index = output_indexes["finished"]
+            self._prompt_index = output_indexes["prompt_token_num"]
+            self._cached_index = output_indexes["prompt_cached_token_num"]
+            self._template_finish_reason = int(finish_reason)
+            self._template_finished = bool(finished)
+            self._template_prompt_tokens = prompt_tokens
+            self._template_cached_tokens = cached_tokens
+            self._template_think_token_num = generate_think_token_num
+            logging.debug(
+                "[DashScGrpc] [%s] generated_ids: %s",
+                self._request_log_tag,
+                generated_ids,
+            )
+            logging.debug(
+                "[DashScGrpc] [%s] return_input_ids=%s prompt_len=%s is_streaming=%s",
+                self._request_log_tag,
+                self._return_input_ids,
+                len(self._request_input_ids or []),
+                self._is_streaming,
+            )
+            return response
 
-    if return_input_ids and request_input_ids is not None:
-        _append_prompt_token_ids_output(infer, request_input_ids)
+        response = predict_v2_pb2.ModelStreamInferResponse()
+        response.CopyFrom(self._template)
+        infer = response.infer_response
 
-    _append_generated_ids_output(infer, generated_ids)
-    _append_finish_reason_output(infer, finished, finish_reason_override)
-    _append_finished_output(infer, finished)
-    _append_aux_info_metrics_outputs(
-        infer,
-        out_py,
-        prompt_token_fallback=len(request_input_ids or []),
-    )
-    infer.parameters["incremental_output"].int64_param = 1 if is_streaming else 0
-    _append_dashllm_limit_parameters(
-        infer,
-        generate_config=generate_config,
-        eos_token_id=eos_token_id,
-        max_token_id=max_token_id,
-        generate_think_token_num=generate_think_token_num,
-    )
+        generated_raw = (
+            struct.pack("<%di" % len(generated_ids), *generated_ids)
+            if generated_ids
+            else struct.pack("<i", 0)
+        )
+        infer.raw_output_contents[self._generated_index] = generated_raw
+        infer.outputs[self._generated_index].shape[:] = [1, len(generated_ids)]
 
-    logging.debug("[DashScGrpc] [%s] generated_ids: %s", request_log_tag, generated_ids)
-    logging.debug(
-        "[DashScGrpc] [%s] return_input_ids=%s prompt_len=%s is_streaming=%s",
-        request_log_tag,
-        return_input_ids,
-        len(request_input_ids or []),
-        is_streaming,
-    )
-    return stream_resp
+        if int(finish_reason) != self._template_finish_reason:
+            infer.raw_output_contents[self._finish_index] = struct.pack(
+                "<q", int(finish_reason)
+            )
+        if bool(finished) != self._template_finished:
+            infer.raw_output_contents[self._finished_index] = (
+                b"\x01" if finished else b"\x00"
+            )
+        if prompt_tokens != self._template_prompt_tokens:
+            infer.raw_output_contents[self._prompt_index] = struct.pack(
+                "<i", prompt_tokens
+            )
+            infer.parameters["prompt_token_num"].int64_param = prompt_tokens
+        if cached_tokens != self._template_cached_tokens:
+            infer.raw_output_contents[self._cached_index] = struct.pack(
+                "<i", cached_tokens
+            )
+            infer.parameters["prompt_cached_token_num"].int64_param = cached_tokens
+
+        if generate_think_token_num != self._template_think_token_num:
+            if generate_think_token_num is None:
+                if "generate_think_token_num" in infer.parameters:
+                    del infer.parameters["generate_think_token_num"]
+            else:
+                infer.parameters["generate_think_token_num"].int64_param = int(
+                    generate_think_token_num
+                )
+
+        logging.debug(
+            "[DashScGrpc] [%s] generated_ids: %s",
+            self._request_log_tag,
+            generated_ids,
+        )
+        logging.debug(
+            "[DashScGrpc] [%s] return_input_ids=%s prompt_len=%s is_streaming=%s",
+            self._request_log_tag,
+            self._return_input_ids,
+            len(self._request_input_ids or []),
+            self._is_streaming,
+        )
+        return response
 
 
 def build_dash_error_response(

--- a/rtp_llm/dash_sc/inference/servicer.py
+++ b/rtp_llm/dash_sc/inference/servicer.py
@@ -46,13 +46,15 @@ from rtp_llm.dash_sc.codec import (
     DASH_ERROR_TOO_LONG,
     DASH_ERROR_UNSUPPORTED,
     DashErrorSpec,
+    DashScInputIdsError,
     DashScParameterError,
     DashScRequestControls,
     LLMFinishReason,
+    ParsedInputIds,
     SamplingParams,
+    StreamResponseBuilder,
     _token_ids_list_from_generate_output,
     build_dash_error_response,
-    build_stream_response_from_generate_outputs,
     parse_dash_sc_grpc_request,
     prepend_to_generated_ids_tensor,
 )
@@ -378,7 +380,7 @@ def _build_empty_think_phase2_input_ids(
 def _make_generate_input(
     *,
     request_id: int,
-    input_ids_list: list[int],
+    input_ids_tensor: torch.Tensor,
     generate_config: GenerateConfig,
     invocation_metadata: Optional[GrpcMetadata],
     request_headers: Optional[dict[str, str]] = None,
@@ -388,7 +390,7 @@ def _make_generate_input(
     trace_id = str(generate_config.trace_id or extract_trace_id(headers) or "")
     return GenerateInput(
         request_id=request_id,
-        token_ids=torch.tensor(input_ids_list, dtype=torch.int),
+        token_ids=input_ids_tensor,
         mm_inputs=[],
         generate_config=generate_config,
         headers=headers,
@@ -498,7 +500,7 @@ def _apply_dash_sc_controls_to_generate_config(
 
 async def iter_real_model_stream_infer(
     request: predict_v2_pb2.ModelInferRequest,
-    input_ids_list: list[int],
+    input_ids: ParsedInputIds,
     sampling: SamplingParams,
     request_controls: DashScRequestControls,
     backend_visitor: _BackendVisitor,
@@ -521,7 +523,7 @@ async def iter_real_model_stream_infer(
     the HTTP path). ``request.id`` (string) is preserved as the trace id.
 
     ``echo_prefix_ids`` is the auto-derived "thinking prefill" token id sequence. When
-    non-empty and ``input_ids_list`` ends with it, the first non-empty ``generated_ids``
+    non-empty and ``input_ids.values`` ends with it, the first non-empty ``generated_ids``
     chunk gets ``echo_prefix_ids`` prepended so downstream consumers that rely on the
     prefill-echo contract (dashllm-style) see the expected first token.
 
@@ -542,6 +544,7 @@ async def iter_real_model_stream_infer(
     + tuple hashing entirely. The slow branch only fires when a caller explicitly
     sets ``stop_words_list`` on the request.
     """
+    input_ids_list = input_ids.values
     trace_str = str(request.id)
     tag = stream_log_tag(request_id_numeric=rtp_llm_request_id, trace_id=trace_str)
     runtime = think_runtime if think_runtime is not None else _ThinkRuntime()
@@ -609,18 +612,28 @@ async def iter_real_model_stream_infer(
         # availability). ``in_think_mode`` is per-request — ``add_thinking_params``
         # sets it from generate_config and a request can override it.
         phase2_enabled = runtime.phase2_enabled and bool(generate_config.in_think_mode)
-        cumulative_sent_ids: list[int] = []
+        cumulative_sent_len = 0
         generate_think_token_num: Optional[int] = None
         generate_input = _make_generate_input(
             request_id=rtp_llm_request_id,
-            input_ids_list=input_ids_list,
+            input_ids_tensor=input_ids.tensor,
             generate_config=generate_config,
             invocation_metadata=invocation_metadata,
             request_headers=request_controls.request_headers,
         )
         is_streaming = bool(generate_config.is_streaming)
         logging.debug("[DashScGrpc] [%s] generate_input: %s", tag, generate_input)
-        request_shape = list(request.inputs[0].shape) if request.inputs else None
+        response_builder = StreamResponseBuilder(
+            dash_sc_request_id=request.id,
+            model_name=request.model_name,
+            request_log_tag=tag,
+            request_input_ids=input_ids_list,
+            return_input_ids=request_controls.return_input_ids,
+            is_streaming=is_streaming,
+            generate_config=generate_config,
+            eos_token_id=eos_id,
+            max_token_id=max_id,
+        )
         chunk_idx = 0
         phase2_needed = False
         # One-shot guard: ``phase2_triggered`` flips True the instant we
@@ -650,19 +663,7 @@ async def iter_real_model_stream_infer(
                 # model_rpc_client copies the final submitted role_addrs here.
                 access_agg.record_role_addrs(aux_info.role_addrs, phase="phase1")
             if not generated_ids and not out_py.finished:
-                response = build_stream_response_from_generate_outputs(
-                    dash_sc_request_id=request.id,
-                    model_name=request.model_name,
-                    go=go,
-                    request_log_tag=tag,
-                    request_input_ids=input_ids_list,
-                    return_input_ids=request_controls.return_input_ids,
-                    is_streaming=is_streaming,
-                    generate_config=generate_config,
-                    eos_token_id=eos_id,
-                    max_token_id=max_id,
-                    _request_shape=request_shape,
-                )
+                response = response_builder.build(go, token_ids=generated_ids)
                 stats = (
                     0,
                     False,
@@ -697,9 +698,7 @@ async def iter_real_model_stream_infer(
                 if close_offset is not None and (
                     term_offset is None or close_offset < term_offset
                 ):
-                    generate_think_token_num = (
-                        len(cumulative_sent_ids) + close_offset + 1
-                    )
+                    generate_think_token_num = cumulative_sent_len + close_offset + 1
                     # Natural ``</think>`` close keeps the stream single-phase
                     # (DashLLM-aligned). Phase-2 is exclusively triggered by
                     # the terminate-token-id (DSV4 token 1) path below — see
@@ -716,9 +715,7 @@ async def iter_real_model_stream_infer(
                 ids_for_accounting = generated_ids
                 if should_echo and not echoed and generated_ids:
                     ids_for_accounting = matched_echo_ids + generated_ids
-                generate_think_token_num = len(cumulative_sent_ids) + len(
-                    ids_for_accounting
-                )
+                generate_think_token_num = cumulative_sent_len + len(ids_for_accounting)
                 will_do_phase2 = True
                 if sampling.max_new_tokens_from_completion_alias:
                     will_do_phase2 = (
@@ -727,22 +724,12 @@ async def iter_real_model_stream_infer(
                         )
                         > 0
                     )
-                cumulative_sent_ids.extend(ids_for_accounting)
+                cumulative_sent_len += len(ids_for_accounting)
                 # Yield thinking content (always intermediate)
                 if generated_ids:
-                    response = build_stream_response_from_generate_outputs(
-                        dash_sc_request_id=request.id,
-                        model_name=request.model_name,
-                        go=go,
-                        request_log_tag=tag,
-                        request_input_ids=input_ids_list,
-                        return_input_ids=request_controls.return_input_ids,
-                        is_streaming=is_streaming,
-                        generate_config=generate_config,
-                        eos_token_id=eos_id,
-                        max_token_id=max_id,
+                    response = response_builder.build(
+                        go,
                         generate_think_token_num=generate_think_token_num,
-                        _request_shape=request_shape,
                         stream_finished=False,
                         token_ids=generated_ids,
                     )
@@ -762,22 +749,12 @@ async def iter_real_model_stream_infer(
                     yield (response, stats) if yield_access_stats else response
                 # Yield </think> close tokens
                 if runtime.eos_tokens:
-                    eos_response = build_stream_response_from_generate_outputs(
-                        dash_sc_request_id=request.id,
-                        model_name=request.model_name,
-                        go=go,
-                        request_log_tag=tag,
-                        request_input_ids=input_ids_list,
-                        return_input_ids=request_controls.return_input_ids,
-                        is_streaming=is_streaming,
-                        generate_config=generate_config,
-                        eos_token_id=eos_id,
-                        max_token_id=max_id,
+                    eos_response = response_builder.build(
+                        go,
                         generate_think_token_num=generate_think_token_num,
                         finish_reason_override=(
                             LLMFinishReason.LENGTH if not will_do_phase2 else None
                         ),
-                        _request_shape=request_shape,
                         stream_finished=not will_do_phase2,
                         token_ids=list(runtime.eos_tokens),
                     )
@@ -800,28 +777,19 @@ async def iter_real_model_stream_infer(
                     )
                 phase2_needed = will_do_phase2
                 break
-            cumulative_sent_ids.extend(ids_for_accounting)
+            cumulative_sent_len += len(ids_for_accounting)
             finish_reason_override = None
             if (
                 out_py.finished
                 and max_new_tokens > 0
-                and len(cumulative_sent_ids) >= max_new_tokens
+                and cumulative_sent_len >= max_new_tokens
             ):
                 finish_reason_override = LLMFinishReason.LENGTH
-            response = build_stream_response_from_generate_outputs(
-                dash_sc_request_id=request.id,
-                model_name=request.model_name,
-                go=go,
-                request_log_tag=tag,
-                request_input_ids=input_ids_list,
-                return_input_ids=request_controls.return_input_ids,
-                is_streaming=is_streaming,
-                generate_config=generate_config,
-                eos_token_id=eos_id,
-                max_token_id=max_id,
+            response = response_builder.build(
+                go,
                 generate_think_token_num=generate_think_token_num,
                 finish_reason_override=finish_reason_override,
-                _request_shape=request_shape,
+                token_ids=generated_ids,
             )
             if should_echo and not echoed and generated_ids:
                 if prepend_to_generated_ids_tensor(
@@ -924,7 +892,7 @@ async def iter_real_model_stream_infer(
             )
             phase2_generate_input = _make_generate_input(
                 request_id=phase2_request_id,
-                input_ids_list=phase2_input_ids,
+                input_ids_tensor=torch.tensor(phase2_input_ids, dtype=torch.int),
                 generate_config=phase2_config,
                 invocation_metadata=invocation_metadata,
                 request_headers=request_controls.request_headers,
@@ -934,24 +902,36 @@ async def iter_real_model_stream_infer(
                 phase2_tag,
                 phase2_generate_input,
             )
+            phase2_response_builder = StreamResponseBuilder(
+                dash_sc_request_id=f"{request.id}{_PHASE2_SUFFIX}",
+                model_name=request.model_name,
+                request_log_tag=phase2_tag,
+                request_input_ids=phase2_input_ids,
+                return_input_ids=request_controls.return_input_ids,
+                is_streaming=is_streaming,
+                generate_config=phase2_config,
+                eos_token_id=eos_id,
+                max_token_id=max_id,
+            )
             phase2_stream = await backend_visitor.enqueue(phase2_generate_input)
-            phase2_cumulative_sent_ids: list[int] = []
+            phase2_sent_len = 0
 
             def _build_phase2_response(
                 resp_go: GenerateOutputs,
+                resp_ids: list[int],
             ) -> tuple[
                 predict_v2_pb2.ModelStreamInferResponse,
                 tuple[int, bool, int, int, int, list[int]],
             ]:
+                nonlocal phase2_sent_len
                 resp_out = resp_go.generate_outputs[0]
-                resp_ids = _token_ids_list_from_generate_output(resp_out)
-                phase2_cumulative_sent_ids.extend(resp_ids)
+                phase2_sent_len += len(resp_ids)
                 phase2_max_new_tokens = int(phase2_config.max_new_tokens or 0)
                 finish_reason_override = None
                 if (
                     resp_out.finished
                     and phase2_max_new_tokens > 0
-                    and len(phase2_cumulative_sent_ids) >= phase2_max_new_tokens
+                    and phase2_sent_len >= phase2_max_new_tokens
                 ):
                     finish_reason_override = LLMFinishReason.LENGTH
                 response_finished = bool(resp_out.finished)
@@ -980,20 +960,11 @@ async def iter_real_model_stream_infer(
                 ):
                     # model_rpc_client copies the final submitted role_addrs here.
                     access_agg.record_role_addrs(aux_info.role_addrs, phase="phase2")
-                response = build_stream_response_from_generate_outputs(
-                    dash_sc_request_id=f"{request.id}{_PHASE2_SUFFIX}",
-                    model_name=request.model_name,
-                    go=resp_go,
-                    request_log_tag=phase2_tag,
-                    request_input_ids=phase2_input_ids,
-                    return_input_ids=request_controls.return_input_ids,
-                    is_streaming=is_streaming,
-                    generate_config=phase2_config,
-                    eos_token_id=eos_id,
-                    max_token_id=max_id,
+                response = phase2_response_builder.build(
+                    resp_go,
                     generate_think_token_num=generate_think_token_num,
                     finish_reason_override=finish_reason_override,
-                    _request_shape=request_shape,
+                    token_ids=resp_ids,
                 )
                 stats = (
                     len(resp_ids),
@@ -1012,7 +983,7 @@ async def iter_real_model_stream_infer(
                 generated_ids = _token_ids_list_from_generate_output(out_py)
                 if not generated_ids and not out_py.finished:
                     continue
-                resp, stats = _build_phase2_response(go)
+                resp, stats = _build_phase2_response(go, generated_ids)
                 yield (resp, stats) if yield_access_stats else resp
     except FtRuntimeException as e:
         _set_access_backend_error_code(access_agg, e)
@@ -1204,7 +1175,7 @@ class DashScInferenceServicer(predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
                     request.model_name,
                 )
                 try:
-                    input_ids_list, sampling, request_controls = (
+                    input_ids, sampling, request_controls = (
                         parse_dash_sc_grpc_request(request)
                     )
                     if sampling is not None and (
@@ -1215,12 +1186,16 @@ class DashScInferenceServicer(predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
                         raise DashScParameterError(
                             "structured output/grammar controls are not supported yet"
                         )
-                except DashScParameterError as e:
+                except (DashScParameterError, DashScInputIdsError) as e:
                     if first_request:
                         record.record_request_frame(request)
                         record.mark_request_done("eof")
                         first_request = False
-                    error_spec = DASH_ERROR_BAD_REQUEST
+                    error_spec = (
+                        DASH_ERROR_BAD_REQUEST
+                        if isinstance(e, DashScParameterError)
+                        else DASH_ERROR_INTERNAL
+                    )
                     resp = build_dash_error_response(
                         str(request.id),
                         request.model_name,
@@ -1236,7 +1211,7 @@ class DashScInferenceServicer(predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
                     )
                     yield resp
                     return
-                if input_ids_list is None:
+                if input_ids is None:
                     if first_request:
                         record.record_request_frame(request)
                         record.mark_request_done("eof")
@@ -1257,10 +1232,10 @@ class DashScInferenceServicer(predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
                     )
                     yield resp
                     return
+                input_ids_list = input_ids.values
                 if first_request:
                     # Hand the record the payload we just parsed so it does not
-                    # decode the same request proto again (the input_ids tensor
-                    # is large for long context).
+                    # decode the same request proto again.
                     record.capture_structured_request(
                         request,
                         input_ids=input_ids_list,
@@ -1302,7 +1277,7 @@ class DashScInferenceServicer(predict_v2_pb2_grpc.GRPCInferenceServiceServicer):
 
                 async for resp, stats in iter_real_model_stream_infer(
                     request,
-                    input_ids_list,
+                    input_ids,
                     sampling,
                     request_controls,
                     self._backend_visitor,

--- a/rtp_llm/dash_sc/inference/servicer.py
+++ b/rtp_llm/dash_sc/inference/servicer.py
@@ -22,7 +22,6 @@ from typing import (
     AsyncIterator,
     Callable,
     Iterable,
-    Iterator,
     Optional,
     Protocol,
 )
@@ -374,48 +373,6 @@ def _build_empty_think_phase2_input_ids(
     if matched_bos_ids and base[-len(matched_bos_ids) :] == matched_bos_ids:
         base = base[: -len(matched_bos_ids)]
     return base + list(empty_think_tokens)
-
-
-def _strip_trailing_eos(
-    generated_ids: list[int], eos_seq: tuple[int, ...]
-) -> list[int]:
-    """Drop a single trailing ``eos_seq`` match from ``generated_ids``.
-
-    Phase-2 sometimes ends its answer with a structural ``</think>\\n\\n``
-    closing tag mirroring the empty-think prompt body — that artifact must not
-    leak into the dashscope-side ``content`` field.
-    """
-    n = len(eos_seq)
-    if n == 0 or len(generated_ids) < n:
-        return generated_ids
-    if list(generated_ids[-n:]) == list(eos_seq):
-        return list(generated_ids[:-n])
-    return generated_ids
-
-
-def _split_on_first_close(
-    generated_ids: list[int],
-    close_token_id: Optional[int],
-    eos_seq: tuple[int, ...],
-) -> tuple[Optional[int], list[int]]:
-    """Find the first ``close_token_id`` and return ``(idx, post_close_ids)``.
-
-    The post-close suffix has the rest of ``eos_seq`` consumed if it appears
-    immediately after the close token, so a multi-token ``</think>\\n\\n`` is
-    treated as a single boundary. Returns ``(None, generated_ids)`` if the
-    close token is not present.
-    """
-    if close_token_id is None:
-        return None, list(generated_ids)
-    for i, tid in enumerate(generated_ids):
-        if tid == close_token_id:
-            tail_start = i + 1
-            if len(eos_seq) > 1:
-                rest = list(eos_seq[1:])
-                if list(generated_ids[tail_start : tail_start + len(rest)]) == rest:
-                    tail_start += len(rest)
-            return i, list(generated_ids[tail_start:])
-    return None, list(generated_ids)
 
 
 def _make_generate_input(
@@ -1048,48 +1005,6 @@ async def iter_real_model_stream_infer(
                 )
                 return response, stats
 
-            # Phase-2 sanitization. The phase-2 prompt ends with
-            # ``<think>\n</think>\n\n``; the model occasionally interprets that
-            # as "think + close again" instead of "content only from here".
-            # Two failure modes observed in MRCR:
-            #
-            #   Case A (leading thinking + answer):
-            #     phase-2 emits ``[reasoning..., </think>, answer...]``. Pre-
-            #     close tokens are accidental reasoning and must NOT reach
-            #     ``content``. Discard them, drop the close + eos rest, emit
-            #     only post-close.
-            #
-            #   Case B (clean answer + trailing eos artifact):
-            #     phase-2 emits ``[answer..., </think>\n\n]`` and then EOSes.
-            #     Pre-close tokens ARE the real content. Keep them, drop only
-            #     the trailing close + eos rest.
-            #
-            # The two cases are distinguished by whether tokens follow the
-            # close: post-close non-empty → Case A; post-close empty AND chunk
-            # finished → Case B; otherwise ambiguous (close split across
-            # chunks) → default to Case A so the next chunk's content streams
-            # cleanly. Pre-close chunks are buffered in ``phase2_pending``
-            # until classification completes.
-            phase2_pending: list[GenerateOutputs] = []
-            phase2_seen_close = False
-
-            def _flush_phase2_pending() -> (
-                Iterator[predict_v2_pb2.ModelStreamInferResponse]
-            ):
-                """Yield buffered chunks, stripping a trailing eos artifact
-                from whichever chunk carries the finish flag."""
-                for buf_go in phase2_pending:
-                    buf_out = buf_go.generate_outputs[0]
-                    if buf_out.finished and runtime.eos_tokens:
-                        buf_ids = _token_ids_list_from_generate_output(buf_out)
-                        cleaned = _strip_trailing_eos(buf_ids, runtime.eos_tokens)
-                        if cleaned != buf_ids:
-                            buf_out.output_ids = torch.tensor(
-                                cleaned, dtype=torch.int32
-                            )
-                    resp, stats = _build_phase2_response(buf_go)
-                    yield (resp, stats) if yield_access_stats else resp
-
             async for go in phase2_stream:
                 if not go.generate_outputs:
                     raise ValueError("empty generate_outputs in phase-2 backend chunk")
@@ -1097,59 +1012,8 @@ async def iter_real_model_stream_infer(
                 generated_ids = _token_ids_list_from_generate_output(out_py)
                 if not generated_ids and not out_py.finished:
                     continue
-
-                if phase2_seen_close:
-                    # Past the boundary: trailing-eos cleanup on the final
-                    # chunk, otherwise pass through.
-                    if out_py.finished and runtime.eos_tokens:
-                        cleaned = _strip_trailing_eos(generated_ids, runtime.eos_tokens)
-                        if cleaned != generated_ids:
-                            generated_ids = cleaned
-                            out_py.output_ids = torch.tensor(
-                                generated_ids, dtype=torch.int32
-                            )
-                    if generated_ids or out_py.finished:
-                        resp, stats = _build_phase2_response(go)
-                        yield (resp, stats) if yield_access_stats else resp
-                    continue
-
-                close_idx, post_close = _split_on_first_close(
-                    generated_ids, think_close_token_id, runtime.eos_tokens
-                )
-                if close_idx is None:
-                    phase2_pending.append(go)
-                    if out_py.finished:
-                        # No close ever — buffered chunks are all content.
-                        for item in _flush_phase2_pending():
-                            yield item
-                        phase2_pending = []
-                    continue
-
-                if post_close:
-                    # Case A: discard pending + emit post-close.
-                    phase2_pending = []
-                    phase2_seen_close = True
-                    if out_py.finished and runtime.eos_tokens:
-                        post_close = _strip_trailing_eos(post_close, runtime.eos_tokens)
-                    out_py.output_ids = torch.tensor(post_close, dtype=torch.int32)
-                    if post_close or out_py.finished:
-                        resp, stats = _build_phase2_response(go)
-                        yield (resp, stats) if yield_access_stats else resp
-                elif out_py.finished:
-                    # Case B: pre-close is real content; keep it, drop close.
-                    pre_close = list(generated_ids[:close_idx])
-                    out_py.output_ids = torch.tensor(pre_close, dtype=torch.int32)
-                    phase2_pending.append(go)
-                    for item in _flush_phase2_pending():
-                        yield item
-                    phase2_pending = []
-                    phase2_seen_close = True
-                else:
-                    # Ambiguous: close split across chunks. Default to Case A
-                    # (drop pending + this chunk's pre-close); next chunk's
-                    # content will stream as content normally.
-                    phase2_pending = []
-                    phase2_seen_close = True
+                resp, stats = _build_phase2_response(go)
+                yield (resp, stats) if yield_access_stats else resp
     except FtRuntimeException as e:
         _set_access_backend_error_code(access_agg, e)
         error_spec = _dash_error_spec_for_ft_exception(e)

--- a/rtp_llm/dash_sc/test/codec_test.py
+++ b/rtp_llm/dash_sc/test/codec_test.py
@@ -11,12 +11,14 @@ import torch
 from rtp_llm.dash_sc.client import build_model_infer_request
 from rtp_llm.dash_sc.codec import (
     DashErrorSpec,
+    DashScInputIdsError,
     DashScParameterError,
-    LLMFinishReason,
     DashScRequestControls,
+    LLMFinishReason,
+    ParsedInputIds,
     SamplingParams,
+    StreamResponseBuilder,
     build_dash_error_response,
-    build_stream_response_from_generate_outputs,
     parse_dash_sc_grpc_request,
     parse_input_ids_from_request,
     parse_request_controls,
@@ -741,7 +743,9 @@ class DashScGrpcRequestTest(TestCase):
 
         ids, sp, op = parse_dash_sc_grpc_request(req)
 
-        self.assertEqual(ids, [1, 2])
+        self.assertIsInstance(ids, ParsedInputIds)
+        assert ids is not None
+        self.assertEqual(ids.values, [1, 2])
         self.assertIsNotNone(sp)
         self.assertIsNotNone(op)
         self.assertEqual(sp.max_new_think_tokens, 7)
@@ -842,7 +846,10 @@ class DashScGrpcRequestTest(TestCase):
         _add_tensor(req, "top_k", "INT32", [1], struct.pack("<i", 10))
         _add_tensor(req, "return_input_ids", "BOOL", [1], b"\x01")
         ids, sp, op = parse_dash_sc_grpc_request(req)
-        self.assertEqual(ids, [1, 2])
+        self.assertIsInstance(ids, ParsedInputIds)
+        assert ids is not None
+        self.assertEqual(ids.values, [1, 2])
+        self.assertEqual(ids.tensor.tolist(), [1, 2])
         self.assertIsNotNone(sp)
         self.assertIsNotNone(op)
         assert sp is not None and op is not None
@@ -855,6 +862,63 @@ class DashScGrpcRequestTest(TestCase):
         self.assertIsNone(ids)
         self.assertIsNone(sp)
         self.assertIsNone(op)
+
+    def test_inference_input_ids_from_int32_wire_buffer(self) -> None:
+        req = predict_v2_pb2.ModelInferRequest()
+        _add_tensor(req, "input_ids", "INT32", [3], struct.pack("<3i", 7, 8, 9))
+
+        parsed, _, _ = parse_dash_sc_grpc_request(req)
+
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed.tensor.dtype, torch.int32)
+        self.assertEqual(parsed.tensor.tolist(), [7, 8, 9])
+        parsed.tensor[0] = 99
+        self.assertEqual(parsed.values, [7, 8, 9])
+        self.assertEqual(parse_input_ids_from_request(req), [7, 8, 9])
+
+    def test_inference_input_ids_from_int64_converts_to_engine_dtype(self) -> None:
+        req = predict_v2_pb2.ModelInferRequest()
+        _add_tensor(req, "input_ids", "INT64", [2], struct.pack("<2q", 10, 11))
+
+        parsed, _, _ = parse_dash_sc_grpc_request(req)
+
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed.tensor.dtype, torch.int32)
+        self.assertEqual(parsed.tensor.tolist(), [10, 11])
+
+    def test_inference_input_ids_from_int64_accepts_int32_boundaries(self) -> None:
+        req = predict_v2_pb2.ModelInferRequest()
+        _add_tensor(
+            req,
+            "input_ids",
+            "INT64",
+            [2],
+            struct.pack("<2q", -(2**31), 2**31 - 1),
+        )
+
+        parsed, _, _ = parse_dash_sc_grpc_request(req)
+
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed.tensor.tolist(), [-(2**31), 2**31 - 1])
+
+    def test_inference_input_ids_from_int64_rejects_int32_overflow(self) -> None:
+        for value in (-(2**40), 2**40):
+            with self.subTest(value=value):
+                req = predict_v2_pb2.ModelInferRequest()
+                _add_tensor(req, "input_ids", "INT64", [1], struct.pack("<q", value))
+                with self.assertRaisesRegex(
+                    DashScInputIdsError, "outside the INT32 range"
+                ):
+                    parse_dash_sc_grpc_request(req)
+
+    def test_inference_input_ids_rejects_misaligned_wire_buffer(self) -> None:
+        req = predict_v2_pb2.ModelInferRequest()
+        _add_tensor(req, "input_ids", "INT32", [1], b"\x01\x02\x03")
+        parsed, _, _ = parse_dash_sc_grpc_request(req)
+        self.assertIsNone(parsed)
 
     def test_sampling_to_generate_config(self) -> None:
         sp = SamplingParams(
@@ -873,16 +937,16 @@ class DashScGrpcRequestTest(TestCase):
         self.assertTrue(gc.return_input_ids)
 
 
-class BuildStreamResponseFromGenerateOutputsTest(TestCase):
+class StreamResponseBuilderTest(TestCase):
     def test_empty_generate_outputs_raises(self) -> None:
         go = GenerateOutputs(generate_outputs=[])
+        builder = StreamResponseBuilder(
+            dash_sc_request_id="r1",
+            model_name="m",
+            request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r1"),
+        )
         with self.assertRaises(ValueError) as ctx:
-            build_stream_response_from_generate_outputs(
-                dash_sc_request_id="r1",
-                model_name="m",
-                go=go,
-                request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r1"),
-            )
+            builder.build(go)
         self.assertIn("non-empty", str(ctx.exception))
 
     def test_basic_generated_ids_finish_aux(self) -> None:
@@ -892,13 +956,12 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
             aux_info=AuxInfo(input_len=10, reuse_len=4),
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="req-a",
             model_name="mdl",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=99, trace_id="req-a"),
             return_input_ids=False,
-        )
+        ).build(go)
         self.assertFalse(resp.error_message)
         infer = resp.infer_response
         self.assertEqual(infer.id, "req-a")
@@ -988,20 +1051,19 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
         ``finished=True`` always maps to 0 (stop), so dashscope-serving
         collapses every cutoff into ``finish_reason='stop'``.
 
-        Expected fix: codec exposes ``LLMFinishReason.LENGTH = 1`` and
-        ``build_stream_response_from_generate_outputs`` takes a
-        ``finish_reason_override`` argument the caller can set when the
-        cumulative output reaches the per-request budget."""
+        The response builder accepts a ``finish_reason_override`` the caller can
+        set when cumulative output reaches the per-request budget."""
         out = GenerateOutput(
             output_ids=torch.tensor([1, 2, 3], dtype=torch.int32),
             finished=True,
             aux_info=AuxInfo(input_len=4, reuse_len=0, output_len=3),
         )
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=GenerateOutputs(generate_outputs=[out]),
             request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r"),
+        ).build(
+            GenerateOutputs(generate_outputs=[out]),
             finish_reason_override=LLMFinishReason.LENGTH,
         )
         infer = resp.infer_response
@@ -1021,12 +1083,11 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
             aux_info=None,
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=0, trace_id="r"),
-        )
+        ).build(go)
         infer = resp.infer_response
         by_name = {
             infer.outputs[i].name: infer.raw_output_contents[i]
@@ -1048,13 +1109,12 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
             aux_info=None,
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=0, trace_id="r"),
             request_input_ids=[10, 11, 12],
-        )
+        ).build(go)
         infer = resp.infer_response
         by_name = {
             infer.outputs[i].name: infer.raw_output_contents[i]
@@ -1071,12 +1131,11 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
             finished=True,
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r"),
-        )
+        ).build(go)
         infer = resp.infer_response
         by_name = {
             infer.outputs[i].name: infer.raw_output_contents[i]
@@ -1090,14 +1149,13 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
             finished=True,
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r"),
             request_input_ids=[1, 2, 3],
             return_input_ids=True,
-        )
+        ).build(go)
         infer = resp.infer_response
         names = [infer.outputs[i].name for i in range(len(infer.outputs))]
         self.assertEqual(
@@ -1121,12 +1179,11 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
     def test_missing_output_ids_empty_generated(self) -> None:
         out = GenerateOutput(output_ids=None, finished=False, aux_info=AuxInfo())
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r"),
-        )
+        ).build(go)
         infer = resp.infer_response
         by_name = {
             infer.outputs[i].name: infer.raw_output_contents[i]
@@ -1134,6 +1191,137 @@ class BuildStreamResponseFromGenerateOutputsTest(TestCase):
         }
         self.assertEqual(by_name["generated_ids"], struct.pack("<i", 0))
         self.assertEqual(list(infer.outputs[0].shape), [1, 0])
+
+    def test_updates_dynamic_fields_without_mutating_prior_frames(self) -> None:
+        generate_config = SamplingParams(
+            max_new_tokens=64, max_new_think_tokens=32
+        ).to_generate_config()
+        static = {
+            "dash_sc_request_id": "req-cached",
+            "model_name": "mdl",
+            "request_log_tag": stream_log_tag(
+                request_id_numeric=99, trace_id="req-cached"
+            ),
+            "request_input_ids": [10, 11, 12],
+            "return_input_ids": True,
+            "is_streaming": True,
+            "generate_config": generate_config,
+            "eos_token_id": 151643,
+            "max_token_id": 151936,
+        }
+        builder = StreamResponseBuilder(**static)
+        cases = (
+            (
+                GenerateOutput(
+                    output_ids=torch.tensor([1, 2]),
+                    finished=False,
+                    aux_info=AuxInfo(input_len=3, reuse_len=1),
+                ),
+                None,
+                None,
+                LLMFinishReason.STREAMING,
+            ),
+            (
+                GenerateOutput(
+                    output_ids=torch.tensor([3, 4, 5]),
+                    finished=False,
+                    aux_info=AuxInfo(input_len=4, reuse_len=2),
+                ),
+                7,
+                None,
+                LLMFinishReason.STREAMING,
+            ),
+            (
+                GenerateOutput(
+                    output_ids=torch.tensor([6]),
+                    finished=True,
+                    aux_info=AuxInfo(input_len=5, reuse_len=3),
+                ),
+                None,
+                LLMFinishReason.LENGTH,
+                LLMFinishReason.LENGTH,
+            ),
+        )
+
+        frames = []
+        for output, think_len, finish_override, expected_finish_reason in cases:
+            go = GenerateOutputs(generate_outputs=[output])
+            token_ids = output.output_ids.tolist()
+            frame = builder.build(
+                go,
+                token_ids=token_ids,
+                generate_think_token_num=think_len,
+                finish_reason_override=finish_override,
+            )
+            frames.append(frame)
+            infer = frame.infer_response
+            by_name = {
+                infer.outputs[i].name: infer.raw_output_contents[i]
+                for i in range(len(infer.outputs))
+            }
+            self.assertEqual(_unpack_int32_le(by_name["generated_ids"]), token_ids)
+            self.assertEqual(
+                _unpack_int64_le(by_name["finish_reason"]),
+                [expected_finish_reason],
+            )
+            self.assertEqual(
+                by_name["finished"], b"\x01" if output.finished else b"\x00"
+            )
+            self.assertEqual(
+                _unpack_int32_le(by_name["prompt_token_num"]),
+                [output.aux_info.input_len],
+            )
+            self.assertEqual(
+                _unpack_int32_le(by_name["prompt_cached_token_num"]),
+                [output.aux_info.reuse_len],
+            )
+            self.assertEqual(
+                infer.parameters["prompt_token_num"].int64_param,
+                output.aux_info.input_len,
+            )
+            self.assertEqual(
+                infer.parameters["prompt_cached_token_num"].int64_param,
+                output.aux_info.reuse_len,
+            )
+            if think_len is None:
+                self.assertNotIn("generate_think_token_num", infer.parameters)
+            else:
+                self.assertEqual(
+                    infer.parameters["generate_think_token_num"].int64_param,
+                    think_len,
+                )
+
+        first_by_name = {
+            frames[0]
+            .infer_response.outputs[i]
+            .name: (frames[0].infer_response.raw_output_contents[i])
+            for i in range(len(frames[0].infer_response.outputs))
+        }
+        self.assertEqual(_unpack_int32_le(first_by_name["generated_ids"]), [1, 2])
+
+    def test_stream_response_builder_removes_template_dynamic_parameter(self) -> None:
+        output = GenerateOutput(
+            output_ids=torch.tensor([1]),
+            finished=False,
+            aux_info=AuxInfo(input_len=1, reuse_len=0),
+        )
+        go = GenerateOutputs(generate_outputs=[output])
+        static = {
+            "dash_sc_request_id": "r",
+            "model_name": "m",
+            "request_log_tag": stream_log_tag(request_id_numeric=1, trace_id="r"),
+        }
+        builder = StreamResponseBuilder(**static)
+        builder.build(go, token_ids=[1], generate_think_token_num=4)
+
+        actual = builder.build(go, token_ids=[2], generate_think_token_num=None)
+        infer = actual.infer_response
+        self.assertNotIn("generate_think_token_num", infer.parameters)
+        by_name = {
+            infer.outputs[i].name: infer.raw_output_contents[i]
+            for i in range(len(infer.outputs))
+        }
+        self.assertEqual(_unpack_int32_le(by_name["generated_ids"]), [2])
 
 
 class PrependToGeneratedIdsTensorTest(TestCase):
@@ -1144,12 +1332,11 @@ class PrependToGeneratedIdsTensorTest(TestCase):
             aux_info=AuxInfo(input_len=0, reuse_len=0),
         )
         go = GenerateOutputs(generate_outputs=[out])
-        resp = build_stream_response_from_generate_outputs(
+        resp = StreamResponseBuilder(
             dash_sc_request_id="r",
             model_name="m",
-            go=go,
             request_log_tag=stream_log_tag(request_id_numeric=1, trace_id="r"),
-        )
+        ).build(go)
         return resp.infer_response
 
     def test_prepend_list_success(self) -> None:

--- a/rtp_llm/dash_sc/test/data/mrcr_deepseek_v4_think_leak_cases.json
+++ b/rtp_llm/dash_sc/test/data/mrcr_deepseek_v4_think_leak_cases.json
@@ -189,7 +189,7 @@
     "rtp_reasoning_prefix": "fFNGmRqEmx**[Date: October 15, 2023]**\\n\\nDear Diary,\\n\\nToday has been one of those days consumed by deep thought. I woke u",
     "smoke_phase1_output_ids": [10, 1, 99],
     "smoke_phase2_output_ids": [30, 31, 32, 128822, 271],
-    "expected_phase2_ids": [30, 31, 32],
+    "expected_phase2_ids": [30, 31, 32, 128822, 271],
     "expected_generate_think_token_num": 2
   },
   {

--- a/rtp_llm/dash_sc/test/inference/mrcr_smoke_test.py
+++ b/rtp_llm/dash_sc/test/inference/mrcr_smoke_test.py
@@ -30,7 +30,11 @@ from pathlib import Path
 
 import torch
 
-from rtp_llm.dash_sc.codec import DashScRequestControls, SamplingParams
+from rtp_llm.dash_sc.codec import (
+    DashScRequestControls,
+    ParsedInputIds,
+    SamplingParams,
+)
 from rtp_llm.dash_sc.inference.servicer import (
     build_think_runtime,
     iter_real_model_stream_infer,
@@ -60,6 +64,13 @@ def _add_input_ids(req: predict_v2_pb2.ModelInferRequest, input_ids: list[int]) 
     inp.datatype = "INT32"
     inp.shape[:] = [len(input_ids)]
     req.raw_input_contents.append(struct.pack("<%di" % len(input_ids), *input_ids))
+
+
+def _parsed_input_ids(values: list[int]) -> ParsedInputIds:
+    return ParsedInputIds(
+        values=values,
+        tensor=torch.tensor(values, dtype=torch.int32),
+    )
 
 
 async def _drain(aiter):
@@ -309,7 +320,7 @@ class DeepSeekV4MrcrSmokeTest(unittest.IsolatedAsyncioTestCase):
             await _drain(
                 iter_real_model_stream_infer(
                     req,
-                    case["input_ids_tail"],
+                    _parsed_input_ids(case["input_ids_tail"]),
                     SamplingParams(max_new_tokens=384000, top_p=1.0, temperature=1.0),
                     DashScRequestControls(enable_thinking=True),
                     visitor,
@@ -392,7 +403,7 @@ class DeepSeekV4MrcrSmokeTest(unittest.IsolatedAsyncioTestCase):
             chunks = await _drain(
                 iter_real_model_stream_infer(
                     req,
-                    input_ids,
+                    _parsed_input_ids(input_ids),
                     case["sampling"],
                     case["request_controls"],
                     visitor,
@@ -471,7 +482,7 @@ class DeepSeekV4MrcrSmokeTest(unittest.IsolatedAsyncioTestCase):
             chunks = await _drain(
                 iter_real_model_stream_infer(
                     req,
-                    input_ids,
+                    _parsed_input_ids(input_ids),
                     SamplingParams(max_new_tokens=384000, top_p=1.0, temperature=1.0),
                     DashScRequestControls(enable_thinking=True),
                     visitor,

--- a/rtp_llm/dash_sc/test/inference/servicer_test.py
+++ b/rtp_llm/dash_sc/test/inference/servicer_test.py
@@ -456,9 +456,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["status_code"], 503)
         self.assertIn("route failed", payload["status_message"])
         self.assertEqual(_finish_reason(chunks[0]), LLMFinishReason.TASK_LIST_FULL)
-        self.assertEqual(
-            access_agg.backend_error_code, "8500_ROUTE_ERROR"
-        )
+        self.assertEqual(access_agg.backend_error_code, "8500_ROUTE_ERROR")
 
     async def test_stream_exception_yields_error_message(self) -> None:
         req = self._minimal_request()
@@ -1328,10 +1326,70 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(value, 1)
         self.assertEqual(tags["protocol"], "dash_sc_grpc")
 
-    async def test_phase2_strips_leading_thinking_then_close(self) -> None:
-        """Phase-2 model occasionally emits accidental thinking followed by
-        ``</think>`` before the real answer. The leading reasoning + close
-        sequence must be stripped so only post-close tokens reach the client."""
+    async def test_phase2_grammar_streams_each_backend_chunk_immediately(self) -> None:
+        req = self._minimal_request()
+        phase1 = GenerateOutputs(
+            generate_outputs=[
+                GenerateOutput(
+                    output_ids=torch.tensor([10, 1], dtype=torch.int32),
+                    finished=False,
+                    aux_info=AuxInfo(input_len=4, reuse_len=0),
+                )
+            ]
+        )
+        phase2_first = GenerateOutputs(
+            generate_outputs=[
+                GenerateOutput(
+                    output_ids=torch.tensor([20, 21], dtype=torch.int32),
+                    finished=False,
+                    aux_info=AuxInfo(input_len=4, reuse_len=0),
+                )
+            ]
+        )
+        phase2_final = GenerateOutputs(
+            generate_outputs=[
+                GenerateOutput(
+                    output_ids=torch.tensor([22], dtype=torch.int32),
+                    finished=True,
+                    aux_info=AuxInfo(input_len=4, reuse_len=0),
+                )
+            ]
+        )
+        phase2_stream = _FakeAsyncStream([phase2_first, phase2_final])
+        visitor = _MultiStreamVisitor([_FakeAsyncStream([phase1]), phase2_stream])
+        tok = _dsv4_tokenizer()
+        env_cfg = _GenerateEnvCfg()
+        responses = iter_real_model_stream_infer(
+            req,
+            [7, 8, 128821],
+            SamplingParams(
+                response_format=json.dumps({"type": "json_object"}),
+            ),
+            OtherParams(enable_thinking=True),
+            visitor,
+            rtp_llm_request_id=100,
+            echo_prefix_ids=[128821, 198],
+            tokenizer=tok,
+            generate_env_config=env_cfg,
+            think_runtime=build_think_runtime(tok, env_cfg, "deepseek_v4"),
+            phase2_request_id_factory=lambda: 200,
+        )
+
+        first_phase2 = None
+        async for response in responses:
+            if response.infer_response.id.endswith("-2"):
+                first_phase2 = response
+                break
+
+        self.assertIsNotNone(first_phase2)
+        self.assertEqual(_gen_ids(first_phase2), [20, 21])
+        self.assertEqual(phase2_stream._emitted, 1)
+
+        remaining = await _drain(responses)
+        self.assertEqual([_gen_ids(chunk) for chunk in remaining], [[22]])
+
+    async def test_phase2_preserves_leading_thinking_then_close(self) -> None:
+        """Phase-2 output is streamed unchanged, matching DashLLM ownership."""
         req = self._minimal_request()
         phase1 = GenerateOutputs(
             generate_outputs=[
@@ -1392,18 +1450,16 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
             )
         )
 
-        # Phase-1 emits two chunks (truncated content then synthesised eos).
-        # Phase-2 sees [55, 56] (accidental thinking, buffered then dropped),
-        # then [128822, 271, 20, 21] (close + tail content). Client only sees
-        # [20, 21] from phase-2.
+        # Phase-2 servicer output is a transparent chunk-for-chunk pass-through.
         phase2_chunks = [c for c in chunks if c.infer_response.id.endswith("-2")]
-        self.assertEqual(len(phase2_chunks), 1)
-        self.assertEqual(_gen_ids(phase2_chunks[0]), [20, 21])
+        self.assertEqual(len(phase2_chunks), 2)
+        self.assertEqual(
+            [_gen_ids(chunk) for chunk in phase2_chunks],
+            [[55, 56], [128822, 271, 20, 21]],
+        )
 
-    async def test_phase2_strips_trailing_eos_artifact(self) -> None:
-        """Phase-2 ends with a structural ``</think>\\n\\n`` closing-tag
-        artifact mirroring the empty-think prompt body. That trailing
-        sequence must not leak into ``content``."""
+    async def test_phase2_preserves_trailing_think_close(self) -> None:
+        """Phase-2 trailing close tokens remain backend-owned output."""
         req = self._minimal_request()
         phase1 = GenerateOutputs(
             generate_outputs=[
@@ -1456,8 +1512,10 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
 
         phase2_chunks = [c for c in chunks if c.infer_response.id.endswith("-2")]
         self.assertEqual(len(phase2_chunks), 1)
-        # Trailing [128822, 271] is stripped; only the real answer ids survive.
-        self.assertEqual(_gen_ids(phase2_chunks[0]), [30, 31, 32])
+        self.assertEqual(
+            _gen_ids(phase2_chunks[0]),
+            [30, 31, 32, 128822, 271],
+        )
 
 
 class IterRealModelStreamInferEchoTest(unittest.IsolatedAsyncioTestCase):

--- a/rtp_llm/dash_sc/test/inference/servicer_test.py
+++ b/rtp_llm/dash_sc/test/inference/servicer_test.py
@@ -31,8 +31,9 @@ from rtp_llm.dash_sc.codec import (
     DASH_ERROR_TOO_LONG,
     DASH_ERROR_UNSUPPORTED,
     DashScParameterError,
-    LLMFinishReason,
     DashScRequestControls,
+    LLMFinishReason,
+    ParsedInputIds,
     SamplingParams,
 )
 from rtp_llm.dash_sc.inference.servicer import (
@@ -63,6 +64,13 @@ def _add_input_tensor(
 
 def _unpack_int32_le(raw: bytes) -> list[int]:
     return list(struct.unpack("<%di" % (len(raw) // 4), raw))
+
+
+def _parsed_input_ids(values: list[int]) -> ParsedInputIds:
+    return ParsedInputIds(
+        values=values,
+        tensor=torch.tensor(values, dtype=torch.int32),
+    )
 
 
 class _FakeAsyncStream:
@@ -300,7 +308,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -319,6 +327,31 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(infer.parameters["prompt_token_num"].int64_param, 2)
         self.assertEqual(infer.parameters["prompt_cached_token_num"].int64_param, 0)
 
+    async def test_reuses_parsed_input_tensor_without_copy(self) -> None:
+        req = self._minimal_request()
+        input_ids = _parsed_input_ids([1, 2])
+        out = GenerateOutput(
+            output_ids=torch.tensor([3], dtype=torch.int32),
+            finished=True,
+            aux_info=AuxInfo(input_len=2, reuse_len=0),
+        )
+        visitor = _FakeVisitor(
+            _FakeAsyncStream([GenerateOutputs(generate_outputs=[out])])
+        )
+
+        await _drain(
+            iter_real_model_stream_infer(
+                req,
+                input_ids,
+                SamplingParams(),
+                DashScRequestControls(),
+                visitor,
+                rtp_llm_request_id=1,
+            )
+        )
+
+        self.assertIs(visitor.last_generate_input.token_ids, input_ids.tensor)
+
     async def test_reasoning_effort_override_reaches_generate_config(self) -> None:
         req = self._minimal_request()
         out = GenerateOutput(
@@ -333,7 +366,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(reasoning_effort="xhigh"),
                 visitor,
@@ -361,7 +394,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(max_new_tokens=3),
                 DashScRequestControls(),
                 visitor,
@@ -380,7 +413,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -405,7 +438,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 _BoomVisitor(),
@@ -440,7 +473,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 _BoomVisitor(),
@@ -465,7 +498,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -578,7 +611,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
             await _drain(
                 iter_real_model_stream_infer(
                     req,
-                    [1, 2],
+                    _parsed_input_ids([1, 2]),
                     SamplingParams(max_new_think_tokens=0),
                     DashScRequestControls(),
                     visitor,
@@ -622,7 +655,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -695,7 +728,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(
                     response_format=json.dumps({"type": "json_object"}),
                 ),
@@ -780,7 +813,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(
                     max_new_tokens=2,
                     max_new_tokens_from_completion_alias=True,
@@ -836,7 +869,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(
                     max_new_tokens=100,
                     max_new_tokens_from_completion_alias=True,
@@ -879,7 +912,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(
                     max_new_tokens=3,
                     max_new_tokens_from_completion_alias=True,
@@ -930,7 +963,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -971,7 +1004,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=False, max_new_think_tokens=0),
                 visitor,
@@ -1033,7 +1066,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1082,7 +1115,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [1, 2],
+                _parsed_input_ids([1, 2]),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -1136,7 +1169,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1188,7 +1221,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1241,7 +1274,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1300,7 +1333,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
             await _drain(
                 iter_real_model_stream_infer(
                     req,
-                    [7, 8, 128821],
+                    _parsed_input_ids([7, 8, 128821]),
                     SamplingParams(),
                     DashScRequestControls(enable_thinking=True),
                     visitor,
@@ -1361,11 +1394,11 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         env_cfg = _GenerateEnvCfg()
         responses = iter_real_model_stream_infer(
             req,
-            [7, 8, 128821],
+            _parsed_input_ids([7, 8, 128821]),
             SamplingParams(
                 response_format=json.dumps({"type": "json_object"}),
             ),
-            OtherParams(enable_thinking=True),
+            DashScRequestControls(enable_thinking=True),
             visitor,
             rtp_llm_request_id=100,
             echo_prefix_ids=[128821, 198],
@@ -1437,7 +1470,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1497,7 +1530,7 @@ class IterRealModelStreamInferTest(unittest.IsolatedAsyncioTestCase):
         chunks = await _drain(
             iter_real_model_stream_infer(
                 req,
-                [7, 8, 128821],
+                _parsed_input_ids([7, 8, 128821]),
                 SamplingParams(),
                 DashScRequestControls(enable_thinking=True),
                 visitor,
@@ -1541,7 +1574,7 @@ class IterRealModelStreamInferEchoTest(unittest.IsolatedAsyncioTestCase):
         return await _drain(
             iter_real_model_stream_infer(
                 self._req(),
-                input_ids,
+                _parsed_input_ids(input_ids),
                 SamplingParams(),
                 DashScRequestControls(),
                 visitor,
@@ -1621,7 +1654,7 @@ class IterRealModelStreamInferStopWordsTest(unittest.IsolatedAsyncioTestCase):
         await _drain(
             iter_real_model_stream_infer(
                 self._req(),
-                [42],
+                _parsed_input_ids([42]),
                 SamplingParams(),
                 DashScRequestControls(),
                 _CaptureVisitor(),
@@ -1657,7 +1690,7 @@ class IterRealModelStreamInferStopWordsTest(unittest.IsolatedAsyncioTestCase):
         await _drain(
             iter_real_model_stream_infer(
                 self._req(),
-                [42],
+                _parsed_input_ids([42]),
                 SamplingParams(stop_words_list=((154827,),)),
                 DashScRequestControls(),
                 _CaptureVisitor(),
@@ -1717,6 +1750,26 @@ class DashScInferenceServicerTest(unittest.IsolatedAsyncioTestCase):
         )
         return _FakeVisitor(
             _FakeAsyncStream([GenerateOutputs(generate_outputs=[out])])
+        )
+
+    async def test_int64_input_overflow_is_rejected_at_parse_boundary(
+        self,
+    ) -> None:
+        req = predict_v2_pb2.ModelInferRequest()
+        req.id = "overflow"
+        req.model_name = "default"
+        _add_input_tensor(req, "input_ids", "INT64", [1], struct.pack("<q", 2**40))
+        visitor = _FakeVisitor(_FakeAsyncStream([]))
+        servicer = DashScInferenceServicer(backend_visitor=visitor)
+
+        responses = await _drain(
+            servicer.ModelStreamInfer(_areq_iter([req]), _FakeGrpcContext())
+        )
+
+        self.assertEqual(visitor.enqueue_called, 0)
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(
+            _finish_reason(responses[0]), DASH_ERROR_INTERNAL.finish_reason
         )
 
     async def test_access_log_records_input_and_generated_ids(self) -> None:


### PR DESCRIPTION
## Summary

- Keep DashSC phase-2 output backend-owned and stream each backend chunk immediately.
- Parse input IDs once into a validated `ParsedInputIds` list/tensor pair and pass the tensor directly to the backend.
- Reuse static protobuf response fields through request-scoped `StreamResponseBuilder`; remove the old standalone response helper.
- Replace cumulative token lists with counters and refresh tests/docs.

## Performance

CPU microbench in `luoli_gpu` (single thread):

- Steady 1-token stream frame: 11.08 us -> 4.88 us.
- 8-frame stream average: 11.49 us/frame -> 6.78 us/frame.
- INT32 input parse + backend tensor, 4K tokens: 175.63 us -> 37.12 us.
- INT32 input parse + backend tensor, 32K tokens: 1.428 ms -> 0.295 ms.
- First response frame adds about 5 us; combined input + first-frame cost breaks even around 128 prompt tokens and improves substantially for longer prompts.

## Validation

- `codec_test`, `inference_servicer_test`, `mrcr_smoke_test`: passed on the source CUDA 13 branch.
- DashSC TP1 smoke: 10/10 passed.
- DashSC PD smoke: 22/22 passed.
- Main-port conflict resolution: `py_compile`, `git diff --check`, and AST validation of every `iter_real_model_stream_infer` call passed.
- Main cannot execute these Bazel tests in the current CUDA 13.2 container because main only has CUDA 12.9 dependencies; FlashInfer fails to compile against CUDA 13 CUB before tests start.
