### PR TITLE
fix: tokenize request stop words in context; fix frontend_app_test port conflicts

### DIFF
--- a/rtp_llm/openai/openai_endpoint.py
+++ b/rtp_llm/openai/openai_endpoint.py
@@ -216,6 +216,30 @@ class OpenaiEndpoint(object):
             no_think_excludes=base_format.no_think_excludes,
         )
 
+    def _tokenize_request_stop_words(self, stop_words: List[str]) -> List[List[int]]:
+        stop_word_ids = []
+        for stop_word in stop_words:
+            # Byte-level tokenizers encode a word differently after a space.
+            variants = [stop_word]
+            if stop_word and not stop_word[0].isspace():
+                variants.append(" " + stop_word)
+            for variant in variants:
+                try:
+                    token_ids = self.tokenizer.encode(variant, add_special_tokens=False)
+                except TypeError:
+                    if not getattr(self, "_legacy_tokenizer_warned", False):
+                        self._legacy_tokenizer_warned = True
+                        logging.warning(
+                            "tokenizer %s does not accept add_special_tokens; "
+                            "stop words may pick up special tokens and never "
+                            "match in the engine",
+                            type(self.tokenizer).__name__,
+                        )
+                    token_ids = self.tokenizer.encode(variant)
+                if token_ids:
+                    stop_word_ids.append(list(token_ids))
+        return stop_word_ids
+
     def _extract_generation_config(
         self,
         request: ChatCompletionRequest,
@@ -252,16 +276,16 @@ class OpenaiEndpoint(object):
         request_stop_words_list = request.stop if request.stop != None else []
         if isinstance(request_stop_words_list, str):
             request_stop_words_list = [request_stop_words_list]
+        else:
+            request_stop_words_list = list(request_stop_words_list)
+        request_stop_words_list.extend(config.stop_words_str)
         config.stop_words_str = list(
-            set(
-                self.stop_words_str_list
-                + request_stop_words_list
-                + config.stop_words_str
-            )
+            set(self.stop_words_str_list + request_stop_words_list)
         )
         config.stop_words_list = self._dedup_stop_words_list(
             self.stop_words_id_list
-            + self.chat_renderer.tokenize_words(config.stop_words_str)
+            + self.chat_renderer.tokenize_words(self.stop_words_str_list)
+            + self._tokenize_request_stop_words(request_stop_words_list)
             + config.stop_words_list
         )
         if request.chat_id != None:

--- a/rtp_llm/test/frontend_test/frontend_app_test.py
+++ b/rtp_llm/test/frontend_test/frontend_app_test.py
@@ -7,8 +7,10 @@ import traceback
 import unittest
 
 import requests
+
 from rtp_llm.ops import RoleType
 from rtp_llm.start_frontend_server import start_frontend_server
+from rtp_llm.test.utils.port_util import PortsContext
 
 
 class FrontendAppTest(unittest.TestCase):
@@ -23,12 +25,26 @@ class FrontendAppTest(unittest.TestCase):
         # Keep only script name
         py_env_configs = setup_args()
         py_env_configs.role_config.role_type = RoleType.FRONTEND
-        # Override with test-specific settings
-        py_env_configs.server_config.start_port = 36000
+        # Override with test-specific settings.
+        # Never hardcode start_port: the test runs on shared CI workers where
+        # a fixed port races with concurrent jobs (Errno 98 Address already in
+        # use). Lock a free consecutive range sized by this test's
+        # worker_info_port_num and hold the locks for the whole test via
+        # addCleanup. The server only binds base+0 here; the locked window
+        # mirrors this test's config, not the production port layout (which
+        # requires at least MIN_WORKER_INFO_PORT_NUM ports).
         py_env_configs.server_config.frontend_server_count = 1
         py_env_configs.server_config.rank_id = 0
         py_env_configs.server_config.frontend_server_id = 0
         py_env_configs.server_config.worker_info_port_num = 8
+        ports_ctx = PortsContext(
+            num_ports=py_env_configs.server_config.worker_info_port_num
+        )
+        ports = ports_ctx.__enter__()
+        # Locks may be released before the daemon server thread exits; the
+        # allocator's bind probe still rejects ports that are actually in use.
+        self.addCleanup(ports_ctx.__exit__, None, None, None)
+        py_env_configs.server_config.start_port = ports[0]
         # Enable fake process mode to avoid loading actual model
         py_env_configs.profiling_debug_logging_config.debug_start_fake_process = 1
 

--- a/rtp_llm/test/generate_config_test.py
+++ b/rtp_llm/test/generate_config_test.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Union
 from unittest import TestCase, main
 
@@ -402,7 +403,7 @@ class OpenaiGenerateConfigTest(TestCase):
         model_stop_word_list: Optional[List[str]] = None,
         env_stop_word_str: Optional[str] = None,
         env_stop_word_list: Optional[str] = None,
-        req_stop: Optional[List[str]] = None,
+        req_stop: Optional[Union[str, List[str]]] = None,
         req_config_stop_word_str: Optional[List[str]] = None,
         req_config_stop_word_list: Optional[List[List[int]]] = None,
         response_format: Optional[Union[str, Dict[str, Any]]] = None,
@@ -1018,6 +1019,11 @@ class OpenaiGenerateConfigTest(TestCase):
             env_stop_word_list="[[3160, 2936, 1140], [41963, 6105, 2936, 1140]]",
         )
 
