### PR TITLE
fix(moe): make ROCm batched (naive) EP routing padding-safe and graph-capturable

### DIFF
--- a/rtp_llm/models_py/modules/base/rocm/select_topk.py
+++ b/rtp_llm/models_py/modules/base/rocm/select_topk.py
@@ -17,10 +17,12 @@ class SelectTopk(nn.Module):
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
     ):
+        # aiter requires int32 and writes topk_ids in place.
+        if topk_ids.dtype != torch.int32:
+            raise TypeError(f"expect int32 topk_ids, got {topk_ids.dtype}")
         token_expert_indicies = torch.empty(
             topk_ids.shape[0], self.top_k, dtype=torch.int32, device=topk_ids.device
         )
-        topk_ids = topk_ids.int()
         aiter.topk_softmax(
             topk_weights,
             topk_ids,

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/fused_moe.py
@@ -62,6 +62,7 @@ class ExpertForwardPayload:
     expert_topk_ids: Optional[torch.Tensor] = None
     expert_topk_weights: Optional[torch.Tensor] = None
     expert_ids_are_local: bool = False
+    router_context: object | None = None
 
 
 @dataclass
@@ -71,6 +72,7 @@ class CombineForwardPayload:
     """
 
     fused_expert_output: torch.Tensor
+    router_context: object | None = None
 
 
 def should_skip_tp_allreduce(
@@ -261,7 +263,6 @@ class FusedMoe(torch.nn.Module):
             topk_weights,
             topk_ids,
         )
-
         if expert_payload.expert_topk_ids is None:
             expert_payload.expert_topk_ids = topk_ids
         if expert_payload.expert_topk_weights is None:
@@ -288,6 +289,7 @@ class FusedMoe(torch.nn.Module):
                 apply_router_weight_on_input=apply_router_weight_on_input,
                 extra_expert_args=extra_expert_args,
             )
+        combine_payload.router_context = expert_payload.router_context
 
         # Finalize arguments are a private per-call protocol. Copy caller
         # input before adding derived values so a reusable dict cannot retain

--- a/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/defs/test/fused_moe_allreduce_contract_test.py
@@ -118,6 +118,21 @@ class FusedMoeSkipAllreduceTest(TestCase):
             _extract_extra_finalize_args(router.finalize)[SKIP_TP_ALLREDUCE_ARG]
         )
 
+    def test_forward_passes_router_context_to_finalize(self):
+        fused_moe, router, _, hidden_states, topk_weights, topk_ids = (
+            self._make_fused_moe(False)
+        )
+        router_context = object()
+        router.prepare.return_value.router_context = router_context
+
+        fused_moe(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
+
+        self.assertIs(router.finalize.call_args.args[0].router_context, router_context)
+
     def test_forward_rejects_skip_tp_allreduce_for_unsupported_router(self):
         fused_moe, router, experts, hidden_states, topk_weights, topk_ids = (
             self._make_fused_moe(False)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
@@ -23,19 +23,18 @@ from rtp_llm.utils.model_weight import W
 
 
 class BatchedTritonExperts(FusedMoeExpertExecutor):
-    """
-    A Triton based MoE expert class that operates on expert batched format,
-    i.e. E x max_num_tokens x K.  This is the format that the pplx
-    dispatch/combine kernels use.
-    """
+    """Triton experts for BatchedDataRouter's (E, rows, hidden) layout."""
 
     @classmethod
     def executor_type(cls):
         return ExecutorType.BATCHED_TRITON
 
+    @property
+    def topk_ids_dtype(self) -> torch.dtype:
+        return torch.int32
+
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
-        """Check if BatchedTritonExperts can handle the configuration"""
         from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
             MoeConfigResolver,
         )
@@ -51,14 +50,10 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
     ):
         super().__init__(config, quant_config, weights)
 
-        # Calculate parameters from config
-        max_num_tokens = (
-            config.ll_num_max_token + config.tp_size - 1
-        ) // config.tp_size
-        self.max_num_tokens = max_num_tokens
-        self.num_dispatchers = 1
         self.w1 = weights[W.moe_w1]
         self.w2 = weights[W.moe_w2]
+        assert self.w1.stride(-1) == 1 and self.w2.stride(-1) == 1
+        assert self.w2.size(0) == self.w1.size(0)
 
     @property
     def local_num_experts(self) -> int:
@@ -73,66 +68,64 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
         apply_router_weight_on_input: bool,
         extra_expert_args: Optional[dict[str, Any]],
     ) -> CombineForwardPayload:
-        # Check constraints.
-        assert payload.expert_x is not None, "expert_x is None"
-        assert payload.expert_x.size(-1) == self.w1.size(
-            2
-        ), f"Hidden size mismatch {payload.expert_x.size(-1)} != {self.w1.size(2)}"
+        if expert_map is not None:
+            raise ValueError("BatchedTritonExperts does not support expert_map")
+        if apply_router_weight_on_input:
+            raise ValueError(
+                "BatchedTritonExperts requires output-side router weighting"
+            )
 
