### PR TITLE
feat(quant): support compressed-tensors W8A8 INT8 checkpoints

### DIFF
--- a/rtp_llm/config/quant_config.py
+++ b/rtp_llm/config/quant_config.py
@@ -1,11 +1,59 @@
 import json
+import logging
 import os
 import weakref
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch
+
+
+def _validate_compressed_targets(group_name: str, group_config: Dict[str, Any]) -> None:
+    targets = group_config.get("targets")
+    if targets is None:
+        return
+    if not isinstance(targets, (list, tuple)) or sorted(targets) != ["Linear"]:
+        raise ValueError(
+            f"compressed-tensors group {group_name} limits quantization to "
+            f"targets={targets}, which is not supported; only a whole-model "
+            '["Linear"] scope can be applied'
+        )
+
+
+def _pick_config_group(config_groups: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Resolve the config group a compressed-tensors checkpoint describes.
+
+    ``group_0`` still wins whenever it is present, so every checkpoint that loads
+    today keeps loading identically. The fallback only covers what the previous
+    hardcoded ``config_groups["group_0"]`` lookup could not read at all: a single
+    group under a checkpoint-defined name, which is how Qwen3.5 ships W8A8.
+    """
+    if "group_0" in config_groups:
+        if len(config_groups) > 1:
+            # Only group_0 is read, exactly as before. Say so, because a
+            # multi-scheme checkpoint would otherwise load as if the other
+            # groups did not exist.
+            logging.getLogger(__name__).warning(
+                "compressed-tensors config_groups %s: only group_0 is applied, "
+                "the rest are ignored",
+                sorted(config_groups),
+            )
+        group_name = "group_0"
+        group_config = config_groups[group_name]
+        return group_name, group_config
+    if len(config_groups) != 1:
+        raise ValueError(
+            "compressed-tensors needs a group_0 entry or exactly one named group, "
+            f"got {sorted(config_groups)}"
+        )
+    group_name, group_config = next(iter(config_groups.items()))
+    # targets describes which modules the group covers and nothing reads it, so
+    # only a whole-model scope can be honoured. Anything narrower would be
+    # applied as if it covered everything and fail later asking a BF16 module
+    # for a weight scale.
+    _validate_compressed_targets(group_name, group_config)
+    return group_name, group_config
 
 
 class QuantizationType(str, Enum):
@@ -169,20 +217,32 @@ class QuantizationConfig(ABC):
                 group_size = weight_block[0]
                 quant_method = Fp8BlockWiseQuantConfig.get_method()
         if quant_method == "compressed-tensors":
-            config_groups = quant_config["config_groups"]
-            weights_config = config_groups["group_0"]["weights"]
-            activation_config = config_groups["group_0"]["input_activations"]
+            group_name, group_config = _pick_config_group(
+                quant_config["config_groups"]
+            )
+            weights_config = group_config["weights"]
+            # Absent or explicitly null when the checkpoint quantizes weights
+            # only. Legacy FP8 per-channel checkpoints accept that shape, while
+            # activation-dependent schemes below require a dict.
+            activation_config = group_config.get("input_activations")
             bits = weights_config["num_bits"]
             if (
                 weights_config["type"] == "float"
                 and bits == 8
                 and weights_config["strategy"] == "channel"
             ):
+                if activation_config is None:
+                    logging.getLogger(__name__).warning(
+                        "compressed-tensors group %s has no input_activations; "
+                        "preserving legacy FP8 per-channel weight-only loading",
+                        group_name,
+                    )
                 quant_method = Fp8PerChannelCompressedQuantConfig.get_method()
             elif (
                 weights_config["type"] == "float"
                 and bits == 8
                 and weights_config["strategy"] == "tensor"
+                and isinstance(activation_config, dict)
             ):
                 quant_method = Fp8PerTensorCompressedQuantConfig.get_method()
                 return Fp8PerTensorCompressedQuantConfig.from_config(
@@ -194,6 +254,39 @@ class QuantizationConfig(ABC):
                         "dynamic": activation_config["dynamic"],
                         "act_scale_suffix": ".input_scale",
                         "weight_scale_suffix": ".weight_scale",
+                    }
+                )
+            elif (
+                weights_config["type"] == "int"
+                and bits == 8
+                and weights_config["strategy"] == "channel"
+                and not weights_config.get("dynamic", False)
+                # Weight-only INT8 checkpoints leave input_activations null; they
+                # fall through to the generic paths below instead of subscripting
+                # a None here.
+                and isinstance(activation_config, dict)
+                and activation_config["type"] == "int"
+                and activation_config["num_bits"] == 8
+                and activation_config["strategy"] == "token"
+                and activation_config.get("dynamic", False)
+            ):
+                _validate_compressed_targets(group_name, group_config)
+                if not weights_config.get(
+                    "symmetric", True
+                ) or not activation_config.get("symmetric", True):
+                    raise ValueError(
+                        f"compressed-tensors group {group_name} uses asymmetric INT8, "
+                        "but only symmetric W8A8 is supported"
+                    )
+                ignore_patterns = quant_config.get("ignore") or []
+                quant_method = CompressedW8A8Int8PerChannelQuantConfig.get_method()
+                return CompressedW8A8Int8PerChannelQuantConfig.from_config(
+                    {
+                        "bits": bits,
+                        "method": quant_method,
+                        "group_size": 0,
+                        "is_quanted": True,
+                        "ignore_patterns": ignore_patterns,
                     }
                 )
             elif (
@@ -215,6 +308,15 @@ class QuantizationConfig(ABC):
                         "is_quanted": True,
                         "ignore_patterns": ignore_patterns,
                     }
+                )
+            if quant_method == "compressed-tensors":
+                # Nothing above recognised the scheme. The generic tail would
+                # otherwise try to instantiate the abstract
+                # CompressedTensorsQuantConfig and surface a TypeError, so name
+                # the unsupported combination instead.
+                raise ValueError(
+                    f"unsupported compressed-tensors scheme in group {group_name}: "
+                    f"weights={weights_config}, input_activations={activation_config}"
                 )
 
         if quant_method == "quark":
@@ -801,6 +903,90 @@ class CompressedW4A8Int4PerChannelQuantConfig(QuantizationConfig):
     @classmethod
     def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
         return CompressedW4A8Int4PerChannelQuantConfig(**config)
+
+
+class CompressedW8A8Int8PerChannelQuantConfig(QuantizationConfig):
+    """Pre-quantized compressed-tensors W8A8 INT8 configuration.
+
+    Weights are static symmetric INT8 per output channel and activations are
+    dynamically quantized to symmetric INT8 per token.
+    """
+
+    def __init__(
+        self,
+        bits: int = 8,
+        group_size: int = 0,
+        is_quanted: bool = True,
+        ignore_patterns: Optional[Sequence[str]] = None,
+    ):
+        assert (
+            bits == 8 and group_size == 0
+        ), f"invalid params {bits} != 8 or {group_size} != 0"
+        super().__init__(bits=bits, group_size=group_size, is_quanted=is_quanted)
+        # Every parameter is named and there is no kwargs sink, so a misspelled
+        # key raises instead of silently leaving the exclude set empty.
+        self._ignore_patterns: List[str] = list(ignore_patterns or [])
+        regex_patterns = [
+            pattern for pattern in self._ignore_patterns if pattern.startswith("re:")
+        ]
+        if regex_patterns:
+            raise ValueError(
+                "W8A8 compressed-tensors ignore does not support re: patterns: "
+                f"{regex_patterns}; use literal module names"
+            )
+        # WeightModule support checks use exclude_modules for checkpoint paths and
+        # {i}-templated model weight definitions. Concrete layer entries are
+        # allowed here because compressed-tensors checkpoints also list ignored
+        # non-quantized parameters. The W8A8 loader rejects one only when it
+        # actually intersects a quantizable template.
+        self.exclude_modules = set(self._ignore_patterns)
+
+    @classmethod
+    def get_method(cls) -> str:
+        # Not registered in preset_quant_config: this scheme is recognised from
+        # the checkpoint's own quantization_config, not selected by hand through
+        # --quantization.
+        return "W8A8_INT8_PER_CHANNEL_COMPRESSED"
+
+    @classmethod
+    def get_algo(cls) -> str:
+        return "w8a8_int8_per_channel"
+
+    @property
+    def ignore_patterns(self) -> List[str]:
+        return self._ignore_patterns
+
+    def get_supported_compute_dtypes(self) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    def get_supported_kv_cache_dtypes(self) -> List[torch.dtype]:
+        # Narrower than the sibling per-channel schemes, which also accept
+        # float8_e4m3fn: linear-layer INT8 and attention KV cache dtype are
+        # independent, but this combination has not been verified here, so a
+        # deployment carrying --fp8_kv_cache is failed at startup rather than
+        # served on an unvalidated path. Widen it with evidence, not by default.
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
+        allowed_keys = {
+            "bits",
+            "method",
+            "group_size",
+            "is_quanted",
+            "ignore_patterns",
+        }
+        unknown_keys = set(config) - allowed_keys
+        if unknown_keys:
+            raise TypeError(
+                f"unexpected W8A8 quantization config keys: {sorted(unknown_keys)}"
+            )
+        return cls(
+            bits=config.get("bits", 8),
+            group_size=config.get("group_size", 0),
+            is_quanted=config.get("is_quanted", True),
+            ignore_patterns=config.get("ignore_patterns"),
+        )
 
 
 DEFAULT_FP8_BLOCK_WISE_QUANT_CONFIG = Fp8BlockWiseQuantConfig(

--- a/rtp_llm/cpp/config/ModelConfig.cc
+++ b/rtp_llm/cpp/config/ModelConfig.cc
@@ -72,6 +72,8 @@ static std::string quantMethodToString(QuantMethod quant_method) {
             return "FP8PTPC";
         case QuantMethod::W4A8INT4PTPC:
             return "W4A8INT4PTPC";
+        case QuantMethod::W8A8INT8PTPC:
+            return "W8A8INT8PTPC";
         case QuantMethod::ModelOptFP4:
             return "ModelOptFP4";
         default:

--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -61,6 +61,8 @@ public:
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
         } else if (model_config.quant_algo.isW4a8Int4PTPC()) {
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
+        } else if (model_config.quant_algo.isW8a8Int8PTPC()) {
+            act_qscheme = rtp_llm::QScheme::Qint8PerToken;
         }
 
         return {attention_config,

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
@@ -430,6 +430,9 @@ WorkerStatusInfo LocalRpcServer::getWorkerStatusInfo(int64_t latest_finished_ver
         case QuantMethod::W4A8INT4PTPC:
             status_info.precision = "W4A8INT4PTPC";
             break;
+        case QuantMethod::W8A8INT8PTPC:
+            status_info.precision = "W8A8INT8PTPC";
+            break;
         case QuantMethod::None:
             status_info.precision = "FP16";
             break;

--- a/rtp_llm/cpp/model_utils/QuantInfo.cc
+++ b/rtp_llm/cpp/model_utils/QuantInfo.cc
@@ -46,6 +46,10 @@ void QuantAlgo::setQuantAlgo(const std::string& quant_method, int64_t bits, int6
         quant_method_ = W4A8INT4PTPC;
         weight_bits_  = 4;
         group_size_   = group_size;
+    } else if (quant_method == "w8a8_int8_per_channel") {
+        quant_method_ = W8A8INT8PTPC;
+        weight_bits_  = 8;
+        group_size_   = 0;
     } else if (quant_method == "mxfp4-quark") {
         quant_method_ = QuarkMXFP4;
         weight_bits_  = 4;

--- a/rtp_llm/cpp/model_utils/QuantInfo.h
+++ b/rtp_llm/cpp/model_utils/QuantInfo.h
@@ -15,7 +15,8 @@ enum QuantMethod {
     FP8PTPC          = 8,
     W4A8INT4PTPC     = 9,
     ModelOptFP4      = 10,
-    QuarkMXFP4         = 11,
+    QuarkMXFP4       = 11,
+    W8A8INT8PTPC     = 12,
 };
 
 struct QuantAlgo {
@@ -49,6 +50,9 @@ public:
     }
     bool isW4a8Int4PTPC() const {
         return quant_method_ == W4A8INT4PTPC;
+    }
+    bool isW8a8Int8PTPC() const {
+        return quant_method_ == W8A8INT8PTPC;
     }
     bool isQuant() const {
         return quant_method_ != None;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1159,7 +1159,8 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .value("FP8PTPC", QuantMethod::FP8PTPC)
         .value("W4A8INT4PTPC", QuantMethod::W4A8INT4PTPC)
         .value("ModelOptFP4", QuantMethod::ModelOptFP4)
-        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4);
+        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4)
+        .value("W8A8INT8PTPC", QuantMethod::W8A8INT8PTPC);
 
     // Register QuantAlgo
     py::class_<QuantAlgo>(m, "QuantAlgo")
@@ -1176,6 +1177,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def("isW4a8Int4PTPC", &QuantAlgo::isW4a8Int4PTPC)
         .def("isModelOptFP4", &QuantAlgo::isModelOptFP4)
         .def("isQuarkMXFP4", &QuantAlgo::isQuarkMXFP4)
+        .def("isW8a8Int8PTPC", &QuantAlgo::isW8a8Int8PTPC)
         .def("isQuant", &QuantAlgo::isQuant)
         .def("isGroupwise", &QuantAlgo::isGroupwise)
         .def("getQuantMethod", &QuantAlgo::getQuantMethod)

--- a/rtp_llm/model_loader/__init__.py
+++ b/rtp_llm/model_loader/__init__.py
@@ -2,6 +2,7 @@ from .attn_weight import AttnAtomicWeight, AttnConfig, MlaAttnAtomicWeight, MlaC
 from .compressed_w4a8_int4_per_channel_weight import (
     LoadCompressedW4A8Int4PerGroupQuantWeight,
 )
+from .compressed_w8a8_int8_per_channel_weight import CompressedW8A8Int8PerChannelWeight
 from .dynamic_fp8_quant_weight import LoadQuantDynamicPerTensorFp8Weight
 from .ffn_weight import (
     FfnAtomicWeight,

--- a/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
+++ b/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
@@ -1,0 +1,51 @@
+"""Loader for compressed-tensors W8A8 INT8 per-channel checkpoints."""
+
+import torch
+
+from rtp_llm.config.quant_config import CompressedW8A8Int8PerChannelQuantConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import (
+    PerChannelFp8Weight,
+    _ckpt_base_matches_quant_exclude,
+)
+from rtp_llm.model_loader.weight_module import WeightModule
+
+
+class CompressedW8A8Int8PerChannelWeight(PerChannelFp8Weight):
+    """Load INT8 kernels and FP32 channel scales without re-quantization.
+
+    Tensor mappings, TP/EP split rules and exclude handling are identical to the
+    per-channel FP8 path, so only the checkpoint dtype and the device
+    post-processing differ: INT8 kernels stay byte-exact and do not pass through
+    FP8 layout conversion.
+    """
+
+    weight_dtype = torch.int8
+    apply_fp8_device_conversion = False
+    supported_quant_config_types = (CompressedW8A8Int8PerChannelQuantConfig,)
+
+    @classmethod
+    def support(
+        cls,
+        quant_config: CompressedW8A8Int8PerChannelQuantConfig,
+        src_weight_info: WeightModule,
+    ) -> bool:
+        if (
+            not quant_config.is_quanted()
+            or not isinstance(quant_config, cls.supported_quant_config_types)
+            or src_weight_info.name not in cls.w8a8_weight_list
+        ):
+            return False
+        for ckpt_w in src_weight_info.weights:
+            base_name = ckpt_w.name.rsplit(".", 1)[0]
+            if (
+                base_name not in quant_config.exclude_modules
+                and _ckpt_base_matches_quant_exclude(
+                    base_name, quant_config.exclude_modules
+                )
+            ):
+                raise ValueError(
+                    "W8A8 compressed-tensors ignore targets only some instances "
+                    f"of quantized weight template {base_name}; per-layer fallback "
+                    "is not supported"
+                )
+        return super().support(quant_config, src_weight_info)

--- a/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -79,6 +79,17 @@ def _ckpt_base_matches_quant_exclude(
     Returns:
         True if the template (with '{i}' replaced by a wildcard for digits) matches any
         concrete path in 'exclude_modules'.
+
+    Note:
+        Matching is per weight *template*, not per layer instance, so excluding a
+        single layer (``model.layers.7.mlp.down_proj``) makes the template match
+        and de-quantizes that weight in *every* layer. The fallback is only
+        numerically correct when the checkpoint excludes the module in all
+        layers; a partial exclusion makes the remaining layers read their
+        quantized bytes as compute-dtype weights, which is a silent numerical
+        error. This is the long-standing behaviour of the FP8 and W4A8 paths and
+        is kept unchanged here; turning a partial exclusion into a startup
+        failure would need the same treatment on all three paths.
     """
     if not exclude_modules:
         return False
@@ -245,6 +256,16 @@ def create_w8a8_fp8_per_channel_weight(
 
 
 class PerChannelFp8Weight(CompositeWeight, QuantWeight):
+    """Loader for pre-quantized per-output-channel weights with FP32 scales.
+
+    The ``Fp8`` here and in the member types this creates is historical: the
+    concrete dtype comes from ``weight_dtype``, so the same tensor mappings,
+    TP/EP split rules and ``_postprocess`` serve the INT8 subclass unchanged.
+    """
+
+    weight_dtype = torch.float8_e4m3fn
+    apply_fp8_device_conversion = True
+
     w8a8_weight_list = {
         W.attn_qkv_w: W.attn_qkv_s,
         W.attn_o_w: W.attn_o_s,
@@ -259,20 +280,28 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
         W.attn_gate_w: W.attn_gate_s,
     }
 
+    # Quant config types this loader claims. Subclasses narrow it to their own
+    # scheme so exactly one loader matches a given config (see
+    # WeightModule.create, which rejects multiple valid classes).
+    supported_quant_config_types: Tuple[type, ...] = (
+        Fp8PerChannelCompressedQuantConfig,
+        Fp8PerChannelQuarkQuantConfig,
+    )
+
     @classmethod
     def support(
         cls, quant_config: QuantizationConfig, src_weight_info: WeightModule
     ) -> bool:
         if not quant_config.is_quanted() or not isinstance(
-            quant_config,
-            (Fp8PerChannelCompressedQuantConfig, Fp8PerChannelQuarkQuantConfig),
+            quant_config, cls.supported_quant_config_types
         ):
             return False
         name = src_weight_info.name
         if name not in cls.w8a8_weight_list:
             return False
-        if quant_config.exclude_modules and hasattr(src_weight_info, "weights"):
-            for ckpt_w in src_weight_info.weights:
+        ckpt_weights = src_weight_info.weights
+        if quant_config.exclude_modules and ckpt_weights:
+            for ckpt_w in ckpt_weights:
                 base_name = ckpt_w.name.rsplit(".", 1)[0]
                 if _ckpt_base_matches_quant_exclude(
                     base_name, quant_config.exclude_modules
@@ -349,7 +378,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.attn_qkv_w,
             qkv_w_list,
             concat_0,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
 
@@ -382,7 +411,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_o_w,
             [CkptWeightInfo(w_name + QW_SUFFIX)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -416,7 +445,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                         align_size=src_weight_info.config.align_size,
                         dim=0,
                     ),
-                    data_type=torch.float8_e4m3fn,
+                    data_type=self.weight_dtype,
                     config=src_weight_info.config,
                 ),
                 create_w8a8_fp8_per_channel_weight(
@@ -450,7 +479,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=0,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -476,7 +505,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=1,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -496,7 +525,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.moe_w2,
             [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
             stack_,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -519,7 +548,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 for w in src_weight_info.weights
             ],
             stack_moe_w1,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -553,7 +582,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
             identity,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -590,7 +619,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             ],
             merge_qkv_z,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -612,7 +641,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_gate_w,
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -651,11 +680,12 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 if scale_weight.dim() == 2
                 else scale_weight
             )
-            kernel_weight, scale_weight = (
-                load_config.exported_device.convert_fp8_weight_params(
-                    kernel_weight, scale_weight
+            if self.apply_fp8_device_conversion:
+                kernel_weight, scale_weight = (
+                    load_config.exported_device.convert_fp8_weight_params(
+                        kernel_weight, scale_weight
+                    )
                 )
-            )
             processed_res[self.scale.name] = scale_weight
             processed_res[self.kernel.name] = kernel_weight
 

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -38,6 +38,16 @@ py_test(
 )
 
 py_test(
+    name = "test_compressed_w8a8_int8_per_channel",
+    srcs = ["test_compressed_w8a8_int8_per_channel.py"],
+    deps = py_test_deps,
+    tags = ["H20"],
+    exec_properties = {
+        'gpu': 'H20',
+    },
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps + [

--- a/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
+++ b/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
@@ -1,0 +1,508 @@
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from rtp_llm.config.quant_config import (
+    CompressedW8A8Int8PerChannelQuantConfig,
+    Fp8PerChannelCompressedQuantConfig,
+    QuantizationConfig,
+)
+from rtp_llm.model_loader.compressed_w8a8_int8_per_channel_weight import (
+    CompressedW8A8Int8PerChannelWeight,
+)
+from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import PerChannelFp8Weight
+from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
+from rtp_llm.models_py.distributed.deepep_wrapper import DeepepWrapperConfig
+from rtp_llm.models_py.modules.factory.fused_moe.strategy_registry import (
+    StrategyRegistry,
+)
+from rtp_llm.models_py.modules.factory.linear.factory import LinearFactory
+from rtp_llm.ops import QuantAlgo
+from rtp_llm.utils.database import BaseDatabase
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
+
+
+def _compressed_group(weight_type="int", symmetric=True):
+    return {
+        "weights": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "channel",
+            "symmetric": symmetric,
+            "dynamic": False,
+        },
+        "input_activations": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "token" if weight_type == "int" else "tensor",
+            "symmetric": symmetric,
+            "dynamic": True,
+        },
+        "targets": ["Linear"],
+    }
+
+
+class _RecordingDevice:
+    """Stand-in for the exported device, the one external dependency here.
+
+    Records how often the FP8 layout conversion runs and returns tensors that
+    cannot be confused with the inputs, so the gate is asserted on behaviour
+    rather than on the class attribute that drives it.
+    """
+
+    def __init__(self):
+        self.convert_calls = 0
+        self.sentinel_kernel = torch.full((1, 1), 7, dtype=torch.int32)
+        self.sentinel_scale = torch.full((1, 1), 9, dtype=torch.int32)
+
+    def maybe_rewrite_weight_by_key(self, key, tensor):
+        return tensor
+
+    def convert_fp8_weight_params(self, kernel, scale):
+        self.convert_calls += 1
+        return self.sentinel_kernel, self.sentinel_scale
+
+
+def _load_config(exported_device):
+    return LoadConfig(
+        database=BaseDatabase(),
+        num_layers=1,
+        hidden_size=2,
+        head_num=1,
+        head_num_kv=1,
+        size_per_head=2,
+        moe_pure_tp_mode=False,
+        align_size=1,
+        moe_align_size=1,
+        moe_layer_index=[],
+        moe_n_group=1,
+        expert_num=0,
+        enable_eplb=False,
+        phy_exp_num=0,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        dp_size=1,
+        dp_rank=0,
+        lm_head_tp_size=1,
+        lm_head_tp_rank=0,
+        ffn_tp_size=1,
+        ffn_tp_rank=0,
+        num_nodes=1,
+        exported_device=exported_device,
+    )
+
+
+class _AcceptingLinear:
+    @classmethod
+    def can_handle(cls, *args):
+        del args
+        return True
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _AcceptingMoeAttributes:
+    @staticmethod
+    def calculate_priority():
+        return 1
+
+
+class _AcceptingMoeStrategy:
+    @staticmethod
+    def can_handle(config):
+        del config
+        return True
+
+    @staticmethod
+    def get_attributes():
+        return _AcceptingMoeAttributes()
+
+
+class BackendAvailabilityGuardTest(unittest.TestCase):
+    def setUp(self):
+        self._linear_strategies = list(LinearFactory._strategies)
+
+    def tearDown(self):
+        LinearFactory._strategies = self._linear_strategies
+
+    @staticmethod
+    def _quant_config():
+        return CompressedW8A8Int8PerChannelQuantConfig()
+
+    @classmethod
+    def _moe_config(cls):
+        return SimpleNamespace(
+            model_config=SimpleNamespace(quant_config=cls._quant_config()),
+            ep_size=1,
+            world_size=1,
+            tp_size=1,
+            moe_config=SimpleNamespace(use_deepep_low_latency=False),
+        )
+
+    def test_linear_reports_missing_w8a8_compute_backend(self):
+        LinearFactory._strategies = []
+        with self.assertRaisesRegex(ValueError, "registered Linear compute backend"):
+            LinearFactory.create_linear(
+                torch.ones((2, 2), dtype=torch.int8),
+                None,
+                torch.ones((2, 1), dtype=torch.float32),
+                self._quant_config(),
+            )
+
+    def test_registered_linear_backend_is_not_blocked(self):
+        LinearFactory._strategies = [_AcceptingLinear]
+        linear = LinearFactory.create_linear(
+            torch.ones((2, 2), dtype=torch.int8),
+            None,
+            torch.ones((2, 1), dtype=torch.float32),
+            self._quant_config(),
+        )
+        self.assertIsInstance(linear, _AcceptingLinear)
+
+    def test_moe_reports_missing_w8a8_compute_backend(self):
+        with self.assertRaisesRegex(ValueError, "registered MOE compute backend"):
+            StrategyRegistry().get_strategy(self._moe_config())
+
+    def test_registered_moe_backend_is_not_blocked(self):
+        registry = StrategyRegistry()
+        strategy = _AcceptingMoeStrategy()
+        registry.register(strategy)
+        self.assertIs(registry.get_strategy(self._moe_config()), strategy)
+
+
+class CompressedW8A8ConfigTest(unittest.TestCase):
+    def _load(self, quantization_config):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with open(os.path.join(model_dir, "config.json"), "w") as output:
+                json.dump({"quantization_config": quantization_config}, output)
+            return QuantizationConfig.load_from_ckpt(model_dir)
+
+    def test_parses_checkpoint_defined_group_name_and_ignore(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {"W8A8": _compressed_group()},
+                "ignore": ["lm_head"],
+            }
+        )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertEqual(config.get_algo(), "w8a8_int8_per_channel")
+        self.assertEqual(config.bits, 8)
+        self.assertEqual(config.group_size(), 0)
+        self.assertEqual(config.exclude_modules, {"lm_head"})
+
+    def test_group_0_still_wins_so_existing_checkpoints_are_unchanged(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {
+                    "group_0": _compressed_group("float"),
+                    "W8A8": _compressed_group("int"),
+                },
+            }
+        )
+        self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+
+    def test_rejects_a_named_group_scoped_to_specific_targets(self):
+        # The named-group fallback is new. Nothing reads targets, so a narrower
+        # scope would be applied as if it covered the whole model.
+        group = _compressed_group()
+        group["targets"] = ["re:.*mlp.*"]
+        with self.assertRaisesRegex(ValueError, "targets"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_w8a8_group_0_rejects_specific_targets(self):
+        group = _compressed_group()
+        group["targets"] = ["re:.*mlp.*"]
+        with self.assertRaisesRegex(ValueError, "targets"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"group_0": group},
+                }
+            )
+
+    def test_fp8_group_0_keeps_legacy_targets_behavior(self):
+        group = _compressed_group("float")
+        group["targets"] = ["re:.*mlp.*"]
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {"group_0": group},
+            }
+        )
+        self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+
+    def test_rejects_string_targets_in_named_group(self):
+        group = _compressed_group()
+        group["targets"] = "Linear"
+        with self.assertRaisesRegex(ValueError, "targets=Linear"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_group_0_wins_and_says_the_siblings_are_dropped(self):
+        with self.assertLogs(level="WARNING") as logs:
+            config = self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {
+                        "group_0": _compressed_group(),
+                        "group_1": _compressed_group(),
+                    },
+                }
+            )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertIn("group_1", "\n".join(logs.output))
+
+    def test_misspelled_config_key_fails_through_production_factory(self):
+        with self.assertRaisesRegex(TypeError, "ignore_pattern"):
+            CompressedW8A8Int8PerChannelQuantConfig.from_config(
+                {
+                    "method": "W8A8_INT8_PER_CHANNEL_COMPRESSED",
+                    "ignore_pattern": ["lm_head"],
+                }
+            )
+
+    def test_rejects_unsupported_regex_ignore_patterns(self):
+        with self.assertRaisesRegex(ValueError, "re: patterns"):
+            CompressedW8A8Int8PerChannelQuantConfig(
+                ignore_patterns=["re:.*\\.mlp\\..*"]
+            )
+
+    def test_accepts_layer_specific_ignores_for_non_quantized_modules(self):
+        patterns = [
+            "model.visual.blocks.0.attn.qkv",
+            "model.language_model.layers.7.mlp.gate",
+            "model.language_model.layers.8.linear_attn.conv1d",
+            "mtp.layers.0.mlp.shared_expert_gate",
+        ]
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=patterns
+        )
+        self.assertEqual(config.exclude_modules, set(patterns))
+
+    def test_precision_validation_rejects_fp8_kv_cache(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        with self.assertRaisesRegex(ValueError, "kv_cache_dtype"):
+            config.verify_compute_dtype_and_kv_cache_dtype(
+                torch.bfloat16, torch.float8_e4m3fn
+            )
+
+    def test_precision_validation_accepts_bf16_kv_cache(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        config.verify_compute_dtype_and_kv_cache_dtype(
+            torch.bfloat16, torch.bfloat16
+        )
+
+    def test_low_latency_bucket_uses_per_token_quantization_sizes(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        self.assertEqual(
+            DeepepWrapperConfig.calc_low_latency_max_token_per_rank(17, 2, config),
+            16,
+        )
+
+    def test_rejects_asymmetric_w8a8(self):
+        with self.assertRaisesRegex(ValueError, "asymmetric INT8"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": _compressed_group(symmetric=False)},
+                }
+            )
+
+    def test_group_0_weight_only_fp8_per_channel_keeps_legacy_loading(self):
+        null_activations = _compressed_group("float")
+        null_activations["input_activations"] = None
+        missing_activations = {
+            key: value
+            for key, value in _compressed_group("float").items()
+            if key != "input_activations"
+        }
+
+        for label, group in (
+            ("null activations", null_activations),
+            ("missing activations", missing_activations),
+        ):
+            with self.subTest(case=label), self.assertLogs(level="WARNING") as logs:
+                config = self._load(
+                    {
+                        "quant_method": "compressed-tensors",
+                        "config_groups": {"group_0": group},
+                    }
+                )
+            self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+            self.assertIn("legacy FP8 per-channel", "\n".join(logs.output))
+
+    def test_unrecognised_scheme_names_itself_instead_of_failing_abstractly(self):
+        # Weight-only INT8 (activations absent or null) and per-tensor INT8
+        # activations must not be read as dynamic per-token W8A8, and the
+        # fall-through must not surface an abstract-class TypeError.
+        weight_only = _compressed_group()
+        weight_only["input_activations"] = None
+        missing_key = {
+            k: v for k, v in _compressed_group().items() if k != "input_activations"
+        }
+        per_tensor = _compressed_group()
+        per_tensor["input_activations"]["strategy"] = "tensor"
+        for label, group in (
+            ("null activations", weight_only),
+            ("missing activations", missing_key),
+            ("per-tensor activations", per_tensor),
+        ):
+            with self.subTest(case=label):
+                with self.assertRaisesRegex(
+                    ValueError, "unsupported compressed-tensors scheme"
+                ):
+                    self._load(
+                        {
+                            "quant_method": "compressed-tensors",
+                            "config_groups": {"W8A8": group},
+                        }
+                    )
+
+
+class CompressedW8A8WeightTest(unittest.TestCase):
+    def _source(self):
+        return AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+
+    def test_support_and_checkpoint_tensor_dtypes(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        source = self._source()
+        self.assertTrue(CompressedW8A8Int8PerChannelWeight.support(config, source))
+
+        weight = WeightModule.create(source, config)
+        self.assertIsInstance(weight, CompressedW8A8Int8PerChannelWeight)
+        self.assertEqual(weight.kernel.data_type, torch.int8)
+        self.assertEqual(weight.scale.data_type, torch.float32)
+        self.assertEqual(
+            weight.kernel.weights[0].name, "model.layers.{i}.self_attn.gate.weight"
+        )
+        self.assertEqual(
+            weight.scale.weights[0].name,
+            "model.layers.{i}.self_attn.gate.weight_scale",
+        )
+
+    def test_concrete_ignore_matching_quantized_template_fails(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.7.self_attn.gate"]
+        )
+        with self.assertRaisesRegex(ValueError, "per-layer fallback"):
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+
+    def test_exact_template_ignore_can_use_unquantized_fallback(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.{i}.self_attn.gate"]
+        )
+        self.assertFalse(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+    def test_non_matching_literal_ignore_keeps_the_quantized_loader(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["lm_head"]
+        )
+        self.assertTrue(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+
+class PerChannelFp8PostprocessTest(unittest.TestCase):
+    """Assert the _postprocess behaviour, not the attribute that drives it."""
+
+    def _run(self, quant_config, kernel_dtype):
+        source = AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+        weight = WeightModule.create(source, quant_config)
+        device = _RecordingDevice()
+        # Non-square so the reshape inside _postprocess is observable.
+        tensors = {
+            weight.kernel.name: torch.arange(6, dtype=torch.int32)
+            .reshape(2, 3)
+            .to(kernel_dtype),
+            weight.scale.name: torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float32),
+        }
+        processed = weight._postprocess(tensors, "cpu", _load_config(device))
+        return weight, device, processed
+
+    def test_int8_skips_the_fp8_conversion(self):
+        # _RecordingDevice.maybe_rewrite_weight_by_key is an identity, so the
+        # tensor comparisons below pin what this loader does to the weights, not
+        # what a production device may still rewrite afterwards.
+        weight, device, processed = self._run(
+            CompressedW8A8Int8PerChannelQuantConfig(), torch.int8
+        )
+        self.assertEqual(device.convert_calls, 0)
+        kernel = processed[weight.kernel.name]
+        self.assertEqual(kernel.dtype, torch.int8)
+        self.assertEqual(tuple(kernel.shape), (3, 2))
+        torch.testing.assert_close(
+            kernel.to(torch.int32),
+            torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+        scale = processed[weight.scale.name]
+        self.assertEqual(scale.dtype, torch.float32)
+        self.assertEqual(tuple(scale.shape), (1, 3))
+
+    def test_fp8_still_runs_the_device_conversion(self):
+        weight, device, processed = self._run(
+            Fp8PerChannelCompressedQuantConfig(bits=8, is_quanted=True),
+            torch.float8_e4m3fn,
+        )
+        self.assertEqual(device.convert_calls, 1)
+        torch.testing.assert_close(
+            processed[weight.kernel.name], device.sentinel_kernel, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            processed[weight.scale.name], device.sentinel_scale, rtol=0, atol=0
+        )
+
+    def test_no_hardcoded_fp8_dtype_survives_in_the_template(self):
+        # A missed call site would keep loading FP8 kernels for an INT8
+        # checkpoint, and the dtype is only reachable through the class attribute.
+        source = inspect.getsource(PerChannelFp8Weight)
+        self.assertEqual(source.count("data_type=torch.float8_e4m3fn"), 0)
+
+
+class QuantAlgoBindingTest(unittest.TestCase):
+    """Pin the python -> C++ string contract the loader relies on."""
+
+    def test_algo_string_round_trips_to_w8a8_int8_ptpc(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        algo = QuantAlgo()
+        algo.setQuantAlgo(config.get_algo().lower(), config.bits, config.group_size())
+        self.assertTrue(algo.isW8a8Int8PTPC())
+        self.assertTrue(algo.isQuant())
+        self.assertFalse(algo.isGroupwise())
+        self.assertEqual(algo.getWeightBits(), 8)
+        self.assertEqual(algo.getActivationBits(), 8)
+        self.assertEqual(algo.getGroupSize(), 0)
+        self.assertIn("W8A8INT8PTPC", str(algo.getQuantMethod()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -232,6 +232,7 @@ class DeepepWrapperConfig:
             "FP8_DYNAMIC_PER_TENSOR",
             "W4A8_INT4_PER_CHANNEL",
             "W4A8_INT4_PER_CHANNEL_COMPRESSED",
+            "W8A8_INT8_PER_CHANNEL_COMPRESSED",
         )
         is_per_group_fp4 = (
             quant_config is not None and quant_config.get_method() == "modelopt_fp4"

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 
@@ -106,17 +106,9 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         )
         quant_method = MoeConfigResolver().get_quant_method(self.config)
         use_fp4 = quant_method == "modelopt_fp4"
-        if use_fp8:
-            a1_quant, a1_scale_quant = self._do_quant(a1)
-            assert a1_scale_quant is not None
-            tp_expert_a1 = torch.narrow(a1_quant, 0, slice_begin, slice_size)
-            tp_expert_a1_scale = torch.narrow(
-                a1_scale_quant, 0, slice_begin, slice_size
-            )
-            tp_expert_input = (tp_expert_a1, tp_expert_a1_scale)
-        else:
-            tp_expert_a1 = torch.narrow(a1, 0, slice_begin, slice_size)
-            tp_expert_input = tp_expert_a1
+        tp_expert_input = self._prepare_dispatch_input(
+            a1, slice_begin, slice_size, use_fp8
+        )
 
         # pre dispatch
         tp_expert_ids = torch.narrow(topk_ids, 0, slice_begin, slice_size).to(
@@ -156,14 +148,16 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
 
         expert_x_scale: Optional[torch.Tensor] = None
         expert_x: torch.Tensor
-        if use_fp8:
-            assert isinstance(output, tuple), "output should be a tuple"
+        if isinstance(output, tuple):
             expert_x, expert_x_scale = output
             # TODO: move it to the executor
-            if self.quant_config.is_per_act_token:
+            if use_fp8 and self.quant_config.is_per_act_token:
                 expert_x_scale = expert_x_scale[:, 0].contiguous()
         else:
-            assert isinstance(output, torch.Tensor), "output should be a tensor"
+            if use_fp8:
+                raise ValueError(
+                    "FP8 DeepEP dispatch must return (activation, scale)"
+                )
             expert_x = output
 
         expert_num_tokens = torch.tensor(
@@ -230,6 +224,29 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
 
         # out_token should be a tensor with shape and dtype like a1
         return out_token
+
+    def _prepare_dispatch_input(
+        self,
+        a1: torch.Tensor,
+        slice_begin: int,
+        slice_size: int,
+        use_fp8: bool,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Prepare one TP slice for DeepEP dispatch.
+
+        Backends may override this hook to dispatch a tensor together with
+        backend-specific metadata such as a per-token quantization scale. A
+        tuple return must preserve the scale layout expected by that backend's
+        executor; the base FP8 path returns ``(activation, scale)``.
+        """
+        if use_fp8:
+            a1_quant, a1_scale_quant = self._do_quant(a1)
+            assert a1_scale_quant is not None
+            return (
+                torch.narrow(a1_quant, 0, slice_begin, slice_size),
+                torch.narrow(a1_scale_quant, 0, slice_begin, slice_size),
+            )
+        return torch.narrow(a1, 0, slice_begin, slice_size)
 
     def _do_quant(
         self, a1: torch.Tensor

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
@@ -3,6 +3,15 @@ py_test_deps = [
 ]
 
 py_test(
+    name = "deepep_normal_router_hook_test",
+    srcs = ["deepep_normal_router_hook_test.py"],
+    deps = py_test_deps,
+    # Imports the CUDA router but exercises the extension contract with CPU tensors.
+    tags = ["H20"],
+    exec_properties = {'gpu':'H20'},
+)
+
+py_test(
     name = "deepep_normal_router_test",
     srcs = ["deepep_normal_router_test.py"],
     deps = py_test_deps + [

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_hook_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_hook_test.py
@@ -1,0 +1,104 @@
+"""DeepEP Normal router backend dispatch hook contract tests."""
+
+from types import SimpleNamespace
+from unittest import TestCase, main
+
+import torch
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.deepep_normal_router import (
+    DeepepNormalRouterBase,
+)
+
+
+class _TupleDispatchBuffer:
+    def get_dispatch_layout(self, topk_ids, expert_num):
+        del expert_num
+        token_count = topk_ids.shape[0]
+        counts = torch.tensor([token_count], dtype=torch.int32)
+        return counts, None, counts, torch.ones(token_count, dtype=torch.bool), None
+
+    def dispatch(self, expert_input, *args, **kwargs):
+        del kwargs
+        self.expert_input = expert_input
+        topk_ids = args[5]
+        topk_weights = args[6]
+        token_count = (
+            expert_input[0].shape[0]
+            if isinstance(expert_input, tuple)
+            else expert_input.shape[0]
+        )
+        return expert_input, topk_ids, topk_weights, [token_count], object(), None
+
+
+class _TupleDispatchRouter(DeepepNormalRouterBase):
+    def _prepare_dispatch_input(self, a1, slice_begin, slice_size, use_fp8):
+        self.hook_called = True
+        assert not use_fp8
+        sliced = torch.narrow(a1, 0, slice_begin, slice_size)
+        return torch.ones_like(sliced, dtype=torch.int8), torch.full(
+            (slice_size, 1), 0.25, dtype=torch.float32
+        )
+
+
+class _InvalidFp8DispatchRouter(DeepepNormalRouterBase):
+    def _prepare_dispatch_input(self, a1, slice_begin, slice_size, use_fp8):
+        assert use_fp8
+        return torch.narrow(a1, 0, slice_begin, slice_size)
+
+
+class DeepepNormalRouterHookTest(TestCase):
+    @staticmethod
+    def _new_router(router_class, quant_dtype):
+        router = object.__new__(router_class)
+        router.config = SimpleNamespace(
+            tp_size=1,
+            tp_rank=0,
+            model_config=SimpleNamespace(quant_config=None),
+        )
+        router.quant_config = FusedMoEQuantConfig(
+            quant_dtype=quant_dtype,
+            per_act_token_quant=True,
+            per_out_ch_quant=True,
+        )
+        buffer = _TupleDispatchBuffer()
+        router.deepep_buffer_wrapper = SimpleNamespace(buffer=buffer)
+        router.expert_num = 2
+        router.rank_expert_offset = 0
+        router.expert_alignment = 1
+        router.handle = None
+        return router, buffer
+
+    def test_backend_hook_preserves_dispatched_tensor_metadata(self):
+        router, buffer = self._new_router(_TupleDispatchRouter, torch.int8)
+        router.hook_called = False
+
+        a1 = torch.randn((3, 4), dtype=torch.bfloat16)
+        topk_ids = torch.zeros((3, 1), dtype=torch.int64)
+        topk_weights = torch.ones((3, 1), dtype=torch.float32)
+        payload = router.prepare(a1, None, None, topk_weights, topk_ids)
+
+        self.assertTrue(router.hook_called)
+        self.assertIsInstance(buffer.expert_input, tuple)
+        self.assertEqual(payload.expert_x.dtype, torch.int8)
+        self.assertIsNotNone(payload.expert_x_scale)
+        self.assertEqual(payload.expert_x_scale.dtype, torch.float32)
+        self.assertEqual(payload.expert_x_scale.shape, (3, 1))
+        self.assertEqual(payload.expert_x_origin_dtype, torch.bfloat16)
+
+    def test_fp8_dispatch_requires_activation_scale_tuple(self):
+        router, _ = self._new_router(
+            _InvalidFp8DispatchRouter, torch.float8_e4m3fn
+        )
+        a1 = torch.randn((3, 4), dtype=torch.bfloat16)
+        topk_ids = torch.zeros((3, 1), dtype=torch.int64)
+        topk_weights = torch.ones((3, 1), dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "must return"):
+            router.prepare(a1, None, None, topk_weights, topk_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/no_quant.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/no_quant.py
@@ -53,6 +53,9 @@ class CudaNoQuantCppStrategy(MoeStrategy):
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method is None)
         checker.check(
             config.moe_strategy == "no_auant_cpp" or config.moe_strategy == "auto"
         )
@@ -78,6 +81,9 @@ class CudaNoQuantDpNormalStrategy(MoeStrategy):
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method is None)
         checker.check(
             config.moe_strategy == "no_auant_dp_normal" or config.moe_strategy == "auto"
         )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
@@ -22,9 +22,27 @@ logger = logging.getLogger(__name__)
 class RocmEpNormalStrategy(MoeStrategy):
     """ROCm EP normal mode strategy"""
 
+    _SUPPORTED_QUANT_METHODS = {
+        None,
+        "FP8_PER_CHANNEL_COMPRESSED",
+        "FP8_PER_CHANNEL_QUARK",
+        "FP8_PER_BLOCK",
+        "modelopt_fp4",
+    }
+
+    @staticmethod
+    def _get_quant_method(config: MoEConfigAdapter) -> Any:
+        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+            MoeConfigResolver,
+        )
+
+        return MoeConfigResolver().get_quant_method(config)
+
     def can_handle(self, config: MoEConfigAdapter) -> bool:
-        """Store config for use in get_attributes(), then delegate to base."""
+        """Filter unsupported quant methods before resolving EP dependencies."""
         self._config = config
+        if self._get_quant_method(config) not in self._SUPPORTED_QUANT_METHODS:
+            return False
         return super().can_handle(config)
 
     def _resolve_executor_and_quant(
@@ -40,15 +58,10 @@ class RocmEpNormalStrategy(MoeStrategy):
             RocmExpertsFp8PerBlock,
             RocmExpertsFp8PerChannel,
         )
-        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
-            MoeConfigResolver,
-        )
-
         config = getattr(self, "_config", None)
-        resolver = MoeConfigResolver()
-        quant_method = resolver.get_quant_method(config) if config else None
+        quant_method = self._get_quant_method(config) if config else None
 
-        if quant_method in ("FP4_PER_GROUP", "FP4_PER_GROUP_QUARK", "modelopt_fp4"):
+        if quant_method == "modelopt_fp4":
             executor_class = RocmExpertsFp4PerGroup
             quant_config = FusedMoEQuantConfig(
                 quant_dtype=torch.float4_e2m1fn_x2,
@@ -67,7 +80,7 @@ class RocmEpNormalStrategy(MoeStrategy):
                 per_out_ch_quant=True,
                 block_shape=None,
             )
-        elif quant_method in ("FP8_PER_BLOCK", "FP8_PER_BLOCK_QUARK"):
+        elif quant_method == "FP8_PER_BLOCK":
             executor_class = RocmExpertsFp8PerBlock
             quant_config = FusedMoEQuantConfig(
                 quant_dtype=get_rocm_fp8_dtype(),
@@ -75,9 +88,13 @@ class RocmEpNormalStrategy(MoeStrategy):
                 per_out_ch_quant=False,
                 block_shape=[128, 128],
             )
-        else:
+        elif quant_method is None:
             executor_class = RocmExpertsBf16
             quant_config = FusedMoEQuantConfig(quant_dtype=None)
+        else:
+            raise ValueError(
+                f"ROCm EP does not support quantization method {quant_method}"
+            )
 
         return executor_class, quant_config
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
@@ -71,6 +71,11 @@ class StrategyRegistry:
         logger.debug(f"[StrategyRegistry] Found {len(candidates)} candidate(s)")
 
         if not candidates:
+            quant_method = (
+                config.model_config.quant_config.get_method()
+                if config.model_config.quant_config is not None
+                else None
+            )
             logger.error(
                 f"No suitable MOE strategy found. Config details: "
                 f"quant_config={config.model_config.quant_config}, "
@@ -79,28 +84,40 @@ class StrategyRegistry:
                 f"tp_size={config.tp_size}, "
                 f"use_deepep_low_latency={config.moe_config.use_deepep_low_latency if config.moe_config else False}"
             )
+            if quant_method == "W8A8_INT8_PER_CHANNEL_COMPRESSED":
+                raise ValueError(
+                    "W8A8_INT8_PER_CHANNEL_COMPRESSED weights were loaded, but "
+                    "no registered MOE compute backend can consume them; install "
+                    "or register a backend with W8A8 INT8 per-channel execution "
+                    "support"
+                )
             raise ValueError(
                 f"No suitable MOE strategy found for configuration. "
                 f"Please check quant_config, ep_size, and parallelism settings."
             )
 
-        # Sort candidates by priority (descending, higher priority first)
-        candidates.sort(key=lambda s: s.priority, reverse=True)
+        # get_attributes() is not a plain accessor -- it does lazy imports and
+        # some backends log from it -- so resolve it once and reuse it for the
+        # candidate log and selection.
+        scored = [(strategy, strategy.get_attributes()) for strategy in candidates]
+
+        # Sort by priority (descending, higher priority first)
+        scored.sort(key=lambda pair: pair[1].calculate_priority(), reverse=True)
 
         # Log all candidate strategies
-        logger.info(f"Found {len(candidates)} candidate strategy(ies) for MOE:")
-        for strategy in candidates:
+        logger.info(f"Found {len(scored)} candidate strategy(ies) for MOE:")
+        for strategy, attrs in scored:
             logger.info(
                 f"  - {strategy.__class__.__name__}: "
-                f"{strategy.get_attributes()} (priority={strategy.priority})"
+                f"{attrs} (priority={attrs.calculate_priority()})"
             )
 
         # Select the strategy with highest priority (first in sorted list)
-        selected = candidates[0]
+        selected, selected_attrs = scored[0]
 
         logger.info(
             f"Selected strategy: {selected.__class__.__name__} "
-            f"with priority {selected.priority}"
+            f"with priority {selected_attrs.calculate_priority()}"
         )
 
         return selected

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock, patch
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.config.quant_config import (
+    CompressedW8A8Int8PerChannelQuantConfig,
     Fp8BlockWiseQuantConfig,
     Fp8DynamicPerTensorQuantConfig,
+    MXFp4QuarkQuantConfig,
     W4a8Int4PerChannelQuantConfig,
 )
 from rtp_llm.device.device_type import DeviceType
@@ -28,7 +30,15 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.strategy import (
     CudaFp8PerBlockPureCPStrategy,
     CudaFp8PerBlockPureDPStrategy,
     CudaFp8PerTensorNoDPStrategy,
+    CudaNoQuantCppStrategy,
+    CudaNoQuantDpNormalStrategy,
     CudaW4a8Int4PerChannelNoDPStrategy,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.strategy.ep import (
+    RocmEpNormalStrategy,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.utils.condition_checker import (
+    ConditionChecker,
 )
 from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig
 
@@ -62,6 +72,13 @@ def create_model_config_with_w4a8_int4_per_channel_quant() -> ModelConfig:
     """Create ModelConfig with W4A8 INT4 per-channel quantization"""
     model_config = ModelConfig()
     model_config.quant_config = W4a8Int4PerChannelQuantConfig()
+    return model_config
+
+
+def create_model_config_with_w8a8_int8_per_channel_quant() -> ModelConfig:
+    """Create ModelConfig with compressed-tensors W8A8 INT8 quantization."""
+    model_config = ModelConfig()
+    model_config.quant_config = CompressedW8A8Int8PerChannelQuantConfig()
     return model_config
 
 
@@ -137,6 +154,77 @@ def create_moe_config_adapter(
         moe_config=moe_config,
         enable_cuda_graph=enable_cuda_graph,
     )
+
+
+class TestCudaNoQuantFallbackStrategies(unittest.TestCase):
+    """No-quant strategy conditions must reject quantized checkpoints."""
+
+    def _conditions_pass(
+        self, strategy: type, model_config: ModelConfig, moe_strategy: str
+    ) -> bool:
+        config = create_moe_config_adapter(
+            model_config=model_config,
+            parallelism_config=create_parallelism_config(),
+            moe_config=create_moe_config(moe_strategy=moe_strategy),
+        )
+        checker = ConditionChecker(f"{strategy.__name__}.check_conditions()")
+        strategy.check_conditions(checker, config)
+        return checker.all_passed()
+
+    def test_cpp_accepts_unquantized_checkpoint(self) -> None:
+        self.assertTrue(
+            self._conditions_pass(
+                CudaNoQuantCppStrategy,
+                create_model_config_without_quant(),
+                "no_auant_cpp",
+            )
+        )
+
+    def test_cpp_rejects_quantized_checkpoint(self) -> None:
+        self.assertFalse(
+            self._conditions_pass(
+                CudaNoQuantCppStrategy,
+                create_model_config_with_w8a8_int8_per_channel_quant(),
+                "no_auant_cpp",
+            )
+        )
+
+    def test_dp_normal_accepts_unquantized_checkpoint(self) -> None:
+        self.assertTrue(
+            self._conditions_pass(
+                CudaNoQuantDpNormalStrategy,
+                create_model_config_without_quant(),
+                "no_auant_dp_normal",
+            )
+        )
+
+    def test_dp_normal_rejects_quantized_checkpoint(self) -> None:
+        self.assertFalse(
+            self._conditions_pass(
+                CudaNoQuantDpNormalStrategy,
+                create_model_config_with_w8a8_int8_per_channel_quant(),
+                "no_auant_dp_normal",
+            )
+        )
+
+
+class TestRocmEpStrategyQuantFiltering(unittest.TestCase):
+    """Unsupported quant methods must leave ROCm EP candidate probing cleanly."""
+
+    def test_unsupported_quant_methods_return_false(self) -> None:
+        for quant_config in (
+            CompressedW8A8Int8PerChannelQuantConfig(),
+            MXFp4QuarkQuantConfig(),
+        ):
+            with self.subTest(quant_method=quant_config.get_method()):
+                model_config = ModelConfig()
+                model_config.quant_config = quant_config
+                config = create_moe_config_adapter(
+                    model_config=model_config,
+                    parallelism_config=create_parallelism_config(),
+                    moe_config=create_moe_config(),
+                )
+                self.assertFalse(RocmEpNormalStrategy().can_handle(config))
 
 
 class TestCudaNoQuantSingleGpuStrategy(unittest.TestCase):

--- a/rtp_llm/models_py/modules/factory/linear/factory.py
+++ b/rtp_llm/models_py/modules/factory/linear/factory.py
@@ -111,6 +111,16 @@ class LinearFactory:
         ]
 
         if not candidates:
+            quant_method = (
+                quant_config.get_method() if quant_config is not None else None
+            )
+            if quant_method == "W8A8_INT8_PER_CHANNEL_COMPRESSED":
+                raise ValueError(
+                    "W8A8_INT8_PER_CHANNEL_COMPRESSED weights were loaded, but "
+                    "no registered Linear compute backend can consume them; "
+                    "install or register a backend with W8A8 INT8 per-channel "
+                    "execution support"
+                )
             raise ValueError(
                 f"No suitable Linear strategy found for:"
                 f"weight.dtype={weight.dtype}, "

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1382,6 +1382,8 @@ class QuantAlgo:
         ...
     def isW4a8Int4PTPC(self) -> bool:
         ...
+    def isW8a8Int8PTPC(self) -> bool:
+        ...
     def isWeightOnlyPerCol(self) -> bool:
         ...
     def setQuantAlgo(self, arg0: str, arg1: int, arg2: int) -> None:
@@ -1413,6 +1415,8 @@ class QuantMethod:
       ModelOptFP4
 
       QuarkMXFP4
+
+      W8A8INT8PTPC
     """
     Awq: typing.ClassVar[QuantMethod]  # value = <QuantMethod.Awq: 3>
     FP8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.FP8PTPC: 8>
@@ -1425,8 +1429,9 @@ class QuantMethod:
     PerTensorQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.PerTensorQuant: 6>
     SmoothQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.SmoothQuant: 4>
     W4A8INT4PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W4A8INT4PTPC: 9>
+    W8A8INT8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W8A8INT8PTPC: 12>
     WeightOnlyPerCol: typing.ClassVar[QuantMethod]  # value = <QuantMethod.WeightOnlyPerCol: 1>
-    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>}
+    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>, 'QuarkMXFP4': <QuantMethod.QuarkMXFP4: 11>, 'W8A8INT8PTPC': <QuantMethod.W8A8INT8PTPC: 12>}
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:


### PR DESCRIPTION
## 背景

支持 compressed-tensors 格式的 W8A8 INT8 checkpoint：

- 权重采用 INT8 per-output-channel 静态量化
- 激活采用 INT8 per-token 动态量化

此前该格式无法被配置解析和权重加载流程完整识别；量化模型还可能误入未量化 executor，造成静默数值错误。

## 主要改动

- 解析 compressed-tensors W8A8 INT8 配置。
- 支持 checkpoint 自定义名称的单配置组。
- 新增 W8A8 INT8 per-channel 权重加载实现。
- 复用现有 per-channel loader 的 tensor mapping 与 TP/EP 切分逻辑。
- INT8 权重保持原始 dtype，不执行 FP8 设备布局转换。
- 在 DeepEP Low-Latency token sizing 中识别
  `W8A8_INT8_PER_CHANNEL_COMPRESSED`。
- 为 DeepEP Normal router 增加 backend-neutral dispatch input 扩展点。
- CUDA no-quant strategy 仅接受未量化模型。
- ROCm EP 在候选扫描阶段过滤不支持的量化方法，不再静默回退 BF16。
- W8A8 暂不允许 FP8 KV cache，未验证组合在启动阶段明确拒绝。

## compressed-tensors 行为边界

本 PR 对新增 W8A8 路径采用 fail-fast 语义：

- 自定义名称的单配置组仅在 `targets` 缺失或等于 `["Linear"]` 时允许加载。
- `group_0` 保持历史解析行为，不新增 `targets` 限制。
- `group_0` 与其他配置组并存时继续优先使用 `group_0`，并告警说明其他组被忽略。
- W8A8 的 `ignore` 暂不支持 `re:`，检测到后明确报错，避免声明的排除规则静默失效。
- 未知 W8A8 配置键会在生产 `_from_config` 入口明确报错。
- 不支持的 compressed-tensors scheme 会报告具体配置组合。
- weight-only FP8 per-channel 配置不会被误识别为动态激活 FP8。
- 非对称 W8A8 INT8 配置暂不支持。

## 范围与执行端

本 PR 负责：

- checkpoint 配置识别
- 权重 dtype、scale 与 tensor mapping
- TP/EP 权重加载
- DeepEP Low-Latency sizing
- DeepEP Normal 的通用 dispatch input 扩展契约
- 阻止量化 checkpoint 误入未量化 executor

本 PR 不在开源仓库内新增 PPU W8A8 INT8 Linear/MoE kernel。

DeepEP Normal 的外源基类通过 `_prepare_dispatch_input()` 提供 backend-neutral 扩展点：

- 默认 BF16/FP8 行为保持不变。
- 下游 backend 可以 override 该方法并返回 `(activation, scale)`。
- PPU backend 在 dispatch 前将 BF16 activation 动态量化为 INT8，并携带 FP32 per-token scale。
- PPU `DeepGemmInt8HybridExecutor` 消费 dispatch 后的 INT8 activation 与 scale。

INT8 kernel、PPU router override 和 executor 均保留在下游内源 backend。未注册支持 backend 时，W8A8 不会静默进入 BF16/no-quant executor，而是在策略选择阶段明确失败。

## 验证

单元测试覆盖：

- W8A8 compressed-tensors 配置识别
- 自定义配置组及 `group_0` 优先级
- named-group `targets` 拒绝及 `group_0` 兼容行为
- 非对称配置及不支持 scheme 的拒绝路径
- `re:` ignore fail-fast
- 生产 `_from_config` 入口拒绝未知键
- INT8 kernel dtype 与 FP32 per-channel scale
- INT8 权重跳过 FP8 设备转换
- Python → C++ `QuantAlgo` 映射
- CUDA no-quant strategy 拒绝量化模型
- ROCm EP unsupported-quant 候选过滤
- DeepEP Low-Latency W8A8 token sizing
- FP8 KV cache 启动拒绝及 BF16 KV cache 正向路径
- DeepEP Normal backend hook 传递 INT8 tensor 与 FP32 scale

集成验证：

- 下游 PPU backend 的 Qwen3.5 W8A8 INT8 TP8/DP1/MTP 8 卡 smoke 已通过。
- BF16 DP4×TP2 DeepEP Low-Latency + CUDA Graph smoke 已通过。
- BF16 TP8 DeepEP Normal + DeepGEMM smoke 已通过。

最新 DeepEP Normal hook 已增加聚焦契约测试；下游 PPU W8A8 DeepEP Normal smoke 将在完整内外源组合对齐后补充验证。

## 回滚

如目标 backend 尚未支持 W8A8，可继续使用 BF16 checkpoint，或回滚本 PR。安全门不会影响未量化模型，但会阻止量化 checkpoint 静默进入未量化执行路径。