+        # Request-level stop words are natural-language phrases: each yields
+        # two token sequences (bare + leading-space variant) because byte-level
+        # BPE merges a leading space into the first token. Model/env stop words
+        # are template special tokens resolved via the renderer and keep a
+        # single sequence; the asymmetry below is intentional.
         self.assert_config_stop_word(
             expect_stop_word_str=[
                 "<|im_end|>",
@@ -1028,8 +1034,10 @@ class OpenaiGenerateConfigTest(TestCase):
             expect_stop_word_list=[
                 [151643],
                 [151645],
-                [2958, 2936, 3409],
-                [41963, 4232, 2936, 3409],
+                [2958, 2936, 3409],  # "req stop word"
+                [4232, 2936, 3409],  # leading-space variant
+                [41963, 4232, 2936, 3409],  # "another req stop word"
+                [2441, 4232, 2936, 3409],  # leading-space variant
             ],
             req_stop=["req stop word", "another req stop word"],
         )
@@ -1044,8 +1052,10 @@ class OpenaiGenerateConfigTest(TestCase):
             expect_stop_word_list=[
                 [151643],
                 [151645],
-                [2958, 2193, 2936, 3409],
-                [41963, 2193, 4232, 2936, 3409],
+                [2958, 2193, 2936, 3409],  # "req config stop word"
+                [4232, 2193, 2936, 3409],  # leading-space variant
+                [41963, 2193, 4232, 2936, 3409],  # "another config req stop word"
+                [2441, 2193, 4232, 2936, 3409],  # leading-space variant
             ],
             req_config_stop_word_str=[
                 "req config stop word",
@@ -1098,13 +1108,24 @@ class OpenaiGenerateConfigTest(TestCase):
                 [3160, 2936, 1140],
                 [41963, 6105, 2936, 1140],  # env_stop_word_list
                 [2958, 2936, 3409],
-                [41963, 4232, 2936, 3409],  # req_stop
+                [4232, 2936, 3409],
+                [41963, 4232, 2936, 3409],
+                [2441, 4232, 2936, 3409],  # req_stop (+ leading-space variants)
                 [2958, 2193, 2936, 3409],
-                [41963, 2193, 4232, 2936, 3409],  # req_config_stop_word_str
+                [4232, 2193, 2936, 3409],
+                [41963, 2193, 4232, 2936, 3409],
+                [2441, 2193, 4232, 2936, 3409],  # req_config_stop_word_str (+ variants)
                 [2958, 2193, 2936, 1140],
-                [41963, 2193, 4232, 2936, 1140],  # req_config_stop_word_list
+                [
+                    41963,
+                    2193,
+                    4232,
+                    2936,
+                    1140,
+                ],  # req_config_stop_word_list (ids as-is)
                 [21912, 2936, 1140],
-                [21912, 2936, 3409],  # duplicate stop word
+                [21912, 2936, 3409],
+                [22737, 2936, 3409],  # duplicate stop word (+ leading-space variant)
             ],
             model_stop_word_str=[
                 "model stop word",
@@ -1130,6 +1151,62 @@ class OpenaiGenerateConfigTest(TestCase):
                 [21912, 2936, 1140],
             ],
         )
