### PR TITLE
fix: keep Qwen3.5 linear-attention BA unswizzled

### DIFF
--- a/rtp_llm/device/device_impl.py
+++ b/rtp_llm/device/device_impl.py
@@ -12,7 +12,7 @@ from rtp_llm.ops.compute_ops import (
     preprocess_weight_scale,
 )
 from rtp_llm.utils.model_weight import W
-from rtp_llm.utils.swizzle_utils import swizzle_tensor
+from rtp_llm.utils.swizzle_utils import should_swizzle_linear_attn_ba, swizzle_tensor
 
 
 def is_gfx950(arch_fallback: Optional[str] = None) -> bool:
@@ -954,7 +954,14 @@ class RocmImpl(GpuImpl):
             W.linear_attn_ba_w,
             W.linear_attn_out_w,
         ]:
-            if self.py_env_configs.py_hw_kernel_config.use_swizzleA:
+            use_swizzle = self.py_env_configs.py_hw_kernel_config.use_swizzleA
+            if key == W.linear_attn_ba_w:
+                # BA remains BF16 even when qkvz is quantized. Select its
+                # physical layout from the actual TP-local shape so aligned
+                # projections keep the fast path while N=24/12 safely fall
+                # back to the raw layout.
+                use_swizzle = use_swizzle and should_swizzle_linear_attn_ba(weight)
+            if use_swizzle:
                 if weight.dtype != torch.float8_e4m3fn:
                     weight = swizzle_tensor(weight.t(), False).t()
                 else:

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from functools import lru_cache
 from typing import Any, Dict, Optional
 
 import torch
@@ -63,7 +64,26 @@ from rtp_llm.ops.compute_ops import (
     PyModelOutputs,
 )
 from rtp_llm.utils.model_weight import W
+from rtp_llm.utils.swizzle_utils import (
+    can_fuse_swizzled_kn,
+    should_swizzle_linear_attn_ba,
+)
 from rtp_llm.utils.util import to_torch_dtype
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=None)
+def _warn_qkvz_ba_swizzle_fallback(
+    qkvz_shape: tuple[int, ...], ba_shape: tuple[int, ...]
+) -> None:
+    logger.warning(
+        "Disabling Qwen3Next qkvz+ba fusion because ROCm swizzle cannot safely "
+        "combine qkvz shape %s with ba shape %s; using separate swizzled qkvz "
+        "and unswizzled ba GEMMs",
+        qkvz_shape,
+        ba_shape,
+    )
 
 
 class Qwen3NextMetadata(object):
@@ -616,15 +636,25 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # Saves a small kernel launch on each forward; on decode (M=1) HBM-access
         # merging shaves a few us per layer (trace measurement: -0.094 ms/step
         # on Qwen3.5-9B TP=2 in the original session).
-        # FP8/quantized: qkvz has scales but ba doesn't, dtypes mismatch -> fall
-        # back to the original 2-GEMM path.
-        self._qkvz_ba_fused = weights.get(W.linear_attn_qkvz_s) is None
+        # Fall back to two GEMMs when qkvz is quantized, or when ROCm swizzle
+        # cannot represent both source weights and their fused output layout.
+        qkvz_w = weights[W.linear_attn_qkvz_w]
+        ba_w = weights[W.linear_attn_ba_w]
+        qkvz_is_bf16 = weights.get(W.linear_attn_qkvz_s) is None
+        _is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
+        rocm_swizzle_enabled = (
+            _is_rocm and hw_kernel_config is not None and hw_kernel_config.use_swizzleA
+        )
+        rocm_fused_layout_safe = not rocm_swizzle_enabled or can_fuse_swizzled_kn(
+            qkvz_w, ba_w
+        )
+        self._qkvz_ba_fused = qkvz_is_bf16 and rocm_fused_layout_safe
+        if qkvz_is_bf16 and rocm_swizzle_enabled and not rocm_fused_layout_safe:
+            _warn_qkvz_ba_swizzle_fallback(tuple(qkvz_w.shape), tuple(ba_w.shape))
+
         if self._qkvz_ba_fused:
-            qkvz_w = weights[W.linear_attn_qkvz_w]
-            ba_w = weights[W.linear_attn_ba_w]
             self._qkvz_size = qkvz_w.shape[1]
             self._ba_size = ba_w.shape[1]
-            _is_rocm = hasattr(torch.version, "hip") and torch.version.hip is not None
             if _is_rocm:
                 # ROCm: cat in [N, K] space then .t() to preserve column-major
                 # physical layout that hipb_mm / swizzle kernels expect.
@@ -657,13 +687,19 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 quant_config,
                 hw_kernel_config=hw_kernel_config,
             )
+            # BA stays BF16 when qkvz is quantized. Keep runtime dispatch paired
+            # with the loader's shape-based layout decision: aligned TP-local
+            # BA uses WithSwizzle; unaligned BA uses NoSwizzle.
+            ba_hw_kernel_config = hw_kernel_config
+            if rocm_swizzle_enabled and not should_swizzle_linear_attn_ba(ba_w):
+                ba_hw_kernel_config = None
             self.in_proj_ba = LinearFactory.create_linear_from_weights(
                 weights,
                 W.linear_attn_ba_w,
                 None,
                 None,
                 quant_config,
-                hw_kernel_config=hw_kernel_config,
+                hw_kernel_config=ba_hw_kernel_config,
             )
             self.in_proj_fused = None
 

