### PR TITLE
fix(rocm): adopt qwen35 fp8 & set moe_pure_tp_preshard default to False

### DIFF
--- a/docs/backend/server_arguments.md
+++ b/docs/backend/server_arguments.md
@@ -206,4 +206,4 @@ RTP-LLM deployments are released as versioned, immutable container images, with 
 | `--load_method` | Specify the weight loading method.<br>Options: auto, fastsafetensors, scratch (`LOAD_METHOD`) | auto |
 | `--force_cpu_load_weights` | Load weights on CPU to reduce device memory usage (`FORCE_CPU_LOAD_WEIGHTS`) | False |
 | `--loader_recycle_handles` | ROCm + safetensors only: close consumed main-model shard handles to release mmap memory. Requires layer-numbered tensors and copies safetensors data out before closing; no effect on fastsafetensors, ViT, EPLB, or .bin weights. (`LOADER_RECYCLE_HANDLES`) | True |
-| `--moe_pure_tp_preshard` | Under pure TP (`tp>1, dp=1, ep=1`), pre-shard supported Qwen3-Next / Qwen3.5 MoE and offline FP8 weights before device copy. Unsupported sources or layouts warn and use legacy full reads. Set false to disable. (`MOE_PURE_TP_PRESHARD`) | True |
+| `--moe_pure_tp_preshard` | Disabled by default. Set true to pre-shard supported Qwen3-Next / Qwen3.5 MoE and offline FP8 weights under pure TP (`tp>1, dp=1, ep=1`) before device copy. Unsupported sources or layouts warn and use legacy full reads. (`MOE_PURE_TP_PRESHARD`) | False |

--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -177,7 +177,7 @@ class LoadConfig:
         self.load_method: str = "auto"
         self.force_cpu_load_weights: bool = False
         self.loader_recycle_handles: bool = True
-        self.moe_pure_tp_preshard: bool = True
+        self.moe_pure_tp_preshard: bool = False
 
     def to_string(self):
         return (

--- a/rtp_llm/model_loader/load_config.py
+++ b/rtp_llm/model_loader/load_config.py
@@ -60,7 +60,7 @@ class LoadConfig(BaseModel):
     phy2log: Optional[List[List[int]]] = None
     use_swizzleA: bool = False
     force_cpu_load_weights: bool = False
-    moe_pure_tp_preshard: bool = True
+    moe_pure_tp_preshard: bool = False
 
     @field_validator("database", "compute_dtype", "quant_algo")
     @classmethod

--- a/rtp_llm/model_loader/loader.py
+++ b/rtp_llm/model_loader/loader.py
@@ -46,7 +46,7 @@ class ModelLoader:
         database: BaseDatabase,
         load_method: LoadMethod = LoadMethod.AUTO,
         force_cpu_load_weights: bool = False,
-        moe_pure_tp_preshard: bool = True,
+        moe_pure_tp_preshard: bool = False,
     ):
         self.model_config = model_config
         self._task_type = model_config.task_type
@@ -828,7 +828,7 @@ def get_model_loader(
     database: BaseDatabase,
     load_method: LoadMethod = LoadMethod.AUTO,
     force_cpu_load_weights: bool = False,
-    moe_pure_tp_preshard: bool = True,
+    moe_pure_tp_preshard: bool = False,
 ) -> ModelLoader:
     if weights_info._head_num % weights_info.tp_size != 0:
         raise Exception(

--- a/rtp_llm/model_loader/model_weight_info.py
+++ b/rtp_llm/model_loader/model_weight_info.py
@@ -12,7 +12,7 @@ from rtp_llm.config.quant_config import (
     ModelOptFp4Config,
     QuantizationConfig,
 )
-from rtp_llm.model_loader.attn_weight import AttnAtomicWeight, AttnConfig
+from rtp_llm.model_loader.attn_weight import AttnConfig
 from rtp_llm.model_loader.ffn_weight import FfnConfig, FfnWeight
 from rtp_llm.model_loader.load_config import LoadConfig, LoadMethod
 from rtp_llm.model_loader.weight_module import (
@@ -30,6 +30,7 @@ from rtp_llm.utils.model_weight import (
     WeightStyle,
     choose_available,
     identity,
+    ones,
     tolerate_failed,
 )
 from rtp_llm.utils.weight_type import WEIGHT_TYPE
@@ -38,10 +39,6 @@ if TYPE_CHECKING:
     from rtp_llm.config.kv_cache_config import KVCacheConfig
     from rtp_llm.config.model_config import ModelConfig
     from rtp_llm.ops import HWKernelConfig, ParallelismConfig
-
-
-def create_scalar_ones(ts: List[torch.Tensor]):
-    return torch.ones([1], dtype=torch.float32).to(ts[0].device)
 
 
 class ModelWeightInfo:
@@ -404,21 +401,15 @@ class ModelDeployWeightInfo:
         self, origin_weight_info: ModelWeightInfo
     ):
         for weights in origin_weight_info.layer_weights:
-            attn_q_weight_info: Optional[CkptWeightInfo] = None
-            for weight in weights:
-                if (
-                    isinstance(weight, AtomicWeight)
-                    or isinstance(weight, AttnAtomicWeight)
-                ) and weight.name == W.attn_qkv_w:
-                    attn_q_weight_info = weight.weights[0]
-                    break
-
-            assert attn_q_weight_info is not None
+            # Hybrid models (Qwen3-Next / Qwen3.5) build linear-attention layers
+            # without attn_o_w, and those layers never consume the scale.
+            if not any(weight.name == W.attn_o_w for weight in weights):
+                continue
             weights.append(
                 AtomicWeight(
                     W.attention_output_static_quant_reciprocal,
-                    [attn_q_weight_info],
-                    create_scalar_ones,
+                    [],
+                    ones,
                     torch.float32,
                 )
             )
@@ -616,7 +607,7 @@ class ModelDeployWeightInfo:
         phy2log: Optional[List[List[int]]] = None,
         exported_device: Optional[Any] = None,
         force_cpu_load_weights: bool = False,
-        moe_pure_tp_preshard: bool = True,
+        moe_pure_tp_preshard: bool = False,
     ):
         merge_lora = False
 

