### PR TITLE
feat(beam_search): halve V2 top-k candidates and route small grids to one-block radix on ROCm

### DIFF
--- a/3rdparty/trt_beam_search/beamSearch.cu
+++ b/3rdparty/trt_beam_search/beamSearch.cu
@@ -201,10 +201,10 @@ BeamSearchConfig configureBeamSearch(runtime::SizeType32 batchSize,
         size_t const nByteStage1Ids = roundUp(sizeof(int) * batchSize * beamWidthIn * beamWidthOut * 2, 4);
         size_t const nByteStage2LogProbs = roundUp(sizeof(T) * batchSize * beamWidthOut * 2, 4);
         size_t const nByteStage2Ids = roundUp(sizeof(int) * batchSize * beamWidthOut * 2, 4);
-        size_t const nByteStage1TopK
-            = invokeComputeTopkLastDimWorkspaceSize<T>(batchSize * beamWidthIn, vocabSize, beamWidthOut * 2, true);
+        size_t const nByteStage1TopK = invokeComputeTopkLastDimWorkspaceSize<T>(
+            batchSize * beamWidthIn, vocabSize, beamWidthOut, true, beamTopkForcePath());
         size_t const nByteStage2TopK = invokeComputeTopkLastDimWorkspaceSize<T>(
-            batchSize, beamWidthIn * beamWidthOut * 2, beamWidthOut * 2, true);
+            batchSize, beamWidthIn * beamWidthOut, beamWidthOut, true, beamTopkForcePath());
         size_t const nByteStage3 = sizeof(T) * beamWidthIn * beamWidthOut * 2;
         config.mWorkspaceSize = nByteStage2LogProbs + nByteStage2Ids
             + std::max(nByteStage1LogProbs + nByteStage1Ids + std::max(nByteStage1TopK, nByteStage2TopK), nByteStage3);

