### PR TITLE
feat(loader): complete GLM newloader support

### DIFF
--- a/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/__init__.py
@@ -1,8 +1,9 @@
 from .language import DeepSeekV32ForCausalLM
 
 # DeepSeekV32ForCausalLM also serves as the new-loader implementation for
-# deepseek2, deepseek3, deepseek_v31, deepseek_v32, glm_5, and kimi_k2. These
-# are architectural variants of the same MLA + MoE family and are handled by
-# the same class via config-driven parameterisation in _extract_config_values.
+# deepseek2, deepseek3, deepseek_v31, deepseek_v32, glm_5, glm4_moe_lite, and
+# kimi_k2. These are architectural variants of the same MLA + MoE family and
+# are handled by the same class via config-driven parameterisation in
+# extract_config_values.
 
 __all__ = ["DeepSeekV32ForCausalLM"]

--- a/rtp_llm/models_py/new_models/deepseek_v3/language.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/language.py
@@ -596,6 +596,18 @@ def extract_config_values(
                 scoring_func = 1
             else:
                 raise ValueError(f"unsupported scoring_func={raw_scoring_func!r}")
+        elif config_json.get("model_type") == "glm4_moe_lite":
+            # GLM-4.7-Flash's official config omits scoring_func because its
+            # reference router is unconditionally sigmoid-based. Resolve that
+            # checkpoint contract here instead of depending on the legacy
+            # Glm4MoeLite config adapter to patch ModelConfig. FusedMoe also
+            # consumes ModelConfig, so keep its view of the routing contract in
+            # sync with the newloader-owned value.
+            scoring_func = 1
+            if isinstance(model_config, dict):
+                model_config["scoring_func"] = scoring_func
+            else:
+                model_config.scoring_func = scoring_func
         n_group = config_json.get("n_group", n_group)
         topk_group = config_json.get("topk_group", topk_group)
         has_moe_norm = config_json.get("norm_topk_prob", has_moe_norm)

--- a/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
+++ b/rtp_llm/models_py/new_models/deepseek_v3/test/test_deepseek_newloader.py
@@ -256,6 +256,57 @@ def _dense_checkpoint_weights():
     }
 
 
+def _glm4_moe_lite_checkpoint_weights():
+    values = _deterministic_values
+    weights = {
+        "model.embed_tokens.weight": values((32, 32), 0),
+        "model.norm.weight": values((32,), 3) + 1.0,
+        "lm_head.weight": values((32, 32), 5),
+    }
+    for layer_idx in range(2):
+        prefix = f"model.layers.{layer_idx}."
+        offset = 11 + layer_idx * 100
+        weights.update(
+            {
+                prefix + "input_layernorm.weight": values((32,), offset) + 1.0,
+                prefix + "self_attn.q_a_proj.weight": values((32, 32), offset + 3),
+                prefix
+                + "self_attn.q_a_layernorm.weight": values((32,), offset + 5)
+                + 1.0,
+                prefix + "self_attn.q_b_proj.weight": values((32, 32), offset + 7),
+                prefix
+                + "self_attn.kv_a_proj_with_mqa.weight": values((36, 32), offset + 11),
+                prefix
+                + "self_attn.kv_a_layernorm.weight": values((32,), offset + 13)
+                + 1.0,
+                prefix + "self_attn.kv_b_proj.weight": values((32, 32), offset + 17),
+                prefix + "self_attn.o_proj.weight": values((32, 16), offset + 19),
+                prefix
+                + "post_attention_layernorm.weight": values((32,), offset + 23)
+                + 1.0,
+            }
+        )
+    weights.update(
+        {
+            "model.layers.0.mlp.gate_proj.weight": values((32, 32), 31),
+            "model.layers.0.mlp.up_proj.weight": values((32, 32), 37),
+            "model.layers.0.mlp.down_proj.weight": values((32, 32), 41),
+            "model.layers.1.mlp.gate.weight": values((4, 32), 131),
+            "model.layers.1.mlp.gate.e_score_correction_bias": values((4,), 137),
+            "model.layers.1.mlp.shared_experts.gate_proj.weight": values((32, 32), 139),
+            "model.layers.1.mlp.shared_experts.up_proj.weight": values((32, 32), 149),
+            "model.layers.1.mlp.shared_experts.down_proj.weight": values((32, 32), 151),
+        }
+    )
+    for expert_id in range(4):
+        prefix = f"model.layers.1.mlp.experts.{expert_id}."
+        offset = 157 + expert_id * 17
+        weights[prefix + "gate_proj.weight"] = values((32, 32), offset)
+        weights[prefix + "up_proj.weight"] = values((32, 32), offset + 3)
+        weights[prefix + "down_proj.weight"] = values((32, 32), offset + 5)
+    return weights
+
+
 def _mtp_loader_model_config(checkpoint_path):
     config = _model_config()
     config.model_type = "deepseek-v3-mtp"