-        assert payload.expert_x.is_contiguous(), "Hidden_states must be contiguous"
-        assert self.w1.stride(-1) == 1, "Stride of last dimension must be 1"
-        assert self.w2.stride(-1) == 1, "Stride of last dimension must be 1"
-        assert payload.expert_x.dtype in [torch.float16, torch.bfloat16]
-        assert payload.expert_tokens_meta is not None
-        assert (
-            payload.expert_tokens_meta.expert_num_tokens is not None
-        ), "expert_num_tokens is None"
-
-        expert_num_tokens = payload.expert_tokens_meta.expert_num_tokens
+        expert_x = payload.expert_x
+        meta = payload.expert_tokens_meta
+        if meta is None or meta.expert_num_tokens is None:
+            raise ValueError("expert_num_tokens is required")
+        expert_num_tokens = meta.expert_num_tokens
 
         E = self.local_num_experts
         N = self.w1.size(1)
-        assert payload.expert_topk_ids is not None
+        if (
+            expert_x.dim() != 3
+            or expert_x.size(0) != E
+            or expert_x.size(2) != self.w1.size(2)
+            or expert_num_tokens.shape != (E,)
+        ):
+            raise ValueError(
+                f"Invalid expert shapes: {tuple(expert_x.shape)}, "
+                f"{tuple(expert_num_tokens.shape)}"
+            )
 
-        assert self.w1.size(0) == E
-        assert self.w2.size(0) == E
-
-        if payload.expert_x.dtype == torch.bfloat16:
+        if expert_x.dtype == torch.bfloat16:
             compute_type = tl.bfloat16
-        elif payload.expert_x.dtype == torch.float16:
+        elif expert_x.dtype == torch.float16:
             compute_type = tl.float16
         else:
-            raise ValueError(f"Unsupported compute_type: {payload.expert_x.dtype}")
+            raise ValueError(f"Unsupported compute_type: {expert_x.dtype}")
 