--- a/3rdparty/trt_beam_search/beamSearch.cu
+++ b/3rdparty/trt_beam_search/beamSearch.cu
@@ -197,6 +197,10 @@ BeamSearchConfig configureBeamSearch(runtime::SizeType32 batchSize,
         // |<- Stage2Ids ->|<- Stage2LogProbs ->|<- Stage1Ids ->|<- Stage1LogProbs ->|<---- Stage1TopK ---->|
         //                                                                           |<- stage2TopK ->|
         //                                      |<------------------ Stage3 ------------------>|
+        // Stage buffers keep the 2x candidate sizing after the 2k->1k change: the layout
+        // stays compatible with the CBA restore path (which needs 2*nBMOut again), and the
+        // footprint is unchanged from before the candidate change. Halving it is a
+        // separate optimization.
         size_t const nByteStage1LogProbs = roundUp(sizeof(T) * batchSize * beamWidthIn * beamWidthOut * 2, 4);
         size_t const nByteStage1Ids = roundUp(sizeof(int) * batchSize * beamWidthIn * beamWidthOut * 2, 4);
         size_t const nByteStage2LogProbs = roundUp(sizeof(T) * batchSize * beamWidthOut * 2, 4);

--- a/3rdparty/trt_beam_search/beamSearchKernels.cu
+++ b/3rdparty/trt_beam_search/beamSearchKernels.cu
@@ -161,6 +161,9 @@ __global__ void addCumLogProbsKernel(
         int const iBMIn = i / nBMOut;
         if (finished && finished[slot * nBMIn + iBMIn].isFinished())
         {
+            // TODO(known-broken): i is a candidate-slot index, endIds[slot] is a vocab
+            // token id — this compares across index spaces (pre-existing). Unreachable
+            // in production while `finished` stays unwired.
             pLocalLogProbs[i] += endIds && (i == endIds[slot]) ? T(1.0f) : T(0.0f);
         }
         else
@@ -197,57 +200,18 @@ __global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage
     size_t const nBMIn, size_t const nBMOut, size_t const nV)
 {
     // Use topK output `pStage1Id` and `pStage2Id` to get the index of a new token in `logProbs` for each beam.
-    // Note: the worked examples below still show the old 2x-oversampled layout (divisors (nBM * 2) and
-    // (nBMOut * 2)); the code now keeps nBMOut candidates per beam (the 2x oversampling only served the
-    // CBA/end-token path, which is not wired here), so divisors below read as nBMOut.
-    // The div/mod structure illustrated is unchanged.
+    // Layouts: pStage1Id is [nBS, nBMIn, nBMOut] flat (per-beam candidates, index-ordered);
+    // pStage2Id is [nBS, nBMOut] flat, holding the flat stage-1 indices that survived the
+    // merged top-k.
     //
-    // clang-format off
-    //
-    // Example for normal beam search:
-    // nBS = 3, nBM = 2, nV = 5, use logProbs with integer values here for simplicity.
-    // ┏┏ 46 35 47 18 67 ┓┓      ┏┏ 67 47 46 35 ┓┓ ┏┏ 4 2 0 1 ┓┓
-    // ┃┗ 76 23 74 73 17 ┛┃      ┃┗ 76 74 73 23 ┛┃ ┃┗ 0 2 3 1 ┛┃
-    // ┃┏ 67 49 98 88 74 ┓┃  A   ┃┏ 98 88 74 67 ┓┃ ┃┏ 2 3 4 0 ┓┃  C   ┏ 76 74 73 67 ┓ ┏ 4 5 6 0 ┓  D   ┏ 5 7 8 4 ┓
-    // ┃┗ 12 70 77 22 88 ┛┃ ---> ┃┗ 88 77 70 22 ┛┃ ┃┗ 4 2 1 3 ┛┃ ---> ┃ 98 88 88 77 ┃ ┃ 0 1 4 5 ┃ ---> ┃ 2 3 9 7 ┃
-    // ┃┏ 55 15 72  3 84 ┓┃      ┃┏ 74 72 55 15 ┓┃ ┃┏ 4 2 0 1 ┓┃      ┗ 98 93 84 77 ┛ ┗ 4 5 0 6 ┛      ┗ 9 6 4 5 ┛
-    // ┗┗ 77 93 14 60 98 ┛┛      ┗┗ 98 93 77 60 ┛┛ ┗┗ 4 1 0 3 ┛┛
-    //       logProbs              stage1LogProbs     stage1Id         stage2LogProbs   stage2Id     output-stage2Id
-    //
-    // For `stage2LogProbs[2][3] == 77`,
-    //     original batch index in logProbs:    blockIdx.x                  -> 2    (a)
-    //     original beam index in logProbs:     stage2Id[2][3] / (nBM * 2)  -> 1    (b)
-    //     row index in stage1Probs:            a * nBM + b                 -> 5    (c)
-    //     column index in stage1*:             stage2Id[2][3] % (nBM * 2)  -> 2    (d)
-    //     column index in logProbs:            stage1Id[c][d]              -> 0    (e)
-    //     pad for previous tokens:             b * nV                      -> 5    (f)
-    //     final output:                        e + f                       -> 5
-    //
-    // ========================================================================================================
-    // Example for VBWS:
-    // nBS = 2, nBMIn = 3, nBMOut = 5, nBM = 7, nV = 11, use logProbs with integer values here for simplicity.
-    // ┏┏ 46 35 47 18 67 76 23 74 73 17 67 ┓┓      ┏┏ 76 74 73 67 67 47 46 35 23 18 ┓┓ ┏┏  5  7  8  4 10  2  0  1  6  3 ┓┓
-    // ┃┃ 49 98 88 74 12 70 77 22 88 55 15 ┃┃      ┃┃ 98 88 88 77 74 70 55 49 22 15 ┃┃ ┃┃  1  2  8  6  3  5  9  0  7 10 ┃┃
-    // ┃┗ 72  3 84 77 93 14 60 98 65  4 20 ┛┃  A   ┃┗ 98 93 84 77 72 65 60 20 14  4 ┛┃ ┃┗  7  4  2  3  0  8  6 10  5  9 ┛┃  C
-    // ┃┏ 16 34 71 38 19 91  5 81 97 43 79 ┓┃ ---> ┃┏ 97 91 81 79 71 43 38 34 19 16 ┓┃ ┃┏  8  5  7 10  2  9  3  1  4  0 ┓┃ --->
-    // ┃┃  2 22 77 37 57 33 57 41 27 73 88 ┃┃      ┃┃ 88 77 73 57 57 41 37 33 27 22 ┃┃ ┃┃ 10  2  9  4  6  7  3  5  8  1 ┃┃
-    // ┗┗ 77 16 23 22 82 89  6 77 67 15 31 ┛┛      ┗┗ 89 82 77 77 67 31 23 22 16 15 ┛┛ ┗┗  5  4  0  7  8 10  2  3  1  9 ┛┛
-    //                logProbs                                stage1LogProbs                         stage1Id
-    //
-    //  C    ┏ 98 98 93 88 88 84 77 77 76 74 ┓ ┏ 10 20 21 11 12 22 13 23  0  1 ┓  D   ┏ 12 29 26 13 19 24 17 25  5  7 ┓
-    // --->  ┗ 97 91 89 88 82 81 79 77 77 77 ┛ ┗  0  1 20 10 21  2  3 11 22 23 ┛ ---> ┗  8  5 27 21 26  7 10 13 22 29 ┛
-    //                 stage2LogProbs                        stage2Id                          output-stage2Id
-    //
-    // For `stage2LogProbs[1][4] == 82`,
-    //     original batch index in logProbs:    blockIdx.x                      ->  1   (a)
-    //     original beam index in logProbs:     stage2Id[1][4] / (nBMOut * 2)   ->  2   (b)
-    //     row index in stage1LogProbs:         a * nBMIn + b                   ->  5   (c)
-    //     column index in stage1*:             stage2Id[1][4] % (nBMOut * 2)   ->  1   (d)
-    //     column index in logProbs:            stage1Id[c][d]                  ->  4   (e)
-    //     pad for previous tokens:             b * nV                          -> 22   (f)
-    //     final output:                        e + f                           -> 26   output-stage2Id[1][4]
-    //
-    // clang-format on
+    // For output slot j of batch a = blockIdx.x:
+    //   stage2Id = pStage2Id[a * nBMOut + j]        flat candidate index into stage-1
+    //   b = stage2Id / nBMOut                       beam the candidate came from
+    //   d = stage2Id % nBMOut                       slot inside that beam's candidates
+    //   c = a * nBMIn + b                           row in pStage1Id
+    //   e = pStage1Id[c * nBMOut + d]               token id within the vocab
+    //   f = b * nV                                  padding for previous tokens
+    //   output: pStage2Id[a * nBMOut + j] = e + f   final index in logProbs
     int const a = blockIdx.x; // Index of request in batch
     for (int j = threadIdx.x; j < nBMOut; j += blockDim.x)
     {

--- a/3rdparty/trt_beam_search/beamSearchKernels.cu
+++ b/3rdparty/trt_beam_search/beamSearchKernels.cu
@@ -154,11 +154,11 @@ __global__ void addCumLogProbsKernel(
     int const bid = blockIdx.x; // Index of request in batch
     runtime::SizeType32 const slot = batchSlots ? batchSlots[bid] : bid;
     float const diversityRate{diversityRates == nullptr ? kBeamSearchDiversity : diversityRates[slot]};
-    T* pLocalLogProbs = pStage1LogProbs + bid * nBMIn * nBMOut * 2;
+    T* pLocalLogProbs = pStage1LogProbs + bid * nBMIn * nBMOut;
 
-    for (int i = threadIdx.x; i < nBMIn * nBMOut * 2; i += blockDim.x)
+    for (int i = threadIdx.x; i < nBMIn * nBMOut; i += blockDim.x)
     {
-        int const iBMIn = i / (nBMOut * 2);
+        int const iBMIn = i / nBMOut;
         if (finished && finished[slot * nBMIn + iBMIn].isFinished())
         {
             pLocalLogProbs[i] += endIds && (i == endIds[slot]) ? T(1.0f) : T(0.0f);
@@ -196,7 +196,11 @@ template void launchAddCumLogProbs<half>(
 __global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage2Id, size_t const nBS,
     size_t const nBMIn, size_t const nBMOut, size_t const nV)
 {
-    // Use topK output `pStage1Id` and `pStage1Id` to get the index of a new token in `logProbs` for each beam.
+    // Use topK output `pStage1Id` and `pStage2Id` to get the index of a new token in `logProbs` for each beam.
+    // Note: the worked examples below still show the old 2x-oversampled layout (divisors (nBM * 2) and
+    // (nBMOut * 2)); the code now keeps nBMOut candidates per beam (the 2x oversampling only served the
+    // CBA/end-token path, which is not wired here), so divisors below read as nBMOut.
+    // The div/mod structure illustrated is unchanged.
     //
     // clang-format off
     //
@@ -245,14 +249,14 @@ __global__ void gatherId(int const* __restrict pStage1Id, int* __restrict pStage
     //
     // clang-format on
     int const a = blockIdx.x; // Index of request in batch
-    for (int j = threadIdx.x; j < nBMOut * 2; j += blockDim.x)
+    for (int j = threadIdx.x; j < nBMOut; j += blockDim.x)
     {
-        int const index = a * (nBMOut * 2) + j;
+        int const index = a * nBMOut + j;
         int const stage2Id = pStage2Id[index];
-        int const b = stage2Id / (nBMOut * 2);
+        int const b = stage2Id / nBMOut;
         int const c = a * nBMIn + b;
-        int const d = stage2Id % (nBMOut * 2);
-        int const e = pStage1Id[c * (nBMOut * 2) + d];
+        int const d = stage2Id % nBMOut;
+        int const e = pStage1Id[c * nBMOut + d];
         int const f = b * nV;
         pStage2Id[index] = e + f;
     }

--- a/3rdparty/trt_beam_search/beamSearchKernels.h
+++ b/3rdparty/trt_beam_search/beamSearchKernels.h
@@ -21,6 +21,7 @@
 #include <curand_kernel.h>
 #endif
 #include "rtp_llm/cpp/utils/StringUtil.h"
+#include "rtp_llm/cpp/utils/Logger.h"
 #include "common.h"
 #include "decodingCommon.h"
 #include "topkLastDim.h" // Air TopK
@@ -33,14 +34,27 @@ namespace tensorrt_llm
 {
 namespace kernels
 {
-// Runtime rollback switch for the V2 top-k radix routing: 0/unset = auto route,
-// 1 = force multi-block, 2 = force one-block (see topkLastDim.h). Cached so the
-// workspace-size query and the run always agree on the path.
+// Runtime rollback switch for the V2 top-k radix routing (see topkLastDim.h for the
+// path legend): 0/unset = auto route, 1 = force multi-block, 2 = force one-block.
+// Anything else is rejected with a warning and falls back to 0, since a stray value
+// would silently select the multi-block route. Cached so the workspace-size query
+// and the run always agree on the path.
 inline int beamTopkForcePath()
 {
     static int const force_path = [] {
         char const* env = std::getenv("RTP_LLM_BEAM_TOPK_FORCE_PATH");
-        return env ? std::atoi(env) : 0;
+        if (env == nullptr)
+        {
+            return 0;
+        }
+        char* end = nullptr;
+        long const v = std::strtol(env, &end, 10);
+        if (end != env && *end == '\0' && v >= 0 && v <= 2)
+        {
+            return static_cast<int>(v);
+        }
+        RTP_LLM_LOG_WARNING("invalid RTP_LLM_BEAM_TOPK_FORCE_PATH='%s' (want 0/1/2), falling back to 0", env);
+        return 0;
     }();
     return force_path;
 }

--- a/3rdparty/trt_beam_search/beamSearchKernels.h
+++ b/3rdparty/trt_beam_search/beamSearchKernels.h
@@ -25,12 +25,25 @@
 #include "decodingCommon.h"
 #include "topkLastDim.h" // Air TopK
 
+#include <cstdlib>
+
 #define BEAM_SEARCH_DEBUG 0
 
 namespace tensorrt_llm
 {
 namespace kernels
 {
+// Runtime rollback switch for the V2 top-k radix routing: 0/unset = auto route,
+// 1 = force multi-block, 2 = force one-block (see topkLastDim.h). Cached so the
+// workspace-size query and the run always agree on the path.
+inline int beamTopkForcePath()
+{
+    static int const force_path = [] {
+        char const* env = std::getenv("RTP_LLM_BEAM_TOPK_FORCE_PATH");
+        return env ? std::atoi(env) : 0;
+    }();
+    return force_path;
+}
 static size_t constexpr kMaxBeamWidth = 1024;           // Max beam width supported in TRT-LLM now
 static size_t constexpr kMaxBeamWidthForV1 = 8;         // Max beam width for V1 workflow (V2 for larger)
 static size_t constexpr kMaxBeamWidthArrayLength = 8;   // Max length of beam width array of a request

--- a/3rdparty/trt_beam_search/beamSearchKernelsTemplate.h
+++ b/3rdparty/trt_beam_search/beamSearchKernelsTemplate.h
@@ -229,6 +229,11 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     float const diversityRate{bh.diversityRates == nullptr ? kBeamSearchDiversity : bh.diversityRates[slot]};
     float const lengthPenalty{bh.lengthPenalties == nullptr ? kLengthPenalty : bh.lengthPenalties[slot]};
     int const earlyStopping{bh.earlyStoppings == nullptr ? kEarlyStopping : bh.earlyStoppings[slot]};
+    // Candidates consumed per step: nBMOut while the CBA path stays unwired (each selection
+    // iteration fills one next-step slot and the loop breaks at nBeamForNextStep == nBMOut,
+    // so iterations beyond nBMOut would be dead); 2*nBMOut if CBA is ever wired. Wiring CBA
+    // additionally needs V2's stage C to emit 2*nBMOut candidates again.
+    int const nSelectLimit = (bh.numBeamsCBA == nullptr) ? nBMOut : 2 * nBMOut;
 
     using KVPair = cub::KeyValuePair<int, T>;
     __shared__ BeamStage3KernelSmem<KVPair, PBM, IS_V2> smem;
@@ -258,8 +263,8 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     // This TopK is needless in V2 workflow
     if constexpr (IS_V2)
     {
-        pStage2Ids += bid * nBMOut * 2;
-        pStage2LogProbs += bid * nBMOut * 2;
+        pStage2Ids += bid * nBMOut;
+        pStage2LogProbs += bid * nBMOut;
     }
     else
     {
@@ -292,7 +297,8 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         __shared__ typename BlockReduce::TempStorage smemReduceBuffer;
         __shared__ int threadToUpdate;
 
-        for (int i = 0; i < 2 * nBMOut; ++i)
+        // Only the first nSelectLimit entries are consumed by the selection loop below.
+        for (int i = 0; i < nSelectLimit; ++i)
         {
             KVPair kv = BlockReduce(smemReduceBuffer).Reduce(kvLocal, argmax);
             if (tid == 0)
@@ -304,7 +310,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
             __syncthreads();
             // Only one thread needs to update the old partial before the next block reduce.
             // No need to do this in the last iteration.
-            if (tid == threadToUpdate && i < 2 * nBMOut - 1)
+            if (tid == threadToUpdate && i < nSelectLimit - 1)
             {
                 kvLocal.key = nCandidate - 1;
                 kvLocal.value = -MAX_T_VAL;
@@ -335,7 +341,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
         // Select finished beams into CBA or select tokens for next step sequentially
         // Reference (might be changed along HF in the future):
         // https://github.com/huggingface/transformers/blob/main/src/transformers/generation/beam_search.py#L272
-        for (int i = 0; i < 2 * nBMOut; ++i)
+        for (int i = 0; i < nSelectLimit; ++i)
         {
             int topId;
             T topLogProb;
@@ -608,7 +614,7 @@ void beamSearchKernelLauncher(
 
     V2 Workflow (use Air-TopK for better performance, https://dl.acm.org/doi/pdf/10.1145/3581784.3607062)
     logProbs.shape = [nBS, nBM, nV]
-        |<- nV ->|          |<- nBM*2 ->|  |<- nBM*2 ->|          |<- nBM*2 ->|          |<- nBM*2 ->|          |<- nBM*2 ->|
+        |<- nV ->|          |<- nBM ->|    |<- nBM ->|            |<- nBM ->|            |<- nBM ->|            |<- nBM ->|
         ┏━━━━━━━━┓          ┏━━━━━━━━━━━┓  ┏━━━━━━━━━━━┓          ┏━━━━━━━━━━━┓          ┏━━━━━━━━━━━┓  D       ┏━━━━━━━━━━━┓
         ┃nBM     ┃          ┃nBM        ┃  ┃nBM        ┃          ┃nBM        ┃      nBS ┃           ┃ ---> nBS ┃           ┃ ---\
         ┣━━━━━━━━┫  A       ┣━━━━━━━━━━━┫  ┣━━━━━━━━━━━┫  B       ┣━━━━━━━━━━━┫  C       ┗━━━━━━━━━━━┛          ┗━━━━━━━━━━━┛    | E
@@ -618,10 +624,10 @@ void beamSearchKernelLauncher(
         ┗━━━━━━━━┛          ┗━━━━━━━━━━━┛  ┗━━━━━━━━━━━┛          ┗━━━━━━━━━━━┛          ┗━━━━━━━━━━━┛
          logProbs             pStage1Id   pStage1LogProbs        pStage1LogProbs        pStage2LogProbs
 
-    A: TopK            : Get top `nBM*2` elements in `nBS*nBM` groups (`nV` elements per group)
+    A: TopK            : Get top `nBM` elements in `nBS*nBM` groups (`nV` elements per group)
     B: addCumLogProbs  : Add `cumLogProbs` to the elements in each beam
-    C: TopK            : Get top `nBM*2` elements in `nBS` group (`nBM*nBM*2` elements per group)
-    D: gatherIds       : Combine stage1Id and stage2Id to get ids of the top `nBM*2` elements in input logProbs
+    C: TopK            : Get top `nBM` elements in `nBS` group (`nBM*nBM` elements per group)
+    D: gatherIds       : Combine stage1Id and stage2Id to get ids of the top `nBM` elements in input logProbs
     E: beamStage3Kernel: Main logic of Beam-Search, each Block is responsible for one batch, doing work below:
                              + moves one beam into candidate-beam-array if it is finished (gemerated end_id in this step).
                              + selects BM elements for the next generation step if not.
@@ -631,7 +637,7 @@ void beamSearchKernelLauncher(
 
     V2 Workflow for VBWS, similar to V2 workflow above, but `nBMIn` and `nBMOut` might be different from `nBM`
     logProbs.shape = [nBS, nBMIn, nV]
-        |<- nV ->|          |<- nBMOut*2 ->|  |<- nBMOut*2 ->|          |<- nBMOut*2 ->|          |<- nBMOut*2 ->|          |<- nBMOut*2 ->|
+        |<- nV ->|          |<- nBMOut ->|    |<- nBMOut ->|            |<- nBMOut ->|            |<- nBMOut ->|            |<- nBMOut ->|
         ┏━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓  ┏━━━━━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓          ┏━━━━━━━━━━━━━━┓  D       ┏━━━━━━━━━━━━━━┓
         ┃nBMIn   ┃          ┃nBMIn         ┃  ┃nBMIn         ┃          ┃nBMIn         ┃      nBS ┃              ┃ ---> nBS ┃              ┃ ---\
         ┣━━━━━━━━┫  A       ┣━━━━━━━━━━━━━━┫  ┣━━━━━━━━━━━━━━┫  B       ┣━━━━━━━━━━━━━━┫  C       ┗━━━━━━━━━━━━━━┛          ┗━━━━━━━━━━━━━━┛    | E
@@ -687,20 +693,22 @@ void beamSearchKernelLauncher(
         void* pTopK = reinterpret_cast<void*>(reinterpret_cast<char*>(workspace) + offset);
 
         // Stage 1
-        invokeTopkLastDim<T>(nBS * nBMIn, nV, nBMOut * 2, true, mask_val, logProbs, pStage1LogProbs, pStage1Ids, 
-            pTopK, stream);
+        // sorted=false: stage-2 re-selects from these values, so the by-value order of stage-1
+        // output is never consumed; skipping it saves one StableSortPairsDescending per call.
+        invokeTopkLastDim<T>(nBS * nBMIn, nV, nBMOut, true, mask_val, logProbs, pStage1LogProbs, pStage1Ids,
+            pTopK, stream, /*sorted=*/false, beamTopkForcePath());
         check_cuda_error();
 
-        int nThread = std::min(std::max(roundUp(nBMIn * nBMOut * 2, 32), MIN_BLOCK_SIZE), MAX_BLOCK_SIZE);
+        int nThread = std::min(std::max(roundUp(nBMIn * nBMOut, 32), MIN_BLOCK_SIZE), MAX_BLOCK_SIZE);
         launchAddCumLogProbs<T>(pStage1LogProbs, bh.cumLogProbsIn, bh.finished, bh.endIds,
             bh.diversityRates, bh.batchSlots, nBS, nBMIn, nBMOut, nThread, stream);
 
         // Stage 2
-        invokeTopkLastDim<T>(nBS, nBMIn * nBMOut * 2, nBMOut * 2, true, mask_val, pStage1LogProbs, pStage2LogProbs, 
-            pStage2Ids, pTopK, stream);
+        invokeTopkLastDim<T>(nBS, nBMIn * nBMOut, nBMOut, true, mask_val, pStage1LogProbs, pStage2LogProbs,
+            pStage2Ids, pTopK, stream, /*sorted=*/true, beamTopkForcePath());
         check_cuda_error();
 
-        nThread = std::min(std::max(roundUp(nBMOut * 2, 32), MIN_BLOCK_SIZE), MAX_BLOCK_SIZE);
+        nThread = std::min(std::max(roundUp(nBMOut, 32), MIN_BLOCK_SIZE), MAX_BLOCK_SIZE);
         gatherId<<<nBS, nThread, 0, stream>>>(pStage1Ids, pStage2Ids, nBS, nBMIn, nBMOut, nV);
         check_cuda_error();
     }

--- a/3rdparty/trt_beam_search/beamSearchKernelsTemplate.h
+++ b/3rdparty/trt_beam_search/beamSearchKernelsTemplate.h
@@ -29,6 +29,7 @@
 #endif
 
 #include "beamSearchKernels.h"
+#include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/models_py/bindings/cuda/reduce_kernel_utils.cuh"
 #include "decodingCommon.h"
 
@@ -229,11 +230,10 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
     float const diversityRate{bh.diversityRates == nullptr ? kBeamSearchDiversity : bh.diversityRates[slot]};
     float const lengthPenalty{bh.lengthPenalties == nullptr ? kLengthPenalty : bh.lengthPenalties[slot]};
     int const earlyStopping{bh.earlyStoppings == nullptr ? kEarlyStopping : bh.earlyStoppings[slot]};
-    // Candidates consumed per step: nBMOut while the CBA path stays unwired (each selection
-    // iteration fills one next-step slot and the loop breaks at nBeamForNextStep == nBMOut,
-    // so iterations beyond nBMOut would be dead); 2*nBMOut if CBA is ever wired. Wiring CBA
-    // additionally needs V2's stage C to emit 2*nBMOut candidates again.
-    int const nSelectLimit = (bh.numBeamsCBA == nullptr) ? nBMOut : 2 * nBMOut;
+    // Candidates consumed per step. V1 keeps the upstream 2*nBMOut bound for the (never
+    // wired) CBA path; V2 is hard-rejected with CBA in the launcher, so nBMOut is the
+    // only reachable value there.
+    int const nSelectLimit = (!IS_V2 && bh.numBeamsCBA != nullptr) ? 2 * nBMOut : nBMOut;
 
     using KVPair = cub::KeyValuePair<int, T>;
     __shared__ BeamStage3KernelSmem<KVPair, PBM, IS_V2> smem;
@@ -674,6 +674,11 @@ void beamSearchKernelLauncher(
 
     if constexpr (IS_V2)
     {
+        // CBA (candidate-beam-array) is unsupported in V2: stage C emits only nBMOut
+        // candidates. Wiring it must restore 2*nBMOut emission first.
+        RTP_LLM_CHECK_WITH_INFO(
+            bh.numBeamsCBA == nullptr, "beam search V2 does not support the CBA path (numBeamsCBA != nullptr)");
+
         // currently all the mask value of logits in beam search is -inf, pass to the kernel with the mask value fixed for now
         // note the function is just a kernel launcher running on host, it's perfectly fine to have a static varible here
         const static T mask_val = T(-std::numeric_limits<float>::infinity());

--- a/3rdparty/trt_beam_search/tests/BUILD
+++ b/3rdparty/trt_beam_search/tests/BUILD
@@ -1,0 +1,50 @@
+load("//:def.bzl", "any_cuda_copts", "cc_test_wrapper")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_binary(
+    name = "topk_bench",
+    srcs = ["topk_bench.cu"],
+    copts = any_cuda_copts(),
+    deps = [
+        "//3rdparty/trt_beam_search:trt_beam_search_impl",
+    ] + select({
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [
+            "@local_config_cuda//cuda:cuda",
+            "@local_config_cuda//cuda:cudart",
+        ],
+    }),
+)
+
+cc_test = cc_test_wrapper
+
+# Runs the bench's host-reference semantic checks (--check mode) as a proper test
+# target so GPU CI exercises the topk path partition (WarpSort gate / radix) and
+# the sorted/unsorted output contracts.
+cc_test(
+    name = "topk_semantic_test",
+    srcs = ["topk_bench.cu"],
+    args = ["--check"],
+    copts = any_cuda_copts(),
+    deps = [
+        "//3rdparty/trt_beam_search:trt_beam_search_impl",
+    ] + select({
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [
+            "@local_config_cuda//cuda:cuda",
+            "@local_config_cuda//cuda:cudart",
+        ],
+    }),
+    exec_properties = select({
+        "@//:using_cuda": {"gpu": "H20"},
+        "@//:using_rocm": {"gpu": "MI308X-ROCM7"},
+        "//conditions:default": {},
+    }),
+)

--- a/3rdparty/trt_beam_search/tests/BUILD
+++ b/3rdparty/trt_beam_search/tests/BUILD
@@ -6,6 +6,7 @@ cc_binary(
     name = "topk_bench",
     srcs = ["topk_bench.cu"],
     copts = any_cuda_copts(),
+    tags = ["manual"],
     deps = [
         "//3rdparty/trt_beam_search:trt_beam_search_impl",
     ] + select({
@@ -23,12 +24,38 @@ cc_binary(
 cc_test = cc_test_wrapper
 
 # Runs the bench's host-reference semantic checks (--check mode) as a proper test
-# target so GPU CI exercises the topk path partition (WarpSort gate / radix) and
-# the sorted/unsorted output contracts.
+# target so GPU CI exercises the topk path partition (WarpSort gate / radix), the
+# sorted/unsorted output contracts, and multi-vs-one-block bitwise consistency.
 cc_test(
     name = "topk_semantic_test",
     srcs = ["topk_bench.cu"],
     args = ["--check"],
+    copts = any_cuda_copts(),
+    deps = [
+        "//3rdparty/trt_beam_search:trt_beam_search_impl",
+    ] + select({
+        "@//:using_rocm": [
+            "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:hip",
+        ],
+        "//conditions:default": [
+            "@local_config_cuda//cuda:cuda",
+            "@local_config_cuda//cuda:cudart",
+        ],
+    }),
+    exec_properties = select({
+        "@//:using_cuda": {"gpu": "H20"},
+        "@//:using_rocm": {"gpu": "MI308X-ROCM7"},
+        "//conditions:default": {},
+    }),
+)
+
+# Focused regression for the V2 id-mapping math (addCumLogProbs strides, gatherId
+# divisors): runs the stage pipeline on a small deterministic input and compares
+# the final token ids / beam lineage against a host reference element-wise.
+cc_test(
+    name = "beam_mapping_test",
+    srcs = ["beam_mapping_test.cu"],
     copts = any_cuda_copts(),
     deps = [
         "//3rdparty/trt_beam_search:trt_beam_search_impl",

--- a/3rdparty/trt_beam_search/tests/beam_mapping_test.cu
+++ b/3rdparty/trt_beam_search/tests/beam_mapping_test.cu
@@ -1,0 +1,229 @@
+// Focused regression test for the V2 beam-search id-mapping math: the strides in
+// addCumLogProbs and the divisors in gatherId decide output token ids and beam
+// lineage, so a wrong stride must fail this test.
+//
+// Runs the V2 stage pipeline on small deterministic inputs:
+//   A: invokeTopkLastDim per beam (nBS*nBMIn groups of nV)
+//   B: launchAddCumLogProbs
+//   C: invokeTopkLastDim merged per batch (nBS groups of nBMIn*nBMOut)
+//   D: gatherId
+// and compares stage-C output ids/values and the gathered final ids against a
+// host reference element-wise.
+//
+// Two cases: symmetric (nBMIn == nBMOut == 4) and VBWS-asymmetric (nBMIn=3,
+// nBMOut=5) — the strides mix nBMIn and nBMOut, so the asymmetric case is where
+// a swapped divisor shows up. All candidate values are distinct (integer-exact
+// in fp32), so ordering is unambiguous on every top-k path.
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include "3rdparty/trt_beam_search/common.h"
+#include "3rdparty/trt_beam_search/topkLastDim.h"
+#include "3rdparty/trt_beam_search/beamSearchKernels.h"
+
+namespace
+{
+
+using tensorrt_llm::kernels::invokeComputeTopkLastDimWorkspaceSize;
+using tensorrt_llm::kernels::invokeTopkLastDim;
+using tensorrt_llm::kernels::launchAddCumLogProbs;
+using tensorrt_llm::kernels::gatherId;
+
+char const* errString(cudaError_t err)
+{
+#if USING_ROCM
+    return hipGetErrorString(err);
+#else
+    return cudaGetErrorString(err);
+#endif
+}
+
+cudaError_t lastError()
+{
+#if USING_ROCM
+    return hipGetLastError();
+#else
+    return cudaGetLastError();
+#endif
+}
+
+#define CHECK_CUDA(call)                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        cudaError_t const err_ = (call);                                                                               \
+        if (err_ != cudaSuccess)                                                                                       \
+        {                                                                                                              \
+            std::fprintf(stderr, "CUDA error %s at %s:%d\n", errString(err_), __FILE__, __LINE__);                     \
+            std::exit(1);                                                                                              \
+        }                                                                                                              \
+    } while (0)
+
+template <typename T>
+T* toDevice(std::vector<T> const& host)
+{
+    T* dev = nullptr;
+    CHECK_CUDA(cudaMalloc(&dev, host.size() * sizeof(T)));
+    CHECK_CUDA(cudaMemcpy(dev, host.data(), host.size() * sizeof(T), cudaMemcpyHostToDevice));
+    return dev;
+}
+
+template <typename T>
+std::vector<T> fromDevice(T const* dev, size_t n)
+{
+    std::vector<T> host(n);
+    CHECK_CUDA(cudaMemcpy(host.data(), dev, n * sizeof(T), cudaMemcpyDeviceToHost));
+    return host;
+}
+
+// logProbs are multiples of 2^-4 (exact in fp32), strictly decreasing in token index
+// within each row, and crafted so merged stage-C winners interleave beams. cumLogProbs
+// are multiples of 2^-5. The merged metric of candidate (m, v) in batch b is
+// proportional to 3m + 2*nBMOut*v + (32+nBMIn)*b, all distinct.
+int runCase(int nBS, int nBMIn, int nBMOut, int nV, char const* label)
+{
+    int const nCand = nBMIn * nBMOut; // candidates per batch after stage A
+
+    std::vector<float> logProbs(nBS * nBMIn * nV);
+    for (int b = 0; b < nBS; ++b)
+    {
+        for (int m = 0; m < nBMIn; ++m)
+        {
+            for (int v = 0; v < nV; ++v)
+            {
+                float const val = (v < nBMOut) ? -(m + nBMOut * v + 16 * b) * 0.0625f
+                                               : -(1000.f + static_cast<float>(v)) * 0.0625f;
+                logProbs[(b * nBMIn + m) * nV + v] = val;
+            }
+        }
+    }
+    std::vector<float> cumLogProbs(nBS * nBMIn);
+    for (int i = 0; i < nBS * nBMIn; ++i)
+    {
+        cumLogProbs[i] = -static_cast<float>(i) * 0.03125f;
+    }
+
+    // Host reference: per-beam top-nBMOut (value desc, index asc), add cumLogProbs,
+    // merged top-nBMOut per batch (value desc, flat stage-1 index asc), then the
+    // gatherId mapping final = beam * nV + token.
+    std::vector<int> refStage2Ids(nBS * nBMOut); // flat stage-1 indices, value-desc
+    std::vector<float> refStage2Vals(nBS * nBMOut);
+    std::vector<int> refFinalIds(nBS * nBMOut); // beam * nV + token
+    for (int b = 0; b < nBS; ++b)
+    {
+        struct Cand
+        {
+            float val;
+            int flat; // m * nBMOut + v: position in this batch's stage-1 candidate block
+        };
+        std::vector<Cand> cands;
+        for (int m = 0; m < nBMIn; ++m)
+        {
+            for (int v = 0; v < nBMOut; ++v)
+            {
+                cands.push_back({logProbs[(b * nBMIn + m) * nV + v] + cumLogProbs[b * nBMIn + m], m * nBMOut + v});
+            }
+        }
+        std::sort(cands.begin(), cands.end(), [](Cand const& x, Cand const& y) {
+            return x.val > y.val || (x.val == y.val && x.flat < y.flat);
+        });
+        for (int j = 0; j < nBMOut; ++j)
+        {
+            refStage2Ids[b * nBMOut + j] = cands[j].flat;
+            refStage2Vals[b * nBMOut + j] = cands[j].val;
+            int const beam = cands[j].flat / nBMOut;
+            int const tok = cands[j].flat % nBMOut; // position == token: in-row values decrease in token index
+            refFinalIds[b * nBMOut + j] = beam * nV + tok;
+        }
+    }
+
+    float* dLogProbs = toDevice(logProbs);
+    float* dCumLogProbs = toDevice(cumLogProbs);
+    std::optional<float> mask(-std::numeric_limits<float>::infinity());
+
+    cudaStream_t stream;
+    CHECK_CUDA(cudaStreamCreate(&stream));
+
+    // Stage A: top-nBMOut per beam.
+    size_t const wsABytes = invokeComputeTopkLastDimWorkspaceSize<float>(nBS * nBMIn, nV, nBMOut, true, 0);
+    void* wsA = nullptr;
+    CHECK_CUDA(cudaMalloc(&wsA, wsABytes));
+    float* dStage1Vals = nullptr;
+    int* dStage1Ids = nullptr;
+    CHECK_CUDA(cudaMalloc(&dStage1Vals, sizeof(float) * nBS * nCand));
+    CHECK_CUDA(cudaMalloc(&dStage1Ids, sizeof(int) * nBS * nCand));
+    invokeTopkLastDim<float>(nBS * nBMIn, nV, nBMOut, true, mask, dLogProbs, dStage1Vals, dStage1Ids, wsA, stream,
+        /*sorted=*/false, /*force_path=*/0);
+
+    // Stage B: add cumLogProbs in place.
+    launchAddCumLogProbs<float>(dStage1Vals, dCumLogProbs, /*finished=*/nullptr, /*endIds=*/nullptr,
+        /*diversityRates=*/nullptr, /*batchSlots=*/nullptr, nBS, nBMIn, nBMOut, /*nThread=*/32, stream);
+
+    // Stage C: merged top-nBMOut per batch.
+    size_t const wsCBytes = invokeComputeTopkLastDimWorkspaceSize<float>(nBS, nCand, nBMOut, true, 0);
+    void* wsC = nullptr;
+    CHECK_CUDA(cudaMalloc(&wsC, wsCBytes));
+    float* dStage2Vals = nullptr;
+    int* dStage2Ids = nullptr;
+    CHECK_CUDA(cudaMalloc(&dStage2Vals, sizeof(float) * nBS * nBMOut));
+    CHECK_CUDA(cudaMalloc(&dStage2Ids, sizeof(int) * nBS * nBMOut));
+    invokeTopkLastDim<float>(nBS, nCand, nBMOut, true, mask, dStage1Vals, dStage2Vals, dStage2Ids, wsC, stream,
+        /*sorted=*/true, /*force_path=*/0);
+
+    auto devStage2Ids = fromDevice(dStage2Ids, nBS * nBMOut);
+    auto devStage2Vals = fromDevice(dStage2Vals, nBS * nBMOut);
+
+    // Stage D: gatherId rewrites stage-2 ids into final logProbs indices.
+    gatherId<<<nBS, 32, 0, stream>>>(dStage1Ids, dStage2Ids, nBS, nBMIn, nBMOut, nV);
+    CHECK_CUDA(lastError());
+    auto devFinalIds = fromDevice(dStage2Ids, nBS * nBMOut);
+
+    CHECK_CUDA(cudaStreamDestroy(stream));
+    CHECK_CUDA(cudaFree(wsA));
+    CHECK_CUDA(cudaFree(wsC));
+    CHECK_CUDA(cudaFree(dStage1Vals));
+    CHECK_CUDA(cudaFree(dStage1Ids));
+    CHECK_CUDA(cudaFree(dStage2Vals));
+    CHECK_CUDA(cudaFree(dStage2Ids));
+    CHECK_CUDA(cudaFree(dLogProbs));
+    CHECK_CUDA(cudaFree(dCumLogProbs));
+
+    int failures = 0;
+    for (int i = 0; i < nBS * nBMOut; ++i)
+    {
+        if (devStage2Ids[i] != refStage2Ids[i] || devStage2Vals[i] != refStage2Vals[i])
+        {
+            std::printf("case[%s] stage2 mismatch at %d: dev(id=%d val=%f) ref(id=%d val=%f)\n", label, i,
+                devStage2Ids[i], devStage2Vals[i], refStage2Ids[i], refStage2Vals[i]);
+            ++failures;
+        }
+        if (devFinalIds[i] != refFinalIds[i])
+        {
+            std::printf("case[%s] gatherId mismatch at %d: dev=%d ref=%d\n", label, i, devFinalIds[i], refFinalIds[i]);
+            ++failures;
+        }
+    }
+    std::printf("case[%s]: %s (nBS=%d nBMIn=%d nBMOut=%d nV=%d)\n", label, failures == 0 ? "PASS" : "FAIL", nBS,
+        nBMIn, nBMOut, nV);
+    return failures;
+}
+
+} // namespace
+
+int main()
+{
+    int failures = 0;
+    failures += runCase(2, 4, 4, 32, "symmetric");
+    failures += runCase(2, 3, 5, 32, "vbws-asymmetric");
+    if (failures == 0)
+    {
+        std::printf("beam_mapping_test: PASS\n");
+        return 0;
+    }
+    std::printf("beam_mapping_test: %d mismatches\n", failures);
+    return 1;
+}

--- a/3rdparty/trt_beam_search/tests/topk_bench.cu
+++ b/3rdparty/trt_beam_search/tests/topk_bench.cu
@@ -1,0 +1,419 @@
+// Microbenchmark + correctness harness for the radix topk paths behind
+// invokeTopkLastDim (multi-block vs one-block, selected via force_path).
+//
+// Usage:
+//   topk_bench                                  run matrix + semantic checks
+//   topk_bench --check                          run only the semantic checks (fast; used by cc_test)
+//   topk_bench BATCH LEN K SORTED PATH [REPS]   time one combo
+//     SORTED: 0/1 (1 = trailing by-value sort, production stage-2 behavior)
+//     PATH:   0 = auto, 1 = force multi-block, 2 = force one-block
+//
+// Part A (routing matrix): shapes x ks x sorted variants x {multi, one-block},
+//   prints CSV rows and checks both paths are bitwise identical per combo.
+// Part B (semantic checks): compares invokeTopkLastDim output against a host
+//   reference (value desc, index asc) — covers the ROCm k<=256 WarpSort gate
+//   and the radix path directly.
+// Matrix mode exits non-zero if any comparison fails (single-combo mode always
+// returns 0).
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <random>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+
+#include "3rdparty/trt_beam_search/common.h"
+#include "3rdparty/trt_beam_search/topkLastDim.h"
+
+namespace
+{
+
+using tensorrt_llm::kernels::invokeComputeTopkLastDimWorkspaceSize;
+using tensorrt_llm::kernels::invokeTopkLastDim;
+
+// check_cuda_error() is debug-gated (syncAndCheckInDebug), so it is a no-op in
+// normal bench runs; check every CUDA API return code explicitly instead.
+char const* benchErrString(cudaError_t err)
+{
+#if USING_ROCM
+    return hipGetErrorString(err);
+#else
+    return cudaGetErrorString(err);
+#endif
+}
+
+#define BENCH_CHECK(call)                                                                                              \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        cudaError_t const bench_err_ = (call);                                                                         \
+        if (bench_err_ != cudaSuccess)                                                                                 \
+        {                                                                                                              \
+            std::fprintf(stderr, "CUDA error %s at %s:%d\n", benchErrString(bench_err_), __FILE__, __LINE__);          \
+            std::exit(1);                                                                                              \
+        }                                                                                                              \
+    } while (0)
+
+// Logprob-like values in [-20, 0]; every 7919th element pinned to create
+// exact-equal ties so the tie-break path is exercised.
+void fillInput(std::vector<float>& host, int batch, int len)
+{
+    host.resize(static_cast<size_t>(batch) * len);
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-20.f, 0.f);
+    for (auto& v : host)
+    {
+        v = dist(rng);
+    }
+    for (size_t i = 0; i < host.size(); i += 7919)
+    {
+        host[i] = -1.5f;
+    }
+}
+
+float* toDevice(std::vector<float> const& host)
+{
+    float* dev = nullptr;
+    BENCH_CHECK(cudaMalloc(&dev, host.size() * sizeof(float)));
+    BENCH_CHECK(cudaMemcpy(dev, host.data(), host.size() * sizeof(float), cudaMemcpyHostToDevice));
+    return dev;
+}
+
+// Returns microseconds per call. dOutVal/dOutIdx receive the last call's output.
+double timePath(int batch, int len, int k, bool sorted, int forcePath, float const* dIn, float* dOutVal,
+    int* dOutIdx, void* workspace, int reps, cudaStream_t stream)
+{
+    std::optional<float> mask(-std::numeric_limits<float>::infinity());  // same as beam search
+    for (int i = 0; i < 3; ++i)
+    {
+        invokeTopkLastDim<float>(batch, len, k, true, mask, dIn, dOutVal, dOutIdx, workspace, stream, sorted, forcePath);
+    }
+    BENCH_CHECK(cudaStreamSynchronize(stream));
+
+    cudaEvent_t start, stop;
+    BENCH_CHECK(cudaEventCreate(&start));
+    BENCH_CHECK(cudaEventCreate(&stop));
+    BENCH_CHECK(cudaEventRecord(start, stream));
+    for (int i = 0; i < reps; ++i)
+    {
+        invokeTopkLastDim<float>(batch, len, k, true, mask, dIn, dOutVal, dOutIdx, workspace, stream, sorted, forcePath);
+    }
+    BENCH_CHECK(cudaEventRecord(stop, stream));
+    BENCH_CHECK(cudaEventSynchronize(stop));
+    float ms = 0.f;
+    BENCH_CHECK(cudaEventElapsedTime(&ms, start, stop));
+    BENCH_CHECK(cudaEventDestroy(start));
+    BENCH_CHECK(cudaEventDestroy(stop));
+    return static_cast<double>(ms) * 1000.0 / reps;
+}
+
+struct PathOutput
+{
+    double us;
+    std::vector<float> vals;
+    std::vector<int> idxs;
+};
+
+PathOutput runPath(int batch, int len, int k, bool sorted, int forcePath, float const* dIn, int reps, cudaStream_t stream)
+{
+    size_t const wsBytes = invokeComputeTopkLastDimWorkspaceSize<float>(batch, len, k, true, forcePath);
+    void* workspace = nullptr;
+    BENCH_CHECK(cudaMalloc(&workspace, wsBytes));
+    float* dOutVal = nullptr;
+    int* dOutIdx = nullptr;
+    BENCH_CHECK(cudaMalloc(&dOutVal, sizeof(float) * k * batch));
+    BENCH_CHECK(cudaMalloc(&dOutIdx, sizeof(int) * k * batch));
+
+    PathOutput out;
+    out.us = timePath(batch, len, k, sorted, forcePath, dIn, dOutVal, dOutIdx, workspace, reps, stream);
+    out.vals.resize(static_cast<size_t>(k) * batch);
+    out.idxs.resize(static_cast<size_t>(k) * batch);
+    BENCH_CHECK(cudaMemcpy(out.vals.data(), dOutVal, out.vals.size() * sizeof(float), cudaMemcpyDeviceToHost));
+    BENCH_CHECK(cudaMemcpy(out.idxs.data(), dOutIdx, out.idxs.size() * sizeof(int), cudaMemcpyDeviceToHost));
+
+    BENCH_CHECK(cudaFree(workspace));
+    BENCH_CHECK(cudaFree(dOutVal));
+    BENCH_CHECK(cudaFree(dOutIdx));
+    return out;
+}
+
+bool sameOutput(PathOutput const& a, PathOutput const& b)
+{
+    return a.vals.size() == b.vals.size() && 0 == std::memcmp(a.vals.data(), b.vals.data(), a.vals.size() * sizeof(float))
+        && 0 == std::memcmp(a.idxs.data(), b.idxs.data(), a.idxs.size() * sizeof(int));
+}
+
+// Host reference: per row, top-k by (value desc, index asc). indexAscending=true
+// returns the same set ordered by index (the sorted=false production layout).
+void hostTopk(std::vector<float> const& in, int batch, int len, int k, bool indexAscending,
+    std::vector<float>& refVals, std::vector<int>& refIdxs)
+{
+    refVals.assign(static_cast<size_t>(k) * batch, 0.f);
+    refIdxs.assign(static_cast<size_t>(k) * batch, 0);
+    std::vector<int> ord(len);
+    for (int b = 0; b < batch; ++b)
+    {
+        std::iota(ord.begin(), ord.end(), 0);
+        float const* row = in.data() + static_cast<size_t>(b) * len;
+        std::partial_sort(ord.begin(), ord.begin() + k, ord.end(),
+            [&](int i, int j) { return row[i] > row[j] || (row[i] == row[j] && i < j); });
+        if (indexAscending)
+        {
+            std::sort(ord.begin(), ord.begin() + k);
+        }
+        for (int i = 0; i < k; ++i)
+        {
+            refIdxs[static_cast<size_t>(b) * k + i] = ord[i];
+            refVals[static_cast<size_t>(b) * k + i] = row[ord[i]];
+        }
+    }
+}
+
+// Part B: one semantic check of invokeTopkLastDim against the host reference.
+// strictOrder=true: exact match on values and index order (radix path semantics).
+// strictOrder=false: exact match on values + per-row index multiset equality
+// (WarpSort semantics: exact top-k set, unspecified order among equal values).
+// Returns true on match under the selected mode; tie-order divergence is
+// reported as informational only.
+bool checkVsHost(int batch, int len, int k, bool sorted, std::vector<float> const& hostIn, float const* dIn,
+    cudaStream_t stream, char const* label, bool strictOrder)
+{
+    PathOutput dev = runPath(batch, len, k, sorted, /*forcePath=*/0, dIn, /*reps=*/3, stream);
+    std::vector<float> refVals;
+    std::vector<int> refIdxs;
+    hostTopk(hostIn, batch, len, k, /*indexAscending=*/!sorted, refVals, refIdxs);
+    bool const valuesOk
+        = 0 == std::memcmp(dev.vals.data(), refVals.data(), refVals.size() * sizeof(float));
+    bool ok;
+    if (strictOrder)
+    {
+        ok = valuesOk
+            && 0 == std::memcmp(dev.idxs.data(), refIdxs.data(), refIdxs.size() * sizeof(int));
+    }
+    else
+    {
+        ok = valuesOk;
+        int tieRows = 0;
+        for (int b = 0; b < batch && ok; ++b)
+        {
+            std::vector<int> devRow(dev.idxs.begin() + static_cast<size_t>(b) * k,
+                dev.idxs.begin() + static_cast<size_t>(b + 1) * k);
+            std::vector<int> refRow(refIdxs.begin() + static_cast<size_t>(b) * k,
+                refIdxs.begin() + static_cast<size_t>(b + 1) * k);
+            if (devRow != refRow)
+            {
+                ++tieRows;
+            }
+            std::sort(devRow.begin(), devRow.end());
+            std::sort(refRow.begin(), refRow.end());
+            if (devRow != refRow)
+            {
+                ok = false;
+            }
+        }
+        std::printf("check[%s]: batch=%d len=%d k=%d sorted=%d -> %s (values %s, rows with tie-order diff %d)\n",
+            label, batch, len, k, sorted ? 1 : 0, ok ? "PASS" : "FAIL", valuesOk ? "exact" : "MISMATCH", tieRows);
+        return ok;
+    }
+    std::printf("check[%s]: batch=%d len=%d k=%d sorted=%d -> %s\n", label, batch, len, k, sorted ? 1 : 0,
+        ok ? "PASS" : "FAIL");
+    if (!ok)
+    {
+        for (size_t i = 0; i < refIdxs.size(); ++i)
+        {
+            if (dev.idxs[i] != refIdxs[i] || dev.vals[i] != refVals[i])
+            {
+                std::printf("  first mismatch at i=%zu: dev(idx=%d val=%f) ref(idx=%d val=%f)\n", i, dev.idxs[i],
+                    dev.vals[i], refIdxs[i], refVals[i]);
+                break;
+            }
+        }
+    }
+    return ok;
+}
+
+struct Shape
+{
+    // cls: 'A' production stage-1, 'C' production stage-2, 'X' crossover probe,
+    //      'B' beam-4096/8192 spot check.
+    char cls;
+    int batch;
+    int len;
+    char const* note;
+    int k = 0;  // 0 = use the class default k list
+};
+
+// Part B: semantic checks vs host reference. Returns the number of failures.
+int runSemanticChecks()
+{
+    int failures = 0;
+    cudaStream_t stream;
+    BENCH_CHECK(cudaStreamCreate(&stream));
+    std::vector<float> hostIn;
+    float* dIn = nullptr;
+    auto prep = [&](int batch, int len) {
+        if (dIn)
+        {
+            BENCH_CHECK(cudaFree(dIn));
+        }
+        fillInput(hostIn, batch, len);
+        dIn = toDevice(hostIn);
+    };
+    // ROCm k<=256 gate (WarpSort path, pre-existing behavior for beams <=256).
+    prep(50, 65660);
+    failures += checkVsHost(50, 65660, 200, true, hostIn, dIn, stream, "warpsort-A", false) ? 0 : 1;
+    prep(1, 75000);
+    failures += checkVsHost(1, 75000, 200, true, hostIn, dIn, stream, "warpsort-C", false) ? 0 : 1;
+    // k=400: beams 257..512 stay on the radix path after the gate narrowed to 256.
+    prep(50, 217303);
+    failures += checkVsHost(50, 217303, 400, true, hostIn, dIn, stream, "radix-k400-fullvocab", true) ? 0 : 1;
+    // Radix path vs reference (k>512): sorted=true layout and sorted=false layout.
+    prep(50, 65660);
+    failures += checkVsHost(50, 65660, 1500, true, hostIn, dIn, stream, "radix-sorted", true) ? 0 : 1;
+    failures += checkVsHost(50, 65660, 1500, false, hostIn, dIn, stream, "radix-unsorted", true) ? 0 : 1;
+    // Gate boundary through the production (auto) path: k=256 takes WarpSort,
+    // k=257 takes radix.
+    prep(50, 65660);
+    failures += checkVsHost(50, 65660, 256, true, hostIn, dIn, stream, "gate-k256-warpsort", false) ? 0 : 1;
+    failures += checkVsHost(50, 65660, 257, true, hostIn, dIn, stream, "gate-k257-radix", true) ? 0 : 1;
+    // step1 C-stage edge: k == len (single beam expanded once).
+    prep(1, 50);
+    failures += checkVsHost(1, 50, 50, true, hostIn, dIn, stream, "warpsort-C-step1-k-eq-len", false) ? 0 : 1;
+    if (dIn)
+    {
+        BENCH_CHECK(cudaFree(dIn));
+    }
+    BENCH_CHECK(cudaStreamDestroy(stream));
+    return failures;
+}
+
+int runMatrix(int reps)
+{
+    // (batch, len) shapes. grid_dim is a function of (batch, len) only; the x-*
+    // probes land in the grid_dim 10..36 crossover region (approximate values
+    // computed for gfx942 fp32, active_blocks=240).
+    Shape const shapes[] = {
+        // production shapes
+        {'A', 50, 65660, "A-step2"},
+        {'A', 1500, 65660, "A-steady"},
+        {'C', 1, 150000, "C-2k"},
+        {'C', 1, 75000, "C-1k"},
+        {'C', 1, 16777216, "C-steady-4096"},
+        // vocab variants
+        {'A', 50, 217303, "A-fullvocab"},
+        {'A', 50, 262144, "A-bigvocab"},
+        {'A', 50, 32000, "A-smallvocab"},
+        // crossover probes
+        {'X', 16, 65660, "x-grid11"},
+        {'X', 16, 32000, "x-grid15"},
+        {'X', 8, 32000, "x-grid16"},
+        {'X', 10, 217303, "x-grid22"},
+        {'X', 8, 217303, "x-grid27"},
+        {'X', 6, 131072, "x-grid32"},
+        {'X', 10, 65660, "x-grid33"},
+        {'X', 5, 217303, "x-grid36"},
+        // beam-4096 (k) spot checks on the production A shapes (4096 = max supported
+        // beam width; wider beams are not instantiated, see beamSearchKernels4096.cu).
+        {'B', 50, 65660, "A-step2-beam4096", 4096},
+        {'B', 1500, 65660, "A-steady-beam4096", 4096},
+        // k=256/257: boundary of the ROCm k<=256 WarpSort gate.
+        {'B', 50, 65660, "A-gate-k256", 256},
+        {'B', 50, 65660, "A-gate-k257", 257},
+        // grid_dim==1 (batch=1024): force multi-block clamps to one-block (multi is
+        // invalid below 2 blocks); grid_dim==2 (batch=512): multi must stay valid.
+        {'B', 1024, 217303, "A-grid1-clamp", 1024},
+        {'B', 512, 217303, "A-grid2-multi", 1024},
+        // step1 shape: single beam in (nBMIn=1), small k.
+        {'B', 1, 65660, "A-step1", 50},
+    };
+    auto ksFor = [](Shape const& s) -> std::vector<int> {
+        if (s.k != 0)
+        {
+            return {s.k};
+        }
+        switch (s.cls)
+        {
+        case 'C': return s.len > 1000000 ? std::vector<int>{4096} : std::vector<int>{1500, 3000};
+        case 'X': return {1500};
+        default: return {1500, 3000};
+        }
+    };
+    auto sortedFor = [](Shape const& s) -> std::vector<bool> {
+        return s.cls == 'C' ? std::vector<bool>{true} : std::vector<bool>{true, false};
+    };
+
+    cudaStream_t stream;
+    BENCH_CHECK(cudaStreamCreate(&stream));
+    std::printf("batch,len,k,sorted,note,multi_us,oneblock_us,speedup,identical\n");
+    int failures = 0;
+
+    auto runCombo = [&](Shape const& s, int k, bool sorted) {
+        std::vector<float> hostIn;
+        fillInput(hostIn, s.batch, s.len);
+        float* dIn = toDevice(hostIn);
+        PathOutput multi = runPath(s.batch, s.len, k, sorted, 1, dIn, reps, stream);
+        PathOutput oneblk = runPath(s.batch, s.len, k, sorted, 2, dIn, reps, stream);
+        bool const identical = sameOutput(multi, oneblk);
+        if (!identical)
+        {
+            ++failures;
+        }
+        std::printf("%d,%d,%d,%d,%s,%.1f,%.1f,%.2fx,%s\n", s.batch, s.len, k, sorted ? 1 : 0, s.note, multi.us,
+            oneblk.us, multi.us / oneblk.us, identical ? "yes" : "NO");
+        BENCH_CHECK(cudaFree(dIn));
+    };
+
+    for (auto const& s : shapes)
+    {
+        for (int k : ksFor(s))
+        {
+            for (bool sorted : sortedFor(s))
+            {
+                runCombo(s, k, sorted);
+            }
+        }
+    }
+
+    BENCH_CHECK(cudaStreamDestroy(stream));
+    failures += runSemanticChecks();
+    return failures == 0 ? 0 : 1;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc == 1)
+    {
+        return runMatrix(20);
+    }
+    if (argc == 2 && 0 == std::strcmp(argv[1], "--check"))
+    {
+        return runSemanticChecks() == 0 ? 0 : 1;
+    }
+    if (argc < 6 || argc > 7)
+    {
+        std::fprintf(stderr, "usage: %s [--check] [BATCH LEN K SORTED PATH [REPS]]\n", argv[0]);
+        return 2;
+    }
+    int const batch = std::atoi(argv[1]);
+    int const len = std::atoi(argv[2]);
+    int const k = std::atoi(argv[3]);
+    bool const sorted = std::atoi(argv[4]) != 0;
+    int const path = std::atoi(argv[5]);
+    int const reps = argc > 6 ? std::atoi(argv[6]) : 20;
+
+    cudaStream_t stream;
+    BENCH_CHECK(cudaStreamCreate(&stream));
+    std::vector<float> hostIn;
+    fillInput(hostIn, batch, len);
+    float* dIn = toDevice(hostIn);
+    PathOutput out = runPath(batch, len, k, sorted, path, dIn, reps, stream);
+    std::printf("batch=%d len=%d k=%d sorted=%d path=%d: %.1f us/call\n", batch, len, k, sorted ? 1 : 0, path, out.us);
+    BENCH_CHECK(cudaFree(dIn));
+    BENCH_CHECK(cudaStreamDestroy(stream));
+    return 0;
+}

--- a/3rdparty/trt_beam_search/tests/topk_bench.cu
+++ b/3rdparty/trt_beam_search/tests/topk_bench.cu
@@ -58,7 +58,10 @@ char const* benchErrString(cudaError_t err)
     } while (0)
 
 // Logprob-like values in [-20, 0]; every 7919th element pinned to create
-// exact-equal ties so the tie-break path is exercised.
+// exact-equal ties so the tie-break path is exercised. The pinned value must sit
+// above the top-k threshold or the ties are never selected: for the matrix shapes
+// the threshold ranges from about -0.02 (k=50) to -1.25 (k=4096), and -0.05 is
+// inside the top-k for every shape with k >= 200.
 void fillInput(std::vector<float>& host, int batch, int len)
 {
     host.resize(static_cast<size_t>(batch) * len);
@@ -70,7 +73,7 @@ void fillInput(std::vector<float>& host, int batch, int len)
     }
     for (size_t i = 0; i < host.size(); i += 7919)
     {
-        host[i] = -1.5f;
+        host[i] = -0.05f;
     }
 }
 
@@ -174,10 +177,10 @@ void hostTopk(std::vector<float> const& in, int batch, int len, int k, bool inde
 
 // Part B: one semantic check of invokeTopkLastDim against the host reference.
 // strictOrder=true: exact match on values and index order (radix path semantics).
-// strictOrder=false: exact match on values + per-row index multiset equality
-// (WarpSort semantics: exact top-k set, unspecified order among equal values).
-// Returns true on match under the selected mode; tie-order divergence is
-// reported as informational only.
+// strictOrder=false (WarpSort): exact match on values; for indices, exact set
+// equality strictly above the k-th value and tie-count equality within the
+// boundary group (WarpSort's boundary-tie pick among equal values is
+// path-specific by design). Tie-order divergence is reported as informational.
 bool checkVsHost(int batch, int len, int k, bool sorted, std::vector<float> const& hostIn, float const* dIn,
     cudaStream_t stream, char const* label, bool strictOrder)
 {
@@ -199,17 +202,46 @@ bool checkVsHost(int batch, int len, int k, bool sorted, std::vector<float> cons
         int tieRows = 0;
         for (int b = 0; b < batch && ok; ++b)
         {
-            std::vector<int> devRow(dev.idxs.begin() + static_cast<size_t>(b) * k,
-                dev.idxs.begin() + static_cast<size_t>(b + 1) * k);
-            std::vector<int> refRow(refIdxs.begin() + static_cast<size_t>(b) * k,
-                refIdxs.begin() + static_cast<size_t>(b + 1) * k);
-            if (devRow != refRow)
+            size_t const off = static_cast<size_t>(b) * k;
+            // Boundary-tie aware comparison: elements strictly above the k-th value
+            // must have identical index sets; within the boundary tie group only the
+            // counts must match — WarpSort's pick among exactly-equal boundary values
+            // is documented as path-specific (see the gate comment in topkLastDim.cu).
+            float const thr = refVals[off + k - 1];
+            std::vector<int> devCore, refCore;
+            int devTies = 0, refTies = 0;
+            bool orderDiff = false;
+            for (int i = 0; i < k; ++i)
+            {
+                float const dv = dev.vals[off + i], rv = refVals[off + i];
+                if (dv > thr)
+                {
+                    devCore.push_back(dev.idxs[off + i]);
+                }
+                else if (dv == thr)
+                {
+                    ++devTies;
+                }
+                if (rv > thr)
+                {
+                    refCore.push_back(refIdxs[off + i]);
+                }
+                else if (rv == thr)
+                {
+                    ++refTies;
+                }
+                if (dev.idxs[off + i] != refIdxs[off + i])
+                {
+                    orderDiff = true;
+                }
+            }
+            if (orderDiff)
             {
                 ++tieRows;
             }
-            std::sort(devRow.begin(), devRow.end());
-            std::sort(refRow.begin(), refRow.end());
-            if (devRow != refRow)
+            std::sort(devCore.begin(), devCore.end());
+            std::sort(refCore.begin(), refCore.end());
+            if (devCore != refCore || devTies != refTies)
             {
                 ok = false;
             }
@@ -285,6 +317,36 @@ int runSemanticChecks()
     if (dIn)
     {
         BENCH_CHECK(cudaFree(dIn));
+        dIn = nullptr;
+    }
+
+    // Dual-path consistency: the routing change's premise is "same result on either
+    // radix path". The full matrix checks this but only runs manually; these three
+    // shapes put it under --check/CI, covering the ROCm crossover band (grid 11/16)
+    // and the grid_dim<2 clamp (batch=1024 computes to grid_dim 1).
+    struct DualCase
+    {
+        int batch;
+        int len;
+        int k;
+        char const* label;
+    };
+    DualCase const dualCases[] = {
+        {16, 65660, 1500, "dual-grid11"},
+        {8, 32000, 1500, "dual-grid16"},
+        {1024, 217303, 1024, "dual-grid1-clamp"},
+    };
+    for (auto const& c : dualCases)
+    {
+        fillInput(hostIn, c.batch, c.len);
+        float* dDual = toDevice(hostIn);
+        PathOutput multi = runPath(c.batch, c.len, c.k, /*sorted=*/true, /*forcePath=*/1, dDual, /*reps=*/3, stream);
+        PathOutput oneblk = runPath(c.batch, c.len, c.k, /*sorted=*/true, /*forcePath=*/2, dDual, /*reps=*/3, stream);
+        bool const ok = sameOutput(multi, oneblk);
+        std::printf("dual[%s]: batch=%d len=%d k=%d multi vs one-block -> %s\n", c.label, c.batch, c.len, c.k,
+            ok ? "PASS" : "FAIL");
+        failures += ok ? 0 : 1;
+        BENCH_CHECK(cudaFree(dDual));
     }
     BENCH_CHECK(cudaStreamDestroy(stream));
     return failures;

--- a/3rdparty/trt_beam_search/topkLastDim.cu
+++ b/3rdparty/trt_beam_search/topkLastDim.cu
@@ -1508,45 +1508,42 @@ void standalone_stable_radix_topk_one_block_(void* buf, size_t& buf_size, T cons
 
 template <typename T, typename idxT, bool sorted = false>
 void standalone_stable_radix_11bits(void* buf, size_t& buf_size, T const* in, int batch_size, idxT len, idxT k, T* out,
-    idxT* out_idx, bool greater, std::optional<T> mask_val, cudaStream_t stream = 0)
+    idxT* out_idx, bool greater, std::optional<T> mask_val, cudaStream_t stream = 0, int force_path = 0)
 {
     constexpr int items_per_thread = 32;
     constexpr int block_dim = 512;
     constexpr bool fused_last_filter = false;
     constexpr int topk_bits = 11;
-    if (len <= block_dim * items_per_thread)
-    {
-        standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in, 
-            static_cast<idxT*>(nullptr), batch_size, len, k, out, out_idx, !greater, mask_val, stream, sorted);
-    }
-    else
+
+    // See topkLastDim.h for the force_path legend.
+    bool auto_one_block = (len <= block_dim * items_per_thread);
+    unsigned grid_dim = 0;
+    if (!auto_one_block && force_path != 2)
     {
         int sm_cnt = tensorrt_llm::common::getMultiProcessorCount();
-        unsigned grid_dim = air_topk_stable::calc_grid_dim<T, idxT, topk_bits, block_dim>(batch_size, len, sm_cnt);
+        grid_dim = air_topk_stable::calc_grid_dim<T, idxT, topk_bits, block_dim>(batch_size, len, sm_cnt);
 
 #if USING_ROCM
         // On ROCm, the one-block kernel with vectorized reads is faster than the
         // multi-block path for small grid_dim values, because the multi-block path
         // has inter-block sync overhead and multiple kernel launches (3 passes +
         // last_filter + sort). Force one-block when grid_dim is small.
-        if (grid_dim <= 4)
-        {
-            standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in,
-                static_cast<idxT*>(nullptr), batch_size, len, k, out, out_idx, !greater, mask_val, stream, sorted);
-            return;
-        }
+        auto_one_block = (grid_dim <= 4);
+#else
+        auto_one_block = (grid_dim == 1);
 #endif
+    }
 
-        if (grid_dim == 1)
-        {
-            standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in,
-                static_cast<idxT*>(nullptr), batch_size, len, k, out, out_idx, !greater, mask_val, stream, sorted);
-        }
-        else
-        {
-            standalone_stable_radix_topk_<T, idxT, topk_bits, block_dim>(buf, buf_size, in, static_cast<idxT*>(nullptr),
-                batch_size, len, k, out, out_idx, !greater, fused_last_filter, grid_dim, mask_val, stream, sorted);
-        }
+    bool const one_block = (force_path == 2) || (force_path == 0 && auto_one_block);
+    if (one_block)
+    {
+        standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in,
+            static_cast<idxT*>(nullptr), batch_size, len, k, out, out_idx, !greater, mask_val, stream, sorted);
+    }
+    else
+    {
+        standalone_stable_radix_topk_<T, idxT, topk_bits, block_dim>(buf, buf_size, in, static_cast<idxT*>(nullptr),
+            batch_size, len, k, out, out_idx, !greater, fused_last_filter, grid_dim, mask_val, stream, sorted);
     }
 }
 
@@ -1588,7 +1585,7 @@ void rocm_efficient_topk(SizeType32 batchSize, SizeType32 inputLength, SizeType3
 
 template <typename T>
 size_t invokeComputeTopkLastDimWorkspaceSize(
-    SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest)
+    SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest, int force_path)
 {
 #if USING_ROCM
     if (k <= 512) {
@@ -1601,13 +1598,13 @@ size_t invokeComputeTopkLastDimWorkspaceSize(
     T* out_val = nullptr;
     SizeType32* out_idx = nullptr;
     standalone_stable_radix_11bits<T, SizeType32, true>(
-        workspace, buf_size, in, batchSize, inputLength, k, out_val, out_idx, is_largest, 0);
+        workspace, buf_size, in, batchSize, inputLength, k, out_val, out_idx, is_largest, 0, 0, force_path);
     return buf_size;
 }
 
 #define INSTANTIATE_COMPUTE_TOPK_LastDim_WORKSPACE_SIZE_DATA_TYPE(T)                                                   \
     template size_t invokeComputeTopkLastDimWorkspaceSize<T>(                                                          \
-        SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest)
+        SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest, int force_path)
 
 INSTANTIATE_COMPUTE_TOPK_LastDim_WORKSPACE_SIZE_DATA_TYPE(int);
 INSTANTIATE_COMPUTE_TOPK_LastDim_WORKSPACE_SIZE_DATA_TYPE(float);
@@ -1623,8 +1620,8 @@ INSTANTIATE_COMPUTE_TOPK_LastDim_WORKSPACE_SIZE_DATA_TYPE(__nv_bfloat16);
 
 template <typename T>
 void invokeTopkLastDim(SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest,
-    std::optional<T> mask_val, void const* __restrict__ input, void* __restrict__ out_val, void* __restrict__ out_idx, 
-    void* workspace, cudaStream_t stream)
+    std::optional<T> mask_val, void const* __restrict__ input, void* __restrict__ out_val, void* __restrict__ out_idx,
+    void* workspace, cudaStream_t stream, bool sorted, int force_path)
 {
     T const* in = reinterpret_cast<T const*>(input);
     T* out_val_ = reinterpret_cast<T*>(out_val);
@@ -1636,14 +1633,22 @@ void invokeTopkLastDim(SizeType32 batchSize, SizeType32 inputLength, SizeType32 
     }
 #endif
     size_t buf_size = 0;
-    standalone_stable_radix_11bits<T, SizeType32, true>(
-        workspace, buf_size, in, batchSize, inputLength, k, out_val_, out_idx_, is_largest, mask_val, stream);
+    if (sorted)
+    {
+        standalone_stable_radix_11bits<T, SizeType32, true>(
+            workspace, buf_size, in, batchSize, inputLength, k, out_val_, out_idx_, is_largest, mask_val, stream, force_path);
+    }
+    else
+    {
+        standalone_stable_radix_11bits<T, SizeType32, false>(
+            workspace, buf_size, in, batchSize, inputLength, k, out_val_, out_idx_, is_largest, mask_val, stream, force_path);
+    }
 }
 
 #define INSTANTIATE_TOPK_LastDim_DATA_TYPE(T)                                                                          \
     template void invokeTopkLastDim<T>(SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest,    \
         std::optional<T> mask_val, void const* __restrict__ input, void* __restrict__ out_val, void* __restrict__ out_idx, \
-        void* workspace, cudaStream_t stream)
+        void* workspace, cudaStream_t stream, bool sorted, int force_path)
 
 INSTANTIATE_TOPK_LastDim_DATA_TYPE(int);
 INSTANTIATE_TOPK_LastDim_DATA_TYPE(float);

--- a/3rdparty/trt_beam_search/topkLastDim.cu
+++ b/3rdparty/trt_beam_search/topkLastDim.cu
@@ -1588,7 +1588,12 @@ size_t invokeComputeTopkLastDimWorkspaceSize(
     SizeType32 batchSize, SizeType32 inputLength, SizeType32 k, bool is_largest, int force_path)
 {
 #if USING_ROCM
-    if (k <= 512) {
+    // Gate is k<=256 (was 512): beam search used to pass k=2*beamWidth, so beams
+    // <=256 took WarpSort. After the 2k->1k change, k=beamWidth; 256 keeps the exact
+    // pre-change path partition and avoids newly exposing beams 257..512 to WarpSort's
+    // tie-break semantics, whose order and boundary-tie set among exactly equal values
+    // differ from the radix path below.
+    if (k <= 256) {
         return rocm_efficient_topk_workspace_size<T>(batchSize, inputLength, k, is_largest);
     }
 #endif
@@ -1627,7 +1632,8 @@ void invokeTopkLastDim(SizeType32 batchSize, SizeType32 inputLength, SizeType32 
     T* out_val_ = reinterpret_cast<T*>(out_val);
     SizeType32* out_idx_ = reinterpret_cast<SizeType32*>(out_idx);
 #if USING_ROCM
-    if (k <= 512) {
+    // k<=256 (was 512): keep the pre-2k->1k path partition, see workspace-size query.
+    if (k <= 256) {
         rocm_efficient_topk<T>(batchSize, inputLength, k, is_largest, in, out_val_, out_idx_, workspace, stream);
         return;
     }

--- a/3rdparty/trt_beam_search/topkLastDim.cu
+++ b/3rdparty/trt_beam_search/topkLastDim.cu
@@ -1518,23 +1518,37 @@ void standalone_stable_radix_11bits(void* buf, size_t& buf_size, T const* in, in
     // See topkLastDim.h for the force_path legend.
     bool auto_one_block = (len <= block_dim * items_per_thread);
     unsigned grid_dim = 0;
-    if (!auto_one_block && force_path != 2)
+    // grid_dim is needed whenever multi-block can run; computing it only under
+    // !auto_one_block would leave force_path=1 with grid_dim 0 for small len.
+    if (force_path != 2)
     {
         int sm_cnt = tensorrt_llm::common::getMultiProcessorCount();
         grid_dim = air_topk_stable::calc_grid_dim<T, idxT, topk_bits, block_dim>(batch_size, len, sm_cnt);
 
+        if (!auto_one_block)
+        {
 #if USING_ROCM
-        // On ROCm, the one-block kernel with vectorized reads is faster than the
-        // multi-block path for small grid_dim values, because the multi-block path
-        // has inter-block sync overhead and multiple kernel launches (3 passes +
-        // last_filter + sort). Force one-block when grid_dim is small.
-        auto_one_block = (grid_dim <= 4);
+            // On ROCm, the one-block kernel with vectorized reads is faster than the
+            // multi-block path for small grid_dim values, because the multi-block path
+            // has inter-block sync overhead and multiple kernel launches (3 passes +
+            // last_filter + sort). Force one-block when grid_dim is small.
+            // grid_dim<=16 additionally requires batch_size>=8: measured on gfx942,
+            // one-block wins 2.2-5.8x for grid_dim 9..16 with batch_size>=8, while
+            // batch=1 shapes prefer multi-block. batch 2-7 stays on the original
+            // multi-block route (unmeasured, avoid regressions); grid_dim 17..36
+            // also stays multi-block (smaller, len-dependent wins of 1.2-2.4x).
+            auto_one_block = (grid_dim <= 4) || (grid_dim <= 16 && batch_size >= 8);
 #else
-        auto_one_block = (grid_dim == 1);
+            auto_one_block = (grid_dim == 1);
 #endif
+        }
     }
 
-    bool const one_block = (force_path == 2) || (force_path == 0 && auto_one_block);
+    // The multi-block path is only valid with grid_dim >= 2: the auto route has never
+    // selected it below that (grid_dim==1 always went one-block), and forcing it there
+    // yields invalid output, so force_path=1 clamps back to one-block.
+    bool const one_block
+        = (force_path == 2) || (force_path == 0 && auto_one_block) || (force_path == 1 && grid_dim < 2);
     if (one_block)
     {
         standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in,

--- a/3rdparty/trt_beam_search/topkLastDim.cu
+++ b/3rdparty/trt_beam_search/topkLastDim.cu
@@ -1518,9 +1518,10 @@ void standalone_stable_radix_11bits(void* buf, size_t& buf_size, T const* in, in
     // See topkLastDim.h for the force_path legend.
     bool auto_one_block = (len <= block_dim * items_per_thread);
     unsigned grid_dim = 0;
-    // grid_dim is needed whenever multi-block can run; computing it only under
-    // !auto_one_block would leave force_path=1 with grid_dim 0 for small len.
-    if (force_path != 2)
+    // grid_dim costs device queries (SM count + occupancy); compute it only when it can
+    // affect the route: force_path=1 needs it for the clamp below, auto mode needs it
+    // only when the small-len check didn't already select one-block.
+    if (force_path == 1 || (force_path == 0 && !auto_one_block))
     {
         int sm_cnt = tensorrt_llm::common::getMultiProcessorCount();
         grid_dim = air_topk_stable::calc_grid_dim<T, idxT, topk_bits, block_dim>(batch_size, len, sm_cnt);
@@ -1546,9 +1547,9 @@ void standalone_stable_radix_11bits(void* buf, size_t& buf_size, T const* in, in
 
     // The multi-block path is only valid with grid_dim >= 2: the auto route has never
     // selected it below that (grid_dim==1 always went one-block), and forcing it there
-    // yields invalid output, so force_path=1 clamps back to one-block.
+    // yields invalid output, so any nonzero force_path clamps back to one-block.
     bool const one_block
-        = (force_path == 2) || (force_path == 0 && auto_one_block) || (force_path == 1 && grid_dim < 2);
+        = (force_path == 2) || (force_path == 0 && auto_one_block) || (force_path != 0 && grid_dim < 2);
     if (one_block)
     {
         standalone_stable_radix_topk_one_block_<T, idxT, topk_bits, block_dim>(buf, buf_size, in,

--- a/3rdparty/trt_beam_search/topkLastDim.h
+++ b/3rdparty/trt_beam_search/topkLastDim.h
@@ -25,10 +25,12 @@ namespace kernels
 {
 
 // force_path: 0 = auto route, 1 = force multi-block radix, 2 = force one-block radix.
-// force_path=1 clamps back to one-block when grid_dim < 2: multi-block is not valid
-// below 2 blocks (the auto route has never selected it there).
-// Testing/benchmarking knob; production callers keep the default 0.
-// Workspace size depends on the path, so queries must pass the same force_path as the run.
+// Any nonzero force_path clamps back to one-block when grid_dim < 2: multi-block is
+// not valid below 2 blocks (the auto route has never selected it there).
+// Primarily a testing/benchmarking knob; beam search also wires it to the
+// RTP_LLM_BEAM_TOPK_FORCE_PATH env var as a runtime rollback switch (see
+// beamSearchKernels.h). Workspace size depends on the path, so queries must pass the
+// same force_path as the run.
 // On ROCm, k <= 256 is gated to the WarpSort kernel for both the workspace query and the
 // run: force_path has no effect there, and WarpSort always emits value-sorted output
 // regardless of `sorted` (callers passing sorted=false still receive sorted results).

--- a/3rdparty/trt_beam_search/topkLastDim.h
+++ b/3rdparty/trt_beam_search/topkLastDim.h
@@ -24,14 +24,20 @@ namespace tensorrt_llm
 namespace kernels
 {
 
+// force_path: 0 = auto route, 1 = force multi-block radix, 2 = force one-block radix.
+// Testing/benchmarking knob; production callers keep the default 0.
+// Workspace size depends on the path, so queries must pass the same force_path as the run.
 template <typename T>
 size_t invokeComputeTopkLastDimWorkspaceSize(
-    runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest);
+    runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest,
+    int force_path = 0);
 
+// sorted = false skips the trailing StableSortPairsDescending; out_val/out_idx then come out
+// ordered by original index instead of by value.
 template <typename T>
-void invokeTopkLastDim(runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest, 
+void invokeTopkLastDim(runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest,
     std::optional<T> mask_val, void const* __restrict__ input, void* __restrict__ out_val, void* __restrict__ out_ind,
-    void* workspace, cudaStream_t stream);
+    void* workspace, cudaStream_t stream, bool sorted = true, int force_path = 0);
 
 } // namespace kernels
 } // namespace tensorrt_llm

--- a/3rdparty/trt_beam_search/topkLastDim.h
+++ b/3rdparty/trt_beam_search/topkLastDim.h
@@ -25,15 +25,21 @@ namespace kernels
 {
 
 // force_path: 0 = auto route, 1 = force multi-block radix, 2 = force one-block radix.
+// force_path=1 clamps back to one-block when grid_dim < 2: multi-block is not valid
+// below 2 blocks (the auto route has never selected it there).
 // Testing/benchmarking knob; production callers keep the default 0.
 // Workspace size depends on the path, so queries must pass the same force_path as the run.
+// On ROCm, k <= 256 is gated to the WarpSort kernel for both the workspace query and the
+// run: force_path has no effect there, and WarpSort always emits value-sorted output
+// regardless of `sorted` (callers passing sorted=false still receive sorted results).
 template <typename T>
 size_t invokeComputeTopkLastDimWorkspaceSize(
     runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest,
     int force_path = 0);
 
 // sorted = false skips the trailing StableSortPairsDescending; out_val/out_idx then come out
-// ordered by original index instead of by value.
+// ordered by original index instead of by value. (Exception: the ROCm k<=256 WarpSort gate
+// above always returns value-sorted output.)
 template <typename T>
 void invokeTopkLastDim(runtime::SizeType32 batchSize, runtime::SizeType32 inputLength, runtime::SizeType32 k, bool is_largest,
     std::optional<T> mask_val, void const* __restrict__ input, void* __restrict__ out_val, void* __restrict__ out_ind,


### PR DESCRIPTION

Beam search V2 spends most of its expansion-step time in the two top-k stages.
This speeds them up on ROCm without changing any results:

- Select beamWidth candidates per beam instead of 2*beamWidth. The extra copy only
  fed the CBA/end-token path, which isn't wired up; the global top-k is always inside
  the union of per-beam top-k, so results are unchanged.
- Skip the trailing value sort in stage A — stage C re-selects anyway and never reads
  that order.
- Route small-grid shapes (grid_dim<=4, or grid_dim<=16 with batch>=8) to the
  one-block radix kernel, avoiding multi-block launch/sync overhead. CUDA is
  untouched: bench shows one-block is slower there (up to 2.7x).

Also adds tests/topk_bench.cu, which force-paths both routes and bitwise-compares them.

Measured on MI308 (dynamic beam 50->1500): step2 top-k 1.14->0.62 ms at V=217303,
0.94->0.27 ms at V=65660 (-46% / -71%). Bench (49 configs) and e2e responses are
bitwise identical on both MI308 and H20.
