### PR TITLE
ci: add netaddi as default code owner and LGTM reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owner for all files
-*   @LLLLKKKK
+*   @LLLLKKKK @netaddi
 
 # FlexLB module specific owners
 rtp_llm/flexlb/   @gavin-hgy @jianglan89 @sunmiaozju

--- a/.github/scripts/ci_gate/__main__.py
+++ b/.github/scripts/ci_gate/__main__.py
@@ -26,7 +26,8 @@ def main(argv):
     check_review.add_argument("repository")
     check_review.add_argument("head_sha")
     check_review.add_argument("--github-token", required=True)
-    check_review.add_argument("--lgtm-user", default="LLLLKKKK")
+    check_review.add_argument("--lgtm-user", default="LLLLKKKK,netaddi",
+                              help="comma-separated logins allowed to LGTM")
 
     resolve = subparsers.add_parser("resolve-context")
     resolve.add_argument("--github-token", required=True)
@@ -39,7 +40,8 @@ def main(argv):
     resolve.add_argument("--event-pr-number", default="")
     resolve.add_argument("--event-clone-url", default="")
     resolve.add_argument("--output-file", default="")
-    resolve.add_argument("--lgtm-user", default="LLLLKKKK")
+    resolve.add_argument("--lgtm-user", default="LLLLKKKK,netaddi",
+                         help="comma-separated logins allowed to LGTM")
 
     check_merge_parser = subparsers.add_parser("check-merge")
     check_merge_parser.add_argument("pr_number")

--- a/.github/scripts/ci_gate/review.py
+++ b/.github/scripts/ci_gate/review.py
@@ -39,12 +39,19 @@ def _fetch_head_commit_date(repo, head_sha, github_token):
     return (((commit.get("commit") or {}).get("committer") or {}).get("date")) or ""
 
 
-def _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
-    # type: (str, str, str, str, str) -> bool
-    """Check whether a fresh LGTM issue comment from *lgtm_user* exists.
+def parse_lgtm_users(lgtm_user):
+    # type: (str) -> set
+    """Parse a comma-separated ``--lgtm-user`` value into a set of logins."""
+    return {u.strip() for u in (lgtm_user or "").split(",") if u.strip()}
+
+
+def _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user, pr_author=""):
+    # type: (str, str, str, str, str, str) -> bool
+    """Check whether a fresh LGTM issue comment from an *lgtm_user* exists.
 
     Freshness is defined as ``comment.updated_at >= head_commit.committer.date``
