### PR TITLE
ci: harden review gate against untrusted CI triggers

### DIFF
--- a/.github/scripts/ci_gate/__main__.py
+++ b/.github/scripts/ci_gate/__main__.py
@@ -28,6 +28,8 @@ def main(argv):
     check_review.add_argument("--github-token", required=True)
     check_review.add_argument("--lgtm-user", default="LLLLKKKK,netaddi",
                               help="comma-separated logins allowed to LGTM")
+    check_review.add_argument("--run-id", default="",
+                              help="workflow run whose creation time anchors LGTM comments")
 
     resolve = subparsers.add_parser("resolve-context")
     resolve.add_argument("--github-token", required=True)
@@ -42,6 +44,8 @@ def main(argv):
     resolve.add_argument("--output-file", default="")
     resolve.add_argument("--lgtm-user", default="LLLLKKKK,netaddi",
                          help="comma-separated logins allowed to LGTM")
+    resolve.add_argument("--run-id", default="",
+                         help="workflow run whose creation time anchors LGTM comments")
 
     check_merge_parser = subparsers.add_parser("check-merge")
     check_merge_parser.add_argument("pr_number")
@@ -118,7 +122,8 @@ def main(argv):
     try:
         if args.command == "check-review":
             return 0 if check_review_qualified(
-                args.pr_number, args.repository, args.head_sha, args.github_token, args.lgtm_user
+                args.pr_number, args.repository, args.head_sha, args.github_token,
+                args.lgtm_user, args.run_id
             ) else 1
         if args.command == "resolve-context":
             return resolve_context(args)