--- a/rtp_llm/model_loader/test/test_model_weight_info.py
+++ b/rtp_llm/model_loader/test/test_model_weight_info.py
@@ -1,12 +1,18 @@
 import unittest
+from types import SimpleNamespace
 from typing import List
 
+import torch
+
+from rtp_llm.model_loader.load_config import LoadConfig
 from rtp_llm.model_loader.model_weight_info import (
     ModelDeployWeightInfo,
     ModelWeightInfo,
 )
+from rtp_llm.model_loader.tensor_source import TensorCollector
+from rtp_llm.model_loader.weight_module import AtomicWeight
 from rtp_llm.utils.database import CkptDatabase
-from rtp_llm.utils.model_weight import CkptWeightInfo
+from rtp_llm.utils.model_weight import CkptWeightInfo, W
 
 
 class FakeCkptFileInfo:
@@ -84,9 +90,7 @@ class ModelDeployWeightInfoCkptRegexTest(unittest.TestCase):
         )
 
     def test_ckpt_tensor_name_regex_escapes_literal_dots(self):
-        pattern = ModelDeployWeightInfo._ckpt_tensor_name_to_regex(
-            "lm_head.weight"
-        )
+        pattern = ModelDeployWeightInfo._ckpt_tensor_name_to_regex("lm_head.weight")
 
         self.assertIsNotNone(pattern.fullmatch("lm_head.weight"))
         self.assertIsNone(pattern.fullmatch("lm_headXweight"))
@@ -113,7 +117,9 @@ class ModelDeployWeightInfoCkptRegexTest(unittest.TestCase):
         self.assertTrue(
             any(pattern.fullmatch("model.embed_tokens.weight") for pattern in patterns)
         )
