### PR TITLE
feat(glm5): Optimize prefill TopK postprocessing, Q-RoPE writes, CP restore, and routing

### DIFF
--- a/rtp_llm/models_py/bindings/cuda/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/BUILD
@@ -247,6 +247,7 @@ cc_library(
         "//rtp_llm/models_py/bindings/cuda/ops:cuda_impl",
         "//rtp_llm/models_py/bindings/core:types_hdr",
         "//rtp_llm/models_py/bindings/cuda/kernels:scaled_fp8_quant",
+        "//rtp_llm/models_py/bindings/cuda/kernels:cuda_no_aux_tc",
         "//rtp_llm/models_py/bindings/cuda/kernels:cuda_graph_prepare",
         "//rtp_llm/models_py/bindings/common/kernels:kernels_ep_util",
         "//rtp_llm/models_py/bindings/common/kernels:kernels_kv_cache",

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
@@ -1,5 +1,7 @@
 #include "rtp_llm/models_py/bindings/cuda/GroupTopKOp.h"
 
+#include <c10/cuda/CUDAGuard.h>
+
 namespace rtp_llm {
 
 GroupTopKOp::GroupTopKOp() {}
@@ -62,6 +64,103 @@ void GroupTopKOp::forward(torch::Tensor&       topk_values,
     return;
 }
 
+void GroupTopKOp::forwardFused(torch::Tensor&       topk_values,
+                               torch::Tensor&       topk_indices,
+                               torch::Tensor const& logits,
+                               torch::Tensor const& correction_bias,
+                               int64_t              n_group,
+                               int64_t              topk_group,
+                               int64_t              topk,
+                               bool                 renormalize,
+                               double               routed_scaling_factor) {
+    TORCH_CHECK(logits.is_cuda() && correction_bias.is_cuda(), "GroupTopK fused inputs must be CUDA tensors");
+    TORCH_CHECK(topk_values.is_cuda() && topk_indices.is_cuda(), "GroupTopK fused outputs must be CUDA tensors");
+    TORCH_CHECK(logits.is_contiguous() && correction_bias.is_contiguous(), "GroupTopK fused inputs must be contiguous");
+    TORCH_CHECK(topk_values.is_contiguous() && topk_indices.is_contiguous(),
+                "GroupTopK fused outputs must be contiguous");
+    TORCH_CHECK(logits.dim() == 2 && logits.size(1) == 256,
+                "GroupTopK fused path requires logits shaped [num_tokens, 256]");
+    TORCH_CHECK(logits.scalar_type() == torch::kBFloat16,
+                "GroupTopK fused path requires BF16 logits; unsupported dtypes must use the legacy path");
+    TORCH_CHECK(correction_bias.dim() == 1 && correction_bias.numel() == 256
+                    && correction_bias.scalar_type() == torch::kFloat32,
+                "GroupTopK fused path requires a contiguous FP32 correction bias with 256 elements");
+    TORCH_CHECK((n_group == 8 && topk_group == 4 && topk == 8)
+                    || (n_group == 1 && topk_group == 1 && topk == 8),
+                "GroupTopK fused path requires (n_group, topk_group, topk)=(8,4,8) or (1,1,8)");
+    TORCH_CHECK(topk_values.scalar_type() == torch::kFloat32 && topk_values.dim() == 2
+                    && topk_values.size(0) == logits.size(0) && topk_values.size(1) == topk,
+                "GroupTopK fused weights must be contiguous FP32 [num_tokens, topk]");
+    TORCH_CHECK(topk_indices.dim() == 2 && topk_indices.size(0) == logits.size(0) && topk_indices.size(1) == topk,
+                "GroupTopK fused indices must be contiguous [num_tokens, topk]");
+    TORCH_CHECK(topk_indices.scalar_type() == torch::kInt32 || topk_indices.scalar_type() == torch::kInt64,
+                "GroupTopK fused indices must use int32 or int64");
+    TORCH_CHECK(logits.get_device() == correction_bias.get_device() && logits.get_device() == topk_values.get_device()
+                    && logits.get_device() == topk_indices.get_device(),
+                "GroupTopK fused inputs and outputs must be on the same CUDA device");
+
+    const int64_t num_tokens = logits.size(0);
+    if (num_tokens == 0) {
+        return;
+    }
+#ifdef ENABLE_BF16
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto                 stream     = c10::cuda::getCurrentCUDAStream(logits.get_device());
+    const auto*          logits_ptr = reinterpret_cast<const __nv_bfloat16*>(logits.data_ptr<at::BFloat16>());
+    const float*         bias_ptr   = correction_bias.data_ptr<float>();
+    float*               values_ptr = topk_values.data_ptr<float>();
+
+    switch (topk_indices.scalar_type()) {
+        case torch::kInt64:
+            if (n_group == 1) {
+                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int64_t>(logits_ptr,
+                                                                      bias_ptr,
+                                                                      values_ptr,
+                                                                      topk_indices.data_ptr<int64_t>(),
+                                                                      num_tokens,
+                                                                      renormalize,
+                                                                      routed_scaling_factor,
+                                                                      stream);
+            } else {
+                invokeFusedNoAuxTc<__nv_bfloat16, int64_t>(logits_ptr,
+                                                           bias_ptr,
+                                                           values_ptr,
+                                                           topk_indices.data_ptr<int64_t>(),
+                                                           num_tokens,
+                                                           renormalize,
+                                                           routed_scaling_factor,
+                                                           stream);
+            }
+            break;
+        case torch::kInt32:
+            if (n_group == 1) {
+                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int32_t>(logits_ptr,
+                                                                      bias_ptr,
+                                                                      values_ptr,
+                                                                      topk_indices.data_ptr<int32_t>(),
+                                                                      num_tokens,
+                                                                      renormalize,
+                                                                      routed_scaling_factor,
+                                                                      stream);
+            } else {
+                invokeFusedNoAuxTc<__nv_bfloat16, int32_t>(logits_ptr,
+                                                           bias_ptr,
+                                                           values_ptr,
+                                                           topk_indices.data_ptr<int32_t>(),
+                                                           num_tokens,
+                                                           renormalize,
+                                                           routed_scaling_factor,
+                                                           stream);
+            }
+            break;
+        default:
+            TORCH_CHECK(false, "GroupTopK fused indices must use int32 or int64");
+    }
+#else
+    TORCH_CHECK(false, "GroupTopK fused path requires ENABLE_BF16");
+#endif
+}
+
 void registerGroupTopKOp(const pybind11::module& m) {
     pybind11::class_<GroupTopKOp>(m, "GroupTopKOp")
         .def(pybind11::init<>())
@@ -71,6 +170,17 @@ void registerGroupTopKOp(const pybind11::module& m) {
              pybind11::arg("topk_indices"),
              pybind11::arg("scores"),
              pybind11::arg("scores_with_bias"),
+             pybind11::arg("n_group"),
+             pybind11::arg("topk_group"),
+             pybind11::arg("topk"),
+             pybind11::arg("renormalize"),
+             pybind11::arg("routed_scaling_factor"))
+        .def("forward_fused",
+             &GroupTopKOp::forwardFused,
+             pybind11::arg("topk_values"),
+             pybind11::arg("topk_indices"),
+             pybind11::arg("logits"),
+             pybind11::arg("correction_bias"),
              pybind11::arg("n_group"),
              pybind11::arg("topk_group"),
              pybind11::arg("topk"),

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.cc
@@ -1,8 +1,32 @@
 #include "rtp_llm/models_py/bindings/cuda/GroupTopKOp.h"
 
+#include "rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h"
+
 #include <c10/cuda/CUDAGuard.h>
 
 namespace rtp_llm {
+
+namespace {
+bool canUseFused(const torch::Tensor& values,
+                 const torch::Tensor& indices,
+                 const torch::Tensor& logits,
+                 const torch::Tensor& bias,
+                 int64_t n_group,
+                 int64_t topk_group,
+                 int64_t topk) {
+    return logits.is_cuda() && logits.is_contiguous() && logits.dim() == 2 && logits.size(1) == 256
+        && logits.scalar_type() == torch::kBFloat16 && bias.is_cuda() && bias.is_contiguous()
+        && bias.dim() == 1 && bias.numel() == 256 && bias.scalar_type() == torch::kFloat32
+        && values.is_cuda() && values.is_contiguous() && values.scalar_type() == torch::kFloat32
+        && values.dim() == 2 && values.size(0) == logits.size(0) && values.size(1) == topk
+        && indices.is_cuda() && indices.is_contiguous() && indices.dim() == 2
+        && indices.size(0) == logits.size(0) && indices.size(1) == topk
+        && (indices.scalar_type() == torch::kInt32 || indices.scalar_type() == torch::kInt64)
+        && logits.device() == bias.device() && logits.device() == values.device()
+        && logits.device() == indices.device()
+        && canUseFusedNoAuxTcBf16(logits.size(1), n_group, topk_group, topk);
+}
+}  // namespace
 
 GroupTopKOp::GroupTopKOp() {}
 
@@ -85,8 +109,7 @@ void GroupTopKOp::forwardFused(torch::Tensor&       topk_values,
     TORCH_CHECK(correction_bias.dim() == 1 && correction_bias.numel() == 256
                     && correction_bias.scalar_type() == torch::kFloat32,
                 "GroupTopK fused path requires a contiguous FP32 correction bias with 256 elements");
-    TORCH_CHECK((n_group == 8 && topk_group == 4 && topk == 8)
-                    || (n_group == 1 && topk_group == 1 && topk == 8),
+    TORCH_CHECK(canUseFusedNoAuxTcBf16(logits.size(1), n_group, topk_group, topk),
                 "GroupTopK fused path requires (n_group, topk_group, topk)=(8,4,8) or (1,1,8)");
     TORCH_CHECK(topk_values.scalar_type() == torch::kFloat32 && topk_values.dim() == 2
                     && topk_values.size(0) == logits.size(0) && topk_values.size(1) == topk,
@@ -99,66 +122,46 @@ void GroupTopKOp::forwardFused(torch::Tensor&       topk_values,
                     && logits.get_device() == topk_indices.get_device(),
                 "GroupTopK fused inputs and outputs must be on the same CUDA device");
 
-    const int64_t num_tokens = logits.size(0);
-    if (num_tokens == 0) {
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto stream = c10::cuda::getCurrentCUDAStream(logits.get_device());
+    const auto index_type = topk_indices.scalar_type() == torch::kInt64 ? FusedNoAuxTcIndexType::INT64
+                                                                        : FusedNoAuxTcIndexType::INT32;
+    const bool launched = invokeFusedNoAuxTcBf16(logits.data_ptr<at::BFloat16>(),
+                                                  correction_bias.data_ptr<float>(),
+                                                  topk_values.data_ptr<float>(),
+                                                  topk_indices.mutable_data_ptr(),
+                                                  index_type,
+                                                  logits.size(0),
+                                                  logits.size(1),
+                                                  n_group,
+                                                  topk_group,
+                                                  topk,
+                                                  renormalize,
+                                                  routed_scaling_factor,
+                                                  stream);
+    TORCH_CHECK(launched, "GroupTopK fused path requires an ENABLE_BF16 CUDA build");
+}
+
+void GroupTopKOp::forwardAuto(torch::Tensor&       topk_values,
+                              torch::Tensor&       topk_indices,
+                              torch::Tensor const& logits,
+                              torch::Tensor const& correction_bias,
+                              int64_t              n_group,
+                              int64_t              topk_group,
+                              int64_t              topk,
+                              bool                 renormalize,
+                              double               routed_scaling_factor,
+                              bool                 enable_fused) {
+    if (enable_fused && canUseFused(topk_values, topk_indices, logits, correction_bias,
+                                    n_group, topk_group, topk)) {
+        forwardFused(topk_values, topk_indices, logits, correction_bias, n_group, topk_group, topk,
+                     renormalize, routed_scaling_factor);
         return;
     }
-#ifdef ENABLE_BF16
-    c10::cuda::CUDAGuard device_guard(logits.device());
-    auto                 stream     = c10::cuda::getCurrentCUDAStream(logits.get_device());
-    const auto*          logits_ptr = reinterpret_cast<const __nv_bfloat16*>(logits.data_ptr<at::BFloat16>());
-    const float*         bias_ptr   = correction_bias.data_ptr<float>();
-    float*               values_ptr = topk_values.data_ptr<float>();
-
-    switch (topk_indices.scalar_type()) {
-        case torch::kInt64:
-            if (n_group == 1) {
-                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int64_t>(logits_ptr,
-                                                                      bias_ptr,
-                                                                      values_ptr,
-                                                                      topk_indices.data_ptr<int64_t>(),
-                                                                      num_tokens,
-                                                                      renormalize,
-                                                                      routed_scaling_factor,
-                                                                      stream);
-            } else {
-                invokeFusedNoAuxTc<__nv_bfloat16, int64_t>(logits_ptr,
-                                                           bias_ptr,
-                                                           values_ptr,
-                                                           topk_indices.data_ptr<int64_t>(),
-                                                           num_tokens,
-                                                           renormalize,
-                                                           routed_scaling_factor,
-                                                           stream);
-            }
-            break;
-        case torch::kInt32:
-            if (n_group == 1) {
-                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int32_t>(logits_ptr,
-                                                                      bias_ptr,
-                                                                      values_ptr,
-                                                                      topk_indices.data_ptr<int32_t>(),
-                                                                      num_tokens,
-                                                                      renormalize,
-                                                                      routed_scaling_factor,
-                                                                      stream);
-            } else {
-                invokeFusedNoAuxTc<__nv_bfloat16, int32_t>(logits_ptr,
-                                                           bias_ptr,
-                                                           values_ptr,
-                                                           topk_indices.data_ptr<int32_t>(),
-                                                           num_tokens,
-                                                           renormalize,
-                                                           routed_scaling_factor,
-                                                           stream);
-            }
-            break;
-        default:
-            TORCH_CHECK(false, "GroupTopK fused indices must use int32 or int64");
-    }
-#else
-    TORCH_CHECK(false, "GroupTopK fused path requires ENABLE_BF16");
-#endif
+    auto scores = logits.to(torch::kFloat32).sigmoid();
+    auto scores_with_bias = scores + correction_bias.unsqueeze(0);
+    forward(topk_values, topk_indices, scores, scores_with_bias, n_group, topk_group, topk,
+            renormalize, routed_scaling_factor);
 }
 
 void registerGroupTopKOp(const pybind11::module& m) {
@@ -185,6 +188,18 @@ void registerGroupTopKOp(const pybind11::module& m) {
              pybind11::arg("topk_group"),
              pybind11::arg("topk"),
              pybind11::arg("renormalize"),
-             pybind11::arg("routed_scaling_factor"));
+             pybind11::arg("routed_scaling_factor"))
+        .def("forward_auto",
+             &GroupTopKOp::forwardAuto,
+             pybind11::arg("topk_values"),
+             pybind11::arg("topk_indices"),
+             pybind11::arg("logits"),
+             pybind11::arg("correction_bias"),
+             pybind11::arg("n_group"),
+             pybind11::arg("topk_group"),
+             pybind11::arg("topk"),
+             pybind11::arg("renormalize"),
+             pybind11::arg("routed_scaling_factor"),
+             pybind11::arg("enable_fused"));
 }
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
@@ -3,7 +3,6 @@
 #include <torch/torch.h>
 #include <torch/extension.h>
 #include <c10/cuda/CUDAStream.h>
-#include "rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h"
 
 namespace rtp_llm {
 
@@ -28,6 +27,16 @@ public:
                       int64_t              topk,
                       bool                 renormalize,
                       double               routed_scaling_factor);
+    void forwardAuto(torch::Tensor&       topk_values,
+                     torch::Tensor&       topk_indices,
+                     torch::Tensor const& logits,
+                     torch::Tensor const& correction_bias,
+                     int64_t              n_group,
+                     int64_t              topk_group,
+                     int64_t              topk,
+                     bool                 renormalize,
+                     double               routed_scaling_factor,
+                     bool                 enable_fused);
 };
 
 void registerGroupTopKOp(const pybind11::module& m);

--- a/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
+++ b/rtp_llm/models_py/bindings/cuda/GroupTopKOp.h
@@ -19,6 +19,15 @@ public:
                  int64_t              topk,
                  bool                 renormalize,
                  double               routed_scaling_factor);
+    void forwardFused(torch::Tensor&       topk_values,
+                      torch::Tensor&       topk_indices,
+                      torch::Tensor const& logits,
+                      torch::Tensor const& correction_bias,
+                      int64_t              n_group,
+                      int64_t              topk_group,
+                      int64_t              topk,
+                      bool                 renormalize,
+                      double               routed_scaling_factor);
 };
 
 void registerGroupTopKOp(const pybind11::module& m);

--- a/rtp_llm/models_py/bindings/cuda/kernels/BUILD
+++ b/rtp_llm/models_py/bindings/cuda/kernels/BUILD
@@ -66,8 +66,10 @@ cc_library(
         "//rtp_llm/models_py/bindings/cuda:cuda_utils_cu",
         ":cuda_utils_common",
         "//rtp_llm/cpp/utils:core_utils",
+        "@local_config_cuda//cuda:cuda_headers",
     ],
     copts = cuda_copts(),
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
@@ -775,29 +775,29 @@ void invokeFusedNoAuxTc(const InputT*      logits,
 
 template<typename InputT, typename IdxT>
 __global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
-                                                         const float* correction_bias,
-                                                         float* topk_values,
-                                                         IdxT* topk_indices,
-                                                         int64_t num_tokens,
-                                                         int norm_node,
-                                                         double routed_scaling_factor) {
+                                                         const float*  correction_bias,
+                                                         float*        topk_values,
+                                                         IdxT*         topk_indices,
+                                                         int64_t       num_tokens,
+                                                         int           norm_node,
+                                                         double        routed_scaling_factor) {
     constexpr int32_t NUM_EXPERTS = 256;
-    constexpr int32_t TOPK = 8;
-    __shared__ float shared_scores[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
-    __shared__ float shared_scores_with_bias[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+    constexpr int32_t TOPK        = 8;
+    __shared__ float  shared_scores[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+    __shared__ float  shared_scores_with_bias[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
 
-    const int32_t warp_id = threadIdx.x / WARP_SIZE;
-    const int32_t lane_id = threadIdx.x % WARP_SIZE;
-    const int64_t token_id = static_cast<int64_t>(blockIdx.x) * NUM_WARPS_PER_BLOCK + warp_id;
-    const bool valid = token_id < num_tokens;
-    float* warp_scores = shared_scores + warp_id * NUM_EXPERTS;
-    float* warp_scores_with_bias = shared_scores_with_bias + warp_id * NUM_EXPERTS;
+    const int32_t warp_id               = threadIdx.x / WARP_SIZE;
+    const int32_t lane_id               = threadIdx.x % WARP_SIZE;
+    const int64_t token_id              = static_cast<int64_t>(blockIdx.x) * NUM_WARPS_PER_BLOCK + warp_id;
+    const bool    valid                 = token_id < num_tokens;
+    float*        warp_scores           = shared_scores + warp_id * NUM_EXPERTS;
+    float*        warp_scores_with_bias = shared_scores_with_bias + warp_id * NUM_EXPERTS;
 
     if (valid) {
         const InputT* token_logits = logits + token_id * NUM_EXPERTS;
 #pragma unroll
         for (int32_t expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
-            const float score = strict_group_topk_sigmoid(strict_group_topk_input_to_float(token_logits[expert]));
+            const float score   = strict_group_topk_sigmoid(strict_group_topk_input_to_float(token_logits[expert]));
             warp_scores[expert] = score;
             warp_scores_with_bias[expert] = score + correction_bias[expert];
         }
@@ -806,16 +806,15 @@ __global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
 
     warp_topk::WarpSelect<WARP_SIZE, true, float, int32_t, true> queue(TOPK, -INFINITY);
     for (int32_t expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
-        const float candidate = valid && isfinite(warp_scores_with_bias[expert])
-                                    ? warp_scores_with_bias[expert]
-                                    : -INFINITY;
+        const float candidate =
+            valid && isfinite(warp_scores_with_bias[expert]) ? warp_scores_with_bias[expert] : -INFINITY;
         queue.add(candidate, expert);
     }
     // WarpSelect::done contains a block-wide barrier; invalid tail warps participate too.
     queue.done();
 
     extern __shared__ char smem_buf[];
-    int32_t* selected = reinterpret_cast<int32_t*>(smem_buf);
+    int32_t*               selected = reinterpret_cast<int32_t*>(smem_buf);
     selected += warp_id * TOPK;
     bool lane_has_valid = false;
     if (valid) {
@@ -824,7 +823,7 @@ __global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
             lane_has_valid = lane_has_valid || isfinite(warp_scores_with_bias[expert]);
         }
     }
-    lane_has_valid = valid && lane_has_valid;
+    lane_has_valid       = valid && lane_has_valid;
     const bool any_valid = __any_sync(FULL_WARP_MASK, lane_has_valid);
     if (any_valid) {
         __syncwarp();
@@ -834,7 +833,7 @@ __global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
     __syncthreads();
 
     float topk_sum = norm_node == 0 ? 1.0f : 1e-20f;
-    float value = 0.0f;
+    float value    = 0.0f;
     if (any_valid && lane_id < TOPK) {
         value = warp_scores[selected[lane_id]];
     }
@@ -848,45 +847,34 @@ __global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
         const int64_t output_offset = token_id * TOPK + lane_id;
         if (any_valid) {
             topk_indices[output_offset] = static_cast<IdxT>(selected[lane_id]);
-            topk_values[output_offset] = value / topk_sum * routed_scaling_factor;
+            topk_values[output_offset]  = value / topk_sum * routed_scaling_factor;
         } else {
             topk_indices[output_offset] = static_cast<IdxT>(lane_id);
-            topk_values[output_offset] = 1.0f / TOPK;
+            topk_values[output_offset]  = 1.0f / TOPK;
         }
     }
 }
 
 template<typename InputT, typename IdxT>
 void invokeFusedNoAuxTcSingleGroup(const InputT* logits,
-                                   const float* correction_bias,
-                                   float* topk_values,
-                                   IdxT* topk_indices,
-                                   int64_t num_tokens,
-                                   int norm_node,
-                                   double routed_scaling_factor,
-                                   cudaStream_t stream) {
+                                   const float*  correction_bias,
+                                   float*        topk_values,
+                                   IdxT*         topk_indices,
+                                   int64_t       num_tokens,
+                                   int           norm_node,
+                                   double        routed_scaling_factor,
+                                   cudaStream_t  stream) {
     const int64_t num_blocks = (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
-    const size_t dynamic_smem_in_bytes =
+    const size_t  dynamic_smem_in_bytes =
         warp_topk::calc_smem_size_for_block_wide<float, int32_t>(NUM_WARPS_PER_BLOCK, 8);
-    LAUNCH_KERNEL_WITH_PDL((fused_glm5_no_aux_tc_single_group_kernel<InputT, IdxT>),
-                           num_blocks,
-                           BLOCK_SIZE,
-                           dynamic_smem_in_bytes,
-                           stream,
-                           logits,
-                           correction_bias,
-                           topk_values,
-                           topk_indices,
-                           num_tokens,
-                           norm_node,
-                           routed_scaling_factor);
+    fused_glm5_no_aux_tc_single_group_kernel<InputT, IdxT><<<num_blocks, BLOCK_SIZE, dynamic_smem_in_bytes, stream>>>(
+        logits, correction_bias, topk_values, topk_indices, num_tokens, norm_node, routed_scaling_factor);
     check_cuda_error();
 }
 
 bool canUseFusedNoAuxTcBf16(int64_t num_experts, int64_t n_group, int64_t topk_group, int64_t topk) {
 #ifdef ENABLE_BF16
-    return num_experts == 256 && topk == 8
-        && ((n_group == 1 && topk_group == 1) || (n_group == 8 && topk_group == 4));
+    return num_experts == 256 && topk == 8 && ((n_group == 1 && topk_group == 1) || (n_group == 8 && topk_group == 4));
 #else
     return false;
 #endif
@@ -933,13 +921,13 @@ bool invokeFusedNoAuxTcBf16(const void*           logits,
                                                                       stream);
             } else {
                 invokeFusedNoAuxTc<__nv_bfloat16, int64_t>(logits_bf16,
-                                                            correction_bias,
-                                                            topk_values,
-                                                            indices,
-                                                            num_tokens,
-                                                            renormalize,
-                                                            routed_scaling_factor,
-                                                            stream);
+                                                           correction_bias,
+                                                           topk_values,
+                                                           indices,
+                                                           num_tokens,
+                                                           renormalize,
+                                                           routed_scaling_factor,
+                                                           stream);
             }
             break;
         }
@@ -956,13 +944,13 @@ bool invokeFusedNoAuxTcBf16(const void*           logits,
                                                                       stream);
             } else {
                 invokeFusedNoAuxTc<__nv_bfloat16, int32_t>(logits_bf16,
-                                                            correction_bias,
-                                                            topk_values,
-                                                            indices,
-                                                            num_tokens,
-                                                            renormalize,
-                                                            routed_scaling_factor,
-                                                            stream);
+                                                           correction_bias,
+                                                           topk_values,
+                                                           indices,
+                                                           num_tokens,
+                                                           renormalize,
+                                                           routed_scaling_factor,
+                                                           stream);
             }
             break;
         }
@@ -1065,15 +1053,15 @@ INSTANTIATE_NOAUX_TC(float, int64_t);
 INSTANTIATE_FUSED_NOAUX_TC(__nv_bfloat16, int32_t);
 INSTANTIATE_FUSED_NOAUX_TC(__nv_bfloat16, int64_t);
 
-#define INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(InputT, IdxT)                                                         \
-    template void invokeFusedNoAuxTcSingleGroup<InputT, IdxT>(const InputT* logits,                                  \
-                                                               const float* correction_bias,                          \
-                                                               float* topk_values,                                    \
-                                                               IdxT* topk_indices,                                    \
-                                                               int64_t const num_tokens,                              \
-                                                               int norm_node,                                         \
-                                                               double const routed_scaling_factor,                    \
-                                                               cudaStream_t const stream);
+#define INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(InputT, IdxT)                                                          \
+    template void invokeFusedNoAuxTcSingleGroup<InputT, IdxT>(const InputT*      logits,                               \
+                                                              const float*       correction_bias,                      \
+                                                              float*             topk_values,                          \
+                                                              IdxT*              topk_indices,                         \
+                                                              int64_t const      num_tokens,                           \
+                                                              int                norm_node,                            \
+                                                              double const       routed_scaling_factor,                \
+                                                              cudaStream_t const stream);
 
 INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(__nv_bfloat16, int32_t);
 INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(__nv_bfloat16, int64_t);

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
@@ -21,6 +21,7 @@
 #include "no_aux_tc_kernels.h"
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cmath>
 
 namespace cg = cooperative_groups;
 
@@ -579,6 +580,309 @@ __global__ void group_idx_and_topk_idx_kernel(T*            scores,
 #endif
 }
 
+template<typename InputT>
+__device__ __forceinline__ float strict_group_topk_input_to_float(InputT value) {
+    return static_cast<float>(value);
+}
+
+template<>
+__device__ __forceinline__ float strict_group_topk_input_to_float(__nv_bfloat16 value) {
+    return __bfloat162float(value);
+}
+
+__device__ __forceinline__ float strict_group_topk_sigmoid(float value) {
+    // Match the PyTorch CUDA float sigmoid source form. This target must not be
+    // compiled with fast-math: BF16 exhaustive testing relies on bitwise FP32
+    // equivalence before the legacy TopK helpers consume the scores.
+    const float one = 1.0f;
+    return one / (one + std::exp(-value));
+}
+
+template<typename InputT, typename IdxT>
+__global__ void fused_glm5_no_aux_tc_kernel(const InputT* logits,
+                                            const float*  correction_bias,
+                                            float*        topk_values,
+                                            IdxT*         topk_indices,
+                                            int64_t       num_tokens,
+                                            int           norm_node,
+                                            double        routed_scaling_factor) {
+    constexpr int32_t NUM_EXPERTS       = 256;
+    constexpr int32_t NUM_GROUPS        = 8;
+    constexpr int32_t EXPERTS_PER_GROUP = 32;
+    constexpr int32_t TOPK_GROUP        = 4;
+    constexpr int32_t TOPK              = 8;
+
+    __shared__ float shared_scores[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+    __shared__ float shared_scores_with_bias[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+    __shared__ float shared_group_scores[NUM_WARPS_PER_BLOCK * NUM_GROUPS];
+
+    const int32_t warp_id  = threadIdx.x / WARP_SIZE;
+    const int32_t lane_id  = threadIdx.x % WARP_SIZE;
+    const int64_t token_id = static_cast<int64_t>(blockIdx.x) * NUM_WARPS_PER_BLOCK + warp_id;
+    const bool    valid    = token_id < num_tokens;
+
+    float* warp_scores           = shared_scores + warp_id * NUM_EXPERTS;
+    float* warp_scores_with_bias = shared_scores_with_bias + warp_id * NUM_EXPERTS;
+    float* warp_group_scores     = shared_group_scores + warp_id * NUM_GROUPS;
+
+    cg::thread_block          block = cg::this_thread_block();
+    cg::thread_block_tile<32> tile  = cg::tiled_partition<32>(block);
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    if (valid) {
+        const InputT* token_logits = logits + token_id * NUM_EXPERTS;
+#pragma unroll
+        for (int32_t group = 0; group < NUM_GROUPS; ++group) {
+            const int32_t expert = group * EXPERTS_PER_GROUP + lane_id;
+            const float   score  = strict_group_topk_sigmoid(strict_group_topk_input_to_float(token_logits[expert]));
+            warp_scores[expert]  = score;
+            warp_scores_with_bias[expert] = score + correction_bias[expert];
+        }
+    }
+    __syncthreads();
+
+    if (valid) {
+#pragma unroll
+        for (int32_t group = 0; group < NUM_GROUPS; ++group) {
+            topk_with_k2(warp_group_scores + group,
+                         warp_scores_with_bias + group * EXPERTS_PER_GROUP,
+                         tile,
+                         lane_id,
+                         EXPERTS_PER_GROUP);
+        }
+    }
+    __syncthreads();
+
+    float   topk_group_value         = cuda::std::numeric_limits<float>::lowest();
+    int32_t num_equalto_topkth_group = 0;
+    if (valid) {
+        float         value          = cuda::std::numeric_limits<float>::lowest();
+        const int32_t target_num_min = WARP_SIZE - NUM_GROUPS + TOPK_GROUP;
+        if (lane_id < NUM_GROUPS && isfinite(warp_group_scores[lane_id])) {
+            value = warp_group_scores[lane_id];
+        }
+
+        int count_equal_to_top_value     = WARP_SIZE - NUM_GROUPS;
+        int pre_count_equal_to_top_value = 0;
+        while (count_equal_to_top_value < target_num_min) {
+            __syncwarp();
+            topk_group_value = cg::reduce(tile, value, cg::greater<float>());
+            if (value == topk_group_value) {
+                value = cuda::std::numeric_limits<float>::lowest();
+            }
+            pre_count_equal_to_top_value = count_equal_to_top_value;
+            count_equal_to_top_value =
+                __popc(__ballot_sync(FULL_WARP_MASK, value == cuda::std::numeric_limits<float>::lowest()));
+        }
+        num_equalto_topkth_group = target_num_min - pre_count_equal_to_top_value;
+    }
+    __syncthreads();
+
+    extern __shared__ char smem_buf[];
+    int32_t*               s_topk_idx = reinterpret_cast<int32_t*>(smem_buf);
+    float* s_topk_value = reinterpret_cast<float*>(s_topk_idx + NUM_WARPS_PER_BLOCK * TOPK) + warp_id * TOPK;
+    s_topk_idx += warp_id * TOPK;
+
+    warp_topk::WarpSelect<WARP_SIZE, true, float, int32_t, true> queue(TOPK, -INFINITY);
+
+    int        count_equalto_topkth_group = 0;
+    const bool if_proceed_next_topk       = valid && topk_group_value != cuda::std::numeric_limits<float>::lowest();
+    if (if_proceed_next_topk) {
+#pragma unroll
+        for (int32_t group = 0; group < NUM_GROUPS; ++group) {
+            if (warp_group_scores[group] > topk_group_value
+                || (warp_group_scores[group] == topk_group_value
+                    && count_equalto_topkth_group < num_equalto_topkth_group)) {
+                const int32_t offset    = group * EXPERTS_PER_GROUP;
+                const float   candidate = isfinite(warp_scores_with_bias[offset + lane_id]) ?
+                                              warp_scores_with_bias[offset + lane_id] :
+                                              cuda::std::numeric_limits<float>::lowest();
+                queue.add(candidate, offset + lane_id);
+                if (warp_group_scores[group] == topk_group_value) {
+                    ++count_equalto_topkth_group;
+                }
+            }
+        }
+    }
+
+    // WarpSelect::done() contains a block-wide barrier. Invalid tail warps and
+    // fallback warps must participate even when they never called queue.add().
+    queue.done();
+    if (if_proceed_next_topk) {
+        __syncwarp();
+        queue.dumpIdx(s_topk_idx);
+        __syncwarp();
+    }
+
+    float topk_sum = norm_node == 0 ? 1.0f : 1e-20f;
+    if (if_proceed_next_topk) {
+        const int32_t index = lane_id;
+        const float   value = index < TOPK ? warp_scores[s_topk_idx[index]] : 0.0f;
+        if (index < TOPK) {
+            s_topk_value[index] = value;
+        }
+        if (norm_node == 1) {
+            topk_sum += cg::reduce(tile, value, cg::plus<float>());
+        }
+    }
+    __syncthreads();
+
+    if (valid && lane_id < TOPK) {
+        const int64_t output_offset = token_id * TOPK + lane_id;
+        if (if_proceed_next_topk) {
+            topk_indices[output_offset] = static_cast<IdxT>(s_topk_idx[lane_id]);
+            topk_values[output_offset]  = s_topk_value[lane_id] / topk_sum * routed_scaling_factor;
+        } else {
+            topk_indices[output_offset] = static_cast<IdxT>(lane_id);
+            topk_values[output_offset]  = 1.0f / TOPK;
+        }
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template<typename InputT, typename IdxT>
+void invokeFusedNoAuxTc(const InputT*      logits,
+                        const float*       correction_bias,
+                        float*             topk_values,
+                        IdxT*              topk_indices,
+                        int64_t const      num_tokens,
+                        int                norm_node,
+                        double const       routed_scaling_factor,
+                        cudaStream_t const stream) {
+    const int64_t num_blocks = (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
+    const size_t  dynamic_smem_in_bytes =
+        warp_topk::calc_smem_size_for_block_wide<float, int32_t>(NUM_WARPS_PER_BLOCK, 8);
+    LAUNCH_KERNEL_WITH_PDL((fused_glm5_no_aux_tc_kernel<InputT, IdxT>),
+                           num_blocks,
+                           BLOCK_SIZE,
+                           dynamic_smem_in_bytes,
+                           stream,
+                           logits,
+                           correction_bias,
+                           topk_values,
+                           topk_indices,
+                           num_tokens,
+                           norm_node,
+                           routed_scaling_factor);
+    check_cuda_error();
+}
+
+template<typename InputT, typename IdxT>
+__global__ void fused_glm5_no_aux_tc_single_group_kernel(const InputT* logits,
+                                                         const float* correction_bias,
+                                                         float* topk_values,
+                                                         IdxT* topk_indices,
+                                                         int64_t num_tokens,
+                                                         int norm_node,
+                                                         double routed_scaling_factor) {
+    constexpr int32_t NUM_EXPERTS = 256;
+    constexpr int32_t TOPK = 8;
+    __shared__ float shared_scores[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+    __shared__ float shared_scores_with_bias[NUM_WARPS_PER_BLOCK * NUM_EXPERTS];
+
+    const int32_t warp_id = threadIdx.x / WARP_SIZE;
+    const int32_t lane_id = threadIdx.x % WARP_SIZE;
+    const int64_t token_id = static_cast<int64_t>(blockIdx.x) * NUM_WARPS_PER_BLOCK + warp_id;
+    const bool valid = token_id < num_tokens;
+    float* warp_scores = shared_scores + warp_id * NUM_EXPERTS;
+    float* warp_scores_with_bias = shared_scores_with_bias + warp_id * NUM_EXPERTS;
+
+    if (valid) {
+        const InputT* token_logits = logits + token_id * NUM_EXPERTS;
+#pragma unroll
+        for (int32_t expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
+            const float score = strict_group_topk_sigmoid(strict_group_topk_input_to_float(token_logits[expert]));
+            warp_scores[expert] = score;
+            warp_scores_with_bias[expert] = score + correction_bias[expert];
+        }
+    }
+    __syncthreads();
+
+    warp_topk::WarpSelect<WARP_SIZE, true, float, int32_t, true> queue(TOPK, -INFINITY);
+    for (int32_t expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
+        const float candidate = valid && isfinite(warp_scores_with_bias[expert])
+                                    ? warp_scores_with_bias[expert]
+                                    : -INFINITY;
+        queue.add(candidate, expert);
+    }
+    // WarpSelect::done contains a block-wide barrier; invalid tail warps participate too.
+    queue.done();
+
+    extern __shared__ char smem_buf[];
+    int32_t* selected = reinterpret_cast<int32_t*>(smem_buf);
+    selected += warp_id * TOPK;
+    bool lane_has_valid = false;
+    if (valid) {
+#pragma unroll
+        for (int32_t expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
+            lane_has_valid = lane_has_valid || isfinite(warp_scores_with_bias[expert]);
+        }
+    }
+    lane_has_valid = valid && lane_has_valid;
+    const bool any_valid = __any_sync(FULL_WARP_MASK, lane_has_valid);
+    if (any_valid) {
+        __syncwarp();
+        queue.dumpIdx(selected);
+        __syncwarp();
+    }
+    __syncthreads();
+
+    float topk_sum = norm_node == 0 ? 1.0f : 1e-20f;
+    float value = 0.0f;
+    if (any_valid && lane_id < TOPK) {
+        value = warp_scores[selected[lane_id]];
+    }
+    if (any_valid && norm_node == 1) {
+        auto tile = cg::tiled_partition<32>(cg::this_thread_block());
+        topk_sum += cg::reduce(tile, value, cg::plus<float>());
+    }
+    __syncthreads();
+
+    if (valid && lane_id < TOPK) {
+        const int64_t output_offset = token_id * TOPK + lane_id;
+        if (any_valid) {
+            topk_indices[output_offset] = static_cast<IdxT>(selected[lane_id]);
+            topk_values[output_offset] = value / topk_sum * routed_scaling_factor;
+        } else {
+            topk_indices[output_offset] = static_cast<IdxT>(lane_id);
+            topk_values[output_offset] = 1.0f / TOPK;
+        }
+    }
+}
+
+template<typename InputT, typename IdxT>
+void invokeFusedNoAuxTcSingleGroup(const InputT* logits,
+                                   const float* correction_bias,
+                                   float* topk_values,
+                                   IdxT* topk_indices,
+                                   int64_t num_tokens,
+                                   int norm_node,
+                                   double routed_scaling_factor,
+                                   cudaStream_t stream) {
+    const int64_t num_blocks = (num_tokens - 1) / NUM_WARPS_PER_BLOCK + 1;
+    const size_t dynamic_smem_in_bytes =
+        warp_topk::calc_smem_size_for_block_wide<float, int32_t>(NUM_WARPS_PER_BLOCK, 8);
+    LAUNCH_KERNEL_WITH_PDL((fused_glm5_no_aux_tc_single_group_kernel<InputT, IdxT>),
+                           num_blocks,
+                           BLOCK_SIZE,
+                           dynamic_smem_in_bytes,
+                           stream,
+                           logits,
+                           correction_bias,
+                           topk_values,
+                           topk_indices,
+                           num_tokens,
+                           norm_node,
+                           routed_scaling_factor);
+    check_cuda_error();
+}
+
 template<typename T, typename IdxT>
 void invokeNoAuxTc(T*                 scores,
                    T*                 group_scores,
@@ -654,5 +958,33 @@ INSTANTIATE_NOAUX_TC(float, int64_t);
 // #ifdef ENABLE_BF16
 // INSTANTIATE_NOAUX_TC(__nv_bfloat16, int32_t);
 // #endif
+
+#define INSTANTIATE_FUSED_NOAUX_TC(InputT, IdxT)                                                                       \
+    template void invokeFusedNoAuxTc<InputT, IdxT>(const InputT*      logits,                                          \
+                                                   const float*       correction_bias,                                 \
+                                                   float*             topk_values,                                     \
+                                                   IdxT*              topk_indices,                                    \
+                                                   int64_t const      num_tokens,                                      \
+                                                   int                norm_node,                                       \
+                                                   double const       routed_scaling_factor,                           \
+                                                   cudaStream_t const stream);
+
+#ifdef ENABLE_BF16
+INSTANTIATE_FUSED_NOAUX_TC(__nv_bfloat16, int32_t);
+INSTANTIATE_FUSED_NOAUX_TC(__nv_bfloat16, int64_t);
+
+#define INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(InputT, IdxT)                                                         \
+    template void invokeFusedNoAuxTcSingleGroup<InputT, IdxT>(const InputT* logits,                                  \
+                                                               const float* correction_bias,                          \
+                                                               float* topk_values,                                    \
+                                                               IdxT* topk_indices,                                    \
+                                                               int64_t const num_tokens,                              \
+                                                               int norm_node,                                         \
+                                                               double const routed_scaling_factor,                    \
+                                                               cudaStream_t const stream);
+
+INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(__nv_bfloat16, int32_t);
+INSTANTIATE_FUSED_NOAUX_TC_SINGLE_GROUP(__nv_bfloat16, int64_t);
+#endif
 
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.cu
@@ -883,6 +883,98 @@ void invokeFusedNoAuxTcSingleGroup(const InputT* logits,
     check_cuda_error();
 }
 
+bool canUseFusedNoAuxTcBf16(int64_t num_experts, int64_t n_group, int64_t topk_group, int64_t topk) {
+#ifdef ENABLE_BF16
+    return num_experts == 256 && topk == 8
+        && ((n_group == 1 && topk_group == 1) || (n_group == 8 && topk_group == 4));
+#else
+    return false;
+#endif
+}
+
+bool invokeFusedNoAuxTcBf16(const void*           logits,
+                            const float*          correction_bias,
+                            float*                topk_values,
+                            void*                 topk_indices,
+                            FusedNoAuxTcIndexType index_type,
+                            int64_t               num_tokens,
+                            int64_t               num_experts,
+                            int64_t               n_group,
+                            int64_t               topk_group,
+                            int64_t               topk,
+                            bool                  renormalize,
+                            double                routed_scaling_factor,
+                            cudaStream_t          stream) {
+    if (!canUseFusedNoAuxTcBf16(num_experts, n_group, topk_group, topk)) {
+        return false;
+    }
+    if (num_tokens < 0) {
+        return false;
+    }
+    if (num_tokens == 0) {
+        return true;
+    }
+    if (logits == nullptr || correction_bias == nullptr || topk_values == nullptr || topk_indices == nullptr) {
+        return false;
+    }
+#ifdef ENABLE_BF16
+    const auto* logits_bf16 = static_cast<const __nv_bfloat16*>(logits);
+    switch (index_type) {
+        case FusedNoAuxTcIndexType::INT64: {
+            auto* indices = static_cast<int64_t*>(topk_indices);
+            if (n_group == 1) {
+                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int64_t>(logits_bf16,
+                                                                      correction_bias,
+                                                                      topk_values,
+                                                                      indices,
+                                                                      num_tokens,
+                                                                      renormalize,
+                                                                      routed_scaling_factor,
+                                                                      stream);
+            } else {
+                invokeFusedNoAuxTc<__nv_bfloat16, int64_t>(logits_bf16,
+                                                            correction_bias,
+                                                            topk_values,
+                                                            indices,
+                                                            num_tokens,
+                                                            renormalize,
+                                                            routed_scaling_factor,
+                                                            stream);
+            }
+            break;
+        }
+        case FusedNoAuxTcIndexType::INT32: {
+            auto* indices = static_cast<int32_t*>(topk_indices);
+            if (n_group == 1) {
+                invokeFusedNoAuxTcSingleGroup<__nv_bfloat16, int32_t>(logits_bf16,
+                                                                      correction_bias,
+                                                                      topk_values,
+                                                                      indices,
+                                                                      num_tokens,
+                                                                      renormalize,
+                                                                      routed_scaling_factor,
+                                                                      stream);
+            } else {
+                invokeFusedNoAuxTc<__nv_bfloat16, int32_t>(logits_bf16,
+                                                            correction_bias,
+                                                            topk_values,
+                                                            indices,
+                                                            num_tokens,
+                                                            renormalize,
+                                                            routed_scaling_factor,
+                                                            stream);
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+#else
+    return false;
+#endif
+}
+
 template<typename T, typename IdxT>
 void invokeNoAuxTc(T*                 scores,
                    T*                 group_scores,

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
@@ -34,4 +34,24 @@ void invokeNoAuxTc(T*                 scores,
                    double const       routed_scaling_factor,
                    cudaStream_t const stream = 0);
 
+template<typename InputT, typename IdxT>
+void invokeFusedNoAuxTc(const InputT*      logits,
+                        const float*       correction_bias,
+                        float*             topk_values,
+                        IdxT*              topk_indices,
+                        int64_t const      num_tokens,
+                        int                norm_node,
+                        double const       routed_scaling_factor,
+                        cudaStream_t const stream = 0);
+
+template<typename InputT, typename IdxT>
+void invokeFusedNoAuxTcSingleGroup(const InputT*      logits,
+                                   const float*       correction_bias,
+                                   float*             topk_values,
+                                   IdxT*              topk_indices,
+                                   int64_t const      num_tokens,
+                                   int                norm_node,
+                                   double const       routed_scaling_factor,
+                                   cudaStream_t const stream = 0);
+
 }  // namespace rtp_llm

--- a/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
+++ b/rtp_llm/models_py/bindings/cuda/kernels/no_aux_tc_kernels.h
@@ -17,7 +17,35 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include <cuda_runtime_api.h>
+
 namespace rtp_llm {
+
+enum class FusedNoAuxTcIndexType {
+    INT32,
+    INT64,
+};
+
+// Framework-independent entry point shared by the binding and routed-MoE
+// callers. Callers retain ownership of all device buffers. The launcher
+// returns false without enqueueing work when its contract is not met.
+bool canUseFusedNoAuxTcBf16(int64_t num_experts, int64_t n_group, int64_t topk_group, int64_t topk);
+
+bool invokeFusedNoAuxTcBf16(const void*            logits,
+                            const float*           correction_bias,
+                            float*                 topk_values,
+                            void*                  topk_indices,
+                            FusedNoAuxTcIndexType  index_type,
+                            int64_t                num_tokens,
+                            int64_t                num_experts,
+                            int64_t                n_group,
+                            int64_t                topk_group,
+                            int64_t                topk,
+                            bool                   renormalize,
+                            double                 routed_scaling_factor,
+                            cudaStream_t           stream = 0);
 
 template<typename T, typename IdxT>
 void invokeNoAuxTc(T*                 scores,

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -26,7 +26,6 @@ from rtp_llm.models_py.modules import (
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
-from rtp_llm.models_py.utils.fuse_config import glm5_prefill_refine_enabled
 from rtp_llm.models_py.modules.factory.linear.fixed_m_linear import fixed_m_linear
 from rtp_llm.models_py.modules.hybrid.glm5_cmp import (
     Glm5Cmp,
@@ -255,8 +254,18 @@ class GenericMoeLayer(nn.Module):
             self.shared_expert_gate = None
             self.sigmoid_gate_scale_add = None
 
-        # for group topk
+        # GroupTopK is the router used before both the ordinary fused-MoE
+        # executors and MegaMoE. It owns fused/legacy dispatch so callers can
+        # pass the original BF16 gate output without materializing FP32 scores.
         self.correction_bias = weights.get(W.e_score_correction_b, None)
+        if self.correction_bias is not None:
+            self.group_topk = GroupTopK(hw_kernel_config=hw_kernel_config)
+            self.renormalize = self.config.has_moe_norm
+            self.num_expert_group = self.config.moe_n_group
+            self.topk_group = self.config.moe_topk_group
+            self.routed_scaling_factor = self.config.routed_scaling_factor
+        else:
+            self.group_topk = None
 
     def clone_for_cuda_graph(self) -> "GenericMoeLayer":
         clone = object.__new__(type(self))
@@ -286,6 +295,12 @@ class GenericMoeLayer(nn.Module):
         clone.shared_expert_gate = self.shared_expert_gate
         clone.sigmoid_gate_scale_add = self.sigmoid_gate_scale_add
         clone.correction_bias = self.correction_bias
+        clone.group_topk = self.group_topk
+        if self.group_topk is not None:
+            clone.renormalize = self.renormalize
+            clone.num_expert_group = self.num_expert_group
+            clone.topk_group = self.topk_group
+            clone.routed_scaling_factor = self.routed_scaling_factor
         clone._use_mega_moe_fused_shared = self._use_mega_moe_fused_shared
         return clone
 
@@ -319,10 +334,6 @@ class GenericMoeLayer(nn.Module):
             router_logits = self.gate(
                 hidden_states
             )  # fuse kernel: nvjet_tst_64x8_64x16_2x4_h_bz_NNT (bf16 nn.Linear router, every layer)
-        router_logits_fp32 = (
-            router_logits.float()
-        )  # fuse kernel: at::native::unrolled_elementwise_kernel<direct_copy_kernel_cuda> (bf16 -> fp32 cast)
-
         topk_weights = torch.empty(
             (num_tokens, self.top_k),
             dtype=torch.float32,
@@ -337,29 +348,22 @@ class GenericMoeLayer(nn.Module):
         )
 
         if self.correction_bias is not None:
-            self.group_topk = GroupTopK(hw_kernel_config=None)
-            self.renormalize = self.config.has_moe_norm
-            self.num_expert_group = self.config.moe_n_group
-
-            self.topk_group = self.config.moe_topk_group
-            self.n_routed_experts = self.config.expert_num  # config.n_routed_experts
-            self.routed_scaling_factor = self.config.routed_scaling_factor
-            use_fused_group_topk = is_prefill and glm5_prefill_refine_enabled()
+            assert self.group_topk is not None
             self.group_topk(
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                scores=router_logits if use_fused_group_topk else router_logits_fp32,
+                scores=router_logits,
                 correction_bias=self.correction_bias,
                 n_group=self.num_expert_group,
                 topk_group=self.topk_group,
                 topk=self.top_k,
                 renormalize=self.renormalize,
                 routed_scaling_factor=self.routed_scaling_factor,
-                use_fused=use_fused_group_topk,
+                use_fused=is_prefill,
             )
         else:
             # Top-K selection using C++ SelectTopkOp
-            self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+            self.select_topk(router_logits.float(), topk_ids, topk_weights)
 
         if self.fake_balance_expert is not None:
             self.fake_balance_expert(topk_ids, topk_weights)
@@ -747,7 +751,11 @@ class GenericMoeDecoderLayer(nn.Module):
                     hidden_states=hidden_states, fmha_impl=fmha_impl, kv_cache=kv_cache
                 )
 
-            hidden_states, residual = self._fwd_mlp_or_moe(hidden_states, residual, bool(attention_inputs and attention_inputs.is_prefill))
+        hidden_states, residual = self._fwd_mlp_or_moe(
+            hidden_states,
+            residual,
+            bool(attention_inputs and attention_inputs.is_prefill),
+        )
 
         return DecodeLayerOutput(hidden_states, residual, topk_indices)
 

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -26,6 +26,7 @@ from rtp_llm.models_py.modules import (
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
+from rtp_llm.models_py.utils.fuse_config import glm5_prefill_refine_enabled
 from rtp_llm.models_py.modules.factory.linear.fixed_m_linear import fixed_m_linear
 from rtp_llm.models_py.modules.hybrid.glm5_cmp import (
     Glm5Cmp,
@@ -33,7 +34,7 @@ from rtp_llm.models_py.modules.hybrid.glm5_cmp import (
     should_enable_glm5_cmp,
 )
 from rtp_llm.ops import HWKernelConfig, MoeConfig, ParallelismConfig
-from rtp_llm.ops.compute_ops import LayerKVCache, PyModelInputs, PyModelOutputs
+from rtp_llm.ops.compute_ops import LayerKVCache, PyAttentionInputs, PyModelInputs, PyModelOutputs
 from rtp_llm.utils.dsa_indexing import dsa_layer_has_indexer, dsa_layer_skips_topk
 from rtp_llm.utils.model_weight import W
 
@@ -307,6 +308,7 @@ class GenericMoeLayer(nn.Module):
         hidden_states: torch.Tensor,
         x_fp8: "Optional[torch.Tensor]" = None,
         x_scale: "Optional[torch.Tensor]" = None,
+        is_prefill: bool = False,
     ) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
         if self.gate_chunk_rows > 0 and num_tokens > 0:
@@ -335,23 +337,25 @@ class GenericMoeLayer(nn.Module):
         )
 
         if self.correction_bias is not None:
-            self.group_topk = GroupTopK()
+            self.group_topk = GroupTopK(hw_kernel_config=None)
             self.renormalize = self.config.has_moe_norm
             self.num_expert_group = self.config.moe_n_group
 
             self.topk_group = self.config.moe_topk_group
             self.n_routed_experts = self.config.expert_num  # config.n_routed_experts
             self.routed_scaling_factor = self.config.routed_scaling_factor
+            use_fused_group_topk = is_prefill and glm5_prefill_refine_enabled()
             self.group_topk(
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                scores=router_logits_fp32,
+                scores=router_logits if use_fused_group_topk else router_logits_fp32,
                 correction_bias=self.correction_bias,
                 n_group=self.num_expert_group,
                 topk_group=self.topk_group,
                 topk=self.top_k,
                 renormalize=self.renormalize,
                 routed_scaling_factor=self.routed_scaling_factor,
+                use_fused=use_fused_group_topk,
             )
         else:
             # Top-K selection using C++ SelectTopkOp
@@ -582,6 +586,7 @@ class GenericMoeDecoderLayer(nn.Module):
         self,
         hidden_states: torch.Tensor,
         residual: torch.Tensor,
+        is_prefill: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Run residual add, RMSNorm, then the dense MLP or MoE."""
         # Dense MLP: fuse add + RMSNorm + FP8 quant; up_proj consumes FP8 directly.
@@ -594,7 +599,7 @@ class GenericMoeDecoderLayer(nn.Module):
                 group_size=128,
                 scale_ue8m0=self.mlp.up_proj.scale_ue8m0,
             )
-            hidden_states = self.mlp(hidden_states, x_fp8=fp8_hs, x_scale=scale)
+            hidden_states = self.mlp(hidden_states, x_fp8=fp8_hs, x_scale=scale, is_prefill=is_prefill) if isinstance(self.mlp, GenericMoeLayer) else self.mlp(hidden_states, x_fp8=fp8_hs, x_scale=scale)
         # MoE: keep BF16 for routing/routed experts and FP8 for the shared expert.
         elif self._fuse_post_norm_quant_moe and hidden_states.dim() == 2:
             bf16_hs, fp8_hs, scale = fused_add_rmsnorm_fp8_quant_with_bf16_output(
@@ -605,13 +610,13 @@ class GenericMoeDecoderLayer(nn.Module):
                 group_size=128,
                 scale_ue8m0=self.mlp.shared_expert.up_proj.scale_ue8m0,
             )
-            hidden_states = self.mlp(bf16_hs, x_fp8=fp8_hs, x_scale=scale)
+            hidden_states = self.mlp(bf16_hs, x_fp8=fp8_hs, x_scale=scale, is_prefill=is_prefill) if isinstance(self.mlp, GenericMoeLayer) else self.mlp(bf16_hs, x_fp8=fp8_hs, x_scale=scale)
         # Fallback: use the standard norm path and let MLP/MoE prepare its inputs.
         else:
             hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual
             )
-            hidden_states = self.mlp(hidden_states)
+            hidden_states = self.mlp(hidden_states, is_prefill=is_prefill) if isinstance(self.mlp, GenericMoeLayer) else self.mlp(hidden_states)
         return hidden_states, residual
 
     def _forward_cmp(
@@ -686,6 +691,7 @@ class GenericMoeDecoderLayer(nn.Module):
         prev_topk_indices: Optional[torch.Tensor] = None,
         enable_cmp: bool = False,
         force_reuse_topk_indices: bool = False,
+        attention_inputs: Optional[PyAttentionInputs] = None,
     ) -> DecodeLayerOutput:
         if enable_cmp:
             return self._forward_cmp(
@@ -741,7 +747,7 @@ class GenericMoeDecoderLayer(nn.Module):
                     hidden_states=hidden_states, fmha_impl=fmha_impl, kv_cache=kv_cache
                 )
 
-        hidden_states, residual = self._fwd_mlp_or_moe(hidden_states, residual)
+            hidden_states, residual = self._fwd_mlp_or_moe(hidden_states, residual, bool(attention_inputs and attention_inputs.is_prefill))
 
         return DecodeLayerOutput(hidden_states, residual, topk_indices)
 
@@ -841,6 +847,7 @@ class GenericMoeModel(GptModelBase):
                 kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
                 prev_topk_indices=prev_topk_indices,
                 enable_cmp=enable_cmp,
+                attention_inputs=inputs.attention_inputs,
             )
             hidden_states = output.hidden_states
             residual = output.residual

--- a/rtp_llm/models_py/model_desc/kimi_linear.py
+++ b/rtp_llm/models_py/model_desc/kimi_linear.py
@@ -699,6 +699,11 @@ class KimiLinearDecoderLayer(nn.Module):
         attention_inputs: Optional[PyAttentionInputs] = None,
         attn_meta: KimiLinearMetadata = KimiLinearMetadata(),
     ) -> DecodeLayerOutput:
+        mlp_phase_kwargs = (
+            {"is_prefill": bool(attention_inputs and attention_inputs.is_prefill)}
+            if isinstance(self.mlp, GenericMoeLayer)
+            else {}
+        )
         # Fused: residual = residual + hidden_states, hidden_states = RMSNorm(residual)
         hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
@@ -722,7 +727,10 @@ class KimiLinearDecoderLayer(nn.Module):
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
 
         # MLP (Dense or MoE)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(
+            hidden_states,
+            **mlp_phase_kwargs,
+        )
 
         return DecodeLayerOutput(hidden_states, residual)
 

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -933,6 +933,11 @@ class Qwen3NextDecoderLayer(nn.Module):
         attention_inputs: Optional[PyAttentionInputs] = None,
         attn_meta: Qwen3NextMetadata = Qwen3NextMetadata(),
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        mlp_phase_kwargs = (
+            {"is_prefill": bool(attention_inputs and attention_inputs.is_prefill)}
+            if isinstance(self.mlp, GenericMoeLayer)
+            else {}
+        )
         if self._fuse_input_norm_quant and hidden_states.dim() == 2:
             # Dual-output: fp8 feeds qkv_proj/gate (which take fp8+scale via
             # ``x_fp8/x_scale``), AND bf16_hs replaces hidden_states for any
@@ -993,7 +998,12 @@ class Qwen3NextDecoderLayer(nn.Module):
                 group_size=128,
                 scale_ue8m0=self.mlp.up_proj.scale_ue8m0,
             )
-            hidden_states = self.mlp(hidden_states, x_fp8=fp8_hs, x_scale=scale)
+            hidden_states = self.mlp(
+                hidden_states,
+                x_fp8=fp8_hs,
+                x_scale=scale,
+                **mlp_phase_kwargs,
+            )
         elif self._fuse_post_norm_quant_moe and hidden_states.dim() == 2:
             bf16_hs, fp8_hs, scale = fused_add_rmsnorm_fp8_quant_with_bf16_output(
                 hidden_states,
@@ -1003,12 +1013,20 @@ class Qwen3NextDecoderLayer(nn.Module):
                 group_size=128,
                 scale_ue8m0=self.mlp.shared_expert.up_proj.scale_ue8m0,
             )
-            hidden_states = self.mlp(bf16_hs, x_fp8=fp8_hs, x_scale=scale)
+            hidden_states = self.mlp(
+                bf16_hs,
+                x_fp8=fp8_hs,
+                x_scale=scale,
+                **mlp_phase_kwargs,
+            )
         else:
             hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual
             )
-            hidden_states = self.mlp(hidden_states)
+            hidden_states = self.mlp(
+                hidden_states,
+                **mlp_phase_kwargs,
+            )
         return hidden_states, residual
 
 

--- a/rtp_llm/models_py/modules/base/cuda/indexer_op.py
+++ b/rtp_llm/models_py/modules/base/cuda/indexer_op.py
@@ -11,6 +11,8 @@ from rtp_llm.models_py.distributed.collective_torch import Group, barrier
 from rtp_llm.models_py.distributed.pynccl_cp import all_gather
 from rtp_llm.models_py.kernels.cuda.fp8_kernel import sgl_per_token_group_quant_fp8
 from rtp_llm.models_py.modules.dsv4.chunk_env import dsv4_chunk_tokens_from_env
+from rtp_llm.models_py.triton_kernels.sparse_mla.topk_index_postprocess import fused_stage1_request_indices
+from rtp_llm.models_py.utils.fuse_config import glm5_prefill_refine_enabled
 from rtp_llm.ops.compute_ops import KVCache, rtp_llm_ops
 
 # Try to import CUDA dependencies, but don't fail if running on CPU
@@ -238,6 +240,7 @@ class IndexerOp(nn.Module):
         self.block_size = block_size
         self.scale_fmt = scale_fmt
         self.is_neox_style = is_neox_style
+        self._fuse_prefill_index_ops = glm5_prefill_refine_enabled()
 
         glm5_topk_backend = os.environ.get(
             "GLM5_INDEXER_TOPK_BACKEND", "dsv4_persistent"
@@ -892,12 +895,20 @@ class IndexerOp(nn.Module):
             )
             if _fp8_prefill_topk_canonicalize():
                 topk_part = _canonicalize_topk_indices(topk_part)
-            topk_result[row_start:row_end] = torch.where(
-                topk_part >= 0,
-                topk_part
-                + fmha_params.topk_indices_offset[row_start:row_end].unsqueeze(1),
-                topk_part,
-            )
+            output = topk_result[row_start:row_end]
+            fused_output = None
+            if self._fuse_prefill_index_ops:
+                fused_output = fused_stage1_request_indices(
+                    topk_part,
+                    fmha_params.topk_indices_offset[row_start:row_end],
+                    output=output,
+                )
+            if fused_output is None:
+                output.copy_(torch.where(
+                    topk_part >= 0,
+                    topk_part + fmha_params.topk_indices_offset[row_start:row_end].unsqueeze(1),
+                    topk_part,
+                ))
             del logits, topk_part
             row_start = row_end
 
@@ -1089,11 +1100,20 @@ class IndexerOp(nn.Module):
                 )
                 if _fp8_prefill_topk_canonicalize():
                     topk_part = _canonicalize_topk_indices(topk_part)
-                topk_result[row_start:row_end] = torch.where(
-                    topk_part >= 0,
-                    topk_part + topk_off[row_start:row_end].unsqueeze(1),
-                    topk_part,
-                )
+                output = topk_result[row_start:row_end]
+                fused_output = None
+                if self._fuse_prefill_index_ops:
+                    fused_output = fused_stage1_request_indices(
+                        topk_part,
+                        topk_off[row_start:row_end],
+                        output=output,
+                    )
+                if fused_output is None:
+                    output.copy_(torch.where(
+                        topk_part >= 0,
+                        topk_part + topk_off[row_start:row_end].unsqueeze(1),
+                        topk_part,
+                    ))
                 del logits_p, topk_part
                 row_start = row_end
             return topk_result

--- a/rtp_llm/models_py/modules/base/cuda/select_topk.py
+++ b/rtp_llm/models_py/modules/base/cuda/select_topk.py
@@ -1,8 +1,11 @@
+from typing import Any, Optional
+
 import torch
 from torch import nn
 
 import rtp_llm.ops.compute_ops as compute_ops
 from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.utils.fuse_config import glm5_prefill_refine_enabled
 
 
 class SelectTopk(nn.Module):
@@ -21,11 +24,55 @@ class SelectTopk(nn.Module):
 
 
 class GroupTopK(nn.Module):
-    def __init__(self):
+    def __init__(
+        self,
+        use_fused: Optional[bool] = None,
+        hw_kernel_config: Optional[Any] = None,
+    ):
         super().__init__()
         self.group_topk_op = compute_ops.GroupTopKOp()
+        if use_fused is None:
+            use_fused = glm5_prefill_refine_enabled(hw_kernel_config)
+        self.use_fused = use_fused
 
-    def forward(
+    @staticmethod
+    def _fused_supported(
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        scores: torch.Tensor,
+        correction_bias: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+    ) -> bool:
+        return (
+            scores.is_cuda
+            and scores.is_contiguous()
+            and scores.ndim == 2
+            and scores.shape[1] == 256
+            and scores.dtype == torch.bfloat16
+            and correction_bias.is_cuda
+            and correction_bias.is_contiguous()
+            and correction_bias.dtype == torch.float32
+            and correction_bias.ndim == 1
+            and correction_bias.numel() == 256
+            and topk_weights.is_cuda
+            and topk_weights.is_contiguous()
+            and topk_weights.dtype == torch.float32
+            and topk_weights.shape == (scores.shape[0], topk)
+            and topk_ids.is_cuda
+            and topk_ids.is_contiguous()
+            and topk_ids.dtype in (torch.int32, torch.int64)
+            and topk_ids.shape == (scores.shape[0], topk)
+            and scores.device
+            == correction_bias.device
+            == topk_weights.device
+            == topk_ids.device
+            and (n_group, topk_group) in ((8, 4), (1, 1))
+            and topk == 8
+        )
+
+    def forward_legacy(
         self,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
@@ -37,7 +84,8 @@ class GroupTopK(nn.Module):
         renormalize: bool,
         routed_scaling_factor: float,
     ):
-        scores = scores.sigmoid()
+        # The legacy C++ kernel unconditionally reads both score tensors as FP32.
+        scores = scores.float().sigmoid()
         scores_with_bias = scores + correction_bias.unsqueeze(0)
         self.group_topk_op.forward(
             topk_weights,
@@ -50,6 +98,107 @@ class GroupTopK(nn.Module):
             renormalize,
             routed_scaling_factor,
         )
+
+    def can_use_fused(
+        self,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        scores: torch.Tensor,
+        correction_bias: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+        use_fused: Optional[bool] = None,
+    ) -> bool:
+        """Whether the strict fused op can consume these BF16 logits."""
+        if use_fused is None:
+            use_fused = self.use_fused
+        else:
+            use_fused = self.use_fused and use_fused
+        return use_fused and self._fused_supported(
+            topk_weights,
+            topk_ids,
+            scores,
+            correction_bias,
+            n_group,
+            topk_group,
+            topk,
+        )
+
+    def forward_fused(
+        self,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        scores: torch.Tensor,
+        correction_bias: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+        renormalize: bool,
+        routed_scaling_factor: float,
+    ):
+        if not self._fused_supported(
+            topk_weights,
+            topk_ids,
+            scores,
+            correction_bias,
+            n_group,
+            topk_group,
+            topk,
+        ):
+            raise ValueError(
+                "fused GroupTopK requires contiguous BF16 [T, 256] logits, "
+                "FP32 [256] bias, (n_group, topk_group, topk)=(8,4,8) or (1,1,8)"
+            )
+        self.group_topk_op.forward_fused(
+            topk_weights,
+            topk_ids,
+            scores,
+            correction_bias,
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+        )
+
+    def forward(
+        self,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        scores: torch.Tensor,
+        correction_bias: torch.Tensor,
+        n_group: int,
+        topk_group: int,
+        topk: int,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        use_fused: Optional[bool] = None,
+    ):
+        args = (
+            topk_weights,
+            topk_ids,
+            scores,
+            correction_bias,
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+        )
+        if self.can_use_fused(
+            topk_weights,
+            topk_ids,
+            scores,
+            correction_bias,
+            n_group,
+            topk_group,
+            topk,
+            use_fused=use_fused,
+        ):
+            self.forward_fused(*args)
+        else:
+            self.forward_legacy(*args)
 
 
 class FakeBalanceExpert(nn.Module):

--- a/rtp_llm/models_py/modules/base/cuda/select_topk.py
+++ b/rtp_llm/models_py/modules/base/cuda/select_topk.py
@@ -186,19 +186,8 @@ class GroupTopK(nn.Module):
             renormalize,
             routed_scaling_factor,
         )
-        if self.can_use_fused(
-            topk_weights,
-            topk_ids,
-            scores,
-            correction_bias,
-            n_group,
-            topk_group,
-            topk,
-            use_fused=use_fused,
-        ):
-            self.forward_fused(*args)
-        else:
-            self.forward_legacy(*args)
+        enable_fused = self.use_fused and (use_fused is None or use_fused)
+        self.group_topk_op.forward_auto(*args, enable_fused=enable_fused)
 
 
 class FakeBalanceExpert(nn.Module):

--- a/rtp_llm/models_py/modules/base/cuda/test/BUILD
+++ b/rtp_llm/models_py/modules/base/cuda/test/BUILD
@@ -54,6 +54,13 @@ py_test (
     exec_properties = {'gpu':'H20'},
 )
 
+py_test (
+    name = "group_topk_benchmark",
+    srcs = ["group_topk_benchmark.py"],
+    deps = py_test_deps,
+    tags = ["manual"],
+)
+
 
 py_test (
     name = "torch_symm_mem_test",

--- a/rtp_llm/models_py/modules/base/cuda/test/group_topk_benchmark.py
+++ b/rtp_llm/models_py/modules/base/cuda/test/group_topk_benchmark.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from collections import Counter
+from typing import Callable
+
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+from rtp_llm.models_py.modules import GroupTopK
+
+
+DEFAULT_TOKEN_COUNTS = [1, 7, 17, 64, 128, 257, 1024, 4096, 6954, 8192, 16384]
+PROFILE_TOKEN_COUNTS = {1, 128, 1024, 6954, 16384}
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * fraction)
+    return ordered[index]
+
+
+def _event_metrics(
+    function: Callable[[], None], warmup: int, iterations: int
+) -> dict[str, float]:
+    for _ in range(warmup):
+        function()
+    torch.cuda.synchronize()
+
+    samples_us = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        function()
+        end.record()
+        end.synchronize()
+        samples_us.append(start.elapsed_time(end) * 1000.0)
+    return {
+        "median_us": statistics.median(samples_us),
+        "p90_us": _percentile(samples_us, 0.90),
+        "min_us": min(samples_us),
+        "max_us": max(samples_us),
+    }
+
+
+def _kernel_metrics(
+    function: Callable[[], None], warmup: int, iterations: int
+) -> dict[str, object]:
+    for _ in range(warmup):
+        function()
+    torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CUDA]) as profiler:
+        for _ in range(iterations):
+            function()
+            profiler.step()
+    torch.cuda.synchronize()
+
+    kernel_time_us = 0.0
+    kernel_names: Counter[str] = Counter()
+    for event in profiler.events():
+        if event.device_type != torch.autograd.DeviceType.CUDA:
+            continue
+        kernel_time_us += float(event.device_time_total)
+        kernel_names[event.name] += 1
+    return {
+        "kernel_sum_us_per_iter": kernel_time_us / iterations,
+        "launches_per_iter": sum(kernel_names.values()) / iterations,
+        "kernel_names": dict(kernel_names),
+    }
+
+
+def _token_counts() -> list[int]:
+    value = os.environ.get("M_LIST", "")
+    if not value:
+        return DEFAULT_TOKEN_COUNTS
+    return [int(item) for item in value.split(",") if item.strip()]
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    warmup = int(os.environ.get("WARMUP", "30"))
+    iterations = int(os.environ.get("ITERS", "100"))
+    profile_iterations = int(os.environ.get("PROFILE_ITERS", "20"))
+    torch.manual_seed(20260814)
+
+    group_topk = GroupTopK(use_fused=True)
+    results = []
+    for tokens in _token_counts():
+        logits = torch.randn((tokens, 256), dtype=torch.bfloat16, device="cuda")
+        correction_bias = torch.randn((256,), dtype=torch.float32, device="cuda")
+        outputs = {}
+        functions = {}
+        for candidate, implementation in (
+            ("baseline", "forward_legacy"),
+            ("fused", "forward_fused"),
+        ):
+            values = torch.empty((tokens, 8), dtype=torch.float32, device="cuda")
+            indices = torch.empty((tokens, 8), dtype=torch.int64, device="cuda")
+
+            def run(
+                implementation: str = implementation,
+                values: torch.Tensor = values,
+                indices: torch.Tensor = indices,
+            ) -> None:
+                getattr(group_topk, implementation)(
+                    values,
+                    indices,
+                    logits,
+                    correction_bias,
+                    1,
+                    1,
+                    8,
+                    True,
+                    2.5,
+                )
+
+            run()
+            functions[candidate] = run
+            outputs[candidate] = (values.clone(), indices.clone())
+
+        torch.testing.assert_close(
+            outputs["fused"][0], outputs["baseline"][0], rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            outputs["fused"][1], outputs["baseline"][1], rtol=0, atol=0
+        )
+
+        row = {"tokens": tokens}
+        for candidate, function in functions.items():
+            metrics: dict[str, object] = _event_metrics(
+                function, warmup, iterations
+            )
+            if tokens in PROFILE_TOKEN_COUNTS:
+                metrics.update(
+                    _kernel_metrics(function, warmup, profile_iterations)
+                )
+            row[candidate] = metrics
+        row["event_speedup"] = (
+            row["baseline"]["median_us"] / row["fused"]["median_us"]
+        )
+        if tokens in PROFILE_TOKEN_COUNTS:
+            row["kernel_speedup"] = (
+                row["baseline"]["kernel_sum_us_per_iter"]
+                / row["fused"]["kernel_sum_us_per_iter"]
+            )
+        results.append(row)
+
+    payload = {
+        "meta": {
+            "device": torch.cuda.get_device_name(),
+            "dtype": "BF16",
+            "shape": "[T,256]",
+            "n_group": 1,
+            "topk_group": 1,
+            "topk": 8,
+            "warmup": warmup,
+            "iterations": iterations,
+            "profile_iterations": profile_iterations,
+            "input_output_allocations_timed": False,
+            "implementation_internal_allocations_in_event_timing": True,
+            "torch_compile": False,
+        },
+        "results": results,
+    }
+    print("GROUP_TOPK_BENCHMARK_JSON=" + json.dumps(payload, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/base/cuda/test/group_topk_test.py
+++ b/rtp_llm/models_py/modules/base/cuda/test/group_topk_test.py
@@ -86,6 +86,15 @@ class GroupTopKTest(TestCase):
             renormalize,
             routed_scaling_factor,
         )
+        auto_values, auto_indices = self._call(
+            group_topk,
+            "forward",
+            logits,
+            correction_bias,
+            index_dtype,
+            renormalize,
+            routed_scaling_factor,
+        )
         torch.testing.assert_close(
             fused_values,
             legacy_values,
@@ -94,6 +103,14 @@ class GroupTopKTest(TestCase):
             equal_nan=True,
         )
         torch.testing.assert_close(fused_indices, legacy_indices, rtol=0, atol=0)
+        torch.testing.assert_close(
+            auto_values,
+            legacy_values,
+            rtol=0,
+            atol=0,
+            equal_nan=True,
+        )
+        torch.testing.assert_close(auto_indices, legacy_indices, rtol=0, atol=0)
 
     def test_bf16_matches_legacy_bit_exact(self) -> None:
         token_counts = (0, 1, 7, 16, 17, 33, 64, 257, 6954, 8192)
@@ -252,6 +269,34 @@ class GroupTopKTest(TestCase):
                 use_fused=True,
             )
         )
+        disabled_values, disabled_indices = self._call(
+            disabled_group_topk,
+            "forward",
+            bf16_logits,
+            correction_bias,
+            torch.int64,
+            True,
+            1.0,
+        )
+        disabled_legacy_values, disabled_legacy_indices = self._call(
+            disabled_group_topk,
+            "forward_legacy",
+            bf16_logits,
+            correction_bias,
+            torch.int64,
+            True,
+            1.0,
+        )
+        torch.testing.assert_close(
+            disabled_values,
+            disabled_legacy_values,
+            rtol=0,
+            atol=0,
+            equal_nan=True,
+        )
+        torch.testing.assert_close(
+            disabled_indices, disabled_legacy_indices, rtol=0, atol=0
+        )
         self.assertFalse(
             group_topk.can_use_fused(
                 values,
@@ -405,6 +450,18 @@ class GroupTopKTest(TestCase):
                         topk_group=1,
                         topk=8,
                     )
+                    auto_values, auto_indices = self._call(
+                        group_topk,
+                        "forward",
+                        logits,
+                        correction_bias,
+                        index_dtype,
+                        renormalize,
+                        2.5,
+                        n_group=1,
+                        topk_group=1,
+                        topk=8,
+                    )
                     torch.testing.assert_close(
                         fused_values,
                         legacy_values,
@@ -413,6 +470,14 @@ class GroupTopKTest(TestCase):
                         equal_nan=True,
                     )
                     torch.testing.assert_close(fused_indices, legacy_indices, rtol=0, atol=0)
+                    torch.testing.assert_close(
+                        auto_values,
+                        legacy_values,
+                        rtol=0,
+                        atol=0,
+                        equal_nan=True,
+                    )
+                    torch.testing.assert_close(auto_indices, legacy_indices, rtol=0, atol=0)
                     self.assertTrue(
                         group_topk.can_use_fused(
                             fused_values,

--- a/rtp_llm/models_py/modules/base/cuda/test/group_topk_test.py
+++ b/rtp_llm/models_py/modules/base/cuda/test/group_topk_test.py
@@ -1,180 +1,429 @@
 import itertools
-import os
-import sys
-from typing import Callable, Optional
 from unittest import SkipTest, TestCase, main
 
 import torch
 
-device = torch.device(f"cuda")
 from rtp_llm.models_py.modules import GroupTopK
 
 
-def biased_grouped_topk_impl(
-    hidden_states: torch.Tensor,
-    gating_output: torch.Tensor,
-    correction_bias: torch.Tensor,
-    topk: int,
-    renormalize: bool,
-    num_expert_group: Optional[int] = None,
-    topk_group: Optional[int] = None,
-    num_fused_shared_experts: int = 0,
-    routed_scaling_factor: Optional[float] = None,
-):
-    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+class GroupTopKTest(TestCase):
+    NUM_EXPERTS = 256
+    NUM_GROUPS = 8
+    TOPK_GROUP = 4
+    TOPK = 8
 
-    scores = gating_output.sigmoid()
-    num_token = scores.shape[0]
-    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
-    group_scores = (
-        scores_for_choice.view(num_token, num_expert_group, -1)
-        .topk(2, dim=-1)[0]
-        .sum(dim=-1)
-    )  # [n, n_group]
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[
-        1
-    ]  # [n, top_k_group]
-    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
-    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
-    score_mask = (
-        group_mask.unsqueeze(-1)
-        .expand(num_token, num_expert_group, scores.shape[-1] // num_expert_group)
-        .reshape(num_token, -1)
-    )  # [n, e]
-    tmp_scores = scores_for_choice.masked_fill(
-        ~score_mask.bool(), float("-inf")
-    )  # [n, e]
-    # TODO: NPU can't support directly evaluating a comparison for now
-    _, topk_ids = torch.topk(
-        tmp_scores,
-        k=topk,
-        dim=-1,
-        sorted=(True if num_fused_shared_experts > 0 else False),
-    )
-    topk_weights = scores.gather(1, topk_ids)
-    if renormalize:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
-
-    if routed_scaling_factor != 1.0:
-        topk_weights = topk_weights * routed_scaling_factor
-    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
-
-
-def select_experts(
-    hidden_states: torch.Tensor,
-    router_logits: torch.Tensor,
-    top_k: int,
-    use_grouped_topk: bool,
-    renormalize: bool,
-    topk_group: Optional[int] = None,
-    num_expert_group: Optional[int] = None,
-    custom_routing_function: Optional[Callable] = None,
-    correction_bias: Optional[torch.Tensor] = None,
-    torch_native: bool = False,
-    routed_scaling_factor: Optional[float] = None,
-    num_token_non_padded: Optional[torch.Tensor] = None,
-    num_fused_shared_experts: int = 0,
-):
-    if use_grouped_topk:
-        assert topk_group is not None
-        assert num_expert_group is not None
-        topk_weights, topk_ids = biased_grouped_topk_impl(
-            hidden_states=hidden_states,
-            gating_output=router_logits,
-            correction_bias=correction_bias,
-            topk=top_k,
-            renormalize=renormalize,
-            num_expert_group=num_expert_group,
-            topk_group=topk_group,
-            num_fused_shared_experts=num_fused_shared_experts,
-            routed_scaling_factor=routed_scaling_factor,
-        )
-        return topk_weights, topk_ids
-    else:
-        raise ValueError(f"Unsupported grouped topk: {use_grouped_topk}")
-
-
-class MLATest(TestCase):
-    SEQ_LEN = [7]
-    NUM_EXPERT = [256]
-    NUM_EXPERT_GROUP = [8]
-    TOPK_GROUP = [4]
-    TOPK = [8]
-
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         if not torch.cuda.is_available():
             raise SkipTest("CUDA is not available")
-        torch.set_default_device(device)
 
-    def _run_mla_test(
-        self, seq_length, num_experts, num_expert_group, topk_group, topk
-    ):
-        dtype = torch.float32
-
-        torch.manual_seed(seq_length)
-        gating_output = torch.rand(
-            (seq_length, num_experts), dtype=dtype, device="cuda"
-        )
-        bias = torch.rand(num_experts, dtype=dtype, device="cuda")
-        scores = gating_output
-        group_topk = GroupTopK()
-
-        output = torch.empty(
-            (seq_length, topk),
-            dtype=torch.float32,
-            device=scores.device,
+    def _empty_outputs(
+        self, tokens: int, index_dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        values = torch.empty(
+            (tokens, self.TOPK), dtype=torch.float32, device="cuda"
         )
         indices = torch.empty(
-            (seq_length, topk),
-            dtype=torch.int64,
-            device=scores.device,
+            (tokens, self.TOPK), dtype=index_dtype, device="cuda"
         )
+        return values, indices
 
-        group_topk(
-            topk_weights=output,
+    def _call(
+        self,
+        group_topk: GroupTopK,
+        implementation: str,
+        logits: torch.Tensor,
+        correction_bias: torch.Tensor,
+        index_dtype: torch.dtype,
+        renormalize: bool,
+        routed_scaling_factor: float,
+        n_group: int | None = None,
+        topk_group: int | None = None,
+        topk: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        n_group = self.NUM_GROUPS if n_group is None else n_group
+        topk_group = self.TOPK_GROUP if topk_group is None else topk_group
+        topk = self.TOPK if topk is None else topk
+        values = torch.empty((logits.shape[0], topk), dtype=torch.float32, device="cuda")
+        indices = torch.empty((logits.shape[0], topk), dtype=index_dtype, device="cuda")
+        getattr(group_topk, implementation)(
+            topk_weights=values,
             topk_ids=indices,
-            scores=scores,
-            correction_bias=bias,
-            n_group=num_expert_group,
+            scores=logits,
+            correction_bias=correction_bias,
+            n_group=n_group,
             topk_group=topk_group,
             topk=topk,
-            renormalize=True,
-            routed_scaling_factor=2.5,
+            renormalize=renormalize,
+            routed_scaling_factor=routed_scaling_factor,
         )
-        indices = indices.to(torch.int32)
+        return values, indices
 
-        ref_output, ref_indices = select_experts(
-            hidden_states=scores,
-            router_logits=scores,
-            correction_bias=bias,
-            routed_scaling_factor=2.5,
-            use_grouped_topk=True,
-            top_k=topk,
-            renormalize=True,
-            topk_group=topk_group,
-            num_expert_group=num_expert_group,
-            num_fused_shared_experts=1,
+    def _assert_strict_match(
+        self,
+        logits: torch.Tensor,
+        correction_bias: torch.Tensor,
+        index_dtype: torch.dtype,
+        renormalize: bool,
+        routed_scaling_factor: float,
+    ) -> None:
+        group_topk = GroupTopK(use_fused=True)
+        legacy_values, legacy_indices = self._call(
+            group_topk,
+            "forward_legacy",
+            logits,
+            correction_bias,
+            index_dtype,
+            renormalize,
+            routed_scaling_factor,
         )
-        torch.testing.assert_close(ref_output, output, atol=2e-2, rtol=0)
-        torch.testing.assert_close(ref_indices, indices, atol=0, rtol=0)
+        fused_values, fused_indices = self._call(
+            group_topk,
+            "forward_fused",
+            logits,
+            correction_bias,
+            index_dtype,
+            renormalize,
+            routed_scaling_factor,
+        )
+        torch.testing.assert_close(
+            fused_values,
+            legacy_values,
+            rtol=0,
+            atol=0,
+            equal_nan=True,
+        )
+        torch.testing.assert_close(fused_indices, legacy_indices, rtol=0, atol=0)
 
-    def test_mlp(self):
-        for params in itertools.product(
-            self.SEQ_LEN,
-            self.NUM_EXPERT,
-            self.NUM_EXPERT_GROUP,
-            self.TOPK_GROUP,
-            self.TOPK,
+    def test_bf16_matches_legacy_bit_exact(self) -> None:
+        token_counts = (0, 1, 7, 16, 17, 33, 64, 257, 6954, 8192)
+        seeds = (0, 20260806)
+        index_dtypes = (torch.int32, torch.int64)
+        renormalize_values = (False, True)
+        scaling_factors = (1.0, 2.5, 1.234567)
+
+        for tokens, seed, index_dtype, renormalize, scale in itertools.product(
+            token_counts,
+            seeds,
+            index_dtypes,
+            renormalize_values,
+            scaling_factors,
         ):
             with self.subTest(
-                seq_length=params[0],
-                num_experts=params[1],
-                num_expert_group=params[2],
-                topk_group=params[3],
-                topk=params[4],
+                tokens=tokens,
+                seed=seed,
+                index_dtype=index_dtype,
+                renormalize=renormalize,
+                scale=scale,
             ):
-                self._run_mla_test(*params)
+                torch.manual_seed(seed)
+                logits = torch.randn(
+                    (tokens, self.NUM_EXPERTS),
+                    dtype=torch.float32,
+                    device="cuda",
+                ).to(torch.bfloat16)
+                correction_bias = torch.randn(
+                    (self.NUM_EXPERTS,), dtype=torch.float32, device="cuda"
+                )
+                self._assert_strict_match(
+                    logits,
+                    correction_bias,
+                    index_dtype,
+                    renormalize,
+                    scale,
+                )
 
+    def test_ties_nonfinite_and_fallback_match_legacy(self) -> None:
+        equal_logits = torch.zeros(
+            (33, self.NUM_EXPERTS), dtype=torch.bfloat16, device="cuda"
+        )
+        zero_bias = torch.zeros(
+            (self.NUM_EXPERTS,), dtype=torch.float32, device="cuda"
+        )
+        self._assert_strict_match(
+            equal_logits, zero_bias, torch.int64, True, 2.5
+        )
+
+        pattern = torch.tensor(
+            [
+                float("-inf"),
+                -100.0,
+                -0.0,
+                0.0,
+                100.0,
+                float("inf"),
+                float("nan"),
+            ],
+            dtype=torch.float32,
+            device="cuda",
+        )
+        repeats = (4 * self.NUM_EXPERTS + pattern.numel() - 1) // pattern.numel()
+        nonfinite_logits = pattern.repeat(repeats)[: 4 * self.NUM_EXPERTS]
+        nonfinite_logits = nonfinite_logits.view(4, self.NUM_EXPERTS).to(
+            torch.bfloat16
+        )
+        nonfinite_bias = torch.linspace(
+            -1.0, 1.0, self.NUM_EXPERTS, dtype=torch.float32, device="cuda"
+        )
+        nonfinite_bias[::31] = float("nan")
+        nonfinite_bias[1::37] = float("inf")
+        nonfinite_bias[2::41] = float("-inf")
+        self._assert_strict_match(
+            nonfinite_logits, nonfinite_bias, torch.int32, False, 1.234567
+        )
+
+        fallback_logits = torch.full(
+            (17, self.NUM_EXPERTS),
+            float("nan"),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        self._assert_strict_match(
+            fallback_logits, zero_bias, torch.int64, True, 2.5
+        )
+        fallback_values, fallback_indices = self._call(
+            GroupTopK(use_fused=True),
+            "forward_fused",
+            fallback_logits,
+            zero_bias,
+            torch.int64,
+            True,
+            2.5,
+        )
+        torch.testing.assert_close(
+            fallback_values,
+            torch.full_like(fallback_values, 1.0 / self.TOPK),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            fallback_indices,
+            torch.arange(self.TOPK, dtype=torch.int64, device="cuda")
+            .unsqueeze(0)
+            .expand_as(fallback_indices),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_support_gate_and_fp32_fallback(self) -> None:
+        group_topk = GroupTopK(use_fused=True)
+        bf16_logits = torch.randn(
+            (7, self.NUM_EXPERTS), dtype=torch.bfloat16, device="cuda"
+        )
+        fp32_logits = bf16_logits.float()
+        correction_bias = torch.randn(
+            (self.NUM_EXPERTS,), dtype=torch.float32, device="cuda"
+        )
+        values, indices = self._empty_outputs(7, torch.int64)
+
+        self.assertTrue(
+            group_topk.can_use_fused(
+                values,
+                indices,
+                bf16_logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+            )
+        )
+        self.assertFalse(
+            group_topk.can_use_fused(
+                values,
+                indices,
+                bf16_logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+                use_fused=False,
+            )
+        )
+        disabled_group_topk = GroupTopK(use_fused=False)
+        self.assertFalse(
+            disabled_group_topk.can_use_fused(
+                values,
+                indices,
+                bf16_logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+                use_fused=True,
+            )
+        )
+        self.assertFalse(
+            group_topk.can_use_fused(
+                values,
+                indices,
+                fp32_logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+            )
+        )
+        with self.assertRaises(ValueError):
+            self._call(
+                group_topk,
+                "forward_fused",
+                fp32_logits,
+                correction_bias,
+                torch.int64,
+                True,
+                1.0,
+            )
+
+        legacy_values, legacy_indices = self._call(
+            group_topk,
+            "forward_legacy",
+            fp32_logits,
+            correction_bias,
+            torch.int64,
+            True,
+            1.0,
+        )
+        fallback_values, fallback_indices = self._call(
+            group_topk,
+            "forward",
+            fp32_logits,
+            correction_bias,
+            torch.int64,
+            True,
+            1.0,
+        )
+        torch.testing.assert_close(
+            fallback_values, legacy_values, rtol=0, atol=0, equal_nan=True
+        )
+        torch.testing.assert_close(
+            fallback_indices, legacy_indices, rtol=0, atol=0
+        )
+
+        noncontiguous_logits = torch.randn(
+            (self.NUM_EXPERTS, 7), dtype=torch.bfloat16, device="cuda"
+        ).transpose(0, 1)
+        self.assertFalse(
+            group_topk.can_use_fused(
+                values,
+                indices,
+                noncontiguous_logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+            )
+        )
+
+    def test_cuda_graph_replay_matches_legacy(self) -> None:
+        torch.manual_seed(20260806)
+        logits = torch.randn(
+            (33, self.NUM_EXPERTS), dtype=torch.bfloat16, device="cuda"
+        )
+        correction_bias = torch.randn(
+            (self.NUM_EXPERTS,), dtype=torch.float32, device="cuda"
+        )
+        group_topk = GroupTopK(use_fused=True)
+        legacy_values, legacy_indices = self._call(
+            group_topk,
+            "forward_legacy",
+            logits,
+            correction_bias,
+            torch.int64,
+            True,
+            2.5,
+        )
+        graph_values, graph_indices = self._empty_outputs(33, torch.int64)
+
+        group_topk.forward_fused(
+            graph_values,
+            graph_indices,
+            logits,
+            correction_bias,
+            self.NUM_GROUPS,
+            self.TOPK_GROUP,
+            self.TOPK,
+            True,
+            2.5,
+        )
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            group_topk.forward_fused(
+                graph_values,
+                graph_indices,
+                logits,
+                correction_bias,
+                self.NUM_GROUPS,
+                self.TOPK_GROUP,
+                self.TOPK,
+                True,
+                2.5,
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            graph_values, legacy_values, rtol=0, atol=0, equal_nan=True
+        )
+        torch.testing.assert_close(graph_indices, legacy_indices, rtol=0, atol=0)
+
+
+    def test_glm51_single_group_matches_legacy(self) -> None:
+        """Official GLM-5.1 routing: n_group=1, topk_group=1, topk=8."""
+        torch.manual_seed(20260814)
+        group_topk = GroupTopK(use_fused=True)
+        for tokens in (1, 7, 128, 6954):
+            for index_dtype in (torch.int32, torch.int64):
+                for renormalize in (False, True):
+                    logits = torch.randn(
+                        (tokens, self.NUM_EXPERTS), dtype=torch.bfloat16, device="cuda"
+                    )
+                    correction_bias = torch.randn(
+                        (self.NUM_EXPERTS,), dtype=torch.float32, device="cuda"
+                    )
+                    legacy_values, legacy_indices = self._call(
+                        group_topk,
+                        "forward_legacy",
+                        logits,
+                        correction_bias,
+                        index_dtype,
+                        renormalize,
+                        2.5,
+                        n_group=1,
+                        topk_group=1,
+                        topk=8,
+                    )
+                    fused_values, fused_indices = self._call(
+                        group_topk,
+                        "forward_fused",
+                        logits,
+                        correction_bias,
+                        index_dtype,
+                        renormalize,
+                        2.5,
+                        n_group=1,
+                        topk_group=1,
+                        topk=8,
+                    )
+                    torch.testing.assert_close(
+                        fused_values,
+                        legacy_values,
+                        rtol=0,
+                        atol=0,
+                        equal_nan=True,
+                    )
+                    torch.testing.assert_close(fused_indices, legacy_indices, rtol=0, atol=0)
+                    self.assertTrue(
+                        group_topk.can_use_fused(
+                            fused_values,
+                            fused_indices,
+                            logits,
+                            correction_bias,
+                            1,
+                            1,
+                            8,
+                        )
+                    )
 
 if __name__ == "__main__":
     main()

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_cp_impl.py
@@ -40,11 +40,11 @@ from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.cp_uti
 from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.triton_kv_scatter import (
     triton_kv_scatter,
 )
-from rtp_llm.ops import AttentionConfigs, FMHAConfig, FMHAType, ParallelismConfig
-from rtp_llm.ops.compute_ops import KVCache, PyAttentionInputs, rtp_llm_ops
 from rtp_llm.models_py.triton_kernels.sparse_mla.topk_index_postprocess import (
     fused_stage2_global_indices,
 )
+from rtp_llm.ops import AttentionConfigs, FMHAConfig, FMHAType, ParallelismConfig
+from rtp_llm.ops.compute_ops import KVCache, PyAttentionInputs, rtp_llm_ops
 
 from .flashmla_sparse_impl import (
     SparseMlaFp8DecodeParams,
@@ -922,7 +922,7 @@ class SparseMlaFp8CPOp(SparseMlaFp8Op):
         ).reshape(-1, local_fused.size(-1))
         restore_indices = self.sharded_kv_restore_indices
         direct_restore = (
-            getattr(self, "_glm5_prefill_refine_enabled", False)
+            self._fuse_prefill_index_ops
             and gathered.is_cuda
             and gathered.is_contiguous()
             and ws.fused_kv.is_cuda
@@ -1001,7 +1001,7 @@ class SparseMlaFp8CPOp(SparseMlaFp8Op):
         offsets = ws.workspace_starts[self.precomputed_req_ids]
         topk_2d = _topk_2d(topk)
         global_indices = None
-        if getattr(self, "_glm5_prefill_refine_enabled", False):
+        if self._fuse_prefill_index_ops:
             global_indices = fused_stage2_global_indices(topk_2d, offsets)
         if global_indices is None:
             # Preserve -1 padding so flash_mla_sparse_fwd skips invalid positions.

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_cp_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_cp_impl.py
@@ -42,6 +42,9 @@ from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.triton_kv_scatter
 )
 from rtp_llm.ops import AttentionConfigs, FMHAConfig, FMHAType, ParallelismConfig
 from rtp_llm.ops.compute_ops import KVCache, PyAttentionInputs, rtp_llm_ops
+from rtp_llm.models_py.triton_kernels.sparse_mla.topk_index_postprocess import (
+    fused_stage2_global_indices,
+)
 
 from .flashmla_sparse_impl import (
     SparseMlaFp8DecodeParams,
@@ -50,6 +53,7 @@ from .flashmla_sparse_impl import (
     _as_uint8,
     _GatherWorkspace,
     _topk_2d,
+    supports_q_rope_direct_write,
 )
 
 
@@ -916,7 +920,26 @@ class SparseMlaFp8CPOp(SparseMlaFp8Op):
         gathered = all_gather(
             local_fused.contiguous(), group=Group.TP, role="mla_history"
         ).reshape(-1, local_fused.size(-1))
-        ws.fused_kv.copy_(gathered[self.sharded_kv_restore_indices])
+        restore_indices = self.sharded_kv_restore_indices
+        direct_restore = (
+            getattr(self, "_glm5_prefill_refine_enabled", False)
+            and gathered.is_cuda
+            and gathered.is_contiguous()
+            and ws.fused_kv.is_cuda
+            and ws.fused_kv.is_contiguous()
+            and restore_indices.is_cuda
+            and restore_indices.is_contiguous()
+            and restore_indices.dtype == torch.int64
+            and gathered.dtype == ws.fused_kv.dtype
+            and gathered.ndim == ws.fused_kv.ndim == 2
+            and restore_indices.ndim == 1
+            and restore_indices.numel() == ws.fused_kv.size(0)
+            and gathered.size(1) == ws.fused_kv.size(1)
+        )
+        if direct_restore:
+            torch.index_select(gathered, 0, restore_indices, out=ws.fused_kv)
+        else:
+            ws.fused_kv.copy_(gathered[restore_indices])
 
     def _attend_with_kvcache(
         self,
@@ -977,14 +1000,16 @@ class SparseMlaFp8CPOp(SparseMlaFp8Op):
             )
         offsets = ws.workspace_starts[self.precomputed_req_ids]
         topk_2d = _topk_2d(topk)
-        # FIX: topk_2d contains -1 as padding (invalid KV position).
-        # Adding offsets to -1 turns it into a large positive index that
-        # points into another request's KV region in fused_kv, causing
-        # cross-request KV pollution → gibberish / repeat output.
-        # Preserve -1 so flash_mla_sparse_fwd skips these positions.
-        padding_mask = topk_2d < 0
-        raw_global = topk_2d + offsets.unsqueeze(1)
-        global_indices = raw_global.masked_fill(padding_mask, -1).unsqueeze(1)
+        global_indices = None
+        if getattr(self, "_glm5_prefill_refine_enabled", False):
+            global_indices = fused_stage2_global_indices(topk_2d, offsets)
+        if global_indices is None:
+            # Preserve -1 padding so flash_mla_sparse_fwd skips invalid positions.
+            padding_mask = topk_2d < 0
+            raw_global = topk_2d + offsets.unsqueeze(1)
+            global_indices = raw_global.masked_fill(padding_mask, -1).unsqueeze(1)
+        else:
+            global_indices = global_indices.unsqueeze(1)
         out, _, _ = flash_mla_sparse_fwd(
             q0,
             ws.fused_kv.unsqueeze(1),
@@ -1213,15 +1238,52 @@ class SparseMlaCpImpl(SparseMlaImpl):
         # get pos=0 but never read: q is selected by total_local_ids; k_pe is
         # all-gathered then re-indexed by kv_restore_unpad_indices.
         q_pe = q[:, :, self.nope_head_dim :]
+        q_transformed: Optional[torch.Tensor] = None
+        direct_q_output = (
+            getattr(self, "_glm5_prefill_refine_enabled", False)
+            and self.is_prefill
+            and self.fmha_impl.full_rope_pos_ids is not None
+            and self._kv_cache_type == "fp8_ds_mla"
+            and self.num_heads == 64
+            and self.nope_head_dim == 192
+            and self.rope_head_dim == 64
+            and self.kv_lora_rank == 512
+            and q.is_cuda
+            and q.dtype == torch.bfloat16
+            and q.is_contiguous()
+            and q.ndim == 3
+            and tuple(q.shape[1:]) == (64, 256)
+        )
+        if direct_q_output:
+            candidate = self._allocate_q_transformed(q)
+            if supports_q_rope_direct_write(
+                q,
+                candidate,
+                kv_lora_rank=self.kv_lora_rank,
+                rope_head_dim=self.rope_head_dim,
+                is_neox_style=self._is_neox_style,
+                kv_cache_type=self._kv_cache_type,
+            ):
+                q_transformed = candidate
         if self.fmha_impl.full_rope_pos_ids is not None:
             self.rope_impl.forward(
                 q_pe,
                 k_pe,
                 self.rope_params,
                 precomputed_pos_ids=self.fmha_impl.full_rope_pos_ids,
+                q_rope_output=(
+                    q_transformed[..., self.kv_lora_rank :]
+                    if q_transformed is not None
+                    else None
+                ),
             )
 
-        q_transformed = self._apply_input_bmm(q, layer_id)
+        q_transformed = self._apply_input_bmm(
+            q,
+            layer_id,
+            q_transformed=q_transformed,
+            q_rope_is_packed=q_transformed is not None,
+        )
         attn_output = self.fmha_impl.forward(
             q_transformed,
             compressed_kv,

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_impl.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/flashmla_sparse_impl.py
@@ -43,8 +43,15 @@ from rtp_llm.models_py.triton_kernels.sparse_mla.block_index_to_global import (
 )
 from rtp_llm.models_py.triton_kernels.sparse_mla.fused_qk_rope_cat_cache_mla import (
     fused_qk_rope_cat_cache_mla,
+    supports_q_rope_direct_write,
 )
-from rtp_llm.models_py.utils.fuse_config import fuse_kernels_enabled
+from rtp_llm.models_py.triton_kernels.sparse_mla.topk_index_postprocess import (
+    fused_stage2_global_indices,
+)
+from rtp_llm.models_py.utils.fuse_config import (
+    fuse_kernels_enabled,
+    glm5_prefill_refine_enabled,
+)
 from rtp_llm.ops import (
     AttentionConfigs,
     FMHAConfig,
@@ -106,6 +113,7 @@ class SparseMlaOp(object):
         self.softmax_extra_scale = softmax_extra_scale
         self.scale = (self.qk_head_dim**-0.5) * softmax_extra_scale
         self.top_k = top_k
+        self._fuse_prefill_index_ops = glm5_prefill_refine_enabled()
 
         # Filled by plan() each forward
         self.block_table: Optional[torch.Tensor] = None
@@ -149,6 +157,22 @@ class SparseMlaOp(object):
             BLOCK_N=min(128, topk),
             HAS_PREFILL_WORKSPACE=False,
         )
+        return global_2d.unsqueeze(1)
+
+    def _convert_topk_indices_to_workspace(
+        self,
+        topk_indices: torch.Tensor,
+        workspace_offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Request-local TopK to gather-workspace offsets, preserving sentinels."""
+        topk_2d = _topk_2d(topk_indices)
+        global_2d = None
+        if self._fuse_prefill_index_ops:
+            global_2d = fused_stage2_global_indices(topk_2d, workspace_offsets)
+        if global_2d is None:
+            padding_mask = topk_2d < 0
+            raw_global = topk_2d + workspace_offsets.unsqueeze(1)
+            global_2d = raw_global.masked_fill(padding_mask, -1)
         return global_2d.unsqueeze(1)
 
     def forward(
@@ -345,10 +369,9 @@ class SparseMlaFp8Op(SparseMlaOp):
 
         # Request-local topk → workspace offset (ws_starts[req] + local_pos)
         offsets = ws.workspace_starts[self.mla_params.batch_indice_d]
-        topk_2d = _topk_2d(topk_indices)
-        padding_mask = topk_2d < 0
-        raw_global = topk_2d + offsets.unsqueeze(1)
-        global_indices = raw_global.masked_fill(padding_mask, -1).unsqueeze(1)
+        global_indices = self._convert_topk_indices_to_workspace(
+            topk_indices, offsets
+        )
 
         out, _, _ = flash_mla_sparse_fwd(
             q,
@@ -472,6 +495,7 @@ class SparseMlaImpl(MlaImplBase):
         )
 
         self._fuse_qk_rope_cat_cache_mla = fuse_kernels_enabled()
+        self._glm5_prefill_refine_enabled = glm5_prefill_refine_enabled()
         self._kv_cache_type = (
             "fp8_ds_mla"
             if attn_configs.kv_cache_dtype == KvCacheDataType.FP8
@@ -655,24 +679,41 @@ class SparseMlaImpl(MlaImplBase):
 
     # -- BMMs ----------------------------------------------------------------
 
-    def _apply_input_bmm(self, q: torch.Tensor, layer_id: int) -> torch.Tensor:
-        """Project q_nope @ W_kc to kv_lora_rank, assemble [T, H, kv_lora_rank|rope].
-
-        q_pe is a strided view from torch.split — calling .contiguous() here would
-        re-introduce the very copy the strided triton kernel is replacing.
-        """
-        q_nope, q_pe = q.view(
-            -1, self.num_heads, self.nope_head_dim + self.rope_head_dim
-        ).split([self.nope_head_dim, self.rope_head_dim], dim=-1)
-
-        q_transformed = torch.empty(
-            q_nope.shape[0],
+    def _allocate_q_transformed(self, q: torch.Tensor) -> torch.Tensor:
+        return torch.empty(
+            q.shape[0],
             self.num_heads,
             self.kv_lora_rank + self.rope_head_dim,
             dtype=q.dtype,
             device=q.device,
         )
-        strided_slice_copy_(q_transformed, q_pe, self.kv_lora_rank)
+
+    def _apply_input_bmm(
+        self,
+        q: torch.Tensor,
+        layer_id: int,
+        q_transformed: Optional[torch.Tensor] = None,
+        q_rope_is_packed: bool = False,
+    ) -> torch.Tensor:
+        """Project q_nope @ W_kc to kv_lora_rank, assemble [T, H, kv_lora_rank|rope].
+
+        The GLM5 FP8 prefill fast path writes rotated Q directly into the suffix
+        before this BMM. Other paths retain the strided Q-RoPE copy fallback.
+        """
+        q_nope, q_pe = q.view(
+            -1, self.num_heads, self.nope_head_dim + self.rope_head_dim
+        ).split([self.nope_head_dim, self.rope_head_dim], dim=-1)
+
+        if q_transformed is None:
+            q_transformed = self._allocate_q_transformed(q)
+        else:
+            assert q_transformed.shape == (
+                q_nope.shape[0],
+                self.num_heads,
+                self.kv_lora_rank + self.rope_head_dim,
+            )
+        if not q_rope_is_packed:
+            strided_slice_copy_(q_transformed, q_pe, self.kv_lora_rank)
 
         if q_nope.shape[0] > 0:
             k_weight = self.weights[layer_id][W.mla_kc]
@@ -716,7 +757,35 @@ class SparseMlaImpl(MlaImplBase):
 
         # 1. RoPE on q_pe and k_pe; write KV to cache + optional store
         q_pe = q[:, :, self.nope_head_dim :]
+        q_transformed: Optional[torch.Tensor] = None
         if self._fuse_qk_rope_cat_cache_mla and kv_cache is not None:
+            direct_q_output = (
+                self._glm5_prefill_refine_enabled
+                and self.is_prefill
+                and not bool(getattr(self.attn_inputs, "is_target_verify", False))
+                and self._kv_cache_type == "fp8_ds_mla"
+                and self.num_heads == 64
+                and self.nope_head_dim == 192
+                and self.rope_head_dim == 64
+                and self.kv_lora_rank == 512
+                and self._is_neox_style
+                and q.is_cuda
+                and q.dtype == torch.bfloat16
+                and q.is_contiguous()
+                and q.ndim == 3
+                and tuple(q.shape[1:]) == (64, 256)
+            )
+            if direct_q_output:
+                candidate = self._allocate_q_transformed(q)
+                if supports_q_rope_direct_write(
+                    q,
+                    candidate,
+                    kv_lora_rank=self.kv_lora_rank,
+                    rope_head_dim=self.rope_head_dim,
+                    is_neox_style=self._is_neox_style,
+                    kv_cache_type=self._kv_cache_type,
+                ):
+                    q_transformed = candidate
             fused_qk_rope_cat_cache_mla(
                 q=q,
                 compressed_kv=compressed_kv,
@@ -729,6 +798,7 @@ class SparseMlaImpl(MlaImplBase):
                 rope_head_dim=self.rope_head_dim,
                 is_neox_style=self._is_neox_style,
                 kv_cache_type=self._kv_cache_type,
+                q_transformed=q_transformed,
             )
         else:
             self.rope_impl.forward(q_pe, k_pe, self.rope_params)
@@ -740,7 +810,12 @@ class SparseMlaImpl(MlaImplBase):
         )
 
         # 2. Project q via W_kc into the absorbed kv_lora_rank space
-        q_transformed = self._apply_input_bmm(q, layer_id)
+        q_transformed = self._apply_input_bmm(
+            q,
+            layer_id,
+            q_transformed=q_transformed,
+            q_rope_is_packed=q_transformed is not None,
+        )
 
         # 3. Sparse attention. FP8 op consumes paged shape; BF16 op wants flat.
         if self.fmha_impl.expects_paged_kv:

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/rope_emb_new.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/rope_emb_new.py
@@ -27,12 +27,13 @@ class NewMlaRotaryEmbeddingOp(object):
         key: torch.Tensor,
         fmha_params: rtp_llm_ops.SparseMlaParams,
         precomputed_pos_ids: torch.Tensor = None,
+        q_rope_output: Optional[torch.Tensor] = None,
     ):
 
         rope._apply_rope_pos_ids_cos_sin_cache(
             q=query,
             k=key.unsqueeze(1),
-            q_rope=query,
+            q_rope=query if q_rope_output is None else q_rope_output,
             k_rope=key.unsqueeze(1),
             cos_sin_cache=self.cos_sin_cache,
             pos_ids=(

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/test/flashmla_sparse_cp_op_test.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/test/flashmla_sparse_cp_op_test.py
@@ -303,13 +303,21 @@ class SparseMlaFp8CPOpTest(TestCase):
         op.sharded_workspace_starts = torch.tensor(
             [0], dtype=torch.int32, device=device
         )
+        op.sharded_actual_local_kv_lens = torch.tensor(
+            [64], dtype=torch.int32, device=device
+        )
+        op.sharded_actual_workspace_starts = torch.tensor(
+            [0], dtype=torch.int32, device=device
+        )
         op.sharded_kv_restore_indices = torch.arange(2, dtype=torch.long, device=device)
         op.sharded_total_local_kv_len = 64
+        op.sharded_actual_total_local_kv_len = 64
         op.sharded_slot_mapping = None
         op.block_table = torch.zeros((1, 1), dtype=torch.int32, device=device)
         op.total_local_ids = torch.empty(0, dtype=torch.long, device=device)
         op.total_local_ids_is_identity = False
         op.mla_params = None
+        op._fuse_prefill_index_ops = False
 
         kv_cache = LayerKVCache()
         kv_cache.kv_cache_base = torch.empty(
@@ -360,6 +368,95 @@ class SparseMlaFp8CPOpTest(TestCase):
             "empty-Q sharded ranks must still join the KV all_gather",
         )
         self.assertEqual(cp_gather_shapes, [(64, 576)])
+
+    def test_sharded_kv_restore_fused_unfused_exact(self):
+        """Direct-out index_select must be bit-exact with legacy gather+copy."""
+        from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl import (
+            flashmla_sparse_cp_impl,
+        )
+
+        device = self.device
+        rows = 17
+        width = 576
+        torch.manual_seed(20260804)
+        gathered_source = torch.randn(
+            (rows, width),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        restore_indices = torch.tensor(
+            [16, 0, 9, 3, 12, 1, 15, 5, 7, 2, 14, 6, 10, 4, 13, 8, 11],
+            dtype=torch.long,
+            device=device,
+        )
+        expected = gathered_source[restore_indices]
+
+        kv_cache = LayerKVCache()
+        kv_cache.kv_cache_base = torch.empty(
+            (1, 64, 656),
+            dtype=torch.uint8,
+            device=device,
+        )
+
+        def run_variant(enable_fused: bool) -> torch.Tensor:
+            op = object.__new__(flashmla_sparse_cp_impl.SparseMlaFp8CPOp)
+            op._fuse_prefill_index_ops = enable_fused
+            op._gather = SimpleNamespace(
+                fused_kv=torch.empty_like(expected),
+                batch_size=1,
+            )
+            op.sharded_local_kv_lens = torch.tensor(
+                [rows], dtype=torch.int32, device=device
+            )
+            op.sharded_actual_local_kv_lens = torch.tensor(
+                [rows], dtype=torch.int32, device=device
+            )
+            op.sharded_actual_workspace_starts = torch.tensor(
+                [0], dtype=torch.int32, device=device
+            )
+            op.sharded_kv_restore_indices = restore_indices
+            op.sharded_total_local_kv_len = rows
+            op.sharded_actual_total_local_kv_len = rows
+            op.block_table = torch.zeros(
+                (1, 1), dtype=torch.int32, device=device
+            )
+
+            def fake_gather_cache(_src, dst, *_args):
+                dst.copy_(gathered_source)
+
+            def copy_actual_to_padded(
+                actual,
+                padded,
+                per_req_actual_local_kv_lens,
+                per_req_padded_local_kv_lens,
+            ):
+                del per_req_actual_local_kv_lens
+                del per_req_padded_local_kv_lens
+                padded.copy_(actual)
+
+            with patch.object(
+                rtp_llm_ops,
+                "cp_gather_and_upconvert_fp8_kv_cache_v2",
+                side_effect=fake_gather_cache,
+            ), patch.object(
+                flashmla_sparse_cp_impl,
+                "_scatter_actual_to_padded",
+                side_effect=copy_actual_to_padded,
+            ), patch.object(
+                flashmla_sparse_cp_impl,
+                "all_gather",
+                side_effect=lambda tensor, group=None, role=None: tensor,
+            ):
+                op._gather_sharded_kv_cache(kv_cache)
+            return op._gather.fused_kv.clone()
+
+        unfused = run_variant(enable_fused=False)
+        fused = run_variant(enable_fused=True)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(unfused, expected, rtol=0, atol=0)
+        torch.testing.assert_close(fused, expected, rtol=0, atol=0)
+        torch.testing.assert_close(fused, unfused, rtol=0, atol=0)
 
     def test_total_local_ids_identity_detection(self):
         from rtp_llm.models_py.modules.factory.attention.cuda_cp_impl.prefill_mha.cp_utils import (

--- a/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/test/flashmla_sparse_cp_op_test.py
+++ b/rtp_llm/models_py/modules/factory/attention/cuda_mla_impl/test/flashmla_sparse_cp_op_test.py
@@ -398,7 +398,7 @@ class SparseMlaFp8CPOpTest(TestCase):
             device=device,
         )
 
-        def run_variant(enable_fused: bool) -> torch.Tensor:
+        def run_variant(enable_fused: bool) -> Tuple[torch.Tensor, int]:
             op = object.__new__(flashmla_sparse_cp_impl.SparseMlaFp8CPOp)
             op._fuse_prefill_index_ops = enable_fused
             op._gather = SimpleNamespace(
@@ -417,9 +417,7 @@ class SparseMlaFp8CPOpTest(TestCase):
             op.sharded_kv_restore_indices = restore_indices
             op.sharded_total_local_kv_len = rows
             op.sharded_actual_total_local_kv_len = rows
-            op.block_table = torch.zeros(
-                (1, 1), dtype=torch.int32, device=device
-            )
+            op.block_table = torch.zeros((1, 1), dtype=torch.int32, device=device)
 
             def fake_gather_cache(_src, dst, *_args):
                 dst.copy_(gathered_source)
@@ -446,13 +444,17 @@ class SparseMlaFp8CPOpTest(TestCase):
                 flashmla_sparse_cp_impl,
                 "all_gather",
                 side_effect=lambda tensor, group=None, role=None: tensor,
-            ):
+            ), patch.object(
+                torch, "index_select", wraps=torch.index_select
+            ) as index_select:
                 op._gather_sharded_kv_cache(kv_cache)
-            return op._gather.fused_kv.clone()
+            return op._gather.fused_kv.clone(), index_select.call_count
 
-        unfused = run_variant(enable_fused=False)
-        fused = run_variant(enable_fused=True)
+        unfused, unfused_index_select_calls = run_variant(enable_fused=False)
+        fused, fused_index_select_calls = run_variant(enable_fused=True)
         torch.cuda.synchronize()
+        self.assertEqual(unfused_index_select_calls, 0)
+        self.assertEqual(fused_index_select_calls, 1)
 
         torch.testing.assert_close(unfused, expected, rtol=0, atol=0)
         torch.testing.assert_close(fused, expected, rtol=0, atol=0)

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/fused_qk_rope_cat_cache_mla.py
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/fused_qk_rope_cat_cache_mla.py
@@ -167,6 +167,7 @@ def _fused_qk_rope_cat_cache_mla_bf16_kernel(
 @triton.jit
 def _fused_qk_rope_cat_cache_mla_fp8_kernel(
     Q,
+    Q_TRANSFORMED,
     K_PE,
     KV_CACHE_FP8,
     KV_CACHE_FP32,
@@ -178,6 +179,8 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
     SCALE_MIN_PTR,
     stride_q_t,
     stride_q_h,
+    stride_qout_t,
+    stride_qout_h,
     stride_kpe_t,
     stride_ck_t,
     stride_kvc_u8_page,
@@ -189,11 +192,14 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
     BLOCK_SIZE: tl.constexpr,
     H: tl.constexpr,
     Q_ROPE_OFFSET: tl.constexpr,
+    Q_OUT_OFFSET: tl.constexpr,
     KV_LORA: tl.constexpr,
     ROPE: tl.constexpr,
     HALF_ROPE: tl.constexpr,
     QUANT_BLOCK: tl.constexpr,
     IS_NEOX: tl.constexpr,
+    WRITE_Q_OUTPUT: tl.constexpr,
+    WRITE_Q_INPLACE: tl.constexpr,
     BLOCK_H_TILE: tl.constexpr,
     H_TILES: tl.constexpr,
     NUM_K_BLOCKS: tl.constexpr,
@@ -211,6 +217,7 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
         h_offs = h_start + tl.arange(0, BLOCK_H_TILE)
         h_mask = h_offs < H
         q_base = t * stride_q_t
+        qout_base = t * stride_qout_t
         m2d = h_mask[:, None]
 
         if IS_NEOX:
@@ -226,10 +233,25 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
             )
             x1 = tl.load(Q + addrs_lo, mask=m2d, other=0.0).to(tl.float32)
             x2 = tl.load(Q + addrs_hi, mask=m2d, other=0.0).to(tl.float32)
-            y1 = tl.extra.libdevice.fma_rn(x1, c[None, :], -x2 * s[None, :])
-            y2 = tl.extra.libdevice.fma_rn(x2, c[None, :], x1 * s[None, :])
-            tl.store(Q + addrs_lo, y1.to(tl.bfloat16), mask=m2d)
-            tl.store(Q + addrs_hi, y2.to(tl.bfloat16), mask=m2d)
+            y1_bf = tl.extra.libdevice.fma_rn(
+                x1, c[None, :], -x2 * s[None, :]
+            ).to(tl.bfloat16)
+            y2_bf = tl.extra.libdevice.fma_rn(
+                x2, c[None, :], x1 * s[None, :]
+            ).to(tl.bfloat16)
+            if WRITE_Q_OUTPUT:
+                out_lo = (
+                    qout_base
+                    + h_offs[:, None] * stride_qout_h
+                    + Q_OUT_OFFSET
+                    + rh[None, :]
+                )
+                out_hi = out_lo + HALF_ROPE
+                tl.store(Q_TRANSFORMED + out_lo, y1_bf, mask=m2d)
+                tl.store(Q_TRANSFORMED + out_hi, y2_bf, mask=m2d)
+            if WRITE_Q_INPLACE:
+                tl.store(Q + addrs_lo, y1_bf, mask=m2d)
+                tl.store(Q + addrs_hi, y2_bf, mask=m2d)
         else:
             addrs_e = (
                 q_base + h_offs[:, None] * stride_q_h + Q_ROPE_OFFSET + 2 * rh[None, :]
@@ -237,10 +259,25 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
             addrs_o = addrs_e + 1
             xe = tl.load(Q + addrs_e, mask=m2d, other=0.0).to(tl.float32)
             xo = tl.load(Q + addrs_o, mask=m2d, other=0.0).to(tl.float32)
-            ye = tl.extra.libdevice.fma_rn(xe, c[None, :], -xo * s[None, :])
-            yo = tl.extra.libdevice.fma_rn(xo, c[None, :], xe * s[None, :])
-            tl.store(Q + addrs_e, ye.to(tl.bfloat16), mask=m2d)
-            tl.store(Q + addrs_o, yo.to(tl.bfloat16), mask=m2d)
+            ye_bf = tl.extra.libdevice.fma_rn(
+                xe, c[None, :], -xo * s[None, :]
+            ).to(tl.bfloat16)
+            yo_bf = tl.extra.libdevice.fma_rn(
+                xo, c[None, :], xe * s[None, :]
+            ).to(tl.bfloat16)
+            if WRITE_Q_OUTPUT:
+                out_e = (
+                    qout_base
+                    + h_offs[:, None] * stride_qout_h
+                    + Q_OUT_OFFSET
+                    + 2 * rh[None, :]
+                )
+                out_o = out_e + 1
+                tl.store(Q_TRANSFORMED + out_e, ye_bf, mask=m2d)
+                tl.store(Q_TRANSFORMED + out_o, yo_bf, mask=m2d)
+            if WRITE_Q_INPLACE:
+                tl.store(Q + addrs_e, ye_bf, mask=m2d)
+                tl.store(Q + addrs_o, yo_bf, mask=m2d)
 
     elif h_blk < H_TILES + NUM_K_BLOCKS - 1:
         slot = tl.load(SLOT_MAPPING + t).to(tl.int64)
@@ -318,6 +355,33 @@ def _fused_qk_rope_cat_cache_mla_fp8_kernel(
             )
 
 
+def supports_q_rope_direct_write(
+    q: torch.Tensor,
+    q_transformed: torch.Tensor,
+    *,
+    kv_lora_rank: int,
+    rope_head_dim: int,
+    is_neox_style: bool,
+    kv_cache_type: str,
+) -> bool:
+    """Return whether the validated GLM5 FP8 direct-output contract holds."""
+    return (
+        kv_cache_type == "fp8_ds_mla"
+        and kv_lora_rank == 512
+        and rope_head_dim == 64
+        and q.is_cuda
+        and q.dtype == torch.bfloat16
+        and q.is_contiguous()
+        and q.ndim == 3
+        and tuple(q.shape[1:]) == (64, 256)
+        and q_transformed.is_cuda
+        and q_transformed.device == q.device
+        and q_transformed.dtype == torch.bfloat16
+        and q_transformed.is_contiguous()
+        and q_transformed.shape == (q.shape[0], 64, 576)
+    )
+
+
 def fused_qk_rope_cat_cache_mla(
     q: torch.Tensor,
     compressed_kv: torch.Tensor,
@@ -330,6 +394,7 @@ def fused_qk_rope_cat_cache_mla(
     rope_head_dim: int,
     is_neox_style: bool,
     kv_cache_type: str = "auto",
+    q_transformed: Optional[torch.Tensor] = None,
 ) -> None:
     """Fused RoPE + paged KV cache write for sparse MLA.
 
@@ -347,12 +412,28 @@ def fused_qk_rope_cat_cache_mla(
         rope_head_dim: RoPE dimension (e.g. 64)
         is_neox_style: True for NEOX rotation
         kv_cache_type: "auto" or "fp8_ds_mla"
+        q_transformed: optional GLM5 FP8 output [T, 64, 576]; when set,
+                       rotated Q is written to its suffix instead of q in-place
     """
     assert q.dim() == 3 and q.dtype == torch.bfloat16
     assert compressed_kv.dim() == 2 and compressed_kv.dtype == torch.bfloat16
     assert k_pe.dim() == 2 and k_pe.dtype == torch.bfloat16
     assert kv_cache.dim() == 3
     assert cos_sin_cache.dtype == torch.float32
+
+    if q_transformed is not None and not supports_q_rope_direct_write(
+        q,
+        q_transformed,
+        kv_lora_rank=kv_lora_rank,
+        rope_head_dim=rope_head_dim,
+        is_neox_style=is_neox_style,
+        kv_cache_type=kv_cache_type,
+    ):
+        raise ValueError(
+            "q_transformed direct output requires contiguous GLM5 FP8 tensors: "
+            "q [T,64,256] BF16 and output [T,64,576] BF16"
+        )
+    direct_q_output = q_transformed is not None
 
     T, H, qk_head_dim = q.shape
     nope_head_dim = qk_head_dim - rope_head_dim
@@ -409,9 +490,11 @@ def fused_qk_rope_cat_cache_mla(
         kvc_fp8 = kv_cache.view(torch.float8_e4m3fn)
         kvc_fp32 = kv_cache.view(torch.float32)
         kvc_bf16 = kv_cache.view(torch.bfloat16)
+        q_output = q if q_transformed is None else q_transformed
         fp8_grid = (T, h_tiles + _NUM_FP8_K_BLOCKS)
         _fused_qk_rope_cat_cache_mla_fp8_kernel[fp8_grid](
             q,
+            q_output,
             k_pe,
             kvc_fp8,
             kvc_fp32,
@@ -423,6 +506,8 @@ def fused_qk_rope_cat_cache_mla(
             _get_fp8_scale_min(kv_cache.device),
             q.stride(0),
             q.stride(1),
+            q_output.stride(0),
+            q_output.stride(1),
             k_pe.stride(0),
             compressed_kv.stride(0),
             kvc_fp8.stride(0),
@@ -434,11 +519,14 @@ def fused_qk_rope_cat_cache_mla(
             BLOCK_SIZE=block_size,
             H=H,
             Q_ROPE_OFFSET=nope_head_dim,
+            Q_OUT_OFFSET=kv_lora_rank,
             KV_LORA=kv_lora_rank,
             ROPE=rope_head_dim,
             HALF_ROPE=half_rope,
             QUANT_BLOCK=128,
             IS_NEOX=is_neox_style,
+            WRITE_Q_OUTPUT=direct_q_output,
+            WRITE_Q_INPLACE=not direct_q_output,
             BLOCK_H_TILE=_BLOCK_H_TILE,
             H_TILES=h_tiles,
             NUM_K_BLOCKS=_NUM_FP8_K_BLOCKS,

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/test/BUILD
@@ -52,3 +52,23 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "test_q_rope_direct_write",
+    srcs = ["test_q_rope_direct_write.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)
+
+py_test(
+    name = "q_rope_direct_write_benchmark",
+    srcs = ["q_rope_direct_write_benchmark.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    tags = ["manual"],
+)

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/test/BUILD
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/test/BUILD
@@ -65,6 +65,17 @@ py_test(
 )
 
 py_test(
+    name = "test_topk_index_postprocess",
+    srcs = ["test_topk_index_postprocess.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)
+
+py_test(
     name = "q_rope_direct_write_benchmark",
     srcs = ["q_rope_direct_write_benchmark.py"],
     deps = [

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/test/q_rope_direct_write_benchmark.py
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/test/q_rope_direct_write_benchmark.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from collections import Counter
+from typing import Callable
+
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.rope_emb_new import (
+    NewMlaRotaryEmbeddingOp,
+)
+from rtp_llm.models_py.triton_kernels.common.strided_slice_copy import (
+    strided_slice_copy_,
+)
+
+
+HEADS = 64
+NOPE = 192
+ROPE = 64
+KV_LORA = 512
+Q_OUT = KV_LORA + ROPE
+TOKEN_COUNTS = [1, 17, 128, 257, 1024, 4096, 6954, 8192, 16384]
+PROFILE_TOKEN_COUNTS = {1, 128, 1024, 6954, 16384}
+
+
+def _cos_sin_cache(device: torch.device) -> torch.Tensor:
+    inv = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, ROPE, 2, device=device, dtype=torch.float32)
+            / ROPE
+        )
+    )
+    positions = torch.arange(16384.0, device=device)
+    return torch.cat(
+        [torch.outer(positions, inv).cos(), torch.outer(positions, inv).sin()],
+        dim=-1,
+    )
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[round((len(ordered) - 1) * fraction)]
+
+
+def _event_metrics(
+    function: Callable[[], None], warmup: int, iterations: int
+) -> dict[str, float]:
+    for _ in range(warmup):
+        function()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        function()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    return {
+        "median_us": statistics.median(samples),
+        "p90_us": _percentile(samples, 0.90),
+        "min_us": min(samples),
+        "max_us": max(samples),
+    }
+
+
+def _kernel_metrics(
+    function: Callable[[], None], warmup: int, iterations: int
+) -> dict[str, object]:
+    for _ in range(warmup):
+        function()
+    torch.cuda.synchronize()
+    with profile(activities=[ProfilerActivity.CUDA]) as profiler:
+        for _ in range(iterations):
+            function()
+            profiler.step()
+    torch.cuda.synchronize()
+
+    kernel_time_us = 0.0
+    names: Counter[str] = Counter()
+    for event in profiler.events():
+        if event.device_type != torch.autograd.DeviceType.CUDA:
+            continue
+        kernel_time_us += float(event.device_time_total)
+        names[event.name] += 1
+    return {
+        "kernel_sum_us_per_iter": kernel_time_us / iterations,
+        "launches_per_iter": sum(names.values()) / iterations,
+        "kernel_names": dict(names),
+    }
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    warmup = int(os.environ.get("WARMUP", "30"))
+    iterations = int(os.environ.get("ITERS", "100"))
+    profile_iterations = int(os.environ.get("PROFILE_ITERS", "20"))
+    raw_tokens = os.environ.get("M_LIST", "")
+    token_counts = (
+        [int(item) for item in raw_tokens.split(",") if item.strip()]
+        if raw_tokens
+        else TOKEN_COUNTS
+    )
+    device = torch.device("cuda")
+    cache = _cos_sin_cache(device)
+    rope_op = NewMlaRotaryEmbeddingOp(cache, is_neox_style=False)
+    torch.manual_seed(20260814)
+    results = []
+
+    for tokens in token_counts:
+        positions = torch.randint(
+            0, 16383, (tokens,), dtype=torch.int32, device=device
+        )
+        q_baseline = torch.randn(
+            (tokens, HEADS, ROPE), dtype=torch.bfloat16, device=device
+        )
+        q_direct = q_baseline.clone()
+        k_baseline = torch.randn(
+            (tokens, ROPE), dtype=torch.bfloat16, device=device
+        )
+        k_direct = k_baseline.clone()
+        output_baseline = torch.empty(
+            (tokens, HEADS, Q_OUT), dtype=torch.bfloat16, device=device
+        )
+        output_direct = torch.empty_like(output_baseline)
+
+        def baseline() -> None:
+            rope_op.forward(
+                q_baseline,
+                k_baseline,
+                None,
+                precomputed_pos_ids=positions,
+            )
+            strided_slice_copy_(output_baseline, q_baseline, KV_LORA)
+
+        def direct() -> None:
+            rope_op.forward(
+                q_direct,
+                k_direct,
+                None,
+                precomputed_pos_ids=positions,
+                q_rope_output=output_direct[..., KV_LORA:],
+            )
+
+        row: dict[str, object] = {"tokens": tokens}
+        for name, function in (("baseline", baseline), ("direct", direct)):
+            metrics: dict[str, object] = _event_metrics(
+                function, warmup, iterations
+            )
+            if tokens in PROFILE_TOKEN_COUNTS:
+                metrics.update(
+                    _kernel_metrics(function, warmup, profile_iterations)
+                )
+            row[name] = metrics
+        row["event_speedup"] = (
+            row["baseline"]["median_us"] / row["direct"]["median_us"]
+        )
+        if tokens in PROFILE_TOKEN_COUNTS:
+            row["kernel_speedup"] = (
+                row["baseline"]["kernel_sum_us_per_iter"]
+                / row["direct"]["kernel_sum_us_per_iter"]
+            )
+        results.append(row)
+
+    payload = {
+        "meta": {
+            "device": torch.cuda.get_device_name(),
+            "dtype": "BF16",
+            "q_shape": "[T,64,64]",
+            "output_shape": "[T,64,576]",
+            "is_neox_style": False,
+            "warmup": warmup,
+            "iterations": iterations,
+            "profile_iterations": profile_iterations,
+            "input_output_allocations_timed": False,
+            "torch_compile": False,
+        },
+        "results": results,
+    }
+    print("Q_ROPE_DIRECT_WRITE_BENCHMARK_JSON=" + json.dumps(payload, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/test/test_q_rope_direct_write.py
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/test/test_q_rope_direct_write.py
@@ -1,0 +1,281 @@
+"""Correctness tests for GLM5 FP8 Q-RoPE direct output."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.modules.factory.attention.cuda_mla_impl.rope_emb_new import (
+    NewMlaRotaryEmbeddingOp,
+)
+from rtp_llm.models_py.triton_kernels.sparse_mla.fused_qk_rope_cat_cache_mla import (
+    fused_qk_rope_cat_cache_mla,
+    supports_q_rope_direct_write,
+)
+
+HEADS = 64
+NOPE = 192
+ROPE = 64
+KV_LORA = 512
+QK_DIM = NOPE + ROPE
+Q_OUT_DIM = KV_LORA + ROPE
+BLOCK_SIZE = 64
+FP8_SLOT_BYTES = 656
+
+
+def _cos_sin_cache(device: torch.device) -> torch.Tensor:
+    inv = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, ROPE, 2, device=device, dtype=torch.float32)
+            / ROPE
+        )
+    )
+    positions = torch.arange(16384.0, device=device)
+    return torch.cat(
+        [torch.outer(positions, inv).cos(), torch.outer(positions, inv).sin()],
+        dim=-1,
+    )
+
+
+def _make_inputs(tokens: int, seed: int = 0) -> tuple[torch.Tensor, ...]:
+    device = torch.device("cuda")
+    torch.manual_seed(seed)
+    pages = max(1, (tokens + BLOCK_SIZE - 1) // BLOCK_SIZE)
+    q = torch.randn(
+        tokens,
+        HEADS,
+        QK_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    compressed_kv = torch.randn(
+        tokens,
+        KV_LORA,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    k_pe = torch.randn(
+        tokens,
+        ROPE,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    kv_cache = torch.full(
+        (pages, BLOCK_SIZE, FP8_SLOT_BYTES),
+        0xAA,
+        dtype=torch.uint8,
+        device=device,
+    )
+    slot_mapping = torch.arange(tokens, dtype=torch.int64, device=device)
+    if tokens:
+        slot_mapping[::7] = -1
+    positions = torch.randint(
+        0,
+        16383,
+        (tokens,),
+        dtype=torch.int32,
+        device=device,
+    )
+    return (
+        q,
+        compressed_kv,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        positions,
+        _cos_sin_cache(device),
+    )
+
+
+def _run(
+    q: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_transformed: torch.Tensor | None = None,
+    is_neox_style: bool = True,
+) -> None:
+    fused_qk_rope_cat_cache_mla(
+        q=q,
+        compressed_kv=compressed_kv,
+        k_pe=k_pe,
+        kv_cache=kv_cache,
+        slot_mapping=slot_mapping,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        kv_lora_rank=KV_LORA,
+        rope_head_dim=ROPE,
+        is_neox_style=is_neox_style,
+        kv_cache_type="fp8_ds_mla",
+        q_transformed=q_transformed,
+    )
+
+
+class QRoPEDirectWriteContractTest(unittest.TestCase):
+    def test_rejects_non_cuda_contract(self) -> None:
+        q = torch.empty((1, HEADS, QK_DIM), dtype=torch.bfloat16)
+        output = torch.empty((1, HEADS, Q_OUT_DIM), dtype=torch.bfloat16)
+        self.assertFalse(
+            supports_q_rope_direct_write(
+                q,
+                output,
+                kv_lora_rank=KV_LORA,
+                rope_head_dim=ROPE,
+                is_neox_style=True,
+                kv_cache_type="fp8_ds_mla",
+            )
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class QRoPEDirectWriteCudaTest(unittest.TestCase):
+    def _check_exact(self, tokens: int, is_neox_style: bool) -> None:
+        inputs = _make_inputs(tokens, seed=20260730 + tokens)
+        q, compressed_kv, k_pe, kv_cache, slot_mapping, positions, cache = inputs
+        q_before = q.clone()
+
+        q_ref = q.clone()
+        k_pe_ref = k_pe.clone()
+        kv_cache_ref = kv_cache.clone()
+        _run(
+            q_ref,
+            compressed_kv,
+            k_pe_ref,
+            kv_cache_ref,
+            slot_mapping,
+            positions,
+            cache,
+            is_neox_style=is_neox_style,
+        )
+
+        q_direct = q.clone()
+        k_pe_direct = k_pe.clone()
+        kv_cache_direct = kv_cache.clone()
+        q_output = torch.empty(
+            (tokens, HEADS, Q_OUT_DIM),
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        _run(
+            q_direct,
+            compressed_kv,
+            k_pe_direct,
+            kv_cache_direct,
+            slot_mapping,
+            positions,
+            cache,
+            q_transformed=q_output,
+            is_neox_style=is_neox_style,
+        )
+
+        weight = torch.randn(
+            HEADS,
+            NOPE,
+            KV_LORA,
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        q_output_ref = torch.empty_like(q_output)
+        q_output_ref[..., KV_LORA:] = q_ref[..., NOPE:]
+        if tokens:
+            torch.bmm(
+                q_ref[..., :NOPE].transpose(0, 1),
+                weight,
+                out=q_output_ref[..., :KV_LORA].transpose(0, 1),
+            )
+            torch.bmm(
+                q_direct[..., :NOPE].transpose(0, 1),
+                weight,
+                out=q_output[..., :KV_LORA].transpose(0, 1),
+            )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(q_direct, q_before, rtol=0, atol=0)
+        torch.testing.assert_close(k_pe_direct, k_pe_ref, rtol=0, atol=0)
+        torch.testing.assert_close(kv_cache_direct, kv_cache_ref, rtol=0, atol=0)
+        torch.testing.assert_close(q_output, q_output_ref, rtol=0, atol=0)
+
+    def test_exact_small_prime_and_glm5_shapes(self) -> None:
+        for is_neox_style in (False, True):
+            for tokens in (0, 1, 17, 257):
+                with self.subTest(
+                    tokens=tokens, is_neox_style=is_neox_style
+                ):
+                    self._check_exact(tokens, is_neox_style)
+
+    def test_flashinfer_interleaved_output_view_exact(self) -> None:
+        tokens = 257
+        inputs = _make_inputs(tokens, seed=20260814)
+        q, _, k_pe, _, _, positions, cache = inputs
+        q_pe = q[..., NOPE:]
+        q_before = q_pe.clone()
+        q_ref = q_pe.clone()
+        k_ref = k_pe.clone()
+        rope_op = NewMlaRotaryEmbeddingOp(cache, is_neox_style=False)
+        rope_op.forward(q_ref, k_ref, None, precomputed_pos_ids=positions)
+
+        q_direct = q_pe.clone()
+        k_direct = k_pe.clone()
+        q_output = torch.full(
+            (tokens, HEADS, Q_OUT_DIM),
+            1.0,
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        rope_op.forward(
+            q_direct,
+            k_direct,
+            None,
+            precomputed_pos_ids=positions,
+            q_rope_output=q_output[..., KV_LORA:],
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(q_direct, q_before, rtol=0, atol=0)
+        torch.testing.assert_close(k_direct, k_ref, rtol=0, atol=0)
+        torch.testing.assert_close(
+            q_output[..., KV_LORA:], q_ref, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            q_output[..., :KV_LORA],
+            torch.ones_like(q_output[..., :KV_LORA]),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_cuda_graph_capture_and_replay(self) -> None:
+        inputs = _make_inputs(17, seed=20260731)
+        q, compressed_kv, k_pe, kv_cache, slot_mapping, positions, cache = inputs
+        # Direct-write owns only the RoPE suffix. Initialize the BMM prefix
+        # with a finite sentinel so the full-tensor replay check also verifies
+        # that capture/replay does not overwrite memory outside that suffix.
+        output = torch.full(
+            (17, HEADS, Q_OUT_DIM),
+            1.0,
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+
+        _run(*inputs, q_transformed=output, is_neox_style=False)
+        torch.cuda.synchronize()
+        output_ptr = output.data_ptr()
+        expected = output.clone()
+        q_before = q.clone()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            _run(*inputs, q_transformed=output, is_neox_style=False)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertEqual(output.data_ptr(), output_ptr)
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        torch.testing.assert_close(q, q_before, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/test/test_topk_index_postprocess.py
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/test/test_topk_index_postprocess.py
@@ -1,0 +1,134 @@
+"""Correctness tests for sparse-MLA Top-K index postprocessing."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from rtp_llm.models_py.triton_kernels.sparse_mla.topk_index_postprocess import (
+    fused_stage1_request_indices,
+    fused_stage2_global_indices,
+)
+
+
+def _make_case(
+    rows: int,
+    cols: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    row_ids = torch.arange(rows, device="cuda", dtype=torch.int32)
+    col_ids = torch.arange(cols, device="cuda", dtype=torch.int32).view(1, -1)
+    valid_lengths = torch.clamp((row_ids * 8 + 1) // 4, min=0, max=cols)
+    raw_indices = torch.where(
+        col_ids < valid_lengths.view(-1, 1),
+        col_ids.expand(rows, cols),
+        torch.full((rows, cols), -1, device="cuda", dtype=torch.int32),
+    ).contiguous()
+    ragged_offsets = ((row_ids // 97) * 4096).contiguous()
+    workspace_offsets = ((row_ids // 193) * 32768).contiguous()
+    return raw_indices, ragged_offsets, workspace_offsets
+
+
+def _reference(
+    raw_indices: torch.Tensor,
+    ragged_offsets: torch.Tensor,
+    workspace_offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    request_local = torch.where(
+        raw_indices >= 0,
+        raw_indices + ragged_offsets.view(-1, 1),
+        raw_indices,
+    )
+    attention_global = torch.where(
+        request_local < 0,
+        -1,
+        request_local + workspace_offsets.view(-1, 1),
+    )
+    return request_local, attention_global
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TopKIndexPostprocessTest(unittest.TestCase):
+    def _check_case(self, rows: int, cols: int) -> None:
+        raw, ragged_offsets, workspace_offsets = _make_case(rows, cols)
+        expected_request, expected_global = _reference(
+            raw,
+            ragged_offsets,
+            workspace_offsets,
+        )
+
+        request_output = torch.empty_like(raw)
+        actual_request = fused_stage1_request_indices(
+            raw,
+            ragged_offsets,
+            output=request_output,
+        )
+        self.assertIs(actual_request, request_output)
+
+        global_output = torch.empty_like(raw)
+        actual_global = fused_stage2_global_indices(
+            expected_request,
+            workspace_offsets,
+            output=global_output,
+        )
+        self.assertIs(actual_global, global_output)
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(actual_request, expected_request, rtol=0, atol=0)
+        torch.testing.assert_close(actual_global, expected_global, rtol=0, atol=0)
+
+    def test_small_non_power_of_two(self) -> None:
+        self._check_case(7, 13)
+
+    def test_prime_rows(self) -> None:
+        self._check_case(257, 512)
+
+    def test_glm5_layer6_shape(self) -> None:
+        self._check_case(6954, 2048)
+
+    def test_empty_rows(self) -> None:
+        self._check_case(0, 2048)
+
+    def test_negative_sentinel_contract(self) -> None:
+        raw = torch.tensor(
+            [[0, 3, -1, -2], [5, -1, 7, -9]],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        ragged_offsets = torch.tensor([10, 100], dtype=torch.int32, device="cuda")
+        workspace_offsets = torch.tensor(
+            [1000, 2000], dtype=torch.int32, device="cuda"
+        )
+        expected_request, expected_global = _reference(
+            raw,
+            ragged_offsets,
+            workspace_offsets,
+        )
+        actual_request = fused_stage1_request_indices(raw, ragged_offsets)
+        assert actual_request is not None
+        actual_global = fused_stage2_global_indices(
+            actual_request,
+            workspace_offsets,
+        )
+        assert actual_global is not None
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(actual_request, expected_request, rtol=0, atol=0)
+        torch.testing.assert_close(actual_global, expected_global, rtol=0, atol=0)
+        self.assertEqual(int(actual_request[0, 3].item()), -2)
+        self.assertEqual(int(actual_global[0, 3].item()), -1)
+
+    def test_unsupported_inputs_return_none(self) -> None:
+        raw_cpu = torch.zeros((2, 4), dtype=torch.int32)
+        offsets_cpu = torch.zeros((2,), dtype=torch.int32)
+        self.assertIsNone(fused_stage1_request_indices(raw_cpu, offsets_cpu))
+
+        raw_cuda = torch.zeros((2, 8), dtype=torch.int32, device="cuda")
+        offsets_cuda = torch.zeros((2,), dtype=torch.int32, device="cuda")
+        self.assertIsNone(
+            fused_stage2_global_indices(raw_cuda[:, ::2], offsets_cuda)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/rtp_llm/models_py/triton_kernels/sparse_mla/topk_index_postprocess.py
+++ b/rtp_llm/models_py/triton_kernels/sparse_mla/topk_index_postprocess.py
@@ -1,0 +1,132 @@
+"""Fused Top-K index postprocessing for sparse-MLA prefill."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _topk_stage1_offset_mask_kernel(
+    raw_indices_ptr,
+    ragged_offsets_ptr,
+    request_output_ptr,
+    num_elements,
+    N_COLS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    linear = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = linear < num_elements
+    raw = tl.load(raw_indices_ptr + linear, mask=mask)
+    row = linear // N_COLS
+    ragged_offset = tl.load(ragged_offsets_ptr + row, mask=mask)
+    request_local = tl.where(raw >= 0, raw + ragged_offset, raw)
+    tl.store(request_output_ptr + linear, request_local, mask=mask)
+
+
+@triton.jit
+def _topk_stage2_workspace_mask_kernel(
+    request_indices_ptr,
+    workspace_offsets_ptr,
+    global_output_ptr,
+    num_elements,
+    N_COLS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    linear = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = linear < num_elements
+    request_local = tl.load(request_indices_ptr + linear, mask=mask)
+    row = linear // N_COLS
+    workspace_offset = tl.load(workspace_offsets_ptr + row, mask=mask)
+    attention_global = tl.where(
+        request_local < 0,
+        -1,
+        request_local + workspace_offset,
+    )
+    tl.store(global_output_ptr + linear, attention_global, mask=mask)
+
+
+def _supported(
+    indices: torch.Tensor,
+    row_offsets: torch.Tensor,
+    output: Optional[torch.Tensor],
+) -> bool:
+    if not (
+        indices.is_cuda
+        and row_offsets.is_cuda
+        and indices.dtype == torch.int32
+        and row_offsets.dtype == torch.int32
+        and indices.ndim == 2
+        and row_offsets.ndim == 1
+        and indices.is_contiguous()
+        and row_offsets.is_contiguous()
+        and row_offsets.numel() == indices.shape[0]
+        and row_offsets.device == indices.device
+    ):
+        return False
+    if output is None:
+        return True
+    return (
+        output.is_cuda
+        and output.dtype == torch.int32
+        and output.shape == indices.shape
+        and output.is_contiguous()
+        and output.device == indices.device
+    )
+
+
+def fused_stage1_request_indices(
+    raw_indices: torch.Tensor,
+    ragged_offsets: torch.Tensor,
+    output: Optional[torch.Tensor] = None,
+) -> Optional[torch.Tensor]:
+    """Add each row's ragged offset while preserving negative sentinels."""
+
+    if not _supported(raw_indices, ragged_offsets, output):
+        return None
+    if output is None:
+        output = torch.empty_like(raw_indices)
+    if raw_indices.numel() == 0:
+        return output
+    block_size = 256
+    _topk_stage1_offset_mask_kernel[(triton.cdiv(raw_indices.numel(), block_size),)](
+        raw_indices,
+        ragged_offsets,
+        output,
+        raw_indices.numel(),
+        N_COLS=raw_indices.shape[1],
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return output
+
+
+def fused_stage2_global_indices(
+    request_indices: torch.Tensor,
+    workspace_offsets: torch.Tensor,
+    output: Optional[torch.Tensor] = None,
+) -> Optional[torch.Tensor]:
+    """Add each row's workspace offset and canonicalize invalid values to -1."""
+
+    if not _supported(request_indices, workspace_offsets, output):
+        return None
+    if output is None:
+        output = torch.empty_like(request_indices)
+    if request_indices.numel() == 0:
+        return output
+    block_size = 256
+    _topk_stage2_workspace_mask_kernel[
+        (triton.cdiv(request_indices.numel(), block_size),)
+    ](
+        request_indices,
+        workspace_offsets,
+        output,
+        request_indices.numel(),
+        N_COLS=request_indices.shape[1],
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return output

--- a/rtp_llm/models_py/utils/fuse_config.py
+++ b/rtp_llm/models_py/utils/fuse_config.py
@@ -1,10 +1,14 @@
-"""Single switch for ALL Triton fuse kernels in the model_py path.
+"""Switches for optional fused fast paths in the model_py path.
 
 Master switch lives on ``HWKernelConfig.enable_fuse_kernels`` (default
 ``True``) and is settable via CLI ``--enable_fuse_kernels`` / env var
-``ENABLE_FUSE_KERNELS``. Set to ``False`` to globally bypass to the
-unfused baseline path (useful for debugging or precision verification
-against the pre-fuse implementation).
+``ENABLE_FUSE_KERNELS``. Set to ``False`` to bypass registered optional
+fast paths to their fallbacks. Some pre-existing CUDA/cuBLAS fused
+operations remain enabled and are outside this switch.
+
+``RTP_LLM_GLM5_PREFILL_REFINE`` (default ``False``) is an opt-in switch
+for the GLM5 prefill refinements added together. Keep the master switch
+enabled and set this switch explicitly for a same-binary strict A/B.
 
 Covered fuse paths:
   - Qwen3.5 / Qwen3-Next decoder layer fuses
@@ -17,12 +21,16 @@ Covered fuse paths:
   - ``MlaAttention._fuse_kv_a_norm`` / ``_fuse_q_a_norm_mode``
     (DSA-F1a / F1b)
   - ``Indexer._get_logits_head_gate`` (DSA-F3 logits gate)
+  - GLM5 prefill refine gate:
+    - sparse-MLA prefill TopK index postprocessing
+    - GLM5 FP8 prefill Q-RoPE direct-write into the absorbed-Q output layout
+    - CP restore direct-out
+    - ``GenericMoeLayer`` fused sigmoid + bias + grouped TopK
 
 Not gated (always fused; no off branch):
-  - ``flashmla_sparse_impl._apply_input_bmm`` (DSA-F5B
-    ``strided_slice_copy_``) and ``_apply_output_bmm`` (DSA-F6a output BMM)
-    — cuBLAS bmm is invariant under our layout choice, so the fused
-    cuBLAS-strideC path is always preferred.
+  - The absorbed-Q input BMM and ``_apply_output_bmm`` (DSA-F6a output BMM)
+    use the cuBLAS stride-out layout. When Q-RoPE direct-write is unavailable,
+    the input path retains ``strided_slice_copy_`` as the exact fallback.
 
 Callers either:
   * Pass ``hw_kernel_config`` to ``fuse_kernels_enabled(hw_kernel_config)``
@@ -39,7 +47,7 @@ from typing import Any, Optional
 
 
 def fuse_kernels_enabled(hw_kernel_config: Optional[Any] = None) -> bool:
-    """Return whether Triton fuse kernels should run (vs. unfused baseline).
+    """Return whether registered optional fused fast paths should run.
 
     Resolution order:
       1. If ``hw_kernel_config`` is provided and has the
@@ -54,4 +62,22 @@ def fuse_kernels_enabled(hw_kernel_config: Optional[Any] = None) -> bool:
     val = os.environ.get("ENABLE_FUSE_KERNELS")
     if val is None:
         return True
+    return val.lower() in ("1", "true", "yes", "on")
+
+
+def glm5_prefill_refine_enabled(hw_kernel_config: Optional[Any] = None) -> bool:
+    """Return whether the GLM5 prefill refinement group should run.
+
+    The refinement gate is nested under ``ENABLE_FUSE_KERNELS``. With the
+    master switch enabled, only explicit truthy values for
+    ``RTP_LLM_GLM5_PREFILL_REFINE`` enable the refinements. When unset or
+    false, the pre-refinement production paths run while preserving previously
+    existing fused kernels. The gate is process-wide; for a PD prefill A/B,
+    change it only in the prefill role and keep decode fixed.
+    """
+    if not fuse_kernels_enabled(hw_kernel_config):
+        return False
+    val = os.environ.get("RTP_LLM_GLM5_PREFILL_REFINE")
+    if val is None:
+        return False
     return val.lower() in ("1", "true", "yes", "on")

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -170,6 +170,10 @@ class GroupTopKOp:
 
     def forward(self, topk_values: torch.Tensor, topk_indices: torch.Tensor, scores: torch.Tensor, scores_with_bias: torch.Tensor, n_group: int, topk_group: int, topk: int, renormalize: bool, routed_scaling_factor: float) -> None:
         ...
+
+    def forward_fused(self, topk_values: torch.Tensor, topk_indices: torch.Tensor, logits: torch.Tensor, correction_bias: torch.Tensor, n_group: int, topk_group: int, topk: int, renormalize: bool, routed_scaling_factor: float) -> None:
+        ...
+
 class SelectTopkOp:
     def __init__(self, model_config: libth_transformer_config.ModelConfig) -> None:
         ...

--- a/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/rtp_llm_ops.pyi
@@ -174,6 +174,9 @@ class GroupTopKOp:
     def forward_fused(self, topk_values: torch.Tensor, topk_indices: torch.Tensor, logits: torch.Tensor, correction_bias: torch.Tensor, n_group: int, topk_group: int, topk: int, renormalize: bool, routed_scaling_factor: float) -> None:
         ...
 
+    def forward_auto(self, topk_values: torch.Tensor, topk_indices: torch.Tensor, logits: torch.Tensor, correction_bias: torch.Tensor, n_group: int, topk_group: int, topk: int, renormalize: bool, routed_scaling_factor: float, enable_fused: bool) -> None:
+        ...
+
 class SelectTopkOp:
     def __init__(self, model_config: libth_transformer_config.ModelConfig) -> None:
         ...


### PR DESCRIPTION
## 背景

  GLM5 FP8 prefill 路径中存在多处中间 tensor、额外 kernel launch
  以及 device-to-device copy。对于长上下文和 Context Parallel 场景，
  这些开销会放大 prefill latency。
## 优化内容

  ### 1. Sparse MLA TopK 索引后处理融合

  将 sparse MLA TopK 索引的两阶段后处理分别融合：

  - request-local offset 加法和负 sentinel 保留；
  - workspace offset、非法索引归一化和最终索引生成。

  减少中间 tensor、kernel launch 和额外 device-to-device copy。

  ### 2. FP8 Q-RoPE direct-write

  在满足 GLM5 FP8 contract 的 prefill 路径中，RoPE kernel 直接将旋转后的
  Q 写入 Q-absorb 所需的目标 layout，跳过后续的
  `strided_slice_copy_`。

  不满足 contract 时继续使用原有 Q 写回和 copy 路径。

  ### 3. CP KV restore direct-out

  在 Context Parallel 的 KV restore 路径中，满足 layout、dtype、device
  和 contiguous 条件时，使用 `index_select(..., out=...)` 直接写入最终
  workspace，消除临时 gather tensor 和后续 D2D copy。

  ### 4. MegaMoE Router fused GroupTopK

  为 GLM5 MegaMoE router 增加 strict fused GroupTopK CUDA kernel，在一次
  kernel launch 中完成：

  - BF16 logits sigmoid；
  - correction bias；
  - grouped TopK；
  - expert TopK；
  - renormalize 和 routed scaling。

  legacy `load_python_model=0` 路径现在通过 `GenericMoeLayer` 接入
  `GroupTopK.forwardAuto`，支持 fused/legacy 自动 dispatch。

  ## 开关和兼容性

  本次四项优化统一由以下开关控制：

  ```text
  ENABLE_FUSE_KERNELS=1
  RTP_LLM_GLM5_PREFILL_REFINE=1

  其中：

  - ENABLE_FUSE_KERNELS 是已有的总开关；
  - RTP_LLM_GLM5_PREFILL_REFINE 用于严格 A/B 控制本次新增的四条
    GLM5 prefill 优化；

  - refine 开关关闭时，四条路径均回退到优化前实现；
  - 输入 dtype、shape、stride、device 或 routing 参数不满足 fused
    contract 时，自动回退到 legacy 实现；

  - decode 路径不使用本次 prefill-only 优化。

  ## 正确性验证

  - 增加 sparse MLA TopK 后处理测试；
  - 增加 Q-RoPE direct-write 与 legacy 路径一致性测试；
  - 增加 CP restore direct-out 与 gather/copy 路径一致性测试；
  - 增加 fused GroupTopK 与 legacy GroupTopK 的严格一致性测试；
  - 覆盖负 sentinel、非连续输入、FP32 fallback、CUDA Graph 和不同
    token 数等场景；

  - 完成 GLM5 prefill refine on/off smoke 和 CUDA trace 对比；
  - refine on 路径验证 fused kernel 选择，refine off 路径验证 legacy
    fallback。

  ## 影响范围

  本 PR 主要影响 GLM5 FP8 prefill，尤其是 Sparse MLA、CP 和 MegaMoE
  场景。其他模型、decode 路径以及不满足 fused contract 的输入继续使用
  原有实现。
