### PR TITLE
perf(cuda): fuse context-parallel all-gather prefill

### DIFF
--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -338,6 +338,9 @@ def set_parallelism_config(
 
     if py_prefill_cp_config:
         parallelism_config.prefill_cp_config.method = py_prefill_cp_config.method
+        parallelism_config.prefill_cp_config.all_gather_impl = (
+            py_prefill_cp_config.all_gather_impl
+        )
         parallelism_config.prefill_cp_config.comm_buffer_size = (
             py_prefill_cp_config.comm_buffer_size
         )

--- a/rtp_llm/config/test/server_config_setup_test.py
+++ b/rtp_llm/config/test/server_config_setup_test.py
@@ -8,7 +8,7 @@ from rtp_llm.config.server_config_setup import (
     set_parallelism_config,
     setup_and_configure_server,
 )
-from rtp_llm.ops import NcclCommConfig, RoleType
+from rtp_llm.ops import CPAllGatherImpl, NcclCommConfig, RoleType
 from rtp_llm.server.server_args.server_args import setup_args
 
 
@@ -135,6 +135,7 @@ class GenerateConfigTest(TestCase):
 
     def test_set_parallelism_config_propagates_prefill_cp_cache_fields(self):
         py_env_configs = PyEnvConfigs()
+        py_env_configs.prefill_cp_config.all_gather_impl = CPAllGatherImpl.FUSED
         py_env_configs.prefill_cp_config.kv_cache_sharded = True
         py_env_configs.prefill_cp_config.prefill_cp_size = 4
 
@@ -145,6 +146,10 @@ class GenerateConfigTest(TestCase):
 
         self.assertTrue(
             py_env_configs.parallelism_config.prefill_cp_config.kv_cache_sharded
+        )
+        self.assertEqual(
+            py_env_configs.parallelism_config.prefill_cp_config.all_gather_impl,
+            CPAllGatherImpl.FUSED,
         )
         self.assertEqual(
             py_env_configs.parallelism_config.prefill_cp_config.prefill_cp_size, 4

--- a/rtp_llm/cpp/cache/test/KVCacheResourceTest.cc
+++ b/rtp_llm/cpp/cache/test/KVCacheResourceTest.cc
@@ -170,10 +170,12 @@ TEST(KVCacheResourceTest, InitializationDoesNotRetainTopology) {
 
 TEST(PrefillCPConfigTest, ToStringIncludesShardingFields) {
     PrefillCPConfig config;
+    config.all_gather_impl  = CPAllGatherImpl::FUSED;
     config.kv_cache_sharded = true;
     config.prefill_cp_size  = 2;
 
     const auto text = config.to_string();
+    EXPECT_NE(text.find("all_gather_impl: FUSED"), std::string::npos);
     EXPECT_NE(text.find("kv_cache_sharded: 1"), std::string::npos);
     EXPECT_NE(text.find("prefill_cp_size: 2"), std::string::npos);
 }

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -43,7 +43,8 @@ std::string PrefillCPConfig::to_string() const {
             oss << "UNKNOWN";
             break;
     }
-    oss << "\n comm_buffer_size: " << comm_buffer_size << "\n"
+    oss << "\n all_gather_impl: " << (all_gather_impl == CPAllGatherImpl::FUSED ? "FUSED" : "LEGACY") << "\n"
+        << " comm_buffer_size: " << comm_buffer_size << "\n"
         << " kv_cache_sharded: " << kv_cache_sharded << "\n"
         << " prefill_cp_size: " << prefill_cp_size << "\n";
     return oss.str();

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -26,12 +26,17 @@ enum class CPRotateMethod {
     PREFILL_CP              = 4,
     UNKNOWN                 = 5,
 };
+enum class CPAllGatherImpl {
+    LEGACY = 0,
+    FUSED  = 1,
+};
 struct PrefillCPConfig {
-    CPRotateMethod method           = CPRotateMethod::DISABLED;
-    size_t         comm_buffer_size = 512 * 1024 * 1024;  // 512MB
-    bool           kv_cache_sharded = false;
-    int64_t        prefill_cp_size  = 0;
-    bool           is_enabled() const {
+    CPRotateMethod  method           = CPRotateMethod::DISABLED;
+    CPAllGatherImpl all_gather_impl  = CPAllGatherImpl::LEGACY;
+    size_t          comm_buffer_size = 512 * 1024 * 1024;  // 512MB
+    bool            kv_cache_sharded = false;
+    int64_t         prefill_cp_size  = 0;
+    bool            is_enabled() const {
         return method != CPRotateMethod::DISABLED && method != CPRotateMethod::UNKNOWN
                && method != CPRotateMethod::PREFILL_CP;
     }
@@ -367,7 +372,7 @@ struct FIFOSchedulerConfig {
     //   "N"   -> 1 prefill : N decode (decode-heavy); "1" = strict alternation.
     //   "1/X" -> X prefill : 1 decode (prefill-heavy).
     //   invalid input falls back to "1".
-    std::string decode_prefill_ratio = "1";
+    std::string decode_prefill_ratio        = "1";
     bool        cp_force_single_prefill     = true;
     int64_t     max_inited_kv_cache_streams = 0;
     std::string to_string() const;
@@ -376,9 +381,9 @@ struct FIFOSchedulerConfig {
 struct GrammarConfig {
     bool constrained_json_disable_any_whitespace = false;
     // Service-level xgrammar matcher policy. Requests cannot override it.
-    bool                 terminate_without_stop_token = false;
-    int                  num_workers                  = 8;
-    std::string          tokenizer_info_json;
+    bool        terminate_without_stop_token = false;
+    int         num_workers                  = 8;
+    std::string tokenizer_info_json;
     // Byte cap on xgrammar's internal compiled-grammar cache; <=0 = unlimited.
     int64_t     compiler_cache_bytes = 512 * 1024 * 1024;
     std::string to_string() const;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -169,6 +169,11 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .value("UNKNOWN", CPRotateMethod::UNKNOWN)
         .export_values();
 
+    py::enum_<CPAllGatherImpl>(m, "CPAllGatherImpl")
+        .value("LEGACY", CPAllGatherImpl::LEGACY)
+        .value("FUSED", CPAllGatherImpl::FUSED)
+        .export_values();
+
     py::enum_<FMHAType>(m, "FMHAType")
         .value("FLASH_INFER", FMHAType::FLASH_INFER)
         .value("NONE", FMHAType::NONE)
@@ -2070,6 +2075,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
     py::class_<PrefillCPConfig>(m, "PrefillCPConfig")
         .def(py::init<>())
         .def_readwrite("method", &PrefillCPConfig::method)
+        .def_readwrite("all_gather_impl", &PrefillCPConfig::all_gather_impl)
         .def_readwrite("comm_buffer_size", &PrefillCPConfig::comm_buffer_size)
         .def_readwrite("kv_cache_sharded", &PrefillCPConfig::kv_cache_sharded)
         .def_readwrite("prefill_cp_size", &PrefillCPConfig::prefill_cp_size)
@@ -2078,10 +2084,14 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def("is_prefill_enabled", &PrefillCPConfig::is_prefill_enabled)
         .def(py::pickle(
             [](const PrefillCPConfig& self) {
-                return py::make_tuple(self.method, self.comm_buffer_size, self.kv_cache_sharded, self.prefill_cp_size);
+                return py::make_tuple(self.method,
+                                      self.comm_buffer_size,
+                                      self.kv_cache_sharded,
+                                      self.prefill_cp_size,
+                                      self.all_gather_impl);
             },
             [](py::tuple t) {
-                if (t.size() != 2 && t.size() != 4)
+                if (t.size() != 2 && t.size() != 4 && t.size() != 5)
                     throw std::runtime_error("Invalid state!");
                 PrefillCPConfig c;
                 try {
@@ -2090,6 +2100,9 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     if (t.size() >= 4) {
                         c.kv_cache_sharded = t[2].cast<bool>();
                         c.prefill_cp_size  = t[3].cast<int64_t>();
+                    }
+                    if (t.size() >= 5) {
+                        c.all_gather_impl = t[4].cast<CPAllGatherImpl>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("PrefillCPConfig unpickle error: ") + e.what());

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -721,23 +721,17 @@ def all_reduce(tensor: torch.Tensor, group: Group) -> torch.Tensor:
     return tensor
 
 
-def all_gather(tensor: torch.Tensor, group: Group) -> torch.Tensor:
-    """Gather tensors from all ranks in the group.
-
-    Args:
-        tensor: Tensor to gather from this rank
-        group: Process group to use
-
-    Returns:
-        Concatenated tensor containing all gathered tensors
-        (shape: [world_size * tensor.shape[0]] + list(tensor.shape)[1:])
-    """
+def _all_gather_impl(
+    tensor: torch.Tensor,
+    group: Group,
+    output: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Gather through the configured fast path or a caller-provided output."""
     rocm_rccl = _get_rocm_rccl()
     if rocm_rccl is not None:
         rocm_rccl.ensure_capture_comm_ready(group == Group.TP)
         if rocm_rccl.should_use_capture_collectives(group == Group.TP):
-            process_group = _get_group(group)
-            return rocm_rccl.capture_all_gather(tensor, process_group)
+            return rocm_rccl.capture_all_gather(tensor, _get_group(group))
 
     if group == Group.TP:
         symm_mem_comm = _get_symm_mem().get_symm_mem_communicator()
@@ -753,14 +747,41 @@ def all_gather(tensor: torch.Tensor, group: Group) -> torch.Tensor:
 
     process_group = _get_group(group)
     world_size = torch.distributed.get_world_size(process_group)
+    expected_shape = [world_size * tensor.shape[0]] + list(tensor.shape)[1:]
+    if output is None:
+        output = torch.empty(expected_shape, device=tensor.device, dtype=tensor.dtype)
+    elif list(output.shape) != expected_shape:
+        raise ValueError(
+            f"all_gather_into output shape {list(output.shape)} does not match "
+            f"expected shape {expected_shape}"
+        )
+    torch.distributed.all_gather_into_tensor(output, tensor, group=process_group)
+    return output
 
-    tensor_list = torch.zeros(
-        [world_size * tensor.shape[0]] + list(tensor.shape)[1:],
-        device=tensor.device,
-        dtype=tensor.dtype,
-    )
-    torch.distributed.all_gather_into_tensor(tensor_list, tensor, group=process_group)
-    return tensor_list
+
+def all_gather_into(
+    output: torch.Tensor, tensor: torch.Tensor, group: Group
+) -> torch.Tensor:
+    """Gather into ``output`` on the standard path while preserving TP fast paths.
+
+    RCCL capture and symmetric-memory implementations own their result storage and
+    may return a different tensor. Callers must use the returned tensor.
+    """
+    return _all_gather_impl(tensor, group, output)
+
+
+def all_gather(tensor: torch.Tensor, group: Group) -> torch.Tensor:
+    """Gather tensors from all ranks in the group.
+
+    Args:
+        tensor: Tensor to gather from this rank
+        group: Process group to use
+
+    Returns:
+        Concatenated tensor containing all gathered tensors
+        (shape: [world_size * tensor.shape[0]] + list(tensor.shape)[1:])
+    """
+    return _all_gather_impl(tensor, group)
 
     # reference old implementation
     # tensor_list = [torch.zeros_like(tensor) for _ in range(world_size)]
@@ -796,7 +817,10 @@ def reduce_scatter(input_tensor: torch.Tensor, group: Group) -> torch.Tensor:
         dtype=input_tensor.dtype,
     )
     torch.distributed.reduce_scatter_tensor(
-        output_tensor, input_tensor, op=torch.distributed.ReduceOp.SUM, group=process_group
+        output_tensor,
+        input_tensor,
+        op=torch.distributed.ReduceOp.SUM,
+        group=process_group,
     )
     return output_tensor
 

--- a/rtp_llm/models_py/distributed/test/collective_torch_test.py
+++ b/rtp_llm/models_py/distributed/test/collective_torch_test.py
@@ -17,6 +17,7 @@ from rtp_llm.models_py.distributed.collective_torch import (
     Group,
     _get_group,
     all_gather,
+    all_gather_into,
     all_reduce,
     broadcast,
     destroy_distributed_environment,
@@ -227,6 +228,15 @@ def _test_all_gather_collective(
                 result, expected
             ), f"Rank {rank} all_gather {group_type}: Expected {expected.cpu()}, got {result.cpu()}"
 
+            output = torch.empty_like(expected)
+            result_into = all_gather_into(output, tensor, group=group_type)
+            torch.cuda.synchronize()
+            torch.distributed.barrier(group=process_group)
+            assert torch.allclose(result_into, expected), (
+                f"Rank {rank} all_gather_into {group_type}: "
+                f"Expected {expected.cpu()}, got {result_into.cpu()}"
+            )
+
     # All ranks synchronize before next test
     torch.distributed.barrier()
 
@@ -259,12 +269,13 @@ def _test_reduce_scatter_collective(
             # mis-scatter (e.g. wrong offset) cannot be hidden by uniform
             # inputs. Chunk c on rank r holds the value (r+1) * (c+1).
             input_tensor = torch.empty(
-                group_size * chunk_size, hidden_dim,
+                group_size * chunk_size,
+                hidden_dim,
                 device=f"cuda:{parallelism_config.local_rank}",
             )
             for c in range(group_size):
-                input_tensor[c * chunk_size : (c + 1) * chunk_size] = (
-                    (rank + 1) * (c + 1)
+                input_tensor[c * chunk_size : (c + 1) * chunk_size] = (rank + 1) * (
+                    c + 1
                 )
 
             result = reduce_scatter(input_tensor, group=group_type)
@@ -277,10 +288,14 @@ def _test_reduce_scatter_collective(
             # If reduce_scatter mis-aligned chunks, expected != observed.
             expected_sum = sum(r + 1 for r in group_ranks)
             expected_chunk_value = expected_sum * (local_idx + 1)
-            expected = torch.ones(
-                chunk_size, hidden_dim,
-                device=f"cuda:{parallelism_config.local_rank}",
-            ) * expected_chunk_value
+            expected = (
+                torch.ones(
+                    chunk_size,
+                    hidden_dim,
+                    device=f"cuda:{parallelism_config.local_rank}",
+                )
+                * expected_chunk_value
+            )
 
             assert result.shape == (chunk_size, hidden_dim), (
                 f"Rank {rank} reduce_scatter {group_type}: "
@@ -322,7 +337,8 @@ def _test_allgather_reduce_scatter_roundtrip(
 
             # Each rank starts with its own scattered chunk
             original = torch.randn(
-                chunk_size, hidden_dim,
+                chunk_size,
+                hidden_dim,
                 device=f"cuda:{parallelism_config.local_rank}",
             )
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Optional
 
 import torch
@@ -22,9 +21,9 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.fused_
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
 from rtp_llm.ops import (
     AttentionConfigs,
+    CPAllGatherImpl,
     CPRotateMethod,
     FMHAType,
-    KvCacheDataType,
     ParallelismConfig,
 )
 from rtp_llm.ops.compute_ops import (
@@ -33,23 +32,34 @@ from rtp_llm.ops.compute_ops import (
     PyAttentionInputs,
 )
 
-_all_gather_impl_name = os.environ.get("RTP_CP_IMPL", "fused").lower()
-if _all_gather_impl_name == "legacy":
-    _all_gather_impl = PCPAllGatherAttnOp
-else:
-    if _all_gather_impl_name != "fused":
-        logging.warning(
-            "Unknown RTP_CP_IMPL=%s; using fused all-gather CP",
-            _all_gather_impl_name,
-        )
-    _all_gather_impl = PCPFusedPagedAttnOp
-
-
 impl_map = {
-    CPRotateMethod.ALL_GATHER: _all_gather_impl,
+    CPRotateMethod.ALL_GATHER: PCPAllGatherAttnOp,
     CPRotateMethod.ALLTOALL: PCPAll2AllAttnOp,
     CPRotateMethod.ALL_GATHER_WITH_OVERLAP: PCPAllGatherOverlapAttnOp,
 }
+
+
+def select_prefill_cp_impl(
+    attn_configs: AttentionConfigs,
+    attn_inputs: PyAttentionInputs,
+    parallelism_config: ParallelismConfig,
+):
+    """Select a CP implementation, falling back when fused cannot run safely."""
+    method = parallelism_config.prefill_cp_config.method
+    impl = impl_map[method]
+    if (
+        method == CPRotateMethod.ALL_GATHER
+        and parallelism_config.prefill_cp_config.all_gather_impl
+        == CPAllGatherImpl.FUSED
+    ):
+        supported, reason = PCPFusedPagedAttnOp.can_run(
+            attn_configs, attn_inputs, parallelism_config
+        )
+        if supported:
+            impl = PCPFusedPagedAttnOp
+        else:
+            logging.warning("Falling back to legacy all-gather CP: %s", reason)
+    return impl
 
 
 class CPFlashInferImpl(FMHAImplBase):
@@ -158,27 +168,8 @@ class CPFlashInferImpl(FMHAImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
 
-        method = parallelism_config.prefill_cp_config.method
-        impl = impl_map[method]
-        if impl is PCPFusedPagedAttnOp:
-            if attn_configs.kv_cache_dtype != KvCacheDataType.BASE:
-                logging.warning(
-                    "Falling back to legacy all-gather CP for %s KV cache",
-                    attn_configs.kv_cache_dtype,
-                )
-                impl = PCPAllGatherAttnOp
-            elif (
-                attn_configs.kernel_tokens_per_block
-                and attn_configs.kernel_tokens_per_block
-                != attn_configs.tokens_per_block
-            ):
-                logging.warning(
-                    "Falling back to legacy all-gather CP because "
-                    "kernel_tokens_per_block (%s) != tokens_per_block (%s)",
-                    attn_configs.kernel_tokens_per_block,
-                    attn_configs.tokens_per_block,
-                )
-                impl = PCPAllGatherAttnOp
+        impl = select_prefill_cp_impl(attn_configs, attn_inputs, parallelism_config)
+        logging.info("Selected prefill CP implementation: %s", impl.__name__)
         self.fmha_impl = impl(attn_configs, attn_inputs, parallelism_config)
         self.rope_kvcache_impl = FusedRopeKVCachePrefillOpQKVOut(attn_configs)
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from typing import Optional
 
 import torch
@@ -14,16 +16,37 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.allgat
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.alltoall_cp_impl import (
     PCPAll2AllAttnOp,
 )
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.fused_allgather_cp_impl import (
+    PCPFusedPagedAttnOp,
+)
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import FMHAImplBase
-from rtp_llm.ops import AttentionConfigs, CPRotateMethod, FMHAType, ParallelismConfig
+from rtp_llm.ops import (
+    AttentionConfigs,
+    CPRotateMethod,
+    FMHAType,
+    KvCacheDataType,
+    ParallelismConfig,
+)
 from rtp_llm.ops.compute_ops import (
     FusedRopeKVCachePrefillOpQKVOut,
     LayerKVCache,
     PyAttentionInputs,
 )
 
+_all_gather_impl_name = os.environ.get("RTP_CP_IMPL", "fused").lower()
+if _all_gather_impl_name == "legacy":
+    _all_gather_impl = PCPAllGatherAttnOp
+else:
+    if _all_gather_impl_name != "fused":
+        logging.warning(
+            "Unknown RTP_CP_IMPL=%s; using fused all-gather CP",
+            _all_gather_impl_name,
+        )
+    _all_gather_impl = PCPFusedPagedAttnOp
+
+
 impl_map = {
-    CPRotateMethod.ALL_GATHER: PCPAllGatherAttnOp,
+    CPRotateMethod.ALL_GATHER: _all_gather_impl,
     CPRotateMethod.ALLTOALL: PCPAll2AllAttnOp,
     CPRotateMethod.ALL_GATHER_WITH_OVERLAP: PCPAllGatherOverlapAttnOp,
 }
@@ -136,7 +159,27 @@ class CPFlashInferImpl(FMHAImplBase):
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
 
         method = parallelism_config.prefill_cp_config.method
-        self.fmha_impl = impl_map[method](attn_configs, attn_inputs, parallelism_config)
+        impl = impl_map[method]
+        if impl is PCPFusedPagedAttnOp:
+            if attn_configs.kv_cache_dtype != KvCacheDataType.BASE:
+                logging.warning(
+                    "Falling back to legacy all-gather CP for %s KV cache",
+                    attn_configs.kv_cache_dtype,
+                )
+                impl = PCPAllGatherAttnOp
+            elif (
+                attn_configs.kernel_tokens_per_block
+                and attn_configs.kernel_tokens_per_block
+                != attn_configs.tokens_per_block
+            ):
+                logging.warning(
+                    "Falling back to legacy all-gather CP because "
+                    "kernel_tokens_per_block (%s) != tokens_per_block (%s)",
+                    attn_configs.kernel_tokens_per_block,
+                    attn_configs.tokens_per_block,
+                )
+                impl = PCPAllGatherAttnOp
+        self.fmha_impl = impl(attn_configs, attn_inputs, parallelism_config)
         self.rope_kvcache_impl = FusedRopeKVCachePrefillOpQKVOut(attn_configs)
 
         # Store input info

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/fused_allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/fused_allgather_cp_impl.py
@@ -1,0 +1,297 @@
+"""Fused all-gather context-parallel prefill attention.
+
+The operator keeps RTP-LLM's zigzag CP layout and KV-cache side effect, but
+reduces the per-layer data path to one packed K/V all-gather, one paged-cache
+append, and one paged attention call.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+from flashinfer import BatchPrefillWithPagedKVCacheWrapper
+from flashinfer.page import append_paged_kv_cache
+
+from rtp_llm.models_py.distributed.collective_torch import Group, _get_group
+from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
+    get_py_flashinfer_workspace_buffer,
+    release_py_flashinfer_workspace_buffer,
+)
+from rtp_llm.ops import AttentionConfigs, ParallelismConfig
+from rtp_llm.ops.compute_ops import (
+    KVCache,
+    ParamsBase,
+    PyAttentionInputs,
+    fill_mla_params,
+    get_scalar_type,
+)
+
+
+class _CPGeometry:
+    """Prepare-time mapping from gathered zigzag slots to paged requests."""
+
+    def __init__(
+        self,
+        attn_inputs: PyAttentionInputs,
+        cp_size: int,
+        cp_rank: int,
+        page_size: int,
+        device: torch.device,
+    ):
+        cp_info = attn_inputs.context_parallel_info
+        self.cp_size = cp_size
+        self.cp_rank = cp_rank
+        self.page_size = page_size
+        self.device = device
+
+        self.chunk_lengths: List[int] = cp_info.prefill_cp_chunk_lengths.tolist()
+        self.prefix_lengths: List[int] = attn_inputs.prefix_lengths.tolist()
+        self.batch_size = len(self.chunk_lengths)
+        self.half_lengths = [chunk_length // 2 for chunk_length in self.chunk_lengths]
+        self.tokens_local = sum(self.chunk_lengths)
+        self.gathered_slots = self.cp_size * self.tokens_local
+        self.padded_lengths = [
+            chunk_length * self.cp_size for chunk_length in self.chunk_lengths
+        ]
+
+        assert all(
+            chunk_length % 2 == 0 for chunk_length in self.chunk_lengths
+        ), "fused CP prefill requires an even local chunk length"
+        assert self.batch_size > 0, "fused CP prefill requires a non-empty batch"
+
+        # restore[sequence_position] gives its rank-major all-gather slot. Scatter
+        # the cache metadata through that permutation so append performs the
+        # zigzag restore without materializing sequence-ordered K and V tensors.
+        restore = cp_info.prefill_qkv_restore_indice.to(
+            device=device, dtype=torch.int64
+        )
+        assert restore.numel() == sum(self.padded_lengths), (
+            f"restore indices ({restore.numel()}) must cover the padded sequence "
+            f"({sum(self.padded_lengths)})"
+        )
+
+        batch_parts = [
+            torch.full((length,), batch, dtype=torch.int32, device=device)
+            for batch, length in enumerate(self.padded_lengths)
+        ]
+        position_parts = [
+            torch.arange(length, dtype=torch.int32, device=device).add(
+                self.prefix_lengths[batch]
+            )
+            for batch, length in enumerate(self.padded_lengths)
+        ]
+        batch_by_position = (
+            batch_parts[0] if self.batch_size == 1 else torch.cat(batch_parts)
+        )
+        position_by_position = (
+            position_parts[0] if self.batch_size == 1 else torch.cat(position_parts)
+        )
+
+        self.gathered_batch = torch.empty(
+            self.gathered_slots, dtype=torch.int32, device=device
+        )
+        self.gathered_position = torch.empty(
+            self.gathered_slots, dtype=torch.int32, device=device
+        )
+        self.gathered_batch[restore] = batch_by_position
+        self.gathered_position[restore] = position_by_position
+
+    def half_kv_lengths(self, batch: int) -> tuple[int, int]:
+        """Return the low/high zigzag requests' KV lengths in padded space."""
+        half_length = self.half_lengths[batch]
+        prefix_length = self.prefix_lengths[batch]
+        padded_length = self.padded_lengths[batch]
+        return (
+            prefix_length + (self.cp_rank + 1) * half_length,
+            prefix_length + padded_length - self.cp_rank * half_length,
+        )
+
+    def paged_plan_tensors(
+        self, block_ids_host: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build two overlapping paged requests per non-empty batch item."""
+        qo_indptr = [0]
+        kv_indptr = [0]
+        last_page_lengths: List[int] = []
+        page_indices: List[torch.Tensor] = []
+
+        for batch in range(self.batch_size):
+            half_length = self.half_lengths[batch]
+            if half_length == 0:
+                continue
+            block_ids = block_ids_host[batch]
+            for kv_length in self.half_kv_lengths(batch):
+                page_count = (kv_length + self.page_size - 1) // self.page_size
+                assert page_count > 0, "non-empty CP request has no KV page"
+                page_indices.append(block_ids[:page_count])
+                kv_indptr.append(kv_indptr[-1] + page_count)
+                last_page_lengths.append(kv_length - (page_count - 1) * self.page_size)
+                qo_indptr.append(qo_indptr[-1] + half_length)
+
+        assert page_indices, "fused CP prefill produced no paged requests"
+        return (
+            torch.tensor(qo_indptr, dtype=torch.int32),
+            torch.tensor(kv_indptr, dtype=torch.int32),
+            torch.cat(page_indices).to(dtype=torch.int32, device=self.device),
+            torch.tensor(last_page_lengths, dtype=torch.int32),
+        )
+
+
+class PCPFusedPagedAttnOp:
+    """All-gather CP prefill using a packed collective and paged attention."""
+
+    def __init__(
+        self,
+        attn_configs: AttentionConfigs,
+        attn_inputs: PyAttentionInputs,
+        parallelism_config: Optional[ParallelismConfig] = None,
+        backend: str = "auto",
+        causal: bool = True,
+        kv_layout: str = "NHD",
+    ):
+        assert causal, "CP prefill only supports causal attention"
+        assert parallelism_config is not None
+
+        self.attn_inputs = attn_inputs
+        self.attn_configs = attn_configs
+        self.num_qo_heads = attn_configs.head_num
+        self.num_kv_heads = attn_configs.kv_head_num
+        self.head_dim = attn_configs.size_per_head
+        self.seq_size_per_block = (
+            attn_configs.kernel_tokens_per_block or attn_configs.tokens_per_block
+        )
+        assert self.seq_size_per_block == attn_configs.tokens_per_block, (
+            "fused CP prefill requires kernel_tokens_per_block "
+            f"({attn_configs.kernel_tokens_per_block}) to equal tokens_per_block "
+            f"({attn_configs.tokens_per_block})"
+        )
+
+        self.device = torch.device("cuda", torch.cuda.current_device())
+        self.dtype = get_scalar_type(attn_inputs.dtype)
+        self.cp_info = attn_inputs.context_parallel_info
+        self.prefill_cp_rank = parallelism_config.tp_rank
+        self.prefill_cp_size = parallelism_config.tp_size
+        self.workspace_buffer = get_py_flashinfer_workspace_buffer()
+        self.paged_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+            self.workspace_buffer, kv_layout="HND", backend=backend
+        )
+
+        self.geometry: Optional[_CPGeometry] = None
+        self.kv_gather: Optional[torch.Tensor] = None
+        self.kv_local: Optional[torch.Tensor] = None
+        self.output: Optional[torch.Tensor] = None
+        self.process_group = None
+
+    def __del__(self):
+        if hasattr(self, "workspace_buffer"):
+            release_py_flashinfer_workspace_buffer(self.workspace_buffer)
+
+    def support(self, attention_inputs: PyAttentionInputs) -> bool:
+        return attention_inputs.is_prefill
+
+    def prepare(self, attention_inputs: PyAttentionInputs) -> ParamsBase:
+        geometry = _CPGeometry(
+            attention_inputs,
+            self.prefill_cp_size,
+            self.prefill_cp_rank,
+            self.seq_size_per_block,
+            self.device,
+        )
+        self.geometry = geometry
+
+        # CPFlashInferImpl is shared by every transformer layer in a prefill. The
+        # request-scoped scratch below is therefore allocated once and reused
+        # by all layers, without process-global buffers that could alias requests.
+        self.kv_gather = torch.empty(
+            geometry.gathered_slots,
+            2,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.kv_local = torch.empty(
+            geometry.tokens_local,
+            2,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.output = torch.empty(
+            geometry.tokens_local,
+            self.num_qo_heads,
+            self.head_dim,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.process_group = _get_group(Group.TP)
+
+        params = fill_mla_params(
+            attention_inputs.prefix_lengths,
+            attention_inputs.sequence_lengths,
+            self.cp_info.prefill_actual_input_lengths_cpu,
+            attention_inputs.kv_cache_kernel_block_id,
+            self.seq_size_per_block,
+        )
+        qo_indptr, kv_indptr, page_indices, last_page_lengths = (
+            geometry.paged_plan_tensors(attention_inputs.kv_cache_kernel_block_id)
+        )
+        self.paged_wrapper.plan(
+            qo_indptr=qo_indptr,
+            paged_kv_indptr=kv_indptr,
+            paged_kv_indices=page_indices,
+            paged_kv_last_page_len=last_page_lengths,
+            num_qo_heads=self.num_qo_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_dim_qk=self.head_dim,
+            page_size=self.seq_size_per_block,
+            causal=True,
+            q_data_type=self.dtype,
+        )
+        return params
+
+    def forward(
+        self,
+        qkv: torch.Tensor,
+        kv_cache: Optional[KVCache] = None,
+        params: Optional[ParamsBase] = None,
+    ) -> torch.Tensor:
+        assert self.geometry is not None
+        assert self.kv_gather is not None and self.kv_local is not None
+        assert self.output is not None and kv_cache is not None and params is not None
+
+        qkv = qkv.view(qkv.shape[0], -1)
+        q_width = self.num_qo_heads * self.head_dim
+        q = qkv[:, :q_width].view(-1, self.num_qo_heads, self.head_dim)
+
+        # Pack K and V into one local tensor. NCCL gathers both into the persistent
+        # destination without relying on overlapping collective input/output.
+        self.kv_local.copy_(
+            qkv[:, q_width:].view(-1, 2, self.num_kv_heads, self.head_dim)
+        )
+        torch.distributed.all_gather_into_tensor(
+            self.kv_gather, self.kv_local, group=self.process_group
+        )
+
+        kv_cache_tensor = kv_cache.kv_cache_base.view(
+            -1,
+            2,
+            self.num_kv_heads,
+            self.seq_size_per_block,
+            self.head_dim,
+        )
+        append_paged_kv_cache(
+            append_key=self.kv_gather[:, 0],
+            append_value=self.kv_gather[:, 1],
+            batch_indices=self.geometry.gathered_batch,
+            positions=self.geometry.gathered_position,
+            paged_kv_cache=kv_cache_tensor,
+            kv_indices=params.page_indice_d,
+            kv_indptr=params.decode_page_indptr_d,
+            kv_last_page_len=params.paged_kv_last_page_len_d,
+            kv_layout="HND",
+        )
+
+        return self.paged_wrapper.run(q, kv_cache_tensor, out=self.output)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/fused_allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/fused_allgather_cp_impl.py
@@ -13,12 +13,12 @@ import torch
 from flashinfer import BatchPrefillWithPagedKVCacheWrapper
 from flashinfer.page import append_paged_kv_cache
 
-from rtp_llm.models_py.distributed.collective_torch import Group, _get_group
+from rtp_llm.models_py.distributed.collective_torch import Group, all_gather_into
 from rtp_llm.models_py.modules.factory.attention.cuda_impl.py_flashinfer_mha import (
     get_py_flashinfer_workspace_buffer,
     release_py_flashinfer_workspace_buffer,
 )
-from rtp_llm.ops import AttentionConfigs, ParallelismConfig
+from rtp_llm.ops import AttentionConfigs, KvCacheDataType, ParallelismConfig
 from rtp_llm.ops.compute_ops import (
     KVCache,
     ParamsBase,
@@ -53,6 +53,13 @@ class _CPGeometry:
         self.gathered_slots = self.cp_size * self.tokens_local
         self.padded_lengths = [
             chunk_length * self.cp_size for chunk_length in self.chunk_lengths
+        ]
+        self.actual_lengths: List[int] = (
+            cp_info.prefill_actual_input_lengths_cpu.tolist()
+        )
+        self.actual_page_counts = [
+            (prefix + actual + self.page_size - 1) // self.page_size
+            for prefix, actual in zip(self.prefix_lengths, self.actual_lengths)
         ]
 
         assert all(
@@ -124,6 +131,10 @@ class _CPGeometry:
             for kv_length in self.half_kv_lengths(batch):
                 page_count = (kv_length + self.page_size - 1) // self.page_size
                 assert page_count > 0, "non-empty CP request has no KV page"
+                assert page_count <= self.actual_page_counts[batch], (
+                    f"fused CP request {batch} needs {page_count} pages but only "
+                    f"{self.actual_page_counts[batch]} were allocated"
+                )
                 page_indices.append(block_ids[:page_count])
                 kv_indptr.append(kv_indptr[-1] + page_count)
                 last_page_lengths.append(kv_length - (page_count - 1) * self.page_size)
@@ -148,23 +159,20 @@ class PCPFusedPagedAttnOp:
         parallelism_config: Optional[ParallelismConfig] = None,
         backend: str = "auto",
         causal: bool = True,
-        kv_layout: str = "NHD",
     ):
+        self.workspace_buffer: Optional[torch.Tensor] = None
         assert causal, "CP prefill only supports causal attention"
         assert parallelism_config is not None
 
-        self.attn_inputs = attn_inputs
-        self.attn_configs = attn_configs
+        supported, reason = self.can_run(attn_configs, attn_inputs, parallelism_config)
+        if not supported:
+            raise ValueError(f"fused CP prefill is not supported: {reason}")
+
         self.num_qo_heads = attn_configs.head_num
         self.num_kv_heads = attn_configs.kv_head_num
         self.head_dim = attn_configs.size_per_head
         self.seq_size_per_block = (
             attn_configs.kernel_tokens_per_block or attn_configs.tokens_per_block
-        )
-        assert self.seq_size_per_block == attn_configs.tokens_per_block, (
-            "fused CP prefill requires kernel_tokens_per_block "
-            f"({attn_configs.kernel_tokens_per_block}) to equal tokens_per_block "
-            f"({attn_configs.tokens_per_block})"
         )
 
         self.device = torch.device("cuda", torch.cuda.current_device())
@@ -181,11 +189,105 @@ class PCPFusedPagedAttnOp:
         self.kv_gather: Optional[torch.Tensor] = None
         self.kv_local: Optional[torch.Tensor] = None
         self.output: Optional[torch.Tensor] = None
-        self.process_group = None
 
     def __del__(self):
-        if hasattr(self, "workspace_buffer"):
+        if self.workspace_buffer is not None:
             release_py_flashinfer_workspace_buffer(self.workspace_buffer)
+            self.workspace_buffer = None
+
+    @classmethod
+    def can_run(
+        cls,
+        attn_configs: AttentionConfigs,
+        attn_inputs: PyAttentionInputs,
+        parallelism_config: ParallelismConfig,
+    ) -> tuple[bool, str]:
+        if attn_configs.kv_cache_dtype != KvCacheDataType.BASE:
+            return False, f"KV cache dtype is {attn_configs.kv_cache_dtype}"
+
+        page_size = (
+            attn_configs.kernel_tokens_per_block or attn_configs.tokens_per_block
+        )
+        if page_size <= 0:
+            return False, f"invalid page size {page_size}"
+        if page_size != attn_configs.tokens_per_block:
+            return False, (
+                f"kernel_tokens_per_block ({page_size}) differs from "
+                f"tokens_per_block ({attn_configs.tokens_per_block})"
+            )
+
+        cp_size = parallelism_config.tp_size
+        if cp_size <= 0:
+            return False, f"invalid CP size {cp_size}"
+        if page_size % (2 * cp_size) != 0:
+            return False, (
+                f"page size {page_size} is not divisible by 2 * CP size "
+                f"({2 * cp_size})"
+            )
+
+        cp_info = attn_inputs.context_parallel_info
+        chunk_lengths = cp_info.prefill_cp_chunk_lengths.tolist()
+        actual_lengths = cp_info.prefill_actual_input_lengths_cpu.tolist()
+        prefix_lengths = attn_inputs.prefix_lengths.tolist()
+        batch_size = len(chunk_lengths)
+        if not (
+            batch_size == len(actual_lengths) == len(prefix_lengths) and batch_size > 0
+        ):
+            return False, "inconsistent or empty CP batch geometry"
+
+        block_ids = attn_inputs.kv_cache_kernel_block_id
+        if block_ids is None or block_ids.dim() != 2:
+            return False, "fused CP requires a 2-D paged KV block table"
+        block_capacity = block_ids.size(-1)
+        has_query_tokens = False
+        for batch, (chunk, actual, prefix) in enumerate(
+            zip(chunk_lengths, actual_lengths, prefix_lengths)
+        ):
+            if chunk < 0 or actual < 0 or prefix < 0:
+                return False, f"request {batch} has negative CP geometry"
+            if chunk % 2 != 0:
+                return False, f"request {batch} has odd local chunk length {chunk}"
+            if prefix % page_size != 0:
+                return False, (
+                    f"request {batch} prefix length {prefix} is not page aligned"
+                )
+            padded = chunk * cp_size
+            if actual > padded:
+                return False, (
+                    f"request {batch} actual length {actual} exceeds padded "
+                    f"length {padded}"
+                )
+            has_query_tokens = has_query_tokens or chunk > 0
+            actual_pages = (prefix + actual + page_size - 1) // page_size
+            padded_pages = (prefix + padded + page_size - 1) // page_size
+            # Defence in depth: unreachable while the page_size % (2 * cp_size) and
+            # page-aligned-prefix guards above hold, because roundup(actual,
+            # 2 * cp_size) then always lands inside the pages already allocated for
+            # `actual`. Kept so a future relaxation of either guard fails closed.
+            if padded_pages > actual_pages:
+                return False, (
+                    f"request {batch} padding needs {padded_pages} pages but only "
+                    f"{actual_pages} pages are allocated"
+                )
+            if actual_pages > block_capacity:
+                return False, (
+                    f"request {batch} needs {actual_pages} pages but block table "
+                    f"capacity is {block_capacity}"
+                )
+            if torch.any(block_ids[batch, :actual_pages] < 0).item():
+                return False, f"request {batch} has unallocated KV cache pages"
+
+        if not has_query_tokens:
+            return False, "fused CP requires at least one query token"
+
+        padded_slots = sum(chunk_lengths) * cp_size
+        restore = cp_info.prefill_qkv_restore_indice
+        if restore.numel() != padded_slots:
+            return False, (
+                f"restore indices ({restore.numel()}) do not cover padded slots "
+                f"({padded_slots})"
+            )
+        return True, "supported"
 
     def support(self, attention_inputs: PyAttentionInputs) -> bool:
         return attention_inputs.is_prefill
@@ -226,8 +328,6 @@ class PCPFusedPagedAttnOp:
             dtype=self.dtype,
             device=self.device,
         )
-        self.process_group = _get_group(Group.TP)
-
         params = fill_mla_params(
             attention_inputs.prefix_lengths,
             attention_inputs.sequence_lengths,
@@ -258,6 +358,12 @@ class PCPFusedPagedAttnOp:
         kv_cache: Optional[KVCache] = None,
         params: Optional[ParamsBase] = None,
     ) -> torch.Tensor:
+        """Run one layer and return request-scoped reusable output storage.
+
+        The Q view intentionally keeps the packed-QKV row stride; FlashInfer's
+        paged prefill kernel accepts this layout. The returned tensor is reused by
+        the next layer and must not be retained across ``forward`` calls.
+        """
         assert self.geometry is not None
         assert self.kv_gather is not None and self.kv_local is not None
         assert self.output is not None and kv_cache is not None and params is not None
@@ -271,9 +377,7 @@ class PCPFusedPagedAttnOp:
         self.kv_local.copy_(
             qkv[:, q_width:].view(-1, 2, self.num_kv_heads, self.head_dim)
         )
-        torch.distributed.all_gather_into_tensor(
-            self.kv_gather, self.kv_local, group=self.process_group
-        )
+        gathered_kv = all_gather_into(self.kv_gather, self.kv_local, Group.TP)
 
         kv_cache_tensor = kv_cache.kv_cache_base.view(
             -1,
@@ -282,9 +386,11 @@ class PCPFusedPagedAttnOp:
             self.seq_size_per_block,
             self.head_dim,
         )
+        # Capability checks guarantee padded slots stay in this request's already
+        # allocated last page. Valid queries cannot attend to the padded tail.
         append_paged_kv_cache(
-            append_key=self.kv_gather[:, 0],
-            append_value=self.kv_gather[:, 1],
+            append_key=gathered_kv[:, 0],
+            append_value=gathered_kv[:, 1],
             batch_indices=self.geometry.gathered_batch,
             positions=self.geometry.gathered_position,
             paged_kv_cache=kv_cache_tensor,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
@@ -42,6 +42,18 @@ py_test(
 )
 
 py_test(
+    name = "test_fused_allgather_cp_impl",
+    srcs = ["test_fused_allgather_cp_impl.py"],
+    deps = py_test_deps + [":cp_test_utils"] + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20'},
+)
+
+py_test(
     name = "test_alltoall_cp_impl",
     srcs = ["test_alltoall_cp_impl.py"],
     deps = py_test_deps + [":cp_test_utils"] + select({

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
@@ -319,8 +319,7 @@ def compute_rank_positions(lengths: List[int], cp_size: int) -> List[List[int]]:
 
 
 class CPAttnTestBase(unittest.TestCase):
-    """Base class with the correctness drivers.  Subclasses set ``OP_CLASS``
-    and ``AG_MODULE`` (the module path where ``all_gather`` is imported)."""
+    """Base class with correctness drivers for context-parallel attention."""
 
     OP_CLASS = None  # override in subclass
     AG_MODULE: str = ""  # override in subclass
@@ -336,6 +335,24 @@ class CPAttnTestBase(unittest.TestCase):
 
     def _extra_patches(self, stack: contextlib.ExitStack):
         """Override to add extra mock patches (e.g. user-buffers)."""
+
+    def _patch_all_gather(
+        self,
+        stack: contextlib.ExitStack,
+        all_local_k: List[torch.Tensor],
+        all_local_v: List[torch.Tensor],
+        kv_head_num: int,
+        head_dim: int,
+    ):
+        """Mock the two legacy K/V all-gathers on one GPU."""
+        call_idx = [0]
+
+        def mock_ag(tensor, group=None):
+            data = all_local_k if call_idx[0] % 2 == 0 else all_local_v
+            call_idx[0] += 1
+            return torch.cat(data, dim=0)
+
+        stack.enter_context(patch(f"{self.AG_MODULE}.all_gather", side_effect=mock_ag))
 
     def _assert_close(
         self,
@@ -445,16 +462,9 @@ class CPAttnTestBase(unittest.TestCase):
             total_blocks, kv_head_num, tokens_per_block, head_dim, device=self.device
         )
 
-        call_idx = [0]
-
-        def mock_ag(tensor, group=None):
-            data = all_local_k if call_idx[0] % 2 == 0 else all_local_v
-            call_idx[0] += 1
-            return torch.cat(data, dim=0)
-
         with contextlib.ExitStack() as stack:
-            stack.enter_context(
-                patch(f"{self.AG_MODULE}.all_gather", side_effect=mock_ag)
+            self._patch_all_gather(
+                stack, all_local_k, all_local_v, kv_head_num, head_dim
             )
             self._extra_patches(stack)
 
@@ -598,16 +608,9 @@ class CPAttnTestBase(unittest.TestCase):
             tokens_per_block,
         )
 
-        call_idx = [0]
-
-        def mock_ag(tensor, group=None):
-            data = all_local_k if call_idx[0] % 2 == 0 else all_local_v
-            call_idx[0] += 1
-            return torch.cat(data, dim=0)
-
         with contextlib.ExitStack() as stack:
-            stack.enter_context(
-                patch(f"{self.AG_MODULE}.all_gather", side_effect=mock_ag)
+            self._patch_all_gather(
+                stack, all_local_k, all_local_v, kv_head_num, head_dim
             )
             self._extra_patches(stack)
 

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
@@ -68,8 +68,23 @@ def build_restore_indices(cp_chunk_lengths: List[int], cp_size: int) -> torch.Te
     return torch.tensor(restore, dtype=torch.int32)
 
 
-def build_padding_mask(cp_chunk_lengths: List[int], cp_size: int) -> torch.Tensor:
-    return torch.ones(sum(cp_chunk_lengths) * cp_size, dtype=torch.int32)
+def build_padding_mask(
+    cp_chunk_lengths: List[int],
+    cp_size: int,
+    actual_lengths: List[int] | None = None,
+) -> torch.Tensor:
+    if actual_lengths is None:
+        actual_lengths = [chunk * cp_size for chunk in cp_chunk_lengths]
+    parts = []
+    for actual, chunk in zip(actual_lengths, cp_chunk_lengths):
+        padded = chunk * cp_size
+        if actual > padded:
+            raise ValueError(
+                f"actual length {actual} exceeds padded CP length {padded}"
+            )
+        parts.append(torch.ones(actual, dtype=torch.int32))
+        parts.append(torch.zeros(padded - actual, dtype=torch.int32))
+    return torch.cat(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -207,9 +222,9 @@ def build_cp_attn_inputs(
     cp_info = PyContextParallelParams()
     cp_info.prefill_cp_chunk_lengths = torch.tensor(cp_chunk_lengths, dtype=torch.int32)
     cp_info.prefill_cp_padding_lengths = torch.zeros(batch_size, dtype=torch.int32)
-    cp_info.prefill_qkv_padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(
-        device
-    )
+    cp_info.prefill_qkv_padding_mask = build_padding_mask(
+        cp_chunk_lengths, cp_size, actual_lengths=new_lengths
+    ).to(device)
     cp_info.prefill_qkv_restore_indice = build_restore_indices(
         cp_chunk_lengths, cp_size
     ).to(device)
@@ -319,7 +334,12 @@ def compute_rank_positions(lengths: List[int], cp_size: int) -> List[List[int]]:
 
 
 class CPAttnTestBase(unittest.TestCase):
-    """Base class with correctness drivers for context-parallel attention."""
+    """Correctness drivers for context-parallel attention implementations.
+
+    Subclasses provide ``OP_CLASS`` and may override ``_patch_all_gather``.
+    ``AG_MODULE`` is only used by the default hook for implementations that call
+    ``collective_torch.all_gather``.
+    """
 
     OP_CLASS = None  # override in subclass
     AG_MODULE: str = ""  # override in subclass
@@ -341,8 +361,7 @@ class CPAttnTestBase(unittest.TestCase):
         stack: contextlib.ExitStack,
         all_local_k: List[torch.Tensor],
         all_local_v: List[torch.Tensor],
-        kv_head_num: int,
-        head_dim: int,
+        cp_rank: int,
     ):
         """Mock the two legacy K/V all-gathers on one GPU."""
         call_idx = [0]
@@ -463,9 +482,7 @@ class CPAttnTestBase(unittest.TestCase):
         )
 
         with contextlib.ExitStack() as stack:
-            self._patch_all_gather(
-                stack, all_local_k, all_local_v, kv_head_num, head_dim
-            )
+            self._patch_all_gather(stack, all_local_k, all_local_v, cp_rank)
             self._extra_patches(stack)
 
             op = self.OP_CLASS(attn_cfg, attn_inputs, par_cfg)
@@ -609,9 +626,7 @@ class CPAttnTestBase(unittest.TestCase):
         )
 
         with contextlib.ExitStack() as stack:
-            self._patch_all_gather(
-                stack, all_local_k, all_local_v, kv_head_num, head_dim
-            )
+            self._patch_all_gather(stack, all_local_k, all_local_v, cp_rank)
             self._extra_patches(stack)
 
             op = self.OP_CLASS(attn_cfg, attn_inputs, par_cfg)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_fused_allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_fused_allgather_cp_impl.py
@@ -1,12 +1,20 @@
 """Correctness tests for the fused all-gather CP prefill operator."""
 
 import contextlib
+import logging
 import math
+import unittest
 from typing import List
 from unittest.mock import patch
 
 import torch
 
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_cp_flashinfer import (
+    select_prefill_cp_impl,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.allgather_cp_impl import (
+    PCPAllGatherAttnOp,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.fused_allgather_cp_impl import (
     PCPFusedPagedAttnOp,
 )
@@ -19,6 +27,7 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils
     make_kv_cache,
     reference_causal_attention,
 )
+from rtp_llm.ops import CPAllGatherImpl, CPRotateMethod, KvCacheDataType
 
 _FUSED_MODULE = (
     "rtp_llm.models_py.modules.factory.attention.cuda_cp_impl."
@@ -28,52 +37,56 @@ _FUSED_MODULE = (
 
 class TestPCPFusedPagedAttnOp(CPAttnTestBase):
     OP_CLASS = PCPFusedPagedAttnOp
-    AG_MODULE = _FUSED_MODULE
 
     def _patch_all_gather(
         self,
         stack: contextlib.ExitStack,
         all_local_k: List[torch.Tensor],
         all_local_v: List[torch.Tensor],
-        kv_head_num: int,
-        head_dim: int,
+        cp_rank: int,
     ):
-        payload = torch.cat(
-            [
+        def mock_all_gather_into(output, input_, group):
+            self.assertEqual(group.name, "TP")
+            tokens_local, _, kv_head_num, head_dim = input_.shape
+            packed = [
                 torch.stack(
                     (
-                        local_k.view(-1, kv_head_num, head_dim),
-                        local_v.view(-1, kv_head_num, head_dim),
+                        local_k.view(tokens_local, kv_head_num, head_dim),
+                        local_v.view(tokens_local, kv_head_num, head_dim),
                     ),
                     dim=1,
                 )
                 for local_k, local_v in zip(all_local_k, all_local_v)
-            ],
-            dim=0,
-        )
-
-        def mock_all_gather_into_tensor(output, input_, group=None, async_op=False):
+            ]
+            self.assertTrue(torch.equal(input_, packed[cp_rank]))
+            payload = torch.cat(packed, dim=0)
             output.copy_(payload.view_as(output))
-            return None
+            return output
 
-        stack.enter_context(patch(f"{_FUSED_MODULE}._get_group", return_value=None))
         stack.enter_context(
-            patch(
-                f"{_FUSED_MODULE}.torch.distributed.all_gather_into_tensor",
-                side_effect=mock_all_gather_into_tensor,
-            )
+            patch(f"{_FUSED_MODULE}.all_gather_into", side_effect=mock_all_gather_into)
         )
 
     def test_no_prefix(self):
         cases = [
-            ([32], 2, 0, 8, 2, 64),
-            ([32], 2, 1, 8, 2, 64),
-            ([64], 4, 2, 8, 2, 64),
-            ([32, 64], 2, 1, 8, 2, 64),
-            ([128], 4, 3, 32, 4, 128),
-            ([128], 8, 5, 64, 8, 128),
+            ([20], 2, 0, 8, 2, 64, 16),
+            ([20, 36], 2, 1, 8, 2, 64, 16),
+            ([32], 2, 0, 8, 2, 64, 16),
+            ([32], 2, 1, 8, 2, 64, 16),
+            ([64], 4, 2, 8, 2, 64, 32),
+            ([32, 64], 2, 1, 8, 2, 64, 16),
+            ([128], 4, 3, 32, 4, 128, 64),
+            ([128], 8, 5, 64, 8, 128, 64),
         ]
-        for lengths, cp_size, rank, q_heads, kv_heads, head_dim in cases:
+        for (
+            lengths,
+            cp_size,
+            rank,
+            q_heads,
+            kv_heads,
+            head_dim,
+            tokens_per_block,
+        ) in cases:
             with self.subTest(lengths=lengths, cp_size=cp_size, rank=rank):
                 self.run_no_prefix(
                     batch_size=len(lengths),
@@ -83,22 +96,37 @@ class TestPCPFusedPagedAttnOp(CPAttnTestBase):
                     head_num=q_heads,
                     kv_head_num=kv_heads,
                     head_dim=head_dim,
-                    tokens_per_block=16,
+                    tokens_per_block=tokens_per_block,
                 )
 
     def test_prefix_cache(self):
+        # Same prefix matrix as the legacy all-gather suite: both the single-request
+        # and the batched non-block-aligned cases, over 16/32/64-token pages.
         cases = [
-            ([32], [64], 2, 0),
-            ([32], [64], 2, 1),
-            ([32, 64], [64, 128], 2, 0),
-            ([64], [64], 4, 2),
+            ([20], [48], 2, 0, 8, 2, 64, 16),
+            ([20, 36], [48, 32], 2, 0, 8, 2, 64, 16),
+            ([32], [64], 2, 0, 8, 2, 64, 16),
+            ([32], [64], 2, 1, 8, 2, 64, 16),
+            ([32, 64], [64, 128], 2, 0, 8, 2, 64, 32),
+            ([64], [128], 2, 0, 32, 8, 128, 64),
+            ([64], [64], 4, 2, 8, 2, 64, 16),
         ]
-        for new_lengths, prefix_lengths, cp_size, rank in cases:
+        for (
+            new_lengths,
+            prefix_lengths,
+            cp_size,
+            rank,
+            q_heads,
+            kv_heads,
+            head_dim,
+            tokens_per_block,
+        ) in cases:
             with self.subTest(
                 new_lengths=new_lengths,
                 prefix_lengths=prefix_lengths,
                 cp_size=cp_size,
                 rank=rank,
+                tokens_per_block=tokens_per_block,
             ):
                 self.run_with_prefix(
                     batch_size=len(new_lengths),
@@ -106,7 +134,10 @@ class TestPCPFusedPagedAttnOp(CPAttnTestBase):
                     prefix_lengths=prefix_lengths,
                     cp_size=cp_size,
                     cp_rank=rank,
-                    tokens_per_block=16,
+                    head_num=q_heads,
+                    kv_head_num=kv_heads,
+                    head_dim=head_dim,
+                    tokens_per_block=tokens_per_block,
                 )
 
     def test_non_aligned_sequence_uses_padded_geometry(self):
@@ -171,31 +202,38 @@ class TestPCPFusedPagedAttnOp(CPAttnTestBase):
             ),
             dim=-1,
         )
+        q_width = head_num * head_dim
+        self.assertFalse(qkv[:, :q_width].is_contiguous())
 
+        # A second prefix-only request owns the page immediately after request 0.
+        # Padding for request 0 must stay in its allocated last page.
         attn_inputs = build_cp_attn_inputs(
-            [actual_length],
-            [chunk_length],
+            [actual_length, tokens_per_block],
+            [chunk_length, 0],
             cp_size,
             tokens_per_block,
+            prefix_lengths=[0, tokens_per_block],
             device=self.device,
         )
-        attn_inputs.context_parallel_info.prefill_qkv_padding_mask[actual_length:] = 0
         total_blocks = math.ceil(actual_length / tokens_per_block)
         kv_cache = make_kv_cache(
-            total_blocks,
+            total_blocks + 1,
             kv_head_num,
             tokens_per_block,
             head_dim,
             device=self.device,
         )
+        kv_cache.kv_cache_base[total_blocks].fill_(7)
+        adjacent_request_block = kv_cache.kv_cache_base[total_blocks].clone()
 
         with contextlib.ExitStack() as stack:
-            self._patch_all_gather(
-                stack, all_local_k, all_local_v, kv_head_num, head_dim
-            )
+            self._patch_all_gather(stack, all_local_k, all_local_v, cp_rank)
             op = self.OP_CLASS(attn_cfg, attn_inputs, par_cfg)
             params = op.prepare(attn_inputs)
             output = op.forward(qkv, kv_cache, params)
+            output_storage = output.data_ptr()
+            repeated_output = op.forward(qkv, kv_cache, params)
+            self.assertEqual(repeated_output.data_ptr(), output_storage)
 
         valid_local = [
             local
@@ -215,3 +253,185 @@ class TestPCPFusedPagedAttnOp(CPAttnTestBase):
         )
         self.assertTrue(torch.equal(cache_k, k_padded[:actual_length]))
         self.assertTrue(torch.equal(cache_v, v_padded[:actual_length]))
+
+        tail_start = actual_length % tokens_per_block
+        tail_end = padded_length % tokens_per_block
+        padded_tail_k = kv_cache.kv_cache_base[
+            total_blocks - 1, 0, :, tail_start:tail_end
+        ]
+        padded_tail_v = kv_cache.kv_cache_base[
+            total_blocks - 1, 1, :, tail_start:tail_end
+        ]
+        self.assertTrue(
+            torch.equal(
+                padded_tail_k.permute(1, 0, 2),
+                k_padded[actual_length:padded_length],
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                padded_tail_v.permute(1, 0, 2),
+                v_padded[actual_length:padded_length],
+            )
+        )
+        self.assertTrue(
+            torch.equal(kv_cache.kv_cache_base[total_blocks], adjacent_request_block)
+        )
+
+    def test_dispatch_defaults_to_legacy(self):
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+
+        self.assertEqual(
+            par_cfg.prefill_cp_config.all_gather_impl,
+            CPAllGatherImpl.LEGACY,
+        )
+        self.assertIs(
+            select_prefill_cp_impl(attn_cfg, attn_inputs, par_cfg),
+            PCPAllGatherAttnOp,
+        )
+
+    def test_dispatch_selects_fused_when_supported(self):
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        par_cfg.prefill_cp_config.all_gather_impl = CPAllGatherImpl.FUSED
+
+        self.assertIs(
+            select_prefill_cp_impl(attn_cfg, attn_inputs, par_cfg),
+            PCPFusedPagedAttnOp,
+        )
+
+    def test_dispatch_falls_back_for_unsupported_capabilities(self):
+        # Every entry also pins *which* guard rejects the geometry. Asserting only
+        # the returned class would stay green even if a case tripped an unintended
+        # check, leaving the guard it was written for unexercised.
+        cases = []
+
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        attn_cfg.kv_cache_dtype = KvCacheDataType.FP8
+        cases.append(("FP8 KV cache", "KV cache dtype", attn_cfg, par_cfg, attn_inputs))
+
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        attn_cfg.kernel_tokens_per_block = 32
+        cases.append(
+            (
+                "mismatched page sizes",
+                "kernel_tokens_per_block",
+                attn_cfg,
+                par_cfg,
+                attn_inputs,
+            )
+        )
+
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        attn_inputs.kv_cache_kernel_block_id[0, 1] = -1
+        cases.append(
+            (
+                "unallocated page id",
+                "unallocated KV cache pages",
+                attn_cfg,
+                par_cfg,
+                attn_inputs,
+            )
+        )
+
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        attn_inputs.kv_cache_kernel_block_id = (
+            attn_inputs.kv_cache_kernel_block_id.unsqueeze(0)
+        )
+        cases.append(
+            (
+                "3-D block table",
+                "2-D paged KV block table",
+                attn_cfg,
+                par_cfg,
+                attn_inputs,
+            )
+        )
+
+        attn_cfg, par_cfg, attn_inputs = self._make_dispatch_case()
+        attn_inputs.context_parallel_info.prefill_cp_chunk_lengths = torch.tensor(
+            [0], dtype=torch.int32
+        )
+        attn_inputs.context_parallel_info.prefill_actual_input_lengths_cpu = (
+            torch.tensor([0], dtype=torch.int32)
+        )
+        attn_inputs.context_parallel_info.prefill_qkv_restore_indice = torch.empty(
+            0, dtype=torch.int32, device=self.device
+        )
+        cases.append(
+            (
+                "empty query batch",
+                "at least one query token",
+                attn_cfg,
+                par_cfg,
+                attn_inputs,
+            )
+        )
+
+        # page_size 12 with cp_size 4: 12 % 8 != 0, so rounding a request up to a
+        # multiple of 2 * cp_size could spill past the last page it owns -- and
+        # request 1 here owns the very next block, which is what such a spill would
+        # corrupt. This divisibility guard is what makes that spill unreachable:
+        # once page_size % (2 * cp_size) == 0 and prefixes are page-aligned,
+        # roundup(actual, 2 * cp_size) always lands inside the pages already
+        # allocated for `actual`, so the later "padding needs N pages but only M are
+        # allocated" check can never fire (verified by exhaustive search over
+        # cp_size, page_size, prefix and length). It is kept as defence in depth.
+        cp_size = 4
+        attn_cfg, par_cfg = make_configs(
+            tokens_per_block=12, cp_size=cp_size, cp_rank=0
+        )
+        actual_length = 12
+        padded_length = math.ceil(actual_length / (2 * cp_size)) * 2 * cp_size
+        attn_inputs = build_cp_attn_inputs(
+            [actual_length, actual_length],
+            [padded_length // cp_size, 0],
+            cp_size,
+            attn_cfg.tokens_per_block,
+            prefix_lengths=[0, actual_length],
+            device=self.device,
+        )
+        par_cfg.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        par_cfg.prefill_cp_config.all_gather_impl = CPAllGatherImpl.FUSED
+        cases.append(
+            (
+                "page size not divisible by 2 * CP size",
+                "is not divisible by 2 * CP size",
+                attn_cfg,
+                par_cfg,
+                attn_inputs,
+            )
+        )
+
+        for name, expected_reason, case_cfg, case_par_cfg, case_inputs in cases:
+            with self.subTest(name=name):
+                supported, reason = PCPFusedPagedAttnOp.can_run(
+                    case_cfg, case_inputs, case_par_cfg
+                )
+                self.assertFalse(supported)
+                self.assertIn(expected_reason, reason)
+                self.assertIs(
+                    select_prefill_cp_impl(case_cfg, case_inputs, case_par_cfg),
+                    PCPAllGatherAttnOp,
+                )
+
+    def _make_dispatch_case(self):
+        cp_size = 2
+        attn_cfg, par_cfg = make_configs(
+            tokens_per_block=16, cp_size=cp_size, cp_rank=0
+        )
+        attn_cfg.kv_cache_dtype = KvCacheDataType.BASE
+        par_cfg.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        attn_inputs = build_cp_attn_inputs(
+            [20],
+            [10],
+            cp_size,
+            attn_cfg.tokens_per_block,
+            device=self.device,
+        )
+        return attn_cfg, par_cfg, attn_inputs
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger().setLevel(logging.INFO)
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_fused_allgather_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_fused_allgather_cp_impl.py
@@ -1,0 +1,217 @@
+"""Correctness tests for the fused all-gather CP prefill operator."""
+
+import contextlib
+import math
+from typing import List
+from unittest.mock import patch
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.fused_allgather_cp_impl import (
+    PCPFusedPagedAttnOp,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
+    CPAttnTestBase,
+    build_cp_attn_inputs,
+    compute_rank_positions,
+    extract_kv_from_paged_cache,
+    make_configs,
+    make_kv_cache,
+    reference_causal_attention,
+)
+
+_FUSED_MODULE = (
+    "rtp_llm.models_py.modules.factory.attention.cuda_cp_impl."
+    "prefill_mha.fused_allgather_cp_impl"
+)
+
+
+class TestPCPFusedPagedAttnOp(CPAttnTestBase):
+    OP_CLASS = PCPFusedPagedAttnOp
+    AG_MODULE = _FUSED_MODULE
+
+    def _patch_all_gather(
+        self,
+        stack: contextlib.ExitStack,
+        all_local_k: List[torch.Tensor],
+        all_local_v: List[torch.Tensor],
+        kv_head_num: int,
+        head_dim: int,
+    ):
+        payload = torch.cat(
+            [
+                torch.stack(
+                    (
+                        local_k.view(-1, kv_head_num, head_dim),
+                        local_v.view(-1, kv_head_num, head_dim),
+                    ),
+                    dim=1,
+                )
+                for local_k, local_v in zip(all_local_k, all_local_v)
+            ],
+            dim=0,
+        )
+
+        def mock_all_gather_into_tensor(output, input_, group=None, async_op=False):
+            output.copy_(payload.view_as(output))
+            return None
+
+        stack.enter_context(patch(f"{_FUSED_MODULE}._get_group", return_value=None))
+        stack.enter_context(
+            patch(
+                f"{_FUSED_MODULE}.torch.distributed.all_gather_into_tensor",
+                side_effect=mock_all_gather_into_tensor,
+            )
+        )
+
+    def test_no_prefix(self):
+        cases = [
+            ([32], 2, 0, 8, 2, 64),
+            ([32], 2, 1, 8, 2, 64),
+            ([64], 4, 2, 8, 2, 64),
+            ([32, 64], 2, 1, 8, 2, 64),
+            ([128], 4, 3, 32, 4, 128),
+            ([128], 8, 5, 64, 8, 128),
+        ]
+        for lengths, cp_size, rank, q_heads, kv_heads, head_dim in cases:
+            with self.subTest(lengths=lengths, cp_size=cp_size, rank=rank):
+                self.run_no_prefix(
+                    batch_size=len(lengths),
+                    sequence_lengths=lengths,
+                    cp_size=cp_size,
+                    cp_rank=rank,
+                    head_num=q_heads,
+                    kv_head_num=kv_heads,
+                    head_dim=head_dim,
+                    tokens_per_block=16,
+                )
+
+    def test_prefix_cache(self):
+        cases = [
+            ([32], [64], 2, 0),
+            ([32], [64], 2, 1),
+            ([32, 64], [64, 128], 2, 0),
+            ([64], [64], 4, 2),
+        ]
+        for new_lengths, prefix_lengths, cp_size, rank in cases:
+            with self.subTest(
+                new_lengths=new_lengths,
+                prefix_lengths=prefix_lengths,
+                cp_size=cp_size,
+                rank=rank,
+            ):
+                self.run_with_prefix(
+                    batch_size=len(new_lengths),
+                    new_lengths=new_lengths,
+                    prefix_lengths=prefix_lengths,
+                    cp_size=cp_size,
+                    cp_rank=rank,
+                    tokens_per_block=16,
+                )
+
+    def test_non_aligned_sequence_uses_padded_geometry(self):
+        actual_length = 65
+        cp_size = 4
+        cp_rank = 0
+        padded_length = math.ceil(actual_length / (2 * cp_size)) * 2 * cp_size
+        chunk_length = padded_length // cp_size
+        head_num, kv_head_num, head_dim = 8, 2, 64
+        tokens_per_block = 16
+
+        attn_cfg, par_cfg = make_configs(
+            head_num=head_num,
+            kv_head_num=kv_head_num,
+            head_dim=head_dim,
+            tokens_per_block=tokens_per_block,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+        )
+        q_padded = torch.randn(
+            padded_length,
+            head_num,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        k_padded = torch.randn(
+            padded_length,
+            kv_head_num,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        v_padded = torch.randn_like(k_padded)
+        reference = reference_causal_attention(
+            q_padded[:actual_length],
+            k_padded[:actual_length],
+            v_padded[:actual_length],
+            [0, actual_length],
+        )
+
+        rank_positions = compute_rank_positions([padded_length], cp_size)
+        all_local_k = [
+            k_padded[torch.tensor(positions, device=self.device)].reshape(
+                -1, kv_head_num * head_dim
+            )
+            for positions in rank_positions
+        ]
+        all_local_v = [
+            v_padded[torch.tensor(positions, device=self.device)].reshape(
+                -1, kv_head_num * head_dim
+            )
+            for positions in rank_positions
+        ]
+        local_positions = rank_positions[cp_rank]
+        local_index = torch.tensor(local_positions, device=self.device)
+        qkv = torch.cat(
+            (
+                q_padded[local_index].reshape(-1, head_num * head_dim),
+                all_local_k[cp_rank],
+                all_local_v[cp_rank],
+            ),
+            dim=-1,
+        )
+
+        attn_inputs = build_cp_attn_inputs(
+            [actual_length],
+            [chunk_length],
+            cp_size,
+            tokens_per_block,
+            device=self.device,
+        )
+        attn_inputs.context_parallel_info.prefill_qkv_padding_mask[actual_length:] = 0
+        total_blocks = math.ceil(actual_length / tokens_per_block)
+        kv_cache = make_kv_cache(
+            total_blocks,
+            kv_head_num,
+            tokens_per_block,
+            head_dim,
+            device=self.device,
+        )
+
+        with contextlib.ExitStack() as stack:
+            self._patch_all_gather(
+                stack, all_local_k, all_local_v, kv_head_num, head_dim
+            )
+            op = self.OP_CLASS(attn_cfg, attn_inputs, par_cfg)
+            params = op.prepare(attn_inputs)
+            output = op.forward(qkv, kv_cache, params)
+
+        valid_local = [
+            local
+            for local, position in enumerate(local_positions)
+            if position < actual_length
+        ]
+        valid_positions = [
+            position for position in local_positions if position < actual_length
+        ]
+        self._assert_close(
+            output[torch.tensor(valid_local, device=self.device)],
+            reference[torch.tensor(valid_positions, device=self.device)],
+        )
+
+        cache_k, cache_v = extract_kv_from_paged_cache(
+            kv_cache, [actual_length], tokens_per_block
+        )
+        self.assertTrue(torch.equal(cache_k, k_padded[:actual_length]))
+        self.assertTrue(torch.equal(cache_v, v_padded[:actual_length]))

--- a/rtp_llm/ops/__init__.py
+++ b/rtp_llm/ops/__init__.py
@@ -162,6 +162,7 @@ try:
         check_rope_cache,
         get_rope_cache,
         get_rope_cache_once,
+        CPAllGatherImpl,
         CPRotateMethod,
         PrefillCPConfig,
     )

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -4,7 +4,7 @@ import typing
 
 import torch
 
-__all__: list[str] = ['ALLTOALL', 'ALL_GATHER', 'ALL_GATHER_WITH_OVERLAP', 'ActivationType', 'ArpcConfig', 'AttentionConfigs', 'BatchDecodeSchedulerConfig', 'CPRotateMethod', 'CacheStoreConfig', 'ConcurrencyConfig', 'DISABLED', 'DataType', 'DeviceResourceConfig', 'EPLBConfig', 'EplbMode', 'FIFOSchedulerConfig', 'FMHAConfig', 'FMHAType', 'FfnDisAggregateConfig', 'GrammarConfig', 'GrpcConfig', 'HWKernelConfig', 'HybridAttentionConfig', 'HybridAttentionType', 'KVCacheConfig', 'KvCacheDataType', 'LayerNormType', 'LinearAttentionConfig', 'MMModelConfig',
+__all__: list[str] = ['ALLTOALL', 'ALL_GATHER', 'ALL_GATHER_WITH_OVERLAP', 'ActivationType', 'ArpcConfig', 'AttentionConfigs', 'BatchDecodeSchedulerConfig', 'CPAllGatherImpl', 'CPRotateMethod', 'CacheStoreConfig', 'ConcurrencyConfig', 'DISABLED', 'DataType', 'DeviceResourceConfig', 'EPLBConfig', 'EplbMode', 'FIFOSchedulerConfig', 'FMHAConfig', 'FMHAType', 'FUSED', 'FfnDisAggregateConfig', 'GrammarConfig', 'GrpcConfig', 'HWKernelConfig', 'HybridAttentionConfig', 'HybridAttentionType', 'KVCacheConfig', 'KvCacheDataType', 'LEGACY', 'LayerNormType', 'LinearAttentionConfig', 'MMModelConfig',
                       'MiscellaneousConfig', 'MlaOpsType', 'ModelConfig', 'ModelSpecificConfig', 'MoeConfig', 'NcclCommConfig', 'NormType', 'PDSepConfig', 'PREFILL_CP', 'ParallelismConfig', 'PrefillCPConfig', 'ProfilingDebugLoggingConfig', 'QuantAlgo', 'QuantMethod', 'RoleSpecialTokens', 'RoleType', 'RopeCache', 'RopeConfig', 'RopeStyle', 'RuntimeConfig', 'SpecialTokens', 'SpeculativeExecutionConfig', 'SpeculativeType', 'TaskType', 'UNKNOWN', 'VitConfig', 'VitSeparation', 'check_rope_cache', 'get_block_cache_keys', 'get_rope_cache', 'get_rope_cache_once']
 
 
@@ -119,6 +119,39 @@ class BatchDecodeSchedulerConfig:
     def __setstate__(self, arg0: tuple) -> None:
         ...
     def to_string(self) -> str:
+        ...
+class CPAllGatherImpl:
+    """
+    Members:
+
+      LEGACY
+
+      FUSED
+    """
+    FUSED: typing.ClassVar[CPAllGatherImpl]  # value = <CPAllGatherImpl.FUSED: 1>
+    LEGACY: typing.ClassVar[CPAllGatherImpl]  # value = <CPAllGatherImpl.LEGACY: 0>
+    __members__: typing.ClassVar[dict[str, CPAllGatherImpl]]  # value = {'LEGACY': <CPAllGatherImpl.LEGACY: 0>, 'FUSED': <CPAllGatherImpl.FUSED: 1>}
+    def __eq__(self, other: typing.Any) -> bool:
+        ...
+    def __getstate__(self) -> int:
+        ...
+    def __hash__(self) -> int:
+        ...
+    def __index__(self) -> int:
+        ...
+    def __init__(self, value: int) -> None:
+        ...
+    def __init__(self) -> None:
+        ...
+    def __setstate__(self, state: int) -> None:
+        ...
+    def __str__(self) -> str:
+        ...
+    @property
+    def name(self) -> str:
+        ...
+    @property
+    def value(self) -> int:
         ...
 class CPRotateMethod:
     """
@@ -1287,6 +1320,7 @@ class ParallelismConfig:
     def to_string(self) -> str:
         ...
 class PrefillCPConfig:
+    all_gather_impl: CPAllGatherImpl
     comm_buffer_size: int
     kv_cache_sharded: bool
     method: CPRotateMethod
@@ -1819,5 +1853,7 @@ ALLTOALL: CPRotateMethod  # value = <CPRotateMethod.ALLTOALL: 3>
 ALL_GATHER: CPRotateMethod  # value = <CPRotateMethod.ALL_GATHER: 1>
 ALL_GATHER_WITH_OVERLAP: CPRotateMethod  # value = <CPRotateMethod.ALL_GATHER_WITH_OVERLAP: 2>
 DISABLED: CPRotateMethod  # value = <CPRotateMethod.DISABLED: 0>
+FUSED: CPAllGatherImpl  # value = <CPAllGatherImpl.FUSED: 1>
+LEGACY: CPAllGatherImpl  # value = <CPAllGatherImpl.LEGACY: 0>
 PREFILL_CP: CPRotateMethod  # value = <CPRotateMethod.PREFILL_CP: 4>
 UNKNOWN: CPRotateMethod  # value = <CPRotateMethod.UNKNOWN: 5>

--- a/rtp_llm/server/server_args/parallel_group_args.py
+++ b/rtp_llm/server/server_args/parallel_group_args.py
@@ -1,5 +1,9 @@
-from rtp_llm.ops import CPRotateMethod
-from rtp_llm.server.server_args.util import str2_cp_rotate_method, str2bool
+from rtp_llm.ops import CPAllGatherImpl, CPRotateMethod
+from rtp_llm.server.server_args.util import (
+    str2_cp_all_gather_impl,
+    str2_cp_rotate_method,
+    str2bool,
+)
 
 
 def init_parallel_group_args(
@@ -83,6 +87,14 @@ def init_parallel_group_args(
         type=str2_cp_rotate_method,
         default=CPRotateMethod.DISABLED,
         help="指定用于上下文并行通信方法。可选值: ALL_GATHER, ALL_GATHER_WITH_OVERLAP, ALLTOALL",
+    )
+    parallel_group.add_argument(
+        "--cp_all_gather_impl",
+        env_name="RTP_CP_IMPL",
+        bind_to=(prefill_cp_config, "all_gather_impl"),
+        type=str2_cp_all_gather_impl,
+        default=CPAllGatherImpl.LEGACY,
+        help="Select the ALL_GATHER context-parallel implementation: LEGACY or FUSED.",
     )
     parallel_group.add_argument(
         "--comm_buffer_size",

--- a/rtp_llm/server/server_args/test/server_args_test.py
+++ b/rtp_llm/server/server_args/test/server_args_test.py
@@ -1,8 +1,12 @@
+import argparse
 import importlib
 import json
 import os
 import sys
 from unittest import TestCase, main
+
+from rtp_llm.ops import CPAllGatherImpl
+from rtp_llm.server.server_args.util import str2_cp_all_gather_impl
 
 
 class ServerArgsPyEnvConfigsTest(TestCase):
@@ -19,6 +23,10 @@ class ServerArgsSetTest(TestCase):
         os.environ.clear()
         os.environ.update(self._environ_backup)
         sys.argv = self._argv_backup
+
+    def test_invalid_cp_all_gather_impl_is_rejected(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            str2_cp_all_gather_impl("fuse")
 
     def test_env_vars_set_to_py_env_configs(self):
         """Test that environment variables are correctly set to py_env_configs."""
@@ -38,6 +46,7 @@ class ServerArgsSetTest(TestCase):
         os.environ["DASH_SC_GRPC_PRE_STOP_DRAIN_SECONDS"] = "9"
         os.environ["LOADER_RECYCLE_HANDLES"] = "false"
         os.environ["MOE_PURE_TP_PRESHARD"] = "false"
+        os.environ["RTP_CP_IMPL"] = "FUSED"
 
         sys.argv = ["prog"]
 
@@ -56,6 +65,10 @@ class ServerArgsSetTest(TestCase):
         self.assertEqual(py_env_configs.parallelism_config.tp_size, 4)
         self.assertEqual(py_env_configs.parallelism_config.dp_size, 2)
         self.assertEqual(py_env_configs.parallelism_config.world_size, 8)
+        self.assertEqual(
+            py_env_configs.prefill_cp_config.all_gather_impl,
+            CPAllGatherImpl.FUSED,
+        )
 
         # Verify concurrency_config
         self.assertEqual(py_env_configs.concurrency_config.concurrency_limit, 64)
@@ -126,6 +139,8 @@ class ServerArgsSetTest(TestCase):
             "false",
             "--disable_flashinfer_native",
             "true",
+            "--cp_all_gather_impl",
+            "legacy",
             # Note: max_seq_len is in ModelConfig, not ModelArgs
             # It will be set when ModelConfig is created from model_args
         ]
@@ -147,6 +162,10 @@ class ServerArgsSetTest(TestCase):
         self.assertEqual(py_env_configs.parallelism_config.tp_size, 8)
         self.assertEqual(py_env_configs.parallelism_config.dp_size, 4)
         self.assertEqual(py_env_configs.parallelism_config.world_size, 32)
+        self.assertEqual(
+            py_env_configs.prefill_cp_config.all_gather_impl,
+            CPAllGatherImpl.LEGACY,
+        )
 
         # Verify concurrency_config
         self.assertEqual(py_env_configs.concurrency_config.concurrency_limit, 128)

--- a/rtp_llm/server/server_args/util.py
+++ b/rtp_llm/server/server_args/util.py
@@ -1,6 +1,6 @@
 import argparse
 
-from rtp_llm.ops import CPRotateMethod
+from rtp_llm.ops import CPAllGatherImpl, CPRotateMethod
 
 
 def str2bool(v):
@@ -35,3 +35,17 @@ def str2_cp_rotate_method(value):
             f"Invalid cp_rotate_method: {value}. "
             f"Must be one of: ALL_GATHER, ALL_GATHER_WITH_OVERLAP, ALLTOALL, PREFILL_CP"
         )
+
+
+def str2_cp_all_gather_impl(value):
+    """Convert a string to the configured all-gather CP implementation."""
+    if isinstance(value, CPAllGatherImpl):
+        return value
+    value_upper = value.upper()
+    if value_upper == "LEGACY":
+        return CPAllGatherImpl.LEGACY
+    if value_upper == "FUSED":
+        return CPAllGatherImpl.FUSED
+    raise argparse.ArgumentTypeError(
+        f"Invalid cp_all_gather_impl: {value}. Must be one of: LEGACY, FUSED"
+    )


### PR DESCRIPTION
### Description

The current MHA/GQA context-parallel all-gather prefill path repeats several communication and data-layout operations in every transformer layer:

```text
K all-gather + V all-gather
        -> restore global K/V order
        -> two ragged-attention calls
        -> merge attention states and restore output order
        -> write the KV cache
```

This requires two collectives, materializes reordered K/V tensors, invokes attention twice, and merges the two partial results. The launch, synchronization, temporary-allocation, and data-movement costs are repeated for every layer, and they do not shrink with sequence length: at 1,024 tokens the existing implementation takes 0.289-0.306 ms per layer across four different Q/KV head shapes and both CP4 and CP8 - essentially flat, although the attention math in those configurations differs by more than an order of magnitude.

The zigzag CP layout provides an opportunity to remove most of this overhead. Each rank's two local query segments attend to continuous prefixes of the global KV sequence, while the paged KV cache can represent overlapping requests without materializing a fully reordered K/V tensor.

### Proposed Solution

Add a fused paged-attention implementation for `CPRotateMethod.ALL_GATHER` with the following flow:

```text
pack local K and V together
        -> one all_gather_into
        -> express zigzag-to-global mapping through cache positions
        -> append to the paged KV cache once
        -> run one 2*batch paged-prefill attention call
```

The implementation:

- gathers K and V with one collective instead of two;
- routes that collective through a new public `collective_torch.all_gather_into(output, tensor, group)` wrapper, so the existing RCCL-capture and symmetric-memory fast paths still apply (the wrapper returns the tensor to use, because those fast paths own their result storage);
- reuses gather and output buffers across transformer layers within one prefill request, request-scoped rather than process-global;
- encodes zigzag restoration in KV-cache positions instead of materializing reordered K/V tensors;
- represents the two causal prefixes as overlapping paged requests and processes them with one attention call, covering prefix cache and new tokens in the same call;
- uses a strided Q view from packed QKV, avoiding an extra permutation, contiguous copy, and output scatter;
- supports non-aligned sequence lengths through padded zigzag geometry, with padding placed in the already allocated tail of the last cache page and masked by causal attention for every valid query.

### Compatibility and Fallback

The fused path is **opt-in and off by default**. It is selected by the new `--cp_all_gather_impl` server argument (`CPAllGatherImpl.LEGACY` | `CPAllGatherImpl.FUSED`, default `LEGACY`), which is part of the normal configuration system: declared in `rtp_llm/cpp/config/ConfigModules.h`, bound in `rtp_llm/cpp/pybind/ConfigInit.cc`, and registered in `rtp_llm/server/server_args/parallel_group_args.py`. Nothing is read from the environment at import time.

Selection happens per request in `select_prefill_cp_impl()`, which calls `PCPFusedPagedAttnOp.can_run()` and falls back to the existing operator with a logged reason when any precondition fails:

```text
non-BASE (INT8/FP8) KV cache dtype
kernel_tokens_per_block != tokens_per_block, or a non-positive page size
page_size % (2 * cp_size) != 0
prefix length not page aligned
odd local chunk length, negative geometry, or actual > padded length
missing or non-2-D paged block table
block-table capacity smaller than the pages needed
unallocated (negative) page id inside the used range
no query token in the batch
restore indices that do not cover the padded slots
```

Deployments that do not set the flag keep the current behaviour bit-for-bit; a rollback is a config change rather than a revert. The overlap and all-to-all CP implementations are untouched.

### Validation

**In-tree unit test.** `test_fused_allgather_cp_impl.py`, target `//rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test:test_fused_allgather_cp_impl`, has 6 tests and a `unittest.main()` entry point. Every attention case is checked against FlashInfer's non-paged ragged prefill with `torch.allclose(rtol=1e-2, atol=1e-2)`, *and* the K/V read back out of the paged cache is checked with `torch.equal`. The mocked collective asserts it is issued on `Group.TP` and that the local input equals this rank's slice of the gathered payload.

| Test | Coverage | Cases |
|:--|:--|--:|
| `test_no_prefix` | CP2/CP4/CP8, ranks 0-5, batch 1 and 2, Q/KV heads 8/2, 32/4 and 64/8, head dim 64 and 128, page size 16/32/64 | 8 |
| `test_prefix_cache` | the same axes with a page-aligned prefix cache of 32-128 tokens, single and multi request, page size 16/32/64 | 7 |
| `test_non_aligned_sequence_uses_padded_geometry` | a 65-token CP4 request padded to 72: non-contiguous Q view, valid-position output and cache contents, padded tail written inside the already allocated last page, buffer reuse across two `forward` calls, and an adjacent request's cache block asserted bit-unchanged | 1 |
| `test_dispatch_defaults_to_legacy` | the default `all_gather_impl` selects the legacy operator | 1 |
| `test_dispatch_selects_fused_when_supported` | `FUSED` plus a supported geometry selects the fused operator | 1 |
| `test_dispatch_falls_back_for_unsupported_capabilities` | six unsupported geometries; asserts the fallback class *and* the reason string of the specific guard that must reject each case | 6 |

**Operator-level correctness against an FP32 oracle (8 GPUs, real NCCL).** The oracle is causal attention accumulated in FP32 and blocked over queries - deliberately not `single_prefill_with_kv_cache`, which the existing operator uses internally. Pass criteria per case: `max_diff <= 1.1e-2`, `mean_diff <= 5e-4`, and K and V read back from the paged cache exactly equal to the inputs, comparing real (non-pad) positions only. The harness also emulates a fragmented block pool with scattered physical block ids.

Matrix: four Q/KV head shapes (64/8, 32/4, 8/1, 4/1 - Qwen3-32B and Qwen3-30B-A3B at TP1 and TP8), CP4 and CP8, every rank in the group, lengths 1,024 / 4,097 / 16,384 / 32,768 / 65,536 / 98,301 / 131,072, plus 4,096 new tokens on a 2,048-token prefix, and all four implementations. Result: **1,536 comparisons over 64 configurations x every rank x four implementations, 0 failed.**

| Implementation | Configurations | Max absolute diff | Max mean diff | K/V bit-exact |
|:--|--:|--:|--:|--:|
| fused | 64 | 0.01031 | 0.000286 | 64/64 |
| legacy all-gather | 64 | 0.01031 | 0.000286 | 64/64 |
| all-gather overlap | 64 | 0.01031 | 0.000295 | 64/64 |
| all-to-all | 64 | 0.01031 | 0.000321 | 64/64 |

The fused operator's error against the FP32 oracle is identical to the existing operator's, and the worst case for all four is the same configuration (98,301 tokens, CP4, padded geometry). Different implementations change floating-point reduction order, so token-for-token output identity is not required; the error envelope and the exact cache contents are.

**Padding page-boundary safety.** The concern is that `roundup(actual, 2 * cp_size)` might need a page the request does not own. Brute force over `cp_size` in {1,2,4,8,16}, `page_size` in [1,256], prefix 0-8 pages and actual length in [1,1024]:

| Divisibility guard | Combinations checked | Cases needing an unowned page |
|:--|--:|--:|
| `page_size % (2 * cp_size) == 0` enforced | 2,285,568 | 0 |
| guard removed | 11,796,480 | 938,088 |

With the guard and page-aligned prefixes the spill is unreachable rather than merely unobserved; without the guard it is common. `can_run()` keeps the explicit page-count check anyway, so relaxing either guard later fails closed instead of corrupting a neighbour.

**Negative controls.** A suite that cannot fail proves nothing: perturbing the FP32 reference turns the unit suite red, and replacing `can_run`'s reason string produces one failure per dispatch subcase, confirming the reason assertions are load-bearing and that the target does not pass by running zero cases.

### Performance

8x NVIDIA H20-3e, 143 GB HBM per device, PyTorch 2.8.0+cu128. CP4 uses 4 devices, CP8 all 8.

Operator `forward` time, fused versus the existing all-gather implementation, aggregated over the eight (head shape, CP degree) combinations. `prepare` is outside the measured region.

| Input | Geomean speedup | Min | Max |
|---:|---:|---:|---:|
| 1,024 | 2.41x | 2.27x | 2.48x |
| 4,096 | 1.53x | 1.28x | 2.43x |
| 8,192 | 1.24x | 1.14x | 1.38x |
| 16,384 | 1.11x | 1.02x | 1.26x |
| 32,768 | 1.06x | 0.97x | 1.14x |

Fused is faster at 39 of 40 points; the exception is 4/1 heads at CP8 and 32,768 tokens (0.97x), where per-rank attention is small enough that run-to-run variance is comparable to the difference.

End-to-end median engine TTFT (`aux_info.first_token_cost_time`), batch size 1, native endpoint, no prefix reuse, two warmups and five measured requests per point. The baseline at each length is the fastest of legacy all-gather, overlap and all-to-all.

| Model | CP | Speedup range, 1k-128k | Geomean, all lengths | Geomean, 8k-128k | Time saved at 128k |
|:--|--:|:--|--:|--:|--:|
| Qwen3-30B-A3B-Instruct-2507-FP8 | 4 | 1.014x - 1.142x | 1.064x | 1.039x | 243.7 ms |
| Qwen3-30B-A3B-Instruct-2507-FP8 | 8 | 1.014x - 1.220x | 1.074x | 1.040x | 111.6 ms |
| Qwen3-32B | 4 | 1.007x - 1.031x | 1.019x | 1.014x | 367.3 ms |
| Qwen3-32B | 8 | 1.010x - 1.046x | 1.025x | 1.019x | 231.0 ms |

Fused is ahead of the best baseline at all 36 points. The relative gain narrows as the input grows, because this change removes communication and data movement while attention math takes an increasing share of TTFT; the absolute time saved keeps growing, since the eliminated data movement also grows with sequence length. Dense GEMM is a larger share of Qwen3-32B's TTFT, so its relative gain is smaller than A3B's.