-        self.assertTrue(any(pattern.fullmatch("lm_head.weight") for pattern in patterns))
+        self.assertTrue(
+            any(pattern.fullmatch("lm_head.weight") for pattern in patterns)
+        )
         self.assertTrue(
             any(
                 pattern.fullmatch("model.layers.0.self_attn.q_proj.weight")
@@ -133,6 +139,62 @@ class ModelDeployWeightInfoCkptRegexTest(unittest.TestCase):
         patterns = ModelDeployWeightInfo._collect_ckpt_tensor_name_regexes(weight_info)
 
         self.assertEqual(patterns, [])
+
+
+class AttentionOutputStaticQuantReciprocalTest(unittest.TestCase):
+    def test_reciprocal_added_only_to_layers_with_attention_output(self):
+        # layer 0 mimics a hybrid linear-attention layer: no attention output
+        # projection at all. layer 1 mimics a normal MHA layer.
+        weight_info = ModelWeightInfo(
+            weights=[],
+            layer_weights=[
+                [
+                    AtomicWeight(
+                        W.linear_attn_out_w,
+                        [CkptWeightInfo("model.layers.{i}.linear_attn.out_proj.w")],
+                    )
+                ],
+                [
+                    AtomicWeight(
+                        W.attn_o_w,
+                        [CkptWeightInfo("model.layers.{i}.self_attn.o_proj.weight")],
+                    )
+                ],
+            ],
+        )
+        deploy_info = RecordingDeployWeightInfo(make_database([]), weight_info)
+
+        result = deploy_info._add_attention_output_static_quant_reciprocal(weight_info)
+
+        linear_layer, mha_layer = result.layer_weights
+        self.assertEqual([w.name for w in linear_layer], [W.linear_attn_out_w])
+        self.assertEqual(
+            [w.name for w in mha_layer],
+            [W.attn_o_w, W.attention_output_static_quant_reciprocal],
+        )
+
+        # The scale has no ckpt dependency, so it is loaded from an empty
+        # collector and must still yield a float32 one on the target device.
+        reciprocal = mha_layer[-1]
+        self.assertEqual(reciprocal.get_tensor_names(1, None), set())
+        loaded = reciprocal.load(
+            TensorCollector(set(), make_database([])),
+            1,
+            "cpu",
+            LoadConfig.model_construct(
+                tp_size=1,
+                dp_size=1,
+                ep_size=1,
+                merge_lora=False,
+                exported_device=SimpleNamespace(
+                    maybe_rewrite_weight_by_key=lambda _, tensor: tensor
+                ),
+            ),
+        )
+        torch.testing.assert_close(
+            loaded[W.attention_output_static_quant_reciprocal],
+            torch.ones(1, dtype=torch.float32),
+        )
 
 
 class CkptDatabaseFilterTest(unittest.TestCase):
@@ -177,9 +239,7 @@ class CkptDatabaseFilterTest(unittest.TestCase):
             ["irrelevant.weight"],
         )
         database = make_database([original_file])
-        patterns = [
-            ModelDeployWeightInfo._ckpt_tensor_name_to_regex("required.weight")
-        ]
+        patterns = [ModelDeployWeightInfo._ckpt_tensor_name_to_regex("required.weight")]
 
         database.filter_by_tensor_name_regexes(patterns)
 
@@ -202,9 +262,7 @@ class CkptDatabaseFilterTest(unittest.TestCase):
             FakeCkptFileInfo("b.safetensors", ["b.weight"]),
         ]
         database = make_database(files)
-        patterns = [
-            ModelDeployWeightInfo._ckpt_tensor_name_to_regex("missing.weight")
-        ]
+        patterns = [ModelDeployWeightInfo._ckpt_tensor_name_to_regex("missing.weight")]
 
         database.filter_by_tensor_name_regexes(patterns)
 
@@ -227,9 +285,7 @@ class CreateModelWeightInfoFilterOrderTest(unittest.TestCase):
         )
         returned_weight_info = ModelWeightInfo(
             weights=[],
-            layer_weights=[
-                [FakeWeight(["mtp.layers.{i}.self_attn.q_proj.weight"])]
-            ],
+            layer_weights=[[FakeWeight(["mtp.layers.{i}.self_attn.q_proj.weight"])]],
         )
         weight_info = RecordingDeployWeightInfo(database, returned_weight_info)
 

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -77,7 +77,7 @@ class BaseModel(object):
         device_resource_config: Optional[DeviceResourceConfig],
         force_cpu_load_weights: bool = False,
         loader_recycle_handles: bool = False,
-        moe_pure_tp_preshard: bool = True,
+        moe_pure_tp_preshard: bool = False,
     ) -> None:
         """Initialize BaseModel with independent configuration objects.
         Args:
@@ -260,7 +260,7 @@ class BaseModel(object):
         force_cpu_load_weights: bool = False,
         skip_python_model: bool = False,
         loader_recycle_handles: bool = False,
-        moe_pure_tp_preshard: bool = True,
+        moe_pure_tp_preshard: bool = False,
     ) -> "BaseModel":
         """Create model from independent configuration objects.
 

--- a/rtp_llm/models_py/utils/test/typed_storage_view_test.py
+++ b/rtp_llm/models_py/utils/test/typed_storage_view_test.py
@@ -166,6 +166,31 @@ class LinearCacheConverterTest(TestCase):
         conv_view[1, 1, 3] = torch.tensor(-7, dtype=torch.bfloat16, device=self.device)
         self.assertEqual(conv_view[1, 1, 3].item(), -7)
 
