### PR TITLE
feat: add forward warmup for PD engines

### DIFF
--- a/rtp_llm/cpp/cache/BUILD
+++ b/rtp_llm/cpp/cache/BUILD
@@ -2,6 +2,14 @@ load("//:def.bzl", "copts")
 load("//bazel:arch_select.bzl", "torch_deps")
 
 cc_library(
+    name = "runtime_memory_sizing",
+    srcs = ["RuntimeMemorySizing.cc"],
+    hdrs = ["RuntimeMemorySizing.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "cp_slot_mapper",
     srcs = ["CPSlotMapper.cc"],
     hdrs = ["CPSlotMapper.h"],
@@ -104,6 +112,57 @@ cc_library(
 )
 
 cc_library(
+    name = "warm_up_result",
+    hdrs = [
+        "WarmUpResult.h",
+    ],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "memory_evaluation_sizing",
+    srcs = ["MemoryEvaluationHelper.cc"],
+    hdrs = ["MemoryEvaluationHelper.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cache_config",
+        ":runtime_memory_sizing",
+        ":warm_up_result",
+        ":warmup_result_assembly",
+        "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/config:model_config",
+        "//rtp_llm/cpp/utils:core_utils",
+        "//rtp_llm/cpp/utils:memory_status",
+    ],
+)
+
+cc_library(
+    name = "memory_evaluation_sizing_device",
+    srcs = ["MemoryEvaluationHelperDevice.cc"],
+    hdrs = ["MemoryEvaluationHelperDevice.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":memory_evaluation_sizing",
+        "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
+    ] + torch_deps(),
+)
+
+cc_library(
+    name = "warmup_result_assembly",
+    srcs = ["WarmUpResultAssembly.cc"],
+    hdrs = ["WarmUpResultAssembly.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":warm_up_result",
+        "//rtp_llm/cpp/utils:memory_status",
+    ],
+)
+
+cc_library(
     name = "cache_types",
     srcs = [
         "Types.cc",
@@ -111,7 +170,6 @@ cc_library(
     hdrs = [
         "CacheConfig.h",
         "Types.h",
-        "WarmUpResult.h",
     ],
     copts = copts(),
     visibility = ["//visibility:public"],
@@ -122,6 +180,7 @@ cc_library(
         ":cache_group_type",
         ":cache_layout",
         ":kv_cache_specs",
+        ":warm_up_result",
         "//:rtp_compute_ops",
         "//rtp_llm/cpp/config:config_modules",
         "//rtp_llm/cpp/engine_base/stream:complete_token_ids",
@@ -299,7 +358,6 @@ cc_library(
         "HybridConfigCreator.cc",
         "HybridPoolConfigCreator.cc",
         "KVCacheHashUtil.cc",
-        "MemoryEvaluationHelper.cc",
         "SingleConfigCreator.cc",
     ],
     hdrs = [
@@ -307,7 +365,6 @@ cc_library(
         "HybridConfigCreator.h",
         "HybridPoolConfigCreator.h",
         "KVCacheHashUtil.h",
-        "MemoryEvaluationHelper.h",
         "SingleConfigCreator.h",
     ],
     copts = copts(),
@@ -317,9 +374,10 @@ cc_library(
         ":cache_types",
         ":kv_cache_allocator",
         ":prefill_cache_hit_metrics_reporter",
+        ":memory_evaluation_sizing",
+        ":memory_evaluation_sizing_device",
         "//rtp_llm/cpp/config:model_config",
         "//rtp_llm/cpp/engine_base/stream:complete_token_ids",
-        "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/models_py/bindings/core:type_convert",
         "//rtp_llm/cpp/disaggregate/cache_store",
         "//rtp_llm/cpp/metrics",
@@ -330,14 +388,6 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ] + torch_deps() + select({
-        "@//:using_cuda": [
-            "//rtp_llm/models_py/bindings/cuda:cuda_host_utils",
-        ],
-        "@//:using_rocm": [
-            "//rtp_llm/models_py/bindings/rocm:rocm_host_utils",
-        ],
-        "//conditions:default": [],
-    }) + select({
         "//:using_remote_kv_cache": [
             ":storage_3fs",
         ],

--- a/rtp_llm/cpp/cache/CacheConfigCreator.cc
+++ b/rtp_llm/cpp/cache/CacheConfigCreator.cc
@@ -7,7 +7,7 @@
 #include "rtp_llm/cpp/cache/HybridPoolConfigCreator.h"
 #include "rtp_llm/cpp/cache/HybridConfigCreator.h"
 #include "rtp_llm/cpp/cache/KVCacheSpecDesc.h"
-#include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
+#include "rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.h"
 #include "rtp_llm/cpp/cache/SingleConfigCreator.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/cpp/utils/Logger.h"
@@ -114,7 +114,6 @@ uint32_t computeBlockNum(CacheConfig&                                     config
                          const ModelConfig&                               model_config,
                          const RuntimeConfig&                             runtime_config,
                          const KVCacheConfig&                             kv_cache_config,
-                         const ParallelismConfig&                         parallelism_config,
                          const std::optional<WarmUpResult>&               warm_up_result,
                          const std::optional<SpeculativeExecutionConfig>& sp_config) {
     if (kv_cache_config.test_block_num > 0) {
@@ -123,8 +122,8 @@ uint32_t computeBlockNum(CacheConfig&                                     config
         return static_cast<uint32_t>(kv_cache_config.test_block_num);
     }
 
-    const auto kv_cache_mem_size = MemoryEvaluationHelper::getKVCacheMemorySize(
-        runtime_config, kv_cache_config, model_config, parallelism_config, warm_up_result, sp_config);
+    const auto kv_cache_mem_size = getKVCacheMemorySizeFromDevice(
+        runtime_config, kv_cache_config, model_config, warm_up_result, sp_config);
     config.finalizeBlockNums(0, runtime_config);
 
     const auto block_budget = blockBudgetForConfig(config);
@@ -225,10 +224,10 @@ CacheConfig CacheConfigCreator::createConfig(const ModelConfig&                 
     config.linear_step = kv_cache_config.linear_step;
     setupKernelSeqSize(config, kv_cache_config, "cache");
 
-    uint32_t block_num = computeBlockNum(
-        config, model_config, runtime_config, kv_cache_config, parallelism_config, warm_up_result, sp_config);
+    uint32_t block_num =
+        computeBlockNum(config, model_config, runtime_config, kv_cache_config, warm_up_result, sp_config);
     RTP_LLM_CHECK_WITH_INFO(block_num > 0,
-                            "kv cache needs at least 1 block but %ld, each block needs %ld MiB memory",
+                            "kv cache needs at least 1 block but %u, each block needs %ld MiB memory",
                             block_num,
                             static_cast<long>(config.block_size_bytes / 1024 / 1024));
 
@@ -306,8 +305,8 @@ CacheConfig CacheConfigCreator::createSpConfig(const ModelConfig&               
     if (kv_cache_config.test_block_num > 0) {
         block_num = kv_cache_config.test_block_num;
     } else {
-        const auto kv_cache_mem_size = MemoryEvaluationHelper::getKVCacheMemorySize(
-            runtime_config, kv_cache_config, score_model_config, parallelism_config, warm_up_result, sp_config);
+        const auto kv_cache_mem_size = getKVCacheMemorySizeFromDevice(
+            runtime_config, kv_cache_config, score_model_config, warm_up_result, sp_config);
 
         if (explicit_pool_reserve > 0) {
             RTP_LLM_CHECK_WITH_INFO(

--- a/rtp_llm/cpp/cache/MemoryEvaluationHelper.cc
+++ b/rtp_llm/cpp/cache/MemoryEvaluationHelper.cc
@@ -1,31 +1,40 @@
 #include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
+#include "rtp_llm/cpp/cache/RuntimeMemorySizing.h"
 
-#include <numeric>
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <limits>
 
-#if USING_CUDA
-#include <cuda_runtime.h>
-#elif USING_ROCM
-#include <hip/hip_runtime.h>
-#include "rtp_llm/models_py/bindings/rocm/hip_host_utils.h"
-#endif
-
-#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+#include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/cpp/utils/Logger.h"
-#if USING_CUDA
-#include "rtp_llm/models_py/bindings/cuda/cuda_host_utils.h"
-#endif
 
 namespace rtp_llm {
+
+namespace {
+constexpr size_t kBytesPerMiB = 1024 * 1024;
+constexpr size_t kNoWarmupFloorBytes = 2048ULL * kBytesPerMiB;
+
+size_t checkedMiBToBytes(int64_t value, const char* name) {
+    RTP_LLM_CHECK_WITH_INFO(value >= 0, "%s must be non-negative, got %ld", name, value);
+    RTP_LLM_CHECK_WITH_INFO(static_cast<uint64_t>(value) <= std::numeric_limits<size_t>::max() / kBytesPerMiB,
+                            "%s is too large: %ld MiB",
+                            name,
+                            value);
+    return static_cast<size_t>(value) * kBytesPerMiB;
+}
+
+}  // namespace
 
 // Helper function to update memory size if below minimum requirement
 void MemoryEvaluationHelper::updateMemoryIfNeeded(size_t& current_size, size_t min_required, const char* scenario) {
     if (current_size < min_required) {
-        current_size = min_required;
-        RTP_LLM_LOG_INFO("%s needs at least %ld MiB memory for runtime by default, "
-                         "but only %ld MiB memory reserved. adjust to minimal value.",
+        const size_t original_size = current_size;
+        current_size               = min_required;
+        RTP_LLM_LOG_INFO("%s runtime memory reserve adjusted from %ld MiB to %ld MiB",
                          scenario,
-                         min_required / 1024 / 1024,
-                         current_size / 1024 / 1024);
+                         original_size / 1024 / 1024,
+                         min_required / 1024 / 1024);
     }
 }
 
@@ -39,32 +48,15 @@ rtp_llm::DataType MemoryEvaluationHelper::getDataTypeForCache(const ModelConfig&
     return dtype;
 }
 
-size_t MemoryEvaluationHelper::getDefaultRuntimeMemorySize(const RuntimeConfig&     runtime_config,
-                                                           const ParallelismConfig& parallelism_config,
-                                                           const ModelConfig&       model_config,
-                                                           const std::optional<SpeculativeExecutionConfig>& sp_config) {
-    size_t reserve_runtime_mem_bytes = runtime_config.reserve_runtime_mem_mb * 1024 * 1024;
-    RTP_LLM_LOG_INFO("RuntimeConfig has reserve_runtime_mem_mb=%ld", runtime_config.reserve_runtime_mem_mb);
-
-    // Reserve at least 5% of total GPU memory for runtime (forward pass intermediates, cublas workspace, etc.)
-    // with a minimum floor of 2048 MiB. This is needed because KV cache is pre-allocated as a fixed block,
-    // and the remaining GPU memory must be sufficient for model forward passes.
-    size_t                  total_gpu_bytes = 0;
-    [[maybe_unused]] size_t free_gpu_bytes  = 0;
-#if USING_CUDA
-    check_cuda_value(cudaMemGetInfo(&free_gpu_bytes, &total_gpu_bytes));
-#elif USING_ROCM
-    ROCM_CHECK(hipMemGetInfo(&free_gpu_bytes, &total_gpu_bytes));
-#endif
-    const auto minimal_runtime_bytes = std::max(2048L * 1024 * 1024, (long)(total_gpu_bytes * 0.05));
-    if (reserve_runtime_mem_bytes < minimal_runtime_bytes) {
-        RTP_LLM_LOG_INFO("tp_size %d needs at least %ld MiB memory for runtime by default, "
-                         "but only %ld MiB reserved memory set by config. adjust to minimal value.",
-                         parallelism_config.get_attn_tp_size(),
-                         minimal_runtime_bytes / 1024 / 1024,
-                         reserve_runtime_mem_bytes / 1024 / 1024);
-        reserve_runtime_mem_bytes = minimal_runtime_bytes;
-    }
+size_t
+MemoryEvaluationHelper::getConfiguredRuntimeMemorySize(const RuntimeConfig&                             runtime_config,
+                                                       const ModelConfig&                               model_config,
+                                                       const std::optional<SpeculativeExecutionConfig>& sp_config) {
+    // The C++ field drops the trailing "r" of the CLI flag; operator-facing text carries both
+    // spellings so either one greps.
+    static constexpr const char* kReserveKnobName = "reserve_runtime_mem_mb (--reserver_runtime_mem_mb)";
+    size_t reserve_runtime_mem_bytes = checkedMiBToBytes(runtime_config.reserve_runtime_mem_mb, kReserveKnobName);
+    RTP_LLM_LOG_INFO("RuntimeConfig has %s=%ld", kReserveKnobName, runtime_config.reserve_runtime_mem_mb);
 
     if (model_config.mm_model_config.is_multimodal) {
         const auto minimal_runtime_required = 2L * 1024 * 1024 * 1024;  // 2 GiB
@@ -82,58 +74,76 @@ size_t MemoryEvaluationHelper::getDefaultRuntimeMemorySize(const RuntimeConfig& 
 size_t MemoryEvaluationHelper::getKVCacheMemorySize(const RuntimeConfig&                             runtime_config,
                                                     const KVCacheConfig&                             kv_cache_config,
                                                     const ModelConfig&                               model_config,
-                                                    const ParallelismConfig&                         parallelism_config,
+                                                    const MemoryStatus&                              gpu_memory_status,
                                                     const std::optional<WarmUpResult>&               warm_up_result,
                                                     const std::optional<SpeculativeExecutionConfig>& sp_config) {
-    size_t device_reserved_memory_bytes = getGpuExecStatus().device_memory_status.available_bytes;
-    size_t runtime_required_bytes       = 0;
+    const auto& gpu_mem = gpu_memory_status;
+    size_t device_reserved_memory_bytes = gpu_mem.available_bytes;
 
     if (kv_cache_config.kv_cache_mem_mb > 0) {
         RTP_LLM_LOG_INFO("KVCacheConfig explicitly specified kv cache memory size %ld MiB",
                          kv_cache_config.kv_cache_mem_mb);
-        return kv_cache_config.kv_cache_mem_mb * 1024 * 1024;
+        return checkedMiBToBytes(kv_cache_config.kv_cache_mem_mb, "kv_cache_mem_mb");
     }
 
-    size_t env_runtime_required_bytes = MemoryEvaluationHelper::getDefaultRuntimeMemorySize(
-        runtime_config, parallelism_config, model_config, sp_config);
+    size_t configured_runtime_required_bytes =
+        MemoryEvaluationHelper::getConfiguredRuntimeMemorySize(runtime_config, model_config, sp_config);
 
+    size_t warmup_required_bytes    = 0;
+    size_t cuda_graph_memory_bytes  = 0;
+    bool   has_trusted_measurement  = false;
     if (warm_up_result) {
-        if (device_reserved_memory_bytes != warm_up_result->device_reserved_bytes) {
-            RTP_LLM_LOG_WARNING("device reserved memory bytes %ld when create config does not equal to "
-                                "the amount when warm up %ld. take min value.",
-                                device_reserved_memory_bytes,
-                                warm_up_result->device_reserved_bytes);
-            device_reserved_memory_bytes =
-                std::min(device_reserved_memory_bytes, warm_up_result->device_reserved_bytes);
+        if (warm_up_result->forward_measurement_trusted) {
+            warmup_required_bytes   = warm_up_result->measured_total_growth_bytes;
+            has_trusted_measurement = true;
+        }
+        if (warm_up_result->cuda_graph_measurement_trusted) {
+            cuda_graph_memory_bytes = warm_up_result->cuda_graph_memory_bytes;
+            has_trusted_measurement = true;
         }
 
-        runtime_required_bytes = std::max(env_runtime_required_bytes, warm_up_result->max_used_memory);
-
-        RTP_LLM_LOG_INFO(
-            "devices reserved %ld MiB memory, warm up consumed %ld MiB max memory, env runtime memory %ld MiB, final runtime memory %ld MiB",
-            device_reserved_memory_bytes / 1024 / 1024,
-            warm_up_result->max_used_memory / 1024 / 1024,
-            env_runtime_required_bytes / 1024 / 1024,
-            runtime_required_bytes / 1024 / 1024);
-    } else {
-        runtime_required_bytes = env_runtime_required_bytes;
-        RTP_LLM_LOG_INFO("warm up result not available, use default runtime memory size %ld MiB",
-                         runtime_required_bytes / 1024 / 1024);
+        if (has_trusted_measurement) {
+            device_reserved_memory_bytes = warm_up_result->available_bytes_pre_warmup;
+        } else {
+            if (device_reserved_memory_bytes != warm_up_result->device_reserved_bytes) {
+                RTP_LLM_LOG_WARNING("device reserved memory bytes %ld when create config does not equal to "
+                                    "the amount when warm up %ld. take min value.",
+                                    device_reserved_memory_bytes,
+                                    warm_up_result->device_reserved_bytes);
+                device_reserved_memory_bytes =
+                    std::min(device_reserved_memory_bytes, warm_up_result->device_reserved_bytes);
+            }
+        }
     }
 
     size_t sample_need_mem =
         (size_t)runtime_config.max_generate_batch_size * model_config.vocab_size * 4 * 8;  // just estimated value
-    RTP_LLM_LOG_INFO("sampler needs %ld MiB memory, model runtime needs %ld MiB memory, take max value.",
-                     sample_need_mem / 1024 / 1024,
-                     runtime_required_bytes / 1024 / 1024);
-    runtime_required_bytes = std::max(sample_need_mem, runtime_required_bytes);
+    const double safety_ratio = kv_cache_config.runtime_mem_safety_ratio;
+    RuntimeMemorySizingInput sizing_input;
+    sizing_input.has_warmup               = has_trusted_measurement;
+    sizing_input.configured_reserve_bytes = configured_runtime_required_bytes;
+    sizing_input.warmup_required_bytes    = warmup_required_bytes;
+    sizing_input.cuda_graph_memory_bytes  = cuda_graph_memory_bytes;
+    sizing_input.sampler_required_bytes   = sample_need_mem;
+    sizing_input.total_gpu_bytes          = gpu_mem.total_bytes;
+    sizing_input.safety_ratio             = safety_ratio;
+    sizing_input.no_warmup_floor_bytes    = kNoWarmupFloorBytes;
+    RuntimeMemorySizingResult sizing;
+    try {
+        sizing = calculateRuntimeMemorySizing(sizing_input);
+    } catch (const std::exception& e) {
+        RTP_LLM_FAIL("%s", e.what());
+    }
+    const size_t runtime_required_bytes = sizing.runtime_required_bytes;
 
-    RTP_LLM_CHECK_WITH_INFO(device_reserved_memory_bytes > runtime_required_bytes,
-                            "device reserved memory %ld  MiB is less than runtime required memory %ld MiB",
-                            device_reserved_memory_bytes / 1024 / 1024,
-                            runtime_required_bytes / 1024 / 1024);
+    RTP_LLM_CHECK_WITH_INFO(
+        device_reserved_memory_bytes > runtime_required_bytes,
+        "device reserved memory %ld MiB is less than runtime required memory %ld MiB",
+        device_reserved_memory_bytes / 1024 / 1024,
+        runtime_required_bytes / 1024 / 1024);
 
-    const auto kv_cache_mem_size = device_reserved_memory_bytes - runtime_required_bytes;
+    auto kv_cache_mem_size = device_reserved_memory_bytes - runtime_required_bytes;
+
     RTP_LLM_LOG_INFO("cache config final decided kv cache memory size %ld MiB", kv_cache_mem_size / 1024 / 1024);
     return kv_cache_mem_size;
 }

--- a/rtp_llm/cpp/cache/MemoryEvaluationHelper.h
+++ b/rtp_llm/cpp/cache/MemoryEvaluationHelper.h
@@ -1,25 +1,34 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 #include "rtp_llm/cpp/cache/WarmUpResult.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
 #include "rtp_llm/cpp/config/ModelConfig.h"
+#include "rtp_llm/cpp/utils/MemoryStatus.h"
 
 namespace rtp_llm {
 
 class MemoryEvaluationHelper {
 public:
+    // The operator-configured reserve (reserve_runtime_mem_mb), raised to a scenario floor for
+    // multimodal and speculative deployments. Named "configured" rather than "default" because
+    // it is only one term of the sizing max() in getKVCacheMemorySize, not a fallback used when
+    // nothing else applies.
     static size_t
-                  getDefaultRuntimeMemorySize(const RuntimeConfig&                             runtime_config,
-                                              const ParallelismConfig&                         parallelism_config,
-                                              const ModelConfig&                               model_config,
-                                              const std::optional<SpeculativeExecutionConfig>& sp_config = std::nullopt);
+                  getConfiguredRuntimeMemorySize(const RuntimeConfig&                             runtime_config,
+                                                 const ModelConfig&                               model_config,
+                                                 const std::optional<SpeculativeExecutionConfig>& sp_config = std::nullopt);
+    // Testable core of the device entry point: takes the memory sample as an argument instead
+    // of reading the GPU via getGpuExecStatus(), so unit tests can drive the sizing decisions
+    // (warmup-vs-no-warmup formula selection, measurement degradation, the device_reserved min
+    // reduction, knob validation) without a device. The device entry point is a thin wrapper.
     static size_t getKVCacheMemorySize(const RuntimeConfig&                             runtime_config,
                                        const KVCacheConfig&                             kv_cache_config,
                                        const ModelConfig&                               model_config,
-                                       const ParallelismConfig&                         parallelism_config,
+                                       const MemoryStatus&                              gpu_memory_status,
                                        const std::optional<WarmUpResult>&               warm_up_result = std::nullopt,
                                        const std::optional<SpeculativeExecutionConfig>& sp_config      = std::nullopt);
 

--- a/rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.cc
+++ b/rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.cc
@@ -1,0 +1,20 @@
+#include "rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.h"
+
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm {
+
+size_t getKVCacheMemorySizeFromDevice(const RuntimeConfig&                             runtime_config,
+                                      const KVCacheConfig&                             kv_cache_config,
+                                      const ModelConfig&                               model_config,
+                                      const std::optional<WarmUpResult>&               warm_up_result,
+                                      const std::optional<SpeculativeExecutionConfig>& sp_config) {
+    return MemoryEvaluationHelper::getKVCacheMemorySize(runtime_config,
+                                                        kv_cache_config,
+                                                        model_config,
+                                                        getGpuExecStatus().device_memory_status,
+                                                        warm_up_result,
+                                                        sp_config);
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.h
+++ b/rtp_llm/cpp/cache/MemoryEvaluationHelperDevice.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
+
+namespace rtp_llm {
+
+// Samples the current device and delegates the sizing decision to MemoryEvaluationHelper.
+// Provided by //rtp_llm/cpp/cache:memory_evaluation_sizing_device.
+size_t getKVCacheMemorySizeFromDevice(
+    const RuntimeConfig&                             runtime_config,
+    const KVCacheConfig&                             kv_cache_config,
+    const ModelConfig&                               model_config,
+    const std::optional<WarmUpResult>&               warm_up_result = std::nullopt,
+    const std::optional<SpeculativeExecutionConfig>& sp_config      = std::nullopt);
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/RuntimeMemorySizing.cc
+++ b/rtp_llm/cpp/cache/RuntimeMemorySizing.cc
@@ -1,0 +1,52 @@
+#include "rtp_llm/cpp/cache/RuntimeMemorySizing.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace rtp_llm {
+
+RuntimeMemorySizingResult calculateRuntimeMemorySizing(const RuntimeMemorySizingInput& input) {
+    if (!std::isfinite(input.safety_ratio) || input.safety_ratio < 0.0 || input.safety_ratio >= 1.0) {
+        throw std::invalid_argument("runtime_mem_safety_ratio must be finite and in [0, 1), got "
+                                    + std::to_string(input.safety_ratio));
+    }
+
+    const double applied_safety_ratio = input.has_warmup ? input.safety_ratio : kNoWarmupSafetyRatio;
+    const size_t safety_ratio_bytes   = static_cast<size_t>(input.total_gpu_bytes * applied_safety_ratio);
+
+    if (!input.has_warmup) {
+        RuntimeMemorySizingResult result;
+        result.runtime_required_bytes = std::max({input.configured_reserve_bytes,
+                                                  input.sampler_required_bytes,
+                                                  input.no_warmup_floor_bytes,
+                                                  safety_ratio_bytes});
+        return result;
+    }
+
+    const size_t base_required_bytes =
+        std::max({input.configured_reserve_bytes, input.warmup_required_bytes, input.sampler_required_bytes});
+
+    if (base_required_bytes > std::numeric_limits<size_t>::max() - input.cuda_graph_memory_bytes) {
+        throw std::overflow_error(
+            "runtime memory sizing overflow: base_required_bytes=" + std::to_string(base_required_bytes)
+            + " plus cuda_graph_memory_bytes=" + std::to_string(input.cuda_graph_memory_bytes) + " exceeds size_t");
+    }
+    const size_t required_with_cuda_graph = base_required_bytes + input.cuda_graph_memory_bytes;
+    if (required_with_cuda_graph > std::numeric_limits<size_t>::max() - safety_ratio_bytes) {
+        throw std::overflow_error(
+            "runtime memory sizing overflow: base_required_bytes=" + std::to_string(base_required_bytes)
+            + " (configured_reserve=" + std::to_string(input.configured_reserve_bytes)
+            + ", warmup_required=" + std::to_string(input.warmup_required_bytes)
+            + ", sampler_required=" + std::to_string(input.sampler_required_bytes)
+            + "), cuda_graph_memory_bytes=" + std::to_string(input.cuda_graph_memory_bytes)
+            + " plus safety_ratio_bytes=" + std::to_string(safety_ratio_bytes) + " exceeds size_t");
+    }
+    RuntimeMemorySizingResult result;
+    result.runtime_required_bytes = required_with_cuda_graph + safety_ratio_bytes;
+    return result;
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/RuntimeMemorySizing.h
+++ b/rtp_llm/cpp/cache/RuntimeMemorySizing.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+
+namespace rtp_llm {
+
+inline constexpr double kNoWarmupSafetyRatio = 0.05;
+
+// Pure sizing math. A trusted warmup uses normal forward growth, an independent CUDA graph
+// measurement, and additive safety headroom; the fallback path preserves the previous behavior.
+struct RuntimeMemorySizingInput {
+    bool   has_warmup               = false;
+    size_t configured_reserve_bytes = 0;
+    size_t warmup_required_bytes    = 0;
+    size_t cuda_graph_memory_bytes  = 0;
+    size_t sampler_required_bytes   = 0;
+    size_t total_gpu_bytes          = 0;
+    double safety_ratio             = 0.0;
+    size_t no_warmup_floor_bytes    = 0;
+};
+
+struct RuntimeMemorySizingResult {
+    size_t runtime_required_bytes = 0;
+};
+
+RuntimeMemorySizingResult calculateRuntimeMemorySizing(const RuntimeMemorySizingInput& input);
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/WarmUpResult.h
+++ b/rtp_llm/cpp/cache/WarmUpResult.h
@@ -1,10 +1,32 @@
 #pragma once
 
+#include <cstddef>
+
 namespace rtp_llm {
 
 struct WarmUpResult {
+    // Free memory at the trace baseline: the weights are loaded and the warmup has allocated
+    // nothing yet. This is the pool the KV budget divides whenever the measurement is used, and it
+    // is paired with measured_total_growth_bytes below -- base and growth term are read at the same
+    // instant, so neither side has to reason about what the teardown handed back.
+    size_t available_bytes_pre_warmup = 0;
+    // Free memory after the traced executor was released and emptyCache() ran, still inside the
+    // trace window. The base for every path that *discards* the measurement: those reserve a static
+    // amount that does not account for what the warmup left resident, so they have to divide the
+    // pool that already excludes it. Also the inherited (pre-feature) sizing base.
     size_t device_reserved_bytes = 0;
-    size_t max_used_memory       = 0;
+    // Trust is tracked independently for the normal forward and CUDA Graph measurements. A zero
+    // forward growth is still a valid measurement, and must not discard a separately measured
+    // CUDA Graph requirement.
+    bool forward_measurement_trusted    = false;
+    bool cuda_graph_measurement_trusted = false;
+    // Normal-forward persistent device growth plus transient torch headroom. This is paired with
+    // the pre-warmup free-memory baseline for KV sizing and deliberately excludes CUDA graphs.
+    size_t measured_total_growth_bytes = 0;
+    // Device-memory decrease while constructing and capturing the temporary CUDA graphs. Kept
+    // separate from normal forward growth so graph-pool reservation and driver allocations that
+    // are not represented by torch allocated peak are still deducted from the KV budget.
+    size_t cuda_graph_memory_bytes = 0;
 };
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/WarmUpResultAssembly.cc
+++ b/rtp_llm/cpp/cache/WarmUpResultAssembly.cc
@@ -1,0 +1,33 @@
+#include "rtp_llm/cpp/cache/WarmUpResultAssembly.h"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace rtp_llm {
+
+WarmUpResult assembleWarmUpResult(size_t              pre_warmup_available_bytes,
+                                  const MemoryStatus& post_teardown_status,
+                                  bool                measurement_trusted) {
+    WarmUpResult result;
+    result.available_bytes_pre_warmup  = pre_warmup_available_bytes;
+    result.device_reserved_bytes       = post_teardown_status.available_bytes;
+    result.forward_measurement_trusted = measurement_trusted;
+
+    const size_t persistent_device_growth = poolShrinkBytes(result);
+    const size_t transient_torch_headroom =
+        post_teardown_status.torch_allocated_peak_bytes > post_teardown_status.allocated_bytes ?
+            post_teardown_status.torch_allocated_peak_bytes - post_teardown_status.allocated_bytes :
+            0;
+    if (persistent_device_growth > std::numeric_limits<size_t>::max() - transient_torch_headroom) {
+        throw std::overflow_error("warmup memory measurement overflow: persistent_device_growth="
+                                  + std::to_string(persistent_device_growth)
+                                  + " plus transient_torch_headroom=" + std::to_string(transient_torch_headroom)
+                                  + " exceeds size_t");
+    }
+
+    result.measured_total_growth_bytes = persistent_device_growth + transient_torch_headroom;
+    return result;
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/WarmUpResultAssembly.h
+++ b/rtp_llm/cpp/cache/WarmUpResultAssembly.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "rtp_llm/cpp/cache/WarmUpResult.h"
+#include "rtp_llm/cpp/utils/MemoryStatus.h"
+
+namespace rtp_llm {
+
+// How much the warmup permanently cost the device: the pre-warmup free pool minus what was free
+// after teardown. Clamped at 0 (an unrelated release between the samples can invert them). This is
+// also the persistent component of measured_total_growth_bytes; sharing one definition keeps the
+// sizing calculations consistent.
+inline size_t poolShrinkBytes(const WarmUpResult& result) {
+    return result.available_bytes_pre_warmup > result.device_reserved_bytes ?
+               result.available_bytes_pre_warmup - result.device_reserved_bytes :
+               0;
+}
+
+// Turns the samples taken inside the warmup trace window into the KV-sizing inputs.
+//
+// pre_warmup_available_bytes is free memory at the trace baseline (weights loaded, the warmup has
+// allocated nothing); post_teardown_status is sampled after the traced executor has been released
+// and emptyCache() has run, but still inside the window. Its allocator peak still covers the full
+// window because releasing memory does not lower the high-water mark.
+//
+// The normal-forward requirement follows vLLM's accounting model:
+//   persistent device growth = pre-warmup free - post-teardown free
+//   transient torch headroom = post-teardown torch allocated peak - post-teardown torch allocated
+// This counts every resident allocation once through cudaMemGetInfo, then adds only torch memory
+// that existed at the high-water mark and was released before the final sample. Reading the peak
+// from the final snapshot covers the complete trace window, including executor teardown.
+// CUDA graph capture is intentionally outside this trace and is stored separately in
+// WarmUpResult::cuda_graph_memory_bytes.
+// measurement_trusted applies to the forward measurement. CUDA Graph trust is assigned only after
+// graph capture succeeds; both fields default to false for fail-closed manual construction.
+//
+// Pure computation, deliberately free of logging and device access: it throws
+// std::overflow_error instead of asserting so the caller can route the failure through its own
+// error handling (same split as calculateRuntimeMemorySizing).
+WarmUpResult assembleWarmUpResult(size_t              pre_warmup_available_bytes,
+                                  const MemoryStatus& post_teardown_status,
+                                  bool                measurement_trusted);
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -61,6 +61,41 @@ cc_library(
 )
 
 cc_test(
+    name = "runtime_memory_sizing_test",
+    srcs = ["RuntimeMemorySizingTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:runtime_memory_sizing",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "warmup_result_assembly_test",
+    srcs = ["WarmUpResultAssemblyTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:warmup_result_assembly",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "memory_evaluation_helper_test",
+    srcs = ["MemoryEvaluationHelperTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:memory_evaluation_sizing",
+        "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/config:model_config",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ] + torch_deps(),
+)
+
+cc_test(
     name = "cache_topology_test",
     srcs = ["CacheTopologyTest.cc"],
     copts = test_copts,

--- a/rtp_llm/cpp/cache/test/MemoryEvaluationHelperTest.cc
+++ b/rtp_llm/cpp/cache/test/MemoryEvaluationHelperTest.cc
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
+
+namespace rtp_llm {
+namespace {
+
+constexpr size_t MiB = 1024 * 1024;
+constexpr size_t GiB = 1024 * MiB;
+
+class MemoryEvaluationHelperTest: public ::testing::Test {
+protected:
+    MemoryEvaluationHelperTest() {
+        runtime_config_.reserve_runtime_mem_mb    = 1024;
+        runtime_config_.max_generate_batch_size   = 1;
+        model_config_.vocab_size                  = 1024;
+        kv_cache_config_.kv_cache_mem_mb          = 0;
+        kv_cache_config_.runtime_mem_safety_ratio = 0.05;
+        status_.available_bytes                   = 40 * GiB;
+        status_.total_bytes                       = 80 * GiB;
+    }
+
+    size_t size(const std::optional<WarmUpResult>& warm_up_result = std::nullopt) {
+        return MemoryEvaluationHelper::getKVCacheMemorySize(
+            runtime_config_, kv_cache_config_, model_config_, status_, warm_up_result);
+    }
+
+    RuntimeConfig runtime_config_;
+    KVCacheConfig kv_cache_config_;
+    ModelConfig model_config_;
+    MemoryStatus status_;
+};
+
+TEST_F(MemoryEvaluationHelperTest, ExplicitKvCacheSizeTakesPrecedence) {
+    kv_cache_config_.kv_cache_mem_mb = 4096;
+    EXPECT_EQ(size(), 4096 * MiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, NoWarmupUsesFixedFloorAndRatio) {
+    EXPECT_EQ(size(), 36 * GiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, TrustedWarmupDeductsMeasuredGrowthCudaGraphAndSafety) {
+    WarmUpResult warm_up;
+    warm_up.forward_measurement_trusted    = true;
+    warm_up.cuda_graph_measurement_trusted = true;
+    warm_up.available_bytes_pre_warmup     = 42 * GiB;
+    warm_up.device_reserved_bytes          = 40 * GiB;
+    warm_up.measured_total_growth_bytes    = 6 * GiB;
+    warm_up.cuda_graph_memory_bytes        = 2 * GiB;
+
+    EXPECT_EQ(size(warm_up), 30 * GiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, ForwardOnlyMeasurementUsesForwardGrowthAndSafety) {
+    WarmUpResult warm_up;
+    warm_up.forward_measurement_trusted = true;
+    warm_up.available_bytes_pre_warmup  = 42 * GiB;
+    warm_up.measured_total_growth_bytes = 6 * GiB;
+
+    EXPECT_EQ(size(warm_up), 32 * GiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, GraphOnlyMeasurementUsesGraphGrowthAndSafety) {
+    WarmUpResult warm_up;
+    warm_up.cuda_graph_measurement_trusted = true;
+    warm_up.available_bytes_pre_warmup     = 42 * GiB;
+    warm_up.cuda_graph_memory_bytes        = 2 * GiB;
+
+    EXPECT_EQ(size(warm_up), 35 * GiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, ZeroForwardGrowthDoesNotDiscardTrustedGraphMeasurement) {
+    WarmUpResult warm_up;
+    warm_up.forward_measurement_trusted    = true;
+    warm_up.cuda_graph_measurement_trusted = true;
+    warm_up.available_bytes_pre_warmup     = 42 * GiB;
+    warm_up.measured_total_growth_bytes    = 0;
+    warm_up.cuda_graph_memory_bytes        = 2 * GiB;
+
+    EXPECT_EQ(size(warm_up), 35 * GiB);
+}
+
+TEST_F(MemoryEvaluationHelperTest, UntrustedWarmupUsesFallbackSizing) {
+    WarmUpResult warm_up;
+    warm_up.forward_measurement_trusted = false;
+    warm_up.available_bytes_pre_warmup  = 60 * GiB;
+    warm_up.device_reserved_bytes       = 38 * GiB;
+    warm_up.measured_total_growth_bytes = 6 * GiB;
+    warm_up.cuda_graph_memory_bytes     = 20 * GiB;
+
+    EXPECT_EQ(size(warm_up), 34 * GiB);
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/RuntimeMemorySizingTest.cc
+++ b/rtp_llm/cpp/cache/test/RuntimeMemorySizingTest.cc
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+
+#include "rtp_llm/cpp/cache/RuntimeMemorySizing.h"
+
+namespace rtp_llm {
+namespace {
+
+constexpr size_t GiB = 1024ULL * 1024 * 1024;
+
+TEST(RuntimeMemorySizingTest, WarmupAddsCudaGraphAndSafetyToMeasuredRequirement) {
+    RuntimeMemorySizingInput input;
+    input.has_warmup               = true;
+    input.configured_reserve_bytes = 1 * GiB;
+    input.warmup_required_bytes    = 6 * GiB;
+    input.cuda_graph_memory_bytes  = 2 * GiB;
+    input.sampler_required_bytes   = 2 * GiB;
+    input.total_gpu_bytes          = 80 * GiB;
+    input.safety_ratio             = 0.05;
+
+    const auto result = calculateRuntimeMemorySizing(input);
+    EXPECT_EQ(result.runtime_required_bytes, 12 * GiB);
+}
+
+TEST(RuntimeMemorySizingTest, NoWarmupKeepsFixedFloorSemantics) {
+    RuntimeMemorySizingInput input;
+    input.configured_reserve_bytes = 1 * GiB;
+    input.total_gpu_bytes          = 20 * GiB;
+    input.safety_ratio             = 0.05;
+    input.no_warmup_floor_bytes    = 2 * GiB;
+
+    EXPECT_EQ(calculateRuntimeMemorySizing(input).runtime_required_bytes, 2 * GiB);
+}
+
+TEST(RuntimeMemorySizingTest, RejectsInvalidSafetyRatios) {
+    RuntimeMemorySizingInput input;
+    for (double ratio : {-0.01, 1.0, std::numeric_limits<double>::quiet_NaN()}) {
+        input.safety_ratio = ratio;
+        EXPECT_THROW(calculateRuntimeMemorySizing(input), std::invalid_argument);
+    }
+}
+
+TEST(RuntimeMemorySizingTest, RejectsWarmupOverflow) {
+    RuntimeMemorySizingInput input;
+    input.has_warmup               = true;
+    input.warmup_required_bytes    = std::numeric_limits<size_t>::max();
+    input.configured_reserve_bytes = 1;
+    input.total_gpu_bytes          = 2;
+    input.safety_ratio             = 0.5;
+
+    EXPECT_THROW(calculateRuntimeMemorySizing(input), std::overflow_error);
+}
+
+TEST(RuntimeMemorySizingTest, RejectsCudaGraphOverflow) {
+    RuntimeMemorySizingInput input;
+    input.has_warmup              = true;
+    input.warmup_required_bytes   = std::numeric_limits<size_t>::max();
+    input.cuda_graph_memory_bytes = 1;
+
+    EXPECT_THROW(calculateRuntimeMemorySizing(input), std::overflow_error);
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/WarmUpResultAssemblyTest.cc
+++ b/rtp_llm/cpp/cache/test/WarmUpResultAssemblyTest.cc
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+
+#include "rtp_llm/cpp/cache/WarmUpResultAssembly.h"
+
+namespace rtp_llm {
+namespace {
+
+constexpr size_t GiB = 1024ULL * 1024 * 1024;
+
+MemoryStatus makeStatus(size_t peak, size_t current, size_t available) {
+    MemoryStatus status;
+    status.torch_allocated_peak_bytes = peak;
+    status.allocated_bytes            = current;
+    status.available_bytes            = available;
+    return status;
+}
+
+TEST(WarmUpResultAssemblyTest, CombinesPersistentGrowthAndTransientTorchHeadroom) {
+    const auto result = assembleWarmUpResult(64 * GiB, makeStatus(12 * GiB, 3 * GiB, 62 * GiB), true);
+
+    EXPECT_EQ(result.measured_total_growth_bytes, 11 * GiB);
+    EXPECT_TRUE(result.forward_measurement_trusted);
+    EXPECT_FALSE(result.cuda_graph_measurement_trusted);
+}
+
+TEST(WarmUpResultAssemblyTest, ClampsNegativeGrowthComponentsToZero) {
+    const auto result = assembleWarmUpResult(40 * GiB, makeStatus(2 * GiB, 3 * GiB, 41 * GiB), true);
+    EXPECT_EQ(result.measured_total_growth_bytes, 0u);
+}
+
+TEST(WarmUpResultAssemblyTest, RejectsGrowthSumOverflow) {
+    const auto status = makeStatus(1, 0, 0);
+    EXPECT_THROW(assembleWarmUpResult(std::numeric_limits<size_t>::max(), status, true), std::overflow_error);
+}
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -130,6 +130,7 @@ std::string KVCacheConfig::to_string() const {
         << "fp8_kv_cache: " << fp8_kv_cache << "\n"
         << "ssm_state_dtype: " << ssm_state_dtype << "\n"
         << "kv_cache_mem_mb: " << kv_cache_mem_mb << "\n"
+        << "runtime_mem_safety_ratio: " << runtime_mem_safety_ratio << "\n"
         << "seq_size_per_block: " << seq_size_per_block << "\n"
         << "kernel_seq_size_per_block: " << kernel_seq_size_per_block << "\n"
         << "test_block_num: " << test_block_num << "\n"

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -11,6 +11,8 @@
 
 namespace rtp_llm {
 
+inline constexpr double kDefaultRuntimeMemorySafetyRatio = 0.10;
+
 /** NCCL communication config (ip + ports). Aligns with Python NcclCommConfig. */
 struct NcclCommConfig {
     std::string master_ip   = "";
@@ -170,10 +172,11 @@ struct KVCacheConfig {
     int64_t                                 memory_cache_disk_sync_timeout_ms = 30000;
     int                                     linear_step                       = 1;  // for linear attention cache reuse
     // Fields merged from PyKvCacheConfig
-    int         fp8_kv_cache              = 0;
-    std::string ssm_state_dtype           = "bf16";
-    int64_t     kv_cache_mem_mb           = -1;
-    int         seq_size_per_block        = 64;
+    int         fp8_kv_cache                = 0;
+    std::string ssm_state_dtype             = "bf16";
+    int64_t     kv_cache_mem_mb             = -1;
+    double      runtime_mem_safety_ratio     = kDefaultRuntimeMemorySafetyRatio;
+    int         seq_size_per_block           = 64;
     int         kernel_seq_size_per_block = 0;
     int         test_block_num            = 0;
     int         use_block_cache           = -1;  // -1 means not set, use Optional<int> equivalent

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_base.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_base.h
@@ -57,6 +57,7 @@ public:
     virtual void           setTokenTypeEmbedding(torch::Tensor token_type_embedding)    = 0;
     virtual void           setInputEmbeddingScalar(float input_embedding_scalar)        = 0;
     virtual bool           canRun(const PyModelInputs& inputs, CudaGraphState& state)   = 0;
+    virtual size_t         cudaGraphMemoryBytes() const                                 = 0;
     virtual void           prepareAttentionInputs(const PyModelInputs& inputs,
                                                   CudaGraphState&      state,
                                                   bool                 skip_forward_event_sync = false) = 0;

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_decode.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_decode.cc
@@ -7,11 +7,22 @@ void CudaGraphRunner::replayDecode(int bs) {
 }
 
 std::vector<int> CudaGraphRunner::getDecodeBatchSizesToCapture() {
+    RTP_LLM_CHECK_WITH_INFO(max_bs_ > 0, "decode CUDA graph max batch size must be positive, got %zu", max_bs_);
+
     // If decode_capture_batch_sizes_ is provided from Python, use it directly
     if (!decode_capture_batch_sizes_.empty()) {
         RTP_LLM_LOG_INFO("Using decode capture batch sizes from Python: %zu sizes", decode_capture_batch_sizes_.size());
+        for (const int batch_size : decode_capture_batch_sizes_) {
+            RTP_LLM_CHECK_WITH_INFO(batch_size > 0 && static_cast<size_t>(batch_size) <= max_bs_,
+                                    "decode CUDA graph capture batch size must be in [1, %zu], got %d",
+                                    max_bs_,
+                                    batch_size);
+        }
         // Sort in ascending order (from small to large)
         std::sort(decode_capture_batch_sizes_.begin(), decode_capture_batch_sizes_.end());
+        decode_capture_batch_sizes_.erase(
+            std::unique(decode_capture_batch_sizes_.begin(), decode_capture_batch_sizes_.end()),
+            decode_capture_batch_sizes_.end());
         return decode_capture_batch_sizes_;
     }
 

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -932,10 +932,10 @@ void CudaGraphRunner::initCaptureAttentionInputs(PyModelInputs& inputs, int max_
     }
 
     const int64_t max_blocks = max_kv_blocks * seq_size_per_block_ / kernel_seq_size_per_block_;
-    // kv_cache_kernel_block_id_device [batch_size, block_num]
+    // Capture uses block 0 for every synthetic sequence. Runtime replay replaces
+    // these placeholder IDs with the request's actual block table.
     inputs.attention_inputs.kv_cache_kernel_block_id_device =
         torch::zeros({int(max_bs_), max_blocks}, options_cuda_int32_);
-
     inputs.attention_inputs.kv_cache_kernel_block_id =
         torch::zeros({int(max_bs_), max_blocks}, options_cpu_int32_).pin_memory();
 
@@ -1069,6 +1069,10 @@ void CudaGraphRunner::initCapture() {
     if (enable_cuda_graph_) {
         RTP_LLM_LOG_INFO("CUDA graph capture is enabled");
         shared_graph_pool_ = cuda_graph::graphPoolHandle();
+        cuda_graph::graphDeviceSynchronize();
+        size_t free_before_capture  = 0;
+        size_t total_before_capture = 0;
+        cuda_graph::graphMemGetInfo(&free_before_capture, &total_before_capture);
         if (is_prefill_cuda_graph_mode_) {
             RTP_LLM_LOG_INFO("CUDA graph capture for prefill, num_tokens_per_bs_: %d", num_tokens_per_bs_);
         }
@@ -1136,6 +1140,17 @@ void CudaGraphRunner::initCapture() {
             captureDecode();
         }
         logCudaGraphPoolMemory("after_capture");
+        cuda_graph::graphDeviceSynchronize();
+        size_t free_after_capture  = 0;
+        size_t total_after_capture = 0;
+        cuda_graph::graphMemGetInfo(&free_after_capture, &total_after_capture);
+        RTP_LLM_CHECK_WITH_INFO(total_before_capture == total_after_capture,
+                                "CUDA graph memory total changed during capture: before=%zu, after=%zu",
+                                total_before_capture,
+                                total_after_capture);
+        cuda_graph_memory_bytes_ =
+            free_before_capture > free_after_capture ? free_before_capture - free_after_capture : 0;
+        RTP_LLM_LOG_INFO("[CudaGraph Memory] measured capture memory=%zu MiB", cuda_graph_memory_bytes_ / 1024 / 1024);
     } else {
         initKernelInternalMemory();
         RTP_LLM_LOG_INFO("CUDA graph capture is not enabled, skipping initialization");

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.h
@@ -92,6 +92,9 @@ public:
     int            getCurrentRealGraphBs(const CudaGraphState& state) const;
     PyModelOutputs forward(const PyModelInputs& inputs, CudaGraphState& state) override;
     void           initCapture() override;
+    size_t         cudaGraphMemoryBytes() const override {
+        return cuda_graph_memory_bytes_;
+    }
 
     // Factory methods for test: take GraphParams so callers can reuse the same struct
     static CudaGraphRunner* createForPrefill(py::object py_instance, GraphParams params);
@@ -173,6 +176,7 @@ private:
     at::TensorOptions                      options_cuda_int32_;
     at::TensorOptions                      options_cpu_int32_;
     at::TensorOptions                      options_cuda_float_;
+    size_t                                 cuda_graph_memory_bytes_{0};
     cuda_graph::GraphPoolHandle            shared_graph_pool_{};
 
     std::vector<std::string>      kv_cache_group_tags_;

--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -16,6 +16,7 @@ class Executor {
 public:
     Executor() {};
     virtual absl::Status process(const std::list<GenerateStreamPtr>& streams, int64_t schedule_time_us = 0) = 0;
+    virtual size_t cudaGraphMemoryBytes() const { return 0; }
 
     static GptModelDescription genModelDescription(const ModelConfig&       model_config,
                                                    const ParallelismConfig& parallelism_config,

--- a/rtp_llm/cpp/models/ModelTypes.h
+++ b/rtp_llm/cpp/models/ModelTypes.h
@@ -143,6 +143,9 @@ public:
     virtual GptModelOutputs forward(const GptModelInputs& inputs) = 0;
     virtual void            releaseBuffers() {}
     virtual void            prepareAttentionInputs(const GptModelInputs& inputs) {}
+    virtual size_t          cudaGraphMemoryBytes() const {
+        return 0;
+    }
 
     // Refresh only kv_cache_kernel_block_id-dependent state on a previously-
     // prepared attention_inputs_ (e.g., after an MTP propose+verify re-gather).

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -73,6 +73,9 @@ public:
     torch::Tensor   getMtpTargetHiddenStates(int64_t num_tokens) override;
     torch::Tensor   getMtpLastHiddenStates(int64_t num_tokens) override;
     bool            hasMtpTargetHiddenBuffer() const override;
+    size_t          cudaGraphMemoryBytes() const override {
+        return graph_runner_ ? graph_runner_->cudaGraphMemoryBytes() : 0;
+    }
     void            prepareAttentionInputs(const GptModelInputs& inputs) override;
     void            prepareAttentionInputs(const GptModelInputs& inputs, bool skip_forward_event_sync);
     void            updateKVCacheKernelBlockId(const GptModelInputs& inputs) override;
@@ -286,7 +289,10 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
             graph_params.input_hidden_size = static_cast<size_t>(width);
         }
         graph_params.model_data_type            = dtype;
-        graph_params.max_context_batch_size     = params.concurrency_config.concurrency_limit;
+        RTP_LLM_CHECK_WITH_INFO(params.concurrency_config.concurrency_limit >= 1,
+                                "CUDA graph max batch size must be positive, got %d",
+                                params.concurrency_config.concurrency_limit);
+        graph_params.max_context_batch_size = static_cast<size_t>(params.concurrency_config.concurrency_limit);
         graph_params.prefill_capture_seq_lens   = params.hw_kernel_config.prefill_capture_seq_lens;
         graph_params.decode_capture_batch_sizes = params.hw_kernel_config.decode_capture_batch_sizes;
         if (params.kv_cache_layer_layout.has_value()) {

--- a/rtp_llm/cpp/normal_engine/BUILD
+++ b/rtp_llm/cpp/normal_engine/BUILD
@@ -13,6 +13,7 @@ cc_library(
     ]),
     deps = [
         "//rtp_llm/cpp/config:role_types",
+        "//rtp_llm/cpp/cache:warmup_result_assembly",
         "//rtp_llm/cpp/models:models",
         "//rtp_llm/cpp/models:logits_processor",
         "//rtp_llm/cpp/engine_base:engine_base",

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -8,6 +8,7 @@
 #include "rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.h"
 #include "rtp_llm/cpp/engine_base/schedulers/BatchDecodeScheduler.h"
 #include "rtp_llm/cpp/cache/CacheConfigCreator.h"
+#include "rtp_llm/cpp/cache/WarmUpResultAssembly.h"
 #include "rtp_llm/cpp/engine_base/system_prompt/SystemPromptConstructor.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
@@ -20,6 +21,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <list>
 #include <memory>
 #include <thread>
@@ -83,6 +85,66 @@ bool shouldRefreshCacheStatusSnapshot(RoleType role_type, const std::list<Genera
         return stream && !stream->isFakeStream() && stream->isContextStream();
     });
 }
+
+#if USING_CUDA
+// Starts tracing on construction and, on every exit path including a throwing preRun, destroys
+// the warmup executor before closing the trace phase.
+class WarmupTraceScope {
+public:
+    explicit WarmupTraceScope(std::unique_ptr<Executor>& executor): executor_(executor) {
+        rtp_llm::setTraceMemory(true);
+        // Sampled after setTraceMemory on purpose: that call runs emptyCache() and snapshots the
+        // growth baselines, so free memory here is the same steady state (weights only) the growth
+        // deltas are measured against. Sampling before it would include loader-cached free blocks
+        // the warmup is free to reuse, overstating the pool relative to the growth.
+        pre_warmup_available_bytes_ = getGpuExecStatus().device_memory_status.available_bytes;
+    }
+
+    ~WarmupTraceScope() {
+        executor_.reset();
+        rtp_llm::setTraceMemory(false);
+    }
+
+    // Releases the traced executor and samples memory again while the trace window is still open.
+    // Two consumers: the raw post-teardown readings, logged to show what the warmup left behind,
+    // and available_bytes, which is the sizing base for the paths that discard the measurement.
+    // Sampling after setTraceMemory(false) would not work: closing the phase makes isTraceMemory()
+    // false, so getGpuExecStatus() no longer fills the traced growth fields and they read back as 0.
+    MemoryStatus teardownAndSample() {
+        executor_.reset();
+        cudaDeviceSynchronize();
+        c10::cuda::CUDACachingAllocator::emptyCache();
+        return getGpuExecStatus().device_memory_status;
+    }
+
+    // Free memory at the trace baseline: weights loaded, warmup has allocated nothing.
+    size_t preWarmupAvailableBytes() const {
+        return pre_warmup_available_bytes_;
+    }
+
+    WarmupTraceScope(const WarmupTraceScope&)            = delete;
+    WarmupTraceScope& operator=(const WarmupTraceScope&) = delete;
+
+private:
+    std::unique_ptr<Executor>& executor_;
+    size_t                     pre_warmup_available_bytes_ = 0;
+};
+
+WarmUpResult makeWarmUpResult(size_t              pre_warmup_available_bytes,
+                              const MemoryStatus& post_teardown_status,
+                              bool                measurement_trusted,
+                              const char*         phase) {
+    WarmUpResult result;
+    try {
+        result = assembleWarmUpResult(pre_warmup_available_bytes, post_teardown_status, measurement_trusted);
+    } catch (const std::exception& e) {
+        RTP_LLM_FAIL("%s %s", phase, e.what());
+    }
+
+    return result;
+}
+#endif
+
 }  // anonymous namespace
 
 NormalEngine::NormalEngine(const EngineInitParams&                       params,
@@ -147,7 +209,10 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
 
     std::optional<WarmUpResult> warm_up_result = std::nullopt;
 #if USING_CUDA
-    if (runtime_config.warm_up && (!model_config_.mm_model_config.is_multimodal)
+    const bool is_warmup_role = pd_sep_config.role_type == RoleType::PREFILL
+                                || pd_sep_config.role_type == RoleType::DECODE
+                                || pd_sep_config.role_type == RoleType::PDFUSION;
+    if (runtime_config.warm_up && is_warmup_role && (!model_config_.mm_model_config.is_multimodal)
         && !ffn_disaggregate_config.enable_ffn_disaggregate) {
         // warm up
         RTP_LLM_LOG_INFO("warm up (max_context_batch_size %d, max_seq_len %d calculate_loss %d) query begin",
@@ -155,12 +220,15 @@ NormalEngine::NormalEngine(const EngineInitParams&                       params,
                          model_config_.max_seq_len,
                          int(runtime_config.warm_up_with_loss));
         warm_up_result = warmUp(params);
-        RTP_LLM_LOG_INFO(
-            "warm up done, max runtime used memory: %ld bytes (%ld MiB), device reserved memory: %ld bytes (%ld MiB)",
-            warm_up_result->max_used_memory,
-            warm_up_result->max_used_memory / 1024 / 1024,
-            warm_up_result->device_reserved_bytes,
-            warm_up_result->device_reserved_bytes / 1024 / 1024);
+        RTP_LLM_LOG_INFO("warm up done, measured runtime memory: %ld bytes (%ld MiB), "
+                         "cuda graph memory: %ld bytes (%ld MiB), "
+                         "device reserved memory: %ld bytes (%ld MiB)",
+                         warm_up_result->measured_total_growth_bytes,
+                         warm_up_result->measured_total_growth_bytes / 1024 / 1024,
+                         warm_up_result->cuda_graph_memory_bytes,
+                         warm_up_result->cuda_graph_memory_bytes / 1024 / 1024,
+                         warm_up_result->device_reserved_bytes,
+                         warm_up_result->device_reserved_bytes / 1024 / 1024);
     } else {
         RTP_LLM_LOG_INFO("skip warm up.");
     }
@@ -279,6 +347,9 @@ int64_t NormalEngine::getLastScheduleTime() {
 }
 
 WarmUpResult NormalEngine::warmUp(const EngineInitParams& params) {
+    // Baseline dispatch order preserved: the batch-decode-scheduler branch takes precedence over
+    // the role mapping. PDFUSION maps to prefillWarmUp like before the warmup feature; its
+    // measurement is discarded by the constructor gate (forward measurement trust is false).
     if (runtime_config.use_batch_decode_scheduler) {
         if (runtime_config.batch_decode_scheduler_config.batch_decode_scheduler_warmup_type == 0) {
             return decodeWarmUp(params);
@@ -334,19 +405,90 @@ WarmUpResult NormalEngine::prefillWarmUp(const EngineInitParams& params) {
     RTP_LLM_FAIL("prefillWarmUp is not supported on non-CUDA platforms");
     return {};
 #else
-    auto fake_input                                   = makeFakeInput(getWarmUpInputLength());
-    fake_input->generate_config->num_return_sequences = runtime_config.fifo_scheduler_config.max_context_batch_size;
+    // Reject negatives before the cast: this is an int64_t knob, and a C-style cast to size_t
+    // would turn -1 into SIZE_MAX, which surfaces later as an unrelated overflow error. Name the
+    // knob instead, like checkedMiBToBytes does.
+    const int64_t configured_context_batch = runtime_config.fifo_scheduler_config.max_context_batch_size;
+    RTP_LLM_CHECK_WITH_INFO(configured_context_batch >= 0,
+                            "max_context_batch_size must be non-negative, got %ld",
+                            configured_context_batch);
+    // Pre-feature shape, deliberately unchanged: one sequence per max_context_batch_size, each at
+    // the framework warmup input length. getWarmUpInputLength() owns that length -- it derives it
+    // from max_seq_len and the speculative reserve_step, and rejects max_seq_len <= 1.
+    const size_t num_seqs       = (size_t)configured_context_batch;
+    const size_t tokens_per_seq = getWarmUpInputLength();
+    RTP_LLM_CHECK_WITH_INFO(tokens_per_seq == 0 || num_seqs <= std::numeric_limits<size_t>::max() / tokens_per_seq,
+                            "prefill warmup actual input token count overflow");
+    const size_t actual_input_tokens = num_seqs * tokens_per_seq;
+
+    // getWarmUpInputLength() already rejects max_seq_len <= 1, so what is left to catch here is
+    // max_context_batch_size == 0, which would make this a zero-sequence forward.
+    RTP_LLM_CHECK_WITH_INFO(actual_input_tokens > 0,
+                            "prefill warmup would run a zero-token forward (num_seqs=%ld); "
+                            "max_context_batch_size must be at least 1",
+                            (long)num_seqs);
+
+    auto fake_input                                   = makeFakeInput(tokens_per_seq);
+    fake_input->generate_config->num_return_sequences = num_seqs;
     fake_input->generate_config->calculate_loss       = int(runtime_config.warm_up_with_loss);
-    rtp_llm::setTraceMemory(true);
-    executor_.reset(new NormalExecutor(params, nullptr, true, false, 0, mla_ops_type_));
-    THROW_IF_STATUSOR_ERROR(preRun(fake_input, preRunMode::prefill_warm_up));
-    const auto max_consumed = getGpuExecStatus().device_memory_status.max_consumed_bytes;
-    rtp_llm::setTraceMemory(false);
-    (void)executor_.reset(nullptr);
-    cudaDeviceSynchronize();
-    c10::cuda::CUDACachingAllocator::emptyCache();
-    const auto device_status = getGpuExecStatus();
-    return WarmUpResult({device_status.device_memory_status.available_bytes, max_consumed});
+
+    std::shared_ptr<KVCacheManager> profiling_cache_manager;
+    std::shared_ptr<KVCacheManager> saved_cache_manager;
+    if (propose_params_) {
+        KVCacheConfig profiling_kv_cache_config = kv_cache_config;
+        profiling_kv_cache_config.test_block_num = 1;
+        auto profiling_cache_config = CacheConfigCreator::createSpConfig(
+            model_config_,
+            propose_params_->getEngineInitParams().model_config_,
+            parallelism_config,
+            runtime_config,
+            profiling_kv_cache_config,
+            sp_config,
+            std::nullopt,
+            isMTPEagle(),
+            isEagle());
+        profiling_cache_manager = make_shared<KVCacheManager>(profiling_cache_config,
+                                                               false,
+                                                               nullptr,
+                                                               kv_cache_config,
+                                                               parallelism_config,
+                                                               runtime_config,
+                                                               sp_config,
+                                                               pd_sep_config,
+                                                               cache_store_config);
+        RTP_LLM_CHECK_WITH_INFO(profiling_cache_manager->init(), "init prefill profiling KV cache failed");
+        saved_cache_manager = resource_context_.cache_manager;
+        resource_context_.cache_manager = profiling_cache_manager;
+    }
+    MemoryStatus post_teardown_status;
+    size_t       pre_warmup_available = 0;
+    {
+        WarmupTraceScope trace_scope(executor_);
+        if (propose_params_) {
+            executor_.reset(new MtpExecutor(params,
+                                             propose_params_,
+                                             profiling_cache_manager,
+                                             mla_ops_type_,
+                                             kv_cache_group_num_,
+                                             true,
+                                             false));
+        } else {
+            executor_.reset(new NormalExecutor(params, nullptr, true, false, 0, mla_ops_type_));
+        }
+        THROW_IF_STATUSOR_ERROR(preRun(fake_input, preRunMode::prefill_warm_up));
+        post_teardown_status = trace_scope.teardownAndSample();
+        pre_warmup_available = trace_scope.preWarmupAvailableBytes();
+    }
+    if (propose_params_) {
+        executor_.reset();
+        resource_context_.cache_manager = saved_cache_manager;
+        profiling_cache_manager.reset();
+    }
+    return makeWarmUpResult(pre_warmup_available,
+                            post_teardown_status,
+                            pd_sep_config.role_type == RoleType::PREFILL
+                                || pd_sep_config.role_type == RoleType::DECODE,
+                            "PREFILL_WARMUP");
 #endif
 }
 
@@ -355,10 +497,11 @@ WarmUpResult NormalEngine::decodeWarmUp(const EngineInitParams& params) {
     RTP_LLM_FAIL("decodeWarmUp is not supported on non-CUDA platforms");
     return {};
 #else
-    auto fake_input                                   = makeFakeInput(getWarmUpInputLength());
-    fake_input->generate_config->num_return_sequences = runtime_config.max_generate_batch_size;
+    const size_t num_return_sequences                 = (size_t)runtime_config.max_generate_batch_size;
+    const size_t kv_seq_len                           = getWarmUpInputLength();
+    auto         fake_input                           = makeFakeInput(kv_seq_len);
+    fake_input->generate_config->num_return_sequences = num_return_sequences;
     fake_input->generate_config->calculate_loss       = int(runtime_config.warm_up_with_loss);
-    rtp_llm::setTraceMemory(true);
 
     // Do NOT override seq_size_per_block here. createBasicConfig already
     // returns the correct value: model_config.attn_config.tokens_per_block
@@ -368,9 +511,41 @@ WarmUpResult NormalEngine::decodeWarmUp(const EngineInitParams& params) {
     // value when the user passed --seq_size_per_block < 256.
     const int cache_gen_num_per_cycle =
         sp_config.type != SP_TYPE_NONE ? static_cast<int>(sp_config.gen_num_per_cycle) : 0;
-    auto cache_config = CacheConfigCreator::createBasicConfig(
-        model_config_, parallelism_config, false, cache_gen_num_per_cycle);
-    cache_config.block_num = 5;
+    CacheConfig config_seed;
+    if (propose_params_) {
+        KVCacheConfig profiling_kv_cache_config = kv_cache_config;
+        profiling_kv_cache_config.test_block_num = 1;
+        config_seed = CacheConfigCreator::createSpConfig(model_config_,
+                                                         propose_params_->getEngineInitParams().model_config_,
+                                                         parallelism_config,
+                                                         runtime_config,
+                                                         profiling_kv_cache_config,
+                                                         sp_config,
+                                                         std::nullopt,
+                                                         isMTPEagle(),
+                                                         isEagle());
+    } else {
+        config_seed = CacheConfigCreator::createBasicConfig(model_config_,
+                                                            parallelism_config,
+                                                            false,
+                                                            cache_gen_num_per_cycle);
+    }
+    const auto&   configured_capture_batch_sizes = params.hw_kernel_config.decode_capture_batch_sizes;
+    const int64_t max_num_requests               = std::max<int64_t>(0, runtime_config.max_generate_batch_size);
+    const int64_t max_capture_batch_size =
+        configured_capture_batch_sizes.empty() ?
+            max_num_requests :
+            std::max<int64_t>(
+                0, *std::max_element(configured_capture_batch_sizes.begin(), configured_capture_batch_sizes.end()));
+    // Match vLLM's minimal profiling KV cache: one block per capturable request,
+    // bounded by both the request limit and the largest CUDA Graph batch.
+    const size_t temporary_block_num =
+        static_cast<size_t>(std::max<int64_t>(1, std::min(max_num_requests, max_capture_batch_size)));
+    RTP_LLM_CHECK_WITH_INFO(temporary_block_num <= std::numeric_limits<uint32_t>::max(),
+                            "decode warmup temporary block num is too large: %zu",
+                            temporary_block_num);
+    config_seed.block_num = static_cast<uint32_t>(temporary_block_num);
+    auto cache_config = std::move(config_seed);
     // createBasicConfig's SingleConfigCreator / HybridConfigCreator paths can
     // leave kernel_seq_size_per_block at 0 (only the real createConfig path
     // runs setupKernelSeqSize). PyWrappedModel asserts kernel_tokens_per_block
@@ -380,20 +555,100 @@ WarmUpResult NormalEngine::decodeWarmUp(const EngineInitParams& params) {
     }
     ParallelismConfig temp_parallelism_config;
     RuntimeConfig     temp_runtime_config;
-    auto              cache_manager = make_shared<KVCacheManager>(
-        cache_config, true, nullptr, KVCacheConfig{}, temp_parallelism_config, temp_runtime_config);
+
+    // The temporary profiling KV pool must not reduce the pool available to the final cache.
+    // Clear loader leftovers and save the sizing base before allocating that temporary pool. The
+    // forward trace starts below, after the pool exists, so its peak delta excludes the pool too.
+    cudaDeviceSynchronize();
+    c10::cuda::CUDACachingAllocator::emptyCache();
+    const size_t sizing_base_available = getGpuExecStatus().device_memory_status.available_bytes;
+
+    // Preserve the explicitly sized profiling cache so its configured capacity
+    // remains stable across ordinary-runtime and CUDA Graph profiling.
+    auto cache_manager = make_shared<KVCacheManager>(
+        cache_config,
+        false,
+        nullptr,
+        kv_cache_config,
+        parallelism_config,
+        runtime_config,
+        sp_config,
+        pd_sep_config,
+        cache_store_config);
+    RTP_LLM_CHECK_WITH_INFO(cache_manager->cacheConfig().block_num == temporary_block_num,
+                            "decode profiling KV cache block num changed: expected=%zu, actual=%u",
+                            temporary_block_num,
+                            cache_manager->cacheConfig().block_num);
     if (!cache_manager->init()) {
         RTP_LLM_FAIL("init kv cache manager failed in decodeWarmUp");
     }
-    executor_.reset(new NormalExecutor(params, cache_manager, true, false, 0, mla_ops_type_));
-    THROW_IF_STATUSOR_ERROR(preRun(fake_input, preRunMode::decode_warm_up));
-    const auto max_consumed = getGpuExecStatus().device_memory_status.max_consumed_bytes;
-    rtp_llm::setTraceMemory(false);
-    (void)executor_.reset(nullptr);
+
+    MemoryStatus post_teardown_status;
+    size_t       pre_warmup_available = 0;
+    {
+        // Profile the production decode forward without capture so its Torch peak does not absorb
+        // only part of the graph pool. CUDA graph memory is measured independently below.
+        WarmupTraceScope trace_scope(executor_);
+        if (propose_params_) {
+            executor_.reset(new MtpExecutor(params,
+                                             propose_params_,
+                                             cache_manager,
+                                             mla_ops_type_,
+                                             kv_cache_group_num_,
+                                             true,
+                                             false));
+        } else {
+            executor_.reset(new NormalExecutor(params,
+                                               cache_manager,
+                                               true,
+                                               false,
+                                               0,
+                                               mla_ops_type_,
+                                               nullptr,
+                                               nullptr,
+                                               false));
+        }
+        THROW_IF_STATUSOR_ERROR(preRun(fake_input, preRunMode::decode_warm_up));
+        post_teardown_status = trace_scope.teardownAndSample();
+        pre_warmup_available = trace_scope.preWarmupAvailableBytes();
+    }
+    auto result = makeWarmUpResult(pre_warmup_available,
+                                   post_teardown_status,
+                                   pd_sep_config.role_type == RoleType::PREFILL
+                                       || pd_sep_config.role_type == RoleType::DECODE,
+                                   "DECODE_WARMUP");
+
+    if (params.hw_kernel_config.enable_cuda_graph) {
+        // Capture the full configured graph set against the same minimal KV layout as the formal
+        // executor. CudaGraphRunner measures the device-free delta across this capture phase.
+        std::unique_ptr<Executor> graph_profile_executor;
+        if (propose_params_) {
+            graph_profile_executor = std::make_unique<MtpExecutor>(params,
+                                                                    propose_params_,
+                                                                    cache_manager,
+                                                                    mla_ops_type_,
+                                                                    kv_cache_group_num_,
+                                                                    true,
+                                                                    true);
+        } else {
+            graph_profile_executor =
+                std::make_unique<NormalExecutor>(params, cache_manager, true, false, 0, mla_ops_type_);
+        }
+        result.cuda_graph_memory_bytes = graph_profile_executor->cudaGraphMemoryBytes();
+        RTP_LLM_CHECK_WITH_INFO(result.cuda_graph_memory_bytes > 0,
+                                "decode CUDA graph capture reported zero device memory growth");
+        result.cuda_graph_measurement_trusted = result.forward_measurement_trusted;
+        graph_profile_executor.reset();
+        cudaDeviceSynchronize();
+        c10::cuda::CUDACachingAllocator::emptyCache();
+    }
+
+    cache_manager.reset();
     cudaDeviceSynchronize();
     c10::cuda::CUDACachingAllocator::emptyCache();
-    const auto device_status = getGpuExecStatus();
-    return WarmUpResult({device_status.device_memory_status.available_bytes, max_consumed});
+    result.available_bytes_pre_warmup = sizing_base_available;
+    result.device_reserved_bytes      = getGpuExecStatus().device_memory_status.available_bytes;
+    return result;
 #endif
 }
 

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.cc
@@ -61,7 +61,8 @@ NormalExecutor::NormalExecutor(const EngineInitParams&                params,
                                int                                    propose_model_index,
                                MlaOpsType                             mla_ops_type,
                                std::function<void()>                  profile_step_start,
-                               std::function<void()>                  profile_step_finish):
+                               std::function<void()>                  profile_step_finish,
+                               bool                                   allow_cuda_graph):
     Executor(),
     cache_manager_(cache_manager),
     warm_up_(warm_up),
@@ -153,7 +154,8 @@ NormalExecutor::NormalExecutor(const EngineInitParams&                params,
     }
     if (!params.py_model.is_none()) {
         RTP_LLM_LOG_INFO("init executor with python model");
-        model_.reset(new PyWrappedModel(model_init_params, params.py_model));
+        model_.reset(new PyWrappedModel(
+            model_init_params, params.py_model, false, false, DSparkModelRole::NONE, allow_cuda_graph));
     } else if (test_model_factory) {
         RTP_LLM_LOG_INFO("init executor with test model factory");
         model_ = test_model_factory(model_init_params);

--- a/rtp_llm/cpp/normal_engine/NormalExecutor.h
+++ b/rtp_llm/cpp/normal_engine/NormalExecutor.h
@@ -30,7 +30,8 @@ public:
                             int                                    propose_model_index = 0,
                             MlaOpsType                             mla_ops_type        = MlaOpsType::AUTO,
                             std::function<void()>                  profile_step_start  = nullptr,
-                            std::function<void()>                  profile_step_finish = nullptr);
+                            std::function<void()>                  profile_step_finish = nullptr,
+                            bool                                   allow_cuda_graph    = true);
     ~NormalExecutor();
     absl::Status process(const std::list<GenerateStreamPtr>& streams, int64_t schedule_time_us = 0) override;
     void         reportMetrics(const StreamGroups&                        stream_groups,
@@ -52,6 +53,9 @@ public:
     static ModelFactory test_model_factory;
 
     bool updateEplbConfig(const EPLBConfig& config) override;
+    size_t cudaGraphMemoryBytes() const {
+        return model_ ? model_->cudaGraphMemoryBytes() : 0;
+    }
 
 protected:
     // Stream-async dispatch gate. Reuses the same env var as MtpExecutor so a

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -535,7 +535,8 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
                          const std::shared_ptr<KVCacheManager>&         cache_manager,
                          MlaOpsType                                     mla_ops_type,
                          int32_t                                        kv_cache_group_num,
-                         bool                                           warm_up):
+                         bool                                           warm_up,
+                         bool                                           allow_cuda_graph):
     Executor(),
     cache_manager_(cache_manager),
     metrics_reporter_(params.metrics_reporter),
@@ -672,7 +673,7 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
 
     if (!params.py_model.is_none()) {
         RTP_LLM_LOG_INFO("init executor with python model");
-        model_.reset(new PyWrappedModel(model_init_params, params.py_model, false, true));
+        model_.reset(new PyWrappedModel(model_init_params, params.py_model, false, true, DSparkModelRole::NONE, allow_cuda_graph));
     }
 
     // when warmup, cache manager maybe nullptr
@@ -716,7 +717,7 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
                                 mtp_params->model_config_.hc_mult});
         if (!params.py_sp_model.is_none()) {
             RTP_LLM_LOG_INFO("[speculative decoding] using py model");
-            const bool enable_cuda_graph = params.hw_kernel_config.enable_cuda_graph;
+            const bool enable_cuda_graph = params.hw_kernel_config.enable_cuda_graph && allow_cuda_graph;
             // A DSpARK PREFILL worker only seeds the draft feature KV through
             // the ordinary CP-capable prefill path and never runs the
             // fixed-width decode proposal or tail commit. Capturing those
@@ -726,9 +727,9 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
             draft_model_.reset(new PyWrappedModel(model_params,
                                                   params.py_sp_model,
                                                   false,
-                                                  false,
-                                                  is_dspark_ ? DSparkModelRole::PROPOSE : DSparkModelRole::NONE,
-                                                  draft_graph_allowed));
+                                       false,
+                                       is_dspark_ ? DSparkModelRole::PROPOSE : DSparkModelRole::NONE,
+                                       draft_graph_allowed && allow_cuda_graph));
             // dspark use DSparkModelRole to call commit func, and token_per_bs is different
             // so another model is required
             if (enable_cuda_graph || is_dspark_) {
@@ -741,7 +742,7 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
                                        !is_dspark_,
                                        false,
                                        is_dspark_ ? DSparkModelRole::COMMIT : DSparkModelRole::NONE,
-                                       draft_graph_allowed));
+                                       draft_graph_allowed && allow_cuda_graph));
             }
         }
         break;  // NOTE: only support one mtp model now
@@ -2178,6 +2179,17 @@ absl::Status MtpExecutor::process(const std::list<GenerateStreamPtr>& streams, i
     }
 
     return absl::OkStatus();
+}
+
+size_t MtpExecutor::cudaGraphMemoryBytes() const {
+    size_t bytes = model_ ? model_->cudaGraphMemoryBytes() : 0;
+    if (draft_model_) {
+        bytes += draft_model_->cudaGraphMemoryBytes();
+    }
+    if (sp_prefill_draft_model_) {
+        bytes += sp_prefill_draft_model_->cudaGraphMemoryBytes();
+    }
+    return bytes;
 }
 
 bool MtpExecutor::updateEplbConfig(const EPLBConfig& config) {

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.h
@@ -44,10 +44,12 @@ public:
                          const std::shared_ptr<KVCacheManager>&         cache_manager,
                          MlaOpsType                                     mla_ops_type       = MlaOpsType::AUTO,
                          int32_t                                        kv_cache_group_num = 1,
-                         bool                                           warm_up            = false);
+                         bool                                           warm_up            = false,
+                         bool                                           allow_cuda_graph  = true);
 
     absl::Status process(const std::list<GenerateStreamPtr>& streams, int64_t schedule_time_us = 0) override;
     bool         updateEplbConfig(const EPLBConfig& config) override;
+    size_t       cudaGraphMemoryBytes() const override;
 
     void setTargetModel(std::unique_ptr<ModelBase> model) {
         model_ = std::move(model);

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -479,6 +479,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("fp8_kv_cache", &KVCacheConfig::fp8_kv_cache)
         .def_readwrite("ssm_state_dtype", &KVCacheConfig::ssm_state_dtype)
         .def_readwrite("kv_cache_mem_mb", &KVCacheConfig::kv_cache_mem_mb)
+        .def_readwrite("runtime_mem_safety_ratio", &KVCacheConfig::runtime_mem_safety_ratio)
         .def_readwrite("seq_size_per_block", &KVCacheConfig::seq_size_per_block)
         .def_readwrite("kernel_seq_size_per_block", &KVCacheConfig::kernel_seq_size_per_block)
         .def_readwrite("test_block_num", &KVCacheConfig::test_block_num)
@@ -580,10 +581,11 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.load_cache_retry_times,
                                       self.dsv4_fixed_pool_blocks,
                                       self.dsv4_hca_state_pool_blocks,
-                                      self.dsv4_fixed_pool_use_memory);
+                                      self.dsv4_fixed_pool_use_memory,
+                                      self.runtime_mem_safety_ratio);
             },
             [](py::tuple t) {
-                if (t.size() != 43 && t.size() != 54 && t.size() != 57)
+                if (t.size() != 43 && t.size() != 54 && t.size() != 57 && t.size() != 58)
                     throw std::runtime_error("Invalid state!");
                 KVCacheConfig c;
                 try {
@@ -644,10 +646,12 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                         c.load_cache_retry_times                  = t[53].cast<int>();
                     }
                     if (t.size() >= 57) {
-                        // DSV4 fixed-pool knobs.
                         c.dsv4_fixed_pool_blocks     = t[54].cast<uint32_t>();
                         c.dsv4_hca_state_pool_blocks = t[55].cast<uint32_t>();
                         c.dsv4_fixed_pool_use_memory = t[56].cast<bool>();
+                    }
+                    if (t.size() == 58) {
+                        c.runtime_mem_safety_ratio = t[57].cast<double>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("KVCacheConfig unpickle error: ") + e.what());

--- a/rtp_llm/cpp/utils/BUILD
+++ b/rtp_llm/cpp/utils/BUILD
@@ -45,6 +45,13 @@ cc_library(
 )
 
 cc_library(
+    name = "memory_status",
+    hdrs = ["MemoryStatus.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "profiling_scope",
     hdrs = [
         "ProfilingScope.h",

--- a/rtp_llm/cpp/utils/MemoryStatus.h
+++ b/rtp_llm/cpp/utils/MemoryStatus.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstddef>
+
+namespace rtp_llm {
+
+// Device memory counters shared by the device sampler and
+// dependency-free sizing/assembly code. Keep this POD independent of bindings and torch.
+struct MemoryStatus {
+    size_t used_bytes = 0;
+    size_t free_bytes = 0;
+    // Device total as reported by cudaMemGetInfo/hipMemGetInfo.
+    size_t total_bytes     = 0;
+    size_t available_bytes = 0;  // free GPU memory available for allocation
+    size_t allocated_bytes = 0;  // current bytes held by live torch allocations
+    // Absolute torch allocated high-water mark since resetPeakStats(). Unlike reserved_bytes,
+    // allocated_bytes excludes unused caching-allocator blocks. The warmup assembler compares
+    // this with allocated_bytes after teardown to recover only the transient torch headroom.
+    size_t torch_allocated_peak_bytes = 0;
+};
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/core/BUILD
+++ b/rtp_llm/models_py/bindings/core/BUILD
@@ -175,6 +175,7 @@ cc_library(
         "//rtp_llm/models_py/bindings/core:types_hdr",
         "//rtp_llm/cpp/config:model_config",
         "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/utils:memory_status",
     ],
     visibility = ["//visibility:public"],
     copts = copts(),

--- a/rtp_llm/models_py/bindings/core/DeviceData.h
+++ b/rtp_llm/models_py/bindings/core/DeviceData.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <stddef.h>
 #include <string>
+#include "rtp_llm/cpp/utils/MemoryStatus.h"
 #include "rtp_llm/models_py/bindings/core/Types.h"
 #include "rtp_llm/cpp/config/ModelConfig.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
@@ -27,14 +28,6 @@ struct ExecProperties {
     bool ffn_as_service              = false;
     bool enable_prefill_cp           = false;
     bool prefill_cp_kv_cache_sharded = false;
-};
-
-struct MemoryStatus {
-    size_t used_bytes         = 0;
-    size_t free_bytes         = 0;
-    size_t available_bytes    = 0;  // free GPU memory available for allocation
-    size_t allocated_bytes    = 0;  // memory allocated via current device
-    size_t max_consumed_bytes = 0;  // only applicable if RTP_LLM_TRACE_MEMORY is enabled.
 };
 
 // runtime device status, such as available memory.

--- a/rtp_llm/models_py/bindings/core/ExecOps.cc
+++ b/rtp_llm/models_py/bindings/core/ExecOps.cc
@@ -51,6 +51,7 @@ void             multiMergeCopy(const MultiMergeCopyParams& params);
 #include <cuda_runtime.h>
 #include <cuda_profiler_api.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 #include "rtp_llm/models_py/bindings/cuda/cuda_host_utils.h"
 #elif USING_ROCM
 #include <hip/hip_runtime.h>
@@ -530,17 +531,27 @@ void cudaProfilerEnd() {
 // Status queries
 // ============================================================
 
+namespace {
+static bool g_trace_memory = false;
+}  // namespace
+
 ExecStatus getGpuExecStatus() {
     MemoryStatus mem;
-    size_t       total_bytes = 0;
 #if USING_CUDA
-    auto error = cudaMemGetInfo(&mem.free_bytes, &total_bytes);
+    auto error = cudaMemGetInfo(&mem.free_bytes, &mem.total_bytes);
     RTP_LLM_CHECK(error == cudaSuccess);
 #elif USING_ROCM
-    hipMemGetInfo(&mem.free_bytes, &total_bytes);
+    ROCM_CHECK(hipMemGetInfo(&mem.free_bytes, &mem.total_bytes));
 #endif
-    mem.used_bytes      = total_bytes - mem.free_bytes;
+    mem.used_bytes      = mem.total_bytes - mem.free_bytes;
     mem.available_bytes = mem.free_bytes;
+#if USING_CUDA
+    if (isTraceMemory()) {
+        const auto& stats = c10::cuda::CUDACachingAllocator::getDeviceStats(at::cuda::current_device());
+        mem.allocated_bytes            = static_cast<size_t>(stats.allocated_bytes[0].current);
+        mem.torch_allocated_peak_bytes = static_cast<size_t>(stats.allocated_bytes[0].peak);
+    }
+#endif
     ExecStatus status;
     status.device_memory_status = mem;
     return status;
@@ -550,11 +561,17 @@ torch::Device getTorchCudaDevice() {
     return torch::Device(torch::kCUDA);
 }
 
-namespace {
-static bool g_trace_memory = false;
+bool isTraceMemory() {
+    return g_trace_memory;
 }
 
 void setTraceMemory(bool trace_memory) {
+#if USING_CUDA
+    if (trace_memory) {
+        c10::cuda::CUDACachingAllocator::emptyCache();
+        c10::cuda::CUDACachingAllocator::resetPeakStats(at::cuda::current_device());
+    }
+#endif
     g_trace_memory = trace_memory;
 }
 
@@ -641,7 +658,7 @@ void clearCommOpsUnlocked() {
 }  // anonymous namespace
 
 void execBroadcast(const BroadcastParams& params) {
-    py::function           fn;
+    py::function fn;
     py::gil_scoped_acquire gil;
     {
         std::lock_guard<std::mutex> lock(g_comm_mutex);
@@ -687,7 +704,7 @@ bool isCpuTpBroadcasterInitialized() {
 }
 
 AllReduceOutput execAllReduce(const AllReduceParams& params) {
-    py::function           fn;
+    py::function fn;
     py::gil_scoped_acquire gil;
     {
         std::lock_guard<std::mutex> lock(g_comm_mutex);
@@ -705,7 +722,7 @@ AllReduceOutput execAllReduce(const AllReduceParams& params) {
 }
 
 void execAllGather(const AllGatherParams& params) {
-    py::function           fn;
+    py::function fn;
     py::gil_scoped_acquire gil;
     {
         std::lock_guard<std::mutex> lock(g_comm_mutex);

--- a/rtp_llm/models_py/bindings/core/ExecOps.h
+++ b/rtp_llm/models_py/bindings/core/ExecOps.h
@@ -65,6 +65,7 @@ void cudaProfilerEnd();
 ExecStatus    getGpuExecStatus();
 torch::Device getTorchCudaDevice();
 void          setTraceMemory(bool trace_memory);
+bool isTraceMemory();
 
 // ===================================================================
 // Copy ops

--- a/rtp_llm/models_py/bindings/core/test/BUILD
+++ b/rtp_llm/models_py/bindings/core/test/BUILD
@@ -52,6 +52,14 @@ cc_test(
     exec_properties = {'gpu':'A10'},
 )
 
+cc_test(
+    name = "trace_memory_ops_test",
+    srcs = ["TraceMemoryOpsTest.cc"],
+    deps = exec_ops_test_deps,
+    copts = test_copts,
+    exec_properties = {"gpu": "H20"},
+)
+
 # Exercise the CPU fallback without initializing or allocating a GPU.
 cc_test(
     name = "packed_mask_logits_cpu_fallback_test",

--- a/rtp_llm/models_py/bindings/core/test/TraceMemoryOpsTest.cc
+++ b/rtp_llm/models_py/bindings/core/test/TraceMemoryOpsTest.cc
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#if USING_CUDA
+#include <c10/cuda/CUDACachingAllocator.h>
+#endif
+
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm {
+namespace {
+
+class TraceMemoryOpsTest: public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        initRuntime(0, false, false, MlaOpsType::AUTO);
+        auto init = torch::empty({1}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+        (void)init;
+    }
+};
+
+TEST_F(TraceMemoryOpsTest, TraceWindowActivatesThenCloses) {
+    setTraceMemory(true);
+    EXPECT_TRUE(isTraceMemory());
+    setTraceMemory(false);
+    EXPECT_FALSE(isTraceMemory());
+
+    const auto memory = getGpuExecStatus().device_memory_status;
+    EXPECT_EQ(memory.torch_allocated_peak_bytes, 0u);
+    EXPECT_GT(memory.total_bytes, 0u);
+}
+
+#if USING_CUDA
+TEST_F(TraceMemoryOpsTest, TracksAllocatedPeakAndCurrent) {
+    constexpr size_t kProbeBytes = 256ULL * 1024 * 1024;
+    setTraceMemory(true);
+    const auto baseline = getGpuExecStatus().device_memory_status;
+    {
+        auto held = torch::empty({static_cast<int64_t>(kProbeBytes)},
+                                 torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+        const auto memory = getGpuExecStatus().device_memory_status;
+        EXPECT_GE(memory.torch_allocated_peak_bytes, baseline.allocated_bytes + kProbeBytes);
+    }
+    c10::cuda::CUDACachingAllocator::emptyCache();
+
+    const auto memory = getGpuExecStatus().device_memory_status;
+    EXPECT_GE(memory.torch_allocated_peak_bytes, baseline.allocated_bytes + kProbeBytes);
+    EXPECT_LT(memory.allocated_bytes, baseline.allocated_bytes + kProbeBytes);
+    setTraceMemory(false);
+}
+#endif
+
+}  // namespace
+}  // namespace rtp_llm

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -693,6 +693,7 @@ class KVCacheConfig:
     dsv4_fixed_pool_use_memory: bool
     fp8_kv_cache: int
     kv_cache_mem_mb: int
+    runtime_mem_safety_ratio: float
     linear_step: int
     max_block_size_per_item: int
     memory_cache_size_mb: int

--- a/rtp_llm/server/server_args/concurrent_group_args.py
+++ b/rtp_llm/server/server_args/concurrent_group_args.py
@@ -1,4 +1,20 @@
+import argparse
+
 from rtp_llm.server.server_args.util import str2bool
+
+
+def _positive_concurrency_limit(value):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"must be an integer in [1, 2147483647], got {value!r}"
+        )
+    if not 1 <= parsed <= 2**31 - 1:
+        raise argparse.ArgumentTypeError(
+            f"must be an integer in [1, 2147483647], got {value!r}"
+        )
+    return parsed
 
 
 def init_concurrent_group_args(parser, concurrency_config):
@@ -18,7 +34,7 @@ def init_concurrent_group_args(parser, concurrency_config):
         "--concurrency_limit",
         env_name="CONCURRENCY_LIMIT",
         bind_to=(concurrency_config, 'concurrency_limit'),
-        type=int,
+        type=_positive_concurrency_limit,
         default=32,
         help="设置系统允许的最大并发请求数量。",
     )

--- a/rtp_llm/server/server_args/kv_cache_group_args.py
+++ b/rtp_llm/server/server_args/kv_cache_group_args.py
@@ -1,4 +1,17 @@
+import argparse
+import math
+
 from rtp_llm.server.server_args.util import str2bool
+
+
+def runtime_mem_safety_ratio(value):
+    try:
+        ratio = float(value)
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if not math.isfinite(ratio) or ratio < 0.0 or ratio >= 1.0:
+        raise argparse.ArgumentTypeError("must be finite and in [0, 1)")
+    return ratio
 
 
 def init_kv_cache_group_args(parser, kv_cache_config):
@@ -6,6 +19,21 @@ def init_kv_cache_group_args(parser, kv_cache_config):
     # KV Cache 相关配置
     ##############################################################################################################
     kv_cache_group = parser.add_argument_group("KVCache")
+    default_safety_ratio = kv_cache_config.runtime_mem_safety_ratio
+    kv_cache_group.add_argument(
+        "--runtime_mem_safety_ratio",
+        env_name="RUNTIME_MEM_SAFETY_RATIO",
+        bind_to=(kv_cache_config, "runtime_mem_safety_ratio"),
+        type=runtime_mem_safety_ratio,
+        metavar="FLOAT",
+        default=default_safety_ratio,
+        help=(
+            "运行期显存安全余量占 GPU 总显存的比例。"
+            f"范围 [0,1)，默认 {default_safety_ratio}；值越大 KV cache 越小。"
+            "warmup 路径将其作为实测增长之外的加性余量；no-warmup 路径固定使用 5% 下限；"
+            "需要固定绝对预留时使用 --reserver_runtime_mem_mb。"
+        ),
+    )
     kv_cache_group.add_argument(
         "--reuse_cache",
         env_name="REUSE_CACHE",

--- a/rtp_llm/test/smoke/suites_h20_oss.bzl
+++ b/rtp_llm/test/smoke/suites_h20_oss.bzl
@@ -149,6 +149,21 @@ def h20_oss_suites():
                 },
                 gpu_type=["H20"],
             ),
+            # End-to-end coverage for measured runtime-memory sizing. Startup must complete
+            # automatic KV allocation on both PD roles before the golden request can succeed.
+            smoke_test(
+                name="forward_warmup_pd",
+                task_info="data/model/qwen3_moe/q_r_30b_py_tp2.json",
+                envs={
+                    "prefill": [],
+                    "decode": [],
+                },
+                smoke_args={
+                    "prefill": "--checkpoint_path /mnt/nas1/hf/Qwen3-30B-A3B-Instruct-2507-FP8 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --role_type PREFILL --tp_size 2 --ep_size 2 --world_size 2 --max_seq_len 32768 --max_context_batch_size 2 --concurrency_limit 32 --warm_up 1 --runtime_mem_safety_ratio 0.10 --use_deepep_moe 1 --use_deepep_low_latency 0 --load_method scratch",
+                    "decode": "--checkpoint_path /mnt/nas1/hf/Qwen3-30B-A3B-Instruct-2507-FP8 --act_type BF16 --cache_store_rdma_mode 0 --use_local 1 --role_type DECODE --tp_size 2 --ep_size 2 --world_size 2 --max_seq_len 32768 --max_context_batch_size 2 --concurrency_limit 32 --warm_up 1 --runtime_mem_safety_ratio 0.10 --enable_cuda_graph 1 --decode_capture_config 1,8,16 --use_deepep_moe 1 --use_deepep_low_latency 1 --load_method scratch",
+                },
+                gpu_type=["H20"],
+            ),
         ],
     )
 


### PR DESCRIPTION
### Summary

**改动前的现状**：startup warmup forward 已经存在，`--warm_up` 也默认开启，但测量结果没有接入 KV
cache 定容。`getGpuExecStatus()` 不写有效峰值，`WarmUpResult` 的 measured growth 恒为 0；KV 以临时
executor teardown 后的 available memory 为基数，旧公式实际只预留
`max(configured, sampler, 2048 MiB, 5% x total_gpu)`。

**本 PR 的改动**：

1. 在 startup dummy forward 前后采集 torch allocator peak、非 torch 显存增长和 teardown 后可用显存，
   组装为可信的 `WarmUpResult`。
2. PREFILL、DECODE 使用实测增长定容：
   `max(configured, measured_growth, sampler) + safety_ratio x total_gpu`；PDFUSION 和测量失效路径继续使用
   原 no-warmup 公式。
3. 可信测量路径把 available memory 的定容采样点从 **warmup teardown 后**前移到 **warmup forward 前**，
   使 base 与 measured growth 使用同一个 baseline；以
   `config-time available - safety_ratio_bytes` 作为最终 cap。PDFUSION 和测量失效路径仍使用 teardown 后
   的 available memory，测量为 0 时 fail-closed 回退。
4. 增加 `[WARMUP_DONE]`、`[KV_ALLOC]`、`[KV_ALLOC_LOCAL]`、`[KV_ALLOC_CAPPED]` 日志，保留每卡结果并由
   既有跨 rank min reduction 选择最终 `block_num`。

当前分支只包含 runtime measurement 和 sizing，dummy forward 使用模型自然路由。

### 发布说明

1. PD 分离的 PREFILL/DECODE role 会用启动期 forward 的实测显存增长确定 KV cache 容量。可信路径的
   safety 从旧公式中的下限项变为增长量之外的加性余量。
2. PDFUSION 仍执行既有 startup forward，但其 measurement 不受信任，继续以 post-teardown 可用显存和
   原 no-warmup 公式定容，因此不会因本次测量接入改变容量。
3. 新增 `--runtime_mem_safety_ratio`（默认 0.05，范围 `[0, 1)`）和
   `--runtime_mem_no_warmup_floor_mb`（默认 2048）。可信 warmup 路径如需绝对预留下限，继续使用
   `--reserver_runtime_mem_mb`。
4. 显式 `--kv_cache_mem_mb` 仍可完全绕开自动定容；`--warm_up 0` 可整体回到 no-warmup 公式。
5. 同时修正 pybind communication callbacks 的 GIL/互斥锁顺序，避免 startup control thread 执行
   warmup forward 时发生锁序反转。

### available memory 采样时刻变化

旧路径使用 warmup teardown 后的空闲显存，并套用静态 no-warmup 公式：

```text
KV = available_post_teardown
     - max(configured, sampler, no_warmup_floor, safety)
```

可信测量路径改用 dummy forward 前的空闲显存，使 base 与实测增长共享同一个 baseline：

```text
KV = available_pre_warmup
     - (max(configured, measured_total_growth, sampler) + safety)
```

`measured_total_growth` 已包含 warmup 后常驻的显存；若再从 post-teardown base 中扣除它，会重复预留。
不采信或零测量路径仍使用 post-teardown base 和旧公式。可信路径最终不超过
`config-time available - safety`，触发封顶时输出 `[KV_ALLOC_CAPPED]`。

### H20 实测结果

Qwen3-30B-A3B-Instruct-2507-FP8，H20，
TP1 x DP4 / EP4，`MAX_SEQ_LEN=32768`。

PREFILL 使用 DeepEP normal + DeepGemmHybridExecutor，负载为 `2 x 32767` token、自然路由；DECODE
显式使用 DeepEP normal，负载为 `128 x 32767` KV、单步 decode、自然路由。

| role | measured total growth | safety | runtime reserve | 最终容量依据 |
| --- | ---: | ---: | ---: | --- |
| PREFILL | **30488 MiB**（torch 30420 + non-torch 68） | 4867 MiB | **35355 MiB** | rank 1，8193 blocks |
| DECODE (DeepEP normal) | **1852 MiB**（torch 1784 + non-torch 68） | 4867 MiB | **6719 MiB** | 四卡相同，12966 blocks |

旧公式在本环境中预留 4867 MiB。PREFILL 四卡 measured growth 为 23810、30488、24522、19118 MiB，
最大相差 11370 MiB，说明每卡独立测量和跨 rank 取最小容量仍有必要。

### 回滚路径

| 手段 | 采样基数与公式 | 适用场景及代价 |
| --- | --- | --- |
| `--reserver_runtime_mem_mb <MiB>` | 仍使用 pre-warmup base 和可信测量公式，仅抬高 `configured` 项 | 保留 forward 实测，为可信路径增加绝对预留下限；这不是采样时刻回滚 |
| `--warm_up 0` | 不执行 startup forward，使用 cache-config 时 available 和旧 no-warmup 公式 | 关闭测量链路的整体回滚口；同时失去原有 warmup 的 lazy init / 启动期后端校验，不等同于升级前“forward 仍执行”的默认行为 |
| `--kv_cache_mem_mb <MiB>` | 不使用 available 采样和自动公式 | 最确定的容量回滚；需要人工给定容量并自行承担过大导致 OOM、过小损失吞吐的风险 |