--- a/.github/scripts/ci_gate/rerun.py
+++ b/.github/scripts/ci_gate/rerun.py
@@ -16,7 +16,7 @@ NO_RUN_COMMENT = (
     "or if the original run was deleted.\n\n"
     "**To fix:** push any commit (even empty: "
     "`git commit --allow-empty -m \"trigger CI\" && git push`) "
-    "to create a native build run, then re-approve or submit a review comment saying `lgtm ready to ci`."
+    "to create a native build run, then re-approve or post `lgtm ready to ci`."
 )
 
 EXPIRED_RUN_COMMENT = (
@@ -24,7 +24,7 @@ EXPIRED_RUN_COMMENT = (
     "but it is too old to rerun (>30 days).\n\n"
     "**To fix:** push any commit (even empty: "
     "`git commit --allow-empty -m \"trigger CI\" && git push`) "
-    "to create a fresh native build run, then re-approve or submit a review comment saying `lgtm ready to ci`."
+    "to create a fresh native build run, then re-approve or post `lgtm ready to ci`."
 )
 
 

--- a/.github/scripts/ci_gate/rerun.py
+++ b/.github/scripts/ci_gate/rerun.py
@@ -16,7 +16,7 @@ NO_RUN_COMMENT = (
     "or if the original run was deleted.\n\n"
     "**To fix:** push any commit (even empty: "
     "`git commit --allow-empty -m \"trigger CI\" && git push`) "
-    "to create a native build run, then re-approve or post `lgtm ready to ci`."
+    "to create a native build run, then re-approve or submit a review comment saying `lgtm ready to ci`."
 )
 
 EXPIRED_RUN_COMMENT = (
@@ -24,7 +24,7 @@ EXPIRED_RUN_COMMENT = (
     "but it is too old to rerun (>30 days).\n\n"
     "**To fix:** push any commit (even empty: "
     "`git commit --allow-empty -m \"trigger CI\" && git push`) "
-    "to create a fresh native build run, then re-approve or post `lgtm ready to ci`."
+    "to create a fresh native build run, then re-approve or submit a review comment saying `lgtm ready to ci`."
 )
 
 

--- a/.github/scripts/ci_gate/review.py
+++ b/.github/scripts/ci_gate/review.py
@@ -42,8 +42,72 @@ def parse_lgtm_users(lgtm_user):
     return {u.strip() for u in (lgtm_user or "").split(",") if u.strip()}
 
 
-def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
-    # type: (str, str, str, str, str) -> bool
+def _fetch_head_push_time(repo, run_id, github_token):
+    # type: (str, str, str) -> str
+    """Return when GitHub created *run_id*, i.e. when this HEAD was pushed.
+
+    Used as the freshness anchor for LGTM issue comments. A commit's
+    ``committer.date`` cannot be used: it is chosen by whoever pushes, so
+    backdating a commit would make an older LGTM look fresh again. A workflow
+    run's ``created_at`` is assigned by GitHub, is unchanged by reruns, and a
+    new run is created whenever a SHA is (re-)pushed as the PR head.
+    """
+    run = github_get(
+        repo, "/actions/runs/%s" % run_id,
+        "fetching workflow run %s" % run_id, github_token,
+    )
+    if not isinstance(run, dict):
+        raise GateError("::error::Unexpected workflow run response for %s" % run_id, 2)
+    return run.get("created_at") or ""
+
+
+def _check_issue_comments_qualified(pr_number, repo, github_token, lgtm_user, pr_author, run_id):
+    # type: (str, str, str, str, str, str) -> bool
+    """Check for an LGTM issue comment posted after the current HEAD was pushed.
+
+    Issue comments carry no ``commit_id``, so freshness is anchored on the
+    server-assigned creation time of this workflow run. Comments from the PR
+    author never qualify (no self-LGTM).
+    """
+    if not run_id:
+        log("No workflow run id available, skipping issue comment check")
+        return False
+
+    pushed_at = _fetch_head_push_time(repo, run_id, github_token)
+    if not pushed_at:
+        log("Could not determine head push time, skipping issue comment check")
+        return False
+
+    comments = github_get_pages(
+        repo, "/issues/%s/comments" % pr_number,
+        "fetching issue comments for PR #%s" % pr_number, github_token,
+    )
+
+    lgtm_users = parse_lgtm_users(lgtm_user)
+    lgtm_phrase = "lgtm ready to ci"
+    latest_match = None  # type: Any
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        user = (comment.get("user") or {}).get("login", "")
+        body = (comment.get("body") or "").lower()
+        updated_at = comment.get("updated_at", "")
+        if user in lgtm_users and user != pr_author and lgtm_phrase in body and updated_at >= pushed_at:
+            if latest_match is None or updated_at > (latest_match.get("updated_at") or ""):
+                latest_match = comment
+
+    if latest_match:
+        log("PR #%s has fresh LGTM issue comment from %s (updated_at: %s >= pushed: %s)"
+            % (pr_number, (latest_match.get("user") or {}).get("login", ""),
+               latest_match.get("updated_at", ""), pushed_at))
+        return True
+
+    log("PR #%s has no qualifying fresh issue comment" % pr_number)
+    return False
+
+
+def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user, run_id=""):
+    # type: (str, str, str, str, str, str) -> bool
     pr_data = github_get(repo, "/pulls/%s" % pr_number, "fetching PR #%s" % pr_number, github_token)
     if not isinstance(pr_data, dict):
         raise GateError("::error::Unexpected PR response for #%s" % pr_number, 2)
@@ -72,7 +136,10 @@ def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
             log("PR #%s has latest fresh LGTM from %s" % (pr_number, user))
             return True
 
-    log("PR #%s has no qualifying fresh review" % pr_number)
+    if _check_issue_comments_qualified(pr_number, repo, github_token, lgtm_user, pr_author, run_id):
+        return True
+
+    log("PR #%s has no qualifying fresh review or issue comment" % pr_number)
     return False
 
 
@@ -139,7 +206,11 @@ def resolve_context(args):
         write_output("qualified", "true", args.output_file)
         return 0
 
-    qualified = check_review_qualified(pr_number, repo, head_sha, args.github_token, args.lgtm_user)
+    # The LGTM-comment anchor is this run's creation time, which only matches
+    # the head push for the pull_request event; a dispatch run starts "now".
+    comment_anchor_run = "" if event_name == "workflow_dispatch" else args.run_id
+    qualified = check_review_qualified(
+        pr_number, repo, head_sha, args.github_token, args.lgtm_user, comment_anchor_run)
     write_output("qualified", "true" if qualified else "false", args.output_file)
     if not qualified:
         log("::error::No qualifying review — build check will report failure")

--- a/.github/scripts/ci_gate/review.py
+++ b/.github/scripts/ci_gate/review.py
@@ -7,6 +7,9 @@ from .common import GateError, is_true, log, short_sha, write_output
 from .github import github_get, github_get_pages
 
 
+TRUSTED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
 def latest_fresh_reviews(reviews, head_sha, pr_author):
     # type: (List[Dict[str, Any]], str, str) -> List[Dict[str, Any]]
     latest_by_user = {}  # type: Dict[str, Dict[str, Any]]
@@ -16,6 +19,12 @@ def latest_fresh_reviews(reviews, head_sha, pr_author):
         if review.get("commit_id") != head_sha:
             continue
         if user.get("type") == "Bot":
+            continue
+        # Anyone can review a public repo; only repo/org insiders may gate CI.
+        association = (review.get("author_association") or "").upper()
+        if association not in TRUSTED_ASSOCIATIONS:
+            log("Ignoring %s review from %s (association: %s)"
+                % (review.get("state", "?"), login, association or "NONE"))
             continue
         if review.get("state") == "COMMENTED" and login == pr_author:
             continue
@@ -27,63 +36,10 @@ def latest_fresh_reviews(reviews, head_sha, pr_author):
     return list(latest_by_user.values())
 
 
-def _fetch_head_commit_date(repo, head_sha, github_token):
-    # type: (str, str, str) -> str
-    """Return the committer date (ISO 8601) of the given commit."""
-    commit = github_get(
-        repo, "/commits/%s" % head_sha,
-        "fetching commit %s" % short_sha(head_sha), github_token,
-    )
-    if not isinstance(commit, dict):
-        raise GateError("::error::Unexpected commit response for %s" % short_sha(head_sha), 2)
-    return (((commit.get("commit") or {}).get("committer") or {}).get("date")) or ""
-
-
 def parse_lgtm_users(lgtm_user):
     # type: (str) -> set
     """Parse a comma-separated ``--lgtm-user`` value into a set of logins."""
     return {u.strip() for u in (lgtm_user or "").split(",") if u.strip()}
-
-
-def _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user, pr_author=""):
-    # type: (str, str, str, str, str, str) -> bool
-    """Check whether a fresh LGTM issue comment from an *lgtm_user* exists.
-
-    Freshness is defined as ``comment.updated_at >= head_commit.committer.date``
-    because issue comments have no ``commit_id`` field. Comments from the PR
-    author never qualify (no self-LGTM).
-    """
-    head_date = _fetch_head_commit_date(repo, head_sha, github_token)
-    if not head_date:
-        log("Could not determine head commit date, skipping issue comment check")
-        return False
-
-    comments = github_get_pages(
-        repo, "/issues/%s/comments" % pr_number,
-        "fetching issue comments for PR #%s" % pr_number, github_token,
-    )
-
-    lgtm_users = parse_lgtm_users(lgtm_user)
-    lgtm_phrase = "lgtm ready to ci"
-    latest_match = None  # type: Any
-    for comment in comments:
-        if not isinstance(comment, dict):
-            continue
-        user = (comment.get("user") or {}).get("login", "")
-        body = (comment.get("body") or "").lower()
-        updated_at = comment.get("updated_at", "")
-        if user in lgtm_users and user != pr_author and lgtm_phrase in body and updated_at >= head_date:
-            if latest_match is None or updated_at > (latest_match.get("updated_at") or ""):
-                latest_match = comment
-
-    if latest_match:
-        log("PR #%s has fresh LGTM issue comment from %s (updated_at: %s >= commit: %s)"
-            % (pr_number, (latest_match.get("user") or {}).get("login", ""),
-               latest_match.get("updated_at", ""), head_date))
-        return True
-
-    log("PR #%s has no qualifying fresh issue comment" % pr_number)
-    return False
 
 
 def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
