### PR TITLE
fix(flashinfer): refresh CUDA-core decode graph replay plan

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional
+from threading import Lock
+from typing import Any, NamedTuple, Optional
 
 import torch
 from flashinfer.cascade import merge_state_in_place
@@ -32,6 +33,7 @@ from rtp_llm.ops.compute_ops import (
 
 # Constants
 DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB = 128
+
 
 # FP8 KV cache uses a unit quantization scale: K/V are cast
 # directly to float8_e4m3fn and FA3 FP8 kernels run with scale_q/k/v = 1.0.
@@ -72,7 +74,7 @@ def quantize_to_fp8_if_needed(
 
 # Global workspace buffer pool
 _g_py_flashinfer_workspace_pool: list[torch.Tensor] = []
-_g_py_flashinfer_pool_lock = __import__("threading").Lock()
+_g_py_flashinfer_pool_lock = Lock()
 
 
 def get_py_flashinfer_workspace_buffer(device: str = "cuda") -> torch.Tensor:
@@ -109,13 +111,28 @@ def _host_i32(t):
 def _device_or(device_tensor, host_tensor):
     """Prefer the *_device mirror; fall back to the base field.
 
+    A defined device mirror is authoritative even when it is empty; optional
+    metadata such as prefix lengths uses an empty tensor as a valid value.
     Unit tests (and some callers) construct PyAttentionInputs with only the
     base fields populated (possibly already CUDA-resident), so the device
     mirror may be missing.
     """
-    if device_tensor is not None and device_tensor.numel() >= 0:
+    if device_tensor is not None:
         return device_tensor
     return host_tensor
+
+
+def _host_block_table(attn_inputs: PyAttentionInputs) -> Optional[torch.Tensor]:
+    """Prefer the host block table and fall back to its device mirror.
+
+    CudaGraphRunner may leave padding rows at a block ID from an earlier active
+    batch. Those IDs remain valid cache blocks, and graph output for padding
+    slots is discarded; only active rows contribute observable output.
+    """
+    block_id = attn_inputs.kv_cache_kernel_block_id
+    if block_id is None or block_id.numel() == 0:
+        block_id = attn_inputs.kv_cache_kernel_block_id_device
+    return block_id
 
 
 def attn_kv_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
@@ -137,6 +154,126 @@ def attn_q_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
     ):
         return torch.float8_e4m3fn
     return attn_configs.dtype
+
+
+class _DecodeGraphHostFillInputs(NamedTuple):
+    prefix_lengths: torch.Tensor
+    sequence_lengths: torch.Tensor
+    input_lengths: torch.Tensor
+    kv_cache_block_id_host: Optional[torch.Tensor]
+
+
+def _validated_decode_host_block_table(
+    attn_inputs: PyAttentionInputs,
+    batch_size: int,
+    logical_sequence_lengths: torch.Tensor,
+    seq_size_per_block: int,
+) -> torch.Tensor:
+    block_id = _host_i32(_host_block_table(attn_inputs))
+    if block_id is None or block_id.numel() == 0:
+        raise ValueError("FlashInfer decode requires a KV cache block table")
+    if block_id.dim() != 2:
+        raise ValueError(
+            "FlashInfer decode KV cache block table must be 2-D, "
+            f"got {block_id.dim()}-D"
+        )
+    if block_id.size(0) < batch_size:
+        raise ValueError(
+            "FlashInfer decode KV cache block table has fewer rows than "
+            f"the batch: rows={block_id.size(0)}, input_lengths={batch_size}"
+        )
+    max_logical_length = (
+        int(logical_sequence_lengths.max().item())
+        if logical_sequence_lengths.numel() > 0
+        else 0
+    )
+    required_columns = (
+        max_logical_length + seq_size_per_block - 1
+    ) // seq_size_per_block
+    if block_id.size(1) < required_columns:
+        raise ValueError(
+            "FlashInfer decode KV cache block table has fewer columns than "
+            "required by the longest sequence: "
+            f"columns={block_id.size(1)}, required={required_columns}"
+        )
+    return block_id
+
+
+def _decode_graph_host_fill_inputs(
+    attn_inputs: PyAttentionInputs,
+    seq_size_per_block: int,
+) -> _DecodeGraphHostFillInputs:
+    """Return validated host metadata for FlashInfer CUDA graph planning.
+
+    CudaGraphRunner supplies complete pinned host mirrors, including padding
+    slots. Prefix lengths are retained for direct PyFlashinferDecodeAttnOp
+    callers that use the existing C++ prefix contract. Compatibility callers
+    with CUDA-resident base tensors are normalized through synchronous D2H;
+    the production graph runner stays on pinned host mirrors.
+    """
+    prefix_lengths = _host_i32(attn_inputs.prefix_lengths)
+    if prefix_lengths is None:
+        prefix_lengths = torch.empty(0, dtype=torch.int32)
+    input_lengths = _host_i32(attn_inputs.input_lengths)
+    if input_lengths is None:
+        raise ValueError("FlashInfer decode requires input lengths")
+    if input_lengths.dim() != 1:
+        raise ValueError(
+            "FlashInfer decode input_lengths must be 1-D, "
+            f"got {input_lengths.dim()}-D"
+        )
+    batch_size = input_lengths.size(0)
+    has_prefix_lengths = prefix_lengths is not None and prefix_lengths.numel() > 0
+    if has_prefix_lengths:
+        if prefix_lengths.dim() != 1:
+            raise ValueError(
+                "FlashInfer decode prefix_lengths must be 1-D, "
+                f"got {prefix_lengths.dim()}-D"
+            )
+        if prefix_lengths.size(0) != batch_size:
+            raise ValueError(
+                "FlashInfer decode metadata batch size mismatch: "
+                f"input_lengths={batch_size}, "
+                f"prefix_lengths={prefix_lengths.size(0)}"
+            )
+        sequence_lengths = torch.empty(0, dtype=torch.int32)
+        logical_sequence_lengths = prefix_lengths + input_lengths
+    else:
+        sequence_lengths = attn_inputs.sequence_lengths
+        if sequence_lengths is None or sequence_lengths.numel() == 0:
+            raise ValueError(
+                "FlashInfer CUDA graph decode requires non-empty "
+                "sequence_lengths covering all padding slots; provide the "
+                "pinned host mirror because sequence_lengths_plus_1_device "
+                "alone is unsupported"
+            )
+        sequence_lengths = _host_i32(sequence_lengths)
+        if sequence_lengths.dim() != 1:
+            raise ValueError(
+                "FlashInfer decode sequence_lengths must be 1-D, "
+                f"got {sequence_lengths.dim()}-D"
+            )
+        if batch_size != sequence_lengths.size(0):
+            raise ValueError(
+                "FlashInfer decode metadata batch size mismatch: "
+                f"input_lengths={batch_size}, "
+                f"sequence_lengths={sequence_lengths.size(0)}"
+            )
+        logical_sequence_lengths = sequence_lengths + 1
+
+    block_id = _validated_decode_host_block_table(
+        attn_inputs,
+        batch_size,
+        logical_sequence_lengths,
+        seq_size_per_block,
+    )
+
+    return _DecodeGraphHostFillInputs(
+        prefix_lengths=prefix_lengths,
+        sequence_lengths=sequence_lengths,
+        input_lengths=input_lengths,
+        kv_cache_block_id_host=block_id,
+    )
 
 
 class PyFlashinferPrefillPagedAttnOp(object):
@@ -192,9 +329,7 @@ class PyFlashinferPrefillPagedAttnOp(object):
         forbid_realloc: True only when called from prepare_cuda_graph (replay); forbids buffer realloc.
         """
         check_attention_inputs(attn_inputs)
-        block_id_host = attn_inputs.kv_cache_kernel_block_id
-        if block_id_host is None or block_id_host.numel() == 0:
-            block_id_host = attn_inputs.kv_cache_kernel_block_id_device
+        block_id_host = _host_block_table(attn_inputs)
         # Keep the same fill path for capture and replay: the host fill sizes
         # buffers exactly while the device fill sizes for the worst case, so
         # switching paths between capture and replay forces a (forbidden)
@@ -1029,23 +1164,95 @@ class PyFlashinferDecodeAttnOp(object):
             attn_q_dtype(attn_configs) if self.use_tensor_core else self.dtype
         )
         self.enable_cuda_graph = attn_inputs.is_cuda_graph
+        # Snapshot of the page indptr used by the last CUDA-core graph plan.
+        # Dtype, head counts, and page size are fixed for this op's lifetime.
+        self._cuda_core_plan_page_indptr_h: Optional[torch.Tensor] = None
+        self._graph_buffers_bound = False
+        self._graph_batch_size: Optional[int] = None
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
         release_py_flashinfer_workspace_buffer(self.g_workspace_buffer)
 
     def set_params(self, params: rtp_llm_ops.FlashInferMlaAttnParams) -> None:
-        """Set the params object to be used by this op."""
+        """Set params before prepare() binds their buffers to the wrapper."""
+        if self.enable_cuda_graph and self._graph_buffers_bound:
+            raise RuntimeError(
+                "FlashInfer CUDA graph params must be set before prepare()"
+            )
+        self._cuda_core_plan_page_indptr_h = None
         self.fmha_params = params
 
-    def _requires_tensor_core_cuda_graph_replan(self) -> bool:
-        # Tensor-core decode refreshes replay-time plan metadata.
+    def _is_cuda_core_graph_mode(self) -> bool:
+        return self.enable_cuda_graph and not self.use_tensor_core
+
+    def _uses_tensor_core_host_plan(self) -> bool:
+        # Tensor-core decode plans from host mirrors in eager and graph modes.
         return self.use_tensor_core
 
+    def _cuda_graph_replay_needs_replan(self) -> bool:
+        current_page_indptr = self.fmha_params.decode_page_indptr_h
+        return self._cuda_core_plan_page_indptr_h is None or not torch.equal(
+            self._cuda_core_plan_page_indptr_h,
+            current_page_indptr,
+        )
+
+    def _validate_cuda_graph_buffer_binding(self) -> None:
+        if not self._graph_buffers_bound or self._graph_batch_size is None:
+            raise RuntimeError(
+                "FlashInfer CUDA graph replay requires prepare() to bind buffers"
+            )
+        if self.decode_wrapper._fixed_batch_size != self._graph_batch_size:
+            raise RuntimeError(
+                "FlashInfer CUDA graph wrapper fixed batch size changed after "
+                "buffer binding"
+            )
+        buffer_pairs = (
+            (
+                "page indptr",
+                self.decode_wrapper._paged_kv_indptr_buf,
+                self.fmha_params.decode_page_indptr_d,
+            ),
+            (
+                "page indices",
+                self.decode_wrapper._paged_kv_indices_buf,
+                self.fmha_params.page_indice_d,
+            ),
+            (
+                "last-page lengths",
+                self.decode_wrapper._paged_kv_last_page_len_buf,
+                self.fmha_params.paged_kv_last_page_len_d,
+            ),
+        )
+        for name, wrapper_buffer, params_buffer in buffer_pairs:
+            if wrapper_buffer.data_ptr() != params_buffer.data_ptr():
+                raise RuntimeError(
+                    f"FlashInfer CUDA graph {name} buffer no longer aliases "
+                    "the bound params buffer"
+                )
+
     def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
-        if self._requires_tensor_core_cuda_graph_replan():
+        is_cuda_core_graph_mode = self._is_cuda_core_graph_mode()
+        if is_cuda_core_graph_mode:
+            # A failed plan must not leave a stale topology marked as reusable.
+            self._cuda_core_plan_page_indptr_h = None
+        if self._uses_tensor_core_host_plan():
+            # Tensor-core decode plans from host mirrors in both eager and graph
+            # modes; only replay decides whether another plan call is required.
             page_indptr = self.fmha_params.decode_page_indptr_h
             page_indice = self.fmha_params.page_indice_h
+            last_page_len = self.fmha_params.paged_kv_last_page_len_h
+            plan_kwargs = {"non_blocking": True}
+        elif is_cuda_core_graph_mode:
+            # The repository-pinned FlashInfer CUDA-core BatchDecode derives
+            # its work partition from page indptr. The last-page-length values
+            # are read by the kernel at runtime; their tensor length still
+            # matches the graph's fixed batch size. Keep both metadata tensors
+            # on host to avoid a D2H copy. Indices stay in the graph-bound
+            # device buffer refreshed by fill_params() before each replay;
+            # forbid_realloc=True preserves its capture-time storage.
+            page_indptr = self.fmha_params.decode_page_indptr_h
+            page_indice = self.fmha_params.page_indice_d
             last_page_len = self.fmha_params.paged_kv_last_page_len_h
             plan_kwargs = {"non_blocking": True}
         else:
@@ -1067,23 +1274,48 @@ class PyFlashinferDecodeAttnOp(object):
             o_data_type=self.dtype,
             **plan_kwargs,
         )
+        if is_cuda_core_graph_mode:
+            self._cuda_core_plan_page_indptr_h = (
+                self.fmha_params.decode_page_indptr_h.clone()
+            )
 
     def prepare(
         self,
         attn_inputs: PyAttentionInputs,
         forbid_realloc: bool = False,
     ) -> ParamsBase:
-        """
-        Prepare the decode wrapper with paged KV cache parameters.
-
-        forbid_realloc: True only when called from prepare_cuda_graph (replay); forbids buffer realloc.
-        """
-        # Tensor-core decode plans from the HOST mirrors
-        # (decode_page_indptr_h etc. in _plan_decode_wrapper); the device fill
-        # only populates the device buffers and leaves the host mirrors at
+        """Prepare decode metadata; graph replay has a dedicated refresh entry."""
+        if self.enable_cuda_graph and self._graph_buffers_bound:
+            raise RuntimeError(
+                "FlashInfer CUDA graph prepare() cannot be called after buffers "
+                "are bound; use prepare_for_cuda_graph_replay()"
+            )
+        # Graph planning uses HOST mirrors for tensor-core decode and for the
+        # CUDA-core topology cache. The device fill leaves those mirrors at
         # their stale capacity sizes (MIN_CACHE_BATCH_SIZE), which corrupts
-        # plan's batch size. Route tensor-core through the host fill.
-        if attn_inputs.input_lengths.is_cuda and not self.use_tensor_core:
+        # the plan's batch size, so both graph backends use the host fill.
+        # CudaGraphRunner supplies pinned host mirrors before graph capture.
+        # Compatibility callers outside capture may pass CUDA-resident base
+        # tensors and pay a synchronous D2H in _host_i32() on this path.
+        fill_inputs: Optional[_DecodeGraphHostFillInputs] = None
+        if self.enable_cuda_graph:
+            fill_inputs = _decode_graph_host_fill_inputs(
+                attn_inputs,
+                self.seq_size_per_block,
+            )
+            self.fmha_params.fill_params(
+                prefix_lengths=fill_inputs.prefix_lengths,
+                sequence_lengths=fill_inputs.sequence_lengths,
+                input_lengths=fill_inputs.input_lengths,
+                kv_cache_block_id_host=fill_inputs.kv_cache_block_id_host,
+                seq_size_per_block=self.seq_size_per_block,
+                forbid_realloc=forbid_realloc,
+            )
+        elif (
+            attn_inputs.input_lengths is not None
+            and attn_inputs.input_lengths.is_cuda
+            and not self.use_tensor_core
+        ):
             self.fmha_params.fill_params_mha_device(
                 _device_or(
                     attn_inputs.prefix_lengths_device, attn_inputs.prefix_lengths
@@ -1098,9 +1330,7 @@ class PyFlashinferDecodeAttnOp(object):
                 forbid_realloc=forbid_realloc,
             )
         else:
-            block_id_host = attn_inputs.kv_cache_kernel_block_id
-            if block_id_host is None or block_id_host.numel() == 0:
-                block_id_host = attn_inputs.kv_cache_kernel_block_id_device
+            block_id_host = _host_block_table(attn_inputs)
             self.fmha_params.fill_params(
                 _host_i32(attn_inputs.prefix_lengths),
                 _host_i32(attn_inputs.sequence_lengths),
@@ -1111,7 +1341,11 @@ class PyFlashinferDecodeAttnOp(object):
             )
 
         if self.enable_cuda_graph and self.decode_wrapper._fixed_batch_size == 0:
-            batch_size = attn_inputs.input_lengths.size(0)
+            batch_size = (
+                fill_inputs.input_lengths.size(0)
+                if fill_inputs is not None
+                else attn_inputs.input_lengths.size(0)
+            )
             self.decode_wrapper._use_cuda_graph = True
             # Both decode backends read these buffers during run(); replay only
             # updates fmha_params in-place, so the wrapper must hold these views.
@@ -1123,6 +1357,8 @@ class PyFlashinferDecodeAttnOp(object):
             )
             self.decode_wrapper._paged_kv_indices_buf = self.fmha_params.page_indice_d
             self.decode_wrapper._fixed_batch_size = batch_size
+            self._graph_batch_size = batch_size
+            self._graph_buffers_bound = True
             if self.use_tensor_core:
                 self.decode_wrapper._qo_indptr_buf = torch.arange(
                     batch_size + 1,
@@ -1130,44 +1366,75 @@ class PyFlashinferDecodeAttnOp(object):
                     device=self.g_workspace_buffer.device,
                 )
 
+        if self.enable_cuda_graph:
+            self._validate_cuda_graph_buffer_binding()
         self._plan_decode_wrapper(attn_inputs)
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
         """Refresh FlashInfer runtime buffers before replaying the captured graph."""
-        if not attn_inputs.sequence_lengths.is_cuda:
-            # Host pipeline: refresh host metadata. Tensor-core decode must
-            # re-plan from these mirrors because its plan uses host metadata.
-            block_id_host = attn_inputs.kv_cache_kernel_block_id
-            if block_id_host is None or block_id_host.numel() == 0:
-                block_id_host = attn_inputs.kv_cache_kernel_block_id_device
-            self.fmha_params.fill_params(
-                _host_i32(attn_inputs.prefix_lengths),
-                _host_i32(attn_inputs.sequence_lengths),
-                _host_i32(attn_inputs.input_lengths),
-                _host_i32(block_id_host),
-                self.seq_size_per_block,
-                forbid_realloc=True,
+        if not self.enable_cuda_graph:
+            if not attn_inputs.sequence_lengths.is_cuda:
+                block_id_host = _host_block_table(attn_inputs)
+                self.fmha_params.fill_params(
+                    _host_i32(attn_inputs.prefix_lengths),
+                    _host_i32(attn_inputs.sequence_lengths),
+                    _host_i32(attn_inputs.input_lengths),
+                    _host_i32(block_id_host),
+                    self.seq_size_per_block,
+                    forbid_realloc=True,
+                )
+                if self._uses_tensor_core_host_plan():
+                    self._plan_decode_wrapper(attn_inputs)
+                return
+
+            seq_plus_1 = attn_inputs.sequence_lengths_plus_1_device
+            if seq_plus_1 is None or not seq_plus_1.is_cuda:
+                seq_plus_1 = (attn_inputs.sequence_lengths.to(torch.int32) + 1).cuda()
+            block_id = _device_or(
+                attn_inputs.kv_cache_kernel_block_id_device,
+                attn_inputs.kv_cache_kernel_block_id,
             )
-            if self._requires_tensor_core_cuda_graph_replan():
-                self._plan_decode_wrapper(attn_inputs)
+            if block_id is not None and not block_id.is_cuda:
+                block_id = block_id.cuda()
+            self.fmha_params.fill_decode_cuda_graph_params(
+                seq_plus_1,
+                block_id,
+                self.seq_size_per_block,
+            )
             return
 
-        # Device pipeline: update the device-resident buffers in place.
-        seq_plus_1 = attn_inputs.sequence_lengths_plus_1_device
-        if seq_plus_1 is None or not seq_plus_1.is_cuda:
-            seq_plus_1 = (attn_inputs.sequence_lengths.to(torch.int32) + 1).cuda()
-        block_id = _device_or(
-            attn_inputs.kv_cache_kernel_block_id_device,
-            attn_inputs.kv_cache_kernel_block_id,
-        )
-        if block_id is not None and not block_id.is_cuda:
-            block_id = block_id.cuda()
-        self.fmha_params.fill_decode_cuda_graph_params(
-            seq_plus_1,
-            block_id,
+        if not self._graph_buffers_bound:
+            raise RuntimeError(
+                "FlashInfer CUDA graph replay requires prepare() to bind buffers"
+            )
+        # Both graph backends plan from host metadata. Keep replay on the same
+        # host fill path even when a compatibility caller supplies CUDA-resident
+        # base tensors, otherwise tensor-core would replan from stale mirrors.
+        # Validate aliases before refreshing params so failures leave all graph
+        # metadata in its last usable state.
+        self._validate_cuda_graph_buffer_binding()
+        fill_inputs = _decode_graph_host_fill_inputs(
+            attn_inputs,
             self.seq_size_per_block,
         )
+        replay_batch_size = fill_inputs.input_lengths.size(0)
+        if replay_batch_size != self._graph_batch_size:
+            raise RuntimeError(
+                "FlashInfer CUDA graph replay batch size must match the bound "
+                f"graph batch: replay={replay_batch_size}, "
+                f"bound={self._graph_batch_size}"
+            )
+        self.fmha_params.fill_params(
+            prefix_lengths=fill_inputs.prefix_lengths,
+            sequence_lengths=fill_inputs.sequence_lengths,
+            input_lengths=fill_inputs.input_lengths,
+            kv_cache_block_id_host=fill_inputs.kv_cache_block_id_host,
+            seq_size_per_block=self.seq_size_per_block,
+            forbid_realloc=True,
+        )
+        if self._uses_tensor_core_host_plan() or self._cuda_graph_replay_needs_replan():
+            self._plan_decode_wrapper(attn_inputs)
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -1,3 +1,5 @@
+import inspect
+from functools import cache
 from threading import Lock
 from typing import Any, NamedTuple, Optional
 
@@ -125,14 +127,20 @@ def _device_or(device_tensor, host_tensor):
 def _host_block_table(attn_inputs: PyAttentionInputs) -> Optional[torch.Tensor]:
     """Prefer the host block table and fall back to its device mirror.
 
-    CudaGraphRunner may leave padding rows at a block ID from an earlier active
-    batch. Those IDs remain valid cache blocks, and graph output for padding
-    slots is discarded; only active rows contribute observable output.
+    CudaGraphRunner clears padding rows to reserved block 0. Direct callers may
+    use another valid block for padding; graph output for those rows is still
+    discarded, so only active rows contribute observable output.
     """
     block_id = attn_inputs.kv_cache_kernel_block_id
     if block_id is None or block_id.numel() == 0:
         block_id = attn_inputs.kv_cache_kernel_block_id_device
     return block_id
+
+
+@cache
+def _decode_plan_supports_disable_split_kv(wrapper_type: type[Any]) -> bool:
+    """Probe each FlashInfer wrapper implementation once per process."""
+    return "disable_split_kv" in inspect.signature(wrapper_type.plan).parameters
 
 
 def attn_kv_dtype(attn_configs: AttentionConfigs) -> torch.dtype:
@@ -160,7 +168,7 @@ class _DecodeGraphHostFillInputs(NamedTuple):
     prefix_lengths: torch.Tensor
     sequence_lengths: torch.Tensor
     input_lengths: torch.Tensor
-    kv_cache_block_id_host: Optional[torch.Tensor]
+    kv_cache_block_id_host: torch.Tensor
 
 
 def _validated_decode_host_block_table(
@@ -236,6 +244,10 @@ def _decode_graph_host_fill_inputs(
                 f"input_lengths={batch_size}, "
                 f"prefix_lengths={prefix_lengths.size(0)}"
             )
+        # This branch is the existing C++ prefix contract: callers select it by
+        # providing prefix_lengths, and logical lengths are defined solely as
+        # prefix_lengths + input_lengths. sequence_lengths belongs to the
+        # mutually exclusive decode contract below and is intentionally ignored.
         sequence_lengths = torch.empty(0, dtype=torch.int32)
         logical_sequence_lengths = prefix_lengths + input_lengths
     else:
@@ -607,9 +619,7 @@ class PyFlashinferPrefillAttnOp(object):
 
         # Encoder-only models (BERT) have no paged kv cache; fill_params
         # pybind requires a Tensor, so substitute an empty int32 tensor.
-        kv_block_id = attn_inputs.kv_cache_kernel_block_id
-        if kv_block_id is None or kv_block_id.numel() == 0:
-            kv_block_id = attn_inputs.kv_cache_kernel_block_id_device
+        kv_block_id = _host_block_table(attn_inputs)
         if kv_block_id is None:
             kv_block_id = torch.empty(0, dtype=torch.int32)
 
@@ -718,9 +728,7 @@ class PyFlashinferHybridPrefillAttnOp(object):
         forbid_realloc: bool = False,
     ) -> ParamsBase:
         """Prepare ragged-new and paged-prefix FlashInfer wrappers."""
-        block_table = attn_inputs.kv_cache_kernel_block_id
-        if block_table is None or block_table.numel() == 0:
-            block_table = attn_inputs.kv_cache_kernel_block_id_device
+        block_table = _host_block_table(attn_inputs)
         assert (
             block_table is not None and block_table.numel() > 0
         ), "hybrid prefill requires a non-empty kv_cache_kernel_block_id"
@@ -784,9 +792,7 @@ class PyFlashinferHybridPrefillAttnOp(object):
 
     @staticmethod
     def support(attn_inputs: PyAttentionInputs) -> bool:
-        block_table = attn_inputs.kv_cache_kernel_block_id
-        if block_table is None or block_table.numel() == 0:
-            block_table = attn_inputs.kv_cache_kernel_block_id_device
+        block_table = _host_block_table(attn_inputs)
         prefix_lengths = attn_inputs.prefix_lengths
         return (
             block_table is not None
@@ -1156,6 +1162,12 @@ class PyFlashinferDecodeAttnOp(object):
             "HND",
             use_tensor_cores=self.use_tensor_core,
         )
+        # FlashInfer 0.2.5 exposes _plan_info but predates disable_split_kv;
+        # newer repository pins accept the kwarg. Probe once so all versions
+        # keep their native plan contract while sharing the launch-plan guard.
+        self._decode_plan_supports_disable_split_kv = (
+            _decode_plan_supports_disable_split_kv(type(self.decode_wrapper))
+        )
         self.dtype = attn_configs.dtype
         self.kv_dtype = attn_kv_dtype(attn_configs)
         # CUDA-core decode dequantizes FP8 KV; tensor-core decode uses the
@@ -1167,8 +1179,13 @@ class PyFlashinferDecodeAttnOp(object):
         # Snapshot of the page indptr used by the last CUDA-core graph plan.
         # Dtype, head counts, and page size are fixed for this op's lifetime.
         self._cuda_core_plan_page_indptr_h: Optional[torch.Tensor] = None
+        # FlashInfer passes plan_info values into the captured kernel launch.
+        # Replanning may refresh metadata buffers, but it must not select a
+        # different launch plan after capture.
+        self._cuda_graph_plan_info: Optional[tuple[int, ...]] = None
         self._graph_buffers_bound = False
         self._graph_batch_size: Optional[int] = None
+        self._graph_qo_indptr_buffer: Optional[torch.Tensor] = None
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
 
     def __del__(self):
@@ -1181,14 +1198,12 @@ class PyFlashinferDecodeAttnOp(object):
                 "FlashInfer CUDA graph params must be set before prepare()"
             )
         self._cuda_core_plan_page_indptr_h = None
+        self._cuda_graph_plan_info = None
+        self._graph_qo_indptr_buffer = None
         self.fmha_params = params
 
     def _is_cuda_core_graph_mode(self) -> bool:
         return self.enable_cuda_graph and not self.use_tensor_core
-
-    def _uses_tensor_core_host_plan(self) -> bool:
-        # Tensor-core decode plans from host mirrors in eager and graph modes.
-        return self.use_tensor_core
 
     def _cuda_graph_replay_needs_replan(self) -> bool:
         current_page_indptr = self.fmha_params.decode_page_indptr_h
@@ -1197,52 +1212,85 @@ class PyFlashinferDecodeAttnOp(object):
             current_page_indptr,
         )
 
+    def _cuda_graph_wrapper_attr(self, name: str) -> Any:
+        try:
+            return getattr(self.decode_wrapper, name)
+        except AttributeError as error:
+            raise RuntimeError(
+                "FlashInfer CUDA graph wrapper does not expose required "
+                f"runtime attribute {name}"
+            ) from error
+
     def _validate_cuda_graph_buffer_binding(self) -> None:
         if not self._graph_buffers_bound or self._graph_batch_size is None:
             raise RuntimeError(
                 "FlashInfer CUDA graph replay requires prepare() to bind buffers"
             )
-        if self.decode_wrapper._fixed_batch_size != self._graph_batch_size:
+        wrapper_batch_size = self._cuda_graph_wrapper_attr("_fixed_batch_size")
+        if wrapper_batch_size != self._graph_batch_size:
             raise RuntimeError(
                 "FlashInfer CUDA graph wrapper fixed batch size changed after "
-                "buffer binding"
+                "buffer binding: "
+                f"wrapper={wrapper_batch_size}, "
+                f"bound={self._graph_batch_size}"
             )
-        buffer_pairs = (
+        buffer_pairs = [
             (
                 "page indptr",
-                self.decode_wrapper._paged_kv_indptr_buf,
+                self._cuda_graph_wrapper_attr("_paged_kv_indptr_buf"),
                 self.fmha_params.decode_page_indptr_d,
             ),
             (
                 "page indices",
-                self.decode_wrapper._paged_kv_indices_buf,
+                self._cuda_graph_wrapper_attr("_paged_kv_indices_buf"),
                 self.fmha_params.page_indice_d,
             ),
             (
                 "last-page lengths",
-                self.decode_wrapper._paged_kv_last_page_len_buf,
+                self._cuda_graph_wrapper_attr("_paged_kv_last_page_len_buf"),
                 self.fmha_params.paged_kv_last_page_len_d,
             ),
-        )
+        ]
+        if self.use_tensor_core:
+            if self._graph_qo_indptr_buffer is None:
+                raise RuntimeError(
+                    "FlashInfer tensor-core CUDA graph query indptr buffer was "
+                    "not bound during prepare()"
+                )
+            buffer_pairs.append(
+                (
+                    "query indptr",
+                    self._cuda_graph_wrapper_attr("_qo_indptr_buf"),
+                    self._graph_qo_indptr_buffer,
+                )
+            )
         for name, wrapper_buffer, params_buffer in buffer_pairs:
             if wrapper_buffer.data_ptr() != params_buffer.data_ptr():
                 raise RuntimeError(
                     f"FlashInfer CUDA graph {name} buffer no longer aliases "
-                    "the bound params buffer"
+                    "the bound params buffer: "
+                    f"wrapper_ptr={wrapper_buffer.data_ptr()}, "
+                    f"params_ptr={params_buffer.data_ptr()}"
                 )
 
-    def _plan_decode_wrapper(self, attn_inputs: PyAttentionInputs) -> None:
+    def _plan_decode_wrapper(self) -> None:
         is_cuda_core_graph_mode = self._is_cuda_core_graph_mode()
         if is_cuda_core_graph_mode:
             # A failed plan must not leave a stale topology marked as reusable.
             self._cuda_core_plan_page_indptr_h = None
-        if self._uses_tensor_core_host_plan():
+        if self.use_tensor_core:
             # Tensor-core decode plans from host mirrors in both eager and graph
             # modes; only replay decides whether another plan call is required.
             page_indptr = self.fmha_params.decode_page_indptr_h
             page_indice = self.fmha_params.page_indice_h
             last_page_len = self.fmha_params.paged_kv_last_page_len_h
             plan_kwargs = {"non_blocking": True}
+            if self.enable_cuda_graph and self._decode_plan_supports_disable_split_kv:
+                # Split-KV can change the number of launched CTAs as sequence
+                # lengths change, which is incompatible with a captured graph.
+                # Older FlashInfer pins lack this kwarg; their graph-aware plan
+                # remains protected by the launch metadata check below.
+                plan_kwargs["disable_split_kv"] = True
         elif is_cuda_core_graph_mode:
             # The repository-pinned FlashInfer CUDA-core BatchDecode derives
             # its work partition from page indptr. The last-page-length values
@@ -1251,6 +1299,9 @@ class PyFlashinferDecodeAttnOp(object):
             # on host to avoid a D2H copy. Indices stay in the graph-bound
             # device buffer refreshed by fill_params() before each replay;
             # forbid_realloc=True preserves its capture-time storage.
+            # disable_split_kv is consumed only by FlashInfer's tensor-core FA2
+            # planner, so the CUDA-core path relies on topology replanning plus
+            # the launch-plan invariant checked below.
             page_indptr = self.fmha_params.decode_page_indptr_h
             page_indice = self.fmha_params.page_indice_d
             last_page_len = self.fmha_params.paged_kv_last_page_len_h
@@ -1274,6 +1325,30 @@ class PyFlashinferDecodeAttnOp(object):
             o_data_type=self.dtype,
             **plan_kwargs,
         )
+        if self.enable_cuda_graph:
+            try:
+                plan_info = self.decode_wrapper._plan_info
+            except AttributeError as error:
+                raise RuntimeError(
+                    "FlashInfer CUDA graph plan does not expose launch metadata"
+                ) from error
+            if plan_info is None:
+                raise RuntimeError(
+                    "FlashInfer CUDA graph plan did not produce launch metadata"
+                )
+            current_plan_info = tuple(int(value) for value in plan_info)
+            if self._cuda_graph_plan_info is None:
+                self._cuda_graph_plan_info = current_plan_info
+            elif current_plan_info != self._cuda_graph_plan_info:
+                raise RuntimeError(
+                    "FlashInfer CUDA graph launch plan changed after capture; "
+                    "the replay shape is incompatible with the captured graph: "
+                    f"captured={self._cuda_graph_plan_info}, "
+                    f"replay={current_plan_info}, "
+                    f"batch_size={self._graph_batch_size}, "
+                    "page_indptr="
+                    f"{self.fmha_params.decode_page_indptr_h.tolist()}"
+                )
         if is_cuda_core_graph_mode:
             self._cuda_core_plan_page_indptr_h = (
                 self.fmha_params.decode_page_indptr_h.clone()
@@ -1365,10 +1440,11 @@ class PyFlashinferDecodeAttnOp(object):
                     dtype=torch.int32,
                     device=self.g_workspace_buffer.device,
                 )
+                self._graph_qo_indptr_buffer = self.decode_wrapper._qo_indptr_buf
 
         if self.enable_cuda_graph:
             self._validate_cuda_graph_buffer_binding()
-        self._plan_decode_wrapper(attn_inputs)
+        self._plan_decode_wrapper()
         return self.fmha_params
 
     def prepare_for_cuda_graph_replay(self, attn_inputs: PyAttentionInputs) -> None:
@@ -1384,8 +1460,8 @@ class PyFlashinferDecodeAttnOp(object):
                     self.seq_size_per_block,
                     forbid_realloc=True,
                 )
-                if self._uses_tensor_core_host_plan():
-                    self._plan_decode_wrapper(attn_inputs)
+                if self.use_tensor_core:
+                    self._plan_decode_wrapper()
                 return
 
             seq_plus_1 = attn_inputs.sequence_lengths_plus_1_device
@@ -1404,10 +1480,6 @@ class PyFlashinferDecodeAttnOp(object):
             )
             return
 
-        if not self._graph_buffers_bound:
-            raise RuntimeError(
-                "FlashInfer CUDA graph replay requires prepare() to bind buffers"
-            )
         # Both graph backends plan from host metadata. Keep replay on the same
         # host fill path even when a compatibility caller supplies CUDA-resident
         # base tensors, otherwise tensor-core would replan from stale mirrors.
@@ -1433,8 +1505,8 @@ class PyFlashinferDecodeAttnOp(object):
             seq_size_per_block=self.seq_size_per_block,
             forbid_realloc=True,
         )
-        if self._uses_tensor_core_host_plan() or self._cuda_graph_replay_needs_replan():
-            self._plan_decode_wrapper(attn_inputs)
+        if self.use_tensor_core or self._cuda_graph_replay_needs_replan():
+            self._plan_decode_wrapper()
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         return True

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import torch
 from attention_ref import compute_flashinfer_decode_reference
-from base_attention_test import BaseAttentionTest
+from base_attention_test import BaseAttentionTest, TestConfig
 
 from rtp_llm.models_py.modules.factory.attention.cuda_impl import py_flashinfer_mha
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
@@ -29,6 +29,16 @@ class PageMetadata(NamedTuple):
     page_indptr: List[int]
     page_indices: List[int]
     last_page_lens: List[int]
+
+
+class _CudaGraphTestDecodeAttnOp(PyFlashinferDecodeAttnOp):
+    """Keep actual-graph test workspaces out of the process-global pool."""
+
+    def __del__(self):
+        # A failed assertion can keep the captured graph alive through its
+        # traceback. Releasing that workspace to the global pool would let a
+        # later test reuse storage that the graph still references.
+        pass
 
 
 class TestPyFlashinferDecodeAttnOp(BaseAttentionTest):
@@ -384,6 +394,9 @@ class TestDecodeHostFillValidation(BaseAttentionTest):
             inputs,
             config.seq_size_per_block,
         )
+        self.assertFalse(fill_inputs.sequence_lengths.is_cuda)
+        self.assertFalse(fill_inputs.input_lengths.is_cuda)
+        self.assertFalse(fill_inputs.kv_cache_block_id_host.is_cuda)
         self.assertEqual(
             fill_inputs.sequence_lengths.tolist(),
             [sequence_length - 1 for sequence_length in sequence_lengths],
@@ -405,70 +418,72 @@ class TestDecodeHostFillValidation(BaseAttentionTest):
     def test_validates_required_lengths(self):
         """Compatibility fallback rejects missing or mismatched lengths."""
         config = self._create_config()
-        inputs = self._create_attention_inputs_base(
-            batch_size=2,
-            sequence_lengths=[64, 128],
-            seq_size_per_block=config.seq_size_per_block,
-        )
-        inputs.is_prefill = False
-        inputs.is_cuda_graph = True
-        invalid_inputs = PyAttentionInputs()
-        invalid_inputs.input_lengths = inputs.input_lengths
-        invalid_inputs.sequence_lengths = torch.empty(0, dtype=torch.int32)
-        invalid_inputs.prefix_lengths = inputs.prefix_lengths
-        invalid_inputs.kv_cache_kernel_block_id = inputs.kv_cache_kernel_block_id
-        invalid_inputs.kv_cache_kernel_block_id_device = (
-            inputs.kv_cache_kernel_block_id_device
-        )
-        invalid_inputs.is_cuda_graph = True
-        with self.assertRaisesRegex(ValueError, "requires non-empty sequence_lengths"):
-            py_flashinfer_mha._decode_graph_host_fill_inputs(
-                invalid_inputs,
+
+        def make_inputs() -> PyAttentionInputs:
+            inputs = self._create_attention_inputs_base(
+                batch_size=2,
+                sequence_lengths=[64, 128],
+                seq_size_per_block=config.seq_size_per_block,
+            )
+            inputs.is_prefill = False
+            inputs.is_cuda_graph = True
+            return inputs
+
+        def make_partial_inputs(
+            include_input_lengths: bool = True,
+            include_prefix_lengths: bool = True,
+        ) -> PyAttentionInputs:
+            source = make_inputs()
+            inputs = PyAttentionInputs()
+            if include_input_lengths:
+                inputs.input_lengths = source.input_lengths
+            if include_prefix_lengths:
+                inputs.prefix_lengths = source.prefix_lengths
+            inputs.sequence_lengths = source.sequence_lengths
+            inputs.kv_cache_kernel_block_id = source.kv_cache_kernel_block_id
+            inputs.kv_cache_kernel_block_id_device = (
+                source.kv_cache_kernel_block_id_device
+            )
+            inputs.is_cuda_graph = True
+            return inputs
+
+        with self.subTest(case="missing sequence lengths"):
+            inputs = make_inputs()
+            inputs.sequence_lengths = torch.empty(0, dtype=torch.int32)
+            with self.assertRaisesRegex(
+                ValueError, "requires non-empty sequence_lengths"
+            ):
+                py_flashinfer_mha._decode_graph_host_fill_inputs(
+                    inputs,
+                    config.seq_size_per_block,
+                )
+
+        with self.subTest(case="missing input lengths"):
+            inputs = make_partial_inputs(include_input_lengths=False)
+            with self.assertRaisesRegex(ValueError, "requires input lengths"):
+                py_flashinfer_mha._decode_graph_host_fill_inputs(
+                    inputs,
+                    config.seq_size_per_block,
+                )
+
+        with self.subTest(case="missing prefix lengths"):
+            inputs = make_partial_inputs(include_prefix_lengths=False)
+            fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
+                inputs,
                 config.seq_size_per_block,
             )
+            self.assertEqual(fill_inputs.prefix_lengths.numel(), 0)
 
-        invalid_inputs.sequence_lengths = torch.tensor([63, 127], dtype=torch.int32)
-        missing_input_lengths = PyAttentionInputs()
-        missing_input_lengths.sequence_lengths = invalid_inputs.sequence_lengths
-        missing_input_lengths.prefix_lengths = invalid_inputs.prefix_lengths
-        missing_input_lengths.kv_cache_kernel_block_id = (
-            invalid_inputs.kv_cache_kernel_block_id
-        )
-        missing_input_lengths.kv_cache_kernel_block_id_device = (
-            invalid_inputs.kv_cache_kernel_block_id_device
-        )
-        with self.assertRaisesRegex(ValueError, "requires input lengths"):
-            py_flashinfer_mha._decode_graph_host_fill_inputs(
-                missing_input_lengths,
-                config.seq_size_per_block,
-            )
+        with self.subTest(case="mismatched sequence batch"):
+            inputs = make_inputs()
+            inputs.input_lengths = torch.ones(1, dtype=torch.int32)
+            with self.assertRaisesRegex(ValueError, "batch size mismatch"):
+                py_flashinfer_mha._decode_graph_host_fill_inputs(
+                    inputs,
+                    config.seq_size_per_block,
+                )
 
-        missing_prefix_lengths = PyAttentionInputs()
-        missing_prefix_lengths.input_lengths = inputs.input_lengths
-        missing_prefix_lengths.sequence_lengths = torch.tensor(
-            [63, 127], dtype=torch.int32
-        )
-        missing_prefix_lengths.kv_cache_kernel_block_id = (
-            inputs.kv_cache_kernel_block_id
-        )
-        missing_prefix_lengths.kv_cache_kernel_block_id_device = (
-            inputs.kv_cache_kernel_block_id_device
-        )
-        fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
-            missing_prefix_lengths,
-            config.seq_size_per_block,
-        )
-        self.assertEqual(fill_inputs.prefix_lengths.numel(), 0)
-
-        invalid_inputs.input_lengths = torch.ones(1, dtype=torch.int32)
-        with self.assertRaisesRegex(ValueError, "batch size mismatch"):
-            py_flashinfer_mha._decode_graph_host_fill_inputs(
-                invalid_inputs,
-                config.seq_size_per_block,
-            )
-
-    def test_accepts_prefix_lengths_and_rejects_input_mismatch(self):
-        """Prefix metadata is preserved and must align with input lengths."""
+    def _create_prefix_graph_inputs(self) -> tuple[PyAttentionInputs, TestConfig]:
         config = self._create_config(head_num=32, head_num_kv=32)
         inputs = self._create_attention_inputs_base(
             batch_size=2,
@@ -478,9 +493,12 @@ class TestDecodeHostFillValidation(BaseAttentionTest):
         inputs.is_prefill = False
         inputs.is_cuda_graph = True
         inputs.prefix_lengths = torch.tensor([63, 127], dtype=torch.int32)
-        # Keep the fallback source deliberately different so this test fails if
-        # prefix_lengths + input_lengths is accidentally ignored.
         inputs.sequence_lengths = torch.tensor([7, 7], dtype=torch.int32)
+        return inputs, config
+
+    def test_accepts_prefix_lengths(self):
+        """Prefix metadata is preserved and takes the C++ prefix path."""
+        inputs, config = self._create_prefix_graph_inputs()
         fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
             inputs,
             config.seq_size_per_block,
@@ -497,6 +515,9 @@ class TestDecodeHostFillValidation(BaseAttentionTest):
         self.assertEqual(fmha_params.decode_page_indptr_h.tolist(), [0, 1, 3])
         self.assertEqual(fmha_params.paged_kv_last_page_len_h.tolist(), [64, 64])
 
+    def test_accepts_prefix_lengths_without_sequence_lengths(self):
+        """The existing C++ prefix contract does not require sequence lengths."""
+        inputs, config = self._create_prefix_graph_inputs()
         # C++ fillParams ignores sequence_lengths when prefix lengths exist;
         # preserve that pre-existing prefix-only input contract.
         inputs.sequence_lengths = torch.empty(0, dtype=torch.int32)
@@ -512,6 +533,9 @@ class TestDecodeHostFillValidation(BaseAttentionTest):
         self.assertEqual(prefix_only_params.decode_page_indptr_h.tolist(), [0, 1, 3])
         self.assertEqual(prefix_only_params.paged_kv_last_page_len_h.tolist(), [64, 64])
 
+    def test_rejects_prefix_input_batch_mismatch(self):
+        """Prefix and input metadata must describe the same graph batch."""
+        inputs, config = self._create_prefix_graph_inputs()
         inputs.prefix_lengths = torch.tensor([63], dtype=torch.int32)
         with self.assertRaisesRegex(ValueError, "prefix_lengths=1"):
             py_flashinfer_mha._decode_graph_host_fill_inputs(
@@ -524,8 +548,7 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     """Test CUDA graph buffer management for PyFlashinferDecodeAttnOp.
 
     These tests exercise the Python prepare/replay boundary for both decode
-    backends and actual CUDA-core graph capture/replay. Tensor-core graph
-    coverage remains at the Python boundary in this target.
+    backends and actual CUDA-core and tensor-core graph capture/replay.
     """
 
     def _assert_cuda_core_graph_mode(self, attn_op) -> None:
@@ -761,6 +784,52 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
         logging.info("_fixed_batch_size correctly set after prepare()")
 
+    def test_disable_split_kv_capability_probe_is_cached(self):
+        """Repeated decode-op construction probes a wrapper type only once."""
+        config = self._create_config()
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        capability_probe = py_flashinfer_mha._decode_plan_supports_disable_split_kv
+        capability_probe.cache_clear()
+        try:
+            first_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            second_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            cache_info = capability_probe.cache_info()
+            self.assertEqual(cache_info.misses, 1)
+            self.assertEqual(cache_info.hits, 1)
+            self.assertEqual(
+                first_op._decode_plan_supports_disable_split_kv,
+                second_op._decode_plan_supports_disable_split_kv,
+            )
+        finally:
+            capability_probe.cache_clear()
+
+    def test_tensor_core_graph_omits_unsupported_disable_split_kv(self):
+        """Legacy FlashInfer plans keep their native CUDA graph signature."""
+        config = self._create_config()
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        self.assertTrue(attn_op.use_tensor_core)
+        attn_op._decode_plan_supports_disable_split_kv = False
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare(inputs)
+
+        self.assertNotIn("disable_split_kv", plan_mock.call_args.kwargs)
+        self.assertIsNotNone(attn_op._cuda_graph_plan_info)
+
     def test_set_params_rejects_rebind_after_cuda_graph_prepare(self):
         """Graph wrapper buffers cannot be rebound after prepare()."""
         config = self._create_config(head_num=32, head_num_kv=32)
@@ -800,8 +869,8 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             attn_op.prepare(inputs)
         self._assert_graph_buffer_pointers(attn_op, fmha_params, graph_buffer_pointers)
 
-    def test_replay_rejects_empty_sequence_lengths(self):
-        """Graph replay rejects empty sequence metadata."""
+    def test_replay_rejects_device_only_sequence_length_mirror(self):
+        """Replay requires the host mirror supplied by CudaGraphRunner."""
         config = self._create_config(head_num=32, head_num_kv=32)
         capture_bs = 4
         capture_inputs = self._create_cuda_graph_inputs(
@@ -883,6 +952,22 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
                 original_plan_topology,
             )
         )
+
+    def test_replay_reports_missing_graph_wrapper_buffer(self):
+        """A dependency contract mismatch reports a graph-specific error."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(inputs)
+        del attn_op.decode_wrapper._paged_kv_indices_buf
+
+        with self.assertRaisesRegex(RuntimeError, "_paged_kv_indices_buf"):
+            attn_op.prepare_for_cuda_graph_replay(inputs)
 
     def test_replay_rejects_batch_size_change_before_refresh(self):
         """A wrong replay batch cannot resize graph-bound metadata buffers."""
@@ -1030,6 +1115,12 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             self.assertFalse(capture_call.args[1].is_cuda)
             self.assertFalse(capture_call.args[2].is_cuda)
             self.assertTrue(capture_call.kwargs["non_blocking"])
+            self.assertEqual(
+                "disable_split_kv" in capture_call.kwargs,
+                attn_op._decode_plan_supports_disable_split_kv,
+            )
+            if attn_op._decode_plan_supports_disable_split_kv:
+                self.assertTrue(capture_call.kwargs["disable_split_kv"])
             self.assertTrue(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
             self.assertEqual(
                 attn_op.decode_wrapper._qo_indptr_buf.numel(), capture_bs + 1
@@ -1104,6 +1195,17 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         with self.assertRaisesRegex(RuntimeError, "use prepare_for_cuda_graph_replay"):
             attn_op.prepare(inputs)
         self.assertIs(attn_op.fmha_params, original_params)
+
+        attn_op.decode_wrapper._qo_indptr_buf = (
+            attn_op.decode_wrapper._qo_indptr_buf.clone()
+        )
+        replay_inputs = self._create_cuda_graph_inputs(
+            2,
+            [129, 193],
+            config.seq_size_per_block,
+        )
+        with self.assertRaisesRegex(RuntimeError, "query indptr buffer no longer"):
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
 
     def test_cuda_core_replay_replans_only_on_page_topology_change(self):
         """CUDA-core replay caches only topology and refreshes graph buffers."""
@@ -1278,25 +1380,121 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         self.assertEqual(plan_mock.call_count, 1)
         self.assertIsNotNone(attn_op._cuda_core_plan_page_indptr_h)
 
-    def _run_cuda_core_actual_graph_replay_matches_reference(
+    def test_replay_rejects_changed_flashinfer_launch_plan(self):
+        """Replay fails if replanning selects a launch incompatible with capture."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(capture_inputs)
+        captured_plan_info = attn_op._cuda_graph_plan_info
+        original_plan = attn_op.decode_wrapper.plan
+
+        def incompatible_plan(*args, **kwargs):
+            original_plan(*args, **kwargs)
+            raw_plan_info = attn_op.decode_wrapper._plan_info
+            plan_info = list(raw_plan_info)
+            self.assertGreater(len(plan_info), 0)
+            plan_info[0] += 1
+            attn_op.decode_wrapper._plan_info = plan_info
+
+        replay_inputs = self._create_cuda_graph_inputs(
+            2,
+            [129, 193],
+            config.seq_size_per_block,
+        )
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            side_effect=incompatible_plan,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "launch plan changed"):
+                attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+        self.assertEqual(attn_op._cuda_graph_plan_info, captured_plan_info)
+        self.assertIsNone(attn_op._cuda_core_plan_page_indptr_h)
+
+    def test_prefix_replay_rejects_more_reuse_pages_than_capture(self):
+        """Prefix graph replay cannot grow its capture-time reuse workspace."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+            use_prefix_lengths=True,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(capture_inputs)
+
+        replay_inputs = self._create_cuda_graph_inputs(
+            2,
+            [193, 193],
+            config.seq_size_per_block,
+            use_prefix_lengths=True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "Buffer reallocation required"):
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+
+    def _run_actual_graph_replay_matches_reference(
         self,
         use_prefix_lengths: bool,
+        expect_tensor_core: bool,
+        head_num_kv: int = 32,
         active_batch_size: Optional[int] = None,
         padding_block_id: int = 0,
     ) -> None:
-        config = self._create_config(head_num=32, head_num_kv=32)
+        if not is_sm90():
+            self.skipTest(
+                "FlashInfer 0.6.9 real decode CUDA graph capture is not "
+                "supported by the sm8x or sm12x test targets; metadata and "
+                "replanning tests remain enabled on those platforms"
+            )
+        config = self._create_config(head_num=32, head_num_kv=head_num_kv)
         capture_bs = 2
-        # Prefix metadata also sizes FlashInfer's reuse-page workspace. Give
-        # capture enough aggregate reuse pages for both replay shapes while
-        # changing their per-request page topology.
-        capture_sequence_lengths = [64, 384] if use_prefix_lengths else [64, 128]
+        if use_prefix_lengths:
+            # Prefix metadata also sizes FlashInfer's reuse-page workspace.
+            capture_sequence_lengths = [64, 384]
+        else:
+            # CudaGraphRunner captures with near-max lengths, then replays the
+            # graph with shorter live sequences.
+            capture_sequence_lengths = [512, 512]
         capture_inputs = self._create_cuda_graph_inputs(
             capture_bs,
             capture_sequence_lengths,
             config.seq_size_per_block,
             use_prefix_lengths=use_prefix_lengths,
         )
-        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        # Actual capture fixtures must not recycle a workspace still referenced
+        # by another graph created earlier in this process.
+        graph_workspace = torch.zeros(
+            py_flashinfer_mha.DEFAULT_PY_FLASHINFER_WORKSPACE_SIZE_MB * 1024 * 1024,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        graph = None
+        graph_output = None
+        attn_op = None
+
+        def cleanup_graph_resources():
+            nonlocal graph, graph_output, attn_op, graph_workspace
+            graph_output = None
+            graph = None
+            attn_op = None
+            graph_workspace = None
+            torch.cuda.synchronize()
+
+        self.addCleanup(cleanup_graph_resources)
+        with mock.patch.object(
+            py_flashinfer_mha,
+            "get_py_flashinfer_workspace_buffer",
+            return_value=graph_workspace,
+        ):
+            attn_op = _CudaGraphTestDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertEqual(attn_op.use_tensor_core, expect_tensor_core)
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
         attn_op.prepare(capture_inputs)
@@ -1312,6 +1510,19 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             padding_block_id=padding_block_id,
             use_prefix_lengths=use_prefix_lengths,
         )
+        same_topology_sequence_lengths = [130, 194]
+        if active_batch_size is not None:
+            same_topology_sequence_lengths = same_topology_sequence_lengths[
+                :active_batch_size
+            ]
+        same_topology_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            same_topology_sequence_lengths,
+            config.seq_size_per_block,
+            active_batch_size=active_batch_size,
+            padding_block_id=padding_block_id,
+            use_prefix_lengths=use_prefix_lengths,
+        )
         local_head_num = config.head_num // config.tp_size
         local_kv_head_num = config.head_num_kv // config.tp_size
         static_q = self._create_query_tensor(
@@ -1320,11 +1531,8 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             config.size_per_head,
         )
         total_blocks = max(
-            self._calculate_total_blocks(
-                replay_sequence_lengths,
-                config.seq_size_per_block,
-            ),
-            padding_block_id + 1,
+            int(inputs.kv_cache_kernel_block_id.max().item()) + 1
+            for inputs in (capture_inputs, replay_inputs, same_topology_inputs)
         )
         kv_cache, k_cache, v_cache = self._create_kv_cache(
             total_blocks,
@@ -1359,26 +1567,13 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             config.seq_size_per_block,
         )
 
-        same_topology_sequence_lengths = [130, 194]
-        if active_batch_size is not None:
-            same_topology_sequence_lengths = same_topology_sequence_lengths[
-                :active_batch_size
-            ]
-        same_topology_inputs = self._create_cuda_graph_inputs(
-            capture_bs,
-            same_topology_sequence_lengths,
-            config.seq_size_per_block,
-            active_batch_size=active_batch_size,
-            padding_block_id=padding_block_id,
-            use_prefix_lengths=use_prefix_lengths,
-        )
         with mock.patch.object(
             attn_op.decode_wrapper,
             "plan",
             wraps=attn_op.decode_wrapper.plan,
         ) as plan_mock:
             attn_op.prepare_for_cuda_graph_replay(same_topology_inputs)
-        self.assertEqual(plan_mock.call_count, 0)
+        self.assertEqual(plan_mock.call_count, 1 if expect_tensor_core else 0)
         graph.replay()
         torch.cuda.synchronize()
         self._assert_active_output_matches_reference(
@@ -1394,13 +1589,19 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
 
     def test_cuda_core_actual_graph_replay_matches_reference(self):
         """Capture and replay CUDA-core decode after crossing a page boundary."""
-        if self.kv_cache_dtype == KvCacheDataType.FP8 and not is_sm90():
-            self.skipTest(
-                "Real FP8 KV CUDA graph capture is limited to the SM90 target; "
-                "non-SM90 targets retain focused replay coverage"
-            )
-        self._run_cuda_core_actual_graph_replay_matches_reference(
+        self._run_actual_graph_replay_matches_reference(
             use_prefix_lengths=False,
+            expect_tensor_core=False,
+            active_batch_size=1,
+            padding_block_id=7,
+        )
+
+    def test_actual_tensor_core_graph_replay_matches_reference(self):
+        """Capture and replay GQA tensor-core decode across a page boundary."""
+        self._run_actual_graph_replay_matches_reference(
+            use_prefix_lengths=False,
+            expect_tensor_core=True,
+            head_num_kv=8,
             active_batch_size=1,
             padding_block_id=7,
         )
@@ -1409,8 +1610,11 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         """Capture and replay the compatible prefix-length metadata contract."""
         if self.kv_cache_dtype == KvCacheDataType.FP8:
             self.skipTest("Prefix metadata is dtype-independent and covered by FP16")
-        self._run_cuda_core_actual_graph_replay_matches_reference(
-            use_prefix_lengths=True
+        self._run_actual_graph_replay_matches_reference(
+            use_prefix_lengths=True,
+            expect_tensor_core=False,
+            active_batch_size=1,
+            padding_block_id=7,
         )
 
     def test_cuda_core_replay_matches_reference_with_stale_padding_ids(self):

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_py_flashinfer_mha_decode.py
@@ -2,15 +2,18 @@ import logging
 import math
 import sys
 import unittest
-from typing import List
+from typing import List, NamedTuple, Optional
+from unittest import mock
 
 import torch
 from attention_ref import compute_flashinfer_decode_reference
 from base_attention_test import BaseAttentionTest
 
+from rtp_llm.models_py.modules.factory.attention.cuda_impl import py_flashinfer_mha
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     PyFlashinferDecodeAttnOp,
 )
+from rtp_llm.models_py.utils.arch import is_sm90
 from rtp_llm.ops import KvCacheDataType
 from rtp_llm.ops.compute_ops import (
     PyAttentionInputs,
@@ -20,6 +23,12 @@ from rtp_llm.ops.compute_ops import (
 )
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+class PageMetadata(NamedTuple):
+    page_indptr: List[int]
+    page_indices: List[int]
+    last_page_lens: List[int]
 
 
 class TestPyFlashinferDecodeAttnOp(BaseAttentionTest):
@@ -286,16 +295,241 @@ class TestPyFlashinferDecodeAttnOp(BaseAttentionTest):
                 seq_size_per_block=64,
             )
 
+    def test_eager_cuda_metadata_plans_on_device_and_matches_reference(self):
+        """Eager CUDA-core decode plans on device and matches the reference."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        sequence_lengths = [100, 200]
+        batch_size = len(sequence_lengths)
+        attn_inputs = self._create_attention_inputs(
+            batch_size,
+            sequence_lengths,
+            config.seq_size_per_block,
+        )
+        attn_inputs.is_cuda_graph = False
+        attn_inputs.sequence_lengths = attn_inputs.sequence_lengths.cuda()
+        attn_inputs.input_lengths = attn_inputs.input_lengths.cuda()
+        attn_inputs.prefix_lengths = attn_inputs.prefix_lengths.cuda()
+
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, attn_inputs)
+        self.assertFalse(attn_op.use_tensor_core)
+        self.assertFalse(attn_op._is_cuda_core_graph_mode())
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            params = attn_op.prepare(attn_inputs)
+            self.assertEqual(plan_mock.call_count, 1)
+            plan_call = plan_mock.call_args
+            self.assertTrue(plan_call.args[0].is_cuda)
+            self.assertTrue(plan_call.args[1].is_cuda)
+            self.assertTrue(plan_call.args[2].is_cuda)
+            self.assertNotIn("non_blocking", plan_call.kwargs)
+
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        q = self._create_query_tensor(batch_size, local_head_num, config.size_per_head)
+        total_blocks = self._calculate_total_blocks(
+            sequence_lengths, config.seq_size_per_block
+        )
+        kv_cache, k_cache, v_cache = self._create_kv_cache(
+            total_blocks,
+            config.seq_size_per_block,
+            local_kv_head_num,
+            config.size_per_head,
+            dtype=self.cache_dtype(config.attn_configs),
+        )
+        output = attn_op.forward(q, kv_cache, params)
+        block_id_list = self._generate_block_id_list(
+            attn_inputs, sequence_lengths, config.seq_size_per_block
+        )
+        reference = compute_flashinfer_decode_reference(
+            q.to(attn_op.q_dtype).to(q.dtype),
+            k_cache.to(q.dtype),
+            v_cache.to(q.dtype),
+            sequence_lengths,
+            block_id_list,
+            config.seq_size_per_block,
+        )
+        self._assert_output_close(
+            output,
+            reference,
+            name="Eager CUDA-metadata decode output",
+        )
+
+
+class TestDecodeHostFillValidation(BaseAttentionTest):
+    """Validate CUDA-core graph host metadata before it reaches C++."""
+
+    def test_normalizes_cuda_sequence_metadata(self):
+        """CUDA-resident base metadata is copied to validated host tensors."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        sequence_lengths = [64, 129]
+        inputs = self._create_attention_inputs_base(
+            batch_size=2,
+            sequence_lengths=sequence_lengths,
+            seq_size_per_block=config.seq_size_per_block,
+        )
+        inputs.is_prefill = False
+        inputs.is_cuda_graph = True
+        inputs.sequence_lengths = torch.tensor(
+            [sequence_length - 1 for sequence_length in sequence_lengths],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
+            inputs,
+            config.seq_size_per_block,
+        )
+        self.assertEqual(
+            fill_inputs.sequence_lengths.tolist(),
+            [sequence_length - 1 for sequence_length in sequence_lengths],
+        )
+
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        self.assertTrue(attn_op._is_cuda_core_graph_mode())
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(inputs)
+        self.assertEqual(
+            fmha_params.paged_kv_last_page_len_h.tolist(),
+            [
+                sequence_length % config.seq_size_per_block or config.seq_size_per_block
+                for sequence_length in sequence_lengths
+            ],
+        )
+
+    def test_validates_required_lengths(self):
+        """Compatibility fallback rejects missing or mismatched lengths."""
+        config = self._create_config()
+        inputs = self._create_attention_inputs_base(
+            batch_size=2,
+            sequence_lengths=[64, 128],
+            seq_size_per_block=config.seq_size_per_block,
+        )
+        inputs.is_prefill = False
+        inputs.is_cuda_graph = True
+        invalid_inputs = PyAttentionInputs()
+        invalid_inputs.input_lengths = inputs.input_lengths
+        invalid_inputs.sequence_lengths = torch.empty(0, dtype=torch.int32)
+        invalid_inputs.prefix_lengths = inputs.prefix_lengths
+        invalid_inputs.kv_cache_kernel_block_id = inputs.kv_cache_kernel_block_id
+        invalid_inputs.kv_cache_kernel_block_id_device = (
+            inputs.kv_cache_kernel_block_id_device
+        )
+        invalid_inputs.is_cuda_graph = True
+        with self.assertRaisesRegex(ValueError, "requires non-empty sequence_lengths"):
+            py_flashinfer_mha._decode_graph_host_fill_inputs(
+                invalid_inputs,
+                config.seq_size_per_block,
+            )
+
+        invalid_inputs.sequence_lengths = torch.tensor([63, 127], dtype=torch.int32)
+        missing_input_lengths = PyAttentionInputs()
+        missing_input_lengths.sequence_lengths = invalid_inputs.sequence_lengths
+        missing_input_lengths.prefix_lengths = invalid_inputs.prefix_lengths
+        missing_input_lengths.kv_cache_kernel_block_id = (
+            invalid_inputs.kv_cache_kernel_block_id
+        )
+        missing_input_lengths.kv_cache_kernel_block_id_device = (
+            invalid_inputs.kv_cache_kernel_block_id_device
+        )
+        with self.assertRaisesRegex(ValueError, "requires input lengths"):
+            py_flashinfer_mha._decode_graph_host_fill_inputs(
+                missing_input_lengths,
+                config.seq_size_per_block,
+            )
+
+        missing_prefix_lengths = PyAttentionInputs()
+        missing_prefix_lengths.input_lengths = inputs.input_lengths
+        missing_prefix_lengths.sequence_lengths = torch.tensor(
+            [63, 127], dtype=torch.int32
+        )
+        missing_prefix_lengths.kv_cache_kernel_block_id = (
+            inputs.kv_cache_kernel_block_id
+        )
+        missing_prefix_lengths.kv_cache_kernel_block_id_device = (
+            inputs.kv_cache_kernel_block_id_device
+        )
+        fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
+            missing_prefix_lengths,
+            config.seq_size_per_block,
+        )
+        self.assertEqual(fill_inputs.prefix_lengths.numel(), 0)
+
+        invalid_inputs.input_lengths = torch.ones(1, dtype=torch.int32)
+        with self.assertRaisesRegex(ValueError, "batch size mismatch"):
+            py_flashinfer_mha._decode_graph_host_fill_inputs(
+                invalid_inputs,
+                config.seq_size_per_block,
+            )
+
+    def test_accepts_prefix_lengths_and_rejects_input_mismatch(self):
+        """Prefix metadata is preserved and must align with input lengths."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_attention_inputs_base(
+            batch_size=2,
+            sequence_lengths=[64, 128],
+            seq_size_per_block=config.seq_size_per_block,
+        )
+        inputs.is_prefill = False
+        inputs.is_cuda_graph = True
+        inputs.prefix_lengths = torch.tensor([63, 127], dtype=torch.int32)
+        # Keep the fallback source deliberately different so this test fails if
+        # prefix_lengths + input_lengths is accidentally ignored.
+        inputs.sequence_lengths = torch.tensor([7, 7], dtype=torch.int32)
+        fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
+            inputs,
+            config.seq_size_per_block,
+        )
+        self.assertEqual(fill_inputs.prefix_lengths.tolist(), [63, 127])
+        self.assertEqual(
+            fill_inputs.input_lengths.tolist(), inputs.input_lengths.tolist()
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        self.assertTrue(attn_op._is_cuda_core_graph_mode())
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(inputs)
+        self.assertEqual(fmha_params.decode_page_indptr_h.tolist(), [0, 1, 3])
+        self.assertEqual(fmha_params.paged_kv_last_page_len_h.tolist(), [64, 64])
+
+        # C++ fillParams ignores sequence_lengths when prefix lengths exist;
+        # preserve that pre-existing prefix-only input contract.
+        inputs.sequence_lengths = torch.empty(0, dtype=torch.int32)
+        prefix_only_fill_inputs = py_flashinfer_mha._decode_graph_host_fill_inputs(
+            inputs,
+            config.seq_size_per_block,
+        )
+        self.assertEqual(prefix_only_fill_inputs.sequence_lengths.numel(), 0)
+        prefix_only_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        prefix_only_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        prefix_only_op.set_params(prefix_only_params)
+        prefix_only_op.prepare(inputs)
+        self.assertEqual(prefix_only_params.decode_page_indptr_h.tolist(), [0, 1, 3])
+        self.assertEqual(prefix_only_params.paged_kv_last_page_len_h.tolist(), [64, 64])
+
+        inputs.prefix_lengths = torch.tensor([63], dtype=torch.int32)
+        with self.assertRaisesRegex(ValueError, "prefix_lengths=1"):
+            py_flashinfer_mha._decode_graph_host_fill_inputs(
+                inputs,
+                config.seq_size_per_block,
+            )
+
 
 class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
     """Test CUDA graph buffer management for PyFlashinferDecodeAttnOp.
 
-    Verifies the critical invariants that the C++ CUDA graph runner depends on:
-    1. prepare() with is_cuda_graph=True sets _fixed_batch_size and wires up
-       the decode_wrapper's internal buffers for graph capture.
-    2. prepare_for_cuda_graph_replay() refreshes both page tables and, for
-       tensor-core decode, cached plan metadata without reallocating buffers.
+    These tests exercise the Python prepare/replay boundary for both decode
+    backends and actual CUDA-core graph capture/replay. Tensor-core graph
+    coverage remains at the Python boundary in this target.
     """
+
+    def _assert_cuda_core_graph_mode(self, attn_op) -> None:
+        self.assertTrue(attn_op._is_cuda_core_graph_mode())
 
     def _create_cuda_graph_inputs(
         self,
@@ -303,22 +537,50 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         sequence_lengths: List[int],
         seq_size_per_block: int,
         dtype: torch.dtype = torch.float16,
+        active_batch_size: Optional[int] = None,
+        block_id_offset: int = 0,
+        padding_block_id: int = 0,
+        use_prefix_lengths: bool = False,
     ) -> PyAttentionInputs:
-        """Create inputs with is_cuda_graph=True, mimicking cuda_graph_runner.cc."""
+        """Create graph inputs with the runner's logical padding lengths."""
+        if active_batch_size is None:
+            active_batch_size = batch_size
+        if len(sequence_lengths) != active_batch_size:
+            raise ValueError("sequence_lengths must match active_batch_size")
+        if active_batch_size > batch_size:
+            raise ValueError("active_batch_size must not exceed batch_size")
+
+        # The runner pads a captured batch with decode slots whose previous
+        # sequence length is zero; fill_params() therefore exposes one page
+        # with last_page_len=1 for every padding slot.
+        logical_sequence_lengths = sequence_lengths + [1] * (
+            batch_size - active_batch_size
+        )
         attn_inputs = PyAttentionInputs()
         attn_inputs.is_prefill = False
         attn_inputs.is_cuda_graph = True
 
-        seq_t = torch.tensor(sequence_lengths, dtype=torch.int32)
-        attn_inputs.sequence_lengths = (seq_t - 1).pin_memory()
+        seq_t = torch.tensor(logical_sequence_lengths, dtype=torch.int32)
         attn_inputs.input_lengths = torch.ones(
             batch_size, dtype=torch.int32
         ).pin_memory()
-        attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32).pin_memory()
+        if use_prefix_lengths:
+            attn_inputs.prefix_lengths = (seq_t - 1).pin_memory()
+            attn_inputs.sequence_lengths = torch.empty(
+                0, dtype=torch.int32
+            ).pin_memory()
+        else:
+            attn_inputs.prefix_lengths = torch.empty(0, dtype=torch.int32).pin_memory()
+            attn_inputs.sequence_lengths = (seq_t - 1).pin_memory()
 
         kv_cache_block_id = self._create_kv_cache_block_ids(
-            batch_size, sequence_lengths, seq_size_per_block
+            batch_size, logical_sequence_lengths, seq_size_per_block
         )
+        for batch_idx, seq_len in enumerate(sequence_lengths):
+            page_count = math.ceil(seq_len / seq_size_per_block)
+            kv_cache_block_id[batch_idx, :page_count] += block_id_offset
+        if active_batch_size < batch_size:
+            kv_cache_block_id[active_batch_size:, 0] = padding_block_id
         attn_inputs.kv_cache_kernel_block_id = kv_cache_block_id
         attn_inputs.kv_cache_kernel_block_id_device = kv_cache_block_id.cuda()
 
@@ -328,9 +590,155 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         attn_inputs.dtype = get_typemeta(torch.zeros([1], dtype=dtype))
         return attn_inputs
 
+    def _expected_page_metadata(
+        self,
+        active_sequence_lengths: List[int],
+        seq_size_per_block: int,
+        batch_size: Optional[int] = None,
+        block_id_offset: int = 0,
+        padding_block_id: int = 0,
+    ) -> PageMetadata:
+        """Derive page layout independently using the runner padding contract."""
+        active_batch_size = len(active_sequence_lengths)
+        if batch_size is None:
+            batch_size = active_batch_size
+        if active_batch_size > batch_size:
+            raise ValueError("active batch size must not exceed batch_size")
+        sequence_lengths = active_sequence_lengths + [1] * (
+            batch_size - active_batch_size
+        )
+        page_counts = [
+            math.ceil(seq_len / seq_size_per_block) for seq_len in sequence_lengths
+        ]
+        page_indptr = [0]
+        for page_count in page_counts:
+            page_indptr.append(page_indptr[-1] + page_count)
+        page_indices = []
+        next_block_id = block_id_offset
+        for batch_idx, page_count in enumerate(page_counts):
+            if batch_idx < active_batch_size:
+                page_indices.extend(range(next_block_id, next_block_id + page_count))
+                next_block_id += page_count
+            else:
+                page_indices.extend([padding_block_id] * page_count)
+        last_page_lens = [
+            seq_len % seq_size_per_block or seq_size_per_block
+            for seq_len in sequence_lengths
+        ]
+        return PageMetadata(page_indptr, page_indices, last_page_lens)
+
+    def test_padding_page_metadata_oracle_matches_runner_contract(self):
+        """Anchor the independently calculated oracle to literal padding values."""
+        inputs = self._create_cuda_graph_inputs(
+            4,
+            [100, 200],
+            seq_size_per_block=64,
+            active_batch_size=2,
+        )
+        self.assertEqual(inputs.sequence_lengths.tolist(), [99, 199, 0, 0])
+        expected = self._expected_page_metadata(
+            [100, 200],
+            seq_size_per_block=64,
+            batch_size=4,
+        )
+        self.assertEqual(expected.page_indptr, [0, 2, 6, 7, 8])
+        self.assertEqual(expected.page_indices, [0, 1, 2, 3, 4, 5, 0, 0])
+        self.assertEqual(expected.last_page_lens, [36, 8, 1, 1])
+
+    def _assert_page_metadata(
+        self,
+        fmha_params,
+        expected: PageMetadata,
+    ) -> None:
+        self.assertEqual(
+            fmha_params.decode_page_indptr_h.tolist(), expected.page_indptr
+        )
+        self.assertEqual(fmha_params.page_indice_h.tolist(), expected.page_indices)
+        self.assertEqual(
+            fmha_params.paged_kv_last_page_len_h.tolist(),
+            expected.last_page_lens,
+        )
+        torch.cuda.synchronize()
+        self.assertEqual(
+            fmha_params.decode_page_indptr_d.cpu().tolist(), expected.page_indptr
+        )
+        self.assertEqual(
+            fmha_params.page_indice_d.cpu().tolist(), expected.page_indices
+        )
+        self.assertEqual(
+            fmha_params.paged_kv_last_page_len_d.cpu().tolist(),
+            expected.last_page_lens,
+        )
+
+    def _assert_graph_buffer_pointers(
+        self,
+        attn_op,
+        fmha_params,
+        pointers,
+        qo_indptr_ptr: Optional[int] = None,
+    ) -> None:
+        current_pointers = (
+            fmha_params.decode_page_indptr_d.data_ptr(),
+            fmha_params.page_indice_d.data_ptr(),
+            fmha_params.paged_kv_last_page_len_d.data_ptr(),
+        )
+        self.assertEqual(current_pointers, pointers)
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(), pointers[0]
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(), pointers[1]
+        )
+        self.assertEqual(
+            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
+            pointers[2],
+        )
+        if qo_indptr_ptr is not None:
+            self.assertEqual(
+                attn_op.decode_wrapper._qo_indptr_buf.data_ptr(), qo_indptr_ptr
+            )
+
+    def _assert_plan_dtypes(self, plan_call, attn_op) -> None:
+        self.assertEqual(plan_call.kwargs["q_data_type"], attn_op.q_dtype)
+        self.assertEqual(plan_call.kwargs["kv_data_type"], attn_op.kv_dtype)
+        self.assertEqual(plan_call.kwargs["o_data_type"], attn_op.dtype)
+
+    def _assert_active_output_matches_reference(
+        self,
+        output: torch.Tensor,
+        attn_inputs: PyAttentionInputs,
+        sequence_lengths: List[int],
+        q: torch.Tensor,
+        q_dtype: torch.dtype,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        seq_size_per_block: int,
+    ) -> None:
+        active_batch_size = len(sequence_lengths)
+        block_id_list = []
+        for batch_idx, seq_len in enumerate(sequence_lengths):
+            page_count = math.ceil(seq_len / seq_size_per_block)
+            block_id_list.append(
+                attn_inputs.kv_cache_kernel_block_id[batch_idx, :page_count].tolist()
+            )
+        reference_q = q[:active_batch_size].to(q_dtype).to(q.dtype)
+        reference = compute_flashinfer_decode_reference(
+            reference_q,
+            k_cache.to(q.dtype),
+            v_cache.to(q.dtype),
+            sequence_lengths,
+            block_id_list,
+            seq_size_per_block,
+        )
+        self._assert_output_close(
+            output[:active_batch_size],
+            reference,
+            name=f"CUDA-core graph replay output ({sequence_lengths})",
+        )
+
     def test_capture_sets_fixed_batch_size(self):
         """prepare() with is_cuda_graph=True must set _fixed_batch_size."""
-        config = self._create_config()
+        config = self._create_config(head_num=32, head_num_kv=32)
         capture_bs = 4
         seq_lens = [64, 128, 256, 512]
         inputs = self._create_cuda_graph_inputs(
@@ -348,11 +756,255 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         attn_op.prepare(inputs)
 
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+        self.assertTrue(attn_op._graph_buffers_bound)
+        self.assertEqual(attn_op._graph_batch_size, capture_bs)
         self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
         logging.info("_fixed_batch_size correctly set after prepare()")
 
+    def test_set_params_rejects_rebind_after_cuda_graph_prepare(self):
+        """Graph wrapper buffers cannot be rebound after prepare()."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        original_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(original_params)
+        attn_op.prepare(inputs)
+
+        with self.assertRaisesRegex(RuntimeError, "must be set before prepare"):
+            attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        self.assertIs(attn_op.fmha_params, original_params)
+
+    def test_prepare_rejects_rebind_after_cuda_graph_prepare(self):
+        """A second prepare() cannot silently rebind graph wrapper buffers."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(inputs)
+        graph_buffer_pointers = (
+            fmha_params.decode_page_indptr_d.data_ptr(),
+            fmha_params.page_indice_d.data_ptr(),
+            fmha_params.paged_kv_last_page_len_d.data_ptr(),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "use prepare_for_cuda_graph_replay"):
+            attn_op.prepare(inputs)
+        self._assert_graph_buffer_pointers(attn_op, fmha_params, graph_buffer_pointers)
+
+    def test_replay_rejects_empty_sequence_lengths(self):
+        """Graph replay rejects empty sequence metadata."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_bs = 4
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [64, 128, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self.assertFalse(attn_op.use_tensor_core)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+
+        run_seq_lens = [100, 200]
+        run_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            run_seq_lens,
+            config.seq_size_per_block,
+            active_batch_size=len(run_seq_lens),
+        )
+        run_inputs.sequence_lengths_plus_1_device = (
+            run_inputs.sequence_lengths.to(device="cuda", dtype=torch.int32) + 1
+        )
+        run_inputs.sequence_lengths = torch.empty(0, dtype=torch.int32, device="cuda")
+        # The graph contract belongs to the captured op, not mutable replay input.
+        run_inputs.is_cuda_graph = False
+        with self.assertRaisesRegex(
+            ValueError, "requires non-empty sequence_lengths covering all padding slots"
+        ):
+            attn_op.prepare_for_cuda_graph_replay(run_inputs)
+
+    def test_replay_rejects_unbound_cuda_core_graph_op(self):
+        """CUDA-core graph replay requires a completed initial prepare()."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        graph_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        graph_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        with self.assertRaisesRegex(RuntimeError, r"requires prepare\(\)"):
+            graph_op.prepare_for_cuda_graph_replay(inputs)
+
+    def test_replay_rejects_changed_graph_buffer_alias(self):
+        """Replay fails fast if a dependency stops preserving bound storage."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(inputs)
+        original_last_page_lengths = (
+            attn_op.fmha_params.paged_kv_last_page_len_h.clone()
+        )
+        original_plan_topology = attn_op._cuda_core_plan_page_indptr_h.clone()
+        attn_op.decode_wrapper._paged_kv_indices_buf = (
+            attn_op.decode_wrapper._paged_kv_indices_buf.clone()
+        )
+        same_topology_inputs = self._create_cuda_graph_inputs(
+            2,
+            [63, 127],
+            config.seq_size_per_block,
+        )
+        with self.assertRaisesRegex(RuntimeError, "page indices buffer no longer"):
+            attn_op.prepare_for_cuda_graph_replay(same_topology_inputs)
+        self.assertTrue(
+            torch.equal(
+                attn_op.fmha_params.paged_kv_last_page_len_h,
+                original_last_page_lengths,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                attn_op._cuda_core_plan_page_indptr_h,
+                original_plan_topology,
+            )
+        )
+
+    def test_replay_rejects_batch_size_change_before_refresh(self):
+        """A wrong replay batch cannot resize graph-bound metadata buffers."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+        original_indptr = fmha_params.decode_page_indptr_h.clone()
+
+        wrong_batch_inputs = self._create_cuda_graph_inputs(
+            1,
+            [129],
+            config.seq_size_per_block,
+        )
+        with self.assertRaisesRegex(RuntimeError, "replay=1, bound=2"):
+            attn_op.prepare_for_cuda_graph_replay(wrong_batch_inputs)
+        self.assertTrue(torch.equal(fmha_params.decode_page_indptr_h, original_indptr))
+
+        replay_inputs = self._create_cuda_graph_inputs(
+            2,
+            [129, 193],
+            config.seq_size_per_block,
+        )
+        attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+        self.assertEqual(fmha_params.decode_page_indptr_h.numel(), 3)
+
+    def test_replay_rejects_non_vector_input_lengths(self):
+        """A tensor with the right element count cannot masquerade as a batch."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        attn_op.prepare(capture_inputs)
+        original_indptr = fmha_params.decode_page_indptr_h.clone()
+
+        invalid_inputs = self._create_cuda_graph_inputs(
+            2,
+            [129, 193],
+            config.seq_size_per_block,
+        )
+        invalid_inputs.input_lengths = invalid_inputs.input_lengths.reshape(1, 2)
+        with self.assertRaisesRegex(ValueError, "input_lengths must be 1-D"):
+            attn_op.prepare_for_cuda_graph_replay(invalid_inputs)
+        self.assertTrue(torch.equal(fmha_params.decode_page_indptr_h, original_indptr))
+
+    def test_host_fill_validates_kv_cache_block_table_shape(self):
+        """Malformed block tables fail before reaching the C++ fill helper."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        with self.subTest(shape="missing"):
+            inputs = PyAttentionInputs()
+            with self.assertRaisesRegex(ValueError, "requires a KV cache block table"):
+                py_flashinfer_mha._validated_decode_host_block_table(
+                    inputs,
+                    2,
+                    torch.tensor([64, 128], dtype=torch.int32),
+                    config.seq_size_per_block,
+                )
+
+        with self.subTest(shape="empty"):
+            inputs = self._create_cuda_graph_inputs(
+                2,
+                [64, 128],
+                config.seq_size_per_block,
+            )
+            inputs.kv_cache_kernel_block_id = torch.empty(0, dtype=torch.int32)
+            inputs.kv_cache_kernel_block_id_device = torch.empty(
+                0, dtype=torch.int32, device="cuda"
+            )
+            attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            with self.assertRaisesRegex(ValueError, "requires a KV cache block table"):
+                attn_op.prepare(inputs)
+
+        with self.subTest(shape="one-dimensional"):
+            inputs = self._create_cuda_graph_inputs(
+                2,
+                [64, 128],
+                config.seq_size_per_block,
+            )
+            inputs.kv_cache_kernel_block_id = torch.arange(4, dtype=torch.int32)
+            attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            with self.assertRaisesRegex(ValueError, "must be 2-D, got 1-D"):
+                attn_op.prepare(inputs)
+
+        with self.subTest(shape="insufficient rows"):
+            inputs = self._create_cuda_graph_inputs(
+                2,
+                [64, 128],
+                config.seq_size_per_block,
+            )
+            inputs.kv_cache_kernel_block_id = torch.zeros((1, 4), dtype=torch.int32)
+            attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            with self.assertRaisesRegex(
+                ValueError, "fewer rows than the batch: rows=1, input_lengths=2"
+            ):
+                attn_op.prepare(inputs)
+
+        with self.subTest(shape="insufficient columns"):
+            inputs = self._create_cuda_graph_inputs(
+                2,
+                [65, 128],
+                config.seq_size_per_block,
+            )
+            inputs.kv_cache_kernel_block_id = torch.zeros((2, 1), dtype=torch.int32)
+            attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+            with self.assertRaisesRegex(
+                ValueError, "fewer columns.*columns=1, required=2"
+            ):
+                attn_op.prepare(inputs)
+
     def test_replay_refreshes_plan_metadata(self):
-        """Tensor-core replay must refresh FlashInfer plan metadata."""
+        """Tensor-core replay replans because its plan consumes KV lengths."""
         config = self._create_config()
         capture_bs = 8
         capture_seq_lens = [64, 128, 256, 512, 64, 128, 256, 512]
@@ -364,77 +1016,100 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         self.assertTrue(attn_op.use_tensor_core)
-        self.assertTrue(attn_op._requires_tensor_core_cuda_graph_replan())
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
-        attn_op.prepare(capture_inputs)
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare(capture_inputs)
+            self.assertEqual(plan_mock.call_count, 1)
+            capture_call = plan_mock.call_args
+            self.assertFalse(capture_call.args[0].is_cuda)
+            self.assertFalse(capture_call.args[1].is_cuda)
+            self.assertFalse(capture_call.args[2].is_cuda)
+            self.assertTrue(capture_call.kwargs["non_blocking"])
+            self.assertTrue(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
+            self.assertEqual(
+                attn_op.decode_wrapper._qo_indptr_buf.numel(), capture_bs + 1
+            )
+            qo_indptr_ptr = attn_op.decode_wrapper._qo_indptr_buf.data_ptr()
+            self._assert_plan_dtypes(capture_call, attn_op)
+            graph_buffer_pointers = (
+                fmha_params.decode_page_indptr_d.data_ptr(),
+                fmha_params.page_indice_d.data_ptr(),
+                fmha_params.paged_kv_last_page_len_d.data_ptr(),
+            )
+            self._assert_graph_buffer_pointers(
+                attn_op,
+                fmha_params,
+                graph_buffer_pointers,
+                qo_indptr_ptr=qo_indptr_ptr,
+            )
+
+            plan_mock.reset_mock()
+            run_seq_lens = [100, 200, 300, 400, 64, 128, 256, 512]
+            run_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                run_seq_lens,
+                config.seq_size_per_block,
+            )
+            # Tensor-core graph replay must normalize CUDA-resident metadata to
+            # the host mirrors consumed by plan().
+            run_inputs.sequence_lengths = run_inputs.sequence_lengths.cuda()
+            attn_op.prepare_for_cuda_graph_replay(run_inputs)
+            self.assertEqual(plan_mock.call_count, 1)
+            self._assert_plan_dtypes(plan_mock.call_args, attn_op)
+            expected = self._expected_page_metadata(
+                run_seq_lens,
+                config.seq_size_per_block,
+                batch_size=capture_bs,
+            )
+            self._assert_page_metadata(fmha_params, expected)
+            self._assert_graph_buffer_pointers(
+                attn_op,
+                fmha_params,
+                graph_buffer_pointers,
+                qo_indptr_ptr=qo_indptr_ptr,
+            )
+            attn_op.prepare_for_cuda_graph_replay(run_inputs)
+            self.assertEqual(plan_mock.call_count, 2)
+            self._assert_plan_dtypes(plan_mock.call_args, attn_op)
+            self._assert_graph_buffer_pointers(
+                attn_op,
+                fmha_params,
+                graph_buffer_pointers,
+                qo_indptr_ptr=qo_indptr_ptr,
+            )
 
         self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
-        fixed_buffer_ptrs = {
-            "page_indptr": attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(),
-            "page_indices": attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(),
-            "last_page_len": attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
-            "qo_indptr": attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
-        }
 
-        original_plan = attn_op.decode_wrapper.plan
-        plan_calls = []
-
-        def counted_plan(*args, **kwargs):
-            plan_calls.append((args, kwargs))
-            return original_plan(*args, **kwargs)
-
-        attn_op.decode_wrapper.plan = counted_plan
-
-        run_seq_lens = [100, 200, 300, 400, 64, 128, 256, 512]
-        run_inputs = self._create_cuda_graph_inputs(
-            capture_bs,
-            run_seq_lens,
+    def test_tensor_core_graph_rejects_buffer_rebind(self):
+        """Tensor-core graph buffers share the same one-time binding contract."""
+        config = self._create_config()
+        inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
             config.seq_size_per_block,
         )
-        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, inputs)
+        self.assertTrue(attn_op.use_tensor_core)
+        original_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(original_params)
+        attn_op.prepare(inputs)
 
-        self.assertEqual(len(plan_calls), 1)
-        plan_args, plan_kwargs = plan_calls[0]
-        self.assertFalse(plan_args[0].is_cuda)
-        self.assertFalse(plan_args[1].is_cuda)
-        self.assertFalse(plan_args[2].is_cuda)
-        self.assertTrue(plan_kwargs["non_blocking"])
-        self.assertEqual(plan_kwargs["q_data_type"], attn_op.q_dtype)
-        self.assertEqual(plan_kwargs["kv_data_type"], attn_op.kv_dtype)
-        self.assertEqual(plan_kwargs["o_data_type"], config.attn_configs.dtype)
+        with self.assertRaisesRegex(RuntimeError, "must be set before prepare"):
+            attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        with self.assertRaisesRegex(RuntimeError, "use prepare_for_cuda_graph_replay"):
+            attn_op.prepare(inputs)
+        self.assertIs(attn_op.fmha_params, original_params)
 
-        # Replay must preserve every address referenced by the captured graph.
-        self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(),
-            fixed_buffer_ptrs["page_indptr"],
-        )
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(),
-            fixed_buffer_ptrs["page_indices"],
-        )
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
-            fixed_buffer_ptrs["last_page_len"],
-        )
-        self.assertEqual(
-            attn_op.decode_wrapper._qo_indptr_buf.data_ptr(),
-            fixed_buffer_ptrs["qo_indptr"],
-        )
-
-        page_indptr = fmha_params.decode_page_indptr_h
-        self.assertIsNotNone(page_indptr)
-        self.assertGreaterEqual(len(page_indptr), capture_bs + 1)
-        logging.info(
-            f"Replay OK: _fixed_batch_size={attn_op.decode_wrapper._fixed_batch_size}, "
-            f"page_indptr={page_indptr.tolist()}"
-        )
-
-    def test_cuda_core_replay_does_not_replan(self):
-        """CUDA-core replay only refreshes parameter buffers."""
+    def test_cuda_core_replay_replans_only_on_page_topology_change(self):
+        """CUDA-core replay caches only topology and refreshes graph buffers."""
         config = self._create_config(head_num=32, head_num_kv=32)
         capture_bs = 4
