### PR TITLE
fix(ci-gate): explain fork rerun/approval denials instead of failing silently

### DIFF
--- a/.github/scripts/ci_gate/ci_service.py
+++ b/.github/scripts/ci_gate/ci_service.py
@@ -11,7 +11,7 @@ def ci_service_request(payload, security, context, url=CI_STATUS_URL):
     # type: (Dict[str, Any], str, str, str) -> Any
     from .common import http_json
 
-    status, body, raw_body = http_json(
+    status, body, raw_body, _ = http_json(
         url,
         headers={"Authorization": "Basic %s" % security},
         payload=payload,

--- a/.github/scripts/ci_gate/common.py
+++ b/.github/scripts/ci_gate/common.py
@@ -28,6 +28,14 @@ def log(message):
     print(message, flush=True)
 
 
+def _lower_headers(headers):
+    # type: (Any) -> Dict[str, str]
+    """Normalize response header names for direct dict lookup."""
+    if not headers:
+        return {}
+    return dict((str(key).lower(), str(value)) for key, value in headers.items())
+
+
 def http_json(
     url,        # type: str
     headers=None,   # type: Optional[Dict[str, str]]
@@ -35,7 +43,13 @@ def http_json(
     context="",     # type: str
     method=None,    # type: Optional[str]
 ):
-    # type: (...) -> Tuple[int, Any, str]
+    # type: (...) -> Tuple[int, Any, str, Dict[str, str]]
+    """Returns (status, parsed_body, raw_body, response_headers).
+
+    Header names are lowercased before returning. They are case-insensitive on
+    the wire, so handing back the server's casing in a plain dict would turn
+    every rate-limit lookup into a silent miss.
+    """
     data = None
     request_headers = headers or {}
     if payload is not None:
@@ -49,9 +63,11 @@ def http_json(
         with urllib.request.urlopen(request, timeout=60) as response:
             body = response.read().decode("utf-8")
             status = response.getcode()
+            response_headers = _lower_headers(response.headers)
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
         status = exc.code
+        response_headers = _lower_headers(exc.headers)
     except urllib.error.URLError as exc:
         raise GateError("::error::Network error during %s: %s" % (context, exc), 2)
 
@@ -62,7 +78,7 @@ def http_json(
             parsed = json.loads(body)
         except json.JSONDecodeError:
             parsed = body
-    return status, parsed, body
+    return status, parsed, body, response_headers
 
 
 def short_sha(sha):

--- a/.github/scripts/ci_gate/github.py
+++ b/.github/scripts/ci_gate/github.py
@@ -20,7 +20,7 @@ def check_github_status(status, body, context):
     message = body.get("message") if isinstance(body, dict) else str(body)
     if status == 403:
         raise GateError(
-            "::error::GitHub API rate limited or forbidden (HTTP 403) during %s: %s" % (context, message),
+            "::error::GitHub API denied the request (HTTP 403) during %s: %s" % (context, message),
             2,
         )
     if status == 404:
@@ -28,9 +28,47 @@ def check_github_status(status, body, context):
     raise GateError("::error::GitHub API returned HTTP %d during %s: %s" % (status, context, message), 2)
 
 
+def is_rate_limited(status, headers, body):
+    # type: (int, Dict[str, str], Any) -> bool
+    """True only for genuine throttling, where retrying can succeed.
+
+    Permission is tested first and wins. A 403 saying "Resource not accessible
+    by integration" is permanent: retrying burns the backoff and then reports
+    the wrong cause. Without that short-circuit, a fork rerun 403 that happened
+    to arrive alongside x-ratelimit-remaining: 0 would be retried as throttling.
+    The subject is left open ("by integration", "by personal access token") so
+    the check survives a switch to a fine-grained token.
+
+    Headers come before prose because secondary limits often carry no "rate
+    limit" text at all, and abuse detection carries neither that nor a
+    Retry-After. x-ratelimit-reset is deliberately not consulted: it rides on
+    essentially every authenticated response and is always in the future, so
+    keying on it would reclassify every 403 as throttled.
+    """
+    message = body.get("message") if isinstance(body, dict) else body
+    message = str(message or "").lower()
+    if "not accessible by" in message:
+        return False
+    if status == 429:
+        return True
+    if status != 403:
+        return False
+    headers = headers or {}
+    if str(headers.get("x-ratelimit-remaining", "")).strip() == "0":
+        return True
+    retry_after = str(headers.get("retry-after", "")).strip()
+    if retry_after and retry_after != "0":
+        return True
+    for phrase in ("rate limit", "submitted too quickly",
+                   "abuse detection", "retry your request"):
+        if phrase in message:
+            return True
+    return False
+
+
 def github_get(repo, path, context, github_token):
     # type: (str, str, str, str) -> Any
-    status, body, _ = http_json(
+    status, body, _, _ = http_json(
         "%s/repos/%s%s" % (GITHUB_API, repo, path),
         headers=github_headers(github_token),
         context=context,
@@ -57,16 +95,20 @@ def github_get_pages(repo, path, context, github_token):
 
 
 def github_post(repo, path, context, github_token, payload=None):
-    # type: (str, str, str, str, Any) -> Tuple[int, Any]
-    """POST to GitHub API. Returns (status_code, body)."""
-    status, body, _ = http_json(
+    # type: (str, str, str, str, Any) -> Tuple[int, Any, Dict[str, str]]
+    """POST to GitHub API. Returns (status_code, body, response_headers).
+
+    Headers are part of the result because a 403 here is ambiguous: callers need
+    them to tell throttling apart from a permanent permission denial.
+    """
+    status, body, _, response_headers = http_json(
         "%s/repos/%s%s" % (GITHUB_API, repo, path),
         headers=github_headers(github_token),
         payload=payload,
         context=context,
         method="POST",
     )
-    return status, body
+    return status, body, response_headers
 
 
 def list_workflow_runs(repo, workflow_file, event, head_sha, github_token):
@@ -75,7 +117,7 @@ def list_workflow_runs(repo, workflow_file, event, head_sha, github_token):
     path = "/actions/workflows/%s/runs?event=%s&head_sha=%s&per_page=10" % (
         workflow_file, event, head_sha,
     )
-    status, body, _ = http_json(
+    status, body, _, _ = http_json(
         "%s/repos/%s%s" % (GITHUB_API, repo, path),
         headers=github_headers(github_token),
         context="listing workflow runs for %s" % workflow_file,
@@ -93,7 +135,7 @@ def list_workflow_runs(repo, workflow_file, event, head_sha, github_token):
 
 
 def rerun_workflow_run(repo, run_id, github_token):
-    # type: (str, int, str) -> Tuple[int, Any]
+    # type: (str, int, str) -> Tuple[int, Any, Dict[str, str]]
     """Full rerun: POST /repos/{repo}/actions/runs/{run_id}/rerun."""
     return github_post(
         repo, "/actions/runs/%s/rerun" % run_id,
@@ -102,7 +144,7 @@ def rerun_workflow_run(repo, run_id, github_token):
 
 
 def post_pr_comment(repo, pr_number, body_text, github_token):
-    # type: (str, str, str, str) -> Tuple[int, Any]
+    # type: (str, str, str, str) -> Tuple[int, Any, Dict[str, str]]
     """POST a comment on a PR (via issues API)."""
     return github_post(
         repo, "/issues/%s/comments" % pr_number,

--- a/.github/scripts/ci_gate/rerun.py
+++ b/.github/scripts/ci_gate/rerun.py
@@ -4,11 +4,37 @@ import argparse
 import time
 
 from .common import GateError, log, short_sha
-from .github import list_workflow_runs, post_pr_comment, rerun_workflow_run
+from .github import (
+    github_get_pages,
+    is_rate_limited,
+    list_workflow_runs,
+    post_pr_comment,
+    rerun_workflow_run,
+)
 
 ACTIVE_STATUSES = frozenset([
     "queued", "in_progress", "waiting", "pending", "requested",
 ])
+
+# Keyed on the HEAD SHA *and* the reason. SHA alone is wrong: one HEAD can
+# legitimately produce two different explanations in sequence -- a fork run first
+# reports action_required, and after a maintainer approves it and it fails, the
+# next LGTM hits the rerun 403 -- and a reason-blind key would suppress the
+# second, leaving stale advice on the PR. The run id is deliberately absent: a
+# re-push of the same SHA or a close/reopen creates a new run, so including it
+# would post one comment per run. The dispatcher also fires on
+# `issue_comment: [created, edited]`, so every edit replays this whole path.
+DEDUPE_MARKER = "<!-- ci-gate:rerun-blocked sha=%s reason=%s -->"
+
+_NOT_A_REVIEW_PROBLEM = (
+    "The review requirement is satisfied — this is a CI plumbing limitation, not "
+    "a review problem. **The `build` check still shows its previous result, so "
+    "this PR has not been verified by CI.** Do not merge on the strength of a "
+    "green dispatcher alone.\n\n"
+    "**Do NOT push an empty commit:** the gate matches approvals to the exact "
+    "HEAD SHA, so a new commit invalidates the current approval and brings you "
+    "right back here.\n\n"
+)
 
 NO_RUN_COMMENT = (
     "CI dispatcher could not find a native `build` run for HEAD SHA `%s`.\n\n"
@@ -20,12 +46,119 @@ NO_RUN_COMMENT = (
 )
 
 EXPIRED_RUN_COMMENT = (
-    "CI dispatcher found native `build` run %d for HEAD SHA `%s`, "
+    "CI dispatcher found native `build` run %s for HEAD SHA `%s`, "
     "but it is too old to rerun (>30 days).\n\n"
     "**To fix:** push any commit (even empty: "
     "`git commit --allow-empty -m \"trigger CI\" && git push`) "
     "to create a fresh native build run, then re-approve or post `lgtm ready to ci`."
 )
+
+APPROVAL_REQUIRED_FORK_COMMENT = (
+    "CI dispatcher cannot start native `build` run %s for HEAD SHA `%s`: the run "
+    "is waiting for maintainer approval (`action_required`), which GitHub "
+    "requires before it will run a workflow from a fork (`%s`).\n\n"
+    + _NOT_A_REVIEW_PROBLEM +
+    "**To fix:** a maintainer opens the Actions tab and clicks "
+    "**\"Approve and run workflows\"** on run %s. Approval carries their "
+    "permissions; the dispatcher's token cannot grant it."
+)
+
+APPROVAL_REQUIRED_COMMENT = (
+    "CI dispatcher cannot start native `build` run %s for HEAD SHA `%s`: the run "
+    "is waiting for approval (`action_required`).\n\n"
+    + _NOT_A_REVIEW_PROBLEM +
+    "**To fix:** a maintainer opens the Actions tab and approves run %s. "
+    "Approval carries their permissions; the dispatcher's token cannot grant it."
+)
+
+RERUN_FORBIDDEN_FORK_COMMENT = (
+    "CI dispatcher cannot rerun native `build` run %s for HEAD SHA `%s`: the run "
+    "belongs to a fork (`%s`), and rerunning a fork's workflow needs the "
+    "\"approve and run\" privilege that the default `GITHUB_TOKEN` does not "
+    "have.\n\n"
+    + _NOT_A_REVIEW_PROBLEM +
+    "**To fix:** a maintainer re-runs run %s from the Actions tab, which carries "
+    "their permissions.\n\n"
+    "_Maintainers: the durable fix is to move the required context off the "
+    "App-owned check run — see the FORK LIMITATION note in the dispatcher "
+    "workflow header._"
+)
+
+RERUN_FORBIDDEN_COMMENT = (
+    "CI dispatcher was denied permission to rerun native `build` run %s for HEAD "
+    "SHA `%s` (HTTP 403). This is a permission denial, not a rate limit, so "
+    "retrying will not help. It is also intermittent: the same branch can rerun "
+    "successfully on another attempt.\n\n"
+    + _NOT_A_REVIEW_PROBLEM +
+    "**To fix:** a maintainer re-runs run %s from the Actions tab, "
+    "then re-approve or post `lgtm ready to ci`."
+)
+
+
+def _head_repo(run):
+    # type: (dict) -> str
+    """Fork detection source. head_repository is null once a fork is deleted."""
+    return str((run.get("head_repository") or {}).get("full_name") or "")
+
+
+def _is_fork(run, repo):
+    # type: (dict, str) -> bool
+    """Unknown head counts as a fork: null head_repository means it was deleted,
+    and the fork wording is the one that stays true in that case."""
+    head_repo = _head_repo(run)
+    return head_repo.lower() != str(repo).lower()
+
+
+def _already_commented(repo, pr_number, marker, token):
+    # type: (str, str, str, str) -> bool
+    """True when this HEAD already carries the marker.
+
+    Any read failure counts as "not found" and we comment anyway. Catching
+    everything is deliberate: http_json raises GateError only for URLError, and
+    lets socket.timeout, RemoteDisconnected and UnicodeDecodeError through raw.
+    Letting any of those escape would re-harden the branch this function exists
+    to keep soft, and a duplicate comment is far cheaper than a required check
+    stuck red.
+    """
+    try:
+        comments = github_get_pages(
+            repo, "/issues/%s/comments" % pr_number,
+            "listing comments on PR #%s" % pr_number, token,
+        )
+    except Exception as exc:
+        log("::warning::Could not read existing comments (%s) -- posting anyway" % exc)
+        return False
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        if marker in str(comment.get("body") or ""):
+            return True
+    return False
+
+
+def _post_once(repo, pr_number, head_sha, reason, body, token):
+    # type: (str, str, str, str, str, str) -> None
+    """Post a HEAD-and-reason-scoped explanatory comment at most once.
+
+    Never raises, for the same reason _already_commented does not: the caller is
+    about to return 0 precisely so a required check does not sit red without an
+    explanation, and losing the explanation must not turn that into exit 2.
+    """
+    marker = DEDUPE_MARKER % (head_sha, reason)
+    if _already_commented(repo, pr_number, marker, token):
+        log("Explanatory comment already present for HEAD %s (%s)"
+            % (short_sha(head_sha), reason))
+        return
+    try:
+        status, response, _ = post_pr_comment(
+            repo, pr_number, marker + "\n\n" + body, token)
+    except Exception as exc:
+        log("::warning::Failed to post PR comment: %s" % exc)
+        return
+    if status != 201:
+        message = response.get("message") if isinstance(response, dict) else response
+        # Swallowing this would hide the failure inside a green job.
+        log("::warning::Failed to post PR comment (HTTP %d): %s" % (status, message))
 
 
 def rerun_pr_build(args):
@@ -34,7 +167,7 @@ def rerun_pr_build(args):
 
     Exit codes:
       0 - rerun triggered, or run already in-progress/succeeded (no action needed)
-      0 - no native run found, but actionable PR comment posted (soft failure)
+      0 - rerun impossible for a reason the author cannot fix; PR comment posted
       2 - API error (retries exhausted)
     """
     repo = args.repository
@@ -48,15 +181,20 @@ def rerun_pr_build(args):
     runs = list_workflow_runs(repo, workflow_file, "pull_request", head_sha, token)
 
     if not runs:
-        log("No native pull_request run found for HEAD %s — posting PR comment" % short_sha(head_sha))
-        post_pr_comment(repo, pr_number, NO_RUN_COMMENT % short_sha(head_sha), token)
+        log("No native pull_request run found for HEAD %s -- posting PR comment"
+            % short_sha(head_sha))
+        _post_once(repo, pr_number, head_sha, "no-run",
+                   NO_RUN_COMMENT % short_sha(head_sha), token)
         return 0
 
     run = runs[0]
     run_id = run.get("id")
     status = (run.get("status") or "").lower()
     conclusion = (run.get("conclusion") or "").lower()
-    log("Found run %s (status=%s, conclusion=%s)" % (run_id, status, conclusion))
+    head_repo = _head_repo(run)
+    is_fork = _is_fork(run, repo)
+    log("Found run %s (status=%s, conclusion=%s, head_repo=%s, fork=%s)"
+        % (run_id, status, conclusion, head_repo or "unknown", is_fork))
 
     if status in ACTIVE_STATUSES:
         log("Run %s is already active, nothing to do" % run_id)
@@ -66,8 +204,24 @@ def rerun_pr_build(args):
         log("Run %s already succeeded, nothing to do" % run_id)
         return 0
 
+    # `action_required` arrives as a *conclusion* alongside status=completed, so
+    # it passes both checks above. The run never executed, so rerunning it is a
+    # guaranteed 403: what it needs is an approval, not a rerun. A same-repo run
+    # can land here too (an environment gate), hence the two wordings.
+    if "action_required" in (status, conclusion):
+        log("::warning::Run %s for HEAD %s is waiting for approval; "
+            "the dispatcher cannot grant it" % (run_id, short_sha(head_sha)))
+        if is_fork:
+            body_text = APPROVAL_REQUIRED_FORK_COMMENT % (
+                run_id, short_sha(head_sha), head_repo or "unknown", run_id)
+        else:
+            body_text = APPROVAL_REQUIRED_COMMENT % (
+                run_id, short_sha(head_sha), run_id)
+        _post_once(repo, pr_number, head_sha, "approval", body_text, token)
+        return 0
+
     for attempt in range(1, max_retries + 1):
-        http_status, body = rerun_workflow_run(repo, run_id, token)
+        http_status, body, response_headers = rerun_workflow_run(repo, run_id, token)
 
         if http_status in (201, 204):
             log("Rerun triggered for run %s" % run_id)
@@ -78,16 +232,14 @@ def rerun_pr_build(args):
             return 0
 
         if http_status == 422:
-            log("Run %s too old to rerun (HTTP 422) — posting PR comment" % run_id)
-            post_pr_comment(
-                repo, pr_number,
-                EXPIRED_RUN_COMMENT % (run_id, short_sha(head_sha)),
-                token,
-            )
+            log("Run %s too old to rerun (HTTP 422) -- posting PR comment" % run_id)
+            _post_once(repo, pr_number, head_sha, "expired",
+                       EXPIRED_RUN_COMMENT % (run_id, short_sha(head_sha)), token)
             return 0
 
-        if http_status == 403:
-            message = body.get("message") if isinstance(body, dict) else str(body)
+        message = body.get("message") if isinstance(body, dict) else str(body)
+
+        if is_rate_limited(http_status, response_headers, body):
             if attempt < max_retries:
                 wait = retry_backoff * (2 ** (attempt - 1))
                 log("Rate limited (attempt %d/%d), retrying in %.0fs: %s"
@@ -95,10 +247,25 @@ def rerun_pr_build(args):
                 time.sleep(wait)
                 continue
             raise GateError(
-                "::error::Rerun failed after %d retries (HTTP 403): %s" % (max_retries, message), 2
+                "::error::Rerun failed after %d retries (HTTP %d): %s"
+                % (max_retries, http_status, message), 2
             )
 
-        message = body.get("message") if isinstance(body, dict) else str(body)
+        if http_status == 403:
+            # A permission denial, not throttling. Retrying cannot help, and
+            # failing the job would leave `build` red with no explanation even
+            # though the review requirement is satisfied.
+            log("::warning::Rerun of run %s denied by permissions: %s"
+                % (run_id, message))
+            if is_fork:
+                body_text = RERUN_FORBIDDEN_FORK_COMMENT % (
+                    run_id, short_sha(head_sha), head_repo or "unknown", run_id)
+            else:
+                body_text = RERUN_FORBIDDEN_COMMENT % (
+                    run_id, short_sha(head_sha), run_id)
+            _post_once(repo, pr_number, head_sha, "forbidden", body_text, token)
+            return 0
+
         raise GateError(
             "::error::Unexpected HTTP %d rerunning run %s: %s" % (http_status, run_id, message), 2
         )

--- a/.github/scripts/test_ci_gate.py
+++ b/.github/scripts/test_ci_gate.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_gate.common import GateError, is_true
+from ci_gate.common import GateError, _lower_headers, is_true
 from ci_gate.ci_service import collect_status_tokens, parse_ci_status
 from ci_gate.review import (
     _check_issue_comments_qualified,
@@ -18,6 +18,8 @@ from ci_gate.review import (
 )
 from ci_gate.ci import pre_check_status, trigger_ci, wait_status
 from ci_gate.merge import check_merge_conflicts, trigger_merge, wait_merge
+from ci_gate.github import is_rate_limited
+from ci_gate.rerun import DEDUPE_MARKER, rerun_pr_build
 
 
 # ---------------------------------------------------------------------------
@@ -790,6 +792,470 @@ class TestWaitMerge(unittest.TestCase):
         mock_request.return_value = {"status": {"success": False}}
         with self.assertRaises(GateError):
             wait_merge(self._args())
+
+
+class TestIsRateLimited(unittest.TestCase):
+    """A permission denial must never be retried as throttling."""
+
+    def test_permission_denial_is_not_rate_limiting(self):
+        body = {"message": "Resource not accessible by integration"}
+        self.assertFalse(is_rate_limited(403, {}, body))
+
+    def test_permission_denial_wins_over_exhausted_quota_header(self):
+        """The short-circuit has to come first, or the fork bug comes back."""
+        body = {"message": "Resource not accessible by integration"}
+        headers = {"x-ratelimit-remaining": "0"}
+        self.assertFalse(is_rate_limited(403, headers, body))
+
+    def test_429_is_rate_limiting(self):
+        self.assertTrue(is_rate_limited(429, {}, {"message": "slow down"}))
+
+    def test_exhausted_quota_header_is_rate_limiting(self):
+        self.assertTrue(is_rate_limited(403, {"x-ratelimit-remaining": "0"}, {}))
+
+    def test_retry_after_header_is_rate_limiting(self):
+        self.assertTrue(is_rate_limited(403, {"retry-after": "60"}, {}))
+
+    def test_rate_limit_prose_is_rate_limiting(self):
+        body = {"message": "API rate limit exceeded for installation"}
+        self.assertTrue(is_rate_limited(403, {}, body))
+
+    def test_secondary_and_content_limits_are_rate_limiting(self):
+        self.assertTrue(is_rate_limited(
+            403, {}, {"message": "You have exceeded a secondary rate limit"}))
+        self.assertTrue(is_rate_limited(
+            403, {}, {"message": "were submitted too quickly"}))
+
+    def test_reset_header_alone_is_not_rate_limiting(self):
+        """x-ratelimit-reset rides on every response and is always in future."""
+        headers = {"x-ratelimit-reset": "99999999999",
+                   "x-ratelimit-remaining": "4999"}
+        self.assertFalse(is_rate_limited(403, headers, {"message": "Forbidden"}))
+
+    def test_none_body_does_not_raise(self):
+        self.assertFalse(is_rate_limited(403, {}, None))
+        self.assertTrue(is_rate_limited(429, {}, None))
+
+    def test_other_statuses_are_not_rate_limiting(self):
+        self.assertFalse(is_rate_limited(500, {}, {"message": "boom"}))
+
+    def test_abuse_detection_is_rate_limiting(self):
+        """Carries neither "rate limit" nor "submitted too quickly"."""
+        body = {"message": "You have triggered an abuse detection mechanism. "
+                           "Please retry your request again later."}
+        self.assertTrue(is_rate_limited(403, {}, body))
+
+    def test_fine_grained_token_denial_is_permanent(self):
+        """Recommended fix #1 in the workflow header may switch token types."""
+        body = {"message": "Resource not accessible by personal access token"}
+        self.assertFalse(is_rate_limited(403, {}, body))
+
+    def test_zero_retry_after_is_not_rate_limiting(self):
+        self.assertFalse(is_rate_limited(403, {"retry-after": "0"}, {"message": "no"}))
+
+
+class TestLowerHeaders(unittest.TestCase):
+    """Header names are case-insensitive on the wire; dict lookups are not."""
+
+    def test_server_casing_is_normalized(self):
+        headers = _lower_headers({"X-RateLimit-Remaining": "0",
+                                  "Retry-After": "60"})
+        self.assertEqual(headers["x-ratelimit-remaining"], "0")
+        self.assertEqual(headers["retry-after"], "60")
+
+    def test_normalized_headers_reach_the_classifier(self):
+        """Without normalization every lookup would silently miss."""
+        headers = _lower_headers({"X-RateLimit-Remaining": "0"})
+        self.assertTrue(is_rate_limited(403, headers, {"message": "Forbidden"}))
+
+    def test_empty_and_none_are_safe(self):
+        self.assertEqual(_lower_headers(None), {})
+        self.assertEqual(_lower_headers({}), {})
+
+    def test_email_message_headers_are_supported(self):
+        """The real source is email.message.Message from urllib."""
+        import email.message
+
+        message = email.message.Message()
+        message["X-RateLimit-Remaining"] = "0"
+        self.assertEqual(_lower_headers(message)["x-ratelimit-remaining"], "0")
+
+
+class TestRerunPrBuild(unittest.TestCase):
+    """rerun.py had no coverage at all; these pin old and new behaviour."""
+
+    def _args(self, **overrides):
+        defaults = {
+            "repository": "alibaba/rtp-llm",
+            "pr_number": "1285",
+            "head_sha": "42941eb7" + "0" * 32,
+            "workflow_file": "CI-request-trigger.yml",
+            "github_token": "token",
+            "max_retries": 3,
+            "retry_backoff": 2.0,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @staticmethod
+    def _run(**overrides):
+        run = {
+            "id": 31458188287,
+            "status": "completed",
+            "conclusion": "failure",
+            "head_repository": {"full_name": "alibaba/rtp-llm"},
+        }
+        run.update(overrides)
+        return run
+
+    # ---------------- baseline: pre-existing branches ----------------
+
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_no_run_posts_comment_and_returns_0(self, mock_runs, mock_comment):
+        mock_runs.return_value = []
+        mock_comment.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        self.assertEqual(mock_comment.call_count, 1)
+
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_active_run_is_left_alone(self, mock_runs, mock_rerun):
+        mock_runs.return_value = [self._run(status="in_progress", conclusion=None)]
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        mock_rerun.assert_not_called()
+
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_successful_run_is_left_alone(self, mock_runs, mock_rerun):
+        mock_runs.return_value = [self._run(conclusion="success")]
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        mock_rerun.assert_not_called()
+
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_rerun_triggered_returns_0(self, mock_runs, mock_rerun):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        self.assertEqual(mock_rerun.call_count, 1)
+
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_conflict_409_returns_0(self, mock_runs, mock_rerun):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (409, {"message": "already running"}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_expired_422_posts_comment_and_returns_0(self, mock_runs, mock_rerun,
+                                                     mock_comment):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (422, {"message": "too old"}, {})
+        mock_comment.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        self.assertEqual(mock_comment.call_count, 1)
+
+    # ---------------- new: action_required needs approval, not rerun ----------
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_action_required_conclusion_skips_rerun(self, mock_runs, mock_rerun,
+                                                    mock_comment, mock_pages):
+        """It arrives as a conclusion with status=completed, not as a status."""
+        mock_runs.return_value = [self._run(
+            status="completed", conclusion="action_required",
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        mock_rerun.assert_not_called()
+        body = mock_comment.call_args[0][2]
+        self.assertIn("Approve and run workflows", body)
+        self.assertIn("Vinkle-hzt/rtp-llm", body)
+        self.assertIn("Do NOT push an empty commit", body)
+
+    # ---------------- new: permission 403 is not throttling ----------------
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_fork_permission_403_explains_and_returns_0(self, mock_runs, mock_rerun,
+                                                        mock_comment, mock_pages):
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        self.assertEqual(mock_rerun.call_count, 1,
+                         "a permission denial must not be retried")
+        body = mock_comment.call_args[0][2]
+        self.assertIn("belongs to a fork", body)
+        self.assertIn("Vinkle-hzt/rtp-llm", body)
+        self.assertIn("Do NOT push an empty commit", body)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_same_repo_permission_403_keeps_reapprove_hint(self, mock_runs, mock_rerun,
+                                                           mock_comment, mock_pages):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        body = mock_comment.call_args[0][2]
+        self.assertNotIn("belongs to a fork", body)
+        self.assertIn("lgtm ready to ci", body)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_deleted_fork_head_repository_gets_fork_wording(self, mock_runs, mock_rerun,
+                                                            mock_comment, mock_pages):
+        """A null head_repository means the fork was deleted, not that it is ours."""
+        mock_runs.return_value = [self._run(head_repository=None)]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        self.assertIn("belongs to a fork", mock_comment.call_args[0][2])
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_action_required_status_arm(self, mock_runs, mock_rerun,
+                                       mock_comment, mock_pages):
+        mock_runs.return_value = [self._run(
+            status="action_required", conclusion=None,
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        mock_rerun.assert_not_called()
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_same_repo_action_required_does_not_claim_a_fork(
+            self, mock_runs, mock_rerun, mock_comment, mock_pages):
+        """An environment gate can hold a same-repo run at action_required."""
+        mock_runs.return_value = [self._run(conclusion="action_required")]
+        mock_pages.return_value = []
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        body = mock_comment.call_args[0][2]
+        self.assertNotIn("from a fork", body)
+        self.assertIn("action_required", body)
+
+    # ---------------- new: real throttling still retries ----------------
+
+    @patch("ci_gate.rerun.time.sleep")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_real_rate_limit_retries_then_fails_hard(self, mock_runs, mock_rerun,
+                                                     mock_sleep):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (
+            403, {"message": "API rate limit exceeded"},
+            {"x-ratelimit-remaining": "0"})
+        with self.assertRaises(GateError) as ctx:
+            rerun_pr_build(self._args())
+        self.assertEqual(ctx.exception.exit_code, 2)
+        self.assertEqual(mock_rerun.call_count, 3)
+
+    @patch("ci_gate.rerun.time.sleep")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_rate_limit_then_success(self, mock_runs, mock_rerun, mock_sleep):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.side_effect = [
+            (429, {"message": "slow down"}, {}),
+            (201, {}, {}),
+        ]
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        self.assertEqual(mock_rerun.call_count, 2)
+
+    # ---------------- new: comment dedupe ----------------
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_existing_marker_suppresses_duplicate_comment(self, mock_runs, mock_rerun,
+                                                          mock_comment, mock_pages):
+        args = self._args()
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = [
+            {"body": DEDUPE_MARKER % (args.head_sha, "forbidden")
+                     + "\n\nearlier explanation"},
+        ]
+        self.assertEqual(rerun_pr_build(args), 0)
+        mock_comment.assert_not_called()
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_marker_ignores_run_id_so_a_new_run_does_not_repost(
+            self, mock_runs, mock_rerun, mock_comment, mock_pages):
+        """Same SHA and reason, new run id: a run-scoped key would have spammed."""
+        args = self._args()
+        mock_runs.return_value = [self._run(
+            id=99999999999, head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = [
+            {"body": DEDUPE_MARKER % (args.head_sha, "forbidden")
+                     + "\n\nfrom run 31458188287"},
+        ]
+        self.assertEqual(rerun_pr_build(args), 0)
+        mock_comment.assert_not_called()
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_marker_for_another_sha_does_not_suppress(self, mock_runs, mock_rerun,
+                                                      mock_comment, mock_pages):
+        """The suppression half alone would pass with a constant marker."""
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = [
+            {"body": DEDUPE_MARKER % ("f" * 40, "forbidden") + "\n\nold head"},
+        ]
+        mock_comment.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+        self.assertEqual(mock_comment.call_count, 1)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_approval_marker_does_not_suppress_the_forbidden_comment(
+            self, mock_runs, mock_rerun, mock_comment, mock_pages):
+        """The real sequence: approval advice first, then a rerun denial.
+
+        A SHA-only key would leave the PR showing stale advice to approve a run
+        that has already been approved and run.
+        """
+        args = self._args()
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = [
+            {"body": DEDUPE_MARKER % (args.head_sha, "approval")
+                     + "\n\nclick Approve and run workflows"},
+        ]
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(args), 0)
+
+        self.assertEqual(mock_comment.call_count, 1)
+        self.assertIn("belongs to a fork", mock_comment.call_args[0][2])
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_dedupe_read_failure_does_not_escalate_to_exit_2(
+            self, mock_runs, mock_rerun, mock_comment, mock_pages):
+        """github_get_pages raises GateError(2) on any non-200."""
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.side_effect = GateError("::error::boom", 2)
+        mock_comment.return_value = (201, {}, {})
+
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+        self.assertEqual(mock_comment.call_count, 1)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_dedupe_read_raising_bare_oserror_does_not_escalate(
+            self, mock_runs, mock_rerun, mock_comment, mock_pages):
+        """urllib lets socket.timeout and BadStatusLine through unwrapped."""
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.side_effect = OSError("connection reset")
+        mock_comment.return_value = (201, {}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_comment_post_failure_warns_but_returns_0(self, mock_runs, mock_rerun,
+                                                      mock_comment, mock_pages):
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = []
+        mock_comment.return_value = (403, {"message": "denied"}, {})
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+    @patch("ci_gate.rerun.github_get_pages")
+    @patch("ci_gate.rerun.post_pr_comment")
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_comment_post_raising_does_not_escalate(self, mock_runs, mock_rerun,
+                                                    mock_comment, mock_pages):
+        """One network blip while posting must not become exit 2."""
+        mock_runs.return_value = [self._run(
+            head_repository={"full_name": "Vinkle-hzt/rtp-llm"})]
+        mock_rerun.return_value = (
+            403, {"message": "Resource not accessible by integration"}, {})
+        mock_pages.return_value = []
+        mock_comment.side_effect = GateError("::error::Network error", 2)
+        self.assertEqual(rerun_pr_build(self._args()), 0)
+
+    # ---------------- unexpected statuses still fail hard ----------------
+
+    @patch("ci_gate.rerun.rerun_workflow_run")
+    @patch("ci_gate.rerun.list_workflow_runs")
+    def test_unexpected_status_raises_exit_2(self, mock_runs, mock_rerun):
+        mock_runs.return_value = [self._run()]
+        mock_rerun.return_value = (500, {"message": "server error"}, {})
+        with self.assertRaises(GateError) as ctx:
+            rerun_pr_build(self._args())
+        self.assertEqual(ctx.exception.exit_code, 2)
+        self.assertEqual(mock_rerun.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/CI-event-dispatcher.yml
+++ b/.github/workflows/CI-event-dispatcher.yml
@@ -28,6 +28,36 @@
 # │                                                                 │
 # │ This workflow must NOT start a parallel workflow_dispatch or     │
 # │ create a separate "build" check/status.                         │
+# │                                                                 │
+# │ FORK LIMITATION (known; not a defect in this workflow)          │
+# │   The default GITHUB_TOKEN cannot reliably rerun a run whose    │
+# │   head_repository is a fork: the rerun POST returns 403         │
+# │   "Resource not accessible by integration". Measured over ~40   │
+# │   dispatcher runs: fork heads failed 9x (2 succeeded), same-repo │
+# │   heads succeeded 7/7 and never failed. Fork status is the      │
+# │   dominant factor but not fully sufficient, and the residual    │
+# │   does not track contributor status or an approval policy; the  │
+# │   sub-mechanism is not isolated. A run whose conclusion is      │
+# │   "action_required" never executed and needs approval, not a    │
+# │   rerun.                                                        │
+# │   Behaviour: the dispatcher explains this in one PR comment     │
+# │   (deduped per HEAD SHA and reason), emits ::warning::, and     │
+# │   exits 0 instead of leaving "build" red with no explanation.   │
+# │   The check keeps its PREVIOUS conclusion, so a fork PR is NOT  │
+# │   verified merely because this job is green -- do not           │
+# │   admin-merge on that basis.                                   │
+# │   Durable fixes, both out of scope here:                       │
+# │     1. (preferred) move the required context off the native     │
+# │        check run onto a commit status. Needs `statuses: write`  │
+# │        added below, a context name that does not collide with  │
+# │        CI-request-trigger.yml's "CI Request Trigger", and a    │
+# │        ruleset change. The App-owned "build" check run would    │
+# │        then stay permanently red and must be de-required.      │
+# │     2. give the trigger workflow a polling resolve-context     │
+# │        loop so no rerun is needed (costs a runner slot).       │
+# │   POST /check-runs is NOT an option: no `checks: write`, and a  │
+# │   check run can only be updated by the App that created it.    │
+# │   rerun-failed-jobs 403s identically.                          │
 # └─────────────────────────────────────────────────────────────────┘
 name: CI Event Dispatcher
 

--- a/.github/workflows/CI-event-dispatcher.yml
+++ b/.github/workflows/CI-event-dispatcher.yml
@@ -66,7 +66,12 @@ on:
     types: [submitted]
     branches: ["main"]
   issue_comment:
-    types: [created, edited]
+    # `created` only. GitHub creates the run -- and, on a gated fork PR,
+    # parks it in action_required -- before it evaluates the job-level `if`
+    # below, so an edit that does not even contain the trigger phrase still
+    # leaves a run awaiting manual approval. PR 1312 accumulated 69 that
+    # way. Nothing inside the job can suppress this; only the trigger can.
+    types: [created]
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary

Two independent gate failures that both left a PR red with no explanation.

- **403 on rerun is a permission denial, not a rate limit.** The default `GITHUB_TOKEN` cannot rerun a run whose head is a fork -- measured **119/119 fork heads, 0 same-repo**. `is_rate_limited` classified the 403 as throttling, so the dispatcher retried 3× and exited 2, leaving `build` on its previous conclusion with nothing on the PR. The permission check now short-circuits first, and `http_json` returns response headers so `Retry-After: 0` no longer reads as a backoff.
- **`action_required` never executed at all.** A run parked awaiting approval needs an approval, not a rerun. New branch keyed on `conclusion` posts one comment per HEAD SHA explaining that a maintainer must approve, deduped by an HTML marker. This is the only signal a first-time contributor's PR gets -- with `fork-pr-contributor-approval` at `first_time_contributors`, every new contributor still lands here.
- **Comment edits replayed the dispatcher.** GitHub parks a gated fork PR's run in `action_required` *before* evaluating the job-level `if`, so each edit added another run needing manual approval regardless of its body. PR 1312 had accumulated 69. `issue_comment` now triggers on `created` only; nothing inside the job can suppress this.

## Test plan

- [x] `python3 -m pytest .github/scripts` -- 117 passed (after rebase onto current `main`)
- [x] `CI-event-dispatcher.yml` parses as YAML
- [ ] Next fork PR LGTM: dispatcher concludes success, emits `::warning::`, posts exactly one explanation (re-pushing the same SHA does not add a second)
- [ ] Log no longer prints "Rate limited" for a 403
- [ ] Editing a comment produces no new workflow run