### PR TITLE
fix(model_rpc): forward all_probs across the model-RPC wire

### DIFF
--- a/rtp_llm/cpp/model_rpc/QueryConverter.cc
+++ b/rtp_llm/cpp/model_rpc/QueryConverter.cc
@@ -352,6 +352,15 @@ void QueryConverter::transResponse(GenerateOutputsPB*     outputs,
 
     stackBuffersToTensorPB(flatten_output->mutable_logits(), source_outputs, [](const auto& r) { return r.logits; });
 
+    // OpenAI logprobs live in AuxInfo in-process; FlattenOutputPB owns the
+    // tensor on the model-RPC wire. Deliberately outside the dump_aux_info
+    // gate: presence is already gated by generate_config->aux_info on the
+    // producer side (NormalGenerateStream), and the Python client parses
+    // this field outside its aux_info branch.
+    stackBuffersToTensorPB(flatten_output->mutable_all_probs(), source_outputs, [](const auto& r) {
+        return r.aux_info.all_probs;
+    });
+
     stackBuffersToTensorPB(
         flatten_output->mutable_all_hidden_states(), source_outputs, [](const auto& r) { return r.all_hidden_states; });
 

--- a/rtp_llm/cpp/model_rpc/test/QueryConverterTest.cc
+++ b/rtp_llm/cpp/model_rpc/test/QueryConverterTest.cc
@@ -98,6 +98,7 @@ TEST_F(QueryConverterTest, testTransOutput) {
         hidden_states_data[i] = i;
     }
     res.hidden_states.emplace(hidden_states_tensor);
+    res.aux_info.all_probs = torch::tensor({{0.1f, 0.2f, 0.7f}}, torch::kFloat32);
     outputs.generate_outputs.push_back(res);
 
     GenerateOutputsPB outputs_pb;
@@ -136,6 +137,61 @@ TEST_F(QueryConverterTest, testTransOutput) {
     for (int i = 0; i < 6; ++i) {
         ASSERT_FLOAT_EQ(hidden_states_vector[i], i);
     }
+    ASSERT_TRUE(output_pb.has_all_probs());
+    const auto& all_probs_pb = output_pb.all_probs();
+    ASSERT_EQ(all_probs_pb.data_type(), TensorPB_DataType::TensorPB_DataType_FP32);
+    ASSERT_EQ(all_probs_pb.shape_size(), 3);
+    ASSERT_EQ(all_probs_pb.shape(0), 1);
+    ASSERT_EQ(all_probs_pb.shape(1), 1);
+    ASSERT_EQ(all_probs_pb.shape(2), 3);
+    std::vector<float> all_probs(all_probs_pb.fp32_data().size() / sizeof(float));
+    ASSERT_EQ(all_probs.size(), 3u);
+    std::memcpy(all_probs.data(), all_probs_pb.fp32_data().data(), all_probs_pb.fp32_data().size());
+    EXPECT_FLOAT_EQ(all_probs[0], 0.1f);
+    EXPECT_FLOAT_EQ(all_probs[1], 0.2f);
+    EXPECT_FLOAT_EQ(all_probs[2], 0.7f);
+}
+
+TEST_F(QueryConverterTest, testTransOutputAllProbsMultiOutput) {
+    // Pins the batch-dim semantics model_rpc_client.py relies on:
+    // all_all_probs[i] must be row i of the stacked [n, 1, vocab] tensor,
+    // in generate_outputs order.
+    GenerateOutputs outputs;
+    for (int i = 0; i < 2; ++i) {
+        GenerateOutput res;
+        res.output_ids         = torch::zeros({1, 1}, torch::kInt32);
+        res.aux_info.all_probs = torch::tensor({{0.25f + i, 0.5f + i, 0.75f + i}}, torch::kFloat32);
+        outputs.generate_outputs.push_back(res);
+    }
+    GenerateOutputsPB outputs_pb;
+    QueryConverter::transResponse(&outputs_pb, &outputs, true, "", 10000);
+
+    const auto& all_probs_pb = outputs_pb.flatten_output().all_probs();
+    ASSERT_EQ(all_probs_pb.shape_size(), 3);
+    ASSERT_EQ(all_probs_pb.shape(0), 2);
+    ASSERT_EQ(all_probs_pb.shape(1), 1);
+    ASSERT_EQ(all_probs_pb.shape(2), 3);
+    std::vector<float> all_probs(all_probs_pb.fp32_data().size() / sizeof(float));
+    ASSERT_EQ(all_probs.size(), 6u);
+    std::memcpy(all_probs.data(), all_probs_pb.fp32_data().data(), all_probs_pb.fp32_data().size());
+    EXPECT_FLOAT_EQ(all_probs[0], 0.25f);  // output 0, vocab 0
+    EXPECT_FLOAT_EQ(all_probs[3], 1.25f);  // output 1, vocab 0
+}
+
+TEST_F(QueryConverterTest, testTransOutputWithoutAllProbs) {
+    // No logprobs requested -> no vocab-sized payload on the wire. The
+    // has-bit is set by the unconditional mutable_all_probs() evaluation,
+    // so absence is expressed as an empty shape, which is what
+    // model_rpc_client.py checks before parsing.
+    GenerateOutputs outputs;
+    GenerateOutput  res;
+    res.output_ids = torch::zeros({1, 1}, torch::kInt32);
+    outputs.generate_outputs.push_back(res);
+    GenerateOutputsPB outputs_pb;
+    QueryConverter::transResponse(&outputs_pb, &outputs, true, "", 10000);
+
+    EXPECT_EQ(outputs_pb.flatten_output().all_probs().shape_size(), 0);
+    EXPECT_EQ(outputs_pb.flatten_output().all_probs().fp32_data().size(), 0u);
 }
 
 TEST_F(QueryConverterTest, TransTensorPB_FP32) {


### PR DESCRIPTION
Split out of #1251 per review (无关改动): a generic serialization fix, not part of the DSpark restructure.

`transResponse` never serialized `AuxInfo.all_probs` into `FlattenOutputPB` even though the proto field exists: the backend computed OpenAI logprobs and silently dropped them before the frontend renderer, which then failed with a generic internal error whenever a request set `logprobs`. Discovered while validating target-only DSpark deployments, but the defect affects every deployment requesting logprobs over the model-RPC wire.

## Validation

`query_converter_test` green, including three new cases pinning the wire format:
- value/dtype/shape round trip for a known `[1, V]` tensor;
- two-output stacking order (`[2, 1, V]`) that the Python client's `all_all_probs[i]` slicing relies on;
- no-logprobs requests stay payload-free (absence = empty shape; the has-bit is set by the unconditional `mutable_` evaluation, same as the sibling fields).

The intentionally aux_info-gate-free placement is documented at the call site (producer-side `generate_config->aux_info` already gates presence; the Python client parses this field outside its aux_info branch). Per-token payload observability / server-side top-k trimming is deferred as suggested (needs a proto extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)