@@ -532,6 +583,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
             "deepseek_v31",
             "deepseek_v32",
             "glm_5",
+            "glm4_moe_lite",
             "kimi_k2",
         ):
             with self.subTest(model_type=model_type):
@@ -558,6 +610,7 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                 "deepseek_v31",
                 "deepseek_v32",
                 "glm_5",
+                "glm4_moe_lite",
                 "kimi_k2",
             ):
                 with self.subTest(model_type=model_type):
@@ -576,6 +629,174 @@ class DeepSeekNewloaderTest(unittest.TestCase):
                         model.embed_tokens.weight,
                         weights["model.embed_tokens.weight"],
                     )
+
+    def test_glm4_moe_lite_official_config_contract(self):
+        model_config = _model_config()
+        model_config.model_type = "glm4_moe_lite"
+        model_config.hidden_size = 2048
+        model_config.num_layers = 47
+        model_config.vocab_size = 154880
+        model_config.max_seq_len = 8192
+        model_config.layernorm_eps = 1e-5
+        model_config.expert_num = 64
+        model_config.moe_k = 4
+        # The official checkpoint omits scoring_func; do not rely on the
+        # legacy GLM adapter changing this otherwise incorrect input value.
+        model_config.scoring_func = 0
+        model_config.routed_scaling_factor = 1.8
+        model_config.moe_n_group = 1
+        model_config.moe_topk_group = 1
+        model_config.attn_config.head_num = 20
+        model_config.attn_config.q_lora_rank = 768
+        model_config.attn_config.kv_lora_rank = 512
+        model_config.attn_config.nope_head_dim = 192
+        model_config.attn_config.rope_head_dim = 64
+        model_config.attn_config.v_head_dim = 256
+        model_config.attn_config.is_sparse = False
+
+        config_json = {
+            "model_type": "glm4_moe_lite",
+            "architectures": ["Glm4MoeLiteForCausalLM"],
+            "hidden_size": 2048,
+            "intermediate_size": 10240,
+            "max_position_embeddings": 202752,
+            "moe_intermediate_size": 1536,
+            "topk_method": "noaux_tc",
+            "norm_topk_prob": True,
+            "num_attention_heads": 20,
+            "n_group": 1,
+            "topk_group": 1,
+            "n_routed_experts": 64,
+            "n_shared_experts": 1,
+            "routed_scaling_factor": 1.8,
+            "num_experts_per_tok": 4,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 47,
+            "num_nextn_predict_layers": 1,
+            "rms_norm_eps": 1e-5,
+            "rope_scaling": None,
+            "rope_theta": 1000000,
+            "tie_word_embeddings": False,
+            "dtype": "bfloat16",
+            "q_lora_rank": 768,
+            "kv_lora_rank": 512,
+            "qk_nope_head_dim": 192,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 256,
+            "vocab_size": 154880,
+        }
+
+        cfg = extract_config_values(model_config, _load_config(), config_json)
+        self.assertEqual(cfg["scoring_func"], 1)
+        self.assertEqual(cfg["topk_method"], "noaux_tc")
+        self.assertTrue(cfg["has_e_score_correction"])
+        self.assertTrue(cfg["has_moe_norm"])
+        self.assertEqual(cfg["moe_layer_index"], list(range(1, 47)))
+        self.assertEqual(cfg["dense_intermediate_size"], 10240)
+        self.assertEqual(cfg["moe_intermediate_size"], 1536)
+        self.assertEqual(cfg["shared_expert_intermediate_size"], 1536)
+        self.assertEqual(cfg["q_lora_rank"], 768)
+        self.assertEqual(cfg["kv_lora_rank"], 512)
+        self.assertFalse(cfg["is_sparse"])
+
+        rope_cache = build_rope_cache(
+            config_json,
+            max_seq_len=32,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(rope_cache.shape, (32, 64))
+        self.assertEqual(rope_cache.dtype, torch.float32)
+
+    def _gpu_glm4_moe_lite_loads_without_legacy_config_adapter(self):
+        weights = _glm4_moe_lite_checkpoint_weights()
+        # Official GLM-4.7-Flash checkpoints append one MTP layer after the
+        # score model. The score-model filter must ignore it without weakening
+        # unknown-tensor validation inside the two owned layers.
+        weights["model.layers.2.embed_tokens.weight"] = _deterministic_values(
+            (32, 32), 211
+        )
+        config_json = {
+            "model_type": "glm4_moe_lite",
+            "architectures": ["Glm4MoeLiteForCausalLM"],
+            "hidden_size": 32,
+            "intermediate_size": 32,
+            "max_position_embeddings": 128,
+            "moe_intermediate_size": 32,
+            "topk_method": "noaux_tc",
+            "norm_topk_prob": True,
+            "num_attention_heads": 4,
+            "n_group": 1,
+            "topk_group": 1,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "routed_scaling_factor": 1.8,
+            "num_experts_per_tok": 2,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 2,
+            "num_nextn_predict_layers": 1,
+            "rms_norm_eps": 1e-6,
+            "rope_scaling": None,
+            "rope_theta": 1000000,
+            "tie_word_embeddings": False,
+            "dtype": "bfloat16",
+            "q_lora_rank": 32,
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 4,
+            "qk_rope_head_dim": 4,
+            "v_head_dim": 4,
+            "vocab_size": 32,
+        }
+
+        with tempfile.TemporaryDirectory() as checkpoint_path:
+            with open(
+                f"{checkpoint_path}/config.json",
+                "w",
+                encoding="utf-8",
+            ) as config_file:
+                json.dump(config_json, config_file)
+            save_file(weights, f"{checkpoint_path}/model.safetensors")
+
+            model_config = _model_config(q_lora_rank=32)
+            model_config.model_type = "glm4_moe_lite"
+            model_config.ckpt_path = checkpoint_path
+            model_config.hidden_size = 32
+            model_config.vocab_size = 32
+            model_config.num_layers = 2
+            model_config.expert_num = 4
+            model_config.moe_k = 2
+            model_config.scoring_func = 0
+            model_config.routed_scaling_factor = 1.8
+            model_config.moe_n_group = 1
+            model_config.moe_topk_group = 1
+            model_config.has_moe_norm = True
+            model_config.data_type = "bf16"
+            model_config.attn_config.kv_lora_rank = 32
+            model_config.attn_config.nope_head_dim = 4
+            model_config.attn_config.rope_head_dim = 4
+            model_config.attn_config.v_head_dim = 4
+
+            model = NewModelLoader(
+                model_config=model_config,
+                load_config=NewLoaderConfig(
+                    compute_dtype=torch.bfloat16,
+                    device="cuda",
+                    parallelism_config=_single_rank_parallelism_config(),
+                ),
+                model_path=checkpoint_path,
+            ).load()
+
+        self.assertEqual(model_config.scoring_func, 1)
+        self.assertIsInstance(model.layers[0].mlp, DeepSeekV32MLP)
+        self.assertIsInstance(model.layers[1].mlp, DeepSeekV32MoEBlock)
+        self.assertTrue(model.layers[1].mlp.correction_bias)
+        self.assertIsNotNone(model.layers[1].mlp.experts.fused_moe)
+        torch.testing.assert_close(
+            model.layers[1].mlp.gate.e_score_correction_bias.cpu(),
+            weights["model.layers.1.mlp.gate.e_score_correction_bias"],
+        )
+        torch.testing.assert_close(
+            model.lm_head.weight.cpu(), weights["lm_head.weight"].bfloat16()
+        )
 
     def test_new_model_loader_safetensors_forward_matches_reference(self):
         weights = _dense_checkpoint_weights()

--- a/rtp_llm/models_py/registry.py
+++ b/rtp_llm/models_py/registry.py
@@ -189,6 +189,7 @@ for _deepseek_model_type in (
     "deepseek_v31",
     "deepseek_v32",
     "glm_5",
+    "glm4_moe_lite",
     "kimi_k2",
 ):
     register_lazy_model(

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -4,7 +4,8 @@ def h20_oss_suites():
     # H20 (SM9x) — Architecture-grouped suites
     # ============================================================================
 
-    # Newloader production boundaries for Qwen3 dense and DeepSeek V3.2.
+    # Newloader production boundaries for Qwen3 dense, DeepSeek V3.2, and
+    # GLM MLA/MoE variants.
     # DeepSeek score-model coverage includes MLA, FP8 KV, TP2, DeepEP, and
     # CUDA Graph; MTP uses the four-layer checkpoint for score and the extracted
     # layer-61 checkpoint for draft, so both assets match their actual layouts.
@@ -30,6 +31,20 @@ def h20_oss_suites():
                 task_info="data/model/deepseek_v32_4layers/v32_fp8_q_r_h20.json",
                 smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --reserver_runtime_mem_mb 20000 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --sp_type mtp --sp_model_type deepseek-v3-mtp --sp_checkpoint_path /mnt/nas1/hf/DeepSeek-V3.2-Exp-MTP --sp_act_type BF16",
                 envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="h20_glm5_newloader_fp8kv",
+                task_info="data/model/glm5/glm_5_fp8_q_r_h20.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 512 --act_type BF16 --enable_cuda_graph 0 --tp_size 1 --world_size 1 --dp_size 1 --fp8_kv_cache 1 --kernel_seq_size_per_block 64",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch", "ACCL_LOW_LATENCY_OPTIMIZE=1"],
+                gpu_type=["H20"],
+            ),
+            smoke_test(
+                name="h20_glm4_moe_lite_newloader",
+                task_info="data/model/glm4_moe_lite/q_r_h20.json",
+                smoke_args="--warm_up 0 --seq_size_per_block 64 --act_type BF16 --enable_cuda_graph 0 --tp_size 1 --world_size 1 --dp_size 1",
+                envs=["USE_NEW_LOADER=1", "LOAD_METHOD=scratch"],
                 gpu_type=["H20"],
             ),
         ],


