### PR TITLE
feat: enable Qwen3.5 W8A8 integration

### DIFF
--- a/docs/backend/backend_registration.md
+++ b/docs/backend/backend_registration.md
@@ -1,0 +1,201 @@
+# 外部后端延迟注册机制
+
+RTP-LLM 支持将设备相关后端放在开源目录之外，例如内源后端或第三方扩展。
+这些后端可能需要扩展 Linear、Fused MoE、Attention，或者向命令行参数中增加
+后端特有的 MoE 策略，但不应将设备相关导入直接写入公共 Factory。
+
+本文说明外部后端的延迟注册约定，包括入口加载、注册时序、槽位生命周期、公开
+接口、扩展方式、失败语义、兼容性边界和测试范围。本机制是独立的运行时扩展能力，
+不包含任何具体量化格式、权重加载流程或设备 kernel。
+
+## 为什么需要延迟注册
+
+外部后端入口需要先登记扩展意图，但入口导入阶段不能直接调用
+`LinearFactory.register()` 或 `StrategyRegistry.register()`，因为对应 Factory
+可能尚未创建。反过来，如果外部入口为了注册实现而提前导入 Fused MoE 或 Attention
+Factory，又会连带加载通信库和设备库，影响本来不使用这些 Factory 的进程。
+
+因此，外部后端入口只在指定槽位中登记注册函数：
+
+```python
+from rtp_llm.utils.backend_registry import register_backend_hook
+
+
+register_backend_hook("linear", register_linear_impl)
+```
+
+公共 Factory 在原生 registry 或实现列表准备完成后，再执行该槽位中的注册函数：
+
+```python
+run_backend_registrations("linear", factory=LinearFactory)
+```
+
+所有 `run_backend_registrations()` 调用都会先通过稳定的 `models_py` 入口加载
+可选后端，再读取和执行槽位中的 hook。因此即使业务代码先导入某个公共 Factory，
+外部入口也能在该 Factory 消费槽位之前完成登记。`setup_args()` 还会在创建 parser
+和参数组之前显式加载同一个入口，保证参数扩展遵循相同顺序。
+
+外源环境中没有 `internal_source` 时，入口加载返回 `False`，槽位没有 hook 时
+正常 no-op，不改变现有 CUDA 或 ROCm 路径。
+
+## 公开接口
+
+注册接口位于 `rtp_llm.utils.backend_registry`：
+
+```python
+ensure_backend_entrypoint_loaded()
+register_backend_hook(slot, hook)
+run_backend_registrations(slot, repeatable=False, **context)
+```
+
+`ensure_backend_entrypoint_loaded()` 只依赖稳定的可选入口名，不依赖任何具体内源
+模块。入口导入本身带缓存，同一进程中的重复调用不会重复执行入口模块。
+
+`register_backend_hook()` 按登记顺序保存 hook。某个槽位开始执行后，hook 集合即
+冻结；再向该槽位登记 hook 会抛出 `RuntimeError`，避免不同 Factory 或 parser
+实例看到不一致的扩展集合。
+
+`run_backend_registrations()` 先确保入口已加载，再使用关键字参数将槽位上下文传给
+hook。默认生命周期是一次性：同一槽位最多执行一次，后续调用是 no-op。设置
+`repeatable=True` 时，首次执行仍会冻结 hook 集合，但以后每次调用都会把同一组
+hook 重放到新的 owner 上。一个槽位开始后不能在一次性和可重复生命周期之间切换。
+
+hook 抛出的异常不会被吞掉。后端声明了某项注册但注册失败时，启动过程应立即失败，
+不能静默回退到其他实现，否则可能把配置错误延迟到 kernel 执行阶段，甚至产生错误
+计算结果。
+
+`reset_backend_registrations()` 用于清理进程级注册状态，只供单元测试使用。
+
+## 扩展槽位
+
+| 槽位 | 生命周期 | 执行位置 | 传给 hook 的上下文 | 用途 |
+| --- | --- | --- | --- | --- |
+| `linear` | 一次性 | 原生 `LinearFactory` 实现导入完成后 | `factory` | 注册外部 `LinearBase` 实现 |
+| `fused_moe` | 一次性 | 设备侧 `StrategyRegistry` 填充并安装完成后 | `registry` | 注册外部 Fused MoE 策略 |
+| `attention` | 一次性 | 原生 Attention 实现列表填充完成后 | `prefill_mha_imps`、`decode_mha_imps`、`prefill_mla_imps`、`decode_mla_imps` | 按优先级插入外部 Attention 实现 |
+| `moe_strategy_choices` | 每个 parser 重放 | 公共 parser 创建 `--moe_strategy` 参数后 | `parser` | 增加外部后端提供的 MoE 策略名称 |
+
+Attention 实现列表的顺序就是选择优先级，越靠前的实现越先参与匹配。hook 可以直接
+操作四个实现列表，根据后端能力将实现插入到合适位置。公共注册机制只提供列表和
+生命周期，不规定具体后端的优先级策略。
+
+`moe_strategy_choices` 必须对每个新 parser 重放，因为 `setup_args()` 可以在
+同一进程中调用多次，每次都会创建新的 parser 和新的 choices 列表。该槽位继续使用
+`parser=` 上下文，现有外部 hook 不需要修改函数签名。
+
+## 后端接入示例
+
+后端入口只负责登记 hook。较重的实现模块可以放在回调内部导入，等公共 Factory
+完成初始化并执行相应槽位时再加载：
+
+```python
+from rtp_llm.utils.backend_registry import register_backend_hook
+
+
+def _register_linear(factory):
+    from my_backend.linear import MyLinear
+
+    factory.register(MyLinear)
+
+
+def _register_moe(registry):
+    from my_backend.moe import MyMoeStrategy
+
+    registry.register(MyMoeStrategy())
+
+
+def _extend_moe_choices(parser):
+    for action in parser._actions:
+        if "--moe_strategy" in action.option_strings:
+            choices = list(action.choices or ())
+            if "my_backend_strategy" not in choices:
+                choices.append("my_backend_strategy")
+            action.choices = choices
+            return
+    raise RuntimeError("--moe_strategy 尚未初始化")
+
+
+register_backend_hook("linear", _register_linear)
+register_backend_hook("fused_moe", _register_moe)
+register_backend_hook("moe_strategy_choices", _extend_moe_choices)
+```
+
+入口层注册应具备幂等性，因为同一个入口可能由参数解析或不同 Factory 的导入路径
+触达。公共入口加载带缓存，后端仍应避免自行调用安装函数时重复登记同一个 callable。
+
+外部入口在登记阶段不应导入公共 Factory。具体实现模块应放在 hook 内部延迟导入，
+这样 Factory 加载入口时不会形成循环依赖。
+
+## 失败语义
+
+注册机制采用 fail-fast 行为：
+
+- 槽位开始执行后再登记 hook，抛出 `RuntimeError`；
+- 槽位开始后改变一次性或可重复生命周期，抛出 `RuntimeError`；
+- hook 内部异常直接向上传递；
+- 没有 hook 的槽位正常执行并成为 no-op；
+- 一次性槽位重复执行不会重复注册实现；
+- 可重复槽位对每个 owner 重放首次冻结的 hook 集合；
+- 不同槽位之间相互隔离，并分别维护执行状态。
+
+注册状态由进程级锁保护，避免并发导入或并发初始化时重复消费一次性槽位。这些约束
+用于避免后端注册失败后继续选择不兼容的公开实现。
+
+## 修改文件与职责
+
+本机制的修改按照公共模块的所有权组织：
+
+| 文件 | 职责 |
+| --- | --- |
+| `rtp_llm/utils/backend_registry.py` | 加载可选入口、保存和冻结 hook、管理一次性或可重复生命周期、拒绝过晚注册，并提供测试清理接口 |
+| `rtp_llm/models_py/modules/factory/linear/__init__.py` | 在原生 Linear 实现注册后执行 `linear` 槽位 |
+| `rtp_llm/models_py/modules/factory/fused_moe/__init__.py` | 在设备侧 registry 安装后执行 `fused_moe` 槽位 |
+| `rtp_llm/models_py/modules/factory/attention/__init__.py` | 使用四个有序实现列表执行 `attention` 槽位 |
+| `rtp_llm/server/server_args/moe_group_args.py` | 在公共 CLI 参数创建后，对每个 parser 执行 `moe_strategy_choices` 槽位 |
+| `rtp_llm/server/server_args/server_args.py` | 在创建 parser 和参数组之前确保可选后端入口已加载 |
+| `rtp_llm/utils/test/backend_registry_test.py` 及其 `BUILD` target | 验证入口顺序、registry 状态、生命周期和错误约定 |
+| `rtp_llm/server/server_args/test/server_args_test.py` | 验证连续创建的 parser 都能解析外部 MoE 策略 |
+| `docs/backend/backend_registration.md` 和 `docs/index.rst` | 发布并索引外部后端接入约定 |
+
+## 兼容性与职责边界
+
+所有 Factory 槽位仍位于现有公共 registry 初始化完成之后。没有外部后端登记 hook
+时，执行槽位只是 no-op，现有 CUDA 和 ROCm 的实现加载、优先级和选择逻辑保持
+不变。
+
+本次生命周期修复保留已有的槽位名和关键字上下文，包括
+`factory=`、`registry=`、四个 Attention 列表以及 `parser=`。外部后端不需要
+修改现有 hook 函数签名。公共代码负责入口顺序、槽位名称、执行时机和上下文；外部
+后端负责具体实现、能力检查以及自身实现之间的优先级。
+
+`backend_registry.py` 必须保持设备和厂商无关，不应加入 PPU、CUDA、ROCm 或其他
+后端的具体实现名称和导入。
+
+本注册机制不包含以下内容：
+
+- 具体设备的 Linear、Fused MoE 或 Attention 实现；
+- 权重格式、权重加载和量化配置解析；
+- GEMM、activation quantization 或其他设备 kernel；
+- 设备能力判断、实现优先级和 warmup 策略；
+- 具体外部后端的正确性、性能和端到端验证。
+
+本机制只定义公共扩展点及其生命周期。具体外部后端按需登记 hook，并自行负责实现
+选择、能力判断和运行时验证。
+
+## 测试覆盖
+
+公共 registry 的定向测试覆盖：
+
+- 消费槽位前加载可选入口，入口能够及时登记 hook；
+- hook 延迟执行和关键字上下文传递；
+- 多个 hook 的登记顺序；
+- 不同槽位之间的状态隔离；
+- 一次性槽位最多执行一次；
+- 可重复槽位对不同 owner 重放同一组 hook；
+- 过晚注册和生命周期切换时抛出异常；
+- hook 异常向上传递；
+- 空槽位 no-op；
+- 连续两次 `setup_args()` 都能解析外部 MoE 策略。
+
+具体外部后端还需要独立验证：hook 是否注册了预期实现、Factory 是否能在对应设备
+能力条件下选择该实现，以及 kernel 等价性、分布式行为、性能和端到端推理结果。

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ The core features include:
    backend/server_arguments.md
    backend/sampling_params.md
    backend/attention_backend.md
+   backend/backend_registration.md
 
 .. toctree::
    :maxdepth: 1

--- a/rtp_llm/config/quant_config.py
+++ b/rtp_llm/config/quant_config.py
@@ -1,11 +1,59 @@
 import json
