### PR TITLE
perf(rocm): tune batch copy

### DIFF
--- a/rtp_llm/cpp/testing/BUILD
+++ b/rtp_llm/cpp/testing/BUILD
@@ -64,6 +64,7 @@ cc_library(
 cc_library(
     name = "base_tests",
     hdrs = [
+        "BatchCopyTest.hpp",
         "BeamSearchOpTest.hpp",
     ],
     deps = [

--- a/rtp_llm/cpp/testing/BatchCopyTest.hpp
+++ b/rtp_llm/cpp/testing/BatchCopyTest.hpp
@@ -1,0 +1,209 @@
+#pragma once
+
+#include "rtp_llm/cpp/testing/TestBase.h"
+#include <numeric>
+#include <random>
+#include <vector>
+
+using namespace std;
+using namespace rtp_llm;
+
+class BatchCopyTest: public DeviceTestBase {
+public:
+    void SetUp() override {
+        DeviceTestBase::SetUp();
+    }
+
+protected:
+    torch::Tensor createDeviceTensorWithData(size_t num_floats, float start_val) {
+        vector<float> data(num_floats);
+        iota(data.begin(), data.end(), start_val);
+        return createDeviceTensor<float>({static_cast<int64_t>(num_floats)}, data);
+    }
+
+    torch::Tensor createEmptyDeviceTensor(size_t num_floats) {
+        return createDeviceTensor({static_cast<int64_t>(num_floats)}, torch::kFloat32);
+    }
+
+    torch::Tensor createHostTensorWithData(size_t num_floats, float start_val) {
+        vector<float> data(num_floats);
+        iota(data.begin(), data.end(), start_val);
+        return createHostTensor<float>({static_cast<int64_t>(num_floats)}, data);
+    }
+
+    torch::Tensor createEmptyHostTensor(size_t num_floats) {
+        return torch::empty({static_cast<int64_t>(num_floats)}, torch::kFloat32);
+    }
+
+    void addTensorCopy(BatchCopyParams& params, const torch::Tensor& dst, const torch::Tensor& src) {
+        params.add(dst.data_ptr(),
+                   src.data_ptr(),
+                   dst.nbytes(),
+                   BatchCopyParams::get_copy_type(torchDeviceToMemoryType(dst.device()),
+                                                  torchDeviceToMemoryType(src.device())));
+    }
+
+    void runBatchCopy(BatchCopyParams& params) {
+        execBatchCopy(params);
+        runtimeSyncAndCheck();
+    }
+
+    vector<float> readBack(const torch::Tensor& tensor) {
+        return getTensorValues<float>(tensor);
+    }
+
+    // ---- D2D tests ----
+
+    void testD2DSingleCopy() {
+        const size_t n   = 64;
+        auto         src = createDeviceTensorWithData(n, 1.0f);
+        auto         dst = createEmptyDeviceTensor(n);
+
+        BatchCopyParams params;
+        addTensorCopy(params, dst, src);
+        runBatchCopy(params);
+
+        auto result = readBack(dst);
+        for (size_t i = 0; i < n; i++) {
+            EXPECT_FLOAT_EQ(result[i], static_cast<float>(i + 1));
+        }
+    }
+
+    void testD2DMultipleCopies() {
+        const size_t n1 = 32, n2 = 128, n3 = 17;
+        auto         src1 = createDeviceTensorWithData(n1, 0.0f);
+        auto         src2 = createDeviceTensorWithData(n2, 100.0f);
+        auto         src3 = createDeviceTensorWithData(n3, 500.0f);
+
+        auto dst1 = createEmptyDeviceTensor(n1);
+        auto dst2 = createEmptyDeviceTensor(n2);
+        auto dst3 = createEmptyDeviceTensor(n3);
+
+        BatchCopyParams params;
+        addTensorCopy(params, dst1, src1);
+        addTensorCopy(params, dst2, src2);
+        addTensorCopy(params, dst3, src3);
+        runBatchCopy(params);
+
+        auto r1 = readBack(dst1);
+        auto r2 = readBack(dst2);
+        auto r3 = readBack(dst3);
+
+        for (size_t i = 0; i < n1; i++)
+            EXPECT_FLOAT_EQ(r1[i], static_cast<float>(i));
+        for (size_t i = 0; i < n2; i++)
+            EXPECT_FLOAT_EQ(r2[i], static_cast<float>(i + 100));
+        for (size_t i = 0; i < n3; i++)
+            EXPECT_FLOAT_EQ(r3[i], static_cast<float>(i + 500));
+    }
+
+    void testD2DUniformSizes() {
+        // All copies have the same size; exercises the row-aligned kernel path.
+        const size_t copy_size  = 256;
+        const int    num_copies = 16;
+
+        vector<torch::Tensor> srcs, dsts;
+        for (int i = 0; i < num_copies; i++) {
+            srcs.push_back(createDeviceTensorWithData(copy_size, static_cast<float>(i * 1000)));
+            dsts.push_back(createEmptyDeviceTensor(copy_size));
+        }
+
+        BatchCopyParams params;
+        for (int i = 0; i < num_copies; i++) {
+            addTensorCopy(params, dsts[i], srcs[i]);
+        }
+        runBatchCopy(params);
+
+        for (int i = 0; i < num_copies; i++) {
+            auto result = readBack(dsts[i]);
+            for (size_t j = 0; j < copy_size; j++) {
+                EXPECT_FLOAT_EQ(result[j], static_cast<float>(i * 1000 + j));
+            }
+        }
+    }
+
+    void testD2DVariableSizes() {
+        // Different sizes per copy; exercises the variable-size kernel path.
+        vector<size_t> sizes = {1, 7, 33, 64, 127, 256, 513, 1024};
+
+        vector<torch::Tensor> srcs, dsts;
+        for (size_t i = 0; i < sizes.size(); i++) {
+            srcs.push_back(createDeviceTensorWithData(sizes[i], static_cast<float>(i * 10000)));
+            dsts.push_back(createEmptyDeviceTensor(sizes[i]));
+        }
+
+        BatchCopyParams params;
+        for (size_t i = 0; i < sizes.size(); i++) {
+            addTensorCopy(params, dsts[i], srcs[i]);
+        }
+        runBatchCopy(params);
+
+        for (size_t i = 0; i < sizes.size(); i++) {
+            auto result = readBack(dsts[i]);
+            ASSERT_EQ(result.size(), sizes[i]);
+            for (size_t j = 0; j < sizes[i]; j++) {
+                EXPECT_FLOAT_EQ(result[j], static_cast<float>(i * 10000 + j));
+            }
+        }
+    }
+
+    void testD2DLargeBatch() {
+        // Stress test with many small copies
+        const int    num_copies = 256;
+        const size_t elem_count = 16;
+
+        vector<torch::Tensor> srcs, dsts;
+        for (int i = 0; i < num_copies; i++) {
+            srcs.push_back(createDeviceTensorWithData(elem_count, static_cast<float>(i)));
+            dsts.push_back(createEmptyDeviceTensor(elem_count));
+        }
+
+        BatchCopyParams params;
+        for (int i = 0; i < num_copies; i++) {
+            addTensorCopy(params, dsts[i], srcs[i]);
+        }
+        runBatchCopy(params);
+
+        for (int i = 0; i < num_copies; i++) {
+            auto result = readBack(dsts[i]);
+            for (size_t j = 0; j < elem_count; j++) {
+                EXPECT_FLOAT_EQ(result[j], static_cast<float>(i + j));
+            }
+        }
+    }
+
+    void testD2DWithH2DAndD2H() {
+        // Mixed copy types in a single batchCopy call
+        const size_t n          = 64;
+        auto         device_src = createDeviceTensorWithData(n, 0.0f);
+        auto         device_dst = createEmptyDeviceTensor(n);
+
+        // Also add a D2H copy
+        auto host_dst = createEmptyHostTensor(n);
+
+        // And an H2D copy
+        auto host_src    = createHostTensorWithData(n, 2000.0f);
+        auto device_dst2 = createEmptyDeviceTensor(n);
+
+        BatchCopyParams params;
+        addTensorCopy(params, device_dst, device_src);  // D2D
+        addTensorCopy(params, host_dst, device_src);    // D2H
+        addTensorCopy(params, device_dst2, host_src);   // H2D
+        runBatchCopy(params);
+
+        // Verify D2D
+        auto r1 = readBack(device_dst);
+        for (size_t i = 0; i < n; i++)
+            EXPECT_FLOAT_EQ(r1[i], static_cast<float>(i));
+
+        // Verify D2H
+        auto* h = host_dst.data_ptr<float>();
+        for (size_t i = 0; i < n; i++)
+            EXPECT_FLOAT_EQ(h[i], static_cast<float>(i));
+
+        // Verify H2D
+        auto r2 = readBack(device_dst2);
+        for (size_t i = 0; i < n; i++)
+            EXPECT_FLOAT_EQ(r2[i], static_cast<float>(i + 2000));
+    }
+};

--- a/rtp_llm/models_py/bindings/common/kernels/batch_copy.cu
+++ b/rtp_llm/models_py/bindings/common/kernels/batch_copy.cu
@@ -30,9 +30,14 @@ static inline int getMultiProcessorCount() {
     return nSM;
 }
 
+#if USING_CUDA
 static constexpr size_t WARP_SIZE = 32;
-static constexpr size_t SEG_SIZE  = WARP_SIZE * sizeof(uint4);
-using CopyUnit                    = uint4;
+#elif USING_ROCM
+static constexpr size_t WARP_SIZE = 64;
+#endif
+
+static constexpr size_t SEG_SIZE = WARP_SIZE * sizeof(uint4);
+using CopyUnit                   = uint4;
 
 template<bool NeedsCleanup>
 __global__ void
@@ -166,13 +171,53 @@ static __global__ void batchCopy(char* __restrict__ const* __restrict__ dst,
                     }
 #if USING_CUDA
                     __syncwarp();
-#elif USING_ROCM
-                    __syncthreads();
 #endif
                 }
             }
         }
     };
