### PR TITLE
fix(qwen3.5): stabilize prefill context parallelism

### DIFF
--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -78,10 +78,7 @@ def auto_configure_deepep(
     prefill_cp_enabled = parallelism_config.prefill_cp_config.is_enabled()
     is_single_gpu = ep_size == 1
     is_pure_tp = (
-        tp_size > 1
-        and dp_size == 1
-        and ep_size == tp_size
-        and not prefill_cp_enabled
+        tp_size > 1 and dp_size == 1 and ep_size == tp_size and not prefill_cp_enabled
     )
     # Explicit opt-in via --moe_strategy must preserve use_all_gather, otherwise
     # the matching strategy's check_conditions (which requires use_all_gather)
@@ -340,9 +337,17 @@ def set_parallelism_config(
         )
 
     if py_prefill_cp_config:
+        if py_prefill_cp_config.segment_size_alignment <= 0:
+            raise ValueError(
+                "CP segment_size_alignment must be greater than 0, got "
+                f"{py_prefill_cp_config.segment_size_alignment}"
+            )
         parallelism_config.prefill_cp_config.method = py_prefill_cp_config.method
         parallelism_config.prefill_cp_config.comm_buffer_size = (
             py_prefill_cp_config.comm_buffer_size
+        )
+        parallelism_config.prefill_cp_config.segment_size_alignment = (
+            py_prefill_cp_config.segment_size_alignment
         )
     logging.info(
         f"set_parallelism_config: rank {world_rank}\nparallelism_config={parallelism_config.to_string()}world_rank={world_rank}\n"
@@ -371,11 +376,69 @@ def _infer_model_type(ckpt_path: str) -> Optional[str]:
         return None
 
 
-def setup_default_args(py_env_configs):
-    set_parallelism_config(
-        py_env_configs.parallelism_config,
-        py_prefill_cp_config=py_env_configs.prefill_cp_config,
+def _configure_model_prefill_cp(py_env_configs: PyEnvConfigs) -> None:
+    prefill_cp_config = py_env_configs.prefill_cp_config
+    if not prefill_cp_config.is_enabled():
+        return
+
+    # These processes do not execute the language-model forward and may share
+    # the backend's environment without participating in context parallelism.
+    if py_env_configs.role_config.role_type in (RoleType.FRONTEND, RoleType.VIT):
+        return
+
+    if py_env_configs.device_resource_config.enable_layer_micro_batch:
+        raise ValueError(
+            "Context parallelism cannot be combined with layer micro-batching: "
+            "the layer micro-batch forward path does not apply CP input/output "
+            "processing. "
+            "Set ENABLE_LAYER_MICRO_BATCH=0 when CP_ROTATE_METHOD is enabled."
+        )
+
+    model_cls = ModelDict.get_model_cls(py_env_configs.model_args.model_type)
+    if model_cls is None:
+        import rtp_llm.models  # noqa: F401 - populate the model registry
+
+        model_cls = ModelDict.get_model_cls(py_env_configs.model_args.model_type)
+    if model_cls is None:
+        raise ValueError(
+            "Cannot configure context parallelism for unknown model_type="
+            f"{py_env_configs.model_args.model_type}"
+        )
+
+    required_alignment = model_cls.prefill_cp_segment_size_alignment()
+    if required_alignment <= 0:
+        raise ValueError(
+            f"Model {py_env_configs.model_args.model_type} returned invalid CP "
+            f"segment alignment {required_alignment}"
+        )
+    # This is an internal model requirement, not a user-tunable setting.
+    prefill_cp_config.segment_size_alignment = required_alignment
+    py_env_configs.parallelism_config.prefill_cp_config.segment_size_alignment = (
+        required_alignment
     )
+
+    required_block_alignment = model_cls.prefill_cp_cache_block_size_alignment()
+    if required_block_alignment <= 0:
+        raise ValueError(
+            f"Model {py_env_configs.model_args.model_type} returned invalid CP "
+            f"cache block alignment {required_block_alignment}"
+        )
+    cache_block_size = py_env_configs.kv_cache_config.seq_size_per_block
+    if cache_block_size > 0 and cache_block_size % required_block_alignment != 0:
+        raise ValueError(
+            f"KV cache block size {cache_block_size} is incompatible with CP for "
+            f"{py_env_configs.model_args.model_type}, which requires a multiple of "
+            f"{required_block_alignment}"
+        )
+
+    model_cls.validate_prefill_cp_topology(
+        py_env_configs.parallelism_config,
+        py_env_configs.role_config.role_type,
+        py_env_configs.ffn_disaggregate_config.enable_ffn_disaggregate,
+    )
+
+
+def setup_default_args(py_env_configs):
     if not py_env_configs.model_args.tokenizer_path:
         py_env_configs.model_args.tokenizer_path = py_env_configs.model_args.ckpt_path
 
@@ -417,6 +480,12 @@ def setup_default_args(py_env_configs):
         logging.info("set SEQ_SIZE_PER_BLOCK 256 by default")
     if py_env_configs.kv_cache_config.seq_size_per_block == 0:
         py_env_configs.kv_cache_config.seq_size_per_block = 64
+
+    set_parallelism_config(
+        py_env_configs.parallelism_config,
+        py_prefill_cp_config=py_env_configs.prefill_cp_config,
+    )
+    _configure_model_prefill_cp(py_env_configs)
 
     # Set NCCL_P2P_DISABLE for RTX GPUs or when CUDA is not available
     # Frontend doesn't need this setting

--- a/rtp_llm/config/test/server_config_setup_test.py
+++ b/rtp_llm/config/test/server_config_setup_test.py
@@ -1,16 +1,155 @@
+import pickle
 import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
 from rtp_llm.config.py_config_modules import PyEnvConfigs
 from rtp_llm.config.server_config_setup import (
+    _configure_model_prefill_cp,
     set_parallelism_config,
     setup_and_configure_server,
+    setup_default_args,
 )
+from rtp_llm.model_factory_register import ModelDict
+from rtp_llm.ops import CPRotateMethod, ParallelismConfig, PrefillCPConfig, RoleType
 from rtp_llm.server.server_args.server_args import setup_args
 
 
 class GenerateConfigTest(TestCase):
+    def test_incompatible_model_cp_cache_block_size_is_rejected(self):
+        import rtp_llm.models.qwen3_next.qwen3_next  # noqa: F401
+
+        py_env_configs = self._qwen35_cp_configs()
+        py_env_configs.kv_cache_config.seq_size_per_block = 96
+
+        with self.assertRaisesRegex(ValueError, "KV cache block size 96"):
+            _configure_model_prefill_cp(py_env_configs)
+
+    def test_cp_with_layer_micro_batch_is_rejected(self):
+        py_env_configs = PyEnvConfigs()
+        py_env_configs.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        py_env_configs.device_resource_config.enable_layer_micro_batch = 1
+
+        with self.assertRaisesRegex(ValueError, "layer micro-batching"):
+            _configure_model_prefill_cp(py_env_configs)
+
+    def test_non_positive_cp_alignment_is_rejected(self):
+        py_env_configs = PyEnvConfigs()
+        py_env_configs.prefill_cp_config.segment_size_alignment = 0
+
+        with self.assertRaisesRegex(ValueError, "must be greater than 0"):
+            set_parallelism_config(
+                py_env_configs.parallelism_config,
+                py_prefill_cp_config=py_env_configs.prefill_cp_config,
+            )
+
+    def test_unknown_cp_model_is_rejected(self):
+        py_env_configs = PyEnvConfigs()
+        py_env_configs.model_args.model_type = "unregistered_model"
+        py_env_configs.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+
+        with patch.object(
+            ModelDict, "get_model_cls", return_value=None
+        ), self.assertRaisesRegex(ValueError, "unknown model_type"):
+            _configure_model_prefill_cp(py_env_configs)
+
+    def test_non_model_roles_ignore_shared_cp_environment(self):
+        for role_type in (RoleType.FRONTEND, RoleType.VIT):
+            with self.subTest(role_type=role_type):
+                py_env_configs = PyEnvConfigs()
+                py_env_configs.model_args.model_type = "unregistered_model"
+                py_env_configs.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+                py_env_configs.device_resource_config.enable_layer_micro_batch = 1
+                py_env_configs.role_config.role_type = role_type
+
+                _configure_model_prefill_cp(py_env_configs)
+
+    def test_prefill_cp_config_pickle_roundtrip_preserves_alignment(self):
+        cp_config = PrefillCPConfig()
+        cp_config.method = CPRotateMethod.ALL_GATHER
+        cp_config.segment_size_alignment = 64
+
+        restored_cp = pickle.loads(pickle.dumps(cp_config))
+        self.assertEqual(restored_cp.method, CPRotateMethod.ALL_GATHER)
+        self.assertEqual(restored_cp.segment_size_alignment, 64)
+
+        parallelism_config = ParallelismConfig()
+        parallelism_config.prefill_cp_config = cp_config
+        restored_parallelism = pickle.loads(pickle.dumps(parallelism_config))
+        self.assertEqual(
+            restored_parallelism.prefill_cp_config.segment_size_alignment, 64
+        )
+
+    def test_qwen35_cp_supported_topology_is_accepted(self):
+        import rtp_llm.models.qwen3_next.qwen3_next  # noqa: F401
+
+        py_env_configs = self._qwen35_cp_configs()
+        with patch(
+            "rtp_llm.config.server_config_setup.torch.cuda.is_available",
+            return_value=False,
+        ):
+            setup_default_args(py_env_configs)
+
+        self.assertEqual(py_env_configs.prefill_cp_config.segment_size_alignment, 64)
+        self.assertEqual(
+            py_env_configs.parallelism_config.prefill_cp_config.segment_size_alignment,
+            64,
+        )
+
+    def test_qwen35_cp_unsupported_topologies_are_rejected(self):
+        import rtp_llm.models.qwen3_next.qwen3_next  # noqa: F401
+
+        invalid_configs = (
+            ("tp_size", 1),
+            ("world_size", 8),
+            ("dp_size", 2),
+            ("ep_size", 4),
+            ("pp_size", 2),
+            ("ffn_sp_size", 2),
+        )
+        for field, value in invalid_configs:
+            with self.subTest(field=field, value=value):
+                py_env_configs = self._qwen35_cp_configs()
+                setattr(py_env_configs.parallelism_config, field, value)
+                with self.assertRaisesRegex(ValueError, "Qwen3-Next/Qwen3.5"):
+                    _configure_model_prefill_cp(py_env_configs)
+
+        py_env_configs = self._qwen35_cp_configs()
+        py_env_configs.role_config.role_type = RoleType.PREFILL
+        with self.assertRaisesRegex(ValueError, "Qwen3-Next/Qwen3.5"):
+            _configure_model_prefill_cp(py_env_configs)
+
+        py_env_configs = self._qwen35_cp_configs()
+        py_env_configs.ffn_disaggregate_config.enable_ffn_disaggregate = True
+        with self.assertRaisesRegex(ValueError, "Qwen3-Next/Qwen3.5"):
+            _configure_model_prefill_cp(py_env_configs)
+
+    def test_qwen35_cp_default_ep_is_rejected_after_normalization(self):
+        import rtp_llm.models.qwen3_next.qwen3_next  # noqa: F401
+
+        py_env_configs = self._qwen35_cp_configs()
+        py_env_configs.parallelism_config.ep_size = 0
+        with patch(
+            "rtp_llm.config.server_config_setup.torch.cuda.is_available",
+            return_value=False,
+        ), self.assertRaisesRegex(ValueError, "set EP_SIZE=1 explicitly"):
+            setup_default_args(py_env_configs)
+        self.assertEqual(py_env_configs.parallelism_config.ep_size, 4)
+
+    @staticmethod
+    def _qwen35_cp_configs() -> PyEnvConfigs:
+        py_env_configs = PyEnvConfigs()
+        py_env_configs.model_args.model_type = "qwen35_dense"
+        py_env_configs.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+        py_env_configs.kv_cache_config.seq_size_per_block = 256
+        py_env_configs.parallelism_config.tp_size = 4
+        py_env_configs.parallelism_config.world_size = 4
+        py_env_configs.parallelism_config.dp_size = 1
+        py_env_configs.parallelism_config.ep_size = 1
+        py_env_configs.parallelism_config.pp_size = 1
+        py_env_configs.parallelism_config.ffn_sp_size = 1
+        py_env_configs.role_config.role_type = RoleType.PDFUSION
+        return py_env_configs
 
     # EnvArgumentParser in setup_args() reads these env vars (START_PORT, TP_SIZE, etc.)
     # and binds them to py_env_configs; server_port = start_port + rank_id * worker_info_port_num (rank_id=0 here).
@@ -30,11 +169,6 @@ class GenerateConfigTest(TestCase):
         clear=True,
     )
     def test_simple(self):
-        from rtp_llm.config.server_config_setup import (
-            fetch_model_files_to_local,
-            setup_default_args,
-        )
-
         py_env_configs: PyEnvConfigs = setup_args()
         setup_and_configure_server(py_env_configs)
         pc = py_env_configs.parallelism_config

--- a/rtp_llm/cpp/config/ConfigModules.cc
+++ b/rtp_llm/cpp/config/ConfigModules.cc
@@ -5,7 +5,9 @@
 #include <algorithm>
 #include <string>
 #include <cctype>
+#include <limits>
 #include <regex>
+#include <stdexcept>
 
 namespace rtp_llm {
 
@@ -20,6 +22,28 @@ std::string NcclCommConfig::to_string() const {
 }
 
 // PrefillCPConfig
+size_t PrefillCPConfig::padded_sequence_length(size_t input_length, size_t cp_size) const {
+    if (cp_size == 0) {
+        throw std::invalid_argument("cp_size must be greater than 0");
+    }
+    if (segment_size_alignment == 0) {
+        throw std::invalid_argument("CP segment_size_alignment must be greater than 0");
+    }
+    if (cp_size > std::numeric_limits<size_t>::max() / 2 / segment_size_alignment) {
+        throw std::overflow_error("CP sequence alignment exceeds size_t range");
+    }
+    const size_t alignment = 2 * cp_size * segment_size_alignment;
+    const size_t remainder = input_length % alignment;
+    if (remainder == 0) {
+        return input_length;
+    }
+    const size_t padding = alignment - remainder;
+    if (input_length > std::numeric_limits<size_t>::max() - padding) {
+        throw std::overflow_error("CP padded sequence length exceeds size_t range");
+    }
+    return input_length + padding;
+}
+
 std::string PrefillCPConfig::to_string() const {
     std::ostringstream oss;
     oss << "method: ";
@@ -43,7 +67,8 @@ std::string PrefillCPConfig::to_string() const {
             oss << "UNKNOWN";
             break;
     }
-    oss << "\n comm_buffer_size: " << comm_buffer_size << "\n";
+    oss << "\n comm_buffer_size: " << comm_buffer_size << "\n segment_size_alignment: " << segment_size_alignment
+        << "\n";
     return oss.str();
 }
 

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -29,13 +29,16 @@ enum class CPRotateMethod {
 struct PrefillCPConfig {
     CPRotateMethod method           = CPRotateMethod::DISABLED;
     size_t         comm_buffer_size = 512 * 1024 * 1024;  // 512MB
-    bool           is_enabled() const {
+    // Token alignment required by one of the 2 * CP zigzag segments.
+    size_t segment_size_alignment = 1;
+    bool   is_enabled() const {
         return method != CPRotateMethod::DISABLED && method != CPRotateMethod::UNKNOWN
                && method != CPRotateMethod::PREFILL_CP;
     }
     bool is_prefill_enabled() const {
         return method == CPRotateMethod::PREFILL_CP;
     }
+    size_t      padded_sequence_length(size_t input_length, size_t cp_size) const;
     std::string to_string() const;
 };
 struct FfnDisAggregateConfig {

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -412,6 +412,11 @@ GptModelOutputs PyWrappedModel::forwardMicroBatched(const GptModelInputs& inputs
     return callForwardPostLayers(hidden_states, inputs, false);
 }
 
+bool PyWrappedModel::shouldUseContextParallel(const GptModelInputs& inputs, bool enable_prefill_cp) {
+    return enable_prefill_cp && inputs.input_lengths.size(0) > 0 && inputs.sequence_lengths.size(0) == 0
+           && !inputs.is_target_verify && !inputs.last_hidden_states.defined();
+}
+
 GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
     RTP_LLM_PROFILE_SCOPE("py_model.forward");
     d2d_copies_.clear();
@@ -427,28 +432,35 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             return forwardMicroBatched(inputs);
         }
         PyContextParallelParams cp_params;
-        if (device_props_.enable_prefill_cp) {
-            context_parallel_processor_->handleInputs(const_cast<GptModelInputs&>(inputs), cp_params);
+        GptModelInputs          cp_model_inputs;
+        const GptModelInputs*   forward_inputs = &inputs;
+        // Only a pure initial-prompt prefill enters CP. Decode, mixed batches,
+        // target verification, and MTP draft forwards stay on the regular path.
+        const bool use_context_parallel = shouldUseContextParallel(inputs, device_props_.enable_prefill_cp);
+        if (use_context_parallel) {
+            cp_model_inputs = inputs;
+            context_parallel_processor_->handleInputs(cp_model_inputs, cp_params);
+            forward_inputs = &cp_model_inputs;
         }
 
         torch::Tensor token_ids;
-        token_ids = tensorHoldHostAndToCuda(inputs.combo_tokens);
+        token_ids = tensorHoldHostAndToCuda(forward_inputs->combo_tokens);
 
         torch::Tensor input_hiddens =
-            inputs.last_hidden_states.defined() ? inputs.last_hidden_states : torch::empty({0});
+            forward_inputs->last_hidden_states.defined() ? forward_inputs->last_hidden_states : torch::empty({0});
 
-        auto attention_inputs      = buildPyAttentionInputs(inputs);
-        auto bert_embedding_inputs = buildBertEmbeddingInputs(inputs);
+        auto attention_inputs      = buildPyAttentionInputs(*forward_inputs);
+        auto bert_embedding_inputs = buildBertEmbeddingInputs(*forward_inputs);
 
-        if (device_props_.enable_prefill_cp) {
+        if (use_context_parallel) {
             attention_inputs.context_parallel_info = cp_params;
         }
 
         if (!inputs.warmup && inputs.pd_separation) {
-            attention_inputs.cache_store_inputs = prepareWriteCacheParams(inputs);
+            attention_inputs.cache_store_inputs = prepareWriteCacheParams(*forward_inputs);
             cache_store_async_writer_->init();
         }
-        setupKVCacheForAttentionInputs(attention_inputs, inputs);
+        setupKVCacheForAttentionInputs(attention_inputs, *forward_inputs);
 
         calculatePaddingOffset(attention_inputs);
         attention_inputs.padding_offset = tensorHoldHostAndToCuda(attention_inputs.padding_offset);
@@ -494,7 +506,7 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
         }
 
         RTP_LLM_LOG_DEBUG("Python object instance forward method called successfully.");
-        if (device_props_.enable_prefill_cp) {
+        if (use_context_parallel) {
             size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, inputs, cp_params);
             return callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens);
         }
@@ -631,7 +643,10 @@ GptModelOutputs PyWrappedModel::forwardPostLayers(torch::Tensor         hidden,
 
         auto logits = torch::mm(last_hidden.to(lm_head->kernel.dtype()), lm_head->kernel.t()).to(torch::kFloat32);
         printTorchTensorData(logits, "logits");
-        if (device_props_.tp_size > 1) {
+        // Gather only when weight loading actually sharded lm_head. Prefill CP
+        // normally keeps a full-vocabulary copy on every rank, while layouts
+        // involving another parallel dimension may still shard it.
+        if (device_props_.tp_size > 1 && !device_props_.lm_head_is_replicated) {
             logits = tpSyncEmbeddingOrLogits(logits);
         }
         if (check_nan_) {

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -42,6 +42,8 @@ public:
     void            releaseBuffers() override;
 
 private:
+    static bool shouldUseContextParallel(const GptModelInputs& inputs, bool enable_prefill_cp);
+
     std::optional<PyCacheStoreInputs> prepareWriteCacheParams(const GptModelInputs& inputs);
 
 private:

--- a/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.cc
+++ b/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.cc
@@ -3,6 +3,8 @@
 #include "rtp_llm/models_py/bindings/core/OpData.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/models_py/bindings/OpDefs.h"
+#include <cstring>
+#include <limits>
 
 namespace rtp_llm {
 
@@ -13,17 +15,50 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
 #else
     int prefill_cp_rank = parallelism_config_.tp_rank;
     int prefill_cp_size = parallelism_config_.tp_size;
-    int cp_align_size   = prefill_cp_size * 2;
 
     static const auto pinned_i32 = torch::TensorOptions(torch::kInt32).pinned_memory(true);
 
-    auto& total_input_tokens       = model_input.combo_tokens;
-    auto& input_lengths            = model_input.input_lengths;
-    auto& sequence_lengths         = model_input.sequence_lengths;
-    auto  input_lengths_cpu_tensor = input_lengths.clone().pin_memory();
+    const auto& total_input_tokens = model_input.combo_tokens;
+    const auto& input_lengths      = model_input.input_lengths;
+    const auto& sequence_lengths   = model_input.sequence_lengths;
+
+    RTP_LLM_CHECK_WITH_INFO(prefill_cp_size > 0, "CP size must be positive, got %d", prefill_cp_size);
+    RTP_LLM_CHECK_WITH_INFO(prefill_cp_rank >= 0 && prefill_cp_rank < prefill_cp_size,
+                            "CP rank %d is outside [0, %d)",
+                            prefill_cp_rank,
+                            prefill_cp_size);
+    RTP_LLM_CHECK_WITH_INFO(total_input_tokens.defined(), "CP combo tokens must be defined");
+    RTP_LLM_CHECK_WITH_INFO(total_input_tokens.device().is_cpu(), "CP combo tokens must be on CPU");
+    RTP_LLM_CHECK_WITH_INFO(total_input_tokens.scalar_type() == torch::kInt32, "CP combo tokens must be int32");
+    RTP_LLM_CHECK_WITH_INFO(total_input_tokens.dim() == 1,
+                            "CP combo tokens must be one-dimensional, got %ld dimensions",
+                            total_input_tokens.dim());
+    RTP_LLM_CHECK_WITH_INFO(input_lengths.defined(), "CP input lengths must be defined");
+    RTP_LLM_CHECK_WITH_INFO(input_lengths.device().is_cpu(), "CP input lengths must be on CPU");
+    RTP_LLM_CHECK_WITH_INFO(input_lengths.scalar_type() == torch::kInt32, "CP input lengths must be int32");
+    RTP_LLM_CHECK_WITH_INFO(
+        input_lengths.dim() == 1, "CP input lengths must be one-dimensional, got %ld dimensions", input_lengths.dim());
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths.defined(), "CP sequence lengths must be defined");
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths.device().is_cpu(), "CP sequence lengths must be on CPU");
+    RTP_LLM_CHECK_WITH_INFO(sequence_lengths.dim() == 1,
+                            "CP sequence lengths must be one-dimensional, got %ld dimensions",
+                            sequence_lengths.dim());
+    RTP_LLM_CHECK_WITH_INFO(input_lengths.size(0) >= sequence_lengths.size(0),
+                            "CP input batch size %ld is smaller than decode batch size %ld",
+                            input_lengths.size(0),
+                            sequence_lengths.size(0));
+
+    auto input_lengths_cpu_tensor = input_lengths.clone().pin_memory();
+    auto cp_input_lengths         = input_lengths_cpu_tensor.clone().pin_memory();
+
+    const int64_t original_token_count = total_input_tokens.size(0);
 
     size_t num_decode_stream  = sequence_lengths.size(0);
     size_t num_prefill_stream = input_lengths.size(0) - num_decode_stream;
+    RTP_LLM_CHECK_WITH_INFO(num_decode_stream <= static_cast<size_t>(original_token_count),
+                            "Decode batch size %zu exceeds CP token count %ld",
+                            num_decode_stream,
+                            original_token_count);
 
     auto prefill_cp_padding_lengths = torch::empty({(int64_t)num_prefill_stream}, pinned_i32);
     auto prefill_cp_chunk_lengths   = torch::empty({(int64_t)num_prefill_stream}, pinned_i32);
@@ -33,10 +68,19 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
     size_t prefill_cp_split_tokens_size = 0;
     for (size_t p = 0; p < num_prefill_stream; ++p) {
         int num_prefill_token = input_lengths.data_ptr<int32_t>()[num_decode_stream + p];
+        RTP_LLM_CHECK_WITH_INFO(num_prefill_token > 0,
+                                "CP prefill stream %zu must contain at least one token, got %d",
+                                p,
+                                num_prefill_token);
 
-        int padded_seq_len = ((num_prefill_token + cp_align_size - 1) / cp_align_size) * cp_align_size;
-        int padding_size   = padded_seq_len - num_prefill_token;
-        int chunk_size     = padded_seq_len / prefill_cp_size;
+        const size_t padded_seq_len_size = parallelism_config_.prefill_cp_config.padded_sequence_length(
+            static_cast<size_t>(num_prefill_token), static_cast<size_t>(prefill_cp_size));
+        RTP_LLM_CHECK_WITH_INFO(padded_seq_len_size <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                                "CP padded sequence length %zu exceeds int32 range",
+                                padded_seq_len_size);
+        const int padded_seq_len = static_cast<int>(padded_seq_len_size);
+        int padding_size = padded_seq_len - num_prefill_token;
+        int chunk_size   = padded_seq_len / prefill_cp_size;
 
         prefill_cp_split_tokens_size += chunk_size;
         padding_lengths[p] = padding_size;
@@ -48,10 +92,11 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
     auto prefill_shuffle_indices = torch::empty({(int64_t)prefill_cp_split_tokens_size}, pinned_i32);
 
     int* input_token_ptr             = cp_split_input_tokens.data_ptr<int>();
-    int* input_length_ptr            = input_lengths.data_ptr<int32_t>();
+    int* input_length_ptr            = cp_input_lengths.data_ptr<int32_t>();
     int* prefill_shuffle_indices_ptr = prefill_shuffle_indices.data_ptr<int>();
 
     int input_token_idx       = 0;
+    int prefill_shuffle_idx   = 0;
     int total_input_token_idx = 0;
 
     if (num_decode_stream > 0) {
@@ -66,6 +111,11 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
         int input_chunk_length   = prefill_cp_chunk_lengths.data_ptr<int>()[p];
         int input_padding_length = prefill_cp_padding_lengths.data_ptr<int>()[p];
         int input_length         = input_lengths.data_ptr<int32_t>()[num_decode_stream + p];
+        RTP_LLM_CHECK_WITH_INFO(total_input_token_idx + input_length <= original_token_count,
+                                "CP prefill stream %zu ends at token %d, beyond combo token count %ld",
+                                p,
+                                total_input_token_idx + input_length,
+                                original_token_count);
 
         int*             src_tokens = total_input_tokens.data_ptr<int32_t>() + total_input_token_idx;
         std::vector<int> total_input_token_vec(src_tokens, src_tokens + input_length);
@@ -83,16 +133,23 @@ void IContextParallelProcessor::handleInputs(GptModelInputs&                    
 
         std::memcpy(input_token_ptr + input_token_idx, chunk_input_token.data(), input_chunk_length * sizeof(int));
         std::memcpy(
-            prefill_shuffle_indices_ptr + input_token_idx, shuffle_index.data(), input_chunk_length * sizeof(int));
+            prefill_shuffle_indices_ptr + prefill_shuffle_idx, shuffle_index.data(), input_chunk_length * sizeof(int));
         input_token_idx += input_chunk_length;
+        prefill_shuffle_idx += input_chunk_length;
         total_input_token_idx += input_length;
         input_length_ptr[num_decode_stream + p] = input_chunk_length;
     }
 
-    model_input.combo_tokens = cp_split_input_tokens;
-    auto cp_padding_lengths  = prefill_cp_padding_lengths;
-    auto cp_chunk_lengths    = prefill_cp_chunk_lengths;
-    auto shuffle_indices     = prefill_shuffle_indices;
+    RTP_LLM_CHECK_WITH_INFO(total_input_token_idx == original_token_count,
+                            "CP input lengths cover %d tokens, but combo tokens contain %ld",
+                            total_input_token_idx,
+                            original_token_count);
+
+    model_input.combo_tokens  = cp_split_input_tokens;
+    model_input.input_lengths = cp_input_lengths;
+    auto cp_padding_lengths = prefill_cp_padding_lengths;
+    auto cp_chunk_lengths   = prefill_cp_chunk_lengths;
+    auto shuffle_indices    = prefill_shuffle_indices;
 
     auto qkv_restore_indice = generateQKVRestoreIndices(cp_chunk_lengths, prefill_cp_size);
     auto qkv_padding_mask   = generateQKVPaddingMask(cp_chunk_lengths, cp_padding_lengths, prefill_cp_size);

--- a/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.h
+++ b/rtp_llm/cpp/models/context_parallel/ContextParallelProcessorBase.h
@@ -27,6 +27,7 @@ public:
     void handleInputs(GptModelInputs& model_input, torch_ext::PyContextParallelParams& cp_params);
 
     /// @brief Gather outputs from all CP ranks and restore original token order.
+    /// @param inputs Original, unsharded request metadata.
     virtual size_t handleOutputs(torch::Tensor&                            hidden_states,
                                  const GptModelInputs&                     inputs,
                                  const torch_ext::PyContextParallelParams& cp_params) = 0;

--- a/rtp_llm/cpp/models/test/ModelDataTest.cc
+++ b/rtp_llm/cpp/models/test/ModelDataTest.cc
@@ -2,8 +2,14 @@
 #include "gtest/gtest.h"
 
 #include "rtp_llm/cpp/testing/TestBase.h"
+#include "rtp_llm/cpp/models/context_parallel/ZigzagProcessor.h"
 #include "rtp_llm/cpp/models/ModelTypes.h"
+#include "rtp_llm/cpp/models/PyWrappedModel.h"
 #include "rtp_llm/cpp/models/Sampler.h"
+#include "rtp_llm/models_py/bindings/OpDefs.h"
+#include "rtp_llm/models_py/bindings/core/OpData.h"
+
+#include <limits>
 
 using namespace std;
 
@@ -57,6 +63,106 @@ TEST_F(ModelDataTest, testConstruct) {
     builder.setSequenceLengths(sampler_inputs, sequence_lengths);
     auto sl = sampler_inputs.sequence_lengths;
     EXPECT_EQ(std::vector<int>(sl.data_ptr<int>(), sl.data_ptr<int>() + sl.numel()), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(PyWrappedModelTest, ContextParallelRequiresPurePrefill) {
+    GptModelInputs inputs;
+    inputs.input_lengths    = torch::empty({1}, torch::kInt32);
+    inputs.sequence_lengths = torch::empty({0}, torch::kInt32);
+
+    EXPECT_TRUE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, false));
+
+    inputs.is_target_verify = true;
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+    inputs.is_target_verify = false;
+
+    inputs.last_hidden_states = torch::empty({1, 1});
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+}
+
+TEST(PyWrappedModelTest, ContextParallelRejectsDecodeAndMixedBatches) {
+    GptModelInputs inputs;
+    inputs.input_lengths    = torch::empty({0}, torch::kInt32);
+    inputs.sequence_lengths = torch::empty({0}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs.input_lengths    = torch::empty({1}, torch::kInt32);
+    inputs.sequence_lengths = torch::empty({1}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+
+    inputs.input_lengths = torch::empty({2}, torch::kInt32);
+    EXPECT_FALSE(PyWrappedModel::shouldUseContextParallel(inputs, true));
+}
+
+TEST_F(ModelDataTest, ContextParallelHandleInputsUsesProductionMetadata) {
+    const auto original_tokens = torch::arange(100, 358, torch::TensorOptions().dtype(torch::kInt32));
+    const auto original_lengths = torch::tensor({1, 257}, torch::kInt32);
+    const auto prefix_lengths   = torch::tensor({64, 128}, torch::kInt32);
+
+    for (int rank: {0, 3}) {
+        ParallelismConfig config;
+        config.tp_size                                  = 4;
+        config.tp_rank                                  = rank;
+        config.prefill_cp_config.segment_size_alignment = 64;
+        ZigZagProcessor processor(config);
+
+        GptModelInputs inputs;
+        inputs.combo_tokens     = original_tokens;
+        inputs.input_lengths    = original_lengths;
+        inputs.sequence_lengths = torch::empty({0}, torch::kInt32);
+        inputs.prefix_lengths   = prefix_lengths;
+        torch_ext::PyContextParallelParams cp_params;
+
+        processor.handleInputs(inputs, cp_params);
+
+        EXPECT_TRUE(torch::equal(original_tokens, torch::arange(100, 358, torch::kInt32)));
+        EXPECT_TRUE(torch::equal(original_lengths, torch::tensor({1, 257}, torch::kInt32)));
+        EXPECT_TRUE(torch::equal(inputs.input_lengths, torch::tensor({128, 128}, torch::kInt32)));
+        EXPECT_TRUE(torch::equal(inputs.prefix_lengths, prefix_lengths));
+        EXPECT_TRUE(torch::equal(cp_params.prefill_actual_input_lengths_cpu, original_lengths));
+        EXPECT_TRUE(
+            torch::equal(cp_params.prefill_cp_padding_lengths.cpu(), torch::tensor({511, 255}, torch::kInt32)));
+        EXPECT_TRUE(torch::equal(cp_params.prefill_cp_chunk_lengths.cpu(), torch::tensor({128, 128}, torch::kInt32)));
+        EXPECT_EQ(cp_params.prefill_qkv_padding_mask.sum().item<int>(), 258);
+
+        const auto shuffle = cp_params.prefill_shuffle_indices.cpu();
+        ASSERT_EQ(shuffle.numel(), 256);
+        ASSERT_EQ(inputs.combo_tokens.numel(), 256);
+        const int actual_lengths[] = {1, 257};
+        const int source_offsets[] = {0, 1};
+        int       valid_tokens     = 0;
+        for (int batch = 0; batch < 2; ++batch) {
+            for (int local = 0; local < 128; ++local) {
+                const int index    = batch * 128 + local;
+                const int position = shuffle[index].item<int>();
+                if (position < actual_lengths[batch]) {
+                    ++valid_tokens;
+                    EXPECT_EQ(inputs.combo_tokens[index].item<int>(),
+                              original_tokens[source_offsets[batch] + position].item<int>());
+                } else {
+                    EXPECT_EQ(inputs.combo_tokens[index].item<int>(), 0);
+                }
+            }
+        }
+        EXPECT_EQ(valid_tokens, 65);
+    }
+}
+
+TEST_F(ModelDataTest, ContextParallelHandleInputsRejectsAlignmentOverflow) {
+    ParallelismConfig config;
+    config.tp_size                                  = 4;
+    config.tp_rank                                  = 0;
+    config.prefill_cp_config.segment_size_alignment = std::numeric_limits<size_t>::max();
+    ZigZagProcessor processor(config);
+
+    GptModelInputs inputs;
+    inputs.combo_tokens     = torch::tensor({1}, torch::kInt32);
+    inputs.input_lengths    = torch::tensor({1}, torch::kInt32);
+    inputs.sequence_lengths = torch::empty({0}, torch::kInt32);
+    torch_ext::PyContextParallelParams cp_params;
+
+    EXPECT_THROW(processor.handleInputs(inputs, cp_params), std::overflow_error);
 }
 
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1586,20 +1586,27 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def(py::init<>())
         .def_readwrite("method", &PrefillCPConfig::method)
         .def_readwrite("comm_buffer_size", &PrefillCPConfig::comm_buffer_size)
+        .def_readwrite("segment_size_alignment", &PrefillCPConfig::segment_size_alignment)
         .def("to_string", &PrefillCPConfig::to_string)
         .def("is_enabled", &PrefillCPConfig::is_enabled)
         .def("is_prefill_enabled", &PrefillCPConfig::is_prefill_enabled)
-        .def(py::pickle([](const PrefillCPConfig& self) { return py::make_tuple(self.method, self.comm_buffer_size); },
-                        [](py::tuple t) {
-                            if (t.size() != 2)
-                                throw std::runtime_error("Invalid state!");
-                            PrefillCPConfig c;
-                            try {
-                                c.method           = t[0].cast<CPRotateMethod>();
-                                c.comm_buffer_size = t[1].cast<size_t>();
-                            } catch (const std::exception& e) {
-                                throw std::runtime_error(std::string("PrefillCPConfig unpickle error: ") + e.what());
-                            }
-                            return c;
-                        }));
+        .def(py::pickle(
+            [](const PrefillCPConfig& self) {
+                return py::make_tuple(self.method, self.comm_buffer_size, self.segment_size_alignment);
+            },
+            [](py::tuple t) {
+                // Runtime process-transfer format; producer and consumer use
+                // the same binary, so accepting partial states is unsafe.
+                if (t.size() != 3)
+                    throw std::runtime_error("Invalid state!");
+                PrefillCPConfig c;
+                try {
+                    c.method                 = t[0].cast<CPRotateMethod>();
+                    c.comm_buffer_size       = t[1].cast<size_t>();
+                    c.segment_size_alignment = t[2].cast<size_t>();
+                } catch (const std::exception& e) {
+                    throw std::runtime_error(std::string("PrefillCPConfig unpickle error: ") + e.what());
+                }
+                return c;
+            }));
 }

--- a/rtp_llm/model_factory_register.py
+++ b/rtp_llm/model_factory_register.py
@@ -57,6 +57,11 @@ def register_hf_repo(name: str, model_type: str):
 
 class ModelDict:
     @staticmethod
+    def get_model_cls(model_type: str) -> Optional[Type[Any]]:
+        global _model_factory
+        return _model_factory.get(model_type)
+
+    @staticmethod
     def get_ft_model_type_by_hf_repo(repo: str) -> Optional[str]:
         global _hf_repo_2_ft
         model_type = _hf_repo_2_ft.get(repo, None)

--- a/rtp_llm/models/base_model.py
+++ b/rtp_llm/models/base_model.py
@@ -27,6 +27,7 @@ from rtp_llm.ops import (
     MoeConfig,
     ParallelismConfig,
     ProfilingDebugLoggingConfig,
+    RoleType,
     VitSeparation,
 )
 from rtp_llm.utils.database import CkptDatabase
@@ -164,6 +165,26 @@ class BaseModel(object):
 
     def support_cuda_graph(self) -> bool:
         return False
+
+    @classmethod
+    def prefill_cp_segment_size_alignment(cls) -> int:
+        """Token alignment required by one context-parallel zigzag segment."""
+        return 1
+
+    @classmethod
+    def prefill_cp_cache_block_size_alignment(cls) -> int:
+        """KV cache block alignment required by context-parallel prefill."""
+        return 1
+
+    @classmethod
+    def validate_prefill_cp_topology(
+        cls,
+        parallelism_config: ParallelismConfig,
+        role_type: RoleType,
+        ffn_disaggregate_enabled: bool,
+    ) -> None:
+        """Reject unsupported model-specific CP topologies before startup."""
+        pass
 
     def _load(self, device: str):
         # set empty weights for attention service

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -10,10 +10,54 @@ from rtp_llm.models.qwen3_next.qwen3_next_weight import (
     Qwen35DenseWeight,
     Qwen35MoeWeight,
 )
-from rtp_llm.ops import HybridAttentionType
+from rtp_llm.ops import HybridAttentionType, ParallelismConfig, RoleType
 
 
 class Qwen3NextBase(BaseModel):
+    @classmethod
+    def prefill_cp_segment_size_alignment(cls) -> int:
+        return 64
+
+    @classmethod
+    def prefill_cp_cache_block_size_alignment(cls) -> int:
+        return 64
+
+    @classmethod
+    def validate_prefill_cp_topology(
+        cls,
+        parallelism_config: ParallelismConfig,
+        role_type: RoleType,
+        ffn_disaggregate_enabled: bool,
+    ) -> None:
+        valid = (
+            parallelism_config.tp_size >= 2
+            and parallelism_config.world_size == parallelism_config.tp_size
+            and parallelism_config.dp_size == 1
+            and parallelism_config.ep_size == 1
+            and parallelism_config.pp_size == 1
+            and parallelism_config.ffn_sp_size == 1
+            and role_type == RoleType.PDFUSION
+            and not ffn_disaggregate_enabled
+        )
+        if valid:
+            return
+
+        raise ValueError(
+            "Qwen3-Next/Qwen3.5 prefill CP requires "
+            "TP_SIZE=WORLD_SIZE>=2, DP_SIZE=1, EP_SIZE=1, PP_SIZE=1, "
+            "FFN_SP_SIZE=1, ROLE_TYPE=PDFUSION, and FFN disaggregation disabled; "
+            "set EP_SIZE=1 explicitly because the default EP_SIZE=0 expands to "
+            "TP_SIZE*DP_SIZE; "
+            f"got TP_SIZE={parallelism_config.tp_size}, "
+            f"WORLD_SIZE={parallelism_config.world_size}, "
+            f"DP_SIZE={parallelism_config.dp_size}, "
+            f"EP_SIZE={parallelism_config.ep_size}, "
+            f"PP_SIZE={parallelism_config.pp_size}, "
+            f"FFN_SP_SIZE={parallelism_config.ffn_sp_size}, "
+            f"ROLE_TYPE={role_type.name}, "
+            f"ENABLE_FFN_DISAGGREGATE={int(ffn_disaggregate_enabled)}"
+        )
+
     def _create_python_model(self):
         model_config = self.model_config
         parallelism_config = self.parallelism_config

--- a/rtp_llm/models_py/bindings/core/DeviceData.h
+++ b/rtp_llm/models_py/bindings/core/DeviceData.h
@@ -18,9 +18,10 @@ struct ExecProperties {
     size_t tp_rank = 0;
     size_t tp_size = 1;
 
-    bool   enable_sp         = false;
-    size_t overlap_comm_type = 0;
-    size_t m_split           = 0;
+    bool   enable_sp             = false;
+    bool   lm_head_is_replicated = true;
+    size_t overlap_comm_type     = 0;
+    size_t m_split               = 0;
 
     MicroBatchType enable_layer_micro_batch = MicroBatchType::NONE;
 
@@ -45,9 +46,14 @@ struct ExecStatus {
 inline ExecProperties buildExecProperties(const ParallelismConfig&    parallelism_config,
                                           const DeviceResourceConfig& device_resource_config) {
     ExecProperties props;
-    props.tp_rank                  = parallelism_config.tp_rank;
-    props.tp_size                  = parallelism_config.tp_size;
-    props.enable_sp                = parallelism_config.enable_sp;
+    props.tp_rank   = parallelism_config.tp_rank;
+    props.tp_size   = parallelism_config.tp_size;
+    props.enable_sp = parallelism_config.enable_sp;
+    // lm_head splits only across physical TP. It stays replicated for TP=1 or
+    // when AtomicWeight::_split bypasses parallel splitting altogether.
+    const bool bypasses_weight_split = parallelism_config.get_attn_tp_size() <= 1 && parallelism_config.dp_size <= 1
+                                       && parallelism_config.ep_size <= 1;
+    props.lm_head_is_replicated    = parallelism_config.tp_size <= 1 || bypasses_weight_split;
     props.enable_prefill_cp        = parallelism_config.prefill_cp_config.is_enabled();
     props.ffn_as_service           = parallelism_config.ffn_disaggregate_config.is_ffn_service();
     props.enable_layer_micro_batch = static_cast<MicroBatchType>(device_resource_config.enable_layer_micro_batch);

--- a/rtp_llm/models_py/bindings/core/test/BUILD
+++ b/rtp_llm/models_py/bindings/core/test/BUILD
@@ -34,6 +34,16 @@ cc_test(
 )
 
 cc_test_wrapper(
+    name = "device_data_test",
+    srcs = ["DeviceDataTest.cc"],
+    deps = [
+        "//rtp_llm/models_py/bindings/core:device_data",
+        "@com_google_googletest//:gtest_main",
+    ],
+    copts = copts(),
+)
+
+cc_test_wrapper(
     name = "cache_store_async_writer_test",
     srcs = ["CacheStoreAsyncWriterTest.cpp"],
     deps = [

--- a/rtp_llm/models_py/bindings/core/test/DeviceDataTest.cc
+++ b/rtp_llm/models_py/bindings/core/test/DeviceDataTest.cc
@@ -1,0 +1,31 @@
+#include "gtest/gtest.h"
+
+#include "rtp_llm/models_py/bindings/core/DeviceData.h"
+
+namespace rtp_llm {
+
+TEST(DeviceDataTest, LmHeadReplicationMatchesWeightLayout) {
+    ParallelismConfig    parallelism_config;
+    DeviceResourceConfig device_resource_config;
+
+    EXPECT_TRUE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+
+    parallelism_config.ep_size = 4;
+    EXPECT_TRUE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+
+    parallelism_config.ep_size = 1;
+    parallelism_config.tp_size = 4;
+    EXPECT_FALSE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+
+    parallelism_config.prefill_cp_config.method = CPRotateMethod::ALL_GATHER;
+    EXPECT_TRUE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+
+    parallelism_config.ep_size = 4;
+    EXPECT_FALSE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+
+    parallelism_config.ep_size = 1;
+    parallelism_config.dp_size = 2;
+    EXPECT_FALSE(buildExecProperties(parallelism_config, device_resource_config).lm_head_is_replicated);
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/models_py/distributed/test/user_buffers_test.py
+++ b/rtp_llm/models_py/distributed/test/user_buffers_test.py
@@ -106,6 +106,7 @@ def _test_send_recv_tensor(comm: UserBufferCommunicator, rank: int, world_size: 
         [1024, 4096], dtype=torch.float32, device=src_tensor.device
     )
     assert torch.equal(expect_tensor, dst_tensor)
+
     logging.info(f"Rank {rank}: send recv valid tensor test passed")
 
 
@@ -176,6 +177,51 @@ class TestUserBufferCommunicator(unittest.TestCase):
         except RuntimeError:
             pass  # Already set
         self.port_manager = PortManager()
+
+    @mock.patch("rtp_llm.models_py.distributed.user_buffers.userbuffers_send")
+    def test_send_waits_for_tensor_producer(self, mock_send):
+        comm = object.__new__(UserBufferCommunicator)
+        comm.local_rank = 0
+        comm.per_rank_buffer_size = 1024
+        comm._ub_handle = 1
+        comm._communicator_ptr = 2
+        comm._rank_offsets = {0: 0}
+        comm._send_streams = {1: mock.Mock(cuda_stream=3)}
+        comm.cleanup = mock.Mock()
+        current_stream = mock.Mock()
+        tensor = torch.empty(4, device="cuda")
+
+        with mock.patch.object(
+            torch.cuda, "current_stream", return_value=current_stream
+        ):
+            self.assertTrue(comm.send(tensor, dst=1))
+
+        send_stream = comm._send_streams[1]
+        send_stream.wait_stream.assert_called_once_with(current_stream)
+        current_stream.wait_stream.assert_called_once_with(send_stream)
+        mock_send.assert_called_once()
+
+    @mock.patch("rtp_llm.models_py.distributed.user_buffers.userbuffers_recv")
+    def test_recv_waits_for_tensor_consumer(self, mock_recv):
+        comm = object.__new__(UserBufferCommunicator)
+        comm.local_rank = 0
+        comm.per_rank_buffer_size = 1024
+        comm._ub_handle = 1
+        comm._communicator_ptr = 2
+        comm._rank_offsets = {1: 0}
+        comm._recv_stream = mock.Mock(cuda_stream=3)
+        comm.cleanup = mock.Mock()
+        current_stream = mock.Mock()
+        tensor = torch.empty(4, device="cuda")
+
+        with mock.patch.object(
+            torch.cuda, "current_stream", return_value=current_stream
+        ):
+            self.assertTrue(comm.recv(tensor, src=1))
+
+        comm._recv_stream.wait_stream.assert_called_once_with(current_stream)
+        current_stream.wait_stream.assert_called_once_with(comm._recv_stream)
+        mock_recv.assert_called_once()
 
     def _run_multi_process_test(self, worker_func, world_size: int, test_name: str):
         """Helper to run a multi-process test"""

--- a/rtp_llm/models_py/distributed/user_buffers.py
+++ b/rtp_llm/models_py/distributed/user_buffers.py
@@ -178,7 +178,17 @@ class UserBufferCommunicator:
         if not self.can_handle_tensor(tensor):
             return False
 
+        current_stream = torch.cuda.current_stream()
+        send_stream = self._enqueue_send(tensor, dst, current_stream)
+        current_stream.wait_stream(send_stream)
+        return True
+
+    def _enqueue_send(
+        self, tensor: torch.Tensor, dst: int, source_stream: torch.cuda.Stream
+    ) -> torch.cuda.Stream:
         data_bytes = tensor.numel() * tensor.element_size()
+        send_stream = self._send_streams[dst]
+        send_stream.wait_stream(source_stream)
         userbuffers_send(
             tensor,
             self._ub_handle,
@@ -187,10 +197,9 @@ class UserBufferCommunicator:
             data_bytes,
             self._communicator_ptr,
             dst,
-            self._send_streams[dst].cuda_stream,
+            send_stream.cuda_stream,
         )
-        torch.cuda.current_stream().wait_stream(self._send_streams[dst])
-        return True
+        return send_stream
 
     def recv(
         self,
@@ -213,6 +222,15 @@ class UserBufferCommunicator:
         if not self.can_handle_tensor(tensor):
             return False
 
+        current_stream = torch.cuda.current_stream()
+        recv_stream = self._enqueue_recv(tensor, src, current_stream)
+        current_stream.wait_stream(recv_stream)
+        return True
+
+    def _enqueue_recv(
+        self, tensor: torch.Tensor, src: int, target_stream: torch.cuda.Stream
+    ) -> torch.cuda.Stream:
+        self._recv_stream.wait_stream(target_stream)
         userbuffers_recv(
             tensor,
             self._ub_handle,
@@ -222,7 +240,26 @@ class UserBufferCommunicator:
             src,
             self._recv_stream.cuda_stream,
         )
-        torch.cuda.current_stream().wait_stream(self._recv_stream)
+        return self._recv_stream
+
+    def send_recv(
+        self,
+        send_tensor: torch.Tensor,
+        dst: int,
+        recv_tensor: torch.Tensor,
+        src: int,
+    ) -> bool:
+        """Enqueue a full-duplex exchange without serializing receive after send."""
+        if not self.can_handle_tensor(send_tensor) or not self.can_handle_tensor(
+            recv_tensor
+        ):
+            return False
+
+        current_stream = torch.cuda.current_stream()
+        send_stream = self._enqueue_send(send_tensor, dst, current_stream)
+        recv_stream = self._enqueue_recv(recv_tensor, src, current_stream)
+        current_stream.wait_stream(send_stream)
+        current_stream.wait_stream(recv_stream)
         return True
 
     def all_gather(

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -8,7 +8,12 @@ from torch import nn
 import rtp_llm.ops.compute_ops as compute_ops
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.model_loader.model_weight_info import ModelWeights
-from rtp_llm.models_py.distributed.collective_torch import Group, all_gather, all_reduce
+from rtp_llm.models_py.distributed.collective_torch import (
+    Group,
+    all_gather,
+    all_reduce,
+    broadcast,
+)
 from rtp_llm.models_py.model_desc.block_map import select_block_map_for_layer
 from rtp_llm.models_py.model_desc.generic_moe import GenericMoeLayer
 from rtp_llm.models_py.model_desc.module_base import GptModelBase
@@ -21,7 +26,10 @@ from rtp_llm.models_py.modules import (
     RMSNorm,
     RMSResNorm,
 )
-from rtp_llm.models_py.modules.base.common.kvcache_store import WriteCacheStoreOp
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.linear_attn_utils import (
+    ZigzagCPPlan,
+    get_segment_valid_lengths,
+)
 from rtp_llm.models_py.triton_kernels.causal_conv1d import (
     CausalConv1dMetadata,
     causal_conv1d_fn,
@@ -64,26 +72,26 @@ class Qwen3NextMetadata(object):
         is_target_verify: bool = False,
         full_prefill_conv1d_meta: Optional[CausalConv1dMetadata] = None,
         full_prefill_cu_seqlens: Optional[torch.Tensor] = None,
-        cp_restore_indices: Optional[torch.Tensor] = None,
+        cp_local_conv1d_meta: Optional[CausalConv1dMetadata] = None,
+        cp_local_conv_cu_seqlens: Optional[torch.Tensor] = None,
+        cp_local_conv_prefix_lengths: Optional[torch.Tensor] = None,
+        is_cp_linear_attn: bool = False,
         cp_local_extract_indices: Optional[torch.Tensor] = None,
         cp_local_valid_mask: Optional[torch.Tensor] = None,
-        cp_write_cache_store_impl: Optional[WriteCacheStoreOp] = None,
     ):
         self.prefill_conv1d_meta = prefill_conv1d_meta
         self.is_target_verify = is_target_verify
         self.full_prefill_conv1d_meta = full_prefill_conv1d_meta
         self.full_prefill_cu_seqlens = full_prefill_cu_seqlens
-        self.cp_restore_indices = cp_restore_indices
+        self.cp_local_conv1d_meta = cp_local_conv1d_meta
+        self.cp_local_conv_cu_seqlens = cp_local_conv_cu_seqlens
+        self.cp_local_conv_prefix_lengths = cp_local_conv_prefix_lengths
+        self.is_cp_linear_attn = is_cp_linear_attn
         self.cp_local_extract_indices = cp_local_extract_indices
         self.cp_local_valid_mask = cp_local_valid_mask
-        self.cp_write_cache_store_impl = cp_write_cache_store_impl
 
     def get_prefill_conv1d_meta(self) -> Optional[CausalConv1dMetadata]:
         return self.prefill_conv1d_meta
-
-    @property
-    def is_cp_linear_attn(self) -> bool:
-        return self.cp_restore_indices is not None
 
 
 class Qwen3NextGatedDeltaNetBase(torch.nn.Module):
@@ -201,6 +209,49 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
         ).transpose(0, 1)
         return out
 
+    def _run_chunk_gdn(
+        self,
+        mixed_qkv: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: Optional[torch.Tensor],
+        cu_seqlens: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run the shared prefill GDN kernel from an explicit boundary state."""
+        if mixed_qkv.shape[0] >= 2048 and self.head_k_dim == self.head_v_dim:
+            query, key, value = scatter_qkv(
+                mixed_qkv,
+                self.local_num_k_heads,
+                self.local_num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+            )
+        else:
+            query, key, value = torch.split(
+                mixed_qkv,
+                [
+                    self.local_num_k_heads * self.head_k_dim,
+                    self.local_num_k_heads * self.head_k_dim,
+                    self.local_num_v_heads * self.head_v_dim,
+                ],
+                dim=-1,
+            )
+            query = query.view(1, -1, self.local_num_k_heads, self.head_k_dim)
+            key = key.view(1, -1, self.local_num_k_heads, self.head_k_dim)
+            value = value.view(1, -1, self.local_num_v_heads, self.head_v_dim)
+
+        return chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+        )
+
     def _fla(
         self,
         mixed_qkv: torch.Tensor,
@@ -237,44 +288,12 @@ class Qwen3NextGatedDeltaNetPrefill(Qwen3NextGatedDeltaNetBase):
                 initial_states,
                 seq_size_per_block,
             )
-        # M >= 2048: scatter_qkv (Triton, SGLang port) avoids the .view() ->
-        # .contiguous() copies that torch.split + view triggers. Below 2048,
-        # kernel launch overhead beats the savings (microbench measured).
-        if mixed_qkv.shape[0] >= 2048 and self.head_k_dim == self.head_v_dim:
-            query, key, value = scatter_qkv(
-                mixed_qkv,
-                self.local_num_k_heads,
-                self.local_num_v_heads,
-                self.head_k_dim,
-                self.head_v_dim,
-            )
-        else:
-            query, key, value = torch.split(
-                mixed_qkv,
-                [
-                    self.local_num_k_heads * self.head_k_dim,
-                    self.local_num_k_heads * self.head_k_dim,
-                    self.local_num_v_heads * self.head_v_dim,
-                ],
-                dim=-1,
-            )
-            query = query.view(
-                1, query.shape[0], self.local_num_k_heads, self.head_k_dim
-            )
-            key = key.view(1, key.shape[0], self.local_num_k_heads, self.head_k_dim)
-            value = value.view(
-                1, value.shape[0], self.local_num_v_heads, self.head_v_dim
-            )
-        attn_out, h, final_state = chunk_gated_delta_rule(
-            query,
-            key,
-            value,
+        attn_out, h, final_state = self._run_chunk_gdn(
+            mixed_qkv,
             g,
             beta,
-            initial_state=initial_states,
-            output_final_state=True,
-            cu_seqlens=cu_seqlens_without_padding,
-            use_qk_l2norm_in_kernel=True,
+            initial_states,
+            cu_seqlens_without_padding,
         )
         if ssm_states is not None:
             store_ssm_state_to_block_map(
@@ -478,6 +497,7 @@ class Qwen3NextAttention(CausalAttention):
         layernorm_eps: float,
         quant_config: Optional[object] = None,
         hw_kernel_config: Optional["HWKernelConfig"] = None,
+        layer_idx: int = 0,
     ):
         super().__init__(
             attn_config,
@@ -486,6 +506,7 @@ class Qwen3NextAttention(CausalAttention):
             layernorm_eps,
             quant_config,
             hw_kernel_config=hw_kernel_config,
+            layer_idx=layer_idx,
         )
         # maybe fuse gate in qkv_proj later
         self.gate = LinearFactory.create_linear_from_weights(
@@ -511,6 +532,19 @@ class Qwen3NextAttention(CausalAttention):
 
 
 class Qwen3NextGatedDeltaNet(nn.Module):
+    _linear_cp_relay_logged = False
+    _linear_cp_prefix_reuse_logged = False
+    _linear_cp_fallback_reasons_logged: set[str] = set()
+    _linear_cp_fatal_reasons = frozenset(
+        {
+            "missing_prefix_cache",
+            "unaligned_internal_prefix",
+            "missing_prefix_block_map",
+            "prefix_block_out_of_range",
+            "missing_prefix_boundary_state",
+        }
+    )
+
     def __init__(
         self,
         linear_attn_config: LinearAttentionConfig,
@@ -595,8 +629,458 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # b,a should be contiguous for fused_gdn_gating
         return mixed_qkv, z, b, a
 
-    # TODO: extract shared conv1d/FLA/ssm-state logic with Qwen3NextGatedDeltaNetPrefill
-    # to eliminate duplication
+    @staticmethod
+    def _get_linear_cp_relay_fallback_reason(
+        attention_inputs: PyAttentionInputs,
+        kv_cache_tensor: Optional[torch.Tensor],
+        seq_size_per_block: int,
+        attn_meta: Qwen3NextMetadata,
+    ) -> Optional[str]:
+        """Return why the linear-attention CP relay cannot run, if applicable."""
+        if attention_inputs.input_lengths.shape[0] != 1:
+            return "unsupported_context_batch_size"
+        if attention_inputs.is_cuda_graph:
+            return "cuda_graph"
+
+        prefix_len = int(attention_inputs.prefix_lengths[0].item())
+        if prefix_len > 0:
+            block_map = attention_inputs.kv_cache_kernel_block_id_host
+            if kv_cache_tensor is None:
+                return "missing_prefix_cache"
+            if prefix_len % seq_size_per_block != 0:
+                return "unaligned_internal_prefix"
+            if block_map is None:
+                return "missing_prefix_block_map"
+            prefix_block_pos = prefix_len // seq_size_per_block - 1
+            if prefix_block_pos >= block_map.shape[1]:
+                return "prefix_block_out_of_range"
+            if int(block_map[0, prefix_block_pos].item()) <= 0:
+                return "missing_prefix_boundary_state"
+        if (
+            attn_meta.cp_local_conv1d_meta is None
+            or attn_meta.cp_local_conv_cu_seqlens is None
+            or attn_meta.cp_local_conv_prefix_lengths is None
+        ):
+            return "missing_local_conv_metadata"
+        return None
+
+    def _log_linear_cp_fallback_once(
+        self, reason: str, attention_inputs: PyAttentionInputs
+    ) -> None:
+        logged_reasons = type(self)._linear_cp_fallback_reasons_logged
+        if reason in logged_reasons:
+            return
+        logged_reasons.add(reason)
+        prefix_len = int(attention_inputs.prefix_lengths[0].item())
+        logging.info(
+            "Qwen3.5 linear CP relay fallback: cp_size=%d, reason=%s, "
+            "prefix_len=%d. "
+            "The general path still preserves allocator prefix reuse.",
+            self.parallelism_config.tp_size,
+            reason,
+            prefix_len,
+        )
+
+    @classmethod
+    def _raise_for_invalid_cp_state(
+        cls, reason: Optional[str], prefix_len: int
+    ) -> None:
+        if reason not in cls._linear_cp_fatal_reasons:
+            return
+        raise RuntimeError(
+            "Qwen3.5 CP prefill invariant violated: "
+            f"reason={reason}, prefix_len={prefix_len}. "
+            "The general path cannot safely reconstruct this input."
+        )
+
+    def _run_linear_cp_gdn_segment(
+        self,
+        mixed_qkv: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run one contiguous GDN segment from an explicit FP32 boundary state."""
+        gdn = self.prefill_gdn
+        cu_seqlens = torch.tensor(
+            [0, mixed_qkv.shape[0]],
+            dtype=torch.int32,
+            device=mixed_qkv.device,
+        )
+        attn_out, chunk_states, final_state = gdn._run_chunk_gdn(
+            mixed_qkv,
+            g,
+            beta,
+            initial_state,
+            cu_seqlens,
+        )
+        return attn_out.squeeze_(0), chunk_states, final_state
+
+    @staticmethod
+    def _get_linear_cp_cache_blocks(
+        attention_inputs: PyAttentionInputs,
+        seq_size_per_block: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return new-token block ends and their layer-local cache block IDs."""
+        new_len = int(
+            attention_inputs.context_parallel_info.prefill_actual_input_lengths_cpu[
+                0
+            ].item()
+        )
+        prefix_len = int(attention_inputs.prefix_lengths[0].item())
+        total_len = prefix_len + new_len
+        device = attention_inputs.kv_cache_kernel_block_id_device.device
+        first_full_block_end = prefix_len + seq_size_per_block
+        absolute_block_ends = torch.arange(
+            first_full_block_end,
+            max(first_full_block_end, total_len),
+            seq_size_per_block,
+            dtype=torch.long,
+            device=device,
+        )
+        absolute_block_ends = torch.cat(
+            [
+                absolute_block_ends,
+                torch.tensor([total_len], dtype=torch.long, device=device),
+            ]
+        )
+        block_positions = (absolute_block_ends - 1) // seq_size_per_block
+        block_ids = attention_inputs.kv_cache_kernel_block_id_device[
+            0, block_positions
+        ].long()
+        return absolute_block_ends - prefix_len, block_ids
+
+    @staticmethod
+    def _copy_linear_cp_prefix_ssm_state(
+        ssm_states: torch.Tensor, prefix_block_id: int
+    ) -> torch.Tensor:
+        """Copy a cached boundary into the FP32 relay buffer."""
+        return (
+            ssm_states[prefix_block_id].to(dtype=torch.float32, copy=True).unsqueeze(0)
+        )
+
+    @staticmethod
+    def _sync_linear_cp_cache_states(
+        local_states: torch.Tensor,
+        cache_states: torch.Tensor,
+        block_ids: torch.Tensor,
+    ) -> None:
+        """Merge rank-owned states and write valid allocated cache blocks."""
+        local_states = all_reduce(local_states, group=Group.TP)
+        valid_positions = torch.nonzero(block_ids > 0, as_tuple=False).flatten()
+        if valid_positions.numel() == 0:
+            return
+        cache_states.index_copy_(
+            0,
+            block_ids[valid_positions],
+            local_states[valid_positions].to(cache_states.dtype),
+        )
+
+    @staticmethod
+    def _record_linear_cp_segment_ssm_states(
+        local_block_states: torch.Tensor,
+        block_ends: torch.Tensor,
+        segment_start: int,
+        segment_end: int,
+        chunk_states: torch.Tensor,
+        final_state: torch.Tensor,
+    ) -> None:
+        """Record cache boundaries owned by one contiguous 64-aligned segment."""
+        block_positions = torch.nonzero(
+            (block_ends > segment_start) & (block_ends <= segment_end),
+            as_tuple=False,
+        ).flatten()
+        if block_positions.numel() == 0:
+            return
+
+        offsets = block_ends[block_positions] - segment_start
+        chunk_indices = offsets // 64
+        selected_states = chunk_states[
+            0, chunk_indices.clamp_max(chunk_states.shape[1] - 1)
+        ]
+        ends_at_segment = offsets == segment_end - segment_start
+        selected_states = torch.where(
+            ends_at_segment[:, None, None, None], final_state[0], selected_states
+        )
+        local_block_states.index_copy_(
+            0, block_positions, selected_states.to(local_block_states.dtype)
+        )
+
+    @staticmethod
+    def _record_linear_cp_segment_conv_states(
+        local_block_states: torch.Tensor,
+        block_ends: torch.Tensor,
+        segment_start: int,
+        segment_valid_length: int,
+        segment_with_halo: torch.Tensor,
+    ) -> None:
+        """Record real conv tails, using the predecessor halo at segment start."""
+        if segment_valid_length == 0:
+            return
+        segment_end = segment_start + segment_valid_length
+        block_positions = torch.nonzero(
+            (block_ends > segment_start) & (block_ends <= segment_end),
+            as_tuple=False,
+        ).flatten()
+        if block_positions.numel() == 0:
+            return
+
+        state_len = local_block_states.shape[1]
+        offsets = block_ends[block_positions] - segment_start
+        state_offsets = torch.arange(
+            state_len, dtype=torch.long, device=segment_with_halo.device
+        )
+        state_indices = offsets[:, None] + state_offsets[None, :]
+        local_block_states.index_copy_(
+            0, block_positions, segment_with_halo[state_indices]
+        )
+
+    def _forward_linear_cp_conv(
+        self,
+        mixed_qkv: torch.Tensor,
+        prefix_conv_state: Optional[torch.Tensor],
+        kv_cache_tensor: Optional[torch.Tensor],
+        cache_block_ends: Optional[torch.Tensor],
+        cache_block_ids: Optional[torch.Tensor],
+        attn_meta: Qwen3NextMetadata,
+        cp_plan: ZigzagCPPlan,
+        segment_valid_lengths: tuple[int, ...],
+    ) -> torch.Tensor:
+        """Run local causal conv using fixed-size zigzag predecessor halos."""
+        gdn = self.prefill_gdn
+        state_len = gdn.linear_conv_kernel_dim - 1
+        segment_tokens = mixed_qkv.shape[0] // 2
+        local_segments = mixed_qkv.reshape(2, segment_tokens, -1)
+        local_tails = local_segments[:, -state_len:, :].contiguous()
+
+        gathered_tails = all_gather(local_tails.flatten(0, 1), group=Group.TP).reshape(
+            cp_plan.cp_size, 2, state_len, -1
+        )
+        front_source, back_source = cp_plan.halo_sources
+        first_halo = (
+            prefix_conv_state
+            if prefix_conv_state is not None
+            else torch.zeros_like(local_tails[0])
+        )
+        if front_source is not None:
+            first_halo = gathered_tails[front_source]
+        second_halo = gathered_tails[back_source]
+        local_segment_halos = first_halo, second_halo
+
+        haloed_qkv = torch.cat(
+            [
+                first_halo,
+                local_segments[0],
+                second_halo,
+                local_segments[1],
+            ],
+            dim=0,
+        )
+        haloed_out = causal_conv1d_fn(
+            x=haloed_qkv.transpose(0, 1),
+            weight=gdn.conv_weights,
+            bias=None,
+            conv_states=None,
+            query_start_loc=attn_meta.cp_local_conv_cu_seqlens,
+            block_map=None,
+            prefix_lengths=attn_meta.cp_local_conv_prefix_lengths,
+            seq_size_per_block=1,
+            metadata=attn_meta.cp_local_conv1d_meta,
+        ).transpose(0, 1)
+
+        haloed_segment_tokens = segment_tokens + state_len
+        local_out = torch.cat(
+            [
+                haloed_out[state_len:haloed_segment_tokens],
+                haloed_out[
+                    haloed_segment_tokens + state_len : 2 * haloed_segment_tokens
+                ],
+            ],
+            dim=0,
+        )
+
+        if (
+            kv_cache_tensor is not None
+            and cache_block_ends is not None
+            and cache_block_ids is not None
+        ):
+            conv_states = gdn._get_conv_states(kv_cache_tensor)
+            local_block_states = conv_states.new_zeros(
+                cache_block_ends.shape[0], state_len, mixed_qkv.shape[-1]
+            )
+            for local_segment_id, global_segment_id in enumerate(
+                cp_plan.local_global_segments
+            ):
+                segment_with_halo = torch.cat(
+                    [
+                        local_segment_halos[local_segment_id],
+                        local_segments[local_segment_id],
+                    ],
+                    dim=0,
+                )
+                self._record_linear_cp_segment_conv_states(
+                    local_block_states,
+                    cache_block_ends,
+                    global_segment_id * segment_tokens,
+                    segment_valid_lengths[global_segment_id],
+                    segment_with_halo,
+                )
+            self._sync_linear_cp_cache_states(
+                local_block_states, conv_states, cache_block_ids
+            )
+        return local_out
+
+    def _forward_linear_cp_relay(
+        self,
+        local_mixed_qkv: torch.Tensor,
+        z: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        prefix_ssm_state: Optional[torch.Tensor],
+        kv_cache_tensor: Optional[torch.Tensor],
+        cache_block_ends: Optional[torch.Tensor],
+        cache_block_ids: Optional[torch.Tensor],
+        cp_plan: ZigzagCPPlan,
+        segment_valid_lengths: tuple[int, ...],
+    ) -> torch.Tensor:
+        """Compute each GDN token once using ordered FP32 state broadcasts."""
+        if not type(self)._linear_cp_relay_logged:
+            logging.info(
+                "Qwen3.5 linear CP relay enabled: cp_size=%d; GDN is partitioned; "
+                "causal conv uses fixed-size CP halos; "
+                "block-aligned prefix reuse is supported",
+                cp_plan.cp_size,
+            )
+            type(self)._linear_cp_relay_logged = True
+
+        gdn = self.prefill_gdn
+        g, beta = fused_gdn_gating(gdn.alog, a, b, gdn.dt_bias)
+
+        local_tokens = local_mixed_qkv.shape[0]
+        segment_tokens = local_tokens // 2
+        rank = cp_plan.cp_rank
+        state = (
+            prefix_ssm_state
+            if prefix_ssm_state is not None
+            else torch.zeros(
+                1,
+                gdn.local_num_v_heads,
+                gdn.head_k_dim,
+                gdn.head_v_dim,
+                dtype=torch.float32,
+                device=local_mixed_qkv.device,
+            )
+        )
+        local_attn_out = torch.zeros(
+            local_tokens,
+            gdn.local_num_v_heads,
+            gdn.head_v_dim,
+            dtype=local_mixed_qkv.dtype,
+            device=local_mixed_qkv.device,
+        )
+        ssm_states = (
+            gdn._get_ssm_states(kv_cache_tensor)
+            if kv_cache_tensor is not None
+            else None
+        )
+        local_block_states = (
+            ssm_states.new_zeros(cache_block_ends.shape[0], *ssm_states.shape[1:])
+            if ssm_states is not None and cache_block_ends is not None
+            else None
+        )
+
+        relay_steps = cp_plan.relay_steps
+        ub_communicator = None
+        if getattr(self.parallelism_config, "use_ub_comm", False):
+            from rtp_llm.models_py.distributed.user_buffers import (
+                get_user_buffers_communicator,
+            )
+
+            ub_communicator = get_user_buffers_communicator()
+        # The user-buffer communicator must cover exactly the CP ranks.
+        use_ub_relay = (
+            ub_communicator is not None
+            and getattr(ub_communicator, "world_size", cp_plan.cp_size)
+            == cp_plan.cp_size
+            and ub_communicator.can_handle_tensor(state)
+        )
+        for step_index, step in enumerate(relay_steps):
+            valid_tokens = step.valid_token_count(segment_valid_lengths)
+            if rank == step.owner_rank and valid_tokens > 0:
+                local_start = step.first_local_segment * segment_tokens
+                local_end = local_start + valid_tokens
+                global_start = step.first_global_segment * segment_tokens
+                local_attn_out[local_start:local_end], chunk_states, state = (
+                    self._run_linear_cp_gdn_segment(
+                        local_mixed_qkv[local_start:local_end],
+                        g[:, local_start:local_end].contiguous(),
+                        beta[:, local_start:local_end].contiguous(),
+                        state,
+                    )
+                )
+                if local_block_states is not None:
+                    self._record_linear_cp_segment_ssm_states(
+                        local_block_states,
+                        cache_block_ends,
+                        global_start,
+                        global_start + valid_tokens,
+                        chunk_states,
+                        state,
+                    )
+            if step_index + 1 >= len(relay_steps):
+                continue
+
+            next_step = relay_steps[step_index + 1]
+            if use_ub_relay:
+                if rank == step.owner_rank:
+                    if not ub_communicator.send(state, dst=next_step.owner_rank):
+                        raise RuntimeError(
+                            "Qwen3.5 CP relay state does not fit the user-buffer "
+                            "communication capacity"
+                        )
+                elif rank == next_step.owner_rank:
+                    if not ub_communicator.recv(state, src=step.owner_rank):
+                        raise RuntimeError(
+                            "Qwen3.5 CP relay state receive failed in user-buffer "
+                            "communication"
+                        )
+            else:
+                broadcast(state, src=step.owner_rank, group=Group.TP)
+
+        if (
+            local_block_states is not None
+            and ssm_states is not None
+            and cache_block_ids is not None
+        ):
+            self._sync_linear_cp_cache_states(
+                local_block_states, ssm_states, cache_block_ids
+            )
+
+        local_attn_out = self.norm(
+            local_attn_out.reshape(-1, self.head_v_dim),
+            z.reshape(-1, self.head_v_dim),
+        )
+        local_attn_out = local_attn_out.reshape(
+            -1, self.local_num_v_heads * self.head_v_dim
+        )
+        local_attn_out = self.out_proj(local_attn_out)
+        local_segment_valid_lengths = tuple(
+            segment_valid_lengths[segment_id]
+            for segment_id in cp_plan.local_global_segments
+        )
+        local_valid_mask = torch.cat(
+            [
+                torch.arange(segment_tokens, device=local_attn_out.device)
+                < valid_length
+                for valid_length in local_segment_valid_lengths
+            ]
+        )
+        return torch.where(
+            local_valid_mask[:, None],
+            local_attn_out,
+            torch.zeros_like(local_attn_out),
+        )
+
     def _forward_cp_prefill(
         self,
         mixed_qkv: torch.Tensor,
@@ -607,9 +1091,97 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         kv_cache: Optional[LayerKVCache],
         attn_meta: Qwen3NextMetadata,
     ) -> torch.Tensor:
-        """CP prefill path: all-gather projected states, compute on full sequence,
-        extract local zigzag tokens."""
+        """CP prefill path with a partitioned GDN relay and general fallback."""
         cp_info = attention_inputs.context_parallel_info
+
+        kv_cache_tensor: Optional[torch.Tensor] = None
+        seq_size_per_block = 1
+        if kv_cache is not None:
+            kv_cache_tensor = kv_cache.kv_cache_base.reshape(
+                kv_cache.kv_cache_base.shape[0], -1
+            )
+            seq_size_per_block = kv_cache.seq_size_per_block
+
+        fallback_reason = self._get_linear_cp_relay_fallback_reason(
+            attention_inputs,
+            kv_cache_tensor,
+            seq_size_per_block,
+            attn_meta,
+        )
+        use_linear_cp_relay = fallback_reason is None
+        if fallback_reason is not None:
+            self._raise_for_invalid_cp_state(
+                fallback_reason,
+                int(attention_inputs.prefix_lengths[0].item()),
+            )
+            self._log_linear_cp_fallback_once(fallback_reason, attention_inputs)
+
+        if use_linear_cp_relay:
+            cp_plan = ZigzagCPPlan(
+                cp_size=self.parallelism_config.tp_size,
+                cp_rank=self.parallelism_config.tp_rank,
+            )
+            segment_tokens = mixed_qkv.shape[0] // 2
+            actual_tokens = int(cp_info.prefill_actual_input_lengths_cpu[0].item())
+            segment_valid_lengths = get_segment_valid_lengths(
+                actual_tokens, segment_tokens, cp_plan.cp_size
+            )
+            cache_block_ends: Optional[torch.Tensor] = None
+            cache_block_ids: Optional[torch.Tensor] = None
+            prefix_conv_state: Optional[torch.Tensor] = None
+            prefix_ssm_state: Optional[torch.Tensor] = None
+            if kv_cache_tensor is not None:
+                cache_block_ends, cache_block_ids = self._get_linear_cp_cache_blocks(
+                    attention_inputs, seq_size_per_block
+                )
+                prefix_len = int(attention_inputs.prefix_lengths[0].item())
+                if prefix_len > 0:
+                    prefix_block_pos = prefix_len // seq_size_per_block - 1
+                    prefix_block_id = int(
+                        attention_inputs.kv_cache_kernel_block_id_host[
+                            0, prefix_block_pos
+                        ].item()
+                    )
+                    prefix_conv_state = self.prefill_gdn._get_conv_states(
+                        kv_cache_tensor
+                    )[prefix_block_id]
+                    prefix_ssm_state = self._copy_linear_cp_prefix_ssm_state(
+                        self.prefill_gdn._get_ssm_states(kv_cache_tensor),
+                        prefix_block_id,
+                    )
+                    if not type(self)._linear_cp_prefix_reuse_logged:
+                        logging.info(
+                            "Qwen3.5 linear CP prefix state restored: cp_size=%d, "
+                            "prefix_len=%d, seq_size_per_block=%d, block_id=%d",
+                            cp_plan.cp_size,
+                            prefix_len,
+                            seq_size_per_block,
+                            prefix_block_id,
+                        )
+                        type(self)._linear_cp_prefix_reuse_logged = True
+            local_mixed_qkv = self._forward_linear_cp_conv(
+                mixed_qkv,
+                prefix_conv_state,
+                kv_cache_tensor,
+                cache_block_ends,
+                cache_block_ids,
+                attn_meta,
+                cp_plan,
+                segment_valid_lengths,
+            )
+            local_attn_out = self._forward_linear_cp_relay(
+                local_mixed_qkv,
+                z,
+                b,
+                a,
+                prefix_ssm_state,
+                kv_cache_tensor,
+                cache_block_ends,
+                cache_block_ids,
+                cp_plan,
+                segment_valid_lengths,
+            )
+            return local_attn_out
 
         packed = torch.cat([mixed_qkv, b, a], dim=-1)
         full_packed = all_gather(packed, group=Group.TP)
@@ -628,14 +1200,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         gdn = self.prefill_gdn
         full_cu = attn_meta.full_prefill_cu_seqlens
         full_conv_meta = attn_meta.full_prefill_conv1d_meta
-
-        kv_cache_tensor: Optional[torch.Tensor] = None
-        seq_size_per_block = 1
-        if kv_cache is not None:
-            kv_cache_tensor = kv_cache.kv_cache_base.reshape(
-                kv_cache.kv_cache_base.shape[0], -1
-            )
-            seq_size_per_block = kv_cache.seq_size_per_block
 
         conv_states = (
             gdn._get_conv_states(kv_cache_tensor).transpose(1, 2)
@@ -679,38 +1243,12 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 seq_size_per_block,
             )
 
-        if full_mixed_qkv.shape[0] >= 2048 and gdn.head_k_dim == gdn.head_v_dim:
-            query, key, value = scatter_qkv(
-                full_mixed_qkv,
-                gdn.local_num_k_heads,
-                gdn.local_num_v_heads,
-                gdn.head_k_dim,
-                gdn.head_v_dim,
-            )
-        else:
-            query, key, value = torch.split(
-                full_mixed_qkv,
-                [
-                    gdn.local_num_k_heads * gdn.head_k_dim,
-                    gdn.local_num_k_heads * gdn.head_k_dim,
-                    gdn.local_num_v_heads * gdn.head_v_dim,
-                ],
-                dim=-1,
-            )
-            query = query.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
-            key = key.view(1, -1, gdn.local_num_k_heads, gdn.head_k_dim)
-            value = value.view(1, -1, gdn.local_num_v_heads, gdn.head_v_dim)
-
-        attn_out, h, final_state = chunk_gated_delta_rule(
-            query,
-            key,
-            value,
+        attn_out, h, final_state = gdn._run_chunk_gdn(
+            full_mixed_qkv,
             g,
             beta,
-            initial_state=initial_states,
-            output_final_state=True,
-            cu_seqlens=full_cu,
-            use_qk_l2norm_in_kernel=True,
+            initial_states,
+            full_cu,
         )
 
         if ssm_states is not None:
@@ -724,9 +1262,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 seq_size_per_block,
                 chunk_size=64,
             )
-
-        if kv_cache is not None and attn_meta.cp_write_cache_store_impl is not None:
-            attn_meta.cp_write_cache_store_impl(kv_cache)
 
         full_attn_out = attn_out.squeeze_(0)
 
@@ -830,6 +1365,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 config.layernorm_eps,
                 config.quant_config,
                 hw_kernel_config=hw_kernel_config,
+                layer_idx=layer_idx,
             )
 
         if config.moe_style == 2:
@@ -940,18 +1476,18 @@ class Qwen3NextModel(GptModelBase):
     ) -> tuple[
         Optional[CausalConv1dMetadata],
         Optional[torch.Tensor],
+        Optional[CausalConv1dMetadata],
+        Optional[torch.Tensor],
         Optional[torch.Tensor],
         Optional[torch.Tensor],
         Optional[torch.Tensor],
     ]:
-        """Precompute metadata for CP linear attention (per-layer all-gather path).
+        """Precompute metadata for CP linear-attention prefill paths.
 
-        Returns (full_conv1d_meta, full_cu_seqlens, restore_indices,
-                 local_extract_indices, local_valid_mask).
+        Returns full-sequence fallback metadata, local halo-conv metadata,
+        and local extraction indices.
         """
         cp_info = attention_inputs.context_parallel_info
-        if cp_info is None:
-            return None, None, None, None, None
 
         # In CP mode the TP group is repurposed as the CP group, so tp_size == cp_size.
         cp_size = self.parallelism_config.tp_size
@@ -969,9 +1505,30 @@ class Qwen3NextModel(GptModelBase):
         restore_indices = cp_info.prefill_qkv_restore_indice
         padding_mask = cp_info.prefill_qkv_padding_mask
         unpad_restore = restore_indices[padding_mask == 1]
-
         total_ag = padding_mask.shape[0]
         local_chunk_total = total_ag // cp_size
+
+        cp_local_conv1d_meta = None
+        cp_local_conv_cu_seqlens = None
+        cp_local_conv_prefix_lengths = None
+        if cp_size >= 2 and full_new_lengths.shape[0] == 1:
+            state_len = self.config.linear_attention_config.linear_conv_kernel_dim - 1
+            segment_tokens = local_chunk_total // 2
+            if local_chunk_total % 2 == 0 and segment_tokens >= state_len:
+                haloed_segment_tokens = segment_tokens + state_len
+                cp_local_conv_cu_seqlens = torch.tensor(
+                    [0, haloed_segment_tokens, 2 * haloed_segment_tokens],
+                    dtype=torch.int32,
+                    device=device,
+                )
+                cp_local_conv_prefix_lengths = torch.zeros(
+                    2, dtype=torch.int32, device=device
+                )
+                cp_local_conv1d_meta = prepare_causal_conv1d_metadata(
+                    query_start_loc=cp_local_conv_cu_seqlens,
+                    device=device,
+                )
+
         local_start = cp_rank * local_chunk_total
 
         inv_restore = torch.full((total_ag,), -1, dtype=torch.long, device=device)
@@ -986,7 +1543,9 @@ class Qwen3NextModel(GptModelBase):
         return (
             full_conv1d_meta,
             full_cu,
-            restore_indices,
+            cp_local_conv1d_meta,
+            cp_local_conv_cu_seqlens,
+            cp_local_conv_prefix_lengths,
             cp_local_extract_indices,
             cp_local_valid_mask,
         )
@@ -999,34 +1558,29 @@ class Qwen3NextModel(GptModelBase):
         attention_inputs: PyAttentionInputs = inputs.attention_inputs
         prefill_conv1d_meta = None
         is_target_verify = attention_inputs.is_target_verify
-        is_cp = self.parallelism_config.prefill_cp_config.is_enabled()
+        is_cp = attention_inputs.context_parallel_info is not None
 
         full_prefill_conv1d_meta = None
         full_prefill_cu_seqlens = None
-        cp_restore_indices = None
+        cp_local_conv1d_meta = None
+        cp_local_conv_cu_seqlens = None
+        cp_local_conv_prefix_lengths = None
         cp_local_extract_indices = None
         cp_local_valid_mask = None
-        cp_write_cache_store_impl = None
 
         if attention_inputs.is_prefill and not is_target_verify:
             if is_cp:
                 (
                     full_prefill_conv1d_meta,
                     full_prefill_cu_seqlens,
-                    cp_restore_indices,
+                    cp_local_conv1d_meta,
+                    cp_local_conv_cu_seqlens,
+                    cp_local_conv_prefix_lengths,
                     cp_local_extract_indices,
                     cp_local_valid_mask,
                 ) = self._build_cp_linear_attn_metadata(
                     attention_inputs, hidden_states.device
                 )
-                if attention_inputs.cache_store_inputs:
-                    cp_info = attention_inputs.context_parallel_info
-                    cp_write_cache_store_impl = WriteCacheStoreOp(
-                        cp_info.prefill_actual_input_lengths_cpu,
-                        attention_inputs.prefix_lengths,
-                        attention_inputs.kv_cache_block_id_host,
-                        attention_inputs.cache_store_inputs,
-                    )
             else:
                 cu_seqlen_without_padding = attention_inputs.cu_seqlens
                 prefill_conv1d_meta = prepare_causal_conv1d_metadata(
@@ -1039,10 +1593,12 @@ class Qwen3NextModel(GptModelBase):
             is_target_verify=is_target_verify,
             full_prefill_conv1d_meta=full_prefill_conv1d_meta,
             full_prefill_cu_seqlens=full_prefill_cu_seqlens,
-            cp_restore_indices=cp_restore_indices,
+            cp_local_conv1d_meta=cp_local_conv1d_meta,
+            cp_local_conv_cu_seqlens=cp_local_conv_cu_seqlens,
+            cp_local_conv_prefix_lengths=cp_local_conv_prefix_lengths,
+            is_cp_linear_attn=is_cp,
             cp_local_extract_indices=cp_local_extract_indices,
             cp_local_valid_mask=cp_local_valid_mask,
-            cp_write_cache_store_impl=cp_write_cache_store_impl,
         )
 
         if fmha_impl is None:

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -35,6 +35,8 @@ def get_mla_impl(
 ) -> MlaImplBase:
 
     mla_impls = PREFILL_MLA_IMPS if attn_inputs.is_prefill else DECODE_MLA_IMPS
+    # CP is process-wide, but decode/MTP/verify forwards do not carry CP metadata.
+    uses_context_parallel = attn_inputs.context_parallel_info is not None
     for impl in mla_impls:
         # Check support before creating instance
         if not impl.support(attn_configs, attn_inputs):
@@ -50,7 +52,7 @@ def get_mla_impl(
             )
         )
 
-        if not use_fast_path and not impl.support_parallelism_config(
+        if uses_context_parallel and not impl.support_parallelism_config(
             parallelism_config
         ):
             continue
@@ -149,6 +151,8 @@ def get_fmha_impl(
     attn_inputs.is_cuda_graph = is_cuda_graph
 
     mha_impls = PREFILL_MHA_IMPS if attn_inputs.is_prefill else DECODE_MHA_IMPS
+    # CP is process-wide, but decode/MTP/verify forwards do not carry CP metadata.
+    uses_context_parallel = attn_inputs.context_parallel_info is not None
 
     for impl in mha_impls:
         # Check if this FMHA implementation is disabled before creating instance
@@ -163,7 +167,9 @@ def get_fmha_impl(
             continue
 
         # Check if implementation supports parallelism config
-        if not impl.support_parallelism_config(parallelism_config):
+        if uses_context_parallel and not impl.support_parallelism_config(
+            parallelism_config
+        ):
             continue
         try:
             instance = impl(attn_configs, attn_inputs, parallelism_config)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/linear_attn_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/linear_attn_utils.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ZigzagRelayStep:
+    """One contiguous stateful-attention call in global token order."""
+
+    owner_rank: int
+    first_global_segment: int
+    first_local_segment: int
+    segment_count: int = 1
+
+    def valid_token_count(self, segment_valid_lengths: tuple[int, ...]) -> int:
+        end = self.first_global_segment + self.segment_count
+        if len(segment_valid_lengths) < end:
+            raise ValueError(
+                f"segment_valid_lengths must contain at least {end} entries, "
+                f"got {len(segment_valid_lengths)}"
+            )
+        return sum(segment_valid_lengths[self.first_global_segment : end])
+
+
+@dataclass(frozen=True)
+class ZigzagCPPlan:
+    """Topology shared by stateful linear-attention CP implementations.
+
+    A sequence is split into ``2 * cp_size`` segments. Rank ``r`` stores
+    segment ``r`` followed by segment ``2 * cp_size - 1 - r``. Stateful
+    attention must nevertheless consume the segments in global order.
+    """
+
+    cp_size: int
+    cp_rank: int
+
+    def __post_init__(self) -> None:
+        if self.cp_size < 2:
+            raise ValueError(f"cp_size must be at least 2, got {self.cp_size}")
+        if not 0 <= self.cp_rank < self.cp_size:
+            raise ValueError(
+                f"cp_rank must be in [0, {self.cp_size}), got {self.cp_rank}"
+            )
+
+    @property
+    def global_segment_count(self) -> int:
+        return 2 * self.cp_size
+
+    @property
+    def local_global_segments(self) -> tuple[int, int]:
+        return self.cp_rank, self.global_segment_count - 1 - self.cp_rank
+
+    @property
+    def halo_sources(
+        self,
+    ) -> tuple[Optional[tuple[int, int]], tuple[int, int]]:
+        """Return predecessor ``(rank, local_segment)`` for both local segments.
+
+        ``None`` denotes the sequence boundary, whose halo comes from the
+        reusable prefix state (or zeros when no prefix exists).
+        """
+        front_source = None if self.cp_rank == 0 else (self.cp_rank - 1, 0)
+        back_source = (
+            (self.cp_rank, 0)
+            if self.cp_rank == self.cp_size - 1
+            else (self.cp_rank + 1, 1)
+        )
+        return front_source, back_source
+
+    @property
+    def relay_steps(self) -> tuple[ZigzagRelayStep, ...]:
+        """Return the minimal ordered relay schedule for this CP size.
+
+        The innermost rank owns the two adjacent middle segments, so they are
+        combined into one call. Every other rank contributes one front and one
+        back call, yielding ``2 * cp_size - 1`` calls and one fewer transfers.
+        """
+        front = tuple(
+            ZigzagRelayStep(
+                owner_rank=rank,
+                first_global_segment=rank,
+                first_local_segment=0,
+            )
+            for rank in range(self.cp_size - 1)
+        )
+        middle = (
+            ZigzagRelayStep(
+                owner_rank=self.cp_size - 1,
+                first_global_segment=self.cp_size - 1,
+                first_local_segment=0,
+                segment_count=2,
+            ),
+        )
+        back = tuple(
+            ZigzagRelayStep(
+                owner_rank=rank,
+                first_global_segment=self.global_segment_count - 1 - rank,
+                first_local_segment=1,
+            )
+            for rank in range(self.cp_size - 2, -1, -1)
+        )
+        return front + middle + back
+
+
+def get_segment_valid_lengths(
+    actual_tokens: int, segment_tokens: int, cp_size: int
+) -> tuple[int, ...]:
+    """Return real-token counts for every padded global zigzag segment."""
+    if actual_tokens < 0:
+        raise ValueError(f"actual_tokens must be non-negative, got {actual_tokens}")
+    if segment_tokens <= 0:
+        raise ValueError(f"segment_tokens must be positive, got {segment_tokens}")
+    if cp_size < 2:
+        raise ValueError(f"cp_size must be at least 2, got {cp_size}")
+    capacity = 2 * cp_size * segment_tokens
+    if actual_tokens > capacity:
+        raise ValueError(
+            f"actual_tokens ({actual_tokens}) exceeds CP capacity ({capacity})"
+        )
+
+    return tuple(
+        max(0, min(segment_tokens, actual_tokens - i * segment_tokens))
+        for i in range(2 * cp_size)
+    )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_cp_flashinfer.py
@@ -158,10 +158,6 @@ class CPFlashInferImpl(FMHAImplBase):
 
         self.attn_inputs = attn_inputs
 
-    def support(self) -> bool:
-        """Check if this implementation supports current inputs."""
-        return self.fmha_impl.support(self.attn_inputs)
-
     @classmethod
     def support(cls, attn_configs: AttentionConfigs, attn_inputs: PyAttentionInputs):
         return True
@@ -177,10 +173,10 @@ class CPFlashInferImpl(FMHAImplBase):
         self,
         qkv: torch.Tensor,
         kv_cache: Optional[KVCache],
-        need_rope_kv_cache: bool = True,
+        layer_idx: int = 0,
     ) -> torch.Tensor:
         assert self.rope_kvcache_impl is not None and self.rope_params is not None
-        if need_rope_kv_cache:
+        if self.need_rope_kv_cache:
             fmha_input = self.rope_kvcache_impl.forward(qkv, kv_cache, self.rope_params)
         else:
             fmha_input = qkv

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/prefill_mha/alltoall_cp_impl.py
@@ -74,6 +74,9 @@ class PCPAll2AllAttnOp:
         self.math_events = [torch.cuda.Event() for _ in range(self.prefill_cp_size)]
 
         self.all_shuffle_indices = None
+        self.cache_append_indices = None
+        self.cache_append_batch_indices = None
+        self.cache_append_positions = None
         self.half_q_idx = self.half_kv_idx = None
 
         # Init flashinfer attention wrappers
@@ -158,6 +161,29 @@ class PCPAll2AllAttnOp:
                 for i, cl in enumerate(chunk_lens)
             ]
         )
+        token_actual_lengths = self.cp_info.prefill_actual_input_lengths_cpu.to(
+            self.device
+        )[self.append_batch_indice.long()]
+        token_prefix_lengths = self.attn_inputs.prefix_lengths.to(self.device)[
+            self.append_batch_indice.long()
+        ]
+        self.cache_append_indices = []
+        self.cache_append_batch_indices = []
+        self.cache_append_positions = []
+        for shuffle_positions in self.all_shuffle_indices:
+            valid_indices = torch.nonzero(
+                (shuffle_positions >= 0)
+                & (shuffle_positions < token_actual_lengths),
+                as_tuple=False,
+            ).flatten()
+            self.cache_append_indices.append(valid_indices)
+            self.cache_append_batch_indices.append(
+                self.append_batch_indice.index_select(0, valid_indices)
+            )
+            self.cache_append_positions.append(
+                shuffle_positions.index_select(0, valid_indices)
+                + token_prefix_lengths.index_select(0, valid_indices)
+            )
 
         self.has_prefix = self.attn_inputs.prefix_lengths.any().item()
         if self.has_prefix:
@@ -174,6 +200,29 @@ class PCPAll2AllAttnOp:
             )
 
         return params
+
+    def _append_kv_cache(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        source_rank: int,
+        kv_cache_tensor: torch.Tensor,
+        params: ParamsBase,
+    ) -> None:
+        valid_indices = self.cache_append_indices[source_rank]
+        if valid_indices.numel() == 0:
+            return
+        append_paged_kv_cache(
+            append_key=key.index_select(0, valid_indices),
+            append_value=value.index_select(0, valid_indices),
+            batch_indices=self.cache_append_batch_indices[source_rank],
+            positions=self.cache_append_positions[source_rank],
+            paged_kv_cache=kv_cache_tensor,
+            kv_indices=params.page_indice_d,
+            kv_indptr=params.decode_page_indptr_d,
+            kv_last_page_len=params.paged_kv_last_page_len_d,
+            kv_layout="HND",
+        )
 
     def forward(
         self,
@@ -230,8 +279,12 @@ class PCPAll2AllAttnOp:
                     if self.use_ub and self.ub_communicator.can_handle_tensor(
                         kv_buffer
                     ):
-                        self.ub_communicator.send(kv_buffer, dst=next_rank_id)
-                        self.ub_communicator.recv(recv_buf, src=prev_rank_id)
+                        self.ub_communicator.send_recv(
+                            kv_buffer,
+                            dst=next_rank_id,
+                            recv_tensor=recv_buf,
+                            src=prev_rank_id,
+                        )
                     else:
                         if self.prefill_cp_rank < next_rank_id:
                             send(kv_buffer, dst=next_rank_id, group=Group.TP)
@@ -247,16 +300,12 @@ class PCPAll2AllAttnOp:
                 k = k.reshape(-1, self.num_kv_heads, self.head_dim)
                 v = v.reshape(-1, self.num_kv_heads, self.head_dim)
 
-                append_paged_kv_cache(
-                    append_key=k,
-                    append_value=v,
-                    batch_indices=self.append_batch_indice,
-                    positions=self.all_shuffle_indices[self.prefill_cp_rank],
-                    paged_kv_cache=kv_cache_tensor,
-                    kv_indices=params.page_indice_d,
-                    kv_indptr=params.decode_page_indptr_d,
-                    kv_last_page_len=params.paged_kv_last_page_len_d,
-                    kv_layout="HND",
+                self._append_kv_cache(
+                    k,
+                    v,
+                    self.prefill_cp_rank,
+                    kv_cache_tensor,
+                    params,
                 )
 
                 q_reshaped = q.reshape(-1, self.num_qo_heads, self.head_dim)
@@ -294,16 +343,12 @@ class PCPAll2AllAttnOp:
                 )
                 # TODO: make write local kvcache async
                 src_rank = (self.prefill_cp_rank - round_id) % self.prefill_cp_size
-                append_paged_kv_cache(
-                    append_key=remote_k,
-                    append_value=remote_v,
-                    batch_indices=self.append_batch_indice,
-                    positions=self.all_shuffle_indices[src_rank],
-                    paged_kv_cache=kv_cache_tensor,
-                    kv_indices=params.page_indice_d,
-                    kv_indptr=params.decode_page_indptr_d,
-                    kv_last_page_len=params.paged_kv_last_page_len_d,
-                    kv_layout="HND",
+                self._append_kv_cache(
+                    remote_k,
+                    remote_v,
+                    src_rank,
+                    kv_cache_tensor,
+                    params,
                 )
                 if round_id > self.prefill_cp_rank:
                     q_split = (

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/BUILD
@@ -7,6 +7,12 @@ flashinfer_deps = [
     "//rtp_llm:flashinfer-python",
 ]
 
+flashinfer_compatible_with = select({
+    "@//:using_cuda12_9_x86": [],
+    "@//:cuda_pre_12_9": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
 py_library(
     name = "cp_test_utils",
     srcs = ["cp_test_utils.py"],
@@ -27,6 +33,39 @@ py_test(
     }),
     tags = ["A10"],
     exec_properties = {'gpu': 'A10'},
+)
+
+py_test(
+    name = "test_linear_attn_utils",
+    srcs = ["test_linear_attn_utils.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    target_compatible_with = flashinfer_compatible_with,
+)
+
+py_test(
+    name = "test_attn_factory_cp_selection",
+    srcs = ["test_attn_factory_cp_selection.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    target_compatible_with = flashinfer_compatible_with,
+)
+
+py_test(
+    name = "test_prefill_cp_flashinfer_contract",
+    srcs = ["test_prefill_cp_flashinfer_contract.py"],
+    deps = py_test_deps + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    target_compatible_with = flashinfer_compatible_with,
 )
 
 py_test(
@@ -73,6 +112,21 @@ py_test(
         "@//:cuda_pre_12_9": flashinfer_deps,
         "//conditions:default": []
     }),
-    tags = ["manual"],
+    tags = ["H20"],
     exec_properties = {'gpu': 'H20'},
+    timeout = "long",
+)
+
+py_test(
+    name = "test_cp_relay_distributed",
+    srcs = ["test_cp_relay_distributed.py"],
+    deps = py_test_deps + [":cp_test_utils"] + select({
+        "@//:using_cuda12_9_x86": flashinfer_deps,
+        "@//:cuda_pre_12_9": flashinfer_deps,
+        "//conditions:default": []
+    }),
+    env = {"GPU_COUNT": "2"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '2'},
+    timeout = "moderate",
 )

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/cp_test_utils.py
@@ -68,8 +68,28 @@ def build_restore_indices(cp_chunk_lengths: List[int], cp_size: int) -> torch.Te
     return torch.tensor(restore, dtype=torch.int32)
 
 
-def build_padding_mask(cp_chunk_lengths: List[int], cp_size: int) -> torch.Tensor:
-    return torch.ones(sum(cp_chunk_lengths) * cp_size, dtype=torch.int32)
+def build_padding_mask(
+    cp_chunk_lengths: List[int],
+    cp_size: int,
+    padding_lengths: List[int] | None = None,
+) -> torch.Tensor:
+    if padding_lengths is None:
+        padding_lengths = [0] * len(cp_chunk_lengths)
+    masks = []
+    for chunk_length, padding_length in zip(cp_chunk_lengths, padding_lengths):
+        padded_length = chunk_length * cp_size
+        valid_length = padded_length - padding_length
+        if valid_length < 0:
+            raise ValueError("padding length exceeds padded sequence length")
+        masks.append(
+            torch.cat(
+                [
+                    torch.ones(valid_length, dtype=torch.int32),
+                    torch.zeros(padding_length, dtype=torch.int32),
+                ]
+            )
+        )
+    return torch.cat(masks)
 
 
 # ---------------------------------------------------------------------------
@@ -203,13 +223,21 @@ def build_cp_attn_inputs(
 
     # new_lengths = sequence_lengths - prefix_lengths (total new tokens per batch)
     new_lengths = [sl - pl for sl, pl in zip(sequence_lengths, prefix_lengths)]
+    padded_new_lengths = [cl * cp_size for cl in cp_chunk_lengths]
+    padding_lengths = [
+        padded - actual for padded, actual in zip(padded_new_lengths, new_lengths)
+    ]
+    if any(padding < 0 for padding in padding_lengths):
+        raise ValueError("CP chunk length is smaller than the real input length")
 
     cp_info = PyContextParallelParams()
     cp_info.prefill_cp_chunk_lengths = torch.tensor(cp_chunk_lengths, dtype=torch.int32)
-    cp_info.prefill_cp_padding_lengths = torch.zeros(batch_size, dtype=torch.int32)
-    cp_info.prefill_qkv_padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(
-        device
+    cp_info.prefill_cp_padding_lengths = torch.tensor(
+        padding_lengths, dtype=torch.int32
     )
+    cp_info.prefill_qkv_padding_mask = build_padding_mask(
+        cp_chunk_lengths, cp_size, padding_lengths
+    ).to(device)
     cp_info.prefill_qkv_restore_indice = build_restore_indices(
         cp_chunk_lengths, cp_size
     ).to(device)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_alltoall_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_alltoall_cp_impl.py
@@ -69,15 +69,14 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
         new_lengths: List[int],
         cp_size: int,
         rank: int,
-        prefix_lengths: List[int] | None = None,
+        padded_lengths: List[int] | None = None,
         device: torch.device = torch.device("cuda"),
     ) -> torch.Tensor:
-        if prefix_lengths is None:
-            prefix_lengths = [0] * len(new_lengths)
+        if padded_lengths is None:
+            padded_lengths = new_lengths
         indices: List[int] = []
-        for new_len, pl in zip(new_lengths, prefix_lengths):
-            positions = zigzag_positions_for_rank(new_len, cp_size, rank)
-            indices.extend(p + pl for p in positions)
+        for padded_len in padded_lengths:
+            indices.extend(zigzag_positions_for_rank(padded_len, cp_size, rank))
         return torch.tensor(indices, dtype=torch.int32, device=device)
 
     # ---- mock builders ----
@@ -345,7 +344,6 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
                 new_lengths,
                 cp_size,
                 r,
-                prefix_lengths=prefix_lengths,
                 device=self.device,
             )
             for r in range(cp_size)
@@ -506,6 +504,83 @@ class TestPCPAll2AllAttnOp(unittest.TestCase):
             cp_rank=2,
             tokens_per_block=16,
         )
+
+    def test_cache_append_offsets_prefix_and_filters_production_padding(self):
+        cp_size = 4
+        actual_lengths = [1, 257]
+        prefix_lengths = [64, 128]
+        sequence_lengths = [
+            prefix + actual
+            for prefix, actual in zip(prefix_lengths, actual_lengths)
+        ]
+        chunk_lengths = [128, 128]
+        padded_lengths = [chunk * cp_size for chunk in chunk_lengths]
+        all_shuffle = [
+            self._build_shuffle_indices(
+                actual_lengths,
+                cp_size,
+                rank,
+                padded_lengths=padded_lengths,
+                device=self.device,
+            )
+            for rank in range(cp_size)
+        ]
+        attn_cfg, par_cfg = make_configs(cp_size=cp_size, cp_rank=0)
+        attn_inputs = build_cp_attn_inputs(
+            sequence_lengths,
+            chunk_lengths,
+            cp_size,
+            tokens_per_block=16,
+            prefix_lengths=prefix_lengths,
+            device=self.device,
+        )
+        attn_inputs.context_parallel_info.prefill_shuffle_indices = all_shuffle[
+            0
+        ]
+
+        with patch(
+            f"{_A2A_MODULE}.all_gather",
+            return_value=torch.cat(all_shuffle),
+        ), patch(
+            f"{_A2A_MODULE}.get_user_buffers_communicator",
+            return_value=None,
+        ):
+            op = PCPAll2AllAttnOp(attn_cfg, attn_inputs, par_cfg)
+            params = op.prepare(attn_inputs)
+
+        expected_counts = [65, 64, 64, 65]
+        keys = torch.arange(
+            sum(chunk_lengths), dtype=torch.float32, device=self.device
+        ).reshape(-1, 1, 1)
+        values = -keys
+        for rank, expected_count in enumerate(expected_counts):
+            batch_indices = op.cache_append_batch_indices[rank]
+            positions = op.cache_append_positions[rank]
+            self.assertEqual(positions.numel(), expected_count)
+            for batch, (prefix, actual) in enumerate(
+                zip(prefix_lengths, actual_lengths)
+            ):
+                batch_positions = positions[batch_indices == batch]
+                self.assertTrue(torch.all(batch_positions >= prefix))
+                self.assertTrue(torch.all(batch_positions < prefix + actual))
+
+            with patch(f"{_A2A_MODULE}.append_paged_kv_cache") as append_mock:
+                op._append_kv_cache(
+                    keys,
+                    values,
+                    rank,
+                    torch.empty(0, device=self.device),
+                    params,
+                )
+            append_mock.assert_called_once()
+            kwargs = append_mock.call_args.kwargs
+            expected_indices = op.cache_append_indices[rank]
+            self.assertTrue(
+                torch.equal(kwargs["append_key"], keys[expected_indices])
+            )
+            self.assertTrue(
+                torch.equal(kwargs["append_value"], values[expected_indices])
+            )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_attn_factory_cp_selection.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_attn_factory_cp_selection.py
@@ -1,0 +1,62 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from rtp_llm.models_py.modules.factory.attention import attn_factory
+
+
+class _ImplWithoutPrefillCP:
+    @staticmethod
+    def support(attn_configs, attn_inputs):
+        return True
+
+    @classmethod
+    def support_parallelism_config(cls, parallelism_config):
+        return False
+
+    def __init__(self, attn_configs, attn_inputs, parallelism_config):
+        self.fmha_params = object()
+
+    def support_cuda_graph(self):
+        return False
+
+
+class TestAttentionFactoryCPSelection(unittest.TestCase):
+    def test_cp_config_does_not_filter_non_cp_forward(self):
+        attn_inputs = SimpleNamespace(
+            is_prefill=True,
+            is_target_verify=True,
+            context_parallel_info=None,
+        )
+        with patch.object(
+            attn_factory, "PREFILL_MHA_IMPS", [_ImplWithoutPrefillCP]
+        ):
+            impl = attn_factory.get_fmha_impl(
+                None,
+                None,
+                attn_inputs,
+                parallelism_config=object(),
+            )
+
+        self.assertIsInstance(impl, _ImplWithoutPrefillCP)
+
+    def test_cp_metadata_filters_non_cp_prefill_implementation(self):
+        attn_inputs = SimpleNamespace(
+            is_prefill=True,
+            is_target_verify=False,
+            context_parallel_info=object(),
+        )
+        with patch.object(
+            attn_factory, "PREFILL_MHA_IMPS", [_ImplWithoutPrefillCP]
+        ):
+            with self.assertRaisesRegex(Exception, "can not find mha type"):
+                attn_factory.get_fmha_impl(
+                    None,
+                    None,
+                    attn_inputs,
+                    parallelism_config=object(),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
@@ -1,28 +1,37 @@
 """
-Unit tests for CP linear attention (GatedDeltaNet) per-layer all-gather path.
+Unit tests for CP linear attention (GatedDeltaNet) fallback and halo paths.
 
 Tests:
   1. Index math: cp_local_extract_indices correctly maps zigzag positions
   2. Full forward: single-rank mock verifies CP output matches non-CP reference
+  3. Cache: zigzag halo conv and every GDN block boundary match the full sequence
 """
 
 import contextlib
 import logging
 import math
 import unittest
+from types import SimpleNamespace
 from typing import List
 from unittest.mock import patch
 
 import torch
 
+from rtp_llm.models_py.model_desc.qwen3_next import (
+    Qwen3NextMetadata,
+    Qwen3NextModel,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.linear_attn_utils import (
+    ZigzagCPPlan,
+    get_segment_valid_lengths,
+)
 from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
     build_cp_attn_inputs,
-    build_padding_mask,
-    build_restore_indices,
     compute_rank_positions,
     zigzag_positions_for_rank,
 )
 from rtp_llm.models_py.triton_kernels.causal_conv1d import (
+    causal_conv1d_fn,
     prepare_causal_conv1d_metadata,
 )
 
@@ -60,6 +69,59 @@ def _add_device_tensors(inputs, device: torch.device):
     )
 
 
+def _build_production_cp_metadata(
+    attention_inputs,
+    cp_size: int,
+    cp_rank: int,
+    linear_config,
+    device: torch.device,
+) -> Qwen3NextMetadata:
+    model = SimpleNamespace(
+        parallelism_config=SimpleNamespace(tp_size=cp_size, tp_rank=cp_rank),
+        config=SimpleNamespace(linear_attention_config=linear_config),
+    )
+    (
+        full_conv_meta,
+        full_cu,
+        local_conv_meta,
+        local_conv_cu,
+        local_conv_prefix_lengths,
+        local_extract_indices,
+        local_valid_mask,
+    ) = Qwen3NextModel._build_cp_linear_attn_metadata(model, attention_inputs, device)
+    return Qwen3NextMetadata(
+        full_prefill_conv1d_meta=full_conv_meta,
+        full_prefill_cu_seqlens=full_cu,
+        cp_local_conv1d_meta=local_conv_meta,
+        cp_local_conv_cu_seqlens=local_conv_cu,
+        cp_local_conv_prefix_lengths=local_conv_prefix_lengths,
+        is_cp_linear_attn=True,
+        cp_local_extract_indices=local_extract_indices,
+        cp_local_valid_mask=local_valid_mask,
+    )
+
+
+class _RelayHarness:
+    _linear_cp_relay_logged = True
+
+
+def _make_relay_harness(rank: int, device: torch.device) -> _RelayHarness:
+    harness = _RelayHarness()
+    harness.parallelism_config = SimpleNamespace(tp_rank=rank)
+    harness.prefill_gdn = SimpleNamespace(
+        alog=torch.zeros(1, dtype=torch.bfloat16, device=device),
+        dt_bias=torch.zeros(1, dtype=torch.bfloat16, device=device),
+        local_num_v_heads=1,
+        head_k_dim=1,
+        head_v_dim=1,
+    )
+    harness.head_v_dim = 1
+    harness.local_num_v_heads = 1
+    harness.norm = lambda attn_out, _: attn_out
+    harness.out_proj = lambda attn_out: attn_out
+    return harness
+
+
 class TestCPLinearAttnIndexMath(unittest.TestCase):
     """Verify that _build_cp_linear_attn_metadata produces correct extract indices."""
 
@@ -69,45 +131,34 @@ class TestCPLinearAttnIndexMath(unittest.TestCase):
         cp_size: int,
         cp_rank: int,
         device: torch.device,
+        padded_sequence_lengths: List[int] | None = None,
     ):
-        """Reproduce the index construction from Qwen3NextModel._build_cp_linear_attn_metadata."""
-        cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
-        restore_indices = build_restore_indices(cp_chunk_lengths, cp_size).to(device)
-        padding_mask = build_padding_mask(cp_chunk_lengths, cp_size).to(device)
-        unpad_restore = restore_indices[padding_mask == 1]
-
-        total_ag = padding_mask.shape[0]
-        local_chunk_total = total_ag // cp_size
-        local_start = cp_rank * local_chunk_total
-        local_end = local_start + local_chunk_total
-
-        inv_restore = torch.empty(total_ag, dtype=torch.long, device=device)
-        inv_restore.fill_(-1)
-        inv_restore[unpad_restore.long()] = torch.arange(
-            unpad_restore.shape[0], device=device
+        if padded_sequence_lengths is None:
+            padded_sequence_lengths = sequence_lengths
+        cp_chunk_lengths = [sl // cp_size for sl in padded_sequence_lengths]
+        attention_inputs = build_cp_attn_inputs(
+            sequence_lengths,
+            cp_chunk_lengths,
+            cp_size,
+            tokens_per_block=64,
+            device=device,
         )
+        metadata = _build_production_cp_metadata(
+            attention_inputs,
+            cp_size,
+            cp_rank,
+            SimpleNamespace(linear_conv_kernel_dim=4),
+            device,
+        )
+        return metadata.cp_local_extract_indices
 
-        local_mask = padding_mask[local_start:local_end]
-        local_ag_positions = torch.arange(local_start, local_end, device=device)[
-            local_mask == 1
-        ]
-        return inv_restore[local_ag_positions]
-
-    def test_single_seq_cp2_rank0(self):
+    def test_single_seq_cp2_all_ranks(self):
         device = torch.device("cpu")
-        seq_lengths = [16]
-        cp_size, cp_rank = 2, 0
-        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
-        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
-        self.assertEqual(idx.tolist(), expected)
-
-    def test_single_seq_cp2_rank1(self):
-        device = torch.device("cpu")
-        seq_lengths = [16]
-        cp_size, cp_rank = 2, 1
-        idx = self._build_indices(seq_lengths, cp_size, cp_rank, device)
-        expected = zigzag_positions_for_rank(16, cp_size, cp_rank)
-        self.assertEqual(idx.tolist(), expected)
+        for rank in range(2):
+            with self.subTest(rank=rank):
+                idx = self._build_indices([16], 2, rank, device)
+                expected = zigzag_positions_for_rank(16, 2, rank)
+                self.assertEqual(idx.tolist(), expected)
 
     def test_single_seq_cp4(self):
         device = torch.device("cpu")
@@ -141,6 +192,86 @@ class TestCPLinearAttnIndexMath(unittest.TestCase):
         total = sum(seq_lengths)
         self.assertEqual(sorted(all_indices), list(range(total)))
 
+    def test_non_aligned_sequence_uses_only_real_tokens(self):
+        actual_length = 257
+        padded_length = 512
+        all_indices = []
+        for rank in range(2):
+            idx = self._build_indices(
+                [actual_length],
+                cp_size=2,
+                cp_rank=rank,
+                device=torch.device("cpu"),
+                padded_sequence_lengths=[padded_length],
+            )
+            expected = [
+                position
+                for position in zigzag_positions_for_rank(padded_length, 2, rank)
+                if position < actual_length
+            ]
+            valid_indices = idx.tolist()
+            self.assertEqual(valid_indices, expected)
+            all_indices.extend(valid_indices)
+        self.assertEqual(sorted(all_indices), list(range(actual_length)))
+
+    def test_cp2_relay_eligibility_reports_invalid_internal_prefix(self):
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        attention_inputs = SimpleNamespace(
+            input_lengths=torch.tensor([256], dtype=torch.int32),
+            is_cuda_graph=False,
+            prefix_lengths=torch.tensor([64], dtype=torch.int32),
+            kv_cache_kernel_block_id_host=torch.tensor([[1]], dtype=torch.int32),
+        )
+        attn_meta = SimpleNamespace(
+            cp_local_conv1d_meta=object(),
+            cp_local_conv_cu_seqlens=object(),
+            cp_local_conv_prefix_lengths=object(),
+        )
+
+        reason = Qwen3NextGatedDeltaNet._get_linear_cp_relay_fallback_reason(
+            attention_inputs,
+            kv_cache_tensor=torch.empty(1, 1),
+            seq_size_per_block=64,
+            attn_meta=attn_meta,
+        )
+        self.assertIsNone(reason)
+
+        attention_inputs.prefix_lengths = torch.tensor([65], dtype=torch.int32)
+        reason = Qwen3NextGatedDeltaNet._get_linear_cp_relay_fallback_reason(
+            attention_inputs,
+            kv_cache_tensor=torch.empty(1, 1),
+            seq_size_per_block=64,
+            attn_meta=attn_meta,
+        )
+        self.assertEqual(reason, "unaligned_internal_prefix")
+        with self.assertRaisesRegex(RuntimeError, "cannot safely reconstruct"):
+            Qwen3NextGatedDeltaNet._raise_for_invalid_cp_state(reason, 65)
+
+    def test_cp_relay_missing_local_conv_metadata_falls_back(self):
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        attention_inputs = SimpleNamespace(
+            input_lengths=torch.tensor([256], dtype=torch.int32),
+            is_cuda_graph=False,
+            prefix_lengths=torch.tensor([0], dtype=torch.int32),
+            kv_cache_kernel_block_id_host=None,
+        )
+        attn_meta = SimpleNamespace(
+            cp_local_conv1d_meta=None,
+            cp_local_conv_cu_seqlens=None,
+            cp_local_conv_prefix_lengths=None,
+        )
+
+        reason = Qwen3NextGatedDeltaNet._get_linear_cp_relay_fallback_reason(
+            attention_inputs,
+            kv_cache_tensor=None,
+            seq_size_per_block=64,
+            attn_meta=attn_meta,
+        )
+        self.assertEqual(reason, "missing_local_conv_metadata")
+        Qwen3NextGatedDeltaNet._raise_for_invalid_cp_state(reason, 0)
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestCPLinearAttnForward(unittest.TestCase):
@@ -150,6 +281,402 @@ class TestCPLinearAttnForward(unittest.TestCase):
         self.device = torch.device("cuda")
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
+
+    def _run_cp2_gdn_relay_reference(
+        self, actual_tokens: int, segment_tokens: int
+    ) -> None:
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+        from rtp_llm.models_py.triton_kernels.fla.chunk import chunk_gated_delta_rule
+
+        num_k_heads = 2
+        num_v_heads = 4
+        head_dim = 64
+
+        query = torch.randn(
+            1,
+            actual_tokens,
+            num_k_heads,
+            head_dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        key = torch.randn_like(query)
+        value = torch.randn(
+            1,
+            actual_tokens,
+            num_v_heads,
+            head_dim,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        g = -torch.rand(
+            1,
+            actual_tokens,
+            num_v_heads,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        beta = torch.rand(
+            1,
+            actual_tokens,
+            num_v_heads,
+            device=self.device,
+            dtype=torch.bfloat16,
+        )
+        initial_state = torch.randn(
+            1,
+            num_v_heads,
+            head_dim,
+            head_dim,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        full_cu = torch.tensor(
+            [0, actual_tokens], dtype=torch.int32, device=self.device
+        )
+
+        with torch.no_grad():
+            expected, expected_chunks, expected_final = chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=full_cu,
+                use_qk_l2norm_in_kernel=True,
+            )
+
+            state = initial_state.clone()
+            block_ends = torch.cat(
+                [
+                    torch.arange(
+                        64,
+                        actual_tokens,
+                        64,
+                        dtype=torch.long,
+                        device=self.device,
+                    ),
+                    torch.tensor([actual_tokens], dtype=torch.long, device=self.device),
+                ]
+            )
+            expected_block_states = torch.cat(
+                [expected_chunks[0, 1:], expected_final]
+            ).to(torch.bfloat16)
+            rank_block_states = [
+                torch.zeros_like(expected_block_states)
+                for _ in range(2)
+            ]
+            relayed_outputs = []
+            valid_lengths = get_segment_valid_lengths(
+                actual_tokens, segment_tokens, cp_size=2
+            )
+            for step in ZigzagCPPlan(2, 0).relay_steps:
+                length = step.valid_token_count(valid_lengths)
+                if length == 0:
+                    continue
+                start = step.first_global_segment * segment_tokens
+                end = start + length
+                segment_cu = torch.tensor(
+                    [0, length], dtype=torch.int32, device=self.device
+                )
+                segment_out, segment_chunks, state = chunk_gated_delta_rule(
+                    query[:, start:end],
+                    key[:, start:end],
+                    value[:, start:end],
+                    g[:, start:end],
+                    beta[:, start:end],
+                    initial_state=state,
+                    output_final_state=True,
+                    cu_seqlens=segment_cu,
+                    use_qk_l2norm_in_kernel=True,
+                )
+                relayed_outputs.append(segment_out)
+                Qwen3NextGatedDeltaNet._record_linear_cp_segment_ssm_states(
+                    rank_block_states[step.owner_rank],
+                    block_ends,
+                    start,
+                    end,
+                    segment_chunks,
+                    state,
+                )
+
+        actual = torch.cat(relayed_outputs, dim=1)
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(state, expected_final, rtol=1e-3, atol=1e-3)
+
+        actual_block_states = rank_block_states[0] + rank_block_states[1]
+        torch.testing.assert_close(
+            actual_block_states, expected_block_states, rtol=1e-2, atol=1e-2
+        )
+
+    def test_cp2_gdn_relay_matches_full_sequence(self):
+        """Aligned and padded relay outputs and block states match a full GDN call."""
+        for actual_tokens, segment_tokens in ((256, 64), (257, 128)):
+            with self.subTest(actual_tokens=actual_tokens):
+                self._run_cp2_gdn_relay_reference(actual_tokens, segment_tokens)
+
+    def test_cp2_cache_block_boundaries(self):
+        """Cache writes use absolute prefix positions and partial final blocks."""
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        cases = (
+            (
+                [384],
+                [128],
+                [128],
+                [11, 12, 13, 14, 15, 16],
+                [64, 128, 192, 256],
+                [13, 14, 15, 16],
+            ),
+            ([1], [64], None, [11], [1], [11]),
+        )
+        for case in cases:
+            sequence_lengths, chunks, prefixes, ids, expected_ends, expected_ids = case
+            with self.subTest(sequence_lengths=sequence_lengths):
+                attention_inputs = build_cp_attn_inputs(
+                    sequence_lengths=sequence_lengths,
+                    cp_chunk_lengths=chunks,
+                    cp_size=2,
+                    tokens_per_block=64,
+                    prefix_lengths=prefixes,
+                    device=self.device,
+                )
+                block_ids = torch.tensor([ids], dtype=torch.int32, device=self.device)
+                attention_inputs = _AttnInputsWrapper(
+                    attention_inputs,
+                    {"kv_cache_kernel_block_id_device": block_ids},
+                )
+                block_ends, selected_ids = (
+                    Qwen3NextGatedDeltaNet._get_linear_cp_cache_blocks(
+                        attention_inputs, seq_size_per_block=64
+                    )
+                )
+                self.assertEqual(block_ends.tolist(), expected_ends)
+                self.assertEqual(selected_ids.tolist(), expected_ids)
+
+    def test_cp2_cache_state_sync_uses_collective_result(self):
+        """Cache writes must use collectives that return a new output tensor."""
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        local_states = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        original_local_states = local_states.clone()
+        reduced_states = torch.tensor(
+            [[11.0, 12.0], [13.0, 14.0]],
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        cache_states = torch.zeros(4, 2, dtype=torch.bfloat16, device=self.device)
+        block_ids = torch.tensor([1, 3], dtype=torch.long, device=self.device)
+
+        with patch(
+            "rtp_llm.models_py.model_desc.qwen3_next.all_reduce",
+            return_value=reduced_states,
+        ):
+            Qwen3NextGatedDeltaNet._sync_linear_cp_cache_states(
+                local_states, cache_states, block_ids
+            )
+
+        torch.testing.assert_close(cache_states[block_ids], reduced_states)
+        torch.testing.assert_close(local_states, original_local_states)
+
+    def test_fp32_prefix_ssm_state_uses_detached_relay_buffer(self):
+        """In-place relay communication must not overwrite a cached prefix state."""
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        cache_storage = torch.randn(
+            3 * 2 * 4 * 4, dtype=torch.float32, device=self.device
+        )
+        cache_states = cache_storage.view(3, 2, 4, 4)
+        expected_cache = cache_states.clone()
+
+        relay_state = Qwen3NextGatedDeltaNet._copy_linear_cp_prefix_ssm_state(
+            cache_states, prefix_block_id=1
+        )
+        self.assertEqual(relay_state.dtype, torch.float32)
+        self.assertNotEqual(
+            relay_state.untyped_storage().data_ptr(),
+            cache_states.untyped_storage().data_ptr(),
+        )
+
+        relay_state.fill_(0)
+        torch.testing.assert_close(cache_states, expected_cache)
+
+    def test_padded_conv_cache_uses_predecessor_halo(self):
+        """A short real segment must not read its cache tail from padding."""
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        local_block_states = torch.zeros(
+            2, 3, 1, dtype=torch.bfloat16, device=self.device
+        )
+        block_ends = torch.tensor([1, 2], dtype=torch.long, device=self.device)
+        predecessor_halo = torch.tensor(
+            [[10.0], [11.0], [12.0]],
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        padded_segment = torch.tensor(
+            [[20.0], [21.0], [99.0], [99.0]],
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+
+        Qwen3NextGatedDeltaNet._record_linear_cp_segment_conv_states(
+            local_block_states,
+            block_ends,
+            segment_start=0,
+            segment_valid_length=2,
+            segment_with_halo=torch.cat([predecessor_halo, padded_segment]),
+        )
+
+        expected = torch.tensor(
+            [[[11.0], [12.0], [20.0]], [[12.0], [20.0], [21.0]]],
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        torch.testing.assert_close(local_block_states, expected)
+
+    def test_relay_follows_generic_zigzag_schedule(self):
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        module_path = "rtp_llm.models_py.model_desc.qwen3_next"
+        local_qkv = torch.arange(4, dtype=torch.bfloat16, device=self.device).unsqueeze(
+            1
+        )
+        z = torch.zeros_like(local_qkv)
+        g = torch.zeros(1, 4, 1, dtype=torch.float32, device=self.device)
+        beta = torch.zeros(1, 4, 1, dtype=torch.bfloat16, device=self.device)
+
+        for cp_size in (2, 3, 4, 5, 8):
+            relay_steps = ZigzagCPPlan(cp_size, 0).relay_steps
+            for rank in range(cp_size):
+                segment_calls = []
+                broadcast_sources = []
+
+                harness = _make_relay_harness(rank, self.device)
+
+                def run_segment(mixed_qkv, segment_g, segment_beta, initial_state):
+                    segment_calls.append(
+                        (mixed_qkv.clone(), float(initial_state.item()))
+                    )
+                    segment_out = torch.zeros(
+                        mixed_qkv.shape[0],
+                        1,
+                        1,
+                        dtype=mixed_qkv.dtype,
+                        device=mixed_qkv.device,
+                    )
+                    chunk_states = torch.empty(
+                        1, 1, 1, 1, 1, dtype=torch.float32, device=mixed_qkv.device
+                    )
+                    return segment_out, chunk_states, initial_state + 1
+
+                def relay_broadcast(state, src, group):
+                    broadcast_sources.append(src)
+                    if rank != src:
+                        state.fill_(len(broadcast_sources))
+
+                harness._run_linear_cp_gdn_segment = run_segment
+                with patch(
+                    f"{module_path}.fused_gdn_gating", return_value=(g, beta)
+                ), patch(f"{module_path}.broadcast", side_effect=relay_broadcast):
+                    output = Qwen3NextGatedDeltaNet._forward_linear_cp_relay(
+                        harness,
+                        local_qkv,
+                        z,
+                        torch.empty(4, 1, device=self.device),
+                        torch.empty(4, 1, device=self.device),
+                        prefix_ssm_state=None,
+                        kv_cache_tensor=None,
+                        cache_block_ends=None,
+                        cache_block_ids=None,
+                        cp_plan=ZigzagCPPlan(cp_size, rank),
+                        segment_valid_lengths=(2,) * (2 * cp_size),
+                    )
+
+                self.assertEqual(
+                    broadcast_sources,
+                    [step.owner_rank for step in relay_steps[:-1]],
+                )
+                self.assertEqual(output.shape, (4, 1))
+                owned_steps = [
+                    (step_index, step)
+                    for step_index, step in enumerate(relay_steps)
+                    if step.owner_rank == rank
+                ]
+                self.assertEqual(
+                    [call[1] for call in segment_calls],
+                    [float(step_index) for step_index, _ in owned_steps],
+                )
+                for call, (_, step) in zip(segment_calls, owned_steps):
+                    local_start = step.first_local_segment * 2
+                    local_end = local_start + step.segment_count * 2
+                    torch.testing.assert_close(
+                        call[0], local_qkv[local_start:local_end]
+                    )
+
+    def test_cp2_relay_trims_padded_segments(self):
+        """The production relay must never advance state through padding tokens."""
+        from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
+
+        module_path = "rtp_llm.models_py.model_desc.qwen3_next"
+        segment_valid_lengths = (128, 128, 1, 0)
+
+        for rank, expected_call_length in ((0, 128), (1, 129)):
+
+            harness = _make_relay_harness(rank, self.device)
+
+            segment_call_lengths = []
+
+            def run_segment(mixed_qkv, segment_g, segment_beta, initial_state):
+                segment_call_lengths.append(mixed_qkv.shape[0])
+                segment_out = torch.ones(
+                    mixed_qkv.shape[0],
+                    1,
+                    1,
+                    dtype=mixed_qkv.dtype,
+                    device=mixed_qkv.device,
+                )
+                chunk_states = torch.empty(
+                    1, 1, 1, 1, 1, dtype=torch.float32, device=mixed_qkv.device
+                )
+                return segment_out, chunk_states, initial_state
+
+            harness._run_linear_cp_gdn_segment = run_segment
+            local_qkv = torch.randn(256, 1, dtype=torch.bfloat16, device=self.device)
+            z = torch.zeros_like(local_qkv)
+            g = torch.zeros(1, 256, 1, dtype=torch.float32, device=self.device)
+            beta = torch.zeros(1, 256, 1, dtype=torch.bfloat16, device=self.device)
+
+            with patch(
+                f"{module_path}.fused_gdn_gating", return_value=(g, beta)
+            ), patch(f"{module_path}.broadcast"):
+                output = Qwen3NextGatedDeltaNet._forward_linear_cp_relay(
+                    harness,
+                    local_qkv,
+                    z,
+                    torch.empty(256, 1, device=self.device),
+                    torch.empty(256, 1, device=self.device),
+                    prefix_ssm_state=None,
+                    kv_cache_tensor=None,
+                    cache_block_ends=None,
+                    cache_block_ids=None,
+                    cp_plan=ZigzagCPPlan(2, rank),
+                    segment_valid_lengths=segment_valid_lengths,
+                )
+
+            self.assertEqual(segment_call_lengths, [expected_call_length])
+            local_valid_tokens = 128 if rank == 0 else 129
+            self.assertEqual(
+                torch.count_nonzero(output[:local_valid_tokens]).item(),
+                local_valid_tokens,
+            )
+            self.assertEqual(torch.count_nonzero(output[local_valid_tokens:]).item(), 0)
 
     def _run_cp_vs_nocp(
         self,
@@ -162,11 +689,13 @@ class TestCPLinearAttnForward(unittest.TestCase):
         head_v_dim: int = 64,
         hidden_size: int = 256,
         conv_kernel_dim: int = 4,
+        halo_conv_only: bool = False,
+        prefix_tokens: int = 0,
     ):
         """Test that CP linear attn forward matches non-CP on the same data."""
         from rtp_llm.models_py.model_desc.qwen3_next import (
             Qwen3NextGatedDeltaNet,
-            Qwen3NextMetadata,
+            fused_gdn_gating,
         )
         from rtp_llm.models_py.triton_kernels.causal_conv1d import (
             prepare_causal_conv1d_metadata,
@@ -174,10 +703,19 @@ class TestCPLinearAttnForward(unittest.TestCase):
         from rtp_llm.ops import DataType, LinearAttentionConfig, ParallelismConfig
         from rtp_llm.ops.compute_ops import PyAttentionInputs, PyContextParallelParams
 
-        assert all(sl % (cp_size * 2) == 0 for sl in sequence_lengths)
-        cp_chunk_lengths = [sl // cp_size for sl in sequence_lengths]
+        if halo_conv_only:
+            sequence_alignment = cp_size * 2 * 64
+            padded_sequence_lengths = [
+                math.ceil(sl / sequence_alignment) * sequence_alignment
+                for sl in sequence_lengths
+            ]
+        else:
+            assert all(sl % (cp_size * 2) == 0 for sl in sequence_lengths)
+            padded_sequence_lengths = sequence_lengths
+        cp_chunk_lengths = [sl // cp_size for sl in padded_sequence_lengths]
         total_tokens = sum(sequence_lengths)
         batch_size = len(sequence_lengths)
+        assert prefix_tokens == 0 or batch_size == 1
 
         linear_cfg = LinearAttentionConfig()
         linear_cfg.linear_num_key_heads = num_k_heads
@@ -239,6 +777,17 @@ class TestCPLinearAttnForward(unittest.TestCase):
         full_hidden = torch.randn(
             total_tokens, hidden_size, device=self.device, dtype=torch.bfloat16
         )
+        if padded_sequence_lengths != sequence_lengths:
+            assert batch_size == 1
+            padding_hidden = torch.randn(
+                padded_sequence_lengths[0] - sequence_lengths[0],
+                hidden_size,
+                device=self.device,
+                dtype=torch.bfloat16,
+            )
+            cp_full_hidden = torch.cat([full_hidden, padding_hidden])
+        else:
+            cp_full_hidden = full_hidden
 
         # --- Non-CP reference ---
         full_cu = torch.zeros(batch_size + 1, dtype=torch.int32, device=self.device)
@@ -266,78 +815,273 @@ class TestCPLinearAttnForward(unittest.TestCase):
             ref_output = module(full_hidden, None, None, nocp_inputs, nocp_meta)
 
         # --- CP path (mocked all_gather) ---
-        all_rank_pos = compute_rank_positions(sequence_lengths, cp_size)
+        all_rank_pos = compute_rank_positions(padded_sequence_lengths, cp_size)
         rank_positions = all_rank_pos[cp_rank]
         rank_idx = torch.tensor(rank_positions, device=self.device)
-        local_hidden = full_hidden[rank_idx].contiguous()
+        local_hidden = cp_full_hidden[rank_idx].contiguous()
 
         cp_attn_inputs = build_cp_attn_inputs(
-            sequence_lengths,
+            [sl + prefix_tokens for sl in sequence_lengths],
             cp_chunk_lengths,
             cp_size,
             tokens_per_block=16,
+            prefix_lengths=[prefix_tokens] * batch_size,
             device=self.device,
         )
         cp_attn_inputs = _add_device_tensors(cp_attn_inputs, self.device)
 
         all_rank_packed: List[torch.Tensor] = []
+        all_rank_tails: List[torch.Tensor] = []
         with torch.no_grad():
             for r in range(cp_size):
                 r_pos = torch.tensor(all_rank_pos[r], device=self.device)
-                r_hidden = full_hidden[r_pos]
+                r_hidden = cp_full_hidden[r_pos]
                 r_qkvz = module.in_proj_qkvz(r_hidden)
                 r_ba = module.in_proj_ba(r_hidden)
                 r_mixed_qkv, r_z, r_b, r_a = module.fix_query_key_value_ordering(
                     r_qkvz, r_ba
                 )
                 all_rank_packed.append(torch.cat([r_mixed_qkv, r_b, r_a], dim=-1))
+                local_segment_tokens = r_mixed_qkv.shape[0] // 2
+                all_rank_tails.append(
+                    r_mixed_qkv.reshape(2, local_segment_tokens, -1)[
+                        :, -(conv_kernel_dim - 1) :, :
+                    ].contiguous()
+                )
 
         cp_info = cp_attn_inputs.context_parallel_info
         restore_indices = cp_info.prefill_qkv_restore_indice
         padding_mask = cp_info.prefill_qkv_padding_mask
         unpad_restore = restore_indices[padding_mask == 1]
-
-        total_ag = padding_mask.shape[0]
-        local_chunk_total = total_ag // cp_size
-        local_start = cp_rank * local_chunk_total
-        local_end = local_start + local_chunk_total
-
-        inv_restore = torch.empty(total_ag, dtype=torch.long, device=self.device)
-        inv_restore.fill_(-1)
-        inv_restore[unpad_restore.long()] = torch.arange(
-            unpad_restore.shape[0], device=self.device
+        cp_meta = _build_production_cp_metadata(
+            cp_attn_inputs, cp_size, cp_rank, linear_cfg, self.device
         )
-        local_inv = inv_restore[local_start:local_end]
-        cp_local_valid_mask = local_inv >= 0
-        cp_local_extract_idx = local_inv[cp_local_valid_mask]
-
-        actual_lengths = torch.tensor(sequence_lengths, dtype=torch.int32)
-        full_cu_from_actual = torch.zeros(
-            batch_size + 1, dtype=torch.int32, device=self.device
-        )
-        full_cu_from_actual[1:] = torch.tensor(
-            sequence_lengths, device=self.device
-        ).cumsum(0)
-
-        full_conv_meta = prepare_causal_conv1d_metadata(
-            query_start_loc=full_cu_from_actual, device=self.device
-        )
-
-        cp_meta = Qwen3NextMetadata(
-            full_prefill_conv1d_meta=full_conv_meta,
-            full_prefill_cu_seqlens=full_cu_from_actual,
-            cp_restore_indices=restore_indices,
-            cp_local_extract_indices=cp_local_extract_idx,
-            cp_local_valid_mask=cp_local_valid_mask,
-        )
+        full_cu_from_actual = cp_meta.full_prefill_cu_seqlens
+        full_conv_meta = cp_meta.full_prefill_conv1d_meta
+        cp_local_extract_idx = cp_meta.cp_local_extract_indices
+        cp_local_valid_mask = cp_meta.cp_local_valid_mask
 
         def mock_ag(tensor, group=None):
+            if tensor.shape[-1] == qkv_dim:
+                return torch.cat([tail.flatten(0, 1) for tail in all_rank_tails], dim=0)
             return torch.cat(all_rank_packed, dim=0)
 
+        module.parallelism_config.tp_size = cp_size
+        module.parallelism_config.tp_rank = cp_rank
+        module.parallelism_config.dp_size = 1
+
         AG_MODULE = "rtp_llm.models_py.model_desc.qwen3_next"
-        with patch(f"{AG_MODULE}.all_gather", side_effect=mock_ag):
+        if halo_conv_only:
+            full_packed = torch.cat(all_rank_packed, dim=0)[unpad_restore]
+            full_mixed_qkv = full_packed[:, :qkv_dim].contiguous()
+            with torch.no_grad():
+                prefix_conv_state = None
+                expected_conv_input = full_mixed_qkv
+                expected_conv_cu = full_cu_from_actual
+                if prefix_tokens > 0:
+                    prefix_hidden = torch.randn(
+                        prefix_tokens,
+                        hidden_size,
+                        device=self.device,
+                        dtype=torch.bfloat16,
+                    )
+                    prefix_qkvz = module.in_proj_qkvz(prefix_hidden)
+                    prefix_ba = module.in_proj_ba(prefix_hidden)
+                    prefix_mixed_qkv, _, _, _ = module.fix_query_key_value_ordering(
+                        prefix_qkvz, prefix_ba
+                    )
+                    prefix_conv_state = prefix_mixed_qkv[
+                        -(conv_kernel_dim - 1) :
+                    ].contiguous()
+                    expected_conv_input = torch.cat(
+                        [prefix_mixed_qkv, full_mixed_qkv], dim=0
+                    )
+                    expected_conv_cu = torch.tensor(
+                        [0, prefix_tokens + total_tokens],
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                expected_conv_meta = prepare_causal_conv1d_metadata(
+                    query_start_loc=expected_conv_cu, device=self.device
+                )
+                expected_full_conv = causal_conv1d_fn(
+                    x=expected_conv_input.transpose(0, 1),
+                    weight=module.prefill_gdn.conv_weights,
+                    bias=None,
+                    conv_states=None,
+                    query_start_loc=expected_conv_cu,
+                    block_map=None,
+                    prefix_lengths=torch.zeros(
+                        batch_size, dtype=torch.int32, device=self.device
+                    ),
+                    seq_size_per_block=1,
+                    metadata=expected_conv_meta,
+                ).transpose(0, 1)
+                expected_full_conv = expected_full_conv[prefix_tokens:]
+
+                local_qkvz = module.in_proj_qkvz(local_hidden)
+                local_ba = module.in_proj_ba(local_hidden)
+                local_mixed_qkv, _, _, _ = module.fix_query_key_value_ordering(
+                    local_qkvz, local_ba
+                )
+                state_len = conv_kernel_dim - 1
+                cache_block_ends = torch.cat(
+                    [
+                        torch.arange(
+                            64,
+                            total_tokens,
+                            64,
+                            dtype=torch.long,
+                            device=self.device,
+                        ),
+                        torch.tensor(
+                            [total_tokens], dtype=torch.long, device=self.device
+                        ),
+                    ]
+                )
+                cache_block_ids = torch.arange(
+                    1,
+                    cache_block_ends.shape[0] + 1,
+                    dtype=torch.long,
+                    device=self.device,
+                )
+                tail_offsets = torch.arange(
+                    -state_len, 0, dtype=torch.long, device=self.device
+                )
+                expected_block_states = full_mixed_qkv[
+                    cache_block_ends[:, None] + tail_offsets[None, :]
+                ]
+                conv_states = torch.zeros(
+                    cache_block_ends.shape[0] + 1,
+                    state_len,
+                    qkv_dim,
+                    dtype=local_mixed_qkv.dtype,
+                    device=self.device,
+                )
+
+                global_segment_ids = (cache_block_ends - 1) // local_segment_tokens
+                owners = torch.minimum(
+                    global_segment_ids, 2 * cp_size - 1 - global_segment_ids
+                )
+
+                def mock_all_reduce(tensor, group=None):
+                    owned = owners == cp_rank
+                    torch.testing.assert_close(
+                        tensor[owned], expected_block_states[owned]
+                    )
+                    self.assertEqual(torch.count_nonzero(tensor[~owned]).item(), 0)
+                    tensor.copy_(expected_block_states)
+                    return tensor
+
+                with patch(f"{AG_MODULE}.all_gather", side_effect=mock_ag), patch(
+                    f"{AG_MODULE}.all_reduce", side_effect=mock_all_reduce
+                ), patch.object(
+                    type(module.prefill_gdn),
+                    "_get_conv_states",
+                    return_value=conv_states,
+                ):
+                    actual_local_conv = module._forward_linear_cp_conv(
+                        local_mixed_qkv,
+                        prefix_conv_state,
+                        kv_cache_tensor=torch.empty(0, device=self.device),
+                        cache_block_ends=cache_block_ends,
+                        cache_block_ids=cache_block_ids,
+                        attn_meta=cp_meta,
+                        cp_plan=ZigzagCPPlan(cp_size, cp_rank),
+                        segment_valid_lengths=get_segment_valid_lengths(
+                            total_tokens, local_segment_tokens, cp_size
+                        ),
+                    )
+
+            expected_local_conv = expected_full_conv[cp_local_extract_idx]
+            torch.testing.assert_close(
+                actual_local_conv[cp_local_valid_mask],
+                expected_local_conv,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+            torch.testing.assert_close(
+                conv_states[cache_block_ids], expected_block_states
+            )
+            self.assertEqual(torch.count_nonzero(conv_states[0]).item(), 0)
+            return
+
+        cp_plan = None
+        expected_broadcast_states = []
+        if batch_size == 1:
+            full_packed = torch.cat(all_rank_packed, dim=0)[unpad_restore]
+            full_mixed_qkv, full_b, full_a = torch.split(
+                full_packed, [qkv_dim, num_v_heads, num_v_heads], dim=-1
+            )
+            with torch.no_grad():
+                full_conv = causal_conv1d_fn(
+                    x=full_mixed_qkv.transpose(0, 1),
+                    weight=module.prefill_gdn.conv_weights,
+                    bias=None,
+                    conv_states=None,
+                    query_start_loc=full_cu_from_actual,
+                    block_map=None,
+                    prefix_lengths=torch.zeros(
+                        batch_size, dtype=torch.int32, device=self.device
+                    ),
+                    seq_size_per_block=1,
+                    metadata=full_conv_meta,
+                ).transpose(0, 1)
+                full_g, full_beta = fused_gdn_gating(
+                    module.prefill_gdn.alog,
+                    full_a.contiguous(),
+                    full_b.contiguous(),
+                    module.prefill_gdn.dt_bias,
+                )
+
+                cp_plan = ZigzagCPPlan(cp_size, cp_rank)
+                segment_tokens = local_hidden.shape[0] // 2
+                segment_valid_lengths = get_segment_valid_lengths(
+                    total_tokens, segment_tokens, cp_size
+                )
+                relay_state = torch.zeros(
+                    1,
+                    num_v_heads,
+                    head_k_dim,
+                    head_v_dim,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
+                for step_index, step in enumerate(cp_plan.relay_steps):
+                    valid_tokens = step.valid_token_count(segment_valid_lengths)
+                    if valid_tokens > 0:
+                        global_start = step.first_global_segment * segment_tokens
+                        global_end = global_start + valid_tokens
+                        _, _, relay_state = module._run_linear_cp_gdn_segment(
+                            full_conv[global_start:global_end],
+                            full_g[:, global_start:global_end].contiguous(),
+                            full_beta[:, global_start:global_end].contiguous(),
+                            relay_state,
+                        )
+                    if step_index + 1 < len(cp_plan.relay_steps):
+                        expected_broadcast_states.append(relay_state.clone())
+
+        broadcast_index = 0
+
+        def mock_broadcast(state, src, group=None):
+            nonlocal broadcast_index
+            self.assertIsNotNone(cp_plan)
+            step = cp_plan.relay_steps[broadcast_index]
+            self.assertEqual(src, step.owner_rank)
+            expected_state = expected_broadcast_states[broadcast_index]
+            if cp_rank == src:
+                torch.testing.assert_close(state, expected_state, rtol=1e-3, atol=1e-3)
+            else:
+                state.copy_(expected_state)
+            broadcast_index += 1
+
+        with patch(f"{AG_MODULE}.all_gather", side_effect=mock_ag), patch(
+            f"{AG_MODULE}.broadcast", side_effect=mock_broadcast
+        ):
             with torch.no_grad():
                 cp_output = module(local_hidden, None, None, cp_attn_inputs, cp_meta)
+
+        self.assertEqual(broadcast_index, len(expected_broadcast_states))
 
         ref_local = ref_output[rank_idx]
         diff = (cp_output.float() - ref_local.float()).abs()
@@ -350,10 +1094,58 @@ class TestCPLinearAttnForward(unittest.TestCase):
         )
 
     def test_single_seq_cp2(self):
-        self._run_cp_vs_nocp(sequence_lengths=[32], cp_size=2, cp_rank=0)
+        self._run_cp_vs_nocp(sequence_lengths=[256], cp_size=2, cp_rank=0)
 
     def test_single_seq_cp2_rank1(self):
-        self._run_cp_vs_nocp(sequence_lengths=[32], cp_size=2, cp_rank=1)
+        self._run_cp_vs_nocp(sequence_lengths=[256], cp_size=2, cp_rank=1)
+
+    def test_aligned_single_seq_cp2_all_ranks(self):
+        for rank in range(2):
+            self._run_cp_vs_nocp(
+                sequence_lengths=[256], cp_size=2, cp_rank=rank, halo_conv_only=True
+            )
+
+    def test_aligned_single_seq_cp2_with_prefix(self):
+        self._run_cp_vs_nocp(
+            sequence_lengths=[256],
+            cp_size=2,
+            cp_rank=0,
+            halo_conv_only=True,
+            prefix_tokens=64,
+        )
+
+    def test_padded_single_seq_cp2_all_ranks(self):
+        for rank in range(2):
+            self._run_cp_vs_nocp(
+                sequence_lengths=[257], cp_size=2, cp_rank=rank, halo_conv_only=True
+            )
+
+    def test_padded_single_seq_cp2_with_prefix(self):
+        self._run_cp_vs_nocp(
+            sequence_lengths=[257],
+            cp_size=2,
+            cp_rank=0,
+            halo_conv_only=True,
+            prefix_tokens=64,
+        )
+
+    def test_aligned_single_seq_cp4_all_ranks(self):
+        for rank in range(4):
+            self._run_cp_vs_nocp(
+                sequence_lengths=[512],
+                cp_size=4,
+                cp_rank=rank,
+                halo_conv_only=True,
+            )
+
+    def test_aligned_single_seq_cp8_outer_and_middle_ranks(self):
+        for rank in (0, 7):
+            self._run_cp_vs_nocp(
+                sequence_lengths=[1024],
+                cp_size=8,
+                cp_rank=rank,
+                halo_conv_only=True,
+            )
 
     def test_multi_batch_cp2(self):
         self._run_cp_vs_nocp(sequence_lengths=[16, 32], cp_size=2, cp_rank=0)

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_relay_distributed.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_relay_distributed.py
@@ -1,0 +1,485 @@
+"""Two-rank integration test for the Qwen3.5 linear-attention CP relay."""
+
+import os
+import tempfile
+import unittest
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from rtp_llm.models_py.distributed import collective_torch, user_buffers
+from rtp_llm.models_py.distributed.collective_torch import Group
+from rtp_llm.models_py.model_desc.qwen3_next import (
+    Qwen3NextGatedDeltaNet,
+    Qwen3NextMetadata,
+    Qwen3NextModel,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.linear_attn_utils import (
+    ZigzagCPPlan,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.test.cp_test_utils import (
+    build_cp_attn_inputs,
+    compute_rank_positions,
+)
+from rtp_llm.models_py.triton_kernels.causal_conv1d import (
+    prepare_causal_conv1d_metadata,
+)
+from rtp_llm.ops import (
+    CPRotateMethod,
+    DataType,
+    LinearAttentionConfig,
+    ParallelismConfig,
+)
+from rtp_llm.utils.model_weight import W
+
+_WORLD_SIZE = 2
+
+
+def _install_world_as_tp_group() -> None:
+    collective_torch._group_map.clear()
+    collective_torch._group_map[Group.DP_AND_TP] = dist.group.WORLD
+    collective_torch._parallelism_config = SimpleNamespace(
+        tp_size=_WORLD_SIZE,
+        dp_size=1,
+        world_size=_WORLD_SIZE,
+    )
+    collective_torch._initialized = True
+
+
+def _clear_collective_state() -> None:
+    collective_torch._group_map.clear()
+    collective_torch._parallelism_config = None
+    collective_torch._initialized = False
+
+
+def _run_user_buffer_exchange(rank: int) -> None:
+    communicator = user_buffers.get_user_buffers_communicator()
+    peer = 1 - rank
+    source = torch.empty(1 << 16, dtype=torch.float32, device=f"cuda:{rank}")
+    destination = torch.empty_like(source)
+    communication_stream = torch.cuda.Stream(device=rank)
+    with torch.cuda.stream(communication_stream):
+        source.fill_(rank + 1)
+        destination.fill_(-1)
+        if not communicator.send_recv(
+            source,
+            dst=peer,
+            recv_tensor=destination,
+            src=peer,
+        ):
+            raise AssertionError("UserBuffer exchange unexpectedly exceeded capacity")
+    communication_stream.synchronize()
+    torch.testing.assert_close(destination, torch.full_like(destination, peer + 1))
+
+
+def _run_relay(rank: int, use_user_buffers: bool) -> None:
+    device = torch.device(f"cuda:{rank}")
+    local_qkv = torch.arange(4, dtype=torch.bfloat16, device=device).unsqueeze(1)
+    z = torch.zeros_like(local_qkv)
+    g = torch.zeros(1, 4, 1, dtype=torch.float32, device=device)
+    beta = torch.zeros(1, 4, 1, dtype=torch.bfloat16, device=device)
+    initial_states = []
+
+    class _RelayHarness:
+        _linear_cp_relay_logged = True
+
+    harness = _RelayHarness()
+    harness.parallelism_config = SimpleNamespace(use_ub_comm=use_user_buffers)
+    harness.prefill_gdn = SimpleNamespace(
+        alog=torch.zeros(1, dtype=torch.bfloat16, device=device),
+        dt_bias=torch.zeros(1, dtype=torch.bfloat16, device=device),
+        local_num_v_heads=1,
+        head_k_dim=1,
+        head_v_dim=1,
+    )
+    harness.head_v_dim = 1
+    harness.local_num_v_heads = 1
+    harness.norm = lambda attn_out, _: attn_out
+    harness.out_proj = lambda attn_out: attn_out
+
+    def run_segment(mixed_qkv, segment_g, segment_beta, initial_state):
+        del segment_g, segment_beta
+        initial_states.append(float(initial_state.item()))
+        final_state = initial_state + 1
+        segment_out = torch.full(
+            (mixed_qkv.shape[0], 1, 1),
+            float(final_state.item()),
+            dtype=mixed_qkv.dtype,
+            device=mixed_qkv.device,
+        )
+        chunk_states = torch.empty(
+            1, 1, 1, 1, 1, dtype=torch.float32, device=mixed_qkv.device
+        )
+        return segment_out, chunk_states, final_state
+
+    harness._run_linear_cp_gdn_segment = run_segment
+    with patch(
+        "rtp_llm.models_py.model_desc.qwen3_next.fused_gdn_gating",
+        return_value=(g, beta),
+    ):
+        output = Qwen3NextGatedDeltaNet._forward_linear_cp_relay(
+            harness,
+            local_qkv,
+            z,
+            torch.empty(4, 1, device=device),
+            torch.empty(4, 1, device=device),
+            prefix_ssm_state=None,
+            kv_cache_tensor=None,
+            cache_block_ends=None,
+            cache_block_ids=None,
+            cp_plan=ZigzagCPPlan(_WORLD_SIZE, rank),
+            segment_valid_lengths=(2,) * (2 * _WORLD_SIZE),
+        )
+
+    expected_states = [0.0, 2.0] if rank == 0 else [1.0]
+    if initial_states != expected_states:
+        raise AssertionError(
+            f"rank {rank} initial states {initial_states} != {expected_states}"
+        )
+    expected_output = (
+        torch.tensor([1, 1, 3, 3], dtype=torch.bfloat16, device=device)
+        if rank == 0
+        else torch.full((4,), 2, dtype=torch.bfloat16, device=device)
+    ).unsqueeze(1)
+    torch.testing.assert_close(output, expected_output)
+
+
+def _make_linear_attention_module(
+    rank: int, device: torch.device
+) -> tuple[Qwen3NextGatedDeltaNet, LinearAttentionConfig, ParallelismConfig]:
+    head_dim = 64
+    hidden_size = 64
+    qkv_dim = 3 * head_dim
+
+    linear_config = LinearAttentionConfig()
+    linear_config.linear_num_key_heads = 1
+    linear_config.linear_num_value_heads = 1
+    linear_config.linear_key_head_dim = head_dim
+    linear_config.linear_value_head_dim = head_dim
+    linear_config.linear_conv_kernel_dim = 4
+    linear_config.ssm_state_dtype = DataType.TYPE_BF16
+    linear_config.conv_state_dtype = DataType.TYPE_BF16
+
+    parallelism_config = ParallelismConfig()
+    parallelism_config.tp_size = _WORLD_SIZE
+    parallelism_config.tp_rank = rank
+    parallelism_config.dp_size = 1
+    parallelism_config.world_size = _WORLD_SIZE
+    parallelism_config.world_rank = rank
+    parallelism_config.prefill_cp_config.method = CPRotateMethod.ALL_GATHER
+
+    torch.manual_seed(20260901)
+    def randn(*shape):
+        return torch.randn(*shape, dtype=torch.bfloat16, device=device)
+
+    weights = {
+        W.linear_attn_conv1d_w: randn(qkv_dim, 1, 4),
+        W.linear_attn_dt_b: randn(1),
+        W.linear_attn_alog: randn(1),
+        W.linear_attn_norm_w: randn(head_dim),
+        W.linear_attn_qkvz_w: randn(hidden_size, 4 * head_dim),
+        W.linear_attn_qkvz_s: None,
+        W.linear_attn_ba_w: randn(hidden_size, 2),
+        W.linear_attn_out_w: randn(head_dim, hidden_size),
+        W.linear_attn_out_s: None,
+    }
+    module = Qwen3NextGatedDeltaNet(
+        linear_config, parallelism_config, weights, layernorm_eps=1e-6
+    ).to(device)
+    return module, linear_config, parallelism_config
+
+
+def _make_prefill_inputs(
+    new_tokens: int,
+    prefix_tokens: int,
+    block_ids: torch.Tensor,
+    device: torch.device,
+    context_parallel_info=None,
+):
+    return SimpleNamespace(
+        is_prefill=True,
+        is_target_verify=False,
+        is_cuda_graph=False,
+        cu_seqlens=torch.tensor([0, new_tokens], dtype=torch.int32, device=device),
+        input_lengths=torch.tensor([new_tokens], dtype=torch.int32),
+        prefix_lengths=torch.tensor([prefix_tokens], dtype=torch.int32),
+        prefix_lengths_d=torch.tensor([prefix_tokens], dtype=torch.int32, device=device),
+        kv_cache_block_id_host=block_ids.cpu(),
+        kv_cache_kernel_block_id_host=block_ids.cpu(),
+        kv_cache_kernel_block_id_device=block_ids,
+        kv_cache_kernel_block_id_device_by_group=None,
+        cache_store_inputs=None,
+        context_parallel_info=context_parallel_info,
+    )
+
+
+def _run_prefix_reuse_model(rank: int) -> None:
+    device = torch.device(f"cuda:{rank}")
+    module, linear_config, parallelism_config = _make_linear_attention_module(
+        rank, device
+    )
+    prefix_tokens = 64
+    new_tokens = 256
+    tokens_per_block = 64
+    block_ids = torch.arange(1, 6, dtype=torch.int32, device=device).unsqueeze(0)
+
+    converter = module.prefill_gdn.linear_cache_converter
+    cache_elements = converter.block_size_bytes // converter.dtype_size_bytes(
+        torch.bfloat16
+    )
+
+    def make_cache(base):
+        return SimpleNamespace(
+            kv_cache_base=base,
+            seq_size_per_block=tokens_per_block,
+        )
+
+    seed_cache = make_cache(
+        torch.zeros(6, cache_elements, dtype=torch.bfloat16, device=device)
+    )
+    seed_ssm_states = module.prefill_gdn._get_ssm_states(seed_cache.kv_cache_base)
+    seed_conv_states = module.prefill_gdn._get_conv_states(seed_cache.kv_cache_base)
+    torch.manual_seed(20260902)
+    prefix_ssm_state = torch.randn_like(seed_ssm_states[1])
+    prefix_conv_state = torch.randn_like(seed_conv_states[1])
+    seed_ssm_states[1].copy_(prefix_ssm_state)
+    seed_conv_states[1].copy_(prefix_conv_state)
+    new_hidden = torch.randn(new_tokens, 64, dtype=torch.bfloat16, device=device)
+    cp_cache = make_cache(seed_cache.kv_cache_base.clone())
+    reference_cache = make_cache(seed_cache.kv_cache_base.clone())
+
+    reference_inputs = _make_prefill_inputs(
+        new_tokens, prefix_tokens, block_ids, device
+    )
+    reference_meta = Qwen3NextMetadata(
+        prefill_conv1d_meta=prepare_causal_conv1d_metadata(
+            reference_inputs.cu_seqlens, device
+        )
+    )
+    with torch.no_grad(), patch(
+        "rtp_llm.models_py.model_desc.qwen3_next.compute_ops.write_cache_store"
+    ):
+        reference_output = module(
+            new_hidden, None, reference_cache, reference_inputs, reference_meta
+        )
+
+    rank_positions = compute_rank_positions([new_tokens], _WORLD_SIZE)[rank]
+    local_indices = torch.tensor(rank_positions, dtype=torch.long, device=device)
+    local_hidden = new_hidden[local_indices].contiguous()
+    built_cp_inputs = build_cp_attn_inputs(
+        sequence_lengths=[prefix_tokens + new_tokens],
+        cp_chunk_lengths=[new_tokens // _WORLD_SIZE],
+        cp_size=_WORLD_SIZE,
+        tokens_per_block=tokens_per_block,
+        prefix_lengths=[prefix_tokens],
+        device=device,
+    )
+    cp_inputs = _make_prefill_inputs(
+        new_tokens // _WORLD_SIZE,
+        prefix_tokens,
+        block_ids,
+        device,
+        context_parallel_info=built_cp_inputs.context_parallel_info,
+    )
+
+    captured_metadata = []
+
+    def decoder_layer(
+        hidden_states,
+        residual,
+        fmha_impl,
+        kv_cache,
+        attention_inputs,
+        attn_meta,
+    ):
+        captured_metadata.append(attn_meta)
+        return (
+            module(hidden_states, fmha_impl, kv_cache, attention_inputs, attn_meta),
+            residual,
+        )
+
+    def build_cp_metadata(attention_inputs, metadata_device):
+        return Qwen3NextModel._build_cp_linear_attn_metadata(
+            model, attention_inputs, metadata_device
+        )
+
+    model = SimpleNamespace(
+        embed_tokens=lambda _: local_hidden,
+        config=SimpleNamespace(linear_attention_config=linear_config),
+        parallelism_config=parallelism_config,
+        layers=[decoder_layer],
+        kv_cache=SimpleNamespace(get_layer_cache=lambda _: cp_cache),
+        norm=lambda hidden_states, residual: (hidden_states, residual),
+    )
+    model._build_cp_linear_attn_metadata = build_cp_metadata
+    model_inputs = SimpleNamespace(
+        input_ids=torch.arange(local_hidden.shape[0], device=device),
+        attention_inputs=cp_inputs,
+    )
+    with torch.no_grad(), patch.object(
+        module,
+        "_forward_linear_cp_conv",
+        wraps=module._forward_linear_cp_conv,
+    ) as run_conv, patch.object(
+        module,
+        "_run_linear_cp_gdn_segment",
+        wraps=module._run_linear_cp_gdn_segment,
+    ) as run_segment:
+        cp_output = Qwen3NextModel.forward(
+            model, model_inputs, SimpleNamespace(fmha_params=None)
+        ).hidden_states
+
+    if len(captured_metadata) != 1:
+        raise AssertionError(f"rank {rank} did not receive exactly one metadata object")
+    cp_metadata = captured_metadata[0]
+    torch.testing.assert_close(
+        cp_metadata.cp_local_extract_indices,
+        local_indices,
+    )
+    if not bool(cp_metadata.cp_local_valid_mask.all().item()):
+        raise AssertionError(f"rank {rank} unexpectedly received padded CP tokens")
+    torch.testing.assert_close(
+        cp_output,
+        reference_output[local_indices],
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.testing.assert_close(run_conv.call_args.args[1], prefix_conv_state)
+
+    if rank == 0:
+        torch.testing.assert_close(
+            run_segment.call_args_list[0].args[3],
+            prefix_ssm_state.float().unsqueeze(0),
+        )
+
+    cp_ssm_states = module.prefill_gdn._get_ssm_states(cp_cache.kv_cache_base)
+    cp_conv_states = module.prefill_gdn._get_conv_states(cp_cache.kv_cache_base)
+    reference_ssm_states = module.prefill_gdn._get_ssm_states(
+        reference_cache.kv_cache_base
+    )
+    reference_conv_states = module.prefill_gdn._get_conv_states(
+        reference_cache.kv_cache_base
+    )
+    torch.testing.assert_close(cp_ssm_states[1], prefix_ssm_state)
+    torch.testing.assert_close(cp_conv_states[1], prefix_conv_state)
+    # The general prefill writer does not materialize the first post-prefix
+    # intermediate SSM boundary; later boundaries remain a valid oracle.
+    torch.testing.assert_close(
+        cp_ssm_states[3:6], reference_ssm_states[3:6], rtol=2e-2, atol=2e-2
+    )
+    torch.testing.assert_close(
+        cp_conv_states[2:6], reference_conv_states[2:6], rtol=1e-2, atol=1e-2
+    )
+    if torch.count_nonzero(cp_ssm_states[2:6]).item() == 0:
+        raise AssertionError(f"rank {rank} did not write new SSM cache states")
+    if torch.count_nonzero(cp_conv_states[2:6]).item() == 0:
+        raise AssertionError(f"rank {rank} did not write new convolution cache states")
+
+
+def _relay_worker(rank: int, world_size: int, init_file: str) -> None:
+    if world_size != _WORLD_SIZE:
+        raise AssertionError(f"expected world_size={_WORLD_SIZE}, got {world_size}")
+
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    try:
+        dist.init_process_group(
+            backend="nccl",
+            init_method=f"file://{init_file}",
+            rank=rank,
+            world_size=world_size,
+            timeout=timedelta(seconds=120),
+        )
+        _install_world_as_tp_group()
+
+        _run_relay(rank, use_user_buffers=False)
+        dist.barrier()
+        _run_prefix_reuse_model(rank)
+        dist.barrier()
+
+        user_buffers.init_user_buffers_communicator(
+            dist.group.WORLD,
+            rank,
+            world_size,
+            buffer_size=1 << 20,
+        )
+        _run_user_buffer_exchange(rank)
+        dist.barrier()
+        _run_relay(rank, use_user_buffers=True)
+        torch.cuda.synchronize(device)
+        dist.barrier()
+    finally:
+        try:
+            user_buffers.destroy_user_buffers_communicator()
+        except (NameError, RuntimeError):
+            pass
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        _clear_collective_state()
+
+
+class CPRelayDistributedTest(unittest.TestCase):
+    def test_user_buffer_exchange_launches_before_stream_waits(self) -> None:
+        communicator = object.__new__(user_buffers.UserBufferCommunicator)
+        communicator.local_rank = 0
+        communicator.per_rank_buffer_size = 1024
+        communicator._ub_handle = 1
+        communicator._communicator_ptr = 2
+        communicator._rank_offsets = {0: 0, 1: 512}
+        send_stream = mock.Mock(cuda_stream=11)
+        recv_stream = mock.Mock(cuda_stream=12)
+        current_stream = mock.Mock()
+        communicator._send_streams = {1: send_stream}
+        communicator._recv_stream = recv_stream
+        communicator.cleanup = mock.Mock()
+        timeline = []
+        send_stream.wait_stream.side_effect = lambda _: timeline.append("send-ready")
+        recv_stream.wait_stream.side_effect = lambda _: timeline.append("recv-ready")
+        current_stream.wait_stream.side_effect = lambda stream: timeline.append(
+            "send-done" if stream is send_stream else "recv-done"
+        )
+
+        with patch.object(
+            torch.cuda, "current_stream", return_value=current_stream
+        ), patch.object(
+            user_buffers,
+            "userbuffers_send",
+            side_effect=lambda *args: timeline.append("send"),
+        ), patch.object(
+            user_buffers,
+            "userbuffers_recv",
+            side_effect=lambda *args: timeline.append("recv"),
+        ):
+            tensor = torch.empty(4, device="cuda")
+            self.assertTrue(
+                communicator.send_recv(tensor, 1, torch.empty_like(tensor), 1)
+            )
+
+        self.assertEqual(
+            timeline,
+            ["send-ready", "send", "recv-ready", "recv", "send-done", "recv-done"],
+        )
+
+    def test_two_rank_nccl_and_user_buffer_relay(self) -> None:
+        if not torch.cuda.is_available() or torch.cuda.device_count() < _WORLD_SIZE:
+            self.skipTest("two CUDA devices are required")
+        if not dist.is_available() or not dist.is_nccl_available():
+            self.skipTest("NCCL torch.distributed backend is required")
+
+        with tempfile.TemporaryDirectory(prefix="qwen35_cp_relay_") as temp_dir:
+            init_file = os.path.join(temp_dir, "nccl_file_store")
+            mp.spawn(
+                _relay_worker,
+                args=(_WORLD_SIZE, init_file),
+                nprocs=_WORLD_SIZE,
+                join=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_linear_attn_utils.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_linear_attn_utils.py
@@ -1,0 +1,109 @@
+import unittest
+
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.linear_attn_utils import (
+    ZigzagCPPlan,
+    get_segment_valid_lengths,
+)
+
+
+class TestZigzagCPPlan(unittest.TestCase):
+    def test_relay_covers_every_segment_in_global_order(self):
+        for cp_size in (2, 3, 4, 5, 8, 16):
+            steps = ZigzagCPPlan(cp_size, 0).relay_steps
+            global_segments = [
+                segment
+                for step in steps
+                for segment in range(
+                    step.first_global_segment,
+                    step.first_global_segment + step.segment_count,
+                )
+            ]
+
+            self.assertEqual(global_segments, list(range(2 * cp_size)))
+            self.assertEqual(len(steps), 2 * cp_size - 1)
+
+    def test_relay_steps_reference_the_owners_local_layout(self):
+        for cp_size in (2, 3, 4, 5, 8, 16):
+            for step in ZigzagCPPlan(cp_size, 0).relay_steps:
+                owner_segments = ZigzagCPPlan(
+                    cp_size, step.owner_rank
+                ).local_global_segments
+                actual = owner_segments[
+                    step.first_local_segment : step.first_local_segment
+                    + step.segment_count
+                ]
+                expected = tuple(
+                    range(
+                        step.first_global_segment,
+                        step.first_global_segment + step.segment_count,
+                    )
+                )
+                self.assertEqual(actual, expected)
+
+    def test_halo_source_owns_the_previous_global_segment(self):
+        for cp_size in (2, 3, 4, 5, 8, 16):
+            for rank in range(cp_size):
+                plan = ZigzagCPPlan(cp_size, rank)
+                for global_segment, source in zip(
+                    plan.local_global_segments, plan.halo_sources
+                ):
+                    if global_segment == 0:
+                        self.assertIsNone(source)
+                        continue
+                    self.assertIsNotNone(source)
+                    source_rank, source_local_segment = source
+                    source_global_segment = ZigzagCPPlan(
+                        cp_size, source_rank
+                    ).local_global_segments[source_local_segment]
+                    self.assertEqual(source_global_segment, global_segment - 1)
+
+    def test_invalid_topology_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "cp_size must be at least 2"):
+            ZigzagCPPlan(1, 0)
+        with self.assertRaisesRegex(ValueError, "cp_rank must be in"):
+            ZigzagCPPlan(4, 4)
+
+    def test_relay_rejects_incomplete_valid_lengths(self):
+        step = ZigzagCPPlan(2, 0).relay_steps[-1]
+        with self.assertRaisesRegex(ValueError, "at least 4 entries"):
+            step.valid_token_count((64, 64, 64))
+
+
+class TestSegmentValidLengths(unittest.TestCase):
+    def test_padding_is_excluded_for_arbitrary_cp_sizes(self):
+        for cp_size in (2, 3, 4, 5, 8, 16):
+            segment_tokens = 64
+            actual_tokens = (2 * cp_size - 2) * segment_tokens + 17
+            expected = (segment_tokens,) * (2 * cp_size - 2) + (17, 0)
+            self.assertEqual(
+                get_segment_valid_lengths(actual_tokens, segment_tokens, cp_size),
+                expected,
+            )
+
+    def test_capacity_overflow_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "exceeds CP capacity"):
+            get_segment_valid_lengths(513, segment_tokens=64, cp_size=4)
+
+    def test_invalid_length_arguments_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "actual_tokens must be non-negative"):
+            get_segment_valid_lengths(-1, segment_tokens=64, cp_size=2)
+        with self.assertRaisesRegex(ValueError, "segment_tokens must be positive"):
+            get_segment_valid_lengths(1, segment_tokens=0, cp_size=2)
+
+    def test_relay_consumes_every_real_token_exactly_once(self):
+        segment_tokens = 64
+        for cp_size in (2, 3, 4, 5, 8, 16):
+            capacity = 2 * cp_size * segment_tokens
+            for actual_tokens in (1, 63, 64, 65, capacity - 1, capacity):
+                valid_lengths = get_segment_valid_lengths(
+                    actual_tokens, segment_tokens, cp_size
+                )
+                relayed_tokens = sum(
+                    step.valid_token_count(valid_lengths)
+                    for step in ZigzagCPPlan(cp_size, 0).relay_steps
+                )
+                self.assertEqual(relayed_tokens, actual_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_prefill_cp_flashinfer_contract.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_prefill_cp_flashinfer_contract.py
@@ -1,0 +1,70 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl import (
+    prefill_cp_flashinfer,
+)
+from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_cp_flashinfer import (
+    CPFlashInferImpl,
+)
+
+
+class TestCPFlashInferForwardContract(unittest.TestCase):
+    @staticmethod
+    def _make_impl(need_rope_kv_cache):
+        method = object()
+        attn_configs = SimpleNamespace(need_rope_kv_cache=need_rope_kv_cache)
+        attn_inputs = SimpleNamespace(is_prefill=True, cache_store_inputs=None)
+        parallelism_config = SimpleNamespace(
+            prefill_cp_config=SimpleNamespace(method=method)
+        )
+        fmha_impl = Mock()
+        rope_impl = Mock()
+
+        with patch.dict(
+            prefill_cp_flashinfer.impl_map,
+            {method: Mock(return_value=fmha_impl)},
+            clear=True,
+        ), patch.object(
+            prefill_cp_flashinfer,
+            "FusedRopeKVCachePrefillOpQKVOut",
+            return_value=rope_impl,
+        ):
+            impl = CPFlashInferImpl(attn_configs, attn_inputs, parallelism_config)
+
+        return impl, fmha_impl, rope_impl
+
+    def test_layer_zero_does_not_disable_rope(self):
+        impl, fmha_impl, rope_impl = self._make_impl(True)
+
+        qkv = torch.randn(2, 8)
+        rope_output = torch.randn(2, 8)
+        attention_output = torch.randn(2, 4)
+        rope_impl.forward.return_value = rope_output
+        fmha_impl.forward.return_value = attention_output
+
+        result = impl.forward(qkv, kv_cache=None, layer_idx=0)
+
+        rope_impl.forward.assert_called_once_with(qkv, None, impl.rope_params)
+        fmha_impl.forward.assert_called_once_with(rope_output, None, impl.fmha_params)
+        self.assertIs(result, attention_output)
+
+    def test_forward_skips_rope_when_disabled(self):
+        impl, fmha_impl, rope_impl = self._make_impl(False)
+
+        qkv = torch.randn(2, 8)
+        attention_output = torch.randn(2, 4)
+        fmha_impl.forward.return_value = attention_output
+
+        result = impl.forward(qkv, kv_cache=None, layer_idx=0)
+
+        rope_impl.forward.assert_not_called()
+        fmha_impl.forward.assert_called_once_with(qkv, None, impl.fmha_params)
+        self.assertIs(result, attention_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1369,6 +1369,7 @@ class ParallelismConfig:
 class PrefillCPConfig:
     comm_buffer_size: int
     method: CPRotateMethod
+    segment_size_alignment: int
 
     def __getstate__(self) -> tuple:
         ...


### PR DESCRIPTION
## 背景

Qwen3.5 混合使用 Full Attention 和 Linear Attention。现有 prefill context parallelism 按 zigzag 方式切分序列，能够处理 Full Attention 层；但 Linear Attention 层中的 Gated DeltaNet 需要为每个 shard 提供正确的全局前缀状态，原有路径未在 shard 之间维护这一递推状态，因而无法保持完整的全局因果语义。本 PR 补齐 Qwen3.5 混合注意力的 prefill CP 路径，并完成 CP=2/4/8 的正确性与性能验证。

## 主要改动

- 按全局 token 顺序 relay FP32 Gated DeltaNet 状态，每个 segment 只计算一次。
- 为分片后的因果卷积补充 predecessor halo，并屏蔽 padding token。
- 正确维护 SSM/conv cache、部分尾块和 block-aligned prefix reuse。
- 增加模型相关的 CP segment alignment，并兼容旧 `PrefillCPConfig` pickle。
- 避免 CP rank 重复生成完整词表 logits。
- 保持 decode、MTP 和 target verification 使用原有路径。
- 对当前不支持的 layer micro-batch、DP/PP/EP 等组合在启动阶段 fail-fast。
- 补充配置、拓扑、attention 选择、relay、padding、cache 和 prefix reuse 测试。

CP 未启用时现有行为不变；本 PR 不修改 checkpoint、权重格式或外部依赖。

## 正确性验证

在 Qwen3.5-9B BF16 上验证了 8K/16K/32K/64K：

- CP=2/4/8 的贪心生成 token、文本和结束状态均与 CP=1 完全一致。
- 64K 连续生成 128 token，CP=2/4/8 均为 128/128 一致。
- 64K 首 token Top-1 一致；logits 最大绝对误差约 0.1373，相对 L2 误差约
  0.743%，未观察到生成结果差异。
- 所有请求成功，无通信错误、显存错误或服务崩溃。

## Prefill 性能初测

单位为毫秒，括号内为相对 CP=1 加速比。测试不包含 decode。

| 上下文 | CP=1 | CP=2 | CP=4 | CP=8 |
|---:|---:|---:|---:|---:|
| 8K | 591.739 | 377.785 (1.57x) | 315.251 (1.88x) | 430.633 (1.37x) |
| 16K | 1245.322 | 750.412 (1.66x) | 513.273 (2.43x) | 535.901 (2.32x) |
| 32K | 2731.318 | 1568.306 (1.74x) | 978.645 (2.79x) | 805.429 (3.39x) |
| 64K | 6362.523 | 3511.247 (1.81x) | 2043.692 (3.11x) | 1482.101 (4.29x) |

测试环境：8 x RTX PRO 5000 72GB、SM120、CUDA 12.9，batch size 1，
concurrency 1，KV cache reuse 关闭；每个点 warmup 1 次后测量 5 次，去掉
最快和最慢结果取平均。

当前验证范围为单机、DP=1，尚未覆盖多节点和多 DP 部署。