+import logging
 import os
 import weakref
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import torch
+
+
+def _validate_compressed_targets(group_name: str, group_config: Dict[str, Any]) -> None:
+    targets = group_config.get("targets")
+    if targets is None:
+        return
+    if not isinstance(targets, (list, tuple)) or sorted(targets) != ["Linear"]:
+        raise ValueError(
+            f"compressed-tensors group {group_name} limits quantization to "
+            f"targets={targets}, which is not supported; only a whole-model "
+            '["Linear"] scope can be applied'
+        )
+
+
+def _pick_config_group(config_groups: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Resolve the config group a compressed-tensors checkpoint describes.
+
+    ``group_0`` still wins whenever it is present, so every checkpoint that loads
+    today keeps loading identically. The fallback only covers what the previous
+    hardcoded ``config_groups["group_0"]`` lookup could not read at all: a single
+    group under a checkpoint-defined name, which is how Qwen3.5 ships W8A8.
+    """
+    if "group_0" in config_groups:
+        if len(config_groups) > 1:
+            # Only group_0 is read, exactly as before. Say so, because a
+            # multi-scheme checkpoint would otherwise load as if the other
+            # groups did not exist.
+            logging.getLogger(__name__).warning(
+                "compressed-tensors config_groups %s: only group_0 is applied, "
+                "the rest are ignored",
+                sorted(config_groups),
+            )
+        group_name = "group_0"
+        group_config = config_groups[group_name]
+        return group_name, group_config
+    if len(config_groups) != 1:
+        raise ValueError(
+            "compressed-tensors needs a group_0 entry or exactly one named group, "
+            f"got {sorted(config_groups)}"
+        )
+    group_name, group_config = next(iter(config_groups.items()))
+    # targets describes which modules the group covers and nothing reads it, so
+    # only a whole-model scope can be honoured. Anything narrower would be
+    # applied as if it covered everything and fail later asking a BF16 module
+    # for a weight scale.
+    _validate_compressed_targets(group_name, group_config)
+    return group_name, group_config
 
 
 class QuantizationType(str, Enum):
@@ -169,20 +217,35 @@ class QuantizationConfig(ABC):
                 group_size = weight_block[0]
                 quant_method = Fp8BlockWiseQuantConfig.get_method()
         if quant_method == "compressed-tensors":
-            config_groups = quant_config["config_groups"]
-            weights_config = config_groups["group_0"]["weights"]
-            activation_config = config_groups["group_0"]["input_activations"]
-            bits = weights_config["num_bits"]
+            group_name, group_config = _pick_config_group(
+                quant_config["config_groups"]
+            )
+            weights_config = group_config["weights"]
+            # Absent or explicitly null when the checkpoint quantizes weights
+            # only. Legacy FP8 per-channel checkpoints accept that shape, while
+            # activation-dependent schemes below require a dict.
+            activation_config = group_config.get("input_activations")
+            bits = weights_config.get("num_bits")
+            weight_type = weights_config.get("type")
+            weight_strategy = weights_config.get("strategy")
+            weight_dynamic = weights_config.get("dynamic", False)
             if (
-                weights_config["type"] == "float"
+                weight_type == "float"
                 and bits == 8
-                and weights_config["strategy"] == "channel"
+                and weight_strategy == "channel"
             ):
+                if activation_config is None:
+                    logging.getLogger(__name__).warning(
+                        "compressed-tensors group %s has no input_activations; "
+                        "preserving legacy FP8 per-channel weight-only loading",
+                        group_name,
+                    )
                 quant_method = Fp8PerChannelCompressedQuantConfig.get_method()
             elif (
-                weights_config["type"] == "float"
+                weight_type == "float"
                 and bits == 8
-                and weights_config["strategy"] == "tensor"
+                and weight_strategy == "tensor"
+                and isinstance(activation_config, dict)
             ):
                 quant_method = Fp8PerTensorCompressedQuantConfig.get_method()
                 return Fp8PerTensorCompressedQuantConfig.from_config(
@@ -191,15 +254,48 @@ class QuantizationConfig(ABC):
                         "method": quant_method,
                         "group_size": group_size,
                         "is_quanted": True,
-                        "dynamic": activation_config["dynamic"],
+                        "dynamic": activation_config.get("dynamic", False),
                         "act_scale_suffix": ".input_scale",
                         "weight_scale_suffix": ".weight_scale",
                     }
                 )
             elif (
-                weights_config["type"] == "int"
+                weight_type == "int"
+                and bits == 8
+                and weight_strategy == "channel"
+                and not weight_dynamic
+                # Weight-only INT8 checkpoints leave input_activations null; they
+                # fall through to the generic paths below instead of subscripting
+                # a None here.
+                and isinstance(activation_config, dict)
+                and activation_config.get("type") == "int"
+                and activation_config.get("num_bits") == 8
+                and activation_config.get("strategy") == "token"
+                and activation_config.get("dynamic", False)
+            ):
+                _validate_compressed_targets(group_name, group_config)
+                if not weights_config.get(
+                    "symmetric", True
+                ) or not activation_config.get("symmetric", True):
+                    raise ValueError(
+                        f"compressed-tensors group {group_name} uses asymmetric INT8, "
+                        "but only symmetric W8A8 is supported"
+                    )
+                ignore_patterns = quant_config.get("ignore") or []
+                quant_method = CompressedW8A8Int8PerChannelQuantConfig.get_method()
+                return CompressedW8A8Int8PerChannelQuantConfig.from_config(
+                    {
+                        "bits": bits,
+                        "method": quant_method,
+                        "group_size": 0,
+                        "is_quanted": True,
+                        "ignore_patterns": ignore_patterns,
+                    }
+                )
+            elif (
+                weight_type == "int"
                 and bits == 4
-                and weights_config["strategy"] == "group"
+                and weight_strategy == "group"
             ):
                 # Kimi-K2.5 routed-expert MoE: int4 g32 symmetric, dyn fp8 act.
                 group_size = int(weights_config.get("group_size", 32))
@@ -215,6 +311,15 @@ class QuantizationConfig(ABC):
                         "is_quanted": True,
                         "ignore_patterns": ignore_patterns,
                     }
+                )
+            if quant_method == "compressed-tensors":
+                # Nothing above recognised the scheme. The generic tail would
+                # otherwise try to instantiate the abstract
+                # CompressedTensorsQuantConfig and surface a TypeError, so name
+                # the unsupported combination instead.
+                raise ValueError(
+                    f"unsupported compressed-tensors scheme in group {group_name}: "
+                    f"weights={weights_config}, input_activations={activation_config}"
                 )
 
         if quant_method == "quark":
@@ -801,6 +906,83 @@ class CompressedW4A8Int4PerChannelQuantConfig(QuantizationConfig):
     @classmethod
     def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
         return CompressedW4A8Int4PerChannelQuantConfig(**config)
+
+
+class CompressedW8A8Int8PerChannelQuantConfig(QuantizationConfig):
+    """Pre-quantized compressed-tensors W8A8 INT8 configuration.
+
+    Weights are static symmetric INT8 per output channel and activations are
+    dynamically quantized to symmetric INT8 per token.
+    """
+
+    def __init__(
+        self,
+        bits: int = 8,
+        group_size: int = 0,
+        is_quanted: bool = True,
+        ignore_patterns: Optional[Sequence[str]] = None,
+    ):
+        assert (
+            bits == 8 and group_size == 0
+        ), f"invalid params {bits} != 8 or {group_size} != 0"
+        super().__init__(bits=bits, group_size=group_size, is_quanted=is_quanted)
+        # Every parameter is named and there is no kwargs sink, so a misspelled
+        # key raises instead of silently leaving the exclude set empty.
+        self._ignore_patterns: List[str] = list(ignore_patterns or [])
+        # WeightModule support checks use exclude_modules for checkpoint paths and
+        # {i}-templated model weight definitions. Concrete layer entries are
+        # allowed here because compressed-tensors checkpoints also list ignored
+        # non-quantized parameters. Regex entries are interpreted against the
+        # template by the loader; a concrete partial-layer entry still fails
+        # fast when it intersects a quantizable template.
+        self.exclude_modules = set(self._ignore_patterns)
+
+    @classmethod
+    def get_method(cls) -> str:
+        # Not registered in preset_quant_config: this scheme is recognised from
+        # the checkpoint's own quantization_config, not selected by hand through
+        # --quantization.
+        return "W8A8_INT8_PER_CHANNEL_COMPRESSED"
+
+    @classmethod
+    def get_algo(cls) -> str:
+        return "w8a8_int8_per_channel"
+
+    @property
+    def ignore_patterns(self) -> List[str]:
+        return self._ignore_patterns
+
+    def get_supported_compute_dtypes(self) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    def get_supported_kv_cache_dtypes(self) -> List[torch.dtype]:
+        # Narrower than the sibling per-channel schemes, which also accept
+        # float8_e4m3fn: linear-layer INT8 and attention KV cache dtype are
+        # independent, but this combination has not been verified here, so a
+        # deployment carrying --fp8_kv_cache is failed at startup rather than
+        # served on an unvalidated path. Widen it with evidence, not by default.
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def _from_config(cls, config: Dict[str, Any]) -> "QuantizationConfig":
+        allowed_keys = {
+            "bits",
+            "method",
+            "group_size",
+            "is_quanted",
+            "ignore_patterns",
+        }
+        unknown_keys = set(config) - allowed_keys
+        if unknown_keys:
+            raise TypeError(
+                f"unexpected W8A8 quantization config keys: {sorted(unknown_keys)}"
+            )
+        return cls(
+            bits=config.get("bits", 8),
+            group_size=config.get("group_size", 0),
+            is_quanted=config.get("is_quanted", True),
+            ignore_patterns=config.get("ignore_patterns"),
+        )
 
 
 DEFAULT_FP8_BLOCK_WISE_QUANT_CONFIG = Fp8BlockWiseQuantConfig(

--- a/rtp_llm/cpp/config/ModelConfig.cc
+++ b/rtp_llm/cpp/config/ModelConfig.cc
@@ -72,6 +72,8 @@ static std::string quantMethodToString(QuantMethod quant_method) {
             return "FP8PTPC";
         case QuantMethod::W4A8INT4PTPC:
             return "W4A8INT4PTPC";
+        case QuantMethod::W8A8INT8PTPC:
+            return "W8A8INT8PTPC";
         case QuantMethod::ModelOptFP4:
             return "ModelOptFP4";
         default:

--- a/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
+++ b/rtp_llm/cpp/cuda_graph/cuda_graph_runner.cc
@@ -387,6 +387,16 @@ void CudaGraphRunner::prepareAttentionInputs(const PyModelInputs& inputs,
     }
 #endif
 
+    if (!has_tagged_cache) {
+        // The host mirror must be cleared with the device block table. fillParams
+        // walks every graph-batch row and may dereference padding rows when a
+        // backend keeps input_lengths uniform for graph-stable cu_seqlens. Without
+        // this reset, a padding row can retain a previous replay's block ID and
+        // route a KV write into a live request's block. Block 0 is reserved and is
+        // therefore the safe destination for padding rows.
+        py_model_inputs_.attention_inputs.kv_cache_kernel_block_id.fill_(0);
+    }
+
     // NOTE: kv_cache_block_id_{host,device} are physical block IDs dedicated for cache store
     // (see OpDefs.h). They are NOT consumed by any GPU attention kernel during CUDA graph replay;
     // attention kernels only use kv_cache_kernel_block_id_{host,device}. Cache store operations

--- a/rtp_llm/cpp/engine_base/Executor.h
+++ b/rtp_llm/cpp/engine_base/Executor.h
@@ -61,6 +61,8 @@ public:
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
         } else if (model_config.quant_algo.isW4a8Int4PTPC()) {
             act_qscheme = rtp_llm::QScheme::Qfp8PerToken;
+        } else if (model_config.quant_algo.isW8a8Int8PTPC()) {
+            act_qscheme = rtp_llm::QScheme::Qint8PerToken;
         }
 
         return {attention_config,

--- a/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/LocalRpcServer.cc
@@ -430,6 +430,9 @@ WorkerStatusInfo LocalRpcServer::getWorkerStatusInfo(int64_t latest_finished_ver
         case QuantMethod::W4A8INT4PTPC:
             status_info.precision = "W4A8INT4PTPC";
             break;
+        case QuantMethod::W8A8INT8PTPC:
+            status_info.precision = "W8A8INT8PTPC";
+            break;
         case QuantMethod::None:
             status_info.precision = "FP16";
             break;

--- a/rtp_llm/cpp/model_utils/QuantInfo.cc
+++ b/rtp_llm/cpp/model_utils/QuantInfo.cc
@@ -46,6 +46,10 @@ void QuantAlgo::setQuantAlgo(const std::string& quant_method, int64_t bits, int6
         quant_method_ = W4A8INT4PTPC;
         weight_bits_  = 4;
         group_size_   = group_size;
+    } else if (quant_method == "w8a8_int8_per_channel") {
+        quant_method_ = W8A8INT8PTPC;
+        weight_bits_  = 8;
+        group_size_   = 0;
     } else if (quant_method == "mxfp4-quark") {
         quant_method_ = QuarkMXFP4;
         weight_bits_  = 4;

--- a/rtp_llm/cpp/model_utils/QuantInfo.h
+++ b/rtp_llm/cpp/model_utils/QuantInfo.h
@@ -15,7 +15,8 @@ enum QuantMethod {
     FP8PTPC          = 8,
     W4A8INT4PTPC     = 9,
     ModelOptFP4      = 10,
-    QuarkMXFP4         = 11,
+    QuarkMXFP4       = 11,
+    W8A8INT8PTPC     = 12,
 };
 
 struct QuantAlgo {
@@ -49,6 +50,9 @@ public:
     }
     bool isW4a8Int4PTPC() const {
         return quant_method_ == W4A8INT4PTPC;
+    }
+    bool isW8a8Int8PTPC() const {
+        return quant_method_ == W8A8INT8PTPC;
     }
     bool isQuant() const {
         return quant_method_ != None;

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1159,7 +1159,8 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .value("FP8PTPC", QuantMethod::FP8PTPC)
         .value("W4A8INT4PTPC", QuantMethod::W4A8INT4PTPC)
         .value("ModelOptFP4", QuantMethod::ModelOptFP4)
-        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4);
+        .value("QuarkMXFP4", QuantMethod::QuarkMXFP4)
+        .value("W8A8INT8PTPC", QuantMethod::W8A8INT8PTPC);
 
     // Register QuantAlgo
     py::class_<QuantAlgo>(m, "QuantAlgo")
@@ -1176,6 +1177,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def("isW4a8Int4PTPC", &QuantAlgo::isW4a8Int4PTPC)
         .def("isModelOptFP4", &QuantAlgo::isModelOptFP4)
         .def("isQuarkMXFP4", &QuantAlgo::isQuarkMXFP4)
+        .def("isW8a8Int8PTPC", &QuantAlgo::isW8a8Int8PTPC)
         .def("isQuant", &QuantAlgo::isQuant)
         .def("isGroupwise", &QuantAlgo::isGroupwise)
         .def("getQuantMethod", &QuantAlgo::getQuantMethod)

--- a/rtp_llm/device/device_type.py
+++ b/rtp_llm/device/device_type.py
@@ -32,3 +32,7 @@ def is_cuda() -> bool:
 
 def is_hip() -> bool:
     return get_device_type() == DeviceType.ROCm
+
+
+def is_ppu() -> bool:
+    return get_device_type() == DeviceType.Ppu

--- a/rtp_llm/model_loader/__init__.py
+++ b/rtp_llm/model_loader/__init__.py
@@ -2,6 +2,7 @@ from .attn_weight import AttnAtomicWeight, AttnConfig, MlaAttnAtomicWeight, MlaC
 from .compressed_w4a8_int4_per_channel_weight import (
     LoadCompressedW4A8Int4PerGroupQuantWeight,
 )
+from .compressed_w8a8_int8_per_channel_weight import CompressedW8A8Int8PerChannelWeight
 from .dynamic_fp8_quant_weight import LoadQuantDynamicPerTensorFp8Weight
 from .ffn_weight import (
     FfnAtomicWeight,

--- a/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
+++ b/rtp_llm/model_loader/compressed_w8a8_int8_per_channel_weight.py
@@ -1,0 +1,55 @@
+"""Loader for compressed-tensors W8A8 INT8 per-channel checkpoints."""
+
+import torch
+
+from rtp_llm.config.quant_config import CompressedW8A8Int8PerChannelQuantConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import (
+    PerChannelFp8Weight,
+    _ckpt_base_matches_quant_exclude,
+    _ckpt_base_matches_regex_exclude,
+)
+from rtp_llm.model_loader.weight_module import WeightModule
+
+
+class CompressedW8A8Int8PerChannelWeight(PerChannelFp8Weight):
+    """Load INT8 kernels and FP32 channel scales without re-quantization.
+
+    Tensor mappings, TP/EP split rules and exclude handling are identical to the
+    per-channel FP8 path, so only the checkpoint dtype and the device
+    post-processing differ: INT8 kernels stay byte-exact and do not pass through
+    FP8 layout conversion.
+    """
+
+    weight_dtype = torch.int8
+    apply_fp8_device_conversion = False
+    supported_quant_config_types = (CompressedW8A8Int8PerChannelQuantConfig,)
+
+    @classmethod
+    def support(
+        cls,
+        quant_config: CompressedW8A8Int8PerChannelQuantConfig,
+        src_weight_info: WeightModule,
+    ) -> bool:
+        if (
+            not quant_config.is_quanted()
+            or not isinstance(quant_config, cls.supported_quant_config_types)
+            or src_weight_info.name not in cls.w8a8_weight_list
+        ):
+            return False
+        for ckpt_w in src_weight_info.weights:
+            base_name = ckpt_w.name.rsplit(".", 1)[0]
+            if (
+                base_name not in quant_config.exclude_modules
+                and _ckpt_base_matches_quant_exclude(
+                    base_name, quant_config.exclude_modules
+                )
+                and not _ckpt_base_matches_regex_exclude(
+                    base_name, quant_config.exclude_modules
+                )
+            ):
+                raise ValueError(
+                    "W8A8 compressed-tensors ignore targets only some instances "
+                    f"of quantized weight template {base_name}; per-layer fallback "
+                    "is not supported"
+                )
+        return super().support(quant_config, src_weight_info)

--- a/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
+++ b/rtp_llm/model_loader/per_channel_fp8_quant_weight.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -79,15 +79,52 @@ def _ckpt_base_matches_quant_exclude(
     Returns:
         True if the template (with '{i}' replaced by a wildcard for digits) matches any
         concrete path in 'exclude_modules'.
+
+    Note:
+        Matching is per weight *template*, not per layer instance, so excluding a
+        single layer (``model.layers.7.mlp.down_proj``) makes the template match
+        and de-quantizes that weight in *every* layer. The fallback is only
+        numerically correct when the checkpoint excludes the module in all
+        layers; a partial exclusion makes the remaining layers read their
+        quantized bytes as compute-dtype weights, which is a silent numerical
+        error. This is the long-standing behaviour of the FP8 and W4A8 paths and
+        is kept unchanged here; turning a partial exclusion into a startup
+        failure would need the same treatment on all three paths.
     """
     if not exclude_modules:
         return False
     if base_name_template in exclude_modules:
         return True
     rx = _exclude_pattern_for(base_name_template)
-    if rx is None:
-        return False
-    return any(rx.match(ex) for ex in exclude_modules)
+    for exclude in exclude_modules:
+        if exclude.startswith("re:"):
+            try:
+                candidate = base_name_template.replace("{i}", "0")
+                if re.search(exclude[3:], candidate):
+                    return True
+            except re.error as error:
+                raise ValueError(
+                    f"invalid compressed-tensors ignore regex {exclude!r}"
+                ) from error
+        elif rx is not None and rx.match(exclude):
+            return True
+    return False
+
+
+def _ckpt_base_matches_regex_exclude(base_name_template: str, exclude_modules: set) -> bool:
+    """Return whether a regex ignore matches the whole weight template."""
+    candidate = base_name_template.replace("{i}", "0")
+    for exclude in exclude_modules:
+        if not exclude.startswith("re:"):
+            continue
+        try:
+            if re.search(exclude[3:], candidate):
+                return True
+        except re.error as error:
+            raise ValueError(
+                f"invalid compressed-tensors ignore regex {exclude!r}"
+            ) from error
+    return False
 
 
 def _identity_ensure_2d(
@@ -245,6 +282,16 @@ def create_w8a8_fp8_per_channel_weight(
 
 
 class PerChannelFp8Weight(CompositeWeight, QuantWeight):
+    """Loader for pre-quantized per-output-channel weights with FP32 scales.
+
+    The ``Fp8`` here and in the member types this creates is historical: the
+    concrete dtype comes from ``weight_dtype``, so the same tensor mappings,
+    TP/EP split rules and ``_postprocess`` serve the INT8 subclass unchanged.
+    """
+
+    weight_dtype = torch.float8_e4m3fn
+    apply_fp8_device_conversion = True
+
     w8a8_weight_list = {
         W.attn_qkv_w: W.attn_qkv_s,
         W.attn_o_w: W.attn_o_s,
@@ -259,20 +306,28 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
         W.attn_gate_w: W.attn_gate_s,
     }
 
+    # Quant config types this loader claims. Subclasses narrow it to their own
+    # scheme so exactly one loader matches a given config (see
+    # WeightModule.create, which rejects multiple valid classes).
+    supported_quant_config_types: Tuple[type, ...] = (
+        Fp8PerChannelCompressedQuantConfig,
+        Fp8PerChannelQuarkQuantConfig,
+    )
+
     @classmethod
     def support(
         cls, quant_config: QuantizationConfig, src_weight_info: WeightModule
     ) -> bool:
         if not quant_config.is_quanted() or not isinstance(
-            quant_config,
-            (Fp8PerChannelCompressedQuantConfig, Fp8PerChannelQuarkQuantConfig),
+            quant_config, cls.supported_quant_config_types
         ):
             return False
         name = src_weight_info.name
         if name not in cls.w8a8_weight_list:
             return False
-        if quant_config.exclude_modules and hasattr(src_weight_info, "weights"):
-            for ckpt_w in src_weight_info.weights:
+        ckpt_weights = src_weight_info.weights
+        if quant_config.exclude_modules and ckpt_weights:
+            for ckpt_w in ckpt_weights:
                 base_name = ckpt_w.name.rsplit(".", 1)[0]
                 if _ckpt_base_matches_quant_exclude(
                     base_name, quant_config.exclude_modules
@@ -349,7 +404,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.attn_qkv_w,
             qkv_w_list,
             concat_0,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
 
@@ -382,7 +437,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_o_w,
             [CkptWeightInfo(w_name + QW_SUFFIX)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -416,7 +471,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                         align_size=src_weight_info.config.align_size,
                         dim=0,
                     ),
-                    data_type=torch.float8_e4m3fn,
+                    data_type=self.weight_dtype,
                     config=src_weight_info.config,
                 ),
                 create_w8a8_fp8_per_channel_weight(
@@ -450,7 +505,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=0,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -476,7 +531,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                     align_size=src_weight_info.config.align_size,
                     dim=1,
                 ),
-                data_type=torch.float8_e4m3fn,
+                data_type=self.weight_dtype,
                 config=src_weight_info.config,
             )
             scale = create_w8a8_fp8_per_channel_weight(
@@ -496,7 +551,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             W.moe_w2,
             [CkptWeightInfo(w_name + QW_SUFFIX, identity)],
             stack_,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -519,7 +574,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 for w in src_weight_info.weights
             ],
             stack_moe_w1,
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -553,7 +608,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
             identity,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -590,7 +645,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             ],
             merge_qkv_z,
             src_weight_info.config,
-            torch.float8_e4m3fn,
+            self.weight_dtype,
         )
 
         scale = W8A8Fp8PerChannelLinearAttnAtomicWeight(
@@ -612,7 +667,7 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
             src_weight_info,
             W.attn_gate_w,
             [CkptWeightInfo(w_name + QW_SUFFIX, src_weight_info.weights[0].merge_fun)],
-            data_type=torch.float8_e4m3fn,
+            data_type=self.weight_dtype,
             config=src_weight_info.config,
         )
         scale = create_w8a8_fp8_per_channel_weight(
@@ -651,11 +706,12 @@ class PerChannelFp8Weight(CompositeWeight, QuantWeight):
                 if scale_weight.dim() == 2
                 else scale_weight
             )