+}
+
+// Block-per-entry kernel for variable-size copies.
+// Each block handles exactly one copy entry; threads within the block
+// cooperate to copy that entry's data using uint4 loads/stores.
+// This avoids the warp-scheduler while-loop overhead of the original kernel.
+template<bool IsAligned>
+static __global__ void batchCopyBlockPerEntry(char* __restrict__ const* __restrict__ dst,
+                                              char const* __restrict__ const* __restrict__ src,
+                                              size_t* __restrict__ bytes,
+                                              size_t batch_size) {
+    const size_t batch_idx = blockIdx.x;
+    if (batch_idx >= batch_size) {
+        return;
+    }
+
+    const size_t cur_bytes           = bytes[batch_idx];
+    const char* __restrict__ cur_src = src[batch_idx];
+    char* __restrict__ cur_dst       = dst[batch_idx];
+
+    const size_t num_uint4 = cur_bytes / sizeof(uint4);
+
+    // Copy uint4-aligned portion
+    for (size_t i = threadIdx.x; i < num_uint4; i += blockDim.x) {
+#if USING_CUDA
+        const auto tmp = __ldcs(reinterpret_cast<const uint4*>(cur_src) + i);
+        __stcs(reinterpret_cast<uint4*>(cur_dst) + i, tmp);
+#elif USING_ROCM
+        reinterpret_cast<uint4*>(cur_dst)[i] = reinterpret_cast<const uint4*>(cur_src)[i];
+#endif
+    }
+
+    // Handle sub-uint4 remainder bytes
+    if constexpr (!IsAligned) {
+        const size_t remainder = cur_bytes % sizeof(uint4);
+        if (remainder > 0) {
+            const size_t base = num_uint4 * sizeof(uint4);
+            for (size_t i = threadIdx.x; i < remainder; i += blockDim.x) {
+                cur_dst[base + i] = cur_src[base + i];
+            }
+        }
+    }
 }
 
 void invokeBatchCopy(void* const*           dst,
@@ -193,14 +238,19 @@ void invokeBatchCopy(void* const*           dst,
     if (config.uniform_size > 0) {
         const bool has_remaining_bytes = !config.is_fully_aligned;
 
-        const int     grid_size  = batch_size;
+        const int grid_size = batch_size;
+#if USING_CUDA
         constexpr int block_size = 512;
+#elif USING_ROCM
+        constexpr int block_size = 1024;
+#endif
 
         DISPATCH_BOOL(NeedsCleanup, has_remaining_bytes, [&]() {
             batchCopyRowAlignedKernel<NeedsCleanup><<<grid_size, block_size, 0, stream>>>(
                 reinterpret_cast<char* const*>(dst), reinterpret_cast<char const* const*>(src), config.uniform_size);
         });
     } else {
+#if USING_CUDA
         int sm_count = getMultiProcessorCount();
         DISPATCH_BOOL(IsAligned, config.is_fully_aligned, [&]() {
             constexpr auto kernel           = batchCopy<IsAligned>;
@@ -212,6 +262,18 @@ void invokeBatchCopy(void* const*           dst,
             kernel<<<sm_count * block_num_per_sm, block_size, smem_size, stream>>>(
                 reinterpret_cast<char* const*>(dst), reinterpret_cast<char const* const*>(src), bytes, batch_size);
         });
+#elif USING_ROCM
+        // Variable-size path: one block per copy entry.
+        // Block size of 512 threads (8 wavefronts/block on MI308X) increases
+        // in-flight memory requests per block vs 256, improving bandwidth
+        // utilization for large entries.
+        constexpr int block_size = 512;
+        const int     grid_size  = static_cast<int>(batch_size);
+        DISPATCH_BOOL(IsAligned, config.is_fully_aligned, [&]() {
+            batchCopyBlockPerEntry<IsAligned><<<grid_size, block_size, 0, stream>>>(
+                reinterpret_cast<char* const*>(dst), reinterpret_cast<char const* const*>(src), bytes, batch_size);
+        });
+#endif
     }
 
     check_cuda_error();

--- a/rtp_llm/models_py/bindings/core/test/ExecOpsTest.cc
+++ b/rtp_llm/models_py/bindings/core/test/ExecOpsTest.cc
@@ -347,56 +347,6 @@ TEST_F(ExecOpsTest, testNoBlockCopy) {
     ASSERT_TRUE(torch::equal(src, dst));
 }
 
-TEST_F(ExecOpsTest, testBatchCopyD2D) {
-    auto src1 = torch::randn({8}, torch::kCUDA);
-    auto src2 = torch::randn({16}, torch::kCUDA);
-    auto dst1 = torch::empty({8}, torch::kCUDA);
-    auto dst2 = torch::empty({16}, torch::kCUDA);
-
-    BatchCopyParams params;
-    auto&           d2d = params.copy_buffers[BatchCopyParams::D2D];
-    d2d.src_ptr.push_back(src1.data_ptr());
-    d2d.dst_ptr.push_back(dst1.data_ptr());
-    d2d.sizes.push_back(src1.nbytes());
-    d2d.src_ptr.push_back(src2.data_ptr());
-    d2d.dst_ptr.push_back(dst2.data_ptr());
-    d2d.sizes.push_back(src2.nbytes());
-
-    ASSERT_NO_THROW(execBatchCopy(params));
-    runtimeSyncAndCheck();
-    ASSERT_TRUE(torch::equal(src1, dst1));
-    ASSERT_TRUE(torch::equal(src2, dst2));
-}
-
-TEST_F(ExecOpsTest, testBatchCopyH2D) {
-    auto src = torch::randn({8}, torch::kCPU);
-    auto dst = torch::empty({8}, torch::kCUDA);
-
-    BatchCopyParams params;
-    auto&           h2d = params.copy_buffers[BatchCopyParams::H2D];
-    h2d.src_ptr.push_back(src.data_ptr());
-    h2d.dst_ptr.push_back(dst.data_ptr());
-    h2d.sizes.push_back(src.nbytes());
-
-    ASSERT_NO_THROW(execBatchCopy(params));
-    runtimeSyncAndCheck();
-    ASSERT_TRUE(torch::equal(src, dst.cpu()));
-}
-
-TEST_F(ExecOpsTest, testBatchCopyD2H) {
-    auto src = torch::randn({8}, torch::kCUDA);
-    auto dst = torch::empty({8}, torch::kCPU);
-
-    BatchCopyParams params;
-    auto&           d2h = params.copy_buffers[BatchCopyParams::D2H];
-    d2h.src_ptr.push_back(src.data_ptr());
-    d2h.dst_ptr.push_back(dst.data_ptr());
-    d2h.sizes.push_back(src.nbytes());
-
-    ASSERT_NO_THROW(execBatchCopy(params));
-    ASSERT_TRUE(torch::equal(src.cpu(), dst));
-}
-
 TEST_F(ExecOpsTest, testGetGpuExecStatus) {
     auto status = getGpuExecStatus();
     ASSERT_GT(status.device_memory_status.free_bytes, 0u);

--- a/rtp_llm/models_py/bindings/cuda/ops/tests/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/ops/tests/BUILD
@@ -36,6 +36,16 @@ test_deps = [
     ":cuda_test_util",
 ] + torch_deps()
 
+cc_test(
+    name = "batch_copy_test",
+    srcs = [
+        "CudaBatchCopyTest.cc",
+    ],
+    data = [],
+    copts = copts(),
+    deps = test_deps,
+    exec_properties = {'gpu':'H20'},
+)
 
 cc_test(
     name = "cuda_mask_logits_op_test",

--- a/rtp_llm/models_py/bindings/cuda/ops/tests/CudaBatchCopyTest.cc
+++ b/rtp_llm/models_py/bindings/cuda/ops/tests/CudaBatchCopyTest.cc
@@ -1,0 +1,23 @@
+#include "rtp_llm/cpp/testing/BatchCopyTest.hpp"
+#include <gtest/gtest.h>
+
+class CudaBatchCopyTest: public BatchCopyTest {};
+
+TEST_F(CudaBatchCopyTest, D2DSingleCopy) {
+    testD2DSingleCopy();
+}
+TEST_F(CudaBatchCopyTest, D2DMultipleCopies) {
+    testD2DMultipleCopies();
+}
+TEST_F(CudaBatchCopyTest, D2DUniformSizes) {
+    testD2DUniformSizes();
+}
+TEST_F(CudaBatchCopyTest, D2DVariableSizes) {
+    testD2DVariableSizes();
+}
+TEST_F(CudaBatchCopyTest, D2DLargeBatch) {
+    testD2DLargeBatch();
+}
+TEST_F(CudaBatchCopyTest, D2DWithH2DAndD2H) {
+    testD2DWithH2DAndD2H();
+}

--- a/rtp_llm/models_py/bindings/rocm/ops/tests/BUILD
+++ b/rtp_llm/models_py/bindings/rocm/ops/tests/BUILD
@@ -10,6 +10,18 @@ test_deps = [
 ] + torch_deps()
 
 cc_test(
+    name = "batch_copy_test",
+    srcs = [
+        "ROCmBatchCopyTest.cc",
+    ],
+    data = [],
+    copts = copts(),
+    deps = test_deps,
+    tags = ["rocm"],
+    exec_properties = {'gpu':'MI308X-ROCM7'},
+)
+
+cc_test(
     name = "beam_search_op_test",
     srcs = [
         "RocmBeamSearchOpTest.cc",

--- a/rtp_llm/models_py/bindings/rocm/ops/tests/ROCmBatchCopyTest.cc
+++ b/rtp_llm/models_py/bindings/rocm/ops/tests/ROCmBatchCopyTest.cc
@@ -1,0 +1,23 @@
+#include "rtp_llm/cpp/testing/BatchCopyTest.hpp"
+#include <gtest/gtest.h>
+
+class ROCmBatchCopyTest: public BatchCopyTest {};
+
+TEST_F(ROCmBatchCopyTest, D2DSingleCopy) {
+    testD2DSingleCopy();
+}
+TEST_F(ROCmBatchCopyTest, D2DMultipleCopies) {
+    testD2DMultipleCopies();
+}
+TEST_F(ROCmBatchCopyTest, D2DUniformSizes) {
+    testD2DUniformSizes();
+}
+TEST_F(ROCmBatchCopyTest, D2DVariableSizes) {
+    testD2DVariableSizes();
+}
+TEST_F(ROCmBatchCopyTest, D2DLargeBatch) {
+    testD2DLargeBatch();
+}
+TEST_F(ROCmBatchCopyTest, D2DWithH2DAndD2H) {
+    testD2DWithH2DAndD2H();
+}


### PR DESCRIPTION
## Summary

- Tune the ROCm batch-copy implementation for wavefront-aware execution and larger row-aligned launch blocks.
- Add a ROCm block-per-entry kernel for variable-size copies while preserving the CUDA path.
- Add MI308X-backed coverage for single, multiple, uniform-size, variable-size, large-batch, and mixed D2D/H2D/D2H copies.