--- a/rtp_llm/models_py/model_desc/test/BUILD
+++ b/rtp_llm/models_py/model_desc/test/BUILD
@@ -48,3 +48,15 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "qwen3_next_qkvz_ba_fusion_test_rocm",
+    srcs = ["qwen3_next_qkvz_ba_fusion_test.py"],
+    main = "qwen3_next_qkvz_ba_fusion_test.py",
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["rocm"],
+    exec_properties = {'gpu': 'MI308X-ROCM7', 'gpu_count': '1'},
+)

--- a/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
+++ b/rtp_llm/models_py/model_desc/test/qwen3_next_qkvz_ba_fusion_test.py
@@ -4,10 +4,11 @@ The fusion concatenates the in_proj_qkvz and in_proj_ba weights along the
 output dim and runs a single GEMM, then slices the output to recover the
 two original projections. This must be:
   (1) numerically equivalent to running the two GEMMs separately, and
-  (2) bypassed when linear_attn_qkvz_s is present (FP8 path).
+  (2) bypassed for FP8 qkvz or a ROCm swizzle-incompatible fused layout.
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -22,6 +23,37 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
         self.device = torch.device("cuda:0")
         torch.manual_seed(0)
         torch.cuda.manual_seed(0)
+
+    def test_rocm_ba_loader_rewrite_follows_local_shape(self) -> None:
+        from rtp_llm.device.device_impl import RocmImpl
+        from rtp_llm.utils.model_weight import W
+        from rtp_llm.utils.swizzle_utils import swizzle_tensor
+
+        fake_impl = SimpleNamespace(
+            _is_gfx950=lambda: False,
+            py_env_configs=SimpleNamespace(
+                py_hw_kernel_config=SimpleNamespace(use_swizzleA=True)
+            ),
+        )
+        aligned_ba = torch.randn(2048, 16, dtype=torch.bfloat16, device=self.device)
+        expected_aligned = swizzle_tensor(aligned_ba.t(), False).t()
+
+        rewritten_aligned = RocmImpl.maybe_rewrite_weight_by_key(
+            fake_impl,
+            W.linear_attn_ba_w,
+            aligned_ba,
+        )
+        self.assertTrue(torch.equal(rewritten_aligned, expected_aligned))
+
+        unaligned_ba = torch.randn(5120, 24, dtype=torch.bfloat16, device=self.device)
+        unaligned_before = unaligned_ba.clone()
+        rewritten_unaligned = RocmImpl.maybe_rewrite_weight_by_key(
+            fake_impl,
+            W.linear_attn_ba_w,
+            unaligned_ba,
+        )
+        self.assertIs(rewritten_unaligned, unaligned_ba)
+        self.assertTrue(torch.equal(rewritten_unaligned, unaligned_before))
 
     # ---- (1) low-level math equivalence ----
 
@@ -59,18 +91,22 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
 
     # ---- (2) Qwen3NextGatedDeltaNet end-to-end ----
 
-    def _build_module(self, weights_extra=None):
+    def _build_module(self, weights_extra=None, hw_kernel_config=None, num_v_heads=4):
         """Construct a small Qwen3NextGatedDeltaNet with random weights.
 
         Mirrors the setup pattern in
         rtp_llm/models_py/modules/factory/attention/cuda_cp_impl/test/test_cp_linear_attn.py
         but at the smallest legal sizes so the test runs fast.
+
+        num_v_heads controls the BA out-dim (= 2 * num_v_heads): 4 -> 8
+        (not 16-aligned), 8 -> 16 (aligned). hw_kernel_config is forwarded to
+        the module so the in_proj_ba swizzle/NoSwizzle decision can be observed.
         """
         from rtp_llm.models_py.model_desc.qwen3_next import Qwen3NextGatedDeltaNet
         from rtp_llm.ops import DataType, LinearAttentionConfig, ParallelismConfig
         from rtp_llm.utils.model_weight import W
 
-        num_k_heads, num_v_heads = 2, 4
+        num_k_heads = 2
         head_k_dim, head_v_dim = 32, 32
         hidden_size, conv_kernel_dim = 128, 4
 
@@ -116,7 +152,63 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
         if weights_extra:
             weights.update(weights_extra)
 
