### PR TITLE
perf(cuda): avoid TTFT spike from tpSync pinned-buffer allocation

### DIFF
--- a/rtp_llm/cpp/models/ModelTypes.cc
+++ b/rtp_llm/cpp/models/ModelTypes.cc
@@ -167,14 +167,13 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
         auto options     = torch::TensorOptions(torch_dtype);
         if (atype == rtp_llm::AllocationType::DEVICE) {
             options = options.device(torch::kCUDA);
+        } else {
+            // Broadcast receive buffers need pinned storage. Allocate it directly to avoid
+            // copying an uninitialized pageable allocation in Tensor::pin_memory().
+            options = options.pinned_memory(true);
         }
         std::vector<int64_t> dims64(dims.begin(), dims.end());
-        auto                 tensor = torch::empty(dims64, options);
-        // NCCL broadcast requires pinned memory for CPU buffers
-        if (atype != rtp_llm::AllocationType::DEVICE) {
-            tensor = tensor.pin_memory();
-        }
-        return tensor;
+        return torch::empty(dims64, options);
     };
 
     bool is_non_root = parallelism_config.tp_rank != 0;
@@ -355,7 +354,9 @@ void tpSyncModelInputs(GptModelInputs& inputs, const ParallelismConfig& parallel
     torch::Tensor cpu_packed, gpu_packed;
 
     if (cpu_total_bytes > 0) {
-        cpu_packed = torch::empty({cpu_total_bytes}, torch::kUInt8).pin_memory();
+        // The memcpy loop below initializes this buffer after allocation.
+        cpu_packed = torch::empty(
+            {cpu_total_bytes}, torch::TensorOptions(torch::kUInt8).pinned_memory(true));
         if (is_root) {
             auto* base = static_cast<uint8_t*>(cpu_packed.data_ptr());
             for (auto& e : cpu_entries) {


### PR DESCRIPTION
### Description

`tpSyncModelInputs()` creates host-side broadcast buffers with the following pattern:

```cpp
torch::empty(dims, options).pin_memory();
```

`Tensor::pin_memory()` does not pin the original allocation in place. It allocates new pinned storage and copies the pageable tensor into it. The affected tensors are uninitialized send buffers or receive buffers whose contents are populated immediately afterward by `memcpy` or broadcast, so the copy moves data that is never consumed.

The redundant copy becomes particularly expensive when it crosses PyTorch TensorIterator's parallelization threshold. For the packed uint8 buffer in the measured Qwen CP8 configuration, its size is approximately four bytes per token plus a 1,292-byte fixed header. It therefore crosses `GRAIN_SIZE == 32768` at approximately:

```text
(32768 - 1292) / 4 ~= 7869 tokens
```

At that boundary, each rank launches a wide OpenMP team for a roughly 32 KB copy. Multiple ranks contend for the same host CPUs and then wait for the slowest rank at the following broadcast, making the host-side cost visible in TTFT.

| Input length | TTFT before the fix |
|---:|---:|
| 7,868 tokens | 142.6 ms |
| 7,869 tokens | 191.0 ms |

Adding one token increases TTFT by approximately 48.4 ms. Intercepting `GOMP_parallel` identifies the following path:

```text
GOMP_parallel
  -> TensorIteratorBase::for_each
  -> direct_copy_kernel
  -> _pin_memory
  -> pin_memory
  -> tpSyncModelInputs
```

The same issue exists in the host receive tensors created by `allocBuf()`. In particular, the int32 `combo_tokens` tensor independently reaches the 32,768-element threshold at 32,768 tokens.

### Proposed Solution

Allocate pinned storage directly through `TensorOptions`:

```cpp
auto options = torch::TensorOptions(dtype).pinned_memory(true);
auto tensor = torch::empty(dims, options);
```

Apply the same change to the packed uint8 buffer:

```cpp
cpu_packed = torch::empty(
    {cpu_total_bytes},
    torch::TensorOptions(torch::kUInt8).pinned_memory(true));
```

The change should cover:

- host broadcast receive tensors allocated by `allocBuf()`; and
- the packed host send/receive buffer `cpu_packed`.

The small `shape_hints_t`, `mm_features_shape_t`, and `mm_extra_input_shape_t` metadata buffers are far below the parallel threshold and can remain unchanged to keep the patch focused.

### Correctness and Safety

Both the old and proposed paths return an uninitialized pinned CPU tensor with the same shape and dtype. The tensor is populated by the same subsequent `memcpy` or broadcast operation. The only removed operation is a copy of uninitialized data:

```text
Before: pageable allocation + pinned allocation + unused copy
After:  pinned allocation
```

This does not change input contents, broadcast ordering, device synchronization, model computation, or numerical results.

An equivalent eight-rank allocation test measured the following above the threshold:

| Allocation pattern | Median wall time | CPU consumption |
|:--|--:|--:|
| `empty().pin_memory()` | approximately 71 ms | approximately 1,270 core-ms/call |
| `empty(..., pin_memory=True)` | approximately 0.002 ms | approximately 0.6 core-ms/call |

The exact end-to-end benefit is configuration-dependent: the packed-buffer size must cross the threshold in the tested range, and the number of ranks and OpenMP threads must be high enough to cause host contention. The redundant allocation and copy are unnecessary regardless of whether a visible TTFT step occurs.