### PR TITLE
ci: add post-merge K3 two-host smoke for feat/k3_dev

### DIFF
--- a/.github/scripts/get-k3-ci-result.sh
+++ b/.github/scripts/get-k3-ci-result.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+    echo "Usage: $0 <commit-sha> <security> <owner/repository> <branch>" >&2
+}
+
+[[ $# -eq 4 ]] || {
+    usage
+    exit 2
+}
+
+commit_sha="$1"
+security="$2"
+repository="$3"
+branch="$4"
+
+[[ "${commit_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "invalid commit SHA" >&2
+    exit 2
+}
+[[ "${repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+    echo "invalid GitHub repository" >&2
+    exit 2
+}
+[[ "${branch}" == "feat/k3_dev" ]] || {
+    echo "refusing unexpected branch: ${branch}" >&2
+    exit 2
+}
+
+: "${K3_AONE_PIPELINE_ID:?K3_AONE_PIPELINE_ID is required}"
+project_id="${K3_AONE_PROJECT_ID:-2654816}"
+status_url="${K3_CI_STATUS_URL:-https://get-tasend-back-twkvcdsbpj.cn-hangzhou-vpc.fcapp.run}"
+repository_url="https://github.com/${repository}.git"
+
+payload="$({
+    jq -n \
+        --arg commit_id "${commit_sha}" \
+        --arg repository_url "${repository_url}" \
+        --arg project_id "${project_id}" \
+        --arg pipeline_id "${K3_AONE_PIPELINE_ID}" \
+        '{
+            type: "RETRIEVE-TASK-STATUS",
+            commitId: $commit_id,
+            repositoryUrl: $repository_url,
+            aone: {
+                projectId: $project_id,
+                pipelineId: $pipeline_id
+            }
+        }'
+})"
+
+response="$(curl --silent --show-error --fail-with-body \
+    --header 'Content-Type: application/json' \
+    --header "Authorization: Basic ${security}" \
+    --data-binary "${payload}" \
+    "${status_url}")"
+
+task_id="$(jq -r '.taskId // .data.taskId // empty' <<<"${response}" 2>/dev/null || true)"
+status="$(jq -c '.status // "UNKNOWN"' <<<"${response}" 2>/dev/null || printf '%s' '"UNKNOWN"')"
+task_url="https://code.alibaba-inc.com/foundation_models/RTP-LLM/ci/jobs?pipelineId=${K3_AONE_PIPELINE_ID}${task_id:+&pipelineRunId=${task_id}}&createType=yaml"
+
+echo "K3 CI status: commit=${commit_sha} status=${status}${task_id:+ task_id=${task_id}}"
+echo "K3 CI task: ${task_url}"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "- Aone status: \`${status}\`"
+        echo "- [Aone task](${task_url})"
+    } >>"${GITHUB_STEP_SUMMARY}"
+fi
+
+if [[ "${K3_STATUS_ONCE:-0}" == "1" ]]; then
+    exit 0
+fi
+
+case "${status}" in
+    *SUCCESS*|*DONE*|*PASS*) exit 0 ;;
+    *FAILED*|*ERROR*|*TIMEOUT*|*CANCELLED*|*CANCELED*) exit 1 ;;
+    *) exit 3 ;;
+esac