+    def test_gpu_linear_cache_converter_float8_e4m3fnuz(self) -> None:
+        # ssm state is 1 * 2 * 2 * 4B = 16B, fnuz conv state (3 - 1) * 4 * 1B = 8B
+        converter = LinearCacheConverter(
+            local_num_v_heads=1,
+            head_v_dim=2,
+            head_k_dim=2,
+            ssm_state_dtype=torch.float32,
+            linear_conv_kernel_dim=3,
+            qkv_size=4,
+            conv_state_dtype=torch.float8_e4m3fnuz,
+        )
+        self.assertEqual(converter.block_size_bytes, 24)
+
+        # 2 blocks of 16 bfloat16 elements: 32B per block, 8B of them padding.
+        base = torch.arange(32, dtype=torch.bfloat16, device=self.device).reshape(2, 16)
+        self.assertEqual(converter.get_block_size_bytes(base), 32)
+
+        conv_view = converter.get_conv_state_tensor(base)
+
+        self.assertEqual(conv_view.shape, (2, 2, 4))
+        self.assertEqual(conv_view.stride(), (32, 4, 1))
+        self.assertEqual(conv_view.dtype, torch.float8_e4m3fnuz)
+        self.assertEqual(conv_view.storage_offset(), 16)
+        self._assert_view_matches_bytes(base, conv_view, (32, 4, 1), 16)
+
 
 if __name__ == "__main__":
     main()

--- a/rtp_llm/models_py/utils/typed_storage_view.py
+++ b/rtp_llm/models_py/utils/typed_storage_view.py
@@ -6,6 +6,7 @@ TORCH_DTYPE_SIZE_BYTES = {
     torch.float32: 4,
     torch.int8: 1,
     torch.float8_e4m3fn: 1,
+    torch.float8_e4m3fnuz: 1,
 }
 
 

--- a/rtp_llm/server/server_args/load_group_args.py
+++ b/rtp_llm/server/server_args/load_group_args.py
@@ -35,6 +35,6 @@ def init_load_group_args(parser, load_config, model_args):
         env_name="MOE_PURE_TP_PRESHARD",
         bind_to=(load_config, "moe_pure_tp_preshard"),
         type=str2bool,
-        default=True,
-        help="pure TP 下预切分已支持的 MoE 权重；置假回滚为全量读取",
+        default=False,
+        help="默认关闭；设为 true 后在 pure TP 下预切分已支持的 MoE 权重；不支持的来源或布局回退为全量读取",
     )

--- a/rtp_llm/server/server_args/test/server_args_test.py
+++ b/rtp_llm/server/server_args/test/server_args_test.py
@@ -37,7 +37,7 @@ class ServerArgsSetTest(TestCase):
         os.environ["FRONTEND_PRE_STOP_DRAIN_SECONDS"] = "2.5"
         os.environ["DASH_SC_GRPC_PRE_STOP_DRAIN_SECONDS"] = "9"
         os.environ["LOADER_RECYCLE_HANDLES"] = "false"
-        os.environ["MOE_PURE_TP_PRESHARD"] = "false"
+        os.environ["MOE_PURE_TP_PRESHARD"] = "true"
 
         sys.argv = ["prog"]
 
@@ -83,8 +83,8 @@ class ServerArgsSetTest(TestCase):
 
         # Verify load_config: the flag came from LOADER_RECYCLE_HANDLES=false.
         self.assertFalse(py_env_configs.load_config.loader_recycle_handles)
-        # MOE_PURE_TP_PRESHARD=false must override the True default.
-        self.assertFalse(py_env_configs.load_config.moe_pure_tp_preshard)
+        # MOE_PURE_TP_PRESHARD=true explicitly enables the opt-in path.
+        self.assertTrue(py_env_configs.load_config.moe_pure_tp_preshard)
         # Note: max_seq_len is in ModelConfig, not RuntimeConfig or EngineConfig
         # It will be set when ModelConfig is created from model_args
 
@@ -170,7 +170,7 @@ class ServerArgsSetTest(TestCase):
 
         # Pins the shipped defaults: neither env nor argv sets the flags here.
         self.assertTrue(py_env_configs.load_config.loader_recycle_handles)
-        self.assertTrue(py_env_configs.load_config.moe_pure_tp_preshard)
+        self.assertFalse(py_env_configs.load_config.moe_pure_tp_preshard)
         # Note: max_seq_len is in ModelConfig, not RuntimeConfig or EngineConfig
         # It will be set when ModelConfig is created from model_args
 


### PR DESCRIPTION
## Summary
Fix Qwen3.5 FP8 loading on ROCm; make pure-TP MoE pre-sharding opt-in.

## Changes
- `model_weight_info.py`: anchor static-quant reciprocal on `attn_o_w`
  (its actual consumer) and skip layers without it, instead of asserting
  on `attn_qkv_w` — hybrid linear-attention layers have no QKV weight.
- `typed_storage_view.py`: add `torch.float8_e4m3fnuz: 1`.
- `moe_pure_tp_preshard`: default `True` -> `False`. Pre-sharding only
  pays off when MoE weights are split into many small ckpt files; with
  few large shards it is slower than a full read.

## Behavior change
Pure-TP MoE now defaults to legacy full reads. Enable per model with
`MOE_PURE_TP_PRESHARD=true` where it measures faster.