### PR TITLE
Feature/qwen35 mtp pd cg smoke

### DIFF
--- a/rtp_llm/model_factory_register.py
+++ b/rtp_llm/model_factory_register.py
@@ -266,6 +266,10 @@ def _register_builtin_lazy_models() -> None:
         "rtp_llm.models.qwen3_next.qwen3_next_mtp",
         ["Qwen35MoeMTPForCausalLM"],
     )
+    register_lazy_model(
+        "qwen35_dense_mtp",
+        "rtp_llm.models.qwen3_next.qwen3_next_mtp",
+    )
     register_lazy_model("qwen_vl", "rtp_llm.models.qwen_vl", ["QWenMLMHeadModel"])
     register_lazy_model(
         "qwen2_vl",

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -75,6 +75,7 @@ test_suite(
         ":smoke_rocm_dense",
         ":smoke_rocm_moe",
         ":smoke_rocm_qwen35_mrope_cg",
+        ":smoke_rocm_qwen35_mtp",
         ":smoke_rocm_eagle",
         ":smoke_rocm_pd",
         ":smoke_rocm_embedding",

--- a/rtp_llm/test/smoke/data/model/qwen3_next/qwen35_dense_fp8_tp1_mtp_pd.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_next/qwen35_dense_fp8_tp1_mtp_pd.json
@@ -1,0 +1,106 @@
+{
+    "model_type": "qwen35_dense",
+    "model_path": "/ckpt/qwen35/Qwen3.5-27B",
+    "query_result": [
+        {
+            "query": {
+                "prompt": "$prompt:s2",
+                "generate_config": {
+                    "max_new_tokens": 8,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "temperature": 0,
+                    "random_seed": 42,
+                    "aux_info": true,
+                    "can_use_pd_separation": true,
+                    "reuse_cache": false
+                }
+            },
+            "result": {
+                "response": "\n\n<think>\n\n</think>\n\n围绕“英语",
+                "finished": true,
+                "aux_info": {
+                    "input_len": 8,
+                    "reuse_len": 0,
+                    "output_len": 8,
+                    "iter_count": 3
+                }
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:s1",
+                "generate_config": {
+                    "max_new_tokens": 20,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "temperature": 0,
+                    "random_seed": 42,
+                    "aux_info": true,
+                    "can_use_pd_separation": true,
+                    "reuse_cache": false
+                }
+            },
+            "result": {
+                "response": "\n\nThe CAP Theorem, also known as Brewer's Theorem, is a fundamental concept in distributed",
+                "finished": true,
+                "aux_info": {
+                    "input_len": 6,
+                    "reuse_len": 0,
+                    "output_len": 20,
+                    "iter_count": 8
+                }
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:x2",
+                "generate_config": {
+                    "max_new_tokens": 20,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "temperature": 0,
+                    "random_seed": 42,
+                    "aux_info": true,
+                    "can_use_pd_separation": true,
+                    "reuse_cache": true
+                }
+            },
+            "result": {
+                "response": "\r\n\r\n——基本形成现代工业强市格局。工业增加值年均增长12%以上，到2",
+                "finished": true,
+                "aux_info": {
+                    "input_len": 3612,
+                    "reuse_len": 0,
+                    "output_len": 20,
+                    "iter_count": 8
+                }
+            }
+        },
+        {
+            "query": {
+                "prompt": "$prompt:x2",
+                "generate_config": {
+                    "max_new_tokens": 20,
+                    "top_k": 1,
+                    "top_p": 0,
+                    "temperature": 0,
+                    "random_seed": 42,
+                    "aux_info": true,
+                    "can_use_pd_separation": true,
+                    "reuse_cache": true
+                }
+            },
+            "result": {
+                "response": "\r\n\r\n——基本形成现代工业强市格局。工业增加值年均增长12%以上，到2",
+                "finished": true,
+                "aux_info": {
+                    "input_len": 3612,
+                    "reuse_len": 3072,
+                    "output_len": 20,
+                    "iter_count": 8
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -53,6 +53,8 @@ def rocm_oss_suites():
                 smoke_args="--quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --use_asm_pa 1 --fp8_kv_cache 1 --enable_cuda_graph 1 --warm_up 1 --act_type BF16 --reserver_runtime_mem_mb 70000 --test_block_num 1000",
                 gpu_type=["MI308X-ROCM7"],
             ),
+            # With FP8 KV and a 16-token kernel page, vectorized and linear V have
+            # identical byte offsets, so the NonAsm pair needs no Triton fallback.
             smoke_test(
                 name="rocm_dense_qwen3_8b_ptpc_fp8kv_no_asm_pa",
                 task_info="data/model/qwen3/ptpc_q_r_8b.json",
@@ -92,8 +94,18 @@ def rocm_oss_suites():
     native.test_suite(
         name = "smoke_rocm_qwen35_mrope_cg",
         tests = [
+            # Aiter prefill and Triton decode share the vectorized-V pair even
+            # when the standalone ASM flag is off.
             smoke_test(
                 name="rocm_qwen35_bf16_mrope_cg",
+                task_info="data/model/qwen35/qwen35_bf16_rocm.json",
+                smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 0 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+            # use_asm_pa 1 keeps the vectorized-V pair (ASM prefill + TritonVectorized
+            # decode) under end-to-end CUDA Graph coverage.
+            smoke_test(
+                name="rocm_qwen35_bf16_mrope_cg_asm_pa",
                 task_info="data/model/qwen35/qwen35_bf16_rocm.json",
                 smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
                 gpu_type=["MI308X-ROCM7"],
@@ -102,6 +114,25 @@ def rocm_oss_suites():
                 name="rocm_qwen35_bf16_mrope_cg_triton_linear",
                 task_info="data/model/qwen35/qwen35_bf16_rocm.json",
                 smoke_args="--warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 512 --max_seq_len 409600 --tp_size 1 --world_size 1 --use_asm_pa 0 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                gpu_type=["MI308X-ROCM7"],
+            ),
+        ],
+    )
+
+    # ROCm Qwen3.5 dense MTP: TP1 PD separation with decode CUDA Graph.
+    # The fixture intentionally mixes short/long prompts and repeats the long
+    # prompt with reuse_cache enabled so both the fresh and reused KV paths are
+    # exercised while gen_num_per_cycle=3 checks the requested MTP step.
+    native.test_suite(
+        name = "smoke_rocm_qwen35_mtp",
+        tests = [
+            smoke_test(
+                name="rocm_qwen35_dense_mtp_pd_fp8_tp1_step3_cg",
+                task_info="data/model/qwen3_next/qwen35_dense_fp8_tp1_mtp_pd.json",
+                smoke_args={
+                    "prefill": "--load_cache_timeout_ms 120000 --load_method scratch --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 64 --max_seq_len 12800 --tp_size 1 --world_size 1 --ep_size 1 --reuse_cache 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --sp_model_type qwen35_dense_mtp --gen_num_per_cycle 3 --sp_type eagle --sp_checkpoint_path /ckpt/qwen35/Qwen3.5-27B --sp_act_type bf16 --cache_store_rdma_mode 0 --use_local 1 --role_type PREFILL",
+                    "decode": "--load_cache_timeout_ms 120000 --load_method scratch --warm_up 0 --act_type BF16 --seq_size_per_block 1024 --kernel_seq_size_per_block 16 --test_block_num 64 --max_seq_len 12800 --tp_size 1 --world_size 1 --ep_size 1 --reuse_cache 1 --use_asm_pa 1 --use_aiter_pa 1 --use_triton_pa 1 --reserver_runtime_mem_mb 40480 --quantization FP8_PER_CHANNEL_COMPRESSED --use_swizzleA 1 --sp_model_type qwen35_dense_mtp --gen_num_per_cycle 3 --sp_type eagle --sp_checkpoint_path /ckpt/qwen35/Qwen3.5-27B --sp_act_type bf16 --cache_store_rdma_mode 0 --use_local 1 --role_type DECODE --concurrency_limit 4 --enable_cuda_graph 1 --enable_cuda_graph_debug_mode 1 --decode_capture_config '1,2,3,4'",
+                },
                 gpu_type=["MI308X-ROCM7"],
             ),
         ],


### PR DESCRIPTION
  - Keep Qwen3.5 MTP ROCm Aiter prefill/decode V-cache layout vectorized and graph-safe.
  - Fix CUDA-graph replay for short MTP batches by preserving capture-width compact indices and bounding attention metadata/block-table padding.
  - Add TP1 PD smoke coverage for MTP step=3, cache reuse, and decode CUDA graph replay.