### PR DESCRIPTION
   ## Summary

  Add clean NewLoader support for GLM MLA/MoE models:

  - GLM-5 (`glm_5`)
  - GLM-4.7-Flash (`glm4_moe_lite`)

  Both models reuse the config-driven `DeepSeekV32ForCausalLM` implementation because they share the same MLA + MoE checkpoint layout.

  ## Implementation

  - Register `glm4_moe_lite` in the typed lazy NewLoader registry.
  - Load checkpoint tensors directly into module-owned parameters.
  - Do not depend on `ModelWeightInfo`, `AtomicWeight`, `CustomAtomicWeight`, or the legacy `W.*` weight-loading layout.
  - Handle the official GLM-4.7 config contract where `scoring_func` is omitted but the reference router is sigmoid-based.
  - Synchronize the resolved routing mode to `ModelConfig`, which is also consumed by FusedMoE.
  - Preserve strict missing/unknown tensor validation.
  - Filter the appended GLM-4.7 MTP layer from the score-model load.
  - Add H20 NewLoader smoke cases for GLM-5 and GLM-4.7-Flash.

  ## Test Coverage

  Added coverage for:

  - typed lazy registry resolution;
  - real safetensors loading through `NewModelLoader`;
  - official GLM-4.7 configuration values;
  - dense and MoE layer topology;
  - Q-LoRA MLA projections;
  - sigmoid/noaux routing and correction bias;
  - shared and routed experts;
  - appended MTP-layer filtering;
  - H20 and ROCm GPU post-load/FusedMoE construction.

  Validation completed:

  - H20 `foundation_test`: PASS
  - H20 DeepSeek/GLM load suite: PASS
  - H20 DeepSeek/GLM GPU suite: PASS
  - ROCm `foundation_test`: PASS
  - ROCm DeepSeek/GLM load suite: PASS
  - ROCm GPU applicable tests: PASS
  - GLM-5 local-checkpoint smoke: PASS
    - requests: 1/1
    - compare diff count: 0
  - pre-commit, Black, isort, py_compile and `git diff --check`: PASS