--- a/.github/scripts/trigger-k3-ci.sh
+++ b/.github/scripts/trigger-k3-ci.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+    echo "Usage: $0 <commit-sha> <security> <owner/repository> <branch> <github-run-id> <github-run-attempt>" >&2
+}
+
+[[ $# -eq 6 ]] || {
+    usage
+    exit 2
+}
+
+commit_sha="$1"
+security="$2"
+repository="$3"
+branch="$4"
+github_run_id="$5"
+github_run_attempt="$6"
+
+[[ "${commit_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "invalid commit SHA" >&2
+    exit 2
+}
+[[ "${repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+    echo "invalid GitHub repository" >&2
+    exit 2
+}
+[[ "${branch}" == "feat/k3_dev" ]] || {
+    echo "refusing unexpected branch: ${branch}" >&2
+    exit 2
+}
+[[ "${github_run_id}" =~ ^[0-9]+$ && "${github_run_attempt}" =~ ^[0-9]+$ ]] || {
+    echo "invalid GitHub run identity" >&2
+    exit 2
+}
+
+: "${K3_AONE_PIPELINE_ID:?K3_AONE_PIPELINE_ID is required}"
+[[ "${K3_AONE_PIPELINE_ID}" =~ ^[0-9]+$ ]] || {
+    echo "K3_AONE_PIPELINE_ID must be numeric" >&2
+    exit 2
+}
+
+project_id="${K3_AONE_PROJECT_ID:-2654816}"
+trigger_url="${K3_CI_TRIGGER_URL:-https://triggerid-to-mq-wjrdhcgbie.cn-hangzhou-vpc.fcapp.run}"
+repository_url="https://github.com/${repository}.git"
+request_id="k3-ci:${repository}:${branch}:${commit_sha}"
+aone_task_url="https://code.alibaba-inc.com/foundation_models/RTP-LLM/ci/jobs?pipelineId=${K3_AONE_PIPELINE_ID}&createType=yaml"
+
+payload="$({
+    jq -n \
+        --arg commit_id "${commit_sha}" \
+        --arg repository_url "${repository_url}" \
+        --arg repository "${repository}" \
+        --arg branch "${branch}" \
+        --arg github_run_id "${github_run_id}" \
+        --arg github_run_attempt "${github_run_attempt}" \
+        --arg request_id "${request_id}" \
+        --arg aone_task_url "${aone_task_url}" \
+        --arg project_id "${project_id}" \
+        --arg pipeline_id "${K3_AONE_PIPELINE_ID}" \
+        '{
+            type: "CREATE-TASK",
+            commitId: $commit_id,
+            repositoryUrl: $repository_url,
+            prId: "0",
+            aone: {
+                projectId: $project_id,
+                pipelineId: $pipeline_id
+            },
+            params: {
+                "cancel-in-progress": "false",
+                github_commit: $commit_id,
+                github_branch: $branch,
+                github_repository: $repository,
+                github_run_id: $github_run_id,
+                github_run_attempt: $github_run_attempt,
+                k3_request_id: $request_id,
+                commit_sha: $commit_id,
+                branch: $branch,
+                repository: $repository,
+                request_id: $request_id,
+                aone_task_url: $aone_task_url,
+                k3_prefill_host: "106",
+                k3_decode_host: "142"
+            }
+        }'
+})"
+
+response_file="$(mktemp)"
+trap 'rm -f "${response_file}"' EXIT
+
+http_code="$(curl --silent --show-error \
+    --output "${response_file}" \
+    --write-out '%{http_code}' \
+    --header 'Content-Type: application/json' \
+    --header "Authorization: Basic ${security}" \
+    --data-binary "${payload}" \
+    "${trigger_url}")"
+
+case "${http_code}" in
+    2??) ;;
+    *)
+        echo "K3 CI enqueue failed with HTTP ${http_code}" >&2
+        sed -n '1,40p' "${response_file}" >&2
+        exit 1
+        ;;
+esac
+
+task_id="$(jq -r '.taskId // .data.taskId // .id // empty' "${response_file}" 2>/dev/null || true)"
+echo "K3 CI accepted: request_id=${request_id} commit=${commit_sha} pipeline=${K3_AONE_PIPELINE_ID}${task_id:+ task_id=${task_id}}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'request_id=%s\n' "${request_id}" >>"${GITHUB_OUTPUT}"
+    printf 'task_id=%s\n' "${task_id}" >>"${GITHUB_OUTPUT}"
+fi