-        return Qwen3NextGatedDeltaNet(cfg, par, weights, layernorm_eps=1e-6).to(dev)
+        return Qwen3NextGatedDeltaNet(
+            cfg, par, weights, layernorm_eps=1e-6, hw_kernel_config=hw_kernel_config
+        ).to(dev)
+
+    def _build_with_mocked_linears(
+        self,
+        *,
+        is_rocm: bool,
+        use_swizzle: bool,
+        num_v_heads: int,
+        quantized_qkvz: bool = False,
+    ):
+        """Construct a module while recording only its linear dispatch policy."""
+        from rtp_llm.models_py.modules.factory.linear.factory import LinearFactory
+        from rtp_llm.ops import HWKernelConfig
+        from rtp_llm.utils.model_weight import W
+
+        hw = HWKernelConfig()
+        hw.use_swizzleA = use_swizzle
+        weights_extra = None
+        if quantized_qkvz:
+            weights_extra = {
+                W.linear_attn_qkvz_s: torch.randn(
+                    8, dtype=torch.float32, device=self.device
+                )
+            }
+
+        hip_version = "test-rocm" if is_rocm else None
+        with patch.object(torch.version, "hip", hip_version, create=True), patch.object(
+            LinearFactory,
+            "create_linear",
+            side_effect=lambda *a, **kw: MagicMock(name="MockFusedLinear"),
+        ) as fused_factory, patch.object(
+            LinearFactory,
+            "create_linear_from_weights",
+            side_effect=lambda *a, **kw: MagicMock(name="MockLinear"),
+        ) as weights_factory:
+            module = self._build_module(
+                weights_extra=weights_extra,
+                hw_kernel_config=hw,
+                num_v_heads=num_v_heads,
+            )
+
+        return module, hw, fused_factory, weights_factory
+
+    @staticmethod
+    def _factory_call_for_weight(mock_factory, weight_key):
+        calls = [
+            call
+            for call in mock_factory.call_args_list
+            if len(call.args) >= 2 and call.args[1] == weight_key
+        ]
+        if len(calls) != 1:
+            raise AssertionError(
+                f"expected one factory call for {weight_key}, got {len(calls)}"
+            )
+        return calls[0]
 
     def test_bf16_path_takes_fusion(self) -> None:
         """When linear_attn_qkvz_s is None (BF16), fusion is enabled."""
@@ -125,6 +217,86 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
         self.assertIsNotNone(module.in_proj_fused)
         self.assertIsNone(module.in_proj_qkvz)
         self.assertIsNone(module.in_proj_ba)