+        active_bs = 2
         capture_seq_lens = [64, 128, 256, 512]
 
         capture_inputs = self._create_cuda_graph_inputs(
@@ -442,101 +1117,403 @@ class TestPyFlashinferDecodeCudaGraph(BaseAttentionTest):
             capture_seq_lens,
             config.seq_size_per_block,
         )
+        # A CUDA-resident base field must not switch graph capture to the
+        # device-only fill route: CUDA-core planning consumes host metadata.
+        capture_inputs.input_lengths = capture_inputs.input_lengths.cuda()
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         self.assertFalse(attn_op.use_tensor_core)
-        self.assertFalse(attn_op._requires_tensor_core_cuda_graph_replan())
+        self._assert_cuda_core_graph_mode(attn_op)
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
-        attn_op.prepare(capture_inputs)
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare(capture_inputs)
+            graph_buffer_pointers = (
+                fmha_params.decode_page_indptr_d.data_ptr(),
+                fmha_params.page_indice_d.data_ptr(),
+                fmha_params.paged_kv_last_page_len_d.data_ptr(),
+            )
+            with self.subTest(phase="capture host plan"):
+                self.assertEqual(plan_mock.call_count, 1)
+                capture_expected = self._expected_page_metadata(
+                    capture_seq_lens,
+                    config.seq_size_per_block,
+                    batch_size=capture_bs,
+                )
+                self._assert_page_metadata(fmha_params, capture_expected)
+                self.assertNotEqual(
+                    attn_op._cuda_core_plan_page_indptr_h.data_ptr(),
+                    fmha_params.decode_page_indptr_h.data_ptr(),
+                )
+                capture_call = plan_mock.call_args
+                self._assert_plan_dtypes(capture_call, attn_op)
+                self.assertFalse(capture_call.args[0].is_cuda)
+                self.assertTrue(capture_call.args[1].is_cuda)
+                self.assertFalse(capture_call.args[2].is_cuda)
+                self.assertTrue(capture_call.kwargs["non_blocking"])
+                self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
+                self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
+                self.assertFalse(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
+                self._assert_graph_buffer_pointers(
+                    attn_op, fmha_params, graph_buffer_pointers
+                )
 
-        self.assertTrue(attn_op.decode_wrapper._use_cuda_graph)
-        self.assertEqual(attn_op.decode_wrapper._fixed_batch_size, capture_bs)
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_indptr_buf.data_ptr(),
-            fmha_params.decode_page_indptr_d.data_ptr(),
-        )
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_indices_buf.data_ptr(),
-            fmha_params.page_indice_d.data_ptr(),
-        )
-        self.assertEqual(
-            attn_op.decode_wrapper._paged_kv_last_page_len_buf.data_ptr(),
-            fmha_params.paged_kv_last_page_len_d.data_ptr(),
-        )
-        self.assertFalse(hasattr(attn_op.decode_wrapper, "_qo_indptr_buf"))
+            plan_mock.reset_mock()
+            changed_seq_lens = [100, 200]
+            changed_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                changed_seq_lens,
+                config.seq_size_per_block,
+                active_batch_size=active_bs,
+            )
+            attn_op.prepare_for_cuda_graph_replay(changed_inputs)
+            expected = self._expected_page_metadata(
+                changed_seq_lens,
+                config.seq_size_per_block,
+                batch_size=capture_bs,
+            )
+            with self.subTest(phase="changed topology replans"):
+                self.assertEqual(plan_mock.call_count, 1)
+                changed_call = plan_mock.call_args
+                self._assert_plan_dtypes(changed_call, attn_op)
+                self.assertFalse(changed_call.args[0].is_cuda)
+                self.assertTrue(changed_call.args[1].is_cuda)
+                self.assertFalse(changed_call.args[2].is_cuda)
+                self.assertTrue(changed_call.kwargs["non_blocking"])
+                self._assert_page_metadata(fmha_params, expected)
+                self._assert_graph_buffer_pointers(
+                    attn_op, fmha_params, graph_buffer_pointers
+                )
+                self.assertEqual(
+                    attn_op._cuda_core_plan_page_indptr_h.tolist(),
+                    expected.page_indptr,
+                )
 