+        num_rows = expert_x.size(1)
+        # GEMMs skip rows past expert_num_tokens; activation padding is discarded.
         intermediate_cache1 = torch.empty(
-            (E, self.max_num_tokens, N),
-            device=payload.expert_x.device,
-            dtype=payload.expert_x.dtype,
+            (E, num_rows, N),
+            device=expert_x.device,
+            dtype=expert_x.dtype,
         )
         intermediate_cache2 = torch.empty(
-            (E, self.max_num_tokens, N // 2),
-            device=payload.expert_x.device,
-            dtype=payload.expert_x.dtype,
-        )
-        output_shape = (
-            self.local_num_experts,
-            self.max_num_tokens,
-            self.w2.size(1),
+            (E, num_rows, N // 2),
+            device=expert_x.device,
+            dtype=expert_x.dtype,
         )
         output = torch.empty(
-            output_shape, device=payload.expert_x.device, dtype=self.w2.dtype
+            (E, num_rows, self.w2.size(1)),
+            device=expert_x.device,
+            dtype=self.w2.dtype,
         )
 
-        # MM1
         invoke_moe_batched_triton_kernel(
-            A=payload.expert_x,
+            A=expert_x,
             B=self.w1,
             C=intermediate_cache1,
             expert_num_tokens=expert_num_tokens,
             compute_type=compute_type,
         )
-
-        intermediate_cache2.fill_(0)
 
         silu_and_mul(
             intermediate_cache2.view(-1, N // 2),

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/executor/batched_triton_executor.py
@@ -87,6 +87,8 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
             expert_x.dim() != 3
             or expert_x.size(0) != E
             or expert_x.size(2) != self.w1.size(2)
+            or expert_x.size(2) != self.w2.size(1)
+            or expert_x.dtype != self.w2.dtype
             or expert_num_tokens.shape != (E,)
         ):
             raise ValueError(
@@ -113,11 +115,6 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
             device=expert_x.device,
             dtype=expert_x.dtype,
         )
-        output = torch.empty(
-            (E, num_rows, self.w2.size(1)),
-            device=expert_x.device,
-            dtype=self.w2.dtype,
-        )
 
         invoke_moe_batched_triton_kernel(
             A=expert_x,
@@ -135,9 +132,9 @@ class BatchedTritonExperts(FusedMoeExpertExecutor):
         invoke_moe_batched_triton_kernel(
             A=intermediate_cache2,
             B=self.w2,
-            C=output,
+            C=expert_x,
             expert_num_tokens=expert_num_tokens,
             compute_type=compute_type,
         )
 
-        return CombineForwardPayload(fused_expert_output=output)
+        return CombineForwardPayload(fused_expert_output=expert_x)

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/common/router/batched_data_router.py
@@ -1,5 +1,4 @@
-# Note: A simple non-batched FusedMoeDataRouter implementation temporary, perhaps delete this file in the future.
-
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import torch
@@ -21,64 +20,20 @@ from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
 from rtp_llm.models_py.modules.factory.fused_moe.defs.type import RouterType
 
 
-def normalize_scales_shape(scales: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
-    if scales is not None:
-        if scales.numel() == 1:
-            scales = scales.view(1, 1)
-        else:
-            scales = scales.view(-1, scales.size(-1))
-    return scales
-
-
-class TopKWeightAndReduceNaiveBatched(object):
-    def __init__(self, rank: int):
-        self.rank = rank
-
-    def apply(
-        self,
-        fused_expert_output: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        apply_router_weight_on_input: bool,
-    ) -> torch.Tensor:
-        assert fused_expert_output.ndim == 3
-        num_tokens = topk_ids.size(0)
-        num_local_experts = fused_expert_output.size(0)
-        K = fused_expert_output.size(-1)
-
-        output = torch.zeros(
-            (num_tokens, K),
-            device=fused_expert_output.device,
-            dtype=fused_expert_output.dtype,
-        )
-
-        assert output.size() == (
-            num_tokens,
-            K,
-        ), f"Expected output size {(num_tokens, K)}, but got {output.size()}"
-
-        first_expert = num_local_experts * self.rank
-        last_expert = first_expert + num_local_experts
-
-        for expert_id in range(first_expert, last_expert):
-            matching_tokens = topk_ids == expert_id
-            topks = torch.any(matching_tokens, dim=1).flatten()
-            rows = torch.count_nonzero(matching_tokens)
-            rhs = fused_expert_output[expert_id - first_expert, :rows, :]
-            if not apply_router_weight_on_input:
-                rhs.mul_(topk_weights[matching_tokens].view(rhs.size(0), 1))
-            output[topks] = output[topks] + rhs
-
-        return output
+@dataclass(frozen=True, slots=True)
+class _BatchedRoutingPlan:
+    packed_rows: torch.Tensor
+    routed: torch.Tensor
 
 
 class BatchedDataRouter(FusedMoeDataRouter):
     """Router for the batched expert-output layout.
 
-    This router intentionally retains its own TP all-reduce in ``finalize``.
-    Its batched combine contract is not the pure-TP partial-output contract
-    required by GenericMoeLayer's unified shared-expert reduction, so it does
-    not advertise deferred TP all-reduce support.
+    Keeps its own TP all-reduce in ``finalize``: its batched combine contract is
+    not the pure-TP partial-output contract that GenericMoeLayer's unified
+    shared-expert reduction needs, so it does not advertise deferral.
+
+    The expert block is ``local_experts x num_tokens x hidden``.
     """
 
     @classmethod
@@ -87,15 +42,13 @@ class BatchedDataRouter(FusedMoeDataRouter):
 
     @classmethod
     def check_conditions(cls, checker: Any, config: MoEConfigAdapter) -> None:
-        """Check if BatchedDataRouter can handle the configuration"""
         from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
             MoeConfigResolver,
         )
 
         resolver = MoeConfigResolver()
         checker.check(not resolver.has_quantization(config))
-
-        checker.check(resolver.is_single_gpu(config) or resolver.is_tp_equal_ep(config))
+        checker.check(resolver.is_tp_equal_ep(config))
 
     def __init__(
         self,
@@ -104,14 +57,8 @@ class BatchedDataRouter(FusedMoeDataRouter):
     ):
         super().__init__(config, quant_config)
 
-        # Calculate parameters from config
-        max_num_tokens = (
-            config.ll_num_max_token + config.tp_size - 1
-        ) // config.tp_size
-        self.max_num_tokens = max_num_tokens
         self.ep_rank = config.ep_rank
-        self.tp_size = config.tp_size
-        self.num_local_experts = config.expert_num // self.tp_size
+        self.num_local_experts = config.expert_num // config.ep_size
 
     def prepare(
         self,
@@ -121,50 +68,55 @@ class BatchedDataRouter(FusedMoeDataRouter):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> ExpertForwardPayload:
-        assert a1.dim() == 2
-        assert topk_ids.dim() == 2
-        assert a1.size(0) == topk_ids.size(0)
-        assert a1_scale is None and a2_scale is None, "not support quanted moe"
+        assert (
+            a1.dim() == 2 and topk_weights.dim() == 2 and topk_ids.dim() == 2
+        ), "a1, topk_weights, and topk_ids must be rank-2 tensors"
+        assert a1.size(0) == topk_ids.size(
+            0
+        ), "a1 and topk_ids must have the same token count"
+        assert (
+            topk_weights.shape == topk_ids.shape
+        ), "topk_weights and topk_ids must have the same shape"
+        assert (
+            a1_scale is None and a2_scale is None
+        ), "BatchedDataRouter does not support quantized MoE"
 
-        _, hidden_dim = a1.size()
+        num_tokens = a1.size(0)
+        num_experts = self.num_local_experts
+        token_ids = torch.arange(num_tokens, device=a1.device, dtype=torch.int32)
 
-        tokens_per_expert = torch.zeros(
-            self.num_local_experts, dtype=torch.int, device=a1.device
+        # Shapes below depend only on num_tokens, keeping the plan CUDA-Graph
+        # capturable: no boolean indexing, no device-to-host expert counts.
+        slots = topk_ids.to(dtype=torch.int64, copy=True)
+        slots.sub_(num_experts * self.ep_rank)
+        routed = (slots >= 0) & (slots < num_experts)
+        # Column num_experts is scratch: non-local ids cannot hit a real column.
+        slots.masked_fill_(~routed, num_experts)
+        match = torch.zeros(
+            (num_tokens, num_experts + 1), dtype=torch.bool, device=a1.device
+        ).scatter_(1, slots, routed)
+        # Unrouted slots point at placeholder row 0 and are masked in finalize.
+        seen = match.cumsum(0, dtype=torch.int32)
+        packed_rows = torch.where(
+            routed, slots * num_tokens + torch.gather(seen, 1, slots) - 1, 0
         )
 
-        if self.quant_config.quant_dtype is None:
-            b_type = a1.dtype
-        else:
-            b_type = self.quant_config.quant_dtype
-
-        assert isinstance(b_type, torch.dtype)
-
-        b_a1 = torch.zeros(
-            (self.num_local_experts, self.max_num_tokens, hidden_dim),
-            dtype=b_type,
-            device=a1.device,
+        # Initialize padding with valid token ids, then overwrite the packed
+        # live rows. The extra row absorbs every non-local slot.
+        token_indices = token_ids.expand(num_experts + 1, -1).clone()
+        positions = torch.where(routed, packed_rows, num_experts * num_tokens)
+        token_indices.view(-1).scatter_(
+            0,
+            positions.reshape(-1),
+            token_ids.view(-1, 1).expand_as(positions).reshape(-1),
         )
-
-        first_expert = self.num_local_experts * self.ep_rank
-        last_expert = first_expert + self.num_local_experts
-
-        for expert_id in range(first_expert, last_expert):
-            topks = torch.any(topk_ids == expert_id, dim=1).flatten()
-            rows = torch.count_nonzero(topks.flatten())
-            if rows == 0:
-                continue
-            idx = expert_id - first_expert
-            tokens_per_expert[idx] = rows
-            rhs = a1[topks]
-            b_a1[idx, :rows, :] = rhs
-
+        expert_num_tokens = match[:, :num_experts].sum(0, dtype=torch.int32)
         return ExpertForwardPayload(
-            expert_x=b_a1,
-            expert_x_scale=None,
+            expert_x=a1[token_indices[:num_experts]],
             expert_tokens_meta=ExpertTokensMetadata(
-                expert_num_tokens=tokens_per_expert,
-                expert_num_tokens_cpu=None,
+                expert_num_tokens=expert_num_tokens
             ),
+            router_context=_BatchedRoutingPlan(packed_rows, routed),
         )
 
     def finalize(
@@ -175,13 +127,33 @@ class BatchedDataRouter(FusedMoeDataRouter):
         apply_router_weight_on_input: bool,
         extra_finalize_args: Optional[FinalizeArgs],
     ) -> torch.Tensor:
-        weight_and_reduce_impl = TopKWeightAndReduceNaiveBatched(self.ep_rank)
-        output = weight_and_reduce_impl.apply(
-            fused_expert_output=payload.fused_expert_output,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            apply_router_weight_on_input=apply_router_weight_on_input,
+        plan = payload.router_context
+        if not isinstance(plan, _BatchedRoutingPlan):
+            raise TypeError("BatchedDataRouter requires its prepared routing context")
+        packed_rows, routed = plan.packed_rows, plan.routed
+
+        expert_output = payload.fused_expert_output
+        num_tokens, top_k = packed_rows.size()
+        expected_shape = (self.num_local_experts, num_tokens)
+        assert expert_output.shape[:2] == expected_shape, (
+            f"Expected expert block {expected_shape}, "
+            f"got {tuple(expert_output.shape[:2])}"
         )
+
+        hidden_dim = expert_output.size(-1)
+        rows = (
+            expert_output.reshape(-1, hidden_dim)
+            .index_select(0, packed_rows.reshape(-1))
+            .view(num_tokens, top_k, hidden_dim)
+        )
+        # Mask before any arithmetic: unrouted slots gathered the placeholder
+        # row 0, which the executor may never have written.
+        rows.masked_fill_(~routed.unsqueeze(-1), 0)
+        if not apply_router_weight_on_input:
+            rows.mul_(topk_weights.to(rows.dtype).unsqueeze(-1))
+        # Reducing over top-k, not experts, fixes the float accumulation order.
+        output = rows.sum(1)
+
         if self.tp_size > 1:
             output = all_reduce(output, Group.TP)
         return output

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
@@ -7,10 +7,11 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
-from rtp_llm.models_py.distributed import collective_torch
+from rtp_llm.models_py.distributed import collective_torch, rocm_rccl
 from rtp_llm.models_py.distributed.collective_torch import (
     Group,
     destroy_distributed_environment,
@@ -18,11 +19,26 @@ from rtp_llm.models_py.distributed.collective_torch import (
 )
 from rtp_llm.models_py.model_desc import generic_moe as generic_moe_module
 from rtp_llm.models_py.model_desc.generic_moe import GenericMoeLayer
+from rtp_llm.models_py.modules.base.rocm.select_topk import SelectTopk
+from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
+    MoEConfigAdapter,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.defs.fused_moe import FusedMoe
+from rtp_llm.models_py.modules.factory.fused_moe.defs.quant_config import (
+    FusedMoEQuantConfig,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.common.executor.batched_triton_executor import (
+    BatchedTritonExperts,
+)
+from rtp_llm.models_py.modules.factory.fused_moe.impl.common.router.batched_data_router import (
+    BatchedDataRouter,
+)
 from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.routers import (
     pure_tp_router as pure_tp_router_module,
 )
 from rtp_llm.models_py.modules.hybrid import dense_mlp as dense_mlp_module
 from rtp_llm.ops import ActivationType, MoeConfig, NcclCommConfig, ParallelismConfig
+from rtp_llm.test.utils.cuda_graph_util import graph_capture
 from rtp_llm.test.utils.port_util import PortManager
 from rtp_llm.utils.model_weight import W
 
@@ -163,6 +179,126 @@ def _build_real_layer(rank, parallelism_config, with_gate):
     return layer
 
 
+def _build_batched_moe(rank, parallelism_config):
+    device = torch.device(f"cuda:{rank}")
+    model_config = ModelConfig()
+    model_config.hidden_size = 256
+    model_config.inter_size = 128
+    model_config.expert_num = 8
+    model_config.moe_k = 2
+    model_config.activation_type = ActivationType.Swiglu
+    model_config.data_type = "bf16"
+    moe_config = MoeConfig()
+    moe_config.ll_num_max_token = 1
+    config = MoEConfigAdapter(model_config, parallelism_config, moe_config)
+    quant_config = FusedMoEQuantConfig(quant_dtype=None)
+
+    generator = torch.Generator().manual_seed(20260901)
+    w1 = (
+        torch.randn(8, 256, 256, generator=generator)
+        .to(device=device, dtype=torch.bfloat16)
+        .mul_(0.1)
+    )
+    w2 = (
+        torch.randn(8, 256, 128, generator=generator)
+        .to(device=device, dtype=torch.bfloat16)
+        .mul_(0.1)
+    )
+    local = slice(rank * 4, (rank + 1) * 4)
+    experts = BatchedTritonExperts(
+        config,
+        quant_config,
+        {
+            W.moe_w1: w1[local].contiguous(),
+            W.moe_w2: w2[local].contiguous(),
+        },
+    )
+    fused_moe = FusedMoe(BatchedDataRouter(config, quant_config), experts, 8)
+    return SelectTopk(model_config), fused_moe, w1, w2
+
+
+def _batched_inputs(case, device):
+    generator = torch.Generator().manual_seed(3100 + case)
+    hidden = torch.randn(4, 256, generator=generator).to(
+        device=device, dtype=torch.bfloat16
+    )
+    logits = torch.full((4, 8), -10.0, device=device)
+    tokens = torch.arange(4, device=device)
+    if case == 0:
+        logits[tokens, tokens] = 3.0
+        logits[tokens, 4 + (tokens + 1) % 4] = 2.0
+    else:
+        logits[:, 0] = 3.0
+        logits[:, 4] = 2.0
+    return hidden, logits
+
+
+def _batched_reference(hidden, logits, w1, w2):
+    topk_logits, topk_ids = torch.topk(logits, 2, dim=-1)
+    topk_weights = torch.softmax(topk_logits, dim=-1)
+    output = torch.zeros_like(hidden)
+    for expert_id in range(8):
+        token_ids, slots = torch.where(topk_ids == expert_id)
+        projected = F.linear(hidden[token_ids], w1[expert_id])
+        value, gate = projected.chunk(2, dim=-1)
+        expert_output = F.linear(F.silu(gate) * value, w2[expert_id])
+        expert_output.mul_(topk_weights[token_ids, slots, None].to(expert_output.dtype))
+        output.index_add_(0, token_ids, expert_output)
+    return output, topk_ids.to(torch.int32), topk_weights
+
+
+def _run_batched_eager_and_graph(rank):
+    device = torch.device(f"cuda:{rank}")
+    parallelism_config = _make_real_parallelism(rank, 2)
+    parallelism_config.ep_size = 2
+    parallelism_config.ep_rank = rank
+    select_topk, fused_moe, w1, w2 = _build_batched_moe(rank, parallelism_config)
+    hidden, logits = _batched_inputs(0, device)
+    topk_ids = torch.empty(
+        hidden.size(0), 2, dtype=fused_moe.topk_ids_dtype, device=device
+    )
+    topk_weights = torch.empty(hidden.size(0), 2, device=device)
+
+    def forward():
+        select_topk(logits, topk_ids, topk_weights)
+        return fused_moe(hidden, topk_weights, topk_ids, activation="SiGLU")
+
+    def assert_result(output):
+        expected, expected_ids, expected_weights = _batched_reference(
+            hidden, logits, w1, w2
+        )
+        torch.testing.assert_close(topk_ids, expected_ids, rtol=0, atol=0)
+        torch.testing.assert_close(topk_weights, expected_weights, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(output, expected, rtol=5e-2, atol=5e-2)
+
+    assert_result(forward())
+
+    stream = torch.cuda.Stream(device=device)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        forward()
+    stream.synchronize()
+    dist.barrier()
+
+    with patch.object(
+        rocm_rccl, "_is_hipgraph_capture_active", return_value=True
+    ), graph_capture(stream=stream) as graph:
+        graph_output = forward()
+    stream.synchronize()
+    rocm_rccl.finish_hipgraph_capture_session()
+
+    replay_hidden, replay_logits = _batched_inputs(1, device)
+    dist.broadcast(replay_hidden, src=0)
+    dist.broadcast(replay_logits, src=0)
+    hidden.copy_(replay_hidden)
+    logits.copy_(replay_logits)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        graph.replay()
+    stream.synchronize()
+    assert_result(graph_output)
+
+
 def _run_real_two_gpu_case(rank, world_size, ports, with_gate):
     parallelism_config = _make_real_parallelism(rank, world_size)
     initialized = False
@@ -236,8 +372,10 @@ def _run_real_two_gpu_case(rank, world_size, ports, with_gate):
             rtol=2e-2,
             atol=2e-3,
         )
-        if unified_output is legacy_output:
-            raise AssertionError("unified and legacy outputs unexpectedly alias")
+        if not with_gate:
+            dist.barrier()
+            _run_batched_eager_and_graph(rank)
+            dist.barrier()
         if rank == 0:
             print(
                 f"[real_tp_unified] gate={with_gate} unified_calls={unified_calls} "

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/test_generic_moe_allreduce.py
@@ -435,6 +435,13 @@ def _configured_gpu_count():
     "requires a ROCm build of PyTorch",
 )
 class GenericMoeRealAllreduceTest(TestCase):
+    def test_select_topk_rejects_non_int32_ids(self):
+        config = ModelConfig()
+        config.moe_k = 2
+        x = torch.empty(1, 2, device="cuda")
+        with self.assertRaisesRegex(TypeError, "expect int32"):
+            SelectTopk(config)(torch.empty(1, 8, device="cuda"), x.long(), x)
+
     def test_two_gpu_real_layer_matches_legacy_for_gated_and_ungated(self):
         if _configured_gpu_count() < 2:
             self.fail(

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/BUILD
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/BUILD
@@ -16,3 +16,12 @@ py_test(
     tags = ["open_skip"],
     exec_properties = {'gpu':'H20'},
 )
+
+py_test(
+    name = "test_batched_data_router_ep",
+    srcs = ["test_batched_data_router_ep.py"],
+    deps = [
+        "//rtp_llm:testlib",
+    ],
+    exec_properties = {'gpu':'H20'},
+)

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_batched_data_router_ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_batched_data_router_ep.py
@@ -208,6 +208,15 @@ class BatchedDataRouterEpTest(unittest.TestCase):
         )
         self.assertEqual(out.shape, (0, HIDDEN))
 
+    def test_zero_tokens_round_trip_through_fused_moe(self) -> None:
+        experts = mock.Mock()
+        fused_moe = moe_defs.FusedMoe(self.router, experts, EXPERT_NUM)
+        empty = torch.zeros((0, TOP_K))
+        with mock.patch.object(batched_data_router, "all_reduce", lambda t, _: t):
+            out = fused_moe(torch.zeros((0, HIDDEN)), empty, empty.to(torch.int32))
+        experts.execute.assert_not_called()
+        self.assertEqual(out.shape, (0, HIDDEN))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rtp_llm/models_py/modules/factory/fused_moe/tests/test_batched_data_router_ep.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/tests/test_batched_data_router_ep.py
@@ -1,0 +1,213 @@
+import unittest
+from typing import Optional
+from unittest import mock
+
+import torch
+
+from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.models_py.distributed.collective_torch import Group
+from rtp_llm.models_py.modules.factory.fused_moe.defs import config_adapter
+from rtp_llm.models_py.modules.factory.fused_moe.defs import fused_moe as moe_defs
+from rtp_llm.models_py.modules.factory.fused_moe.defs import quant_config
+from rtp_llm.models_py.modules.factory.fused_moe.impl.common.router import (
+    batched_data_router,
+)
+from rtp_llm.ops import MoeConfig, ParallelismConfig
+
+EXPERT_NUM = 8
+TP_SIZE = 2
+EP_RANK = 1
+LOCAL_EXPERTS = EXPERT_NUM // TP_SIZE
+LOCAL_LO = LOCAL_EXPERTS * EP_RANK
+TOP_K = 2
+HIDDEN = 4
+NUM_TOKENS = 6
+
+
+class BatchedDataRouterEpTest(unittest.TestCase):
+    """Covers the non-local-expert branch that tp_size == ep_size == 1 hides:
+    with ep_rank > 0 most top-k slots fall outside this rank, so ``routed`` is a
+    real mask over the scratch column and over finalize's zeroing."""
+
+    @staticmethod
+    def _make_config(max_tokens: int) -> config_adapter.MoEConfigAdapter:
+        model_config = ModelConfig()
+        model_config.hidden_size = HIDDEN
+        model_config.expert_num = EXPERT_NUM
+        model_config.moe_k = TOP_K
+        parallelism = ParallelismConfig()
+        parallelism.tp_size = TP_SIZE
+        parallelism.ep_size = TP_SIZE
+        parallelism.ep_rank = EP_RANK
+        moe_config = MoeConfig()
+        moe_config.ll_num_max_token = max_tokens
+        return config_adapter.MoEConfigAdapter(
+            model_config=model_config,
+            parallelism_config=parallelism,
+            moe_config=moe_config,
+        )
+
+    @classmethod
+    def _make_router(cls, max_tokens: int) -> batched_data_router.BatchedDataRouter:
+        return batched_data_router.BatchedDataRouter(
+            config=cls._make_config(max_tokens),
+            quant_config=quant_config.FusedMoEQuantConfig(quant_dtype=None),
+        )
+
+    def setUp(self) -> None:
+        self.router = self._make_router(NUM_TOKENS)
+        torch.manual_seed(0)
+        self.a1 = torch.arange(NUM_TOKENS * HIDDEN, dtype=torch.float32).view(
+            NUM_TOKENS, HIDDEN
+        )
+        # Boundary ids: LOCAL_LO-1 is the last non-local id, LOCAL_LO the first
+        # local one. Local expert 0 stays empty so its placeholder row is poison.
+        self.topk_ids = torch.tensor(
+            [(LOCAL_LO - 1, LOCAL_LO + 1), (LOCAL_LO + 1, EXPERT_NUM - 1)]
+            + [(0, LOCAL_LO + 2), (0, LOCAL_LO - 1)]
+            + [(EXPERT_NUM - 1, LOCAL_LO + 1), (LOCAL_LO + 2, 1)],
+            dtype=torch.int32,
+        )
+        self.topk_weights = torch.rand(NUM_TOKENS, TOP_K) + 0.5
+        self.payload = self._prepare(self.a1, self.topk_weights, self.topk_ids)
+        meta = self.payload.expert_tokens_meta
+        assert meta is not None and meta.expert_num_tokens is not None
+        self.counts = meta.expert_num_tokens
+
+    def _prepare(
+        self, a1: torch.Tensor, weights: torch.Tensor, ids: torch.Tensor
+    ) -> moe_defs.ExpertForwardPayload:
+        return self.router.prepare(a1, None, None, weights, ids)
+
+    def _finalize(
+        self,
+        expert_output: torch.Tensor,
+        weights: Optional[torch.Tensor] = None,
+        ids: Optional[torch.Tensor] = None,
+        prepared: Optional[moe_defs.ExpertForwardPayload] = None,
+    ) -> torch.Tensor:
+        prepared = self.payload if prepared is None else prepared
+        reducer = mock.MagicMock(side_effect=lambda t, _g: t)
+        with mock.patch.object(batched_data_router, "all_reduce", reducer):
+            result = self.router.finalize(
+                moe_defs.CombineForwardPayload(
+                    fused_expert_output=expert_output,
+                    router_context=prepared.router_context,
+                ),
+                self.topk_weights if weights is None else weights,
+                self.topk_ids if ids is None else ids,
+                False,
+                None,
+            )
+        reducer.assert_called_once()
+        self.assertIs(reducer.call_args.args[1], Group.TP)
+        return result
+
+    def _assert_round_trip(
+        self,
+        payload: moe_defs.ExpertForwardPayload,
+        a1: torch.Tensor,
+        ids: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """Pack ``expert_output`` from the plan, poison every padding tail with a
+        non-finite value, finalize, and compare against the reference weighted
+        sum. The poison proves rows past each expert's count are never gathered,
+        and a fully non-local token must come out exactly zero -- masking has to
+        precede the weight multiply, else NaN * 0 == NaN."""
+        meta = payload.expert_tokens_meta
+        assert meta is not None and meta.expert_num_tokens is not None
+        expert_output = torch.zeros(LOCAL_EXPERTS, a1.size(0), HIDDEN)
+        for e in range(LOCAL_EXPERTS):
+            tokens = (ids == e + LOCAL_LO).any(dim=1).nonzero().flatten()
+            self.assertEqual(
+                int(meta.expert_num_tokens[e]), tokens.numel(), f"expert {e} count"
+            )
+            live = tokens.numel()
+            expert_output[e, :live] = payload.expert_x[e, :live]
+            expert_output[e, live:] = float("inf") if e % 2 else float("nan")
+
+        out = self._finalize(expert_output, weights, ids, payload)
+        self.assertTrue(torch.isfinite(out).all(), "padding leaked into the output")
+        local = (ids >= LOCAL_LO) & (ids < EXPERT_NUM)
+        torch.testing.assert_close(out, a1 * (local * weights).sum(1, keepdim=True))
+        return out
+
+    def test_plan_packs_every_local_slot_exactly_once(self) -> None:
+        for e in range(LOCAL_EXPERTS):
+            tokens = (self.topk_ids == e + LOCAL_LO).any(dim=1).nonzero().flatten()
+            self.assertEqual(int(self.counts[e]), tokens.numel(), f"expert {e} count")
+            # Exact, not a multiset compare: packed row ranks fix token order
+            # inside each expert block and finalize relies on that order.
+            packed = self.payload.expert_x[e, : tokens.numel()]
+            self.assertTrue(torch.equal(packed, self.a1[tokens]), f"expert {e} rows")
+
+    def test_finalize_ignores_poisoned_padding(self) -> None:
+        self._assert_round_trip(self.payload, self.a1, self.topk_ids, self.topk_weights)
+
+    def test_prepared_payloads_are_independent(self) -> None:
+        a1 = torch.arange(3 * HIDDEN, dtype=torch.float32).view(3, HIDDEN)
+        ids = torch.tensor(
+            [(LOCAL_LO, 0), (LOCAL_LO + 1, LOCAL_LO + 2), (1, EXPERT_NUM - 1)],
+            dtype=torch.int32,
+        )
+        weights = torch.rand(3, TOP_K) + 0.5
+        self._assert_round_trip(self._prepare(a1, weights, ids), a1, ids, weights)
+        # The setUp fixture must survive an unrelated prepare/finalize: routing
+        # state travels on the payload, not on the router instance.
+        self._assert_round_trip(self.payload, self.a1, self.topk_ids, self.topk_weights)
+
+    def test_finalize_rejects_missing_or_foreign_context(self) -> None:
+        expert_output = self.payload.expert_x.clone()
+        for router_context in (None, object()):
+            with self.subTest(router_context=router_context), self.assertRaisesRegex(
+                TypeError, "prepared routing context"
+            ):
+                self.router.finalize(
+                    moe_defs.CombineForwardPayload(
+                        fused_expert_output=expert_output,
+                        router_context=router_context,
+                    ),
+                    self.topk_weights,
+                    self.topk_ids,
+                    False,
+                    None,
+                )
+
+    def test_round_trip_matches_reference_across_token_counts(self) -> None:
+        """Cover singleton input and prefill beyond the configured decode capacity."""
+        for n in (1, 33):
+            with self.subTest(num_tokens=n):
+                router = self._make_router(1)
+                a1 = torch.randn(n, HIDDEN)
+                ids = torch.randint(0, EXPERT_NUM, (n, TOP_K), dtype=torch.int32)
+                weights = torch.rand(n, TOP_K) + 0.5
+                self._assert_round_trip(
+                    router.prepare(a1, None, None, weights, ids), a1, ids, weights
+                )
+
+    def test_zero_tokens_round_trips(self) -> None:
+        """Empty batch is reachable on a DP rank; deriving the counts from the
+        last cumsum row used to raise IndexError."""
+        empty = torch.zeros((0, TOP_K))
+        payload = self._prepare(torch.zeros((0, HIDDEN)), empty, empty.to(torch.int32))
+        meta = payload.expert_tokens_meta
+        assert meta is not None and meta.expert_num_tokens is not None
+
+        self.assertEqual(payload.expert_x.shape, (LOCAL_EXPERTS, 0, HIDDEN))
+        self.assertTrue(
+            torch.equal(
+                meta.expert_num_tokens, torch.zeros(LOCAL_EXPERTS, dtype=torch.int32)
+            )
+        )
+        out = self._finalize(
+            torch.zeros((LOCAL_EXPERTS, 0, HIDDEN)),
+            empty,
+            empty.to(torch.int32),
+            payload,
+        )
+        self.assertEqual(out.shape, (0, HIDDEN))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/triton_kernels/moe/grouped_gemm.py
+++ b/rtp_llm/models_py/triton_kernels/moe/grouped_gemm.py
@@ -138,6 +138,7 @@ def batched_triton_kernel(
 ):
     expert_id = tl.program_id(axis=0)
     e_num_tokens = tl.load(expert_num_tokens + expert_id)
+    e_num_tokens = tl.maximum(tl.minimum(e_num_tokens, max_num_tokens), 0)
     if e_num_tokens == 0:
         # Early exit
         return


### PR DESCRIPTION

## 概要

本 PR 修复了 ROCm naive EP（`tp_size == ep_size`）路径中 `BatchedDataRouter` 与 `BatchedTritonExperts` 的容量、padding 和 HIP Graph 捕获问题。旧实现按 expert 在 Python 中循环，通过 boolean indexing 和 `count_nonzero()` 动态生成路由结果，既会引入 GPU 到 CPU 同步、阻止 Graph capture，又将单 expert 容量限制为 `ll_num_max_token / tp_size`，无法覆盖所有 token 命中同一 expert 的合法最坏情况；此外，ROCm `SelectTopk` 在 caller 提供 int64 buffer 时会通过 `.int()` 创建临时副本，导致 aiter 原地写入副本而原始路由仍未初始化。

## 实现

新实现把路由改为固定形状的打包、计算和还原流程：`prepare()` 使用 match 矩阵、`cumsum` 和 `scatter` 一次性生成每个 top-k slot 对应 expert 输出行的 `packed_rows`，以及标记该 slot 是否属于当前 EP rank 的 `routed`，再将输入打包为 `[num_local_experts, num_tokens, hidden]`，并通过 `expert_num_tokens` 告诉 grouped GEMM 每个 expert 的有效前缀长度。路由计划通过新增的 per-forward `router_context` 穿过 `FusedMoe` 和 executor 传给 `finalize()`；`finalize()` 使用固定形状的 `index_select` 将 expert 输出还原为 `[num_tokens, top_k, hidden]`，在任何乘法前清零非本地占位行，避免未初始化 padding 中的 NaN 传播，再乘 top-k 权重、沿 top-k 归约并执行 TP all-reduce。executor 同时改为按实际 `num_tokens` 分配 scratch 和输出 buffer，删除失效的固定容量与清零逻辑，声明 `topk_ids_dtype = int32`，并补充输入布局和 expert 维度检查以防 Triton kernel 越界；ROCm `SelectTopk` 则删除 `.int()` 临时转换，要求 caller 直接提供 int32 buffer，确保 aiter 原地写入真实路由。整个流程的 tensor shape 只由 token 数、top-k、本地 expert 数和 hidden size 决定，路由变化只改变 tensor 内容，因此不再依赖 `.item()`、动态长度 boolean indexing 或设备到主机同步，可安全进行 HIP Graph capture 和 replay。

## 测试

- 新增 `test_batched_data_router_ep.py`，覆盖路由打包顺序、非本地 slot、NaN/Inf padding、独立 per-forward context、空 batch，以及 token 数超过配置 decode 容量的场景。
- 新增 `router_context` 从 `prepare()` 透传到 `finalize()` 的协议测试。
- 扩展 MI308X 双卡测试，覆盖 eager、HIP Graph capture，以及更换输入后的 replay，并与独立参考实现比较数值结果。
- 将 batched router 单测注册到 Bazel 测试目标。

## 影响与边界

- 消除 naive EP warm-up 的单 expert 容量溢出、非本地 padding 的 NaN 通路，以及逐 expert 路由产生的 D2H 同步。
- 修复 ROCm top-k 在 int64 caller buffer 下可能返回未初始化路由的问题。
- batched expert workspace 改为按当前 `num_tokens` 分配：decode 场景更小，并覆盖单 expert 最坏负载；长 prefill 下稠密 `[num_local_experts, num_tokens, ...]` 布局的显存和 padding activation 开销仍会随 token 数及本地 expert 数增长，需要在生产规模下继续关注峰值显存和时延。