### PR TITLE
feat(rocm): optimize Qwen3.5 MTP latency and stability

### DIFF
--- a/rtp_llm/cpp/normal_engine/NormalSamplerInputGatherer.cc
+++ b/rtp_llm/cpp/normal_engine/NormalSamplerInputGatherer.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include "torch/all.h"
 #include "rtp_llm/cpp/normal_engine/NormalSamplerInputGatherer.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
@@ -57,13 +58,16 @@ absl::StatusOr<SamplerInputs> NormalSamplerInputGatherer::gather(const StreamGro
                           tensorDebugStringWithData<int32_t>(sampler_inputs.token_ids).c_str());
     }
 
-    auto vocab_size           = (size_t)model_output.logits.size(1);
-    sampler_inputs.vocab_size = vocab_size;
-    if (all_streams.front()->outputVocabSize() > 0) {
+    auto       vocab_size            = (size_t)model_output.logits.size(1);
+    const auto output_vocab_size     = all_streams.front()->outputVocabSize();
+    const auto configured_vocab_size = output_vocab_size > 0 ? output_vocab_size : all_streams.front()->vocabSize();
+    const auto valid_vocab_size      = std::min(vocab_size, configured_vocab_size);
+    sampler_inputs.vocab_size        = vocab_size;
+    if (output_vocab_size > 0) {
         auto* top_k_values = sampler_inputs.top_k.data_ptr<int32_t>();
         for (size_t index = 0; index < sampler_inputs.batch_size; ++index) {
             if (top_k_values[index] > 0) {
-                top_k_values[index] = std::min<int32_t>(top_k_values[index], static_cast<int32_t>(vocab_size));
+                top_k_values[index] = std::min<int32_t>(top_k_values[index], static_cast<int32_t>(valid_vocab_size));
             }
         }
     }
@@ -100,6 +104,10 @@ absl::StatusOr<SamplerInputs> NormalSamplerInputGatherer::gather(const StreamGro
         logits_tensor = model_output.logits.clone();
     } else {
         logits_tensor = model_output.logits;
+    }
+    if (vocab_size > valid_vocab_size) {
+        logits_tensor.narrow(1, valid_vocab_size, vocab_size - valid_vocab_size)
+            .fill_(-std::numeric_limits<float>::infinity());
     }
     sampler_inputs.logits = logits_tensor;
 

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -163,7 +163,7 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
                                  int64_t                                     batch_size,
                                  int64_t                                     propose_step) {
     output.processor_errors = verify_result.processor_errors;
-    torch::Tensor cap_src = verify_result.spec_cap_gpu;
+    torch::Tensor cap_src   = verify_result.spec_cap_gpu;
     if (!cap_src.defined() && verify_result.spec_cap_cpu.defined()) {
         // Non-CUDA builds get no device mirror from the runner; upload the CPU
         // cap so accept-len capping still applies (main parity).
@@ -195,8 +195,7 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
     auto          target_tokens = target_token_ids.reshape({batch_size, propose_step + 1, token_stride})
                              .select(2, token_stride - 1)
                              .to(output.accept_tokens.options());
-    auto cap_index =
-        cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
+    auto cap_index   = cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
     auto replacement = target_tokens.gather(1, cap_index.unsqueeze(1));
 
     auto cols = torch::arange(propose_step + 1,
@@ -442,8 +441,8 @@ static std::shared_ptr<NormalGenerateStream> makeFakeStream(int                 
     return fake_stream;
 }
 
-static SpeculativeExecutorStreamOutputPtr makeFakeSPOutputBuffer(
-    DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
+static SpeculativeExecutorStreamOutputPtr
+makeFakeSPOutputBuffer(DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
     auto sp_buffer = std::make_shared<SpeculativeExecutorStreamOutput>();
 
     sp_buffer->propose_step = propose_step;
@@ -509,10 +508,10 @@ GenerateStreamPtr MtpExecutor::createMinFakeDecodeStream(int                    
     auto seq_len = fake_stream->seqLength();
 
     // set device state
-    auto int32_gpu = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
-    auto accept_len_gpu = torch::ones({1}, int32_gpu);
-    auto accept_tokens_gpu = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
-    auto next_seq_len_gpu = torch::ones({1}, int32_gpu) + 1;
+    auto int32_gpu          = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    auto accept_len_gpu     = torch::ones({1}, int32_gpu);
+    auto accept_tokens_gpu  = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
+    auto next_seq_len_gpu   = torch::ones({1}, int32_gpu) + 1;
     auto propose_tokens_gpu = is_dspark ? torch::Tensor() : torch::zeros({1, 1}, int32_gpu);
 
     fake_stream->setMtpAsyncDeviceState(GenerateStream::MtpAsyncDeviceState{
@@ -676,10 +675,10 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     // when warmup, cache manager maybe nullptr
-    const auto& cache_config = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
-    const auto  group_types  = cache_config.groupTypesSnapshot();
-    is_linear_attention_model_ =
-        std::any_of(group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
+    const auto& cache_config   = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
+    const auto  group_types    = cache_config.groupTypesSnapshot();
+    is_linear_attention_model_ = std::any_of(
+        group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
     batch_stream_processor_.reset(new MtpBatchStreamProcessor(params.model_config_,
                                                               params.pd_sep_config,
                                                               params.profiling_debug_logging_config,
@@ -766,7 +765,6 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     RTP_LLM_LOG_INFO("[speculative decoding] d2t_map size: %ld", d2t_map_.defined() ? d2t_map_.numel() : 0);
-
 }
 
 /*
@@ -892,10 +890,9 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.prefill_step(target_model_forward)");
         maybePrintModelInput(model_input, "prefill target model");
-        int64_t start_time_us               = autil::TimeUtility::currentTimeInMicroSeconds();
-        model_output = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
-        maybeOverrideLastHiddenWithMtpBuffer(
-            model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
+        int64_t start_time_us = autil::TimeUtility::currentTimeInMicroSeconds();
+        model_output          = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
+        maybeOverrideLastHiddenWithMtpBuffer(model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
         model_forward_us += autil::TimeUtility::currentTimeInMicroSeconds() - start_time_us;
     }
 
@@ -1201,7 +1198,6 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
 
     RtpLLMExecutorMetricsCollector& executor_collector = metrics_collector.executor_collector;
 
-    StreamGroups    stream_groups(streams);
     GptModelInputs  model_input;
     GptModelOutputs model_output;
     GptModelOutputs draft_prefill_model_output;
@@ -1216,8 +1212,8 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     torch::Tensor              spec_token_ids_t;
     std::vector<torch::Tensor> draft_probs_list;
     torch::Event               accept_len_ready_event = cuda_graph::makeGraphEvent();
-    auto spec_logits_result = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
-    int64_t model_forward_us = 0;
+    auto                       spec_logits_result     = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
+    int64_t                    model_forward_us       = 0;
 
     // Stream-async events are recorded on the main stream as soon as tensors
     // become valid. rejection_event guards accept_len/tokens D2H; draft_event
@@ -1229,6 +1225,12 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     bool                          spec_logits_processor_present           = false;
 
     waitPreviousBookkeepingAndKvSwaps(streams);
+    // Snapshot stream_groups only after the previous round's async bookkeeping
+    // has published its accepted tokens. Otherwise maxSeqLen() lags the real
+    // stream->seqLength() by gamma+1 and undersizes the verify sampler history,
+    // aborting the first MTP decode with
+    // "MTP verify sampler history exceeds its allocated width".
+    StreamGroups stream_groups(streams);
     prepareGrpcMtpDeviceState(streams, buffer_holder_);
 
     {
@@ -1280,7 +1282,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
         }
         ensureModelInputsOnCuda(model_input, "decode.after_tp_sync");
     }
-    size_t batch_size             = model_input.input_lengths.size(0);
+    size_t batch_size = model_input.input_lengths.size(0);
     spec_logits_processor_present =
         isTpRank0() && !warm_up_ && !model_input.is_fake_stream && hasSpecLogitsProcessor(streams);
 
@@ -1574,7 +1576,7 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
     }
     const auto& cache_cfg = cache_manager_->cacheConfig();
     // NOTE: combo_tokens never used in prepare stage, so it is safe to use shallow copy
-    auto model_input_copy                    = model_input;
+    auto model_input_copy                  = model_input;
     model_input_copy.kv_block_stride_bytes = cache_cfg.kv_block_stride_bytes;
     model_input_copy.kv_scale_stride_bytes = cache_cfg.kv_scale_stride_bytes;
     {
@@ -1623,11 +1625,10 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
                                                                static_cast<int64_t>(batch_size * (propose_step_ + 1)),
                                                                static_cast<int64_t>(propose_step_ + 1),
                                                                cuda_i32);
-            const auto& target_prefix_lengths = target_prefix_lengths_for_prepare.defined() ?
-                                                    target_prefix_lengths_for_prepare :
-                                                    model_input.prefix_lengths;
-            model_input_copy.prefix_lengths =
-                toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
+            const auto& target_prefix_lengths        = target_prefix_lengths_for_prepare.defined() ?
+                                                           target_prefix_lengths_for_prepare :
+                                                           model_input.prefix_lengths;
+            model_input_copy.prefix_lengths          = toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
             model_input_copy.sequence_lengths_plus_1 = model_input_copy.prefix_lengths + 1;
         }
     }
@@ -1719,9 +1720,8 @@ GptModelOutputs MtpExecutor::runTargetVerifyForward(GptModelInputs& model_input,
         if (!useDeviceInput() && model_input.kv_cache_kernel_block_id.defined()
             && model_input.kv_cache_kernel_block_id.is_cuda()) {
             RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(kv_cache_kernel_block_id_to_host)");
-            auto host_table =
-                torch::empty(model_input.kv_cache_kernel_block_id.sizes(),
-                             torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
+            auto host_table = torch::empty(model_input.kv_cache_kernel_block_id.sizes(),
+                                           torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
             host_table.copy_(model_input.kv_cache_kernel_block_id, /*non_blocking=*/false);
             model_input.kv_cache_kernel_block_id = host_table;
         }
@@ -2117,7 +2117,7 @@ absl::Status MtpExecutor::process(const std::list<GenerateStreamPtr>& streams, i
         schedule_time_us = process_start_time_us;
     }
     MtpMetricsCollector metrics_collector;
-    auto tps_active_guard =
+    auto                tps_active_guard =
         tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
     auto wall_tps_active_guard =
         wall_tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
@@ -2209,12 +2209,12 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
         tensor_d      = tensor_d.reshape({static_cast<int64_t>(batch_size)});
         return tensor_d.is_contiguous() ? tensor_d : tensor_d.contiguous();
     };
-    spec_prefix_lengths = model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
-                              toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
-                              (model_input.sequence_lengths.defined() ?
-                                   (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1)
-                                       .to(torch::kInt32) :
-                                   torch::Tensor());
+    spec_prefix_lengths =
+        model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
+            toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
+            (model_input.sequence_lengths.defined() ?
+                 (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1).to(torch::kInt32) :
+                 torch::Tensor());
     // prefix_lengths belongs to the eventual target verify input. Draft decode
     // attention metadata must be driven only by sequence_lengths.
     model_input.prefix_lengths = torch::empty({0}, cuda_i32);
@@ -2255,11 +2255,9 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
                 // Batch gather: [batch, propose_step+1] -> pick column [accept_len-1] per row
                 auto accept_tokens_2d = torch::cat(accept_tokens_slices, 0);  // [batch, cols]
                 auto accept_len_batch = torch::cat(accept_len_slices, 0);     // [batch]
-                auto idx_long = (accept_len_batch.to(torch::kInt64) - 1)
-                                    .reshape({(int64_t)batch_size, 1});
-                pre_target_token_t = accept_tokens_2d.gather(1, idx_long)
-                                         .reshape({(int64_t)batch_size})
-                                         .to(torch::kInt32);
+                auto idx_long         = (accept_len_batch.to(torch::kInt64) - 1).reshape({(int64_t)batch_size, 1});
+                pre_target_token_t =
+                    accept_tokens_2d.gather(1, idx_long).reshape({(int64_t)batch_size}).to(torch::kInt32);
             }
         }
         if (!all_device_state && all_streams.empty()) {
@@ -2323,7 +2321,7 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.draft_model_decode(build_spec_decode_input)");
         // prepare spec decode input
-        const auto    tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
+        const auto tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
         (void)tokens_per_batch;  // consumed only by the USING_CUDA fused path
         torch::Tensor input_lengths;
 #if USING_CUDA
@@ -2365,8 +2363,8 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
 #endif
 
         model_input.input_lengths  = std::move(input_lengths);
-        model_input.prefix_lengths    = spec_prefix_lengths;
-        model_input.combo_tokens      = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
+        model_input.prefix_lengths = spec_prefix_lengths;
+        model_input.combo_tokens   = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
         batch_stream_processor_->expandTargetVerifyPositionIds(stream_groups, model_input);
         model_input.sequence_lengths =
             torch::empty({0}, torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
@@ -2453,8 +2451,8 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     }
 
     // Batch compute next_seq_len from host seqLength (sync path: host is authoritative)
-    const auto pin_i32      = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
-    const auto cuda_i32     = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    const auto pin_i32          = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
+    const auto cuda_i32         = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
     auto       next_seq_len_cpu = torch::empty({batch_size}, pin_i32);
     {
         int64_t i = 0;
@@ -2471,13 +2469,12 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     torch::Tensor last_hidden_all;
     const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
-        const auto hidden_size  = draft_all_hidden_full.size(1);
-        auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
-        auto       accept_i32   = accept_len_all.to(torch::kInt32);
-        auto       idx_long     = (accept_i32.to(torch::kInt64) - 1)
-                                     .reshape({batch_size, 1, 1})
-                                     .expand({batch_size, 1, hidden_size});
-        last_hidden_all         = hidden_3d.gather(1, idx_long).squeeze(1);
+        const auto hidden_size = draft_all_hidden_full.size(1);
+        auto       hidden_3d   = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
+        auto       accept_i32  = accept_len_all.to(torch::kInt32);
+        auto       idx_long =
+            (accept_i32.to(torch::kInt64) - 1).reshape({batch_size, 1, 1}).expand({batch_size, 1, hidden_size});
+        last_hidden_all = hidden_3d.gather(1, idx_long).squeeze(1);
     }
 
     // One clone for all probs
@@ -2491,13 +2488,12 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     int64_t idx             = 0;
     for (auto& stream : all_streams) {
         GenerateStream::MtpAsyncDeviceState state;
-        state.accept_len_gpu     = accept_len_all.narrow(0, idx, 1);
-        state.accept_tokens_gpu  = accept_tokens_all.narrow(0, idx, 1);
+        state.accept_len_gpu    = accept_len_all.narrow(0, idx, 1);
+        state.accept_tokens_gpu = accept_tokens_all.narrow(0, idx, 1);
         state.propose_tokens_gpu =
             propose_tokens_all.defined() ? propose_tokens_all.narrow(0, idx, 1) : torch::Tensor();
-        state.next_seq_len_gpu   = next_seq_len_owned.narrow(0, idx, 1);
-        state.last_hidden_states_gpu =
-            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.next_seq_len_gpu       = next_seq_len_owned.narrow(0, idx, 1);
+        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {
@@ -2520,11 +2516,11 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
                                               std::shared_ptr<torch::Event>                draft_event) {
     RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(dispatch_output_async)");
 
-    const auto& accept_len_gpu_all    = spec_decode_output.accept_len;
-    const auto& accept_tokens_gpu_all = spec_decode_output.accept_tokens;
+    const auto& accept_len_gpu_all     = spec_decode_output.accept_len;
+    const auto& accept_tokens_gpu_all  = spec_decode_output.accept_tokens;
     const auto& propose_tokens_gpu_all = draft_prefill_output.sampler_output.token_ids;
-    const auto& draft_all_hidden_full = draft_prefill_output.model_output.all_hidden_states;
-    const auto& draft_all_probs_full  = draft_prefill_output.sampler_output.all_probs;
+    const auto& draft_all_hidden_full  = draft_prefill_output.model_output.all_hidden_states;
+    const auto& draft_all_probs_full   = draft_prefill_output.sampler_output.all_probs;
 
     auto       all_streams = stream_groups.allStreams();
     const auto batch_size  = static_cast<int64_t>(all_streams.size());
@@ -2547,23 +2543,22 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
             if (gpu_val.defined() && gpu_val.is_cuda()) {
                 prev_slices.push_back(gpu_val.reshape({1}));
             } else {
-                prev_slices.push_back(
-                    torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
+                prev_slices.push_back(torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
             }
         }
         prev_seq_len_all = torch::cat(prev_slices, 0);
 
         next_seq_len_all = torch::empty({batch_size}, cuda_i32);
-        hidden_idx_all = torch::empty({batch_size}, cuda_i64);
+        hidden_idx_all   = torch::empty({batch_size}, cuda_i64);
 
         auto accept_len_i32 = accept_len_gpu_all.to(torch::kInt32);
 #if USING_CUDA
         invokeMtpDispatchStatePrepare(accept_len_i32,
-                                       prev_seq_len_all,
-                                       next_seq_len_all,
-                                       hidden_idx_all,
-                                       batch_size,
-                                       at::cuda::getCurrentCUDAStream().stream());
+                                      prev_seq_len_all,
+                                      next_seq_len_all,
+                                      hidden_idx_all,
+                                      batch_size,
+                                      at::cuda::getCurrentCUDAStream().stream());
 #else
         next_seq_len_all = prev_seq_len_all + accept_len_i32;
         hidden_idx_all   = (accept_len_i32.to(torch::kInt64) - 1);
@@ -2572,7 +2567,7 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
 
     // 2. Batch gather hidden states (1 gather op instead of N index_selects)
     torch::Tensor last_hidden_all;
-    const auto stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
+    const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
         const auto hidden_size  = draft_all_hidden_full.size(1);
         auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
@@ -2596,8 +2591,7 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
         state.propose_tokens_gpu =
             propose_tokens_gpu_all.defined() ? propose_tokens_gpu_all.narrow(0, idx, 1) : torch::Tensor();
         state.next_seq_len_gpu       = next_seq_len_all.narrow(0, idx, 1);
-        state.last_hidden_states_gpu =
-            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {

--- a/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/MtpExecutor.cc
@@ -163,7 +163,7 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
                                  int64_t                                     batch_size,
                                  int64_t                                     propose_step) {
     output.processor_errors = verify_result.processor_errors;
-    torch::Tensor cap_src   = verify_result.spec_cap_gpu;
+    torch::Tensor cap_src = verify_result.spec_cap_gpu;
     if (!cap_src.defined() && verify_result.spec_cap_cpu.defined()) {
         // Non-CUDA builds get no device mirror from the runner; upload the CPU
         // cap so accept-len capping still applies (main parity).
@@ -195,7 +195,8 @@ void applySpecLogitsAcceptLenCap(const SpecLogitsVerifyRunner::LaunchResult& ver
     auto          target_tokens = target_token_ids.reshape({batch_size, propose_step + 1, token_stride})
                              .select(2, token_stride - 1)
                              .to(output.accept_tokens.options());
-    auto cap_index   = cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
+    auto cap_index =
+        cap_src.to(torch::TensorOptions().device(output.accept_tokens.device()).dtype(torch::kLong));
     auto replacement = target_tokens.gather(1, cap_index.unsqueeze(1));
 
     auto cols = torch::arange(propose_step + 1,
@@ -441,8 +442,8 @@ static std::shared_ptr<NormalGenerateStream> makeFakeStream(int                 
     return fake_stream;
 }
 
-static SpeculativeExecutorStreamOutputPtr
-makeFakeSPOutputBuffer(DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
+static SpeculativeExecutorStreamOutputPtr makeFakeSPOutputBuffer(
+    DataType data_type, size_t hidden_size, size_t vocab_size, size_t propose_step, bool is_dspark) {
     auto sp_buffer = std::make_shared<SpeculativeExecutorStreamOutput>();
 
     sp_buffer->propose_step = propose_step;
@@ -508,10 +509,10 @@ GenerateStreamPtr MtpExecutor::createMinFakeDecodeStream(int                    
     auto seq_len = fake_stream->seqLength();
 
     // set device state
-    auto int32_gpu          = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
-    auto accept_len_gpu     = torch::ones({1}, int32_gpu);
-    auto accept_tokens_gpu  = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
-    auto next_seq_len_gpu   = torch::ones({1}, int32_gpu) + 1;
+    auto int32_gpu = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    auto accept_len_gpu = torch::ones({1}, int32_gpu);
+    auto accept_tokens_gpu = torch::zeros({1, max_new_tokens + 1}, int32_gpu);
+    auto next_seq_len_gpu = torch::ones({1}, int32_gpu) + 1;
     auto propose_tokens_gpu = is_dspark ? torch::Tensor() : torch::zeros({1, 1}, int32_gpu);
 
     fake_stream->setMtpAsyncDeviceState(GenerateStream::MtpAsyncDeviceState{
@@ -546,7 +547,7 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     role_type_(params.pd_sep_config.role_type),
     collect_metrics_stream_(cuda_graph::graphGetStreamFromPool(true)),
     target_verify_prepare_runner_(cuda_graph::graphGetStreamFromPool(true)),
-    draft_prefill_prepare_runner_(cuda_graph::graphGetStreamFromPool(true)),
+    draft_prefill_prepare_runner_(cuda_graph::graphGetStreamFromPool(false)),
     spec_logits_verify_runner_(std::make_unique<SpecLogitsVerifyRunner>()),
     spec_logits_verify_async_runner_(cuda_graph::graphGetStreamFromPool(true)),
     spec_bookkeeping_runner_(cuda_graph::graphGetStreamFromPool(true)) {
@@ -675,10 +676,10 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     // when warmup, cache manager maybe nullptr
-    const auto& cache_config   = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
-    const auto  group_types    = cache_config.groupTypesSnapshot();
-    is_linear_attention_model_ = std::any_of(
-        group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
+    const auto& cache_config = cache_manager ? cache_manager->cacheConfig() : CacheConfig();
+    const auto  group_types  = cache_config.groupTypesSnapshot();
+    is_linear_attention_model_ =
+        std::any_of(group_types.begin(), group_types.end(), [](CacheGroupType type) { return type == CacheGroupType::LINEAR; });
     batch_stream_processor_.reset(new MtpBatchStreamProcessor(params.model_config_,
                                                               params.pd_sep_config,
                                                               params.profiling_debug_logging_config,
@@ -765,6 +766,7 @@ MtpExecutor::MtpExecutor(const EngineInitParams&                        params,
     }
 
     RTP_LLM_LOG_INFO("[speculative decoding] d2t_map size: %ld", d2t_map_.defined() ? d2t_map_.numel() : 0);
+
 }
 
 /*
@@ -890,9 +892,10 @@ absl::Status MtpExecutor::prefillStep(const std::list<GenerateStreamPtr>& stream
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.prefill_step(target_model_forward)");
         maybePrintModelInput(model_input, "prefill target model");
-        int64_t start_time_us = autil::TimeUtility::currentTimeInMicroSeconds();
-        model_output          = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
-        maybeOverrideLastHiddenWithMtpBuffer(model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
+        int64_t start_time_us               = autil::TimeUtility::currentTimeInMicroSeconds();
+        model_output = std::move(forwardModel(model_.get(), model_input, ModelInputsModelRole::TARGET));
+        maybeOverrideLastHiddenWithMtpBuffer(
+            model_output, *model_, cp_enabled ? -1 : model_input.combo_tokens.numel());
         model_forward_us += autil::TimeUtility::currentTimeInMicroSeconds() - start_time_us;
     }
 
@@ -1212,8 +1215,8 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     torch::Tensor              spec_token_ids_t;
     std::vector<torch::Tensor> draft_probs_list;
     torch::Event               accept_len_ready_event = cuda_graph::makeGraphEvent();
-    auto                       spec_logits_result     = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
-    int64_t                    model_forward_us       = 0;
+    auto spec_logits_result = std::make_shared<SpecLogitsVerifyRunner::LaunchResult>();
+    int64_t model_forward_us = 0;
 
     // Stream-async events are recorded on the main stream as soon as tensors
     // become valid. rejection_event guards accept_len/tokens D2H; draft_event
@@ -1225,11 +1228,6 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
     bool                          spec_logits_processor_present           = false;
 
     waitPreviousBookkeepingAndKvSwaps(streams);
-    // Snapshot stream_groups only after the previous round's async bookkeeping
-    // has published its accepted tokens. Otherwise maxSeqLen() lags the real
-    // stream->seqLength() by gamma+1 and undersizes the verify sampler history,
-    // aborting the first MTP decode with
-    // "MTP verify sampler history exceeds its allocated width".
     StreamGroups stream_groups(streams);
     prepareGrpcMtpDeviceState(streams, buffer_holder_);
 
@@ -1282,7 +1280,7 @@ absl::Status MtpExecutor::decodeStep(const std::list<GenerateStreamPtr>& streams
         }
         ensureModelInputsOnCuda(model_input, "decode.after_tp_sync");
     }
-    size_t batch_size = model_input.input_lengths.size(0);
+    size_t batch_size             = model_input.input_lengths.size(0);
     spec_logits_processor_present =
         isTpRank0() && !warm_up_ && !model_input.is_fake_stream && hasSpecLogitsProcessor(streams);
 
@@ -1576,7 +1574,7 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
     }
     const auto& cache_cfg = cache_manager_->cacheConfig();
     // NOTE: combo_tokens never used in prepare stage, so it is safe to use shallow copy
-    auto model_input_copy                  = model_input;
+    auto model_input_copy                    = model_input;
     model_input_copy.kv_block_stride_bytes = cache_cfg.kv_block_stride_bytes;
     model_input_copy.kv_scale_stride_bytes = cache_cfg.kv_scale_stride_bytes;
     {
@@ -1625,10 +1623,11 @@ void MtpExecutor::launchTargetVerifyPrepareAsync(const GptModelInputs& model_inp
                                                                static_cast<int64_t>(batch_size * (propose_step_ + 1)),
                                                                static_cast<int64_t>(propose_step_ + 1),
                                                                cuda_i32);
-            const auto& target_prefix_lengths        = target_prefix_lengths_for_prepare.defined() ?
-                                                           target_prefix_lengths_for_prepare :
-                                                           model_input.prefix_lengths;
-            model_input_copy.prefix_lengths          = toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
+            const auto& target_prefix_lengths = target_prefix_lengths_for_prepare.defined() ?
+                                                    target_prefix_lengths_for_prepare :
+                                                    model_input.prefix_lengths;
+            model_input_copy.prefix_lengths =
+                toCudaInt32WithHostHold(target_prefix_lengths, buffer_holder_);
             model_input_copy.sequence_lengths_plus_1 = model_input_copy.prefix_lengths + 1;
         }
     }
@@ -1720,8 +1719,9 @@ GptModelOutputs MtpExecutor::runTargetVerifyForward(GptModelInputs& model_input,
         if (!useDeviceInput() && model_input.kv_cache_kernel_block_id.defined()
             && model_input.kv_cache_kernel_block_id.is_cuda()) {
             RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(kv_cache_kernel_block_id_to_host)");
-            auto host_table = torch::empty(model_input.kv_cache_kernel_block_id.sizes(),
-                                           torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
+            auto host_table =
+                torch::empty(model_input.kv_cache_kernel_block_id.sizes(),
+                             torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
             host_table.copy_(model_input.kv_cache_kernel_block_id, /*non_blocking=*/false);
             model_input.kv_cache_kernel_block_id = host_table;
         }
@@ -2117,7 +2117,7 @@ absl::Status MtpExecutor::process(const std::list<GenerateStreamPtr>& streams, i
         schedule_time_us = process_start_time_us;
     }
     MtpMetricsCollector metrics_collector;
-    auto                tps_active_guard =
+    auto tps_active_guard =
         tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
     auto wall_tps_active_guard =
         wall_tps_reporter_.makeActiveGuard(metrics_reporter_ && isTpRank0() && !warm_up_ && !streams.empty());
@@ -2209,12 +2209,12 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
         tensor_d      = tensor_d.reshape({static_cast<int64_t>(batch_size)});
         return tensor_d.is_contiguous() ? tensor_d : tensor_d.contiguous();
     };
-    spec_prefix_lengths =
-        model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
-            toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
-            (model_input.sequence_lengths.defined() ?
-                 (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1).to(torch::kInt32) :
-                 torch::Tensor());
+    spec_prefix_lengths = model_input.prefix_lengths.defined() && model_input.prefix_lengths.numel() > 0 ?
+                              toCudaInt32WithHostHold(model_input.prefix_lengths, buffer_holder_) :
+                              (model_input.sequence_lengths.defined() ?
+                                   (toCudaInt32WithHostHold(model_input.sequence_lengths, buffer_holder_) - 1)
+                                       .to(torch::kInt32) :
+                                   torch::Tensor());
     // prefix_lengths belongs to the eventual target verify input. Draft decode
     // attention metadata must be driven only by sequence_lengths.
     model_input.prefix_lengths = torch::empty({0}, cuda_i32);
@@ -2255,9 +2255,11 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
                 // Batch gather: [batch, propose_step+1] -> pick column [accept_len-1] per row
                 auto accept_tokens_2d = torch::cat(accept_tokens_slices, 0);  // [batch, cols]
                 auto accept_len_batch = torch::cat(accept_len_slices, 0);     // [batch]
-                auto idx_long         = (accept_len_batch.to(torch::kInt64) - 1).reshape({(int64_t)batch_size, 1});
-                pre_target_token_t =
-                    accept_tokens_2d.gather(1, idx_long).reshape({(int64_t)batch_size}).to(torch::kInt32);
+                auto idx_long = (accept_len_batch.to(torch::kInt64) - 1)
+                                    .reshape({(int64_t)batch_size, 1});
+                pre_target_token_t = accept_tokens_2d.gather(1, idx_long)
+                                         .reshape({(int64_t)batch_size})
+                                         .to(torch::kInt32);
             }
         }
         if (!all_device_state && all_streams.empty()) {
@@ -2321,7 +2323,7 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
     {
         RTP_LLM_PROFILE_SCOPE("executor.mtp.draft_model_decode(build_spec_decode_input)");
         // prepare spec decode input
-        const auto tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
+        const auto    tokens_per_batch = static_cast<int32_t>(propose_step_ + 1);
         (void)tokens_per_batch;  // consumed only by the USING_CUDA fused path
         torch::Tensor input_lengths;
 #if USING_CUDA
@@ -2363,8 +2365,8 @@ void MtpExecutor::draftModelDecode(GptModelInputs&             model_input,
 #endif
 
         model_input.input_lengths  = std::move(input_lengths);
-        model_input.prefix_lengths = spec_prefix_lengths;
-        model_input.combo_tokens   = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
+        model_input.prefix_lengths    = spec_prefix_lengths;
+        model_input.combo_tokens      = draft_token_ids_t.reshape({(int64_t)(batch_size * (propose_step_ + 1))});
         batch_stream_processor_->expandTargetVerifyPositionIds(stream_groups, model_input);
         model_input.sequence_lengths =
             torch::empty({0}, torch::TensorOptions(torch::kInt32).device(torch::kCPU).pinned_memory(true));
@@ -2451,8 +2453,8 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     }
 
     // Batch compute next_seq_len from host seqLength (sync path: host is authoritative)
-    const auto pin_i32          = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
-    const auto cuda_i32         = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
+    const auto pin_i32      = torch::TensorOptions().dtype(torch::kInt32).pinned_memory(true);
+    const auto cuda_i32     = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA);
     auto       next_seq_len_cpu = torch::empty({batch_size}, pin_i32);
     {
         int64_t i = 0;
@@ -2469,12 +2471,13 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     torch::Tensor last_hidden_all;
     const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
-        const auto hidden_size = draft_all_hidden_full.size(1);
-        auto       hidden_3d   = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
-        auto       accept_i32  = accept_len_all.to(torch::kInt32);
-        auto       idx_long =
-            (accept_i32.to(torch::kInt64) - 1).reshape({batch_size, 1, 1}).expand({batch_size, 1, hidden_size});
-        last_hidden_all = hidden_3d.gather(1, idx_long).squeeze(1);
+        const auto hidden_size  = draft_all_hidden_full.size(1);
+        auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
+        auto       accept_i32   = accept_len_all.to(torch::kInt32);
+        auto       idx_long     = (accept_i32.to(torch::kInt64) - 1)
+                                     .reshape({batch_size, 1, 1})
+                                     .expand({batch_size, 1, hidden_size});
+        last_hidden_all         = hidden_3d.gather(1, idx_long).squeeze(1);
     }
 
     // One clone for all probs
@@ -2488,12 +2491,13 @@ void MtpExecutor::publishSyncMtpDeviceState(const StreamGroups&                 
     int64_t idx             = 0;
     for (auto& stream : all_streams) {
         GenerateStream::MtpAsyncDeviceState state;
-        state.accept_len_gpu    = accept_len_all.narrow(0, idx, 1);
-        state.accept_tokens_gpu = accept_tokens_all.narrow(0, idx, 1);
+        state.accept_len_gpu     = accept_len_all.narrow(0, idx, 1);
+        state.accept_tokens_gpu  = accept_tokens_all.narrow(0, idx, 1);
         state.propose_tokens_gpu =
             propose_tokens_all.defined() ? propose_tokens_all.narrow(0, idx, 1) : torch::Tensor();
-        state.next_seq_len_gpu       = next_seq_len_owned.narrow(0, idx, 1);
-        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.next_seq_len_gpu   = next_seq_len_owned.narrow(0, idx, 1);
+        state.last_hidden_states_gpu =
+            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {
@@ -2516,11 +2520,11 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
                                               std::shared_ptr<torch::Event>                draft_event) {
     RTP_LLM_PROFILE_SCOPE("executor.mtp.decode_step(dispatch_output_async)");
 
-    const auto& accept_len_gpu_all     = spec_decode_output.accept_len;
-    const auto& accept_tokens_gpu_all  = spec_decode_output.accept_tokens;
+    const auto& accept_len_gpu_all    = spec_decode_output.accept_len;
+    const auto& accept_tokens_gpu_all = spec_decode_output.accept_tokens;
     const auto& propose_tokens_gpu_all = draft_prefill_output.sampler_output.token_ids;
-    const auto& draft_all_hidden_full  = draft_prefill_output.model_output.all_hidden_states;
-    const auto& draft_all_probs_full   = draft_prefill_output.sampler_output.all_probs;
+    const auto& draft_all_hidden_full = draft_prefill_output.model_output.all_hidden_states;
+    const auto& draft_all_probs_full  = draft_prefill_output.sampler_output.all_probs;
 
     auto       all_streams = stream_groups.allStreams();
     const auto batch_size  = static_cast<int64_t>(all_streams.size());
@@ -2543,22 +2547,23 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
             if (gpu_val.defined() && gpu_val.is_cuda()) {
                 prev_slices.push_back(gpu_val.reshape({1}));
             } else {
-                prev_slices.push_back(torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
+                prev_slices.push_back(
+                    torch::tensor({static_cast<int32_t>(stream->seqLength())}, cuda_i32));
             }
         }
         prev_seq_len_all = torch::cat(prev_slices, 0);
 
         next_seq_len_all = torch::empty({batch_size}, cuda_i32);
-        hidden_idx_all   = torch::empty({batch_size}, cuda_i64);
+        hidden_idx_all = torch::empty({batch_size}, cuda_i64);
 
         auto accept_len_i32 = accept_len_gpu_all.to(torch::kInt32);
 #if USING_CUDA
         invokeMtpDispatchStatePrepare(accept_len_i32,
-                                      prev_seq_len_all,
-                                      next_seq_len_all,
-                                      hidden_idx_all,
-                                      batch_size,
-                                      at::cuda::getCurrentCUDAStream().stream());
+                                       prev_seq_len_all,
+                                       next_seq_len_all,
+                                       hidden_idx_all,
+                                       batch_size,
+                                       at::cuda::getCurrentCUDAStream().stream());
 #else
         next_seq_len_all = prev_seq_len_all + accept_len_i32;
         hidden_idx_all   = (accept_len_i32.to(torch::kInt64) - 1);
@@ -2567,7 +2572,7 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
 
     // 2. Batch gather hidden states (1 gather op instead of N index_selects)
     torch::Tensor last_hidden_all;
-    const auto    stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
+    const auto stream_hidden_len = static_cast<int64_t>(propose_step_ + 1);
     if (propose_step_ > 1 && !is_dspark_ && draft_all_hidden_full.defined()) {
         const auto hidden_size  = draft_all_hidden_full.size(1);
         auto       hidden_3d    = draft_all_hidden_full.reshape({batch_size, stream_hidden_len, hidden_size});
@@ -2591,7 +2596,8 @@ absl::Status MtpExecutor::dispatchDecodeAsync(const StreamGroups&               
         state.propose_tokens_gpu =
             propose_tokens_gpu_all.defined() ? propose_tokens_gpu_all.narrow(0, idx, 1) : torch::Tensor();
         state.next_seq_len_gpu       = next_seq_len_all.narrow(0, idx, 1);
-        state.last_hidden_states_gpu = last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
+        state.last_hidden_states_gpu =
+            last_hidden_all.defined() ? last_hidden_all.narrow(0, idx, 1) : torch::Tensor();
 
         const auto next_batch_size = stream->nextBatchSize();
         if (draft_probs_all.defined() && next_batch_size > 0) {

--- a/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/SpeculativeSampler.cc
@@ -10,23 +10,13 @@ namespace speculative {
 
 FastTopKSamplerOutput FastTopKSampler::forward(const torch::Tensor& logits, int top_k) {
     FastTopKSamplerOutput output;
-    auto                  draft_probs = torch::softmax(logits, -1);
 
-    std::tuple<torch::Tensor, torch::Tensor> sample_res;
     if (top_k == 1) {
-        sample_res = torch::max(draft_probs, -1, true);
+        output.token_ids = torch::argmax(logits, -1, true);
+        output.all_probs = torch::zeros_like(logits).scatter_(-1, output.token_ids, 1.0);
     } else {
-        sample_res = torch::topk(draft_probs, top_k, -1);
-    }
-
-    output.token_ids = std::get<1>(sample_res);
-    if (top_k == 1) {
-        // A deterministic top-1 proposal must be represented by its point-mass
-        // distribution when rejection sampling computes its acceptance ratio.
-        output.all_probs = torch::zeros_like(draft_probs).scatter_(-1, output.token_ids, 1.0);
-    } else {
-        // Preserve the existing multi-candidate behavior. This path does not
-        // describe the deterministic top-1 proposal fixed above.
+        auto draft_probs = torch::softmax(logits, -1);
+        output.token_ids = std::get<1>(torch::topk(draft_probs, top_k, -1));
         output.all_probs = std::move(draft_probs);
     }
 

--- a/rtp_llm/cpp/normal_engine/speculative/test/SpeculativeSamplerTest.cc
+++ b/rtp_llm/cpp/normal_engine/speculative/test/SpeculativeSamplerTest.cc
@@ -16,6 +16,7 @@ TEST(FastTopKSamplerTest, TopKOneReturnsArgmaxIndex) {
     ASSERT_EQ(out.token_ids.size(0), 1);
     ASSERT_EQ(out.token_ids.size(1), 1);
     EXPECT_EQ(out.token_ids[0][0].item<int64_t>(), 2);
+    EXPECT_TRUE(torch::equal(out.all_probs, torch::tensor({{0.0f, 0.0f, 1.0f, 0.0f}})));
 }
 
 TEST(FastTopKSamplerTest, TopKGreaterThanOneReturnsTopKIndices) {

--- a/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/NormalBatchStreamProcessorTest.cc
@@ -615,7 +615,7 @@ TEST_F(NormalBatchStreamProcessorTest, testOutputVocabClampsPositiveTopKToLogits
     EXPECT_EQ(sampler_inputs->top_k.data_ptr<int32_t>()[0], 2);
 }
 
-TEST_F(NormalBatchStreamProcessorTest, testDisabledOutputVocabPreservesTopK) {
+TEST_F(NormalBatchStreamProcessorTest, testDisabledOutputVocabMasksPaddedLogits) {
     ResourceContext resource_context;
     ModelConfig     model_config;
     model_config.max_seq_len = 8;
@@ -623,10 +623,11 @@ TEST_F(NormalBatchStreamProcessorTest, testDisabledOutputVocabPreservesTopK) {
     model_config.num_layers  = 1;
     RuntimeConfig runtime_config;
 
-    auto query                    = make_shared<GenerateInput>();
-    query->input_ids              = hostIntBuffer({2});
-    query->generate_config        = make_shared<GenerateConfig>();
-    query->generate_config->top_k = 8;
+    auto query                               = make_shared<GenerateInput>();
+    query->input_ids                         = hostIntBuffer({2});
+    query->generate_config                   = make_shared<GenerateConfig>();
+    query->generate_config->top_k            = 8;
+    query->generate_config->return_all_probs = ReturnAllProbsMode::DEFAULT;
     auto stream = make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
     stream->generate_status_->status = StreamState::RUNNING;
 
@@ -637,11 +638,14 @@ TEST_F(NormalBatchStreamProcessorTest, testDisabledOutputVocabPreservesTopK) {
         model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
     StreamGroups    stream_groups({stream});
     GptModelOutputs model_output;
-    model_output.logits = torch::zeros({1, 2}, torch::kFloat32).to(torch::kCUDA);
+    model_output.logits = torch::zeros({1, 16}, torch::kFloat32).to(torch::kCUDA);
+    model_output.logits.narrow(1, 10, 6).fill_(100.0f);
 
     auto sampler_inputs = processor.gatherSamplerInput(stream_groups, GptModelInputs(), model_output);
     ASSERT_TRUE(sampler_inputs.ok());
     EXPECT_EQ(sampler_inputs->top_k.data_ptr<int32_t>()[0], 8);
+    EXPECT_EQ(sampler_inputs->all_probs.size(1), 16);
+    EXPECT_TRUE(torch::isneginf(sampler_inputs->logits.narrow(1, 10, 6)).all().item<bool>());
 }
 
 TEST_F(NormalBatchStreamProcessorTest, testPaddedSizeLargerThanKKeepsDispatchAndSamplingOnK) {

--- a/rtp_llm/cpp/test/BUILD
+++ b/rtp_llm/cpp/test/BUILD
@@ -64,9 +64,9 @@ cc_test(
     deps = test_deps + [
         ":test_utils",
     ],
-    env = select({
-        "@//:using_rocm": {"TEST_USING_DEVICE": "ROCM",},
-        "//conditions:default": {"TEST_USING_DEVICE": "CUDA",},
+    env = device_test_envs(),
+    exec_properties = select({
+        "@//:using_rocm": {"gpu": "MI308X-ROCM7"},
+        "//conditions:default": {"gpu": "H20"},
     }),
-    exec_properties = {'gpu':'H20'},
 )

--- a/rtp_llm/cpp/test/SamplerTest.cc
+++ b/rtp_llm/cpp/test/SamplerTest.cc
@@ -269,4 +269,29 @@ TEST_F(SamplerTest, testGeneralSampling) {
             }
         }
     }
+
+    auto oracle_logits        = logits[1].repeat({(int64_t)batch_size, 1});
+    inputs.repetition_penalty = inputs.presence_penalty = inputs.frequency_penalty = torch::Tensor();
+    inputs.temperature = torch::ones({(int64_t)batch_size}, torch::kFloat32).pin_memory();
+    inputs.top_k.fill_(1);
+    inputs.top_p.fill_(1.0f);
+    inputs.logits        = oracle_logits.clone();
+    inputs.all_probs     = torch::empty_like(oracle_logits);
+    inputs.cum_log_probs = torch::Tensor();
+    outputs              = sampler_->forward(inputs);
+    auto point_mass      = torch::zeros_like(oracle_logits).scatter_(1, oracle_logits.argmax(-1, true), 1.0);
+    EXPECT_TRUE(torch::allclose(outputs.all_probs, point_mass));
+
+    // The original top token probability exceeds 0.5, so top-p keeps only token 7.
+    inputs.top_k.fill_(2);
+    inputs.top_p.fill_(0.5f);
+    inputs.token_ids     = output_token_ids.clone();
+    inputs.logits        = oracle_logits.clone();
+    inputs.all_probs     = torch::empty({(int64_t)batch_size, 4}, logits.options());
+    inputs.cum_log_probs = cum_log_probs.clone();
+    outputs              = sampler_->forward(inputs);
+    EXPECT_TRUE(
+        torch::equal(outputs.token_ids.select(1, step).cpu(), torch::full({(int64_t)batch_size}, 7, torch::kInt32)));
+    EXPECT_TRUE(torch::equal(outputs.all_probs, point_mass.slice(1, 0, 4)));
+    EXPECT_TRUE(torch::allclose(outputs.cum_log_probs, cum_log_probs));
 }

--- a/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
+++ b/rtp_llm/models_py/bindings/core/CudaSampleOp.cc
@@ -313,6 +313,11 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
     if (params.cum_log_probs.has_value() && !output_all_probs_t.defined()) {
         output_all_probs_t = torch::zeros_like(probs_t);
     }
+    const auto output_width = output_all_probs_t.defined() ? output_all_probs_t.size(1) : probs_t.size(1);
+    RTP_LLM_CHECK_WITH_INFO(output_width > 0 && output_width <= probs_t.size(1),
+                            "output probability width must be in (0, padded vocab size]");
+    const bool need_full_sampling_probs = output_all_probs_t.defined() && output_width < probs_t.size(1);
+    auto       sampling_probs_t         = need_full_sampling_probs ? torch::zeros_like(probs_t) : output_all_probs_t;
 
     // top_k/top_p are CPU tensors with int32/float32 dtype
     auto top_k_ptr = params.top_k.data_ptr<int32_t>();
@@ -320,7 +325,7 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
 
     std::transform(top_p_ptr, top_p_ptr + batch_size, top_p_ptr, [&](auto t) { return std::abs(t) < 1e-7 ? 1.0 : t; });
 
-    const bool need_renorm_probs  = output_all_probs_t.defined() && !params.return_original_all_probs;
+    const bool need_renorm_probs  = sampling_probs_t.defined() && !params.return_original_all_probs;
     const bool all_top_k_one      = std::all_of(top_k_ptr, top_k_ptr + batch_size, [](auto t) { return t == 1; });
     const bool all_top_k_no_limit = std::all_of(top_k_ptr, top_k_ptr + batch_size, [](auto t) { return t <= 0; });
     const bool all_top_p_one =
@@ -331,7 +336,7 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
         samples_t.copy_(selected_tokens, true);
         success = torch::Tensor();  // mark as undefined — all succeeded
         if (need_renorm_probs) {
-            top_k_renorm_probs(probs_t, output_all_probs_t, top_k_t, 0, (int64_t)cur_stream);
+            top_k_renorm_probs(probs_t, sampling_probs_t, top_k_t, 0, (int64_t)cur_stream);
         }
     } else if (all_top_k_no_limit) {
         top_p_sampling_from_probs(probs_t,
@@ -347,7 +352,7 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
                                   0,
                                   (int64_t)cur_stream);
         if (need_renorm_probs) {
-            top_p_renorm_probs(probs_t, output_all_probs_t, top_p_t, 1.0, (int64_t)cur_stream);
+            top_p_renorm_probs(probs_t, sampling_probs_t, top_p_t, 1.0, (int64_t)cur_stream);
         }
     } else {
         // top_k<=0 means "no limit" in RTP config. The combined FlashInfer
@@ -368,7 +373,7 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
                                       0,
                                       (int64_t)cur_stream);
             if (need_renorm_probs) {
-                top_k_renorm_probs(probs_t, output_all_probs_t, top_k_t, 0, (int64_t)cur_stream);
+                top_k_renorm_probs(probs_t, sampling_probs_t, top_k_t, 0, (int64_t)cur_stream);
             }
         } else {
             top_k_top_p_sampling_from_probs(probs_t,
@@ -386,25 +391,24 @@ static GreedyOutput flashinferSampleGreedy(const GreedyParams& params, const tor
                                             0,
                                             (int64_t)cur_stream);
             if (need_renorm_probs) {
-                torch::Tensor temp_t = torch::zeros_like(output_all_probs_t);
+                torch::Tensor temp_t = torch::zeros_like(sampling_probs_t);
                 top_k_renorm_probs(probs_t, temp_t, top_k_t, 1.0, (int64_t)cur_stream);
-                top_p_renorm_probs(temp_t, output_all_probs_t, top_p_t, 1.0, (int64_t)cur_stream);
+                top_p_renorm_probs(temp_t, sampling_probs_t, top_p_t, 1.0, (int64_t)cur_stream);
             }
         }
     }
 
-    if (params.return_original_all_probs && output_all_probs_t.defined()) {
-        top_k_renorm_probs(probs_t, output_all_probs_t, std::nullopt, 1 << 30, (int64_t)cur_stream);
+    if (params.return_original_all_probs && sampling_probs_t.defined()) {
+        sampling_probs_t.copy_(probs_t);
+    }
+    if (need_full_sampling_probs) {
+        output_all_probs_t.copy_(sampling_probs_t.slice(1, 0, output_width));
     }
 
     if (params.cum_log_probs.has_value()) {
-
-        // [batch_size]
         auto cum_log_probs_t = params.cum_log_probs.value();
-        // [batch_size]
-        auto token_probs_t     = output_all_probs_t.gather(1, samples_t.transpose(1, 0).to(torch::kLong)).squeeze(1);
-        auto token_probs_t_log = token_probs_t.log();
-        cum_log_probs_t.add_(token_probs_t_log.to(cum_log_probs_t.device()));
+        auto token_probs_t   = sampling_probs_t.gather(1, samples_t.transpose(1, 0).to(torch::kLong)).squeeze(1);
+        cum_log_probs_t.add_(token_probs_t.log().to(cum_log_probs_t.device()));
     }
 
     // Copy results back: transpose and copy to token_ids
@@ -684,15 +688,17 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
         }
     }
 
-    // 3. Fast path for topk = 1
-    auto top_k_ptr = reinterpret_cast<uint32_t*>(params.top_k.data_ptr<int32_t>());
-    if (std::all_of(top_k_ptr, top_k_ptr + batch_size, [&](auto t) { return t == 1; })
-        && !params.output_all_probs.has_value()) {
+    auto       top_k_ptr     = reinterpret_cast<uint32_t*>(params.top_k.data_ptr<int32_t>());
+    const bool all_top_k_one = std::all_of(top_k_ptr, top_k_ptr + batch_size, [](auto t) { return t == 1; });
+    if (all_top_k_one && !params.cum_log_probs.has_value() && !params.return_original_all_probs
+        && (!params.output_all_probs.has_value() || params.output_all_probs->size(1) == vocab_size_padded)) {
         torch::Tensor samples_t =
             transposed_tokens.slice(0, transposed_tokens.size(0) - 1, transposed_tokens.size(0)).squeeze(0);
-        torch::Tensor probs_t         = params.logits;
-        torch::Tensor selected_tokens = torch::argmax(probs_t, -1, /*keepdim=*/false);
+        torch::Tensor selected_tokens = torch::argmax(params.logits, -1, /*keepdim=*/false);
         samples_t.copy_(selected_tokens);
+        if (params.output_all_probs.has_value()) {
+            params.output_all_probs->zero_().scatter_(1, selected_tokens.unsqueeze(1), 1.0);
+        }
 
         auto output_tokens = transposed_tokens.transpose(0, 1).contiguous();
         params.token_ids.copy_(output_tokens);
@@ -720,7 +726,6 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
     auto top_p_t   = params.top_p;
     auto top_p_ptr = params.top_p.data_ptr<float>();
 
-    bool          need_renorm_probs = params.output_all_probs.has_value() && !params.return_original_all_probs;
     torch::Tensor output_all_probs_t;
     if (params.output_all_probs.has_value()) {
         output_all_probs_t = params.output_all_probs.value();
@@ -728,15 +733,24 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
     if (params.cum_log_probs.has_value() && !output_all_probs_t.defined()) {
         output_all_probs_t = torch::zeros_like(probs_t);
     }
+    const auto output_width = output_all_probs_t.defined() ? output_all_probs_t.size(1) : probs_t.size(1);
+    RTP_LLM_CHECK_WITH_INFO(output_width > 0 && output_width <= probs_t.size(1),
+                            "output probability width must be in (0, padded vocab size]");
+    const bool need_full_sampling_probs = output_all_probs_t.defined() && output_width < probs_t.size(1);
+    auto       sampling_probs_t         = need_full_sampling_probs ? torch::zeros_like(probs_t) : output_all_probs_t;
+    const bool need_renorm_probs        = sampling_probs_t.defined() && !params.return_original_all_probs;
+    if (params.return_original_all_probs && sampling_probs_t.defined()) {
+        sampling_probs_t.copy_(probs_t);
+    }
 
     std::transform(top_p_ptr, top_p_ptr + batch_size, top_p_ptr, [&](auto t) { return std::abs(t) < 1e-7 ? 1.0 : t; });
 
     // 6. Sample
-    if (std::all_of(top_k_ptr, top_k_ptr + batch_size, [&](auto t) { return t == 1; })) {
+    if (all_top_k_one) {
         torch::Tensor selected_tokens = torch::argmax(probs_t, -1, /*keepdim=*/false);
         samples_t.copy_(selected_tokens);
         if (need_renorm_probs) {
-            top_k_renorm_probs(probs_t, output_all_probs_t, top_k_t, 0, reinterpret_cast<uintptr_t>(cur_stream));
+            top_k_renorm_probs(probs_t, sampling_probs_t, top_k_t, 0, reinterpret_cast<uintptr_t>(cur_stream));
         }
     } else {
         // Use pure PyTorch sampling instead of FlashInfer ROCm kernels.
@@ -747,6 +761,7 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
         //
         // Apply top_k filtering if needed
         auto filtered_probs = probs_t;
+        auto renormalize    = [&] { filtered_probs.div_(filtered_probs.sum(-1, /*keepdim=*/true).clamp_min(1e-10)); };
         bool has_top_k      = !std::all_of(top_k_ptr, top_k_ptr + batch_size, [](auto t) { return t <= 0; });
         if (has_top_k) {
             for (int64_t b = 0; b < (int64_t)batch_size; b++) {
@@ -758,6 +773,7 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
                     row.masked_fill_(row < min_val, 0.0f);
                 }
             }
+            renormalize();
         }
         // Apply top_p (nucleus) filtering if needed
         bool has_top_p =
@@ -774,25 +790,24 @@ GreedyOutput sampleGreedy(const GreedyParams& params) {
                     row.scatter_(0, sorted_indices, sorted_probs);
                 }
             }
+            renormalize();
         }
-        // Re-normalize and sample
-        auto row_sums  = filtered_probs.sum(-1, /*keepdim=*/true);
-        filtered_probs = filtered_probs / row_sums.clamp_min(1e-10);
-        auto selected  = torch::multinomial(filtered_probs, 1, /*replacement=*/false).squeeze(-1);
+        auto selected = torch::multinomial(filtered_probs, 1, /*replacement=*/false).squeeze(-1);
         samples_t.copy_(selected);
         if (need_renorm_probs) {
-            output_all_probs_t.copy_(filtered_probs);
+            sampling_probs_t.copy_(filtered_probs);
         }
     }
 
-    if (params.return_original_all_probs && output_all_probs_t.defined()) {
-        top_k_renorm_probs(probs_t, output_all_probs_t, std::nullopt, 1 << 30, reinterpret_cast<uintptr_t>(cur_stream));
+    if (need_full_sampling_probs) {
+        output_all_probs_t.copy_(sampling_probs_t.slice(1, 0, output_width));
     }
 
     // 7. Update cum_log_probs
     if (params.cum_log_probs.has_value()) {
         auto cum_log_probs_t = params.cum_log_probs.value();
-        cum_log_probs_t.add_(probs_t.log());
+        auto token_probs_t   = sampling_probs_t.gather(1, samples_t.to(torch::kLong).unsqueeze(1)).squeeze(1);
+        cum_log_probs_t.add_(token_probs_t.log().to(cum_log_probs_t.device()));
     }
 
     // 8. Copy results back

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -163,9 +163,24 @@ void updateKvCacheOffset(CKAttn& params, const torch::Tensor& kv_cache_block_id_
     TORCH_CHECK(kv_cache_block_id_device.scalar_type() == at::kInt,
                 "kv_cache_block_id_device must be int32, got ",
                 kv_cache_block_id_device.scalar_type());
-    const int   batch_size        = kv_cache_block_id_device.size(0);
-    const int   max_blocks_per_bs = kv_cache_block_id_device.size(1);
-    hipStream_t stream            = GET_CURRENT_STREAM();
+    const int batch_size        = kv_cache_block_id_device.size(0);
+    const int max_blocks_per_bs = kv_cache_block_id_device.size(1);
+    // params.kv_cache_offset is allocated once by PrepareCKAttn (at capture time on the graph
+    // path) and its address is baked into the by-value KVBlockArray kernarg, so it can never be
+    // reallocated here -- but the write extent comes from the runtime block table. A table larger
+    // than the captured one would write past the buffer and leave KVBlockArray describing a
+    // geometry the storage does not have.
+    const int64_t required = static_cast<int64_t>(batch_size) * 2 * max_blocks_per_bs;
+    TORCH_CHECK(required <= params.kv_cache_offset.numel(),
+                "updateKvCacheOffset would overflow the captured kv_cache_offset: runtime block table is ",
+                batch_size,
+                "x",
+                max_blocks_per_bs,
+                " (needs ",
+                required,
+                " int32) but the buffer holds ",
+                params.kv_cache_offset.numel());
+    hipStream_t stream = GET_CURRENT_STREAM();
     invokeConvertOffsetToBlockArrayData(params.kv_cache_offset.data_ptr<int>(),
                                         kv_cache_block_id_device.data_ptr<int>(),
                                         batch_size,
@@ -561,6 +576,45 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
     bool   store_q     = true;
     bool   store_kv    = false;
     bool   store_cache = kv_cache.has_value();
+
+    // The decode kernel derives every index from its launch geometry (grid is
+    // (token_num, head_num), seq_len is 1) and clamps nothing: batch_idx indexes
+    // sequence_lengths, whose value then becomes a KV store offset. On the CUDA-graph path
+    // those lengths live in pinned host memory, so a bad one silently becomes a wild device
+    // address that faults far from its cause. Check on the host, where already-resident
+    // lengths cost no synchronization.
+    RTP_LLM_CHECK_WITH_INFO(token_num <= batch_size * static_cast<int>(seq_len),
+                            "FusedRopeKVCacheDecodeOp: token_num=%d exceeds batch_size=%d * seq_len=%d, "
+                            "the kernel would index sequence_lengths out of range",
+                            token_num,
+                            batch_size,
+                            static_cast<int>(seq_len));
+    RTP_LLM_CHECK_WITH_INFO(batch_size <= kv_block_array.mMaxSeqs,
+                            "FusedRopeKVCacheDecodeOp: batch_size=%d exceeds kv block table capacity "
+                            "mMaxSeqs=%d",
+                            batch_size,
+                            kv_block_array.mMaxSeqs);
+    if (store_cache && !params->sequence_lengths.is_cuda() && params->sequence_lengths.numel() >= batch_size) {
+        const int64_t kv_token_capacity =
+            static_cast<int64_t>(kv_block_array.mMaxBlocksPerSeq) * kv_block_array.mTokensPerBlock;
+        const int* sequence_lengths_host = params->sequence_lengths.data_ptr<int>();
+        for (int i = 0; i < batch_size; ++i) {
+            const int64_t dst_kv_seq_idx = static_cast<int64_t>(sequence_lengths_host[i]) + max_prefix_length;
+            RTP_LLM_CHECK_WITH_INFO(dst_kv_seq_idx >= 0 && dst_kv_seq_idx < kv_token_capacity,
+                                    "FusedRopeKVCacheDecodeOp: sequence_lengths[%d]=%d (+max_prefix=%d) maps to kv "
+                                    "token %ld, outside the block table capacity %ld "
+                                    "(mMaxBlocksPerSeq=%d * mTokensPerBlock=%d); batch_size=%d token_num=%d",
+                                    i,
+                                    sequence_lengths_host[i],
+                                    max_prefix_length,
+                                    static_cast<long>(dst_kv_seq_idx),
+                                    static_cast<long>(kv_token_capacity),
+                                    kv_block_array.mMaxBlocksPerSeq,
+                                    kv_block_array.mTokensPerBlock,
+                                    batch_size,
+                                    token_num);
+        }
+    }
 
     // Always use aiter_pa for ROCm
     hipStream_t stream_ = GET_CURRENT_STREAM();

--- a/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
+++ b/rtp_llm/models_py/bindings/rocm/FusedRopeKVCacheOp.cc
@@ -163,24 +163,19 @@ void updateKvCacheOffset(CKAttn& params, const torch::Tensor& kv_cache_block_id_
     TORCH_CHECK(kv_cache_block_id_device.scalar_type() == at::kInt,
                 "kv_cache_block_id_device must be int32, got ",
                 kv_cache_block_id_device.scalar_type());
-    const int batch_size        = kv_cache_block_id_device.size(0);
-    const int max_blocks_per_bs = kv_cache_block_id_device.size(1);
-    // params.kv_cache_offset is allocated once by PrepareCKAttn (at capture time on the graph
-    // path) and its address is baked into the by-value KVBlockArray kernarg, so it can never be
-    // reallocated here -- but the write extent comes from the runtime block table. A table larger
-    // than the captured one would write past the buffer and leave KVBlockArray describing a
-    // geometry the storage does not have.
-    const int64_t required = static_cast<int64_t>(batch_size) * 2 * max_blocks_per_bs;
-    TORCH_CHECK(required <= params.kv_cache_offset.numel(),
-                "updateKvCacheOffset would overflow the captured kv_cache_offset: runtime block table is ",
+    const int   batch_size        = kv_cache_block_id_device.size(0);
+    const int   max_blocks_per_bs = kv_cache_block_id_device.size(1);
+    hipStream_t stream            = GET_CURRENT_STREAM();
+    TORCH_CHECK(batch_size <= params.kv_block_array.mMaxSeqs,
+                "runtime batch_size ",
                 batch_size,
-                "x",
+                " exceeds captured mMaxSeqs ",
+                params.kv_block_array.mMaxSeqs);
+    TORCH_CHECK(max_blocks_per_bs == params.kv_block_array.mMaxBlocksPerSeq,
+                "runtime max_blocks_per_bs ",
                 max_blocks_per_bs,
-                " (needs ",
-                required,
-                " int32) but the buffer holds ",
-                params.kv_cache_offset.numel());
-    hipStream_t stream = GET_CURRENT_STREAM();
+                " must equal captured mMaxBlocksPerSeq ",
+                params.kv_block_array.mMaxBlocksPerSeq);
     invokeConvertOffsetToBlockArrayData(params.kv_cache_offset.data_ptr<int>(),
                                         kv_cache_block_id_device.data_ptr<int>(),
                                         batch_size,
@@ -577,44 +572,12 @@ torch::Tensor FusedRopeKVCacheDecodeOpBase::forward(const torch::Tensor&        
     bool   store_kv    = false;
     bool   store_cache = kv_cache.has_value();
 
-    // The decode kernel derives every index from its launch geometry (grid is
-    // (token_num, head_num), seq_len is 1) and clamps nothing: batch_idx indexes
-    // sequence_lengths, whose value then becomes a KV store offset. On the CUDA-graph path
-    // those lengths live in pinned host memory, so a bad one silently becomes a wild device
-    // address that faults far from its cause. Check on the host, where already-resident
-    // lengths cost no synchronization.
-    RTP_LLM_CHECK_WITH_INFO(token_num <= batch_size * static_cast<int>(seq_len),
-                            "FusedRopeKVCacheDecodeOp: token_num=%d exceeds batch_size=%d * seq_len=%d, "
+    // The decode kernel indexes one sequence length per token.
+    RTP_LLM_CHECK_WITH_INFO(token_num <= batch_size,
+                            "FusedRopeKVCacheDecodeOp: token_num=%d exceeds batch_size=%d, "
                             "the kernel would index sequence_lengths out of range",
                             token_num,
-                            batch_size,
-                            static_cast<int>(seq_len));
-    RTP_LLM_CHECK_WITH_INFO(batch_size <= kv_block_array.mMaxSeqs,
-                            "FusedRopeKVCacheDecodeOp: batch_size=%d exceeds kv block table capacity "
-                            "mMaxSeqs=%d",
-                            batch_size,
-                            kv_block_array.mMaxSeqs);
-    if (store_cache && !params->sequence_lengths.is_cuda() && params->sequence_lengths.numel() >= batch_size) {
-        const int64_t kv_token_capacity =
-            static_cast<int64_t>(kv_block_array.mMaxBlocksPerSeq) * kv_block_array.mTokensPerBlock;
-        const int* sequence_lengths_host = params->sequence_lengths.data_ptr<int>();
-        for (int i = 0; i < batch_size; ++i) {
-            const int64_t dst_kv_seq_idx = static_cast<int64_t>(sequence_lengths_host[i]) + max_prefix_length;
-            RTP_LLM_CHECK_WITH_INFO(dst_kv_seq_idx >= 0 && dst_kv_seq_idx < kv_token_capacity,
-                                    "FusedRopeKVCacheDecodeOp: sequence_lengths[%d]=%d (+max_prefix=%d) maps to kv "
-                                    "token %ld, outside the block table capacity %ld "
-                                    "(mMaxBlocksPerSeq=%d * mTokensPerBlock=%d); batch_size=%d token_num=%d",
-                                    i,
-                                    sequence_lengths_host[i],
-                                    max_prefix_length,
-                                    static_cast<long>(dst_kv_seq_idx),
-                                    static_cast<long>(kv_token_capacity),
-                                    kv_block_array.mMaxBlocksPerSeq,
-                                    kv_block_array.mTokensPerBlock,
-                                    batch_size,
-                                    token_num);
-        }
-    }
+                            batch_size);
 
     // Always use aiter_pa for ROCm
     hipStream_t stream_ = GET_CURRENT_STREAM();

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -1216,11 +1216,8 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
     }
 
     // refer to the implementation of hipify decode attention
-    // input_lengths is indexed by sequence, so use batch_idx (derived from blockIdx.x)
-    // rather than blockIdx.y: blockIdx.y is the head index in this launch geometry, so
-    // head-indexing this buffer both picks the wrong sequence and reads past the buffer
-    // whenever the decode batch is smaller than head_num.
-    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    // input_lengths is indexed by sequence (batch_idx), not head index (blockIdx.y).
+    const int  position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_idx];
     const int timestep  = tlength;
@@ -1379,11 +1376,8 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
     }
 
     // refer to the implementation of hipify decode attention
-    // input_lengths is indexed by sequence, so use batch_idx (derived from blockIdx.x)
-    // rather than blockIdx.y: blockIdx.y is the head index in this launch geometry, so
-    // head-indexing this buffer both picks the wrong sequence and reads past the buffer
-    // whenever the decode batch is smaller than head_num.
-    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    // input_lengths is indexed by sequence (batch_idx), not head index (blockIdx.y).
+    const int  position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
     const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_idx];
     const int timestep  = tlength;

--- a/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/fused_rope_kvcache_kernel.cu
@@ -1216,10 +1216,13 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel_v1(T*                 
     }
 
     // refer to the implementation of hipify decode attention
-    const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    // input_lengths is indexed by sequence, so use batch_idx (derived from blockIdx.x)
+    // rather than blockIdx.y: blockIdx.y is the head index in this launch geometry, so
+    // head-indexing this buffer both picks the wrong sequence and reads past the buffer
+    // whenever the decode batch is smaller than head_num.
+    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
-    const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
+    const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_idx];
     const int timestep  = tlength;
     attention_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                          q,
@@ -1376,10 +1379,13 @@ __global__ void add_fusedQKV_bias_transpose_decode_kernel(T*                    
     }
 
     // refer to the implementation of hipify decode attention
-    const auto batch_beam_idx = blockIdx.y;
-    const int  position_id    = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
+    // input_lengths is indexed by sequence, so use batch_idx (derived from blockIdx.x)
+    // rather than blockIdx.y: blockIdx.y is the head index in this launch geometry, so
+    // head-indexing this buffer both picks the wrong sequence and reads past the buffer
+    // whenever the decode batch is smaller than head_num.
+    const int position_id = get_rope_position_id(rope_config, position_ids, token_idx, tidx);
 
-    const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_beam_idx];
+    const int input_len = (input_lengths == nullptr) ? 0 : input_lengths[batch_idx];
     const int timestep  = tlength;
     attention_rope<T, Vec_t, ROPE_STYLE>(rope_config,
                                          q,

--- a/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
@@ -25,14 +25,18 @@
 using namespace std;
 using namespace at;
 
-#define NBLOCKS_PER_GPU 256
-
 namespace rtp_llm {
 
 namespace cg     = cooperative_groups;
 using __bfloat16 = __hip_bfloat16;
 
 static_assert(sizeof(void*) == sizeof(fptr_t));
+static_assert(shouldUseOneStageAllReduce(64, 2, 160 * 1024));
+static_assert(shouldUseOneStageAllReduce(64, 4, 160 * 1024 - 1));
+static_assert(!shouldUseOneStageAllReduce(64, 4, 160 * 1024));
+static_assert(shouldUseOneStageAllReduce(64, 8, 80 * 1024 - 1));
+static_assert(!shouldUseOneStageAllReduce(65, 8, 80 * 1024 - 1));
+static_assert(!shouldUseOneStageAllReduce(64, 8, 80 * 1024));
 
 namespace details {
 
@@ -517,7 +521,7 @@ void allreduce_fusion_kernel_1stage_launcher(AllReduceFusionParams<T> const& par
     constexpr int VEC_SIZE   = details::kBytesPerAccess / sizeof(T);
     constexpr int BLOCK_SIZE = HIDDEN_DIM / VEC_SIZE;
     int           token_num  = params.size / params.hidden_dim;
-    TORCH_CHECK(token_num <= NBLOCKS_PER_GPU);
+    TORCH_CHECK(token_num <= kAllReduceMaxBlocksPerGpu);
     dim3 threadsPerBlock(BLOCK_SIZE);
     dim3 numBlocks(token_num);
     allreduce_fusion_kernel_1stage<T, NRanks, BLOCK_SIZE, QUANT_TYPE>
@@ -532,7 +536,7 @@ void allreduce_kernel_1stage_launcher(AllReduceFusionParams<T> const& params,
     constexpr int VEC_SIZE   = details::kBytesPerAccess / sizeof(T);
     constexpr int BLOCK_SIZE = HIDDEN_DIM / VEC_SIZE;
     int           token_num  = params.size / params.hidden_dim;
-    TORCH_CHECK(token_num <= NBLOCKS_PER_GPU);
+    TORCH_CHECK(token_num <= kAllReduceMaxBlocksPerGpu);
     dim3 threadsPerBlock(BLOCK_SIZE);
     dim3 numBlocks(token_num);
     allreduce_kernel_1stage<T, NRanks, BLOCK_SIZE, QUANT_TYPE>
@@ -669,9 +673,9 @@ void allreduce_fusion_kernel_2stage_launcher(AllReduceFusionParams<T> const& par
                                              gpuStream_t                     stream) {
     constexpr int VEC_SIZE   = details::kBytesPerAccess / sizeof(T);
     constexpr int BLOCK_SIZE = HIDDEN_DIM / VEC_SIZE;
-    int           token_num  = params.size / params.hidden_dim;
+    int64_t       token_num  = params.size / params.hidden_dim;
     dim3          threadsPerBlock(BLOCK_SIZE);
-    token_num = std::min(token_num, NBLOCKS_PER_GPU);
+    token_num = std::min(token_num, kAllReduceMaxBlocksPerGpu);
     dim3 numBlocks(token_num);
     allreduce_fusion_kernel_2stage<T, NRanks, BLOCK_SIZE, QUANT_TYPE>
         <<<numBlocks, threadsPerBlock, 0, stream>>>(params, meta, cptrs);
@@ -684,9 +688,9 @@ void allreduce_kernel_2stage_launcher(AllReduceFusionParams<T> const& params,
                                       gpuStream_t                     stream) {
     constexpr int VEC_SIZE   = details::kBytesPerAccess / sizeof(T);
     constexpr int BLOCK_SIZE = HIDDEN_DIM / VEC_SIZE;
-    int           token_num  = params.size / params.hidden_dim;
+    int64_t       token_num  = params.size / params.hidden_dim;
     dim3          threadsPerBlock(BLOCK_SIZE);
-    token_num = std::min(token_num, NBLOCKS_PER_GPU);
+    token_num = std::min(token_num, kAllReduceMaxBlocksPerGpu);
     dim3 numBlocks(token_num);
     allreduce_kernel_2stage<T, NRanks, BLOCK_SIZE, QUANT_TYPE>
         <<<numBlocks, threadsPerBlock, 0, stream>>>(params, meta, cptrs);
@@ -706,10 +710,8 @@ void allreduce_fusion_kernel_launcher_(AllReduceFusionParams<T> const& params,
     TORCH_CHECK(params.size % params.hidden_dim == 0);
     TORCH_CHECK(params.hidden_dim % VEC_SIZE == 0);
     TORCH_CHECK(params.hidden_dim == HIDDEN_DIM);
-    auto bytes  = params.size * sizeof(T);
-    bool use_1s = token_num <= (NBLOCKS_PER_GPU / 4);
-    use_1s = use_1s && ((NRanks <= 2) || (NRanks <= 4 && bytes < 160 * 1024) || (NRanks <= 8 && bytes < 80 * 1024));
-    if (use_1s) {
+    auto bytes = params.size * sizeof(T);
+    if (shouldUseOneStageAllReduce(token_num, NRanks, bytes)) {
         allreduce_fusion_kernel_1stage_launcher<T, NRanks, HIDDEN_DIM, QUANT_TYPE>(params, meta, cptrs, stream);
     } else {
         allreduce_fusion_kernel_2stage_launcher<T, NRanks, HIDDEN_DIM, QUANT_TYPE>(params, meta, cptrs, stream);
@@ -726,10 +728,8 @@ void allreduce_kernel_launcher_(AllReduceFusionParams<T> const& params,
     TORCH_CHECK(params.size % params.hidden_dim == 0);
     TORCH_CHECK(params.hidden_dim % VEC_SIZE == 0);
     TORCH_CHECK(params.hidden_dim == HIDDEN_DIM);
-    auto bytes  = params.size * sizeof(T);
-    bool use_1s = token_num <= (NBLOCKS_PER_GPU / 4);
-    use_1s = use_1s && ((NRanks <= 2) || (NRanks <= 4 && bytes < 160 * 1024) || (NRanks <= 8 && bytes < 80 * 1024));
-    if (use_1s) {
+    auto bytes = params.size * sizeof(T);
+    if (shouldUseOneStageAllReduce(token_num, NRanks, bytes)) {
         allreduce_kernel_1stage_launcher<T, NRanks, HIDDEN_DIM, QUANT_TYPE>(params, meta, cptrs, stream);
     } else {
         allreduce_kernel_2stage_launcher<T, NRanks, HIDDEN_DIM, QUANT_TYPE>(params, meta, cptrs, stream);
@@ -995,7 +995,7 @@ public:
                   int64_t world_size,
                   int64_t size_in_bytes,
                   int64_t comm_ptrs_buf_len,
-                  int64_t max_thread_blocks = NBLOCKS_PER_GPU,
+                  int64_t max_thread_blocks = kAllReduceMaxBlocksPerGpu,
                   bool    round_robin       = true) {
         TORCH_CHECK(rank < world_size);
         gpuSetDevice(device_id);
@@ -1096,10 +1096,8 @@ public:
         meta.rank       = rank_;
         meta.nranks     = world_size_;
 
-        int64_t token_num = input.numel() / input.size(-1);
-        bool    direct_input =
-            token_num <= (NBLOCKS_PER_GPU / 4)
-            && (world_size_ <= 2 || (world_size_ <= 4 && size < 160 * 1024) || (world_size_ <= 8 && size < 80 * 1024));
+        int64_t   token_num    = input.numel() / input.size(-1);
+        bool      direct_input = shouldUseOneStageAllReduce(token_num, world_size_, size);
         CommPtrs* cptrs;
         bool      cache_hit = false;
         auto      it        = direct_input ? ptr_to_comm_ptrs_.find(ptr) : ptr_to_comm_ptrs_.end();

--- a/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
+++ b/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.cu
@@ -772,6 +772,9 @@ void allreduce_kernel_launcher_hd(AllReduceFusionParams<T> const& params,
         case 4096:
             allreduce_kernel_launcher_<T, NRanks, 4096, QUANT_TYPE>(params, meta, cptrs, stream);
             return;
+        case 3072:
+            allreduce_kernel_launcher_<T, NRanks, 3072, QUANT_TYPE>(params, meta, cptrs, stream);
+            return;
         case 2560:
             allreduce_kernel_launcher_<T, NRanks, 2560, QUANT_TYPE>(params, meta, cptrs, stream);
             return;
@@ -949,21 +952,28 @@ Tensor get_handle(void* ptr) {
 void open_handles(int rank, std::vector<Tensor>& handles, void* ptr, std::vector<void*>& ipc_ptrs) {
     std::vector<gpuIpcMemHandle_t> ipc_handles;
     int                            world_size = handles.size();
+    std::vector<void*>             opened(world_size, nullptr);
     ipc_handles.reserve(world_size);
-    ipc_ptrs.resize(world_size);
     for (auto& handle : handles) {
         gpuIpcMemHandle_t ipc_handle;
         std::memcpy(&ipc_handle, handle.data_ptr(), sizeof(gpuIpcMemHandle_t));
         ipc_handles.push_back(ipc_handle);
     }
     for (int i = 0; i < world_size; ++i) {
-        if (i != rank) {
-            TORCH_CHECK(gpuIpcOpenMemHandle((void**)&ipc_ptrs[i], ipc_handles[i], gpuIpcMemLazyEnablePeerAccess)
-                        == gpuSuccess);
-        } else {
-            ipc_ptrs[i] = ptr;
+        if (i == rank) {
+            opened[i] = ptr;
+            continue;
+        }
+        auto err = gpuIpcOpenMemHandle(&opened[i], ipc_handles[i], gpuIpcMemLazyEnablePeerAccess);
+        if (err != gpuSuccess) {
+            for (int j = 0; j < i; ++j) {
+                if (j != rank && opened[j] != nullptr)
+                    hipIpcCloseMemHandle(opened[j]);
+            }
+            TORCH_CHECK(false, "hipIpcOpenMemHandle failed: ", hipGetErrorString(err));
         }
     }
+    ipc_ptrs.swap(opened);
 }
 
 void create_base_ptr(void** base_ptr, void* ptr) {
@@ -1086,24 +1096,25 @@ public:
         meta.rank       = rank_;
         meta.nranks     = world_size_;
 
+        int64_t token_num = input.numel() / input.size(-1);
+        bool    direct_input =
+            token_num <= (NBLOCKS_PER_GPU / 4)
+            && (world_size_ <= 2 || (world_size_ <= 4 && size < 160 * 1024) || (world_size_ <= 8 && size < 80 * 1024));
         CommPtrs* cptrs;
         bool      cache_hit = false;
-        auto      it = ptr_to_comm_ptrs_.find(ptr);
+        auto      it        = direct_input ? ptr_to_comm_ptrs_.find(ptr) : ptr_to_comm_ptrs_.end();
         if (it != ptr_to_comm_ptrs_.end()) {
             // Validate that the allocation backing this data_ptr hasn't
             // changed (freed + reused by the caching allocator).  If the
             // range no longer matches, the cached IPC slot is stale.
-            auto& slot = it->second;
+            auto&  slot      = it->second;
             void*  cur_start = nullptr;
             size_t cur_size  = 0;
             hipPointerGetAttribute(
-                &cur_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR,
-                reinterpret_cast<hipDeviceptr_t>(ptr));
-            hipPointerGetAttribute(
-                &cur_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE,
-                reinterpret_cast<hipDeviceptr_t>(ptr));
+                &cur_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, reinterpret_cast<hipDeviceptr_t>(ptr));
+            hipPointerGetAttribute(&cur_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE, reinterpret_cast<hipDeviceptr_t>(ptr));
             if (cur_start == slot.range_start && cur_size == slot.range_size) {
-                cptrs = slot.comm_ptrs;
+                cptrs     = slot.comm_ptrs;
                 cache_hit = true;
             } else {
                 // Stale entry — allocation was recycled.  Erase so we fall
@@ -1112,26 +1123,19 @@ public:
             }
         }
         if (!cache_hit) {
-            // Restore fast-path: during graph capture, assign each allreduce
-            // invocation its own comm_ptrs slot and record the input tensor's
-            // data_ptr for later IPC handle exchange (consume_capture).
-            // Verified: ROCm hipGraph capture retains caching-allocator block
-            // references, so IPC handles stay valid across replay.
-            // (ROCm 6.x, PyTorch 2.6, 8×MI300X, 50+ round identical-prompt
-            //  decode + 24h whole-cluster soak with trtallreduce enabled.)
+            // One-stage graph replay reads peer inputs directly; other paths use the workspace.
             gpuStreamCaptureStatus status = gpuStreamCaptureStatusNone;
             if (gpuStreamIsCapturing(stream, &status) != gpuSuccess)
                 status = gpuStreamCaptureStatusNone;
-            // size_in_bytes_ is the workspace buffer size; tensors beyond it
-            // fall back to the copy path because they cannot fit in a single
-            // comm_ptrs slot's IPC-registered region.
             int remaining = comm_ptrs_buf_len_ - used_comm_ptrs_ - static_cast<int>(unregistered_ptrs_.size());
-            if (status == gpuStreamCaptureStatusActive && size < size_in_bytes_ && remaining > 0) {
+            if (direct_input && status == gpuStreamCaptureStatusActive && size < size_in_bytes_ && remaining > 0) {
                 unregistered_ptrs_.push_back(ptr);
                 cptrs = comm_ptrs_ + used_comm_ptrs_ + static_cast<int>(unregistered_ptrs_.size()) - 1;
             } else {
                 cptrs = comm_ptrs_ + 0;
-                gpuMemcpyAsync(data_, ptr, size, gpuMemcpyDeviceToDevice, stream);
+                TORCH_CHECK(size <= size_in_bytes_, "allreduce input exceeds comm workspace capacity");
+                TORCH_CHECK(gpuMemcpyAsync(data_, ptr, size, gpuMemcpyDeviceToDevice, stream) == gpuSuccess,
+                            "failed to stage allreduce input into the comm workspace");
             }
         }
 
@@ -1173,8 +1177,8 @@ public:
     }
 
     void open_captured_handles(std::vector<Tensor>& handles, std::vector<int64_t>& offsets, int64_t ptr_idx) {
-        void*              ptr      = unregistered_ptrs_[ptr_idx];
-        void*              base_ptr = unregistered_base_ptrs_[ptr_idx];
+        void* ptr      = unregistered_ptrs_[ptr_idx];
+        void* base_ptr = unregistered_base_ptrs_[ptr_idx];
 
         // Defensive check: verify the cached pointer still belongs to a valid
         // device allocation.  The caching allocator may have freed and re-used
@@ -1190,39 +1194,57 @@ public:
         // HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR / HIP_POINTER_ATTRIBUTE_RANGE_SIZE
         // to query the allocation range on ROCm.
         hipPointerAttribute_t ptr_attrs = {};
-        hipError_t attr_err = hipPointerGetAttributes(&ptr_attrs, base_ptr);
+        hipError_t            attr_err  = hipPointerGetAttributes(&ptr_attrs, base_ptr);
         TORCH_CHECK(attr_err == hipSuccess,
-                    "[TrtllmAllreduce] cached base_ptr ", base_ptr,
-                    " (ptr_idx=", ptr_idx, ") failed hipPointerGetAttributes (err=",
-                    static_cast<int>(attr_err), "). The pointer is no longer valid — "
+                    "[TrtllmAllreduce] cached base_ptr ",
+                    base_ptr,
+                    " (ptr_idx=",
+                    ptr_idx,
+                    ") failed hipPointerGetAttributes (err=",
+                    static_cast<int>(attr_err),
+                    "). The pointer is no longer valid — "
                     "discard the captured graph and re-capture.");
         TORCH_CHECK(ptr_attrs.type == hipMemoryTypeDevice || ptr_attrs.type == hipMemoryTypeUnified,
-                    "[TrtllmAllreduce] cached base_ptr ", base_ptr,
-                    " (ptr_idx=", ptr_idx, ") is not device memory (type=",
-                    static_cast<int>(ptr_attrs.type), "). The underlying allocation "
+                    "[TrtllmAllreduce] cached base_ptr ",
+                    base_ptr,
+                    " (ptr_idx=",
+                    ptr_idx,
+                    ") is not device memory (type=",
+                    static_cast<int>(ptr_attrs.type),
+                    "). The underlying allocation "
                     "may have been freed. Discard the captured graph and re-capture.");
 
         // Query allocation base address and size via hipPointerGetAttribute.
-        void*  range_start = nullptr;
-        size_t range_size  = 0;
-        hipError_t start_err = hipPointerGetAttribute(
-            &range_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR,
-            reinterpret_cast<hipDeviceptr_t>(base_ptr));
+        void*      range_start = nullptr;
+        size_t     range_size  = 0;
+        hipError_t start_err   = hipPointerGetAttribute(
+            &range_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, reinterpret_cast<hipDeviceptr_t>(base_ptr));
         hipError_t size_err = hipPointerGetAttribute(
-            &range_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE,
-            reinterpret_cast<hipDeviceptr_t>(base_ptr));
-        TORCH_CHECK(start_err == hipSuccess && size_err == hipSuccess
-                    && range_start != nullptr && range_size > 0,
+            &range_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE, reinterpret_cast<hipDeviceptr_t>(base_ptr));
+        TORCH_CHECK(start_err == hipSuccess && size_err == hipSuccess && range_start != nullptr && range_size > 0,
                     "[TrtllmAllreduce] failed to query allocation range for base_ptr ",
-                    base_ptr, " (ptr_idx=", ptr_idx, ", start_err=",
-                    static_cast<int>(start_err), ", size_err=",
-                    static_cast<int>(size_err), "). Discard the captured graph "
+                    base_ptr,
+                    " (ptr_idx=",
+                    ptr_idx,
+                    ", start_err=",
+                    static_cast<int>(start_err),
+                    ", size_err=",
+                    static_cast<int>(size_err),
+                    "). Discard the captured graph "
                     "and re-capture.");
         TORCH_CHECK(reinterpret_cast<char*>(base_ptr) >= reinterpret_cast<char*>(range_start)
-                    && reinterpret_cast<char*>(ptr) < reinterpret_cast<char*>(range_start) + range_size,
-                    "[TrtllmAllreduce] cached ptr ", ptr, " (base_ptr=", base_ptr,
-                    ", ptr_idx=", ptr_idx, ") falls outside the current allocation "
-                    "[", range_start, ", +", range_size,
+                        && reinterpret_cast<char*>(ptr) < reinterpret_cast<char*>(range_start) + range_size,
+                    "[TrtllmAllreduce] cached ptr ",
+                    ptr,
+                    " (base_ptr=",
+                    base_ptr,
+                    ", ptr_idx=",
+                    ptr_idx,
+                    ") falls outside the current allocation "
+                    "[",
+                    range_start,
+                    ", +",
+                    range_size,
                     "). The allocation was likely freed and re-used. "
                     "Discard the captured graph and re-capture.");
 
@@ -1246,13 +1268,9 @@ public:
         void*  reg_start = nullptr;
         size_t reg_size  = 0;
         hipPointerGetAttribute(
-            &reg_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR,
-            reinterpret_cast<hipDeviceptr_t>(ptr));
-        hipPointerGetAttribute(
-            &reg_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE,
-            reinterpret_cast<hipDeviceptr_t>(ptr));
-        ptr_to_comm_ptrs_[ptr] = CachedSlot{
-            comm_ptrs_ + used_comm_ptrs_, reg_start, reg_size};
+            &reg_start, HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR, reinterpret_cast<hipDeviceptr_t>(ptr));
+        hipPointerGetAttribute(&reg_size, HIP_POINTER_ATTRIBUTE_RANGE_SIZE, reinterpret_cast<hipDeviceptr_t>(ptr));
+        ptr_to_comm_ptrs_[ptr] = CachedSlot{comm_ptrs_ + used_comm_ptrs_, reg_start, reg_size};
 
         // Track every ptr registered in this session (vector, NOT set) so
         // that duplicate data_ptrs are counted correctly for rollback.
@@ -1266,8 +1284,8 @@ public:
     void commit_capture() {
         pending_capture_ptrs_.clear();
         // Reset snapshot — nothing to roll back.
-        capture_snapshot_used_       = used_comm_ptrs_;
-        capture_snapshot_ipc_count_  = static_cast<int>(captured_ipc_handles_.size());
+        capture_snapshot_used_      = used_comm_ptrs_;
+        capture_snapshot_ipc_count_ = static_cast<int>(captured_ipc_handles_.size());
     }
 
     // Begin a new capture session: snapshot the current high-water marks so
@@ -1299,9 +1317,9 @@ public:
         // 3. Close and remove IPC handles opened during this session.
         while (static_cast<int>(captured_ipc_handles_.size()) > capture_snapshot_ipc_count_) {
             auto& last = captured_ipc_handles_.back();
-            for (void* ipc_ptr : last) {
-                if (ipc_ptr) {
-                    hipIpcCloseMemHandle(ipc_ptr);
+            for (int i = 0; i < world_size_; ++i) {
+                if (i != rank_ && last[i] != nullptr) {
+                    hipIpcCloseMemHandle(last[i]);
                 }
             }
             captured_ipc_handles_.pop_back();
@@ -1309,27 +1327,27 @@ public:
     }
 
 private:
-    int                                  device_id_;
-    int                                  rank_;
-    int                                  world_size_;
-    int64_t                              size_in_bytes_;
-    int                                  comm_ptrs_buf_len_;
-    int                                  max_thread_blocks_;
-    bool                                 round_robin_;
-    void*                                sync_clock_;
-    void*                                barrier_flags_;
-    void*                                data_;
-    std::vector<void*>                   ipc_barrier_flags_;
-    std::vector<void*>                   ipc_data_;
-    std::vector<void*>                   unregistered_ptrs_;
-    std::vector<void*>                   unregistered_base_ptrs_;
-    std::vector<std::vector<void*>>      captured_ipc_handles_;
-    CommPtrs*                            comm_ptrs_;
-    int                                  used_comm_ptrs_;
+    int                                   device_id_;
+    int                                   rank_;
+    int                                   world_size_;
+    int64_t                               size_in_bytes_;
+    int                                   comm_ptrs_buf_len_;
+    int                                   max_thread_blocks_;
+    bool                                  round_robin_;
+    void*                                 sync_clock_;
+    void*                                 barrier_flags_;
+    void*                                 data_;
+    std::vector<void*>                    ipc_barrier_flags_;
+    std::vector<void*>                    ipc_data_;
+    std::vector<void*>                    unregistered_ptrs_;
+    std::vector<void*>                    unregistered_base_ptrs_;
+    std::vector<std::vector<void*>>       captured_ipc_handles_;
+    CommPtrs*                             comm_ptrs_;
+    int                                   used_comm_ptrs_;
     std::unordered_map<void*, CachedSlot> ptr_to_comm_ptrs_;
-    std::vector<void*>                   pending_capture_ptrs_;      // ptrs registered in current session (allows duplicates)
-    int                                  capture_snapshot_used_ = 0;       // used_comm_ptrs_ at session start
-    int                                  capture_snapshot_ipc_count_ = 0;  // captured_ipc_handles_.size() at session start
+    std::vector<void*> pending_capture_ptrs_;            // ptrs registered in current session (allows duplicates)
+    int                capture_snapshot_used_      = 0;  // used_comm_ptrs_ at session start
+    int                capture_snapshot_ipc_count_ = 0;  // captured_ipc_handles_.size() at session start
 };
 
 // ============================================================================

--- a/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.h
+++ b/rtp_llm/models_py/bindings/rocm/kernels/trtllm_allreduce_fusion.h
@@ -9,6 +9,14 @@
 
 namespace rtp_llm {
 
+inline constexpr int64_t kAllReduceMaxBlocksPerGpu = 256;
+
+inline constexpr bool shouldUseOneStageAllReduce(int64_t token_num, int world_size, int64_t payload_bytes) {
+    return token_num <= kAllReduceMaxBlocksPerGpu / 4
+           && (world_size == 2 || (world_size == 4 && payload_bytes < 160 * 1024)
+               || (world_size == 8 && payload_bytes < 80 * 1024));
+}
+
 using fptr_t = int64_t;
 
 fptr_t init_ar_fusion(

--- a/rtp_llm/models_py/model_desc/generic_moe.py
+++ b/rtp_llm/models_py/model_desc/generic_moe.py
@@ -170,7 +170,6 @@ class GenericMoeLayer(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, _ = hidden_states.shape
         router_logits = self.gate(hidden_states)
-        router_logits_fp32 = router_logits.float()
 
         topk_weights = torch.empty(
             (num_tokens, self.top_k),
@@ -196,7 +195,7 @@ class GenericMoeLayer(nn.Module):
             self.group_topk(
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                scores=router_logits_fp32,
+                scores=router_logits,
                 correction_bias=self.correction_bias,
                 n_group=self.num_expert_group,
                 topk_group=self.topk_group,
@@ -205,8 +204,7 @@ class GenericMoeLayer(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
             )
         else:
-            # Top-K selection using C++ SelectTopkOp
-            self.select_topk(router_logits_fp32, topk_ids, topk_weights)
+            self.select_topk(router_logits, topk_ids, topk_weights)
 
         if self.fake_balance_expert is not None:
             self.fake_balance_expert(topk_ids, topk_weights)

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -938,11 +938,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         local_attn_out[valid_mask] = full_attn_out[attn_meta.cp_local_extract_indices]
 
         local_attn_out = self.norm(
-            local_attn_out.reshape(-1, self.head_v_dim),
-            z.reshape(-1, self.head_v_dim),
-        )
-        local_attn_out = local_attn_out.reshape(
-            -1, self.local_num_v_heads * self.head_v_dim
+            local_attn_out.reshape(-1, self.local_num_v_heads * self.head_v_dim), z
         )
         local_attn_out = self.out_proj(local_attn_out)
         return local_attn_out
@@ -979,10 +975,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 mixed_qkv, b, a, attention_inputs, kv_cache, attn_meta
             )
         attn_output = self.norm(
-            attn_output.reshape(-1, self.head_v_dim), z.reshape(-1, self.head_v_dim)
+            attn_output.reshape(-1, self.local_num_v_heads * self.head_v_dim), z
         )
-        # from [token * head, dim] -> [token, head * dim]
-        attn_output = attn_output.reshape(-1, self.local_num_v_heads * self.head_v_dim)
         attn_output = self.out_proj(attn_output)
         if self.parallelism_config.get_attn_tp_size() > 1:
             attn_output = all_reduce(attn_output, group=Group.TP)

--- a/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
+++ b/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
@@ -212,11 +212,21 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
 
     def test_bf16_path_takes_fusion(self) -> None:
         """When linear_attn_qkvz_s is None (BF16), fusion is enabled."""
+        from rtp_llm.utils.model_weight import W
+
         module = self._build_module()
         self.assertTrue(module._qkvz_ba_fused, "BF16 path must enable fusion")
         self.assertIsNotNone(module.in_proj_fused)
         self.assertIsNone(module.in_proj_qkvz)
         self.assertIsNone(module.in_proj_ba)
+
+        weight = module.weights[W.linear_attn_norm_w]
+        x = torch.randn(2, 128, dtype=torch.bfloat16, device=self.device)
+        gate = torch.ones_like(x)
+        weight.fill_(1)
+        output = module.norm(x, gate)
+        weight.fill_(2)
+        torch.testing.assert_close(module.norm(x, gate), output * 2)
 
     def test_rocm_swizzle_unaligned_bf16_uses_two_gemms(self) -> None:
         """A swizzled qkvz plus raw BA must never become one WithSwizzle GEMM."""

--- a/rtp_llm/models_py/modules/base/cuda/select_topk.py
+++ b/rtp_llm/models_py/modules/base/cuda/select_topk.py
@@ -13,11 +13,11 @@ class SelectTopk(nn.Module):
 
     def forward(
         self,
-        router_logits_fp32: torch.Tensor,
+        router_logits: torch.Tensor,
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
     ):
-        self.select_topk_op.forward(router_logits_fp32, topk_ids, topk_weights)
+        self.select_topk_op.forward(router_logits.float(), topk_ids, topk_weights)
 
 
 class GroupTopK(nn.Module):
@@ -37,7 +37,7 @@ class GroupTopK(nn.Module):
         renormalize: bool,
         routed_scaling_factor: float,
     ):
-        scores = scores.sigmoid()
+        scores = scores.float().sigmoid()
         scores_with_bias = scores + correction_bias.unsqueeze(0)
         self.group_topk_op.forward(
             topk_weights,

--- a/rtp_llm/models_py/modules/base/rocm/select_topk.py
+++ b/rtp_llm/models_py/modules/base/rocm/select_topk.py
@@ -10,23 +10,30 @@ class SelectTopk(nn.Module):
         super().__init__()
         self.config = config
         self.top_k = config.moe_k
+        self._token_expert_indicies = torch.empty(0, dtype=torch.int32)
+
+    def _scratch(self, num_tokens: int, device: torch.device) -> torch.Tensor:
+        if torch.cuda.is_current_stream_capturing():
+            return torch.empty(num_tokens, self.top_k, dtype=torch.int32, device=device)
+        buf = self._token_expert_indicies
+        if buf.numel() < num_tokens * self.top_k or buf.device != device:
+            buf = torch.empty(num_tokens, self.top_k, dtype=torch.int32, device=device)
+            self._token_expert_indicies = buf
+        return buf[:num_tokens]
 
     def forward(
         self,
-        router_logits_fp32: torch.Tensor,
+        router_logits: torch.Tensor,
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
     ):
         # aiter requires int32 and writes topk_ids in place.
         if topk_ids.dtype != torch.int32:
             raise TypeError(f"expect int32 topk_ids, got {topk_ids.dtype}")
-        token_expert_indicies = torch.empty(
-            topk_ids.shape[0], self.top_k, dtype=torch.int32, device=topk_ids.device
-        )
         aiter.topk_softmax(
             topk_weights,
             topk_ids,
-            token_expert_indicies,
-            router_logits_fp32,  # TODO(woosuk): Optimize this.
+            self._scratch(topk_ids.shape[0], topk_ids.device),
+            router_logits,
             True,
         )

--- a/rtp_llm/models_py/modules/base/rocm/test/BUILD
+++ b/rtp_llm/models_py/modules/base/rocm/test/BUILD
@@ -86,10 +86,10 @@ py_test(
         "//rtp_llm:testlib",
         "//rtp_llm/models_py/modules/base/rocm:trt_allreduce",
     ],
-    timeout = "moderate",
-    env = {"GPU_COUNT": "2"},
+    timeout = "long",
+    env = {"GPU_COUNT": "4"},
     tags = ["rocm"],
-    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'2'},
+    exec_properties = {'gpu':'MI308X-ROCM7', 'gpu_count':'4'},
 )
 
 py_test(

--- a/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
@@ -1,35 +1,38 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-# Regression test: trtallreduce IPC fast-path under hipGraph capture + replay.
-# Requires >= 2 ROCm GPUs.
 
 import os
 import socket
-import sys
 import unittest
-import warnings
 
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
-warnings.filterwarnings("ignore", message="barrier.*using the device under current context")
-warnings.filterwarnings("ignore", message="Guessing device ID based on global rank")
-
 REPLAY_ROUNDS = 60
 
 
 def _setup(rank, world_size, port):
-    os.environ.update(MASTER_ADDR="localhost", MASTER_PORT=str(port),
-                      RANK=str(rank), WORLD_SIZE=str(world_size))
+    os.environ.update(
+        MASTER_ADDR="localhost",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
     torch.cuda.set_device(rank)
-    dist.init_process_group("nccl", init_method="env://", world_size=world_size,
-                            rank=rank, device_id=torch.device(f"cuda:{rank}"))
+    dist.init_process_group(
+        "nccl",
+        init_method="env://",
+        world_size=world_size,
+        rank=rank,
+        device_id=torch.device(f"cuda:{rank}"),
+    )
 
 
 def _teardown():
     try:
-        dist.barrier(); torch.cuda.synchronize()
+        dist.barrier()
+        torch.cuda.synchronize()
     except Exception:
         pass
     try:
@@ -40,24 +43,28 @@ def _teardown():
 
 def _free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0)); return s.getsockname()[1]
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 def _launch(fn, world_size=2, timeout=180, **kw):
     port = _free_port()
     procs = []
     for r in range(world_size):
-        p = mp.Process(target=fn, args=(r, world_size, port), kwargs=kw, name=f"rank-{r}")
-        p.start(); procs.append(p)
+        p = mp.Process(
+            target=fn, args=(r, world_size, port), kwargs=kw, name=f"rank-{r}"
+        )
+        p.start()
+        procs.append(p)
     try:
         for p in procs:
             p.join(timeout=timeout)
             if p.exitcode is None:
                 raise RuntimeError(
-                    f"{p.name} timed out after {timeout}s (still running)")
+                    f"{p.name} timed out after {timeout}s (still running)"
+                )
             if p.exitcode != 0:
-                raise RuntimeError(
-                    f"{p.name} exited with code {p.exitcode}")
+                raise RuntimeError(f"{p.name} exited with code {p.exitcode}")
     finally:
         for p in procs:
             if p.is_alive():
@@ -68,7 +75,9 @@ def _launch(fn, world_size=2, timeout=180, **kw):
                 p.join(timeout=2)
 
 
-def _worker_graph_pure_allreduce(rank, world_size, port, num_replays):
+def _worker_graph_pure_allreduce(
+    rank, world_size, port, num_replays, hidden_size=4096, num_tokens=8
+):
     try:
         _setup(rank, world_size, port)
         from rtp_llm.models_py.modules.base.rocm.trt_allreduce import TrtllmDistEnv
@@ -77,81 +86,43 @@ def _worker_graph_pure_allreduce(rank, world_size, port, num_replays):
         env = TrtllmDistEnv(group=dist.group.WORLD, device_id=rank)
 
         torch.manual_seed(42 + rank)
-        inp = torch.randn(8, 4096, dtype=torch.bfloat16, device=dev)
+        inp = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=dev)
 
-        ref = inp.clone(); dist.all_reduce(ref)
+        ref = inp.float()
+        dist.all_reduce(ref)
+        ref = ref.to(inp.dtype)
 
         s = torch.cuda.Stream(device=dev)
+        s.wait_stream(torch.cuda.current_stream(dev))
         with torch.cuda.stream(s):
-            env.allreduce_op(inp.clone(), torch.empty_like(inp)); s.synchronize()
+            eager_in, eager_out = inp.clone(), torch.empty_like(inp)
+            env.allreduce_op(eager_in, eager_out)
+            s.synchronize()
+            torch.testing.assert_close(eager_out, ref, atol=1e-3, rtol=1e-2)
+            assert torch.equal(eager_in, inp)
             g = torch.cuda.CUDAGraph()
             g_in, g_out = inp.clone(), torch.empty_like(inp)
             with torch.cuda.graph(g, stream=s):
                 env.allreduce_op(g_in, g_out)
-        s.synchronize(); env.consume_capture_if_needed()
+        s.synchronize()
+        env.consume_capture_if_needed()
 
+        previous_out = g_out.clone()
         for i in range(num_replays):
-            g_in.copy_(inp); g.replay(); s.synchronize()
-            diff = (g_out - ref).abs().max().item()
-            ref_max = ref.abs().max().item()
-            rel = diff / ref_max if ref_max > 0 else 0
-            assert rel < 1e-2 or diff < 1e-3, \
-                f"[Rank {rank}] replay {i}: rel={rel:.4e} abs={diff:.4e}"
-
-        if rank == 0:
-            print(f"  [graph_pure_allreduce] {num_replays} replays passed")
-    except Exception as e:
-        print(f"[Rank {rank}] FAILED: {e}", file=sys.stderr)
-        import traceback; traceback.print_exc(); raise
-    finally:
-        _teardown()
-
-
-def _worker_graph_fused_rmsnorm(rank, world_size, port, num_replays):
-    try:
-        _setup(rank, world_size, port)
-        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import TrtllmDistEnv
-
-        dev = torch.device(f"cuda:{rank}")
-        env = TrtllmDistEnv(group=dist.group.WORLD, device_id=rank)
-
-        torch.manual_seed(42 + rank)
-        ar_in = torch.randn(8, 4096, dtype=torch.bfloat16, device=dev)
-        res_in = torch.randn(8, 4096, dtype=torch.bfloat16, device=dev)
-        w = torch.randn(4096, dtype=torch.bfloat16, device=dev)
-        eps = 1e-6
-
-        ref_res, ref_norm, _ = env.allreduce_add_rms_native(
-            ar_in.clone(), res_in.clone(), w, eps)
-
-        s = torch.cuda.Stream(device=dev)
-        with torch.cuda.stream(s):
-            env.allreduce_add_rms_fused(ar_in.clone(), res_in.clone(), w, eps)
+            replay_in = torch.roll(inp, shifts=i + 1, dims=-1)
+            replay_ref = replay_in.float()
+            dist.all_reduce(replay_ref)
+            replay_ref = replay_ref.to(replay_in.dtype)
+            s.wait_stream(torch.cuda.current_stream(dev))
+            with torch.cuda.stream(s):
+                g_in.copy_(replay_in)
+                g.replay()
             s.synchronize()
-            g = torch.cuda.CUDAGraph()
-            g_ar, g_res = ar_in.clone(), res_in.clone()
-            with torch.cuda.graph(g, stream=s):
-                g_res_out, g_norm_out, _ = env.allreduce_add_rms_fused(
-                    g_ar, g_res, w, eps)
-        s.synchronize(); env.consume_capture_if_needed()
+            assert torch.equal(g_in, replay_in)
+            assert not torch.equal(g_out, previous_out)
+            torch.testing.assert_close(g_out, replay_ref, atol=2e-2, rtol=1e-2)
+            previous_out.copy_(g_out)
 
-        for i in range(num_replays):
-            g_ar.copy_(ar_in); g_res.copy_(res_in)
-            g.replay(); s.synchronize()
-
-            for name, got, want in [("residual", g_res_out, ref_res),
-                                    ("norm", g_norm_out, ref_norm)]:
-                diff = (got - want).abs().max().item()
-                mx = want.abs().max().item()
-                rel = diff / mx if mx > 0 else 0
-                assert rel < 1e-2 or diff < 1e-3, \
-                    f"[Rank {rank}] replay {i} {name}: rel={rel:.4e} abs={diff:.4e}"
-
-        if rank == 0:
-            print(f"  [graph_fused_rmsnorm] {num_replays} replays passed")
-    except Exception as e:
-        print(f"[Rank {rank}] FAILED: {e}", file=sys.stderr)
-        import traceback; traceback.print_exc(); raise
     finally:
         _teardown()
 
@@ -159,20 +130,34 @@ def _worker_graph_fused_rmsnorm(rank, world_size, port, num_replays):
 class TestTrtAllReduceGraphReplay(unittest.TestCase):
 
     def setUp(self):
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA/ROCm not available")
         if torch.cuda.device_count() < 2:
             self.skipTest("Need >= 2 GPUs")
-        try:
-            mp.set_start_method("spawn", force=True)
-        except RuntimeError:
-            pass
+        mp.set_start_method("spawn", force=True)
 
     def test_graph_replay_pure_allreduce(self):
         _launch(_worker_graph_pure_allreduce, num_replays=REPLAY_ROUNDS)
 
-    def test_graph_replay_fused_rmsnorm(self):
-        _launch(_worker_graph_fused_rmsnorm, num_replays=REPLAY_ROUNDS)
+    def test_graph_replay_pure_allreduce_3072(self):
+        for num_tokens in (8, 128):
+            with self.subTest(num_tokens=num_tokens):
+                _launch(
+                    _worker_graph_pure_allreduce,
+                    num_replays=REPLAY_ROUNDS,
+                    hidden_size=3072,
+                    num_tokens=num_tokens,
+                )
+
+    def test_graph_replay_pure_allreduce_3072_tp4(self):
+        self.assertGreaterEqual(torch.cuda.device_count(), 4)
+        for num_tokens in (8, 128):
+            with self.subTest(num_tokens=num_tokens):
+                _launch(
+                    _worker_graph_pure_allreduce,
+                    world_size=4,
+                    num_replays=10,
+                    hidden_size=3072,
+                    num_tokens=num_tokens,
+                )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
+++ b/rtp_llm/models_py/modules/base/rocm/test/test_trt_allreduce_graph_replay.py
@@ -127,6 +127,62 @@ def _worker_graph_pure_allreduce(
         _teardown()
 
 
+def _worker_graph_fused_rmsnorm(
+    rank, world_size, port, num_replays, num_tokens, fp8_out
+):
+    try:
+        _setup(rank, world_size, port)
+        from rtp_llm.models_py.modules.base.rocm.trt_allreduce import TrtllmDistEnv
+
+        dev = torch.device(f"cuda:{rank}")
+        env = TrtllmDistEnv(group=dist.group.WORLD, device_id=rank)
+        torch.manual_seed(42 + rank)
+        ar = torch.randn(num_tokens, 4096, dtype=torch.bfloat16, device=dev)
+        residual = torch.randn_like(ar)
+        weight = torch.randn(4096, dtype=torch.bfloat16, device=dev)
+        stream = torch.cuda.Stream(device=dev)
+        stream.wait_stream(torch.cuda.current_stream(dev))
+        with torch.cuda.stream(stream):
+            env.allreduce_add_rms_fused(
+                ar.clone(), residual.clone(), weight, 1e-6, fp8_out
+            )
+            stream.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            graph_ar, graph_residual = ar.clone(), residual.clone()
+            with torch.cuda.graph(graph, stream=stream):
+                graph_res, graph_norm, graph_scale = env.allreduce_add_rms_fused(
+                    graph_ar, graph_residual, weight, 1e-6, fp8_out
+                )
+        stream.synchronize()
+        env.consume_capture_if_needed()
+
+        for i in range(num_replays):
+            replay_ar = torch.roll(ar, i + 1, -1)
+            replay_residual = torch.roll(residual, i + 1, -1)
+            ref_res, ref_norm, ref_scale = env.allreduce_add_rms_native(
+                replay_ar.clone(), replay_residual.clone(), weight, 1e-6, fp8_out
+            )
+            stream.wait_stream(torch.cuda.current_stream(dev))
+            with torch.cuda.stream(stream):
+                graph_ar.copy_(replay_ar)
+                graph_residual.copy_(replay_residual)
+                graph.replay()
+            stream.synchronize()
+            assert torch.equal(graph_ar, replay_ar)
+            assert torch.equal(graph_residual, replay_residual)
+            torch.testing.assert_close(graph_res, ref_res, atol=2e-2, rtol=1e-2)
+            if fp8_out:
+                torch.testing.assert_close(graph_scale, ref_scale, atol=1e-5, rtol=0.1)
+                got = graph_norm.float() * graph_scale
+                want = ref_norm.float() * ref_scale
+                diff = (got - want).abs().max().item()
+                assert diff < 0.05 or diff / want.abs().max().item() < 0.1
+            else:
+                torch.testing.assert_close(graph_norm, ref_norm, atol=2e-2, rtol=1e-2)
+    finally:
+        _teardown()
+
+
 class TestTrtAllReduceGraphReplay(unittest.TestCase):
 
     def setUp(self):
@@ -158,6 +214,17 @@ class TestTrtAllReduceGraphReplay(unittest.TestCase):
                     hidden_size=3072,
                     num_tokens=num_tokens,
                 )
+
+    def test_graph_replay_fused_rmsnorm(self):
+        for num_tokens in (8, 128):
+            for fp8_out in (False, True):
+                with self.subTest(num_tokens=num_tokens, fp8_out=fp8_out):
+                    _launch(
+                        _worker_graph_fused_rmsnorm,
+                        num_replays=4,
+                        num_tokens=num_tokens,
+                        fp8_out=fp8_out,
+                    )
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/base/rocm/trt_allreduce.py
+++ b/rtp_llm/models_py/modules/base/rocm/trt_allreduce.py
@@ -2,17 +2,21 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 # Adapted from atrex trt_allreduce for rtp-llm ROCm backend.
 
-from typing import Optional, Tuple
+import logging
 from contextlib import contextmanager
+from typing import Optional, Tuple
 
 import torch
-from torch import Tensor
 import torch.distributed as dist
+from torch import Tensor
 from torch.distributed import ProcessGroup
+
 
 def _get_handle_class():
     from rtp_llm.ops.compute_ops import rtp_llm_ops
+
     return rtp_llm_ops.TrtllmArFusionHandle
+
 
 FP8_DTYPE = torch.float8_e4m3fnuz
 
@@ -31,7 +35,7 @@ FP8_QUANT_TYPE_ID = FP8_QUANT_TYPE_IDS[FP8_DTYPE]
 
 # Supported hidden_size for trtllm allreduce kernels (pure allreduce).
 # Must match the switch cases in allreduce_kernel_launcher_hd (trtllm_allreduce_fusion.cu).
-ALLREDUCE_SUPPORTED_HIDDEN_SIZES = frozenset({1024, 2048, 2560, 4096, 5120})
+ALLREDUCE_SUPPORTED_HIDDEN_SIZES = frozenset({1024, 2048, 2560, 3072, 4096, 5120})
 
 # Supported hidden_size for fused allreduce + residual + rmsnorm kernels.
 # Must match the switch cases in allreduce_fusion_kernel_launcher_hd (trtllm_allreduce_fusion.cu).
@@ -73,36 +77,61 @@ class TrtllmDistEnv:
         if self.world_size not in self._SUPPORTED_WORLD_SIZES:
             return
 
+        candidate = None
         try:
             TrtllmArFusionHandle = _get_handle_class()
-            self.handle = TrtllmArFusionHandle(
-                self.device_id, self.rank, self.world_size,
-                max_size_in_bytes, comm_ptrs_buf_len
+            candidate = TrtllmArFusionHandle(
+                self.device_id,
+                self.rank,
+                self.world_size,
+                max_size_in_bytes,
+                comm_ptrs_buf_len,
             )
-
-            barrier_handle = self.handle.get_barrier_handle()
-            data_handle = self.handle.get_data_handle()
+            barrier_handle = candidate.get_barrier_handle()
+            data_handle = candidate.get_data_handle()
+            local_success = True
         except Exception as e:
-            import logging
             logging.warning(
                 "TRT-LLM AllReduce initialization failed (likely insufficient GPU memory, "
                 "requested %d bytes for data buffer). Falling back to RCCL. Error: %s",
-                max_size_in_bytes * 2, e,
+                max_size_in_bytes * 2,
+                e,
             )
-            self.handle = None
-            self.disabled = True
-            return
+            local_success = False
 
-        self._barrier()
+        success_flags = [None] * self.world_size
+        dist.all_gather_object(success_flags, local_success, group=self.group)
+        if not all(success_flags):
+            candidate = None
+            self.disabled = True
+            self._barrier()
+            return
 
         barrier_handle_list = [None] * self.world_size
         data_handle_list = [None] * self.world_size
         dist.all_gather_object(barrier_handle_list, barrier_handle, group=self.group)
         dist.all_gather_object(data_handle_list, data_handle, group=self.group)
 
-        self.handle.open_barrier_handles(barrier_handle_list)
-        self.handle.open_data_handles(data_handle_list)
+        try:
+            candidate.open_barrier_handles(barrier_handle_list)
+            candidate.open_data_handles(data_handle_list)
+            local_success = True
+        except Exception as e:
+            logging.warning(
+                "TRT-LLM AllReduce IPC open failed on rank %d. Falling back to RCCL: %s",
+                self.rank,
+                e,
+            )
+            local_success = False
 
+        dist.all_gather_object(success_flags, local_success, group=self.group)
+        if not all(success_flags):
+            candidate = None
+            self.disabled = True
+            self._barrier()
+            return
+
+        self.handle = candidate
         self._barrier()
 
     def _barrier(self):
@@ -123,10 +152,12 @@ class TrtllmDistEnv:
             offsets = torch.tensor([], dtype=torch.int64)
             local_success = False
             import logging
+
             logging.warning(
                 "[TrtllmAllreduce] get_captured_handles failed on rank %d: %s. "
                 "Will coordinate with other ranks to discard this capture.",
-                self.rank, e,
+                self.rank,
+                e,
             )
 
         # All ranks must agree on success; if any rank failed, everyone must
@@ -177,7 +208,9 @@ class TrtllmDistEnv:
             handle_list = [None] * self.world_size
             offset_list = [None] * self.world_size
             dist.all_gather_object(handle_list, handles[idx], group=self.group)
-            dist.all_gather_object(offset_list, int(offsets[idx].item()), group=self.group)
+            dist.all_gather_object(
+                offset_list, int(offsets[idx].item()), group=self.group
+            )
             self._barrier()
 
             # open_captured_handles may TORCH_CHECK-fail on some ranks (e.g.
@@ -275,7 +308,10 @@ class TrtllmDistEnv:
         fp8_out: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """Reference implementation using standard ops (for correctness testing)."""
-        def rms_norm_forward(hidden_states: Tensor, weight: Tensor, epsilon: float) -> Tensor:
+
+        def rms_norm_forward(
+            hidden_states: Tensor, weight: Tensor, epsilon: float
+        ) -> Tensor:
             input_dtype = hidden_states.dtype
             variance = hidden_states.float().pow(2).mean(-1, keepdim=True)
             hidden_states = hidden_states * torch.rsqrt(variance + epsilon)
@@ -295,8 +331,10 @@ class TrtllmDistEnv:
             return residual_out, norm_out, norm_out_scale
         else:
             scale_out = torch.empty(
-                allreduce_in.shape[0], 1,
-                dtype=torch.float32, device=allreduce_in.device,
+                allreduce_in.shape[0],
+                1,
+                dtype=torch.float32,
+                device=allreduce_in.device,
             )
             return residual_out, norm_out, scale_out
 
@@ -309,14 +347,19 @@ class TrtllmDistEnv:
         fp8_out: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """Fused AllReduce + Residual Add + RMSNorm kernel."""
+        hidden_size = allreduce_in.size(-1)
+        if hidden_size not in ALLREDUCE_FUSION_SUPPORTED_HIDDEN_SIZES:
+            raise ValueError(f"Unsupported fused AllReduce hidden size: {hidden_size}")
         self._prepare_capture(allreduce_in)
         residual_out = torch.empty_like(allreduce_in)
 
         if fp8_out:
             norm_out = torch.empty_like(allreduce_in, dtype=FP8_DTYPE)
             scale_out = torch.empty(
-                allreduce_in.shape[0], 1,
-                dtype=torch.float32, device=allreduce_in.device,
+                allreduce_in.shape[0],
+                1,
+                dtype=torch.float32,
+                device=allreduce_in.device,
             )
         else:
             norm_out = torch.empty_like(allreduce_in)
@@ -369,7 +412,8 @@ class TrtllmCommManager:
         self.group = group
         self.device_id = device_id
         self.dist_env = TrtllmDistEnv(
-            group=self.group, device_id=self.device_id,
+            group=self.group,
+            device_id=self.device_id,
         )
         self.initialized = True
 
@@ -392,7 +436,8 @@ def ensure_trtllm_comm_initialized(
         or _trtllm_comm_manager.device_id != device_id
     ):
         _trtllm_comm_manager.initialize(
-            group=group, device_id=device_id,
+            group=group,
+            device_id=device_id,
         )
 
     if _trtllm_comm_manager.initialized and _trtllm_comm_manager.dist_env.disabled:
@@ -452,9 +497,7 @@ def consume_capture() -> None:
     the internal capture flag.
     """
     if torch.cuda.is_current_stream_capturing():
-        raise RuntimeError(
-            "consume_capture must not run during stream capture."
-        )
+        raise RuntimeError("consume_capture must not run during stream capture.")
     if (
         _trtllm_comm_manager is not None
         and _trtllm_comm_manager.initialized
@@ -502,7 +545,9 @@ def allreduce_residual_rmsnorm(
     if not ensure_trtllm_comm_initialized(group, device_id):
         raise RuntimeError("TRT-LLM AllReduce Fusion workspace is not initialized")
     return _trtllm_comm_manager.dist_env.allreduce_add_rms_fused(
-        allreduce_in, residual_in, rms_weight, eps, fp8_out,
+        allreduce_in,
+        residual_in,
+        rms_weight,
+        eps,
+        fp8_out,
     )
-
-

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
 # ============================================================================
 # Device-specific Attention implementation registration
 # ============================================================================
-from rtp_llm.models_py.modules.factory.attention import attn_factory
 from rtp_llm.models_py.modules.factory.attention.attn_factory import (
     DECODE_MHA_IMPS,
     DECODE_MLA_IMPS,
@@ -34,19 +33,20 @@ if device_type == DeviceType.ROCm:
     from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
         AiterDecodeImplAsm,
         AiterDecodeImplNonAsm,
-        AiterDecodeImplTriton,
+        AiterDecodeImplTritonLinear,
+        AiterDecodeImplTritonVectorized,
         AiterPrefillImplAsm,
         AiterPrefillImplNonAsm,
         AiterPrefillImplPaged,
-        validate_v_layout,
     )
-
-    attn_factory.VALIDATE_FMHA_CONFIG = validate_v_layout
 
     PREFILL_MHA_IMPS.append(AiterPrefillImplPaged)
     PREFILL_MHA_IMPS.append(AiterPrefillImplAsm)
     PREFILL_MHA_IMPS.append(AiterPrefillImplNonAsm)
-    DECODE_MHA_IMPS.append(AiterDecodeImplTriton)
+    # Vectorized first: where the layout preflight does not apply, this keeps the
+    # default decode writer matching the ASM prefill writer.
+    DECODE_MHA_IMPS.append(AiterDecodeImplTritonVectorized)
+    DECODE_MHA_IMPS.append(AiterDecodeImplTritonLinear)
     DECODE_MHA_IMPS.append(AiterDecodeImplAsm)
     DECODE_MHA_IMPS.append(AiterDecodeImplNonAsm)
 elif device_type == DeviceType.Cuda:

--- a/rtp_llm/models_py/modules/factory/attention/__init__.py
+++ b/rtp_llm/models_py/modules/factory/attention/__init__.py
@@ -24,7 +24,6 @@ from rtp_llm.models_py.modules.factory.attention.attn_factory import (
     PREFILL_MHA_IMPS,
     PREFILL_MLA_IMPS,
 )
-
 from rtp_llm.utils.backend_registry import run_backend_registrations
 
 device_type = get_device_type()
@@ -33,8 +32,7 @@ if device_type == DeviceType.ROCm:
     from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
         AiterDecodeImplAsm,
         AiterDecodeImplNonAsm,
-        AiterDecodeImplTritonLinear,
-        AiterDecodeImplTritonVectorized,
+        AiterDecodeImplTriton,
         AiterPrefillImplAsm,
         AiterPrefillImplNonAsm,
         AiterPrefillImplPaged,
@@ -43,10 +41,7 @@ if device_type == DeviceType.ROCm:
     PREFILL_MHA_IMPS.append(AiterPrefillImplPaged)
     PREFILL_MHA_IMPS.append(AiterPrefillImplAsm)
     PREFILL_MHA_IMPS.append(AiterPrefillImplNonAsm)
-    # Vectorized first: where the layout preflight does not apply, this keeps the
-    # default decode writer matching the ASM prefill writer.
-    DECODE_MHA_IMPS.append(AiterDecodeImplTritonVectorized)
-    DECODE_MHA_IMPS.append(AiterDecodeImplTritonLinear)
+    DECODE_MHA_IMPS.append(AiterDecodeImplTriton)
     DECODE_MHA_IMPS.append(AiterDecodeImplAsm)
     DECODE_MHA_IMPS.append(AiterDecodeImplNonAsm)
 elif device_type == DeviceType.Cuda:

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Callable, Dict, List, Optional, Union
 
+from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.model_loader.model_weight_info import ModelWeights
 from rtp_llm.models_py.modules.factory.attention.fmha_impl_base import (
     FMHAImplBase,
@@ -24,11 +25,6 @@ PREFILL_MHA_IMPS: List[type[FMHAImplBase]] = []
 DECODE_MHA_IMPS: List[type[FMHAImplBase]] = []
 PREFILL_MLA_IMPS: List[type[MlaImplBase]] = []
 DECODE_MLA_IMPS: List[type[MlaImplBase]] = []
-
-# ROCm installs this hook to reject incompatible prefill/decode V layouts.
-VALIDATE_FMHA_CONFIG: Optional[
-    Callable[[AttentionConfigs, PyAttentionInputs, Optional[FMHAConfig]], bool]
-] = None
 
 FLASHINFER_TRTLLM_GEN_IMPLS = {
     "FlashInferTRTLLMPrefillImpl",
@@ -132,16 +128,17 @@ def _is_fmha_impl_disabled(
     # FlashInfer native implementations
     elif "FlashInfer" in impl_class_name or "Flashinfer" in impl_class_name:
         return fmha_config.disable_flashinfer_native
-    # Aiter ASM / Paged prefill
-    elif (
-        "AiterPrefillImplAsm" in impl_class_name
-        or "AiterPrefillImplPaged" in impl_class_name
-    ):
-        return not fmha_config.use_asm_pa
-    # Aiter ASM decode — disabled when triton PA is enabled (triton PA takes priority)
+    # Aiter vectorized prefill writer.  Paged prefill and Triton decode consume
+    # vectorized V cache, so Aiter alone enables this writer as well as ASM.
+    elif "AiterPrefillImplAsm" in impl_class_name:
+        return not (
+            fmha_config.use_asm_pa
+            or fmha_config.use_aiter_pa
+            or fmha_config.use_triton_pa
+        )
+    elif "AiterPrefillImplPaged" in impl_class_name:
+        return not (fmha_config.use_asm_pa or fmha_config.use_aiter_pa)
     elif "AiterDecodeImplAsm" in impl_class_name:
-        if fmha_config.use_triton_pa:
-            return True
         return not fmha_config.use_asm_pa
     # Aiter Non-ASM implementations
     elif (
@@ -151,7 +148,10 @@ def _is_fmha_impl_disabled(
         return not fmha_config.use_aiter_pa
     # Aiter Triton implementations
     elif "AiterDecodeImplTriton" in impl_class_name:
-        return not fmha_config.use_triton_pa
+        return not (
+            fmha_config.use_triton_pa
+            or (fmha_config.use_aiter_pa and not fmha_config.use_asm_pa)
+        )
     # Default: not disabled
     return False
 
@@ -170,37 +170,47 @@ def get_fmha_impl(
     attn_inputs.is_cuda_graph = is_cuda_graph
 
     mha_impls = PREFILL_MHA_IMPS if attn_inputs.is_prefill else DECODE_MHA_IMPS
-    strict_impl_selection = VALIDATE_FMHA_CONFIG is not None and VALIDATE_FMHA_CONFIG(
-        attn_configs, attn_inputs, fmha_config
-    )
+    # ROCm pins one V layout across prefill and decode; other backends do not.
+    layout_ok = None
+    if get_device_type() == DeviceType.ROCm:
+        from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
+            v_layout_filter,
+        )
 
+        layout_ok = v_layout_filter(attn_configs, attn_inputs, fmha_config)
+
+    skipped: List[str] = []
     for impl in mha_impls:
         # Check if this FMHA implementation is disabled before creating instance
         impl_class_name = impl.__name__
 
         # Skip if this FMHA implementation is disabled in config
         if _is_fmha_impl_disabled(impl_class_name, fmha_config):
+            skipped.append(f"{impl_class_name}: disabled by config")
             continue
 
         # Check support before creating instance
         if not impl.support(attn_configs, attn_inputs):
+            skipped.append(f"{impl_class_name}: support() rejected")
+            continue
+
+        if layout_ok is not None and not layout_ok(impl):
+            skipped.append(f"{impl_class_name}: V layout mismatch")
             continue
 
         # Check if implementation supports parallelism config
         if not impl.support_parallelism_config(parallelism_config):
+            skipped.append(f"{impl_class_name}: parallelism config unsupported")
             continue
-        kwargs = {"fmha_config": fmha_config} if impl.accepts_fmha_config else {}
         try:
-            instance = impl(attn_configs, attn_inputs, parallelism_config, **kwargs)
+            instance = impl(attn_configs, attn_inputs, parallelism_config)
+            if not is_cuda_graph or instance.support_cuda_graph():
+                return instance
+            skipped.append(f"{impl_class_name}: no cuda graph support")
         except Exception as e:
-            # ROCm validation predicts the selected cache layout, so falling back
-            # after construction could select a reader with a different layout.
-            if strict_impl_selection:
-                raise
             logging.warning(f"Failed to instantiate {impl_class_name}: {e}")
+            skipped.append(f"{impl_class_name}: instantiation failed ({e})")
             continue
-        if not is_cuda_graph or instance.support_cuda_graph():
-            return instance
     if (
         attn_configs.rope_config.style == RopeStyle.Mrope
         and not attn_configs.rope_config.mrope_interleaved
@@ -211,7 +221,7 @@ def get_fmha_impl(
             "non-interleaved layout by default; do not flip mrope_interleaved because "
             "that changes RoPE semantics. Use a CUDA backend for these checkpoints."
         )
-    raise Exception("can not find mha type")
+    raise Exception(f"can not find mha type; candidates skipped: {'; '.join(skipped)}")
 
 
 class AttnImplFactory(object):

--- a/rtp_llm/models_py/modules/factory/attention/attn_factory.py
+++ b/rtp_llm/models_py/modules/factory/attention/attn_factory.py
@@ -128,17 +128,16 @@ def _is_fmha_impl_disabled(
     # FlashInfer native implementations
     elif "FlashInfer" in impl_class_name or "Flashinfer" in impl_class_name:
         return fmha_config.disable_flashinfer_native
-    # Aiter vectorized prefill writer.  Paged prefill and Triton decode consume
-    # vectorized V cache, so Aiter alone enables this writer as well as ASM.
-    elif "AiterPrefillImplAsm" in impl_class_name:
-        return not (
-            fmha_config.use_asm_pa
-            or fmha_config.use_aiter_pa
-            or fmha_config.use_triton_pa
-        )
-    elif "AiterPrefillImplPaged" in impl_class_name:
-        return not (fmha_config.use_asm_pa or fmha_config.use_aiter_pa)
+    # Aiter ASM / Paged prefill
+    elif (
+        "AiterPrefillImplAsm" in impl_class_name
+        or "AiterPrefillImplPaged" in impl_class_name
+    ):
+        return not fmha_config.use_asm_pa
+    # Aiter ASM decode — disabled when triton PA is enabled (triton PA takes priority)
     elif "AiterDecodeImplAsm" in impl_class_name:
+        if fmha_config.use_triton_pa:
+            return True
         return not fmha_config.use_asm_pa
     # Aiter Non-ASM implementations
     elif (
@@ -148,10 +147,7 @@ def _is_fmha_impl_disabled(
         return not fmha_config.use_aiter_pa
     # Aiter Triton implementations
     elif "AiterDecodeImplTriton" in impl_class_name:
-        return not (
-            fmha_config.use_triton_pa
-            or (fmha_config.use_aiter_pa and not fmha_config.use_asm_pa)
-        )
+        return not fmha_config.use_triton_pa
     # Default: not disabled
     return False
 
@@ -170,47 +166,44 @@ def get_fmha_impl(
     attn_inputs.is_cuda_graph = is_cuda_graph
 
     mha_impls = PREFILL_MHA_IMPS if attn_inputs.is_prefill else DECODE_MHA_IMPS
-    # ROCm pins one V layout across prefill and decode; other backends do not.
-    layout_ok = None
+    strict_impl_selection = False
     if get_device_type() == DeviceType.ROCm:
         from rtp_llm.models_py.modules.factory.attention.rocm_impl.aiter import (
-            v_layout_filter,
+            validate_v_layout,
         )
 
-        layout_ok = v_layout_filter(attn_configs, attn_inputs, fmha_config)
+        strict_impl_selection = validate_v_layout(
+            attn_configs, attn_inputs, fmha_config
+        )
 
-    skipped: List[str] = []
     for impl in mha_impls:
         # Check if this FMHA implementation is disabled before creating instance
         impl_class_name = impl.__name__
 
         # Skip if this FMHA implementation is disabled in config
         if _is_fmha_impl_disabled(impl_class_name, fmha_config):
-            skipped.append(f"{impl_class_name}: disabled by config")
             continue
 
         # Check support before creating instance
         if not impl.support(attn_configs, attn_inputs):
-            skipped.append(f"{impl_class_name}: support() rejected")
-            continue
-
-        if layout_ok is not None and not layout_ok(impl):
-            skipped.append(f"{impl_class_name}: V layout mismatch")
             continue
 
         # Check if implementation supports parallelism config
         if not impl.support_parallelism_config(parallelism_config):
-            skipped.append(f"{impl_class_name}: parallelism config unsupported")
             continue
+        kwargs = {"fmha_config": fmha_config} if impl.accepts_fmha_config else {}
         try:
-            instance = impl(attn_configs, attn_inputs, parallelism_config)
-            if not is_cuda_graph or instance.support_cuda_graph():
-                return instance
-            skipped.append(f"{impl_class_name}: no cuda graph support")
+            instance = impl(attn_configs, attn_inputs, parallelism_config, **kwargs)
         except Exception as e:
+            if strict_impl_selection or (
+                isinstance(e, RuntimeError)
+                and "illegal memory access" in str(e).lower()
+            ):
+                raise
             logging.warning(f"Failed to instantiate {impl_class_name}: {e}")
-            skipped.append(f"{impl_class_name}: instantiation failed ({e})")
             continue
+        if not is_cuda_graph or instance.support_cuda_graph():
+            return instance
     if (
         attn_configs.rope_config.style == RopeStyle.Mrope
         and not attn_configs.rope_config.mrope_interleaved
@@ -221,7 +214,7 @@ def get_fmha_impl(
             "non-interleaved layout by default; do not flip mrope_interleaved because "
             "that changes RoPE semantics. Use a CUDA backend for these checkpoints."
         )
-    raise Exception(f"can not find mha type; candidates skipped: {'; '.join(skipped)}")
+    raise Exception("can not find mha type")
 
 
 class AttnImplFactory(object):

--- a/rtp_llm/models_py/modules/factory/attention/fmha_impl_base.py
+++ b/rtp_llm/models_py/modules/factory/attention/fmha_impl_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import torch
 
@@ -102,7 +102,8 @@ class FMHAImplBase(ABC):
     所有具体的实现类都应该继承此类并实现这些方法。
     """
 
-    accepts_fmha_config = False
+    # KV-cache writer op class; impls sharing a paged KV cache (ROCm) must set it.
+    WRITER: ClassVar[Optional[type]] = None
 
     @abstractmethod
     def forward(

--- a/rtp_llm/models_py/modules/factory/attention/fmha_impl_base.py
+++ b/rtp_llm/models_py/modules/factory/attention/fmha_impl_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 
@@ -102,8 +102,7 @@ class FMHAImplBase(ABC):
     所有具体的实现类都应该继承此类并实现这些方法。
     """
 
-    # KV-cache writer op class; impls sharing a paged KV cache (ROCm) must set it.
-    WRITER: ClassVar[Optional[type]] = None
+    accepts_fmha_config = False
 
     @abstractmethod
     def forward(

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional
+from typing import Any, Callable, List, Optional
 
 import aiter
 import torch
@@ -40,62 +40,132 @@ def _is_mrope_interleaved_supported(attn_configs: AttentionConfigs) -> bool:
     )
 
 
-# aiter.pa_fwd_asm asserts head_size == 128.
-ASM_DECODE_HEAD_SIZES = {128}
+def _writes_linear_v(writer_cls: type, kv_cache_dtype: KvCacheDataType) -> bool:
+    """Whether `writer_cls` stores V linear `[head_dim, page]`, not vectorized.
+
+    Transcribes the C++ writer kernels' getVLocalIdx branches; `resolve_linear_v`
+    mirrors this table, and test_v_layout_contract.LAYOUT_MATRIX pins both.
+    Change all three together."""
+    if writer_cls is FusedRopeKVCacheDecodeOpNonAsm:
+        return True
+    if writer_cls is FusedRopeKVCachePrefillOpNonAsm:
+        return kv_cache_dtype != KvCacheDataType.FP8
+    if writer_cls in (FusedRopeKVCacheDecodeOpAsm, FusedRopeKVCachePrefillOpAsm):
+        return False
+    raise TypeError(f"unknown ROCm KV-cache writer: {writer_cls}")
 
 
-def _kv_vector_width(attn_configs: AttentionConfigs) -> int:
-    itemsize = (
-        1
-        if attn_configs.kv_cache_dtype == KvCacheDataType.FP8
-        else attn_configs.dtype.itemsize
-    )
-    return 16 // itemsize
+def _v_layouts_coincide(page_size: int, element_size: int) -> bool:
+    """Whether linear and vectorized V use identical byte offsets."""
+    return page_size == 16 // element_size
 
 
-def prefill_writes_vectorized_v(
+# aiter.pa_fwd_asm is only built for this head size.
+ASM_DECODE_HEAD_SIZE = 128
+
+
+class UnsupportedVLayout(ValueError):
+    """No prefill/decode pair can store the same V layout under this config."""
+
+
+def resolve_linear_v(
     attn_configs: AttentionConfigs, fmha_config: Optional[FMHAConfig]
 ) -> bool:
-    return (
-        fmha_config is None
-        or fmha_config.use_asm_pa
-        or (attn_configs.kv_cache_dtype == KvCacheDataType.FP8)
+    """Return the common prefill/decode V layout; True means linear.
+
+    Hand-mirrors `_writes_linear_v` plus the flag/head-size gates; keep in sync
+    with it and with test_v_layout_contract.LAYOUT_MATRIX."""
+    use_aiter_pa = fmha_config is None or fmha_config.use_aiter_pa
+    use_asm_pa = fmha_config is None or fmha_config.use_asm_pa
+    use_triton_pa = fmha_config is None or fmha_config.use_triton_pa
+    is_fp8 = attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+
+    # Aiter paged prefill and the Aiter Triton decode path both consume the
+    # vectorized V layout.  `use_aiter_pa` therefore selects the vectorized
+    # pair even when the standalone Triton/ASM flags are both false; the
+    # short-query Triton reader is an internal part of Aiter paged prefill.
+    # NonAsm remains the linear fallback only when the Aiter stack is disabled.
+    # Aiter is deliberately all-vectorized.  ASM can also provide the
+    # vectorized pair when Triton is enabled or when its decode head-size gate
+    # is satisfied.
+    vectorized_pair = (use_aiter_pa and (not use_asm_pa or use_triton_pa)) or (
+        use_asm_pa
+        and (use_triton_pa or attn_configs.size_per_head == ASM_DECODE_HEAD_SIZE)
+    )
+    if vectorized_pair:
+        return False
+    config = (
+        f"use_aiter_pa={use_aiter_pa}, use_asm_pa={use_asm_pa}, "
+        f"use_triton_pa={use_triton_pa}, size_per_head={attn_configs.size_per_head}, "
+        f"kv_cache_dtype={attn_configs.kv_cache_dtype}, "
+        f"kernel_tokens_per_block={attn_configs.kernel_tokens_per_block}"
+    )
+    if not (use_aiter_pa or use_asm_pa):
+        raise UnsupportedVLayout(
+            f"every ROCm KV-cache writer backend is disabled ({config}); "
+            "enable use_aiter_pa or use_asm_pa"
+        )
+    remedies = ["enable use_triton_pa"]
+    if use_asm_pa and attn_configs.size_per_head != ASM_DECODE_HEAD_SIZE:
+        remedies.append(f"use a model with size_per_head={ASM_DECODE_HEAD_SIZE}")
+    if use_aiter_pa and is_fp8:
+        remedies.append("disable the FP8 KV cache")
+    if not use_aiter_pa and not is_fp8:
+        remedies.append("enable use_aiter_pa")
+    raise UnsupportedVLayout(
+        f"no compatible ROCm V-cache writer/reader pair ({config}); "
+        + ", or ".join(remedies)
     )
 
 
-def validate_v_layout(
+def v_layout_filter(
     attn_configs: AttentionConfigs,
     attn_inputs: PyAttentionInputs,
     fmha_config: Optional[FMHAConfig],
-) -> bool:
-    if not attn_configs.need_rope_kv_cache or not _is_mrope_interleaved_supported(
-        attn_configs
+) -> Optional[Callable[[type], bool]]:
+    """Reject candidates whose writer stores the other V layout, or `None` when the
+    writer's own gate (`fused_rope_kvcache_op`) says no cache is written."""
+    block_id = attn_inputs.kv_cache_kernel_block_id
+    if not (
+        attn_configs.need_rope_kv_cache and block_id is not None and block_id.numel()
     ):
-        return False
-    page = attn_configs.kernel_tokens_per_block
-    head = attn_configs.size_per_head
-    width = _kv_vector_width(attn_configs)
-    if head % width or page <= 0 or page % width:
-        raise ValueError(f"invalid V geometry: {head=}, {page=}, {width=}")
-    if attn_inputs.is_prefill or fmha_config is None:
-        return True
-    prefill_vec = prefill_writes_vectorized_v(attn_configs, fmha_config)
-    decode_vec = (
-        prefill_vec
-        if fmha_config.use_triton_pa
-        else (fmha_config.use_asm_pa and head in ASM_DECODE_HEAD_SIZES)
+        return None
+    try:
+        required_linear_v = resolve_linear_v(attn_configs, fmha_config)
+    except UnsupportedVLayout:
+        use_aiter_pa = fmha_config is None or fmha_config.use_aiter_pa
+        # Only FP8 has a mismatched NonAsm pair; FP8 cache elements are one byte.
+        if (
+            use_aiter_pa
+            and attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+            and _v_layouts_coincide(
+                attn_configs.kernel_tokens_per_block, element_size=1
+            )
+        ):
+            required_linear_v = None
+        else:
+            raise
+
+    def accepts(impl: type) -> bool:
+        writer = impl.WRITER
+        if writer is None:
+            raise TypeError(f"{impl.__name__} must declare a WRITER to share a cache")
+        writer_linear_v = _writes_linear_v(writer, attn_configs.kv_cache_dtype)
+        return required_linear_v is None or writer_linear_v == required_linear_v
+
+    return accepts
+
+
+def view_triton_kv_cache(paged_kv_cache: torch.Tensor, linear_v: bool):
+    """Return zero-copy K/V views matching the selected writer layout."""
+    k = paged_kv_cache.select(1, 0)
+    v = paged_kv_cache.select(1, 1)
+    blocks, heads, page, hd = k.shape
+    vs = 16 // k.element_size()
+    v_shape = (
+        (blocks, heads, hd, page) if linear_v else (blocks, heads, page // vs, hd, vs)
     )
-    if prefill_vec != decode_vec and page != width:
-        remedy = "enable --use_triton_pa 1"
-        if attn_configs.kv_cache_dtype == KvCacheDataType.BASE:
-            remedy += " or set --use_asm_pa 0"
-        raise ValueError(
-            f"ROCm KV-cache V layout mismatch: {fmha_config.use_asm_pa=}, "
-            f"{fmha_config.use_triton_pa=}, "
-            f"{head=}, {page=}, {width=}, {prefill_vec=}, {decode_vec=}; "
-            f"{remedy} to select matching prefill/decode implementations"
-        )
-    return True
+    return k.view(blocks, heads, hd // vs, page, vs), v.view(*v_shape)
 
 
 # Pure Python implementation of FMHAParams
@@ -242,7 +312,7 @@ class FMHAParams(ParamsBase):
 
 
 class AiterPrefillAttnOp:
-    def __init__(self, attn_configs: AttentionConfigs, v1_kv_layout: bool = False):
+    def __init__(self, attn_configs: AttentionConfigs, linear_v: bool = False):
         self.head_num = attn_configs.head_num
         self.head_dim = attn_configs.size_per_head
         self.head_num_kv = attn_configs.kv_head_num
@@ -251,10 +321,8 @@ class AiterPrefillAttnOp:
         self.kv_cache_torch_dtype = self._get_kv_cache_torch_dtype(
             attn_configs.kv_cache_dtype, attn_configs.dtype
         )
-        self.v1_kv_layout = v1_kv_layout
-        self.use_compact = (
-            self.v1_kv_layout and attn_configs.kv_cache_dtype != KvCacheDataType.FP8
-        )
+        # Resolved by the caller from its WRITER; also gates the CK compact scratch.
+        self.linear_v = linear_v
         self._block_positions: Optional[torch.Tensor] = None
         self._compact_arange: Optional[torch.Tensor] = None
 
@@ -313,7 +381,7 @@ class AiterPrefillAttnOp:
             sanitized
         )
 
-        if self.use_compact:
+        if self.linear_v:
             # Pre-allocate compact K/V buffers with trailing zero-block for CK
             # speculative read safety. Reused every layer — forward() writes into
             # buf[:num_gathered] and the last row stays zero, eliminating per-layer
@@ -336,7 +404,7 @@ class AiterPrefillAttnOp:
             fmha_params.v_compact_buf = None
 
     def _reshape_kv_cache_vectorized(self, kv_cache_base):
-        """Reshape kv_cache_base into 5D VECTORIZED_LAYOUT for mha_batch_prefill.
+        """View a vectorized KV cache as the 5D tensors expected by CK.
 
         Handles both 2D flat buffer and 5D pre-shaped kv_cache_base.
 
@@ -349,6 +417,9 @@ class AiterPrefillAttnOp:
           Needs permute to convert to vectorized [ps//vs, hd, vs].
         - V1 FP8: kernel uses getVLocalIdx<FP8> → already vectorized [ps//vs, hd, vs].
         - ASM (both BASE and FP8): kernel uses getVLocalIdx<CType> → vectorized.
+
+        The caller routes the first case through _gather_and_reshape_kv_compact;
+        this helper only receives caches that are already vectorized.
         """
         block_num = kv_cache_base.shape[0]
         hk = self.head_num_kv
@@ -356,25 +427,12 @@ class AiterPrefillAttnOp:
         hd = self.head_dim
         vs = 16 // kv_cache_base.element_size()
 
-        # FP8 KV cache always uses vectorized layout (getKLocalIdx<FP8>/getVLocalIdx<FP8>),
-        # regardless of v1_kv_layout flag.
-        is_fp8 = kv_cache_base.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
-        use_v1_linear_v = self.v1_kv_layout and not is_fp8
-
         if kv_cache_base.ndim >= 4:
             # Already shaped as [block_num, 2, hk, ps, hd] or similar multi-dim format.
             k_4d = kv_cache_base.select(1, 0)  # [block_num, hk, ps, hd]
             v_4d = kv_cache_base.select(1, 1)  # [block_num, hk, ps, hd]
             k_cache = k_4d.view(block_num, hk, hd // vs, ps, vs)
-            if use_v1_linear_v:
-                v_linear = v_4d.reshape(block_num, hk, hd, ps)
-                v_cache = (
-                    v_linear.reshape(block_num, hk, hd, ps // vs, vs)
-                    .permute(0, 1, 3, 2, 4)
-                    .contiguous()
-                )
-            else:
-                v_cache = v_4d.view(block_num, hk, ps // vs, hd, vs)
+            v_cache = v_4d.view(block_num, hk, ps // vs, hd, vs)
             return k_cache, v_cache
 
         # 2D flat buffer path
@@ -383,18 +441,7 @@ class AiterPrefillAttnOp:
 
         # K: kernel writes via getKLocalIdx<CType> → vectorized [hd//vs, ps, vs].
         k_cache = flat[:, 0, :, :].view(block_num, hk, hd // vs, ps, vs)
-
-        if use_v1_linear_v:
-            # V1 non-FP8: kernel uses non-template getVLocalIdx → linear [hd, ps].
-            v_linear = flat[:, 1, :, :].view(block_num, hk, hd, ps)
-            v_cache = (
-                v_linear.reshape(block_num, hk, hd, ps // vs, vs)
-                .permute(0, 1, 3, 2, 4)
-                .contiguous()
-            )
-        else:
-            # ASM or FP8: kernel uses getVLocalIdx<CType> → vectorized [ps//vs, hd, vs].
-            v_cache = flat[:, 1, :, :].view(block_num, hk, ps // vs, hd, vs)
+        v_cache = flat[:, 1, :, :].view(block_num, hk, ps // vs, hd, vs)
 
         return k_cache, v_cache
 
@@ -420,7 +467,7 @@ class AiterPrefillAttnOp:
     ):
         """Gather referenced blocks once, then reshape to VECTORIZED_LAYOUT.
 
-        For v1_kv_layout=True (non-ASM, non-FP8) path, the V cache needs a
+        For the linear-V (non-ASM, non-FP8) path, the V cache needs a
         permute+contiguous to convert from linear [hd, ps] to vectorized
         [ps//vs, hd, vs] layout. Doing this on the full KV cache pool is
         extremely expensive. This method gathers all referenced blocks
@@ -565,7 +612,7 @@ class AiterPrefillAttnOp:
         max_seqlen_q = fmha_params.max_seqlen_q
         max_seqlen_k = fmha_params.max_seqlen_k
 
-        if self.use_compact:
+        if self.linear_v:
             block_table = fmha_params.compact_block_table
             k_cache, v_cache = self._gather_and_reshape_kv_compact(
                 kv_cache.kv_cache_base,
@@ -965,22 +1012,8 @@ def _run_triton_paged_attention(
     kv_scale_buf: Optional[torch.Tensor] = None,
     workspace: Optional[dict] = None,
 ) -> torch.Tensor:
-    key_cache = paged_kv_cache.select(1, 0)
-    value_cache = paged_kv_cache.select(1, 1)
-
-    x = 16 // key_cache.element_size()
-    kv_sizes = key_cache.shape
-    # K: [N, nkv, ps, hd] -> [N, nkv, hd//x, ps, x]  (shuffle layout)
-    key_cache = key_cache.view(
-        kv_sizes[0], kv_sizes[1], kv_sizes[3] // x, kv_sizes[2], x
-    )
-    # 4D V is the linear [hd, ps] reader for the Non-ASM writer; 5D V is the
-    # vectorized VALUE_TRANSPOSED reader for the ASM writer.
-    value_cache = value_cache.view(
-        (kv_sizes[0], kv_sizes[1], kv_sizes[3], kv_sizes[2])
-        if linear_v
-        else (kv_sizes[0], kv_sizes[1], kv_sizes[2] // x, kv_sizes[3], x)
-    )
+    # Gluon infers V layout from rank (5D vectorized, 4D linear), so it cannot check.
+    key_cache, value_cache = view_triton_kv_cache(paged_kv_cache, linear_v)
 
     has_kv_scale_base = kv_scale_base is not None and (
         not isinstance(kv_scale_base, torch.Tensor) or kv_scale_base.numel() > 0
@@ -1094,12 +1127,13 @@ def _run_triton_paged_attention(
 
 
 class AiterPrefillAttnOpTriton:
-    def __init__(self, attn_configs: AttentionConfigs):
+    def __init__(self, attn_configs: AttentionConfigs, linear_v: bool):
         self.head_num = attn_configs.head_num
         self.head_dim = attn_configs.size_per_head
         self.head_num_kv = attn_configs.kv_head_num
         self.context_partition_size = 256
         self.alloc_scale = attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+        self.linear_v = linear_v
         self.enable_cuda_graph = False
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
@@ -1157,6 +1191,14 @@ class AiterPrefillAttnOpTriton:
         attn_dtype: torch.dtype,
         device: torch.device,
     ) -> None:
+        """Allocate every Triton PA buffer at capture time.
+
+        Allocating any of these tensors from forward() changes their device
+        addresses between capture and replay and makes the graph either fail to
+        launch or consume stale workspace.  The compact output/index buffers are
+        deliberately capture-sized; replay fills their live prefix and clears
+        the remaining indices.
+        """
         output_dtype = self._graph_output_dtype(attn_dtype)
         query_group_size = self.head_num // self.head_num_kv
         max_context_partition_num = (
@@ -1262,7 +1304,7 @@ class AiterPrefillAttnOpTriton:
             fmha_params.max_seqlen_k,
             self.head_num_kv,
             self.context_partition_size,
-            linear_v=False,
+            linear_v=self.linear_v,
             kv_scale_buf=fmha_params.kv_scale,
             workspace=workspace,
         )
@@ -1564,6 +1606,8 @@ class AiterDecodeAttnOpTriton(AiterDecodeAttnOpBase):
 class AiterPrefillImplAsm(FMHAImplBase):
     """Aiter prefill attention implementation using ASM."""
 
+    WRITER = FusedRopeKVCachePrefillOpAsm
+
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -1572,8 +1616,9 @@ class AiterPrefillImplAsm(FMHAImplBase):
     ) -> None:
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = AiterPrefillAttnOp(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpAsm(attn_configs)
+        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
+        self.fmha_impl = AiterPrefillAttnOp(attn_configs, linear_v)
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         # Store input info
@@ -1624,6 +1669,8 @@ class AiterPrefillImplAsm(FMHAImplBase):
 class AiterPrefillImplNonAsm(FMHAImplBase):
     """Aiter prefill attention implementation using non-ASM."""
 
+    WRITER = FusedRopeKVCachePrefillOpNonAsm
+
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -1632,8 +1679,9 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
     ) -> None:
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        self.fmha_impl = AiterPrefillAttnOp(attn_configs, v1_kv_layout=True)
-        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpNonAsm(attn_configs)
+        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
+        self.fmha_impl = AiterPrefillAttnOp(attn_configs, linear_v)
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         # Store input info
@@ -1684,9 +1732,16 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
 class AiterPrefillImplPaged(FMHAImplBase):
     """Paged prefill impl: dispatches between CK batch-prefill and Triton PA at runtime.
 
-    - seq_len <= 4: Triton PA (short query optimization)
+    - short query (see max_triton_q_len): Triton PA
     - Otherwise: CK batch-prefill (general paged prefill)
+
+    The bound was a hardcoded 4, which sent the MTP verify forward (q_len =
+    gen_num_per_cycle + 1 = 5) down CK batch-prefill. At head_dim 256 that kernel only
+    exists with an M tile of 128, so 5 query rows cost a full tile: 1867 us per launch
+    against 180 us on the Triton path, 37.8% of GPU time in an MTP round.
     """
+
+    WRITER = FusedRopeKVCachePrefillOpAsm
 
     def __init__(
         self,
@@ -1699,10 +1754,18 @@ class AiterPrefillImplPaged(FMHAImplBase):
         self.head_dim = attn_configs.size_per_head
         self.tokens_per_block = attn_configs.kernel_tokens_per_block
 
-        self.batch_prefill_impl = AiterPrefillAttnOpPaged(attn_configs)
-        self.triton_prefill_impl = AiterPrefillAttnOpTriton(attn_configs)
+        # pa_decode_gluon's documented constraint is query_length * query_group_size
+        # <= 64; it also asserts query_length <= 4, so relaxing this bound needs the
+        # matching aiter-side change.
+        kv_heads = max(1, attn_configs.kv_head_num)
+        query_group_size = max(1, attn_configs.head_num // kv_heads)
+        self.max_triton_q_len = max(1, 64 // query_group_size)
 
-        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpAsm(attn_configs)
+        self.batch_prefill_impl = AiterPrefillAttnOpPaged(attn_configs)
+        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
+        self.triton_prefill_impl = AiterPrefillAttnOpTriton(attn_configs, linear_v)
+
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         self.attn_inputs = attn_inputs
@@ -1728,7 +1791,7 @@ class AiterPrefillImplPaged(FMHAImplBase):
         input_lengths = attn_inputs.input_lengths
         batch_size = input_lengths.numel()
         max_q_len = int(input_lengths.max().item()) if batch_size > 0 else 0
-        return batch_size > 0 and 0 < max_q_len <= 4
+        return batch_size > 0 and 0 < max_q_len <= self.max_triton_q_len
 
     def _select_backend(self, attn_inputs: PyAttentionInputs) -> str:
         return "triton" if self._use_triton_paged_prefill(attn_inputs) else "batch"
@@ -1917,6 +1980,11 @@ class AiterPrefillImplPaged(FMHAImplBase):
         prepare_in_place = getattr(self.rope_params, "prepare_in_place", None)
         if callable(prepare_in_place):
             prepare_in_place(attn_inputs)
+        # CKAttn exposes only ``prepare_in_place`` to Python.  Do not mutate
+        # its internal replay-width fields here: doing so raises an
+        # AttributeError during graph capture.  The reader's fixed graph
+        # workspace and compact-index mapping are sufficient to preserve the
+        # captured dense width while returning only live tokens.
 
     def forward(
         self,
@@ -1982,6 +2050,8 @@ class AiterDecodeImplBase(FMHAImplBase):
 
 
 class AiterDecodeImplAsm(AiterDecodeImplBase):
+    WRITER = FusedRopeKVCacheDecodeOpAsm
+
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -1991,7 +2061,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
         self.fmha_impl = AiterDecodeAttnOpAsm(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOpAsm(attn_configs)
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
 
         # Store input info
         self.attn_inputs = attn_inputs
@@ -2007,7 +2077,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
     ) -> bool:
         return (
             _is_mrope_interleaved_supported(attn_configs)
-            and attn_configs.size_per_head in ASM_DECODE_HEAD_SIZES
+            and attn_configs.size_per_head == ASM_DECODE_HEAD_SIZE
         )
 
     def forward(
@@ -2032,6 +2102,8 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
 
 
 class AiterDecodeImplNonAsm(AiterDecodeImplBase):
+    WRITER = FusedRopeKVCacheDecodeOpNonAsm
+
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -2041,7 +2113,7 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
         self.fmha_impl = AiterDecodeAttnOpNonAsm(attn_configs)
-        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOpNonAsm(attn_configs)
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
 
         # Store input info
         self.attn_inputs = attn_inputs
@@ -2081,21 +2153,16 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
 class AiterDecodeImplTriton(AiterDecodeImplBase):
     """Aiter decode attention implementation using Triton."""
 
-    accepts_fmha_config = True
-
     def __init__(
         self,
         attn_configs: AttentionConfigs,
         attn_inputs: PyAttentionInputs,
         parallelism_config: Optional[ParallelismConfig] = None,
-        fmha_config: Optional[FMHAConfig] = None,
     ) -> None:
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        linear_v = not prefill_writes_vectorized_v(attn_configs, fmha_config)
+        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
         self.fmha_impl = AiterDecodeAttnOpTriton(attn_configs, linear_v=linear_v)
-        self.rope_kvcache_impl = (
-            FusedRopeKVCacheDecodeOpNonAsm if linear_v else FusedRopeKVCacheDecodeOpAsm
-        )(attn_configs)
+        self.rope_kvcache_impl = self.WRITER(attn_configs)
 
         self.attn_inputs = attn_inputs
 
@@ -2125,3 +2192,11 @@ class AiterDecodeImplTriton(AiterDecodeImplBase):
         )
 
         return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
+
+
+class AiterDecodeImplTritonLinear(AiterDecodeImplTriton):
+    WRITER = FusedRopeKVCacheDecodeOpNonAsm
+
+
+class AiterDecodeImplTritonVectorized(AiterDecodeImplTriton):
+    WRITER = FusedRopeKVCacheDecodeOpAsm

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/aiter.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Callable, List, Optional
+from typing import Any, Optional
 
 import aiter
 import torch
@@ -40,132 +40,70 @@ def _is_mrope_interleaved_supported(attn_configs: AttentionConfigs) -> bool:
     )
 
 
-def _writes_linear_v(writer_cls: type, kv_cache_dtype: KvCacheDataType) -> bool:
-    """Whether `writer_cls` stores V linear `[head_dim, page]`, not vectorized.
-
-    Transcribes the C++ writer kernels' getVLocalIdx branches; `resolve_linear_v`
-    mirrors this table, and test_v_layout_contract.LAYOUT_MATRIX pins both.
-    Change all three together."""
-    if writer_cls is FusedRopeKVCacheDecodeOpNonAsm:
-        return True
-    if writer_cls is FusedRopeKVCachePrefillOpNonAsm:
-        return kv_cache_dtype != KvCacheDataType.FP8
-    if writer_cls in (FusedRopeKVCacheDecodeOpAsm, FusedRopeKVCachePrefillOpAsm):
-        return False
-    raise TypeError(f"unknown ROCm KV-cache writer: {writer_cls}")
+# aiter.pa_fwd_asm asserts head_size == 128.
+ASM_DECODE_HEAD_SIZES = {128}
 
 
-def _v_layouts_coincide(page_size: int, element_size: int) -> bool:
-    """Whether linear and vectorized V use identical byte offsets."""
-    return page_size == 16 // element_size
+def _kv_vector_width(attn_configs: AttentionConfigs) -> int:
+    itemsize = (
+        1
+        if attn_configs.kv_cache_dtype == KvCacheDataType.FP8
+        else attn_configs.dtype.itemsize
+    )
+    return 16 // itemsize
 
 
-# aiter.pa_fwd_asm is only built for this head size.
-ASM_DECODE_HEAD_SIZE = 128
+def _validate_v_geometry(head: int, page: int, width: int) -> None:
+    if head % width or page <= 0 or page % width:
+        raise ValueError(f"invalid V geometry: {head=}, {page=}, {width=}")
 
 
-class UnsupportedVLayout(ValueError):
-    """No prefill/decode pair can store the same V layout under this config."""
-
-
-def resolve_linear_v(
+def prefill_writes_vectorized_v(
     attn_configs: AttentionConfigs, fmha_config: Optional[FMHAConfig]
 ) -> bool:
-    """Return the common prefill/decode V layout; True means linear.
-
-    Hand-mirrors `_writes_linear_v` plus the flag/head-size gates; keep in sync
-    with it and with test_v_layout_contract.LAYOUT_MATRIX."""
-    use_aiter_pa = fmha_config is None or fmha_config.use_aiter_pa
-    use_asm_pa = fmha_config is None or fmha_config.use_asm_pa
-    use_triton_pa = fmha_config is None or fmha_config.use_triton_pa
-    is_fp8 = attn_configs.kv_cache_dtype == KvCacheDataType.FP8
-
-    # Aiter paged prefill and the Aiter Triton decode path both consume the
-    # vectorized V layout.  `use_aiter_pa` therefore selects the vectorized
-    # pair even when the standalone Triton/ASM flags are both false; the
-    # short-query Triton reader is an internal part of Aiter paged prefill.
-    # NonAsm remains the linear fallback only when the Aiter stack is disabled.
-    # Aiter is deliberately all-vectorized.  ASM can also provide the
-    # vectorized pair when Triton is enabled or when its decode head-size gate
-    # is satisfied.
-    vectorized_pair = (use_aiter_pa and (not use_asm_pa or use_triton_pa)) or (
-        use_asm_pa
-        and (use_triton_pa or attn_configs.size_per_head == ASM_DECODE_HEAD_SIZE)
-    )
-    if vectorized_pair:
-        return False
-    config = (
-        f"use_aiter_pa={use_aiter_pa}, use_asm_pa={use_asm_pa}, "
-        f"use_triton_pa={use_triton_pa}, size_per_head={attn_configs.size_per_head}, "
-        f"kv_cache_dtype={attn_configs.kv_cache_dtype}, "
-        f"kernel_tokens_per_block={attn_configs.kernel_tokens_per_block}"
-    )
-    if not (use_aiter_pa or use_asm_pa):
-        raise UnsupportedVLayout(
-            f"every ROCm KV-cache writer backend is disabled ({config}); "
-            "enable use_aiter_pa or use_asm_pa"
-        )
-    remedies = ["enable use_triton_pa"]
-    if use_asm_pa and attn_configs.size_per_head != ASM_DECODE_HEAD_SIZE:
-        remedies.append(f"use a model with size_per_head={ASM_DECODE_HEAD_SIZE}")
-    if use_aiter_pa and is_fp8:
-        remedies.append("disable the FP8 KV cache")
-    if not use_aiter_pa and not is_fp8:
-        remedies.append("enable use_aiter_pa")
-    raise UnsupportedVLayout(
-        f"no compatible ROCm V-cache writer/reader pair ({config}); "
-        + ", or ".join(remedies)
+    return (
+        fmha_config is None
+        or fmha_config.use_asm_pa
+        or (attn_configs.kv_cache_dtype == KvCacheDataType.FP8)
     )
 
 
-def v_layout_filter(
+def validate_v_layout(
     attn_configs: AttentionConfigs,
     attn_inputs: PyAttentionInputs,
     fmha_config: Optional[FMHAConfig],
-) -> Optional[Callable[[type], bool]]:
-    """Reject candidates whose writer stores the other V layout, or `None` when the
-    writer's own gate (`fused_rope_kvcache_op`) says no cache is written."""
-    block_id = attn_inputs.kv_cache_kernel_block_id
-    if not (
-        attn_configs.need_rope_kv_cache and block_id is not None and block_id.numel()
+) -> bool:
+    if not attn_configs.need_rope_kv_cache or not _is_mrope_interleaved_supported(
+        attn_configs
     ):
-        return None
-    try:
-        required_linear_v = resolve_linear_v(attn_configs, fmha_config)
-    except UnsupportedVLayout:
-        use_aiter_pa = fmha_config is None or fmha_config.use_aiter_pa
-        # Only FP8 has a mismatched NonAsm pair; FP8 cache elements are one byte.
-        if (
-            use_aiter_pa
-            and attn_configs.kv_cache_dtype == KvCacheDataType.FP8
-            and _v_layouts_coincide(
-                attn_configs.kernel_tokens_per_block, element_size=1
-            )
-        ):
-            required_linear_v = None
-        else:
-            raise
-
-    def accepts(impl: type) -> bool:
-        writer = impl.WRITER
-        if writer is None:
-            raise TypeError(f"{impl.__name__} must declare a WRITER to share a cache")
-        writer_linear_v = _writes_linear_v(writer, attn_configs.kv_cache_dtype)
-        return required_linear_v is None or writer_linear_v == required_linear_v
-
-    return accepts
-
-
-def view_triton_kv_cache(paged_kv_cache: torch.Tensor, linear_v: bool):
-    """Return zero-copy K/V views matching the selected writer layout."""
-    k = paged_kv_cache.select(1, 0)
-    v = paged_kv_cache.select(1, 1)
-    blocks, heads, page, hd = k.shape
-    vs = 16 // k.element_size()
-    v_shape = (
-        (blocks, heads, hd, page) if linear_v else (blocks, heads, page // vs, hd, vs)
+        return False
+    if fmha_config is not None and not any(
+        (fmha_config.use_aiter_pa, fmha_config.use_asm_pa, fmha_config.use_triton_pa)
+    ):
+        raise ValueError("every ROCm KV-cache backend is disabled")
+    page = attn_configs.kernel_tokens_per_block
+    head = attn_configs.size_per_head
+    width = _kv_vector_width(attn_configs)
+    _validate_v_geometry(head, page, width)
+    if attn_inputs.is_prefill or fmha_config is None:
+        return True
+    prefill_vec = prefill_writes_vectorized_v(attn_configs, fmha_config)
+    decode_vec = (
+        prefill_vec
+        if fmha_config.use_triton_pa
+        else (fmha_config.use_asm_pa and head in ASM_DECODE_HEAD_SIZES)
     )
-    return k.view(blocks, heads, hd // vs, page, vs), v.view(*v_shape)
+    if prefill_vec != decode_vec and page != width:
+        remedy = "enable --use_triton_pa 1"
+        if attn_configs.kv_cache_dtype == KvCacheDataType.BASE:
+            remedy += " or set --use_asm_pa 0"
+        raise ValueError(
+            f"ROCm KV-cache V layout mismatch: {fmha_config.use_asm_pa=}, "
+            f"{fmha_config.use_triton_pa=}, "
+            f"{head=}, {page=}, {width=}, {prefill_vec=}, {decode_vec=}; "
+            f"{remedy} to select matching prefill/decode implementations"
+        )
+    return True
 
 
 # Pure Python implementation of FMHAParams
@@ -321,7 +259,6 @@ class AiterPrefillAttnOp:
         self.kv_cache_torch_dtype = self._get_kv_cache_torch_dtype(
             attn_configs.kv_cache_dtype, attn_configs.dtype
         )
-        # Resolved by the caller from its WRITER; also gates the CK compact scratch.
         self.linear_v = linear_v
         self._block_positions: Optional[torch.Tensor] = None
         self._compact_arange: Optional[torch.Tensor] = None
@@ -381,7 +318,10 @@ class AiterPrefillAttnOp:
             sanitized
         )
 
-        if self.linear_v:
+        if self.linear_v and self.kv_cache_torch_dtype not in (
+            torch.float8_e4m3fnuz,
+            torch.float8_e4m3fn,
+        ):
             # Pre-allocate compact K/V buffers with trailing zero-block for CK
             # speculative read safety. Reused every layer — forward() writes into
             # buf[:num_gathered] and the last row stays zero, eliminating per-layer
@@ -404,7 +344,7 @@ class AiterPrefillAttnOp:
             fmha_params.v_compact_buf = None
 
     def _reshape_kv_cache_vectorized(self, kv_cache_base):
-        """View a vectorized KV cache as the 5D tensors expected by CK.
+        """Reshape kv_cache_base into 5D VECTORIZED_LAYOUT for mha_batch_prefill.
 
         Handles both 2D flat buffer and 5D pre-shaped kv_cache_base.
 
@@ -417,9 +357,6 @@ class AiterPrefillAttnOp:
           Needs permute to convert to vectorized [ps//vs, hd, vs].
         - V1 FP8: kernel uses getVLocalIdx<FP8> → already vectorized [ps//vs, hd, vs].
         - ASM (both BASE and FP8): kernel uses getVLocalIdx<CType> → vectorized.
-
-        The caller routes the first case through _gather_and_reshape_kv_compact;
-        this helper only receives caches that are already vectorized.
         """
         block_num = kv_cache_base.shape[0]
         hk = self.head_num_kv
@@ -427,12 +364,25 @@ class AiterPrefillAttnOp:
         hd = self.head_dim
         vs = 16 // kv_cache_base.element_size()
 
+        # FP8 KV cache always uses vectorized layout (getKLocalIdx<FP8>/getVLocalIdx<FP8>),
+        # regardless of the linear_v flag.
+        is_fp8 = kv_cache_base.dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+        use_linear_v = self.linear_v and not is_fp8
+
         if kv_cache_base.ndim >= 4:
             # Already shaped as [block_num, 2, hk, ps, hd] or similar multi-dim format.
             k_4d = kv_cache_base.select(1, 0)  # [block_num, hk, ps, hd]
             v_4d = kv_cache_base.select(1, 1)  # [block_num, hk, ps, hd]
             k_cache = k_4d.view(block_num, hk, hd // vs, ps, vs)
-            v_cache = v_4d.view(block_num, hk, ps // vs, hd, vs)
+            if use_linear_v:
+                v_linear = v_4d.reshape(block_num, hk, hd, ps)
+                v_cache = (
+                    v_linear.reshape(block_num, hk, hd, ps // vs, vs)
+                    .permute(0, 1, 3, 2, 4)
+                    .contiguous()
+                )
+            else:
+                v_cache = v_4d.view(block_num, hk, ps // vs, hd, vs)
             return k_cache, v_cache
 
         # 2D flat buffer path
@@ -441,7 +391,18 @@ class AiterPrefillAttnOp:
 
         # K: kernel writes via getKLocalIdx<CType> → vectorized [hd//vs, ps, vs].
         k_cache = flat[:, 0, :, :].view(block_num, hk, hd // vs, ps, vs)
-        v_cache = flat[:, 1, :, :].view(block_num, hk, ps // vs, hd, vs)
+
+        if use_linear_v:
+            # V1 non-FP8: kernel uses non-template getVLocalIdx → linear [hd, ps].
+            v_linear = flat[:, 1, :, :].view(block_num, hk, hd, ps)
+            v_cache = (
+                v_linear.reshape(block_num, hk, hd, ps // vs, vs)
+                .permute(0, 1, 3, 2, 4)
+                .contiguous()
+            )
+        else:
+            # ASM or FP8: kernel uses getVLocalIdx<CType> → vectorized [ps//vs, hd, vs].
+            v_cache = flat[:, 1, :, :].view(block_num, hk, ps // vs, hd, vs)
 
         return k_cache, v_cache
 
@@ -467,7 +428,7 @@ class AiterPrefillAttnOp:
     ):
         """Gather referenced blocks once, then reshape to VECTORIZED_LAYOUT.
 
-        For the linear-V (non-ASM, non-FP8) path, the V cache needs a
+        For the linear V (non-ASM, non-FP8) path, the V cache needs a
         permute+contiguous to convert from linear [hd, ps] to vectorized
         [ps//vs, hd, vs] layout. Doing this on the full KV cache pool is
         extremely expensive. This method gathers all referenced blocks
@@ -612,7 +573,10 @@ class AiterPrefillAttnOp:
         max_seqlen_q = fmha_params.max_seqlen_q
         max_seqlen_k = fmha_params.max_seqlen_k
 
-        if self.linear_v:
+        if self.linear_v and kv_cache.kv_cache_base.dtype not in (
+            torch.float8_e4m3fnuz,
+            torch.float8_e4m3fn,
+        ):
             block_table = fmha_params.compact_block_table
             k_cache, v_cache = self._gather_and_reshape_kv_compact(
                 kv_cache.kv_cache_base,
@@ -821,6 +785,7 @@ class AiterPrefillAttnOpPaged:
         self.kv_indptr_buf: Optional[torch.Tensor] = None
         self.kv_page_indices_buf: Optional[torch.Tensor] = None
         self.descale_buf: Optional[torch.Tensor] = None
+        self.sanitized_bt_buf: Optional[torch.Tensor] = None
         self._block_positions: Optional[torch.Tensor] = None
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
@@ -863,6 +828,14 @@ class AiterPrefillAttnOpPaged:
             device=self.graph_device, dtype=torch.int32
         )
         batch_size = fmha_params.cu_seqlens_q.shape[0] - 1
+        bt = fmha_params.kv_cache_block_id_device
+        extra_pages = (128 + self.tokens_per_block - 1) // self.tokens_per_block
+        required_shape = (batch_size, bt.shape[1] + extra_pages)
+        buffer = self.sanitized_bt_buf
+        if buffer is not None and (
+            buffer.shape != required_shape or buffer.device != self.graph_device
+        ):
+            raise ValueError("Aiter graph buffer changed; recapture required")
         if self.seqlen_k_buf is None or self.seqlen_k_buf.shape[0] < batch_size:
             self.seqlen_k_buf = torch.empty(
                 max(1, batch_size), dtype=torch.int32, device=self.graph_device
@@ -879,15 +852,10 @@ class AiterPrefillAttnOpPaged:
             self.descale_buf = torch.ones(
                 1, dtype=torch.float32, device=self.graph_device
             )
-        # Pre-allocate a fixed-address buffer for the sanitized+padded block_table.
-        # CUDA graph replay requires stable tensor addresses; sanitize produces a
-        # new tensor each call, so we copy_ into this fixed buffer.
-        bt = fmha_params.kv_cache_block_id_device
-        extra_pages = (128 + self.tokens_per_block - 1) // self.tokens_per_block
-        max_cols = bt.shape[1] + extra_pages
-        self.sanitized_bt_buf = torch.zeros(
-            batch_size, max_cols, dtype=torch.int32, device=self.graph_device
-        )
+        if self.sanitized_bt_buf is None:
+            self.sanitized_bt_buf = torch.zeros(
+                required_shape, dtype=torch.int32, device=self.graph_device
+            )
         self.cuda_graph_prepared = True
 
     def forward(self, qkv, kv_cache, fmha_params) -> torch.Tensor:
@@ -1012,8 +980,20 @@ def _run_triton_paged_attention(
     kv_scale_buf: Optional[torch.Tensor] = None,
     workspace: Optional[dict] = None,
 ) -> torch.Tensor:
-    # Gluon infers V layout from rank (5D vectorized, 4D linear), so it cannot check.
-    key_cache, value_cache = view_triton_kv_cache(paged_kv_cache, linear_v)
+    key_cache = paged_kv_cache.select(1, 0)
+    value_cache = paged_kv_cache.select(1, 1)
+
+    x = 16 // key_cache.element_size()
+    kv_sizes = key_cache.shape
+    _validate_v_geometry(kv_sizes[3], kv_sizes[2], x)
+    key_cache = key_cache.view(
+        kv_sizes[0], kv_sizes[1], kv_sizes[3] // x, kv_sizes[2], x
+    )
+    value_cache = value_cache.view(
+        (kv_sizes[0], kv_sizes[1], kv_sizes[3], kv_sizes[2])
+        if linear_v
+        else (kv_sizes[0], kv_sizes[1], kv_sizes[2] // x, kv_sizes[3], x)
+    )
 
     has_kv_scale_base = kv_scale_base is not None and (
         not isinstance(kv_scale_base, torch.Tensor) or kv_scale_base.numel() > 0
@@ -1127,13 +1107,12 @@ def _run_triton_paged_attention(
 
 
 class AiterPrefillAttnOpTriton:
-    def __init__(self, attn_configs: AttentionConfigs, linear_v: bool):
+    def __init__(self, attn_configs: AttentionConfigs):
         self.head_num = attn_configs.head_num
         self.head_dim = attn_configs.size_per_head
         self.head_num_kv = attn_configs.kv_head_num
         self.context_partition_size = 256
         self.alloc_scale = attn_configs.kv_cache_dtype == KvCacheDataType.FP8
-        self.linear_v = linear_v
         self.enable_cuda_graph = False
 
     def support(self, attn_inputs: PyAttentionInputs) -> bool:
@@ -1191,14 +1170,6 @@ class AiterPrefillAttnOpTriton:
         attn_dtype: torch.dtype,
         device: torch.device,
     ) -> None:
-        """Allocate every Triton PA buffer at capture time.
-
-        Allocating any of these tensors from forward() changes their device
-        addresses between capture and replay and makes the graph either fail to
-        launch or consume stale workspace.  The compact output/index buffers are
-        deliberately capture-sized; replay fills their live prefix and clears
-        the remaining indices.
-        """
         output_dtype = self._graph_output_dtype(attn_dtype)
         query_group_size = self.head_num // self.head_num_kv
         max_context_partition_num = (
@@ -1221,6 +1192,9 @@ class AiterPrefillAttnOpTriton:
         # same padded row layout.
         fmha_params.graph_query_length = query_length
         fmha_params.graph_token_q_capacity = fmha_params.token_q_num
+        fmha_params.graph_max_seqlen_k = (
+            max_context_partition_num * self.context_partition_size
+        )
 
         fmha_params.attention_output = torch.empty(
             output_shape, dtype=output_dtype, device=device
@@ -1243,8 +1217,8 @@ class AiterPrefillAttnOpTriton:
 
     def _calc_compact_indices(self, fmha_params: FMHAParams):
         cu_seqlens_q = fmha_params.cu_seqlens_q
-        query_stride = getattr(
-            fmha_params, "graph_query_length", fmha_params.max_seqlen_q
+        query_stride = (
+            getattr(fmha_params, "graph_query_length", 0) or fmha_params.max_seqlen_q
         )
         device = cu_seqlens_q.device
 
@@ -1304,7 +1278,7 @@ class AiterPrefillAttnOpTriton:
             fmha_params.max_seqlen_k,
             self.head_num_kv,
             self.context_partition_size,
-            linear_v=self.linear_v,
+            linear_v=False,
             kv_scale_buf=fmha_params.kv_scale,
             workspace=workspace,
         )
@@ -1606,8 +1580,6 @@ class AiterDecodeAttnOpTriton(AiterDecodeAttnOpBase):
 class AiterPrefillImplAsm(FMHAImplBase):
     """Aiter prefill attention implementation using ASM."""
 
-    WRITER = FusedRopeKVCachePrefillOpAsm
-
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -1616,9 +1588,8 @@ class AiterPrefillImplAsm(FMHAImplBase):
     ) -> None:
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
-        self.fmha_impl = AiterPrefillAttnOp(attn_configs, linear_v)
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.fmha_impl = AiterPrefillAttnOp(attn_configs)
+        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpAsm(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         # Store input info
@@ -1669,8 +1640,6 @@ class AiterPrefillImplAsm(FMHAImplBase):
 class AiterPrefillImplNonAsm(FMHAImplBase):
     """Aiter prefill attention implementation using non-ASM."""
 
-    WRITER = FusedRopeKVCachePrefillOpNonAsm
-
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -1679,9 +1648,8 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
     ) -> None:
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
-        self.fmha_impl = AiterPrefillAttnOp(attn_configs, linear_v)
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.fmha_impl = AiterPrefillAttnOp(attn_configs, linear_v=True)
+        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpNonAsm(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         # Store input info
@@ -1732,16 +1700,9 @@ class AiterPrefillImplNonAsm(FMHAImplBase):
 class AiterPrefillImplPaged(FMHAImplBase):
     """Paged prefill impl: dispatches between CK batch-prefill and Triton PA at runtime.
 
-    - short query (see max_triton_q_len): Triton PA
+    - seq_len <= 4: Triton PA (short query optimization)
     - Otherwise: CK batch-prefill (general paged prefill)
-
-    The bound was a hardcoded 4, which sent the MTP verify forward (q_len =
-    gen_num_per_cycle + 1 = 5) down CK batch-prefill. At head_dim 256 that kernel only
-    exists with an M tile of 128, so 5 query rows cost a full tile: 1867 us per launch
-    against 180 us on the Triton path, 37.8% of GPU time in an MTP round.
     """
-
-    WRITER = FusedRopeKVCachePrefillOpAsm
 
     def __init__(
         self,
@@ -1753,19 +1714,13 @@ class AiterPrefillImplPaged(FMHAImplBase):
         self.head_num_kv = attn_configs.kv_head_num
         self.head_dim = attn_configs.size_per_head
         self.tokens_per_block = attn_configs.kernel_tokens_per_block
-
-        # pa_decode_gluon's documented constraint is query_length * query_group_size
-        # <= 64; it also asserts query_length <= 4, so relaxing this bound needs the
-        # matching aiter-side change.
-        kv_heads = max(1, attn_configs.kv_head_num)
-        query_group_size = max(1, attn_configs.head_num // kv_heads)
-        self.max_triton_q_len = max(1, 64 // query_group_size)
+        query_group_size = max(1, attn_configs.head_num // max(1, self.head_num_kv))
+        self.max_triton_q_len = min(4, 64 // query_group_size)
 
         self.batch_prefill_impl = AiterPrefillAttnOpPaged(attn_configs)
-        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
-        self.triton_prefill_impl = AiterPrefillAttnOpTriton(attn_configs, linear_v)
+        self.triton_prefill_impl = AiterPrefillAttnOpTriton(attn_configs)
 
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.rope_kvcache_impl = FusedRopeKVCachePrefillOpAsm(attn_configs)
         self.rope_kvcache_impl.use_paged_fmha = True
 
         self.attn_inputs = attn_inputs
@@ -1795,6 +1750,9 @@ class AiterPrefillImplPaged(FMHAImplBase):
 
     def _select_backend(self, attn_inputs: PyAttentionInputs) -> str:
         return "triton" if self._use_triton_paged_prefill(attn_inputs) else "batch"
+
+    def support_cuda_graph(self) -> bool:
+        return self.backend == "triton"
 
     def _prepare_backend(self, backend: str) -> FMHAParams:
         if backend == "triton":
@@ -1908,10 +1866,10 @@ class AiterPrefillImplPaged(FMHAImplBase):
                 "prefill_seqlen_k_int32 tensor"
             )
         prefill_seqlen_k.copy_(kv_lens, non_blocking=True)
-
         fmha_params.prefix_lengths = prefix_host.to(
             device=fmha_params.cu_seqlens_q.device
         )
+
         fmha_params.max_seq_len = (
             int(q_lens_host.max().item()) if expected_batch > 0 else 0
         )
@@ -1944,14 +1902,31 @@ class AiterPrefillImplPaged(FMHAImplBase):
                 f"replay={fmha_params.token_q_num}"
             )
 
+        graph_max_seqlen_k = getattr(fmha_params, "graph_max_seqlen_k", None)
+        if (
+            graph_max_seqlen_k is not None
+            and fmha_params.max_seqlen_k > graph_max_seqlen_k
+        ):
+            raise ValueError(
+                "Aiter prefill CUDA graph replay kv length exceeds capture "
+                f"capacity: capture={graph_max_seqlen_k}, replay={fmha_params.max_seqlen_k}"
+            )
+
         kv_block_id = getattr(attn_inputs, "kv_cache_kernel_block_id_device", None)
         if kv_block_id is None:
             kv_block_id = getattr(attn_inputs, "kv_cache_block_id_device", None)
         if kv_block_id is None:
+            raise ValueError("Aiter prefill CUDA graph replay requires block ids")
+        captured = fmha_params.kv_cache_block_id_device
+        if (
+            captured is None
+            or captured.shape != kv_block_id.shape
+            or captured.device != kv_block_id.device
+        ):
             raise ValueError(
-                "Aiter prefill CUDA graph replay requires kv cache block ids"
+                "Aiter prefill CUDA graph block-table shape/device changed; recapture required"
             )
-        fmha_params.kv_cache_block_id_device = kv_block_id
+        captured.copy_(kv_block_id, non_blocking=True)
 
     def prepare_cuda_graph(self, attn_inputs: PyAttentionInputs):
         self.attn_inputs = attn_inputs
@@ -1980,11 +1955,6 @@ class AiterPrefillImplPaged(FMHAImplBase):
         prepare_in_place = getattr(self.rope_params, "prepare_in_place", None)
         if callable(prepare_in_place):
             prepare_in_place(attn_inputs)
-        # CKAttn exposes only ``prepare_in_place`` to Python.  Do not mutate
-        # its internal replay-width fields here: doing so raises an
-        # AttributeError during graph capture.  The reader's fixed graph
-        # workspace and compact-index mapping are sufficient to preserve the
-        # captured dense width while returning only live tokens.
 
     def forward(
         self,
@@ -2050,8 +2020,6 @@ class AiterDecodeImplBase(FMHAImplBase):
 
 
 class AiterDecodeImplAsm(AiterDecodeImplBase):
-    WRITER = FusedRopeKVCacheDecodeOpAsm
-
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -2061,7 +2029,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
         self.fmha_impl = AiterDecodeAttnOpAsm(attn_configs)
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOpAsm(attn_configs)
 
         # Store input info
         self.attn_inputs = attn_inputs
@@ -2077,7 +2045,7 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
     ) -> bool:
         return (
             _is_mrope_interleaved_supported(attn_configs)
-            and attn_configs.size_per_head == ASM_DECODE_HEAD_SIZE
+            and attn_configs.size_per_head in ASM_DECODE_HEAD_SIZES
         )
 
     def forward(
@@ -2102,8 +2070,6 @@ class AiterDecodeImplAsm(AiterDecodeImplBase):
 
 
 class AiterDecodeImplNonAsm(AiterDecodeImplBase):
-    WRITER = FusedRopeKVCacheDecodeOpNonAsm
-
     def __init__(
         self,
         attn_configs: AttentionConfigs,
@@ -2113,7 +2079,7 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
         # Create implementations
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
         self.fmha_impl = AiterDecodeAttnOpNonAsm(attn_configs)
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.rope_kvcache_impl = FusedRopeKVCacheDecodeOpNonAsm(attn_configs)
 
         # Store input info
         self.attn_inputs = attn_inputs
@@ -2153,16 +2119,21 @@ class AiterDecodeImplNonAsm(AiterDecodeImplBase):
 class AiterDecodeImplTriton(AiterDecodeImplBase):
     """Aiter decode attention implementation using Triton."""
 
+    accepts_fmha_config = True
+
     def __init__(
         self,
         attn_configs: AttentionConfigs,
         attn_inputs: PyAttentionInputs,
         parallelism_config: Optional[ParallelismConfig] = None,
+        fmha_config: Optional[FMHAConfig] = None,
     ) -> None:
         self.need_rope_kv_cache = attn_configs.need_rope_kv_cache
-        linear_v = _writes_linear_v(self.WRITER, attn_configs.kv_cache_dtype)
+        linear_v = not prefill_writes_vectorized_v(attn_configs, fmha_config)
         self.fmha_impl = AiterDecodeAttnOpTriton(attn_configs, linear_v=linear_v)
-        self.rope_kvcache_impl = self.WRITER(attn_configs)
+        self.rope_kvcache_impl = (
+            FusedRopeKVCacheDecodeOpNonAsm if linear_v else FusedRopeKVCacheDecodeOpAsm
+        )(attn_configs)
 
         self.attn_inputs = attn_inputs
 
@@ -2192,11 +2163,3 @@ class AiterDecodeImplTriton(AiterDecodeImplBase):
         )
 
         return self.fmha_impl.forward(fmha_input, kv_cache, self.fmha_params)
-
-
-class AiterDecodeImplTritonLinear(AiterDecodeImplTriton):
-    WRITER = FusedRopeKVCacheDecodeOpNonAsm
-
-
-class AiterDecodeImplTritonVectorized(AiterDecodeImplTriton):
-    WRITER = FusedRopeKVCacheDecodeOpAsm

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_decode_triton_noasm.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_decode_triton_noasm.py
@@ -45,28 +45,29 @@ CONTEXT_LENGTH = 6359
 NUM_BLOCKS = math.ceil(CONTEXT_LENGTH / BLOCK_SIZE)
 
 
-def make_config() -> AttentionConfigs:
+def make_config(block_size: int = BLOCK_SIZE) -> AttentionConfigs:
     config = AttentionConfigs()
     config.head_num = HEAD_NUM
     config.kv_head_num = KV_HEAD_NUM
     config.size_per_head = HEAD_DIM
-    config.tokens_per_block = BLOCK_SIZE
-    config.kernel_tokens_per_block = BLOCK_SIZE
+    config.tokens_per_block = block_size
+    config.kernel_tokens_per_block = block_size
     config.max_seq_len = 40960
     config.kv_cache_dtype = KvCacheDataType.BASE
     config.dtype = torch.bfloat16
-    config.need_rope_kv_cache = False
+    config.need_rope_kv_cache = True
     return config
 
 
-def make_inputs(device: torch.device) -> PyAttentionInputs:
+def make_inputs(device: torch.device, block_size: int = BLOCK_SIZE):
     inputs = PyAttentionInputs()
     inputs.is_prefill = False
     inputs.is_cuda_graph = False
     # Decode sees full context after current token is inserted into KV cache.
     inputs.sequence_lengths = torch.tensor([CONTEXT_LENGTH - 1], dtype=torch.int32)
     inputs.input_lengths = torch.tensor([1], dtype=torch.int32)
-    block_table = torch.arange(NUM_BLOCKS, dtype=torch.int32, device=device).view(1, -1)
+    num_blocks = math.ceil(CONTEXT_LENGTH / block_size)
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device=device).view(1, -1)
     inputs.kv_cache_kernel_block_id_device = block_table
     inputs.kv_cache_kernel_block_id = block_table.cpu()
     inputs.kv_cache_block_id_device = block_table
@@ -201,25 +202,27 @@ class AiterDecodeLayoutParityTest(unittest.TestCase):
         self.assertGreater(mismatched_l2, 0.1, f"{mismatched_l2=:.6f}")
 
     def test_factory_pairs_reader_and_writer(self):
-        inputs = make_inputs(torch.device("cuda"))
-        for kv_dtype, use_asm_pa, expected_linear_v, expected_writer in (
-            (KvCacheDataType.BASE, False, True, FusedRopeKVCacheDecodeOpNonAsm),
-            (KvCacheDataType.BASE, True, False, FusedRopeKVCacheDecodeOpAsm),
-            (KvCacheDataType.FP8, False, False, FusedRopeKVCacheDecodeOpAsm),
-        ):
-            with self.subTest(kv_dtype=kv_dtype, use_asm_pa=use_asm_pa):
-                config = make_config()
+        cases = (
+            (KvCacheDataType.BASE, False, 16, True, FusedRopeKVCacheDecodeOpNonAsm),
+            (KvCacheDataType.BASE, True, 32, False, FusedRopeKVCacheDecodeOpAsm),
+            (KvCacheDataType.FP8, False, 16, False, FusedRopeKVCacheDecodeOpAsm),
+            (KvCacheDataType.FP8, False, 32, False, FusedRopeKVCacheDecodeOpAsm),
+        )
+        for kv_dtype, use_asm_pa, page, linear_v, writer in cases:
+            with self.subTest(kv_dtype=kv_dtype, page=page):
+                config = make_config(page)
                 config.kv_cache_dtype = kv_dtype
                 fmha_config = FMHAConfig()
                 fmha_config.use_aiter_pa = True
                 fmha_config.use_asm_pa = use_asm_pa
                 fmha_config.use_triton_pa = True
+                inputs = make_inputs(torch.device("cuda"), page)
                 impl = attn_factory.get_fmha_impl(
                     config, None, inputs, fmha_config=fmha_config
                 )
                 self.assertIsInstance(impl, AiterDecodeImplTriton)
-                self.assertEqual(impl.fmha_impl.linear_v, expected_linear_v)
-                self.assertIs(type(impl.rope_kvcache_impl), expected_writer)
+                self.assertIs(impl.fmha_impl.linear_v, linear_v)
+                self.assertIs(type(impl.rope_kvcache_impl), writer)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
+++ b/rtp_llm/models_py/modules/factory/attention/rocm_impl/test/test_aiter_prefill_op.py
@@ -695,7 +695,7 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
             max_seqlen_k=0,
             token_q_num=0,
             token_kv_num=0,
-            kv_cache_block_id_device=None,
+            kv_cache_block_id_device=torch.zeros(batch_size, 4, dtype=torch.int32),
             prefill_seqlen_k_int32=torch.zeros(batch_size, dtype=torch.int32),
         )
         stub = AiterPrefillImplPaged.__new__(AiterPrefillImplPaged)
@@ -824,18 +824,19 @@ class TestUpdatePrefillParamsForCudaGraph(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._call_update(stub, inputs)
 
-    def test_replay_query_length_above_capture_capacity_raises(self):
-        stub = self._make_stub(batch_size=2)
-        stub.fmha_params.graph_query_length = 4
-        stub.fmha_params.graph_token_q_capacity = 8
-        inputs = self._make_attn_inputs(
-            [5, 0], prefix_lengths=torch.tensor([100, 100], dtype=torch.int32)
-        )
-
-        with self.assertRaisesRegex(
-            ValueError, "query length exceeds capture capacity"
+    def test_replay_capacity_raises(self):
+        for attr, capacity, lengths, prefix, error in (
+            ("graph_query_length", 4, [5, 0], [100, 100], "query length"),
+            ("graph_token_q_capacity", 8, [5, 5], [0, 0], "token count"),
+            ("graph_max_seqlen_k", 512, [1, 0], [600, 0], "kv length"),
         ):
-            self._call_update(stub, inputs)
+            stub = self._make_stub(2)
+            setattr(stub.fmha_params, attr, capacity)
+            inputs = self._make_attn_inputs(
+                lengths, prefix_lengths=torch.tensor(prefix, dtype=torch.int32)
+            )
+            with self.assertRaisesRegex(ValueError, f"{error} exceeds capture"):
+                self._call_update(stub, inputs)
 
 
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillImplPaged module")
@@ -865,6 +866,7 @@ class TestAiterPrefillImplPagedCudaGraphDispatch(unittest.TestCase):
 
         cfg = SimpleNamespace(
             need_rope_kv_cache=need_rope_kv_cache,
+            head_num=8,
             kv_head_num=1,
             size_per_head=8,
             kernel_tokens_per_block=16,
@@ -894,30 +896,20 @@ class TestAiterPrefillImplPagedCudaGraphDispatch(unittest.TestCase):
             observed_pad_query,
         )
 
-    def test_cuda_graph_prepares_only_selected_backend_workspace(self):
-        cases = [([4, 1], "triton"), ([5, 1], "batch")]
-        for input_lengths, expected_backend in cases:
+    def test_cuda_graph_supports_only_triton_backend(self):
+        for input_lengths, expected_backend in (([4, 1], "triton"), ([5, 1], "batch")):
             with self.subTest(expected_backend=expected_backend):
-                (
-                    impl,
-                    batch_impl,
-                    triton_impl,
-                    batch_params,
-                    triton_params,
-                    _,
-                ) = self._make_impl_with_mocked_prepare(input_lengths, True)
-
+                impl, batch_impl, triton_impl, *_ = self._make_impl_with_mocked_prepare(
+                    input_lengths, True
+                )
                 self.assertEqual(impl.backend, expected_backend)
-                if expected_backend == "triton":
-                    triton_impl.prepare.assert_called_once_with(impl.attn_inputs)
-                    batch_impl.prepare.assert_not_called()
-                    self.assertIs(impl.triton_fmha_params, triton_params)
-                    self.assertIsNone(impl.fmha_params)
-                else:
-                    batch_impl.prepare.assert_called_once_with(impl.attn_inputs)
-                    triton_impl.prepare.assert_not_called()
-                    self.assertIs(impl.fmha_params, batch_params)
-                    self.assertIsNone(impl.triton_fmha_params)
+                self.assertEqual(
+                    impl.support_cuda_graph(), expected_backend == "triton"
+                )
+                selected = triton_impl if expected_backend == "triton" else batch_impl
+                rejected = batch_impl if expected_backend == "triton" else triton_impl
+                selected.prepare.assert_called_once_with(impl.attn_inputs)
+                rejected.prepare.assert_not_called()
 
     def test_eager_prepares_only_selected_backend_during_construction(self):
         impl, batch_impl, triton_impl, _, triton_params, _ = (
@@ -1134,8 +1126,28 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
         self.assertEqual(fmha_params.compact_indices.shape, (8,))
         self.assertEqual(fmha_params.graph_query_length, 4)
         self.assertEqual(fmha_params.graph_token_q_capacity, 8)
+        self.assertEqual(fmha_params.graph_max_seqlen_k, 256)
         self.assertFalse(hasattr(fmha_params, "kv_scale"))
         self.assertFalse(hasattr(op, "_graph_output"))
+
+    def test_paged_graph_block_table_buffer_keeps_capture_address(self):
+        from types import SimpleNamespace
+
+        op = AiterPrefillAttnOpPaged(_make_attn_configs(4, 2, 8))
+        params = SimpleNamespace(
+            cu_seqlens_q=torch.zeros(3, dtype=torch.int32),
+            cu_seqlens_k=torch.zeros(3, dtype=torch.int32),
+            kv_cache_block_id_device=torch.zeros(2, 2, dtype=torch.int32),
+        )
+        infer_device = f"{AiterPrefillAttnOpPaged.__module__}._infer_cuda_graph_device"
+        with patch(infer_device, return_value=torch.device("cpu")):
+            op.prepare_cuda_graph(params, SimpleNamespace())
+            captured = op.sanitized_bt_buf
+            op.prepare_cuda_graph(params, SimpleNamespace())
+            self.assertIs(op.sanitized_bt_buf, captured)
+            params.kv_cache_block_id_device = torch.zeros(2, 3, dtype=torch.int32)
+            with self.assertRaisesRegex(ValueError, "recapture required"):
+                op.prepare_cuda_graph(params, SimpleNamespace())
 
     def test_forward_uses_prepared_graph_workspace_without_allocation(self):
         from types import SimpleNamespace
@@ -1196,6 +1208,7 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
         cfg = _make_attn_configs(head_num=4, head_num_kv=2, head_dim=8)
         op = AiterPrefillAttnOpTriton(cfg)
         device = torch.device("cuda")
+        captured_block_ids = torch.full((3, 2), -1, dtype=torch.int32, device=device)
         fmha_params = SimpleNamespace(
             cu_seqlens_q=torch.zeros(4, dtype=torch.int32, device=device),
             cu_seqlens_k=torch.zeros(4, dtype=torch.int32, device=device),
@@ -1203,6 +1216,7 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
                 (3,), -1, dtype=torch.int32, device=device
             ),
             compact_indices=torch.full((6,), -1, dtype=torch.int32, device=device),
+            kv_cache_block_id_device=captured_block_ids,
             graph_device=device,
             token_q_num=6,
             max_seqlen_q=2,
@@ -1230,9 +1244,8 @@ class TestAiterPrefillAttnOpTritonCudaGraphWorkspace(unittest.TestCase):
         self.assertEqual(fmha_params.max_seqlen_k, 7)
         self.assertEqual(fmha_params.token_q_num, 3)
         self.assertEqual(fmha_params.token_kv_num, 21)
-        self.assertEqual(
-            fmha_params.kv_cache_block_id_device.data_ptr(), block_ids.data_ptr()
-        )
+        self.assertIs(fmha_params.kv_cache_block_id_device, captured_block_ids)
+        torch.testing.assert_close(captured_block_ids, block_ids)
         self.assertEqual(fmha_params.compact_indices.cpu().tolist(), [0, 1, 3, 0, 0, 0])
 
     def test_triton_paged_attention_requires_caller_scale_when_kv_scale_base_exists(
@@ -1478,6 +1491,10 @@ class TestAiterPrefillTritonCudaGraphNumerics(unittest.TestCase):
                 ):
                     self._run_replay_case(kv_cache_dtype, replay_lengths)
 
+    def test_fp8_page32_writer_reader(self):
+        self.TOKENS_PER_BLOCK = 32
+        self._run_replay_case(KvCacheDataType.FP8, self.REPLAY_LENGTH_CASES[0])
+
 
 @unittest.skipUnless(_OPS_IMPORTABLE, "Requires AiterPrefillAttnOp module")
 class TestCompactGatherReshape(unittest.TestCase):
@@ -1509,7 +1526,7 @@ class TestCompactGatherReshape(unittest.TestCase):
         )
         if kv_cache_dtype is not None:
             cfg.kv_cache_dtype = kv_cache_dtype
-        return AiterPrefillAttnOp(cfg, v1_kv_layout=True)
+        return AiterPrefillAttnOp(cfg, linear_v=True)
 
     def _make_kv_cache_5d(self, num_blocks, hk, ps, hd, dtype=torch.float16):
         """Create a 5D KV cache: [num_blocks, 2, hk, ps, hd]."""
@@ -1560,16 +1577,15 @@ class TestCompactGatherReshape(unittest.TestCase):
         # for CK speculative prefetch safety (no dedup since torch.unique removed).
         self.assertEqual(k_compact.shape[0], orig_indices.numel() + 1)
 
-    def test_kv_cache_dtype_controls_compact_mode(self):
-        cases = [
-            (KvCacheDataType.BASE, torch.float16, True),
-            (KvCacheDataType.FP8, torch.float8_e4m3fn, False),
-        ]
-        for kv_cache_dtype, expected_torch_dtype, expected_use_compact in cases:
+    def test_kv_cache_dtype_preserves_linear_contract(self):
+        for kv_cache_dtype, expected_torch_dtype in (
+            (KvCacheDataType.BASE, torch.float16),
+            (KvCacheDataType.FP8, torch.float8_e4m3fn),
+        ):
             with self.subTest(kv_cache_dtype=kv_cache_dtype):
                 op = self._make_op(kv_cache_dtype=kv_cache_dtype)
                 self.assertEqual(op.kv_cache_torch_dtype, expected_torch_dtype)
-                self.assertEqual(op.use_compact, expected_use_compact)
+                self.assertTrue(op.linear_v)
 
     # ---- 5D cache path ----------------------------------------------------
 
@@ -1590,18 +1606,7 @@ class TestCompactGatherReshape(unittest.TestCase):
         op = self._make_op()
         kv = self._make_kv_cache_5d(16, 4, 16, 128)
         bt = torch.tensor([[0, 0, 1], [0, 2, 2]], dtype=torch.int32)
-        block_indices, compact_bt, k_buf, v_buf = self._make_compact_bufs(
-            bt, 4, 16, 128
-        )
-        k_compact, v_compact = op._gather_and_reshape_kv_compact(
-            kv, block_indices, k_buf, v_buf
-        )
-        k_full, _ = op._reshape_kv_cache_vectorized(kv)
-        orig_indices = bt.reshape(-1).to(torch.int64)
-        torch.testing.assert_close(
-            k_compact[compact_bt.reshape(-1).to(torch.int64)], k_full[orig_indices]
-        )
-        self.assertEqual(k_compact.shape[0], bt.numel() + 1)
+        self._assert_compact_equiv(op, kv, bt)
 
     def test_5d_non_contiguous_blocks(self):
         """Block indices are sparse across a large pool."""
@@ -1628,18 +1633,7 @@ class TestCompactGatherReshape(unittest.TestCase):
         op = self._make_op()
         kv = self._make_kv_cache_2d(16, 4, 16, 128)
         bt = torch.tensor([[0, 0, 1], [0, 2, 2]], dtype=torch.int32)
-        block_indices, compact_bt, k_buf, v_buf = self._make_compact_bufs(
-            bt, 4, 16, 128
-        )
-        k_compact, v_compact = op._gather_and_reshape_kv_compact(
-            kv, block_indices, k_buf, v_buf
-        )
-        k_full, _ = op._reshape_kv_cache_vectorized(kv)
-        orig_indices = bt.reshape(-1).to(torch.int64)
-        torch.testing.assert_close(
-            k_compact[compact_bt.reshape(-1).to(torch.int64)], k_full[orig_indices]
-        )
-        self.assertEqual(k_compact.shape[0], bt.numel() + 1)
+        self._assert_compact_equiv(op, kv, bt)
 
     def test_2d_oversized_stride_truncates_to_prefix(self):
         op = self._make_op()
@@ -1716,7 +1710,7 @@ class TestCompactGatherReshape(unittest.TestCase):
         ):
             op._forward_paged(q, kv_cache, fmha_params)
 
-        self.assertFalse(op.use_compact)
+        self.assertTrue(op.linear_v)
         self.assertEqual(full_reshape.call_count, 1)
 
     # ---- block table sanitization ------------------------------------------
@@ -2658,7 +2652,7 @@ class TestAiterPrefillImplMropePositionIds(unittest.TestCase):
         self._check_mrope_matches_reference(AiterPrefillImplNonAsm)
 
 
-@unittest.skipUnless(_is_rocm() and _OPS_IMPORTABLE, "Requires ROCm attention wrappers")
+@unittest.skipUnless(_OPS_IMPORTABLE, "Requires ROCm attention wrappers")
 class TestVLayoutContract(unittest.TestCase):
     def _make_case(self, head_dim: int, page: int):
         config = _make_attn_configs(8, 2, head_dim, page)
@@ -2666,6 +2660,8 @@ class TestVLayoutContract(unittest.TestCase):
         config.dtype = torch.bfloat16
         inputs = PyAttentionInputs()
         inputs.is_prefill = True
+        inputs.prefix_lengths = torch.ones(1, dtype=torch.int32)
+        inputs.kv_cache_kernel_block_id = torch.ones(1, 1, dtype=torch.int32)
         return config, inputs
 
     def _decode_flags(self, aiter: bool, asm: bool, triton: bool):
@@ -2673,63 +2669,63 @@ class TestVLayoutContract(unittest.TestCase):
         flags.use_aiter_pa, flags.use_asm_pa, flags.use_triton_pa = aiter, asm, triton
         return flags
 
-    def test_invalid_geometry(self):
-        for head, page, dtype, error in (
-            (100, 32, KvCacheDataType.BASE, "V geometry"),
-            (128, 8, KvCacheDataType.FP8, "width=16"),
-            (128, 12, KvCacheDataType.BASE, "V geometry"),
+    def test_backend_flag_layout_contract(self):
+        for head, page, dtype, flags, error in (
+            (100, 32, KvCacheDataType.BASE, FMHAConfig(), "invalid V geometry"),
+            (128, 8, KvCacheDataType.FP8, FMHAConfig(), "invalid V geometry"),
+            (
+                128,
+                16,
+                KvCacheDataType.BASE,
+                self._decode_flags(False, False, False),
+                "every ROCm",
+            ),
+            (
+                256,
+                32,
+                KvCacheDataType.BASE,
+                self._decode_flags(True, True, False),
+                "layout mismatch",
+            ),
         ):
+            config, inputs = self._make_case(head, page)
+            inputs.is_prefill = False
+            config.kv_cache_dtype = dtype
             with self.subTest(head=head, page=page, dtype=dtype):
-                config, inputs = self._make_case(head, page)
-                config.kv_cache_dtype = dtype
                 with self.assertRaisesRegex(ValueError, error):
-                    validate_v_layout(config, inputs, FMHAConfig())
+                    validate_v_layout(config, inputs, flags)
 
-    def test_factory_rejects_layout_mismatch(self):
-        config, inputs = self._make_case(256, 16)
+        config, inputs = self._make_case(256, 32)
         inputs.is_prefill = False
-        flags = self._decode_flags(aiter=True, asm=True, triton=False)
-        with self.assertRaisesRegex(ValueError, "layout mismatch"):
-            attn_factory.get_fmha_impl(config, None, inputs, fmha_config=flags)
-
-    def test_layout_mismatch_accepted_when_page_equals_width(self):
-        config, inputs = self._make_case(256, 8)
-        inputs.is_prefill = False
-        validate_v_layout(
-            config, inputs, self._decode_flags(aiter=False, asm=True, triton=False)
+        config.kv_cache_dtype = KvCacheDataType.FP8
+        self.assertTrue(
+            validate_v_layout(config, inputs, self._decode_flags(True, False, True))
         )
 
-    def test_fp8_no_asm_requires_page_equals_width(self):
-        config, inputs = self._make_case(128, 32)
-        config.kv_cache_dtype, inputs.is_prefill = KvCacheDataType.FP8, False
-        flags = self._decode_flags(aiter=True, asm=False, triton=False)
-        with self.assertRaisesRegex(ValueError, "layout mismatch"):
-            validate_v_layout(config, inputs, flags)
-        config.kernel_tokens_per_block = 16
-        validate_v_layout(config, inputs, flags)
-
-    def test_constructor_fallback_is_strict_only_with_layout_validator(self):
+    def test_constructor_failure_fallback_respects_fatal_device_faults(self):
         class BrokenImpl:
             accepts_fmha_config = False
+            error = torch.cuda.OutOfMemoryError("out of memory")
             support = support_parallelism_config = staticmethod(lambda *_: True)
 
             def __init__(self, *_):
-                raise RuntimeError("constructor failed")
+                raise type(self).error
 
         class WorkingImpl(BrokenImpl):
             def __init__(self, *_):
                 pass
 
-        _, inputs = self._make_case(128, 16)
+        config, inputs = self._make_case(128, 16)
+        config.need_rope_kv_cache = False
         inputs.is_prefill = False
         with patch.object(attn_factory, "DECODE_MHA_IMPS", [BrokenImpl, WorkingImpl]):
-            with patch.object(attn_factory, "VALIDATE_FMHA_CONFIG", None):
-                with self.assertLogs(level="WARNING"):
-                    impl = attn_factory.get_fmha_impl(AttentionConfigs(), None, inputs)
-                self.assertIsInstance(impl, WorkingImpl)
-            with patch.object(attn_factory, "VALIDATE_FMHA_CONFIG", lambda *_: True):
-                with self.assertRaisesRegex(RuntimeError, "constructor failed"):
-                    attn_factory.get_fmha_impl(AttentionConfigs(), None, inputs)
+            with self.assertLogs(level="WARNING"):
+                impl = attn_factory.get_fmha_impl(config, None, inputs)
+            self.assertIsInstance(impl, WorkingImpl)
+
+            BrokenImpl.error = RuntimeError("HIP error: illegal memory access")
+            with self.assertRaisesRegex(RuntimeError, "illegal memory access"):
+                attn_factory.get_fmha_impl(config, None, inputs)
 
 
 if __name__ == "__main__":

--- a/rtp_llm/models_py/triton_kernels/common/layernorm_gated.py
+++ b/rtp_llm/models_py/triton_kernels/common/layernorm_gated.py
@@ -32,6 +32,7 @@ def _layer_norm_fwd_1pass_kernel(
     BLOCK_N: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     HAS_Z: tl.constexpr,
+    SHARED_WEIGHT: tl.constexpr,
     NORM_BEFORE_GATE: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
     ACTIVATION: tl.constexpr,
@@ -46,9 +47,10 @@ def _layer_norm_fwd_1pass_kernel(
     if not IS_RMS_NORM:
         Mean += group * M
     Rstd += group * M
-    W += group * N
-    if HAS_BIAS:
-        B += group * N
+    if not SHARED_WEIGHT:
+        W += group * N
+        if HAS_BIAS:
+            B += group * N
     # Compute mean and variance
     cols = tl.arange(0, BLOCK_N)
     x = tl.load(X + cols, mask=cols < N, other=0.0).to(tl.float32)
@@ -106,11 +108,12 @@ def layer_norm_fwd(
     if z is not None:
         assert z.stride(-1) == 1
         assert z.shape == (M, N)
-    assert weight.shape == (N,)
+    shared_weight = weight.shape == (group_size,)
+    assert shared_weight or weight.shape == (N,)
     assert weight.stride(-1) == 1
     if bias is not None:
         assert bias.stride(-1) == 1
-        assert bias.shape == (N,)
+        assert bias.shape == weight.shape
     # allocate output
     if out is not None:
         assert out.shape == x.shape
@@ -147,6 +150,7 @@ def layer_norm_fwd(
             group_size,
             eps,
             BLOCK_N=BLOCK_N,
+            SHARED_WEIGHT=shared_weight,
             NORM_BEFORE_GATE=norm_before_gate,
             IS_RMS_NORM=is_rms_norm,
             ACTIVATION=activation,
@@ -187,8 +191,9 @@ class RmsNormGated(torch.nn.Module):
 
     def forward(self, x: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
         assert (
-            x.shape[-1] == self.weight.shape[-1]
-        ), "Input dimension must be equal to weight dimension, input_shape: {}, weight_shape: {}".format(
+            self.weight.shape[-1] == self.group_size
+            or x.shape[-1] == self.weight.shape[-1]
+        ), "Weight must match input or group size, input_shape: {}, weight_shape: {}".format(
             x.shape, self.weight.shape
         )
 


### PR DESCRIPTION
## 性能结论

本 PR 面向 MI308X（ROCm/gfx942）上的 Qwen3.5 TP4/MTP/HIP Graph decode 链路。

### TPOT 阶段性对比

MI308X（gfx942）/ROCm、Qwen3.5-122B-A10B BF16、TP4/EP1/DP1、MTP propose 深度 3、HIP Graph 与异步 decode 同开；workload 为 `input=1`、`output=2048`、`concurrency=8`、`requests=32`，实际 `gen_batch=8`。其中 `9.06 → 7.827 ms` 的两臂均为 32/32 请求完整输出 2048 tokens；`39.45 ms` 是更早修复阶段在同一 b8 工作点记录的 TPOT，仅用于说明组合链路恢复，不并入固定长度吞吐或 E2E A/B。最终 `7.827 ms` 配置还启用了 `USE_SWIZZLEA=1`，因此该阶段收益是代码优化与该配置项的合计。以上数据不与后文不同 harness 的并发矩阵直接横向比较。

| 阶段 | TPOT p50 | 相对上一阶段 | 相对修复前 |
| --- | ---: | ---: | ---: |
| Graph + Async 同开，修复前 | 39.45 ms | — | — |
| 修复异步状态与 Graph 边界后 | 9.06 ms | **−77.0%** | **−77.0%** |
| 最终提交固定长度复测 | 7.827 ms | +4.9%（相对历史 A/B） | **−80.2%** |

最终提交 `541d75e2f6` 的 profiler-off 结果为：TTFT p50/p95/p99 `3246 / 7582 / 8262 ms`，TPOT p50/p95/p99 `7.827 / 10.891 / 12.799 ms`，round p50 `22.745 ms`，tokens/round p50 `2.966`，32/32 请求均完整输出 2048 tokens。Graph 与 Async 组合链路相对最早 39.45 ms 已恢复约 **5.04×**。

Perfetto 中，AllReduce 启动偏差最大值从 **321.525 μs** 降至 **24.295 μs**，超过 100 μs 的样本从 **13/392** 降至 **0/392**，说明跨 rank 到达错位已显著收敛。

### Decode burst 对比（自然 EOS）

| 场景 | TPOT p50 新 | TPOT p50 旧 | 变化 |
| --- | ---: | ---: | ---: |
| concurrency=16 | 9.590 ms | 11.745 ms | **−18.3%** |
| concurrency=32 | 14.971 ms | 19.784 ms | **−24.3%** |

### 在线持续投压对比（固定输出 512 tokens）

| 场景 | 新 | 旧 | 变化 |
| --- | ---: | ---: | ---: |
| TPOT p50，concurrency=256 | 6.860 ms | 8.219 ms | **−16.5%** |
| Output throughput | 691.9 tok/s | 590.3 tok/s | **+17.2%** |
| Decode segment | 3.51 s | 4.21 s | **−16.6%** |

该场景中 prefill segment 为 **1.00 s → 0.93 s**，主要收益来自 decode 侧。

> **数据边界：**decode burst 的旧 harness 存在自然 EOS，因此只用于 TPOT、round latency 与 timeline 调度对比，不用于声明固定 2048-token 吞吐、TTFT 或 E2E 收益。在线持续投压使用固定 512-token 输出，是另一套测试口径。Prefill/TTFT 不是本 PR 的主要优化目标，现有 TTFT 数据仅证明当前版本可运行。

## 背景与目标

Qwen3.5-122B-A10B 在 MI308X 上同时启用 TP4、MTP、HIP Graph 和异步 decode 后，出现首轮状态滞后、Graph capture/replay 边界不完整、KV Cache V-layout 不匹配及跨 rank 调度错位等问题。这些问题会导致首轮 MTP decode 失败、HIP illegal memory access、Graph 路径不稳定，或使 TPOT 从正常水平回退至 39.45 ms。

本 PR 修复上述组合链路，并继续优化 pure-TP 通信、MoE、采样和 PagedAttention 热路径。目前 decode concurrency 4～256 已完成验证；concurrency=512 的 MTP draft warm-up 问题仍保留为已知边界。

## 问题与定位

### 1. MTP 异步状态与 Graph 边界不一致

Graph 与异步 decode 同开时，`StreamGroups` 快照可能早于上一轮 bookkeeping 和 KV swap 完成，导致首轮 MTP 使用滞后的 `seqLength/maxSeqLen`。部分临时缓冲和 KV Cache 写入路径也不满足 graph capture/replay 的地址与布局约束，可能触发 verify history 尺寸错误、graph replay 不稳定或 HIP illegal memory access。

### 2. Draft prepare 优先级放大跨 rank 偏差

Perfetto 显示，高优先级 draft prepare 流会抢占关键通信与计算，使不同 rank 到达 AllReduce 的时间错位。Graph replay 下，这类 rank skew 会转化为 collective 等待并显著拉高 TPOT。

### 3. Pure-TP 通信与 decode 热路径存在冗余

Qwen3.5-122B-A10B 的 `hidden_size=3072` 此前未覆盖 TRT-LLM IPC AllReduce 优化路径；Dense GEMM、shared-expert gate、RMSNorm/router、top-1 sampling、MTP 深度和 PagedAttention 等 decode 热路径也存在额外开销。

## 主要改动

### 1. 修复 MTP 异步状态与 HIP Graph capture/replay

- 在创建 `StreamGroups` 快照前等待上一轮 bookkeeping 和 KV swap 完成，用于确保已接受 token 写回序列状态。
- 区分 eager 与 graph capture 所需的临时缓冲，避免 scratch 地址复用破坏 graph。
- 修正 MTP verify、采样与 KV Cache 写入在 capture/replay 边界上的状态和尺寸约束。
- 补齐 ROCm fused RoPE + KV Cache 写入，并按 reader、cache dtype 和 backend 选择匹配的 V-layout。
- 修正 fused RoPE/KV 写入中输入长度的索引维度，消除潜在的 reader/writer 布局不一致。

### 2. 降低跨 rank 调度偏差

- 将 draft prepare 从高优先级流调整为普通优先级异步流。
- 保留计算与通信 overlap，同时减少对关键 collective 的抢占。

### 3. 接入 hidden size 3072 的 TRT-LLM IPC AllReduce

- 为 `hidden_size=3072` 增加 **pure AllReduce** kernel 实例化；fused AllReduce + residual + RMSNorm 仍只开放已验证的 hidden size。
- 抽取 one/two-stage 统一选路函数，确保 kernel launcher 与 graph direct-input 路径使用同一套 64-token、TP4 160 KiB、TP8 80 KiB 边界。
- pure 3072 覆盖 TP2/TP4、one/two-stage 和动态 graph replay；supported fused RMSNorm 另覆盖 one/two-stage、BF16/FP8、输入不变性以及 residual/norm/scale。
- 该选路仅影响 `hidden_size=3072` 且 `TP > 1` 的 pure AllReduce；其他 hidden size 与 TP1 保持原路径。

### 4. 优化 decode 热路径

- 调优 Dense GEMM 与 Triton PagedAttention 路径。
- 融合 shared-expert gate，精简 RMSNorm/router 路径。
- 对确定性 top-1 proposal 跳过完整 softmax/renorm，直接构造点质量分布。
- 复用 ROCm AITER top-k scratch，减少 eager 路径临时分配；graph capture 使用独立 scratch。
- 调整 MTP 深度，减少单轮 verify 的额外计算与 PagedAttention 开销。
- 修正 padded vocabulary 下 `all_probs` 与 `cum_log_probs` 的宽度和索引关系。