-        plan_calls = []
+            same_topology_seq_lens = [101, 201]
+            block_id_offset = 17
+            same_topology_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                same_topology_seq_lens,
+                config.seq_size_per_block,
+                active_batch_size=active_bs,
+                block_id_offset=block_id_offset,
+            )
+            plan_mock.reset_mock()
+            attn_op.prepare_for_cuda_graph_replay(same_topology_inputs)
+            expected = self._expected_page_metadata(
+                same_topology_seq_lens,
+                config.seq_size_per_block,
+                batch_size=capture_bs,
+                block_id_offset=block_id_offset,
+            )
+            with self.subTest(phase="same topology skips replan"):
+                self.assertEqual(plan_mock.call_count, 0)
+                self._assert_page_metadata(fmha_params, expected)
+                self._assert_graph_buffer_pointers(
+                    attn_op, fmha_params, graph_buffer_pointers
+                )
 
-        def counted_plan(*args, **kwargs):
-            plan_calls.append((args, kwargs))
+            # A skipped topology-only replan must still match the reference.
+            local_head_num = config.head_num // config.tp_size
+            local_kv_head_num = config.head_num_kv // config.tp_size
+            q = self._create_query_tensor(
+                capture_bs, local_head_num, config.size_per_head
+            )
+            total_blocks = max(expected.page_indices) + 1
+            kv_cache, k_cache, v_cache = self._create_kv_cache(
+                total_blocks,
+                config.seq_size_per_block,
+                local_kv_head_num,
+                config.size_per_head,
+                dtype=self.cache_dtype(config.attn_configs),
+            )
+            skipped_replan_output = attn_op.forward(q, kv_cache, fmha_params).clone()
+            self._assert_active_output_matches_reference(
+                skipped_replan_output,
+                same_topology_inputs,
+                same_topology_seq_lens,
+                q,
+                attn_op.q_dtype,
+                k_cache,
+                v_cache,
+                config.seq_size_per_block,
+            )
 