--- a/.github/workflows/k3-ci-feat-k3-dev.yml
+++ b/.github/workflows/k3-ci-feat-k3-dev.yml
@@ -1,0 +1,80 @@
+name: K3 CI feat/k3_dev
+
+on:
+  push:
+    branches:
+      - feat/k3_dev
+
+permissions:
+  contents: read
+
+jobs:
+  enqueue:
+    name: K3 CI / enqueue
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: .github/scripts
+    steps:
+      - name: Checkout exact pushed commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Validate K3 CI configuration
+        env:
+          K3_AONE_PIPELINE_ID: ${{ vars.K3_AONE_PIPELINE_ID }}
+          K3_CI_SECRET: ${{ secrets.K3_CI_SECRET }}
+        run: |
+          set -euo pipefail
+          test -n "${K3_AONE_PIPELINE_ID}" || {
+            echo "K3_AONE_PIPELINE_ID repository variable is not configured" >&2
+            exit 2
+          }
+          test -n "${K3_CI_SECRET}" || {
+            echo "K3_CI_SECRET repository secret is not configured" >&2
+            exit 2
+          }
+          test "${GITHUB_REF_NAME}" = "feat/k3_dev"
+
+      - name: Enqueue two-host K3 smoke
+        id: enqueue
+        env:
+          K3_AONE_PIPELINE_ID: ${{ vars.K3_AONE_PIPELINE_ID }}
+          K3_CI_SECRET: ${{ secrets.K3_CI_SECRET }}
+        run: |
+          set -euo pipefail
+          chmod +x trigger-k3-ci.sh get-k3-ci-result.sh
+          ./trigger-k3-ci.sh \
+            "${GITHUB_SHA}" \
+            "${K3_CI_SECRET}" \
+            "${GITHUB_REPOSITORY}" \
+            "${GITHUB_REF_NAME}" \
+            "${GITHUB_RUN_ID}" \
+            "${GITHUB_RUN_ATTEMPT}"
+
+      - name: Record accepted task
+        env:
+          K3_AONE_PIPELINE_ID: ${{ vars.K3_AONE_PIPELINE_ID }}
+          K3_CI_SECRET: ${{ secrets.K3_CI_SECRET }}
+        run: |
+          set -euo pipefail
+          K3_STATUS_ONCE=1 ./get-k3-ci-result.sh \
+            "${GITHUB_SHA}" \
+            "${K3_CI_SECRET}" \
+            "${GITHUB_REPOSITORY}" \
+            "${GITHUB_REF_NAME}"
+
+      - name: Explain asynchronous result
+        run: |
+          {
+            echo "### K3 two-host smoke queued"
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Branch: \`${GITHUB_REF_NAME}\`"
+            echo "- Final status context: \`K3 CI / two-host smoke\`"
+            echo
+            echo "The Aone controller reports the final result asynchronously; this enqueue job does not hold a runner while 106/142 are busy."
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## What changed

- add a `push` workflow for every update to `feat/k3_dev`
- enqueue the dedicated Aone K3 two-host smoke without GitHub-side cancellation or concurrency replacement
- pass repository, branch, commit SHA, GitHub run metadata, and a stable idempotency request ID
- add one-shot Aone status parsing with distinct accepted/final states and task links

## Why

`feat/k3_dev` currently accepts merges without an automated full-model Kimi K3 regression run. The heavy TP8/EP8 PD smoke requires trusted two-host scheduling on fixed GPU workers, so GitHub only submits the task while Aone owns FIFO resource waiting and result reporting.

## Runtime topology

- Prefill: 106
- Decode: 142
- smoke: `example/k3/kimi_k3_full_model_two_host_pd_smoke.sh`
- suite: `SMOKE_SUITE=all`
- load method: `fastsafetensors`
- GitHub check: `K3 CI / two-host smoke`

## Validation

- `bash -n`
- ShellCheck 0.11
- Actionlint 1.7.12
- `git diff --check`
- Aone YAML syntax validation
- trusted controller unit tests: 8 passed
- 106/142 read-only image, checkpoint, RDMA, lease, task-container and cleanup validation

## Rollout prerequisites

This PR intentionally remains draft until the dedicated Aone pipeline and narrow secrets are provisioned and a manual full smoke passes while both GPU hosts are idle.