-            kernel_weight, scale_weight = (
-                load_config.exported_device.convert_fp8_weight_params(
-                    kernel_weight, scale_weight
+            if self.apply_fp8_device_conversion:
+                kernel_weight, scale_weight = (
+                    load_config.exported_device.convert_fp8_weight_params(
+                        kernel_weight, scale_weight
+                    )
                 )
-            )
             processed_res[self.scale.name] = scale_weight
             processed_res[self.kernel.name] = kernel_weight
 

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -38,6 +38,16 @@ py_test(
 )
 
 py_test(
+    name = "test_compressed_w8a8_int8_per_channel",
+    srcs = ["test_compressed_w8a8_int8_per_channel.py"],
+    deps = py_test_deps,
+    tags = ["H20"],
+    exec_properties = {
+        'gpu': 'H20',
+    },
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps + [

--- a/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
+++ b/rtp_llm/model_loader/test/test_compressed_w8a8_int8_per_channel.py
@@ -1,0 +1,528 @@
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from rtp_llm.config.quant_config import (
+    CompressedW8A8Int8PerChannelQuantConfig,
+    Fp8PerChannelCompressedQuantConfig,
+    QuantizationConfig,
+)
+from rtp_llm.model_loader.compressed_w8a8_int8_per_channel_weight import (
+    CompressedW8A8Int8PerChannelWeight,
+)
+from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.per_channel_fp8_quant_weight import PerChannelFp8Weight
+from rtp_llm.model_loader.weight_module import AtomicWeight, WeightModule
+from rtp_llm.models_py.distributed.deepep_wrapper import DeepepWrapperConfig
+from rtp_llm.models_py.modules.factory.fused_moe.strategy_registry import (
+    StrategyRegistry,
+)
+from rtp_llm.models_py.modules.factory.linear.factory import LinearFactory
+from rtp_llm.ops import QuantAlgo
+from rtp_llm.utils.database import BaseDatabase
+from rtp_llm.utils.model_weight import CkptWeightInfo, W, identity
+
+
+def _compressed_group(weight_type="int", symmetric=True):
+    return {
+        "weights": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "channel",
+            "symmetric": symmetric,
+            "dynamic": False,
+        },
+        "input_activations": {
+            "num_bits": 8,
+            "type": weight_type,
+            "strategy": "token" if weight_type == "int" else "tensor",
+            "symmetric": symmetric,
+            "dynamic": True,
+        },
+        "targets": ["Linear"],
+    }
+
+
+class _RecordingDevice:
+    """Stand-in for the exported device, the one external dependency here.
+
+    Records how often the FP8 layout conversion runs and returns tensors that
+    cannot be confused with the inputs, so the gate is asserted on behaviour
+    rather than on the class attribute that drives it.
+    """
+
+    def __init__(self):
+        self.convert_calls = 0
+        self.sentinel_kernel = torch.full((1, 1), 7, dtype=torch.int32)
+        self.sentinel_scale = torch.full((1, 1), 9, dtype=torch.int32)
+
+    def maybe_rewrite_weight_by_key(self, key, tensor):
+        return tensor
+
+    def convert_fp8_weight_params(self, kernel, scale):
+        self.convert_calls += 1
+        return self.sentinel_kernel, self.sentinel_scale
+
+
+def _load_config(exported_device):
+    return LoadConfig(
+        database=BaseDatabase(),
+        num_layers=1,
+        hidden_size=2,
+        head_num=1,
+        head_num_kv=1,
+        size_per_head=2,
+        moe_pure_tp_mode=False,
+        align_size=1,
+        moe_align_size=1,
+        moe_layer_index=[],
+        moe_n_group=1,
+        expert_num=0,
+        enable_eplb=False,
+        phy_exp_num=0,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        dp_size=1,
+        dp_rank=0,
+        lm_head_tp_size=1,
+        lm_head_tp_rank=0,
+        ffn_tp_size=1,
+        ffn_tp_rank=0,
+        num_nodes=1,
+        exported_device=exported_device,
+    )
+
+
+class _AcceptingLinear:
+    @classmethod
+    def can_handle(cls, *args):
+        del args
+        return True
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _AcceptingMoeAttributes:
+    @staticmethod
+    def calculate_priority():
+        return 1
+
+
+class _AcceptingMoeStrategy:
+    @staticmethod
+    def can_handle(config):
+        del config
+        return True
+
+    @staticmethod
+    def get_attributes():
+        return _AcceptingMoeAttributes()
+
+
+class BackendAvailabilityGuardTest(unittest.TestCase):
+    def setUp(self):
+        self._linear_strategies = list(LinearFactory._strategies)
+
+    def tearDown(self):
+        LinearFactory._strategies = self._linear_strategies
+
+    @staticmethod
+    def _quant_config():
+        return CompressedW8A8Int8PerChannelQuantConfig()
+
+    @classmethod
+    def _moe_config(cls):
+        return SimpleNamespace(
+            model_config=SimpleNamespace(quant_config=cls._quant_config()),
+            ep_size=1,
+            world_size=1,
+            tp_size=1,
+            moe_config=SimpleNamespace(use_deepep_low_latency=False),
+        )
+
+    def test_linear_reports_missing_w8a8_compute_backend(self):
+        LinearFactory._strategies = []
+        with self.assertRaisesRegex(ValueError, "registered Linear compute backend"):
+            LinearFactory.create_linear(
+                torch.ones((2, 2), dtype=torch.int8),
+                None,
+                torch.ones((2, 1), dtype=torch.float32),
+                self._quant_config(),
+            )
+
+    def test_registered_linear_backend_is_not_blocked(self):
+        LinearFactory._strategies = [_AcceptingLinear]
+        linear = LinearFactory.create_linear(
+            torch.ones((2, 2), dtype=torch.int8),
+            None,
+            torch.ones((2, 1), dtype=torch.float32),
+            self._quant_config(),
+        )
+        self.assertIsInstance(linear, _AcceptingLinear)
+
+    def test_moe_reports_missing_w8a8_compute_backend(self):
+        with self.assertRaisesRegex(ValueError, "registered MOE compute backend"):
+            StrategyRegistry().get_strategy(self._moe_config())
+
+    def test_registered_moe_backend_is_not_blocked(self):
+        registry = StrategyRegistry()
+        strategy = _AcceptingMoeStrategy()
+        registry.register(strategy)
+        self.assertIs(registry.get_strategy(self._moe_config()), strategy)
+
+
+class CompressedW8A8ConfigTest(unittest.TestCase):
+    def _load(self, quantization_config):
+        with tempfile.TemporaryDirectory() as model_dir:
+            with open(os.path.join(model_dir, "config.json"), "w") as output:
+                json.dump({"quantization_config": quantization_config}, output)
+            return QuantizationConfig.load_from_ckpt(model_dir)
+
+    def test_parses_checkpoint_defined_group_name_and_ignore(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {"W8A8": _compressed_group()},
+                "ignore": ["lm_head"],
+            }
+        )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertEqual(config.get_algo(), "w8a8_int8_per_channel")
+        self.assertEqual(config.bits, 8)
+        self.assertEqual(config.group_size(), 0)
+        self.assertEqual(config.exclude_modules, {"lm_head"})
+
+    def test_group_0_still_wins_so_existing_checkpoints_are_unchanged(self):
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {
+                    "group_0": _compressed_group("float"),
+                    "W8A8": _compressed_group("int"),
+                },
+            }
+        )
+        self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+
+    def test_rejects_a_named_group_scoped_to_specific_targets(self):
+        # The named-group fallback is new. Nothing reads targets, so a narrower
+        # scope would be applied as if it covered the whole model.
+        group = _compressed_group()
+        group["targets"] = ["re:.*mlp.*"]
+        with self.assertRaisesRegex(ValueError, "targets"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_w8a8_group_0_rejects_specific_targets(self):
+        group = _compressed_group()
+        group["targets"] = ["re:.*mlp.*"]
+        with self.assertRaisesRegex(ValueError, "targets"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"group_0": group},
+                }
+            )
+
+    def test_fp8_group_0_keeps_legacy_targets_behavior(self):
+        group = _compressed_group("float")
+        group["targets"] = ["re:.*mlp.*"]
+        config = self._load(
+            {
+                "quant_method": "compressed-tensors",
+                "config_groups": {"group_0": group},
+            }
+        )
+        self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+
+    def test_rejects_string_targets_in_named_group(self):
+        group = _compressed_group()
+        group["targets"] = "Linear"
+        with self.assertRaisesRegex(ValueError, "targets=Linear"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_group_0_wins_and_says_the_siblings_are_dropped(self):
+        with self.assertLogs(level="WARNING") as logs:
+            config = self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {
+                        "group_0": _compressed_group(),
+                        "group_1": _compressed_group(),
+                    },
+                }
+            )
+        self.assertIsInstance(config, CompressedW8A8Int8PerChannelQuantConfig)
+        self.assertIn("group_1", "\n".join(logs.output))
+
+    def test_misspelled_config_key_fails_through_production_factory(self):
+        with self.assertRaisesRegex(TypeError, "ignore_pattern"):
+            CompressedW8A8Int8PerChannelQuantConfig.from_config(
+                {
+                    "method": "W8A8_INT8_PER_CHANNEL_COMPRESSED",
+                    "ignore_pattern": ["lm_head"],
+                }
+            )
+
+    def test_accepts_regex_ignore_patterns(self):
+        pattern = r"re:.*\.mlp\..*"
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=[pattern]
+        )
+        self.assertIn(pattern, config.exclude_modules)
+
+    def test_missing_w8a8_activation_strategy_reports_unsupported_scheme(self):
+        group = _compressed_group()
+        group["input_activations"].pop("strategy")
+        with self.assertRaisesRegex(ValueError, "unsupported compressed-tensors scheme"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": group},
+                }
+            )
+
+    def test_accepts_layer_specific_ignores_for_non_quantized_modules(self):
+        patterns = [
+            "model.visual.blocks.0.attn.qkv",
+            "model.language_model.layers.7.mlp.gate",
+            "model.language_model.layers.8.linear_attn.conv1d",
+            "mtp.layers.0.mlp.shared_expert_gate",
+        ]
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=patterns
+        )
+        self.assertEqual(config.exclude_modules, set(patterns))
+
+    def test_precision_validation_rejects_fp8_kv_cache(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        with self.assertRaisesRegex(ValueError, "kv_cache_dtype"):
+            config.verify_compute_dtype_and_kv_cache_dtype(
+                torch.bfloat16, torch.float8_e4m3fn
+            )
+
+    def test_precision_validation_accepts_bf16_kv_cache(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        config.verify_compute_dtype_and_kv_cache_dtype(
+            torch.bfloat16, torch.bfloat16
+        )
+
+    def test_low_latency_bucket_uses_per_token_quantization_sizes(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        self.assertEqual(
+            DeepepWrapperConfig.calc_low_latency_max_token_per_rank(17, 2, config),
+            16,
+        )
+
+    def test_rejects_asymmetric_w8a8(self):
+        with self.assertRaisesRegex(ValueError, "asymmetric INT8"):
+            self._load(
+                {
+                    "quant_method": "compressed-tensors",
+                    "config_groups": {"W8A8": _compressed_group(symmetric=False)},
+                }
+            )
+
+    def test_group_0_weight_only_fp8_per_channel_keeps_legacy_loading(self):
+        null_activations = _compressed_group("float")
+        null_activations["input_activations"] = None
+        missing_activations = {
+            key: value
+            for key, value in _compressed_group("float").items()
+            if key != "input_activations"
+        }
+
+        for label, group in (
+            ("null activations", null_activations),
+            ("missing activations", missing_activations),
+        ):
+            with self.subTest(case=label), self.assertLogs(level="WARNING") as logs:
+                config = self._load(
+                    {
+                        "quant_method": "compressed-tensors",
+                        "config_groups": {"group_0": group},
+                    }
+                )
+            self.assertIsInstance(config, Fp8PerChannelCompressedQuantConfig)
+            self.assertIn("legacy FP8 per-channel", "\n".join(logs.output))
+
+    def test_unrecognised_scheme_names_itself_instead_of_failing_abstractly(self):
+        # Weight-only INT8 (activations absent or null) and per-tensor INT8
+        # activations must not be read as dynamic per-token W8A8, and the
+        # fall-through must not surface an abstract-class TypeError.
+        weight_only = _compressed_group()
+        weight_only["input_activations"] = None
+        missing_key = {
+            k: v for k, v in _compressed_group().items() if k != "input_activations"
+        }
+        per_tensor = _compressed_group()
+        per_tensor["input_activations"]["strategy"] = "tensor"
+        for label, group in (
+            ("null activations", weight_only),
+            ("missing activations", missing_key),
+            ("per-tensor activations", per_tensor),
+        ):
+            with self.subTest(case=label):
+                with self.assertRaisesRegex(
+                    ValueError, "unsupported compressed-tensors scheme"
+                ):
+                    self._load(
+                        {
+                            "quant_method": "compressed-tensors",
+                            "config_groups": {"W8A8": group},
+                        }
+                    )
+
+
+class CompressedW8A8WeightTest(unittest.TestCase):
+    def _source(self):
+        return AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+
+    def test_support_and_checkpoint_tensor_dtypes(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        source = self._source()
+        self.assertTrue(CompressedW8A8Int8PerChannelWeight.support(config, source))
+
+        weight = WeightModule.create(source, config)
+        self.assertIsInstance(weight, CompressedW8A8Int8PerChannelWeight)
+        self.assertEqual(weight.kernel.data_type, torch.int8)
+        self.assertEqual(weight.scale.data_type, torch.float32)
+        self.assertEqual(
+            weight.kernel.weights[0].name, "model.layers.{i}.self_attn.gate.weight"
+        )
+        self.assertEqual(
+            weight.scale.weights[0].name,
+            "model.layers.{i}.self_attn.gate.weight_scale",
+        )
+
+    def test_concrete_ignore_matching_quantized_template_fails(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.7.self_attn.gate"]
+        )
+        with self.assertRaisesRegex(ValueError, "per-layer fallback"):
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+
+    def test_exact_template_ignore_can_use_unquantized_fallback(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["model.layers.{i}.self_attn.gate"]
+        )
+        self.assertFalse(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+    def test_regex_template_ignore_can_use_unquantized_fallback(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=[r"re:^model\.layers\.\d+\.self_attn\.gate$"]
+        )
+        self.assertFalse(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+    def test_non_matching_literal_ignore_keeps_the_quantized_loader(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig(
+            ignore_patterns=["lm_head"]
+        )
+        self.assertTrue(
+            CompressedW8A8Int8PerChannelWeight.support(config, self._source())
+        )
+
+
+class PerChannelFp8PostprocessTest(unittest.TestCase):
+    """Assert the _postprocess behaviour, not the attribute that drives it."""
+
+    def _run(self, quant_config, kernel_dtype):
+        source = AtomicWeight(
+            W.attn_gate_w,
+            [CkptWeightInfo("model.layers.{i}.self_attn.gate.weight", identity)],
+        )
+        weight = WeightModule.create(source, quant_config)
+        device = _RecordingDevice()
+        # Non-square so the reshape inside _postprocess is observable.
+        tensors = {
+            weight.kernel.name: torch.arange(6, dtype=torch.int32)
+            .reshape(2, 3)
+            .to(kernel_dtype),
+            weight.scale.name: torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.float32),
+        }
+        processed = weight._postprocess(tensors, "cpu", _load_config(device))
+        return weight, device, processed
+
+    def test_int8_skips_the_fp8_conversion(self):
+        # _RecordingDevice.maybe_rewrite_weight_by_key is an identity, so the
+        # tensor comparisons below pin what this loader does to the weights, not
+        # what a production device may still rewrite afterwards.
+        weight, device, processed = self._run(
+            CompressedW8A8Int8PerChannelQuantConfig(), torch.int8
+        )
+        self.assertEqual(device.convert_calls, 0)
+        kernel = processed[weight.kernel.name]
+        self.assertEqual(kernel.dtype, torch.int8)
+        self.assertEqual(tuple(kernel.shape), (3, 2))
+        torch.testing.assert_close(
+            kernel.to(torch.int32),
+            torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+        scale = processed[weight.scale.name]
+        self.assertEqual(scale.dtype, torch.float32)
+        self.assertEqual(tuple(scale.shape), (1, 3))
+
+    def test_fp8_still_runs_the_device_conversion(self):
+        weight, device, processed = self._run(
+            Fp8PerChannelCompressedQuantConfig(bits=8, is_quanted=True),
+            torch.float8_e4m3fn,
+        )
+        self.assertEqual(device.convert_calls, 1)
+        torch.testing.assert_close(
+            processed[weight.kernel.name], device.sentinel_kernel, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            processed[weight.scale.name], device.sentinel_scale, rtol=0, atol=0
+        )
+
+    def test_no_hardcoded_fp8_dtype_survives_in_the_template(self):
+        # A missed call site would keep loading FP8 kernels for an INT8
+        # checkpoint, and the dtype is only reachable through the class attribute.
+        source = inspect.getsource(PerChannelFp8Weight)
+        self.assertEqual(source.count("data_type=torch.float8_e4m3fn"), 0)
+
+
+class QuantAlgoBindingTest(unittest.TestCase):
+    """Pin the python -> C++ string contract the loader relies on."""
+
+    def test_algo_string_round_trips_to_w8a8_int8_ptpc(self):
+        config = CompressedW8A8Int8PerChannelQuantConfig()
+        algo = QuantAlgo()
+        algo.setQuantAlgo(config.get_algo().lower(), config.bits, config.group_size())
+        self.assertTrue(algo.isW8a8Int8PTPC())
+        self.assertTrue(algo.isQuant())
+        self.assertFalse(algo.isGroupwise())
+        self.assertEqual(algo.getWeightBits(), 8)
+        self.assertEqual(algo.getActivationBits(), 8)
+        self.assertEqual(algo.getGroupSize(), 0)
+        self.assertIn("W8A8INT8PTPC", str(algo.getQuantMethod()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -235,11 +235,21 @@ class Qwen35Moe(Qwen3NextBase):
         moe_config = self.moe_config
         max_generate_batch_size = self.max_generate_batch_size
 
-        from rtp_llm.device.device_type import is_hip
-        from rtp_llm.models_py.utils.arch import is_cuda
+        from rtp_llm.models_py.utils.arch import (
+            get_device_type,
+            is_cuda,
+            is_hip,
+            is_ppu,
+        )
 
-        if not is_cuda() and not is_hip():
-            raise RuntimeError("Qwen3Next is only supported in cuda/rocm arch")
+        # Per-model allowlist: a device belongs here once it has the attention,
+        # MoE and MRoPE impls Qwen35Model needs. Naming the device in the message
+        # keeps it truthful as the list grows.
+        if not is_cuda() and not is_hip() and not is_ppu():
+            raise RuntimeError(
+                "Qwen3Next has no python-model implementation for "
+                f"{get_device_type().name}"
+            )
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen35Model
 
         self.py_model = Qwen35Model(

--- a/rtp_llm/models_py/distributed/deepep_wrapper.py
+++ b/rtp_llm/models_py/distributed/deepep_wrapper.py
@@ -232,6 +232,7 @@ class DeepepWrapperConfig:
             "FP8_DYNAMIC_PER_TENSOR",
             "W4A8_INT4_PER_CHANNEL",
             "W4A8_INT4_PER_CHANNEL_COMPRESSED",
+            "W8A8_INT8_PER_CHANNEL_COMPRESSED",
         )
         is_per_group_fp4 = (
             quant_config is not None and quant_config.get_method() == "modelopt_fp4"

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -26,6 +26,8 @@ from rtp_llm.models_py.modules.factory.attention.attn_factory import (
     PREFILL_MLA_IMPS,
 )
 
+from rtp_llm.utils.backend_registry import run_backend_registrations
+
 device_type = get_device_type()
 if device_type == DeviceType.ROCm:
     # Import to register ROCm FMHA implementations
@@ -150,3 +152,14 @@ else:
     )
 
     PREFILL_MHA_IMPS.append(CPFlashInferImpl)
+
+# Out-of-tree backends registered a hook before this module existed. Ordering in
+# these lists is priority (earlier wins), so a backend inserts rather than
+# appends when it needs to outrank the device impls selected above.
+run_backend_registrations(
+    "attention",
+    prefill_mha_imps=PREFILL_MHA_IMPS,
+    decode_mha_imps=DECODE_MHA_IMPS,
+    prefill_mla_imps=PREFILL_MLA_IMPS,
+    decode_mla_imps=DECODE_MLA_IMPS,
+)

--- a/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/__init__.py
@@ -22,6 +22,7 @@ from rtp_llm.device.device_impl import is_gfx950
 from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.models_py.utils.arch import get_sm, is_cuda
 
+from rtp_llm.utils.backend_registry import run_backend_registrations
 from .defs.fused_moe import FusedMoe
 from .factory import FusedMoeFactory
 from .strategy_registry import StrategyRegistry
@@ -113,3 +114,7 @@ else:
         registry.register(CudaFp4EpNormalStrategy())
         registry.register(CudaFp4NoDPStrategy())
     FusedMoeFactory.set_registry(registry)
+
+# Out-of-tree backends registered a hook before this module existed. Runs for
+# every device branch, after the registry is populated and installed.
+run_backend_registrations("fused_moe", registry=registry)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/deepep_normal_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 
@@ -106,17 +106,9 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
         )
         quant_method = MoeConfigResolver().get_quant_method(self.config)
         use_fp4 = quant_method == "modelopt_fp4"
-        if use_fp8:
-            a1_quant, a1_scale_quant = self._do_quant(a1)
-            assert a1_scale_quant is not None
-            tp_expert_a1 = torch.narrow(a1_quant, 0, slice_begin, slice_size)
-            tp_expert_a1_scale = torch.narrow(
-                a1_scale_quant, 0, slice_begin, slice_size
-            )
-            tp_expert_input = (tp_expert_a1, tp_expert_a1_scale)
-        else:
-            tp_expert_a1 = torch.narrow(a1, 0, slice_begin, slice_size)
-            tp_expert_input = tp_expert_a1
+        tp_expert_input = self._prepare_dispatch_input(
+            a1, slice_begin, slice_size, use_fp8
+        )
 
         # pre dispatch
         tp_expert_ids = torch.narrow(topk_ids, 0, slice_begin, slice_size).to(
@@ -156,14 +148,16 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
 
         expert_x_scale: Optional[torch.Tensor] = None
         expert_x: torch.Tensor
-        if use_fp8:
-            assert isinstance(output, tuple), "output should be a tuple"
+        if isinstance(output, tuple):
             expert_x, expert_x_scale = output
             # TODO: move it to the executor
-            if self.quant_config.is_per_act_token:
+            if use_fp8 and self.quant_config.is_per_act_token:
                 expert_x_scale = expert_x_scale[:, 0].contiguous()
         else:
-            assert isinstance(output, torch.Tensor), "output should be a tensor"
+            if use_fp8:
+                raise ValueError(
+                    "FP8 DeepEP dispatch must return (activation, scale)"
+                )
             expert_x = output
 
         expert_num_tokens = torch.tensor(
@@ -230,6 +224,29 @@ class DeepepNormalRouterBase(FusedMoeDataRouter):
 
         # out_token should be a tensor with shape and dtype like a1
         return out_token
+
+    def _prepare_dispatch_input(
+        self,
+        a1: torch.Tensor,
+        slice_begin: int,
+        slice_size: int,
+        use_fp8: bool,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Prepare one TP slice for DeepEP dispatch.
+
+        Backends may override this hook to dispatch a tensor together with
+        backend-specific metadata such as a per-token quantization scale. A
+        tuple return must preserve the scale layout expected by that backend's
+        executor; the base FP8 path returns ``(activation, scale)``.
+        """
+        if use_fp8:
+            a1_quant, a1_scale_quant = self._do_quant(a1)
+            assert a1_scale_quant is not None
+            return (
+                torch.narrow(a1_quant, 0, slice_begin, slice_size),
+                torch.narrow(a1_scale_quant, 0, slice_begin, slice_size),
+            )
+        return torch.narrow(a1, 0, slice_begin, slice_size)
 
     def _do_quant(
         self, a1: torch.Tensor

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/BUILD
@@ -3,6 +3,15 @@ py_test_deps = [
 ]
 
 py_test(
+    name = "deepep_normal_router_hook_test",
+    srcs = ["deepep_normal_router_hook_test.py"],
+    deps = py_test_deps,
+    # Imports the CUDA router but exercises the extension contract with CPU tensors.
+    tags = ["H20"],
+    exec_properties = {'gpu':'H20'},
+)
+
+py_test(
     name = "deepep_normal_router_test",
     srcs = ["deepep_normal_router_test.py"],
     deps = py_test_deps + [

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_hook_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/routers/test/deepep_normal_router_hook_test.py
@@ -1,0 +1,104 @@
+"""DeepEP Normal router backend dispatch hook contract tests."""
+
+from types import SimpleNamespace
+from unittest import TestCase, main
+
+import torch
+
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.routers.deepep_normal_router import (
+    DeepepNormalRouterBase,
+)
+
+
+class _TupleDispatchBuffer:
+    def get_dispatch_layout(self, topk_ids, expert_num):
+        del expert_num
+        token_count = topk_ids.shape[0]
+        counts = torch.tensor([token_count], dtype=torch.int32)
+        return counts, None, counts, torch.ones(token_count, dtype=torch.bool), None
+
+    def dispatch(self, expert_input, *args, **kwargs):
+        del kwargs
+        self.expert_input = expert_input
+        topk_ids = args[5]
+        topk_weights = args[6]
+        token_count = (
+            expert_input[0].shape[0]
+            if isinstance(expert_input, tuple)
+            else expert_input.shape[0]
+        )
+        return expert_input, topk_ids, topk_weights, [token_count], object(), None
+
+
+class _TupleDispatchRouter(DeepepNormalRouterBase):
+    def _prepare_dispatch_input(self, a1, slice_begin, slice_size, use_fp8):
+        self.hook_called = True
+        assert not use_fp8
+        sliced = torch.narrow(a1, 0, slice_begin, slice_size)
+        return torch.ones_like(sliced, dtype=torch.int8), torch.full(
+            (slice_size, 1), 0.25, dtype=torch.float32
+        )
+
+
+class _InvalidFp8DispatchRouter(DeepepNormalRouterBase):
+    def _prepare_dispatch_input(self, a1, slice_begin, slice_size, use_fp8):
+        assert use_fp8
+        return torch.narrow(a1, 0, slice_begin, slice_size)
+
+
+class DeepepNormalRouterHookTest(TestCase):
+    @staticmethod
+    def _new_router(router_class, quant_dtype):
+        router = object.__new__(router_class)
+        router.config = SimpleNamespace(
+            tp_size=1,
+            tp_rank=0,
+            model_config=SimpleNamespace(quant_config=None),
+        )
+        router.quant_config = FusedMoEQuantConfig(
+            quant_dtype=quant_dtype,
+            per_act_token_quant=True,
+            per_out_ch_quant=True,
+        )
+        buffer = _TupleDispatchBuffer()
+        router.deepep_buffer_wrapper = SimpleNamespace(buffer=buffer)
+        router.expert_num = 2
+        router.rank_expert_offset = 0
+        router.expert_alignment = 1
+        router.handle = None
+        return router, buffer
+
+    def test_backend_hook_preserves_dispatched_tensor_metadata(self):
+        router, buffer = self._new_router(_TupleDispatchRouter, torch.int8)
+        router.hook_called = False
+
+        a1 = torch.randn((3, 4), dtype=torch.bfloat16)
+        topk_ids = torch.zeros((3, 1), dtype=torch.int64)
+        topk_weights = torch.ones((3, 1), dtype=torch.float32)
+        payload = router.prepare(a1, None, None, topk_weights, topk_ids)
+
+        self.assertTrue(router.hook_called)
+        self.assertIsInstance(buffer.expert_input, tuple)
+        self.assertEqual(payload.expert_x.dtype, torch.int8)
+        self.assertIsNotNone(payload.expert_x_scale)
+        self.assertEqual(payload.expert_x_scale.dtype, torch.float32)
+        self.assertEqual(payload.expert_x_scale.shape, (3, 1))
+        self.assertEqual(payload.expert_x_origin_dtype, torch.bfloat16)
+
+    def test_fp8_dispatch_requires_activation_scale_tuple(self):
+        router, _ = self._new_router(
+            _InvalidFp8DispatchRouter, torch.float8_e4m3fn
+        )
+        a1 = torch.randn((3, 4), dtype=torch.bfloat16)
+        topk_ids = torch.zeros((3, 1), dtype=torch.int64)
+        topk_weights = torch.ones((3, 1), dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "must return"):
+            router.prepare(a1, None, None, topk_weights, topk_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/no_quant.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/cuda/strategy/no_quant.py
@@ -53,6 +53,9 @@ class CudaNoQuantCppStrategy(MoeStrategy):
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method is None)
         checker.check(
             config.moe_strategy == "no_auant_cpp" or config.moe_strategy == "auto"
         )
@@ -78,6 +81,9 @@ class CudaNoQuantDpNormalStrategy(MoeStrategy):
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
+        resolver = MoeConfigResolver()
+        quant_method = resolver.get_quant_method(config)
+        checker.check(quant_method is None)
         checker.check(
             config.moe_strategy == "no_auant_dp_normal" or config.moe_strategy == "auto"
         )

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/strategy/ep.py
@@ -22,9 +22,27 @@ logger = logging.getLogger(__name__)
 class RocmEpNormalStrategy(MoeStrategy):
     """ROCm EP normal mode strategy"""
 
+    _SUPPORTED_QUANT_METHODS = {
+        None,
+        "FP8_PER_CHANNEL_COMPRESSED",
+        "FP8_PER_CHANNEL_QUARK",
+        "FP8_PER_BLOCK",
+        "modelopt_fp4",
+    }
+
+    @staticmethod
+    def _get_quant_method(config: MoEConfigAdapter) -> Any:
+        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
+            MoeConfigResolver,
+        )
+
+        return MoeConfigResolver().get_quant_method(config)
+
     def can_handle(self, config: MoEConfigAdapter) -> bool:
-        """Store config for use in get_attributes(), then delegate to base."""
+        """Filter unsupported quant methods before resolving EP dependencies."""
         self._config = config
+        if self._get_quant_method(config) not in self._SUPPORTED_QUANT_METHODS:
+            return False
         return super().can_handle(config)
 
     def _resolve_executor_and_quant(
@@ -40,15 +58,10 @@ class RocmEpNormalStrategy(MoeStrategy):
             RocmExpertsFp8PerBlock,
             RocmExpertsFp8PerChannel,
         )
-        from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
-            MoeConfigResolver,
-        )
-
         config = getattr(self, "_config", None)
-        resolver = MoeConfigResolver()
-        quant_method = resolver.get_quant_method(config) if config else None
+        quant_method = self._get_quant_method(config) if config else None
 
-        if quant_method in ("FP4_PER_GROUP", "FP4_PER_GROUP_QUARK", "modelopt_fp4"):
+        if quant_method == "modelopt_fp4":
             executor_class = RocmExpertsFp4PerGroup
             quant_config = FusedMoEQuantConfig(
                 quant_dtype=torch.float4_e2m1fn_x2,
@@ -67,7 +80,7 @@ class RocmEpNormalStrategy(MoeStrategy):
                 per_out_ch_quant=True,
                 block_shape=None,
             )
-        elif quant_method in ("FP8_PER_BLOCK", "FP8_PER_BLOCK_QUARK"):
+        elif quant_method == "FP8_PER_BLOCK":
             executor_class = RocmExpertsFp8PerBlock
             quant_config = FusedMoEQuantConfig(
                 quant_dtype=get_rocm_fp8_dtype(),
@@ -75,9 +88,13 @@ class RocmEpNormalStrategy(MoeStrategy):
                 per_out_ch_quant=False,
                 block_shape=[128, 128],
             )
-        else:
+        elif quant_method is None:
             executor_class = RocmExpertsBf16
             quant_config = FusedMoEQuantConfig(quant_dtype=None)
+        else:
+            raise ValueError(
+                f"ROCm EP does not support quantization method {quant_method}"
+            )
 
         return executor_class, quant_config
 

--- a/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/strategy_registry.py
@@ -71,6 +71,11 @@ class StrategyRegistry:
         logger.debug(f"[StrategyRegistry] Found {len(candidates)} candidate(s)")
 
         if not candidates:
+            quant_method = (
+                config.model_config.quant_config.get_method()
+                if config.model_config.quant_config is not None
+                else None
+            )
             logger.error(
                 f"No suitable MOE strategy found. Config details: "
                 f"quant_config={config.model_config.quant_config}, "
@@ -79,28 +84,40 @@ class StrategyRegistry:
                 f"tp_size={config.tp_size}, "
                 f"use_deepep_low_latency={config.moe_config.use_deepep_low_latency if config.moe_config else False}"
             )
+            if quant_method == "W8A8_INT8_PER_CHANNEL_COMPRESSED":
+                raise ValueError(
+                    "W8A8_INT8_PER_CHANNEL_COMPRESSED weights were loaded, but "
+                    "no registered MOE compute backend can consume them; install "
+                    "or register a backend with W8A8 INT8 per-channel execution "
+                    "support"
+                )
             raise ValueError(
                 f"No suitable MOE strategy found for configuration. "
                 f"Please check quant_config, ep_size, and parallelism settings."
             )
 
-        # Sort candidates by priority (descending, higher priority first)
-        candidates.sort(key=lambda s: s.priority, reverse=True)
+        # get_attributes() is not a plain accessor -- it does lazy imports and
+        # some backends log from it -- so resolve it once and reuse it for the
+        # candidate log and selection.
+        scored = [(strategy, strategy.get_attributes()) for strategy in candidates]
+
+        # Sort by priority (descending, higher priority first)
+        scored.sort(key=lambda pair: pair[1].calculate_priority(), reverse=True)
 
         # Log all candidate strategies
-        logger.info(f"Found {len(candidates)} candidate strategy(ies) for MOE:")
-        for strategy in candidates:
+        logger.info(f"Found {len(scored)} candidate strategy(ies) for MOE:")
+        for strategy, attrs in scored:
             logger.info(
                 f"  - {strategy.__class__.__name__}: "
-                f"{strategy.get_attributes()} (priority={strategy.priority})"
+                f"{attrs} (priority={attrs.calculate_priority()})"
             )
 
         # Select the strategy with highest priority (first in sorted list)
-        selected = candidates[0]
+        selected, selected_attrs = scored[0]
 
         logger.info(
             f"Selected strategy: {selected.__class__.__name__} "
-            f"with priority {selected.priority}"
+            f"with priority {selected_attrs.calculate_priority()}"
         )
 
         return selected

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_cuda_strategies.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock, patch
 
 from rtp_llm.config.model_config import ModelConfig
 from rtp_llm.config.quant_config import (
+    CompressedW8A8Int8PerChannelQuantConfig,
     Fp8BlockWiseQuantConfig,
     Fp8DynamicPerTensorQuantConfig,
+    MXFp4QuarkQuantConfig,
     W4a8Int4PerChannelQuantConfig,
 )
 from rtp_llm.device.device_type import DeviceType
@@ -28,7 +30,15 @@ from rtp_llm.models_py.modules.factory.fused_moe.impl.cuda.strategy import (
     CudaFp8PerBlockPureCPStrategy,
     CudaFp8PerBlockPureDPStrategy,
     CudaFp8PerTensorNoDPStrategy,
+    CudaNoQuantCppStrategy,
+    CudaNoQuantDpNormalStrategy,
     CudaW4a8Int4PerChannelNoDPStrategy,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.strategy.ep import (
+    RocmEpNormalStrategy,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.utils.condition_checker import (
+    ConditionChecker,
 )
 from rtp_llm.ops import CPRotateMethod, MoeConfig, ParallelismConfig
 
@@ -62,6 +72,13 @@ def create_model_config_with_w4a8_int4_per_channel_quant() -> ModelConfig:
     """Create ModelConfig with W4A8 INT4 per-channel quantization"""
     model_config = ModelConfig()
     model_config.quant_config = W4a8Int4PerChannelQuantConfig()
+    return model_config
+
+
+def create_model_config_with_w8a8_int8_per_channel_quant() -> ModelConfig:
+    """Create ModelConfig with compressed-tensors W8A8 INT8 quantization."""
+    model_config = ModelConfig()
+    model_config.quant_config = CompressedW8A8Int8PerChannelQuantConfig()
     return model_config
 
 
@@ -137,6 +154,77 @@ def create_moe_config_adapter(
         moe_config=moe_config,
         enable_cuda_graph=enable_cuda_graph,
     )
+
+
+class TestCudaNoQuantFallbackStrategies(unittest.TestCase):
+    """No-quant strategy conditions must reject quantized checkpoints."""
+
+    def _conditions_pass(
+        self, strategy: type, model_config: ModelConfig, moe_strategy: str
+    ) -> bool:
+        config = create_moe_config_adapter(
+            model_config=model_config,
+            parallelism_config=create_parallelism_config(),
+            moe_config=create_moe_config(moe_strategy=moe_strategy),
+        )
+        checker = ConditionChecker(f"{strategy.__name__}.check_conditions()")
+        strategy.check_conditions(checker, config)
+        return checker.all_passed()
+
+    def test_cpp_accepts_unquantized_checkpoint(self) -> None:
+        self.assertTrue(
+            self._conditions_pass(
+                CudaNoQuantCppStrategy,
+                create_model_config_without_quant(),
+                "no_auant_cpp",
+            )
+        )
+
+    def test_cpp_rejects_quantized_checkpoint(self) -> None:
+        self.assertFalse(
+            self._conditions_pass(
+                CudaNoQuantCppStrategy,
+                create_model_config_with_w8a8_int8_per_channel_quant(),
+                "no_auant_cpp",
+            )
+        )
+
+    def test_dp_normal_accepts_unquantized_checkpoint(self) -> None:
+        self.assertTrue(
+            self._conditions_pass(
+                CudaNoQuantDpNormalStrategy,
+                create_model_config_without_quant(),
+                "no_auant_dp_normal",
+            )
+        )
+
+    def test_dp_normal_rejects_quantized_checkpoint(self) -> None:
+        self.assertFalse(
+            self._conditions_pass(
+                CudaNoQuantDpNormalStrategy,
+                create_model_config_with_w8a8_int8_per_channel_quant(),
+                "no_auant_dp_normal",
+            )
+        )
+
+
+class TestRocmEpStrategyQuantFiltering(unittest.TestCase):
+    """Unsupported quant methods must leave ROCm EP candidate probing cleanly."""
+
+    def test_unsupported_quant_methods_return_false(self) -> None:
+        for quant_config in (
+            CompressedW8A8Int8PerChannelQuantConfig(),
+            MXFp4QuarkQuantConfig(),
+        ):
+            with self.subTest(quant_method=quant_config.get_method()):
+                model_config = ModelConfig()
+                model_config.quant_config = quant_config
+                config = create_moe_config_adapter(
+                    model_config=model_config,
+                    parallelism_config=create_parallelism_config(),
+                    moe_config=create_moe_config(),
+                )
+                self.assertFalse(RocmEpNormalStrategy().can_handle(config))
 
 
 class TestCudaNoQuantSingleGpuStrategy(unittest.TestCase):

--- a/rtp_llm/models_py/modules/factory/linear/__init__.py
+++ b/rtp_llm/models_py/modules/factory/linear/__init__.py
@@ -7,6 +7,7 @@ import logging
 
 from rtp_llm.device.device_type import DeviceType, get_device_type
 
+from rtp_llm.utils.backend_registry import run_backend_registrations
 from .factory import LinearFactory
 from .linear_base import LinearBase
 
@@ -25,3 +26,6 @@ try:
         import rtp_llm.models_py.modules.factory.linear.impl.cuda  # noqa: F401
 except Exception as e:
     logging.warning(f"Failed to import Linear implementation: {e}")
+
+# Out-of-tree backends registered a hook before this module existed.
+run_backend_registrations("linear", factory=LinearFactory)

--- a/rtp_llm/models_py/modules/factory/linear/factory.py
+++ b/rtp_llm/models_py/modules/factory/linear/factory.py
@@ -111,6 +111,16 @@ class LinearFactory:
         ]
 
         if not candidates:
+            quant_method = (
+                quant_config.get_method() if quant_config is not None else None
+            )
+            if quant_method == "W8A8_INT8_PER_CHANNEL_COMPRESSED":
+                raise ValueError(
+                    "W8A8_INT8_PER_CHANNEL_COMPRESSED weights were loaded, but "
+                    "no registered Linear compute backend can consume them; "
+                    "install or register a backend with W8A8 INT8 per-channel "
+                    "execution support"
+                )
             raise ValueError(
                 f"No suitable Linear strategy found for:"
                 f"weight.dtype={weight.dtype}, "

--- a/rtp_llm/models_py/utils/arch.py
+++ b/rtp_llm/models_py/utils/arch.py
@@ -3,7 +3,13 @@ from typing import Optional, Tuple, Union
 
 import torch
 
-from rtp_llm.device.device_type import DeviceType, get_device_type, is_cuda, is_hip
+from rtp_llm.device.device_type import (
+    DeviceType,
+    get_device_type,
+    is_cuda,
+    is_hip,
+    is_ppu,
+)
 
 
 def _canonical_cuda_device(device_id: Optional[Union[int, torch.device]]) -> int:

--- a/rtp_llm/ops/libth_transformer_config.pyi
+++ b/rtp_llm/ops/libth_transformer_config.pyi
@@ -1382,6 +1382,8 @@ class QuantAlgo:
         ...
     def isW4a8Int4PTPC(self) -> bool:
         ...
+    def isW8a8Int8PTPC(self) -> bool:
+        ...
     def isWeightOnlyPerCol(self) -> bool:
         ...
     def setQuantAlgo(self, arg0: str, arg1: int, arg2: int) -> None:
@@ -1413,6 +1415,8 @@ class QuantMethod:
       ModelOptFP4
 
       QuarkMXFP4
+
+      W8A8INT8PTPC
     """
     Awq: typing.ClassVar[QuantMethod]  # value = <QuantMethod.Awq: 3>
     FP8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.FP8PTPC: 8>
@@ -1425,8 +1429,9 @@ class QuantMethod:
     PerTensorQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.PerTensorQuant: 6>
     SmoothQuant: typing.ClassVar[QuantMethod]  # value = <QuantMethod.SmoothQuant: 4>
     W4A8INT4PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W4A8INT4PTPC: 9>
+    W8A8INT8PTPC: typing.ClassVar[QuantMethod]  # value = <QuantMethod.W8A8INT8PTPC: 12>
     WeightOnlyPerCol: typing.ClassVar[QuantMethod]  # value = <QuantMethod.WeightOnlyPerCol: 1>
-    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>}
+    __members__: typing.ClassVar[dict[str, QuantMethod]]  # value = {'None': <QuantMethod.None: 0>, 'WeightOnlyPerCol': <QuantMethod.WeightOnlyPerCol: 1>, 'GptQ': <QuantMethod.GptQ: 2>, 'Awq': <QuantMethod.Awq: 3>, 'SmoothQuant': <QuantMethod.SmoothQuant: 4>, 'OmniQuant': <QuantMethod.OmniQuant: 5>, 'PerTensorQuant': <QuantMethod.PerTensorQuant: 6>, 'FP8Quant': <QuantMethod.FP8Quant: 7>, 'FP8PTPC': <QuantMethod.FP8PTPC: 8>, 'W4A8INT4PTPC': <QuantMethod.W4A8INT4PTPC: 9>, 'ModelOptFP4': <QuantMethod.ModelOptFP4: 10>, 'QuarkMXFP4': <QuantMethod.QuarkMXFP4: 11>, 'W8A8INT8PTPC': <QuantMethod.W8A8INT8PTPC: 12>}
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:

--- a/rtp_llm/server/server_args/moe_group_args.py
+++ b/rtp_llm/server/server_args/moe_group_args.py
@@ -1,4 +1,5 @@
 from rtp_llm.server.server_args.util import str2bool
+from rtp_llm.utils.backend_registry import run_backend_registrations
 
 
 def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
@@ -194,3 +195,7 @@ def init_moe_group_args(parser, moe_config, eplb_config, deep_ep_config):
         default="auto",
         help="指定 FP4 MOE算子。可选值: auto (自动选择), trtllm (使用 TensorRT-LLM), cutedsl (使用 CuTe DSL)。",
     )
+
+    # Out-of-tree backends ship MoE strategies the public parser must not
+    # advertise, so let them extend the accepted choices here instead.
+    run_backend_registrations("moe_strategy_choices", repeatable=True, parser=parser)

--- a/rtp_llm/server/server_args/server_args.py
+++ b/rtp_llm/server/server_args/server_args.py
@@ -65,6 +65,7 @@ from rtp_llm.server.server_args.speculative_decoding_group_args import (
     init_speculative_decoding_group_args,
 )
 from rtp_llm.server.server_args.vit_group_args import init_vit_group_args
+from rtp_llm.utils.backend_registry import ensure_backend_entrypoint_loaded
 
 _T = TypeVar("_T")
 
@@ -528,6 +529,9 @@ def setup_args(args: Optional[Sequence[str]] = None) -> PyEnvConfigs:
     capacity estimator, reuse the exact same parser and config bindings without
     temporarily replacing global process arguments.
     """
+    # Internal backends must register parser and factory hooks before the
+    # corresponding public argument groups and factories are initialized.
+    ensure_backend_entrypoint_loaded()
     parser = EnvArgumentParser(description="RTP LLM")
 
     # 先创建配置对象

--- a/rtp_llm/server/server_args/test/BUILD
+++ b/rtp_llm/server/server_args/test/BUILD
@@ -5,6 +5,7 @@ py_test(
         "//rtp_llm:testlib",
         "//rtp_llm/server:server",
         "//rtp_llm:config_ops",
+        "//rtp_llm:utils",
     ],
     exec_properties = {'gpu':'H20'},
 )

--- a/rtp_llm/server/server_args/test/server_args_test.py
+++ b/rtp_llm/server/server_args/test/server_args_test.py
@@ -4,10 +4,64 @@ import os
 import pickle
 import sys
 from unittest import TestCase, main
+from unittest.mock import patch
+
+from rtp_llm.utils.backend_registry import (
+    register_backend_hook,
+    reset_backend_registrations,
+)
 
 
 class ServerArgsPyEnvConfigsTest(TestCase):
     """Test that environment variables and command line arguments are correctly set to py_env_configs structure."""
+
+    def test_internal_backend_registers_moe_choice_before_parser_initialization(self):
+        from rtp_llm.server.server_args import server_args
+
+        loaded = False
+
+        def load_backend():
+            nonlocal loaded
+            if not loaded:
+                register_backend_hook(
+                    "moe_strategy_choices",
+                    lambda parser: next(
+                        action
+                        for action in parser._actions
+                        if "--moe_strategy" in action.option_strings
+                    ).choices.append("external_test_strategy"),
+                )
+                loaded = True
+            return True
+
+        reset_backend_registrations()
+        try:
+            with (
+                patch.dict(os.environ, {}, clear=True),
+                patch.object(
+                    server_args,
+                    "ensure_backend_entrypoint_loaded",
+                    side_effect=load_backend,
+                ),
+                patch(
+                    "rtp_llm.utils.backend_registry.ensure_backend_entrypoint_loaded",
+                    return_value=True,
+                ),
+            ):
+                first_configs = server_args.setup_args(
+                    ["--moe_strategy", "external_test_strategy"]
+                )
+                second_configs = server_args.setup_args(
+                    ["--moe_strategy", "external_test_strategy"]
+                )
+            self.assertEqual(
+                first_configs.moe_config.moe_strategy, "external_test_strategy"
+            )
+            self.assertEqual(
+                second_configs.moe_config.moe_strategy, "external_test_strategy"
+            )
+        finally:
+            reset_backend_registrations()
 
 
 class ServerArgsSetTest(TestCase):

--- a/rtp_llm/utils/backend_registry.py
+++ b/rtp_llm/utils/backend_registry.py
@@ -1,0 +1,156 @@
+"""Deferred registration of out-of-tree model backends.
+
+Every slot consumer loads the optional backend entrypoint through
+``run_backend_registrations()`` before it initialises the slot. A backend
+cannot call ``LinearFactory.register()`` or ``StrategyRegistry.register()``
+at entrypoint import time because the factory does not exist yet. Importing the
+factories early from the backend is not an option either: eager imports of the
+MoE/attention factories pull in communication libraries and have broken server
+startup for configurations that never use them.
+
+Backends therefore record their intent here, and each factory runs the hooks
+for its own slot once it has finished building its registry:
+
+    # backend, at import time
+    register_backend_hook(
+        "linear", lambda factory: factory.register(MyLinear)
+    )
+
+    # factory, at the end of its __init__
+    run_backend_registrations("linear", factory=LinearFactory)
+
+This lives under ``rtp_llm.utils`` rather than next to the factories on
+purpose: the server argument parser also consumes a slot, and importing
+anything under ``models_py.modules.factory`` would execute that package's
+``__init__``, which builds every factory. That is the eager import this
+mechanism exists to avoid.
+
+Hook exceptions are intentionally not swallowed. A backend that registered a
+hook needs it: silently dropping the registration leaves the factory selecting
+a different implementation, which shows up as wrong numerics rather than a
+startup failure.
+"""
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+BackendHook = Callable[..., None]
+
+_hooks: Dict[str, List[BackendHook]] = {}
+_started: Set[str] = set()
+_repeatable: Set[str] = set()
+_lock = threading.RLock()
+_condition = threading.Condition(_lock)
+_inflight: Dict[str, Tuple[int, threading.Event]] = {}
+_failures: Dict[str, BaseException] = {}
+
+
+def ensure_backend_entrypoint_loaded() -> bool:
+    """Load the optional model-backend entrypoint before consuming a slot."""
+    from rtp_llm.utils.import_util import import_optional_internal_source_entrypoint
+
+    return import_optional_internal_source_entrypoint("models_py")
+
+
+def register_backend_hook(slot: str, hook: BackendHook) -> None:
+    """Record ``hook`` to run once the ``slot`` owner is initialised.
+
+    Raises if the slot already started, since late hooks would not be applied
+    consistently to every owner of that slot.
+    """
+    with _condition:
+        if slot in _started:
+            raise RuntimeError(
+                f"backend slot {slot!r} was already initialised; register the "
+                "hook before its owner is initialized"
+            )
+        _hooks.setdefault(slot, []).append(hook)
+
+
+def run_backend_registrations(
+    slot: str, *, repeatable: bool = False, **context: Any
+) -> None:
+    """Run the hooks recorded for ``slot``, passing ``context`` to each.
+
+    By default a slot runs at most once, so a factory re-imported under a
+    different alias does not double-register. A repeatable slot freezes its
+    hook set on the first call and replays those hooks for every new owner.
+    """
+    ensure_backend_entrypoint_loaded()
+
+    # Loading the entrypoint is deliberately outside the condition: its import
+    # body records hooks and therefore needs to acquire this same lock.
+    while True:
+        with _condition:
+            inflight = _inflight.get(slot)
+            if inflight is not None:
+                owner_thread, event = inflight
+                if owner_thread == threading.get_ident():
+                    raise RuntimeError(
+                        f"backend slot {slot!r} registration is re-entrant"
+                    )
+            elif slot in _started:
+                was_repeatable = slot in _repeatable
+                if repeatable != was_repeatable:
+                    raise RuntimeError(
+                        f"backend slot {slot!r} lifecycle changed after it started"
+                    )
+                if not repeatable:
+                    return
+                hooks = tuple(_hooks.get(slot, ()))
+                event = threading.Event()
+                _inflight[slot] = (threading.get_ident(), event)
+                break
+            else:
+                _failures.pop(slot, None)
+                _started.add(slot)
+                if repeatable:
+                    _repeatable.add(slot)
+                event = threading.Event()
+                _inflight[slot] = (threading.get_ident(), event)
+                hooks = tuple(_hooks.get(slot, ()))
+                break
+
+        # Another owner is currently executing this slot. Wait for its result,
+        # then re-evaluate the lifecycle so repeatable slots can replay safely.
+        event.wait()
+        with _condition:
+            failure = _failures.get(slot)
+        if failure is not None:
+            raise RuntimeError(
+                f"backend slot {slot!r} registration failed; retry is allowed"
+            ) from failure
+
+    try:
+        # Hooks may import backend modules and must never execute while holding
+        # the global registry lock. The snapshot keeps late registration
+        # rejected while allowing independent slots to proceed concurrently.
+        for hook in hooks:
+            logger.debug("running backend registration hook for slot %r", slot)
+            hook(**context)
+    except BaseException as error:
+        with _condition:
+            _started.discard(slot)
+            _repeatable.discard(slot)
+            _failures[slot] = error
+            _, event = _inflight.pop(slot)
+            event.set()
+        raise
+    else:
+        with _condition:
+            _, event = _inflight.pop(slot)
+            event.set()
+
+
+def reset_backend_registrations() -> None:
+    """Drop recorded hooks and lifecycle state. For tests only."""
+    with _condition:
+        if _inflight:
+            raise RuntimeError("cannot reset backend registrations while hooks run")
+        _hooks.clear()
+        _started.clear()
+        _repeatable.clear()
+        _failures.clear()

--- a/rtp_llm/utils/test/BUILD
+++ b/rtp_llm/utils/test/BUILD
@@ -224,3 +224,13 @@ py_test(
     ],
     exec_properties = {'gpu':'A10'}
 )
+
+py_test(
+    name = "backend_registry_test",
+    srcs = [
+        "backend_registry_test.py",
+    ],
+    deps = [
+        "//rtp_llm:utils",
+    ],
+)

--- a/rtp_llm/utils/test/backend_registry_test.py
+++ b/rtp_llm/utils/test/backend_registry_test.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import patch
+
+import rtp_llm.utils.backend_registry as backend_registry
+
+from rtp_llm.utils.backend_registry import (
+    register_backend_hook,
+    reset_backend_registrations,
+    run_backend_registrations,
+)
+
+
+class BackendRegistryTest(unittest.TestCase):
+    def setUp(self):
+        reset_backend_registrations()
+        self._entrypoint_patcher = patch(
+            "rtp_llm.utils.import_util.import_optional_internal_source_entrypoint",
+            return_value=False,
+        )
+        self._entrypoint_patcher.start()
+
+    def tearDown(self):
+        self._entrypoint_patcher.stop()
+        reset_backend_registrations()
+
+    def test_hook_runs_with_context_when_slot_drained(self):
+        seen = []
+        register_backend_hook("linear", lambda factory: seen.append(factory))
+
+        self.assertEqual(seen, [], "hook must not run before the slot is drained")
+        run_backend_registrations("linear", factory="LinearFactory")
+        self.assertEqual(seen, ["LinearFactory"])
+
+    def test_hooks_run_in_registration_order(self):
+        seen = []
+        register_backend_hook("moe", lambda: seen.append("first"))
+        register_backend_hook("moe", lambda: seen.append("second"))
+
+        run_backend_registrations("moe")
+        self.assertEqual(seen, ["first", "second"])
+
+    def test_draining_twice_does_not_rerun_hooks(self):
+        calls = []
+        register_backend_hook("linear", lambda: calls.append(1))
+
+        run_backend_registrations("linear")
+        run_backend_registrations("linear")
+        self.assertEqual(calls, [1])
+
+    def test_repeatable_slot_replays_frozen_hooks_for_each_owner(self):
+        seen = []
+        register_backend_hook(
+            "moe_strategy_choices", lambda parser: seen.append(parser)
+        )
+
+        run_backend_registrations(
+            "moe_strategy_choices", repeatable=True, parser="first"
+        )
+        run_backend_registrations(
+            "moe_strategy_choices", repeatable=True, parser="second"
+        )
+
+        self.assertEqual(seen, ["first", "second"])
+
+    def test_repeatable_slot_rejects_late_hooks(self):
+        run_backend_registrations("parser", repeatable=True, parser="first")
+
+        with self.assertRaises(RuntimeError):
+            register_backend_hook("parser", lambda parser: None)
+
+    def test_slot_lifecycle_cannot_change_after_start(self):
+        run_backend_registrations("parser", repeatable=True, parser="first")
+
+        with self.assertRaises(RuntimeError):
+            run_backend_registrations("parser", parser="second")
+
+    @patch("rtp_llm.utils.import_util.import_optional_internal_source_entrypoint")
+    def test_entrypoint_loads_before_slot_is_consumed(self, load_entrypoint):
+        seen = []
+
+        def load(relative_module):
+            self.assertEqual(relative_module, "models_py")
+            register_backend_hook("linear", lambda factory: seen.append(factory))
+            return True
+
+        load_entrypoint.side_effect = load
+        run_backend_registrations("linear", factory="LinearFactory")
+
+        self.assertEqual(seen, ["LinearFactory"])
+
+    def test_other_slots_are_untouched(self):
+        calls = []
+        register_backend_hook("attention", lambda: calls.append(1))
+
+        run_backend_registrations("linear")
+        self.assertEqual(calls, [])
+
+    def test_registering_after_drain_raises(self):
+        run_backend_registrations("linear")
+
+        # A hook recorded after its slot was drained would never run, so
+        # surface it instead of silently dropping the backend.
+        with self.assertRaises(RuntimeError):
+            register_backend_hook("linear", lambda: None)
+
+    def test_hook_exception_propagates(self):
+        def broken():
+            raise ValueError("backend is broken")
+
+        register_backend_hook("linear", broken)
+
+        # Swallowing this would leave the factory silently selecting a
+        # different implementation, i.e. wrong numerics instead of a crash.
+        with self.assertRaisesRegex(ValueError, "backend is broken"):
+            run_backend_registrations("linear")
+
+    def test_failed_hook_does_not_poison_slot(self):
+        attempts = []
+
+        def flaky_hook():
+            attempts.append(len(attempts))
+            if len(attempts) == 1:
+                raise ValueError("transient backend failure")
+
+        register_backend_hook("linear", flaky_hook)
+        with self.assertRaisesRegex(ValueError, "transient backend failure"):
+            run_backend_registrations("linear")
+        run_backend_registrations("linear")
+        self.assertEqual(attempts, [0, 1])
+
+    def test_hooks_run_without_holding_registry_lock(self):
+        lock_owned = []
+
+        def check_lock_state():
+            lock_owned.append(backend_registry._lock._is_owned())
+
+        register_backend_hook("linear", check_lock_state)
+        run_backend_registrations("linear")
+        self.assertEqual(lock_owned, [False])
+
+    def test_draining_slot_without_hooks_is_noop(self):
+        run_backend_registrations("nobody_registered_here")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

本 PR 汇总 PPU Qwen3.5 支持所需的通用外源能力，便于统一 review、CI 验证和合入。

PPU 专属 FA3、DeepGEMM、W8A8 INT8 kernel、router 和 executor 仍保留在内源；本 PR 只提供开源侧可复用的配置、加载、注册契约和正确性修复。

## 主要改动

### 1. compressed-tensors W8A8 INT8

- 识别 INT8 per-output-channel 权重和 INT8 per-token 动态激活配置。
- 加载 INT8 权重与 FP32 per-channel scale，并复用 TP/EP tensor mapping 和切分逻辑。
- 支持 checkpoint 自定义名称的单配置组及 `group_0` 兼容行为。
- 在 DeepEP Low-Latency sizing 中识别 per-token activation quantization。
- 为 DeepEP Normal 提供 backend-neutral `_prepare_dispatch_input()` 扩展契约。
- 阻止量化 checkpoint 静默进入 BF16/no-quant executor。
- 对非对称 W8A8、FP8 KV cache、不支持的 `targets`/scheme/regex ignore 等组合 fail-fast。
- concrete `ignore` 仅在实际部分命中可量化 `{i}` 模板时拒绝，兼容真实 checkpoint 中与量化权重无关的具体层条目。

### 2. out-of-tree backend 延迟注册

- 新增设备无关的 `register_backend_hook()` / `run_backend_registrations()`。
- 提供 `linear`、`fused_moe`、`attention` 和 `moe_strategy_choices` 四个扩展槽位。
- Factory 在完成自身 registry 或实现列表初始化后执行 hook。
- `moe_strategy_choices` 对每个新 parser 重放，其余 Factory 槽位只执行一次。
- hook 异常和过晚注册显式报错，未安装外部 backend 时保持 no-op。
- 增加接入文档、生命周期测试及 parser 重建测试。

内源 PPU backend 在启动时只登记 hook；外源 Factory 消费 hook 后，将内源 FA3、DeepGEMM Linear/MoE strategy 注册到公共 Factory，避免外源直接依赖设备专属实现或使用 monkey patch。

### 3. Qwen3.5 PPU model 入口

- 增加统一的 `is_ppu()` 设备判断。
- 将 PPU 加入 Qwen3.5 Python model 的设备 allowlist。
- 不支持设备时输出真实设备类型。

该改动仅开放模型构建入口，具体 PPU Attention、Linear 和 MoE 实现仍由内源 backend 提供。

### 4. 正确性修复

- CUDA Graph replay 时同步清理 device block table 与 host mirror。
- padding row 统一指向保留的 block 0，避免不同 graph batch size 之间残留 block ID 导致跨请求 KV cache 污染。
- P/D 更新 proposal 状态时保留 MTP proposal 的 GPU tensor，避免后续 MTP decode 使用失效状态。

## 内外源职责

本 PR 负责：

- W8A8 checkpoint 配置识别和权重加载；
- 通用 backend 注册框架；
- DeepEP dispatch 扩展契约和安全门；
- Qwen3.5 PPU model 入口；
- CUDA Graph 与 MTP/PD 公共正确性修复。

本 PR 不包含：

- PPU INT8 quant kernel；
- PPU FA3 Attention；
- PPU DeepGEMM Linear/MoE executor；
- PPU DeepEP router override 和 strategy 实现。

相关实现放置于内源
## Commit 组织

1. `feat(quant): support compressed-tensors W8A8 INT8 checkpoints`
2. `feat(runtime): add deferred out-of-tree backend registration`
3. `feat(ppu): enable Qwen3.5 runtime and correctness fixes`

三个 commit 分别对应量化加载、扩展机制、模型入口与公共正确性修复，最终代码与此前验证组合保持一致。

## 验证

在本 PR 最终代码与内源 PPU backend 的组合上完成：

- W8A8 INT8 smoke：4/4 通过
  - MTP TP8/DP1
  - MTP TP8/DP2
  - MTP + CUDA Graph TP8/DP2
  - Prefill/Decode TP8 → TP8
- BF16 smoke：5/5 通过
  - DeepEP Low-Latency + CUDA Graph
  - DeepEP Normal + DeepGEMM
  - Prefill/Decode TP4 → TP4
  - MTP TP4
  - Prefix Cache TP4
- 生产镜像构建通过。
- Whale 部署验证通过。
- `git diff --check` 通过。

## Supersedes

This PR consolidates and supersedes:

- #1317
- #1297
- #1321
- #1316
