### PR TITLE
feat: fuse pure TP MoE all-reduce

### DIFF
--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, Optional
 
 import torch
@@ -30,6 +31,8 @@ from rtp_llm.ops import HWKernelConfig, MoeConfig, ParallelismConfig
 from rtp_llm.ops.compute_ops import LayerKVCache, PyModelInputs, PyModelOutputs
 from rtp_llm.utils.model_weight import W
 
+logger = logging.getLogger(__name__)
+
 
 class GenericMoeLayer(nn.Module):
     """Generic MoE layer supporting both Qwen3 and internal model."""
@@ -47,6 +50,18 @@ class GenericMoeLayer(nn.Module):
         super().__init__()
         self.config = config
         self.parallelism_config = parallelism_config
+        self.ffn_tp_size = parallelism_config.get_ffn_tp_size()
+        self.ep_size = parallelism_config.ep_size
+        attn_tp_size = parallelism_config.get_attn_tp_size()
+        self.attn_tp_size = attn_tp_size
+        # Router TP reduction uses attention TP (see config_adapter.py). Keep
+        # this relation explicit so ffn_tp_size > 1 implies the router's
+        # original TP reduction also spans more than one rank.
+        if self.ffn_tp_size > attn_tp_size:
+            raise ValueError(
+                f"ffn_tp_size={self.ffn_tp_size} must not exceed "
+                f"attn_tp_size={attn_tp_size}"
+            )
 
         self.hidden_dim = config.hidden_size
         self.ffn_dim = config.inter_size
@@ -85,8 +100,6 @@ class GenericMoeLayer(nn.Module):
         ), "Weights w1 and w2 must be provided"
         self.num_local_experts = self.w1.shape[0]
         self.add_shared_expert = config.moe_style == 2
-        self.ffn_tp_size = parallelism_config.get_ffn_tp_size()
-        self.ep_size = parallelism_config.ep_size
         if self.add_shared_expert:
             self.shared_expert = DenseMLP(
                 config.activation_type,
@@ -114,8 +127,52 @@ class GenericMoeLayer(nn.Module):
             self.shared_expert_gate = None
             self.sigmoid_gate_scale_add = None
 
+        self.use_ep_shared_allreduce = (
+            self.shared_expert is not None and self.ffn_tp_size > 1 and self.ep_size > 1
+        )
+        self.use_unified_tp_allreduce = (
+            self.shared_expert is not None
+            and self.ffn_tp_size > 1
+            and self.ep_size == 1
+            and self.fused_moe.router.supports_skip_tp_allreduce
+        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "GenericMoE unified TP all-reduce %s "
+                "(router=%s, ffn_tp_size=%d, attn_tp_size=%d, ep_size=%d)",
+                "enabled" if self.use_unified_tp_allreduce else "disabled",
+                type(self.fused_moe.router).__name__,
+                self.ffn_tp_size,
+                self.attn_tp_size,
+                self.ep_size,
+            )
+
         # for group topk
         self.correction_bias = weights.get(W.e_score_correction_b, None)
+
+    def _merge_shared_expert_output(
+        self,
+        hidden_states: torch.Tensor,
+        experts_output: torch.Tensor,
+        shared_expert_output: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.shared_expert_gate is not None:
+            gate_output = self.shared_expert_gate(hidden_states)  # [T, 1]
+            self.sigmoid_gate_scale_add(
+                gate_output, shared_expert_output, experts_output
+            )
+            return experts_output
+        return experts_output + shared_expert_output
+
+    def _gate_shared_expert_output(
+        self,
+        hidden_states: torch.Tensor,
+        shared_expert_output: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.shared_expert_gate is not None:
+            gate_output = self.shared_expert_gate(hidden_states)  # [T, 1]
+            return torch.sigmoid(gate_output) * shared_expert_output
+        return shared_expert_output
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
@@ -161,45 +218,53 @@ class GenericMoeLayer(nn.Module):
         if self.fake_balance_expert is not None:
             self.fake_balance_expert(topk_ids, topk_weights)
 
-        is_ep_mode = self.ep_size > 1
         # EP mode: routed expert output is already complete (EP combine handles it).
         # Shared expert output is TP-partial and needs separate allreduce.
-        use_ep_shared_allreduce = (
-            self.shared_expert is not None and self.ffn_tp_size > 1 and is_ep_mode
-        )
-
+        use_ep_shared_allreduce = self.use_ep_shared_allreduce
+        # In pure-TP mode both the routed experts and the shared expert produce
+        # TP-partial outputs.  Reduce their sum once instead of reducing each
+        # path separately.  This is especially important for decode, where the
+        # hidden dimension is small enough that collective launch latency
+        # dominates the payload transfer.
         experts_output = self.fused_moe(
             hidden_states=hidden_states,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             activation="SiGLU",
+            skip_tp_allreduce=self.use_unified_tp_allreduce,
         )
         if self.shared_expert is not None:
             shared_expert_output = self.shared_expert(
                 hidden_states,
-                skip_allreduce=use_ep_shared_allreduce,
+                skip_allreduce=(
+                    use_ep_shared_allreduce or self.use_unified_tp_allreduce
+                ),
             )
-            if use_ep_shared_allreduce:
+            if self.use_unified_tp_allreduce:
+                # Both paths are still TP-partial.  The shared-expert gate is
+                # rank-consistent because hidden_states are replicated across
+                # TP ranks, so it is safe to apply it before the single
+                # all-reduce.
+                experts_output = self._merge_shared_expert_output(
+                    hidden_states, experts_output, shared_expert_output
+                )
+                experts_output = all_reduce(experts_output, group=Group.TP)
+            elif use_ep_shared_allreduce:
                 # EP mode: routed expert output is already complete
                 # (EP combine via all_to_all / all_gather aggregated across ranks).
                 # Only the shared expert output is TP-partial and needs all_reduce.
-                if self.shared_expert_gate is not None:
-                    gate_output = self.shared_expert_gate(hidden_states)  # [T, 1]
-                    shared_expert_output = (
-                        torch.sigmoid(gate_output) * shared_expert_output
-                    )
+                shared_expert_output = self._gate_shared_expert_output(
+                    hidden_states, shared_expert_output
+                )
                 shared_expert_output = all_reduce(shared_expert_output, group=Group.TP)
                 experts_output = experts_output + shared_expert_output
             else:
-                # TP-only mode: same as main - each component does its own allreduce.
-                if self.shared_expert_gate is not None:
-                    gate_output = self.shared_expert_gate(hidden_states)  # [T, 1]
-                    # Fused: experts_output += sigmoid(gate_output) * shared_expert_output
-                    self.sigmoid_gate_scale_add(
-                        gate_output, shared_expert_output, experts_output
-                    )
-                else:
-                    experts_output = experts_output + shared_expert_output
+                # Fallback path: each path is already complete independently.
+                # This includes ffn_tp_size == 1 and routers that do not
+                # support deferred TP reduction, so only local merging remains.
+                experts_output = self._merge_shared_expert_output(
+                    hidden_states, experts_output, shared_expert_output
+                )
 
         return experts_output
 

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -52,16 +52,6 @@ class GenericMoeLayer(nn.Module):
         self.parallelism_config = parallelism_config
         self.ffn_tp_size = parallelism_config.get_ffn_tp_size()
         self.ep_size = parallelism_config.ep_size
-        attn_tp_size = parallelism_config.get_attn_tp_size()
-        self.attn_tp_size = attn_tp_size
-        # Router TP reduction uses attention TP (see config_adapter.py). Keep
-        # this relation explicit so ffn_tp_size > 1 implies the router's
-        # original TP reduction also spans more than one rank.
-        if self.ffn_tp_size > attn_tp_size:
-            raise ValueError(
-                f"ffn_tp_size={self.ffn_tp_size} must not exceed "
-                f"attn_tp_size={attn_tp_size}"
-            )
 
         self.hidden_dim = config.hidden_size
         self.ffn_dim = config.inter_size
@@ -92,6 +82,8 @@ class GenericMoeLayer(nn.Module):
             enable_cuda_graph=enable_cuda_graph,
         )
         self.fused_moe = FusedMoeFactory().create_fused_moe(config_adapter, weights)
+        router = self.fused_moe.router
+        router_tp_size = router.tp_collective_size
 
         self.w1 = weights.get(W.moe_w1, None)
         self.w2 = weights.get(W.moe_w2, None)
@@ -134,16 +126,17 @@ class GenericMoeLayer(nn.Module):
             self.shared_expert is not None
             and self.ffn_tp_size > 1
             and self.ep_size == 1
-            and self.fused_moe.router.supports_skip_tp_allreduce
+            and self.ffn_tp_size == router_tp_size
+            and router.supports_skip_tp_allreduce
         )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "GenericMoE unified TP all-reduce %s "
-                "(router=%s, ffn_tp_size=%d, attn_tp_size=%d, ep_size=%d)",
+                "(router=%s, ffn_tp_size=%d, router_tp_size=%d, ep_size=%d)",
                 "enabled" if self.use_unified_tp_allreduce else "disabled",
-                type(self.fused_moe.router).__name__,
+                type(router).__name__,
                 self.ffn_tp_size,
-                self.attn_tp_size,
+                router_tp_size,
                 self.ep_size,
             )
 
@@ -218,9 +211,6 @@ class GenericMoeLayer(nn.Module):
         if self.fake_balance_expert is not None:
             self.fake_balance_expert(topk_ids, topk_weights)
 
-        # EP mode: routed expert output is already complete (EP combine handles it).
-        # Shared expert output is TP-partial and needs separate allreduce.
-        use_ep_shared_allreduce = self.use_ep_shared_allreduce
         # In pure-TP mode both the routed experts and the shared expert produce
         # TP-partial outputs.  Reduce their sum once instead of reducing each
         # path separately.  This is especially important for decode, where the
@@ -237,7 +227,7 @@ class GenericMoeLayer(nn.Module):
             shared_expert_output = self.shared_expert(
                 hidden_states,
                 skip_allreduce=(
-                    use_ep_shared_allreduce or self.use_unified_tp_allreduce
+                    self.use_ep_shared_allreduce or self.use_unified_tp_allreduce
                 ),
             )
             if self.use_unified_tp_allreduce:
@@ -249,7 +239,7 @@ class GenericMoeLayer(nn.Module):
                     hidden_states, experts_output, shared_expert_output
                 )
                 experts_output = all_reduce(experts_output, group=Group.TP)
-            elif use_ep_shared_allreduce:
+            elif self.use_ep_shared_allreduce:
                 # EP mode: routed expert output is already complete
                 # (EP combine via all_to_all / all_gather aggregated across ranks).
                 # Only the shared expert output is TP-partial and needs all_reduce.
@@ -260,8 +250,8 @@ class GenericMoeLayer(nn.Module):
                 experts_output = experts_output + shared_expert_output
             else:
                 # Fallback path: each path is already complete independently.
-                # This includes ffn_tp_size == 1 and routers that do not
-                # support deferred TP reduction, so only local merging remains.
+                # This includes ffn_tp_size == 1 and routers that retain their
+                # own finalize reduction, so only local merging remains.
                 experts_output = self._merge_shared_expert_output(
                     hidden_states, experts_output, shared_expert_output
                 )