@@ -116,10 +72,7 @@ def check_review_qualified(pr_number, repo, head_sha, github_token, lgtm_user):
             log("PR #%s has latest fresh LGTM from %s" % (pr_number, user))
             return True
 
-    if _check_issue_comments_qualified(pr_number, repo, head_sha, github_token, lgtm_user, pr_author):
-        return True
-
-    log("PR #%s has no qualifying fresh review or issue comment" % pr_number)
+    log("PR #%s has no qualifying fresh review" % pr_number)
     return False
 
 

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 from ci_gate.common import GateError, is_true
 from ci_gate.ci_service import collect_status_tokens, parse_ci_status
 from ci_gate.review import (
+    _check_issue_comments_qualified,
     check_review_qualified,
     latest_fresh_reviews,
     resolve_context,
@@ -267,13 +268,75 @@ class TestCheckReviewQualified(unittest.TestCase):
 
     @patch("ci_gate.review.github_get_pages")
     @patch("ci_gate.review.github_get")
-    def test_only_reviews_are_consulted(self, mock_get, mock_pages):
-        """Issue comments cannot gate CI, so only /reviews is fetched."""
+    def test_no_run_id_skips_comment_path(self, mock_get, mock_pages):
+        """Without a run id there is no trustworthy anchor, so comments are skipped."""
         mock_get.return_value = self._mock_pr()
         mock_pages.return_value = []
         self.assertFalse(check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK"))
         paths = [call.args[1] for call in mock_pages.call_args_list]
         self.assertEqual(paths, ["/pulls/1/reviews"])
+
+
+# ---------------------------------------------------------------------------
+# review._check_issue_comments_qualified (mocked)
+# ---------------------------------------------------------------------------
+class TestCheckIssueCommentsQualified(unittest.TestCase):
+    PUSHED_AT = "2025-04-20T10:00:00Z"
+    RUN_RESPONSE = {"created_at": PUSHED_AT}
+
+    def _comment(self, login="LLLLKKKK", body="lgtm ready to ci", updated_at="2025-04-20T12:00:00Z"):
+        return {"user": {"login": login}, "body": body, "updated_at": updated_at}
+
+    def _check(self, comments, lgtm_user="LLLLKKKK", pr_author="", run_id="42",
+               run_response=None):
+        with patch("ci_gate.review.github_get",
+                   return_value=self.RUN_RESPONSE if run_response is None else run_response), \
+             patch("ci_gate.review.github_get_pages", return_value=comments):
+            return _check_issue_comments_qualified(
+                "1", "repo", "token", lgtm_user, pr_author, run_id)
+
+    def test_comment_after_push_qualifies(self):
+        self.assertTrue(self._check([self._comment()]))
+
+    def test_comment_before_push_rejected(self):
+        self.assertFalse(self._check([self._comment(updated_at="2025-04-20T09:00:00Z")]))
+
+    def test_backdated_commit_cannot_revive_stale_comment(self):
+        """The anchor is the run creation time, so commit dates cannot shift it."""
+        stale = self._comment(updated_at="2025-04-20T09:59:59Z")
+        self.assertFalse(self._check([stale]))
+
+    def test_wrong_author_rejected(self):
+        self.assertFalse(self._check([self._comment(login="other-user")]))
+
+    def test_missing_phrase_rejected(self):
+        self.assertFalse(self._check([self._comment(body="looks good")]))
+
+    def test_no_comments(self):
+        self.assertFalse(self._check([]))
+
+    def test_case_insensitive_phrase(self):
+        self.assertTrue(self._check([self._comment(body="LGTM Ready To CI")]))
+
+    def test_picks_latest_matching_comment(self):
+        comments = [
+            self._comment(updated_at="2025-04-20T11:00:00Z"),
+            self._comment(updated_at="2025-04-20T14:00:00Z"),
+        ]
+        self.assertTrue(self._check(comments))
+
+    def test_multi_lgtm_users_second_user_qualifies(self):
+        self.assertTrue(self._check([self._comment(login="netaddi")], lgtm_user="LLLLKKKK,netaddi"))
+
+    def test_pr_author_self_lgtm_rejected(self):
+        self.assertFalse(self._check(
+            [self._comment(login="netaddi")], lgtm_user="LLLLKKKK,netaddi", pr_author="netaddi"))
+
+    def test_missing_run_id_rejected(self):
+        self.assertFalse(self._check([self._comment()], run_id=""))
+
+    def test_run_without_created_at_rejected(self):
+        self.assertFalse(self._check([self._comment()], run_response={}))
 
 
 
@@ -296,6 +359,7 @@ class TestResolveContextIssueComment(unittest.TestCase):
             "event_pr_number": "42",
             "event_clone_url": "",
             "lgtm_user": "LLLLKKKK",
+            "run_id": "",
             "output_file": "",
         }
         defaults.update(overrides)
@@ -318,7 +382,7 @@ class TestResolveContextIssueComment(unittest.TestCase):
         self.assertIn("head_sha=abc111", contents)
         self.assertIn("clone_url=https://github.com/org/repo.git", contents)
         self.assertIn("qualified=true", contents)
-        mock_qualified.assert_called_once_with("42", "org/repo", "abc111", "tok", "LLLLKKKK")
+        mock_qualified.assert_called_once_with("42", "org/repo", "abc111", "tok", "LLLLKKKK", "")
 
     @patch("ci_gate.review.check_review_qualified")
     @patch("ci_gate.review.github_get")
@@ -356,6 +420,7 @@ class TestResolveContext(unittest.TestCase):
             "event_pr_number": "42",
             "event_clone_url": "https://github.com/org/repo.git",
             "lgtm_user": "LLLLKKKK",
+            "run_id": "",
             "output_file": "/dev/null",
         }
         defaults.update(overrides)
