### PR TITLE
feat(qwen35): enable PPU runtime and safe CUDA graph replay

### DIFF
--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -385,6 +385,16 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     }
 #endif
 
+    if (!has_tagged_cache) {
+        // The host mirror must be cleared with the device block table. fillParams
+        // walks every graph-batch row and may dereference padding rows when a
+        // backend keeps input_lengths uniform for graph-stable cu_seqlens. Without
+        // this reset, a padding row can retain a previous replay's block ID and
+        // route a KV write into a live request's block. Block 0 is reserved and is
+        // therefore the safe destination for padding rows.
+        py_model_inputs_.attention_inputs.kv_cache_kernel_block_id.fill_(0);
+    }
+
     // NOTE: kv_cache_block_id_{host,device} are physical block IDs dedicated for cache store
     // (see OpDefs.h). They are NOT consumed by any GPU attention kernel during CUDA graph replay;
     // attention kernels only use kv_cache_kernel_block_id_{host,device}. Cache store operations

--- a/rtp_llm/device/device_type.py
+++ b/rtp_llm/device/device_type.py
@@ -32,3 +32,7 @@ def is_cuda() -> bool:
 
 def is_hip() -> bool:
     return get_device_type() == DeviceType.ROCm
+
+
+def is_ppu() -> bool:
+    return get_device_type() == DeviceType.Ppu

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -235,11 +235,21 @@ class Qwen35Moe(Qwen3NextBase):
         moe_config = self.moe_config
         max_generate_batch_size = self.max_generate_batch_size
 
-        from rtp_llm.device.device_type import is_hip
-        from rtp_llm.models_py.utils.arch import is_cuda
+        from rtp_llm.models_py.utils.arch import (
+            get_device_type,
+            is_cuda,
+            is_hip,
+            is_ppu,
+        )
 
-        if not is_cuda() and not is_hip():
-            raise RuntimeError("Qwen3Next is only supported in cuda/rocm arch")
+        # Per-model allowlist: a device belongs here once it has the attention,
+        # MoE and MRoPE impls Qwen35Model needs. Naming the device in the message
+        # keeps it truthful as the list grows.
+        if not is_cuda() and not is_hip() and not is_ppu():
+            raise RuntimeError(
+                "Qwen3Next has no python-model implementation for "
+                f"{get_device_type().name}"
+            )
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models_py/utils/arch.py
+++ b/rtp_llm/models_py/utils/arch.py
@@ -3,7 +3,13 @@ from typing import Optional, Tuple, Union
 
 import torch
 
-from rtp_llm.device.device_type import DeviceType, get_device_type, is_cuda, is_hip
+from rtp_llm.device.device_type import (
+    DeviceType,
+    get_device_type,
+    is_cuda,
+    is_hip,
+    is_ppu,
+)
 
 
 def _canonical_cuda_device(device_id: Optional[Union[int, torch.device]]) -> int:


### PR DESCRIPTION
## 背景

Qwen3.5 的 Python model 当前仅允许在 CUDA 和 ROCm 后端构建。PPU 已具备 Qwen3.5 所需的 Attention、MoE 和 MRoPE 实现，但会在模型初始化阶段被设备检查提前拒绝。

同时，Qwen3.5 在 PPU 上启用 CUDA Graph 时暴露了 host block table 的残留问题：不同 graph batch size 之间进行 replay 时，padding row 可能保留上一次 replay 的 block ID，导致 KV 写入其他请求正在使用的 block。

## 修改内容

### Qwen3.5 PPU 支持

- 增加统一的 `is_ppu()` 设备判断。
- 将 PPU 加入 `Qwen35Moe._create_python_model()` 的设备允许列表。
- 改进不支持设备的错误信息，明确输出实际设备类型。
- 统一从 `models_py.utils.arch` 获取设备判断接口。

### CUDA Graph replay 修复

- 在准备非 tagged cache 的 attention inputs 时，同时清理 device block table 和 host mirror。
- 确保 graph padding row 始终指向保留的 block 0。
- 避免不同 graph batch size replay 之间残留 block ID，防止 KV cache 被错误写入其他请求的 block。

## Commit 组织

两个修改保留为独立 commit：

1. Qwen3.5 PPU model 构建支持。
2. CUDA Graph host block table replay 正确性修复。

## 与其他 PR 的关系

本 PR 不包含 MTP proposal GPU 状态修复。该修复已由 PR #1316 提交。

本 PR 与 PR #1316 没有代码依赖，可以独立 review 和合入。

## 验证

- `git diff --check` 通过。
- 相关 Python 文件语法检查通过。
- 等价集成代码此前已通过 PPU Qwen3.5 BF16 和 W8A8 INT8 smoke 验证。