+
+    def test_request_stop_word_edge_cases(self):
+        default_stop_ids = [[151643], [151645]]
+
+        # Empty stop word must not produce any entry.
+        config = self._generate_config_with_stop_word(req_stop=[""])
+        self.assertEqual(sorted(config.stop_words_list), sorted(default_stop_ids))
+
+        # Whitespace-only stop word produces exactly one entry: the guard must
+        # not add a second (double-space) variant.
+        space_ids = self.tokenizer.encode(" ", add_special_tokens=False)
+        config = self._generate_config_with_stop_word(req_stop=[" "])
+        self.assertEqual(
+            sorted(config.stop_words_list),
+            sorted(default_stop_ids + [space_ids]),
+        )
+
+        # Already-space-prefixed stop word produces exactly one entry too.
+        word = " leading space word"
+        word_ids = self.tokenizer.encode(word, add_special_tokens=False)
+        config = self._generate_config_with_stop_word(req_stop=[word])
+        self.assertEqual(
+            sorted(config.stop_words_list),
+            sorted(default_stop_ids + [word_ids]),
+        )
+
+    def test_request_stop_str_form(self):
+        # The OpenAI contract allows request.stop to be a bare string.
+        config = self._generate_config_with_stop_word(req_stop="req stop word")
+        self.assertIn("req stop word", config.stop_words_str)
+        self.assertEqual(
+            sorted(config.stop_words_list),
+            sorted([[151643], [151645], [2958, 2936, 3409], [4232, 2936, 3409]]),
+        )
+
+    def test_request_stop_not_mutated(self):
+        # _extract_generation_config must not mutate the caller's request.stop
+        # in place when folding extra_configs.stop_words_str into it.
+        req_stop = ["req stop word"]
+        self._generate_config_with_stop_word(
+            req_stop=req_stop,
+            req_config_stop_word_str=["req config stop word"],
+        )
+        self.assertEqual(req_stop, ["req stop word"])
+
+    def test_tokenize_request_stop_words_fallback(self):
+        # Tokenizers whose encode() does not accept add_special_tokens fall
+        # back to a bare encode() call and log a warning.
+        class _LegacyTokenizer:
+            def encode(self, text):
+                return [ord(c) for c in text]
+
+        endpoint = SimpleNamespace(tokenizer=_LegacyTokenizer())
+        with self.assertLogs(level="WARNING"):
+            ids = OpenaiEndpoint._tokenize_request_stop_words(endpoint, ["ab"])
+        self.assertEqual(ids, [[97, 98], [32, 97, 98]])
 
 
 class GrammarMultiSequenceConfigTest(TestCase):


### PR DESCRIPTION
## Summary

Two independent fixes, one commit each:

### 1. `fix(openai): tokenize request stop words in context` 

Request-level stop words (`request.stop` / `stop_words_str`) were tokenized
only in their bare form. Byte-level BPE tokenizers (Qwen/GPT style) merge a
leading space into the first token, so a stop word emitted mid-sentence
produces a different token sequence. The engine's token-level matcher
(`GenerateStream::matchStopWordsList`) then never fires and generation
silently runs on to `max_tokens`.

Fix: tokenize each request stop word in both context forms (bare and
space-prefixed) and put both into `stop_words_list`, so the engine and the
renderer stop at the same boundary.

- Model/env stop words keep the existing renderer tokenization path — they
  are special tokens with no space-context issue.
- `encode()` falls back to a call without `add_special_tokens` for
  tokenizers that do not accept the kwarg.

### 2. `fix(test): frontend_app_test port conflict on shared CI workers`

Hardcoded `start_port=36000` races with concurrent jobs on shared CI
workers (`Errno 98: Address already in use`). The test now locks a free
consecutive port range matching the server port layout
(`base + 0..worker_info_port_num-1`) via `PortsContext` and holds the locks
for the whole test via `addCleanup`.

## Files changed

- `rtp_llm/openai/openai_endpoint.py` — split request-level vs model-level
  stop-word tokenization; add `_tokenize_request_stop_words()`
- `rtp_llm/test/generate_config_test.py` — golden update: each request stop
  word now yields a pair of token sequences (bare + space-prefixed)
- `rtp_llm/test/frontend_test/frontend_app_test.py` — port range locking

## Testing

- `//rtp_llm/test:generate_config_test` PASS
- `//rtp_llm/test:renderer_stop_words_test` PASS
- `//rtp_llm/test/frontend_test:frontend_app_test` PASS