@@ -389,6 +454,34 @@ class TestResolveContext(unittest.TestCase):
         ]
         result = resolve_context(self._base_args())
         self.assertEqual(result, 0)
+
+    @patch("ci_gate.review.check_review_qualified")
+    @patch("ci_gate.review.github_get")
+    def test_run_id_forwarded_for_pull_request(self, mock_get, mock_qualified):
+        """pull_request runs are created at push time, so their id anchors comments."""
+        mock_get.return_value = {
+            "user": {"login": "author"},
+            "head": {"sha": "aaa111", "repo": {"clone_url": "url"}},
+            "state": "open",
+        }
+        mock_qualified.return_value = True
+        resolve_context(self._base_args(run_id="999"))
+        self.assertEqual(mock_qualified.call_args.args[-1], "999")
+
+    @patch("ci_gate.review.check_review_qualified")
+    @patch("ci_gate.review.github_get")
+    def test_run_id_dropped_for_workflow_dispatch(self, mock_get, mock_qualified):
+        """A dispatch run starts now, so it must not anchor LGTM comments."""
+        mock_get.return_value = {
+            "user": {"login": "author"},
+            "head": {"sha": "aaa111", "repo": {"clone_url": "url"}},
+            "state": "open",
+        }
+        mock_qualified.return_value = True
+        resolve_context(self._base_args(
+            event_name="workflow_dispatch", input_pr_number="42",
+            input_head_sha="aaa111", run_id="999"))
+        self.assertEqual(mock_qualified.call_args.args[-1], "")
 
     @patch("ci_gate.review.github_get")
     def test_head_changed_returns_1(self, mock_get):

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -11,8 +11,6 @@ from unittest.mock import MagicMock, patch
 from ci_gate.common import GateError, is_true
 from ci_gate.ci_service import collect_status_tokens, parse_ci_status
 from ci_gate.review import (
-    _check_issue_comments_qualified,
-    _fetch_head_commit_date,
     check_review_qualified,
     latest_fresh_reviews,
     resolve_context,
@@ -152,13 +150,15 @@ class TestParseCiStatus(unittest.TestCase):
 # review.latest_fresh_reviews
 # ---------------------------------------------------------------------------
 class TestLatestFreshReviews(unittest.TestCase):
-    def _review(self, login, state, commit_id="abc123", user_type="User", review_id=1, body=""):
+    def _review(self, login, state, commit_id="abc123", user_type="User", review_id=1, body="",
+                association="MEMBER"):
         return {
             "id": review_id,
             "user": {"login": login, "type": user_type},
             "state": state,
             "commit_id": commit_id,
             "body": body,
+            "author_association": association,
         }
 
     def test_filters_wrong_commit(self):
@@ -170,6 +170,25 @@ class TestLatestFreshReviews(unittest.TestCase):
         reviews = [self._review("bot", "APPROVED", user_type="Bot")]
         result = latest_fresh_reviews(reviews, "abc123", "author")
         self.assertEqual(result, [])
+
+    def test_filters_untrusted_association(self):
+        reviews = [
+            self._review("stranger", "APPROVED", association="NONE"),
+            self._review("drive-by", "CHANGES_REQUESTED", association="FIRST_TIME_CONTRIBUTOR", review_id=2),
+            self._review("forker", "APPROVED", association="CONTRIBUTOR", review_id=3),
+            self._review("no-assoc", "APPROVED", association="", review_id=4),
+        ]
+        result = latest_fresh_reviews(reviews, "abc123", "author")
+        self.assertEqual(result, [])
+
+    def test_keeps_trusted_associations(self):
+        reviews = [
+            self._review("owner", "APPROVED", association="OWNER", review_id=1),
+            self._review("member", "APPROVED", association="MEMBER", review_id=2),
+            self._review("collab", "APPROVED", association="COLLABORATOR", review_id=3),
+        ]
+        result = latest_fresh_reviews(reviews, "abc123", "author")
+        self.assertEqual(len(result), 3)
 
     def test_filters_author_comment(self):
         reviews = [self._review("author", "COMMENTED")]
@@ -210,7 +229,7 @@ class TestCheckReviewQualified(unittest.TestCase):
         mock_get.return_value = self._mock_pr()
         mock_pages.return_value = [
             {"id": 1, "user": {"login": "reviewer", "type": "User"},
-             "state": "APPROVED", "commit_id": "sha1", "body": ""}
+             "state": "APPROVED", "commit_id": "sha1", "body": "", "author_association": "MEMBER"}
         ]
         result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertTrue(result)
