### PR TITLE
fix(fp8-kv): repair PyFlashinfer FP8 KV writes

### DIFF
--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/py_flashinfer_mha.py
@@ -8,12 +8,6 @@ from flashinfer.prefill import (
 )
 
 from rtp_llm.models_py.modules.factory.attention import common
-from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb import (
-    MhaRotaryEmbeddingOp,
-)
-from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
-    KVCacheWriteOp,
-)
 from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.flashinfer_mla import (
     check_attention_inputs,
 )
@@ -28,6 +22,8 @@ from rtp_llm.ops import (
 )
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCacheDecodeOp,
+    FusedRopeKVCachePrefillOpQKVOut,
+    FusedRopeKVCachePrefillOpQOut,
     LayerKVCache,
     ParamsBase,
     PyAttentionInputs,
@@ -424,34 +420,29 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         self.attn_inputs = attn_inputs
 
         self.fmha_impl = self._create_fmha_impl(attn_configs, attn_inputs)
-        self.rope_impl = self._create_rope_impl(attn_configs)
-        # Create KV cache write op
-        self.kv_cache_write_op = KVCacheWriteOp(
-            num_kv_heads=attn_configs.kv_head_num,
-            head_size=attn_configs.size_per_head,
-            token_per_block=attn_configs.kernel_tokens_per_block,
-        )
+        self.rope_kvcache_impl = self._create_rope_kvcache_impl(attn_configs)
         self.create_params(attn_inputs)
         self.fmha_impl.prepare(attn_inputs)
         self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
         self.fmha_impl.prepare(attn_inputs, forbid_realloc=True)
+        new_kv_cache_offset = self.rope_kvcache_impl.prepare(
+            attn_inputs
+        ).kv_cache_offset
+        assert (self.rope_params.kv_cache_offset is None) == (
+            new_kv_cache_offset is None
+        )
+        if new_kv_cache_offset is not None:
+            common.copy_kv_cache_offset(
+                self.rope_params.kv_cache_offset, new_kv_cache_offset
+            )
 
     def create_params(self, attn_inputs: PyAttentionInputs):
-        """Create FlashInfer MLA attention parameters.
-
-        Similar to MLA implementation, this creates and initializes the params
-        that will be used for both FMHA and RoPE operations.
-        """
+        """Create the independent FlashInfer FMHA and fused RoPE parameters."""
         self.fmha_params = rtp_llm_ops.FlashInferMlaAttnParams()
-        self.rope_params = self.fmha_params
-        # Pass the shared params to all ops
         self.fmha_impl.set_params(self.fmha_params)
