### PR TITLE
fix(smoke): update moe CP PD golden after RoPE fix

### DIFF
--- a/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_30b_fp8_py_cp2.json
+++ b/rtp_llm/test/smoke/data/model/qwen3_moe/q_r_30b_fp8_py_cp2.json
@@ -14,7 +14,7 @@
                 "_prompt_source": "chat-template wrapping $prompt:s1"
             },
             "result": {
-                "response": "It looks like you're asking about the",
+                "response": "The **CAP Theorem**, also known",
                 "finished": true
             }
         }


### PR DESCRIPTION
## 变更说明                                                                                                                                                              

更新 `//rtp_llm/test/smoke:moe_cp_pd` 在 CP RoPE 正确性修复后的 smoke golden。本 PR 不包含生产逻辑变更。                                                                 

### 背景                                                                                                                                                                 
                                                                                                                                                                           
#1250 修复了 CPFlashInferImpl.forward() 的参数契约问题。

调用方 modules/hybrid/causal_attention.py:86 的调用方式为：

```
attn_output = fmha_impl.forward(qkv, kv_cache, self.layer_idx)
```
第三个参数实际是 layer_idx，但旧函数将其定义为 need_rope_kv_cache。因此，第 0 层传入的 layer_idx=0 会被解释为 False，导致该层跳过 RoPE。                                 

  修复 commit：51f598686 (https://github.com/alibaba/rtp-llm/pull/1250/commits/51f598686e581cc50c05ef11fb5002c378c0c3a5)                                                   

  ### CI 影响

  上述修复导致 //rtp_llm/test/smoke:moe_cp_pd 的确定性输出发生变化。

  该 smoke 的输入为：

  System: You are a helpful assistant.
  User:   what is CAP Theorem ?

  输出变化如下：

  - 旧 golden：It looks like you're asking about the
  - 新输出：The **CAP Theorem**, also known

  新输出能够直接回答输入问题，也符合第 0 层恢复按模型配置执行 RoPE 后的预期行为。

  因此，本 PR 更新已过期的 smoke golden，使其与修复后的行为保持一致。