### PR TITLE
feat(quant): add W8A8 INT8 per-channel compressed-tensors support

### DIFF
--- a/rtp_llm/config/quant_config.py
+++ b/rtp_llm/config/quant_config.py
@@ -1,11 +1,51 @@
 import json
+import logging
 import os
 import weakref
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch
+
+
+def _pick_config_group(config_groups: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Resolve the config group a compressed-tensors checkpoint describes.
+
+    ``group_0`` still wins whenever it is present, so every checkpoint that loads
+    today keeps loading identically. The fallback only covers what the previous
+    hardcoded ``config_groups["group_0"]`` lookup could not read at all: a single
+    group under a checkpoint-defined name, which is how Qwen3.5 ships W8A8.
+    """
+    if "group_0" in config_groups:
+        if len(config_groups) > 1:
+            # Only group_0 is read, exactly as before. Say so, because a
+            # multi-scheme checkpoint would otherwise load as if the other
+            # groups did not exist.
+            logging.getLogger(__name__).warning(
+                "compressed-tensors config_groups %s: only group_0 is applied, "
+                "the rest are ignored",
+                sorted(config_groups),
+            )
+        return "group_0", config_groups["group_0"]
+    if len(config_groups) != 1:
+        raise ValueError(
+            "compressed-tensors needs a group_0 entry or exactly one named group, "
+            f"got {sorted(config_groups)}"
+        )
+    group_name, group_config = next(iter(config_groups.items()))
+    # targets describes which modules the group covers and nothing reads it, so
+    # only a whole-model scope can be honoured. Anything narrower would be
+    # applied as if it covered everything and fail later asking a BF16 module
+    # for a weight scale.
+    targets = group_config.get("targets")
+    if targets is not None and sorted(targets) != ["Linear"]:
+        raise ValueError(
+            f"compressed-tensors group {group_name} limits quantization to "
+            f"targets={targets}, which is not supported; only a whole-model "
+            '["Linear"] scope can be applied'
+        )
+    return group_name, group_config
 
 
 class QuantizationType(str, Enum):
@@ -51,6 +91,24 @@ class QuantizationConfig(ABC):
     def get_supported_compute_dtypes(self) -> List[torch.dtype]:
         """List of supported activation dtypes."""
         raise NotImplementedError
+
+    def get_moe_activation_quant_spec(self) -> Optional[Tuple[torch.dtype, bool]]:
+        """``(dtype, per_act_token)`` a MoE strategy must produce for this scheme.
+
+        The spec is a property of the scheme, not of a particular checkpoint:
+        it is compared against what strategies can produce, and only along the
+        two dimensions it names. A checkpoint whose ``ignore`` list keeps the MoE
+        experts in the compute dtype still reports a spec here and is still
+        rejected, even though an unquantized strategy could have served it.
+
+        ``None`` -- the default -- means MoE layers may keep activations
+        unquantized, which covers weight-only schemes and every scheme whose MoE
+        executors derive the activation format themselves. A scheme that returns a
+        spec is rejected at strategy selection unless some registered strategy
+        actually produces that dtype *at that granularity*, so an unwired
+        combination fails at startup instead of deep inside a kernel.
+        """
+        return None
 
     @abstractmethod
     def get_supported_kv_cache_dtypes(self) -> List[torch.dtype]:
@@ -169,9 +227,14 @@ class QuantizationConfig(ABC):
                 group_size = weight_block[0]
                 quant_method = Fp8BlockWiseQuantConfig.get_method()
         if quant_method == "compressed-tensors":
-            config_groups = quant_config["config_groups"]
-            weights_config = config_groups["group_0"]["weights"]
-            activation_config = config_groups["group_0"]["input_activations"]
+            group_name, group_config = _pick_config_group(
+                quant_config["config_groups"]
+            )
+            weights_config = group_config["weights"]
+            # Absent or explicitly null when the checkpoint quantizes weights
+            # only; the branches below all require a dict, so keep it optional
+            # here instead of raising a bare KeyError.
+            activation_config = group_config.get("input_activations")
             bits = weights_config["num_bits"]
             if (
                 weights_config["type"] == "float"
@@ -183,6 +246,7 @@ class QuantizationConfig(ABC):
                 weights_config["type"] == "float"
                 and bits == 8
                 and weights_config["strategy"] == "tensor"
+                and isinstance(activation_config, dict)
             ):
                 quant_method = Fp8PerTensorCompressedQuantConfig.get_method()
                 return Fp8PerTensorCompressedQuantConfig.from_config(
@@ -194,6 +258,38 @@ class QuantizationConfig(ABC):
                         "dynamic": activation_config["dynamic"],
                         "act_scale_suffix": ".input_scale",
                         "weight_scale_suffix": ".weight_scale",
+                    }
+                )
+            elif (
+                weights_config["type"] == "int"
+                and bits == 8
+                and weights_config["strategy"] == "channel"
+                and not weights_config.get("dynamic", False)
+                # Weight-only INT8 checkpoints leave input_activations null; they
+                # fall through to the generic paths below instead of subscripting
+                # a None here.
+                and isinstance(activation_config, dict)
+                and activation_config["type"] == "int"
+                and activation_config["num_bits"] == 8
+                and activation_config["strategy"] == "token"
+                and activation_config.get("dynamic", False)
+            ):
+                if not weights_config.get(
+                    "symmetric", True
+                ) or not activation_config.get("symmetric", True):
+                    raise ValueError(
+                        f"compressed-tensors group {group_name} uses asymmetric INT8, "
+                        "but only symmetric W8A8 is supported"
+                    )
+                ignore_patterns = quant_config.get("ignore") or []
+                quant_method = CompressedW8A8Int8PerChannelQuantConfig.get_method()
+                return CompressedW8A8Int8PerChannelQuantConfig.from_config(
+                    {
+                        "bits": bits,
+                        "method": quant_method,
+                        "group_size": 0,
+                        "is_quanted": True,
+                        "ignore_patterns": ignore_patterns,
                     }
                 )
             elif (
@@ -215,6 +311,15 @@ class QuantizationConfig(ABC):
                         "is_quanted": True,
                         "ignore_patterns": ignore_patterns,
                     }
+                )
+            if quant_method == "compressed-tensors":
+                # Nothing above recognised the scheme. The generic tail would
+                # otherwise try to instantiate the abstract
+                # CompressedTensorsQuantConfig and surface a TypeError, so name
+                # the unsupported combination instead.
+                raise ValueError(
+                    f"unsupported compressed-tensors scheme in group {group_name}: "
+                    f"weights={weights_config}, input_activations={activation_config}"
                 )
 
         if quant_method == "quark":
@@ -801,6 +906,73 @@ class CompressedW4A8Int4PerChannelQuantConfig(QuantizationConfig):
     @classmethod
     def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
         return CompressedW4A8Int4PerChannelQuantConfig(**config)
+
+
+class CompressedW8A8Int8PerChannelQuantConfig(QuantizationConfig):
+    """Pre-quantized compressed-tensors W8A8 INT8 configuration.
+
+    Weights are static symmetric INT8 per output channel and activations are
+    dynamically quantized to symmetric INT8 per token.
+    """
+
+    def __init__(
+        self,
+        bits: int = 8,
+        group_size: int = 0,
+        is_quanted: bool = True,
+        ignore_patterns: Optional[Sequence[str]] = None,
+    ):
+        assert (
+            bits == 8 and group_size == 0
+        ), f"invalid params {bits} != 8 or {group_size} != 0"
+        super().__init__(bits=bits, group_size=group_size, is_quanted=is_quanted)
+        # Every parameter is named and there is no kwargs sink, so a misspelled
+        # key raises instead of silently leaving the exclude set empty.
+        self._ignore_patterns: List[str] = list(ignore_patterns or [])
+        # WeightModule support checks use exclude_modules for concrete checkpoint
+        # paths and {i}-templated model weight definitions.
+        self.exclude_modules = set(self._ignore_patterns)
+
+    @classmethod
+    def get_method(cls) -> str:
+        # Not registered in preset_quant_config: this scheme is recognised from
+        # the checkpoint's own quantization_config, not selected by hand through
+        # --quantization.
+        return "W8A8_INT8_PER_CHANNEL_COMPRESSED"
+
+    @classmethod
+    def get_algo(cls) -> str:
+        return "w8a8_int8_per_channel"
+
+    @property
+    def ignore_patterns(self) -> List[str]:
+        return self._ignore_patterns
+
+    def get_supported_compute_dtypes(self) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    def get_supported_kv_cache_dtypes(self) -> List[torch.dtype]:
+        # Narrower than the sibling per-channel schemes, which also accept
+        # float8_e4m3fn: linear-layer INT8 and attention KV cache dtype are
+        # independent, but this combination has not been verified here, so a
+        # deployment carrying --fp8_kv_cache is failed at startup rather than
+        # served on an unvalidated path. Widen it with evidence, not by default.
+        return [torch.float16, torch.bfloat16]
+
+    def get_moe_activation_quant_spec(self) -> Optional[Tuple[torch.dtype, bool]]:
+        # MoE experts must consume INT8 activations quantized per token; no MoE
+        # strategy ships that here yet, so the combination is rejected at
+        # selection time rather than failing inside a kernel.
+        return (torch.int8, True)
+
+    @classmethod
+    def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
+        return cls(
+            bits=config.get("bits", 8),
+            group_size=config.get("group_size", 0),
+            is_quanted=config.get("is_quanted", True),
+            ignore_patterns=config.get("ignore_patterns"),
+        )
 
 
 DEFAULT_FP8_BLOCK_WISE_QUANT_CONFIG = Fp8BlockWiseQuantConfig(

--- a/rtp_llm/cpp/config/ModelConfig.cc
+++ b/rtp_llm/cpp/config/ModelConfig.cc
@@ -72,6 +72,8 @@ static std::string quantMethodToString(QuantMethod quant_method) {
             return "FP8PTPC";
         case QuantMethod::W4A8INT4PTPC:
             return "W4A8INT4PTPC";
+        case QuantMethod::W8A8INT8PTPC:
+            return "W8A8INT8PTPC";
         case QuantMethod::ModelOptFP4:
             return "ModelOptFP4";
         default:

--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -61,6 +61,8 @@ public:
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
         } else if (model_config.quant_algo.isW4a8Int4PTPC()) {
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
+        } else if (model_config.quant_algo.isW8a8Int8PTPC()) {
+            act_qscheme = rtp_llm::QScheme::Qint8PerToken;
         }
 
         return {attention_config,

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
@@ -418,6 +418,9 @@ WorkerStatusInfo LocalRpcServer::getWorkerStatusInfo(int64_t latest_finished_ver
         case QuantMethod::W4A8INT4PTPC:
             status_info.precision = "W4A8INT4PTPC";
             break;
+        case QuantMethod::W8A8INT8PTPC:
+            status_info.precision = "W8A8INT8PTPC";
+            break;
         case QuantMethod::None:
             status_info.precision = "FP16";
             break;

--- a/rtp_llm/cpp/model_utils/QuantInfo.cc
+++ b/rtp_llm/cpp/model_utils/QuantInfo.cc
@@ -46,6 +46,10 @@ void QuantAlgo::setQuantAlgo(const std::string& quant_method, int64_t bits, int6
         quant_method_ = W4A8INT4PTPC;
         weight_bits_  = 4;
         group_size_   = group_size;
+    } else if (quant_method == "w8a8_int8_per_channel") {
+        quant_method_ = W8A8INT8PTPC;
+        weight_bits_  = 8;
+        group_size_   = 0;
     } else if (quant_method == "mxfp4-quark") {
         quant_method_ = QuarkMXFP4;
         weight_bits_  = 4;

--- a/rtp_llm/cpp/model_utils/QuantInfo.h
+++ b/rtp_llm/cpp/model_utils/QuantInfo.h
@@ -15,7 +15,8 @@ enum QuantMethod {
     FP8PTPC          = 8,
     W4A8INT4PTPC     = 9,
     ModelOptFP4      = 10,
-    QuarkMXFP4         = 11,
+    QuarkMXFP4       = 11,
+    W8A8INT8PTPC     = 12,
 };
 
 struct QuantAlgo {
@@ -49,6 +50,9 @@ public:
     }
     bool isW4a8Int4PTPC() const {
         return quant_method_ == W4A8INT4PTPC;
+    }
+    bool isW8a8Int8PTPC() const {
+        return quant_method_ == W8A8INT8PTPC;
     }
     bool isQuant() const {
         return quant_method_ != None;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1141,7 +1141,8 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .value("FP8PTPC", QuantMethod::FP8PTPC)
         .value("W4A8INT4PTPC", QuantMethod::W4A8INT4PTPC)
         .value("ModelOptFP4", QuantMethod::ModelOptFP4)
-        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4);
+        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4)
+        .value("W8A8INT8PTPC", QuantMethod::W8A8INT8PTPC);
 
     // Register QuantAlgo
     py::class_<QuantAlgo>(m, "QuantAlgo")
@@ -1158,6 +1159,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def("isW4a8Int4PTPC", &QuantAlgo::isW4a8Int4PTPC)
         .def("isModelOptFP4", &QuantAlgo::isModelOptFP4)
         .def("isQuarkMXFP4", &QuantAlgo::isQuarkMXFP4)
+        .def("isW8a8Int8PTPC", &QuantAlgo::isW8a8Int8PTPC)
         .def("isQuant", &QuantAlgo::isQuant)
         .def("isGroupwise", &QuantAlgo::isGroupwise)
         .def("getQuantMethod", &QuantAlgo::getQuantMethod)

--- a/rtp_llm/model_loader/__init__.py
+++ b/rtp_llm/model_loader/__init__.py
@@ -2,6 +2,7 @@ from .attn_weight import AttnAtomicWeight, AttnConfig, MlaAttnAtomicWeight, MlaC
 from .compressed_w4a8_int4_per_channel_weight import (
     LoadCompressedW4A8Int4PerGroupQuantWeight,
 )
+from .compressed_w8a8_int8_per_channel_weight import CompressedW8A8Int8PerChannelWeight
 from .dynamic_fp8_quant_weight import LoadQuantDynamicPerTensorFp8Weight
 from .ffn_weight import (
     FfnAtomicWeight,

--- a/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
+++ b/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
@@ -1,0 +1,20 @@
+"""Loader for compressed-tensors W8A8 INT8 per-channel checkpoints."""
+
+import torch
+
+from rtp_llm.config.quant_config import CompressedW8A8Int8PerChannelQuantConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import PerChannelFp8Weight
+
+
+class CompressedW8A8Int8PerChannelWeight(PerChannelFp8Weight):
+    """Load INT8 kernels and FP32 channel scales without re-quantization.
+
+    Tensor mappings, TP/EP split rules and exclude handling are identical to the
+    per-channel FP8 path, so only the checkpoint dtype and the device
+    post-processing differ: INT8 kernels stay byte-exact and do not pass through
+    FP8 layout conversion.
+    """
+
+    weight_dtype = torch.int8
+    apply_fp8_device_conversion = False
+    supported_quant_config_types = (CompressedW8A8Int8PerChannelQuantConfig,)

--- a/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -79,6 +79,17 @@ def _ckpt_base_matches_quant_exclude(
     Returns:
         True if the template (with '{i}' replaced by a wildcard for digits) matches any
         concrete path in 'exclude_modules'.
+
+    Note:
+        Matching is per weight *template*, not per layer instance, so excluding a
+        single layer (``model.layers.7.mlp.down_proj``) makes the template match
+        and de-quantizes that weight in *every* layer. The fallback is only
+        numerically correct when the checkpoint excludes the module in all
+        layers; a partial exclusion makes the remaining layers read their
+        quantized bytes as compute-dtype weights, which is a silent numerical
+        error. This is the long-standing behaviour of the FP8 and W4A8 paths and
+        is kept unchanged here; turning a partial exclusion into a startup
+        failure would need the same treatment on all three paths.
     """
     if not exclude_modules:
         return False
@@ -245,6 +256,16 @@ def create_w8a8_fp8_per_channel_weight(
 
 
 class PerChannelFp8Weight(CompositeWeight, QuantWeight):
+    """Loader for pre-quantized per-output-channel weights with FP32 scales.
+
+    The ``Fp8`` here and in the member types this creates is historical: the
+    concrete dtype comes from ``weight_dtype``, so the same tensor mappings,
+    TP/EP split rules and ``_postprocess`` serve the INT8 subclass unchanged.
+    """
+
+    weight_dtype = torch.float8_e4m3fn
+    apply_fp8_device_conversion = True
+
     w8a8_weight_list = {
         W.attn_qkv_w: W.attn_qkv_s,
         W.attn_o_w: W.attn_o_s,
@@ -259,20 +280,28 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
         W.attn_gate_w: W.attn_gate_s,
     }
 
+    # Quant config types this loader claims. Subclasses narrow it to their own
+    # scheme so exactly one loader matches a given config (see
+    # WeightModule.create, which rejects multiple valid classes).
+    supported_quant_config_types: Tuple[type, ...] = (
+        Fp8PerChannelCompressedQuantConfig,
+        Fp8PerChannelQuarkQuantConfig,
+    )
+
     @classmethod
     def support(
         cls, quant_config: QuantizationConfig, src_weight_info: WeightModule
     ) -> bool:
         if not quant_config.is_quanted() or not isinstance(
-            quant_config,
-            (Fp8PerChannelCompressedQuantConfig, Fp8PerChannelQuarkQuantConfig),
+            quant_config, cls.supported_quant_config_types
         ):
             return False
         name = src_weight_info.name
         if name not in cls.w8a8_weight_list:
             return False
-        if quant_config.exclude_modules and hasattr(src_weight_info, "weights"):
-            for ckpt_w in src_weight_info.weights:
+        ckpt_weights = src_weight_info.weights
+        if quant_config.exclude_modules and ckpt_weights:
+            for ckpt_w in ckpt_weights:
                 base_name = ckpt_w.name.rsplit(".", 1)[0]
                 if _ckpt_base_matches_quant_exclude(
                     base_name, quant_config.exclude_modules
@@ -349,7 +378,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.attn_qkv_w,
             qkv_w_list,
             concat_0,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
 
@@ -382,7 +411,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_o_w,
             [CkptWeightInfo(w_name + QW_SUFFIX)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -416,7 +445,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                         align_size=src_weight_info.config.align_size,
                         dim=0,
                     ),
-                    data_type=torch.float8_e4m3fn,
+                    data_type=self.weight_dtype,
                     config=src_weight_info.config,
                 ),
                 create_w8a8_fp8_per_channel_weight(
@@ -450,7 +479,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=0,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -476,7 +505,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=1,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -496,7 +525,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.moe_w2,
             [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
             stack_,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -519,7 +548,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 for w in src_weight_info.weights
             ],
             stack_moe_w1,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -553,7 +582,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
             identity,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -590,7 +619,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             ],
             merge_qkv_z,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -612,7 +641,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_gate_w,
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -651,11 +680,12 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 if scale_weight.dim() == 2
                 else scale_weight
             )
-            kernel_weight, scale_weight = (
-                load_config.exported_device.convert_fp8_weight_params(
-                    kernel_weight, scale_weight
+            if self.apply_fp8_device_conversion:
+                kernel_weight, scale_weight = (
+                    load_config.exported_device.convert_fp8_weight_params(
+                        kernel_weight, scale_weight
+                    )
                 )
-            )
             processed_res[self.scale.name] = scale_weight
             processed_res[self.kernel.name] = kernel_weight
 

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -38,6 +38,12 @@ py_test(
 )
 
 py_test(
+    name = "test_compressed_w8a8_int8_per_channel",
+    srcs = ["test_compressed_w8a8_int8_per_channel.py"],
+    deps = py_test_deps,
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps + [

--- a/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
+++ b/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
@@ -1,0 +1,330 @@
+import inspect
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+from rtp_llm.config.quant_config import (
+    CompressedW8A8Int8PerChannelQuantConfig,
+    Fp8PerChannelCompressedQuantConfig,
+    QuantizationConfig,
+)
+from rtp_llm.model_loader.compressed_w8a8_int8_per_channel_weight import (
+    CompressedW8A8Int8PerChannelWeight,
+)
+from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import PerChannelFp8Weight
+from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
+from rtp_llm.ops import QuantAlgo
+from rtp_llm.utils.database import BaseDatabase
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
+
+
+def _compressed_group(weight_type="int", symmetric=True):
+    return {
+        "weights": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "channel",
+            "symmetric": symmetric,
+            "dynamic": False,
+        },
+        "input_activations": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "token" if weight_type == "int" else "tensor",
+            "symmetric": symmetric,
+            "dynamic": True,
+        },
+        "targets": ["Linear"],
+    }
+
+
+class _RecordingDevice:
+    """Stand-in for the exported device, the one external dependency here.
+
+    Records how often the FP8 layout conversion runs and returns tensors that
+    cannot be confused with the inputs, so the gate is asserted on behaviour
+    rather than on the class attribute that drives it.
+    """
+
+    def __init__(self):
+        self.convert_calls = 0
+        self.sentinel_kernel = torch.full((1, 1), 7, dtype=torch.int32)
+        self.sentinel_scale = torch.full((1, 1), 9, dtype=torch.int32)
+
+    def maybe_rewrite_weight_by_key(self, key, tensor):
+        return tensor
+
+    def convert_fp8_weight_params(self, kernel, scale):
+        self.convert_calls += 1
+        return self.sentinel_kernel, self.sentinel_scale
+
+
+def _load_config(exported_device):
+    return LoadConfig(
+        database=BaseDatabase(),
+        num_layers=1,
+        hidden_size=2,
+        head_num=1,
+        head_num_kv=1,
+        size_per_head=2,
+        moe_pure_tp_mode=False,
+        align_size=1,
+        moe_align_size=1,
+        moe_layer_index=[],
+        moe_n_group=1,
+        expert_num=0,
+        enable_eplb=False,
+        phy_exp_num=0,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        dp_size=1,
+        dp_rank=0,
+        lm_head_tp_size=1,
+        lm_head_tp_rank=0,
+        ffn_tp_size=1,
+        ffn_tp_rank=0,
+        num_nodes=1,
+        exported_device=exported_device,
+    )
+
+
+class CompressedW8A8ConfigTest(unittest.TestCase):
+    def _load(self, quantization_config):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with open(os.path.join(model_dir, "config.json"), "w") as output:
+                json.dump({"quantization_config": quantization_config}, output)
+            return QuantizationConfig.load_from_ckpt(model_dir)
+
+    def test_parses_checkpoint_defined_group_name_and_ignore(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {"W8A8": _compressed_group()},
+                "ignore": ["model.layers.0.mlp.gate"],
+            }
+        )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertEqual(config.get_algo(), "w8a8_int8_per_channel")
+        self.assertEqual(config.bits, 8)
+        self.assertEqual(config.group_size(), 0)
+        self.assertEqual(config.exclude_modules, {"model.layers.0.mlp.gate"})
+
+    def test_group_0_still_wins_so_existing_checkpoints_are_unchanged(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {
+                    "group_0": _compressed_group("float"),
+                    "W8A8": _compressed_group("int"),
+                },
+            }
+        )
+        self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+
+    def test_rejects_a_group_scoped_to_specific_targets(self):
+        # Nothing reads targets, so a narrower scope would be applied as if it
+        # covered the whole model. Fail at parse time instead.
+        group = _compressed_group()
+        group["targets"] = ["re:.*mlp.*"]
+        with self.assertRaisesRegex(ValueError, "targets"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_group_0_wins_and_says_the_siblings_are_dropped(self):
+        with self.assertLogs(level="WARNING") as logs:
+            config = self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {
+                        "group_0": _compressed_group(),
+                        "group_1": _compressed_group(),
+                    },
+                }
+            )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertIn("group_1", "\n".join(logs.output))
+
+    def test_misspelled_ignore_patterns_raises_instead_of_emptying_excludes(self):
+        # Matched on the keyword name: an abstract-class TypeError would
+        # otherwise let this pass while the protection it asserts is gone.
+        with self.assertRaisesRegex(TypeError, "ignore_pattern"):
+            CompressedW8A8Int8PerChannelQuantConfig(ignore_pattern=["lm_head"])
+
+    def test_rejects_asymmetric_w8a8(self):
+        with self.assertRaisesRegex(ValueError, "asymmetric INT8"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": _compressed_group(symmetric=False)},
+                }
+            )
+
+    def test_unrecognised_scheme_names_itself_instead_of_failing_abstractly(self):
+        # Weight-only INT8 (activations absent or null) and per-tensor INT8
+        # activations must not be read as dynamic per-token W8A8, and the
+        # fall-through must not surface an abstract-class TypeError.
+        weight_only = _compressed_group()
+        weight_only["input_activations"] = None
+        missing_key = {
+            k: v for k, v in _compressed_group().items() if k != "input_activations"
+        }
+        per_tensor = _compressed_group()
+        per_tensor["input_activations"]["strategy"] = "tensor"
+        for label, group in (
+            ("null activations", weight_only),
+            ("missing activations", missing_key),
+            ("per-tensor activations", per_tensor),
+        ):
+            with self.subTest(case=label):
+                with self.assertRaisesRegex(
+                    ValueError, "unsupported compressed-tensors scheme"
+                ):
+                    self._load(
+                        {
+                            "quant_method": "compressed-tensors",
+                            "config_groups": {"W8A8": group},
+                        }
+                    )
+
+    def test_moe_activation_spec_requires_int8_per_token(self):
+        self.assertEqual(
+            CompressedW8A8Int8PerChannelQuantConfig().get_moe_activation_quant_spec(),
+            (torch.int8, True),
+        )
+        self.assertIsNone(
+            Fp8PerChannelCompressedQuantConfig(
+                bits=8, is_quanted=True
+            ).get_moe_activation_quant_spec()
+        )
+
+
+class CompressedW8A8WeightTest(unittest.TestCase):
+    def _source(self):
+        return AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+
+    def test_support_and_checkpoint_tensor_dtypes(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        source = self._source()
+        self.assertTrue(CompressedW8A8Int8PerChannelWeight.support(config, source))
+
+        weight = WeightModule.create(source, config)
+        self.assertIsInstance(weight, CompressedW8A8Int8PerChannelWeight)
+        self.assertEqual(weight.kernel.data_type, torch.int8)
+        self.assertEqual(weight.scale.data_type, torch.float32)
+        self.assertEqual(
+            weight.kernel.weights[0].name, "model.layers.{i}.self_attn.gate.weight"
+        )
+        self.assertEqual(
+            weight.scale.weights[0].name,
+            "model.layers.{i}.self_attn.gate.weight_scale",
+        )
+
+    def test_ignore_matching_the_template_disables_the_quantized_loader(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.7.self_attn.gate"]
+        )
+        self.assertFalse(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+    def test_non_matching_ignore_keeps_the_quantized_loader(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.7.mlp.down_proj"]
+        )
+        self.assertTrue(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+
+class PerChannelFp8PostprocessTest(unittest.TestCase):
+    """Assert the _postprocess behaviour, not the attribute that drives it."""
+
+    def _run(self, quant_config, kernel_dtype):
+        source = AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+        weight = WeightModule.create(source, quant_config)
+        device = _RecordingDevice()
+        # Non-square so the reshape inside _postprocess is observable.
+        tensors = {
+            weight.kernel.name: torch.arange(6, dtype=torch.int32)
+            .reshape(2, 3)
+            .to(kernel_dtype),
+            weight.scale.name: torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float32),
+        }
+        processed = weight._postprocess(tensors, "cpu", _load_config(device))
+        return weight, device, processed
+
+    def test_int8_skips_the_fp8_conversion(self):
+        # _RecordingDevice.maybe_rewrite_weight_by_key is an identity, so the
+        # tensor comparisons below pin what this loader does to the weights, not
+        # what a production device may still rewrite afterwards.
+        weight, device, processed = self._run(
+            CompressedW8A8Int8PerChannelQuantConfig(), torch.int8
+        )
+        self.assertEqual(device.convert_calls, 0)
+        kernel = processed[weight.kernel.name]
+        self.assertEqual(kernel.dtype, torch.int8)
+        self.assertEqual(tuple(kernel.shape), (3, 2))
+        torch.testing.assert_close(
+            kernel.to(torch.int32),
+            torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+        scale = processed[weight.scale.name]
+        self.assertEqual(scale.dtype, torch.float32)
+        self.assertEqual(tuple(scale.shape), (1, 3))
+
+    def test_fp8_still_runs_the_device_conversion(self):
+        weight, device, processed = self._run(
+            Fp8PerChannelCompressedQuantConfig(bits=8, is_quanted=True),
+            torch.float8_e4m3fn,
+        )
+        self.assertEqual(device.convert_calls, 1)
+        torch.testing.assert_close(
+            processed[weight.kernel.name], device.sentinel_kernel, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            processed[weight.scale.name], device.sentinel_scale, rtol=0, atol=0
+        )
+
+    def test_no_hardcoded_fp8_dtype_survives_in_the_template(self):
+        # A missed call site would keep loading FP8 kernels for an INT8
+        # checkpoint, and the dtype is only reachable through the class attribute.
+        source = inspect.getsource(PerChannelFp8Weight)
+        self.assertEqual(source.count("data_type=torch.float8_e4m3fn"), 0)
+
+
+class QuantAlgoBindingTest(unittest.TestCase):
+    """Pin the python -> C++ string contract the loader relies on."""
+
+    def test_algo_string_round_trips_to_w8a8_int8_ptpc(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        algo = QuantAlgo()
+        algo.setQuantAlgo(config.get_algo().lower(), config.bits, config.group_size())
+        self.assertTrue(algo.isW8a8Int8PTPC())
+        self.assertTrue(algo.isQuant())
+        self.assertFalse(algo.isGroupwise())
+        self.assertEqual(algo.getWeightBits(), 8)
+        self.assertEqual(algo.getActivationBits(), 8)
+        self.assertEqual(algo.getGroupSize(), 0)
+        self.assertIn("W8A8INT8PTPC", str(algo.getQuantMethod()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
@@ -70,6 +70,26 @@ class StrategyRegistry:
         ]
         logger.debug(f"[StrategyRegistry] Found {len(candidates)} candidate(s)")
 
+        # A pre-quantized checkpoint may require MOE experts to consume a
+        # specific activation format. Granularity is part of the contract: an
+        # INT8 per-tensor strategy must not satisfy a scheme that needs INT8 per
+        # token.
+        model_quant_config = config.model_config.quant_config
+        required_act_spec = (
+            model_quant_config.get_moe_activation_quant_spec()
+            if model_quant_config is not None
+            else None
+        )
+        spec_hint = ""
+        if required_act_spec is not None:
+            required_dtype, required_per_act_token = required_act_spec
+            spec_hint = (
+                f" Quantization method {model_quant_config.get_method()} needs a "
+                f"strategy producing {required_dtype} activations "
+                f"({'per token' if required_per_act_token else 'not per token'}); "
+                "MOE layers cannot serve this checkpoint unless one is registered."
+            )
+
         if not candidates:
             logger.error(
                 f"No suitable MOE strategy found. Config details: "
@@ -82,25 +102,60 @@ class StrategyRegistry:
             raise ValueError(
                 f"No suitable MOE strategy found for configuration. "
                 f"Please check quant_config, ep_size, and parallelism settings."
+                f"{spec_hint}"
             )
 
-        # Sort candidates by priority (descending, higher priority first)
-        candidates.sort(key=lambda s: s.priority, reverse=True)
+        # get_attributes() is not a plain accessor -- it does lazy imports and
+        # some backends log from it -- so resolve it once and reuse it for the
+        # activation-format filter, the candidate log and the selection.
+        scored = [(strategy, strategy.get_attributes()) for strategy in candidates]
+
+        if required_act_spec is not None:
+            matching = [
+                (strategy, attrs)
+                for strategy, attrs in scored
+                if (
+                    attrs.quant_config.quant_dtype,
+                    attrs.quant_config.per_act_token_quant,
+                )
+                == required_act_spec
+            ]
+            if not matching:
+                provided = sorted(
+                    str(
+                        (
+                            attrs.quant_config.quant_dtype,
+                            attrs.quant_config.per_act_token_quant,
+                        )
+                    )
+                    for _, attrs in scored
+                )
+                raise ValueError(
+                    f"None of the {len(scored)} candidate strategy(ies) matches the "
+                    f"required activation format (they provide {provided})."
+                    f"{spec_hint}"
+                )
+            # Narrow the selection too, so the strategy that gets picked is the
+            # one the check passed on rather than a higher-priority fallback.
+            scored = matching
+
+        # Sort by priority (descending, higher priority first)
+        scored.sort(key=lambda pair: pair[1].calculate_priority(), reverse=True)
 
         # Log all candidate strategies
-        logger.info(f"Found {len(candidates)} candidate strategy(ies) for MOE:")
-        for strategy in candidates:
+        logger.info(f"Found {len(scored)} candidate strategy(ies) for MOE:")
+        for strategy, attrs in scored:
             logger.info(
                 f"  - {strategy.__class__.__name__}: "
-                f"{strategy.get_attributes()} (priority={strategy.priority})"
+                f"{attrs} (priority={attrs.calculate_priority()})"
             )
 
         # Select the strategy with highest priority (first in sorted list)
-        selected = candidates[0]
+        selected, selected_attrs = scored[0]
 
         logger.info(
             f"Selected strategy: {selected.__class__.__name__} "
-            f"with priority {selected.priority}"
+            f"with priority {selected_attrs.calculate_priority()}"
         )
 
         return selected

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1372,6 +1372,8 @@ class QuantAlgo:
         ...
     def isW4a8Int4PTPC(self) -> bool:
         ...
+    def isW8a8Int8PTPC(self) -> bool:
+        ...
     def isWeightOnlyPerCol(self) -> bool:
         ...
     def setQuantAlgo(self, arg0: str, arg1: int, arg2: int) -> None:
@@ -1403,6 +1405,8 @@ class QuantMethod:
       ModelOptFP4
 
       QuarkMXFP4
+
+      W8A8INT8PTPC
     """
     Awq: typing.ClassVar[QuantMethod]  # value = <QuantMethod.Awq: 3>
     FP8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.FP8PTPC: 8>
@@ -1415,8 +1419,9 @@ class QuantMethod:
     PerTensorQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.PerTensorQuant: 6>
     SmoothQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.SmoothQuant: 4>
     W4A8INT4PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W4A8INT4PTPC: 9>
+    W8A8INT8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W8A8INT8PTPC: 12>
     WeightOnlyPerCol: typing.ClassVar[QuantMethod]  # value = <QuantMethod.WeightOnlyPerCol: 1>
-    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>}
+    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>, 'QuarkMXFP4': <QuantMethod.QuarkMXFP4: 11>, 'W8A8INT8PTPC': <QuantMethod.W8A8INT8PTPC: 12>}
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:


### PR DESCRIPTION
## 功能

识别并加载 compressed-tensors 格式的 W8A8 INT8 checkpoint：权重是静态对称 INT8
per-output-channel，激活是动态对称 INT8 per-token；并把量化语义透传到引擎。

## 范围：只做注册与加载

激活量化 kernel 与 MoE 执行路径**不在本 PR**，它们随提供实现的 backend 一起提交。

公共 CUDA / ROCm 没有消费 INT8 per-token 激活的 MoE 执行实现
（`moe_kernel_quantize_input` 对 int8 仍是 `NotImplementedError`），所以
「MoE + W8A8 INT8」在**选路阶段明确报错**，而不是被未量化的兜底策略静默接手、
最后死在 kernel 里。

**不改变任何既有量化方案的行为。** 所有跨方案共享的代码路径 —— `load_from_ckpt`
的公共尾部、`exclude` 语义、KV cache 校验、MoE router —— 与 `main` **逐字节一致**；
新方案自己的分支在到达公共尾部前就 return。

### 改动分类

**加载必需（约 470 行）**

| 项 | 行数 |
|---|---|
| `quant_config.py`：config 类 + INT8 解析分支 + group 名解析 | +97 |
| `compressed_w8a8_int8_per_channel_weight.py`（新 loader，20 行） | +20 |
| `per_channel_fp8_quant_weight.py`（复用 FP8 loader 的连带代价） | +49 −19 |
| `model_loader/__init__.py`（注册） | +1 |
| `QuantInfo.h/.cc` + `Executor.h`（algo 串 → 枚举 → `QScheme::Qint8PerToken`） | +11 −1 |
| 测试 + BUILD | +336 |

**防护性（约 100 行，不加会出静默错误或不可操作的报错）**

| 项 | 行数 | 不加的后果 |
|---|---|---|
| `strategy_registry.py` MoE 选路守卫 + spec 钩子 | +80 | ROCm EP 的 bf16 兜底会静默消费 INT8 权重。这条路径是本 PR 让 checkpoint 可加载后才第一次可达，因此由本 PR 兜底 |
| fall-through 具名错误 + `input_activations` 改可选 + `targets` 拒绝 | +26 | 裸 `KeyError` / 抽象类 `TypeError` / 窄作用域被当全量应用 |
| `LocalRpcServer.cc` + `ModelConfig.cc` precision 字符串 | +5 | 状态轮询日志刷 `UNKNOWN(12)` + ERROR |
| `ConfigInit.cc` + `.pyi` 枚举暴露 | +9 −2 | 无 python 消费者，纯枚举对齐（顺带修回 `QuarkMXFP4` 未进 `__members__` 的既有漂移）|

## 实现

**配置解析**（`quant_config.py`）

- 新增 `CompressedW8A8Int8PerChannelQuantConfig`，method 串
  `W8A8_INT8_PER_CHANNEL_COMPRESSED`，algo 串 `w8a8_int8_per_channel`。全参数具名、
  **无 `**kwargs` 吸收口**，拼错键名直接 `TypeError`；不登记 `preset_quant_config`，
  只由 checkpoint 自动识别（注释已写明）
- 识别 `weights: int/8/channel/static` + `input_activations: int/8/token/dynamic`，
  非对称变体报错
- 抽 `_pick_config_group()`：group 名由 checkpoint 定义（Qwen3.5 用 `W8A8`），不能
  假定 `group_0`。**有 `group_0` 时仍取 `group_0`**，回退只覆盖旧硬编码查找根本读不了
  的情况：单个自定义名字的组；多组并存时 WARNING 列出被丢弃的组名
- 回退路径拒绝带收窄 `targets` 的组。全仓生产代码从不读 `targets`，窄作用域会被当作
  全量量化，然后在向 BF16 模块索取 `.weight_scale` 时报难定位的加载错误
- `input_activations` 改为可选读取；compressed-tensors 下无分支命中时抛出**点名具体
  组合**的 `ValueError`，替代原先实例化抽象 `CompressedTensorsQuantConfig` 的 `TypeError`
- 本方案自己的分支从 checkpoint 的 `ignore` 键取排除列表并**提前 return**。
  `load_from_ckpt` 的公共尾部仍只读 `exclude`，与 `main` 一致

**权重加载**

`CompressedW8A8Int8PerChannelWeight` 继承 `PerChannelFp8Weight`，只声明三个类属性：

    weight_dtype = torch.int8
    apply_fp8_device_conversion = False
    supported_quant_config_types = (CompressedW8A8Int8PerChannelQuantConfig,)

父类把 10 处硬编码 dtype 改读 `self.weight_dtype`（默认值即原值），`support()` 的
isinstance 白名单改读类属性 —— 子类因此**无需复制**父类 `support()`，11 个权重键的
tensor mapping、TP/EP 切分与 exclude 处理全部复用，新 loader 只有 20 行。基类
docstring 已写明 `Fp8` 为历史命名、实际 dtype 由 `weight_dtype` 决定。

INT8 权重保持不变，跳过 FP8 device layout 转换 —— ROCm 侧
`convert_fp8_weight_params`（`device_impl.py:1003`）首行断言
`weight.dtype == torch.float8_e4m3fn` 并把 e4m3fn 重解释为 e4m3fnuz、scale ×2，
INT8 走该路径必然失败；CUDA 侧为恒等返回，故关闭转换既必要又对 FP8 通路零影响。

**引擎语义**

`QuantMethod::W8A8INT8PTPC` **追加为 12，既有 0~11 取值与顺序未变**，未使用
`export_values()`；映射到 `QScheme::Qint8PerToken`（复用 SmoothQuant/OmniQuant 已有
分支）。含 pybind 绑定、checked-in stub 与 worker status 的 `precision` 字段
（`WorkerStatusPB.precision` 是无白名单自由字符串，新增取值向后兼容）。

**MoE 选路守卫**

`QuantizationConfig.get_moe_activation_quant_spec()` 返回 `(dtype, per_act_token)`，
默认 `None` —— 现有方案全部不受影响。`StrategyRegistry` **先按该 spec 过滤候选、
再排序选优**，所以被选中的必然是校验通过的那个；候选为空时也带上同一条诊断，使 CUDA
与 ROCm 得到一致的启动期提示。`get_attributes()` 每候选只解析一次（该方法内含惰性
import、部分后端在其中打日志），排序键改用已解析的 `attrs.calculate_priority()` ——
与 `strategy.priority` 语义等价，对既有部署零行为变化。

## 行为兼容性

| 场景 | 改前 | 改后 |
|---|---|---|
| 单组 `group_0` | 正常 | 不变 |
| 多组含 `group_0` | 取 `group_0` | 取 `group_0`（结果相同）+ WARNING 列出被丢弃组 |
| 无 `group_0` 单组 | KeyError | 正常解析（本 PR 修的缺陷） |
| 无 `group_0` 多组 | KeyError | 报错并列出组名 |
| 其他方案的 `exclude` | — | 公共尾部未改，与 `main` 一致 |
| 其他方案的 MoE 选路 | — | `get_moe_activation_quant_spec()` 默认 `None`，守卫不触发 |
| FP8 per-channel 加载 | — | 类属性默认值即原硬编码值，10 处替换后行为不变 |

## 测试

`test_compressed_w8a8_int8_per_channel`：**15 例 / 5 个类**

- 解析：自定义组名 + ignore、非对称拒绝、`group_0` 优先（证明既有 checkpoint 不变）、
  未识别组合点名报错（null 激活 / 缺键 / per-tensor 激活三个 subTest）、收窄 `targets`
  被拒、多组时 WARNING 含被丢弃组名、拼错 `ignore_pattern` 抛 `TypeError`
  （`assertRaisesRegex` 锚定关键字名，避免抽象类 `TypeError` 让用例误绿）
- 加载：support 判定与 ckpt 名后缀、ignore 命中模板关闭量化、**非命中 ignore 不影响
  量化**（反向用例）、MoE spec 契约
- `_postprocess` **行为断言**：真实 `LoadConfig` + 记录型 device 替身，非方阵输入使
  内部 reshape 可观测。INT8 路径断言 `convert_fp8_weight_params` **调用 0 次**、
  kernel dtype 仍 int8、形状与元素顺序逐一比对；FP8 路径断言**调用 1 次**且哨兵张量
  写回 kernel 与 scale 两个键。该 device 替身的 `maybe_rewrite_weight_by_key` 是恒等
  实现，故断言范围限定为「本 loader 对权重做了什么」，不外推到生产设备的改写
- 跨语言契约：`setQuantAlgo("w8a8_int8_per_channel", 8, 0)` 往返，断言
  `isW8a8Int8PTPC()`、weight/activation bits 均为 8、`isGroupwise()` 为 False

FP8 回归 `test_per_channel_fp8_helpers` 与 `server_args_test` 同批通过。

## 明确不在本 PR 内的决定

以下几条经核实为**既有行为**或**需要仓外证据**，本 PR 有意不动，避免把无关变更混入：

- **dense Linear 的 W8A8 INT8 执行与具名拒绝**：`should_use_fp8_linear` 白名单不含
  该 method，dense 层会撞通用错误 `No suitable Linear strategy found ...
  weight.dtype=torch.int8`。MoE 侧本 PR 给了具名拒绝，dense 侧未加 —— 这是已知缺口，
  随执行侧一并处理
- **`exclude` 的跨层匹配**按权重模板而非层实例，部分层 exclude 会产生静默数值错误 ——
  FP8 / W4A8 三条 compressed-tensors 路径共有的既有行为。只在 docstring 写明；单独
  收紧其中一条会让三条路径行为不一致
- **`ignore` 的 `re:` 正则前缀**未被识别：同上，属三条路径共有，另开 PR 统一处理
- **FP8 per-channel compressed 路径丢失 `ignore`**：公共尾部只读 `exclude`，这是早于
  本 PR 的缺陷。曾尝试在本 PR 内一并修正，但下游经 `{i}` 模板全层命中会退到非量化
  loader（只做 `.to(convert_type)`、不乘 scale），把启动失败变成静默数值错误 ——
  已回退，另开 PR 处理并补回归用例
- **`targets` 在 `group_0` 路径不校验**：`group_0` 是既有可加载路径，在其上新增拒绝
  会改变现有 checkpoint 的行为，与「零行为变更」前提冲突
- **int4-group / fp8-channel 分支的激活校验**：补校验会改变 W4A8 / FP8 的分类结果
- **KV cache dtype 保持 `[float16, bfloat16]`**：与同族方案不一致是有意的 —— 线性层
  INT8 与 attention KV cache dtype 相互独立，但该组合未经验证，带 `--fp8_kv_cache`
  的部署宁可启动失败也不走未验证路径。已在注释写明「需证据再放宽」
- **`Qint8PerToken` 的 BF16 前提**：与 SmoothQuant 共用取值，而后者在
  `model_config.py` 强制 FP16。「BF16 + Qint8PerToken」是本仓首次出现的组合，全仓
  `act_qscheme` 无施加 dtype 约束的消费方，仓内无法证实影响，故不编结论
- **MoE 守卫与「专家是否真被量化」解耦**：`ignore` 覆盖 MoE experts 的 checkpoint 会
  被拒。已核实 config 层拿到的 `exclude_modules` 只是一组字符串，判断「是否覆盖 MoE
  experts」需要模型特定的 ckpt 命名知识，config 层无法可靠判定（导入 loader 的
  `_ckpt_base_matches_quant_exclude` 会造成循环依赖）。已在 docstring 承认该边界
- **`QuantMethod → string` 两处映射重复**且既有缺口不一致（`ModelOptFP4` /
  `QuarkMXFP4`）：另开 follow-up 收敛到 `QuantInfo.h` 的单一函数
- **`.pyi` 存根一致性**：建议由 `tools/gen_pyi` 生成并在 CI diff；本 PR 手工同步并
  顺带补回既有漂移