### PR TITLE
feat(rocm): add shape-based AITER FMoE tuning

### DIFF
--- a/rtp_llm/BUILD
+++ b/rtp_llm/BUILD
@@ -502,6 +502,7 @@ py_library(
         ":config_ops",
         ":warmup",
         ":jit_cache_manager_lib",
+        "//rtp_llm/models_py/kernel_tuning",
     ],
     data = jit_deps(),
     imports = ["."],

--- a/rtp_llm/models_py/BUILD
+++ b/rtp_llm/models_py/BUILD
@@ -59,6 +59,7 @@ py_library(
         ":utils",
         ":tile_kernels_mhc",
         "//rtp_llm:warmup",
+        "//rtp_llm/models_py/kernel_tuning",
         "//rtp_llm/models_py/triton_kernels:triton_kernels",
         "//rtp_llm/models_py/distributed:deepep_wrapper",
         "//rtp_llm/models_py/distributed:moriep_wrapper",

--- a/rtp_llm/models_py/kernel_tuning/BUILD
+++ b/rtp_llm/models_py/kernel_tuning/BUILD
@@ -1,0 +1,30 @@
+py_library(
+    name = "kernel_tuning",
+    srcs = glob([
+        "*.py",
+        "aiter/*.py",
+    ]),
+    data = glob([
+        "aiter/configs/*.csv",
+    ]),
+    deps = [
+        "//rtp_llm:torch",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "aiter_fmoe_test",
+    srcs = ["test/aiter_fmoe_test.py"],
+    data = [
+        "@rtp_deps//:requirements_lock_rocm.txt",
+        "@rtp_deps//:requirements_rocm.txt",
+    ],
+    deps = [":kernel_tuning"],
+)
+
+py_test(
+    name = "registry_test",
+    srcs = ["test/registry_test.py"],
+    deps = [":kernel_tuning"],
+)

--- a/rtp_llm/models_py/kernel_tuning/__init__.py
+++ b/rtp_llm/models_py/kernel_tuning/__init__.py
@@ -1,0 +1,4 @@
+from rtp_llm.models_py.kernel_tuning.registry import configure_kernel_tuning
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+__all__ = ["KernelTuningStatus", "configure_kernel_tuning"]

--- a/rtp_llm/models_py/kernel_tuning/aiter/__init__.py
+++ b/rtp_llm/models_py/kernel_tuning/aiter/__init__.py
@@ -1,0 +1,15 @@
+from rtp_llm.models_py.kernel_tuning.aiter.fmoe import (
+    AITER_FMOE_GFX942_OVERLAY,
+    AiterFmoeWorkloadSignature,
+    configure_aiter_fmoe_overlays,
+    is_affected_aiter_fmoe_signature,
+    require_aiter_fmoe_tuning,
+)
+
+__all__ = [
+    "AITER_FMOE_GFX942_OVERLAY",
+    "AiterFmoeWorkloadSignature",
+    "configure_aiter_fmoe_overlays",
+    "is_affected_aiter_fmoe_signature",
+    "require_aiter_fmoe_tuning",
+]

--- a/rtp_llm/models_py/kernel_tuning/aiter/configs/gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv
+++ b/rtp_llm/models_py/kernel_tuning/aiter/configs/gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv
@@ -1,0 +1,6 @@
+cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,block_m,ksplit,us1,kernelName1,err1,us2,kernelName2,err2,us,run_1stage,tflops,bw,_tag
+80,1,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,2,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,4,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,8,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,
+80,16,2048,128,256,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fnuz,torch.float8_e4m3fnuz,QuantType.per_Token,1,0,32,0,0.0,_ZN5aiter48fmoe_bf16_pertokenFp8_g1u1_vs_silu_1tg_ps_32x128E,0.0%,0.0,Null,0.0%,0.0,1,0.0,0.0,

--- a/rtp_llm/models_py/kernel_tuning/aiter/fmoe.py
+++ b/rtp_llm/models_py/kernel_tuning/aiter/fmoe.py
@@ -1,0 +1,288 @@
+import csv
+import hashlib
+import importlib.metadata
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+AITER_FMOE_GFX942_OVERLAY = (
+    "aiter_fmoe_gfx942_cu80_m1_16_h2048_i128_e256_topk8_bf16_fp8pt"
+)
+_SUPPORTED_AITER_VERSION = "0.1.21.dev80+g987203ba5.d20260825"
+_SUPPORTED_DEFAULT_CONFIG_SHA256 = (
+    "00a7d76ae7c49760b2bb389d9cd38887713878f139dc49ff3b0af5dc65a6039f"
+)
+_OVERLAY_CONFIG = (
+    Path(__file__).resolve().parent
+    / "configs"
+    / "gfx942_cu80_fmoe_m1_16_h2048_i128_e256_topk8_bf16_fp8pt.csv"
+)
+_DISPATCH_KEY_FIELDS = (
+    "cu_num",
+    "token",
+    "model_dim",
+    "inter_dim",
+    "expert",
+    "topk",
+    "act_type",
+    "dtype",
+    "q_dtype_a",
+    "q_dtype_w",
+    "q_type",
+    "use_g1u1",
+    "doweight_stage1",
+)
+_AFFECTED_TOKEN_BUCKETS = (1, 2, 4, 8, 16)
+
+
+@dataclass(frozen=True)
+class AiterFmoeWorkloadSignature:
+    """Static portion of the AITER FMoE dispatch key.
+
+    Tensor-parallel, expert-parallel, and model identity are intentionally
+    absent. They matter only through the local workload passed to AITER.
+    """
+
+    gfx: str
+    cu_num: int
+    model_dim: int
+    inter_dim: int
+    expert: int
+    topk: int
+    act_type: str
+    dtype: str
+    q_dtype_a: str
+    q_dtype_w: str
+    q_type: str
+    use_g1u1: int
+    doweight_stage1: int
+
+
+_AFFECTED_WORKLOAD_SIGNATURES = frozenset(
+    {
+        AiterFmoeWorkloadSignature(
+            gfx="gfx942",
+            cu_num=80,
+            model_dim=2048,
+            inter_dim=128,
+            expert=256,
+            topk=8,
+            act_type="ActivationType.Silu",
+            dtype="torch.bfloat16",
+            q_dtype_a="torch.float8_e4m3fnuz",
+            q_dtype_w="torch.float8_e4m3fnuz",
+            q_type="QuantType.per_Token",
+            use_g1u1=1,
+            doweight_stage1=0,
+        )
+    }
+)
+
+_CONFIG_STATUS: Optional[KernelTuningStatus] = None
+
+
+def is_affected_aiter_fmoe_signature(
+    signature: AiterFmoeWorkloadSignature,
+) -> bool:
+    return signature in _AFFECTED_WORKLOAD_SIGNATURES
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stock_fmoe_configs(default_config: Path) -> list[Path]:
+    model_config_dir = default_config.parent / "model_configs"
+    model_configs = sorted(
+        path
+        for path in model_config_dir.glob("*tuned_fmoe*.csv")
+        if path.is_file() and "untuned" not in path.name
+    )
+    return [default_config, *model_configs]
+
+
+def _dispatch_keys(config: Path) -> set[tuple[str, ...]]:
+    with config.open(newline="") as source:
+        reader = csv.DictReader(source)
+        fieldnames = set(reader.fieldnames or ())
+        missing = set(_DISPATCH_KEY_FIELDS) - fieldnames
+        if missing:
+            raise ValueError(
+                f"{config} is missing AITER FMoE dispatch columns: {sorted(missing)}"
+            )
+        return {
+            tuple((row.get(field) or "").strip() for field in _DISPATCH_KEY_FIELDS)
+            for row in reader
+        }
+
+
+def _validated_overlay_dispatch_keys(config: Path) -> set[tuple[str, ...]]:
+    with config.open(newline="") as source:
+        reader = csv.DictReader(source)
+        fieldnames = set(reader.fieldnames or ())
+        missing = set(_DISPATCH_KEY_FIELDS) - fieldnames
+        if missing:
+            raise ValueError(
+                f"{config} is missing AITER FMoE dispatch columns: {sorted(missing)}"
+            )
+        rows = list(reader)
+
+    tagged_rows = [row for row in rows if (row.get("_tag") or "").strip()]
+    if tagged_rows:
+        raise ValueError(
+            f"{config} has non-empty _tag values; AITER excludes tagged rows from "
+            "normal FMoE dispatch"
+        )
+
+    actual_keys = {
+        tuple((row.get(field) or "").strip() for field in _DISPATCH_KEY_FIELDS)
+        for row in rows
+    }
+    expected_keys = {
+        tuple(
+            str(token if field == "token" else getattr(signature, field))
+            for field in _DISPATCH_KEY_FIELDS
+        )
+        for signature in _AFFECTED_WORKLOAD_SIGNATURES
+        for token in _AFFECTED_TOKEN_BUCKETS
+    }
+    if actual_keys != expected_keys or len(rows) != len(expected_keys):
+        raise ValueError(
+            f"{config} dispatch rows do not match the declared affected workload "
+            f"signatures and token buckets {_AFFECTED_TOKEN_BUCKETS}"
+        )
+    return actual_keys
+
+
+def _status(
+    applied: bool, reason: str, version: Optional[str] = None
+) -> KernelTuningStatus:
+    return KernelTuningStatus(
+        overlay=AITER_FMOE_GFX942_OVERLAY,
+        applied=applied,
+        reason=reason,
+        dependency_version=version,
+    )
+
+
+def configure_aiter_fmoe_overlays() -> KernelTuningStatus:
+    """Append reviewed RTP dispatch rows before AITER's first FMoE lookup."""
+
+    global _CONFIG_STATUS
+    if _CONFIG_STATUS is not None:
+        return _CONFIG_STATUS
+
+    try:
+        distribution = importlib.metadata.distribution("aiter")
+    except importlib.metadata.PackageNotFoundError:
+        _CONFIG_STATUS = _status(False, "aiter is not installed")
+        return _CONFIG_STATUS
+
+    version = distribution.version
+    if version != _SUPPORTED_AITER_VERSION:
+        _CONFIG_STATUS = _status(
+            False,
+            "unsupported AITER version; review whether the overlay is still needed",
+            version,
+        )
+        return _CONFIG_STATUS
+
+    default_config = Path(
+        distribution.locate_file("aiter/configs/tuned_fmoe.csv")
+    ).resolve()
+    if not default_config.is_file():
+        _CONFIG_STATUS = _status(
+            False, f"AITER default FMoE config is missing: {default_config}", version
+        )
+        return _CONFIG_STATUS
+
+    actual_sha256 = _sha256(default_config)
+    if actual_sha256 != _SUPPORTED_DEFAULT_CONFIG_SHA256:
+        _CONFIG_STATUS = _status(
+            False,
+            "AITER default FMoE config changed; review the RTP overlay before use "
+            f"(expected {_SUPPORTED_DEFAULT_CONFIG_SHA256}, got {actual_sha256})",
+            version,
+        )
+        return _CONFIG_STATUS
+
+    overlay_config = _OVERLAY_CONFIG.resolve()
+    if not overlay_config.is_file():
+        _CONFIG_STATUS = _status(
+            False, f"RTP AITER FMoE overlay is missing: {overlay_config}", version
+        )
+        return _CONFIG_STATUS
+
+    stock_configs = _stock_fmoe_configs(default_config)
+    try:
+        overlay_keys = _validated_overlay_dispatch_keys(overlay_config)
+        for stock_config in stock_configs:
+            duplicate_keys = overlay_keys & _dispatch_keys(stock_config)
+            if duplicate_keys:
+                _CONFIG_STATUS = _status(
+                    False,
+                    "AITER stock FMoE configs now overlap the RTP overlay; review "
+                    f"and remove or refresh {overlay_config}",
+                    version,
+                )
+                return _CONFIG_STATUS
+    except (OSError, ValueError) as error:
+        _CONFIG_STATUS = _status(
+            False, f"failed to validate AITER FMoE config keys: {error}", version
+        )
+        return _CONFIG_STATUS
+
+    existing = os.environ.get("AITER_CONFIG_FMOE")
+    if existing:
+        existing_paths = {
+            str(Path(path).resolve()) for path in existing.split(os.pathsep) if path
+        }
+        if str(overlay_config) not in existing_paths:
+            _CONFIG_STATUS = _status(
+                False,
+                "AITER_CONFIG_FMOE was explicitly set without the RTP overlay; "
+                f"include {overlay_config}",
+                version,
+            )
+            return _CONFIG_STATUS
+    else:
+        config_paths = [*stock_configs, overlay_config]
+        os.environ["AITER_CONFIG_FMOE"] = os.pathsep.join(map(str, config_paths))
+
+    _CONFIG_STATUS = _status(True, "RTP AITER FMoE overlay configured", version)
+    _LOGGER.info(
+        "Configured kernel tuning overlay %s from %s",
+        AITER_FMOE_GFX942_OVERLAY,
+        overlay_config,
+    )
+    return _CONFIG_STATUS
+
+
+def require_aiter_fmoe_tuning(signature: AiterFmoeWorkloadSignature) -> None:
+    """Fail closed only for a workload with known-bad stock dispatch rows."""
+
+    if not is_affected_aiter_fmoe_signature(signature):
+        _LOGGER.debug(
+            "AITER FMoE tuning overlay is not required for workload signature: %s",
+            signature,
+        )
+        return
+    status = configure_aiter_fmoe_overlays()
+    if status.applied:
+        return
+    raise RuntimeError(
+        "The AITER FMoE workload signature "
+        f"{signature} for token buckets {_AFFECTED_TOKEN_BUCKETS} requires the "
+        f"reviewed one-stage tuning overlay, but it is inactive: {status.reason}. "
+        "Revalidate the small-token FMoE kernels and update or remove the overlay."
+    )

--- a/rtp_llm/models_py/kernel_tuning/registry.py
+++ b/rtp_llm/models_py/kernel_tuning/registry.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Optional
+
+import torch
+
+from rtp_llm.models_py.kernel_tuning.aiter.fmoe import configure_aiter_fmoe_overlays
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+_PROVIDERS_BY_ARCH = {
+    "gfx942": (configure_aiter_fmoe_overlays,),
+}
+
+
+def _current_rocm_arch() -> Optional[str]:
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        return None
+    try:
+        properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+        return str(getattr(properties, "gcnArchName", "")).split(":", 1)[0] or None
+    except Exception as error:
+        _LOGGER.warning("Failed to resolve the current ROCm architecture: %s", error)
+        return None
+
+
+def configure_kernel_tuning(
+    arch: Optional[str] = None,
+) -> tuple[KernelTuningStatus, ...]:
+    """Configure registered kernel-tuning providers for the current device."""
+
+    resolved_arch = arch if arch is not None else _current_rocm_arch()
+    statuses = tuple(
+        provider() for provider in _PROVIDERS_BY_ARCH.get(resolved_arch, ())
+    )
+    for status in statuses:
+        if not status.applied:
+            _LOGGER.warning(
+                "Kernel tuning overlay %s is inactive: %s",
+                status.overlay,
+                status.reason,
+            )
+    return statuses

--- a/rtp_llm/models_py/kernel_tuning/test/aiter_fmoe_test.py
+++ b/rtp_llm/models_py/kernel_tuning/test/aiter_fmoe_test.py
@@ -1,0 +1,244 @@
+import csv
+import hashlib
+import os
+import re
+import tempfile
+import unittest
+from dataclasses import fields, replace
+from pathlib import Path
+from unittest import mock
+from urllib.parse import unquote
+
+from rtp_llm.models_py.kernel_tuning.aiter import fmoe
+
+
+_AITER_WHEEL_VERSION_PATTERN = re.compile(
+    r"/aiter/aiter-([^/\s]+)-cp\d+-cp\d+-linux_x86_64\.whl"
+)
+
+
+def _runfile(path: str) -> Path:
+    test_srcdir = os.environ.get("TEST_SRCDIR")
+    if test_srcdir:
+        return Path(test_srcdir) / path
+    return Path(path.replace("rtp_deps/", "deps/", 1))
+
+
+class _FakeDistribution:
+    def __init__(self, root: Path, version: str):
+        self._root = root
+        self.version = version
+
+    def locate_file(self, path: str) -> Path:
+        return self._root / path
+
+
+class AiterFmoeTuningTest(unittest.TestCase):
+    def setUp(self):
+        self._old_env = os.environ.pop("AITER_CONFIG_FMOE", None)
+        fmoe._CONFIG_STATUS = None
+
+    def tearDown(self):
+        if self._old_env is not None:
+            os.environ["AITER_CONFIG_FMOE"] = self._old_env
+        else:
+            os.environ.pop("AITER_CONFIG_FMOE", None)
+        fmoe._CONFIG_STATUS = None
+
+    def _write_config(
+        self, path: Path, tokens: tuple[int, ...] = (64,), tag: str = ""
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "cu_num": "80",
+            "model_dim": "2048",
+            "inter_dim": "128",
+            "expert": "256",
+            "topk": "8",
+            "act_type": "ActivationType.Silu",
+            "dtype": "torch.bfloat16",
+            "q_dtype_a": "torch.float8_e4m3fnuz",
+            "q_dtype_w": "torch.float8_e4m3fnuz",
+            "q_type": "QuantType.per_Token",
+            "use_g1u1": "1",
+            "doweight_stage1": "0",
+            "_tag": tag,
+        }
+        with path.open("w", newline="") as destination:
+            writer = csv.DictWriter(
+                destination, fieldnames=(*fmoe._DISPATCH_KEY_FIELDS, "_tag")
+            )
+            writer.writeheader()
+            for token in tokens:
+                writer.writerow({**row, "token": str(token)})
+
+    def _fixture(self, root: Path, stock_token: int = 64):
+        config_dir = root / "aiter" / "configs"
+        default_config = config_dir / "tuned_fmoe.csv"
+        model_config = config_dir / "model_configs" / "model_tuned_fmoe.csv"
+        overlay_config = root / "rtp_overlay.csv"
+        self._write_config(default_config, (stock_token,))
+        self._write_config(model_config, (stock_token + 1,))
+        self._write_config(overlay_config, fmoe._AFFECTED_TOKEN_BUCKETS)
+        return default_config, model_config, overlay_config
+
+    def _configure(self, root: Path, default_config: Path, overlay_config: Path):
+        default_hash = hashlib.sha256(default_config.read_bytes()).hexdigest()
+        distribution = _FakeDistribution(root, fmoe._SUPPORTED_AITER_VERSION)
+        return mock.patch.multiple(
+            fmoe,
+            _SUPPORTED_DEFAULT_CONFIG_SHA256=default_hash,
+            _OVERLAY_CONFIG=overlay_config,
+        ), mock.patch.object(
+            fmoe.importlib.metadata, "distribution", return_value=distribution
+        )
+
+    def test_configures_additive_overlay_and_keeps_model_configs(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, model_config, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertTrue(status.applied)
+            self.assertEqual(
+                os.environ["AITER_CONFIG_FMOE"].split(os.pathsep),
+                [str(default_config), str(model_config), str(overlay_config)],
+            )
+
+    def test_stock_dispatch_collision_requires_review(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root, stock_token=1)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("overlap", status.reason)
+
+    def test_nonempty_overlay_tag_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            self._write_config(
+                overlay_config,
+                fmoe._AFFECTED_TOKEN_BUCKETS,
+                tag="not-used-for-normal-dispatch",
+            )
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("excludes tagged rows", status.reason)
+
+    def test_version_change_requires_review_for_affected_signature(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._fixture(root)
+            distribution = _FakeDistribution(root, "new-aiter-version")
+            with mock.patch.object(
+                fmoe.importlib.metadata,
+                "distribution",
+                return_value=distribution,
+            ):
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("review", status.reason)
+            with self.assertRaisesRegex(RuntimeError, "Revalidate"):
+                fmoe.require_aiter_fmoe_tuning(self._affected_signature())
+
+    def test_supported_version_matches_pinned_rocm_wheel(self):
+        for requirements_path in (
+            "rtp_deps/requirements_rocm.txt",
+            "rtp_deps/requirements_lock_rocm.txt",
+        ):
+            with self.subTest(requirements_path=requirements_path):
+                requirements = _runfile(requirements_path).read_text()
+                versions = {
+                    unquote(match.group(1))
+                    for match in _AITER_WHEEL_VERSION_PATTERN.finditer(requirements)
+                }
+                self.assertEqual(versions, {fmoe._SUPPORTED_AITER_VERSION})
+
+    def test_installed_aiter_matches_supported_artifacts_when_available(self):
+        try:
+            distribution = fmoe.importlib.metadata.distribution("aiter")
+        except fmoe.importlib.metadata.PackageNotFoundError:
+            self.skipTest("aiter is not installed in this test environment")
+
+        self.assertEqual(distribution.version, fmoe._SUPPORTED_AITER_VERSION)
+        default_config = Path(
+            distribution.locate_file("aiter/configs/tuned_fmoe.csv")
+        ).resolve()
+        self.assertTrue(default_config.is_file())
+        self.assertEqual(
+            fmoe._sha256(default_config), fmoe._SUPPORTED_DEFAULT_CONFIG_SHA256
+        )
+
+    def test_explicit_config_must_include_overlay(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            default_config, _, overlay_config = self._fixture(root)
+            config_patch, distribution_patch = self._configure(
+                root, default_config, overlay_config
+            )
+            os.environ["AITER_CONFIG_FMOE"] = str(default_config)
+            with config_patch, distribution_patch:
+                status = fmoe.configure_aiter_fmoe_overlays()
+
+            self.assertFalse(status.applied)
+            self.assertIn("explicitly set", status.reason)
+
+    def test_signature_is_shape_based_not_model_or_parallelism_based(self):
+        signature = self._affected_signature()
+        self.assertTrue(fmoe.is_affected_aiter_fmoe_signature(signature))
+        self.assertNotIn("model", {field.name for field in fields(signature)})
+        self.assertNotIn("tp_size", {field.name for field in fields(signature)})
+        self.assertNotIn("ep_size", {field.name for field in fields(signature)})
+
+        for name, value in (
+            ("gfx", "gfx950"),
+            ("cu_num", 79),
+            ("model_dim", 4096),
+            ("inter_dim", 256),
+            ("expert", 128),
+            ("topk", 4),
+            ("dtype", "torch.float16"),
+            ("use_g1u1", 0),
+        ):
+            with self.subTest(field=name):
+                self.assertFalse(
+                    fmoe.is_affected_aiter_fmoe_signature(
+                        replace(signature, **{name: value})
+                    )
+                )
+
+    def test_unaffected_signature_does_not_require_an_active_overlay(self):
+        fmoe._CONFIG_STATUS = fmoe._status(False, "inactive")
+        fmoe.require_aiter_fmoe_tuning(
+            replace(self._affected_signature(), inter_dim=256)
+        )
+
+    def test_bundled_overlay_matches_declared_dispatch_rows(self):
+        self.assertEqual(
+            len(fmoe._validated_overlay_dispatch_keys(fmoe._OVERLAY_CONFIG)),
+            len(fmoe._AFFECTED_TOKEN_BUCKETS),
+        )
+
+    @staticmethod
+    def _affected_signature():
+        return next(iter(fmoe._AFFECTED_WORKLOAD_SIGNATURES))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/kernel_tuning/test/registry_test.py
+++ b/rtp_llm/models_py/kernel_tuning/test/registry_test.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest import mock
+
+from rtp_llm.models_py.kernel_tuning import registry
+from rtp_llm.models_py.kernel_tuning.types import KernelTuningStatus
+
+
+class KernelTuningRegistryTest(unittest.TestCase):
+    def test_provider_is_selected_by_compute_architecture(self):
+        status = KernelTuningStatus("test", True, "configured")
+        provider = mock.Mock(return_value=status)
+        with mock.patch.dict(
+            registry._PROVIDERS_BY_ARCH, {"gfx942": (provider,)}, clear=True
+        ):
+            self.assertEqual(registry.configure_kernel_tuning("gfx942"), (status,))
+            self.assertEqual(registry.configure_kernel_tuning("gfx950"), ())
+        provider.assert_called_once_with()
+
+    def test_current_arch_uses_rocm_device_properties(self):
+        properties = mock.Mock(gcnArchName="gfx942:sramecc+:xnack-")
+        with mock.patch.object(
+            registry.torch.cuda, "is_available", return_value=True
+        ), mock.patch.object(registry.torch.version, "hip", "7.0"), mock.patch.object(
+            registry.torch.cuda, "current_device", return_value=2
+        ), mock.patch.object(
+            registry.torch.cuda,
+            "get_device_properties",
+            return_value=properties,
+        ):
+            self.assertEqual(registry._current_rocm_arch(), "gfx942")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/kernel_tuning/types.py
+++ b/rtp_llm/models_py/kernel_tuning/types.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class KernelTuningStatus:
+    overlay: str
+    applied: bool
+    reason: str
+    dependency_version: Optional[str] = None

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/executors/rocm_moe.py
@@ -6,6 +6,10 @@ import torch
 from aiter.fused_moe import fused_moe
 
 from rtp_llm.device.device_impl import is_gfx950
+from rtp_llm.models_py.kernel_tuning.aiter import (
+    AiterFmoeWorkloadSignature,
+    require_aiter_fmoe_tuning,
+)
 from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
     MoEConfigAdapter,
 )
@@ -27,10 +31,55 @@ from rtp_llm.models_py.modules.factory.fused_moe.utils.config_resolver import (
 from rtp_llm.utils.model_weight import W
 
 
-def _moe_activation_type(activation: str) -> aiter.ActivationType:
-    if activation in ("silu", "SiGLU"):
-        return aiter.ActivationType.Silu
-    return aiter.ActivationType.Gelu
+_MOE_ACTIVATION_TYPES = {
+    "gelu": aiter.ActivationType.Gelu,
+    "gated-silu": aiter.ActivationType.Silu,
+    "siglu": aiter.ActivationType.Silu,
+    "silu": aiter.ActivationType.Silu,
+    "swiglu": aiter.ActivationType.Silu,
+}
+
+
+def _moe_activation_type(activation: Any) -> aiter.ActivationType:
+    # ModelConfig canonicalizes activation strings to an RTP ActivationType
+    # enum. Normalize both that representation and the raw strings accepted by
+    # fused_moe so the tuning signature describes the activation actually sent
+    # to AITER.
+    activation_name = str(getattr(activation, "name", activation))
+    activation_name = activation_name.rsplit(".", 1)[-1].lower()
+    try:
+        return _MOE_ACTIVATION_TYPES[activation_name]
+    except KeyError as error:
+        raise ValueError(
+            f"Unsupported AITER FMoE activation: {activation!r} "
+            f"(normalized as {activation_name!r})"
+        ) from error
+
+
+def _aiter_fmoe_workload_signature(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk: int,
+    activation: Any,
+    output_dtype: torch.dtype,
+) -> AiterFmoeWorkloadSignature:
+    properties = torch.cuda.get_device_properties(w1.device)
+    gfx = str(getattr(properties, "gcnArchName", "")).split(":", 1)[0]
+    return AiterFmoeWorkloadSignature(
+        gfx=gfx,
+        cu_num=properties.multi_processor_count,
+        model_dim=w1.shape[2],
+        inter_dim=w2.shape[2],
+        expert=w1.shape[0],
+        topk=topk,
+        act_type=str(_moe_activation_type(activation)),
+        dtype=str(output_dtype),
+        q_dtype_a=str(w1.dtype),
+        q_dtype_w=str(w2.dtype),
+        q_type=str(aiter.QuantType.per_Token),
+        use_g1u1=int(w1.shape[1] == 2 * w2.shape[2]),
+        doweight_stage1=0,
+    )
 
 
 def build_ep_expert_mask(
@@ -197,6 +246,19 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         self.w2 = weights[W.moe_w2]
         self.w1_scale = weights[W.moe_s1]
         self.w2_scale = weights[W.moe_s2]
+        self._configured_activation_type = _moe_activation_type(
+            config.activation_type
+        )
+
+        require_aiter_fmoe_tuning(
+            _aiter_fmoe_workload_signature(
+                self.w1,
+                self.w2,
+                config.moe_k,
+                self._configured_activation_type,
+                config.model_config.compute_dtype,
+            )
+        )
 
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
@@ -224,6 +286,14 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
         assert self.w1.stride(-1) == 1, "Stride of last dimension must be 1"
         assert self.w2.stride(-1) == 1, "Stride of last dimension must be 1"
         assert payload.expert_tokens_meta is not None
+
+        activation_type = _moe_activation_type(activation)
+        if activation_type != self._configured_activation_type:
+            raise ValueError(
+                "MoE activation mismatch: ModelConfig resolved to "
+                f"{self._configured_activation_type}, but execute() received "
+                f"{activation!r}, which resolved to {activation_type}"
+            )
 
         E = self.local_num_experts
         assert payload.expert_topk_ids is not None
@@ -265,7 +335,7 @@ class RocmExpertsFp8PerChannel(FusedMoeExpertExecutor):
             quant_type=aiter.QuantType.per_Token,
             w1_scale=self.w1_scale,
             w2_scale=self.w2_scale,
-            activation=_moe_activation_type(activation),
+            activation=activation_type,
             expert_mask=effective_expert_mask,
         )
 
@@ -320,6 +390,7 @@ class RocmExpertsFp8PerBlock(FusedMoeExpertExecutor):
         self.expert_mask = build_ep_expert_mask(
             self.num_experts, self.ep_rank, self.ep_size, self.w1
         )
+
     @property
     def local_num_experts(self) -> int:
         return self.w1.size(0)
@@ -574,7 +645,9 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
         self.w2_scale = weights[W.moe_s2]
 
         self.hidden_size_raw = config.hidden_size
-        self.intermediate_size_raw = config.model_config.moe_inter_size // config.tp_size
+        self.intermediate_size_raw = (
+            config.model_config.moe_inter_size // config.tp_size
+        )
         packed_factor = 2 if self.w1.dtype == torch.uint8 else 1
         self.hidden_size_padded = self.w1.size(2) * packed_factor
         self.intermediate_size_padded = self.w2.size(1)
@@ -625,7 +698,7 @@ class RocmExpertsMXFp4(FusedMoeExpertExecutor):
             ), "Only support topk=1 when `apply_router_weight_on_input` is True"
             hidden_states = hidden_states * topk_weights.to(hidden_states.dtype)
             topk_weights = torch.ones_like(topk_weights, dtype=torch.float32)
-        
+
         # view w1 and w2 to float4_e2m1fn_x2 if they are uint8
         w1 = self.w1
         w2 = self.w2

--- a/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
+++ b/rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test/rocm_fp8_fused_moe_test.py
@@ -12,9 +12,12 @@ from unittest import SkipTest
 import torch
 
 try:
+    import aiter
     from aiter.ops.shuffle import shuffle_weight  # noqa: F401
 
     from rtp_llm.config.model_config import ModelConfig
+    from rtp_llm.device.device_impl import RocmImpl
+    from rtp_llm.models_py.kernel_tuning.aiter import is_affected_aiter_fmoe_signature
     from rtp_llm.models_py.modules.factory.fused_moe.defs.config_adapter import (
         MoEConfigAdapter,
     )
@@ -34,6 +37,8 @@ try:
     from rtp_llm.models_py.modules.factory.fused_moe.impl.rocm.executors.rocm_moe import (
         RocmExpertsFp8PerBlock,
         RocmExpertsFp8PerChannel,
+        _aiter_fmoe_workload_signature,
+        _moe_activation_type,
     )
     from rtp_llm.ops import MoeConfig, ParallelismConfig
     from rtp_llm.utils.model_weight import W
@@ -51,6 +56,17 @@ def _per_channel_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype):
     scale = (amax / FP8_E4M3FNUZ_MAX).to(torch.float32)
     wq = (w / scale).to(fp8_dtype)
     return wq, scale.squeeze(-1)
+
+
+def _online_loader_quant_fp8(w: torch.Tensor):
+    from rtp_llm.model_loader.per_channel_fp8_quant_weight import (
+        per_channel_cast_to_fp8,
+    )
+
+    wq, scale = per_channel_cast_to_fp8(w)
+    bits = wq.view(torch.int8)
+    bits[bits == -128] = 0
+    return bits.view(torch.float8_e4m3fnuz), scale * 2.0
 
 
 def _per_block_quant_fp8(w: torch.Tensor, fp8_dtype: torch.dtype, block: int = 128):
@@ -78,22 +94,29 @@ def _dequant_per_block(
     return deq.reshape(E, OUT, IN).to(torch.bfloat16)
 
 
-def _make_parallelism_config():
+def _make_parallelism_config(tp_size: int = 1):
     p = ParallelismConfig()
     p.ep_size = 1
     p.ep_rank = 0
-    p.tp_size = 1
+    p.tp_size = tp_size
     p.tp_rank = 0
     p.dp_size = 1
     p.dp_rank = 0
-    p.world_size = 1
+    p.world_size = tp_size
     p.world_rank = 0
     p.local_rank = 0
-    p.local_world_size = 1
+    p.local_world_size = tp_size
     return p
 
 
-def _make_config_adapter(expert_num: int, top_k: int, inter_dim: int):
+def _make_config_adapter(
+    expert_num: int,
+    top_k: int,
+    inter_dim: int,
+    tp_size: int = 1,
+    data_type: str | None = None,
+    activation_type: str = "silu",
+):
     model_config = ModelConfig()
     model_config.attn_config.head_num = 4
     model_config.attn_config.size_per_head = 64
@@ -103,11 +126,13 @@ def _make_config_adapter(expert_num: int, top_k: int, inter_dim: int):
     model_config.expert_num = expert_num
     model_config.moe_k = top_k
     model_config.inter_size = inter_dim
-    model_config.activation_type = "silu"
+    model_config.activation_type = activation_type
+    if data_type is not None:
+        model_config.data_type = data_type
 
     return MoEConfigAdapter(
         model_config=model_config,
-        parallelism_config=_make_parallelism_config(),
+        parallelism_config=_make_parallelism_config(tp_size),
         moe_config=MoeConfig(),
     )
 
@@ -151,6 +176,32 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
     """Cover the refactored single-aiter-fused_moe path (review item #7)."""
 
     M, K, N, E, TOP_K = 16, 256, 256, 4, 2
+
+    def test_activation_type_normalization(self):
+        swiglu_config = ModelConfig()
+        swiglu_config.activation_type = "SiGLU"
+        silu_config = ModelConfig()
+        silu_config.activation_type = "silu"
+
+        silu_aliases = (
+            "silu",
+            "SiGLU",
+            "swiglu",
+            "gated-silu",
+            silu_config.activation_type,
+            swiglu_config.activation_type,
+        )
+        for activation in silu_aliases:
+            with self.subTest(activation=activation):
+                self.assertEqual(
+                    _moe_activation_type(activation), aiter.ActivationType.Silu
+                )
+
+        self.assertEqual(
+            _moe_activation_type("gelu"), aiter.ActivationType.Gelu
+        )
+        with self.assertRaisesRegex(ValueError, "Unsupported AITER FMoE activation"):
+            _moe_activation_type("unknown")
 
     def _run(self, apply_router_weight_on_input: bool):
         payload = self._build_payload(self.M, self.K, self.E, self.TOP_K)
@@ -224,6 +275,116 @@ class RocmExpertsFp8PerChannelTest(_Fp8MoeBaseTest):
     def test_apply_router_weight_on_input(self):
         # PR #882 review #7 specifically called out this newly-enabled path.
         self._run(apply_router_weight_on_input=True)
+
+    def test_small_token_tuned_shape_with_loader_postprocess(self):
+        hidden, local_inter, experts, top_k = 2048, 128, 256, 8
+        runtime_device = RocmImpl.__new__(RocmImpl)
+
+        # Reproduce the FP8 loader conversion, [gate, up] reorder, and the
+        # physical ROCm weight shuffle used by a real checkpoint load.
+        w1_checkpoint = (
+            torch.randn(
+                experts,
+                2 * local_inter,
+                hidden,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.02
+        )
+        w2_checkpoint = (
+            torch.randn(
+                experts,
+                hidden,
+                local_inter,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            * 0.02
+        )
+        w1q_checkpoint, s1_checkpoint = _online_loader_quant_fp8(w1_checkpoint)
+        w2q, s2 = _online_loader_quant_fp8(w2_checkpoint)
+        w1q_loader = runtime_device.cat_0(
+            [
+                w1q_checkpoint[:, local_inter:, :],
+                w1q_checkpoint[:, :local_inter, :],
+            ],
+            dim=1,
+        )
+        s1_loader = torch.cat(
+            [
+                s1_checkpoint[:, local_inter:, :],
+                s1_checkpoint[:, :local_inter, :],
+            ],
+            dim=1,
+        )
+        weights = {
+            W.moe_w1: runtime_device.shuffle_moe_weight(
+                w1q_loader, w1q_loader.dtype, W.moe_w1
+            ),
+            W.moe_w2: runtime_device.shuffle_moe_weight(w2q, w2q.dtype, W.moe_w2),
+            W.moe_s1: runtime_device.shuffle_moe_weight(
+                s1_loader, s1_loader.dtype, W.moe_s1
+            ),
+            W.moe_s2: s2,
+        }
+        w1_dequant = (w1q_checkpoint.float() * s1_checkpoint).to(torch.bfloat16)
+        w2_dequant = (w2q.float() * s2).to(torch.bfloat16)
+
+        # TP is deliberately varied while the local AITER dispatch shape stays
+        # fixed. The tuning decision must therefore be identical for both.
+        for tp_size in (2, 4):
+            config = _make_config_adapter(
+                experts,
+                top_k,
+                local_inter * tp_size,
+                tp_size=tp_size,
+                data_type="bf16",
+                activation_type="SiGLU",
+            )
+            signature = _aiter_fmoe_workload_signature(
+                weights[W.moe_w1],
+                weights[W.moe_w2],
+                config.moe_k,
+                config.activation_type,
+                config.model_config.compute_dtype,
+            )
+            self.assertTrue(is_affected_aiter_fmoe_signature(signature))
+
+            executor = RocmExpertsFp8PerChannel(
+                config,
+                FusedMoEQuantConfig(),
+                weights,
+            )
+            for token_count in (1, 2, 4, 8, 16):
+                with self.subTest(tp_size=tp_size, token_count=token_count):
+                    payload = self._build_payload(token_count, hidden, experts, top_k)
+                    reference = torch_moe_ref(
+                        payload=payload,
+                        activation="silu",
+                        global_num_experts=experts,
+                        expert_map=None,
+                        a2_scale=None,
+                        apply_router_weight_on_input=False,
+                        extra_expert_args=None,
+                        w1=w1_dequant,
+                        w2=w2_dequant,
+                    )
+                    output = executor.execute(
+                        payload=payload,
+                        activation="SiGLU",
+                        expert_map=None,
+                        a2_scale=None,
+                        apply_router_weight_on_input=False,
+                        extra_expert_args=None,
+                    ).fused_expert_output
+                    cosine = torch.nn.functional.cosine_similarity(
+                        output.float(), reference.float(), dim=-1
+                    ).mean()
+
+                    self.assertEqual(output.shape, (token_count, hidden))
+                    self.assertTrue(torch.isfinite(output).all().item())
+                    self.assertGreater(cosine.item(), 0.99)
 
 
 class RocmExpertsFp8PerBlockTest(_Fp8MoeBaseTest):

--- a/rtp_llm/start_backend_server.py
+++ b/rtp_llm/start_backend_server.py
@@ -22,6 +22,7 @@ from rtp_llm.config.server_config_setup import (
     set_parallelism_config,
     setup_cuda_device_and_accl_env,
 )
+from rtp_llm.models_py.kernel_tuning import configure_kernel_tuning
 from rtp_llm.utils.concurrency_controller import (
     ConcurrencyController,
     set_global_controller,
@@ -88,6 +89,7 @@ def local_rank_start(
         py_env_configs.server_config.set_local_rank(local_rank)
         py_env_configs.distribute_config.set_local_rank(local_rank)
         setup_cuda_device_and_accl_env(local_rank)
+        configure_kernel_tuning()
         if py_env_configs.parallelism_config.world_size > 1:
             setproctitle(f"rtp_llm_rank-{local_rank}")
         set_global_controller(global_controller)

--- a/rtp_llm/test/smoke/BUILD
+++ b/rtp_llm/test/smoke/BUILD
@@ -83,6 +83,7 @@ test_suite(
         ":smoke_rocm_dense",
         ":smoke_rocm_moe",
         ":smoke_rocm_qwen35_mrope_cg",
+        ":smoke_rocm_qwen35_mtp",
         ":smoke_rocm_eagle",
         ":smoke_rocm_pd",
         ":smoke_rocm_embedding",

--- a/rtp_llm/test/smoke/suites_rocm_oss.bzl
+++ b/rtp_llm/test/smoke/suites_rocm_oss.bzl
@@ -114,8 +114,7 @@ def rocm_oss_suites():
     )
 
     # ROCm Qwen3.6 dense MTP: TP1 PD separation with decode CUDA Graph.
-    # Keep this suite standalone until Qwen3.6-27B is provisioned on the shared
-    # ROCm CI workers; run it directly on an MI308X host with that checkpoint.
+    # Keep this as a dedicated suite so CI and local runs can select it directly.
     # The fixture intentionally mixes short/long prompts and repeats the long
     # prompt with reuse_cache enabled so both the fresh and reused KV paths are
     # exercised while gen_num_per_cycle=3 checks the requested MTP step.

--- a/rtp_llm/utils/test/jit_cache_manager_test.py
+++ b/rtp_llm/utils/test/jit_cache_manager_test.py
@@ -1028,11 +1028,13 @@ class BackendTest(JitCacheTestBase):
 
     def test_runtime_handler_installed_after_start_requests_shutdown(self):
         handlers = {}
+        events = []
 
         class FakeBackendManager:
             instance = None
 
             def __init__(self, _configs):
+                events.append("backend")
                 self.request_shutdown = mock.Mock()
                 self.serve_forever = mock.Mock()
                 FakeBackendManager.instance = self
@@ -1052,11 +1054,24 @@ class BackendTest(JitCacheTestBase):
             for name in (
                 "copy_gemm_config",
                 "set_parallelism_config",
-                "setup_cuda_device_and_accl_env",
                 "set_global_controller",
                 "setproctitle",
             ):
                 stack.enter_context(mock.patch.object(backend, name))
+            stack.enter_context(
+                mock.patch.object(
+                    backend,
+                    "setup_cuda_device_and_accl_env",
+                    side_effect=lambda *_: events.append("device"),
+                )
+            )
+            stack.enter_context(
+                mock.patch.object(
+                    backend,
+                    "configure_kernel_tuning",
+                    side_effect=lambda: events.append("tuning"),
+                )
+            )
             stack.enter_context(
                 mock.patch.object(
                     backend.signal,
@@ -1067,6 +1082,7 @@ class BackendTest(JitCacheTestBase):
             stack.enter_context(mock.patch.object(backend, "_send_pipe_status", status))
             backend.local_rank_start(None, configs, pipe_writer=object())
         self.assertEqual(status.call_args[0][1], "success")
+        self.assertEqual(events, ["device", "tuning", "backend"])
         handlers[backend.signal.SIGTERM](backend.signal.SIGTERM, None)
         FakeBackendManager.instance.request_shutdown.assert_called_once_with()
         FakeBackendManager.instance.serve_forever.assert_called_once_with()


### PR DESCRIPTION
## Summary

- add a centralized `models_py/kernel_tuning` registry for runtime kernel-tuning overlays
- add a reviewed one-stage AITER FMoE dispatch overlay for the affected gfx942/CU80 small-token workload (`H=2048`, local `I=128`, `E=256`, `topk=8`, BF16 output, per-token FP8)
- gate the overlay by workload shape rather than model name or TP/EP configuration
- fail closed for the affected signature when the AITER version, stock config hash, overlay contents, or stock dispatch overlap requires review
- add config-contract and MI308 numerical regression tests covering loader post-processing, TP2/TP4-equivalent local shapes, and token buckets 1/2/4/8/16
- enable the existing Qwen3.6-27B ROCm FP8 MTP/PD/CUDA-Graph smoke suite in the default CI aggregate

## Validation

- static Starlark syntax and Qwen3.6-27B suite wiring check passed
- `//rtp_llm/models_py/kernel_tuning:aiter_fmoe_test`
- `//rtp_llm/models_py/kernel_tuning:registry_test`
- `//rtp_llm/models_py/modules/factory/fused_moe/impl/rocm/test:rocm_fp8_fused_moe_test`
- default AMD smoke now includes `//rtp_llm/test/smoke:smoke_rocm_qwen35_mtp`

## Maintenance

The overlay is additive and version/hash guarded. An AITER upgrade or an upstream stock dispatch entry for the same key requires an explicit review instead of silently retaining stale RTP tuning.