-        attn_op.decode_wrapper.plan = counted_plan
-
-        run_seq_lens = [100, 200, 256, 512]
-        run_inputs = self._create_cuda_graph_inputs(
-            capture_bs,
-            run_seq_lens,
+    def test_cuda_core_failed_plan_invalidates_topology_snapshot(self):
+        """A failed topology replan cannot leave the old snapshot reusable."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
             config.seq_size_per_block,
         )
-        attn_op.prepare_for_cuda_graph_replay(run_inputs)
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        attn_op.set_params(rtp_llm_ops.FlashInferMlaAttnParams())
+        attn_op.prepare(capture_inputs)
+        self.assertIsNotNone(attn_op._cuda_core_plan_page_indptr_h)
 
-        self.assertEqual(len(plan_calls), 0)
+        replay_inputs = self._create_cuda_graph_inputs(
+            2,
+            [129, 193],
+            config.seq_size_per_block,
+        )
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            side_effect=RuntimeError("injected plan failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "injected plan failure"):
+                attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+        self.assertIsNone(attn_op._cuda_core_plan_page_indptr_h)
 
-    def test_replay_updates_page_tables(self):
-        """Page table buffers must reflect the replay inputs, not capture inputs."""
-        import math
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+        self.assertEqual(plan_mock.call_count, 1)
+        self.assertIsNotNone(attn_op._cuda_core_plan_page_indptr_h)
 
-        config = self._create_config(seq_size_per_block=64)
-        capture_bs = 4
-        capture_seq_lens = [64, 128, 256, 512]
-        active_bs = 2
-        run_seq_lens = [100, 200, 256, 512]
-
+    def _run_cuda_core_actual_graph_replay_matches_reference(
+        self,
+        use_prefix_lengths: bool,
+        active_batch_size: Optional[int] = None,
+        padding_block_id: int = 0,
+    ) -> None:
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_bs = 2
+        # Prefix metadata also sizes FlashInfer's reuse-page workspace. Give
+        # capture enough aggregate reuse pages for both replay shapes while
+        # changing their per-request page topology.
+        capture_sequence_lengths = [64, 384] if use_prefix_lengths else [64, 128]
         capture_inputs = self._create_cuda_graph_inputs(
             capture_bs,
-            capture_seq_lens,
+            capture_sequence_lengths,
             config.seq_size_per_block,
+            use_prefix_lengths=use_prefix_lengths,
         )
         attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
         fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
         attn_op.set_params(fmha_params)
         attn_op.prepare(capture_inputs)
 
-        run_inputs = self._create_cuda_graph_inputs(
+        replay_sequence_lengths = [129, 193]
+        if active_batch_size is not None:
+            replay_sequence_lengths = replay_sequence_lengths[:active_batch_size]
+        replay_inputs = self._create_cuda_graph_inputs(
             capture_bs,
-            run_seq_lens,
+            replay_sequence_lengths,
+            config.seq_size_per_block,
+            active_batch_size=active_batch_size,
+            padding_block_id=padding_block_id,
+            use_prefix_lengths=use_prefix_lengths,
+        )
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        static_q = self._create_query_tensor(
+            capture_bs,
+            local_head_num,
+            config.size_per_head,
+        )
+        total_blocks = max(
+            self._calculate_total_blocks(
+                replay_sequence_lengths,
+                config.seq_size_per_block,
+            ),
+            padding_block_id + 1,
+        )
+        kv_cache, k_cache, v_cache = self._create_kv_cache(
+            total_blocks,
+            config.seq_size_per_block,
+            local_kv_head_num,
+            config.size_per_head,
+            dtype=self.cache_dtype(config.attn_configs),
+        )
+
+        torch.cuda.synchronize()
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            attn_op.forward(static_q, kv_cache, fmha_params)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_output = attn_op.forward(static_q, kv_cache, fmha_params)
+
+        attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+        graph.replay()
+        torch.cuda.synchronize()
+        self._assert_active_output_matches_reference(
+            graph_output,
+            replay_inputs,
+            replay_sequence_lengths,
+            static_q,
+            attn_op.q_dtype,
+            k_cache,
+            v_cache,
             config.seq_size_per_block,
         )
-        attn_op.prepare_for_cuda_graph_replay(run_inputs)
 
-        # Verify page_indptr matches run_seq_lens
-        page_indptr = fmha_params.decode_page_indptr_h.tolist()
-        expected_blocks = [math.ceil(s / 64) for s in run_seq_lens[:active_bs]]
-        expected_indptr = [0]
-        for nb in expected_blocks:
-            expected_indptr.append(expected_indptr[-1] + nb)
-
-        for i in range(active_bs + 1):
-            self.assertEqual(
-                page_indptr[i],
-                expected_indptr[i],
-                f"page_indptr[{i}] mismatch: expected {expected_indptr[i]}, got {page_indptr[i]}",
-            )
-
-        # Verify last_page_len
-        last_page_len = fmha_params.paged_kv_last_page_len_h.tolist()
-        for i, seq_len in enumerate(run_seq_lens[:active_bs]):
-            expected = seq_len % 64 or 64
-            self.assertEqual(
-                last_page_len[i],
-                expected,
-                f"last_page_len[{i}] mismatch: expected {expected}, got {last_page_len[i]}",
-            )
-        expected_last_page_lens = [s % 64 or 64 for s in run_seq_lens[:active_bs]]
-        logging.info(
-            f"Page table update OK: indptr={expected_indptr}, "
-            f"last_page_len={expected_last_page_lens}"
+        same_topology_sequence_lengths = [130, 194]
+        if active_batch_size is not None:
+            same_topology_sequence_lengths = same_topology_sequence_lengths[
+                :active_batch_size
+            ]
+        same_topology_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            same_topology_sequence_lengths,
+            config.seq_size_per_block,
+            active_batch_size=active_batch_size,
+            padding_block_id=padding_block_id,
+            use_prefix_lengths=use_prefix_lengths,
         )
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare_for_cuda_graph_replay(same_topology_inputs)
+        self.assertEqual(plan_mock.call_count, 0)
+        graph.replay()
+        torch.cuda.synchronize()
+        self._assert_active_output_matches_reference(
+            graph_output,
+            same_topology_inputs,
+            same_topology_sequence_lengths,
+            static_q,
+            attn_op.q_dtype,
+            k_cache,
+            v_cache,
+            config.seq_size_per_block,
+        )
+
+    def test_cuda_core_actual_graph_replay_matches_reference(self):
+        """Capture and replay CUDA-core decode after crossing a page boundary."""
+        if self.kv_cache_dtype == KvCacheDataType.FP8 and not is_sm90():
+            self.skipTest(
+                "Real FP8 KV CUDA graph capture is limited to the SM90 target; "
+                "non-SM90 targets retain focused replay coverage"
+            )
+        self._run_cuda_core_actual_graph_replay_matches_reference(
+            use_prefix_lengths=False,
+            active_batch_size=1,
+            padding_block_id=7,
+        )
+
+    def test_cuda_core_prefix_actual_graph_replay_matches_reference(self):
+        """Capture and replay the compatible prefix-length metadata contract."""
+        if self.kv_cache_dtype == KvCacheDataType.FP8:
+            self.skipTest("Prefix metadata is dtype-independent and covered by FP16")
+        self._run_cuda_core_actual_graph_replay_matches_reference(
+            use_prefix_lengths=True
+        )
+
+    def test_cuda_core_replay_matches_reference_with_stale_padding_ids(self):
+        """Replanned active slots match reference despite stale padding IDs."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_bs = 4
+        active_bs = 2
+        padding_block_id = 7
+        capture_inputs = self._create_cuda_graph_inputs(
+            capture_bs,
+            [64, 128, 256, 512],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        q = self._create_query_tensor(capture_bs, local_head_num, config.size_per_head)
+        changed_seq_lens = [100, 200]
+        changed_expected = self._expected_page_metadata(
+            changed_seq_lens,
+            config.seq_size_per_block,
+            batch_size=capture_bs,
+            padding_block_id=padding_block_id,
+        )
+        crossed_page_seq_lens = [129, 201]
+        crossed_expected = self._expected_page_metadata(
+            crossed_page_seq_lens,
+            config.seq_size_per_block,
+            batch_size=capture_bs,
+            padding_block_id=padding_block_id,
+        )
+        required_block_count = (
+            max(
+                max(changed_expected.page_indices),
+                max(crossed_expected.page_indices),
+            )
+            + 1
+        )
+        kv_cache, k_cache, v_cache = self._create_kv_cache(
+            required_block_count,
+            config.seq_size_per_block,
+            local_kv_head_num,
+            config.size_per_head,
+            dtype=self.cache_dtype(config.attn_configs),
+        )
+
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare(capture_inputs)
+
+            changed_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                changed_seq_lens,
+                config.seq_size_per_block,
+                active_batch_size=active_bs,
+                padding_block_id=padding_block_id,
+            )
+            plan_mock.reset_mock()
+            attn_op.prepare_for_cuda_graph_replay(changed_inputs)
+            with self.subTest(phase="changed topology reference"):
+                self.assertEqual(plan_mock.call_count, 1)
+                self._assert_page_metadata(fmha_params, changed_expected)
+                output = attn_op.forward(q, kv_cache, fmha_params).clone()
+                self._assert_active_output_matches_reference(
+                    output,
+                    changed_inputs,
+                    changed_seq_lens,
+                    q,
+                    attn_op.q_dtype,
+                    k_cache,
+                    v_cache,
+                    config.seq_size_per_block,
+                )
+
+            crossed_page_inputs = self._create_cuda_graph_inputs(
+                capture_bs,
+                crossed_page_seq_lens,
+                config.seq_size_per_block,
+                active_batch_size=active_bs,
+                padding_block_id=padding_block_id,
+            )
+            plan_mock.reset_mock()
+            attn_op.prepare_for_cuda_graph_replay(crossed_page_inputs)
+            with self.subTest(phase="page boundary reference"):
+                self.assertEqual(plan_mock.call_count, 1)
+                self._assert_page_metadata(fmha_params, crossed_expected)
+                output = attn_op.forward(q, kv_cache, fmha_params).clone()
+                self._assert_active_output_matches_reference(
+                    output,
+                    crossed_page_inputs,
+                    crossed_page_seq_lens,
+                    q,
+                    attn_op.q_dtype,
+                    k_cache,
+                    v_cache,
+                    config.seq_size_per_block,
+                )
 
 
 class TestPyFlashinferDecodeAttnOpFP8(TestPyFlashinferDecodeAttnOp):
@@ -551,6 +1528,67 @@ class TestPyFlashinferDecodeCudaGraphFP8(TestPyFlashinferDecodeCudaGraph):
     rtol = 4e-2
     atol = 4e-2
     max_mismatch_rate = 1e-5
+
+    def test_cuda_core_fp8_kv_replay_preserves_plan_dtype(self):
+        """CUDA-core FP8 replay retains plan dtype and numerical accuracy."""
+        config = self._create_config(head_num=32, head_num_kv=32)
+        capture_inputs = self._create_cuda_graph_inputs(
+            2,
+            [64, 128],
+            config.seq_size_per_block,
+        )
+        attn_op = PyFlashinferDecodeAttnOp(config.attn_configs, capture_inputs)
+        self._assert_cuda_core_graph_mode(attn_op)
+        fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
+        attn_op.set_params(fmha_params)
+        with mock.patch.object(
+            attn_op.decode_wrapper,
+            "plan",
+            wraps=attn_op.decode_wrapper.plan,
+        ) as plan_mock:
+            attn_op.prepare(capture_inputs)
+            self._assert_plan_dtypes(plan_mock.call_args, attn_op)
+            self.assertEqual(attn_op.kv_dtype, torch.float8_e4m3fn)
+            replay_sequence_lengths = [129, 193]
+            replay_inputs = self._create_cuda_graph_inputs(
+                2,
+                replay_sequence_lengths,
+                config.seq_size_per_block,
+            )
+            plan_mock.reset_mock()
+            attn_op.prepare_for_cuda_graph_replay(replay_inputs)
+            self.assertEqual(plan_mock.call_count, 1)
+            self._assert_plan_dtypes(plan_mock.call_args, attn_op)
+
+        local_head_num = config.head_num // config.tp_size
+        local_kv_head_num = config.head_num_kv // config.tp_size
+        q = self._create_query_tensor(
+            len(replay_sequence_lengths),
+            local_head_num,
+            config.size_per_head,
+        )
+        total_blocks = self._calculate_total_blocks(
+            replay_sequence_lengths,
+            config.seq_size_per_block,
+        )
+        kv_cache, k_cache, v_cache = self._create_kv_cache(
+            total_blocks,
+            config.seq_size_per_block,
+            local_kv_head_num,
+            config.size_per_head,
+            dtype=self.cache_dtype(config.attn_configs),
+        )
+        output = attn_op.forward(q, kv_cache, fmha_params)
+        self._assert_active_output_matches_reference(
+            output,
+            replay_inputs,
+            replay_sequence_lengths,
+            q,
+            attn_op.q_dtype,
+            k_cache,
+            v_cache,
+            config.seq_size_per_block,
+        )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/test/smoke/data/model/qwen3/q_r_block_fp8_flashinfer_decode.json
+++ b/rtp_llm/test/smoke/data/model/qwen3/q_r_block_fp8_flashinfer_decode.json
@@ -1,0 +1,222 @@
+{
+    "model_type": "qwen_3",
+    "model_path": "/mnt/nas1/hf/models--Qwen--Qwen3-1.7B-FP8/snapshots/98342881667bac235ed8605b5ffd8a64a5b99aec",
+    "query_result": [
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": false,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat-",
+                "object": "chat.completion",
+                "created": 1777280342,
+                "model": "",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等。以下是一些关键点，帮助您规划学业与职业生涯：\n\n1. **强基计划择校**：强基计划旨在选拔具有突出才能的高中生，提供进入顶尖高校的机会。建议您关注目标高校的招生要求，提前准备相关学科的竞赛和考试。\n\n2. **综合评价咨询**：综合评价是高校录取的重要依据，建议您了解各高校的综合评价体系，合理规划学科成绩和综合素质评价。\n\n3. **志愿填报**：志愿填报是决定升学方向的关键步骤。建议您根据高考成绩和兴趣，结合高校的录取分数线和专业设置，制定合理的志愿填报策略。\n\n4. **海外院校申请**：如果您有意向申请海外院校，建议您提前了解目标院校的申请要求、语言要求和录取流程，准备相关材料。\n\n5. **学业与职业生涯规划**：建议您在高中阶段明确自己的兴趣和职业目标，通过参加各类活动、实习和课程项目，提升综合素质，为未来的职业生涯打下基础。\n\n如果您需要更具体的指导，如如何选择高校、如何准备综合评价、如何填报志愿等，我可以为您提供进一步的建议和规划。",
+                            "partial": false
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 770,
+                    "completion_tokens": 273,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": {
+                    "iter_count": 273,
+                    "prefix_len": 0,
+                    "input_len": 497,
+                    "output_len": 273,
+                    "step_output_len": 273,
+                    "wait_time": 0.0,
+                    "pd_sep": false,
+                    "cum_log_probs": [],
+                    "beam_responses": [],
+                    "softmax_probs": [],
+                    "reuse_len": 0,
+                    "local_reuse_len": 0,
+                    "remote_reuse_len": 0,
+                    "memory_reuse_len": 0,
+                    "prefill_total_reuse_len": 0,
+                    "prefill_local_reuse_len": 0,
+                    "prefill_remote_reuse_len": 0,
+                    "prefill_memory_reuse_len": 0,
+                    "decode_total_reuse_len": 0,
+                    "decode_local_reuse_len": 0,
+                    "decode_remote_reuse_len": 0,
+                    "decode_memory_reuse_len": 0,
+                    "role_addrs": [],
+                    "aux_string": ""
+                },
+                "extra_outputs": null
+            }
+        },
+        {
+            "endpoint": "/v1/chat/completions",
+            "query": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "$prompt:m2",
+                        "partial": false
+                    },
+                    {
+                        "role": "user",
+                        "content": "$prompt:s6",
+                        "partial": false
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "fcst_result_white_box",
+                            "description": "销量预测白盒，能够分析某货品到某仓库的销量预测白盒化信息。具体输出内容为\"reason\"（归因结果）、\"fcst_sls\"（预测销量）和 \"his_sls\"（历史销量）。",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "description": "服务code",
+                                        "type": "string"
+                                    },
+                                    "params": {
+                                        "description": "服务入参",
+                                        "type": "object",
+                                        "properties": {
+                                            "store_code": {
+                                                "description": "仓code",
+                                                "type": "string"
+                                            },
+                                            "po_id": {
+                                                "description": "采购单ID",
+                                                "type": "string"
+                                            },
+                                            "sc_item_id": {
+                                                "description": "货品id",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "sc_item_id",
+                                            "po_id",
+                                            "store_code"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "code",
+                                    "params"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "stream": true,
+                "extra_configs": {
+                    "top_k": 1,
+                    "chat_template_kwargs": {
+                        "enable_thinking": false
+                    }
+                }
+            },
+            "result": {
+                "id": "chat",
+                "object": "chat.completion.chunk",
+                "created": 1777280342,
+                "model": null,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "我理解您希望获得关于新高考的三年规划与升学指导服务，包括强基计划择校、综合评价咨询、志愿填报、海外院校申请等。以下是一些关键点，帮助您规划学业与职业生涯：\n\n1. **强基计划择校**：强基计划旨在选拔具有突出才能的高中生，提供进入顶尖高校的机会。建议您关注目标高校的招生要求，提前准备相关学科的竞赛和考试。\n\n2. **综合评价咨询**：综合评价是高校录取的重要依据，建议您了解各高校的综合评价体系，合理规划学科成绩和综合素质评价。\n\n3. **志愿填报**：志愿填报是决定升学方向的关键步骤。建议您根据高考成绩和兴趣，结合高校的录取分数线和专业设置，制定合理的志愿填报策略。\n\n4. **海外院校申请**：如果您有意向申请海外院校，建议您提前了解目标院校的申请要求、语言要求和录取流程，准备相关材料。\n\n5. **学业与职业生涯规划**：建议您在高中阶段明确自己的兴趣和职业目标，通过参加各类活动、实习和课程项目，提升综合素质，为未来的职业生涯打下基础。\n\n如果您需要更具体的指导，如如何选择高校、如何准备综合评价、如何填报志愿等，我可以为您提供进一步的建议和规划。"
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 497,
+                    "total_tokens": 770,
+                    "completion_tokens": 273,
+                    "completion_tokens_details": null,
+                    "prompt_tokens_details": null
+                },
+                "debug_info": null,
+                "aux_info": null,
+                "extra_outputs": null
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -225,6 +225,21 @@ def h20_oss_suites():
                 smoke_args="--disable_flashinfer_native 1 --act_type BF16 --reserver_runtime_mem_mb 8192 --tp_size 2 --warm_up 0",
                 gpu_type=["H20"],
             ),
+            # Copy dense_fp8_prequant_tp2's model, requests, and TP2 launch shape;
+            # select Native FlashInfer CUDA Graph and disable competing backends.
+            # The 497-token prompt reaches the 512-token page boundary during decode;
+            # Qwen3-1.7B TP2 has 8 local Q heads / 4 local KV heads, so GQA 2
+            # selects CUDA-core; capture size 2 adds padding.
+            # The golden was sampled from this exact Native FlashInfer graph
+            # configuration; its backend and 64-token page size intentionally
+            # differ from the copied case, while unit tests compare graph replay
+            # directly with an eager reference.
+            smoke_test(
+                name="dense_fp8_prequant_flashinfer_cudagraph",
+                task_info="data/model/qwen3/q_r_block_fp8_flashinfer_decode.json",
+                smoke_args="--disable_flashinfer_native 0 --act_type BF16 --reserver_runtime_mem_mb 8192 --tp_size 2 --warm_up 0 --seq_size_per_block 64 --enable_xqa 0 --enable_flashinfer_trtllm_gen 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_cuda_graph 1 --decode_capture_config '2'",
+                gpu_type=["H20"],
+            ),
             smoke_test(
                 name="dense_fp8pb_dynamic",
                 task_info="data/model/qwen3/q_r_h20.json",


### PR DESCRIPTION
修复 Native FlashInfer CUDA-core decode 在 CUDA Graph replay 时未刷新 plan metadata 的问题，避免 Qwen3-1.7B FP8 + Cuda Graph 运行时 page table 与捕获阶段 plan 不一致导致请求挂起。

  主要改动：

  - CUDA-core replay 每轮刷新 FlashInfer plan。
  - 使用 device page indices，避免阻塞式 H2D 拷贝。
  - 增加异步 plan 输入的 CUDA Event 生命周期保护。
  - 补充真实 CUDA Graph、padding、FP8 plan dtype、异常路径等 UT。
  - 新增 Qwen3-1.7B-FP8 Native FlashInfer CUDA Graph smoke 及独立 golden。