### PR TITLE
feat: monitor repeated model output

### DIFF
--- a/rtp_llm/config/py_config_modules.py
+++ b/rtp_llm/config/py_config_modules.py
@@ -403,6 +403,13 @@ class GenerateEnvConfig:
 
 class RepetitionDetectionConfig:
     def __init__(self):
+        self.output_repetition_monitor: bool = True
+        self.output_repetition_min_repeats: int = 3
+        self.output_repetition_min_dup_tokens: int = 32
+        self.output_repetition_max_period: int = 512
+        self.noncontig_repeat_min_span_tokens: int = 32
+        self.noncontig_repeat_min_occurrences: int = 3
+        self.noncontig_repeat_max_span_tokens: int = 256
         self.tool_call_loop_monitor: bool = True
         self.tool_call_loop_threshold: int = 5
         self.tool_call_loop_max_span_tokens: int = 16384
@@ -411,6 +418,13 @@ class RepetitionDetectionConfig:
 
     def to_string(self):
         return (
+            f"output_repetition_monitor: {self.output_repetition_monitor}\n"
+            f"output_repetition_min_repeats: {self.output_repetition_min_repeats}\n"
+            f"output_repetition_min_dup_tokens: {self.output_repetition_min_dup_tokens}\n"
+            f"output_repetition_max_period: {self.output_repetition_max_period}\n"
+            f"noncontig_repeat_min_span_tokens: {self.noncontig_repeat_min_span_tokens}\n"
+            f"noncontig_repeat_min_occurrences: {self.noncontig_repeat_min_occurrences}\n"
+            f"noncontig_repeat_max_span_tokens: {self.noncontig_repeat_max_span_tokens}\n"
             f"tool_call_loop_monitor: {self.tool_call_loop_monitor}\n"
             f"tool_call_loop_threshold: {self.tool_call_loop_threshold}\n"
             f"tool_call_loop_max_span_tokens: {self.tool_call_loop_max_span_tokens}\n"

--- a/rtp_llm/cpp/repetition/BUILD
+++ b/rtp_llm/cpp/repetition/BUILD
@@ -4,6 +4,13 @@ load("@arch_config//:arch_select.bzl", "torch_deps")
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "online_repetition_tracker_core",
+    srcs = ["OnlineRepetitionTracker.cc"],
+    hdrs = ["OnlineRepetitionTracker.h"],
+    copts = copts(),
+)
+
+cc_library(
     name = "token_tool_call_loop_guard_core",
     srcs = ["TokenToolCallLoopGuard.cc"],
     hdrs = ["TokenToolCallLoopGuard.h"],
@@ -15,6 +22,7 @@ cc_library(
     srcs = ["OnlineRepetitionPybind.cc"],
     copts = copts(),
     deps = [
+        ":online_repetition_tracker_core",
         ":token_tool_call_loop_guard_core",
     ] + torch_deps(),
     alwayslink = True,

--- a/rtp_llm/cpp/repetition/OnlineRepetitionPybind.cc
+++ b/rtp_llm/cpp/repetition/OnlineRepetitionPybind.cc
@@ -1,3 +1,4 @@
+#include "rtp_llm/cpp/repetition/OnlineRepetitionTracker.h"
 #include "rtp_llm/cpp/repetition/TokenToolCallLoopGuard.h"
 
 #include <pybind11/pybind11.h>
@@ -7,6 +8,40 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(libonline_repetition_tracker, m) {
     using namespace rtp_llm;
+
+    py::class_<OnlineRepetitionConfig>(m, "OnlineRepetitionConfig")
+        .def(py::init<>())
+        .def_readwrite("min_repeats", &OnlineRepetitionConfig::min_repeats)
+        .def_readwrite("min_duplicate_tokens", &OnlineRepetitionConfig::min_duplicate_tokens)
+        .def_readwrite("max_period", &OnlineRepetitionConfig::max_period)
+        .def_readwrite("non_contiguous_min_span", &OnlineRepetitionConfig::non_contiguous_min_span)
+        .def_readwrite("non_contiguous_min_occurrences", &OnlineRepetitionConfig::non_contiguous_min_occurrences)
+        .def_readwrite("non_contiguous_max_span", &OnlineRepetitionConfig::non_contiguous_max_span);
+
+    py::class_<OnlineRepetitionResult>(m, "OnlineRepetitionResult")
+        .def_readonly("hit", &OnlineRepetitionResult::hit)
+        .def_readonly("repeat_unit_size", &OnlineRepetitionResult::repeat_unit_size)
+        .def_readonly("repeat_count", &OnlineRepetitionResult::repeat_count)
+        .def_readonly("partial_tail_tokens", &OnlineRepetitionResult::partial_tail_tokens)
+        .def_readonly("covered_token_count", &OnlineRepetitionResult::covered_token_count)
+        .def_readonly("duplicate_token_count", &OnlineRepetitionResult::duplicate_token_count)
+        .def_readonly("start_index", &OnlineRepetitionResult::start_index)
+        .def_readonly("end_index", &OnlineRepetitionResult::end_index)
+        .def_readonly("first_detect_index", &OnlineRepetitionResult::first_detect_index)
+        .def_readonly("non_contiguous", &OnlineRepetitionResult::non_contiguous)
+        .def_readonly("occurrence_count", &OnlineRepetitionResult::occurrence_count);
+
+    py::class_<OnlineRepetitionTracker>(m, "OnlineRepetitionTracker")
+        .def(py::init<OnlineRepetitionConfig>())
+        .def("reset", &OnlineRepetitionTracker::reset)
+        .def("update_many",
+             [](OnlineRepetitionTracker& tracker, const std::vector<int>& token_ids) {
+                 py::gil_scoped_release release;
+                 return tracker.updateMany(token_ids);
+             })
+        .def("finalize", &OnlineRepetitionTracker::considerFinalTail)
+        .def_property_readonly("result", [](const OnlineRepetitionTracker& tracker) { return tracker.result(); })
+        .def_property_readonly("token_count", &OnlineRepetitionTracker::tokenCount);
 
     m.def(
         "check_tool_call_loop",

--- a/rtp_llm/cpp/repetition/OnlineRepetitionTracker.cc
+++ b/rtp_llm/cpp/repetition/OnlineRepetitionTracker.cc
@@ -1,0 +1,245 @@
+#include "rtp_llm/cpp/repetition/OnlineRepetitionTracker.h"
+
+#include <algorithm>
+#include <tuple>
+
+namespace rtp_llm {
+
+namespace {
+
+OnlineRepetitionConfig normalizeConfig(OnlineRepetitionConfig config) {
+    config.min_repeats = std::max(3, config.min_repeats);
+    config.min_duplicate_tokens = std::max(0, config.min_duplicate_tokens);
+    config.max_period = std::max(1, config.max_period);
+    config.non_contiguous_min_span = std::max(8, config.non_contiguous_min_span);
+    config.non_contiguous_min_occurrences = std::max(2, config.non_contiguous_min_occurrences);
+    config.non_contiguous_max_span = std::max(config.non_contiguous_min_span, config.non_contiguous_max_span);
+    return config;
+}
+
+bool betterResult(const OnlineRepetitionResult& lhs, const OnlineRepetitionResult& rhs) {
+    if (!rhs.hit) {
+        return lhs.hit;
+    }
+    if (!lhs.hit) {
+        return false;
+    }
+    return std::make_tuple(lhs.duplicate_token_count, lhs.covered_token_count, -lhs.repeat_unit_size) >
+           std::make_tuple(rhs.duplicate_token_count, rhs.covered_token_count, -rhs.repeat_unit_size);
+}
+
+OnlineRepetitionResult normalizeResultForEnd(const OnlineRepetitionResult& result, int token_count) {
+    if (!result.hit) {
+        return result;
+    }
+    if (result.non_contiguous) {
+        return result;
+    }
+    OnlineRepetitionResult normalized = result;
+    const bool reaches_final_end = token_count >= 0 && result.end_index == token_count;
+    if (reaches_final_end) {
+        normalized.duplicate_token_count =
+            normalized.covered_token_count - normalized.repeat_unit_size;
+        return normalized;
+    }
+
+    normalized.partial_tail_tokens = 0;
+    normalized.covered_token_count =
+        normalized.repeat_count * normalized.repeat_unit_size;
+    normalized.duplicate_token_count =
+        normalized.covered_token_count - normalized.repeat_unit_size;
+    normalized.end_index = normalized.start_index + normalized.covered_token_count;
+    return normalized;
+}
+
+}  // namespace
+
+OnlineRepetitionTracker::OnlineRepetitionTracker(OnlineRepetitionConfig config):
+    config_(normalizeConfig(config)),
+    match_len_by_period_(static_cast<std::size_t>(config_.max_period) + 1, 0),
+    last_match_index_by_period_(static_cast<std::size_t>(config_.max_period) + 1, -2) {}
+
+void OnlineRepetitionTracker::reset() {
+    token_count_ = 0;
+    result_ = OnlineRepetitionResult();
+    positions_by_token_.clear();
+    tokens_.clear();
+    prefix_hash_.assign(1, 0);
+    hash_power_.assign(1, 1);
+    span_occurrences_.clear();
+    std::fill(match_len_by_period_.begin(), match_len_by_period_.end(), 0);
+    std::fill(last_match_index_by_period_.begin(), last_match_index_by_period_.end(), -2);
+}
+
+std::uint64_t OnlineRepetitionTracker::spanHash(int start, int length) const {
+    return prefix_hash_[start + length] - prefix_hash_[start] * hash_power_[length];
+}
+
+bool OnlineRepetitionTracker::considerNonContiguousSpans(int token_index) {
+    static constexpr std::uint64_t kHashBase = 0x9e3779b185ebca87ULL;
+    bool hit_now = false;
+    for (int length = config_.non_contiguous_min_span; length <= config_.non_contiguous_max_span; length *= 2) {
+        if (length > token_count_) {
+            break;
+        }
+        const int start = token_count_ - length;
+        const std::uint64_t hash = spanHash(start, length);
+        const std::uint64_t key = hash ^ (static_cast<std::uint64_t>(length) * kHashBase);
+        auto [it, inserted] = span_occurrences_.try_emplace(key, SpanOccurrence{start, start, 1});
+        if (inserted) {
+            continue;
+        }
+        auto& occurrence = it->second;
+        if (start < occurrence.last_start + length) {
+            continue;
+        }
+        if (!std::equal(tokens_.begin() + occurrence.last_start,
+                        tokens_.begin() + occurrence.last_start + length,
+                        tokens_.begin() + start)) {
+            occurrence = SpanOccurrence{start, start, 1};
+            continue;
+        }
+        occurrence.last_start = start;
+        ++occurrence.count;
+        const int duplicate_tokens = (occurrence.count - 1) * length;
+        if (occurrence.count < config_.non_contiguous_min_occurrences ||
+            duplicate_tokens < config_.min_duplicate_tokens) {
+            continue;
+        }
+        OnlineRepetitionResult candidate;
+        candidate.hit = true;
+        candidate.repeat_unit_size = length;
+        candidate.repeat_count = occurrence.count;
+        candidate.covered_token_count = occurrence.count * length;
+        candidate.duplicate_token_count = duplicate_tokens;
+        candidate.start_index = occurrence.first_start;
+        candidate.end_index = token_index + 1;
+        candidate.first_detect_index = token_index;
+        candidate.non_contiguous = true;
+        candidate.occurrence_count = occurrence.count;
+        if (!result_.hit || betterResult(candidate, result_)) {
+            result_ = candidate;
+        }
+        hit_now = true;
+    }
+    return hit_now;
+}
+
+bool OnlineRepetitionTracker::considerCandidate(int period, int covered, int token_index, bool include_partial_tail) {
+    const int repeat_count = covered / period;
+    if (repeat_count < config_.min_repeats) {
+        return false;
+    }
+
+    const int complete_covered = repeat_count * period;
+    const int duplicate_tokens = (include_partial_tail ? covered : complete_covered) - period;
+    if (duplicate_tokens < config_.min_duplicate_tokens) {
+        return false;
+    }
+
+    OnlineRepetitionResult candidate;
+    candidate.hit = true;
+    candidate.repeat_unit_size = period;
+    candidate.repeat_count = repeat_count;
+    candidate.partial_tail_tokens = covered % period;
+    candidate.covered_token_count = covered;
+    candidate.duplicate_token_count = duplicate_tokens;
+    candidate.start_index = token_index - covered + 1;
+    candidate.end_index = token_index + 1;
+    candidate.first_detect_index = token_index;
+
+    if (!result_.hit || betterResult(candidate, result_)) {
+        result_ = candidate;
+    }
+    return true;
+}
+
+bool OnlineRepetitionTracker::considerMatch(int period, int match_len, int token_index) {
+    return considerCandidate(period, match_len + period, token_index, false);
+}
+
+bool OnlineRepetitionTracker::update(int token_id) {
+    const int token_index = token_count_++;
+    static constexpr std::uint64_t kHashBase = 0x9e3779b185ebca87ULL;
+    tokens_.push_back(token_id);
+    prefix_hash_.push_back(prefix_hash_.back() * kHashBase + static_cast<std::uint32_t>(token_id) + 1);
+    hash_power_.push_back(hash_power_.back() * kHashBase);
+    auto& positions = positions_by_token_[token_id];
+    const int oldest_kept = token_index - config_.max_period;
+    while (positions.first < positions.values.size() &&
+           positions.values[positions.first] < oldest_kept) {
+        ++positions.first;
+    }
+
+    bool hit_now = false;
+    for (std::size_t pos_index = positions.values.size(); pos_index > positions.first;) {
+        --pos_index;
+        const int previous_index = positions.values[pos_index];
+        const int period = token_index - previous_index;
+        if (period <= 0 || period > config_.max_period) {
+            continue;
+        }
+
+        int match_len = 1;
+        if (last_match_index_by_period_[period] == token_index - 1) {
+            match_len = match_len_by_period_[period] + 1;
+        }
+        match_len_by_period_[period] = match_len;
+        last_match_index_by_period_[period] = token_index;
+
+        hit_now = considerMatch(period, match_len, token_index) || hit_now;
+    }
+
+    positions.values.push_back(token_index);
+    hit_now = considerNonContiguousSpans(token_index) || hit_now;
+    return result_.hit || hit_now;
+}
+
+bool OnlineRepetitionTracker::considerFinalTail() {
+    if (token_count_ <= 0) {
+        return result_.hit;
+    }
+    const int token_index = token_count_ - 1;
+    bool hit_now = false;
+    const int max_period = std::min(config_.max_period, token_count_ - 1);
+    for (int period = 1; period <= max_period; ++period) {
+        if (last_match_index_by_period_[period] != token_index) {
+            continue;
+        }
+        const int covered = std::min(match_len_by_period_[period] + period, token_count_);
+        hit_now = considerCandidate(period, covered, token_index, true) || hit_now;
+    }
+    return result_.hit || hit_now;
+}
+
+bool OnlineRepetitionTracker::updateMany(const std::vector<int>& token_ids) {
+    bool hit = result_.hit;
+    for (int token_id : token_ids) {
+        hit = update(token_id) || hit;
+    }
+    return hit;
+}
+
+OnlineRepetitionResult detectOnlineRepetitionHitOnly(
+    const std::vector<int>& token_ids,
+    OnlineRepetitionConfig config) {
+    OnlineRepetitionTracker tracker(config);
+    for (int token_id : token_ids) {
+        if (tracker.update(token_id)) {
+            return normalizeResultForEnd(tracker.result(), -1);
+        }
+    }
+    tracker.considerFinalTail();
+    return normalizeResultForEnd(tracker.result(), -1);
+}
+
+OnlineRepetitionResult detectOnlineRepetitionMax(
+    const std::vector<int>& token_ids,
+    OnlineRepetitionConfig config) {
+    OnlineRepetitionTracker tracker(config);
+    tracker.updateMany(token_ids);
+    tracker.considerFinalTail();
+    return normalizeResultForEnd(tracker.result(), static_cast<int>(token_ids.size()));
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/repetition/OnlineRepetitionTracker.h
+++ b/rtp_llm/cpp/repetition/OnlineRepetitionTracker.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace rtp_llm {
+
+struct OnlineRepetitionConfig {
+    int min_repeats = 3;
+    int min_duplicate_tokens = 32;
+    int max_period = 512;
+    int non_contiguous_min_span = 32;
+    int non_contiguous_min_occurrences = 3;
+    int non_contiguous_max_span = 256;
+};
+
+struct OnlineRepetitionResult {
+    bool hit = false;
+    int repeat_unit_size = 0;
+    int repeat_count = 0;
+    int partial_tail_tokens = 0;
+    int covered_token_count = 0;
+    int duplicate_token_count = 0;
+    int start_index = 0;
+    int end_index = 0;
+    int first_detect_index = 0;
+    bool non_contiguous = false;
+    int occurrence_count = 0;
+};
+
+class OnlineRepetitionTracker {
+public:
+    explicit OnlineRepetitionTracker(OnlineRepetitionConfig config = {});
+
+    void reset();
+    bool update(int token_id);
+    bool updateMany(const std::vector<int>& token_ids);
+    bool considerFinalTail();
+
+    const OnlineRepetitionResult& result() const {
+        return result_;
+    }
+
+    int tokenCount() const {
+        return token_count_;
+    }
+
+private:
+    struct RecentPositions {
+        std::vector<int> values;
+        std::size_t first = 0;
+    };
+
+    struct SpanOccurrence {
+        int first_start = -1;
+        int last_start = -1;
+        int count = 0;
+    };
+
+    OnlineRepetitionConfig config_;
+    int token_count_ = 0;
+    OnlineRepetitionResult result_;
+    std::unordered_map<int, RecentPositions> positions_by_token_;
+    std::vector<int> match_len_by_period_;
+    std::vector<int> last_match_index_by_period_;
+    std::vector<int> tokens_;
+    std::vector<std::uint64_t> prefix_hash_{0};
+    std::vector<std::uint64_t> hash_power_{1};
+    std::unordered_map<std::uint64_t, SpanOccurrence> span_occurrences_;
+
+    bool considerMatch(int period, int match_len, int token_index);
+    bool considerCandidate(int period, int covered, int token_index, bool include_partial_tail);
+    bool considerNonContiguousSpans(int token_index);
+    std::uint64_t spanHash(int start, int length) const;
+};
+
+OnlineRepetitionResult detectOnlineRepetitionHitOnly(
+    const std::vector<int>& token_ids,
+    OnlineRepetitionConfig config = {});
+
+OnlineRepetitionResult detectOnlineRepetitionMax(
+    const std::vector<int>& token_ids,
+    OnlineRepetitionConfig config = {});
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/repetition/test/BUILD
+++ b/rtp_llm/cpp/repetition/test/BUILD
@@ -3,6 +3,13 @@ load("//:def.bzl", "cc_test_wrapper", "copts")
 package(default_visibility = ["//visibility:public"])
 
 cc_test_wrapper(
+    name = "online_repetition_tracker_test",
+    srcs = ["OnlineRepetitionTrackerTest.cc"],
+    deps = ["//rtp_llm/cpp/repetition:online_repetition_tracker_core"],
+    copts = copts(),
+)
+
+cc_test_wrapper(
     name = "token_tool_call_loop_guard_test",
     srcs = ["TokenToolCallLoopGuardTest.cc"],
     deps = [

--- a/rtp_llm/cpp/repetition/test/OnlineRepetitionTrackerTest.cc
+++ b/rtp_llm/cpp/repetition/test/OnlineRepetitionTrackerTest.cc
@@ -1,0 +1,170 @@
+#include "rtp_llm/cpp/repetition/OnlineRepetitionTracker.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#define RTP_EXPECT(expr)                                                                            \
+    do {                                                                                            \
+        if (!(expr)) {                                                                              \
+            std::cerr << __FILE__ << ":" << __LINE__ << " check failed: " << #expr << std::endl;   \
+            std::abort();                                                                           \
+        }                                                                                           \
+    } while (false)
+
+namespace rtp_llm {
+namespace {
+
+OnlineRepetitionConfig testConfig() {
+    OnlineRepetitionConfig config;
+    config.min_repeats = 3;
+    config.min_duplicate_tokens = 0;
+    config.max_period = 512;
+    return config;
+}
+
+void testDetectsTruncatedPeriodicRun() {
+    std::vector<int> tokens;
+    for (int i = 0; i < 8; ++i) {
+        tokens.insert(tokens.end(), {10, 20, 30, 99});
+    }
+    tokens.insert(tokens.end(), {10, 20});
+
+    const auto result = detectOnlineRepetitionMax(tokens, testConfig());
+    RTP_EXPECT(result.hit);
+    RTP_EXPECT(result.repeat_unit_size == 4);
+    RTP_EXPECT(result.repeat_count == 8);
+    RTP_EXPECT(result.partial_tail_tokens == 2);
+    RTP_EXPECT(result.covered_token_count == 34);
+    RTP_EXPECT(result.duplicate_token_count == 30);
+    RTP_EXPECT(result.start_index == 0);
+    RTP_EXPECT(result.end_index == static_cast<int>(tokens.size()));
+}
+
+void testIgnoresTwoRepeats() {
+    std::vector<int> tokens;
+    for (int i = 0; i < 2; ++i) {
+        tokens.insert(tokens.end(), {10, 20, 30, 99});
+    }
+
+    const auto result = detectOnlineRepetitionMax(tokens, testConfig());
+    RTP_EXPECT(!result.hit);
+}
+
+void testMiddleRepeatFollowedBySuffix() {
+    std::vector<int> tokens = {7, 8};
+    for (int i = 0; i < 5; ++i) {
+        tokens.insert(tokens.end(), {1, 2, 3});
+    }
+    tokens.insert(tokens.end(), {4, 5, 6});
+
+    const auto result = detectOnlineRepetitionMax(tokens, testConfig());
+    RTP_EXPECT(result.hit);
+    RTP_EXPECT(result.repeat_unit_size == 3);
+    RTP_EXPECT(result.duplicate_token_count == 12);
+    RTP_EXPECT(result.start_index == 2);
+    RTP_EXPECT(result.end_index == 17);
+}
+
+void testMinDuplicateThreshold() {
+    OnlineRepetitionConfig config = testConfig();
+    config.min_duplicate_tokens = 32;
+    const std::vector<int> tokens = {9, 8, 7, 9, 8, 7, 9, 8, 7};
+
+    const auto result = detectOnlineRepetitionMax(tokens, config);
+    RTP_EXPECT(!result.hit);
+}
+
+void testFinalPartialTailCountsTowardThreshold() {
+    OnlineRepetitionConfig config = testConfig();
+    config.min_duplicate_tokens = 32;
+
+    std::vector<int> unit;
+    for (int i = 0; i < 15; ++i) {
+        unit.push_back(100 + i);
+    }
+    std::vector<int> tokens;
+    for (int i = 0; i < 3; ++i) {
+        tokens.insert(tokens.end(), unit.begin(), unit.end());
+    }
+    tokens.insert(tokens.end(), unit.begin(), unit.begin() + 14);
+
+    const auto result = detectOnlineRepetitionMax(tokens, config);
+    RTP_EXPECT(result.hit);
+    RTP_EXPECT(result.repeat_unit_size == 15);
+    RTP_EXPECT(result.repeat_count == 3);
+    RTP_EXPECT(result.partial_tail_tokens == 14);
+    RTP_EXPECT(result.covered_token_count == 59);
+    RTP_EXPECT(result.duplicate_token_count == 44);
+    RTP_EXPECT(result.start_index == 0);
+    RTP_EXPECT(result.end_index == static_cast<int>(tokens.size()));
+}
+
+void testLongSameToken() {
+    OnlineRepetitionConfig config = testConfig();
+    config.min_duplicate_tokens = 32;
+    const std::vector<int> tokens(1000, 95553);
+
+    const auto result = detectOnlineRepetitionHitOnly(tokens, config);
+    RTP_EXPECT(result.hit);
+    RTP_EXPECT(result.repeat_unit_size == 1);
+    RTP_EXPECT(result.duplicate_token_count >= 32);
+}
+
+void testRandomNoHit() {
+    OnlineRepetitionConfig config = testConfig();
+    config.min_duplicate_tokens = 32;
+    std::mt19937 rng(20260610);
+    std::vector<int> tokens;
+    tokens.reserve(4096);
+    for (int i = 0; i < 4096; ++i) {
+        tokens.push_back(static_cast<int>(rng() + 1000000U));
+    }
+
+    const auto result = detectOnlineRepetitionMax(tokens, config);
+    RTP_EXPECT(!result.hit);
+}
+
+void testNonContiguousRepeatedSpan() {
+    OnlineRepetitionConfig config = testConfig();
+    config.min_duplicate_tokens = 64;
+    config.non_contiguous_min_span = 32;
+    config.non_contiguous_min_occurrences = 3;
+    config.non_contiguous_max_span = 64;
+
+    std::vector<int> repeated;
+    for (int i = 0; i < 32; ++i) {
+        repeated.push_back(1000 + i);
+    }
+    std::vector<int> tokens;
+    for (int occurrence = 0; occurrence < 3; ++occurrence) {
+        tokens.insert(tokens.end(), repeated.begin(), repeated.end());
+        for (int i = 0; i < 17 + occurrence; ++i) {
+            tokens.push_back(5000 + occurrence * 100 + i);
+        }
+    }
+
+    const auto result = detectOnlineRepetitionMax(tokens, config);
+    RTP_EXPECT(result.hit);
+    RTP_EXPECT(result.non_contiguous);
+    RTP_EXPECT(result.repeat_unit_size == 32);
+    RTP_EXPECT(result.occurrence_count == 3);
+    RTP_EXPECT(result.duplicate_token_count == 64);
+}
+
+}  // namespace
+}  // namespace rtp_llm
+
+int main() {
+    rtp_llm::testDetectsTruncatedPeriodicRun();
+    rtp_llm::testIgnoresTwoRepeats();
+    rtp_llm::testMiddleRepeatFollowedBySuffix();
+    rtp_llm::testMinDuplicateThreshold();
+    rtp_llm::testFinalPartialTailCountsTowardThreshold();
+    rtp_llm::testLongSameToken();
+    rtp_llm::testRandomNoHit();
+    rtp_llm::testNonContiguousRepeatedSpan();
+    std::cout << "OnlineRepetitionTracker tests passed\n";
+    return 0;
+}

--- a/rtp_llm/dash_sc/BUILD
+++ b/rtp_llm/dash_sc/BUILD
@@ -17,6 +17,13 @@ filegroup(
 )
 
 py_library(
+    name = "repetition_monitor",
+    srcs = ["repetition_monitor.py"],
+    data = ["//rtp_llm/cpp/repetition:online_repetition_tracker"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
     name = "dash_sc_grpc_server",
     srcs = [
         "__init__.py",
@@ -35,7 +42,6 @@ py_library(
         "proxy/service_route.py",
         "proxy/service_route_config.py",
         "proxy/servicer.py",
-        "repetition_monitor.py",
         "server.py",
         "status.py",
         "structural_tag.py",
@@ -47,6 +53,7 @@ py_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":repetition_monitor",
         "//rtp_llm/server:server",
         ":grpcio",
         ":jsonschema",

--- a/rtp_llm/dash_sc/access_record.py
+++ b/rtp_llm/dash_sc/access_record.py
@@ -517,6 +517,7 @@ class GrpcAccessRecord:
         """
         if token_ids:
             self.generated_ids.extend(token_ids)
+            self._repetition_monitor.update_output_delta(token_ids)
 
     def record_aux_info(self, aux_info: Any, *, overwrite: bool = True) -> None:
         """Keep the latest backend ``AuxInfo`` for the frontend access log."""

--- a/rtp_llm/dash_sc/app.py
+++ b/rtp_llm/dash_sc/app.py
@@ -30,6 +30,7 @@ from rtp_llm.dash_sc.inference.servicer import (
 )
 from rtp_llm.dash_sc.proxy.servicer import DashScProxyServicer
 from rtp_llm.dash_sc.repetition_monitor import (
+    OutputRepetitionConfig,
     RequestRepetitionMonitorConfig,
     ToolCallLoopConfig,
     ToolCallMarkerConfig,
@@ -274,6 +275,15 @@ def _tokenize_marker_text(base_tok: BaseTokenizer, text: str) -> List[int]:
 def _build_repetition_monitor_config(
     config: RepetitionDetectionConfig, base_tok: BaseTokenizer | None = None
 ) -> RequestRepetitionMonitorConfig:
+    output_config = OutputRepetitionConfig(
+        enabled=config.output_repetition_monitor,
+        min_repeats=config.output_repetition_min_repeats,
+        min_duplicate_tokens=config.output_repetition_min_dup_tokens,
+        max_period=config.output_repetition_max_period,
+        non_contiguous_min_span=config.noncontig_repeat_min_span_tokens,
+        non_contiguous_min_occurrences=config.noncontig_repeat_min_occurrences,
+        non_contiguous_max_span=config.noncontig_repeat_max_span_tokens,
+    )
     tool_loop_config = ToolCallLoopConfig(
         enabled=config.tool_call_loop_monitor,
         repeat_threshold=config.tool_call_loop_threshold,
@@ -296,6 +306,7 @@ def _build_repetition_monitor_config(
         if begin_ids and end_ids:
             tool_markers = (ToolCallMarkerConfig(begin_ids=begin_ids, end_ids=end_ids),)
     return RequestRepetitionMonitorConfig(
+        output_config=output_config,
         tool_loop_config=tool_loop_config,
         tool_markers=tool_markers,
     )

--- a/rtp_llm/dash_sc/grpc_metrics.py
+++ b/rtp_llm/dash_sc/grpc_metrics.py
@@ -159,6 +159,34 @@ def _report_frontend_structured_metrics(
         kmonitor.report(GaugeMetrics.INPUT_TOKEN_SIZE_METRIC, record.input_len, tags)
     kmonitor.report(GaugeMetrics.OUTPUT_TOKEN_SIZE_METRIC, record.output_len, tags)
     monitor = record.repetition_monitor
+    if monitor.output_repetition_check_ms > 0:
+        kmonitor.report(
+            GaugeMetrics.OUTPUT_REPETITION_CHECK_RT_METRIC,
+            monitor.output_repetition_check_ms,
+            tags,
+        )
+    output = monitor.output_repetition_result
+    if output is not None and output.hit:
+        kind = (
+            "non_contiguous_span_repeat"
+            if output.non_contiguous
+            else "same_token_run"
+            if output.repeat_unit_size == 1
+            else "exact_ngram_loop"
+            if output.repeat_unit_size <= 64
+            else "long_span_repeat"
+        )
+        output_tags = {**tags, "kind": kind, "action": "metric"}
+        kmonitor.report(AccMetrics.OUTPUT_REPETITION_QPS_METRIC, 1, output_tags)
+        if kind == "same_token_run":
+            kmonitor.report(AccMetrics.SAME_TOKEN_RUN_QPS_METRIC, 1, output_tags)
+        kmonitor.report(GaugeMetrics.OUTPUT_REPETITION_PERIOD_METRIC, output.repeat_unit_size, output_tags)
+        kmonitor.report(GaugeMetrics.OUTPUT_REPETITION_REPEAT_COUNT_METRIC, output.repeat_count, output_tags)
+        kmonitor.report(
+            GaugeMetrics.OUTPUT_REPETITION_DUPLICATE_TOKENS_METRIC,
+            output.duplicate_token_count,
+            output_tags,
+        )
     if monitor.tool_call_loop_check_ms is not None:
         kmonitor.report(
             GaugeMetrics.TOOL_CALL_LOOP_CHECK_RT_METRIC,

--- a/rtp_llm/dash_sc/repetition_monitor.py
+++ b/rtp_llm/dash_sc/repetition_monitor.py
@@ -1,4 +1,4 @@
-"""Low-overhead token tool-call loop monitor for frontend access logging.
+"""Low-overhead output and tool-call repetition monitoring for frontend logging.
 
 The production path calls a native C++/pybind detector once per completed
 request. Python owns token-id policy and access-log fields; C++ owns token-id
@@ -11,7 +11,7 @@ import dataclasses
 import importlib
 import logging
 import time
-from typing import Optional, Protocol, Sequence
+from typing import Any, Optional, Protocol, Sequence
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,10 +23,17 @@ _NATIVE_TRACKER_MODULES = (
     "rtp_llm.cpp.repetition.libonline_repetition_tracker",
     "libonline_repetition_tracker",
 )
-_NATIVE_TRACKER_REQUIRED_API = "check_tool_call_loop"
+_NATIVE_TRACKER_REQUIRED_APIS = (
+    "OnlineRepetitionConfig",
+    "OnlineRepetitionTracker",
+    "check_tool_call_loop",
+)
 
 
 class _NativeRepetitionModule(Protocol):
+    OnlineRepetitionConfig: Any
+    OnlineRepetitionTracker: Any
+
     def check_tool_call_loop(
         self,
         input_ids: Sequence[int],
@@ -63,8 +70,13 @@ def _resolve_native_status() -> NativeModuleStatus:
             break
         except Exception as e:
             errors.append(f"{name}: {type(e).__name__}: {e}")
-    if raw_module is not None and not hasattr(raw_module, _NATIVE_TRACKER_REQUIRED_API):
-        errors.append(f"{module_name}: missing API {_NATIVE_TRACKER_REQUIRED_API}")
+    missing = [
+        name
+        for name in _NATIVE_TRACKER_REQUIRED_APIS
+        if raw_module is not None and not hasattr(raw_module, name)
+    ]
+    if raw_module is not None and missing:
+        errors.append(f"{module_name}: missing API {','.join(missing)}")
         raw_module = None
         module_name = None
     if raw_module is not None:
@@ -98,6 +110,31 @@ class ToolCallMarkerConfig:
 
 
 @dataclasses.dataclass(frozen=True)
+class OutputRepetitionConfig:
+    enabled: bool = True
+    min_repeats: int = 3
+    min_duplicate_tokens: int = 32
+    max_period: int = 512
+    non_contiguous_min_span: int = 32
+    non_contiguous_min_occurrences: int = 3
+    non_contiguous_max_span: int = 256
+
+
+@dataclasses.dataclass(frozen=True)
+class OutputRepetitionResult:
+    hit: bool
+    repeat_unit_size: int
+    repeat_count: int
+    covered_token_count: int
+    duplicate_token_count: int
+    start_index: int
+    end_index: int
+    first_detect_index: int
+    non_contiguous: bool
+    occurrence_count: int
+
+
+@dataclasses.dataclass(frozen=True)
 class ToolCallLoopConfig:
     enabled: bool = True
     repeat_threshold: int = 5
@@ -117,6 +154,9 @@ DEFAULT_TOOL_CALL_LOOP_CONFIG = ToolCallLoopConfig()
 
 @dataclasses.dataclass(frozen=True)
 class RequestRepetitionMonitorConfig:
+    output_config: OutputRepetitionConfig = dataclasses.field(
+        default_factory=lambda: OutputRepetitionConfig(enabled=False)
+    )
     tool_loop_config: ToolCallLoopConfig = dataclasses.field(
         default_factory=ToolCallLoopConfig
     )
@@ -208,6 +248,7 @@ class RequestRepetitionMonitor:
         self.raw_mode = raw_mode
         self.input_ids: Sequence[int] = input_ids or ()
         self.tool_loop_config = tool_loop_config or config.tool_loop_config
+        self.output_config = config.output_config
         # Markers come from the service-level config unless a caller (tests)
         # passes them explicitly.
         self.tool_markers = (
@@ -220,17 +261,89 @@ class RequestRepetitionMonitor:
         self.tool_call_loop_check_ms: Optional[float] = None
         self.tool_call_loop_impl: Optional[str] = None
         self._tool_error: Optional[str] = None
+        self.output_repetition_result: Optional[OutputRepetitionResult] = None
+        self.output_repetition_check_ms: float = 0.0
+        self.output_repetition_impl: Optional[str] = None
+        self._output_error: Optional[str] = None
+        self._output_tracker = None
+        self._output_finalized = False
 
     def set_input_ids(self, input_ids: Optional[Sequence[int]]) -> None:
         self.input_ids = input_ids or ()
 
     def is_active(self) -> bool:
-        """Whether tool-call loop detection will actually run for this request."""
-        return (
-            not self.raw_mode
-            and self.tool_loop_config.enabled
-            and bool(self.tool_markers)
+        return not self.raw_mode and (
+            self.output_config.enabled
+            or (self.tool_loop_config.enabled and bool(self.tool_markers))
         )
+
+    def _ensure_output_tracker(self):
+        if self._output_tracker is not None:
+            return self._output_tracker
+        status = native_online_repetition_status()
+        if not status.available:
+            self.output_repetition_impl = "online_cpp_pybind_unavailable"
+            return None
+        native_config = status.module.OnlineRepetitionConfig()
+        native_config.min_repeats = max(3, int(self.output_config.min_repeats))
+        native_config.min_duplicate_tokens = max(0, int(self.output_config.min_duplicate_tokens))
+        native_config.max_period = max(1, int(self.output_config.max_period))
+        native_config.non_contiguous_min_span = max(8, int(self.output_config.non_contiguous_min_span))
+        native_config.non_contiguous_min_occurrences = max(2, int(self.output_config.non_contiguous_min_occurrences))
+        native_config.non_contiguous_max_span = max(
+            native_config.non_contiguous_min_span,
+            int(self.output_config.non_contiguous_max_span),
+        )
+        self._output_tracker = status.module.OnlineRepetitionTracker(native_config)
+        self.output_repetition_impl = "online_cpp_pybind"
+        return self._output_tracker
+
+    def update_output_delta(self, delta_ids: Sequence[int]) -> None:
+        if self.raw_mode or not self.output_config.enabled or not delta_ids or self._output_finalized:
+            return
+        begin = time.perf_counter()
+        try:
+            tracker = self._ensure_output_tracker()
+            if tracker is not None:
+                tracker.update_many([int(token_id) for token_id in delta_ids])
+        except Exception as e:
+            self._output_error = f"{type(e).__name__}: {e}"
+            self.output_repetition_impl = "online_cpp_pybind_unavailable"
+        finally:
+            self.output_repetition_check_ms += (time.perf_counter() - begin) * 1000.0
+
+    def finalize_output(self) -> None:
+        if self._output_finalized:
+            return
+        self._output_finalized = True
+        if self.raw_mode or not self.output_config.enabled:
+            self.output_repetition_impl = "disabled_raw_mode" if self.raw_mode else "disabled"
+            return
+        begin = time.perf_counter()
+        try:
+            tracker = self._ensure_output_tracker()
+            if tracker is None:
+                return
+            tracker.finalize()
+            result = tracker.result
+            if result.hit:
+                self.output_repetition_result = OutputRepetitionResult(
+                    hit=True,
+                    repeat_unit_size=int(result.repeat_unit_size),
+                    repeat_count=int(result.repeat_count),
+                    covered_token_count=int(result.covered_token_count),
+                    duplicate_token_count=int(result.duplicate_token_count),
+                    start_index=int(result.start_index),
+                    end_index=int(result.end_index),
+                    first_detect_index=int(result.first_detect_index),
+                    non_contiguous=bool(result.non_contiguous),
+                    occurrence_count=int(result.occurrence_count),
+                )
+        except Exception as e:
+            self._output_error = f"{type(e).__name__}: {e}"
+            self.output_repetition_impl = "online_cpp_pybind_unavailable"
+        finally:
+            self.output_repetition_check_ms += (time.perf_counter() - begin) * 1000.0
 
     def _tool_impl_name(self) -> str:
         if self.raw_mode:
@@ -264,18 +377,24 @@ class RequestRepetitionMonitor:
             self.tool_call_loop_check_ms = (time.perf_counter() - begin) * 1000.0
 
     def check_generated_ids(self, generated_ids: Sequence[int]) -> None:
+        self.finalize_output()
         self.check_tool_call_loop(generated_ids)
 
     def monitor_impl(self) -> str:
         if self.raw_mode:
             return "disabled_raw_mode"
-        if self.tool_loop_config.enabled and self.tool_markers:
-            return f"tool={self._tool_impl_name()}"
-        return "disabled"
+        output_impl = self.output_repetition_impl or ("online_cpp_pybind" if self.output_config.enabled else "disabled")
+        return f"output={output_impl},tool={self._tool_impl_name()}"
 
     def monitor_available(self) -> tuple[bool, Optional[str]]:
         if self.raw_mode:
             return False, "raw_mode"
+        if self.output_config.enabled:
+            status = native_online_repetition_status()
+            if not status.available:
+                return False, status.error or "native module unavailable"
+            if self._output_error:
+                return False, f"output: {self._output_error}"
         if self.tool_loop_config.enabled and self.tool_markers:
             status = native_online_repetition_status()
             if not status.available:
@@ -300,20 +419,44 @@ class RequestRepetitionMonitor:
             }
 
         tool_loop = self.tool_call_loop_result
-        hit = bool(tool_loop.hit) if tool_loop is not None else False
-        span = tool_loop.current_span_tokens if hit and tool_loop is not None else None
+        tool_hit = bool(tool_loop.hit) if tool_loop is not None else False
+        output = self.output_repetition_result
+        output_hit = bool(output.hit) if output is not None else False
+        hit = output_hit or tool_hit
+        repetition_tokens = (
+            output.duplicate_token_count
+            if output_hit and output is not None
+            else tool_loop.current_span_tokens
+            if tool_hit and tool_loop is not None
+            else None
+        )
+        tool_span = (
+            tool_loop.current_span_tokens
+            if tool_hit and tool_loop is not None
+            else None
+        )
+        output_kind = None
+        if output_hit and output is not None:
+            if output.non_contiguous:
+                output_kind = "non_contiguous_span_repeat"
+            elif output.repeat_unit_size == 1:
+                output_kind = "same_token_run"
+            elif output.repeat_unit_size <= 64:
+                output_kind = "exact_ngram_loop"
+            else:
+                output_kind = "long_span_repeat"
         return {
             "repetition_detected": hit,
             "repetition_alert": hit,
             "repetition_reason": (
-                f"tool_call_loop:repeat_count={tool_loop.repeat_count}"
-                if hit and tool_loop is not None
-                else None
+                f"output_repetition:{output_kind}:repeat_count={output.repeat_count}"
+                if output_hit and output is not None
+                else (f"tool_call_loop:repeat_count={tool_loop.repeat_count}" if tool_hit and tool_loop is not None else None)
             ),
-            "repetition_primary_source": "tool_call_loop" if hit else None,
-            "repetition_token_len": span,
-            "tool_call_loop_token_len": span,
-            "function_tool_repeated": hit,
+            "repetition_primary_source": "output_repetition" if output_hit else ("tool_call_loop" if tool_hit else None),
+            "repetition_token_len": repetition_tokens,
+            "tool_call_loop_token_len": tool_span,
+            "function_tool_repeated": tool_hit,
             "repetition_monitor_impl": self.monitor_impl(),
             "repetition_monitor_available": True,
             "repetition_monitor_unavailable_reason": None,
@@ -324,7 +467,7 @@ class RequestRepetitionMonitor:
                 if self.tool_call_loop_check_ms is not None
                 else None
             ),
-            "tool_call_loop_hit": hit,
+            "tool_call_loop_hit": tool_hit,
             "tool_call_loop_repeat_count": (
                 tool_loop.repeat_count if tool_loop is not None else None
             ),
@@ -334,4 +477,17 @@ class RequestRepetitionMonitor:
             "tool_call_loop_marker_index": (
                 tool_loop.marker_index if tool_loop is not None else None
             ),
+            "output_repetition": output_hit,
+            "output_repetition_kind": output_kind,
+            "output_repetition_impl": self.output_repetition_impl,
+            "output_repetition_error": self._output_error,
+            "output_repetition_check_ms": round(self.output_repetition_check_ms, 6),
+            "output_repetition_period": output.repeat_unit_size if output is not None else None,
+            "output_repetition_repeat_count": output.repeat_count if output is not None else None,
+            "output_repetition_occurrence_count": output.occurrence_count if output is not None else None,
+            "output_repetition_duplicate_token_count": output.duplicate_token_count if output is not None else None,
+            "output_repetition_covered_token_count": output.covered_token_count if output is not None else None,
+            "output_repetition_start_index": output.start_index if output is not None else None,
+            "output_repetition_end_index": output.end_index if output is not None else None,
+            "output_repetition_first_detect_index": output.first_detect_index if output is not None else None,
         }

--- a/rtp_llm/dash_sc/test/BUILD
+++ b/rtp_llm/dash_sc/test/BUILD
@@ -64,8 +64,7 @@ py_test(
 py_test(
     name = "repetition_monitor_test",
     srcs = ["repetition_monitor_test.py"],
-    data = ["//rtp_llm/cpp/repetition:online_repetition_tracker"],
-    deps = ["//rtp_llm:testlib"],
+    deps = ["//rtp_llm/dash_sc:repetition_monitor"],
     imports = [],
     exec_properties = {"gpu": "A10"},
 )

--- a/rtp_llm/dash_sc/test/repetition_monitor_test.py
+++ b/rtp_llm/dash_sc/test/repetition_monitor_test.py
@@ -8,7 +8,9 @@ from unittest.mock import patch
 import rtp_llm.dash_sc.repetition_monitor as repetition_monitor
 from rtp_llm.dash_sc.repetition_monitor import (
     NativeModuleStatus,
+    OutputRepetitionConfig,
     RequestRepetitionMonitor,
+    RequestRepetitionMonitorConfig,
     ToolCallLoopConfig,
     ToolCallMarkerConfig,
     detect_tool_call_loop,
@@ -34,6 +36,27 @@ def _patched_native_module(fake_native):
 
 def _patched_native_unavailable(error: str = "missing native module"):
     return _native_status(NativeModuleStatus(available=False, error=error))
+
+
+def _fake_output_native(result):
+    class FakeConfig:
+        pass
+
+    class FakeTracker:
+        def __init__(self, _config):
+            self.result = result
+
+        def update_many(self, _token_ids):
+            return self.result
+
+        def finalize(self):
+            return self.result
+
+    return types.SimpleNamespace(
+        OnlineRepetitionConfig=FakeConfig,
+        OnlineRepetitionTracker=FakeTracker,
+        check_tool_call_loop=lambda *_args: (False, 0, 0, -1),
+    )
 
 
 def _fresh_native_status():
@@ -73,11 +96,64 @@ class NativeAvailabilityTest(TestCase):
                 status = repetition_monitor.native_online_repetition_status()
 
         self.assertFalse(status.available)
-        self.assertIn("missing API check_tool_call_loop", status.error)
+        self.assertIn("check_tool_call_loop", status.error)
         self.assertEqual(len(logs.output), 1)
 
 
 class RepetitionMonitorTest(TestCase):
+    def test_streaming_output_repetition_detects_same_token_run(self) -> None:
+        config = RequestRepetitionMonitorConfig(
+            output_config=OutputRepetitionConfig(
+                enabled=True, min_repeats=3, min_duplicate_tokens=8
+            )
+        )
+        result = types.SimpleNamespace(
+            hit=True, repeat_unit_size=1, repeat_count=10,
+            covered_token_count=10, duplicate_token_count=9,
+            start_index=0, end_index=10, first_detect_index=8,
+            non_contiguous=False, occurrence_count=10,
+        )
+        with _patched_native_module(_fake_output_native(result)):
+            monitor = RequestRepetitionMonitor(monitor_config=config)
+            monitor.update_output_delta([42] * 5)
+            monitor.update_output_delta([42] * 5)
+            monitor.finalize_output()
+            fields = monitor.record_fields()
+        self.assertTrue(fields["output_repetition"])
+        self.assertEqual(fields["output_repetition_kind"], "same_token_run")
+        self.assertEqual(fields["output_repetition_period"], 1)
+
+    def test_streaming_output_repetition_detects_non_contiguous_span(self) -> None:
+        config = RequestRepetitionMonitorConfig(
+            output_config=OutputRepetitionConfig(
+                enabled=True,
+                min_repeats=3,
+                min_duplicate_tokens=64,
+                non_contiguous_min_span=32,
+                non_contiguous_min_occurrences=3,
+                non_contiguous_max_span=32,
+            )
+        )
+        repeated = list(range(100, 132))
+        result = types.SimpleNamespace(
+            hit=True, repeat_unit_size=32, repeat_count=3,
+            covered_token_count=96, duplicate_token_count=64,
+            start_index=0, end_index=131, first_detect_index=131,
+            non_contiguous=True, occurrence_count=3,
+        )
+        with _patched_native_module(_fake_output_native(result)):
+            monitor = RequestRepetitionMonitor(monitor_config=config)
+            monitor.update_output_delta(repeated + list(range(1000, 1017)))
+            monitor.update_output_delta(repeated + list(range(2000, 2018)))
+            monitor.update_output_delta(repeated)
+            monitor.finalize_output()
+            fields = monitor.record_fields()
+        self.assertTrue(fields["output_repetition"])
+        self.assertEqual(
+            fields["output_repetition_kind"], "non_contiguous_span_repeat"
+        )
+        self.assertEqual(fields["output_repetition_occurrence_count"], 3)
+
     def test_native_unavailable_surfaces_in_record_fields(self) -> None:
         marker = ToolCallMarkerConfig(begin_ids=(1,), end_ids=(2,))
         with _patched_native_unavailable("no libonline_repetition_tracker"):
@@ -89,7 +165,8 @@ class RepetitionMonitorTest(TestCase):
 
         self.assertFalse(fields["repetition_monitor_available"])
         self.assertEqual(
-            fields["repetition_monitor_impl"], "tool=online_cpp_pybind_unavailable"
+            fields["repetition_monitor_impl"],
+            "output=disabled,tool=online_cpp_pybind_unavailable",
         )
         self.assertIn(
             "no libonline_repetition_tracker",
@@ -119,19 +196,6 @@ class RepetitionMonitorTest(TestCase):
             "RuntimeError: tool loop check failed",
             fields["repetition_monitor_unavailable_reason"],
         )
-
-    def test_packaged_native_module_imports_from_runfiles(self) -> None:
-        with _fresh_native_status():
-            status = repetition_monitor.native_online_repetition_status()
-            self.assertTrue(status.available)
-            self.assertTrue(hasattr(status.module, "check_tool_call_loop"))
-            guard_result = status.module.check_tool_call_loop(
-                [1, 42, 2] * 4, [1, 42, 2], [[1]], [[2]], 5, 16
-            )
-
-        self.assertTrue(guard_result[0])
-        self.assertEqual(guard_result[1], 5)
-        self.assertEqual(guard_result[2], 3)
 
     def test_detect_tool_call_loop_uses_request_level_native_function(self) -> None:
         class FakeNativeResult:

--- a/rtp_llm/metrics/kmonitor_metric_reporter.py
+++ b/rtp_llm/metrics/kmonitor_metric_reporter.py
@@ -74,6 +74,8 @@ class AccMetrics(Enum):
     # Tool-call output fell into a repeated span. Reported once per request by the
     # frontend gRPC access-log interceptor; tags intentionally avoid request_id.
     TOOL_CALL_LOOP_QPS_METRIC = "py_rtp_tool_call_loop_qps"
+    OUTPUT_REPETITION_QPS_METRIC = "py_rtp_output_repetition_qps"
+    SAME_TOKEN_RUN_QPS_METRIC = "py_rtp_same_token_run_qps"
 
 
 class GaugeMetrics(Enum):
@@ -147,6 +149,10 @@ class GaugeMetrics(Enum):
         "py_rtp_tool_call_loop_current_span_tokens"
     )
     TOOL_CALL_LOOP_CHECK_RT_METRIC = "py_rtp_tool_call_loop_check_rt"
+    OUTPUT_REPETITION_CHECK_RT_METRIC = "py_rtp_output_repetition_check_rt"
+    OUTPUT_REPETITION_PERIOD_METRIC = "py_rtp_output_repetition_period"
+    OUTPUT_REPETITION_REPEAT_COUNT_METRIC = "py_rtp_output_repetition_repeat_count"
+    OUTPUT_REPETITION_DUPLICATE_TOKENS_METRIC = "py_rtp_output_repetition_duplicate_tokens"
 
 
 class MetricReporter(object):

--- a/rtp_llm/server/server_args/repetition_detection_group_args.py
+++ b/rtp_llm/server/server_args/repetition_detection_group_args.py
@@ -5,6 +5,56 @@ def init_repetition_detection_group_args(parser, repetition_detection_config):
     group = parser.add_argument_group("Repetition Detection")
 
     group.add_argument(
+        "--output_repetition_monitor",
+        env_name="RTP_LLM_OUTPUT_REPETITION_MONITOR",
+        bind_to=(repetition_detection_config, "output_repetition_monitor"),
+        type=str2bool,
+        default=True,
+    )
+    group.add_argument(
+        "--output_repetition_min_repeats",
+        env_name="RTP_LLM_OUTPUT_REPETITION_MIN_REPEATS",
+        bind_to=(repetition_detection_config, "output_repetition_min_repeats"),
+        type=int,
+        default=3,
+    )
+    group.add_argument(
+        "--output_repetition_min_dup_tokens",
+        env_name="RTP_LLM_OUTPUT_REPETITION_MIN_DUP_TOKENS",
+        bind_to=(repetition_detection_config, "output_repetition_min_dup_tokens"),
+        type=int,
+        default=32,
+    )
+    group.add_argument(
+        "--output_repetition_max_period",
+        env_name="RTP_LLM_OUTPUT_REPETITION_MAX_PERIOD",
+        bind_to=(repetition_detection_config, "output_repetition_max_period"),
+        type=int,
+        default=512,
+    )
+    group.add_argument(
+        "--noncontig_repeat_min_span_tokens",
+        env_name="RTP_LLM_NONCONTIG_REPEAT_MIN_SPAN_TOKENS",
+        bind_to=(repetition_detection_config, "noncontig_repeat_min_span_tokens"),
+        type=int,
+        default=32,
+    )
+    group.add_argument(
+        "--noncontig_repeat_min_occurrences",
+        env_name="RTP_LLM_NONCONTIG_REPEAT_MIN_OCCURRENCES",
+        bind_to=(repetition_detection_config, "noncontig_repeat_min_occurrences"),
+        type=int,
+        default=3,
+    )
+    group.add_argument(
+        "--noncontig_repeat_max_span_tokens",
+        env_name="RTP_LLM_NONCONTIG_REPEAT_MAX_SPAN_TOKENS",
+        bind_to=(repetition_detection_config, "noncontig_repeat_max_span_tokens"),
+        type=int,
+        default=256,
+    )
+
+    group.add_argument(
         "--tool_call_loop_monitor",
         env_name="RTP_LLM_TOOL_CALL_LOOP_MONITOR",
         bind_to=(repetition_detection_config, "tool_call_loop_monitor"),


### PR DESCRIPTION
## Summary

- add online detection for repeated model output, including same-token runs, contiguous n-gram/long-span loops, and non-contiguous repeated spans
- integrate streaming token updates with frontend access logs, metrics, and configurable thresholds
- preserve the existing tool-call loop detector and native-unavailable fallback behavior
- add focused C++ and Python unit tests

## Tests

- `//rtp_llm/cpp/repetition/test:online_repetition_tracker_test`
- `//rtp_llm/dash_sc/test:repetition_monitor_test`

Both targets pass with `--config=cuda13`.