@@ -221,7 +240,7 @@ class TestCheckReviewQualified(unittest.TestCase):
         mock_get.return_value = self._mock_pr()
         mock_pages.return_value = [
             {"id": 1, "user": {"login": "reviewer", "type": "User"},
-             "state": "CHANGES_REQUESTED", "commit_id": "sha1", "body": ""}
+             "state": "CHANGES_REQUESTED", "commit_id": "sha1", "body": "", "author_association": "MEMBER"}
         ]
         result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertFalse(result)
@@ -233,7 +252,7 @@ class TestCheckReviewQualified(unittest.TestCase):
         mock_pages.return_value = [
             {"id": 1, "user": {"login": "LLLLKKKK", "type": "User"},
              "state": "COMMENTED", "commit_id": "sha1",
-             "body": "lgtm ready to ci please"}
+             "body": "lgtm ready to ci please", "author_association": "MEMBER"}
         ]
         result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertTrue(result)
@@ -246,138 +265,16 @@ class TestCheckReviewQualified(unittest.TestCase):
         result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
         self.assertFalse(result)
 
-
-# ---------------------------------------------------------------------------
-# review._check_issue_comments_qualified (mocked)
-# ---------------------------------------------------------------------------
-class TestCheckIssueCommentsQualified(unittest.TestCase):
-    COMMIT_DATE = "2025-04-20T10:00:00Z"
-    COMMIT_RESPONSE = {
-        "commit": {"committer": {"date": COMMIT_DATE}},
-    }
-
-    def _comment(self, login="LLLLKKKK", body="lgtm ready to ci", updated_at="2025-04-20T12:00:00Z"):
-        return {"user": {"login": login}, "body": body, "updated_at": updated_at}
-
     @patch("ci_gate.review.github_get_pages")
     @patch("ci_gate.review.github_get")