-        if self.rope_impl is not None:
-            self.rope_impl.set_params(self.rope_params)
-        # KV cache write always needs params (even without RoPE)
-        self.kv_cache_write_op.set_params(self.rope_params)
+        self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
 
     def _create_fmha_impl(
         self, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
@@ -459,41 +450,9 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         """Create FMHA implementation. To be overridden by subclasses."""
         raise NotImplementedError("Subclass must implement _create_fmha_impl")
 
-    def _create_rope_impl(self, attn_configs: AttentionConfigs) -> Any:
-        """Create RoPE implementation. To be overridden by subclasses."""
-        raise NotImplementedError("Subclass must implement _create_rope_impl")
-
-    def _split_qkv(
-        self, qkv: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Split QKV tensor into query, key, value.
-
-        Args:
-            qkv: QKV tensor [total_tokens, (num_heads + 2*num_kv_heads) * head_dim]
-
-        Returns:
-            Tuple of (query, key, value) tensors
-        """
-        qkv = qkv.reshape(qkv.shape[0], -1)
-        num_heads = self.attn_configs.head_num
-        num_kv_heads = self.attn_configs.kv_head_num
-        head_dim = self.attn_configs.size_per_head
-
-        q, k, v = torch.split(
-            qkv,
-            [
-                head_dim * num_heads,
-                head_dim * num_kv_heads,
-                head_dim * num_kv_heads,
-            ],
-            dim=-1,
-        )
-
-        query = q.reshape(q.shape[0], num_heads, head_dim)
-        key = k.reshape(k.shape[0], num_kv_heads, head_dim)
-        value = v.reshape(v.shape[0], num_kv_heads, head_dim)
-
-        return query, key, value
+    def _create_rope_kvcache_impl(self, attn_configs: AttentionConfigs) -> Any:
+        """Create fused RoPE/KV-cache implementation."""
+        raise NotImplementedError("Subclass must implement _create_rope_kvcache_impl")
 
     def forward(
         self,
@@ -502,20 +461,10 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         layer_idx: int = 0,
     ) -> torch.Tensor:
         """Common forward implementation for all prefill implementations."""
-        # Apply RoPE and KV Cache processing
-        if self.need_rope_kv_cache:
-            if self.rope_impl is not None:
-                # Apply RoPE and get Q, K, V
-                query, key, value = self.rope_impl.forward(qkv)
-            else:
-                # No RoPE, just split QKV
-                query, key, value = self._split_qkv(qkv)
-
-            # Write KV to cache
-            self.kv_cache_write_op.forward(key, value, kv_cache)
-
-            # Pass query to FMHA (for paged) or reconstruct qkv (for ragged)
-            qkv = self._prepare_fmha_input(query, key, value)
+        # One fused op applies RoPE, converts/writes the configured cache dtype,
+        # and returns the layout consumed by the selected FlashInfer FMHA path.
+        if self.need_rope_kv_cache or kv_cache is not None:
+            qkv = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
 
         # Apply write cache store if needed
         common.apply_write_cache_store(
@@ -525,16 +474,9 @@ class PyFlashinferPrefillImplBase(FMHAImplBase):
         # Execute FMHA forward
         return self.fmha_impl.forward(qkv, kv_cache)
 
-    def _prepare_fmha_input(
-        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
-    ) -> torch.Tensor:
-        """Prepare input for FMHA. To be overridden by subclasses if needed."""
-        # Default: just return query (for paged layout)
-        return query
-
 
 class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
-    """FlashInfer prefill implementation with paged KV cache layout using MhaRotaryEmbeddingOp."""
+    """FlashInfer paged prefill with fused RoPE and KV-cache writes."""
 
     def _create_fmha_impl(
         self, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
@@ -542,17 +484,10 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
         """Create paged FMHA implementation."""
         return PyFlashinferPrefillPagedAttnOp(attn_configs, attn_inputs)
 
-    def _create_rope_impl(self, attn_configs: AttentionConfigs) -> Any:
-        """Create RoPE implementation for paged layout."""
-        if attn_configs.rope_config.style == RopeStyle.No:
-            return None
-        return MhaRotaryEmbeddingOp(attn_configs)
-
-    def _prepare_fmha_input(
-        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
-    ) -> torch.Tensor:
-        """For paged layout, only return query (KV is already in cache)."""
-        return query
+    def _create_rope_kvcache_impl(
+        self, attn_configs: AttentionConfigs
+    ) -> FusedRopeKVCachePrefillOpQOut:
+        return FusedRopeKVCachePrefillOpQOut(attn_configs)
 
     @staticmethod
     def support(attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs) -> bool:
@@ -563,7 +498,7 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
            SM12x consumer Blackwell keeps this FlashInfer paged fallback because
            TRTLLMGen/XQA do not have sm_120a support in this build.
         2. The underlying paged FMHA op supports the inputs
-        3. MhaRotaryEmbeddingOp supports the inputs
+        3. MRoPE is not used
         """
         return (
             not is_sm10x()
@@ -576,7 +511,7 @@ class PyFlashinferPagedPrefillImpl(PyFlashinferPrefillImplBase):
 
 
 class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
-    """FlashInfer prefill implementation with ragged KV cache layout using MhaRotaryEmbeddingOp."""
+    """FlashInfer ragged prefill with fused RoPE and KV-cache writes."""
 
     def _create_fmha_impl(
         self, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs
@@ -584,37 +519,10 @@ class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
         """Create ragged FMHA implementation."""
         return PyFlashinferPrefillAttnOp(attn_configs)
 
-    def _create_rope_impl(self, attn_configs: AttentionConfigs) -> Any:
-        """Create RoPE implementation for ragged layout."""
-        if attn_configs.rope_config.style == RopeStyle.No:
-            return None
-        return MhaRotaryEmbeddingOp(attn_configs)
-
-    def _prepare_fmha_input(
-        self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
-    ) -> torch.Tensor:
-        """For ragged layout, reconstruct full qkv tensor from q, k, v."""
-        # query: [total_tokens, num_heads, head_dim]
-        # key: [total_tokens, num_kv_heads, head_dim]
-        # value: [total_tokens, num_kv_heads, head_dim]
-
-        # Flatten to 2D and concatenate
-        q_flat = query.reshape(
-            query.shape[0], -1
-        )  # [total_tokens, num_heads * head_dim]
-        k_flat = key.reshape(
-            key.shape[0], -1
-        )  # [total_tokens, num_kv_heads * head_dim]
-        v_flat = value.reshape(
-            value.shape[0], -1
-        )  # [total_tokens, num_kv_heads * head_dim]
-
-        # Concatenate along feature dimension
-        qkv = torch.cat(
-            [q_flat, k_flat, v_flat], dim=-1
-        )  # [total_tokens, (num_heads + 2*num_kv_heads) * head_dim]
-
-        return qkv
+    def _create_rope_kvcache_impl(
+        self, attn_configs: AttentionConfigs
+    ) -> FusedRopeKVCachePrefillOpQKVOut:
+        return FusedRopeKVCachePrefillOpQKVOut(attn_configs)
 
     def support_cuda_graph(self) -> bool:
         return False
@@ -626,8 +534,7 @@ class PyFlashinferPrefillImpl(PyFlashinferPrefillImplBase):
         Returns True if:
         1. The underlying ragged FMHA op supports the inputs
            (requires prefix_lengths to be empty or zero)
-        2. MhaRotaryEmbeddingOp supports the inputs
-        3. Mrope is not used
+        2. MRoPE is not used
 
         Note: Unlike the paged variant, ragged prefill is kept enabled on
         Blackwell: TRT-LLM Gen prefill requires a paged kv cache and

--- a/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_mha_rotary_emb.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_impl/test/test_flashinfer_prefill/test_mha_rotary_emb.py
@@ -16,7 +16,13 @@ from rtp_llm.models_py.modules.factory.attention.cuda_impl.flashinfer_rotary_emb
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.kv_cache_write_op import (
     KVCacheWriteOp,
 )
-from rtp_llm.ops import AttentionConfigs, RopeStyle
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
+    PyFlashinferPagedPrefillImpl,
+    PyFlashinferPrefillAttnOp,
+    PyFlashinferPrefillImpl,
+    PyFlashinferPrefillPagedAttnOp,
+)
+from rtp_llm.ops import AttentionConfigs, KvCacheDataType, RopeStyle
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCachePrefillOpQOut,
     LayerKVCache,
@@ -567,6 +573,513 @@ class TestMhaRotaryEmbeddingOp(unittest.TestCase):
             "\n✓ All implementations (Reference, Python, C++) produce consistent results"
         )
         print("=" * 80)
+
+    def _write_fp8_reference_cache(
+        self,
+        cache: LayerKVCache,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        input_lengths: list[int],
+        prefix_lengths: list[int],
+        block_ids: torch.Tensor,
+        page_size: int,
+    ) -> None:
+        """Write RoPE output with the fused op's saturating E4M3 contract."""
+        token_index = 0
+        for batch_index, input_length in enumerate(input_lengths):
+            for request_token_index in range(input_length):
+                cache_position = prefix_lengths[batch_index] + request_token_index
+                page_index = int(
+                    block_ids[batch_index, cache_position // page_size].item()
+                )
+                page_offset = cache_position % page_size
+                cache.kv_cache_base[page_index, 0, :, page_offset, :] = (
+                    key[token_index].clamp(-448, 448).to(torch.float8_e4m3fn)
+                )
+                cache.kv_cache_base[page_index, 1, :, page_offset, :] = (
+                    value[token_index].clamp(-448, 448).to(torch.float8_e4m3fn)
+                )
+                token_index += 1
+
+    def test_fused_paged_prefill_fp8_accuracy(self):
+        """Compare fused paged prefill with an explicit FP8 cache reference."""
+        if not self.device_initialized:
+            self.skipTest("device initialization is required")
+
+        batch_size = 4
+        seq_len = 512
+        sequence_lengths = [seq_len] * batch_size
+        total_tokens = sum(sequence_lengths)
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        page_size = 64
+        hidden_size = (num_heads + 2 * num_kv_heads) * head_dim
+
+        config = create_test_attn_config(
+            head_num=num_heads,
+            kv_head_num=num_kv_heads,
+            size_per_head=head_dim,
+            tokens_per_block=page_size,
+            dtype=torch.bfloat16,
+        )
+        config.need_rope_kv_cache = True
+        config.kv_cache_dtype = KvCacheDataType.FP8
+        config.is_causal = True
+
+        input_lengths = torch.tensor(sequence_lengths, dtype=torch.int32)
+        cu_seqlens = torch.arange(
+            0,
+            total_tokens + 1,
+            seq_len,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        pages_per_request = math.ceil(seq_len / page_size)
+        block_ids = torch.arange(
+            batch_size * pages_per_request, dtype=torch.int32
+        ).reshape(batch_size, pages_per_request)
+        positions = torch.arange(seq_len, dtype=torch.int32, device=self.device).repeat(
+            batch_size
+        )
+
+        attn_inputs = PyAttentionInputs()
+        attn_inputs.is_prefill = True
+        attn_inputs.input_lengths = input_lengths.pin_memory()
+        attn_inputs.prefix_lengths = torch.zeros(
+            batch_size, dtype=torch.int32
+        ).pin_memory()
+        attn_inputs.sequence_lengths = input_lengths.pin_memory()
+        attn_inputs.kv_cache_block_id = block_ids
+        attn_inputs.kv_cache_block_id_device = block_ids.to(self.device)
+        attn_inputs.kv_cache_kernel_block_id = block_ids
+        attn_inputs.kv_cache_kernel_block_id_device = block_ids.to(self.device)
+        attn_inputs.cu_seqlens_device = cu_seqlens
+        attn_inputs.cu_kv_seqlens_device = cu_seqlens
+        attn_inputs.combo_position_ids = positions
+        attn_inputs.dtype = get_typemeta(torch.zeros(1, dtype=torch.bfloat16))
+
+        qkv_source = (
+            torch.randn(
+                total_tokens,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.5
+        )
+        num_pages = batch_size * pages_per_request
+
+        def make_cache() -> LayerKVCache:
+            cache = LayerKVCache()
+            cache.kv_cache_base = torch.zeros(
+                num_pages,
+                2,
+                num_kv_heads,
+                page_size,
+                head_dim,
+                dtype=torch.float8_e4m3fn,
+                device=self.device,
+            )
+            cache.kv_scale_base = torch.ones(
+                num_pages,
+                2 * num_kv_heads * page_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
+            return cache
+
+        # Reference pipeline: Python RoPE plus explicit saturating FP8 writes.
+        split_attn = PyFlashinferPrefillPagedAttnOp(config, attn_inputs)
+        split_params = split_attn.prepare(attn_inputs)
+        split_rope = MhaRotaryEmbeddingOp(config)
+        split_rope.set_params(split_params)
+        split_cache = make_cache()
+
+        # Proposed fused pipeline wired through the production implementation.
+        fused_impl = PyFlashinferPagedPrefillImpl(config, attn_inputs)
+        fused_cache = make_cache()
+
+        split_input = qkv_source.clone()
+        split_q, split_k, split_v = split_rope.forward(split_input)
+        self._write_fp8_reference_cache(
+            split_cache,
+            split_k,
+            split_v,
+            sequence_lengths,
+            [0] * batch_size,
+            block_ids,
+            page_size,
+        )
+        split_output = split_attn.forward(split_q, split_cache)
+
+        fused_output = fused_impl.forward(qkv_source.clone(), fused_cache)
+
+        torch.testing.assert_close(
+            fused_cache.kv_cache_base.float(),
+            split_cache.kv_cache_base.float(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        torch.testing.assert_close(
+            fused_output.float(), split_output.float(), rtol=2e-2, atol=2e-2
+        )
+
+    def test_fused_ragged_prefill_fp8_accuracy(self):
+        """Compare fused ragged prefill with an explicit FP8 cache reference."""
+        if not self.device_initialized:
+            self.skipTest("device initialization is required")
+
+        batch_size = 4
+        seq_len = 512
+        total_tokens = batch_size * seq_len
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        page_size = 64
+        hidden_size = (num_heads + 2 * num_kv_heads) * head_dim
+
+        config = create_test_attn_config(
+            head_num=num_heads,
+            kv_head_num=num_kv_heads,
+            size_per_head=head_dim,
+            tokens_per_block=page_size,
+            dtype=torch.bfloat16,
+        )
+        config.need_rope_kv_cache = True
+        config.kv_cache_dtype = KvCacheDataType.FP8
+        config.is_causal = True
+
+        lengths = torch.full((batch_size,), seq_len, dtype=torch.int32)
+        cu_seqlens = torch.arange(
+            0,
+            total_tokens + 1,
+            seq_len,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        pages_per_request = math.ceil(seq_len / page_size)
+        block_ids = torch.arange(
+            batch_size * pages_per_request, dtype=torch.int32
+        ).reshape(batch_size, pages_per_request)
+
+        attn_inputs = PyAttentionInputs()
+        attn_inputs.is_prefill = True
+        attn_inputs.input_lengths = lengths.pin_memory()
+        attn_inputs.prefix_lengths = torch.zeros(
+            batch_size, dtype=torch.int32
+        ).pin_memory()
+        attn_inputs.sequence_lengths = lengths.pin_memory()
+        attn_inputs.kv_cache_block_id = block_ids
+        attn_inputs.kv_cache_block_id_device = block_ids.to(self.device)
+        attn_inputs.kv_cache_kernel_block_id = block_ids
+        attn_inputs.kv_cache_kernel_block_id_device = block_ids.to(self.device)
+        attn_inputs.cu_seqlens_device = cu_seqlens
+        attn_inputs.cu_kv_seqlens_device = cu_seqlens
+        attn_inputs.combo_position_ids = torch.arange(
+            seq_len, dtype=torch.int32, device=self.device
+        ).repeat(batch_size)
+        attn_inputs.dtype = get_typemeta(torch.zeros(1, dtype=torch.bfloat16))
+
+        qkv_source = (
+            torch.randn(
+                total_tokens,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.5
+        )
+        num_pages = batch_size * pages_per_request
+
+        def make_cache() -> LayerKVCache:
+            cache = LayerKVCache()
+            cache.kv_cache_base = torch.zeros(
+                num_pages,
+                2,
+                num_kv_heads,
+                page_size,
+                head_dim,
+                dtype=torch.float8_e4m3fn,
+                device=self.device,
+            )
+            cache.kv_scale_base = torch.ones(
+                num_pages,
+                2 * num_kv_heads * page_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
+            return cache
+
+        split_attn = PyFlashinferPrefillAttnOp(config)
+        split_params = split_attn.prepare(attn_inputs)
+        split_rope = MhaRotaryEmbeddingOp(config)
+        split_rope.set_params(split_params)
+        split_cache = make_cache()
+
+        fused_impl = PyFlashinferPrefillImpl(config, attn_inputs)
+        fused_cache = make_cache()
+
+        split_input = qkv_source.clone()
+        split_q, split_k, split_v = split_rope.forward(split_input)
+        self._write_fp8_reference_cache(
+            split_cache,
+            split_k,
+            split_v,
+            [seq_len] * batch_size,
+            [0] * batch_size,
+            block_ids,
+            page_size,
+        )
+        split_qkv = torch.cat(
+            [
+                split_q.flatten(1),
+                split_k.flatten(1),
+                split_v.flatten(1),
+            ],
+            dim=-1,
+        )
+        split_output = split_attn.forward(split_qkv, split_cache)
+        fused_output = fused_impl.forward(qkv_source.clone(), fused_cache)
+
+        torch.testing.assert_close(
+            fused_cache.kv_cache_base.float(),
+            split_cache.kv_cache_base.float(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        torch.testing.assert_close(
+            fused_output.float(), split_output.float(), rtol=2e-2, atol=2e-2
+        )
+
+    def test_fused_paged_prefill_prefix_and_reused_blocks(self):
+        """Fused writes must preserve prefix offsets and reordered block IDs."""
+        if not self.device_initialized:
+            self.skipTest("device initialization is required")
+
+        input_lengths = [5, 3]
+        prefix_lengths = [8, 0]
+        sequence_lengths = [13, 3]
+        total_tokens = sum(input_lengths)
+        num_heads = 8
+        num_kv_heads = 2
+        head_dim = 128
+        page_size = 8
+        num_pages = 6
+
+        config = create_test_attn_config(
+            head_num=num_heads,
+            kv_head_num=num_kv_heads,
+            size_per_head=head_dim,
+            tokens_per_block=page_size,
+            dtype=torch.bfloat16,
+        )
+        config.need_rope_kv_cache = True
+        config.kv_cache_dtype = KvCacheDataType.FP8
+        config.is_causal = True
+
+        block_ids = torch.tensor([[5, 4], [2, 3]], dtype=torch.int32)
+        attn_inputs = PyAttentionInputs()
+        attn_inputs.is_prefill = True
+        attn_inputs.input_lengths = torch.tensor(
+            input_lengths, dtype=torch.int32
+        ).pin_memory()
+        attn_inputs.prefix_lengths = torch.tensor(
+            prefix_lengths, dtype=torch.int32
+        ).pin_memory()
+        attn_inputs.sequence_lengths = torch.tensor(
+            sequence_lengths, dtype=torch.int32
+        ).pin_memory()
+        attn_inputs.kv_cache_block_id = block_ids
+        attn_inputs.kv_cache_block_id_device = block_ids.to(self.device)
+        attn_inputs.kv_cache_kernel_block_id = block_ids
+        attn_inputs.kv_cache_kernel_block_id_device = block_ids.to(self.device)
+        attn_inputs.cu_seqlens_device = torch.tensor(
+            [0, 5, 8], dtype=torch.int32, device=self.device
+        )
+        attn_inputs.cu_kv_seqlens_device = attn_inputs.cu_seqlens_device
+        attn_inputs.combo_position_ids = torch.tensor(
+            [8, 9, 10, 11, 12, 0, 1, 2],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        attn_inputs.dtype = get_typemeta(torch.zeros(1, dtype=torch.bfloat16))
+
+        qkv = torch.randn(
+            total_tokens,
+            (num_heads + 2 * num_kv_heads) * head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        value_start = (num_heads + num_kv_heads) * head_dim
+        qkv[0::2, value_start:] = 1000
+        qkv[1::2, value_start:] = -1000
+        cache_seed = torch.randn(
+            num_pages,
+            2,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).to(torch.float8_e4m3fn)
+
+        def make_cache() -> LayerKVCache:
+            cache = LayerKVCache()
+            cache.kv_cache_base = cache_seed.clone()
+            cache.kv_scale_base = torch.ones(
+                num_pages,
+                2 * num_kv_heads * page_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
+            return cache
+
+        split_attn = PyFlashinferPrefillPagedAttnOp(config, attn_inputs)
+        split_params = split_attn.prepare(attn_inputs)
+        split_rope = MhaRotaryEmbeddingOp(config)
+        split_rope.set_params(split_params)
+        split_cache = make_cache()
+        query, key, value = split_rope.forward(qkv.clone())
+        self._write_fp8_reference_cache(
+            split_cache,
+            key,
+            value,
+            input_lengths,
+            prefix_lengths,
+            block_ids,
+            page_size,
+        )
+        split_output = split_attn.forward(query, split_cache)
+
+        fused_cache = make_cache()
+        fused_impl = PyFlashinferPagedPrefillImpl(config, attn_inputs)
+        fused_output = fused_impl.forward(qkv.clone(), fused_cache)
+
+        torch.testing.assert_close(
+            fused_cache.kv_cache_base.float(),
+            split_cache.kv_cache_base.float(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        torch.testing.assert_close(
+            fused_output.float(), split_output.float(), rtol=2e-2, atol=2e-2
+        )
+
+    def test_fused_paged_prefill_fp8_cuda_graph_replay(self):
+        """Capture and replay fused preprocessing with a changed block table."""
+        if not self.device_initialized:
+            self.skipTest("device initialization is required")
+
+        batch_size = 2
+        seq_len = 16
+        page_size = 16
+        num_heads = 8
+        num_kv_heads = 2
+        head_dim = 128
+        total_tokens = batch_size * seq_len
+
+        config = create_test_attn_config(
+            head_num=num_heads,
+            kv_head_num=num_kv_heads,
+            size_per_head=head_dim,
+            tokens_per_block=page_size,
+            dtype=torch.bfloat16,
+        )
+        config.need_rope_kv_cache = True
+        config.kv_cache_dtype = KvCacheDataType.FP8
+        config.is_causal = True
+
+        def make_inputs(block_ids: torch.Tensor, is_graph: bool) -> PyAttentionInputs:
+            inputs = PyAttentionInputs()
+            inputs.is_prefill = True
+            inputs.is_cuda_graph = is_graph
+            lengths = torch.full((batch_size,), seq_len, dtype=torch.int32)
+            inputs.input_lengths = lengths.pin_memory()
+            inputs.prefix_lengths = torch.zeros(
+                batch_size, dtype=torch.int32
+            ).pin_memory()
+            inputs.sequence_lengths = lengths.pin_memory()
+            inputs.kv_cache_block_id = block_ids
+            inputs.kv_cache_block_id_device = block_ids.to(self.device)
+            inputs.kv_cache_kernel_block_id = block_ids
+            inputs.kv_cache_kernel_block_id_device = block_ids.to(self.device)
+            inputs.cu_seqlens_device = torch.tensor(
+                [0, seq_len, total_tokens],
+                dtype=torch.int32,
+                device=self.device,
+            )
+            inputs.cu_kv_seqlens_device = inputs.cu_seqlens_device
+            inputs.combo_position_ids = torch.arange(
+                seq_len, dtype=torch.int32, device=self.device
+            ).repeat(batch_size)
+            inputs.dtype = get_typemeta(torch.zeros(1, dtype=torch.bfloat16))
+            return inputs
+
+        def make_cache() -> LayerKVCache:
+            cache = LayerKVCache()
+            cache.kv_cache_base = torch.zeros(
+                batch_size,
+                2,
+                num_kv_heads,
+                page_size,
+                head_dim,
+                dtype=torch.float8_e4m3fn,
+                device=self.device,
+            )
+            cache.kv_scale_base = torch.ones(
+                batch_size,
+                2 * num_kv_heads * page_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
+            return cache
+
+        capture_blocks = torch.tensor([[0], [1]], dtype=torch.int32)
+        replay_blocks = torch.tensor([[1], [0]], dtype=torch.int32)
+        capture_inputs = make_inputs(capture_blocks, True)
+        replay_inputs = make_inputs(replay_blocks, True)
+        graph_impl = PyFlashinferPagedPrefillImpl(config, capture_inputs)
+        graph_cache = make_cache()
+        static_qkv = torch.randn(
+            total_tokens,
+            (num_heads + 2 * num_kv_heads) * head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                graph_impl.forward(static_qkv, graph_cache)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_output = graph_impl.forward(static_qkv, graph_cache)
+
+        replay_qkv = torch.randn_like(static_qkv)
+        graph_impl.prepare_cuda_graph(replay_inputs)
+        static_qkv.copy_(replay_qkv)
+        graph_cache.kv_cache_base.zero_()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        eager_inputs = make_inputs(replay_blocks, False)
+        eager_impl = PyFlashinferPagedPrefillImpl(config, eager_inputs)
+        eager_cache = make_cache()
+        eager_output = eager_impl.forward(replay_qkv, eager_cache)
+
+        torch.testing.assert_close(
+            graph_cache.kv_cache_base.float(),
+            eager_cache.kv_cache_base.float(),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        torch.testing.assert_close(
+            graph_output.float(), eager_output.float(), rtol=2e-2, atol=2e-2
+        )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_flashinfer_device_reuse.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_flashinfer_device_reuse.json
@@ -1,0 +1,41 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0}
+            },
+            "result": {
+                "response": " Mathematics is like a lighthouse, a beacon of",
+                "finished": true,
+                "aux_info": {"input_len": 11, "reuse_len": 0, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        },
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.\n\nAnswer: ",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0, "enable_device_cache": true, "enable_memory_cache": false}
+            },
+            "result": {
+                "response": " Mathematics and a lighthouse are like two different but",
+                "response_alternatives": ["1. Mathematics is like a lighthouse, a"],
+                "finished": true,
+                "aux_info": {"input_len": 14, "reuse_len": 8, "memory_reuse_len": 0, "local_reuse_len": 8, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        },
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.\n\nAnswer: ",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0, "enable_device_cache": false, "enable_memory_cache": false}
+            },
+            "result": {
+                "response": "1. Mathematics is like a lighthouse, a",
+                "finished": true,
+                "aux_info": {"input_len": 14, "reuse_len": 0, "memory_reuse_len": 0, "local_reuse_len": 0, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_flashinfer_memory_reuse.json
+++ b/rtp_llm/test/smoke/data/model/qwen25/q_r_fp8_flashinfer_memory_reuse.json
@@ -1,0 +1,41 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "tokenizer_path": "/mnt/nas1/hf/Qwen2.5-0.5B-Instruct",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0}
+            },
+            "result": {
+                "response": " Mathematics is like a lighthouse, a beacon of",
+                "finished": true,
+                "aux_info": {"input_len": 11, "reuse_len": 0, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        },
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.\n\nAnswer: ",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0, "enable_device_cache": false, "enable_memory_cache": true}
+            },
+            "result": {
+                "response": " Mathematics and a lighthouse are like two different but",
+                "response_alternatives": ["1. Mathematics is like a lighthouse, a"],
+                "finished": true,
+                "aux_info": {"input_len": 14, "reuse_len": 8, "memory_reuse_len": 8, "local_reuse_len": 8, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        },
+        {
+            "query": {
+                "prompt": "Write a detailed analogy between mathematics and a lighthouse.\n\nAnswer: ",
+                "generate_config": {"max_new_tokens": 10, "top_k": 1, "top_p": 0, "enable_device_cache": false, "enable_memory_cache": false}
+            },
+            "result": {
+                "response": "1. Mathematics is like a lighthouse, a",
+                "finished": true,
+                "aux_info": {"input_len": 14, "reuse_len": 0, "memory_reuse_len": 0, "local_reuse_len": 0, "prefix_len": 0, "iter_count": 10, "output_len": 10}
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -214,9 +214,39 @@ def h20_oss_suites():
                 gpu_type=["H20"],
             ),
             smoke_test(
+                name="dense_fp8kv_flashinfer_cudagraph",
+                task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_cudagraph.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 1 --disable_flashinfer_native 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_flashinfer_trtllm_gen 0",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
                 name="dense_fp8kv_flashinfer_prefill",
                 task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_flashinfer_prefill.json",
                 smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 0 --disable_flashinfer_native 0 --frontend_server_count 1",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8kv_pyflashinfer_prefill",
+                task_info="data/model/qwen25/q_r_new_model_py_fp8_kv_cache_flashinfer_prefill.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 0 --disable_flashinfer_native 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_flashinfer_trtllm_gen 0 --frontend_server_count 1",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8kv_flashinfer_prefill_reuse",
+                task_info="data/model/qwen25/q_r_fp8_flashinfer_device_reuse.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 8 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 0 --disable_flashinfer_native 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_flashinfer_trtllm_gen 0 --frontend_server_count 1 --reuse_cache 1",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8kv_flashinfer_cudagraph_reuse",
+                task_info="data/model/qwen25/q_r_fp8_flashinfer_device_reuse.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 8 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 1 --disable_flashinfer_native 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_flashinfer_trtllm_gen 0 --frontend_server_count 1 --reuse_cache 1",
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="dense_fp8kv_flashinfer_prefill_memory_reuse",
+                task_info="data/model/qwen25/q_r_fp8_flashinfer_memory_reuse.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 8 --act_type BF16 --test_block_num 1000 --fp8_kv_cache 1 --enable_cuda_graph 0 --disable_flashinfer_native 0 --enable_flashinfer_trt_fmha_v2 0 --enable_paged_flashinfer_trt_fmha_v2 0 --enable_flashinfer_trtllm_gen 0 --frontend_server_count 1 --reuse_cache 1 --enable_memory_cache 1 --memory_cache_size_mb 1024 --write_cache_sync 1",
                 gpu_type=["H20"],
             ),
             smoke_test(


### PR DESCRIPTION
修复 Native PyFlashinfer 在 FP8 KV Cache 配置下的 prefill 写入问题。为 PyFlashinfer 补齐 BASE/FP8 cache dtype 映射，并新增融合 CUDA kernel，一次完成 BF16/FP16/FP32 到 FP8 E4M3 的饱和转换与 paged KV Cache 写入，避免逐层产生临时 tensor 和额外 kernel。同时补齐 FP8 decode、非连续 QKV、跨页写入及 CUDA Graph capture/replay 测试；smoke 显式锁定 Native PyFlashinfer，并将 device reuse 与 memory reuse 拆分为独立用例。

  主要改动

  - 补齐 KvCacheDataType.BASE/FP8 到 PyTorch dtype 的映射。
  - FP8 KV 采用 implicit scale=1，有限值饱和到 E4M3 [-448, 448]。
  - 新增 append_paged_kv_cache_fp8 CUDA/pybind 接口，直接按 slot_mapping 写入 HND paged cache。
  - 支持生产路径的非连续 QKV view、跨 page 写入和 CUDA Graph replay。
  - 修复 FP8 decode UT 缺失导入。
  - smoke 关闭 TRT FMHA/Gen 等高优先级候选，确保实际执行 Native PyFlashinfer。
  - 拆分 device reuse 和 memory reuse，分别校验 8/8/0 与 8/8/8 reuse 指标。