### PR TITLE
fix: reduce MTP speculative logits verification CPU overhead

### DIFF
--- a/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.cc
+++ b/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.cc
@@ -1,6 +1,8 @@
 #include "rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.h"
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 
 #include "rtp_llm/cpp/cuda_graph/cuda_graph_device_shims.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
@@ -22,22 +24,39 @@ void bitwiseAndInplace(int32_t* dst, const int32_t* src, size_t words) {
     }
 }
 
+using MaskedByteLut = std::array<std::array<bool, 8>, 256>;
+
+const MaskedByteLut& maskedByteLut() {
+    static const MaskedByteLut lut = []() {
+        MaskedByteLut result{};
+        for (size_t value = 0; value < result.size(); ++value) {
+            for (size_t bit = 0; bit < result[value].size(); ++bit) {
+                result[value][bit] = (value & (1u << bit)) == 0u;
+            }
+        }
+        return result;
+    }();
+    return lut;
+}
+
 }  // namespace
 
 SpecLogitsVerifyRunner::SpecLogitsVerifyRunner(): copy_stream_(cuda_graph::graphGetStreamFromPool(true)) {}
 
 void SpecLogitsVerifyRunner::ensureBuffersFit(size_t total_streams,
+                                              size_t active_streams,
                                               int    propose_step,
                                               size_t vocab_size,
                                               size_t bitmask_words) {
     const int64_t B    = static_cast<int64_t>(total_streams);
+    const int64_t A    = static_cast<int64_t>(active_streams);
     const int64_t P    = static_cast<int64_t>(propose_step);
-    const int64_t rows = B * (P + 1);
+    const int64_t rows = A * (P + 1);
     const int64_t W    = static_cast<int64_t>(bitmask_words);
     (void)vocab_size;
 
-    auto cpu_i32     = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
-    auto pinned_i32  = cpu_i32.pinned_memory(true);
+    auto cpu_i32    = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
+    auto pinned_i32 = cpu_i32.pinned_memory(true);
 
     if (!draft_tokens_cpu_.defined() || draft_tokens_cpu_.numel() < B * P) {
         draft_tokens_cpu_ = torch::empty({B, P}, pinned_i32);
@@ -67,7 +86,7 @@ void SpecLogitsVerifyRunner::materializeDraftTokensToCpu(const LaunchTask& task)
     const int64_t draft_offset = draft_cols > P ? 1 : 0;
     RTP_LLM_CHECK_WITH_INFO(draft_cols >= draft_offset + P, "spec logits runner draft token columns mismatch");
     auto draft = task.draft_tokens.reshape({B, draft_cols}).narrow(1, draft_offset, P);
-    auto dst   = draft_tokens_cpu_.narrow(0, 0, B).narrow(1, 0, P);
+    auto dst   = draft_tokens_cpu_.flatten().narrow(0, 0, B * P).view({B, P});
     if (!draft.is_cuda()) {
         auto draft_i32 =
             draft.scalar_type() == torch::kInt32 ? draft.contiguous() : draft.to(torch::kInt32).contiguous();
@@ -90,13 +109,27 @@ void SpecLogitsVerifyRunner::unpackMergedBitmaskToVocabMask(const torch::Tensor&
                                                             size_t               bitmask_words) {
     const auto* merged = merged_bitmask_cpu_.data_ptr<int32_t>();
     auto*       mask   = mask_cpu.data_ptr<bool>();
+    static_assert(sizeof(bool) == 1, "torch bool mask requires one-byte C++ bool");
+    const auto& lut        = maskedByteLut();
+    const auto  full_words = vocab_size / 32;
+    const auto  tail_bits  = vocab_size % 32;
     for (size_t row = 0; row < rows; ++row) {
         const auto* row_bits = merged + row * bitmask_words;
         auto*       row_mask = mask + row * vocab_size;
-        for (size_t token = 0; token < vocab_size; ++token) {
-            const uint32_t word    = static_cast<uint32_t>(row_bits[token / 32]);
-            const bool     allowed = (word & (1u << (token % 32))) != 0u;
-            row_mask[token]        = !allowed;
+        for (size_t word_idx = 0; word_idx < full_words; ++word_idx) {
+            const uint32_t word = static_cast<uint32_t>(row_bits[word_idx]);
+            auto*          out  = row_mask + word_idx * 32;
+            std::memcpy(out, lut[word & 0xffu].data(), 8 * sizeof(bool));
+            std::memcpy(out + 8, lut[(word >> 8) & 0xffu].data(), 8 * sizeof(bool));
+            std::memcpy(out + 16, lut[(word >> 16) & 0xffu].data(), 8 * sizeof(bool));
+            std::memcpy(out + 24, lut[(word >> 24) & 0xffu].data(), 8 * sizeof(bool));
+        }
+        if (tail_bits > 0) {
+            const uint32_t word = static_cast<uint32_t>(row_bits[full_words]);
+            auto*          out  = row_mask + full_words * 32;
+            for (size_t bit = 0; bit < tail_bits; ++bit) {
+                out[bit] = (word & (1u << bit)) == 0u;
+            }
         }
     }
 }
@@ -115,26 +148,44 @@ SpecLogitsVerifyRunner::LaunchResult SpecLogitsVerifyRunner::buildInline(const L
     const size_t rows = B * static_cast<size_t>(P + 1);
     RTP_LLM_CHECK_WITH_INFO(B > 0 && P > 0 && V > 0, "invalid spec logits runner task");
 
-    ensureBuffersFit(B, P, V, W);
-    materializeDraftTokensToCpu(task);
-
-    auto merged = merged_bitmask_cpu_.narrow(0, 0, static_cast<int64_t>(rows)).narrow(1, 0, static_cast<int64_t>(W));
-    fillAllAllow(merged);
-    std::fill_n(spec_cap_cpu_.data_ptr<int32_t>(), B, P);
-
-    auto proc_mask = processor_bitmask_cpu_.narrow(0, 0, P + 1).narrow(1, 0, static_cast<int64_t>(W));
-    bool applied_processor = false;
+    std::vector<size_t> active_stream_indices;
+    std::vector<bool>   active_stream_seen(B, false);
     for (const auto& item : task.active) {
         if (!item.processor || !item.processor->isSpecVerifyEligible()) {
             return {};
         }
-        applied_processor = true;
+        RTP_LLM_CHECK_WITH_INFO(item.stream_idx < B, "spec logits processor stream index out of range");
+        if (!active_stream_seen[item.stream_idx]) {
+            active_stream_seen[item.stream_idx] = true;
+            active_stream_indices.push_back(item.stream_idx);
+        }
+    }
+    std::sort(active_stream_indices.begin(), active_stream_indices.end());
+    const size_t active_streams = active_stream_indices.size();
+    const size_t active_rows    = active_streams * static_cast<size_t>(P + 1);
+    RTP_LLM_CHECK_WITH_INFO(active_rows > 0, "spec logits runner has no active rows");
 
-        fillAllAllow(proc_mask);
+    std::vector<size_t> compact_stream_indices(B, 0);
+    for (size_t compact_idx = 0; compact_idx < active_streams; ++compact_idx) {
+        compact_stream_indices[active_stream_indices[compact_idx]] = compact_idx;
+    }
+
+    ensureBuffersFit(B, active_streams, P, V, W);
+    materializeDraftTokensToCpu(task);
+
+    auto merged = merged_bitmask_cpu_.flatten().narrow(0, 0, static_cast<int64_t>(active_rows * W));
+    fillAllAllow(merged);
+    std::fill_n(spec_cap_cpu_.data_ptr<int32_t>(), B, P);
+
+    const size_t proc_words = static_cast<size_t>(P + 1) * W;
+    auto*        proc_mask  = processor_bitmask_cpu_.data_ptr<int32_t>();
+    for (const auto& item : task.active) {
+        std::fill_n(proc_mask, proc_words, SpecLogitsProcessor::kBitmaskAllowAll);
+
         SpecLogitsProcessorRequest request;
         request.draft_tokens       = draft_tokens_cpu_.data_ptr<int32_t>() + item.stream_idx * P;
         request.propose_step       = P;
-        request.bitmask_cpu_out    = proc_mask.data_ptr<int32_t>();
+        request.bitmask_cpu_out    = proc_mask;
         request.bitmask_size_int32 = W;
         request.vocab_size         = V;
         request.stream_id          = item.stream_id;
@@ -144,42 +195,72 @@ SpecLogitsVerifyRunner::LaunchResult SpecLogitsVerifyRunner::buildInline(const L
         int cap = item.processor->tryAcceptAndFillBitmask(request);
         cap     = std::max(0, std::min(cap, P));
 
-        auto* merged_row = merged_bitmask_cpu_.data_ptr<int32_t>() + item.stream_idx * (P + 1) * W;
-        bitwiseAndInplace(merged_row, proc_mask.data_ptr<int32_t>(), static_cast<size_t>(P + 1) * W);
+        const size_t compact_idx = compact_stream_indices[item.stream_idx];
+        auto*        merged_row  = merged_bitmask_cpu_.data_ptr<int32_t>() + compact_idx * (P + 1) * W;
+        bitwiseAndInplace(merged_row, proc_mask, proc_words);
         auto* cap_ptr            = spec_cap_cpu_.data_ptr<int32_t>();
         cap_ptr[item.stream_idx] = std::min<int32_t>(cap_ptr[item.stream_idx], cap);
         result.applied_processors.push_back({item.stream_id, item.processor_idx});
     }
 
-    if (!applied_processor) {
-        return {};
+    auto* cpu_slot = static_cast<CpuArtifactSlot*>(nullptr);
+    for (auto& slot : cpu_artifact_slots_) {
+        if (!slot.ready_event || slot.ready_event->query()) {
+            cpu_slot = &slot;
+            break;
+        }
+    }
+    if (cpu_slot == nullptr) {
+        cpu_artifact_slots_.emplace_back();
+        cpu_slot = &cpu_artifact_slots_.back();
     }
 
+    const int64_t mask_elements = static_cast<int64_t>(active_rows * V);
+    const int64_t cap_elements  = static_cast<int64_t>(B);
     auto pinned_bool = torch::TensorOptions().dtype(torch::kBool).device(torch::kCPU).pinned_memory(true);
     auto pinned_i32  = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU).pinned_memory(true);
-    auto cuda_bool   = torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA);
-    auto cuda_i32    = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    if (!cpu_slot->mask.defined() || cpu_slot->mask.numel() < mask_elements) {
+        cpu_slot->mask = torch::empty({mask_elements}, pinned_bool);
+    }
+    if (!cpu_slot->cap.defined() || cpu_slot->cap.numel() < cap_elements) {
+        cpu_slot->cap = torch::empty({cap_elements}, pinned_i32);
+    }
+    auto mask_cpu = cpu_slot->mask.narrow(0, 0, mask_elements)
+                        .view({static_cast<int64_t>(active_rows), static_cast<int64_t>(V)});
+    auto cap_cpu = cpu_slot->cap.narrow(0, 0, cap_elements);
 
-    auto mask_cpu = torch::empty({static_cast<int64_t>(rows), static_cast<int64_t>(V)}, pinned_bool);
-    auto cap_cpu  = torch::empty({static_cast<int64_t>(B)}, pinned_i32);
-    auto mask_gpu = torch::empty({static_cast<int64_t>(rows), static_cast<int64_t>(V)}, cuda_bool);
-    auto cap_gpu  = torch::empty({static_cast<int64_t>(B)}, cuda_i32);
-
-    unpackMergedBitmaskToVocabMask(mask_cpu, rows, V, W);
+    unpackMergedBitmaskToVocabMask(mask_cpu, active_rows, V, W);
     cap_cpu.copy_(spec_cap_cpu_.narrow(0, 0, static_cast<int64_t>(B)));
 
     cuda_graph::GraphStreamGuard stream_guard(cuda_graph::toGraphStream(copy_stream_));
-    mask_gpu.copy_(mask_cpu, /*non_blocking=*/true);
+    auto cuda_bool = torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA);
+    auto cuda_i32  = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    auto mask_gpu  = active_rows == rows
+                         ? torch::empty({static_cast<int64_t>(rows), static_cast<int64_t>(V)}, cuda_bool)
+                         : torch::zeros({static_cast<int64_t>(rows), static_cast<int64_t>(V)}, cuda_bool);
+    auto cap_gpu = torch::empty({static_cast<int64_t>(B)}, cuda_i32);
+    if (active_rows == rows) {
+        mask_gpu.copy_(mask_cpu, /*non_blocking=*/true);
+    } else {
+        const int64_t rows_per_stream = static_cast<int64_t>(P + 1);
+        for (size_t compact_idx = 0; compact_idx < active_streams; ++compact_idx) {
+            const int64_t source_row = static_cast<int64_t>(compact_idx) * rows_per_stream;
+            const int64_t target_row = static_cast<int64_t>(active_stream_indices[compact_idx]) * rows_per_stream;
+            mask_gpu.narrow(0, target_row, rows_per_stream)
+                .copy_(mask_cpu.narrow(0, source_row, rows_per_stream), /*non_blocking=*/true);
+        }
+    }
     cap_gpu.copy_(cap_cpu, /*non_blocking=*/true);
     auto ready = std::make_shared<torch::Event>(cuda_graph::makeGraphEvent());
     ready->record(copy_stream_);
+    cpu_slot->ready_event = ready;
     auto consumed = std::make_shared<torch::Event>(cuda_graph::makeGraphEvent());
 
-    result.spec_vocab_mask_gpu  = mask_gpu;
-    result.spec_cap_gpu         = cap_gpu;
-    result.ready_event          = ready;
-    result.consumed_event       = consumed;
-    result.has_active_processor = true;
+    result.spec_vocab_mask_gpu       = mask_gpu;
+    result.spec_cap_gpu              = cap_gpu;
+    result.ready_event               = ready;
+    result.consumed_event            = consumed;
+    result.has_active_processor      = true;
     result.spec_vocab_mask_cpu_owner = mask_cpu;
     result.spec_cap_cpu_owner        = cap_cpu;
     return result;

--- a/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.h
+++ b/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.h
@@ -54,7 +54,11 @@ public:
     LaunchResult buildInline(const LaunchTask& task);
 
 private:
-    void ensureBuffersFit(size_t total_streams, int propose_step, size_t vocab_size, size_t bitmask_words);
+    void ensureBuffersFit(size_t total_streams,
+                          size_t active_streams,
+                          int    propose_step,
+                          size_t vocab_size,
+                          size_t bitmask_words);
     void materializeDraftTokensToCpu(const LaunchTask& task);
     void unpackMergedBitmaskToVocabMask(const torch::Tensor& mask_cpu,
                                         size_t               rows,
@@ -62,11 +66,18 @@ private:
                                         size_t               bitmask_words);
 
 private:
+    struct CpuArtifactSlot {
+        torch::Tensor                 mask;
+        torch::Tensor                 cap;
+        std::shared_ptr<torch::Event> ready_event;
+    };
+
     torch::Stream copy_stream_;
     torch::Tensor draft_tokens_cpu_;
     torch::Tensor processor_bitmask_cpu_;
     torch::Tensor merged_bitmask_cpu_;
     torch::Tensor spec_cap_cpu_;
+    std::vector<CpuArtifactSlot> cpu_artifact_slots_;
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/models/logits_processor/test/BUILD
+++ b/rtp_llm/cpp/models/logits_processor/test/BUILD
@@ -73,3 +73,15 @@ cc_test(
         "TEST_USING_DEVICE": "CPU",
     },
 )
+
+cc_test(
+    name = "spec_logits_verify_runner_perf_test",
+    srcs = [
+        "SpecLogitsVerifyRunnerPerfTest.cc",
+    ],
+    copts = test_copts,
+    deps = test_deps,
+    env = {
+        "TEST_USING_DEVICE": "CUDA",
+    },
+)

--- a/rtp_llm/cpp/models/logits_processor/test/SpecLogitsVerifyRunnerPerfTest.cc
+++ b/rtp_llm/cpp/models/logits_processor/test/SpecLogitsVerifyRunnerPerfTest.cc
@@ -1,0 +1,352 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include "rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.h"
+
+namespace rtp_llm {
+namespace {
+
+constexpr int64_t kStreamCount = 35;
+constexpr int64_t kProposeStep = 3;
+constexpr int64_t kVocabSize   = 129280;
+constexpr int     kWarmupIters = 2;
+constexpr int     kBenchIters  = 8;
+
+using Clock = std::chrono::steady_clock;
+
+class AllowAllSpecProcessor: public SpecLogitsProcessor {
+public:
+    bool isSpecVerifyEligible() const override {
+        return true;
+    }
+
+    int tryAcceptAndFillBitmask(const SpecLogitsProcessorRequest& request) override {
+        // SpecLogitsVerifyRunner pre-fills the processor mask with allow-all.
+        // Keeping this processor intentionally cheap isolates runner overhead
+        // from XGrammar state-machine work.
+        return request.propose_step;
+    }
+};
+
+class MaskTokenSpecProcessor: public SpecLogitsProcessor {
+public:
+    explicit MaskTokenSpecProcessor(int32_t token_id, int cap = -1): token_id_(token_id), cap_(cap) {}
+
+    bool isSpecVerifyEligible() const override {
+        return true;
+    }
+
+    int tryAcceptAndFillBitmask(const SpecLogitsProcessorRequest& request) override {
+        const size_t word_idx = static_cast<size_t>(token_id_ / 32);
+        const auto   bit      = static_cast<uint32_t>(1u << (token_id_ % 32));
+        for (int offset = 0; offset <= request.propose_step; ++offset) {
+            auto* row = request.bitmask_cpu_out + static_cast<size_t>(offset) * request.bitmask_size_int32;
+            row[word_idx] &= static_cast<int32_t>(~bit);
+        }
+        return cap_ < 0 ? request.propose_step : cap_;
+    }
+
+private:
+    int32_t token_id_;
+    int     cap_;
+};
+
+struct LatencyStats {
+    double min_us  = 0;
+    double mean_us = 0;
+    double p50_us  = 0;
+    double p90_us  = 0;
+    double max_us  = 0;
+};
+
+LatencyStats summarize(std::vector<double> samples) {
+    EXPECT_FALSE(samples.empty());
+    std::sort(samples.begin(), samples.end());
+    auto percentile = [&samples](double quantile) {
+        const auto rank = static_cast<size_t>(std::ceil(quantile * samples.size()));
+        return samples[std::min(samples.size() - 1, std::max<size_t>(1, rank) - 1)];
+    };
+
+    LatencyStats stats;
+    stats.min_us  = samples.front();
+    stats.mean_us = std::accumulate(samples.begin(), samples.end(), 0.0) / samples.size();
+    stats.p50_us  = percentile(0.50);
+    stats.p90_us  = percentile(0.90);
+    stats.max_us  = samples.back();
+    return stats;
+}
+
+template<typename Func>
+LatencyStats benchmarkCpu(Func&& func) {
+    for (int i = 0; i < kWarmupIters; ++i) {
+        func();
+    }
+
+    std::vector<double> samples;
+    samples.reserve(kBenchIters);
+    for (int i = 0; i < kBenchIters; ++i) {
+        const auto begin = Clock::now();
+        func();
+        const auto end = Clock::now();
+        samples.push_back(std::chrono::duration<double, std::micro>(end - begin).count());
+    }
+    return summarize(std::move(samples));
+}
+
+void printStats(const std::string& label, const LatencyStats& stats) {
+    std::cout << std::fixed << std::setprecision(3) << "[spec-logits-perf] " << label
+              << " min_us=" << stats.min_us << " mean_us=" << stats.mean_us << " p50_us=" << stats.p50_us
+              << " p90_us=" << stats.p90_us << " max_us=" << stats.max_us << std::endl;
+}
+
+struct BuildLatencyStats {
+    LatencyStats build_cpu;
+    LatencyStats ready_wait;
+};
+
+BuildLatencyStats benchmarkBuild(SpecLogitsVerifyRunner& runner, const SpecLogitsVerifyRunner::LaunchTask& task) {
+    auto run_once = [&runner, &task]() {
+        const auto begin  = Clock::now();
+        auto       result = runner.buildInline(task);
+        const auto built  = Clock::now();
+
+        EXPECT_TRUE(result.has_active_processor);
+        EXPECT_TRUE(result.ready_event != nullptr);
+        if (result.ready_event) {
+            result.ready_event->synchronize();
+        }
+        const auto ready = Clock::now();
+        return std::pair<double, double>{
+            std::chrono::duration<double, std::micro>(built - begin).count(),
+            std::chrono::duration<double, std::micro>(ready - built).count(),
+        };
+    };
+
+    for (int i = 0; i < kWarmupIters; ++i) {
+        run_once();
+    }
+
+    std::vector<double> build_samples;
+    std::vector<double> ready_samples;
+    build_samples.reserve(kBenchIters);
+    ready_samples.reserve(kBenchIters);
+    for (int i = 0; i < kBenchIters; ++i) {
+        auto [build_us, ready_us] = run_once();
+        build_samples.push_back(build_us);
+        ready_samples.push_back(ready_us);
+    }
+    return {summarize(std::move(build_samples)), summarize(std::move(ready_samples))};
+}
+
+SpecLogitsVerifyRunner::LaunchTask makeTask(size_t active_processor_count) {
+    SpecLogitsVerifyRunner::LaunchTask task;
+    task.total_streams = kStreamCount;
+    task.propose_step  = kProposeStep;
+    task.vocab_size    = kVocabSize;
+    task.draft_tokens  = torch::zeros({kStreamCount, kProposeStep}, torch::kInt32);
+
+    auto processor = std::make_shared<AllowAllSpecProcessor>();
+    task.active.reserve(active_processor_count);
+    for (size_t i = 0; i < active_processor_count; ++i) {
+        task.active.push_back({processor,
+                               i,
+                               /*processor_idx=*/0,
+                               /*stream_id=*/i + 1,
+                               /*base_seq_len=*/1024,
+                               /*base_output_len=*/128});
+    }
+    return task;
+}
+
+TEST(SpecLogitsVerifyRunnerTest, PackedToDenseHandlesArbitraryBitsAndTail) {
+    constexpr size_t rows          = 2;
+    constexpr size_t vocab_size    = 35;
+    constexpr size_t bitmask_words = 2;
+
+    SpecLogitsVerifyRunner runner;
+    runner.merged_bitmask_cpu_ = torch::tensor(
+        {1513931685, 5, -1513931686, 2},
+        torch::kInt32);
+    auto mask = torch::empty({static_cast<int64_t>(rows), static_cast<int64_t>(vocab_size)}, torch::kBool);
+
+    runner.unpackMergedBitmaskToVocabMask(mask, rows, vocab_size, bitmask_words);
+
+    const auto* words = runner.merged_bitmask_cpu_.data_ptr<int32_t>();
+    const auto* dense = mask.data_ptr<bool>();
+    for (size_t row = 0; row < rows; ++row) {
+        for (size_t token = 0; token < vocab_size; ++token) {
+            const auto word     = static_cast<uint32_t>(words[row * bitmask_words + token / 32]);
+            const bool expected = (word & (1u << (token % 32))) == 0u;
+            EXPECT_EQ(dense[row * vocab_size + token], expected) << "row=" << row << " token=" << token;
+        }
+    }
+}
+
+TEST(SpecLogitsVerifyRunnerTest, SparseActiveRowsLeaveInactiveRowsUnmasked) {
+    constexpr size_t  stream_count = 3;
+    constexpr int     propose_step = 1;
+    constexpr size_t  vocab_size   = 35;
+    constexpr int32_t masked_token = 34;
+
+    SpecLogitsVerifyRunner runner;
+    SpecLogitsVerifyRunner::LaunchTask task;
+    task.total_streams = stream_count;
+    task.propose_step  = propose_step;
+    task.vocab_size    = vocab_size;
+    task.draft_tokens  = torch::zeros({static_cast<int64_t>(stream_count), propose_step}, torch::kInt32);
+    task.active.push_back({std::make_shared<MaskTokenSpecProcessor>(masked_token),
+                           /*stream_idx=*/1,
+                           /*processor_idx=*/0,
+                           /*stream_id=*/17,
+                           /*base_seq_len=*/0,
+                           /*base_output_len=*/0});
+    task.active.push_back({std::make_shared<MaskTokenSpecProcessor>(masked_token - 1, /*cap=*/0),
+                           /*stream_idx=*/1,
+                           /*processor_idx=*/1,
+                           /*stream_id=*/17,
+                           /*base_seq_len=*/0,
+                           /*base_output_len=*/0});
+
+    auto result = runner.buildInline(task);
+    ASSERT_TRUE(result.ready_event != nullptr);
+    result.ready_event->synchronize();
+    auto mask_cpu = result.spec_vocab_mask_gpu.cpu();
+    auto cap_cpu  = result.spec_cap_gpu.cpu();
+
+    ASSERT_EQ(mask_cpu.dim(), 2);
+    ASSERT_EQ(mask_cpu.size(0), 6);
+    ASSERT_EQ(mask_cpu.size(1), static_cast<int64_t>(vocab_size));
+    for (int64_t row = 0; row < mask_cpu.size(0); ++row) {
+        const bool active_row = row == 2 || row == 3;
+        EXPECT_EQ(mask_cpu[row][masked_token].item<bool>(), active_row) << "row=" << row;
+        EXPECT_EQ(mask_cpu[row][masked_token - 1].item<bool>(), active_row) << "row=" << row;
+        EXPECT_FALSE(mask_cpu[row][0].item<bool>()) << "row=" << row;
+    }
+    EXPECT_EQ(cap_cpu[0].item<int32_t>(), propose_step);
+    EXPECT_EQ(cap_cpu[1].item<int32_t>(), 0);
+    EXPECT_EQ(cap_cpu[2].item<int32_t>(), propose_step);
+    ASSERT_EQ(result.applied_processors.size(), 2);
+    EXPECT_EQ(result.applied_processors[0].stream_id, 17);
+    EXPECT_EQ(result.applied_processors[0].processor_idx, 0);
+    EXPECT_EQ(result.applied_processors[1].stream_id, 17);
+    EXPECT_EQ(result.applied_processors[1].processor_idx, 1);
+}
+
+TEST(SpecLogitsVerifyRunnerTest, AllActiveRowsUseDenseFastPath) {
+    constexpr size_t  stream_count = 2;
+    constexpr int     propose_step = 2;
+    constexpr size_t  vocab_size   = 35;
+    constexpr int32_t first_token  = 0;
+    constexpr int32_t second_token = 34;
+
+    SpecLogitsVerifyRunner runner;
+    SpecLogitsVerifyRunner::LaunchTask task;
+    task.total_streams = stream_count;
+    task.propose_step  = propose_step;
+    task.vocab_size    = vocab_size;
+    task.draft_tokens  = torch::zeros({static_cast<int64_t>(stream_count), propose_step}, torch::kInt32);
+    task.active.push_back({std::make_shared<MaskTokenSpecProcessor>(second_token, /*cap=*/1),
+                           /*stream_idx=*/1,
+                           /*processor_idx=*/7,
+                           /*stream_id=*/22,
+                           /*base_seq_len=*/0,
+                           /*base_output_len=*/0});
+    task.active.push_back({std::make_shared<MaskTokenSpecProcessor>(first_token),
+                           /*stream_idx=*/0,
+                           /*processor_idx=*/3,
+                           /*stream_id=*/11,
+                           /*base_seq_len=*/0,
+                           /*base_output_len=*/0});
+
+    auto result = runner.buildInline(task);
+    ASSERT_TRUE(result.ready_event != nullptr);
+    result.ready_event->synchronize();
+    auto mask_cpu = result.spec_vocab_mask_gpu.cpu();
+    auto cap_cpu  = result.spec_cap_gpu.cpu();
+
+    ASSERT_EQ(mask_cpu.size(0), 6);
+    ASSERT_EQ(mask_cpu.size(1), static_cast<int64_t>(vocab_size));
+    for (int64_t row = 0; row < mask_cpu.size(0); ++row) {
+        const bool first_stream = row < propose_step + 1;
+        EXPECT_EQ(mask_cpu[row][first_token].item<bool>(), first_stream) << "row=" << row;
+        EXPECT_EQ(mask_cpu[row][second_token].item<bool>(), !first_stream) << "row=" << row;
+        EXPECT_FALSE(mask_cpu[row][1].item<bool>()) << "row=" << row;
+    }
+    EXPECT_EQ(cap_cpu[0].item<int32_t>(), propose_step);
+    EXPECT_EQ(cap_cpu[1].item<int32_t>(), 1);
+    ASSERT_EQ(result.applied_processors.size(), 2);
+    EXPECT_EQ(result.applied_processors[0].stream_id, 22);
+    EXPECT_EQ(result.applied_processors[0].processor_idx, 7);
+    EXPECT_EQ(result.applied_processors[1].stream_id, 11);
+    EXPECT_EQ(result.applied_processors[1].processor_idx, 3);
+}
+
+// Manual perf test matching normal_profiler_wr3_1.json:
+// decode_stream_size=35, mtp_step=3, DeepSeek-V4 vocab_size=129280.
+// Run explicitly with --gtest_also_run_disabled_tests.
+TEST(SpecLogitsVerifyRunnerPerfTest, DISABLED_DeepSeekFlashDecodeB35P3) {
+    constexpr int64_t rows           = kStreamCount * (kProposeStep + 1);
+    constexpr int64_t bitmask_words  = (kVocabSize + 31) / 32;
+    constexpr int64_t dense_elements = rows * kVocabSize;
+    constexpr int64_t packed_bytes   = rows * bitmask_words * sizeof(int32_t);
+    constexpr int64_t dense_bytes    = dense_elements * sizeof(bool);
+
+    static_assert(dense_bytes == 18099200, "timeline dense-mask H2D byte count changed");
+    static_assert(kStreamCount * kProposeStep * static_cast<int64_t>(sizeof(int32_t)) == 420,
+                  "timeline draft-token D2H byte count changed");
+
+    std::cout << "[spec-logits-perf] shape B=" << kStreamCount << " P=" << kProposeStep << " V=" << kVocabSize
+              << " rows=" << rows << " packed_bytes=" << packed_bytes << " dense_bytes=" << dense_bytes
+              << " dense_over_packed=" << static_cast<double>(dense_bytes) / packed_bytes << std::endl;
+
+    SpecLogitsVerifyRunner runner;
+
+    // Isolate the packed-to-dense O(B * (P + 1) * V) loop used by buildInline.
+    // The test target compiles with -fno-access-control, matching the existing
+    // logits-processor test convention, so private scratch/method access here
+    // does not change the production API.
+    runner.merged_bitmask_cpu_ = torch::full({rows, bitmask_words},
+                                             SpecLogitsProcessor::kBitmaskAllowAll,
+                                             torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU));
+    auto dense_mask_cpu = torch::empty(
+        {rows, kVocabSize}, torch::TensorOptions().dtype(torch::kBool).device(torch::kCPU).pinned_memory(true));
+
+    auto unpack_stats = benchmarkCpu([&]() {
+        runner.unpackMergedBitmaskToVocabMask(
+            dense_mask_cpu, static_cast<size_t>(rows), kVocabSize, bitmask_words);
+    });
+    printStats("packed_to_dense_cpu", unpack_stats);
+    EXPECT_FALSE(dense_mask_cpu.data_ptr<bool>()[0]);
+    EXPECT_FALSE(dense_mask_cpu.data_ptr<bool>()[dense_elements - 1]);
+
+    // One active processor exercises the compact path: only its P+1 rows are
+    // expanded on CPU and copied into an otherwise-false full GPU mask.
+    auto one_active_task  = makeTask(/*active_processor_count=*/1);
+    auto one_active_stats = benchmarkBuild(runner, one_active_task);
+    printStats("build_inline_one_active_cpu_enqueue", one_active_stats.build_cpu);
+    printStats("build_inline_one_active_ready_wait", one_active_stats.ready_wait);
+
+    // All-active measures the dense fallback and per-processor packed work.
+    auto all_active_task  = makeTask(/*active_processor_count=*/kStreamCount);
+    auto all_active_stats = benchmarkBuild(runner, all_active_task);
+    printStats("build_inline_all_active_cpu_enqueue", all_active_stats.build_cpu);
+    printStats("build_inline_all_active_ready_wait", all_active_stats.ready_wait);
+
+    // Each benchmark iteration waits for ready_event, so the same pinned source
+    // slot should be reused rather than going through the pinned allocator every
+    // decode round.
+    EXPECT_EQ(runner.cpu_artifact_slots_.size(), 1);
+}
+
+}  // namespace
+}  // namespace rtp_llm


### PR DESCRIPTION
## 问题

Timeline 和 CPU Profile 表明，约 122 ms 的空洞并不是由长时间 CUDA 同步导致的。调用方实际是在等待 `buildSpecLogitsVerifyInline` 中的 worker CPU 工作，其中 `unpackMergedBitmaskToVocabMask` 是 Runner 内的主要热点。

原实现存在以下问题：

- 即使只有部分 stream 存在 active speculative logits processor，仍会展开全部 `B * (P + 1)` 行；
- 对 vocabulary 中的每个 token 都执行除法、取模、位测试和一次 bool 写入；
- 每个 decode round 都重新分配 pinned mask 和 cap tensor。

在 `B=35, P=3, V=129280` 时，每次调用需要生成 18,099,200 个 bool，也就是 18.10 MB 的 dense mask。

## 改动

- 使用 256 项 byte LUT 替换逐 token 的 packed bit 解码：每个完整 word 执行 4 次有界的 8-byte copy，仅 vocabulary 尾部保留标量处理。
- 对 active stream index 去重，只为 `active_streams * (P + 1)` 行生成 packed 和 dense CPU mask。
- 保持完整 CUDA 输出约定：稀疏场景将 inactive 行初始化为 `false`，再直接复制各 active row block；全 active 场景使用一次完整 H2D。
- 仅在 producer ready event 完成后复用 pinned CPU artifact。
- 复用 scratch buffer 时先 flatten，再 narrow 和 reshape，避免 batch 或 shape 变化后沿用旧 stride。
- speculative acceptance 语义保持不变。本改动没有引入 timeout、soft budget、fallback，也不会缩短接受长度。

## 代码引用

- [Byte LUT 与 packed-to-dense 展开](https://github.com/alibaba/rtp-llm/blob/4fa9db840721492be0e48e1f0955295987a26804/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.cc#L27-L135)
- [Active stream 压缩、processor AND 合并与 cap 取最小值](https://github.com/alibaba/rtp-llm/blob/4fa9db840721492be0e48e1f0955295987a26804/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.cc#L151-L204)
- [Pinned artifact 复用以及 sparse/all-active H2D 路径](https://github.com/alibaba/rtp-llm/blob/4fa9db840721492be0e48e1f0955295987a26804/rtp_llm/cpp/models/logits_processor/SpecLogitsVerifyRunner.cc#L206-L265)
- [Tail bit、稀疏行、重复 processor 和全 active 正确性测试](https://github.com/alibaba/rtp-llm/blob/4fa9db840721492be0e48e1f0955295987a26804/rtp_llm/cpp/models/logits_processor/test/SpecLogitsVerifyRunnerPerfTest.cc#L171-L292)
- [B=35、P=3、V=129280 手工 Runner 性能测试](https://github.com/alibaba/rtp-llm/blob/4fa9db840721492be0e48e1f0955295987a26804/rtp_llm/cpp/models/logits_processor/test/SpecLogitsVerifyRunnerPerfTest.cc#L294-L348)

## 性能

以下为 Runner-only p50 数据。测试使用轻量 allow-all processor，用于隔离 Runner 自身开销，不包含 grammar 状态机计算：

| 指标 | 优化前 | 优化后 |
|---|---:|---:|
| 完整 packed-to-dense 展开 | 15.811 ms | 0.760 ms |
| `buildInline` CPU enqueue，1 个 active stream | 15.927 ms | 0.055 ms |
| `buildInline` CPU enqueue，35 个 stream 全 active | 16.154 ms | 1.181 ms |

优化后，单 active stream 的 ready-event wait 为 0.032 ms，全 active 为 0.355 ms，因此全 active Runner 从进入到 ready 约为 1.54 ms。单 active stream 时，H2D mask payload 从 18.10 MB 降至 0.517 MB。

## 正确性保证

- `true` 仍表示 masked；inactive stream 对应行保持 `false`，不会屏蔽 logits。
- 同一 stream 存在多个 processor 时，允许 token 仍按 bitwise AND 取交集，speculative cap 仍取最小值，同时保留全部 applied processor ID。
- 全 active 路径与原 dense 路径逐 bit 等价。
- Ready event 同时覆盖 mask 和 cap 的 copy，只有该 event 完成后才复用 pinned CPU storage。

## 验证

- `//rtp_llm/cpp/models/logits_processor/test:spec_logits_verify_runner_perf_test`：通过，包含显式启用的手工性能用例。
- `//rtp_llm/cpp/normal_engine/speculative/test:mtp_executor_test`：通过。
- `git diff --check`：通过。