+
+    def test_rocm_swizzle_unaligned_bf16_uses_two_gemms(self) -> None:
+        """A swizzled qkvz plus raw BA must never become one WithSwizzle GEMM."""
+        from rtp_llm.utils.model_weight import W
+
+        module, hw, fused_factory, weights_factory = self._build_with_mocked_linears(
+            is_rocm=True,
+            use_swizzle=True,
+            num_v_heads=4,
+        )
+
+        self.assertFalse(module._qkvz_ba_fused)
+        fused_factory.assert_not_called()
+        qkvz_call = self._factory_call_for_weight(weights_factory, W.linear_attn_qkvz_w)
+        ba_call = self._factory_call_for_weight(weights_factory, W.linear_attn_ba_w)
+        self.assertIs(qkvz_call.kwargs["hw_kernel_config"], hw)
+        self.assertIsNone(ba_call.kwargs["hw_kernel_config"])
+
+    def test_rocm_swizzle_aligned_bf16_keeps_fusion(self) -> None:
+        from rtp_llm.utils.model_weight import W
+
+        module, hw, fused_factory, weights_factory = self._build_with_mocked_linears(
+            is_rocm=True,
+            use_swizzle=True,
+            num_v_heads=8,
+        )
+
+        self.assertTrue(module._qkvz_ba_fused)
+        fused_factory.assert_called_once()
+        self.assertIs(
+            fused_factory.call_args.kwargs["hw_kernel_config"],
+            hw,
+        )
+        self.assertFalse(
+            any(
+                len(call.args) >= 2
+                and call.args[1] in (W.linear_attn_qkvz_w, W.linear_attn_ba_w)
+                for call in weights_factory.call_args_list
+            )
+        )
+
+    def test_rocm_without_swizzle_keeps_unaligned_bf16_fusion(self) -> None:
+        module, hw, fused_factory, _ = self._build_with_mocked_linears(
+            is_rocm=True,
+            use_swizzle=False,
+            num_v_heads=4,
+        )
+
+        self.assertTrue(module._qkvz_ba_fused)
+        fused_factory.assert_called_once()
+        self.assertIs(fused_factory.call_args.kwargs["hw_kernel_config"], hw)
+
+    def test_cuda_keeps_unaligned_bf16_fusion(self) -> None:
+        module, hw, fused_factory, _ = self._build_with_mocked_linears(
+            is_rocm=False,
+            use_swizzle=True,
+            num_v_heads=4,
+        )
+
+        self.assertTrue(module._qkvz_ba_fused)
+        fused_factory.assert_called_once()
+        self.assertIs(fused_factory.call_args.kwargs["hw_kernel_config"], hw)
+
+    def test_fp8_qkvz_with_aligned_ba_keeps_ba_swizzle(self) -> None:
+        from rtp_llm.utils.model_weight import W
+
+        module, hw, fused_factory, weights_factory = self._build_with_mocked_linears(
+            is_rocm=True,
+            use_swizzle=True,
+            num_v_heads=8,
+            quantized_qkvz=True,
+        )
+
+        self.assertFalse(module._qkvz_ba_fused)
+        fused_factory.assert_not_called()
+        qkvz_call = self._factory_call_for_weight(weights_factory, W.linear_attn_qkvz_w)
+        ba_call = self._factory_call_for_weight(weights_factory, W.linear_attn_ba_w)
+        self.assertEqual(qkvz_call.args[2], W.linear_attn_qkvz_s)
+        self.assertIs(qkvz_call.kwargs["hw_kernel_config"], hw)
+        self.assertIs(ba_call.kwargs["hw_kernel_config"], hw)
 
     def test_quantized_path_falls_back_in_constructor(self) -> None:
         """When linear_attn_qkvz_s is set (FP8 path) the constructor must
@@ -181,6 +353,69 @@ class TestQwen3NextQkvzBaFusion(unittest.TestCase):
             qkvz_calls[0].args[2],
             W.linear_attn_qkvz_s,
             "fallback must pass linear_attn_qkvz_s as scale_key",
+        )
+
+    def _ba_hw_kernel_config_in_fallback(self, num_v_heads):
+        """Build the FP8 fallback (non-fused) branch with swizzle enabled and
+        return the hw_kernel_config the factory received for in_proj_ba.
+
+        Mocks the Linear factory so no real GEMM/strategy lookup runs; we only
+        inspect which hw_kernel_config was wired for the BA projection.
+        """
+        from rtp_llm.models_py.modules.factory.linear.factory import LinearFactory
+        from rtp_llm.ops import HWKernelConfig
+        from rtp_llm.utils.model_weight import W
+
+        hw = HWKernelConfig()
+        hw.use_swizzleA = True
+        # qkvz_s presence forces the 2-GEMM (non-fused) branch where in_proj_ba
+        # is created standalone.
+        scale = torch.randn(8, dtype=torch.float32, device=self.device)
+
+        with patch.object(
+            LinearFactory,
+            "create_linear_from_weights",
+            side_effect=lambda *a, **kw: MagicMock(name="MockLinear"),
+        ) as mock_factory:
+            self._build_module(
+                weights_extra={W.linear_attn_qkvz_s: scale},
+                hw_kernel_config=hw,
+                num_v_heads=num_v_heads,
+            )
+
+        ba_calls = [
+            c
+            for c in mock_factory.call_args_list
+            if len(c.args) >= 2 and c.args[1] == W.linear_attn_ba_w
+        ]
+        self.assertEqual(len(ba_calls), 1, "fallback must build in_proj_ba once")
+        return hw, ba_calls[0].kwargs.get("hw_kernel_config")
+
+    @unittest.skipUnless(
+        torch.version.hip is not None,
+        "ROCm-only BA swizzle dispatch",
+    )
+    def test_in_proj_ba_no_swizzle_when_unaligned(self) -> None:
+        """BA out-dim 8 (= 2*4, not 16-aligned, mirrors TP=4's 24): in_proj_ba
+        must receive hw_kernel_config=None so dispatch picks NoSwizzle,
+        consistent with device_impl skipping the swizzle. This is the crash fix."""
+        _hw, ba_cfg = self._ba_hw_kernel_config_in_fallback(num_v_heads=4)
+        self.assertIsNone(
+            ba_cfg,
+            "unaligned BA must pass hw_kernel_config=None (NoSwizzle dispatch)",
+        )
+
+    @unittest.skipUnless(
+        torch.version.hip is not None,
+        "ROCm-only BA swizzle dispatch",
+    )
+    def test_in_proj_ba_keeps_swizzle_when_aligned(self) -> None:
+        """Quantized qkvz does not disable swizzle for an aligned BF16 BA."""
+        hw, ba_cfg = self._ba_hw_kernel_config_in_fallback(num_v_heads=8)
+        self.assertIs(
+            ba_cfg,
+            hw,
+            "aligned BA must keep WithSwizzle dispatch",
         )
 
     def test_input_project_helper_shapes(self) -> None:

--- a/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
+++ b/rtp_llm/models_py/modules/factory/linear/impl/rocm/test/rocm_linear_test.py
@@ -22,7 +22,7 @@ from rtp_llm.models_py.modules.factory.linear.impl.rocm.f16_linear import (
 )
 from rtp_llm.ops import ActivationType, HWKernelConfig
 from rtp_llm.utils.model_weight import W
-from rtp_llm.utils.swizzle_utils import swizzle_tensor
+from rtp_llm.utils.swizzle_utils import should_swizzle_linear_attn_ba, swizzle_tensor
 
 
 class LinearTorch(nn.Module):
@@ -156,6 +156,19 @@ class LinearTest(TestCase):
         expected = input @ weight
         self.assertTrue(torch.allclose(actual, expected, atol=atol, rtol=rtol))
 
+    def _assert_no_swizzle_linear_matches_reference(
+        self,
+        linear: nn.Module,
+        weight: torch.Tensor,
+        input: torch.Tensor,
+        atol: float = 1e-2,
+        rtol: float = 1e-2,
+    ) -> None:
+        self.assertIsInstance(linear, RocmF16LinearNoSwizzle)
+        actual = linear(input)
+        expected = input @ weight
+        self.assertTrue(torch.allclose(actual, expected, atol=atol, rtol=rtol))
+
     def test_linear(self):
         for params in itertools.product(
             self.NUM_TOKENS,
@@ -174,6 +187,45 @@ class LinearTest(TestCase):
                 has_swizzle=has_swizzle,
             ):
                 self._run_linear_test(num_tokens, k, n, dtype, has_bias, has_swizzle)
+
+    BA_K_N_CASES = [
+        (2048, 32, True),  # Qwen3.6-35B-A3B TP=2
+        (2048, 16, True),  # Qwen3.6-35B-A3B TP=4
+        (5120, 24, False),  # Qwen3.5-27B TP=4
+        (5120, 12, False),  # Qwen3.5-27B TP=8
+    ]
+
+    def test_ba_shape_selects_matching_swizzle_kernel(self):
+        for dtype in self.DTYPES:
+            for k, n, expect_swizzle in self.BA_K_N_CASES:
+                with self.subTest(dtype=dtype, k=k, n=n):
+                    torch.manual_seed(0)
+                    weight = torch.randn(k, n, dtype=dtype)
+                    torch.nn.init.xavier_uniform_(weight)
+                    input = torch.randn(7, k, dtype=dtype)
+                    hw_kernel_config = HWKernelConfig()
+                    hw_kernel_config.use_swizzleA = True
+
+                    should_swizzle = should_swizzle_linear_attn_ba(weight)
+                    self.assertEqual(should_swizzle, expect_swizzle)
+                    kernel_weight = (
+                        self._swizzle_weight(weight) if should_swizzle else weight
+                    )
+                    linear = LinearFactory.create_linear_from_weights(
+                        weights={"weight": kernel_weight},
+                        weight_key="weight",
+                        quant_config=None,
+                        hw_kernel_config=(hw_kernel_config if should_swizzle else None),
+                    )
+                    atol = rtol = 2e-2 if dtype == torch.bfloat16 else 1e-2
+                    if should_swizzle:
+                        self._assert_swizzled_linear_matches_reference(
+                            linear, weight, input, atol, rtol
+                        )
+                    else:
+                        self._assert_no_swizzle_linear_matches_reference(
+                            linear, weight, input, atol, rtol
+                        )
 
     def _run_shared_expert_gate_test(
         self, dtype: _dtype, atol: float, rtol: float

--- a/rtp_llm/openai/renderers/deepseekv4_renderer.py
+++ b/rtp_llm/openai/renderers/deepseekv4_renderer.py
@@ -429,14 +429,30 @@ class DeepseekV4Renderer(ReasoningToolBaseRenderer):
         # Override with custom configs if provided
         # Note: context parameter is not used since RTP-LLM always provides full message history
         if request.chat_template_kwargs:
-            encode_config.update(request.chat_template_kwargs)
+            # ChatCompletionRequest uses disabled/adaptive/enabled, while the
+            # DeepSeek encoding script uses chat/thinking. The request mode was
+            # already resolved above, so do not pass its public enum value into
+            # encode_messages as an encoding-level override.
+            encode_config.update(
+                {
+                    key: value
+                    for key, value in request.chat_template_kwargs.items()
+                    if key != "thinking_mode"
+                }
+            )
 
         if (
             request.extra_configs
             and request.extra_configs.chat_template_kwargs
             and isinstance(request.extra_configs.chat_template_kwargs, dict)
         ):
-            encode_config.update(request.extra_configs.chat_template_kwargs)
+            encode_config.update(
+                {
+                    key: value
+                    for key, value in request.extra_configs.chat_template_kwargs.items()
+                    if key != "thinking_mode"
+                }
+            )
         if request.disable_thinking():
             encode_config["thinking_mode"] = "chat"
 

--- a/rtp_llm/test/deepseekv4_renderer_test.py
+++ b/rtp_llm/test/deepseekv4_renderer_test.py
@@ -7,7 +7,7 @@ from unittest import IsolatedAsyncioTestCase, TestCase, main, skipUnless
 from unittest.mock import AsyncMock, Mock
 
 from rtp_llm.config.exceptions import FtRuntimeException
-from rtp_llm.config.generate_config import GenerateConfig
+from rtp_llm.config.generate_config import GenerateConfig, ThinkingMode
 from rtp_llm.openai.api_datatype import (
     ChatCompletionRequest,
     ChatCompletionResponseStreamChoice,
@@ -73,8 +73,6 @@ class FakeTokenizer:
 
 
 def _make_renderer(encoding_module):
-    from rtp_llm.config.generate_config import ThinkingMode
-
     renderer = DeepseekV4Renderer.__new__(DeepseekV4Renderer)
     renderer.encoding_module = encoding_module
     renderer.tokenizer = FakeTokenizer()
@@ -266,7 +264,9 @@ class DeepseekV4RendererTest(TestCase):
         self.assertEqual(self.renderer.tokenizer.decode(rendered.input_ids), expected)
 
     def test_existing_think_mode_env_path_is_unchanged(self):
+        # The real renderer constructor derives both fields from THINK_MODE.
         self.renderer.think_mode = True
+        self.renderer.default_thinking_mode = ThinkingMode.ENABLED
         messages = [{"role": "user", "content": "Hello"}]
         request = ChatCompletionRequest(messages=messages)
 
@@ -301,7 +301,7 @@ class DeepseekV4RendererTest(TestCase):
             messages=messages,
             extra_configs=GenerateConfig(max_thinking_tokens=0),
             enable_thinking=True,
-            chat_template_kwargs={"thinking_mode": "thinking"},
+            chat_template_kwargs={"thinking_mode": "enabled"},
         )
 
         rendered = self.renderer.render_chat(request)
@@ -309,11 +309,11 @@ class DeepseekV4RendererTest(TestCase):
 
         self.assertEqual(rendered.rendered_prompt, expected)
 
-    def test_thinking_mode_kwarg_still_overrides_encoding_config(self):
+    def test_enabled_thinking_mode_maps_to_thinking_encoding_prompt(self):
         messages = [{"role": "user", "content": "Hello"}]
         request = ChatCompletionRequest(
             messages=messages,
-            chat_template_kwargs={"thinking_mode": "thinking"},
+            chat_template_kwargs={"thinking_mode": "enabled"},
         )
 
         rendered = self.renderer.render_chat(request)
@@ -321,6 +321,22 @@ class DeepseekV4RendererTest(TestCase):
             self.encoding,
             messages,
             thinking_mode="thinking",
+        )
+
+        self.assertEqual(rendered.rendered_prompt, expected)
+
+    def test_adaptive_thinking_uses_chat_encoding_prompt(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            messages=messages,
+            chat_template_kwargs={"thinking_mode": "adaptive"},
+        )
+
+        rendered = self.renderer.render_chat(request)
+        expected = _rtp_expected_prompt(
+            self.encoding,
+            messages,
+            thinking_mode="chat",
         )
 
         self.assertEqual(rendered.rendered_prompt, expected)
@@ -340,7 +356,7 @@ class DeepseekV4RendererTest(TestCase):
                 request = ChatCompletionRequest(
                     messages=messages,
                     reasoning_effort=effort,
-                    chat_template_kwargs={"thinking_mode": "thinking"},
+                    chat_template_kwargs={"thinking_mode": "enabled"},
                 )
                 rendered = self.renderer.render_chat(request)
                 expected = _rtp_expected_prompt(
@@ -356,7 +372,7 @@ class DeepseekV4RendererTest(TestCase):
         request = ChatCompletionRequest(
             messages=messages,
             chat_template_kwargs={
-                "thinking_mode": "thinking",
+                "thinking_mode": "enabled",
                 "reasoning_effort": "xhigh",
             },
         )
@@ -375,7 +391,7 @@ class DeepseekV4RendererTest(TestCase):
         request = ChatCompletionRequest(
             messages=[{"role": "user", "content": "Hello"}],
             reasoning_effort="minimum",
-            chat_template_kwargs={"thinking_mode": "thinking"},
+            chat_template_kwargs={"thinking_mode": "enabled"},
         )
 
         with self.assertRaisesRegex(
@@ -390,10 +406,10 @@ class DeepseekV4RendererTest(TestCase):
         request = ChatCompletionRequest(
             messages=messages,
             reasoning_effort="high",
-            chat_template_kwargs={"thinking_mode": "thinking"},
+            chat_template_kwargs={"thinking_mode": "enabled"},
             extra_configs=GenerateConfig(
                 chat_template_kwargs={
-                    "thinking_mode": "chat",
+                    "thinking_mode": "disabled",
                     "reasoning_effort": "max",
                 }
             ),

--- a/rtp_llm/utils/swizzle_utils.py
+++ b/rtp_llm/utils/swizzle_utils.py
@@ -1,12 +1,19 @@
+from typing import Dict, List
+
 import torch
-from typing import List, Dict
+
 
 def calculate_k_for_swizzling(dtype: torch.dtype):
     if dtype == torch.float32:
         MiK, MiKv = 4, 1
     elif dtype in (torch.float16, torch.half, torch.bfloat16):
         MiK, MiKv = 16, 4
-    elif dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
+    elif dtype in (
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+    ):
         MiK, MiKv = 32, 8
     else:
         raise ValueError(f"unsupported datatype in calculateKforSwizzling: {dtype}")
@@ -14,10 +21,10 @@ def calculate_k_for_swizzling(dtype: torch.dtype):
     PackK = 16 // MiKv // elem_size
     return MiK, MiKv, PackK
 
+
 def swizzle_tensor(
-    src: torch.Tensor,
-    col_maj: bool = False,
-    MiM: int = 16) -> torch.Tensor:
+    src: torch.Tensor, col_maj: bool = False, MiM: int = 16
+) -> torch.Tensor:
     tmp = src.clone()
 
     if col_maj:
@@ -28,10 +35,10 @@ def swizzle_tensor(
 
     MiK, MiKv, PackK = calculate_k_for_swizzling(src.dtype)
 
-    if (MiK == 16):
+    if MiK == 16:
         assert m % 16 == 0, f"swizzle shape m = {m} must be divisible by 16"
         assert k % 32 == 0, f"swizzle shape k = {k} must be divisible by 32"
-    elif (MiK == 32):
+    elif MiK == 32:
         assert m % 16 == 0, f"swizzle shape m = {m} must be divisible by 16"
         assert k % 64 == 0, f"swizzle shape k = {k} must be divisible by 64"
 
@@ -40,3 +47,54 @@ def swizzle_tensor(
 
     dst = tmp.clone()
     return dst.view(src.shape)
+
+
+def can_swizzle_kn(weight: torch.Tensor, dtype: torch.dtype = None) -> bool:
+    """Whether a (k, n) = (hidden, out) weight can be swizzled via
+    swizzle_tensor(weight.t(), col_maj=False).
+
+    That call transposes to (n, k), so ``n`` must be divisible by 16 and ``k``
+    must satisfy the dtype-specific packing divisor. Used by both the data side
+    (device_impl layout rewrite) and dispatch side (linear strategy fallback)
+    so the two stay consistent for the same weight.
+    """
+    if weight.dim() != 2:
+        return False
+    dt = dtype if dtype is not None else weight.dtype
+    try:
+        MiK, _, PackK = calculate_k_for_swizzling(dt)
+    except ValueError:
+        return False
+    k_div = MiK * PackK
+    k, n = weight.shape
+    return (n % 16 == 0) and (k % k_div == 0)
+
+
+def can_fuse_swizzled_kn(
+    first_weight: torch.Tensor, second_weight: torch.Tensor
+) -> bool:
+    """Whether two (k, n) weights can share one swizzled GEMM.
+
+    Each source weight must already be eligible for the same swizzle layout,
+    and concatenating their output dimensions must remain eligible. Checking
+    shapes directly avoids allocating the potentially very large fused weight.
+    """
+    if first_weight.dim() != 2 or second_weight.dim() != 2:
+        return False
+    if first_weight.dtype != second_weight.dtype:
+        return False
+    if first_weight.shape[0] != second_weight.shape[0]:
+        return False
+    if not can_swizzle_kn(first_weight) or not can_swizzle_kn(second_weight):
+        return False
+
+    k = first_weight.shape[0]
+    fused_n = first_weight.shape[1] + second_weight.shape[1]
+    MiK, _, PackK = calculate_k_for_swizzling(first_weight.dtype)
+    k_div = MiK * PackK
+    return (fused_n % 16 == 0) and (k % k_div == 0)
+
+
+def should_swizzle_linear_attn_ba(weight: torch.Tensor) -> bool:
+    """Whether a TP-local Qwen3Next BA weight supports the swizzled layout."""
+    return can_swizzle_kn(weight)

--- a/rtp_llm/utils/test/BUILD
+++ b/rtp_llm/utils/test/BUILD
@@ -16,6 +16,16 @@ filegroup(
 )
 
 py_test(
+    name = "swizzle_utils_test",
+    srcs = [
+        "swizzle_utils_test.py",
+    ],
+    deps = [
+        "//rtp_llm:utils",
+    ],
+)
+
+py_test(
     name = "jit_cache_manager_test",
     size = "large",
     srcs = [

--- a/rtp_llm/utils/test/swizzle_utils_test.py
+++ b/rtp_llm/utils/test/swizzle_utils_test.py
@@ -1,0 +1,138 @@
+"""Unit tests for linear-weight swizzle policy.
+
+The data side and Qwen3Next dispatch must agree on shape support. BA remains
+BF16 when qkvz is quantized, so quantization must not independently disable its
+swizzled layout.
+
+Pure logic + shape math — no CUDA/ROCm needed.
+"""
+
+from unittest import TestCase, main
+
+import torch
+
+from rtp_llm.utils.swizzle_utils import (
+    can_fuse_swizzled_kn,
+    can_swizzle_kn,
+    should_swizzle_linear_attn_ba,
+    swizzle_tensor,
+)
+
+
+class CanSwizzleKnTest(TestCase):
+    def test_linear_attention_ba_swizzle_depends_on_shape(self):
+        aligned_ba = torch.empty(5120, 48, dtype=torch.bfloat16)
+        unaligned_ba = torch.empty(5120, 24, dtype=torch.bfloat16)
+
+        self.assertTrue(should_swizzle_linear_attn_ba(aligned_ba))
+        self.assertFalse(should_swizzle_linear_attn_ba(unaligned_ba))
+
+    def test_ba_alignment_table_bf16(self):
+        # BA local weight is (hidden=5120, out=(b+a)=96/TP). Only the out-dim
+        # (n) alignment changes across TP; hidden (k=5120) is always %32.
+        #   TP=1 -> 96, TP=2 -> 48 : geometrically swizzle-compatible
+        #   TP=4 -> 24, TP=8 -> 12 : unaligned -> fall back
+        for tp, out in {1: 96, 2: 48, 4: 24, 8: 12}.items():
+            w = torch.empty(5120, out, dtype=torch.bfloat16)
+            expected = out % 16 == 0
+            self.assertEqual(can_swizzle_kn(w), expected, f"TP={tp} out={out}")
+
+    def test_qwen35_27b_fused_swizzle_alignment_by_tp(self):
+        # Qwen3.5-27B local qkvz/BA output dimensions after TP sharding.
+        # TP=1/2 keep both source boundaries 16-aligned, while TP=4/8 leave
+        # BA raw and therefore cannot be concatenated with the swizzled qkvz.
+        qkvz_out_by_tp = {1: 16384, 2: 8192, 4: 4096, 8: 2048}
+        ba_out_by_tp = {1: 96, 2: 48, 4: 24, 8: 12}
+        for tp in (1, 2, 4, 8):
+            qkvz = torch.empty(
+                5120, qkvz_out_by_tp[tp], dtype=torch.bfloat16, device="meta"
+            )
+            ba = torch.empty(
+                5120, ba_out_by_tp[tp], dtype=torch.bfloat16, device="meta"
+            )
+            self.assertEqual(
+                can_fuse_swizzled_kn(qkvz, ba),
+                tp in (1, 2),
+                f"TP={tp}",
+            )
+
+    def test_qwen36_35b_a3b_ba_alignment_by_tp(self):
+        # Qwen3.6-35B-A3B BA global shape is (2048, 64). TP=4 therefore has
+        # local N=16 and must retain swizzle; only TP=8 falls back.
+        for tp, out in {1: 64, 2: 32, 4: 16, 8: 8}.items():
+            ba = torch.empty(2048, out, dtype=torch.bfloat16, device="meta")
+            self.assertEqual(
+                should_swizzle_linear_attn_ba(ba),
+                tp in (1, 2, 4),
+                f"TP={tp} out={out}",
+            )
+
+    def test_fused_swizzle_requires_compatible_sources(self):
+        aligned = torch.empty(128, 32, dtype=torch.bfloat16, device="meta")
+        self.assertFalse(
+            can_fuse_swizzled_kn(
+                aligned,
+                torch.empty(96, 16, dtype=torch.bfloat16, device="meta"),
+            )
+        )
+        self.assertFalse(
+            can_fuse_swizzled_kn(
+                aligned,
+                torch.empty(128, 16, dtype=torch.float16, device="meta"),
+            )
+        )
+        self.assertFalse(
+            can_fuse_swizzled_kn(
+                aligned,
+                torch.empty(128, 8, dtype=torch.bfloat16, device="meta"),
+            )
+        )
+
+    def test_k_divisor_bf16_vs_fp8(self):
+        # bf16 requires k % 32 == 0; fp8 requires the stricter k % 64 == 0.
+        # k=96: passes bf16 (96%32==0) but not fp8 (96%64!=0).
+        w_bf16 = torch.empty(96, 32, dtype=torch.bfloat16)
+        w_fp8 = torch.empty(96, 32, dtype=torch.float8_e4m3fn)
+        self.assertTrue(can_swizzle_kn(w_bf16))
+        self.assertFalse(can_swizzle_kn(w_fp8))
+        # k=128 passes both.
+        self.assertTrue(can_swizzle_kn(torch.empty(128, 32, dtype=torch.bfloat16)))
+        self.assertTrue(can_swizzle_kn(torch.empty(128, 32, dtype=torch.float8_e4m3fn)))
+
+    def test_dtype_override(self):
+        # dtype arg overrides the tensor's own dtype (used to reason about a
+        # weight as if it were quantized to fp8).
+        w = torch.empty(96, 32, dtype=torch.bfloat16)
+        self.assertTrue(can_swizzle_kn(w))  # bf16: 96 % 32 == 0
+        self.assertFalse(
+            can_swizzle_kn(w, dtype=torch.float8_e4m3fn)  # fp8: 96 % 64 != 0
+        )
+
+    def test_float32_uses_its_actual_k_divisor(self):
+        self.assertTrue(can_swizzle_kn(torch.empty(48, 32, dtype=torch.float32)))
+
+    def test_unsupported_dtype_returns_false(self):
+        self.assertFalse(can_swizzle_kn(torch.empty(128, 32, dtype=torch.int8)))
+
+    def test_non_2d_returns_false(self):
+        self.assertFalse(can_swizzle_kn(torch.empty(24, dtype=torch.bfloat16)))
+        self.assertFalse(can_swizzle_kn(torch.empty(2, 5120, 24, dtype=torch.bfloat16)))
+
+    def test_judgement_matches_actual_swizzle_constraint(self):
+        # For bf16, the guard must agree with the actual swizzle constraints.
+        # device_impl calls
+        # swizzle_tensor(weight.t(), col_maj=False) on BA (hidden, out).
+        # TP=4 BA (5120, 24): must be rejected AND must actually raise.
+        ba_bad = torch.empty(5120, 24, dtype=torch.bfloat16)
+        self.assertFalse(can_swizzle_kn(ba_bad))
+        with self.assertRaises(AssertionError):
+            swizzle_tensor(ba_bad.t(), False)
+
+        # Aligned counterpart (pad-to-32): must be accepted AND must not raise.
+        ba_ok = torch.empty(5120, 32, dtype=torch.bfloat16)
+        self.assertTrue(can_swizzle_kn(ba_ok))
+        swizzle_tensor(ba_ok.t(), False)  # no exception
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- keep Qwen3.5 linear-attention `in_proj_a` / `in_proj_b` BF16 weights out of the standalone ROCm swizzle path when adjacent QKVZ projections carry FP8 scale metadata
- propagate an explicit per-weight `allow_swizzle` decision through weight loading and device rewrite
- preserve the existing swizzled fused BF16 path and eligible non-BA weights

## Validation

- pre-commit: merge-conflict, symlink, line-ending, trailing-whitespace, Black, and isort checks passed
- MI308X ROCm: 5/5 related Bazel unit tests passed with GPU locking
- real Qwen3.5-27B-FP8 checkpoint, TP=4: all four BA rank shards selected `RocmF16LinearNoSwizzle`; actual ROCm output matched the BF16 reference with `max_abs=0`
- ROCm server libraries built successfully (`//:th_transformer`, `//rtp_llm:rtp_llm_lib`)

No smoke-test source or golden data changes are included.