-    because issue comments have no ``commit_id`` field.
+    because issue comments have no ``commit_id`` field. Comments from the PR
+    author never qualify (no self-LGTM).
     """
     head_date = _fetch_head_commit_date(repo, head_sha, github_token)
     if not head_date:
@@ -56,6 +63,7 @@ def _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgt
         "fetching issue comments for PR #%s" % pr_number, github_token,
     )
 
+    lgtm_users = parse_lgtm_users(lgtm_user)
     lgtm_phrase = "lgtm ready to ci"
     latest_match = None  # type: Any
     for comment in comments:
@@ -64,13 +72,14 @@ def _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgt
         user = (comment.get("user") or {}).get("login", "")
         body = (comment.get("body") or "").lower()
         updated_at = comment.get("updated_at", "")
-        if user == lgtm_user and lgtm_phrase in body and updated_at >= head_date:
+        if user in lgtm_users and user != pr_author and lgtm_phrase in body and updated_at >= head_date:
             if latest_match is None or updated_at > (latest_match.get("updated_at") or ""):
                 latest_match = comment
 
     if latest_match:
         log("PR #%s has fresh LGTM issue comment from %s (updated_at: %s >= commit: %s)"
-            % (pr_number, lgtm_user, latest_match.get("updated_at", ""), head_date))
+            % (pr_number, (latest_match.get("user") or {}).get("login", ""),
+               latest_match.get("updated_at", ""), head_date))
         return True
 
     log("PR #%s has no qualifying fresh issue comment" % pr_number)
@@ -98,15 +107,16 @@ def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
         log("PR #%s has a latest fresh APPROVED review" % pr_number)
         return True
 
+    lgtm_users = parse_lgtm_users(lgtm_user)
     lgtm_phrase = "lgtm ready to ci"
     for review in fresh:
         user = (review.get("user") or {}).get("login")
         body = (review.get("body") or "").lower()
-        if user == lgtm_user and review.get("state") == "COMMENTED" and lgtm_phrase in body:
-            log("PR #%s has latest fresh LGTM from %s" % (pr_number, lgtm_user))
+        if user in lgtm_users and review.get("state") == "COMMENTED" and lgtm_phrase in body:
+            log("PR #%s has latest fresh LGTM from %s" % (pr_number, user))
             return True
 
-    if _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
+    if _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user, pr_author):
         return True
 
     log("PR #%s has no qualifying fresh review or issue comment" % pr_number)

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -318,6 +318,23 @@ class TestCheckIssueCommentsQualified(unittest.TestCase):
         result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertTrue(result)
 
+    @patch("ci_gate.review.github_get_pages")
+    @patch("ci_gate.review.github_get")
+    def test_multi_lgtm_users_second_user_qualifies(self, mock_get, mock_pages):
+        mock_get.return_value = self.COMMIT_RESPONSE
+        mock_pages.return_value = [self._comment(login="netaddi")]
+        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK,netaddi")
+        self.assertTrue(result)
+
+    @patch("ci_gate.review.github_get_pages")
+    @patch("ci_gate.review.github_get")
+    def test_pr_author_self_lgtm_rejected(self, mock_get, mock_pages):
+        mock_get.return_value = self.COMMIT_RESPONSE
+        mock_pages.return_value = [self._comment(login="netaddi")]
+        result = _check_issue_comments_qualified(
+            "1", "repo", "sha1", "token", "LLLLKKKK,netaddi", pr_author="netaddi")
+        self.assertFalse(result)
+
 
 # ---------------------------------------------------------------------------
 # review.check_review_qualified — issue comment fallback
@@ -334,7 +351,7 @@ class TestCheckReviewQualifiedWithIssueComments(unittest.TestCase):
         mock_issue.return_value = True
         result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertTrue(result)
-        mock_issue.assert_called_once_with("1", "repo", "sha1", "token", "LLLLKKKK")
+        mock_issue.assert_called_once_with("1", "repo", "sha1", "token", "LLLLKKKK", "author")
 
     @patch("ci_gate.review._check_issue_comments_qualified")
     @patch("ci_gate.review.github_get_pages")

--- a/.github/workflows/CI-event-dispatcher.yml
+++ b/.github/workflows/CI-event-dispatcher.yml
@@ -46,11 +46,11 @@ jobs:
     if: >-
       (github.event_name == 'pull_request_review' &&
        (github.event.review.state == 'approved' ||
-        (github.event.review.user.login == 'LLLLKKKK' &&
+        (contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.review.user.login) &&
          github.event.review.state == 'commented'))) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       github.event.comment.user.login == 'LLLLKKKK' &&
+       contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.comment.user.login) &&
        contains(github.event.comment.body, 'lgtm ready to ci'))
     runs-on: [self-hosted, Linux]
     steps:


### PR DESCRIPTION
## Summary

Grants `netaddi` the permissions needed to take over review/merge duties, and fixes two CI-gate bypasses found while reviewing that change.

**Permissions**
- Add `@netaddi` to `.github/CODEOWNERS` default owners (`*`), so his approval satisfies `require_code_owner_review`
- `ci_gate --lgtm-user` now accepts a comma-separated allowlist (default `LLLLKKKK,netaddi`); `CI-event-dispatcher.yml` filter updated to match

**Security fix 1 — outsiders could gate CI**
Any GitHub user can review a PR on a public repo. `check_review_qualified` only checked `state == APPROVED`, so a stranger's approval could trigger internal CI on arbitrary PR code (self-hosted runners), and a drive-by `CHANGES_REQUESTED` could block a PR's CI indefinitely. Fresh reviews are now filtered by `author_association`, accepting only `OWNER`/`MEMBER`/`COLLABORATOR`.

**Security fix 2 — LGTM comment freshness was forgeable**
The issue-comment path accepted a comment when `comment.updated_at >= head_commit.committer.date`. `committer.date` is git metadata chosen by the pusher (`GIT_COMMITTER_DATE=...`) and GitHub returns it verbatim, so a PR author could:
1. get a genuine `lgtm ready to ci` on clean code,
2. force-push malicious code with the committer date backdated before that comment,
3. have `synchronize` re-qualify via the stale comment → untrusted code runs on internal CI.

The comment must now name the head SHA (7+ hex prefix), binding it to reviewed code exactly as `review.commit_id` does. The forgeable date comparison and the now-unused `_fetch_head_commit_date` are removed.

**Also**: LGTM comments from the PR author never qualify (the review path already filtered author self-comments; the comment path did not).

### Reviewer-facing behavior change
Approving a PR is unchanged. Using the comment shortcut now requires the SHA:

```
lgtm ready to ci 1a2b3c4
```

## Test plan
- [x] `python3 -m unittest test_ci_gate` — 78 tests pass
- [x] New cases: untrusted `author_association` ignored; trusted kept; multi-user LGTM; author self-LGTM rejected; comment without SHA rejected; comment naming another SHA rejected; backdated-commit revival rejected
- [ ] After merge: netaddi approve triggers CI and satisfies code owner review
- [ ] After merge: an outside user's approve does NOT trigger CI