--- a/rtp_llm/models_py/model_desc/test/BUILD
+++ b/rtp_llm/models_py/model_desc/test/BUILD
@@ -1,3 +1,32 @@
+py_test_deps = [
+    "//rtp_llm/models_py/standalone:py_standalone_testlib",
+]
+
+py_test(
+    name = "generic_moe_allreduce_test",
+    srcs = ["generic_moe_allreduce_test.py"],
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)
+
+py_test(
+    name = "generic_moe_allreduce_test_rocm",
+    srcs = ["generic_moe_allreduce_test.py"],
+    main = "generic_moe_allreduce_test.py",
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)
+
 py_test(
     name = "attention_input_routing_test",
     srcs = ["attention_input_routing_test.py"],

--- a/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
+++ b/rtp_llm/models_py/model_desc/test/generic_moe_allreduce_test.py
@@ -1,0 +1,235 @@
+"""CPU contract tests for GenericMoeLayer's unified TP all-reduce path."""
+
+from types import SimpleNamespace
+from unittest import TestCase, main
+from unittest.mock import MagicMock, Mock, patch
+
+import torch
+
+from rtp_llm.models_py.distributed.collective_torch import Group
+from rtp_llm.models_py.model_desc.generic_moe import GenericMoeLayer
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import FusedMoe
+from rtp_llm.models_py.modules.hybrid.dense_mlp import DenseMLP
+from rtp_llm.utils.model_weight import W
+
+
+def _make_layer(
+    *,
+    supports_skip_tp_allreduce=True,
+    ffn_tp_size=2,
+    attn_tp_size=2,
+    ep_size=1,
+    moe_style=2,
+    with_shared_expert_gate=False,
+):
+    config = SimpleNamespace(
+        hidden_size=8,
+        inter_size=16,
+        expert_num=4,
+        moe_k=2,
+        quant_config=None,
+        activation_type="SiGLU",
+        moe_style=moe_style,
+        eplb_config=SimpleNamespace(phy_exp_num=lambda count: count),
+    )
+    parallelism_config = SimpleNamespace(
+        ep_size=ep_size,
+        dp_rank=0,
+        dp_size=1,
+        get_ffn_tp_size=lambda: ffn_tp_size,
+        get_attn_tp_size=lambda: attn_tp_size,
+    )
+    moe_config = SimpleNamespace(fake_balance_expert=False)
+    weights = {
+        W.moe_w1: torch.empty(4, 2, 8),
+        W.moe_w2: torch.empty(4, 8, 2),
+    }
+    if with_shared_expert_gate:
+        weights[W.shared_expert_gate] = torch.empty(8, 1)
+    fused_moe = SimpleNamespace(
+        topk_ids_dtype=torch.int32,
+        router=SimpleNamespace(
+            supports_skip_tp_allreduce=supports_skip_tp_allreduce,
+            tp_collective_size=attn_tp_size,
+        ),
+    )
+
+    with (
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.LinearFactory.create_linear_from_weights",
+            return_value=Mock(),
+        ),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.SelectTopk",
+            return_value=Mock(),
+        ),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.DenseMLP",
+            return_value=Mock(),
+        ),
+        patch("rtp_llm.models_py.model_desc.generic_moe.MoEConfigAdapter"),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.FusedMoeFactory"
+        ) as fused_moe_factory,
+    ):
+        fused_moe_factory.return_value.create_fused_moe.return_value = fused_moe
+        return GenericMoeLayer(config, parallelism_config, weights, moe_config)
+
+
+def _configure_forward(layer, *, gate_enabled=False):
+    hidden_states = torch.randn(4, 8)
+    routed_output = torch.randn_like(hidden_states)
+    shared_output = torch.randn_like(hidden_states)
+    gate_output = torch.full((4, 1), 2.0)
+
+    layer.gate = Mock(return_value=torch.zeros(4, 4))
+    layer.select_topk = Mock(
+        side_effect=lambda logits, topk_ids, topk_weights: (
+            topk_ids.zero_(),
+            topk_weights.fill_(0.5),
+        )
+    )
+    fused_moe = MagicMock(spec=FusedMoe, return_value=routed_output)
+    fused_moe.topk_ids_dtype = torch.int32
+    layer.fused_moe = fused_moe
+    layer.shared_expert = MagicMock(spec=DenseMLP, return_value=shared_output)
+    if gate_enabled:
+        layer.shared_expert_gate = Mock(return_value=gate_output)
+        layer.sigmoid_gate_scale_add = Mock(
+            side_effect=lambda gate, shared, output: output.add_(
+                torch.sigmoid(gate) * shared
+            )
+        )
+    else:
+        layer.shared_expert_gate = None
+        layer.sigmoid_gate_scale_add = None
+    layer.correction_bias = None
+    return hidden_states, routed_output, shared_output, gate_output, fused_moe
+
+
+class GenericMoeInitializationTest(TestCase):
+    def test_unified_decision_covers_all_predicate_terms(self):
+        cases = (
+            ("pure_tp_shared_supported", True, 2, 1, 2, True),
+            ("ffn_tp_one", True, 1, 1, 2, False),
+            ("ep_mode", True, 2, 2, 2, False),
+            ("no_shared_expert", True, 2, 1, 1, False),
+            ("unsupported_router", False, 2, 1, 2, False),
+        )
+        for name, supports, ffn_tp, ep_size, moe_style, expected in cases:
+            with self.subTest(name=name):
+                layer = _make_layer(
+                    supports_skip_tp_allreduce=supports,
+                    ffn_tp_size=ffn_tp,
+                    ep_size=ep_size,
+                    moe_style=moe_style,
+                )
+                self.assertEqual(layer.use_unified_tp_allreduce, expected)
+
+    def test_router_tp_size_is_part_of_the_constructor_contract(self):
+        self.assertFalse(
+            _make_layer(ffn_tp_size=4, attn_tp_size=2).use_unified_tp_allreduce
+        )
+        self.assertFalse(
+            _make_layer(ffn_tp_size=2, attn_tp_size=4).use_unified_tp_allreduce
+        )
+        self.assertTrue(
+            _make_layer(ffn_tp_size=2, attn_tp_size=2).use_unified_tp_allreduce
+        )
+
+    def test_shared_expert_gate_is_assembled_by_init(self):
+        layer = _make_layer(with_shared_expert_gate=True)
+        self.assertIsNotNone(layer.shared_expert_gate)
+        self.assertIsNotNone(layer.sigmoid_gate_scale_add)
+        self.assertTrue(layer.use_unified_tp_allreduce)
+
+
+class GenericMoeUnifiedAllreduceTest(TestCase):
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_pure_tp_combines_partial_outputs_before_reduce(self, mock_all_reduce):
+        layer = _make_layer()
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+        expected_input = routed_output + shared_output
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        mock_all_reduce.assert_called_once()
+        reduce_input = mock_all_reduce.call_args.args[0]
+        self.assertIs(mock_all_reduce.call_args.kwargs["group"], Group.TP)
+        torch.testing.assert_close(reduce_input, expected_input)
+        torch.testing.assert_close(result, expected_input * 2)
+        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_pure_tp_gate_is_merged_in_place_before_reduce(self, mock_all_reduce):
+        layer = _make_layer()
+        hidden_states, routed_output, shared_output, gate_output, fused_moe = (
+            _configure_forward(layer, gate_enabled=True)
+        )
+        expected_input = routed_output.clone()
+        expected_input.add_(torch.sigmoid(gate_output) * shared_output)
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        reduce_input = mock_all_reduce.call_args.args[0]
+        self.assertIs(reduce_input, routed_output)
+        self.assertIs(layer.shared_expert_gate.call_args.args[0], hidden_states)
+        torch.testing.assert_close(reduce_input, expected_input)
+        torch.testing.assert_close(result, expected_input * 2)
+        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ep_reduces_shared_output_only(self, mock_all_reduce):
+        layer = _make_layer(ep_size=2)
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        reduce_input = mock_all_reduce.call_args.args[0]
+        torch.testing.assert_close(reduce_input, shared_output)
+        torch.testing.assert_close(result, routed_output + shared_output * 2)
+        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ep_gate_is_applied_before_shared_reduce(self, mock_all_reduce):
+        layer = _make_layer(ep_size=2)
+        hidden_states, routed_output, shared_output, gate_output, fused_moe = (
+            _configure_forward(layer, gate_enabled=True)
+        )
+        expected_shared = torch.sigmoid(gate_output) * shared_output
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        reduce_input = mock_all_reduce.call_args.args[0]
+        self.assertIsNot(reduce_input, routed_output)
+        torch.testing.assert_close(reduce_input, expected_shared)
+        torch.testing.assert_close(result, routed_output + expected_shared * 2)
+        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ffn_tp_one_does_not_add_collective(self, mock_all_reduce):
+        layer = _make_layer(ffn_tp_size=1)
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+
+        result = layer(hidden_states)
+
+        mock_all_reduce.assert_not_called()
+        torch.testing.assert_close(result, routed_output + shared_output)
+        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertFalse(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
@@ -1,6 +1,18 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, final
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+    final,
+)
 
 import torch
 
@@ -15,7 +27,15 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.type import (
     RouterType,
 )
 
-SKIP_TP_ALLREDUCE_ARG = "skip_tp_allreduce"
+SKIP_TP_ALLREDUCE_ARG: Final[Literal["skip_tp_allreduce"]] = "skip_tp_allreduce"
+
+
+class FinalizeArgs(TypedDict, total=False):
+    """Private, optional arguments passed from ``FusedMoe`` to routers."""
+
+    a1_shape: torch.Size
+    original_num_tokens: int
+    skip_tp_allreduce: bool
 
 
 @dataclass
@@ -54,7 +74,7 @@ class CombineForwardPayload:
 
 
 def should_skip_tp_allreduce(
-    extra_finalize_args: Optional[Dict[str, Any]],
+    extra_finalize_args: Optional[FinalizeArgs],
 ) -> bool:
     """Return whether a pure-TP router should leave reduction to its caller.
 
@@ -84,6 +104,15 @@ class FusedMoeDataRouter(ABC):
         """
         self.config = config
         self.quant_config = quant_config
+        # Keep the legacy field for router-local logic. Callers that need the
+        # size of the Group.TP collective must use tp_collective_size below.
+        self.tp_size = config.tp_size
+
+    @property
+    def tp_collective_size(self) -> int:
+        """Return the TP size used by this router's Group.TP collective."""
+
+        return self.config.tp_size
 
     @classmethod
     def router_type(cls) -> RouterType:
@@ -91,6 +120,11 @@ class FusedMoeDataRouter(ABC):
 
     @property
     def supports_skip_tp_allreduce(self) -> bool:
+        """Whether ``finalize`` consumes ``skip_tp_allreduce``.
+
+        A router must only override this capability when its finalize path
+        delegates to the shared skip decision (or an equivalent implementation).
+        """
         return False
 
     @classmethod
@@ -123,7 +157,7 @@ class FusedMoeDataRouter(ABC):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         raise NotImplementedError
 
@@ -208,7 +242,7 @@ class FusedMoe(torch.nn.Module):
         a2_scale: Optional[torch.Tensor] = None,
         apply_router_weight_on_input: bool = False,
         extra_expert_args: Optional[Dict[str, Any]] = None,
-        extra_finalize_args: Optional[Dict[str, Any]] = None,
+        extra_finalize_args: Optional[FinalizeArgs] = None,
         skip_tp_allreduce: bool = False,
     ) -> torch.Tensor:
 
@@ -255,16 +289,18 @@ class FusedMoe(torch.nn.Module):
                 extra_expert_args=extra_expert_args,
             )
 