-    def test_fresh_lgtm_qualifies(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment()]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertTrue(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_stale_comment_rejected(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(updated_at="2025-04-19T09:00:00Z")]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertFalse(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_wrong_author_rejected(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(login="other-user")]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertFalse(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_missing_phrase_rejected(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(body="looks good")]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertFalse(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_no_comments(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
+    def test_only_reviews_are_consulted(self, mock_get, mock_pages):
+        """Issue comments cannot gate CI, so only /reviews is fetched."""
+        mock_get.return_value = self._mock_pr()
         mock_pages.return_value = []
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertFalse(result)
+        self.assertFalse(check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK"))
+        paths = [call.args[1] for call in mock_pages.call_args_list]
+        self.assertEqual(paths, ["/pulls/1/reviews"])
 
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_case_insensitive_phrase(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(body="LGTM Ready To CI")]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertTrue(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_picks_latest_matching_comment(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [
-            self._comment(updated_at="2025-04-20T11:00:00Z"),
-            self._comment(updated_at="2025-04-20T14:00:00Z"),
-        ]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertTrue(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_multi_lgtm_users_second_user_qualifies(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(login="netaddi")]
-        result = _check_issue_comments_qualified("1", "repo", "sha1", "token", "LLLLKKKK,netaddi")
-        self.assertTrue(result)
-
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_pr_author_self_lgtm_rejected(self, mock_get, mock_pages):
-        mock_get.return_value = self.COMMIT_RESPONSE
-        mock_pages.return_value = [self._comment(login="netaddi")]
-        result = _check_issue_comments_qualified(
-            "1", "repo", "sha1", "token", "LLLLKKKK,netaddi", pr_author="netaddi")
-        self.assertFalse(result)
-
-
-# ---------------------------------------------------------------------------
-# review.check_review_qualified — issue comment fallback
-# ---------------------------------------------------------------------------
-class TestCheckReviewQualifiedWithIssueComments(unittest.TestCase):
-    """Verify that check_review_qualified falls back to issue comments."""
-
-    @patch("ci_gate.review._check_issue_comments_qualified")
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_no_reviews_falls_back_to_issue_comments(self, mock_get, mock_pages, mock_issue):
-        mock_get.return_value = {"user": {"login": "author"}}
-        mock_pages.return_value = []
-        mock_issue.return_value = True
-        result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertTrue(result)
-        mock_issue.assert_called_once_with("1", "repo", "sha1", "token", "LLLLKKKK", "author")
-
-    @patch("ci_gate.review._check_issue_comments_qualified")
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_approved_review_skips_issue_comments(self, mock_get, mock_pages, mock_issue):
-        mock_get.return_value = {"user": {"login": "author"}}
-        mock_pages.return_value = [
-            {"id": 1, "user": {"login": "rev", "type": "User"},
-             "state": "APPROVED", "commit_id": "sha1", "body": ""}
-        ]
-        result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertTrue(result)
-        mock_issue.assert_not_called()
-
-    @patch("ci_gate.review._check_issue_comments_qualified")
-    @patch("ci_gate.review.github_get_pages")
-    @patch("ci_gate.review.github_get")
-    def test_changes_requested_blocks_even_with_issue_comment(self, mock_get, mock_pages, mock_issue):
-        mock_get.return_value = {"user": {"login": "author"}}
-        mock_pages.return_value = [
-            {"id": 1, "user": {"login": "rev", "type": "User"},
-             "state": "CHANGES_REQUESTED", "commit_id": "sha1", "body": ""}
-        ]
-        result = check_review_qualified("1", "repo", "sha1", "token", "LLLLKKKK")
-        self.assertFalse(result)
-        mock_issue.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -488,7 +385,7 @@ class TestResolveContext(unittest.TestCase):
         }
         mock_pages.return_value = [
             {"id": 1, "user": {"login": "rev", "type": "User"},
-             "state": "APPROVED", "commit_id": "aaa111", "body": ""}
+             "state": "APPROVED", "commit_id": "aaa111", "body": "", "author_association": "MEMBER"}
         ]
         result = resolve_context(self._base_args())
         self.assertEqual(result, 0)

--- a/.github/workflows/CI-event-dispatcher.yml
+++ b/.github/workflows/CI-event-dispatcher.yml
@@ -9,10 +9,10 @@
 # │   → has LGTM → pre-check / trigger / wait internal CI           │
 # │   → CI pass → build check = success → PR mergeable              │
 # │                                                                 │
-# │ LGTM review (this workflow)                                     │
+# │ LGTM review/comment (this workflow)                             │
 # │   → filter: approved review, or LGTM user "lgtm ready to ci"    │
-# │   → reviews only; issue comments cannot gate CI because they    │
-# │     carry no commit_id to pin them to the reviewed code         │
+# │   → reviews are pinned to HEAD by commit_id; LGTM comments are   │
+# │     pinned by requiring them to post-date the head push          │
 # │   → resolve PR number and HEAD SHA from event                   │
 # │   → find existing CI-request-trigger.yml pull_request run       │
 # │     for this HEAD SHA                                           │
@@ -35,24 +35,46 @@ on:
   pull_request_review:
     types: [submitted]
     branches: ["main"]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   actions: write
   pull-requests: write
+  issues: read
 
 jobs:
   dispatch:
     if: >-
-      github.event.review.state == 'approved' ||
-      (contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.review.user.login) &&
-       github.event.review.state == 'commented')
+      (github.event_name == 'pull_request_review' &&
+       (github.event.review.state == 'approved' ||
+        (contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.review.user.login) &&
+         github.event.review.state == 'commented'))) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.comment.user.login) &&
+       contains(github.event.comment.body, 'lgtm ready to ci'))
     runs-on: [self-hosted, Linux]
     steps:
       - name: Resolve PR context
         id: ctx
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request_review" ]; then
+            PR_NUMBER="$REVIEW_PR_NUMBER"
+            HEAD_SHA="$REVIEW_HEAD_SHA"
+          else
+            PR_NUMBER="$COMMENT_PR_NUMBER"
+            HEAD_SHA=$(curl -sf -H "Authorization: token ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
+              | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
+          fi
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
           echo "Dispatching CI for PR #${PR_NUMBER} @ ${HEAD_SHA:0:8}"

--- a/.github/workflows/CI-event-dispatcher.yml
+++ b/.github/workflows/CI-event-dispatcher.yml
@@ -9,8 +9,10 @@
 # │   → has LGTM → pre-check / trigger / wait internal CI           │
 # │   → CI pass → build check = success → PR mergeable              │
 # │                                                                 │
-# │ LGTM review/comment (this workflow)                             │
-# │   → filter: only approved review or LLLLKKKK "lgtm ready to ci"│
+# │ LGTM review (this workflow)                                     │
+# │   → filter: approved review, or LGTM user "lgtm ready to ci"    │
+# │   → reviews only; issue comments cannot gate CI because they    │
+# │     carry no commit_id to pin them to the reviewed code         │
 # │   → resolve PR number and HEAD SHA from event                   │
 # │   → find existing CI-request-trigger.yml pull_request run       │
 # │     for this HEAD SHA                                           │
@@ -33,41 +35,24 @@ on:
   pull_request_review:
     types: [submitted]
     branches: ["main"]
-  issue_comment:
-    types: [created, edited]
 
 permissions:
   actions: write
   pull-requests: write
-  issues: read
 
 jobs:
   dispatch:
     if: >-
-      (github.event_name == 'pull_request_review' &&
-       (github.event.review.state == 'approved' ||
-        (contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.review.user.login) &&
-         github.event.review.state == 'commented'))) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.comment.user.login) &&
-       contains(github.event.comment.body, 'lgtm ready to ci'))
+      github.event.review.state == 'approved' ||
+      (contains(fromJSON('["LLLLKKKK", "netaddi"]'), github.event.review.user.login) &&
+       github.event.review.state == 'commented')
     runs-on: [self-hosted, Linux]
     steps:
       - name: Resolve PR context
         id: ctx
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_review" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            PR_NUMBER="${{ github.event.issue.number }}"
-            HEAD_SHA=$(curl -sf -H "Authorization: token ${GITHUB_TOKEN}" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
-              | python3 -c "import sys,json; print(json.load(sys.stdin)['head']['sha'])")
-          fi
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
           echo "Dispatching CI for PR #${PR_NUMBER} @ ${HEAD_SHA:0:8}"

--- a/.github/workflows/CI-request-trigger.yml
+++ b/.github/workflows/CI-request-trigger.yml
@@ -3,7 +3,7 @@
 # │                                                                 │
 # │ pull_request (opened/synchronize/reopened) — this workflow      │
 # │   → native "build" check run created on PR HEAD SHA             │
-# │   → resolve-context: check for fresh LGTM review/comment       │
+# │   → resolve-context: check for fresh LGTM review               │
 # │   → no fresh LGTM                                              │
 # │       → resolve-context exit 1                                  │
 # │       → build check = failure (blocks merge)                    │
@@ -15,7 +15,7 @@
 # │       → CI pass → build check = success → PR mergeable          │
 # │       → CI fail → build check = failure                         │
 # │                                                                 │
-# │ LGTM review/comment                                            │
+# │ LGTM review                                                    │
 # │   → CI-event-dispatcher.yml handles this event                  │
 # │   → finds this workflow's pull_request run for PR HEAD SHA      │
 # │   → reruns it (POST .../actions/runs/{id}/rerun)                │

--- a/.github/workflows/CI-request-trigger.yml
+++ b/.github/workflows/CI-request-trigger.yml
@@ -3,7 +3,7 @@
 # │                                                                 │
 # │ pull_request (opened/synchronize/reopened) — this workflow      │
 # │   → native "build" check run created on PR HEAD SHA             │
-# │   → resolve-context: check for fresh LGTM review               │
+# │   → resolve-context: check for fresh LGTM review/comment       │
 # │   → no fresh LGTM                                              │
 # │       → resolve-context exit 1                                  │
 # │       → build check = failure (blocks merge)                    │
@@ -15,7 +15,7 @@
 # │       → CI pass → build check = success → PR mergeable          │
 # │       → CI fail → build check = failure                         │
 # │                                                                 │
-# │ LGTM review                                                    │
+# │ LGTM review/comment                                            │
 # │   → CI-event-dispatcher.yml handles this event                  │
 # │   → finds this workflow's pull_request run for PR HEAD SHA      │
 # │   → reruns it (POST .../actions/runs/{id}/rerun)                │
@@ -53,6 +53,7 @@ permissions:
   pull-requests: read
   contents: read
   statuses: write
+  actions: read
 
 concurrency:
   group: >-
@@ -110,6 +111,7 @@ jobs:
             --event-head-sha "${{ github.event.pull_request.head.sha }}" \
             --event-pr-number "${{ github.event.pull_request.number }}" \
             --event-clone-url "${{ github.event.pull_request.head.repo.clone_url }}" \
+            --run-id "${{ github.run_id }}" \
             --output-file "$GITHUB_OUTPUT"
 
       - name: Set pending commit status


### PR DESCRIPTION
## Summary

Fixes two ways to trigger internal CI on self-hosted runners without a legitimate insider review. Both predate the recent gate work; they were found while reviewing #1287. **The `lgtm ready to ci` comment shortcut is preserved** — only its freshness anchor changes.

### 1. Outsiders could gate CI

Anyone can submit a review on a public repo. `check_review_qualified` only checked `state == APPROVED`, so:

- a stranger's approval could trigger internal CI on arbitrary PR code (**untrusted code on self-hosted runners**), and
- a drive-by `CHANGES_REQUESTED` from a non-member could block a PR's CI indefinitely.

Fresh reviews are now filtered by `author_association`, accepting only `OWNER` / `MEMBER` / `COLLABORATOR`. The field ships with each review, so no extra API call.

### 2. LGTM comment freshness was forgeable

The issue-comment path accepted a comment when `comment.updated_at >= head_commit.committer.date`. `committer.date` is git metadata chosen by whoever pushes (`GIT_COMMITTER_DATE=...`, returned verbatim by the API), so a PR author could:

1. get a genuine `lgtm ready to ci` on clean code,
2. force-push malicious code with the committer date backdated before that comment,
3. have `synchronize` re-qualify via the stale comment.

The anchor is now the `created_at` of the `pull_request` workflow run for the current head. GitHub assigns it, reruns do not change it, and re-pushing a SHA as the head creates a new run — so a stale LGTM cannot be revived by backdating. The anchor is dropped for `workflow_dispatch`, whose run starts when dispatched rather than when the head was pushed; that path already has `skip_review_check` for maintainer override.

Requires `actions: read` on `CI-request-trigger.yml` and threads `--run-id ${{ github.run_id }}` into `resolve-context`.

## Behavior

Unchanged for reviewers — approve, a review comment, or a conversation comment saying `lgtm ready to ci` all still gate CI:

```bash
gh pr review N --approve                          # triggers CI + counts as approval
gh pr comment N -b "lgtm ready to ci"             # triggers CI only
```

What changes: an outsider's approve no longer triggers CI, an outsider's `CHANGES_REQUESTED` no longer blocks it, and an LGTM comment predating the current head no longer counts (post it again after a push — which you would do anyway, since `dismiss_stale_reviews_on_push` already invalidates approvals).

To re-run CI after an infra flake, rerun the failed `CI Request Trigger` run (`gh run rerun <id>`); the sign-off is still fresh for that head and `pre_check_status` re-triggers on `FAILED`.

## Test plan
- [x] `python3 -m unittest test_ci_gate` — 77 tests pass
- [x] Untrusted associations (`NONE`/`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/empty) ignored; trusted kept
- [x] Comment before the head push rejected, after it accepted; missing run id or missing `created_at` fails closed
- [x] `run_id` forwarded for `pull_request`, dropped for `workflow_dispatch`
- [x] Both workflow YAMLs parse; dispatcher still triggers on `pull_request_review` + `issue_comment`
- [ ] After merge: outsider approve does NOT trigger CI; insider approve does; `lgtm ready to ci` comment still works