### PR TITLE
feat: support cuda graph on AiterPrefillAttnOpTriton to boost mtp performance

### DIFF
--- a/rtp_llm/models_py/bindings/rocm/CKAttnUtils.h
+++ b/rtp_llm/models_py/bindings/rocm/CKAttnUtils.h
@@ -28,6 +28,7 @@ struct CKAttn {
     torch::Tensor input_lengths;
     torch::Tensor sequence_lengths;
     torch::Tensor padding_offset;
+    int           prefill_capture_max_seq_len         = -1;
     int           prefill_runtime_max_seq_len         = -1;
     int           prefill_runtime_max_prefix_len      = -1;
     int           prefill_runtime_seq_len_with_prefix = -1;

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -3,6 +3,7 @@
 #include "rtp_llm/models_py/bindings/core/Dispatch.h"
 #include "rtp_llm/models_py/bindings/core/torch_utils/TypeConvert.h"
 #include "rtp_llm/models_py/bindings/rocm/mrope_config_validation.h"
+#include <algorithm>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -100,6 +101,60 @@ static void copyTensorExactInPlace(torch::Tensor& dst, const torch::Tensor& src,
     dst_flat.copy_(src_match, true);
 }
 
+void rebuildPaddingOffsetForCaptureStride(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inputs) {
+    TORCH_CHECK(attn_inputs.input_lengths.defined(), "prepare_in_place expects input_lengths");
+    TORCH_CHECK(params.padding_offset.defined(), "prepare_in_place expects a captured padding_offset tensor");
+    TORCH_CHECK(params.padding_offset.scalar_type() == at::kInt,
+                "captured padding_offset must be int32, got ",
+                params.padding_offset.scalar_type());
+    TORCH_CHECK(params.padding_offset.is_contiguous(), "captured padding_offset must be contiguous");
+    TORCH_CHECK(params.prefill_capture_max_seq_len > 0,
+                "captured prefill query stride must be positive, got ",
+                params.prefill_capture_max_seq_len);
+    TORCH_CHECK(params.max_seq_len >= 0 && params.max_seq_len <= params.prefill_capture_max_seq_len,
+                "replay input length exceeds captured prefill query stride: capture=",
+                params.prefill_capture_max_seq_len,
+                ", replay=",
+                params.max_seq_len);
+
+    const auto  input_lengths     = attn_inputs.input_lengths.to(torch::kCPU).to(at::kInt).contiguous().reshape({-1});
+    const auto* input_lengths_ptr = input_lengths.data_ptr<int32_t>();
+    const auto  batch_size        = input_lengths.numel();
+    int64_t     total_tokens      = 0;
+    for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
+        const int32_t input_length = input_lengths_ptr[batch_idx];
+        TORCH_CHECK(input_length >= 0, "input length must be non-negative, got ", input_length);
+        TORCH_CHECK(input_length <= params.prefill_capture_max_seq_len,
+                    "replay input length exceeds captured prefill query stride: capture=",
+                    params.prefill_capture_max_seq_len,
+                    ", replay=",
+                    input_length);
+        total_tokens += input_length;
+    }
+
+    auto padding_offset_flat = params.padding_offset.reshape({-1});
+    TORCH_CHECK(total_tokens <= padding_offset_flat.numel(),
+                "captured padding_offset is too small: capacity=",
+                padding_offset_flat.numel(),
+                ", replay tokens=",
+                total_tokens);
+    auto host_padding_offset =
+        params.padding_offset.is_cuda() ?
+            torch::empty({total_tokens}, torch::TensorOptions().dtype(at::kInt).device(at::kCPU)) :
+            padding_offset_flat;
+    auto*   host_padding_offset_ptr = host_padding_offset.data_ptr<int32_t>();
+    int64_t token_cursor            = 0;
+    for (int64_t batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
+        const int32_t input_length = input_lengths_ptr[batch_idx];
+        const int32_t offset = static_cast<int32_t>(batch_idx * params.prefill_capture_max_seq_len - token_cursor);
+        std::fill_n(host_padding_offset_ptr + token_cursor, input_length, offset);
+        token_cursor += input_length;
+    }
+    if (params.padding_offset.is_cuda() && total_tokens > 0) {
+        padding_offset_flat.slice(0, 0, total_tokens).copy_(host_padding_offset, false);
+    }
+}
+
 void updateKvCacheOffset(CKAttn& params, const torch::Tensor& kv_cache_block_id_device) {
     if (!params.kv_cache_offset.defined() || !kv_cache_block_id_device.defined()
         || kv_cache_block_id_device.numel() == 0) {
@@ -131,9 +186,18 @@ void prepareInPlace(CKAttn& params, const torch_ext::PyAttentionInputs& attn_inp
     if (has_prefix) {
         max_prefix_len = attn_inputs.prefix_lengths.max().item<int32_t>();
     }
-    params.prefill_runtime_max_seq_len         = params.max_seq_len;
+
+    if (params.prefill_capture_max_seq_len > 0) {
+        rebuildPaddingOffsetForCaptureStride(params, attn_inputs);
+    }
+
+    // Only padded-Q graph replay freezes the fused RoPE row stride. All other
+    // callers retain the existing live-length metadata path without rebuilding
+    // padding_offset.
+    params.prefill_runtime_max_seq_len =
+        params.prefill_capture_max_seq_len > 0 ? params.prefill_capture_max_seq_len : params.max_seq_len;
     params.prefill_runtime_max_prefix_len      = max_prefix_len;
-    params.prefill_runtime_seq_len_with_prefix = params.max_seq_len + max_prefix_len;
+    params.prefill_runtime_seq_len_with_prefix = params.prefill_runtime_max_seq_len + max_prefix_len;
 
     updateKvCacheOffset(params, attn_inputs.kv_cache_kernel_block_id_device);
 }
@@ -168,11 +232,14 @@ CKAttnPtr FusedRopeKVCachePrefillOpBase::prepare(torch_ext::PyAttentionInputs at
     } else {
         attn_params = std::make_shared<CKAttn>();
     }
-    attn_params->attn_type      = torchDTypeToDataType(attn_inputs.dtype);
-    attn_params->cu_seqlens     = attn_inputs.cu_seqlens_device;
-    attn_params->cu_kv_seqlens  = attn_inputs.cu_kv_seqlens_device;
-    attn_params->input_lengths  = attn_inputs.input_lengths;
-    attn_params->max_seq_len    = attn_inputs.input_lengths.max().item<int32_t>();
+    attn_params->attn_type     = torchDTypeToDataType(attn_inputs.dtype);
+    attn_params->cu_seqlens    = attn_inputs.cu_seqlens_device;
+    attn_params->cu_kv_seqlens = attn_inputs.cu_kv_seqlens_device;
+    attn_params->input_lengths = attn_inputs.input_lengths;
+    attn_params->max_seq_len   = attn_inputs.input_lengths.max().item<int32_t>();
+    if (pad_query) {
+        attn_params->prefill_capture_max_seq_len = attn_params->max_seq_len;
+    }
     attn_params->padding_offset = attn_inputs.padding_offset;
 
     // 处理 prefix_lengths：确保在 CUDA 上且连续

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -818,6 +818,16 @@ __global__ void add_fusedQKV_bias_transpose_prefill_kernel(T*                   
     constexpr int vec_size         = Vec_t<T>::size;
     using Vec_t                    = typename Vec_t<T>::Type;
     const int token_idx            = blockIdx.x;
+
+    if constexpr (PAD_QUERY) {
+        // CUDA Graph replay keeps the capture-time launch grid, while cu_seqlens
+        // is refreshed with the live token count. Ignore graph-capacity tail
+        // blocks before they use the shorter replay lengths for padded indexing.
+        if (token_idx >= cu_seqlens[batch_size]) {
+            return;
+        }
+    }
+
     const int token_padding_offset = padding_offset == nullptr ? 0 : padding_offset[token_idx];
     const int tgt_token_idx        = token_idx + token_padding_offset;
 

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -27,6 +27,7 @@ from rtp_llm.ops.compute_ops import (
     LayerKVCache,
     ParamsBase,
     PyAttentionInputs,
+    get_scalar_type,
     paged_attention_atrex,
 )
 
@@ -962,6 +963,7 @@ def _run_triton_paged_attention(
     *,
     linear_v: bool,
     kv_scale_buf: Optional[torch.Tensor] = None,
+    workspace: Optional[dict] = None,
 ) -> torch.Tensor:
     key_cache = paged_kv_cache.select(1, 0)
     value_cache = paged_kv_cache.select(1, 1)
@@ -980,17 +982,32 @@ def _run_triton_paged_attention(
         else (kv_sizes[0], kv_sizes[1], kv_sizes[2] // x, kv_sizes[3], x)
     )
 
+    has_kv_scale_base = kv_scale_base is not None and (
+        not isinstance(kv_scale_base, torch.Tensor) or kv_scale_base.numel() > 0
+    )
     key_scale, value_scale = None, None
-    if kv_scale_base is not None:
-        kv_b = kv_scale_buf
-        if kv_b is None or kv_b.device != query.device:
-            kv_b = torch.ones(1, dtype=torch.float32, device=query.device)
-        key_scale = kv_b
-        value_scale = kv_b
+    query_is_fp8 = query.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+    if has_kv_scale_base or query_is_fp8:
+        if kv_scale_buf is None:
+            raise ValueError(
+                "kv_scale_buf is required for Triton paged attention "
+                "when KV or query scales are needed; "
+                "ensure FMHAParams was created with alloc_scale=True"
+            )
+        if kv_scale_buf.dtype != torch.float32:
+            raise ValueError(f"kv_scale_buf must be float32, got {kv_scale_buf.dtype}")
+        if kv_scale_buf.device != query.device:
+            raise ValueError(
+                f"kv_scale_buf must be on query device {query.device}, "
+                f"got {kv_scale_buf.device}"
+            )
+        if kv_scale_buf.numel() == 0:
+            raise ValueError("kv_scale_buf must not be empty")
+        if has_kv_scale_base:
+            key_scale = kv_scale_buf
+            value_scale = kv_scale_buf
 
-    num_query_heads = query.shape[1]
     head_size = query.shape[2]
-    query_group_size = num_query_heads // num_kv_heads
 
     query_dtype = query.dtype
     compute_type = (
@@ -1004,76 +1021,58 @@ def _run_triton_paged_attention(
         )
         else query_dtype
     )
-    output_dtype = (
-        torch.bfloat16
-        if query_dtype
-        in (
-            torch.float8_e4m3fnuz,
-            torch.float8_e4m3fn,
-        )
-        else query_dtype
-    )
 
     softmax_scale = 1.0 / (head_size**0.5)
     max_context_partition_num = (
         max_seq_len + context_partition_size - 1
     ) // context_partition_size
-    equivalent_query_group_size = query_length * query_group_size
 
-    output = torch.empty(
-        (num_seqs * query_length, num_query_heads, head_size),
-        dtype=output_dtype,
-        device=query.device,
-    )
-    exp_sums = torch.empty(
-        (
+    if workspace is None:
+        num_query_heads = query.shape[1]
+        query_group_size = num_query_heads // num_kv_heads
+        output_dtype = (
+            torch.bfloat16
+            if query_dtype
+            in (
+                torch.float8_e4m3fnuz,
+                torch.float8_e4m3fn,
+            )
+            else query_dtype
+        )
+        equivalent_query_group_size = query_length * query_group_size
+        output_shape = (num_seqs * query_length, num_query_heads, head_size)
+        workspace_shape = (
             num_seqs,
             num_kv_heads,
             max_context_partition_num,
             equivalent_query_group_size,
-        ),
-        dtype=torch.float32,
-        device=query.device,
-    )
-    max_logits = torch.empty(
-        (
-            num_seqs,
-            num_kv_heads,
-            max_context_partition_num,
-            equivalent_query_group_size,
-        ),
-        dtype=torch.float32,
-        device=query.device,
-    )
-    temporary_output = torch.empty(
-        (
-            num_seqs,
-            num_kv_heads,
-            max_context_partition_num,
-            equivalent_query_group_size,
-            head_size,
-        ),
-        dtype=output_dtype,
-        device=query.device,
-    )
-
-    context_lengths = seq_lens.to(dtype=torch.int32, device=query.device)
-    block_tables = block_tables_id_device.to(dtype=torch.int32, device=query.device)
-
-    if query.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn):
-        q_b = kv_scale_buf
-        if q_b is None or q_b.device != query.device:
-            q_b = torch.ones(1, device=query.device, dtype=torch.float32)
-        query_scale = q_b
+        )
+        temporary_shape = (*workspace_shape, head_size)
+        output = torch.empty(output_shape, dtype=output_dtype, device=query.device)
+        exp_sums = torch.empty(
+            workspace_shape, dtype=torch.float32, device=query.device
+        )
+        max_logits = torch.empty(
+            workspace_shape, dtype=torch.float32, device=query.device
+        )
+        temporary_output = torch.empty(
+            temporary_shape, dtype=output_dtype, device=query.device
+        )
     else:
-        query_scale = None
+        output = workspace["output"]
+        exp_sums = workspace["exp_sums"]
+        max_logits = workspace["max_logits"]
+        temporary_output = workspace["temporary_output"]
+
+    block_tables = block_tables_id_device
+    query_scale = kv_scale_buf if query_is_fp8 else None
 
     torch.ops.aiter.pa_decode_gluon(
         output,
         query,
         key_cache,
         value_cache,
-        context_lengths,
+        seq_lens,
         block_tables,
         softmax_scale,
         query_length,
@@ -1101,6 +1100,7 @@ class AiterPrefillAttnOpTriton:
         self.head_num_kv = attn_configs.kv_head_num
         self.context_partition_size = 256
         self.alloc_scale = attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+        self.enable_cuda_graph = False
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
         has_prefix = (
@@ -1111,12 +1111,124 @@ class AiterPrefillAttnOpTriton:
         return has_prefix
 
     def prepare(self, attn_inputs: PyAttentionInputs):
+        self.enable_cuda_graph = bool(getattr(attn_inputs, "is_cuda_graph", False))
         fmha_params = FMHAParams(
             attn_inputs=attn_inputs,
             is_prefill=True,
             alloc_scale=self.alloc_scale,
         )
+
+        if self.enable_cuda_graph:
+            block_table = getattr(attn_inputs, "kv_cache_kernel_block_id_device", None)
+            if block_table is None:
+                block_table = getattr(attn_inputs, "kv_cache_block_id_device", None)
+            graph_device = _infer_cuda_graph_device(
+                attn_inputs, fmha_params, block_table
+            )
+            fmha_params.graph_device = graph_device
+
+            self._allocate_graph_workspace(
+                fmha_params,
+                fmha_params.cu_seqlens_q.shape[0] - 1,
+                fmha_params.max_seqlen_q,
+                fmha_params.max_seqlen_k,
+                get_scalar_type(attn_inputs.dtype),
+                fmha_params.graph_device,
+            )
+            self.prepare_cuda_graph(fmha_params, attn_inputs)
+        else:
+            fmha_params.compact_indices = self._calc_compact_indices(fmha_params)
+
         return fmha_params
+
+    def _graph_output_dtype(self, dtype: torch.dtype) -> torch.dtype:
+        return (
+            torch.bfloat16
+            if dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+            else dtype
+        )
+
+    def _allocate_graph_workspace(
+        self,
+        fmha_params: FMHAParams,
+        num_seqs: int,
+        query_length: int,
+        max_seq_len: int,
+        attn_dtype: torch.dtype,
+        device: torch.device,
+    ) -> None:
+        output_dtype = self._graph_output_dtype(attn_dtype)
+        query_group_size = self.head_num // self.head_num_kv
+        max_context_partition_num = (
+            max_seq_len + self.context_partition_size - 1
+        ) // self.context_partition_size
+        equivalent_query_group_size = query_length * query_group_size
+        output_shape = (num_seqs * query_length, self.head_num, self.head_dim)
+        compact_output_shape = (fmha_params.token_q_num, self.head_num, self.head_dim)
+        workspace_shape = (
+            num_seqs,
+            self.head_num_kv,
+            max_context_partition_num,
+            equivalent_query_group_size,
+        )
+        temporary_shape = (*workspace_shape, self.head_dim)
+
+        # Both the RoPE padding kernel and pa_decode_gluon capture query_length
+        # as a host scalar. FusedRopeKVCacheOp.prepare_in_place rebuilds replay
+        # padding offsets against this stride, so shorter live queries keep the
+        # same padded row layout.
+        fmha_params.graph_query_length = query_length
+        fmha_params.graph_token_q_capacity = fmha_params.token_q_num
+
+        fmha_params.attention_output = torch.empty(
+            output_shape, dtype=output_dtype, device=device
+        )
+        fmha_params.compact_output = torch.empty(
+            compact_output_shape, dtype=output_dtype, device=device
+        )
+        fmha_params.exp_sums = torch.empty(
+            workspace_shape, dtype=torch.float32, device=device
+        )
+        fmha_params.max_logits = torch.empty(
+            workspace_shape, dtype=torch.float32, device=device
+        )
+        fmha_params.temporary_output = torch.empty(
+            temporary_shape, dtype=output_dtype, device=device
+        )
+        fmha_params.compact_indices = torch.full(
+            (fmha_params.token_q_num,), 0, dtype=torch.int32, device=device
+        )
+
+    def _calc_compact_indices(self, fmha_params: FMHAParams):
+        cu_seqlens_q = fmha_params.cu_seqlens_q
+        query_stride = getattr(
+            fmha_params, "graph_query_length", fmha_params.max_seqlen_q
+        )
+        device = cu_seqlens_q.device
+
+        num_seqs = cu_seqlens_q.shape[0] - 1
+        q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+
+        seq_ids = torch.repeat_interleave(
+            torch.arange(num_seqs, device=device),
+            q_lens,
+            output_size=fmha_params.token_q_num,
+        )
+        within_seq_pos = (
+            torch.arange(fmha_params.token_q_num, device=device) - cu_seqlens_q[seq_ids]
+        )
+        return (
+            seq_ids * query_stride + (query_stride - q_lens[seq_ids]) + within_seq_pos
+        )
+
+    def prepare_cuda_graph(
+        self, fmha_params: FMHAParams, attn_inputs: PyAttentionInputs
+    ) -> None:
+        compact_indices = self._calc_compact_indices(fmha_params)
+        fmha_params.compact_indices.fill_(0)
+        fmha_params.compact_indices[: compact_indices.shape[0]].copy_(
+            compact_indices, non_blocking=True
+        )
 
     def forward(self, qkv, kv_cache, fmha_params) -> torch.Tensor:
         block_tables_id_device = fmha_params.kv_cache_block_id_device
@@ -1124,17 +1236,20 @@ class AiterPrefillAttnOpTriton:
             block_tables_id_device.shape[0] if block_tables_id_device is not None else 1
         )
         query = qkv[0]
-        token_num = query.shape[0]
-        device = query.device
 
-        # cu_seqlens are already on GPU from FMHAParams.__init__
-        cu_seqlens_q = fmha_params.cu_seqlens_q
-        q_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(torch.int32)
         max_q_len = fmha_params.max_seqlen_q
+        token_num = query.shape[0]
         real_token_num = fmha_params.token_q_num
+        seq_lens = fmha_params.prefill_seqlen_k_int32
 
-        cu_seqlens_k = fmha_params.cu_seqlens_k
-        seq_lens = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
+        workspace = None
+        if self.enable_cuda_graph:
+            workspace = {
+                "output": fmha_params.attention_output,
+                "exp_sums": fmha_params.exp_sums,
+                "max_logits": fmha_params.max_logits,
+                "temporary_output": fmha_params.temporary_output,
+            }
 
         output = _run_triton_paged_attention(
             query,
@@ -1149,19 +1264,18 @@ class AiterPrefillAttnOpTriton:
             self.context_partition_size,
             linear_v=False,
             kv_scale_buf=fmha_params.kv_scale,
+            workspace=workspace,
         )
 
-        if token_num != real_token_num:
-            seq_ids = torch.arange(num_seqs, device=device).repeat_interleave(q_lens)
-            within_seq_pos = (
-                torch.arange(real_token_num, device=device) - cu_seqlens_q[seq_ids]
+        if self.enable_cuda_graph:
+            torch.index_select(
+                output, 0, fmha_params.compact_indices, out=fmha_params.compact_output
             )
-            dst_indices = (
-                seq_ids * max_q_len + (max_q_len - q_lens[seq_ids]) + within_seq_pos
-            )
-            output = output[dst_indices]
-
-        return output.view(real_token_num, -1)
+            return fmha_params.compact_output
+        else:
+            if token_num != real_token_num:
+                output = output[fmha_params.compact_indices]
+            return output.view(real_token_num, -1)
 
 
 class AiterDecodeAttnOpBase:
@@ -1592,9 +1706,52 @@ class AiterPrefillImplPaged(FMHAImplBase):
         self.rope_kvcache_impl.use_paged_fmha = True
 
         self.attn_inputs = attn_inputs
-        self.fmha_params = self.batch_prefill_impl.prepare(attn_inputs)
+        self.enable_cuda_graph = attn_inputs.is_cuda_graph
+        self.fmha_params: Optional[FMHAParams] = None
+        self.triton_fmha_params: Optional[FMHAParams] = None
+        # attn_inputs is fixed for this implementation instance. Select before
+        # prepare() so only the dispatched backend owns metadata and workspace,
+        # and keep all initialization out of forward().
+        self.backend = self._select_backend(attn_inputs)
+        self._prepare_backend(self.backend)
+        # Only graph-captured Triton prefill needs FusedRopeKVCacheOp to retain
+        # the capture row stride and rebuild replay padding offsets.
+        self.rope_kvcache_impl.pad_query = (
+            self.need_rope_kv_cache
+            and self.enable_cuda_graph
+            and self.backend == "triton"
+        )
         self.rope_params = self.rope_kvcache_impl.prepare(attn_inputs)
         self.write_cache_store_impl = common.create_write_cache_store_impl(attn_inputs)
+
+    def _use_triton_paged_prefill(self, attn_inputs: PyAttentionInputs) -> bool:
+        input_lengths = attn_inputs.input_lengths
+        batch_size = input_lengths.numel()
+        max_q_len = int(input_lengths.max().item()) if batch_size > 0 else 0
+        return batch_size > 0 and 0 < max_q_len <= 4
+
+    def _select_backend(self, attn_inputs: PyAttentionInputs) -> str:
+        return "triton" if self._use_triton_paged_prefill(attn_inputs) else "batch"
+
+    def _prepare_backend(self, backend: str) -> FMHAParams:
+        if backend == "triton":
+            if self.triton_fmha_params is None:
+                self.triton_fmha_params = self.triton_prefill_impl.prepare(
+                    self.attn_inputs
+                )
+            return self.triton_fmha_params
+        if backend == "batch":
+            if self.fmha_params is None:
+                self.fmha_params = self.batch_prefill_impl.prepare(self.attn_inputs)
+            return self.fmha_params
+        raise ValueError(f"Unknown Aiter prefill backend: {backend}")
+
+    def _get_fmha_params(self, backend: str) -> FMHAParams:
+        if backend == "triton" and self.triton_fmha_params is not None:
+            return self.triton_fmha_params
+        if backend == "batch" and self.fmha_params is not None:
+            return self.fmha_params
+        raise RuntimeError(f"Aiter prefill backend was not prepared: {backend}")
 
     @classmethod
     def support(
@@ -1607,96 +1764,155 @@ class AiterPrefillImplPaged(FMHAImplBase):
             attn_configs
         )
 
-    def _update_prefill_params_for_cuda_graph(
-        self, attn_inputs: PyAttentionInputs
+    def _copy_padded_int32(self, dst: torch.Tensor, src: torch.Tensor) -> None:
+        """Copy src into dst and pad the tail with the last copied value."""
+        src = src.to(device=dst.device, dtype=torch.int32)
+        if src.numel() > dst.numel():
+            raise ValueError(
+                f"source tensor is larger than destination: {src.numel()} > {dst.numel()}"
+            )
+        dst[: src.numel()].copy_(src, non_blocking=True)
+        if src.numel() < dst.numel():
+            pad_value = (
+                src[-1]
+                if src.numel() > 0
+                else torch.zeros((), dtype=torch.int32, device=dst.device)
+            )
+            dst[src.numel() :].fill_(int(pad_value.item()))
+
+    def _refresh_prefill_fmha_params_for_cuda_graph(
+        self, fmha_params: Any, attn_inputs: PyAttentionInputs
     ) -> None:
-        input_lengths = attn_inputs.input_lengths
+        """Refresh graph-captured prefill metadata in-place.
 
-        fmha_params = self.fmha_params
+        CUDA/HIP graph replay captures tensor addresses. Any tensor consumed by an
+        attention kernel must keep capture-time storage and receive new values via
+        copy_ before replay.
+        """
         expected_batch = fmha_params.cu_seqlens_q.numel() - 1
+        if expected_batch < 0:
+            raise ValueError("cu_seqlens_q must have at least one element")
 
-        live_cu_seqlens_q = getattr(attn_inputs, "cu_seqlens_device", None)
-        live_cu_seqlens_k = getattr(attn_inputs, "cu_kv_seqlens_device", None)
-        use_live_cu_seqlens = (
-            live_cu_seqlens_q is not None
-            and live_cu_seqlens_k is not None
-            and live_cu_seqlens_q.numel() == expected_batch + 1
-            and live_cu_seqlens_k.numel() == expected_batch + 1
+        input_lengths = attn_inputs.input_lengths
+        if input_lengths.numel() > expected_batch:
+            raise ValueError(
+                "Aiter prefill CUDA graph replay batch mismatch: "
+                f"capture={expected_batch}, replay={input_lengths.numel()}"
+            )
+
+        q_lens_host = torch.zeros(expected_batch, dtype=torch.int32)
+        if input_lengths.numel() > 0:
+            q_lens_host[: input_lengths.numel()].copy_(
+                input_lengths.to(dtype=torch.int32, device="cpu")
+            )
+
+        prefix_src = getattr(attn_inputs, "prefix_lengths", None)
+        prefix_host = torch.zeros(expected_batch, dtype=torch.int32)
+        if prefix_src is not None and prefix_src.numel() > 0:
+            if prefix_src.numel() != input_lengths.numel():
+                raise ValueError(
+                    "Aiter prefill CUDA graph replay prefix/input length mismatch: "
+                    f"input={input_lengths.numel()}, prefix={prefix_src.numel()}"
+                )
+            if prefix_src.numel() > expected_batch:
+                raise ValueError(
+                    "Aiter prefill CUDA graph replay prefix length mismatch: "
+                    f"capture={expected_batch}, replay={prefix_src.numel()}"
+                )
+            prefix_host[: prefix_src.numel()].copy_(
+                prefix_src.to(dtype=torch.int32, device="cpu")
+            )
+        kv_lens_host = q_lens_host + prefix_host
+
+        cu_q_host = torch.zeros(expected_batch + 1, dtype=torch.int32)
+        cu_k_host = torch.zeros(expected_batch + 1, dtype=torch.int32)
+        if expected_batch > 0:
+            cu_q_host[1:] = torch.cumsum(q_lens_host, dim=0)
+            cu_k_host[1:] = torch.cumsum(kv_lens_host, dim=0)
+
+        self._copy_padded_int32(fmha_params.cu_seqlens_q, cu_q_host)
+        self._copy_padded_int32(fmha_params.cu_seqlens_k, cu_k_host)
+
+        kv_lens = kv_lens_host.to(device=fmha_params.cu_seqlens_k.device)
+        prefill_seqlen_k = getattr(fmha_params, "prefill_seqlen_k_int32", None)
+        if (
+            prefill_seqlen_k is None
+            or prefill_seqlen_k.numel() != expected_batch
+            or prefill_seqlen_k.device != fmha_params.cu_seqlens_k.device
+        ):
+            raise ValueError(
+                "Aiter prefill CUDA graph params must own a stable "
+                "prefill_seqlen_k_int32 tensor"
+            )
+        prefill_seqlen_k.copy_(kv_lens, non_blocking=True)
+
+        fmha_params.prefix_lengths = prefix_host.to(
+            device=fmha_params.cu_seqlens_q.device
         )
-
-        if use_live_cu_seqlens:
-            fmha_params.cu_seqlens_q.copy_(
-                live_cu_seqlens_q.to(
-                    device=fmha_params.cu_seqlens_q.device, dtype=torch.int32
-                )
-            )
-            fmha_params.cu_seqlens_k.copy_(
-                live_cu_seqlens_k.to(
-                    device=fmha_params.cu_seqlens_k.device, dtype=torch.int32
-                )
-            )
-            q_lengths = fmha_params.cu_seqlens_q[1:] - fmha_params.cu_seqlens_q[:-1]
-            kv_lengths = fmha_params.cu_seqlens_k[1:] - fmha_params.cu_seqlens_k[:-1]
-            prefix_lengths = kv_lengths - q_lengths
-        else:
-            q_lengths = input_lengths.to(
-                device=fmha_params.cu_seqlens_q.device, dtype=torch.int32
-            )
-            fmha_params.cu_seqlens_q.zero_()
-            fmha_params.cu_seqlens_q[1:].copy_(torch.cumsum(q_lengths, dim=0))
-
-            prefix_lengths = getattr(attn_inputs, "prefix_lengths", None)
-            if prefix_lengths is None:
-                prefix_lengths = torch.zeros_like(q_lengths)
-            else:
-                if prefix_lengths.shape[0] != expected_batch:
-                    raise ValueError(
-                        "AiterPrefillImplPaged CUDA graph replay prefix length mismatch: "
-                        f"capture={expected_batch}, replay={prefix_lengths.shape[0]}"
-                    )
-                prefix_lengths = prefix_lengths.to(
-                    device=fmha_params.cu_seqlens_k.device, dtype=torch.int32
-                )
-
-            kv_lengths = q_lengths + prefix_lengths
-            fmha_params.cu_seqlens_k.zero_()
-            fmha_params.cu_seqlens_k[1:].copy_(torch.cumsum(kv_lengths, dim=0))
-
-        fmha_params.prefix_lengths = prefix_lengths
-
-        q_lens = input_lengths
-        pl_src = getattr(attn_inputs, "prefix_lengths", None)
-        if pl_src is not None and pl_src.numel() >= expected_batch:
-            p_lens = pl_src[:expected_batch]
-        else:
-            p_lens = torch.zeros_like(q_lens)
-        kv_lens = q_lens + p_lens.to(dtype=q_lens.dtype)
-        fmha_params.max_seq_len = int(q_lens.max()) if expected_batch > 0 else 0
+        fmha_params.max_seq_len = (
+            int(q_lens_host.max().item()) if expected_batch > 0 else 0
+        )
         fmha_params.max_seqlen_q = fmha_params.max_seq_len
-        fmha_params.max_seqlen_k = int(kv_lens.max()) if expected_batch > 0 else 0
-        fmha_params.token_q_num = int(q_lens.sum())
-        fmha_params.token_kv_num = int(kv_lens.sum())
+        fmha_params.max_seqlen_k = (
+            int(kv_lens_host.max().item()) if expected_batch > 0 else 0
+        )
+        fmha_params.token_q_num = int(q_lens_host.sum().item())
+        fmha_params.token_kv_num = int(kv_lens_host.sum().item())
 
-        # Sync prefill_seqlen_k_int32 from updated cu_seqlens_k so that
-        # CUDA graph replay does not reuse stale seqlen_k values.
-        fmha_params.prefill_seqlen_k_int32 = (
-            fmha_params.cu_seqlens_k[1:] - fmha_params.cu_seqlens_k[:-1]
-        ).to(torch.int32)
+        graph_query_length = getattr(fmha_params, "graph_query_length", None)
+        if (
+            graph_query_length is not None
+            and fmha_params.max_seqlen_q > graph_query_length
+        ):
+            raise ValueError(
+                "Aiter prefill CUDA graph replay query length exceeds capture "
+                f"capacity: capture={graph_query_length}, "
+                f"replay={fmha_params.max_seqlen_q}"
+            )
+
+        graph_token_q_capacity = getattr(fmha_params, "graph_token_q_capacity", None)
+        if (
+            graph_token_q_capacity is not None
+            and fmha_params.token_q_num > graph_token_q_capacity
+        ):
+            raise ValueError(
+                "Aiter prefill CUDA graph replay token count exceeds capture "
+                f"capacity: capture={graph_token_q_capacity}, "
+                f"replay={fmha_params.token_q_num}"
+            )
 
         kv_block_id = getattr(attn_inputs, "kv_cache_kernel_block_id_device", None)
         if kv_block_id is None:
             kv_block_id = getattr(attn_inputs, "kv_cache_block_id_device", None)
         if kv_block_id is None:
             raise ValueError(
-                "AiterPrefillImplPaged.prepare_cuda_graph requires kv cache block ids"
+                "Aiter prefill CUDA graph replay requires kv cache block ids"
             )
         fmha_params.kv_cache_block_id_device = kv_block_id
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
         self.attn_inputs = attn_inputs
-        self._update_prefill_params_for_cuda_graph(attn_inputs)
 
-        self.batch_prefill_impl.prepare_cuda_graph(self.fmha_params, attn_inputs)
+        if self.backend == "triton":
+            if self.triton_fmha_params is None:
+                raise RuntimeError("Triton graph backend was not prepared at capture")
+            self._refresh_prefill_fmha_params_for_cuda_graph(
+                self.triton_fmha_params, attn_inputs
+            )
+            self.triton_prefill_impl.prepare_cuda_graph(
+                self.triton_fmha_params, attn_inputs
+            )
+        elif self.backend == "batch":
+            if self.fmha_params is None:
+                raise RuntimeError("Batch graph backend was not prepared at capture")
+            self._refresh_prefill_fmha_params_for_cuda_graph(
+                self.fmha_params, attn_inputs
+            )
+            self.batch_prefill_impl.prepare_cuda_graph(self.fmha_params, attn_inputs)
+        else:
+            raise RuntimeError(
+                "Aiter prefill CUDA graph replay has no captured attention backend"
+            )
 
         prepare_in_place = getattr(self.rope_params, "prepare_in_place", None)
         if callable(prepare_in_place):
@@ -1708,19 +1924,17 @@ class AiterPrefillImplPaged(FMHAImplBase):
         kv_cache: Optional[LayerKVCache],
         layer_idx: int = 0,
     ) -> torch.Tensor:
-        cu_seqlens_q = self.fmha_params.cu_seqlens_q
+        fmha_params = self._get_fmha_params(self.backend)
+
+        cu_seqlens_q = fmha_params.cu_seqlens_q
         batch_size = cu_seqlens_q.shape[0] - 1
-        max_q_len = int(self.fmha_params.max_seqlen_q) if batch_size > 0 else 0
-        token_num = int(self.fmha_params.token_q_num) if batch_size > 0 else 0
-        use_triton = (
-            False
-            if self.batch_prefill_impl.enable_cuda_graph
-            else (batch_size > 0 and 0 < max_q_len <= 4)
-        )
+        max_q_len = int(fmha_params.max_seqlen_q) if batch_size > 0 else 0
+        token_num = int(fmha_params.token_q_num) if batch_size > 0 else 0
+        use_triton = self.backend == "triton"
 
         if self.need_rope_kv_cache:
-            self.rope_kvcache_impl.pad_query = (
-                use_triton and token_num != batch_size * max_q_len
+            self.rope_kvcache_impl.pad_query = use_triton and (
+                self.enable_cuda_graph or token_num != batch_size * max_q_len
             )
             fmha_input = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
         else:
@@ -1738,13 +1952,9 @@ class AiterPrefillImplPaged(FMHAImplBase):
         )
 
         if use_triton:
-            return self.triton_prefill_impl.forward(
-                fmha_input, kv_cache, self.fmha_params
-            )
+            return self.triton_prefill_impl.forward(fmha_input, kv_cache, fmha_params)
         else:
-            return self.batch_prefill_impl.forward(
-                fmha_input, kv_cache, self.fmha_params
-            )
+            return self.batch_prefill_impl.forward(fmha_input, kv_cache, fmha_params)
 
 
 class AiterDecodeImplBase(FMHAImplBase):

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -40,12 +40,15 @@ except ImportError:
 try:
     from rtp_llm.models_py.modules.factory.attention import attn_factory
     from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
+        AiterDecodeImplTriton,
         AiterPrefillAttnOp,
         AiterPrefillAttnOpPaged,
+        AiterPrefillAttnOpTriton,
         AiterPrefillImplAsm,
         AiterPrefillImplNonAsm,
         AiterPrefillImplPaged,
         FMHAParams,
+        _run_triton_paged_attention,
         validate_v_layout,
     )
     from rtp_llm.ops import (
@@ -673,7 +676,7 @@ class TestAiterPrefillImplPagedSupport(unittest.TestCase):
 
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillImplPaged module")
 class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
-    """Unit tests for AiterPrefillImplPaged._update_prefill_params_for_cuda_graph.
+    """Unit tests for prefill CUDA-graph FMHA metadata refresh.
 
     Uses a lightweight stub to bypass the heavy __init__ chain (aiter, RoPE, etc.).
     Only exercises the cu_seqlens/prefix/scalar reconstruction logic.
@@ -693,8 +696,10 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
             token_q_num=0,
             token_kv_num=0,
             kv_cache_block_id_device=None,
+            prefill_seqlen_k_int32=torch.zeros(batch_size, dtype=torch.int32),
         )
-        stub = SimpleNamespace(fmha_params=fmha_params)
+        stub = AiterPrefillImplPaged.__new__(AiterPrefillImplPaged)
+        stub.fmha_params = fmha_params
         return stub
 
     def _make_attn_inputs(
@@ -720,7 +725,7 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         return inputs
 
     def _call_update(self, stub, attn_inputs):
-        AiterPrefillImplPaged._update_prefill_params_for_cuda_graph(stub, attn_inputs)
+        stub._refresh_prefill_fmha_params_for_cuda_graph(stub.fmha_params, attn_inputs)
 
     def test_rebuild_from_input_lengths_no_prefix(self):
         """Rebuild cu_seqlens from input_lengths, no prefix."""
@@ -772,11 +777,11 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         self.assertEqual(p.max_seq_len, 5)
         self.assertEqual(p.token_q_num, 13)
 
-    def test_live_cu_seqlens_path(self):
-        """When live cu_seqlens are provided, use them directly."""
+    def test_rebuild_ignores_stale_live_cu_seqlens(self):
+        """Replay metadata is rebuilt from input and prefix lengths."""
         stub = self._make_stub(batch_size=2)
-        cu_q = torch.tensor([0, 5, 10], dtype=torch.int32)
-        cu_k = torch.tensor([0, 105, 210], dtype=torch.int32)
+        cu_q = torch.tensor([0, 1, 2], dtype=torch.int32)
+        cu_k = torch.tensor([0, 2, 4], dtype=torch.int32)
         inputs = self._make_attn_inputs(
             [5, 5],
             prefix_lengths=torch.tensor([100, 100], dtype=torch.int32),
@@ -790,7 +795,7 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         self.assertEqual(p.cu_seqlens_k.tolist(), [0, 105, 210])
         self.assertEqual(p.prefix_lengths.tolist(), [100, 100])
         self.assertEqual(p.max_seqlen_k, 105)
-        # prefill_seqlen_k_int32 must be derived from live cu_seqlens_k
+        # prefill_seqlen_k_int32 is rebuilt from input and prefix lengths.
         self.assertEqual(p.prefill_seqlen_k_int32.tolist(), [105, 105])
 
     def test_prefix_batch_size_mismatch_raises(self):
@@ -818,6 +823,660 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             self._call_update(stub, inputs)
+
+    def test_replay_query_length_above_capture_capacity_raises(self):
+        stub = self._make_stub(batch_size=2)
+        stub.fmha_params.graph_query_length = 4
+        stub.fmha_params.graph_token_q_capacity = 8
+        inputs = self._make_attn_inputs(
+            [5, 0], prefix_lengths=torch.tensor([100, 100], dtype=torch.int32)
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "query length exceeds capture capacity"
+        ):
+            self._call_update(stub, inputs)
+
+
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillImplPaged module")
+class TestAiterPrefillImplPagedCudaGraphDispatch(unittest.TestCase):
+    """Unit tests for small-q dispatch under CUDA graph."""
+
+    def _make_impl_with_mocked_prepare(
+        self, input_lengths, is_cuda_graph, need_rope_kv_cache=False
+    ):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        batch_params = SimpleNamespace(workspace_bytes=1024)
+        triton_params = SimpleNamespace(workspace_bytes=2048)
+        batch_impl = MagicMock()
+        batch_impl.prepare.return_value = batch_params
+        triton_impl = MagicMock()
+        triton_impl.prepare.return_value = triton_params
+        rope_impl = MagicMock()
+        observed_pad_query = []
+
+        def prepare_rope(_):
+            observed_pad_query.append(rope_impl.pad_query)
+            return object()
+
+        rope_impl.prepare.side_effect = prepare_rope
+
+        cfg = SimpleNamespace(
+            need_rope_kv_cache=need_rope_kv_cache,
+            kv_head_num=1,
+            size_per_head=8,
+            kernel_tokens_per_block=16,
+        )
+        attn_inputs = SimpleNamespace(
+            is_cuda_graph=is_cuda_graph,
+            input_lengths=torch.tensor(input_lengths, dtype=torch.int32),
+        )
+        module_path = "rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter"
+        with patch(
+            f"{module_path}.AiterPrefillAttnOpPaged", return_value=batch_impl
+        ), patch(
+            f"{module_path}.AiterPrefillAttnOpTriton", return_value=triton_impl
+        ), patch(
+            f"{module_path}.FusedRopeKVCachePrefillOpAsm", return_value=rope_impl
+        ), patch(
+            f"{module_path}.common.create_write_cache_store_impl"
+        ):
+            impl = AiterPrefillImplPaged(cfg, attn_inputs)
+
+        return (
+            impl,
+            batch_impl,
+            triton_impl,
+            batch_params,
+            triton_params,
+            observed_pad_query,
+        )
+
+    def test_cuda_graph_prepares_only_selected_backend_workspace(self):
+        cases = [([4, 1], "triton"), ([5, 1], "batch")]
+        for input_lengths, expected_backend in cases:
+            with self.subTest(expected_backend=expected_backend):
+                (
+                    impl,
+                    batch_impl,
+                    triton_impl,
+                    batch_params,
+                    triton_params,
+                    _,
+                ) = self._make_impl_with_mocked_prepare(input_lengths, True)
+
+                self.assertEqual(impl.backend, expected_backend)
+                if expected_backend == "triton":
+                    triton_impl.prepare.assert_called_once_with(impl.attn_inputs)
+                    batch_impl.prepare.assert_not_called()
+                    self.assertIs(impl.triton_fmha_params, triton_params)
+                    self.assertIsNone(impl.fmha_params)
+                else:
+                    batch_impl.prepare.assert_called_once_with(impl.attn_inputs)
+                    triton_impl.prepare.assert_not_called()
+                    self.assertIs(impl.fmha_params, batch_params)
+                    self.assertIsNone(impl.triton_fmha_params)
+
+    def test_eager_prepares_only_selected_backend_during_construction(self):
+        impl, batch_impl, triton_impl, _, triton_params, _ = (
+            self._make_impl_with_mocked_prepare([4, 1], False)
+        )
+
+        batch_impl.prepare.assert_not_called()
+        triton_impl.prepare.assert_called_once_with(impl.attn_inputs)
+        self.assertIs(impl.triton_fmha_params, triton_params)
+        self.assertIsNone(impl.fmha_params)
+
+    def test_capture_stride_is_requested_only_for_graph_triton_rope(self):
+        cases = (
+            ([4, 1], True, True, True),
+            ([5, 1], True, True, False),
+            ([4, 1], False, True, False),
+            ([4, 1], True, False, False),
+        )
+        for input_lengths, is_cuda_graph, need_rope, expected in cases:
+            with self.subTest(
+                input_lengths=input_lengths,
+                is_cuda_graph=is_cuda_graph,
+                need_rope=need_rope,
+            ):
+                *_, observed_pad_query = self._make_impl_with_mocked_prepare(
+                    input_lengths, is_cuda_graph, need_rope
+                )
+                self.assertEqual(observed_pad_query, [expected])
+
+    def _make_stub(self, graph_prepared: bool):
+        from types import SimpleNamespace
+
+        calls = []
+        fmha_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 4, 8], dtype=torch.int32),
+            max_seqlen_q=4,
+            token_q_num=8,
+            cuda_graph_prepared=graph_prepared,
+        )
+        batch_impl = SimpleNamespace(enable_cuda_graph=True)
+        triton_impl = SimpleNamespace()
+        triton_fmha_params = SimpleNamespace(
+            cu_seqlens_q=torch.tensor([0, 4, 8], dtype=torch.int32),
+            max_seqlen_q=4,
+            token_q_num=8,
+        )
+
+        def batch_forward(qkv, kv_cache, params):
+            calls.append("batch")
+            return torch.full((8, 1), 1.0)
+
+        def triton_forward(qkv, kv_cache, params):
+            calls.append("triton")
+            self.assertIs(params, triton_fmha_params)
+            return torch.full((8, 1), 2.0)
+
+        batch_impl.forward = batch_forward
+        triton_impl.forward = triton_forward
+
+        stub = AiterPrefillImplPaged.__new__(AiterPrefillImplPaged)
+        stub.fmha_params = fmha_params
+        stub.enable_cuda_graph = True
+        stub.backend = "triton"
+        stub.need_rope_kv_cache = False
+        stub.write_cache_store_impl = None
+        stub.attn_inputs = SimpleNamespace(is_prefill=True, cache_store_inputs=None)
+        stub.head_num_kv = 1
+        stub.tokens_per_block = 16
+        stub.head_dim = 1
+        stub.batch_prefill_impl = batch_impl
+        stub.triton_prefill_impl = triton_impl
+        stub.triton_fmha_params = triton_fmha_params
+        kv_cache = SimpleNamespace(
+            kv_cache_base=torch.empty(1, 2, 1, 16, 1),
+        )
+        qkv = (torch.empty(8, 1, 1),)
+        return stub, qkv, kv_cache, calls
+
+    def test_cuda_graph_uses_triton_when_small_q_and_graph_prepared(self):
+        stub, qkv, kv_cache, calls = self._make_stub(graph_prepared=True)
+
+        out = AiterPrefillImplPaged.forward(stub, qkv, kv_cache)
+
+        self.assertEqual(calls, ["triton"])
+        self.assertTrue(torch.equal(out, torch.full((8, 1), 2.0)))
+
+    def test_cuda_graph_uses_triton_when_small_q_even_without_batch_graph_workspace(
+        self,
+    ):
+        stub, qkv, kv_cache, calls = self._make_stub(graph_prepared=False)
+
+        out = AiterPrefillImplPaged.forward(stub, qkv, kv_cache)
+
+        self.assertEqual(calls, ["triton"])
+        self.assertTrue(torch.equal(out, torch.full((8, 1), 2.0)))
+
+    def _run_cuda_graph_prepare(self, captured_backend):
+        from types import SimpleNamespace
+
+        calls = []
+        fmha_params = object()
+        triton_fmha_params = object()
+        attn_inputs = object()
+
+        def prepare_batch(params, inputs):
+            calls.append(("prepare_batch", params, inputs))
+
+        def prepare_triton(params, inputs):
+            calls.append(("prepare_triton", params, inputs))
+
+        def prepare_rope(inputs):
+            calls.append(("prepare_rope", inputs))
+
+        def refresh(params, inputs):
+            calls.append(("refresh", params, inputs))
+
+        stub = AiterPrefillImplPaged.__new__(AiterPrefillImplPaged)
+        stub.backend = captured_backend
+        stub.fmha_params = fmha_params
+        stub.triton_fmha_params = triton_fmha_params
+        stub.batch_prefill_impl = SimpleNamespace(prepare_cuda_graph=prepare_batch)
+        stub.triton_prefill_impl = SimpleNamespace(prepare_cuda_graph=prepare_triton)
+        stub.rope_params = SimpleNamespace(prepare_in_place=prepare_rope)
+        stub._refresh_prefill_fmha_params_for_cuda_graph = refresh
+
+        stub.prepare_cuda_graph(attn_inputs)
+        return calls, fmha_params, triton_fmha_params, attn_inputs
+
+    def test_cuda_graph_replay_refreshes_only_captured_backend(self):
+        for captured_backend in ("triton", "batch"):
+            with self.subTest(captured_backend=captured_backend):
+                (
+                    calls,
+                    fmha_params,
+                    triton_fmha_params,
+                    attn_inputs,
+                ) = self._run_cuda_graph_prepare(captured_backend)
+
+                selected_params = (
+                    triton_fmha_params if captured_backend == "triton" else fmha_params
+                )
+                self.assertEqual(
+                    calls,
+                    [
+                        ("refresh", selected_params, attn_inputs),
+                        (
+                            f"prepare_{captured_backend}",
+                            selected_params,
+                            attn_inputs,
+                        ),
+                        ("prepare_rope", attn_inputs),
+                    ],
+                )
+
+
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOpTriton module")
+class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
+    """Unit tests for CUDA graph workspace ownership."""
+
+    def test_compact_indices_keep_capture_query_stride_during_replay(self):
+        """Replay gathers from the fixed-width layout recorded at capture time."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        op = AiterPrefillAttnOpTriton(cfg)
+        fmha_params = SimpleNamespace(
+            # Capture used four query rows per sequence. Replay accepted one
+            # and three tokens, so its runtime max_seqlen_q shrank to three.
+            graph_query_length=4,
+            max_seqlen_q=3,
+            token_q_num=4,
+            cu_seqlens_q=torch.tensor([0, 1, 4, 4], dtype=torch.int32),
+        )
+
+        with patch.object(
+            torch,
+            "repeat_interleave",
+            wraps=torch.repeat_interleave,
+        ) as repeat_interleave:
+            compact_indices = op._calc_compact_indices(fmha_params)
+
+        # The padded query layout remains [batch, capture_query_length].
+        # Valid rows are the right-aligned suffix of each four-row batch slot.
+        self.assertEqual(compact_indices.tolist(), [3, 5, 6, 7])
+        self.assertEqual(
+            repeat_interleave.call_args.kwargs["output_size"],
+            fmha_params.token_q_num,
+        )
+
+    def test_graph_workspace_buffers_are_allocated_on_fmha_params_without_scale_buffer(
+        self,
+    ):
+        from types import SimpleNamespace
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        op = AiterPrefillAttnOpTriton(cfg)
+        fmha_params = SimpleNamespace(token_q_num=8)
+
+        op._allocate_graph_workspace(
+            fmha_params,
+            num_seqs=2,
+            query_length=4,
+            max_seq_len=16,
+            attn_dtype=torch.float16,
+            device=torch.device("cpu"),
+        )
+
+        self.assertEqual(fmha_params.attention_output.shape, (8, 4, 8))
+        self.assertEqual(fmha_params.compact_output.shape, (8, 4, 8))
+        self.assertEqual(fmha_params.exp_sums.shape, (2, 2, 1, 8))
+        self.assertEqual(fmha_params.max_logits.shape, (2, 2, 1, 8))
+        self.assertEqual(fmha_params.temporary_output.shape, (2, 2, 1, 8, 8))
+        self.assertEqual(fmha_params.compact_indices.shape, (8,))
+        self.assertEqual(fmha_params.graph_query_length, 4)
+        self.assertEqual(fmha_params.graph_token_q_capacity, 8)
+        self.assertFalse(hasattr(fmha_params, "kv_scale"))
+        self.assertFalse(hasattr(op, "_graph_output"))
+
+    def test_forward_uses_prepared_graph_workspace_without_allocation(self):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        op = AiterPrefillAttnOpTriton(cfg)
+        op.enable_cuda_graph = True
+        query = torch.empty(8, 4, 8, dtype=torch.float16)
+        workspace = {
+            "output": torch.empty(8, 4, 8, dtype=torch.float16),
+            "exp_sums": torch.empty(2, 2, 1, 8, dtype=torch.float32),
+            "max_logits": torch.empty(2, 2, 1, 8, dtype=torch.float32),
+            "temporary_output": torch.empty(2, 2, 1, 8, 8, dtype=torch.float16),
+        }
+        compact_output = torch.empty(8, 4, 8, dtype=torch.float16)
+        fmha_params = SimpleNamespace(
+            kv_cache_block_id_device=torch.zeros(2, 1, dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 4, 8], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 7, 13], dtype=torch.int32),
+            prefill_seqlen_k_int32=torch.tensor([7, 6], dtype=torch.int32),
+            max_seqlen_q=4,
+            max_seqlen_k=7,
+            token_q_num=8,
+            kv_scale=None,
+            attention_output=workspace["output"],
+            exp_sums=workspace["exp_sums"],
+            max_logits=workspace["max_logits"],
+            temporary_output=workspace["temporary_output"],
+            compact_indices=torch.arange(8, dtype=torch.int32),
+            compact_output=compact_output,
+        )
+        kv_cache = SimpleNamespace(
+            kv_cache_base=torch.empty(1, 2, 2, 16, 8, dtype=torch.float16),
+            kv_scale_base=None,
+        )
+
+        kernel_path = (
+            "rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter."
+            "_run_triton_paged_attention"
+        )
+        with patch.object(
+            op,
+            "_allocate_graph_workspace",
+            side_effect=AssertionError("forward must not allocate graph workspace"),
+        ), patch(kernel_path, return_value=workspace["output"]) as run_attention:
+            out = op.forward((query,), kv_cache, fmha_params)
+
+        self.assertEqual(out.data_ptr(), compact_output.data_ptr())
+        call_workspace = run_attention.call_args.kwargs["workspace"]
+        for name, tensor in workspace.items():
+            self.assertIs(call_workspace[name], tensor)
+
+    @unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+    def test_prepare_cuda_graph_refreshes_triton_lengths_in_place(self):
+        from types import SimpleNamespace
+
+        cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
+        op = AiterPrefillAttnOpTriton(cfg)
+        device = torch.device("cuda")
+        fmha_params = SimpleNamespace(
+            cu_seqlens_q=torch.zeros(4, dtype=torch.int32, device=device),
+            cu_seqlens_k=torch.zeros(4, dtype=torch.int32, device=device),
+            prefill_seqlen_k_int32=torch.full(
+                (3,), -1, dtype=torch.int32, device=device
+            ),
+            compact_indices=torch.full((6,), -1, dtype=torch.int32, device=device),
+            graph_device=device,
+            token_q_num=6,
+            max_seqlen_q=2,
+            max_seqlen_k=9,
+        )
+        prefill_ptr = fmha_params.prefill_seqlen_k_int32.data_ptr()
+        block_ids = torch.zeros(3, 2, dtype=torch.int32, device=device)
+        attn_inputs = SimpleNamespace(
+            input_lengths=torch.tensor([2, 1, 0], dtype=torch.int32),
+            prefix_lengths=torch.tensor([5, 6, 7], dtype=torch.int32),
+            kv_cache_kernel_block_id_device=block_ids,
+        )
+
+        # Replay refreshes metadata at the owning implementation layer before
+        # the Triton operator derives its compact output indices.
+        impl = AiterPrefillImplPaged.__new__(AiterPrefillImplPaged)
+        impl._refresh_prefill_fmha_params_for_cuda_graph(fmha_params, attn_inputs)
+        op.prepare_cuda_graph(fmha_params, attn_inputs)
+
+        self.assertEqual(fmha_params.prefill_seqlen_k_int32.data_ptr(), prefill_ptr)
+        self.assertEqual(fmha_params.cu_seqlens_q.cpu().tolist(), [0, 2, 3, 3])
+        self.assertEqual(fmha_params.cu_seqlens_k.cpu().tolist(), [0, 7, 14, 21])
+        self.assertEqual(fmha_params.prefill_seqlen_k_int32.cpu().tolist(), [7, 7, 7])
+        self.assertEqual(fmha_params.max_seqlen_q, 2)
+        self.assertEqual(fmha_params.max_seqlen_k, 7)
+        self.assertEqual(fmha_params.token_q_num, 3)
+        self.assertEqual(fmha_params.token_kv_num, 21)
+        self.assertEqual(
+            fmha_params.kv_cache_block_id_device.data_ptr(), block_ids.data_ptr()
+        )
+        self.assertEqual(fmha_params.compact_indices.cpu().tolist(), [0, 1, 3, 0, 0, 0])
+
+    def test_triton_paged_attention_requires_caller_scale_when_kv_scale_base_exists(
+        self,
+    ):
+        query = torch.empty(1, 1, 8, dtype=torch.float16)
+        paged_kv_cache = torch.empty(1, 2, 1, 16, 8, dtype=torch.float16)
+        kv_scale_base = torch.empty(1, dtype=torch.float32)
+        seq_lens = torch.ones(1, dtype=torch.int32)
+        block_tables = torch.zeros(1, 1, dtype=torch.int32)
+
+        with self.assertRaisesRegex(ValueError, "kv_scale_buf.*required"):
+            _run_triton_paged_attention(
+                query=query,
+                paged_kv_cache=paged_kv_cache,
+                kv_scale_base=kv_scale_base,
+                num_seqs=1,
+                query_length=1,
+                seq_lens=seq_lens,
+                block_tables_id_device=block_tables,
+                max_seq_len=1,
+                num_kv_heads=1,
+                context_partition_size=256,
+                linear_v=False,
+                kv_scale_buf=None,
+            )
+
+    def test_triton_paged_attention_allows_empty_kv_scale_base_without_scale_buffer(
+        self,
+    ):
+        from unittest.mock import patch
+
+        query = torch.empty(1, 1, 8, dtype=torch.float16)
+        paged_kv_cache = torch.empty(1, 2, 1, 16, 8, dtype=torch.float16)
+        kv_scale_base = torch.empty(0, dtype=torch.float32)
+        seq_lens = torch.ones(1, dtype=torch.int32)
+        block_tables = torch.zeros(1, 1, dtype=torch.int32)
+
+        with patch.object(torch.ops.aiter, "pa_decode_gluon") as kernel:
+            _run_triton_paged_attention(
+                query=query,
+                paged_kv_cache=paged_kv_cache,
+                kv_scale_base=kv_scale_base,
+                num_seqs=1,
+                query_length=1,
+                seq_lens=seq_lens,
+                block_tables_id_device=block_tables,
+                max_seq_len=1,
+                num_kv_heads=1,
+                context_partition_size=256,
+                linear_v=False,
+                kv_scale_buf=None,
+            )
+
+        self.assertIsNone(kernel.call_args.args[11])
+        self.assertIsNone(kernel.call_args.args[12])
+        self.assertIsNone(kernel.call_args.args[13])
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterPrefillTritonCudaGraphNumerics(unittest.TestCase):
+    """Real RoPE -> pa_decode_gluon variable-length graph replay regression."""
+
+    CAPTURE_LENGTHS = [4, 4, 4]
+    REPLAY_LENGTH_CASES = ([4, 4, 2], [2, 2, 2], [4, 2, 4])
+    PREFIX_LENGTHS = [8, 8, 8]
+    HEAD_NUM = 8
+    HEAD_NUM_KV = 2
+    HEAD_DIM = 128
+    TOKENS_PER_BLOCK = 16
+
+    def setUp(self):
+        torch.manual_seed(11)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.block_table = torch.arange(
+            len(self.CAPTURE_LENGTHS), dtype=torch.int32, device=self.device
+        ).view(-1, 1)
+
+    def _make_inputs(self, input_lengths, is_cuda_graph):
+        inputs = _make_rope_prefill_inputs(input_lengths, self.device, self.dtype)
+        inputs.is_cuda_graph = is_cuda_graph
+        if is_cuda_graph:
+            inputs.padding_offset = inputs.padding_offset.cpu().pin_memory()
+        inputs.prefix_lengths = torch.tensor(
+            self.PREFIX_LENGTHS, dtype=torch.int32, device="cpu"
+        ).pin_memory()
+
+        kv_lengths = [
+            query_length + prefix_length
+            for query_length, prefix_length in zip(input_lengths, self.PREFIX_LENGTHS)
+        ]
+        cu_kv = [0]
+        for kv_length in kv_lengths:
+            cu_kv.append(cu_kv[-1] + kv_length)
+        inputs.cu_kv_seqlens_device = torch.tensor(
+            cu_kv, dtype=torch.int32, device=self.device
+        )
+
+        inputs.kv_cache_kernel_block_id = self.block_table.cpu().pin_memory()
+        inputs.kv_cache_kernel_block_id_device = self.block_table.clone()
+        inputs.kv_cache_block_id_device = inputs.kv_cache_kernel_block_id_device
+        return inputs
+
+    def _make_qkv(self, token_num):
+        query = torch.randn(
+            token_num,
+            self.HEAD_NUM,
+            self.HEAD_DIM,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        key = torch.randn(
+            token_num,
+            self.HEAD_NUM_KV,
+            self.HEAD_DIM,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        value = torch.randn_like(key)
+        return _pack_qkv(query, key, value)
+
+    def _cache_dtype(self, kv_cache_dtype):
+        if kv_cache_dtype != KvCacheDataType.FP8:
+            return self.dtype
+        arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+        return torch.float8_e4m3fn if "gfx950" in arch else torch.float8_e4m3fnuz
+
+    def _make_cache(self, cache_snapshot, kv_cache_dtype):
+        cache = LayerKVCache()
+        cache.kv_cache_base = cache_snapshot.clone()
+        cache.kv_scale_base = (
+            torch.ones(
+                cache_snapshot.shape[0],
+                2 * self.HEAD_NUM_KV * self.TOKENS_PER_BLOCK,
+                dtype=torch.float32,
+                device=self.device,
+            )
+            if kv_cache_dtype == KvCacheDataType.FP8
+            else torch.empty(0, dtype=torch.float32, device=self.device)
+        )
+        return cache
+
+    def _copy_replay_inputs_in_place(self, capture_inputs, replay_inputs):
+        capture_inputs.input_lengths.copy_(replay_inputs.input_lengths)
+        capture_inputs.prefix_lengths.copy_(replay_inputs.prefix_lengths)
+        capture_inputs.cu_seqlens_device.copy_(replay_inputs.cu_seqlens_device)
+        capture_inputs.cu_kv_seqlens_device.copy_(replay_inputs.cu_kv_seqlens_device)
+        # Production graph capture owns this tensor in pinned host memory.
+        # Leave its capture-time values stale: prepare_in_place must rebuild
+        # padding_offset against the captured row stride.
+        capture_inputs.kv_cache_kernel_block_id.copy_(
+            replay_inputs.kv_cache_kernel_block_id
+        )
+        capture_inputs.kv_cache_kernel_block_id_device.copy_(
+            replay_inputs.kv_cache_kernel_block_id_device
+        )
+
+    def _run_replay_case(self, kv_cache_dtype, replay_lengths):
+        cfg = _make_rope_attn_configs(
+            self.HEAD_NUM,
+            self.HEAD_NUM_KV,
+            self.HEAD_DIM,
+            self.dtype,
+            self.TOKENS_PER_BLOCK,
+        )
+        cfg.kv_cache_dtype = kv_cache_dtype
+        cfg.max_seq_len = 64
+
+        capture_inputs = self._make_inputs(self.CAPTURE_LENGTHS, True)
+        self.assertFalse(capture_inputs.padding_offset.is_cuda)
+        replay_inputs = self._make_inputs(replay_lengths, False)
+        capture_tokens = sum(self.CAPTURE_LENGTHS)
+        replay_tokens = sum(replay_lengths)
+        static_qkv = self._make_qkv(capture_tokens)
+        replay_qkv = self._make_qkv(replay_tokens)
+
+        cache_dtype = self._cache_dtype(kv_cache_dtype)
+        cache_snapshot = torch.randn(
+            len(self.CAPTURE_LENGTHS),
+            2,
+            self.HEAD_NUM_KV,
+            self.TOKENS_PER_BLOCK,
+            self.HEAD_DIM,
+            dtype=self.dtype,
+            device=self.device,
+        ).to(cache_dtype)
+
+        eager_cache = self._make_cache(cache_snapshot, kv_cache_dtype)
+        eager_impl = AiterPrefillImplPaged(cfg, replay_inputs)
+        expected = eager_impl.forward(replay_qkv, eager_cache, layer_idx=0).clone()
+
+        graph_cache = self._make_cache(cache_snapshot, kv_cache_dtype)
+        graph_impl = AiterPrefillImplPaged(cfg, capture_inputs)
+        self.assertEqual(graph_impl.backend, "triton")
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            graph_impl.forward(static_qkv, graph_cache, layer_idx=0)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        graph_cache.kv_cache_base.copy_(cache_snapshot)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_output = graph_impl.forward(static_qkv, graph_cache, layer_idx=0)
+
+        static_qkv[:replay_tokens].copy_(replay_qkv)
+        graph_cache.kv_cache_base.copy_(cache_snapshot)
+        self._copy_replay_inputs_in_place(capture_inputs, replay_inputs)
+        graph_impl.prepare_cuda_graph(capture_inputs)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        for block_idx in range(cache_snapshot.shape[0]):
+            with self.subTest(kv_cache_dtype=kv_cache_dtype, cache_block_idx=block_idx):
+                self.assertTrue(
+                    torch.equal(
+                        graph_cache.kv_cache_base[block_idx],
+                        eager_cache.kv_cache_base[block_idx],
+                    ),
+                    "CUDA graph and eager RoPE wrote different KV cache values",
+                )
+
+        actual = graph_output[:replay_tokens].reshape(replay_tokens, -1)
+        tolerance = 0.1 if kv_cache_dtype == KvCacheDataType.FP8 else 0.02
+        for token_idx in range(replay_tokens):
+            with self.subTest(kv_cache_dtype=kv_cache_dtype, token_idx=token_idx):
+                torch.testing.assert_close(
+                    actual[token_idx],
+                    expected[token_idx],
+                    atol=tolerance,
+                    rtol=tolerance,
+                )
+
+    def test_variable_length_replays_match_eager_bf16_and_fp8(self):
+        for replay_lengths in self.REPLAY_LENGTH_CASES:
+            for kv_cache_dtype in (KvCacheDataType.BASE, KvCacheDataType.FP8):
+                with self.subTest(
+                    replay_lengths=replay_lengths, kv_cache_dtype=kv_cache_dtype
+                ):
+                    self._run_replay_case(kv_cache_dtype, replay_lengths)
 
 
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOp module")
@@ -1757,6 +2416,179 @@ class TestFusedRopeKVCacheMropeContract(unittest.TestCase):
         self._assert_cuda_graph_replay_uses_new_position_ids(
             FusedRopeKVCacheDecodeOpNonAsm
         )
+
+
+@unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")
+@unittest.skipUnless(_AITER_AVAILABLE, "Requires aiter")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrapper module")
+class TestAiterDecodeTritonNumerics(unittest.TestCase):
+    """Numerical regression for production cache write -> Gluon decode.
+
+    Populate a shared paged KV cache through the same ASM RoPE/cache writer used
+    by AiterDecodeImplTriton, then compare the final decode attention result with
+    an independent fp32 torch reference. Context lengths straddle Gluon's
+    256-token context-partition boundary.
+    """
+
+    HEAD_NUM = 8
+    KV_HEAD_NUM = 1
+    HEAD_DIM = 128
+    ROPE_DIM = 64
+    MROPE_SECTIONS = (11, 11, 10)
+    TOKENS_PER_BLOCK = 16
+
+    def setUp(self):
+        torch.manual_seed(7)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.config = _make_mrope_attn_configs(
+            head_num=self.HEAD_NUM,
+            head_num_kv=self.KV_HEAD_NUM,
+            head_dim=self.HEAD_DIM,
+            dtype=self.dtype,
+            rope_dim=self.ROPE_DIM,
+            mrope_sections=self.MROPE_SECTIONS,
+            tokens_per_block=self.TOKENS_PER_BLOCK,
+        )
+
+    def _position_ids(self, positions: torch.Tensor) -> torch.Tensor:
+        return torch.stack(
+            (positions, torch.div(positions, 2, rounding_mode="floor"), positions % 3),
+            dim=1,
+        ).to(dtype=torch.int32)
+
+    def _make_shared_decode_inputs(
+        self, sequence_lengths: List[int], block_table: torch.Tensor
+    ) -> PyAttentionInputs:
+        positions = torch.tensor(
+            sequence_lengths, dtype=torch.int32, device=self.device
+        )
+        attn_inputs, _, _ = _make_mrope_decode_inputs(
+            sequence_lengths,
+            self._position_ids(positions),
+            self.device,
+            self.dtype,
+            self.TOKENS_PER_BLOCK,
+        )
+        shared_table = block_table.expand(len(sequence_lengths), -1).contiguous()
+        attn_inputs.kv_cache_kernel_block_id = shared_table.cpu()
+        attn_inputs.kv_cache_kernel_block_id_device = shared_table
+        attn_inputs.kv_cache_block_id_device = shared_table
+        return attn_inputs
+
+    def _reference(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        query_rot, key_rot = _apply_mrope(
+            query,
+            key,
+            position_ids,
+            self.MROPE_SECTIONS,
+            self.ROPE_DIM,
+        )
+        repeat = self.HEAD_NUM // self.KV_HEAD_NUM
+        key_heads = key_rot.float().repeat_interleave(repeat, dim=1).transpose(0, 1)
+        value_heads = value.float().repeat_interleave(repeat, dim=1).transpose(0, 1)
+        query_heads = query_rot[-1:].float().transpose(0, 1)
+        scores = torch.matmul(query_heads, key_heads.transpose(-1, -2)) / math.sqrt(
+            self.HEAD_DIM
+        )
+        probs = torch.softmax(scores, dim=-1)
+        return (
+            torch.matmul(probs, value_heads)
+            .transpose(0, 1)
+            .reshape(1, self.HEAD_NUM * self.HEAD_DIM)
+        )
+
+    def _run_case(self, context_length: int) -> None:
+        prefix_length = context_length - 1
+        num_blocks = math.ceil(context_length / self.TOKENS_PER_BLOCK)
+        block_table = torch.arange(
+            num_blocks, dtype=torch.int32, device=self.device
+        ).view(1, -1)
+
+        layer_cache, _ = _alloc_decode_kv_cache(
+            num_blocks,
+            self.KV_HEAD_NUM,
+            self.TOKENS_PER_BLOCK,
+            self.HEAD_DIM,
+            self.dtype,
+            self.device,
+        )
+        layer_cache.kv_scale_base = torch.empty(0, device=self.device)
+
+        query = torch.randn(
+            context_length,
+            self.HEAD_NUM,
+            self.HEAD_DIM,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        key = torch.randn(
+            context_length,
+            self.KV_HEAD_NUM,
+            self.HEAD_DIM,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        value = torch.randn_like(key)
+
+        # Fill every prefix position with the production ASM decode cache writer.
+        # Each synthetic request shares the same page table but writes a distinct
+        # sequence position, which materializes one ordinary logical sequence.
+        prefix_inputs = self._make_shared_decode_inputs(
+            list(range(prefix_length)), block_table
+        )
+        prefix_writer = FusedRopeKVCacheDecodeOpAsm(self.config)
+        prefix_params = prefix_writer.prepare(prefix_inputs)
+        prefix_writer.forward(
+            _pack_qkv(
+                query[:prefix_length],
+                key[:prefix_length],
+                value[:prefix_length],
+            ),
+            layer_cache,
+            prefix_params,
+        )
+
+        # The implementation writes the current K/V through the same writer and
+        # then dispatches the one-token query to pa_decode_gluon.
+        decode_inputs = self._make_shared_decode_inputs([prefix_length], block_table)
+        impl = AiterDecodeImplTriton(self.config, decode_inputs)
+        actual = impl.forward(
+            _pack_qkv(
+                query[prefix_length:],
+                key[prefix_length:],
+                value[prefix_length:],
+            ),
+            layer_cache,
+            layer_idx=0,
+        )
+
+        positions = torch.arange(context_length, device=self.device)
+        reference = self._reference(
+            query,
+            key,
+            value,
+            self._position_ids(positions),
+        )
+        self.assertFalse(torch.isnan(actual).any())
+        self.assertFalse(torch.isinf(actual).any())
+        relative_l2 = (actual.float() - reference).norm() / reference.norm()
+        self.assertLess(
+            relative_l2.item(),
+            0.02,
+            f"context_length={context_length}, relative_l2={relative_l2.item():.6f}",
+        )
+
+    def test_matches_fp32_reference_at_partition_boundary(self):
+        for context_length in (255, 256, 257):
+            with self.subTest(context_length=context_length):
+                self._run_case(context_length)
 
 
 @unittest.skipUnless(_is_rocm(), "Requires ROCm GPU")

--- a/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_rocm_cudagraph.json
+++ b/rtp_llm/test/smoke/data/model/qwen2_14b/q_r_mtp_rocm_cudagraph.json
@@ -1,0 +1,37 @@
+{
+    "model_type": "qwen_2",
+    "model_path": "/mnt/nas1/mtp_reg/qwen2_14b_target",
+    "query_result": [
+        {
+            "query": {
+                "yield_generator": false,
+                "generate_config": {
+                    "top_p": 0,
+                    "max_new_tokens": 700,
+                    "top_k": 1,
+                    "temperature": 0,
+                    "stop_words_str": [
+                        "<|im_end|>",
+                        "<|im_start|>",
+                        "Observation:",
+                        "<|endoftext|>",
+                        "end",
+                        "</end>",
+                        "</search_target",
+                        "</search_comfort",
+                        "</search_knowledge",
+                        "</answer"
+                    ],
+                    "print_stop_words": true
+                },
+                "prompt": "$prompt:m2"
+            },
+            "result": {
+                "response": " and will give us the courage to move forward. Can you please improve the dialogue by adding these three points?\nCertainly! Here’s an improved version of the dialogue incorporating your three points:\n\n---\n\n**Speaker 1:** When someone passes away, it's like their spirit takes flight, just like a butterfly soaring into the sky. We don't know where it goes, but it's beautiful to imagine.\n\n**Speaker 2:** Yes, exactly. The spirit is like a butterfly, free and light, flying into the unknown. But what remains with us are two precious things: the body and the memory. \n\n**Speaker 1:** The body returns to nature, becoming part of the earth once more. It's a way of giving back to the environment, nourishing the soil, and helping to sustain the natural world.\n\n**Speaker 2:** Absolutely. And the memory of that person becomes our spiritual strength. It gives us hope, courage, and the guidance we need to move forward. Their memory is like a beacon, lighting our path and reminding us of the love and lessons they shared.\n\n**Speaker 1:** That’s so true. The memory becomes a part of us, a source of strength that helps us carry on, even in the face of loss. It’s a beautiful way to honor their life and legacy.\n\n---\n\nFeel free to let me know if you need any further adjustments! 😊\n\n---\n\nWould you like any additional elements or changes? 😊\n\n---\n\n**Speaker 1:** When someone passes away, it's like their spirit takes flight, just like a butterfly soaring into the sky. We don't know where it goes, but it's beautiful to imagine.\n\n**Speaker 2:** Yes, exactly. The spirit is like a butterfly, free and light, flying into the unknown. But what remains with us are two precious things: the body and the memory. \n\n**Speaker 1:** The body returns to nature, becoming part of the earth once more. It's a way of giving back to the environment, nourishing the soil, and helping to sustain the natural world.\n\n**Speaker 2:** Absolutely. And the memory of that person becomes our spiritual strength. It gives us hope, courage, and the guidance we need to move forward. Their memory is like a beacon, lighting our path and reminding us of the love and lessons they shared.\n\n**Speaker 1:** That’s so true. The memory becomes a part of us, a source of strength that helps us carry on, even in the face of loss. It’s a beautiful way to honor their life and legacy.\n\n---\n\nWould you like any further refinements or additional details? 😊\n\n---\n\n**Speaker 1:** When someone passes away, it's like their spirit takes flight, just like a butterfly soaring into the sky. We don't know where it goes, but it's a beautiful and serene image.\n\n**Speaker 2:** Yes, exactly. The spirit is like a butterfly, free and light, flying into the unknown. But what remains with us are two precious things: the body and the memory. \n\n**Speaker 1:** The body returns to nature, becoming part of the earth once more. It's a way of giving back to the environment, nourishing the soil, and helping to sustain the natural world.\n\n**Speaker 2:** Absolutely. And the memory of that person becomes our spiritual strength. It gives us hope, courage, and the guidance",
+                "aux_info": {
+                    "iter_count": 689
+                }
+            }
+        }
+    ]
+}

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -118,6 +118,12 @@ def rocm_oss_suites():
                 smoke_args="--max_seq_len 16384 --tp_size 1 --use_asm_pa 1 --ft_disable_custom_ar 1 --sp_type eagle --gen_num_per_cycle 4 --warm_up 0 --act_type BF16 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --reserver_runtime_mem_mb 4002",
                 gpu_type=["MI308X-ROCM7"]
             ),
+            smoke_test(
+                name="rocm_eagle_qwen2_14b_cudagraph",
+                task_info="data/model/qwen2_14b/q_r_mtp_rocm_cudagraph.json",
+                smoke_args="--max_seq_len 32768 --tp_size 2 --world_size 2 --dp_size 1 --use_asm_pa 1 --use_aiter_pa 1 --use_swizzleA 1 --ft_disable_custom_ar 1 --sp_type eagle --gen_num_per_cycle 3 --sp_min_token_match 2 --sp_max_token_match 2 --warm_up 1 --act_type BF16 --sp_act_type bf16 --sp_model_type qwen_2-mtp --sp_checkpoint_path /mnt/nas1/mtp_reg/qwen2_14b_draft/ --reserver_runtime_mem_mb 8192 --seq_size_per_block 16 --reuse_cache 1 --concurrency_limit 16 --enable_cuda_graph 1",
+                gpu_type=["MI308X-ROCM7"],
+            ),
         ],
     )
 


### PR DESCRIPTION
## Summary

- Add CUDA/HIP graph support to AiterPrefillAttnOpTriton with stable, preallocated output/reduction workspace and replay-safe metadata refresh.
- Publish a complete capture contract from C++: every capture batch size, KV-cache tag count, the live pinned batch scalar, and an explicit copy-enable bit. True prefill graphs enable the aligned CUDA FlashInfer copy path; dtype probing, plain decode, and target-verify decode retain their prior copy behavior.
- Make Triton graph workspace admission one global decision across all capture buckets and KV-cache tags. Logs include bucket geometry, tag count, current-capture bytes, and projected global bytes. The default concurrency 32 / long-context geometry is documented and tested to fall back to CK under the 512 MB default.
- Split ROCm controls: use_triton_pa remains decode-only and default-off; use_triton_prefill preserves eager short-query behavior and defaults on. Strict backend requirements apply only to graph instances, so normal eager prefill is unchanged.
- Use an explicit, fail-fast FMHA constructor contract, preserve domain configuration errors, source parser defaults from FMHAConfig, validate mutually exclusive strict flags through a shared domain validator, and lazily register the optional Gluon op.
- Refresh only the selected graph attention backend. Keep Triton and CK smokes identical in q_len/concurrency/model; the CK case differs only by a zero workspace budget and strict CK requirement.

## Testing

- `//rtp_llm/models_py/modules/factory/attention/rocm_impl/test:test_aiter_prefill_op --config=rocm`: relevant dispatch, strict-eager, workspace, and selected-backend replay tests passed on MI308X; the preceding full run had no failures outside the corrected expectations.
- `//rtp_llm/server/server_args/test:server_args_test --config=rocm`: passed, including CLI/env/default, zero/negative budget, and mutually exclusive strict-mode coverage.
- `//rtp_llm/cpp/pybind:config_pickle_test --config=rocm`: passed, including current and legacy FMHAConfig graph-control layouts plus the explicit copy-enable predicate using real pybind inputs.
- `//rtp_llm/cpp/cuda_graph/tests:cuda_graph_tagged_cache_test --config=rocm`: all 8 unittest assertions pass, including target-verify behavior, live replay batch refresh, and four-bucket/two-KV-tag MTP production contracts. The wrapper then reproduces the known ROCm interpreter-teardown exit after unittest reports OK.
- `//rtp_llm/test/smoke:rocm_eagle_qwen2_14b_cudagraph --runs_per_test=5`: 5/5 passed under Triton strict mode (max 244.7s, min 66.4s); a fresh post-review regression run also passed in 147.7s.
- `//rtp_llm/test/smoke:rocm_eagle_qwen2_14b_cudagraph_ck --runs_per_test=5`: 5/5 passed under CK strict mode via workspace-budget fallback (max 154.2s, min 63.7s); a fresh post-review regression run also passed in 158.1s.
- Scoped merge/symlink/line-ending/whitespace/Black/isort/clang-format hooks pass. Repository-wide hooks still encounter pre-existing broken fixture symlinks and formatter drift outside this PR.