-        # pass a1.shape to finalize for shape check
-        if extra_finalize_args is None:
-            extra_finalize_args = {"a1_shape": a1.shape}
-        else:
-            extra_finalize_args.update({"a1_shape": a1.shape})
+        # Finalize arguments are a private per-call protocol. Copy caller
+        # input before adding derived values so a reusable dict cannot retain
+        # state from a previous forward.
+        finalize_args: FinalizeArgs = {
+            **(extra_finalize_args or {}),
+            "a1_shape": a1.shape,
+        }
 
         # Pure-TP routers normally reduce their routed output in finalize().
         # GenericMoeLayer can set this flag to combine routed and shared-expert
         # partial outputs first, reducing the number of small TP collectives.
-        extra_finalize_args.update(
+        finalize_args.update(
             {
                 "original_num_tokens": hidden_states.size(0),
                 SKIP_TP_ALLREDUCE_ARG: skip_tp_allreduce,
@@ -276,7 +312,7 @@ class FusedMoe(torch.nn.Module):
             expert_payload.expert_topk_weights,
             expert_payload.expert_topk_ids,
             apply_router_weight_on_input,
-            extra_finalize_args,
+            finalize_args,
         )
 
         assert (

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
@@ -15,6 +15,8 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.type import (
     RouterType,
 )
 
+SKIP_TP_ALLREDUCE_ARG = "skip_tp_allreduce"
+
 
 @dataclass
 class ExpertTokensMetadata:
@@ -51,6 +53,23 @@ class CombineForwardPayload:
     fused_expert_output: torch.Tensor
 
 
+def should_skip_tp_allreduce(
+    extra_finalize_args: Optional[Dict[str, Any]],
+) -> bool:
+    """Return whether a pure-TP router should leave reduction to its caller.
+
+    GenericMoeLayer uses this internal finalize argument when it combines the
+    routed and shared-expert partial outputs before issuing one TP all-reduce.
+    Keeping the flag in ``extra_finalize_args`` avoids changing the finalize
+    interface for routers that do not use TP all-reduce.
+    """
+
+    return bool(
+        extra_finalize_args is not None
+        and extra_finalize_args.get(SKIP_TP_ALLREDUCE_ARG, False)
+    )
+
+
 class FusedMoeDataRouter(ABC):
     def __init__(
         self,
@@ -69,6 +88,10 @@ class FusedMoeDataRouter(ABC):
     @classmethod
     def router_type(cls) -> RouterType:
         raise NotImplementedError
+
+    @property
+    def supports_skip_tp_allreduce(self) -> bool:
+        return False
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
@@ -186,7 +209,14 @@ class FusedMoe(torch.nn.Module):
         apply_router_weight_on_input: bool = False,
         extra_expert_args: Optional[Dict[str, Any]] = None,
         extra_finalize_args: Optional[Dict[str, Any]] = None,
+        skip_tp_allreduce: bool = False,
     ) -> torch.Tensor:
+
+        if skip_tp_allreduce and not self.router.supports_skip_tp_allreduce:
+            raise ValueError(
+                "skip_tp_allreduce is only supported by routers that "
+                "advertise supports_skip_tp_allreduce"
+            )
 
         a1 = hidden_states
 
@@ -231,7 +261,15 @@ class FusedMoe(torch.nn.Module):
         else:
             extra_finalize_args.update({"a1_shape": a1.shape})
 
-        extra_finalize_args.update({"original_num_tokens": hidden_states.size(0)})
+        # Pure-TP routers normally reduce their routed output in finalize().
+        # GenericMoeLayer can set this flag to combine routed and shared-expert
+        # partial outputs first, reducing the number of small TP collectives.
+        extra_finalize_args.update(
+            {
+                "original_num_tokens": hidden_states.size(0),
+                SKIP_TP_ALLREDUCE_ARG: skip_tp_allreduce,
+            }
+        )
 
         output = self.router.finalize(
             combine_payload,

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/test/BUILD
@@ -1,15 +1,32 @@
-# The test uses CPU tensors and mocked collectives, but importing FusedMoe
-# traverses the device-dispatch package and loads librtp_compute_ops. Schedule
-# it on the CUDA test image so the runtime dependency is present.
+py_test_deps = [
+    "//rtp_llm/models_py/standalone:py_standalone_testlib",
+]
+
+# The test uses CPU tensors and mocked collectives, but importing
+# models_py.modules reaches the compiled librtp_compute_ops module.  Run it on
+# accelerator images that provide that dependency instead of claiming that a
+# default CPU runner can import it safely.
 py_test(
     name = "fused_moe_allreduce_contract_test",
     srcs = ["fused_moe_allreduce_contract_test.py"],
-    deps = [
-        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    deps = py_test_deps + [
         "//rtp_llm/models_py:models",
         "//rtp_llm:config",
-        "//rtp_llm:testlib",
     ],
+    env = {"GPU_COUNT": "1"},
     tags = ["H20"],
-    exec_properties = {'gpu': 'H20'},
+    exec_properties = {'gpu':'H20', 'gpu_count':'1'},
+)
+
+py_test(
+    name = "fused_moe_allreduce_contract_test_rocm",
+    srcs = ["fused_moe_allreduce_contract_test.py"],
+    main = "fused_moe_allreduce_contract_test.py",
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'1'},
 )

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/test/BUILD
@@ -1,0 +1,15 @@
+# The test uses CPU tensors and mocked collectives, but importing FusedMoe
+# traverses the device-dispatch package and loads librtp_compute_ops. Schedule
+# it on the CUDA test image so the runtime dependency is present.
+py_test(
+    name = "fused_moe_allreduce_contract_test",
+    srcs = ["fused_moe_allreduce_contract_test.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+        "//rtp_llm:testlib",
+    ],
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20'},
+)

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
@@ -1,0 +1,136 @@
+"""Platform-neutral FusedMoe TP all-reduce contract tests."""
+
+from unittest import TestCase, main
+from unittest.mock import Mock
+
+import torch
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    SKIP_TP_ALLREDUCE_ARG,
+    CombineForwardPayload,
+    ExpertForwardPayload,
+    FusedMoe,
+    FusedMoeDataRouter,
+    FusedMoeExpertExecutor,
+)
+
+
+def _extract_extra_finalize_args(router_finalize_mock):
+    kwargs = router_finalize_mock.call_args.kwargs
+    if "extra_finalize_args" in kwargs:
+        return kwargs["extra_finalize_args"]
+    args = router_finalize_mock.call_args.args
+    if not args:
+        raise AssertionError("router.finalize did not receive finalize arguments")
+    return args[-1]
+
+
+class FusedMoeSkipAllreduceTest(TestCase):
+    def _make_fused_moe(self, supports_skip):
+        hidden_states = torch.randn(4, 8)
+        topk_ids = torch.zeros(4, 2, dtype=torch.int32)
+        topk_weights = torch.ones(4, 2, dtype=torch.float32)
+
+        router = Mock(spec=FusedMoeDataRouter)
+        router.supports_skip_tp_allreduce = supports_skip
+        router.prepare.return_value = ExpertForwardPayload(
+            expert_x=hidden_states,
+            expert_topk_ids=topk_ids,
+            expert_topk_weights=topk_weights,
+        )
+        experts = Mock(spec=FusedMoeExpertExecutor)
+        experts.execute.return_value = CombineForwardPayload(
+            fused_expert_output=hidden_states.clone()
+        )
+        router.finalize.return_value = hidden_states.clone()
+        return (
+            FusedMoe(router, experts, expert_num=8),
+            router,
+            experts,
+            hidden_states,
+            topk_weights,
+            topk_ids,
+        )
+
+    def test_forward_passes_skip_tp_allreduce_to_supported_router(self):
+        fused_moe, router, _, hidden_states, topk_weights, topk_ids = (
+            self._make_fused_moe(True)
+        )
+        fused_moe(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            skip_tp_allreduce=True,
+        )
+
+        extra_finalize_args = _extract_extra_finalize_args(router.finalize)
+        self.assertTrue(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+
+    def test_forward_defaults_skip_tp_allreduce_false_for_all_routers(self):
+        for supports_skip in (True, False):
+            with self.subTest(supports_skip=supports_skip):
+                fused_moe, router, _, hidden_states, topk_weights, topk_ids = (
+                    self._make_fused_moe(supports_skip)
+                )
+                fused_moe(
+                    hidden_states=hidden_states,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+
+                extra_finalize_args = _extract_extra_finalize_args(router.finalize)
+                self.assertFalse(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+
+    def test_forward_overrides_conflicting_finalize_skip_key(self):
+        fused_moe, router, _, hidden_states, topk_weights, topk_ids = (
+            self._make_fused_moe(True)
+        )
+        extra_finalize_args = {SKIP_TP_ALLREDUCE_ARG: True}
+        fused_moe(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            extra_finalize_args=extra_finalize_args,
+            skip_tp_allreduce=False,
+        )
+
+        self.assertFalse(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+        self.assertFalse(
+            _extract_extra_finalize_args(router.finalize)[SKIP_TP_ALLREDUCE_ARG]
+        )
+
+    def test_unsupported_router_cannot_be_bypassed_by_finalize_key(self):
+        fused_moe, router, experts, hidden_states, topk_weights, topk_ids = (
+            self._make_fused_moe(False)
+        )
+        extra_finalize_args = {SKIP_TP_ALLREDUCE_ARG: True}
+        fused_moe(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            extra_finalize_args=extra_finalize_args,
+            skip_tp_allreduce=False,
+        )
+
+        self.assertFalse(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+        router.prepare.assert_called_once()
+        experts.execute.assert_called_once()
+
+    def test_forward_rejects_skip_tp_allreduce_for_unsupported_router(self):
+        fused_moe, router, experts, hidden_states, topk_weights, topk_ids = (
+            self._make_fused_moe(False)
+        )
+        with self.assertRaisesRegex(ValueError, "supports_skip_tp_allreduce"):
+            fused_moe(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                skip_tp_allreduce=True,
+            )
+
+        router.prepare.assert_not_called()
+        experts.execute.assert_not_called()
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
@@ -16,13 +16,12 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
 
 
 def _extract_extra_finalize_args(router_finalize_mock):
-    kwargs = router_finalize_mock.call_args.kwargs
-    if "extra_finalize_args" in kwargs:
-        return kwargs["extra_finalize_args"]
     args = router_finalize_mock.call_args.args
-    if not args:
-        raise AssertionError("router.finalize did not receive finalize arguments")
-    return args[-1]
+    if len(args) != 5:
+        raise AssertionError(
+            "router.finalize must receive the five positional finalize arguments"
+        )
+    return args[4]
 
 
 class FusedMoeSkipAllreduceTest(TestCase):
@@ -94,7 +93,7 @@ class FusedMoeSkipAllreduceTest(TestCase):
             skip_tp_allreduce=False,
         )
 
-        self.assertFalse(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+        self.assertTrue(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
         self.assertFalse(
             _extract_extra_finalize_args(router.finalize)[SKIP_TP_ALLREDUCE_ARG]
         )
@@ -112,9 +111,12 @@ class FusedMoeSkipAllreduceTest(TestCase):
             skip_tp_allreduce=False,
         )
 
-        self.assertFalse(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
+        self.assertTrue(extra_finalize_args[SKIP_TP_ALLREDUCE_ARG])
         router.prepare.assert_called_once()
         experts.execute.assert_called_once()
+        self.assertFalse(
+            _extract_extra_finalize_args(router.finalize)[SKIP_TP_ALLREDUCE_ARG]
+        )
 
     def test_forward_rejects_skip_tp_allreduce_for_unsupported_router(self):
         fused_moe, router, experts, hidden_states, topk_weights, topk_ids = (

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
@@ -12,6 +12,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -72,6 +73,14 @@ class TopKWeightAndReduceNaiveBatched(object):
 
 
 class BatchedDataRouter(FusedMoeDataRouter):
+    """Router for the batched expert-output layout.
+
+    This router intentionally retains its own TP all-reduce in ``finalize``.
+    Its batched combine contract is not the pure-TP partial-output contract
+    required by GenericMoeLayer's unified shared-expert reduction, so it does
+    not advertise deferred TP all-reduce support.
+    """
+
     @classmethod
     def router_type(cls):
         return RouterType.BATCHED_DATA
@@ -164,7 +173,7 @@ class BatchedDataRouter(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         weight_and_reduce_impl = TopKWeightAndReduceNaiveBatched(self.ep_rank)
         output = weight_and_reduce_impl.apply(

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_low_latency_router.py
@@ -17,6 +17,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -248,12 +249,12 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
     def _finalize_post_tp_gather(
         self,
         combined_x: torch.Tensor,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         """Finalize post tp gather for DeepEP Low-Latency.
         Args:
             combined_x (torch.Tensor): Combined output from all tp ranks.
-            extra_finalize_args (Optional[Dict[str, Any]]): Extra finalize arguments.
+            extra_finalize_args (Optional[FinalizeArgs]): Extra finalize arguments.
         """
         # Check input data
         assert combined_x.dim() == 2
@@ -286,7 +287,7 @@ class DeepEpLowLatencyRouter(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         """
         Combines expert outputs back to all original ranks.

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
@@ -20,6 +20,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -196,7 +197,7 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         assert self.handle is not None, "handler is None"
         assert payload.fused_expert_output is not None, "fused_expert_output is None"

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_cp_router.py
@@ -13,7 +13,7 @@ Shared expert handling is done at the layer level, not in this router.
 """
 
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 
@@ -23,9 +23,7 @@ from rtp_llm.models_py.distributed.collective_torch import (
     reduce_scatter,
 )
 from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import is_deep_gemm_e8m0_used
-from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
-    sgl_per_token_group_quant_fp8,
-)
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -33,6 +31,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -137,7 +136,7 @@ class PureCpRouterBase(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         return reduce_scatter(payload.fused_expert_output, group=Group.TP)
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_dp_router.py
@@ -16,7 +16,7 @@ trims the output after reduce_scatter.
 """
 
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -27,9 +27,7 @@ from rtp_llm.models_py.distributed.collective_torch import (
     reduce_scatter,
 )
 from rtp_llm.models_py.kernels.cuda.deepgemm_wrapper import is_deep_gemm_e8m0_used
-from rtp_llm.models_py.kernels.cuda.fp8_kernel import (
-    sgl_per_token_group_quant_fp8,
-)
+from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -37,6 +35,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -171,7 +170,7 @@ class PureDpRouterBase(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         # Read the local batch size from extra_finalize_args (injected by
         # FusedMoeDataRouter.forward as original_num_tokens) instead of relying

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
@@ -17,6 +17,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     ExpertForwardPayload,
     ExpertTokensMetadata,
     FusedMoeDataRouter,
+    should_skip_tp_allreduce,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
     FusedMoEQuantConfig,
@@ -41,6 +42,10 @@ class PureTpRouterBase(FusedMoeDataRouter):
     @classmethod
     def router_type(cls):
         return RouterType.PURE_TP
+
+    @property
+    def supports_skip_tp_allreduce(self) -> bool:
+        return True
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
@@ -118,7 +123,7 @@ class PureTpRouterBase(FusedMoeDataRouter):
         extra_finalize_args: Optional[dict[str, Any]],
     ) -> torch.Tensor:
         fused_expert_output = payload.fused_expert_output
-        if self.tp_size > 1:
+        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
             fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
         return fused_expert_output
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/pure_tp_router.py
@@ -16,6 +16,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
     should_skip_tp_allreduce,
 )
@@ -47,10 +48,21 @@ class PureTpRouterBase(FusedMoeDataRouter):
     def supports_skip_tp_allreduce(self) -> bool:
         return True
 
+    def _maybe_all_reduce_tp(
+        self, output: torch.Tensor, extra_finalize_args: Optional[FinalizeArgs]
+    ) -> torch.Tensor:
+        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
+            return all_reduce(output, group=Group.TP)
+        return output
+
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
         """Check if PureTpRouter can handle the configuration"""
         resolver = MoeConfigResolver()
+        # Keep the existing CUDA strategy coverage for EP-equivalent layouts.
+        # The unified TP all-reduce optimization is independently restricted to
+        # ep_size == 1 in GenericMoeLayer, so this router selection predicate
+        # must not narrow the pre-existing CUDA policy here.
         checker.check(resolver.is_single_gpu(config) or resolver.is_tp_equal_ep(config))
         checker.check(resolver.use_all_gather(config))
 
@@ -120,12 +132,11 @@ class PureTpRouterBase(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
-        fused_expert_output = payload.fused_expert_output
-        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
-            fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
-        return fused_expert_output
+        return self._maybe_all_reduce_tp(
+            payload.fused_expert_output, extra_finalize_args
+        )
 
 
 class PureTpRouterNoQuant(PureTpRouterBase):

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
@@ -1,9 +1,12 @@
+py_test_deps = [
+    "//rtp_llm/models_py/standalone:py_standalone_testlib",
+]
+
 py_test(
     name = "deepep_normal_router_test",
     srcs = ["deepep_normal_router_test.py"],
-    deps = [
-        "//rtp_llm/models_py/standalone:py_standalone_testlib",
-        "//rtp_llm/models_py/distributed:collective_torch"
+    deps = py_test_deps + [
+        "//rtp_llm/models_py/distributed:collective_torch",
     ],
     env = {"GPU_COUNT": "2"},
     tags = ["open_skip", "H20"],
@@ -13,11 +16,20 @@ py_test(
 py_test (
     name = "deepep_low_latency_router_test",
     srcs = ["deepep_low_latency_router_test.py"],
-    deps = [
-        "//rtp_llm/models_py/standalone:py_standalone_testlib",
-        "//rtp_llm/models_py/distributed:collective_torch"
+    deps = py_test_deps + [
+        "//rtp_llm/models_py/distributed:collective_torch",
     ],
     env = {"GPU_COUNT": "2"},
     tags = ["open_skip", "H20"],
     exec_properties = {'gpu':'H20', 'gpu_count':'2'},
+)
+
+py_test (
+    name = "pure_tp_router_skip_allreduce_test",
+    srcs = ["pure_tp_router_skip_allreduce_test.py"],
+    deps = py_test_deps,
+    # The CUDA router imports librtp_compute_ops, so this CPU-tensor contract
+    # test still runs in the CUDA image where the runtime library is present.
+    tags = ["H20"],
+    exec_properties = {'gpu':'H20'},
 )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/pure_tp_router_skip_allreduce_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/pure_tp_router_skip_allreduce_test.py
@@ -1,0 +1,107 @@
+"""CUDA Pure TP router contract tests for deferred TP all-reduce."""
+
+from unittest import TestCase, main
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.distributed.collective_torch import Group
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    SKIP_TP_ALLREDUCE_ARG,
+    CombineForwardPayload,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.pure_tp_router import (
+    PureTpRouterNoQuant,
+)
+from rtp_llm.ops import MoeConfig, ParallelismConfig
+
+
+def _make_router(tp_size=2):
+    model_config = ModelConfig()
+    model_config.expert_num = 8
+    model_config.moe_k = 2
+    parallelism_config = ParallelismConfig()
+    parallelism_config.tp_size = tp_size
+    parallelism_config.tp_rank = 0
+    parallelism_config.ep_size = 1
+    parallelism_config.ep_rank = 0
+    parallelism_config.dp_size = 1
+    parallelism_config.dp_rank = 0
+    parallelism_config.world_size = tp_size
+    parallelism_config.world_rank = 0
+    parallelism_config.local_rank = 0
+    parallelism_config.local_world_size = tp_size
+    moe_config = MoeConfig()
+    moe_config.use_all_gather = True
+    config = MoEConfigAdapter(
+        model_config=model_config,
+        parallelism_config=parallelism_config,
+        moe_config=moe_config,
+    )
+    return PureTpRouterNoQuant(config, FusedMoEQuantConfig())
+
+
+class PureTpRouterSkipAllreduceTest(TestCase):
+    def test_pure_tp_router_declares_deferred_reduce_support(self):
+        self.assertTrue(_make_router().supports_skip_tp_allreduce)
+
+    @patch(
+        "rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.pure_tp_router.all_reduce"
+    )
+    def test_finalize_reduction_matrix(self, mock_all_reduce):
+        cases = (
+            (1, None, False),
+            (2, None, True),
+            (2, {SKIP_TP_ALLREDUCE_ARG: False}, True),
+            (2, {SKIP_TP_ALLREDUCE_ARG: True}, False),
+            (1, {SKIP_TP_ALLREDUCE_ARG: True}, False),
+        )
+        for tp_size, extra_finalize_args, expect_all_reduce in cases:
+            with self.subTest(
+                tp_size=tp_size,
+                extra_finalize_args=extra_finalize_args,
+                expect_all_reduce=expect_all_reduce,
+            ):
+                mock_all_reduce.reset_mock()
+                router = _make_router(tp_size=tp_size)
+                expert_output = torch.randn(4, 8)
+                reduced_output = torch.full_like(expert_output, 3.0)
+                mock_all_reduce.return_value = reduced_output
+                if extra_finalize_args is None:
+                    extra_finalize_args = {
+                        "a1_shape": expert_output.shape,
+                        "original_num_tokens": expert_output.shape[0],
+                    }
+                else:
+                    extra_finalize_args = {
+                        "a1_shape": expert_output.shape,
+                        "original_num_tokens": expert_output.shape[0],
+                        **extra_finalize_args,
+                    }
+                result = router.finalize(
+                    payload=CombineForwardPayload(fused_expert_output=expert_output),
+                    topk_weights=torch.ones(4, 2),
+                    topk_ids=torch.zeros(4, 2, dtype=torch.int32),
+                    apply_router_weight_on_input=False,
+                    extra_finalize_args=extra_finalize_args,
+                )
+
+                if expect_all_reduce:
+                    mock_all_reduce.assert_called_once()
+                    self.assertIs(mock_all_reduce.call_args.kwargs["group"], Group.TP)
+                    self.assertIs(mock_all_reduce.call_args.args[0], expert_output)
+                    self.assertIs(result, reduced_output)
+                else:
+                    mock_all_reduce.assert_not_called()
+                    self.assertIs(result, expert_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/deepep_normal_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 
@@ -13,6 +13,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -130,7 +131,7 @@ class DeepepNormalRouter(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         assert self.handle is not None, "handler is None"
         recv_x, _, event = self.deepep_buffer_wrapper.buffer.combine(

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/mori_ep_intranode_router.py
@@ -11,6 +11,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
@@ -73,7 +74,9 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
 
         local_start = self.ep_rank * self.expert_num_per_rank
         local_end = local_start + self.expert_num_per_rank
-        return remap_to_local_ids(dispatch_ids, dispatch_weights, local_start, local_end)
+        return remap_to_local_ids(
+            dispatch_ids, dispatch_weights, local_start, local_end
+        )
 
     def prepare(
         self,
@@ -214,7 +217,7 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         logging.info(
             f"[MoriEpIntranodeRouter] finalize called, ep_rank={self.ep_rank}, chunked={self._is_chunked}"
@@ -228,7 +231,7 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
     def _finalize_single(
         self,
         fused_out: torch.Tensor,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         # Use the cached global dispatch_ids for combine, not the local_ids
         # that were set as expert_topk_ids for the fused_moe kernel.
@@ -253,7 +256,7 @@ class MoriEpIntranodeRouter(FusedMoeDataRouter):
     def _finalize_chunked(
         self,
         fused_out: torch.Tensor,
-        extra_finalize_args: Optional[Dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
         results = []
         offset = 0

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
@@ -5,10 +5,7 @@ import aiter
 import torch
 
 from rtp_llm.device.device_impl import is_gfx950
-from rtp_llm.models_py.distributed.collective_torch import (
-    Group,
-    all_reduce,
-)
+from rtp_llm.models_py.distributed.collective_torch import Group, all_reduce
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -17,6 +14,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     ExpertForwardPayload,
     ExpertTokensMetadata,
     FusedMoeDataRouter,
+    should_skip_tp_allreduce,
 )
 from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
     FusedMoEQuantConfig,
@@ -40,6 +38,10 @@ class PureTpRouterBase(FusedMoeDataRouter):
     @classmethod
     def router_type(cls):
         return RouterType.PURE_TP
+
+    @property
+    def supports_skip_tp_allreduce(self) -> bool:
+        return True
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
@@ -125,7 +127,7 @@ class PureTpRouterBase(FusedMoeDataRouter):
         extra_finalize_args: Optional[dict[str, Any]],
     ) -> torch.Tensor:
         fused_expert_output = payload.fused_expert_output
-        if self.tp_size > 1:
+        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
             fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
         return fused_expert_output
 
@@ -181,18 +183,6 @@ class PureTpRouterFusedQuant(PureTpRouterBase):
         """Pass through BF16 without quantization; fused_moe handles quantization internally."""
         return a1, None
 
-    def finalize(
-        self,
-        payload: CombineForwardPayload,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[dict[str, Any]],
-    ) -> torch.Tensor:
-        fused_expert_output = payload.fused_expert_output
-        if self.tp_size > 1:
-            fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
-        return fused_expert_output
 
 class PureTpRouterFp8PerBlockPassthrough(PureTpRouterBase):
     """Pure TP router for FP8 PerBlock: accepts FP8_PER_BLOCK quant but passes through BF16 without quantization (executor handles quantization internally)."""
@@ -216,6 +206,7 @@ class PureTpRouterFp8PerBlockPassthrough(PureTpRouterBase):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return a1, None
 
+
 class PureTpRouterMXFp4Passthrough(PureTpRouterBase):
     """Pure TP router for the MXFP4 passthrough path."""
 
@@ -233,7 +224,7 @@ class PureTpRouterMXFp4Passthrough(PureTpRouterBase):
         quant_method = resolver.get_quant_method(config)
         checker.check(quant_method == "QuarkMXFP4")
         checker.check(is_gfx950())
-        
+
     def _do_quant(
         self, a1: torch.Tensor
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/routers/pure_tp_router.py
@@ -13,6 +13,7 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
     CombineForwardPayload,
     ExpertForwardPayload,
     ExpertTokensMetadata,
+    FinalizeArgs,
     FusedMoeDataRouter,
     should_skip_tp_allreduce,
 )
@@ -42,6 +43,13 @@ class PureTpRouterBase(FusedMoeDataRouter):
     @property
     def supports_skip_tp_allreduce(self) -> bool:
         return True
+
+    def _maybe_all_reduce_tp(
+        self, output: torch.Tensor, extra_finalize_args: Optional[FinalizeArgs]
+    ) -> torch.Tensor:
+        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
+            return all_reduce(output, group=Group.TP)
+        return output
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
@@ -124,12 +132,11 @@ class PureTpRouterBase(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
-        extra_finalize_args: Optional[dict[str, Any]],
+        extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
-        fused_expert_output = payload.fused_expert_output
-        if self.tp_size > 1 and not should_skip_tp_allreduce(extra_finalize_args):
-            fused_expert_output = all_reduce(fused_expert_output, group=Group.TP)
-        return fused_expert_output
+        return self._maybe_all_reduce_tp(
+            payload.fused_expert_output, extra_finalize_args
+        )
 
 
 class PureTpRouterNoQuant(PureTpRouterBase):

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/BUILD
@@ -37,6 +37,20 @@ py_test (
 )
 
 py_test (
+    name = "test_generic_moe_allreduce",
+    srcs = ["test_generic_moe_allreduce.py"],
+    deps = py_test_deps + [
+        "//rtp_llm/models_py:models",
+        "//rtp_llm:config",
+        "//rtp_llm:testlib",
+    ],
+    timeout = "eternal",
+    env = {"GPU_COUNT": "2"},
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
+)
+
+py_test (
     name = "rocm_fp8_fused_moe_test",
     srcs = ["rocm_fp8_fused_moe_test.py"],
     deps = [

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/moriep_intranode_router_test.py
@@ -237,6 +237,7 @@ class _MockMoEConfig:
     """Minimal mock satisfying MoriEpIntranodeRouter's config requirements."""
 
     def __init__(self, ep_size: int, ep_rank: int, expert_num: int):
+        self.tp_size = 1
         self.ep_size = ep_size
         self.ep_rank = ep_rank
         self.expert_num = expert_num

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
@@ -1,10 +1,9 @@
 """ROCm tests for GenericMoe unified TP all-reduce wiring."""
 
 import multiprocessing as mp
-import socket
-from types import SimpleNamespace
+import os
 from unittest import TestCase, main, skipUnless
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
@@ -24,13 +23,20 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers import (
 )
 from rtp_llm.models_py.modules.hybrid import dense_mlp as dense_mlp_module
 from rtp_llm.ops import ActivationType, MoeConfig, NcclCommConfig, ParallelismConfig
+from rtp_llm.test.utils.port_util import PortManager
 from rtp_llm.utils.model_weight import W
 
 
 class _FixedSelectTopk(nn.Module):
+    def __init__(self, expert_num):
+        super().__init__()
+        self.expert_num = expert_num
+
     def forward(self, logits, topk_ids, topk_weights):
-        topk_ids.zero_()
-        topk_weights.fill_(1.0)
+        token_ids = torch.arange(topk_ids.size(0), device=topk_ids.device)
+        for topk_idx in range(topk_ids.size(1)):
+            topk_ids[:, topk_idx] = (token_ids + topk_idx * 7) % self.expert_num
+        topk_weights.fill_(1.0 / topk_ids.size(1))
 
 
 class _ZeroRouterGate(nn.Module):
@@ -45,31 +51,6 @@ class _ZeroRouterGate(nn.Module):
             dtype=torch.float32,
             device=hidden_states.device,
         )
-
-
-class _SharedUpProjection(nn.Module):
-    def forward(self, hidden_states):
-        return torch.cat((hidden_states, hidden_states), dim=-1)
-
-
-class _SharedDownProjection(nn.Module):
-    def __init__(self, hidden_size):
-        super().__init__()
-        self.hidden_size = hidden_size
-
-    def forward(self, activated):
-        return activated[..., : self.hidden_size]
-
-
-class _SharedGateProjection(nn.Module):
-    def forward(self, hidden_states):
-        return hidden_states[..., :1]
-
-
-def _get_free_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
 
 
 def _make_real_parallelism(rank, world_size):
@@ -117,8 +98,8 @@ def _build_real_layer(rank, parallelism_config, with_gate):
             expert_num, hidden_size, inter_size, device=device, dtype=torch.bfloat16
         )
         * 0.02,
-        W.ffn_w13: torch.empty(1, device=device),
-        W.ffn_w2: torch.empty(1, device=device),
+        W.ffn_w13: torch.empty(hidden_size, 2 * inter_size, device=device),
+        W.ffn_w2: torch.empty(inter_size, hidden_size, device=device),
     }
     if with_gate:
         weights[W.shared_expert_gate] = torch.empty(1, device=device)
@@ -131,11 +112,32 @@ def _build_real_layer(rank, parallelism_config, with_gate):
         if weight_key == W.moe_gate:
             return _ZeroRouterGate(expert_num)
         if weight_key == W.ffn_w13:
-            return _SharedUpProjection()
+            torch.manual_seed(3000 + rank)
+            return nn.Linear(
+                hidden_size,
+                2 * inter_size,
+                bias=False,
+                device=device,
+                dtype=torch.bfloat16,
+            )
         if weight_key == W.ffn_w2:
-            return _SharedDownProjection(hidden_size)
+            torch.manual_seed(4000 + rank)
+            return nn.Linear(
+                inter_size,
+                hidden_size,
+                bias=False,
+                device=device,
+                dtype=torch.bfloat16,
+            )
         if weight_key == W.shared_expert_gate:
-            return _SharedGateProjection()
+            torch.manual_seed(5000)
+            return nn.Linear(
+                hidden_size,
+                1,
+                bias=False,
+                device=device,
+                dtype=torch.bfloat16,
+            )
         raise AssertionError(f"unexpected test linear weight key: {weight_key}")
 
     with patch(
@@ -149,16 +151,19 @@ def _build_real_layer(rank, parallelism_config, with_gate):
             moe_config,
         )
 
-    if type(layer.fused_moe.router).__name__ != "PureTpRouterNoQuant":
+    if type(layer.fused_moe.router) is not pure_tp_router_module.PureTpRouterNoQuant:
         raise AssertionError(
             "real TP integration test selected "
-            f"{type(layer.fused_moe.router).__name__}, expected PureTpRouterNoQuant"
+            f"{type(layer.fused_moe.router).__name__}, expected "
+            "the ROCm PureTpRouterNoQuant class"
         )
-    layer.select_topk = _FixedSelectTopk()
+    if not layer.use_unified_tp_allreduce:
+        raise AssertionError("real pure-TP layer did not enable unified all-reduce")
+    layer.select_topk = _FixedSelectTopk(expert_num)
     return layer
 
 
-def _run_real_two_gpu_case(rank, world_size, port, with_gate):
+def _run_real_two_gpu_case(rank, world_size, ports, with_gate):
     parallelism_config = _make_real_parallelism(rank, world_size)
     initialized = False
     try:
@@ -167,11 +172,11 @@ def _run_real_two_gpu_case(rank, world_size, port, with_gate):
             parallelism_config,
             NcclCommConfig(
                 nccl_ip="127.0.0.1",
-                tp_nccl_port=port + 1,
-                dp_tp_nccl_port=port + 2,
-                ffn_tp_nccl_port=port + 3,
+                tp_nccl_port=ports[1],
+                dp_tp_nccl_port=ports[2],
+                ffn_tp_nccl_port=ports[3],
             ),
-            nccl_init_port=port,
+            nccl_init_port=ports[0],
             backend="nccl",
             timeout=300,
         )
@@ -185,6 +190,12 @@ def _run_real_two_gpu_case(rank, world_size, port, with_gate):
             32, 512, device=torch.device(f"cuda:{rank}"), dtype=torch.bfloat16
         )
         dist.broadcast(hidden_states, src=0)
+        if with_gate:
+            gate_local = layer.shared_expert_gate(hidden_states)
+            gate_rank0 = gate_local.clone()
+            dist.broadcast(gate_rank0, src=0)
+            torch.testing.assert_close(gate_local, gate_rank0, rtol=0.0, atol=0.0)
+            dist.barrier()
         counts = {"all_reduce": 0}
 
         def counted_all_reduce(tensor, group):
@@ -205,12 +216,12 @@ def _run_real_two_gpu_case(rank, world_size, port, with_gate):
             ),
         ):
             layer.use_unified_tp_allreduce = True
-            unified_output = layer(hidden_states.clone())
+            unified_output = layer(hidden_states.clone()).detach().clone()
             unified_calls = counts["all_reduce"]
             dist.barrier()
 
             layer.use_unified_tp_allreduce = False
-            legacy_output = layer(hidden_states.clone())
+            legacy_output = layer(hidden_states.clone()).detach().clone()
             legacy_calls = counts["all_reduce"] - unified_calls
             dist.barrier()
 
@@ -225,6 +236,8 @@ def _run_real_two_gpu_case(rank, world_size, port, with_gate):
             rtol=2e-2,
             atol=2e-3,
         )
+        if unified_output is legacy_output:
+            raise AssertionError("unified and legacy outputs unexpectedly alias")
         if rank == 0:
             print(
                 f"[real_tp_unified] gate={with_gate} unified_calls={unified_calls} "
@@ -237,231 +250,59 @@ def _run_real_two_gpu_case(rank, world_size, port, with_gate):
 
 def _launch_real_two_gpu_case(with_gate):
     world_size = 2
-    port = _get_free_port()
+    ports, port_locks = PortManager().get_consecutive_ports(4)
     context = mp.get_context("spawn")
     processes = [
         context.Process(
             target=_run_real_two_gpu_case,
-            args=(rank, world_size, port, with_gate),
+            args=(rank, world_size, ports, with_gate),
             name=f"generic-moe-rank-{rank}",
         )
         for rank in range(world_size)
     ]
-    for process in processes:
-        process.start()
-    for process in processes:
-        process.join(timeout=300)
-    failed = [process for process in processes if process.exitcode != 0]
-    if failed:
+    try:
         for process in processes:
-            if process.is_alive():
-                process.terminate()
-        raise RuntimeError(
-            "real GenericMoe two-GPU worker failed: "
-            + ", ".join(
-                f"{process.name} exitcode={process.exitcode}" for process in failed
-            )
-        )
-
-
-def _make_layer(
-    *,
-    supports_skip_tp_allreduce=True,
-    ffn_tp_size=2,
-    attn_tp_size=2,
-    ep_size=1,
-    moe_style=2,
-    with_shared_expert_gate=False,
-):
-    config = SimpleNamespace(
-        hidden_size=8,
-        inter_size=16,
-        expert_num=4,
-        moe_k=2,
-        quant_config=None,
-        activation_type="SiGLU",
-        moe_style=moe_style,
-        eplb_config=SimpleNamespace(phy_exp_num=lambda count: count),
-    )
-    parallelism_config = SimpleNamespace(
-        ep_size=ep_size,
-        dp_rank=0,
-        dp_size=1,
-        get_ffn_tp_size=lambda: ffn_tp_size,
-        get_attn_tp_size=lambda: attn_tp_size,
-    )
-    moe_config = SimpleNamespace(fake_balance_expert=False)
-    weights = {
-        W.moe_w1: torch.empty(4, 2, 8),
-        W.moe_w2: torch.empty(4, 8, 2),
-    }
-    if with_shared_expert_gate:
-        weights[W.shared_expert_gate] = torch.empty(8, 1)
-    fused_moe = SimpleNamespace(
-        topk_ids_dtype=torch.int32,
-        router=SimpleNamespace(supports_skip_tp_allreduce=supports_skip_tp_allreduce),
-    )
-
-    with (
-        patch(
-            "rtp_llm.models_py.model_desc.generic_moe.LinearFactory.create_linear_from_weights",
-            return_value=Mock(),
-        ),
-        patch(
-            "rtp_llm.models_py.model_desc.generic_moe.SelectTopk",
-            return_value=Mock(),
-        ),
-        patch(
-            "rtp_llm.models_py.model_desc.generic_moe.DenseMLP",
-            return_value=Mock(),
-        ),
-        patch("rtp_llm.models_py.model_desc.generic_moe.MoEConfigAdapter"),
-        patch(
-            "rtp_llm.models_py.model_desc.generic_moe.FusedMoeFactory"
-        ) as fused_moe_factory,
-    ):
-        fused_moe_factory.return_value.create_fused_moe.return_value = fused_moe
-        return GenericMoeLayer(config, parallelism_config, weights, moe_config)
-
-
-def _configure_forward(layer, *, gate_enabled=False):
-    hidden_states = torch.randn(4, 8)
-    routed_output = torch.randn_like(hidden_states)
-    shared_output = torch.randn_like(hidden_states)
-    gate_output = torch.full((4, 1), 2.0)
-
-    layer.gate = Mock(return_value=torch.zeros(4, 4))
-    layer.select_topk = Mock(
-        side_effect=lambda logits, topk_ids, topk_weights: (
-            topk_ids.zero_(),
-            topk_weights.fill_(0.5),
-        )
-    )
-    fused_moe = Mock(return_value=routed_output)
-    fused_moe.topk_ids_dtype = torch.int32
-    layer.fused_moe = fused_moe
-    layer.shared_expert = Mock(return_value=shared_output)
-    if gate_enabled:
-        layer.shared_expert_gate = Mock(return_value=gate_output)
-        layer.sigmoid_gate_scale_add = Mock(
-            side_effect=lambda gate, shared, output: output.add_(
-                torch.sigmoid(gate) * shared
-            )
-        )
-    else:
-        layer.shared_expert_gate = None
-        layer.sigmoid_gate_scale_add = None
-    layer.correction_bias = None
-    return hidden_states, routed_output, shared_output, gate_output, fused_moe
-
-
-class GenericMoeInitializationTest(TestCase):
-    def test_unified_decision_covers_all_predicate_terms(self):
-        cases = (
-            ("pure_tp_shared_supported", True, 2, 1, 2, True),
-            ("ffn_tp_one", True, 1, 1, 2, False),
-            ("ep_mode", True, 2, 2, 2, False),
-            ("no_shared_expert", True, 2, 1, 1, False),
-            ("unsupported_router", False, 2, 1, 2, False),
-        )
-        for name, supports, ffn_tp, ep_size, moe_style, expected in cases:
-            with self.subTest(name=name):
-                layer = _make_layer(
-                    supports_skip_tp_allreduce=supports,
-                    ffn_tp_size=ffn_tp,
-                    ep_size=ep_size,
-                    moe_style=moe_style,
+            process.start()
+        for process in processes:
+            process.join(timeout=300)
+        failed = [process for process in processes if process.exitcode != 0]
+        if failed:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+            raise RuntimeError(
+                "real GenericMoe two-GPU worker failed: "
+                + ", ".join(
+                    f"{process.name} exitcode={process.exitcode}" for process in failed
                 )
-                self.assertEqual(layer.use_unified_tp_allreduce, expected)
-
-    def test_attn_tp_size_is_part_of_the_constructor_contract(self):
-        with self.assertRaisesRegex(ValueError, "must not exceed"):
-            _make_layer(ffn_tp_size=4, attn_tp_size=2)
-
-        self.assertTrue(
-            _make_layer(ffn_tp_size=2, attn_tp_size=4).use_unified_tp_allreduce
-        )
-
-    def test_shared_expert_gate_is_assembled_by_init(self):
-        layer = _make_layer(with_shared_expert_gate=True)
-        self.assertIsNotNone(layer.shared_expert_gate)
-        self.assertIsNotNone(layer.sigmoid_gate_scale_add)
-        self.assertTrue(layer.use_unified_tp_allreduce)
+            )
+    finally:
+        for lock in port_locks:
+            lock.__exit__(None, None, None)
 
 
-class GenericMoeUnifiedAllreduceTest(TestCase):
-    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
-    def test_pure_tp_combines_partial_outputs_before_reduce(self, mock_all_reduce):
-        layer = _make_layer()
-        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
-            layer
-        )
-        expected_input = routed_output + shared_output
-        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+def _configured_gpu_count():
+    """Read CI GPU allocation without initializing CUDA/HIP in the parent."""
 
-        result = layer(hidden_states)
-
-        mock_all_reduce.assert_called_once()
-        reduce_input = mock_all_reduce.call_args.args[0]
-        self.assertIs(mock_all_reduce.call_args.kwargs["group"], Group.TP)
-        torch.testing.assert_close(reduce_input, expected_input)
-        torch.testing.assert_close(result, expected_input * 2)
-        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
-        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
-
-    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
-    def test_pure_tp_gate_is_merged_in_place_before_reduce(self, mock_all_reduce):
-        layer = _make_layer()
-        hidden_states, routed_output, shared_output, gate_output, fused_moe = (
-            _configure_forward(layer, gate_enabled=True)
-        )
-        expected_input = routed_output.clone()
-        expected_input.add_(torch.sigmoid(gate_output) * shared_output)
-        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
-
-        result = layer(hidden_states)
-
-        reduce_input = mock_all_reduce.call_args.args[0]
-        self.assertIs(reduce_input, routed_output)
-        self.assertIs(layer.shared_expert_gate.call_args.args[0], hidden_states)
-        torch.testing.assert_close(reduce_input, expected_input)
-        torch.testing.assert_close(result, expected_input * 2)
-        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
-
-    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
-    def test_ep_reduces_shared_output_only(self, mock_all_reduce):
-        layer = _make_layer(ep_size=2)
-        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
-            layer
-        )
-        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
-
-        result = layer(hidden_states)
-
-        reduce_input = mock_all_reduce.call_args.args[0]
-        torch.testing.assert_close(reduce_input, shared_output)
-        torch.testing.assert_close(result, routed_output + shared_output * 2)
-        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
-        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
-
-    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
-    def test_ffn_tp_one_does_not_add_collective(self, mock_all_reduce):
-        layer = _make_layer(ffn_tp_size=1)
-        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
-            layer
-        )
-
-        result = layer(hidden_states)
-
-        mock_all_reduce.assert_not_called()
-        torch.testing.assert_close(result, routed_output + shared_output)
-        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
-        self.assertFalse(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+    if (gpu_count := os.environ.get("GPU_COUNT")) is not None:
+        return int(gpu_count)
+    visible_devices = os.environ.get("HIP_VISIBLE_DEVICES")
+    if visible_devices is None:
+        return 0
+    return len([device for device in visible_devices.split(",") if device.strip()])
 
 
-@skipUnless(torch.cuda.is_available(), "ROCm is not available")
+@skipUnless(
+    torch.version.hip is not None,
+    "requires a ROCm build of PyTorch",
+)
 class GenericMoeRealAllreduceTest(TestCase):
     def test_two_gpu_real_layer_matches_legacy_for_gated_and_ungated(self):
+        if _configured_gpu_count() < 2:
+            self.fail(
+                "test target must allocate at least two GPUs; "
+                f"GPU_COUNT={os.environ.get('GPU_COUNT')!r}"
+            )
         for with_gate in (False, True):
             with self.subTest(with_gate=with_gate):
                 _launch_real_two_gpu_case(with_gate)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
@@ -1,0 +1,471 @@
+"""ROCm tests for GenericMoe unified TP all-reduce wiring."""
+
+import multiprocessing as mp
+import socket
+from types import SimpleNamespace
+from unittest import TestCase, main, skipUnless
+from unittest.mock import Mock, patch
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.distributed import collective_torch
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    destroy_distributed_environment,
+    init_distributed_environment,
+)
+from rtp_llm.models_py.model_desc import generic_moe as generic_moe_module
+from rtp_llm.models_py.model_desc.generic_moe import GenericMoeLayer
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers import (
+    pure_tp_router as pure_tp_router_module,
+)
+from rtp_llm.models_py.modules.hybrid import dense_mlp as dense_mlp_module
+from rtp_llm.ops import ActivationType, MoeConfig, NcclCommConfig, ParallelismConfig
+from rtp_llm.utils.model_weight import W
+
+
+class _FixedSelectTopk(nn.Module):
+    def forward(self, logits, topk_ids, topk_weights):
+        topk_ids.zero_()
+        topk_weights.fill_(1.0)
+
+
+class _ZeroRouterGate(nn.Module):
+    def __init__(self, expert_num):
+        super().__init__()
+        self.expert_num = expert_num
+
+    def forward(self, hidden_states):
+        return torch.zeros(
+            hidden_states.size(0),
+            self.expert_num,
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+
+
+class _SharedUpProjection(nn.Module):
+    def forward(self, hidden_states):
+        return torch.cat((hidden_states, hidden_states), dim=-1)
+
+
+class _SharedDownProjection(nn.Module):
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.hidden_size = hidden_size
+
+    def forward(self, activated):
+        return activated[..., : self.hidden_size]
+
+
+class _SharedGateProjection(nn.Module):
+    def forward(self, hidden_states):
+        return hidden_states[..., :1]
+
+
+def _get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _make_real_parallelism(rank, world_size):
+    parallelism_config = ParallelismConfig()
+    parallelism_config.tp_size = world_size
+    parallelism_config.tp_rank = rank
+    parallelism_config.ffn_tp_size = world_size
+    parallelism_config.ffn_tp_rank = rank
+    parallelism_config.ep_size = 1
+    parallelism_config.ep_rank = 0
+    parallelism_config.dp_size = 1
+    parallelism_config.dp_rank = 0
+    parallelism_config.world_size = world_size
+    parallelism_config.world_rank = rank
+    parallelism_config.local_rank = rank
+    parallelism_config.local_world_size = world_size
+    return parallelism_config
+
+
+def _build_real_layer(rank, parallelism_config, with_gate):
+    device = torch.device(f"cuda:{rank}")
+    hidden_size = 512
+    inter_size = 1024
+    expert_num = 32
+
+    config = ModelConfig()
+    config.hidden_size = hidden_size
+    config.inter_size = inter_size
+    config.expert_num = expert_num
+    config.moe_k = 4
+    config.activation_type = ActivationType.Swiglu
+    config.moe_style = 2
+    config.quant_config = None
+
+    # Give each rank a different routed-expert contribution so the test checks
+    # an actual cross-rank sum instead of two identical local tensors.
+    torch.manual_seed(1000 + rank)
+    weights = {
+        W.moe_gate: torch.empty(1, device=device),
+        W.moe_w1: torch.randn(
+            expert_num, 2 * inter_size, hidden_size, device=device, dtype=torch.bfloat16
+        )
+        * 0.02,
+        W.moe_w2: torch.randn(
+            expert_num, hidden_size, inter_size, device=device, dtype=torch.bfloat16
+        )
+        * 0.02,
+        W.ffn_w13: torch.empty(1, device=device),
+        W.ffn_w2: torch.empty(1, device=device),
+    }
+    if with_gate:
+        weights[W.shared_expert_gate] = torch.empty(1, device=device)
+
+    moe_config = MoeConfig()
+    moe_config.use_all_gather = True
+    moe_config.fake_balance_expert = False
+
+    def make_linear(_weights, weight_key, *args, **kwargs):
+        if weight_key == W.moe_gate:
+            return _ZeroRouterGate(expert_num)
+        if weight_key == W.ffn_w13:
+            return _SharedUpProjection()
+        if weight_key == W.ffn_w2:
+            return _SharedDownProjection(hidden_size)
+        if weight_key == W.shared_expert_gate:
+            return _SharedGateProjection()
+        raise AssertionError(f"unexpected test linear weight key: {weight_key}")
+
+    with patch(
+        "rtp_llm.models_py.model_desc.generic_moe.LinearFactory.create_linear_from_weights",
+        side_effect=make_linear,
+    ):
+        layer = GenericMoeLayer(
+            config,
+            parallelism_config,
+            weights,
+            moe_config,
+        )
+
+    if type(layer.fused_moe.router).__name__ != "PureTpRouterNoQuant":
+        raise AssertionError(
+            "real TP integration test selected "
+            f"{type(layer.fused_moe.router).__name__}, expected PureTpRouterNoQuant"
+        )
+    layer.select_topk = _FixedSelectTopk()
+    return layer
+
+
+def _run_real_two_gpu_case(rank, world_size, port, with_gate):
+    parallelism_config = _make_real_parallelism(rank, world_size)
+    initialized = False
+    try:
+        torch.cuda.set_device(rank)
+        init_distributed_environment(
+            parallelism_config,
+            NcclCommConfig(
+                nccl_ip="127.0.0.1",
+                tp_nccl_port=port + 1,
+                dp_tp_nccl_port=port + 2,
+                ffn_tp_nccl_port=port + 3,
+            ),
+            nccl_init_port=port,
+            backend="nccl",
+            timeout=300,
+        )
+        initialized = True
+        layer = _build_real_layer(rank, parallelism_config, with_gate)
+        # TP ranks consume the same replicated hidden states.  Keep the routed
+        # expert weights rank-specific so the collective still sums distinct
+        # partial outputs, while the shared-expert gate remains rank-consistent.
+        torch.manual_seed(2024)
+        hidden_states = torch.randn(
+            32, 512, device=torch.device(f"cuda:{rank}"), dtype=torch.bfloat16
+        )
+        dist.broadcast(hidden_states, src=0)
+        counts = {"all_reduce": 0}
+
+        def counted_all_reduce(tensor, group):
+            if group is not Group.TP:
+                raise AssertionError(f"unexpected collective group: {group}")
+            counts["all_reduce"] += 1
+            return collective_torch.all_reduce(tensor, group)
+
+        with (
+            patch.object(
+                generic_moe_module, "all_reduce", side_effect=counted_all_reduce
+            ),
+            patch.object(
+                dense_mlp_module, "all_reduce", side_effect=counted_all_reduce
+            ),
+            patch.object(
+                pure_tp_router_module, "all_reduce", side_effect=counted_all_reduce
+            ),
+        ):
+            layer.use_unified_tp_allreduce = True
+            unified_output = layer(hidden_states.clone())
+            unified_calls = counts["all_reduce"]
+            dist.barrier()
+
+            layer.use_unified_tp_allreduce = False
+            legacy_output = layer(hidden_states.clone())
+            legacy_calls = counts["all_reduce"] - unified_calls
+            dist.barrier()
+
+        if unified_calls != 1 or legacy_calls != 2:
+            raise AssertionError(
+                f"unexpected TP collective counts: unified={unified_calls}, "
+                f"legacy={legacy_calls}"
+            )
+        torch.testing.assert_close(
+            unified_output,
+            legacy_output,
+            rtol=2e-2,
+            atol=2e-3,
+        )
+        if rank == 0:
+            print(
+                f"[real_tp_unified] gate={with_gate} unified_calls={unified_calls} "
+                f"legacy_calls={legacy_calls} ✓"
+            )
+    finally:
+        if initialized:
+            destroy_distributed_environment()
+
+
+def _launch_real_two_gpu_case(with_gate):
+    world_size = 2
+    port = _get_free_port()
+    context = mp.get_context("spawn")
+    processes = [
+        context.Process(
+            target=_run_real_two_gpu_case,
+            args=(rank, world_size, port, with_gate),
+            name=f"generic-moe-rank-{rank}",
+        )
+        for rank in range(world_size)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=300)
+    failed = [process for process in processes if process.exitcode != 0]
+    if failed:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+        raise RuntimeError(
+            "real GenericMoe two-GPU worker failed: "
+            + ", ".join(
+                f"{process.name} exitcode={process.exitcode}" for process in failed
+            )
+        )
+
+
+def _make_layer(
+    *,
+    supports_skip_tp_allreduce=True,
+    ffn_tp_size=2,
+    attn_tp_size=2,
+    ep_size=1,
+    moe_style=2,
+    with_shared_expert_gate=False,
+):
+    config = SimpleNamespace(
+        hidden_size=8,
+        inter_size=16,
+        expert_num=4,
+        moe_k=2,
+        quant_config=None,
+        activation_type="SiGLU",
+        moe_style=moe_style,
+        eplb_config=SimpleNamespace(phy_exp_num=lambda count: count),
+    )
+    parallelism_config = SimpleNamespace(
+        ep_size=ep_size,
+        dp_rank=0,
+        dp_size=1,
+        get_ffn_tp_size=lambda: ffn_tp_size,
+        get_attn_tp_size=lambda: attn_tp_size,
+    )
+    moe_config = SimpleNamespace(fake_balance_expert=False)
+    weights = {
+        W.moe_w1: torch.empty(4, 2, 8),
+        W.moe_w2: torch.empty(4, 8, 2),
+    }
+    if with_shared_expert_gate:
+        weights[W.shared_expert_gate] = torch.empty(8, 1)
+    fused_moe = SimpleNamespace(
+        topk_ids_dtype=torch.int32,
+        router=SimpleNamespace(supports_skip_tp_allreduce=supports_skip_tp_allreduce),
+    )
+
+    with (
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.LinearFactory.create_linear_from_weights",
+            return_value=Mock(),
+        ),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.SelectTopk",
+            return_value=Mock(),
+        ),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.DenseMLP",
+            return_value=Mock(),
+        ),
+        patch("rtp_llm.models_py.model_desc.generic_moe.MoEConfigAdapter"),
+        patch(
+            "rtp_llm.models_py.model_desc.generic_moe.FusedMoeFactory"
+        ) as fused_moe_factory,
+    ):
+        fused_moe_factory.return_value.create_fused_moe.return_value = fused_moe
+        return GenericMoeLayer(config, parallelism_config, weights, moe_config)
+
+
+def _configure_forward(layer, *, gate_enabled=False):
+    hidden_states = torch.randn(4, 8)
+    routed_output = torch.randn_like(hidden_states)
+    shared_output = torch.randn_like(hidden_states)
+    gate_output = torch.full((4, 1), 2.0)
+
+    layer.gate = Mock(return_value=torch.zeros(4, 4))
+    layer.select_topk = Mock(
+        side_effect=lambda logits, topk_ids, topk_weights: (
+            topk_ids.zero_(),
+            topk_weights.fill_(0.5),
+        )
+    )
+    fused_moe = Mock(return_value=routed_output)
+    fused_moe.topk_ids_dtype = torch.int32
+    layer.fused_moe = fused_moe
+    layer.shared_expert = Mock(return_value=shared_output)
+    if gate_enabled:
+        layer.shared_expert_gate = Mock(return_value=gate_output)
+        layer.sigmoid_gate_scale_add = Mock(
+            side_effect=lambda gate, shared, output: output.add_(
+                torch.sigmoid(gate) * shared
+            )
+        )
+    else:
+        layer.shared_expert_gate = None
+        layer.sigmoid_gate_scale_add = None
+    layer.correction_bias = None
+    return hidden_states, routed_output, shared_output, gate_output, fused_moe
+
+
+class GenericMoeInitializationTest(TestCase):
+    def test_unified_decision_covers_all_predicate_terms(self):
+        cases = (
+            ("pure_tp_shared_supported", True, 2, 1, 2, True),
+            ("ffn_tp_one", True, 1, 1, 2, False),
+            ("ep_mode", True, 2, 2, 2, False),
+            ("no_shared_expert", True, 2, 1, 1, False),
+            ("unsupported_router", False, 2, 1, 2, False),
+        )
+        for name, supports, ffn_tp, ep_size, moe_style, expected in cases:
+            with self.subTest(name=name):
+                layer = _make_layer(
+                    supports_skip_tp_allreduce=supports,
+                    ffn_tp_size=ffn_tp,
+                    ep_size=ep_size,
+                    moe_style=moe_style,
+                )
+                self.assertEqual(layer.use_unified_tp_allreduce, expected)
+
+    def test_attn_tp_size_is_part_of_the_constructor_contract(self):
+        with self.assertRaisesRegex(ValueError, "must not exceed"):
+            _make_layer(ffn_tp_size=4, attn_tp_size=2)
+
+        self.assertTrue(
+            _make_layer(ffn_tp_size=2, attn_tp_size=4).use_unified_tp_allreduce
+        )
+
+    def test_shared_expert_gate_is_assembled_by_init(self):
+        layer = _make_layer(with_shared_expert_gate=True)
+        self.assertIsNotNone(layer.shared_expert_gate)
+        self.assertIsNotNone(layer.sigmoid_gate_scale_add)
+        self.assertTrue(layer.use_unified_tp_allreduce)
+
+
+class GenericMoeUnifiedAllreduceTest(TestCase):
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_pure_tp_combines_partial_outputs_before_reduce(self, mock_all_reduce):
+        layer = _make_layer()
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+        expected_input = routed_output + shared_output
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        mock_all_reduce.assert_called_once()
+        reduce_input = mock_all_reduce.call_args.args[0]
+        self.assertIs(mock_all_reduce.call_args.kwargs["group"], Group.TP)
+        torch.testing.assert_close(reduce_input, expected_input)
+        torch.testing.assert_close(result, expected_input * 2)
+        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_pure_tp_gate_is_merged_in_place_before_reduce(self, mock_all_reduce):
+        layer = _make_layer()
+        hidden_states, routed_output, shared_output, gate_output, fused_moe = (
+            _configure_forward(layer, gate_enabled=True)
+        )
+        expected_input = routed_output.clone()
+        expected_input.add_(torch.sigmoid(gate_output) * shared_output)
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        reduce_input = mock_all_reduce.call_args.args[0]
+        self.assertIs(reduce_input, routed_output)
+        self.assertIs(layer.shared_expert_gate.call_args.args[0], hidden_states)
+        torch.testing.assert_close(reduce_input, expected_input)
+        torch.testing.assert_close(result, expected_input * 2)
+        self.assertTrue(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ep_reduces_shared_output_only(self, mock_all_reduce):
+        layer = _make_layer(ep_size=2)
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+        mock_all_reduce.side_effect = lambda tensor, group: tensor * 2
+
+        result = layer(hidden_states)
+
+        reduce_input = mock_all_reduce.call_args.args[0]
+        torch.testing.assert_close(reduce_input, shared_output)
+        torch.testing.assert_close(result, routed_output + shared_output * 2)
+        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertTrue(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+    @patch("rtp_llm.models_py.model_desc.generic_moe.all_reduce")
+    def test_ffn_tp_one_does_not_add_collective(self, mock_all_reduce):
+        layer = _make_layer(ffn_tp_size=1)
+        hidden_states, routed_output, shared_output, _, fused_moe = _configure_forward(
+            layer
+        )
+
+        result = layer(hidden_states)
+
+        mock_all_reduce.assert_not_called()
+        torch.testing.assert_close(result, routed_output + shared_output)
+        self.assertFalse(fused_moe.call_args.kwargs["skip_tp_allreduce"])
+        self.assertFalse(layer.shared_expert.call_args.kwargs["skip_allreduce"])
+
+
+@skipUnless(torch.cuda.is_available(), "ROCm is not available")
+class GenericMoeRealAllreduceTest(TestCase):
+    def test_two_gpu_real_layer_matches_legacy_for_gated_and_ungated(self):
+        for with_gate in (False, True):
+            with self.subTest(with_gate=with_gate):
+                _launch_real_two_gpu_case(with_gate)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_pure_tp_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_pure_tp_router.py
@@ -1,4 +1,4 @@
-"""Tests for Pure TP Router prepare/finalize flow (CPU-only, no ROCm required)."""
+"""ROCm-specific tests for Pure TP Router prepare/finalize flow."""
 
 from unittest import TestCase, main
 from unittest.mock import patch
@@ -6,14 +6,22 @@ from unittest.mock import patch
 import torch
 
 from rtp_llm.config.model_config import ModelConfig
-from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import MoEConfigAdapter
-from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import CombineForwardPayload
-from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import FusedMoEQuantConfig
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import (
+    SKIP_TP_ALLREDUCE_ARG,
+    CombineForwardPayload,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
 from rtp_llm.ops import MoeConfig, ParallelismConfig
 
 
-def _make_config(expert_num=8, moe_k=2, tp_size=1, tp_rank=0,
-                 ep_size=1, ep_rank=0) -> MoEConfigAdapter:
+def _make_config(
+    expert_num=8, moe_k=2, tp_size=1, tp_rank=0, ep_size=1, ep_rank=0
+) -> MoEConfigAdapter:
     model_config = ModelConfig()
     model_config.attn_config.head_num = 4
     model_config.attn_config.size_per_head = 64
@@ -45,14 +53,19 @@ def _make_config(expert_num=8, moe_k=2, tp_size=1, tp_rank=0,
     )
 
 
-def _make_router(expert_num=8, moe_k=2, tp_size=1, tp_rank=0,
-                 ep_size=1, ep_rank=0):
+def _make_router(expert_num=8, moe_k=2, tp_size=1, tp_rank=0, ep_size=1, ep_rank=0):
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router import (
         PureTpRouterNoQuant,
     )
-    config = _make_config(expert_num=expert_num, moe_k=moe_k,
-                          tp_size=tp_size, tp_rank=tp_rank,
-                          ep_size=ep_size, ep_rank=ep_rank)
+
+    config = _make_config(
+        expert_num=expert_num,
+        moe_k=moe_k,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        ep_size=ep_size,
+        ep_rank=ep_rank,
+    )
     quant_config = FusedMoEQuantConfig(quant_dtype=None)
     return PureTpRouterNoQuant(config, quant_config)
 
@@ -67,8 +80,11 @@ class PureTpRouterPrepareTest(TestCase):
         topk_weights = torch.softmax(torch.randn(16, 2), dim=-1).float()
 
         payload = router.prepare(
-            a1=hidden_states, a1_scale=None, a2_scale=None,
-            topk_weights=topk_weights, topk_ids=topk_ids,
+            a1=hidden_states,
+            a1_scale=None,
+            a2_scale=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
         )
 
         torch.testing.assert_close(payload.expert_x, hidden_states)
@@ -86,8 +102,11 @@ class PureTpRouterPrepareTest(TestCase):
 
         with self.assertRaises(AssertionError):
             router.prepare(
-                a1=hidden_states, a1_scale=torch.ones(4, 1),
-                a2_scale=None, topk_weights=topk_weights, topk_ids=topk_ids,
+                a1=hidden_states,
+                a1_scale=torch.ones(4, 1),
+                a2_scale=None,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
             )
 
 
@@ -108,7 +127,9 @@ class PureTpRouterFinalizeTest(TestCase):
         )
         torch.testing.assert_close(result, expert_output)
 
-    @patch("rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router.all_reduce")
+    @patch(
+        "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router.all_reduce"
+    )
     def test_multi_gpu_calls_all_reduce(self, mock_all_reduce):
         router = _make_router(tp_size=2, tp_rank=0)
         expert_output = torch.randn(16, 64)
@@ -125,6 +146,54 @@ class PureTpRouterFinalizeTest(TestCase):
         )
         mock_all_reduce.assert_called_once()
         torch.testing.assert_close(result, reduced_output)
+
+    @patch(
+        "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router.all_reduce"
+    )
+    def test_multi_gpu_can_defer_all_reduce(self, mock_all_reduce):
+        """The caller can combine TP-partial outputs before reducing once."""
+        router = _make_router(tp_size=2, tp_rank=0)
+        expert_output = torch.randn(16, 64)
+        payload = CombineForwardPayload(fused_expert_output=expert_output)
+
+        result = router.finalize(
+            payload=payload,
+            topk_weights=torch.ones(16, 2, dtype=torch.float32),
+            topk_ids=torch.randint(0, 8, (16, 2), dtype=torch.int32),
+            apply_router_weight_on_input=False,
+            extra_finalize_args={SKIP_TP_ALLREDUCE_ARG: True},
+        )
+
+        mock_all_reduce.assert_not_called()
+        self.assertIs(result, expert_output)
+
+    def test_pure_tp_router_declares_deferred_reduce_support(self):
+        router = _make_router(tp_size=2, tp_rank=0)
+        self.assertTrue(router.supports_skip_tp_allreduce)
+
+    @patch(
+        "rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router.all_reduce"
+    )
+    def test_fused_quant_router_can_defer_all_reduce(self, mock_all_reduce):
+        from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers.pure_tp_router import (
+            PureTpRouterFusedQuant,
+        )
+
+        router = PureTpRouterFusedQuant(
+            _make_config(tp_size=2, tp_rank=0), FusedMoEQuantConfig()
+        )
+        self.assertTrue(router.supports_skip_tp_allreduce)
+        expert_output = torch.randn(16, 64)
+        result = router.finalize(
+            payload=CombineForwardPayload(fused_expert_output=expert_output),
+            topk_weights=torch.ones(16, 2, dtype=torch.float32),
+            topk_ids=torch.randint(0, 8, (16, 2), dtype=torch.int32),
+            apply_router_weight_on_input=False,
+            extra_finalize_args={SKIP_TP_ALLREDUCE_ARG: True},
+        )
+
+        mock_all_reduce.assert_not_called()
+        self.assertIs(result, expert_output)
 
 
 class PureTpRouterCheckConditionsTest(TestCase):
@@ -143,6 +212,7 @@ class PureTpRouterCheckConditionsTest(TestCase):
         from rtp_llm.models_py.modules.factory.fused_moe.utils.condition_checker import (
             ConditionChecker,
         )
+
         checker = ConditionChecker("PureTpRouterNoQuant")
         PureTpRouterNoQuant.check_conditions(checker, config)
         return checker.all_passed()
@@ -166,6 +236,7 @@ class PureTpRouterCheckConditionsTest(TestCase):
         """tp=2, dp=1, ep=2 must NOT match pure-TP."""
         config = _make_config(tp_size=2, ep_size=2)
         self.assertFalse(self._check_passes(config))
+
 
 if __name__ == "__main__":
     main()

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
@@ -40,6 +40,8 @@ class LinearTorch(nn.Module):
 class FakeFusedMoe(nn.Module):
     topk_ids_dtype = torch.int32
 
+    router = SimpleNamespace(supports_skip_tp_allreduce=True)
+
     def forward(self, hidden_states, **kwargs):
         return torch.zeros_like(hidden_states)
 
@@ -205,6 +207,7 @@ class LinearTest(TestCase):
             dp_rank=0,
             dp_size=1,
             get_ffn_tp_size=lambda: 1,
+            get_attn_tp_size=lambda: 1,
         )
         moe_config = SimpleNamespace(fake_balance_expert=False)
         hw_kernel_config = HWKernelConfig()

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
@@ -40,7 +40,10 @@ class LinearTorch(nn.Module):
 class FakeFusedMoe(nn.Module):
     topk_ids_dtype = torch.int32
 
-    router = SimpleNamespace(supports_skip_tp_allreduce=True)
+    router = SimpleNamespace(
+        supports_skip_tp_allreduce=True,
+        tp_collective_size=1,
+    )
 
     def forward(self, hidden_states, **kwargs):
         return torch.zeros_like(hidden_states)


### PR DESCRIPTION
Fuse routed and shared-expert TP-partial outputs before the TP AllReduce in pure-TP MoE layers. This reduces two MoE small AllReduce operations to one while leaving EP and single-TP paths unchanged.