### PR TITLE
PP: data-driven layer partition and cross-stage KV cache topology validation

### DIFF
--- a/rtp_llm/config/pp_layout.py
+++ b/rtp_llm/config/pp_layout.py
@@ -1,0 +1,139 @@
+"""Pipeline-parallel layout helpers.
+
+Single source of truth for the PP layer partition in Python: the partition
+is DECIDED ONCE here (resolve_pp_partition), materialized as per-stage
+layer counts on ParallelismConfig.pp_stage_layer_counts, and consumed
+purely as data everywhere else — weight loading
+(LoadConfig.pp_layer_range / has_pp_embedding / has_pp_lm_head), model
+construction (GptModelBase.pp_layer_ids / pp_has_embedding /
+pp_has_lm_head), cache geometry and the C++ side
+(rtp_llm/cpp/config/PPLayout.h, prefix-sum lookup). Consumers never
+re-derive the partition rule (see stage_layer_range).
+"""
+
+from typing import Callable, List, Optional
+
+
+def even_split_counts(num_layers: int, pp_size: int) -> List[int]:
+    """Default partition: even split, remainder to the earlier stages.
+
+    Returns the layer count of every stage in rank order (e.g. 65 layers,
+    pp=4 -> [17, 16, 16, 16]).
+    """
+    base = num_layers // pp_size
+    rem = num_layers % pp_size
+    return [base + (1 if rank < rem else 0) for rank in range(pp_size)]
+
+
+# ---------------------------------------------------------------------------
+# Model-level partitioner registry (extension point for shape-specialized
+# partitions of irregular models). A partitioner is Python-only; its output
+# travels through the materialized-counts channel, so C++ never needs to
+# understand the partitioning rule.
+# ---------------------------------------------------------------------------
+
+# partition(num_layers, pp_size, model_config) -> per-stage layer counts
+PpPartitioner = Callable[[int, int, object], List[int]]
+_PP_PARTITIONERS: dict = {}
+
+
+def register_pp_partitioner(model_type: str, partitioner: PpPartitioner) -> None:
+    """Attach an optional model-level layer partitioner to a model type."""
+    _PP_PARTITIONERS[model_type] = partitioner
+
+
+def get_pp_partitioner(model_type: str) -> Optional[PpPartitioner]:
+    return _PP_PARTITIONERS.get(model_type)
+
+
+def resolve_pp_partition(
+    num_layers: int,
+    pp_size: int,
+    model_config=None,
+) -> List[int]:
+    """Decide the final PP layer partition and return per-stage layer counts.
+
+    Priority: model-registered partitioner > default even split. The result
+    is validated (length, positivity, sum) and ready to be materialized on
+    ParallelismConfig.pp_stage_layer_counts.
+    """
+    model_type = (
+        getattr(model_config, "model_type", None) if model_config is not None else None
+    )
+    partitioner = get_pp_partitioner(model_type) if model_type else None
+    if partitioner is not None:
+        counts = list(partitioner(num_layers, pp_size, model_config))
+    else:
+        counts = even_split_counts(num_layers, pp_size)
+    _check_partition_counts(counts, num_layers, pp_size)
+    return counts
+
+
+def _check_partition_counts(counts: List[int], num_layers: int, pp_size: int) -> None:
+    if len(counts) != pp_size:
+        raise ValueError(
+            f"pp partition has {len(counts)} stages but pp_size={pp_size}: {counts}"
+        )
+    if any(c <= 0 for c in counts):
+        raise ValueError(
+            f"pp partition must give every stage at least one layer: {counts}"
+        )
+    if sum(counts) != num_layers:
+        raise ValueError(
+            f"pp partition sums to {sum(counts)} but num_layers={num_layers}: {counts}"
+        )
+
+
+def pp_layer_range_from_counts(counts: List[int], pp_rank: int) -> range:
+    """Half-open global layer-id range owned by `pp_rank` under a
+    materialized partition (prefix-sum lookup)."""
+    if not (0 <= pp_rank < len(counts)):
+        raise ValueError(f"pp_rank={pp_rank} out of range for partition {counts}")
+    begin = sum(counts[:pp_rank])
+    return range(begin, begin + counts[pp_rank])
+
+
+def stage_layer_range(
+    num_layers: int,
+    pp_size: int,
+    pp_rank: int,
+    counts: Optional[List[int]] = None,
+) -> range:
+    """Single consumer entry for the stage layer range.
+
+    Three cases only:
+      - materialized partition present -> prefix-sum lookup;
+      - pp_size=1 without materialized data (the normal single-stage
+        deployment never materializes) -> trivially all layers;
+      - pp_size>1 without materialized data -> a startup-path error, NOT a
+        silent fallback (the decision point must have written the counts).
+    """
+    if counts:
+        return pp_layer_range_from_counts(counts, pp_rank)
+    if pp_size <= 1:
+        return range(num_layers)
+    raise ValueError(
+        f"pp_size={pp_size} requires a materialized layer partition "
+        "(pp_stage_layer_counts); it must be written by the startup decision point"
+    )
+
+
+def derive_pp_rank(world_rank: int, dp_size: int, tp_size: int) -> int:
+    """Fallback pp_rank for configs that only carry sizes (fake configs in
+    tests). PP is the outermost dim of the world-rank layout:
+    world_rank = pp_rank * (dp_size * tp_size) + dp_rank * tp_size + tp_rank.
+    Production configs carry pp_rank directly and never need this."""
+    dp_size = max(int(dp_size or 1), 1)
+    tp_size = max(int(tp_size or 1), 1)
+    return int(world_rank or 0) // (dp_size * tp_size)
+
+
+def stage_has_embedding(pp_rank: int) -> bool:
+    """The first stage owns the token/positional embedding."""
+    return pp_rank == 0
+
+
+def stage_has_lm_head(pp_rank: int, pp_size: int) -> bool:
+    """The last stage owns lm_head + final_layernorm. With pp_size=1 the
+    single stage is both first and last."""
+    return pp_rank == pp_size - 1

--- a/rtp_llm/config/server_config_setup.py
+++ b/rtp_llm/config/server_config_setup.py
@@ -303,8 +303,15 @@ def set_parallelism_config(
     parallelism_config.tp_rank = (
         parallelism_config.world_rank % parallelism_config.tp_size
     )
+    # PP-outermost layout (world_rank = pp_rank*(dp*tp) + dp_rank*tp + tp_rank):
+    # "% dp_size" strips the pp component; with pp_size == 1 this reduces to
+    # the historical (world_rank // tp_size). Same convention as
+    # engine_config._update_worker_addrs and collective_torch.
     parallelism_config.dp_rank = (
         parallelism_config.world_rank // parallelism_config.tp_size
+    ) % max(parallelism_config.dp_size, 1)
+    parallelism_config.pp_rank = parallelism_config.world_rank // (
+        max(parallelism_config.dp_size, 1) * parallelism_config.tp_size
     )
     parallelism_config.ep_rank = (
         parallelism_config.world_rank % parallelism_config.ep_size

--- a/rtp_llm/cpp/cache/BUILD
+++ b/rtp_llm/cpp/cache/BUILD
@@ -93,6 +93,19 @@ cc_library(
 )
 
 cc_library(
+    name = "pp_topology_validator",
+    srcs = ["PPTopologyValidator.cc"],
+    hdrs = ["PPTopologyValidator.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":cache_config",
+        ":cache_group_type",
+        "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
+    ],
+)
+
+cc_library(
     name = "cache_layout",
     hdrs = ["BufferTypes.h"],
     copts = copts(),
@@ -318,6 +331,7 @@ cc_library(
         ":kv_cache_allocator",
         ":prefill_cache_hit_metrics_reporter",
         "//rtp_llm/cpp/config:model_config",
+        "//rtp_llm/cpp/config:pp_layout",
         "//rtp_llm/cpp/engine_base/stream:complete_token_ids",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/models_py/bindings/core:type_convert",
@@ -371,6 +385,7 @@ cc_library(
         ":cache_core",
         ":cp_slot_mapper",
         ":prefill_cache_hit_metrics_reporter",
+        ":pp_topology_validator",
         "//rtp_llm/cpp/cache/connector",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/cpp/utils:profiling_scope",

--- a/rtp_llm/cpp/cache/CacheConfig.cc
+++ b/rtp_llm/cpp/cache/CacheConfig.cc
@@ -145,8 +145,8 @@ void CacheConfig::setTopology(std::vector<GroupBase> new_groups, std::vector<Lay
 
     for (size_t gid = 0; gid < new_groups.size(); ++gid) {
         auto& group = new_groups[gid];
-        RTP_LLM_CHECK_WITH_INFO(group.spec != nullptr, "CacheConfig::setTopology got null spec at group %zu", gid);
         RTP_LLM_CHECK_WITH_INFO(!group.tag.empty(), "CacheConfig::setTopology requires tag for group %zu", gid);
+        RTP_LLM_CHECK_WITH_INFO(group.spec != nullptr, "CacheConfig::setTopology got null spec at group %zu", gid);
         RTP_LLM_CHECK_WITH_INFO(group.spec->tag == group.tag,
                                 "CacheConfig::setTopology tag=%s does not match spec tag=%s",
                                 group.tag.c_str(),

--- a/rtp_llm/cpp/cache/CacheConfigCreator.cc
+++ b/rtp_llm/cpp/cache/CacheConfigCreator.cc
@@ -9,6 +9,7 @@
 #include "rtp_llm/cpp/cache/KVCacheSpecDesc.h"
 #include "rtp_llm/cpp/cache/MemoryEvaluationHelper.h"
 #include "rtp_llm/cpp/cache/SingleConfigCreator.h"
+#include "rtp_llm/cpp/config/PPLayout.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 
@@ -180,10 +181,103 @@ LayerKVCacheSpecs CacheConfigCreator::buildLayerSpecsFromDescs(const LayerKVCach
     return layer_specs;
 }
 
+// PP grouping gate shared by every config entry: the hybrid-pool branch of
+// createConfig bypasses createBasicConfig, so both must enforce it.
+void checkPpIndependentPools(const ModelConfig& model_config, const ParallelismConfig& parallelism_config) {
+    RTP_LLM_CHECK_WITH_INFO(parallelism_config.pp_size <= 1
+                                || !model_config.hybrid_attention_config.enable_hybrid_attention
+                                || model_config.hybrid_attention_config.enable_independent_kv_cache_pools,
+                            "pipeline parallelism (pp_size=%ld) requires independent kv cache pools; the hybrid "
+                            "positional grouping is no longer supported",
+                            parallelism_config.pp_size);
+}
+
+// PP gate applied right after the stage slice. Linear tags stay global
+// (assigned at config-build time): cross-stage group identity is reconciled
+// through the canonical group table at startup instead of renaming tags per
+// stage.
+void validateStageScopedDescsForPP(const ModelConfig& stage_config) {
+    // v1 scope: pipeline parallelism only supports paged pools. Opaque
+    // (state / byte-addressed KV) pools use per-stream ring and tail-block
+    // semantics that the leading stage's pools do not model yet.
+    for (size_t layer_id = 0; layer_id < stage_config.kv_cache_spec_descs.size(); ++layer_id) {
+        for (const auto& desc : stage_config.kv_cache_spec_descs[layer_id]) {
+            RTP_LLM_CHECK_WITH_INFO(desc.cache_type != KVCacheSpecType::OpaqueKV
+                                        && desc.cache_type != KVCacheSpecType::OpaqueState,
+                                    "pipeline parallelism does not support opaque kv cache pools (layer %zu, "
+                                    "cache_type=%d) yet",
+                                    layer_id,
+                                    static_cast<int>(desc.cache_type));
+        }
+    }
+}
+
+ModelConfig CacheConfigCreator::stageScopedModelConfig(const ModelConfig&       model_config,
+                                                       const ParallelismConfig& parallelism_config) {
+    const int64_t pp_size = std::max<int64_t>(1, parallelism_config.pp_size);
+    if (pp_size <= 1) {
+        return model_config;
+    }
+
+    RTP_LLM_CHECK_WITH_INFO(parallelism_config.pp_rank >= 0 && parallelism_config.pp_rank < pp_size,
+                            "invalid pp_rank=%ld for pp_size=%ld",
+                            parallelism_config.pp_rank,
+                            pp_size);
+
+    // Strong contract: under pp>1 the partition is always materialized by
+    // the Python decision point (ParallelismConfig.pp_stage_layer_counts);
+    // the even-split fallback in PPLayout exists only for pp_size=1, stale
+    // pickles and legacy fixtures.
+    RTP_LLM_CHECK_WITH_INFO(!parallelism_config.pp_stage_layer_counts.empty(),
+                            "pp_size=%ld requires a materialized layer partition "
+                            "(pp_stage_layer_counts); it must be written by the Python startup decision point",
+                            pp_size);
+
+    // Layer partition: consumed as data (prefix-sum lookup over the
+    // materialized counts), never re-derived here.
+    const PPLayout layout   = PPLayout::fromParallelismConfig(parallelism_config, model_config.num_layers);
+    const auto [begin, end] = layout.myLayerRange();
+    RTP_LLM_CHECK_WITH_INFO(end > begin,
+                            "pp stage %ld owns no layers: num_layers=%ld pp_size=%ld",
+                            parallelism_config.pp_rank,
+                            model_config.num_layers,
+                            pp_size);
+    RTP_LLM_CHECK_WITH_INFO(model_config.kv_cache_spec_descs.size() == static_cast<size_t>(model_config.num_layers),
+                            "kv_cache_spec_descs size %zu != num_layers %ld",
+                            model_config.kv_cache_spec_descs.size(),
+                            model_config.num_layers);
+
+    ModelConfig stage_config = model_config;
+    stage_config.num_layers  = end - begin;
+    stage_config.kv_cache_spec_descs.assign(model_config.kv_cache_spec_descs.begin() + begin,
+                                            model_config.kv_cache_spec_descs.begin() + end);
+
+    auto& types = stage_config.hybrid_attention_config.hybrid_attention_types;
+    if (!types.empty()) {
+        RTP_LLM_CHECK_WITH_INFO(types.size() == static_cast<size_t>(model_config.num_layers),
+                                "hybrid_attention_types size %zu != num_layers %ld",
+                                types.size(),
+                                model_config.num_layers);
+        types.assign(types.begin() + begin, types.begin() + end);
+    }
+    validateStageScopedDescsForPP(stage_config);
+
+    RTP_LLM_LOG_INFO("PP cache stage %ld/%ld owns global layers [%ld, %ld) of %ld",
+                     parallelism_config.pp_rank,
+                     pp_size,
+                     begin,
+                     end,
+                     model_config.num_layers);
+    return stage_config;
+}
+
 CacheConfig CacheConfigCreator::createBasicConfig(const ModelConfig&       model_config,
                                                   const ParallelismConfig& parallelism_config,
                                                   bool                     is_mtp,
                                                   int                      gen_num_per_cycle) {
+    // (PP) gate: pipeline parallelism follows the independent-pool grouping;
+    // the legacy hybrid positional grouping (linear0/linear1/...) is retired.
+    checkPpIndependentPools(model_config, parallelism_config);
     CacheConfig config;
     if (model_config.hybrid_attention_config.enable_independent_kv_cache_pools) {
         KVCacheConfig no_override_config;
@@ -217,6 +311,9 @@ CacheConfig CacheConfigCreator::createConfig(const ModelConfig&                 
                                              const KVCacheConfig&                             kv_cache_config,
                                              const std::optional<WarmUpResult>&               warm_up_result,
                                              const std::optional<SpeculativeExecutionConfig>& sp_config) {
+    // (PP) gate: the hybrid-pool branch below bypasses createBasicConfig, so
+    // enforce the same restriction here.
+    checkPpIndependentPools(model_config, parallelism_config);
     CacheConfig config =
         model_config.hybrid_attention_config.enable_independent_kv_cache_pools ?
             HybridPoolConfigCreator::createConfig(model_config, parallelism_config, kv_cache_config, false, 0) :
@@ -255,6 +352,10 @@ CacheConfig CacheConfigCreator::createSpConfig(const ModelConfig&               
                                                const std::optional<WarmUpResult>& warm_up_result,
                                                bool                               is_mtp,
                                                bool                               is_eagle) {
+    // (PP) gate: the joint main+draft cache geometry is not stage-scoped yet.
+    RTP_LLM_CHECK_WITH_INFO(parallelism_config.pp_size <= 1,
+                            "pipeline parallelism (pp_size=%ld) cannot be combined with speculative execution yet",
+                            parallelism_config.pp_size);
     CacheConfig score_config =
         score_model_config.hybrid_attention_config.enable_independent_kv_cache_pools ?
             HybridPoolConfigCreator::createConfig(

--- a/rtp_llm/cpp/cache/CacheConfigCreator.h
+++ b/rtp_llm/cpp/cache/CacheConfigCreator.h
@@ -53,6 +53,14 @@ public:
                                                       const SpecBuildContext&      ctx,
                                                       int64_t                      expected_layer_num);
 
+    // PP: stage-scoped model config for cache creation. With pp_size>1
+    // returns a copy whose layer-dimension fields (num_layers,
+    // kv_cache_spec_descs, hybrid_attention_types) are sliced to this rank's
+    // layer partition, so downstream creators produce stage-local cache
+    // geometry. With pp_size=1 the copy is identical to the input.
+    static ModelConfig stageScopedModelConfig(const ModelConfig&       model_config,
+                                              const ParallelismConfig& parallelism_config);
+
 private:
     // Removed functions moved to MemoryEvaluationHelper:
     // getDefaultRuntimeMemorySize

--- a/rtp_llm/cpp/cache/CacheTopology.cc
+++ b/rtp_llm/cpp/cache/CacheTopology.cc
@@ -91,6 +91,18 @@ void CacheTopology::validateAndBuildIndex() {
                                     layer_id);
         }
     }
+
+    // Unassigned canonical columns default to the group's own position, so
+    // topologies without a PP canonical table keep identity mapping.
+    std::unordered_set<size_t> canonical_seen;
+    for (size_t group_id = 0; group_id < groups_.size(); ++group_id) {
+        if (groups_[group_id].canonical_idx == kCanonicalIdxUnset) {
+            groups_[group_id].canonical_idx = group_id;
+        }
+        RTP_LLM_CHECK_WITH_INFO(canonical_seen.emplace(groups_[group_id].canonical_idx).second,
+                                "CacheTopology has duplicate canonical_idx=%zu",
+                                groups_[group_id].canonical_idx);
+    }
 }
 
 size_t CacheTopology::groupIdForTag(std::string_view tag) const {
@@ -160,10 +172,12 @@ void CacheTopology::buildSnapshots() const {
     snapshots->group_tags.reserve(groups_.size());
     snapshots->group_types.reserve(groups_.size());
     snapshots->group_spec_types.reserve(groups_.size());
+    snapshots->canonical_indices.reserve(groups_.size());
     for (const auto& group : groups_) {
         snapshots->group_tags.push_back(group.tag);
         snapshots->group_types.push_back(group.policy.group_type);
         snapshots->group_spec_types.push_back(group.spec->type);
+        snapshots->canonical_indices.push_back(group.canonical_idx);
     }
 
     snapshots->layer_group_ids.reserve(layers_.size());
@@ -196,6 +210,11 @@ const std::vector<CacheGroupType>& CacheTopology::groupTypesSnapshot() const {
 const std::vector<KVCacheSpecType>& CacheTopology::groupSpecTypesSnapshot() const {
     std::call_once(snapshot_once_, [this]() { buildSnapshots(); });
     return snapshots_->group_spec_types;
+}
+
+const std::vector<size_t>& CacheTopology::canonicalIndicesSnapshot() const {
+    std::call_once(snapshot_once_, [this]() { buildSnapshots(); });
+    return snapshots_->canonical_indices;
 }
 
 const std::vector<std::vector<int>>& CacheTopology::layerGroupIdsSnapshot() const {

--- a/rtp_llm/cpp/cache/CacheTopology.h
+++ b/rtp_llm/cpp/cache/CacheTopology.h
@@ -15,6 +15,10 @@
 
 namespace rtp_llm {
 
+// Sentinel meaning "canonical column not assigned": the topology fills the
+// group's own position, so canonical indices default to local group order.
+inline constexpr size_t kCanonicalIdxUnset = static_cast<size_t>(-1);
+
 // Immutable cache-group configuration published by CacheConfig. The tag is
 // the semantic identity; numeric group ids are private CacheTopology indices.
 struct GroupBase {
@@ -29,6 +33,10 @@ struct GroupBase {
     size_t   kernel_seq_size_per_block = 0;
     size_t   kv_block_stride_bytes     = 0;
     size_t   kv_scale_stride_bytes     = 0;
+
+    // Column of this group in the PP canonical group table (computed over the
+    // whole model, identical on every stage). Unset keeps identity mapping.
+    size_t canonical_idx = kCanonicalIdxUnset;
 };
 
 // Order is deterministic but carries no business meaning.
@@ -67,6 +75,7 @@ public:
     const std::vector<std::string>&                groupTagsSnapshot() const;
     const std::vector<CacheGroupType>&             groupTypesSnapshot() const;
     const std::vector<KVCacheSpecType>&            groupSpecTypesSnapshot() const;
+    const std::vector<size_t>&                     canonicalIndicesSnapshot() const;
     const std::vector<std::vector<int>>&           layerGroupIdsSnapshot() const;
     const std::vector<std::map<std::string, int>>& layerTagToGroupIdSnapshot() const;
 
@@ -75,6 +84,7 @@ private:
         std::vector<std::string>                group_tags;
         std::vector<CacheGroupType>             group_types;
         std::vector<KVCacheSpecType>            group_spec_types;
+        std::vector<size_t>                     canonical_indices;
         std::vector<std::vector<int>>           layer_group_ids;
         std::vector<std::map<std::string, int>> layer_tag_to_group_id;
     };

--- a/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
+++ b/rtp_llm/cpp/cache/HybridPoolConfigCreator.cc
@@ -278,7 +278,12 @@ CacheConfig createHybridAttentionPoolConfig(const ModelConfig&       model_confi
                                             const KVCacheConfig&     kv_cache_config,
                                             bool                     is_mtp,
                                             int                      gen_num_per_cycle) {
-    const auto    dtype                  = MemoryEvaluationHelper::getDataTypeForCache(model_config);
+    // (PP): with pp_size>1 every stage builds independent-pool geometry only
+    // for its own layer range. Pools stay type-tagged, so cross-stage group
+    // identity is reconciled by the canonical group table at startup.
+    const ModelConfig stage_model_config = CacheConfigCreator::stageScopedModelConfig(model_config, parallelism_config);
+
+    const auto    dtype                  = MemoryEvaluationHelper::getDataTypeForCache(stage_model_config);
     constexpr int kDefaultKvCacheSeqSize = 64;
     const bool    has_seq_override =
         kv_cache_config.seq_size_per_block > 0 && kv_cache_config.seq_size_per_block != kDefaultKvCacheSeqSize;
@@ -298,30 +303,30 @@ CacheConfig createHybridAttentionPoolConfig(const ModelConfig&       model_confi
         kernel_tokens_per_block);
 
     CacheConfig config;
-    config.layer_num                 = static_cast<uint32_t>(model_config.num_layers);
+    config.layer_num                 = static_cast<uint32_t>(stage_model_config.num_layers);
     config.layer_all_num             = config.layer_num;
     config.block_num                 = 0;
     config.seq_size_per_block        = physical_tokens_per_block;
     config.kernel_seq_size_per_block = kernel_tokens_per_block;
-    config.use_mla                   = model_config.attn_config.use_mla;
+    config.use_mla                   = stage_model_config.attn_config.use_mla;
     config.dtype                     = dtype;
     config.linear_step               = 1;
-    config.is_sparse                 = model_config.attn_config.is_sparse;
+    config.is_sparse                 = stage_model_config.attn_config.is_sparse;
 
-    if (!model_config.kv_cache_spec_descs.empty()) {
-        validateHybridPoolDescs(model_config, kernel_tokens_per_block, gen_num_per_cycle);
+    if (!stage_model_config.kv_cache_spec_descs.empty()) {
+        validateHybridPoolDescs(stage_model_config, kernel_tokens_per_block, gen_num_per_cycle);
         SpecBuildContext ctx;
         ctx.dtype                   = dtype;
         ctx.seq_size_per_block      = physical_tokens_per_block;
-        ctx.attn_config             = &model_config.attn_config;
-        ctx.linear_attention_config = &model_config.linear_attention_config;
+        ctx.attn_config             = &stage_model_config.attn_config;
+        ctx.linear_attention_config = &stage_model_config.linear_attention_config;
         ctx.parallelism_config      = &parallelism_config;
         ctx.kernel_tokens_per_block = kernel_tokens_per_block;
         ctx.gen_num_per_cycle       = static_cast<uint32_t>(gen_num_per_cycle);
         auto refreshed_specs        = CacheConfigCreator::buildLayerSpecsFromDescs(
-            model_config.kv_cache_spec_descs, ctx, model_config.num_layers);
+            stage_model_config.kv_cache_spec_descs, ctx, stage_model_config.num_layers);
         populateGroupsFromLayerSpecs(
-            config, model_config.kv_cache_spec_descs, refreshed_specs, model_config, parallelism_config);
+            config, stage_model_config.kv_cache_spec_descs, refreshed_specs, stage_model_config, parallelism_config);
         for (size_t gid = 0; gid < static_cast<size_t>(config.groupNums()); ++gid) {
             const auto& spec               = config.specForGroup(gid);
             config.use_typed_cache_regions = config.use_typed_cache_regions || spec->type == KVCacheSpecType::OpaqueKV
@@ -330,7 +335,7 @@ CacheConfig createHybridAttentionPoolConfig(const ModelConfig&       model_confi
                                                || spec->type == KVCacheSpecType::OpaqueKV
                                                || spec->type == KVCacheSpecType::OpaqueState;
         }
-        for (const auto& layer_descs : model_config.kv_cache_spec_descs) {
+        for (const auto& layer_descs : stage_model_config.kv_cache_spec_descs) {
             for (const auto& desc : layer_descs) {
                 config.is_sparse = config.is_sparse || desc.cache_type == KVCacheSpecType::OpaqueKV;
             }

--- a/rtp_llm/cpp/cache/KVCacheAllocator.cc
+++ b/rtp_llm/cpp/cache/KVCacheAllocator.cc
@@ -259,12 +259,24 @@ void KVCacheAllocator::blockBatchCopy(const torch::Tensor& copy_mapping) {
     const auto*                    mappings = reinterpret_cast<const GroupBlockIdPair*>(copy_mapping.data_ptr());
     std::vector<TaggedBlockIdPair> tagged_mappings;
     tagged_mappings.reserve(static_cast<size_t>(copy_mapping.size(0)));
+    const auto& groups = config_.topology().groups();
     for (int64_t i = 0; i < copy_mapping.size(0); ++i) {
         RTP_LLM_CHECK_WITH_INFO(
             mappings[i].group_id >= 0, "cache block copy mapping has invalid group_id=%d", mappings[i].group_id);
-        tagged_mappings.push_back({config_.topology().groupById(static_cast<size_t>(mappings[i].group_id)).tag,
-                                   mappings[i].src,
-                                   mappings[i].dst});
+        // Wire group_id is a canonical index. Resolve it to the local group
+        // via canonical_idx; copies for groups absent from this stage have
+        // nothing to apply locally and are skipped.
+        const GroupBase* local = nullptr;
+        for (const auto& group : groups) {
+            if (group.canonical_idx == static_cast<size_t>(mappings[i].group_id)) {
+                local = &group;
+                break;
+            }
+        }
+        if (local == nullptr) {
+            continue;
+        }
+        tagged_mappings.push_back({local->tag, mappings[i].src, mappings[i].dst});
     }
     blockBatchCopyByTag(tagged_mappings);
 }

--- a/rtp_llm/cpp/cache/KVCacheManager.cc
+++ b/rtp_llm/cpp/cache/KVCacheManager.cc
@@ -18,6 +18,7 @@
 #include "rtp_llm/cpp/cache/SharedBlockCache.h"
 #include "rtp_llm/cpp/cache/connector/KVCacheConnectorCoordinator.h"
 #include "rtp_llm/cpp/cache/KVCacheHashUtil.h"
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "rtp_llm/cpp/engine_base/stream/CompleteTokenIds.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
@@ -160,16 +161,17 @@ bool cacheStatusSnapshotEnabled() {
 
 }  // namespace
 
-KVCacheManager::KVCacheManager(const CacheConfig&                 config,
-                               bool                               warmup,
-                               const kmonitor::MetricsReporterPtr metrics_reporter,
-                               const KVCacheConfig&               kv_cache_config,
-                               const ParallelismConfig&           parallelism_config,
-                               const RuntimeConfig&               runtime_config,
-                               const SpeculativeExecutionConfig&  sp_config,
-                               const PDSepConfig&                 pd_sep_config,
-                               const CacheStoreConfig&            cache_store_config,
-                               bool                               use_cuda_malloc_block_pool):
+KVCacheManager::KVCacheManager(const CacheConfig&                       config,
+                               bool                                     warmup,
+                               const kmonitor::MetricsReporterPtr       metrics_reporter,
+                               const KVCacheConfig&                     kv_cache_config,
+                               const ParallelismConfig&                 parallelism_config,
+                               const RuntimeConfig&                     runtime_config,
+                               const SpeculativeExecutionConfig&        sp_config,
+                               const PDSepConfig&                       pd_sep_config,
+                               const CacheStoreConfig&                  cache_store_config,
+                               bool                                     use_cuda_malloc_block_pool,
+                               const std::optional<PPValidationResult>& pp_logical_capacity):
     config_(config),
     metrics_reporter_(metrics_reporter),
     kv_cache_config_(kv_cache_config),
@@ -178,11 +180,24 @@ KVCacheManager::KVCacheManager(const CacheConfig&                 config,
     sp_config_(sp_config),
     pd_sep_config_(pd_sep_config),
     cache_store_config_(cache_store_config),
-    use_cuda_malloc_block_pool_(use_cuda_malloc_block_pool) {
+    use_cuda_malloc_block_pool_(use_cuda_malloc_block_pool),
+    pp_logical_capacity_(pp_logical_capacity) {
     if (warmup) {
         config_.finalizeBlockNums(/*global_block_num=*/1, runtime_config_);
     } else {
         allocateAndSync();
+        // PP: cap each group's logical block count at the cross-stage min,
+        // after finalizeBlockNums and before init() builds the pools.
+        if (parallelism_config_.pp_size > 1) {
+            RTP_LLM_CHECK_WITH_INFO(pp_logical_capacity.has_value(),
+                                    "pp_size=%ld requires the PP logical capacity (validator result); "
+                                    "construct KVCacheManager with the initPPCacheGeometry outcome",
+                                    parallelism_config_.pp_size);
+            RTP_LLM_CHECK_WITH_INFO(
+                pp_logical_capacity->ok, "pp logical capacity is invalid: %s", pp_logical_capacity->error.c_str());
+            applyPPCanonicalIndices(config_, *pp_logical_capacity);
+            applyPPLogicalBlockNums(config_, *pp_logical_capacity);
+        }
     }
 
     const auto& cp_cfg = parallelism_config_.prefill_cp_config;
@@ -663,7 +678,12 @@ void KVCacheManager::initConnectorCoordinator() {
 void KVCacheManager::allocateAndSync() {
     RTP_LLM_LOG_INFO("allocateAndSync start, block_num=%d", config_.block_num);
     size_t world_size = parallelism_config_.tp_size * parallelism_config_.dp_size;
-    if (world_size > 1) {
+    // PP: the allgather below sizes its buffer for tp*dp ranks, but the
+    // DP_AND_TP group spans every stage under pp_size>1 (out-of-bounds
+    // writes). Cross-stage capacity is agreed by the PP topology validator
+    // instead (per-tag min), so keep the locally measured block count here.
+    const bool pp_active = parallelism_config_.pp_size > 1;
+    if (world_size > 1 && !pp_active) {
         size_t local_rank    = parallelism_config_.tp_size * parallelism_config_.dp_rank + parallelism_config_.tp_rank;
         auto   block_num_t   = torch::empty({(int64_t)world_size}, torch::kInt32).pin_memory();
         auto   block_num_ptr = block_num_t.data_ptr<int>();

--- a/rtp_llm/cpp/cache/KVCacheManager.h
+++ b/rtp_llm/cpp/cache/KVCacheManager.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -13,6 +14,7 @@
 #include "rtp_llm/cpp/cache/CacheConfig.h"
 #include "rtp_llm/cpp/cache/connector/AsyncContext.h"
 #include "rtp_llm/cpp/cache/KVCacheAllocator.h"
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
 #include "rtp_llm/cpp/cache/connector/KVCacheConnector.h"
 #include "rtp_llm/cpp/model_rpc/proto/model_rpc_service.grpc.pb.h"
@@ -28,16 +30,20 @@ class PrefillCacheHitMetricsReporter;
 
 class KVCacheManager {
 public:
-    KVCacheManager(const CacheConfig&                 config,
-                   bool                               warmup                     = false,
-                   const kmonitor::MetricsReporterPtr metrics_reporter           = nullptr,
-                   const KVCacheConfig&               kv_cache_config            = KVCacheConfig{},
-                   const ParallelismConfig&           parallelism_config         = ParallelismConfig{},
-                   const RuntimeConfig&               runtime_config             = RuntimeConfig{},
-                   const SpeculativeExecutionConfig&  sp_config                  = SpeculativeExecutionConfig{},
-                   const PDSepConfig&                 pd_sep_config              = PDSepConfig{},
-                   const CacheStoreConfig&            cache_store_config         = CacheStoreConfig{},
-                   bool                               use_cuda_malloc_block_pool = false);
+    // pp_logical_capacity: validated cross-stage logical block counts,
+    // REQUIRED under pp_size>1 (applied right after allocateAndSync's
+    // finalizeBlockNums). Leave nullopt for pp_size<=1.
+    KVCacheManager(const CacheConfig&                       config,
+                   bool                                     warmup                     = false,
+                   const kmonitor::MetricsReporterPtr       metrics_reporter           = nullptr,
+                   const KVCacheConfig&                     kv_cache_config            = KVCacheConfig{},
+                   const ParallelismConfig&                 parallelism_config         = ParallelismConfig{},
+                   const RuntimeConfig&                     runtime_config             = RuntimeConfig{},
+                   const SpeculativeExecutionConfig&        sp_config                  = SpeculativeExecutionConfig{},
+                   const PDSepConfig&                       pd_sep_config              = PDSepConfig{},
+                   const CacheStoreConfig&                  cache_store_config         = CacheStoreConfig{},
+                   bool                                     use_cuda_malloc_block_pool = false,
+                   const std::optional<PPValidationResult>& pp_logical_capacity        = std::nullopt);
     ~KVCacheManager();
 
     // 初始化和配置相关
@@ -176,14 +182,15 @@ private:
     CacheConfig         config_;
     KVCacheAllocatorPtr allocator_;
 
-    const kmonitor::MetricsReporterPtr metrics_reporter_;
-    const KVCacheConfig                kv_cache_config_;
-    const ParallelismConfig            parallelism_config_;
-    const RuntimeConfig                runtime_config_;
-    const SpeculativeExecutionConfig   sp_config_;
-    const PDSepConfig                  pd_sep_config_;
-    const CacheStoreConfig             cache_store_config_;
-    const bool                         use_cuda_malloc_block_pool_;
+    const kmonitor::MetricsReporterPtr      metrics_reporter_;
+    const KVCacheConfig                     kv_cache_config_;
+    const ParallelismConfig                 parallelism_config_;
+    const RuntimeConfig                     runtime_config_;
+    const SpeculativeExecutionConfig        sp_config_;
+    const PDSepConfig                       pd_sep_config_;
+    const CacheStoreConfig                  cache_store_config_;
+    const bool                              use_cuda_malloc_block_pool_;
+    const std::optional<PPValidationResult> pp_logical_capacity_;
 
     std::shared_ptr<CPSlotMapper>                   cp_slot_mapper_;
     std::unique_ptr<PrefillCacheHitMetricsReporter> prefill_cache_hit_metrics_reporter_;

--- a/rtp_llm/cpp/cache/PPTopologyValidator.cc
+++ b/rtp_llm/cpp/cache/PPTopologyValidator.cc
@@ -1,0 +1,482 @@
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
+
+#include <algorithm>
+#include <limits>
+#include <sstream>
+#include <unordered_map>
+
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/models_py/bindings/core/ExecOps.h"
+
+namespace rtp_llm {
+
+namespace {
+
+std::string joinTags(const std::vector<std::string>& tags) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < tags.size(); ++i) {
+        if (i > 0) {
+            oss << ",";
+        }
+        oss << tags[i];
+    }
+    return oss.str();
+}
+
+PPValidationResult fail(std::string error) {
+    PPValidationResult result;
+    result.ok    = false;
+    result.error = std::move(error);
+    return result;
+}
+
+}  // namespace
+
+bool StageCacheSnapshot::internallyConsistent() const {
+    const size_t n = group_tags.size();
+    return group_types.size() == n && seq_size_per_block.size() == n && kernel_seq_size_per_block.size() == n
+           && block_nums.size() == n && explicit_block_nums.size() == n && policy_fingerprints.size() == n;
+}
+
+std::string cacheGroupPolicyFingerprint(const CacheGroupPolicy& policy) {
+    // Fixed-field digest covering every field CacheConfig::samePolicy()
+    // compares; uses ':' separators only, so it is wire-safe.
+    std::ostringstream oss;
+    oss << "t" << static_cast<int>(policy.group_type) << ":r" << (policy.enable_prefix_reuse ? 1 : 0) << ":e"
+        << static_cast<int>(policy.evict_policy) << ":v" << (policy.reservable ? 1 : 0) << ":x"
+        << policy.explicit_block_num << ":c" << (policy.charge_to_paged_budget ? 1 : 0) << ":p"
+        << static_cast<int>(policy.memory_placement) << ":a" << policy.active_tail_blocks << ":w"
+        << (policy.validate_tail_blocks ? 1 : 0) << ":m" << static_cast<int>(policy.cp_mapping) << ":s"
+        << static_cast<int>(policy.cp_slice);
+    return oss.str();
+}
+
+StageCacheSnapshot StageCacheSnapshot::fromConfig(const CacheConfig& config) {
+    StageCacheSnapshot snapshot;
+    for (const auto& group : config.topology().groups()) {
+        snapshot.group_tags.push_back(group.tag);
+        snapshot.group_types.push_back(group.policy.group_type);
+        snapshot.seq_size_per_block.push_back(group.seq_size_per_block);
+        snapshot.kernel_seq_size_per_block.push_back(group.kernel_seq_size_per_block);
+        snapshot.block_nums.push_back(group.block_num);
+        snapshot.explicit_block_nums.push_back(group.policy.explicit_block_num);
+        snapshot.policy_fingerprints.push_back(cacheGroupPolicyFingerprint(group.policy));
+    }
+    return snapshot;
+}
+
+namespace {
+
+// Wire format: "v1|tags|types|seq|kseq|blocks|explicit|fingerprints"; tags
+// and fingerprints joined with \x1f, numeric fields joined with ','.
+constexpr char kFieldSep = '|';
+constexpr char kTagSep   = '\x1f';
+constexpr char kNumSep   = ',';
+
+std::vector<std::string> splitFields(const std::string& s, char sep) {
+    std::vector<std::string> parts;
+    std::stringstream        ss(s);
+    std::string              item;
+    while (std::getline(ss, item, sep)) {
+        parts.push_back(item);
+    }
+    return parts;
+}
+
+template<typename T>
+std::string joinNums(const std::vector<T>& values) {
+    std::ostringstream oss;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) {
+            oss << kNumSep;
+        }
+        oss << static_cast<unsigned long long>(values[i]);
+    }
+    return oss.str();
+}
+
+template<typename T>
+std::vector<T> parseNums(const std::string& field, size_t expected_size) {
+    std::vector<T> values;
+    if (field.empty()) {
+        return values;
+    }
+    std::stringstream ss(field);
+    std::string       item;
+    while (std::getline(ss, item, kNumSep)) {
+        values.push_back(static_cast<T>(std::stoull(item)));
+    }
+    RTP_LLM_CHECK_WITH_INFO(values.size() == expected_size,
+                            "PP snapshot field has %zu entries, expected %zu",
+                            values.size(),
+                            expected_size);
+    return values;
+}
+
+}  // namespace
+
+std::string StageCacheSnapshot::serialize() const {
+    std::ostringstream oss;
+    oss << "v1" << kFieldSep;
+    for (size_t i = 0; i < group_tags.size(); ++i) {
+        if (i > 0) {
+            oss << kTagSep;
+        }
+        RTP_LLM_CHECK_WITH_INFO(group_tags[i].find_first_of("\x1f|,") == std::string::npos,
+                                "PP snapshot tag contains a wire-format delimiter: %s",
+                                group_tags[i].c_str());
+        oss << group_tags[i];
+    }
+    oss << kFieldSep << joinNums(group_types) << kFieldSep << joinNums(seq_size_per_block) << kFieldSep
+        << joinNums(kernel_seq_size_per_block) << kFieldSep << joinNums(block_nums) << kFieldSep
+        << joinNums(explicit_block_nums) << kFieldSep;
+    for (size_t i = 0; i < policy_fingerprints.size(); ++i) {
+        if (i > 0) {
+            oss << kTagSep;
+        }
+        RTP_LLM_CHECK_WITH_INFO(policy_fingerprints[i].find_first_of("\x1f|,") == std::string::npos,
+                                "PP snapshot policy fingerprint contains a wire-format delimiter: %s",
+                                policy_fingerprints[i].c_str());
+        oss << policy_fingerprints[i];
+    }
+    return oss.str();
+}
+
+StageCacheSnapshot StageCacheSnapshot::deserialize(const std::string& payload) {
+    const auto fields = splitFields(payload, kFieldSep);
+    RTP_LLM_CHECK_WITH_INFO(fields.size() == 8 && fields[0] == "v1",
+                            "PP snapshot payload is malformed (version/field count)");
+    StageCacheSnapshot snapshot;
+    snapshot.group_tags = splitFields(fields[1], kTagSep);
+    // splitFields on an empty tag field yields zero entries (no empty tag).
+    if (fields[1].empty()) {
+        snapshot.group_tags.clear();
+    }
+    snapshot.group_types               = parseNums<CacheGroupType>(fields[2], snapshot.group_tags.size());
+    snapshot.seq_size_per_block        = parseNums<size_t>(fields[3], snapshot.group_tags.size());
+    snapshot.kernel_seq_size_per_block = parseNums<size_t>(fields[4], snapshot.group_tags.size());
+    snapshot.block_nums                = parseNums<uint32_t>(fields[5], snapshot.group_tags.size());
+    snapshot.explicit_block_nums       = parseNums<uint32_t>(fields[6], snapshot.group_tags.size());
+    snapshot.policy_fingerprints       = splitFields(fields[7], kTagSep);
+    if (fields[7].empty()) {
+        snapshot.policy_fingerprints.clear();
+    }
+    RTP_LLM_CHECK_WITH_INFO(snapshot.internallyConsistent(), "PP snapshot payload failed consistency check");
+    return snapshot;
+}
+
+PPValidationResult validatePPTopology(const std::vector<StageCacheSnapshot>& stages, double capacity_skew_threshold) {
+    PPValidationResult result;
+
+    // pp_size=1 (or nothing reported): degenerates to today's behavior.
+    if (stages.size() <= 1) {
+        result.ok = true;
+        if (stages.size() == 1) {
+            if (!stages[0].internallyConsistent()) {
+                return fail("stage 0 cache snapshot is internally inconsistent");
+            }
+            for (size_t g = 0; g < stages[0].group_tags.size(); ++g) {
+                CanonicalGroupEntry entry;
+                entry.tag                       = stages[0].group_tags[g];
+                entry.type                      = stages[0].group_types[g];
+                entry.seq_size_per_block        = stages[0].seq_size_per_block[g];
+                entry.kernel_seq_size_per_block = stages[0].kernel_seq_size_per_block[g];
+                entry.logical_block_num         = stages[0].block_nums[g];
+                entry.explicit_block_num        = stages[0].explicit_block_nums[g];
+                entry.policy_fingerprint        = stages[0].policy_fingerprints[g];
+                result.canonical_groups.push_back(std::move(entry));
+            }
+        }
+        return result;
+    }
+
+    for (size_t s = 0; s < stages.size(); ++s) {
+        if (!stages[s].internallyConsistent()) {
+            return fail("stage " + std::to_string(s) + " cache snapshot is internally inconsistent");
+        }
+        // Invariant: a hybrid stage (any LINEAR group) must keep at least one
+        // FULL group.
+        const bool has_linear = std::any_of(stages[s].group_types.begin(),
+                                            stages[s].group_types.end(),
+                                            [](CacheGroupType t) { return t == CacheGroupType::LINEAR; });
+        const bool has_full   = std::any_of(stages[s].group_types.begin(),
+                                          stages[s].group_types.end(),
+                                          [](CacheGroupType t) { return t == CacheGroupType::FULL; });
+        if (has_linear && !has_full) {
+            return fail("stage " + std::to_string(s)
+                        + " has LINEAR cache groups but no FULL group; every hybrid PP stage must own at least one "
+                          "full attention layer");
+        }
+        // v1 scope: sliding-window pools use step-derived capacities whose
+        // cross-stage reconciliation is not implemented yet.
+        const bool has_swa = std::any_of(stages[s].group_types.begin(),
+                                         stages[s].group_types.end(),
+                                         [](CacheGroupType t) { return t == CacheGroupType::SWA; });
+        if (has_swa) {
+            return fail("stage " + std::to_string(s)
+                        + " holds an SWA cache group; sliding-window pools do not support pipeline parallelism yet");
+        }
+    }
+
+    const auto& ref            = stages[0];
+    const bool  tag_sets_equal = std::all_of(
+        stages.begin(), stages.end(), [&](const StageCacheSnapshot& s) { return s.group_tags == ref.group_tags; });
+
+    if (tag_sets_equal) {
+        // Elevated path: identical tag sets allow the strict equality check
+        // (the original safety net for stage-scoped isomorphic topologies).
+        for (size_t s = 1; s < stages.size(); ++s) {
+            const auto& cur = stages[s];
+
+            if (cur.group_types != ref.group_types) {
+                return fail("stage " + std::to_string(s) + " group type sequence differs from stage 0");
+            }
+            for (size_t g = 0; g < ref.group_tags.size(); ++g) {
+                if (cur.seq_size_per_block[g] != ref.seq_size_per_block[g]) {
+                    return fail("stage " + std::to_string(s) + " group [" + ref.group_tags[g] + "] seq_size_per_block "
+                                + std::to_string(cur.seq_size_per_block[g]) + " != stage 0 "
+                                + std::to_string(ref.seq_size_per_block[g]));
+                }
+                if (cur.kernel_seq_size_per_block[g] != ref.kernel_seq_size_per_block[g]) {
+                    return fail("stage " + std::to_string(s) + " group [" + ref.group_tags[g]
+                                + "] kernel_seq_size_per_block " + std::to_string(cur.kernel_seq_size_per_block[g])
+                                + " != stage 0 " + std::to_string(ref.kernel_seq_size_per_block[g]));
+                }
+            }
+        }
+    } else {
+        // Pairing path: stage-scoped topologies may legitimately hold
+        // different tag subsets. Match groups by tag name against stage 0
+        // instead of requiring equal tag lists.
+        //
+        // Superset gate: the leading stage issues every block id from its own
+        // physical pools, so it must own every group that appears anywhere.
+        // Bookkeeping-only (layerless) pools are not supported (see the PP
+        // logical bookkeeping design for the future unlock path).
+        for (size_t s = 1; s < stages.size(); ++s) {
+            const auto& cur = stages[s];
+            for (const auto& tag : cur.group_tags) {
+                if (std::find(ref.group_tags.begin(), ref.group_tags.end(), tag) == ref.group_tags.end()) {
+                    return fail("stage " + std::to_string(s) + " owns cache group [" + tag
+                                + "] that is absent from stage 0 [" + joinTags(ref.group_tags)
+                                + "]; the leading PP stage must own every cache group (bookkeeping-only "
+                                  "allocation is not supported)");
+                }
+            }
+            for (size_t g = 0; g < cur.group_tags.size(); ++g) {
+                const auto ref_it = std::find(ref.group_tags.begin(), ref.group_tags.end(), cur.group_tags[g]);
+                RTP_LLM_CHECK_WITH_INFO(ref_it != ref.group_tags.end(),
+                                        "unreachable: stage %zu tag [%s] passed the superset gate",
+                                        s,
+                                        cur.group_tags[g].c_str());
+                const auto rg = static_cast<size_t>(ref_it - ref.group_tags.begin());
+                if (cur.group_types[g] != ref.group_types[rg]) {
+                    return fail("stage " + std::to_string(s) + " group [" + cur.group_tags[g]
+                                + "] type differs from stage 0");
+                }
+                if (cur.seq_size_per_block[g] != ref.seq_size_per_block[rg]) {
+                    return fail("stage " + std::to_string(s) + " group [" + cur.group_tags[g] + "] seq_size_per_block "
+                                + std::to_string(cur.seq_size_per_block[g]) + " != stage 0 "
+                                + std::to_string(ref.seq_size_per_block[rg]));
+                }
+                if (cur.kernel_seq_size_per_block[g] != ref.kernel_seq_size_per_block[rg]) {
+                    return fail("stage " + std::to_string(s) + " group [" + cur.group_tags[g]
+                                + "] kernel_seq_size_per_block " + std::to_string(cur.kernel_seq_size_per_block[g])
+                                + " != stage 0 " + std::to_string(ref.kernel_seq_size_per_block[rg]));
+                }
+            }
+        }
+    }
+
+    // Any group anywhere with zero blocks cannot serve a request.
+    for (size_t s = 0; s < stages.size(); ++s) {
+        for (size_t g = 0; g < stages[s].group_tags.size(); ++g) {
+            if (stages[s].block_nums[g] == 0) {
+                return fail("stage " + std::to_string(s) + " group [" + stages[s].group_tags[g]
+                            + "] has 0 KV blocks; the group could not allocate a single block");
+            }
+        }
+    }
+
+    // Canonical group table: cross-stage union ordered stage-0-first (stage-0
+    // order, then first-seen order on later stages). The leading allocator
+    // issues block ids for every entry, so same-tag owners must agree on
+    // type and geometry even when none of them is stage 0.
+    std::unordered_map<std::string, size_t> canonical_index;
+    std::vector<uint32_t>                   canonical_max_blocks;
+    for (size_t s = 0; s < stages.size(); ++s) {
+        for (size_t g = 0; g < stages[s].group_tags.size(); ++g) {
+            const auto& tag = stages[s].group_tags[g];
+            const auto  it  = canonical_index.find(tag);
+            if (it == canonical_index.end()) {
+                canonical_index.emplace(tag, result.canonical_groups.size());
+                CanonicalGroupEntry entry;
+                entry.tag                       = tag;
+                entry.type                      = stages[s].group_types[g];
+                entry.seq_size_per_block        = stages[s].seq_size_per_block[g];
+                entry.kernel_seq_size_per_block = stages[s].kernel_seq_size_per_block[g];
+                entry.logical_block_num         = stages[s].block_nums[g];
+                entry.explicit_block_num        = stages[s].explicit_block_nums[g];
+                entry.policy_fingerprint        = stages[s].policy_fingerprints[g];
+                result.canonical_groups.push_back(std::move(entry));
+                canonical_max_blocks.push_back(stages[s].block_nums[g]);
+                continue;
+            }
+            auto& entry = result.canonical_groups[it->second];
+            if (stages[s].group_types[g] != entry.type) {
+                return fail("stage " + std::to_string(s) + " group [" + tag
+                            + "] type differs from the canonical entry");
+            }
+            if (stages[s].seq_size_per_block[g] != entry.seq_size_per_block) {
+                return fail("stage " + std::to_string(s) + " group [" + tag + "] seq_size_per_block "
+                            + std::to_string(stages[s].seq_size_per_block[g]) + " != canonical "
+                            + std::to_string(entry.seq_size_per_block));
+            }
+            if (stages[s].kernel_seq_size_per_block[g] != entry.kernel_seq_size_per_block) {
+                return fail("stage " + std::to_string(s) + " group [" + tag + "] kernel_seq_size_per_block "
+                            + std::to_string(stages[s].kernel_seq_size_per_block[g]) + " != canonical "
+                            + std::to_string(entry.kernel_seq_size_per_block));
+            }
+            // Explicit pool sizing comes from deployment-wide config; same-tag
+            // owners diverging means the stages were launched inconsistently.
+            if (stages[s].explicit_block_nums[g] != entry.explicit_block_num) {
+                return fail("stage " + std::to_string(s) + " group [" + tag + "] explicit_block_num "
+                            + std::to_string(stages[s].explicit_block_nums[g]) + " != canonical "
+                            + std::to_string(entry.explicit_block_num));
+            }
+            // Full policy reconciliation: eviction/reuse/placement/tail knobs
+            // must agree across owners of the same pool.
+            if (stages[s].policy_fingerprints[g] != entry.policy_fingerprint) {
+                return fail("stage " + std::to_string(s) + " group [" + tag + "] policy ["
+                            + stages[s].policy_fingerprints[g] + "] != canonical [" + entry.policy_fingerprint + "]");
+            }
+            entry.logical_block_num          = std::min(entry.logical_block_num, stages[s].block_nums[g]);
+            canonical_max_blocks[it->second] = std::max(canonical_max_blocks[it->second], stages[s].block_nums[g]);
+        }
+    }
+
+    // Capacity skew guard over the whole canonical table (not just stage-0
+    // tags): an oversized owner would let the leading allocator issue ids
+    // beyond a smaller owner's pool.
+    for (size_t c = 0; c < result.canonical_groups.size(); ++c) {
+        const auto& entry = result.canonical_groups[c];
+        if (static_cast<double>(canonical_max_blocks[c]) / static_cast<double>(entry.logical_block_num)
+            > capacity_skew_threshold) {
+            std::ostringstream oss;
+            oss << "group [" << entry.tag << "] KV capacity skew too large: max/min = " << canonical_max_blocks[c]
+                << "/" << entry.logical_block_num << " > threshold " << capacity_skew_threshold
+                << "; adjust the layer partition to balance per-stage KV capacity";
+            return fail(oss.str());
+        }
+    }
+
+    // Per-stage logical counts live on the canonical entries themselves;
+    // consumers look entries up by tag (gid is stage-private).
+    result.ok = true;
+    return result;
+}
+
+PPValidationResult initPPCacheGeometry(StageSnapshotCollector& collector, double capacity_skew_threshold) {
+    return validatePPTopology(collector.collect(), capacity_skew_threshold);
+}
+
+std::vector<StageCacheSnapshot> PPSnapshotCollector::collect() {
+    // All-gather over the PP process group; payloads come back in group-rank
+    // order, which equals pp_rank order (lane members are ascending world
+    // ranks), so vector index == stage index.
+    const auto payloads = execPPSnapshotExchange(local_.serialize());
+    RTP_LLM_CHECK_WITH_INFO(!payloads.empty(), "PP snapshot exchange returned no stages");
+    std::vector<StageCacheSnapshot> stages;
+    stages.reserve(payloads.size());
+    for (size_t s = 0; s < payloads.size(); ++s) {
+        try {
+            stages.push_back(StageCacheSnapshot::deserialize(payloads[s]));
+        } catch (const std::exception& e) {
+            RTP_LLM_FAIL("PP snapshot exchange: stage %zu payload rejected: %s", s, e.what());
+        }
+    }
+    return stages;
+}
+
+void applyPPLogicalBlockNums(CacheConfig& config, const PPValidationResult& validation) {
+    RTP_LLM_CHECK_WITH_INFO(validation.ok, "applyPPLogicalBlockNums requires a successful PP validation");
+    const size_t group_num = static_cast<size_t>(config.groupNums());
+    if (group_num == 0) {
+        return;
+    }
+
+    // Look every local group up in the canonical table by tag: entries carry
+    // the cross-stage min over all owners, so groups owned only by later
+    // stages are capped too. Strides are untouched (geometry was already
+    // validated identical for same-tag owners).
+    std::unordered_map<std::string, uint32_t> logical_blocks;
+    logical_blocks.reserve(validation.canonical_groups.size());
+    // The top-level block_num is the capacity yardstick of the paged pools
+    // that follow the global budget (independent-pool semantics): explicitly
+    // sized pools are decoupled from it and must not drag it down.
+    uint32_t paged_min = std::numeric_limits<uint32_t>::max();
+    for (const auto& entry : validation.canonical_groups) {
+        logical_blocks.emplace(entry.tag, entry.logical_block_num);
+        const bool follows_global_budget =
+            entry.explicit_block_num == 0
+            && (entry.type == CacheGroupType::FULL || entry.type == CacheGroupType::LINEAR);
+        if (follows_global_budget) {
+            paged_min = std::min(paged_min, entry.logical_block_num);
+        }
+    }
+
+    std::vector<uint32_t> block_nums;
+    std::vector<size_t>   kv_strides;
+    std::vector<size_t>   scale_strides;
+    block_nums.reserve(group_num);
+    kv_strides.reserve(group_num);
+    scale_strides.reserve(group_num);
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        const auto& group = config.topology().groupById(gid);
+        const auto  it    = logical_blocks.find(group.tag);
+        RTP_LLM_CHECK_WITH_INFO(it != logical_blocks.end(),
+                                "local group [%s] is missing from the PP canonical group table",
+                                group.tag.c_str());
+        // Cap only: entries carry the cross-stage min, but never raise a
+        // locally smaller count.
+        block_nums.push_back(std::min(group.block_num, it->second));
+        kv_strides.push_back(group.kv_block_stride_bytes);
+        scale_strides.push_back(group.kv_scale_stride_bytes);
+    }
+
+    config.setGroupBlockLayout(block_nums, kv_strides, scale_strides);
+    // Keep the top-level (log/scheduler-facing) block count consistent with
+    // the capped paged pools; only ever decreases.
+    if (paged_min != std::numeric_limits<uint32_t>::max() && config.block_num > static_cast<int>(paged_min)) {
+        RTP_LLM_LOG_INFO("PP logical capacity caps local block_num %d to %u (paged-pool canonical min)",
+                         config.block_num,
+                         paged_min);
+        config.block_num = static_cast<int>(paged_min);
+    }
+}
+
+void applyPPCanonicalIndices(CacheConfig& config, const PPValidationResult& validation) {
+    RTP_LLM_CHECK_WITH_INFO(validation.ok, "applyPPCanonicalIndices requires a successful PP validation");
+    const size_t group_num = static_cast<size_t>(config.groupNums());
+    if (group_num == 0) {
+        return;
+    }
+
+    std::unordered_map<std::string, size_t> canonical_index;
+    canonical_index.reserve(validation.canonical_groups.size());
+    for (size_t c = 0; c < validation.canonical_groups.size(); ++c) {
+        canonical_index.emplace(validation.canonical_groups[c].tag, c);
+    }
+
+    auto groups = config.topology().groups();
+    for (auto& group : groups) {
+        const auto it = canonical_index.find(group.tag);
+        RTP_LLM_CHECK_WITH_INFO(it != canonical_index.end(),
+                                "local group [%s] is missing from the PP canonical group table",
+                                group.tag.c_str());
+        group.canonical_idx = it->second;
+    }
+    config.setTopology(std::move(groups), config.topology().layers());
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/PPTopologyValidator.h
+++ b/rtp_llm/cpp/cache/PPTopologyValidator.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/CacheGroupType.h"
+
+namespace rtp_llm {
+
+class CacheConfig;
+
+// Cache geometry snapshot of one PP stage, exchanged at startup after the
+// KV pools are built. All fields are per-group and indexed by gid; the
+// ordered tag list is the semantic identity of the group layout (gid is a
+// stage-private topology index).
+struct StageCacheSnapshot {
+    std::vector<std::string>    group_tags;                 // ordered tag list
+    std::vector<CacheGroupType> group_types;                // type sequence
+    std::vector<size_t>         seq_size_per_block;         // per group
+    std::vector<size_t>         kernel_seq_size_per_block;  // per group
+    std::vector<uint32_t>       block_nums;                 // actually allocated blocks
+    std::vector<uint32_t>       explicit_block_nums;        // 0 = follows the paged budget
+    std::vector<std::string>    policy_fingerprints;        // CacheGroupPolicy digest per group
+
+    // True when all per-group vectors have the same length as group_tags.
+    bool internallyConsistent() const;
+
+    // Builds the snapshot from a fully initialized CacheConfig.
+    static StageCacheSnapshot fromConfig(const CacheConfig& config);
+
+    // Self-describing text wire format; deserialize rejects malformed payloads.
+    std::string               serialize() const;
+    static StageCacheSnapshot deserialize(const std::string& payload);
+};
+
+// One row of the canonical group table: the cross-stage union of cache
+// groups, ordered stage-0-first. Under the stage-0-superset rule (see
+// validatePPTopology) the union equals stage 0's own group list, so the
+// leading allocator physically owns every entry and issues all block ids
+// from its own pools.
+struct CanonicalGroupEntry {
+    std::string    tag;
+    CacheGroupType type                      = CacheGroupType::FULL;
+    size_t         seq_size_per_block        = 0;
+    size_t         kernel_seq_size_per_block = 0;
+    uint32_t       logical_block_num         = 0;  // min across owner stages
+    uint32_t       explicit_block_num        = 0;  // must agree across owners; 0 = budget-following
+    std::string    policy_fingerprint;             // must agree across owners
+};
+
+// Text digest of a CacheGroupPolicy covering every field samePolicy()
+// compares. Delimiter-free by construction (wire-safe).
+std::string cacheGroupPolicyFingerprint(const struct CacheGroupPolicy& policy);
+
+struct PPValidationResult {
+    bool        ok = false;
+    std::string error;  // human-readable reject reason
+    // Whole-model union of cache groups; valid only when ok. Single source
+    // of truth for cross-stage group identity, ordering (canonical_idx) and
+    // logical capacity (per-entry min over owners).
+    std::vector<CanonicalGroupEntry> canonical_groups;
+};
+
+// Validates cache geometry across PP stages and computes the canonical
+// group table. Pairing-by-tag is the base rule; when all stages report the
+// same tag list the strict equality check is elevated automatically.
+// Rules:
+//  - stages.size() <= 1: trivially ok (pp_size=1 behavior)
+//  - internally inconsistent snapshot: fail
+//  - hybrid stage (any LINEAR group) without a FULL group: fail
+//  - any stage owning a group absent from stage 0: fail (stage-0-superset
+//    rule: the leading stage must physically own every cache group, since
+//    it issues all block ids from its own pools)
+//  - shared tags with different type / seq size / kernel seq size: fail
+//  - any group with 0 blocks: fail (group could not allocate)
+//  - capacity skew max/min > capacity_skew_threshold on any tag: fail
+//  - canonical_groups: union over all stages (stage-0 order first);
+//    same-tag owners must agree on type and geometry; logical_block_num is
+//    the min over owners
+PPValidationResult validatePPTopology(const std::vector<StageCacheSnapshot>& stages,
+                                      double                                 capacity_skew_threshold = 1.5);
+
+// Collects cache snapshots from all PP stages.
+class StageSnapshotCollector {
+public:
+    virtual ~StageSnapshotCollector()                 = default;
+    virtual std::vector<StageCacheSnapshot> collect() = 0;
+};
+
+// Local single-stage collector (pp_size=1): returns this stage's own snapshot.
+class LocalStageSnapshotCollector: public StageSnapshotCollector {
+public:
+    explicit LocalStageSnapshotCollector(StageCacheSnapshot snapshot): snapshot_(std::move(snapshot)) {}
+
+    std::vector<StageCacheSnapshot> collect() override {
+        return {snapshot_};
+    }
+
+private:
+    StageCacheSnapshot snapshot_;
+};
+
+// Cross-stage collector: exchanges this stage's serialized snapshot with
+// every PP stage over the PP process group (execPPSnapshotExchange) and
+// deserializes the results in stage (pp_rank) order. Startup-only: all
+// stages must reach the call.
+class PPSnapshotCollector: public StageSnapshotCollector {
+public:
+    explicit PPSnapshotCollector(StageCacheSnapshot local_snapshot): local_(std::move(local_snapshot)) {}
+
+    std::vector<StageCacheSnapshot> collect() override;
+
+private:
+    StageCacheSnapshot local_;
+};
+
+// One-stop startup entry: collect snapshots from all stages, then validate.
+// On failure the caller must abort startup with result.error (fail fast).
+PPValidationResult initPPCacheGeometry(StageSnapshotCollector& collector, double capacity_skew_threshold = 1.5);
+
+// Applies the validated logical (min) block counts to this stage's
+// CacheConfig: every local group is paired with its canonical entry by tag
+// and capped at the entry's cross-stage min (never raised). The top-level
+// block_num is capped at the min over the budget-following paged pools
+// only; explicitly sized pools are decoupled from it. Must run after
+// finalizeBlockNums and before KVCacheManager::init(): pools are physically
+// sized by the capped counts, so a richer stage simply allocates a smaller
+// pool and leaves the surplus VRAM free. No-op for configs without groups.
+void applyPPLogicalBlockNums(CacheConfig& config, const PPValidationResult& validation);
+
+// Fills each local group's canonical_idx from the canonical group table by
+// tag pairing. Must run before KVCacheManager::init(): plan columns are
+// addressed by canonical index and downstream column selection resolves
+// local groups through canonical_idx. Every local tag must appear in the
+// canonical table.
+void applyPPCanonicalIndices(CacheConfig& config, const PPValidationResult& validation);
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/SingleConfigCreator.cc
+++ b/rtp_llm/cpp/cache/SingleConfigCreator.cc
@@ -93,21 +93,25 @@ CacheConfig SingleConfigCreator::createSingleConfig(const ModelConfig&       mod
                                                     int                      gen_num_per_cycle) {
     (void)is_mtp;
 
-    auto       dtype            = MemoryEvaluationHelper::getDataTypeForCache(model_config);
-    const auto tokens_per_block = static_cast<uint32_t>(model_config.attn_config.tokens_per_block);
+    // PP: with pp_size>1 every stage builds cache geometry only for its own
+    // layer range; downstream helpers then operate on local layer ids.
+    const ModelConfig stage_model_config = CacheConfigCreator::stageScopedModelConfig(model_config, parallelism_config);
+
+    auto       dtype            = MemoryEvaluationHelper::getDataTypeForCache(stage_model_config);
+    const auto tokens_per_block = static_cast<uint32_t>(stage_model_config.attn_config.tokens_per_block);
     RTP_LLM_CHECK_WITH_INFO(tokens_per_block > 0, "single seq_size_per_block must be > 0");
 
     SpecBuildContext ctx;
     ctx.dtype                   = dtype;
     ctx.seq_size_per_block      = tokens_per_block;
-    ctx.attn_config             = &model_config.attn_config;
-    ctx.linear_attention_config = &model_config.linear_attention_config;
+    ctx.attn_config             = &stage_model_config.attn_config;
+    ctx.linear_attention_config = &stage_model_config.linear_attention_config;
     ctx.parallelism_config      = &parallelism_config;
     ctx.gen_num_per_cycle       = static_cast<uint32_t>(gen_num_per_cycle);
-    const auto runtime_specs =
-        CacheConfigCreator::buildLayerSpecsFromDescs(model_config.kv_cache_spec_descs, ctx, model_config.num_layers);
+    const auto runtime_specs    = CacheConfigCreator::buildLayerSpecsFromDescs(
+        stage_model_config.kv_cache_spec_descs, ctx, stage_model_config.num_layers);
 
-    auto layer_num = model_config.num_layers;
+    auto layer_num = stage_model_config.num_layers;
 
     CacheConfig config;
     config.layer_num          = static_cast<uint32_t>(layer_num);
@@ -115,11 +119,11 @@ CacheConfig SingleConfigCreator::createSingleConfig(const ModelConfig&       mod
     config.block_num          = 0;
     config.seq_size_per_block = tokens_per_block;
 
-    config.use_mla   = model_config.attn_config.use_mla;
+    config.use_mla   = stage_model_config.attn_config.use_mla;
     config.dtype     = dtype;
-    config.is_sparse = model_config.attn_config.is_sparse;
+    config.is_sparse = stage_model_config.attn_config.is_sparse;
 
-    auto spec = getDefaultSpecFromRuntimeSpecs(model_config, runtime_specs);
+    auto spec = getDefaultSpecFromRuntimeSpecs(stage_model_config, runtime_specs);
 
     std::vector<int> layer_ids(static_cast<size_t>(layer_num));
     std::iota(layer_ids.begin(), layer_ids.end(), 0);
@@ -130,7 +134,7 @@ CacheConfig SingleConfigCreator::createSingleConfig(const ModelConfig&       mod
         spec->type == KVCacheSpecType::LinearAttention ? CacheGroupType::LINEAR : CacheGroupType::FULL;
     group.policy            = defaultCacheGroupPolicy(group_type);
     group.layer_ids         = layer_ids;
-    group.local_kv_head_num = localKvHeadNumForSpec(spec->type, model_config, parallelism_config);
+    group.local_kv_head_num = localKvHeadNumForSpec(spec->type, stage_model_config, parallelism_config);
 
     std::vector<LayerBase> layers(static_cast<size_t>(layer_num));
     for (int64_t layer_id = 0; layer_id < layer_num; ++layer_id) {
@@ -150,7 +154,7 @@ CacheConfig SingleConfigCreator::createSingleConfig(const ModelConfig&       mod
     config.kv_scale_size_bytes   = static_cast<size_t>(config.layer_num) * config.kv_scale_stride_bytes;
 
     if (config.is_sparse) {
-        auto indexer_dim             = model_config.attn_config.indexer_head_dim;
+        auto indexer_dim             = stage_model_config.attn_config.indexer_head_dim;
         config.kv_scale_stride_bytes = (indexer_dim + indexer_dim / 128 * 4) * spec->seq_size_per_block;
         config.kv_scale_size_bytes   = static_cast<size_t>(config.layer_num) * config.kv_scale_stride_bytes;
     }

--- a/rtp_llm/cpp/cache/test/BUILD
+++ b/rtp_llm/cpp/cache/test/BUILD
@@ -73,6 +73,37 @@ cc_test(
 )
 
 cc_test(
+    name = "pp_topology_validator_test",
+    srcs = ["PPTopologyValidatorTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:cache_config",
+        "//rtp_llm/cpp/cache:pp_topology_validator",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    env = {},
+)
+
+# Stage-scoped CacheConfig construction: pp=1 equivalence and per-stage
+# geometry (local layer ids, per-stage block bytes) for pp>1.
+cc_test(
+    name = "pp_stage_cache_config_test",
+    srcs = ["PPStageCacheConfigTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/cache:cache",
+        "//rtp_llm/cpp/cache:cache_core",
+        "//rtp_llm/cpp/cache:pp_topology_validator",
+        "//rtp_llm/cpp/config:model_config",
+        "//rtp_llm/models_py/bindings/core:exec_ops_test_lib",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    env = {},
+)
+
+cc_test(
     name = "cache_layer_layout_test",
     srcs = ["CacheLayerLayoutTest.cc"],
     copts = test_copts,

--- a/rtp_llm/cpp/cache/test/PPStageCacheConfigTest.cc
+++ b/rtp_llm/cpp/cache/test/PPStageCacheConfigTest.cc
@@ -1,0 +1,622 @@
+// Stage-scoped CacheConfig construction.
+//
+// Pins three behaviors:
+//  1. pp_size=1 equivalence: stage scoping is a no-op, configs are identical
+//     to whole-model construction.
+//  2. pp_size>1: every stage builds cache geometry only for its own layer
+//     range: local layer ids, per-stage layer counts, per-stage block bytes.
+//  3. Hybrid cache tags stay global (assigned at config-build time) and pass
+//     through the stage slice unchanged; irregular hybrid patterns and
+//     pp_size > full-layer-count are gated.
+// Also covers the startup gates for paths that are not stage-scoped yet
+// (hybrid-pool / independent KV pools, speculative execution).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/CacheConfigCreator.h"
+#include "rtp_llm/cpp/cache/KVCacheManager.h"
+#include "rtp_llm/cpp/cache/KVCacheSpecDesc.h"
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
+#include "rtp_llm/cpp/config/ModelConfig.h"
+
+namespace rtp_llm {
+namespace test {
+
+// 3 linear + 1 full attention unit (qwen3_next style).
+static ModelConfig makeHybridModelConfig(int64_t num_layers) {
+    ModelConfig cfg;
+    cfg.num_layers                   = num_layers;
+    cfg.max_seq_len                  = 128;
+    cfg.hidden_size                  = 64;
+    cfg.vocab_size                   = 1024;
+    cfg.data_type                    = DataType::TYPE_FP16;
+    cfg.attn_config.head_num         = 2;
+    cfg.attn_config.kv_head_num      = 2;
+    cfg.attn_config.size_per_head    = 16;
+    cfg.attn_config.tokens_per_block = 4;
+    cfg.attn_config.use_mla          = false;
+    cfg.attn_config.kv_cache_dtype   = KvCacheDataType::BASE;
+
+    cfg.linear_attention_config.linear_conv_kernel_dim = 2;
+    cfg.linear_attention_config.linear_key_head_dim    = 8;
+    cfg.linear_attention_config.linear_value_head_dim  = 8;
+    cfg.linear_attention_config.linear_num_key_heads   = 2;
+    cfg.linear_attention_config.linear_num_value_heads = 2;
+
+    cfg.hybrid_attention_config.enable_hybrid_attention = true;
+    cfg.hybrid_attention_config.hybrid_attention_types.resize(static_cast<size_t>(num_layers));
+    cfg.kv_cache_spec_descs.assign(static_cast<size_t>(num_layers), {});
+    for (int64_t i = 0; i < num_layers; ++i) {
+        const bool linear = (i % 4) != 3;
+        cfg.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(i)] =
+            linear ? HybridAttentionType::LINEAR : HybridAttentionType::NONE;
+        cfg.kv_cache_spec_descs[static_cast<size_t>(i)].push_back(
+            linear ? KVCacheSpecDesc{"linear", KVCacheSpecType::LinearAttention} :
+                     KVCacheSpecDesc{"full", KVCacheSpecType::MultiHeadAttention});
+    }
+    return cfg;
+}
+
+// Independent-pool variant (qwen3 future path): type-tagged pools
+// ("full"/"linear"), built through HybridPoolConfigCreator.
+static ModelConfig makeIndependentPoolModelConfig(int64_t num_layers) {
+    ModelConfig cfg                                               = makeHybridModelConfig(num_layers);
+    cfg.hybrid_attention_config.enable_independent_kv_cache_pools = true;
+    return cfg;
+}
+
+static ModelConfig makeSingleModelConfig(int64_t num_layers) {
+    ModelConfig cfg;
+    cfg.num_layers                   = num_layers;
+    cfg.max_seq_len                  = 128;
+    cfg.hidden_size                  = 64;
+    cfg.vocab_size                   = 1024;
+    cfg.data_type                    = DataType::TYPE_FP16;
+    cfg.attn_config.head_num         = 2;
+    cfg.attn_config.kv_head_num      = 2;
+    cfg.attn_config.size_per_head    = 16;
+    cfg.attn_config.tokens_per_block = 4;
+    cfg.attn_config.use_mla          = false;
+    cfg.attn_config.kv_cache_dtype   = KvCacheDataType::BASE;
+    cfg.kv_cache_spec_descs.assign(static_cast<size_t>(num_layers), {});
+    for (int64_t i = 0; i < num_layers; ++i) {
+        cfg.kv_cache_spec_descs[static_cast<size_t>(i)].push_back(
+            KVCacheSpecDesc{"full", KVCacheSpecType::MultiHeadAttention});
+    }
+    return cfg;
+}
+
+static ParallelismConfig makePpConfig(int64_t num_layers, int64_t pp_size, int64_t pp_rank) {
+    ParallelismConfig pc;
+    pc.pp_size = pp_size;
+    pc.pp_rank = pp_rank;
+    // Materialized partition, mirroring what the production Python decision
+    // point (resolve_pp_partition) writes: even split, remainder to earlier
+    // stages. Test-only zero counts are allowed to probe empty-stage guards.
+    const int64_t base = num_layers / pp_size;
+    const int64_t rem  = num_layers % pp_size;
+    for (int64_t stage = 0; stage < pp_size; ++stage) {
+        pc.pp_stage_layer_counts.push_back(base + (stage < rem ? 1 : 0));
+    }
+    return pc;
+}
+
+static size_t countLayersOfType(const CacheConfig& config, CacheGroupType type) {
+    size_t count = 0;
+    for (const auto& group : config.topology().groups()) {
+        if (group.policy.group_type == type) {
+            count += group.layer_ids.size();
+        }
+    }
+    return count;
+}
+
+// ---------------------------------------------------------------------------
+// stageScopedModelConfig: the slicing primitive
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, stageScopedPp1IsIdentity) {
+    const auto mc     = makeHybridModelConfig(8);
+    const auto staged = CacheConfigCreator::stageScopedModelConfig(mc, ParallelismConfig{});
+    EXPECT_EQ(staged.num_layers, 8);
+    EXPECT_EQ(staged.kv_cache_spec_descs.size(), 8u);
+    EXPECT_EQ(staged.hybrid_attention_config.hybrid_attention_types.size(), 8u);
+}
+
+TEST(PPStageCacheConfig, stageScopedMatchesLayerPartition) {
+    // 65 layers, pp=4 -> 17/16/16/16, remainder to earlier stages
+    // (golden values of the Python default partition, even_split_counts).
+    const auto                                     mc       = makeHybridModelConfig(65);
+    const std::vector<std::pair<int64_t, int64_t>> expected = {{0, 17}, {17, 33}, {33, 49}, {49, 65}};
+    for (int64_t rank = 0; rank < 4; ++rank) {
+        const auto staged       = CacheConfigCreator::stageScopedModelConfig(mc, makePpConfig(65, 4, rank));
+        const auto [begin, end] = expected[static_cast<size_t>(rank)];
+        EXPECT_EQ(staged.num_layers, end - begin) << "rank=" << rank;
+        ASSERT_EQ(staged.kv_cache_spec_descs.size(), static_cast<size_t>(end - begin)) << "rank=" << rank;
+        ASSERT_EQ(staged.hybrid_attention_config.hybrid_attention_types.size(), static_cast<size_t>(end - begin))
+            << "rank=" << rank;
+        // Sliced content must equal the corresponding global slice.
+        for (int64_t l = 0; l < end - begin; ++l) {
+            EXPECT_EQ(staged.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(l)],
+                      mc.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(begin + l)])
+                << "rank=" << rank << " local=" << l;
+            ASSERT_EQ(staged.kv_cache_spec_descs[static_cast<size_t>(l)].size(), 1u);
+            ASSERT_EQ(mc.kv_cache_spec_descs[static_cast<size_t>(begin + l)].size(), 1u);
+            // Cache type and tag are preserved verbatim by the slice: tags
+            // stay global and are never renamed per stage.
+            EXPECT_EQ(staged.kv_cache_spec_descs[static_cast<size_t>(l)][0].cache_type,
+                      mc.kv_cache_spec_descs[static_cast<size_t>(begin + l)][0].cache_type)
+                << "rank=" << rank << " local=" << l;
+            EXPECT_EQ(staged.kv_cache_spec_descs[static_cast<size_t>(l)][0].tag,
+                      mc.kv_cache_spec_descs[static_cast<size_t>(begin + l)][0].tag)
+                << "rank=" << rank << " local=" << l;
+        }
+    }
+}
+
+TEST(PPStageCacheConfig, stageScopedRejectsInvalidRankAndEmptyStage) {
+    const auto mc = makeHybridModelConfig(8);
+    EXPECT_THROW(CacheConfigCreator::stageScopedModelConfig(mc, makePpConfig(8, 2, 2)), std::exception);
+    EXPECT_THROW(CacheConfigCreator::stageScopedModelConfig(mc, makePpConfig(8, 2, -1)), std::exception);
+    // 2 layers over 4 stages: ranks 2/3 own zero layers.
+    const auto tiny = makeHybridModelConfig(2);
+    EXPECT_THROW(CacheConfigCreator::stageScopedModelConfig(tiny, makePpConfig(2, 4, 2)), std::exception);
+}
+
+// ---------------------------------------------------------------------------
+// Hybrid creator (qwen3.8-27B path)
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, hybridPp1Baseline) {
+    const auto mc     = makeHybridModelConfig(8);
+    const auto config = CacheConfigCreator::createBasicConfig(mc, ParallelismConfig{}, false, 0);
+    EXPECT_EQ(config.layer_num, 8u);
+    EXPECT_EQ(config.layer_all_num, 8u);
+    EXPECT_EQ(config.topology().layers().size(), 8u);
+    EXPECT_EQ(countLayersOfType(config, CacheGroupType::LINEAR), 6u);
+    EXPECT_EQ(countLayersOfType(config, CacheGroupType::FULL), 2u);
+}
+
+TEST(PPStageCacheConfig, independentPoolPp2SlicesGeometry) {
+    const auto mc = makeIndependentPoolModelConfig(8);
+    for (int64_t rank = 0; rank < 2; ++rank) {
+        const auto stage = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, rank), false, 0);
+        // 8 layers / 2 stages -> 4 local layers, ids renumbered from 0.
+        EXPECT_EQ(stage.layer_num, 4u) << "rank=" << rank;
+        EXPECT_EQ(stage.layer_all_num, 4u) << "rank=" << rank;
+        ASSERT_EQ(stage.topology().layers().size(), 4u) << "rank=" << rank;
+        for (size_t l = 0; l < 4; ++l) {
+            EXPECT_EQ(stage.topology().layers()[l].layer_id, static_cast<int>(l)) << "rank=" << rank;
+        }
+        // 3 linear + 1 full per stage (unit-aligned split of the 3L+1F
+        // cycle), merged into one type-tagged pool each.
+        EXPECT_EQ(countLayersOfType(stage, CacheGroupType::LINEAR), 3u) << "rank=" << rank;
+        EXPECT_EQ(countLayersOfType(stage, CacheGroupType::FULL), 1u) << "rank=" << rank;
+        ASSERT_EQ(stage.groupNums(), 2) << "rank=" << rank;
+        std::vector<std::string> tags;
+        for (const auto& group : stage.topology().groups()) {
+            tags.push_back(group.tag);
+        }
+        std::sort(tags.begin(), tags.end());
+        EXPECT_EQ(tags, (std::vector<std::string>{"full", "linear"})) << "rank=" << rank;
+        EXPECT_TRUE(stage.use_independent_block_pools) << "rank=" << rank;
+    }
+}
+
+TEST(PPStageCacheConfig, independentPoolPp2UnevenSplit) {
+    // 9 layers of the regular 3L+1F period (trailing partial period), even
+    // split 5/4: stage0 [0,5) = 4L+1F, stage1 [5,9) = 3L+1F. Pool geometry
+    // differs across stages; tags stay identical.
+    const auto mc = makeIndependentPoolModelConfig(9);
+
+    const auto stage0 = CacheConfigCreator::createBasicConfig(mc, makePpConfig(9, 2, 0), false, 0);
+    EXPECT_EQ(stage0.layer_num, 5u);
+    EXPECT_EQ(countLayersOfType(stage0, CacheGroupType::LINEAR), 4u);
+    EXPECT_EQ(countLayersOfType(stage0, CacheGroupType::FULL), 1u);
+
+    const auto stage1 = CacheConfigCreator::createBasicConfig(mc, makePpConfig(9, 2, 1), false, 0);
+    EXPECT_EQ(stage1.layer_num, 4u);
+    EXPECT_EQ(countLayersOfType(stage1, CacheGroupType::LINEAR), 3u);
+    EXPECT_EQ(countLayersOfType(stage1, CacheGroupType::FULL), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Single creator (dense models)
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, singlePp2SlicesGeometry) {
+    const auto mc    = makeSingleModelConfig(8);
+    const auto whole = CacheConfigCreator::createBasicConfig(mc, ParallelismConfig{}, false, 0);
+    ASSERT_EQ(whole.layer_num, 8u);
+
+    for (int64_t rank = 0; rank < 2; ++rank) {
+        const auto stage = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, rank), false, 0);
+        EXPECT_EQ(stage.layer_num, 4u) << "rank=" << rank;
+        ASSERT_EQ(stage.groupNums(), 1) << "rank=" << rank;
+        const auto& group = stage.topology().groups()[0];
+        ASSERT_EQ(group.layer_ids.size(), 4u) << "rank=" << rank;
+        for (size_t l = 0; l < 4; ++l) {
+            EXPECT_EQ(group.layer_ids[l], static_cast<int>(l)) << "rank=" << rank;
+        }
+        // Per-block bytes scale with the stage layer count.
+        EXPECT_EQ(stage.block_size_bytes, whole.block_size_bytes / 2) << "rank=" << rank;
+        EXPECT_EQ(stage.layer_to_block_stride_bytes.size(), 4u) << "rank=" << rank;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Global tag pass-through and gates
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, independentPoolPp2TagSubsets) {
+    // Mimics per-position linear tags on a 32-layer 3L+1F model, then
+    // verifies pp=2 keeps the tags: stages own tag SUBSETS (linear0/linear1
+    // vs linear1/linear2) with the shared tag geometry intact — the pairing
+    // case the canonical table reconciles.
+    auto    mc          = makeIndependentPoolModelConfig(32);
+    int64_t linear_seen = 0;
+    for (int64_t i = 0; i < 32; ++i) {
+        if (mc.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(i)] == HybridAttentionType::LINEAR) {
+            mc.kv_cache_spec_descs[static_cast<size_t>(i)][0].tag = "linear" + std::to_string(linear_seen / 8);
+            ++linear_seen;
+        }
+    }
+
+    const std::vector<std::vector<std::string>> expected_tags = {
+        {"full", "linear0", "linear1"},  // stage 0: global linear layers 0-11
+        {"full", "linear1", "linear2"},  // stage 1: global linear layers 12-23
+    };
+    for (int64_t rank = 0; rank < 2; ++rank) {
+        const auto stage = CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, rank), false, 0);
+        ASSERT_EQ(stage.groupNums(), 3) << "rank=" << rank;
+        std::vector<std::string> tags;
+        for (const auto& group : stage.topology().groups()) {
+            tags.push_back(group.tag);
+        }
+        std::sort(tags.begin(), tags.end());
+        auto expected = expected_tags[static_cast<size_t>(rank)];
+        std::sort(expected.begin(), expected.end());
+        EXPECT_EQ(tags, expected) << "rank=" << rank;
+        EXPECT_EQ(countLayersOfType(stage, CacheGroupType::FULL), 4u) << "rank=" << rank;
+        EXPECT_EQ(countLayersOfType(stage, CacheGroupType::LINEAR), 12u) << "rank=" << rank;
+    }
+
+    // The stage-0-superset gate rejects this topology at validation time:
+    // stage 1 owns linear2 which stage 0 lacks (bookkeeping-only allocation
+    // is not supported).
+    auto stage0_cfg = CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, 0), false, 0);
+    auto stage1_cfg = CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, 1), false, 0);
+    stage0_cfg.finalizeBlockNums(100, RuntimeConfig{});
+    stage1_cfg.finalizeBlockNums(100, RuntimeConfig{});
+    const auto validation =
+        validatePPTopology({StageCacheSnapshot::fromConfig(stage0_cfg), StageCacheSnapshot::fromConfig(stage1_cfg)});
+    ASSERT_FALSE(validation.ok);
+    EXPECT_NE(validation.error.find("absent from stage 0"), std::string::npos);
+}
+
+TEST(PPStageCacheConfig, canonicalIndicesFilledFromValidation) {
+    // Full startup pipeline on the pairing case: snapshot exchange ->
+    // validation -> per-stage canonical_idx backfill. Positional tags with a
+    // 24-linear width keep both stages inside the stage-0-superset rule
+    // (24 linear layers total < width -> a single shared "linear0" group).
+    auto    mc          = makeIndependentPoolModelConfig(32);
+    int64_t linear_seen = 0;
+    for (int64_t i = 0; i < 32; ++i) {
+        if (mc.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(i)] == HybridAttentionType::LINEAR) {
+            mc.kv_cache_spec_descs[static_cast<size_t>(i)][0].tag = "linear" + std::to_string(linear_seen / 24);
+            ++linear_seen;
+        }
+    }
+    auto stage0_cfg = CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, 0), false, 0);
+    auto stage1_cfg = CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, 1), false, 0);
+    stage0_cfg.finalizeBlockNums(100, RuntimeConfig{});
+    stage1_cfg.finalizeBlockNums(100, RuntimeConfig{});
+
+    const std::vector<StageCacheSnapshot> stages     = {StageCacheSnapshot::fromConfig(stage0_cfg),
+                                                        StageCacheSnapshot::fromConfig(stage1_cfg)};
+    const auto                            validation = validatePPTopology(stages);
+    ASSERT_TRUE(validation.ok) << validation.error;
+
+    // Under the superset rule the canonical table equals stage 0's own
+    // group list (stage-0 first-seen order).
+    ASSERT_EQ(validation.canonical_groups.size(), 2u);
+    EXPECT_EQ(validation.canonical_groups[0].tag, "linear0");
+    EXPECT_EQ(validation.canonical_groups[1].tag, "full");
+
+    applyPPCanonicalIndices(stage0_cfg, validation);
+    EXPECT_EQ(stage0_cfg.topology().canonicalIndicesSnapshot(), (std::vector<size_t>{0, 1}));
+
+    applyPPCanonicalIndices(stage1_cfg, validation);
+    // stage1 local [linear0, full] maps to canonical [0, 1] by tag, not by
+    // position.
+    EXPECT_EQ(stage1_cfg.topology().canonicalIndicesSnapshot(), (std::vector<size_t>{0, 1}));
+}
+
+TEST(PPStageCacheConfig, canonicalIndicesRejectUnknownTag) {
+    const auto mc     = makeIndependentPoolModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0);
+    config.finalizeBlockNums(100, RuntimeConfig{});
+
+    // Canonical table that lacks the local "linear" tag.
+    PPValidationResult validation;
+    validation.ok = true;
+    CanonicalGroupEntry entry;
+    entry.tag               = "full";
+    entry.logical_block_num = 100;
+    validation.canonical_groups.push_back(entry);
+    EXPECT_THROW(applyPPCanonicalIndices(config, validation), std::exception);
+}
+
+TEST(PPStageCacheConfig, ppRejectsHybridPositionalGrouping) {
+    // The legacy positional grouping (enable_hybrid_attention without
+    // independent pools) is retired for PP; pp=1 stays allowed.
+    const auto mc = makeHybridModelConfig(8);
+    EXPECT_THROW(CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0), std::exception);
+    RuntimeConfig runtime_config;
+    KVCacheConfig kv_cache_config;
+    EXPECT_THROW(CacheConfigCreator::createConfig(mc, makePpConfig(8, 2, 0), runtime_config, kv_cache_config),
+                 std::exception);
+    EXPECT_NO_THROW(CacheConfigCreator::createBasicConfig(mc, ParallelismConfig{}, false, 0));
+}
+
+TEST(PPStageCacheConfig, ppAllowsIndependentPools) {
+    // Independent-pool grouping is the PP path: both createBasicConfig and
+    // createConfig accept pp_size>1 (the old ban is lifted).
+    const auto mc = makeIndependentPoolModelConfig(8);
+    EXPECT_NO_THROW(CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0));
+    RuntimeConfig runtime_config;
+    KVCacheConfig kv_cache_config;
+    kv_cache_config.test_block_num = 8;
+    EXPECT_NO_THROW(CacheConfigCreator::createConfig(mc, makePpConfig(8, 2, 0), runtime_config, kv_cache_config));
+}
+
+TEST(PPStageCacheConfig, ppRejectsOpaquePools) {
+    // Opaque (state / byte-addressed KV) pools are out of PP v1 scope; the
+    // gate fires at the stage slice on the local descs.
+    auto            mc = makeIndependentPoolModelConfig(8);
+    KVCacheSpecDesc state_desc{"state", KVCacheSpecType::OpaqueState};
+    state_desc.entry_elems = 16;
+    state_desc.entry_dtype = DataType::TYPE_FP32;
+    mc.kv_cache_spec_descs[2].push_back(state_desc);
+    EXPECT_THROW(CacheConfigCreator::stageScopedModelConfig(mc, makePpConfig(8, 2, 0)), std::exception);
+    // pp=1: the slicing primitive returns early, so the gate never runs.
+    EXPECT_NO_THROW(CacheConfigCreator::stageScopedModelConfig(mc, ParallelismConfig{}));
+}
+
+TEST(PPStageCacheConfig, heterogeneousLinearTagsLegalUnderPp) {
+    // 32 layers; linear layers alternate two different cache layouts and are
+    // tagged individually. Each tag keeps its own pool, and pp=2 stays legal
+    // (cross-stage geometry is reconciled by the canonical table at
+    // startup).
+    auto    mc         = makeIndependentPoolModelConfig(32);
+    int64_t linear_idx = 0;
+    for (int64_t i = 0; i < 32; ++i) {
+        if (mc.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(i)] == HybridAttentionType::LINEAR) {
+            mc.kv_cache_spec_descs[static_cast<size_t>(i)][0].tag         = "linear_" + std::to_string(linear_idx);
+            mc.kv_cache_spec_descs[static_cast<size_t>(i)][0].entry_elems = (linear_idx % 2 == 0) ? 64u : 128u;
+            ++linear_idx;
+        }
+    }
+    EXPECT_NO_THROW(CacheConfigCreator::createBasicConfig(mc, ParallelismConfig{}, false, 0));
+    EXPECT_NO_THROW(CacheConfigCreator::createBasicConfig(mc, makePpConfig(32, 2, 0), false, 0));
+}
+
+TEST(PPStageCacheConfig, arbitraryRetainedTagNamesPassThrough) {
+    // A full-layer pool may carry any tag name (here "linear0"); tags are
+    // never generated per stage, so no collision semantics apply.
+    auto mc = makeIndependentPoolModelConfig(8);
+    for (int64_t i = 0; i < 8; ++i) {
+        if (mc.hybrid_attention_config.hybrid_attention_types[static_cast<size_t>(i)] != HybridAttentionType::LINEAR) {
+            mc.kv_cache_spec_descs[static_cast<size_t>(i)][0].tag = "linear0";
+        }
+    }
+    EXPECT_NO_THROW(CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Gates for paths that are not stage-scoped yet
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, speculativeGate) {
+    const auto score   = makeSingleModelConfig(4);
+    const auto propose = makeSingleModelConfig(1);
+
+    RuntimeConfig              runtime_config;
+    KVCacheConfig              kv_cache_config;
+    SpeculativeExecutionConfig sp_config;
+    sp_config.type              = SP_TYPE_MTP;
+    sp_config.gen_num_per_cycle = 1;
+
+    EXPECT_THROW(CacheConfigCreator::createSpConfig(score,
+                                                    propose,
+                                                    makePpConfig(4, 2, 0),
+                                                    runtime_config,
+                                                    kv_cache_config,
+                                                    sp_config,
+                                                    std::nullopt,
+                                                    /*is_mtp=*/true,
+                                                    /*is_eagle=*/false),
+                 std::exception);
+}
+
+// ---------------------------------------------------------------------------
+// applyPPLogicalBlockNums: per-tag min consumption
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, applyLogicalBlockNumsCapsByTagNotGid) {
+    const auto mc     = makeIndependentPoolModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0);
+    config.finalizeBlockNums(100, RuntimeConfig{});
+    ASSERT_EQ(config.block_num, 100);
+    const auto group_num = static_cast<size_t>(config.groupNums());
+    ASSERT_GT(group_num, 1u);
+
+    // Simulated cross-stage result: some groups have lower capacity elsewhere.
+    // Reverse the canonical row order to prove pairing is by tag name, not
+    // table position.
+    PPValidationResult validation;
+    validation.ok = true;
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        CanonicalGroupEntry entry;
+        entry.tag               = config.tagForGroup(gid);
+        entry.logical_block_num = gid == 0 ? 60u : 70u;
+        validation.canonical_groups.push_back(std::move(entry));
+    }
+    std::reverse(validation.canonical_groups.begin(), validation.canonical_groups.end());
+
+    std::map<std::string, uint32_t> expected_by_tag;
+    for (const auto& entry : validation.canonical_groups) {
+        expected_by_tag[entry.tag] = entry.logical_block_num;
+    }
+    std::vector<size_t> kv_strides_before;
+    std::vector<size_t> scale_strides_before;
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        kv_strides_before.push_back(config.kvBlockStrideBytesForGroup(gid));
+        scale_strides_before.push_back(config.kvScaleStrideBytesForGroup(gid));
+    }
+
+    applyPPLogicalBlockNums(config, validation);
+
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        EXPECT_EQ(config.blockNumForGroup(gid), expected_by_tag[config.tagForGroup(gid)]) << "gid=" << gid;
+        EXPECT_EQ(config.kvBlockStrideBytesForGroup(gid), kv_strides_before[gid]) << "gid=" << gid;
+        EXPECT_EQ(config.kvScaleStrideBytesForGroup(gid), scale_strides_before[gid]) << "gid=" << gid;
+    }
+    // Top-level block count follows the cross-stage minimum.
+    EXPECT_EQ(config.block_num, 60);
+}
+
+TEST(PPStageCacheConfig, applyLogicalBlockNumsCapsAtCanonicalMinAndNeverRaises) {
+    const auto mc     = makeSingleModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 1), false, 0);
+    config.finalizeBlockNums(50, RuntimeConfig{});
+    ASSERT_EQ(config.groupNums(), 1);
+    const auto tag = config.tagForGroup(0);
+
+    // A LARGER canonical count (a richer owner elsewhere) is never applied
+    // upward: the entry carries the cross-stage min by construction.
+    PPValidationResult validation;
+    validation.ok = true;
+    CanonicalGroupEntry entry;
+    entry.tag               = tag;
+    entry.logical_block_num = 90;
+    validation.canonical_groups.push_back(entry);
+    applyPPLogicalBlockNums(config, validation);
+    EXPECT_EQ(config.blockNumForGroup(0), 50u);
+    EXPECT_EQ(config.block_num, 50);
+
+    // A SMALLER canonical count (a poorer owner elsewhere) caps this stage.
+    config.finalizeBlockNums(50, RuntimeConfig{});
+    validation.canonical_groups[0].logical_block_num = 30;
+    applyPPLogicalBlockNums(config, validation);
+    EXPECT_EQ(config.blockNumForGroup(0), 30u);
+    EXPECT_EQ(config.block_num, 30);
+}
+
+TEST(PPStageCacheConfig, applyLogicalBlockNumsRejectsTagMissingFromCanonicalTable) {
+    const auto mc     = makeSingleModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 1), false, 0);
+    config.finalizeBlockNums(50, RuntimeConfig{});
+
+    // Canonical table without the local tag: the union invariant is broken.
+    PPValidationResult validation;
+    validation.ok = true;
+    CanonicalGroupEntry entry;
+    entry.tag               = "some-other-tag";
+    entry.logical_block_num = 30;
+    validation.canonical_groups.push_back(entry);
+    EXPECT_THROW(applyPPLogicalBlockNums(config, validation), std::exception);
+}
+
+TEST(PPStageCacheConfig, applyLogicalBlockNumsExplicitPoolDoesNotCapTopLevel) {
+    // The top-level block_num tracks the budget-following paged pools only:
+    // an explicitly sized pool must not drag it down.
+    const auto mc     = makeIndependentPoolModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0);
+    config.finalizeBlockNums(100, RuntimeConfig{});
+    ASSERT_EQ(config.groupNums(), 2);
+    const auto linear_gid = config.tagForGroup(0) == "linear" ? 0 : 1;
+    const auto full_gid   = 1 - linear_gid;
+
+    PPValidationResult validation;
+    validation.ok = true;
+    CanonicalGroupEntry full_entry;
+    full_entry.tag               = "full";
+    full_entry.type              = CacheGroupType::FULL;
+    full_entry.logical_block_num = 100;
+    validation.canonical_groups.push_back(full_entry);
+    CanonicalGroupEntry linear_entry;
+    linear_entry.tag                = "linear";
+    linear_entry.type               = CacheGroupType::LINEAR;
+    linear_entry.logical_block_num  = 50;
+    linear_entry.explicit_block_num = 50;  // explicitly sized -> decoupled
+    validation.canonical_groups.push_back(linear_entry);
+
+    applyPPLogicalBlockNums(config, validation);
+    EXPECT_EQ(config.blockNumForGroup(static_cast<size_t>(full_gid)), 100u);
+    EXPECT_EQ(config.blockNumForGroup(static_cast<size_t>(linear_gid)), 50u);
+    // Top-level follows the paged pool, not the explicit one.
+    EXPECT_EQ(config.block_num, 100);
+}
+
+// ---------------------------------------------------------------------------
+// KVCacheManager constructor wiring (B-lite): the cap is applied internally,
+// ordered after allocateAndSync's finalizeBlockNums by construction.
+// ---------------------------------------------------------------------------
+
+TEST(PPStageCacheConfig, managerConstructorRequiresCapacityUnderPp) {
+    const auto mc     = makeIndependentPoolModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0);
+    config.finalizeBlockNums(100, RuntimeConfig{});
+
+    // pp_size>1 without the validator result -> fail fast at construction.
+    EXPECT_THROW(KVCacheManager(config, false, nullptr, KVCacheConfig{}, makePpConfig(8, 2, 0), RuntimeConfig{}),
+                 std::exception);
+}
+
+TEST(PPStageCacheConfig, managerConstructorCapsGroupsByTag) {
+    const auto mc     = makeIndependentPoolModelConfig(8);
+    auto       config = CacheConfigCreator::createBasicConfig(mc, makePpConfig(8, 2, 0), false, 0);
+    config.finalizeBlockNums(100, RuntimeConfig{});
+    const auto group_num = static_cast<size_t>(config.groupNums());
+    ASSERT_GT(group_num, 1u);
+
+    PPValidationResult validation;
+    validation.ok = true;
+    std::map<std::string, uint32_t> expected_by_tag;
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        const auto tag       = config.tagForGroup(gid);
+        expected_by_tag[tag] = gid == 0 ? 60u : 70u;
+        CanonicalGroupEntry entry;
+        entry.tag               = tag;
+        entry.logical_block_num = gid == 0 ? 60u : 70u;
+        validation.canonical_groups.push_back(std::move(entry));
+    }
+
+    KVCacheManager manager(config,
+                           false,
+                           nullptr,
+                           KVCacheConfig{},
+                           makePpConfig(8, 2, 0),
+                           RuntimeConfig{},
+                           SpeculativeExecutionConfig{},
+                           PDSepConfig{},
+                           CacheStoreConfig{},
+                           false,
+                           validation);
+
+    const auto& capped = manager.cacheConfig();
+    for (size_t gid = 0; gid < group_num; ++gid) {
+        EXPECT_EQ(capped.blockNumForGroup(gid), expected_by_tag[capped.tagForGroup(gid)]) << "gid=" << gid;
+    }
+    EXPECT_EQ(capped.block_num, 60);
+}
+
+}  // namespace test
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/cache/test/PPTopologyValidatorTest.cc
+++ b/rtp_llm/cpp/cache/test/PPTopologyValidatorTest.cc
@@ -1,0 +1,455 @@
+// Unit tests for validatePPTopology — startup-time cache geometry validation
+// across PP stages (rejects bad partitions, computes per-group logical block
+// count as the min across stages).
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "rtp_llm/cpp/cache/CacheConfig.h"
+#include "rtp_llm/cpp/cache/MHAKVCacheSpec.h"
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
+
+using namespace std;
+
+namespace rtp_llm {
+
+namespace {
+
+// Single-FULL-group snapshot; tweak fields per test case.
+StageCacheSnapshot makeFullSnapshot(uint32_t blocks, size_t seq = 4, size_t kernel = 4) {
+    StageCacheSnapshot s;
+    s.group_tags                = {"full"};
+    s.group_types               = {CacheGroupType::FULL};
+    s.seq_size_per_block        = {seq};
+    s.kernel_seq_size_per_block = {kernel};
+    s.block_nums                = {blocks};
+    s.explicit_block_nums       = {0};
+    s.policy_fingerprints       = {"t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0"};
+    return s;
+}
+
+// Two-group (FULL + LINEAR) snapshot, Kimi3-style hybrid.
+StageCacheSnapshot makeHybridSnapshot(uint32_t full_blocks, uint32_t linear_blocks) {
+    StageCacheSnapshot s;
+    s.group_tags                = {"full", "linear"};
+    s.group_types               = {CacheGroupType::FULL, CacheGroupType::LINEAR};
+    s.seq_size_per_block        = {4, 4};
+    s.kernel_seq_size_per_block = {2, 4};
+    s.block_nums                = {full_blocks, linear_blocks};
+    s.explicit_block_nums       = {0, 0};
+    s.policy_fingerprints       = {"t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0", "t1:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0"};
+    return s;
+}
+
+// Logical block counts in canonical table order.
+std::vector<uint32_t> canonicalBlockNums(const PPValidationResult& result) {
+    std::vector<uint32_t> nums;
+    nums.reserve(result.canonical_groups.size());
+    for (const auto& entry : result.canonical_groups) {
+        nums.push_back(entry.logical_block_num);
+    }
+    return nums;
+}
+
+}  // namespace
+
+// Case 1: all stages identical -> pass, per-group min computed.
+TEST(PPTopologyValidatorTest, AllIdenticalPasses) {
+    auto stages = {makeHybridSnapshot(100, 50), makeHybridSnapshot(90, 55), makeHybridSnapshot(95, 50)};
+    auto result = validatePPTopology(stages);
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{90, 50}));
+}
+
+// Case 2: single stage (pp_size=1) -> trivially pass, degenerates to today.
+TEST(PPTopologyValidatorTest, SingleStageTriviallyPasses) {
+    auto result = validatePPTopology({makeFullSnapshot(42)});
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{42}));
+}
+
+// Case 3: empty input -> trivially pass with empty result.
+TEST(PPTopologyValidatorTest, EmptyStagesTriviallyPasses) {
+    auto result = validatePPTopology({});
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_TRUE(result.canonical_groups.empty());
+}
+
+// Case 4: a stage holding a tag subset is legitimate under pairing semantics
+// (stage-scoped topologies own tag subsets) -> passes; min is taken only
+// over stages owning each tag.
+TEST(PPTopologyValidatorTest, TagSubsetPassesUnderPairing) {
+    StageCacheSnapshot subset = makeFullSnapshot(70, /*seq=*/4, /*kernel=*/2);  // only the full group
+    auto               result = validatePPTopology({makeHybridSnapshot(100, 50), subset});
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{70, 50}));
+}
+
+// Case 4b: stage-0-superset rule: any stage owning a group that stage 0
+// does not own is rejected (the leading stage must physically own every
+// cache group, since it issues all block ids from its own pools).
+TEST(PPTopologyValidatorTest, NonStage0OwnedTagFails) {
+    StageCacheSnapshot other = makeFullSnapshot(80);
+    other.group_tags         = {"swa"};
+    auto result              = validatePPTopology({makeHybridSnapshot(100, 50), other});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("absent from stage 0"), std::string::npos);
+    EXPECT_NE(result.error.find("must own every cache group"), std::string::npos);
+}
+
+// Case 4c: hybrid stage (LINEAR groups) without any FULL group -> reject.
+TEST(PPTopologyValidatorTest, LinearWithoutFullFails) {
+    StageCacheSnapshot linear_only;
+    linear_only.group_tags                = {"linear"};
+    linear_only.group_types               = {CacheGroupType::LINEAR};
+    linear_only.seq_size_per_block        = {4};
+    linear_only.kernel_seq_size_per_block = {4};
+    linear_only.block_nums                = {50};
+    linear_only.explicit_block_nums       = {0};
+    linear_only.policy_fingerprints       = {"t1:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0"};
+    auto result                           = validatePPTopology({makeHybridSnapshot(100, 50), linear_only});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("no FULL group"), std::string::npos);
+}
+
+// Case 4d: the pairing path still compares geometry of shared tags.
+TEST(PPTopologyValidatorTest, PairingStillChecksSharedGeometry) {
+    StageCacheSnapshot subset = makeFullSnapshot(80, /*seq=*/8);  // seq differs
+    auto               result = validatePPTopology({makeHybridSnapshot(100, 50), subset});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("seq_size_per_block"), std::string::npos);
+}
+
+// Case 5: same tags but swapped type sequence -> reject.
+TEST(PPTopologyValidatorTest, TypeSequenceMismatchFails) {
+    StageCacheSnapshot bad = makeHybridSnapshot(100, 50);
+    bad.group_types        = {CacheGroupType::LINEAR, CacheGroupType::FULL};  // swapped
+
+    auto result = validatePPTopology({makeHybridSnapshot(100, 50), bad});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("type sequence"), std::string::npos);
+}
+
+// Case 6: seq_size_per_block differs -> reject.
+TEST(PPTopologyValidatorTest, SeqSizeMismatchFails) {
+    auto result = validatePPTopology({makeFullSnapshot(100, /*seq=*/4), makeFullSnapshot(100, /*seq=*/8)});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("seq_size_per_block"), std::string::npos);
+}
+
+// Case 7: kernel_seq_size_per_block differs -> reject.
+TEST(PPTopologyValidatorTest, KernelSeqSizeMismatchFails) {
+    auto result = validatePPTopology({makeFullSnapshot(100, 4, /*kernel=*/4), makeFullSnapshot(100, 4, /*kernel=*/2)});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("kernel_seq_size_per_block"), std::string::npos);
+}
+
+// Case 8: capacity skew above threshold -> reject (bad layer split).
+TEST(PPTopologyValidatorTest, CapacitySkewTooLargeFails) {
+    // 100 / 60 = 1.67 > 1.5
+    auto result = validatePPTopology({makeFullSnapshot(100), makeFullSnapshot(60)});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("skew too large"), std::string::npos);
+}
+
+// Case 9: capacity skew within threshold -> pass with min.
+TEST(PPTopologyValidatorTest, CapacitySkewWithinThresholdPasses) {
+    // 100 / 80 = 1.25 <= 1.5
+    auto result = validatePPTopology({makeFullSnapshot(100), makeFullSnapshot(80)});
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{80}));
+}
+
+// Case 10: some stage has 0 blocks for a group -> reject (cannot allocate).
+TEST(PPTopologyValidatorTest, ZeroBlockNumFails) {
+    auto result = validatePPTopology({makeFullSnapshot(100), makeFullSnapshot(0)});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("0 KV blocks"), std::string::npos);
+}
+
+// Case 11: internally inconsistent snapshot -> reject.
+TEST(PPTopologyValidatorTest, InternallyInconsistentFails) {
+    StageCacheSnapshot bad = makeFullSnapshot(100);
+    bad.block_nums         = {100, 90};  // one extra element
+    auto result            = validatePPTopology({makeFullSnapshot(100), bad});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("internally inconsistent"), std::string::npos);
+}
+
+// Case 12: fromConfig builds the snapshot from a real CacheConfig.
+TEST(PPTopologyValidatorTest, FromConfigBuildsSnapshot) {
+    CacheConfig cache_config;
+    cache_config.block_num = 42;
+    auto spec              = std::make_shared<MHAKVCacheSpec>();
+    spec->tag              = "default";
+    std::vector<int> layer_ids(2);
+    std::iota(layer_ids.begin(), layer_ids.end(), 0);
+    cache_config.layer_num     = 2;
+    cache_config.layer_all_num = 2;
+    cache_config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::FULL}, {"default"});
+
+    auto snapshot = StageCacheSnapshot::fromConfig(cache_config);
+    ASSERT_TRUE(snapshot.internallyConsistent());
+    EXPECT_EQ(snapshot.group_tags, (std::vector<std::string>{"default"}));
+    EXPECT_EQ(snapshot.group_types, (std::vector<CacheGroupType>{CacheGroupType::FULL}));
+    ASSERT_EQ(snapshot.block_nums.size(), 1u);
+    EXPECT_EQ(snapshot.block_nums[0], 42u);
+}
+
+// Mock collector returning a fixed list of snapshots (stands in for the
+// real startup exchange).
+class MockStageSnapshotCollector: public StageSnapshotCollector {
+public:
+    explicit MockStageSnapshotCollector(std::vector<StageCacheSnapshot> snapshots): snapshots_(std::move(snapshots)) {}
+
+    std::vector<StageCacheSnapshot> collect() override {
+        return snapshots_;
+    }
+
+private:
+    std::vector<StageCacheSnapshot> snapshots_;
+};
+
+// Case 13: initPPCacheGeometry with the local single-stage collector
+// (pp_size=1 path) -> trivially passes with the stage's own block count.
+TEST(PPTopologyValidatorTest, InitGeometryLocalCollectorPasses) {
+    LocalStageSnapshotCollector collector(makeFullSnapshot(64));
+    auto                        result = initPPCacheGeometry(collector);
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{64}));
+}
+
+// Case 14: initPPCacheGeometry with a multi-stage mock collector -> per-group min.
+TEST(PPTopologyValidatorTest, InitGeometryMultiStageMockComputesMin) {
+    MockStageSnapshotCollector collector({makeHybridSnapshot(100, 50), makeHybridSnapshot(90, 48)});
+    auto                       result = initPPCacheGeometry(collector);
+    ASSERT_TRUE(result.ok) << result.error;
+    EXPECT_EQ(canonicalBlockNums(result), (std::vector<uint32_t>{90, 48}));
+}
+
+// Case 15: initPPCacheGeometry propagates validation failure from the collector data.
+TEST(PPTopologyValidatorTest, InitGeometryFailsOnMismatch) {
+    MockStageSnapshotCollector collector({makeFullSnapshot(100), makeFullSnapshot(10)});  // skew 10x
+    auto                       result = initPPCacheGeometry(collector);
+    ASSERT_FALSE(result.ok);
+    EXPECT_TRUE(result.canonical_groups.empty());
+}
+
+// Case 17: canonical group table for identical stages follows stage-0 order
+// and carries the per-tag logical minimum.
+TEST(PPTopologyValidatorTest, CanonicalGroupsIdenticalStages) {
+    auto result = validatePPTopology({makeHybridSnapshot(100, 50), makeHybridSnapshot(90, 55)});
+    ASSERT_TRUE(result.ok) << result.error;
+    ASSERT_EQ(result.canonical_groups.size(), 2u);
+    EXPECT_EQ(result.canonical_groups[0].tag, "full");
+    EXPECT_EQ(result.canonical_groups[0].logical_block_num, 90u);
+    EXPECT_EQ(result.canonical_groups[0].type, CacheGroupType::FULL);
+    EXPECT_EQ(result.canonical_groups[1].tag, "linear");
+    EXPECT_EQ(result.canonical_groups[1].logical_block_num, 50u);
+    EXPECT_EQ(result.canonical_groups[1].type, CacheGroupType::LINEAR);
+    EXPECT_EQ(result.canonical_groups[1].seq_size_per_block, 4u);
+    EXPECT_EQ(result.canonical_groups[1].kernel_seq_size_per_block, 4u);
+}
+
+// Case 18: a tag owned only by a later stage is rejected by the stage-0
+// superset rule (bookkeeping-only allocation is not supported).
+TEST(PPTopologyValidatorTest, LaterStageOnlyTagFails) {
+    auto stage1 = makeHybridSnapshot(90, 55);
+    stage1.group_tags.push_back("linear1");
+    stage1.group_types.push_back(CacheGroupType::LINEAR);
+    stage1.seq_size_per_block.push_back(4);
+    stage1.kernel_seq_size_per_block.push_back(4);
+    stage1.block_nums.push_back(30);
+    stage1.explicit_block_nums.push_back(0);
+    stage1.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto result = validatePPTopology({makeHybridSnapshot(100, 50), stage1});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("[linear1]"), std::string::npos);
+    EXPECT_NE(result.error.find("absent from stage 0"), std::string::npos);
+}
+
+// Case 19: same tag reported with different types by two non-stage-0 stages
+// is rejected by the canonical consistency check.
+TEST(PPTopologyValidatorTest, CanonicalGroupsRejectNonStage0TypeConflict) {
+    auto stage0 = makeFullSnapshot(100);
+    stage0.group_tags.push_back("x");
+    stage0.group_types.push_back(CacheGroupType::FULL);
+    stage0.seq_size_per_block.push_back(4);
+    stage0.kernel_seq_size_per_block.push_back(4);
+    stage0.block_nums.push_back(40);
+    stage0.explicit_block_nums.push_back(0);
+    stage0.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto stage1 = makeFullSnapshot(90);
+    stage1.group_tags.push_back("x");
+    stage1.group_types.push_back(CacheGroupType::FULL);
+    stage1.seq_size_per_block.push_back(4);
+    stage1.kernel_seq_size_per_block.push_back(4);
+    stage1.block_nums.push_back(40);
+    stage1.explicit_block_nums.push_back(0);
+    stage1.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto stage2 = makeFullSnapshot(95);
+    stage2.group_tags.push_back("x");
+    stage2.group_types.push_back(CacheGroupType::LINEAR);
+    stage2.seq_size_per_block.push_back(4);
+    stage2.kernel_seq_size_per_block.push_back(4);
+    stage2.block_nums.push_back(40);
+    stage2.explicit_block_nums.push_back(0);
+    stage2.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto result = validatePPTopology({stage0, stage1, stage2});
+    ASSERT_FALSE(result.ok);
+    // Identical tag sets elevate to the strict path, where the divergent
+    // type sequence is caught first.
+    EXPECT_NE(result.error.find("type sequence differs from stage 0"), std::string::npos);
+}
+
+// Case 20: capacity skew on a tag owned by all stages is caught at startup
+// instead of overrunning the smaller owner's pool at runtime.
+TEST(PPTopologyValidatorTest, CanonicalGroupsRejectNonStage0Skew) {
+    auto stage0 = makeFullSnapshot(100);
+    stage0.group_tags.push_back("y");
+    stage0.group_types.push_back(CacheGroupType::LINEAR);
+    stage0.seq_size_per_block.push_back(4);
+    stage0.kernel_seq_size_per_block.push_back(4);
+    stage0.block_nums.push_back(100);
+    stage0.explicit_block_nums.push_back(0);
+    stage0.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto stage1 = makeFullSnapshot(100);
+    stage1.group_tags.push_back("y");
+    stage1.group_types.push_back(CacheGroupType::LINEAR);
+    stage1.seq_size_per_block.push_back(4);
+    stage1.kernel_seq_size_per_block.push_back(4);
+    stage1.block_nums.push_back(100);
+    stage1.explicit_block_nums.push_back(0);
+    stage1.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto stage2 = makeFullSnapshot(90);
+    stage2.group_tags.push_back("y");
+    stage2.group_types.push_back(CacheGroupType::LINEAR);
+    stage2.seq_size_per_block.push_back(4);
+    stage2.kernel_seq_size_per_block.push_back(4);
+    stage2.block_nums.push_back(10);
+    stage2.explicit_block_nums.push_back(0);
+    stage2.policy_fingerprints.push_back("t0:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto result = validatePPTopology({stage0, stage1, stage2});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("skew too large"), std::string::npos);
+    EXPECT_NE(result.error.find("[y]"), std::string::npos);
+}
+
+// Case 21: pp_size=1 canonical table equals the stage's own groups.
+TEST(PPTopologyValidatorTest, CanonicalGroupsSingleStage) {
+    auto result = validatePPTopology({makeHybridSnapshot(70, 30)});
+    ASSERT_TRUE(result.ok) << result.error;
+    ASSERT_EQ(result.canonical_groups.size(), 2u);
+    EXPECT_EQ(result.canonical_groups[0].tag, "full");
+    EXPECT_EQ(result.canonical_groups[0].logical_block_num, 70u);
+    EXPECT_EQ(result.canonical_groups[1].tag, "linear");
+    EXPECT_EQ(result.canonical_groups[1].logical_block_num, 30u);
+}
+
+// Case 16 (wire format): serialize/deserialize round trip keeps every
+// field, and malformed payloads are rejected.
+TEST(PPTopologyValidatorTest, SnapshotSerializeRoundTrip) {
+    const auto original = makeHybridSnapshot(120, 45);
+    const auto payload  = original.serialize();
+    const auto decoded  = StageCacheSnapshot::deserialize(payload);
+    EXPECT_EQ(decoded.group_tags, original.group_tags);
+    EXPECT_EQ(decoded.group_types, original.group_types);
+    EXPECT_EQ(decoded.seq_size_per_block, original.seq_size_per_block);
+    EXPECT_EQ(decoded.kernel_seq_size_per_block, original.kernel_seq_size_per_block);
+    EXPECT_EQ(decoded.block_nums, original.block_nums);
+    EXPECT_EQ(decoded.explicit_block_nums, original.explicit_block_nums);
+    EXPECT_EQ(decoded.policy_fingerprints, original.policy_fingerprints);
+
+    EXPECT_THROW(StageCacheSnapshot::deserialize(""), std::exception);
+    // Truncated field list (7 of 8 fields).
+    EXPECT_THROW(StageCacheSnapshot::deserialize("v1|a|0|1|1|1|0"), std::exception);
+    // Unknown versions are rejected outright (all stages run one binary).
+    EXPECT_THROW(StageCacheSnapshot::deserialize("v9|full|0|4|2|1|0|p"), std::exception);
+    // Entry count mismatch between tags and block_nums.
+    EXPECT_THROW(StageCacheSnapshot::deserialize("v1|full|0|4|2|1,2|0|p"), std::exception);
+}
+
+// Case 20: a stage holding an SWA group is rejected (v1 scope: paged pools
+// only under PP).
+TEST(PPTopologyValidatorTest, SwaGroupFails) {
+    StageCacheSnapshot with_swa = makeFullSnapshot(50);
+    with_swa.group_tags.push_back("swa");
+    with_swa.group_types.push_back(CacheGroupType::SWA);
+    with_swa.seq_size_per_block.push_back(4);
+    with_swa.kernel_seq_size_per_block.push_back(4);
+    with_swa.block_nums.push_back(25);
+    with_swa.explicit_block_nums.push_back(0);
+    with_swa.policy_fingerprints.push_back("t2:r1:e0:v1:x0:c0:p0:a0:w1:m0:s0");
+
+    auto result = validatePPTopology({makeFullSnapshot(50), with_swa});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("SWA"), std::string::npos);
+}
+
+// Case 21: same-tag owners must agree on explicit pool sizing.
+TEST(PPTopologyValidatorTest, ExplicitBlockNumMismatchFails) {
+    StageCacheSnapshot a  = makeFullSnapshot(100);
+    a.explicit_block_nums = {256};
+    StageCacheSnapshot b  = makeFullSnapshot(100);
+    b.explicit_block_nums = {512};
+
+    auto result = validatePPTopology({a, b});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("explicit_block_num"), std::string::npos);
+}
+
+// Case 22: identical explicit sizing passes; the canonical entry carries it.
+TEST(PPTopologyValidatorTest, ExplicitBlockNumAgreementPasses) {
+    StageCacheSnapshot a  = makeFullSnapshot(256);
+    a.explicit_block_nums = {256};
+    StageCacheSnapshot b  = makeFullSnapshot(256);
+    b.explicit_block_nums = {256};
+
+    auto result = validatePPTopology({a, b});
+    ASSERT_TRUE(result.ok) << result.error;
+    ASSERT_EQ(result.canonical_groups.size(), 1u);
+    EXPECT_EQ(result.canonical_groups[0].explicit_block_num, 256u);
+    EXPECT_EQ(result.canonical_groups[0].logical_block_num, 256u);
+}
+
+// Case 23 (policy fingerprint): the digest reflects every samePolicy()
+// field; identical policies digest identically.
+TEST(PPTopologyValidatorTest, PolicyFingerprintCoversSamePolicyFields) {
+    CacheGroupPolicy base;
+    const auto       base_fp = cacheGroupPolicyFingerprint(base);
+    EXPECT_EQ(base_fp, cacheGroupPolicyFingerprint(base));
+
+    // Flipping any samePolicy()-compared field changes the digest.
+    CacheGroupPolicy changed = base;
+    changed.memory_placement = CacheMemoryPlacement::HOST_PINNED;
+    EXPECT_NE(base_fp, cacheGroupPolicyFingerprint(changed));
+    changed                     = base;
+    changed.enable_prefix_reuse = false;
+    EXPECT_NE(base_fp, cacheGroupPolicyFingerprint(changed));
+    changed                    = base;
+    changed.active_tail_blocks = 3;
+    EXPECT_NE(base_fp, cacheGroupPolicyFingerprint(changed));
+}
+
+// Case 24: same-tag owners with diverging pool policies are rejected.
+TEST(PPTopologyValidatorTest, PolicyMismatchFails) {
+    StageCacheSnapshot a  = makeFullSnapshot(100);
+    StageCacheSnapshot b  = makeFullSnapshot(100);
+    b.policy_fingerprints = {"t0:r0:e0:v1:x0:c0:p0:a0:w1:m0:s0"};  // reuse off
+
+    auto result = validatePPTopology({a, b});
+    ASSERT_FALSE(result.ok);
+    EXPECT_NE(result.error.find("policy"), std::string::npos);
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/config/BUILD
+++ b/rtp_llm/cpp/config/BUILD
@@ -30,6 +30,19 @@ cc_library(
     copts = copts(),
 )
 
+# PP stage layout helper (consumes the materialized partition from
+# ParallelismConfig; see rtp_llm/config/pp_layout.py for the Python side).
+cc_library(
+    name = "pp_layout",
+    hdrs = ["PPLayout.h"],
+    copts = copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config_modules",
+        "//rtp_llm/cpp/utils:core_utils",
+    ],
+)
+
 cc_library(
     name = "eplb_config",
     hdrs = ["EplbConfig.h"],

--- a/rtp_llm/cpp/config/ConfigModules.h
+++ b/rtp_llm/cpp/config/ConfigModules.h
@@ -35,7 +35,7 @@ struct PrefillCPConfig {
     bool kv_cache_sharded = false;
     // Explicit prefill CP size for decode-side fixed/SWA ring sizing; 0 = unset.
     int64_t prefill_cp_size = 0;
-    bool           is_enabled() const {
+    bool    is_enabled() const {
         return method != CPRotateMethod::DISABLED && method != CPRotateMethod::UNKNOWN
                && method != CPRotateMethod::PREFILL_CP;
     }
@@ -70,6 +70,7 @@ struct ParallelismConfig {
     int64_t tp_rank          = 0;
     int64_t ep_rank          = 0;
     int64_t dp_rank          = 0;
+    int64_t pp_rank          = 0;
     int64_t ffn_tp_size      = 1;
     int64_t ffn_tp_rank      = 0;
     bool    enable_sp        = false;
@@ -80,6 +81,14 @@ struct ParallelismConfig {
     // DeepSeekV4Model's mega-MoE token bound cap) does not have to read
     // os.environ["ROLE_TYPE"] anymore.
     RoleType role_type = RoleType::PDFUSION;
+
+    // Materialized PP layer partition: layer count of every stage in rank
+    // order (e.g. {17,16,16,16}), decided once on the Python side and
+    // shipped as data so C++ never re-derives the partition rule. Empty
+    // means "no materialized partition" and falls back to the even-split
+    // formula (pp_size=1, stale pickles and legacy test fixtures only; the
+    // Python write-back point always materializes for pp_size>1).
+    std::vector<int64_t> pp_stage_layer_counts;
 
     FfnDisAggregateConfig ffn_disaggregate_config;  // FFN disaggregate configuration
 
@@ -189,7 +198,6 @@ struct KVCacheConfig {
     bool    enable_independent_group_eviction       = false;
     int64_t device_cache_min_free_blocks            = 0;
     int     load_cache_retry_times                  = 1;  // Maximum retry attempts for load cache transfer failures
-
 
     // DSV4 fixed-allocation pool block count. 0 means the fixed regions
     // (INDEXER_STATE / CSA_STATE / HCA_STATE / SWA_KV) use the normal
@@ -394,7 +402,7 @@ struct FIFOSchedulerConfig {
     //   "N"   -> 1 prefill : N decode (decode-heavy); "1" = strict alternation.
     //   "1/X" -> X prefill : 1 decode (prefill-heavy).
     //   invalid input falls back to "1".
-    std::string decode_prefill_ratio = "1";
+    std::string decode_prefill_ratio           = "1";
     bool        cp_force_single_prefill        = true;
     int64_t     max_inited_kv_cache_streams    = 0;
     int64_t     max_batch_tokens_without_cache = 0;
@@ -404,9 +412,9 @@ struct FIFOSchedulerConfig {
 struct GrammarConfig {
     bool constrained_json_disable_any_whitespace = false;
     // Service-level xgrammar matcher policy. Requests cannot override it.
-    bool                 terminate_without_stop_token = false;
-    int                  num_workers                  = 8;
-    std::string          tokenizer_info_json;
+    bool        terminate_without_stop_token = false;
+    int         num_workers                  = 8;
+    std::string tokenizer_info_json;
     // Byte cap on xgrammar's internal compiled-grammar cache; <=0 = unlimited.
     int64_t     compiler_cache_bytes = 512 * 1024 * 1024;
     std::string to_string() const;

--- a/rtp_llm/cpp/config/PPLayout.h
+++ b/rtp_llm/cpp/config/PPLayout.h
@@ -1,0 +1,129 @@
+#pragma once
+
+// ============================================================================
+// PP stage layout — the C++ view of the layer partition. All C++ PP
+// stage-role decisions go through this struct; new consumers must not
+// re-derive the formulas inline.
+//
+// Layout decisions encoded here:
+//   1. Stage capability flags instead of a FIRST/MIDDLE/LAST enum
+//      (pp_size=1 is both first and last; enums cannot express that):
+//        has_embedding() = pp_rank == 0
+//        has_lm_head()   = pp_rank == pp_size - 1
+//   2. Layer partition is DATA, not an algorithm: the Python side decides
+//      the partition once (default even split, optional model-level
+//      partitioner) and materializes it as ParallelismConfig.
+//      pp_stage_layer_counts; C++ consumes it by prefix-sum lookup.
+//      The even-split formula remains only as a fallback for pp_size=1,
+//      stale pickles and legacy test fixtures (empty counts).
+// ============================================================================
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/utils/AssertUtils.h"
+
+namespace rtp_llm {
+
+struct PPLayout {
+    int64_t pp_size      = 1;
+    int64_t pp_rank      = 0;
+    int64_t total_layers = 0;
+    // Lane geometry, needed for adjacent-stage rank derivation; filled from
+    // ParallelismConfig.
+    int64_t dp_size = 1;
+    int64_t tp_size = 1;
+    int64_t dp_rank = 0;
+    int64_t tp_rank = 0;
+
+    // Materialized partition: layer count per stage in rank order. Empty
+    // means "not materialized" and layerRangeOf falls back to the even
+    // split formula.
+    std::vector<int64_t> layer_counts;
+
+    // Production constructor: carries the materialized partition over from
+    // ParallelismConfig so callers never rebuild it field by field.
+    static PPLayout fromParallelismConfig(const ParallelismConfig& config, int64_t total_layers) {
+        PPLayout layout;
+        layout.pp_size      = config.pp_size;
+        layout.pp_rank      = config.pp_rank;
+        layout.total_layers = total_layers;
+        layout.dp_size      = config.dp_size;
+        layout.tp_size      = config.tp_size;
+        layout.dp_rank      = config.dp_rank;
+        layout.tp_rank      = config.tp_rank;
+        layout.layer_counts = config.pp_stage_layer_counts;
+        return layout;
+    }
+
+    // Stage capability flags.
+    bool hasEmbedding() const {
+        return pp_rank == 0;
+    }
+    bool hasLmHead() const {
+        return pp_rank == pp_size - 1;
+    }
+
+    // World-rank stride between adjacent stages of the same (dp, tp) lane
+    // under the PP-outermost layout (world_rank = pp*(dp*tp) + dp*tp + tp).
+    int64_t laneStride() const {
+        return dp_size * tp_size;
+    }
+
+    // Ring neighbors: stages wrap around (the last stage's next is stage 0,
+    // the return path for sample results). The transport keeps one send
+    // channel to next and one receive channel from prev on every stage; the
+    // pipeline protocol gates what actually flows on them.
+    int64_t prevStage() const {
+        return (pp_rank + pp_size - 1) % pp_size;
+    }
+    int64_t nextStage() const {
+        return (pp_rank + 1) % pp_size;
+    }
+
+    // World rank of `stage` in this (dp, tp) lane.
+    int64_t rankOfStage(int64_t stage) const {
+        return stage * laneStride() + dp_rank * tp_size + tp_rank;
+    }
+    int64_t prevRank() const {
+        return rankOfStage(prevStage());
+    }
+    int64_t nextRank() const {
+        return rankOfStage(nextStage());
+    }
+
+    // Half-open layer range [begin, end) assigned to `stage`. With a
+    // materialized partition this is a prefix-sum lookup; otherwise it
+    // falls back to the even split (remainder goes to earlier stages) for
+    // pp_size=1, stale pickles and legacy fixtures only — the golden
+    // values stay those of the Python default partition (even_split_counts),
+    // e.g. 65 layers, pp_size=4 -> 17/16/16/16.
+    std::pair<int64_t, int64_t> layerRangeOf(int64_t stage) const {
+        RTP_LLM_CHECK_WITH_INFO(stage >= 0 && stage < pp_size, "invalid pp stage %ld for pp_size %ld", stage, pp_size);
+        if (!layer_counts.empty()) {
+            RTP_LLM_CHECK_WITH_INFO(static_cast<int64_t>(layer_counts.size()) == pp_size,
+                                    "pp_stage_layer_counts size %zu != pp_size %ld",
+                                    layer_counts.size(),
+                                    pp_size);
+            int64_t begin = 0;
+            for (int64_t s = 0; s < stage; ++s) {
+                begin += layer_counts[static_cast<size_t>(s)];
+            }
+            return {begin, begin + layer_counts[static_cast<size_t>(stage)]};
+        }
+        const int64_t base  = total_layers / pp_size;
+        const int64_t rem   = total_layers % pp_size;
+        const int64_t count = base + (stage < rem ? 1 : 0);
+        const int64_t begin = stage * base + (stage < rem ? stage : rem);
+        return {begin, begin + count};
+    }
+
+    // This stage's own layer range.
+    std::pair<int64_t, int64_t> myLayerRange() const {
+        return layerRangeOf(pp_rank);
+    }
+};
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/config/test/BUILD
+++ b/rtp_llm/cpp/config/test/BUILD
@@ -1,0 +1,19 @@
+load("//:def.bzl", "cc_test_wrapper", "copts")
+
+cc_test = cc_test_wrapper
+
+test_copts = [
+    "-fno-access-control",
+] + copts()
+
+cc_test(
+    name = "pp_layout_test",
+    srcs = ["PPLayoutTest.cc"],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/config:pp_layout",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+    env = {},
+)

--- a/rtp_llm/cpp/config/test/PPLayoutTest.cc
+++ b/rtp_llm/cpp/config/test/PPLayoutTest.cc
@@ -1,0 +1,171 @@
+// Unit tests for PPLayout, the C++ consumer of the PP layer partition
+// (materialized as ParallelismConfig.pp_stage_layer_counts by the Python
+// decision point, rtp_llm/config/pp_layout.py). These tests pin the layout
+// decisions (capability flags, ring neighbors, materialized lookup and the
+// even-split fallback); they must stay in sync with test_pp_layer_filter.py.
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "rtp_llm/cpp/config/PPLayout.h"
+
+using namespace std;
+
+namespace rtp_llm {
+
+namespace {
+
+PPLayout makeLayout(int64_t pp_size, int64_t pp_rank, int64_t total_layers) {
+    PPLayout layout;
+    layout.pp_size      = pp_size;
+    layout.pp_rank      = pp_rank;
+    layout.total_layers = total_layers;
+    return layout;
+}
+
+}  // namespace
+
+// pp_size=1 degenerates to today's behavior: the single stage is both first
+// and last, and owns all layers.
+TEST(PPLayoutTest, SingleStageDegenerate) {
+    auto layout = makeLayout(/*pp_size=*/1, /*pp_rank=*/0, /*total_layers=*/64);
+    EXPECT_TRUE(layout.hasEmbedding());
+    EXPECT_TRUE(layout.hasLmHead());
+    EXPECT_EQ(layout.myLayerRange(), (std::pair<int64_t, int64_t>{0, 64}));
+}
+
+// Capability flags across a 4-stage pipeline: only stage 0 has embedding,
+// only the last stage has the LM head, middles have neither.
+TEST(PPLayoutTest, CapabilityFlagsAcrossStages) {
+    for (int64_t rank = 0; rank < 4; ++rank) {
+        auto layout = makeLayout(4, rank, 64);
+        EXPECT_EQ(layout.hasEmbedding(), rank == 0) << "rank " << rank;
+        EXPECT_EQ(layout.hasLmHead(), rank == 3) << "rank " << rank;
+    }
+}
+
+// Ring neighbors for PP transport construction: stages wrap around, and
+// rank derivation is dp-safe.
+TEST(PPLayoutTest, RingNeighborRanks) {
+    // pp=3, dp=1, tp=2, world=6: lane stride = 2.
+    // stage0 = ranks {0,1}, stage1 = {2,3}, stage2 = {4,5}.
+    auto make = [](int64_t pp_rank, int64_t tp_rank) {
+        PPLayout layout;
+        layout.pp_size = 3;
+        layout.pp_rank = pp_rank;
+        layout.dp_size = 1;
+        layout.tp_size = 2;
+        layout.tp_rank = tp_rank;
+        return layout;
+    };
+    EXPECT_EQ(make(0, 0).laneStride(), 2);
+    // Middle stage: prev/next are the adjacent stages.
+    EXPECT_EQ(make(1, 0).prevRank(), 0);
+    EXPECT_EQ(make(1, 0).nextRank(), 4);
+    EXPECT_EQ(make(1, 1).prevRank(), 1);
+    EXPECT_EQ(make(1, 1).nextRank(), 5);
+    // First stage: prev wraps to the last stage.
+    EXPECT_EQ(make(0, 0).prevRank(), 4);
+    EXPECT_EQ(make(0, 0).nextRank(), 2);
+    // Last stage: next wraps to the first stage (sample-result return path).
+    EXPECT_EQ(make(2, 0).prevRank(), 2);
+    EXPECT_EQ(make(2, 0).nextRank(), 0);
+
+    // dp>1: the lane offset (dp_rank*tp_size) must be included. pp=2,
+    // dp=2, tp=2, world=8; lane of rank 3 (dp_rank=1, tp_rank=1) is
+    // {3, 7}, NOT {3, 5}.
+    PPLayout dp_lane;
+    dp_lane.pp_size = 2;
+    dp_lane.pp_rank = 0;
+    dp_lane.dp_size = 2;
+    dp_lane.tp_size = 2;
+    dp_lane.dp_rank = 1;
+    dp_lane.tp_rank = 1;
+    EXPECT_EQ(dp_lane.laneStride(), 4);
+    EXPECT_EQ(dp_lane.rankOfStage(0), 3);
+    EXPECT_EQ(dp_lane.rankOfStage(1), 7);
+    EXPECT_EQ(dp_lane.prevRank(), 7);
+    EXPECT_EQ(dp_lane.nextRank(), 7);
+
+    // pp=1 degenerate: both neighbors are the stage itself.
+    PPLayout single = makeLayout(1, 0, 8);
+    EXPECT_EQ(single.prevRank(), 0);
+    EXPECT_EQ(single.nextRank(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Materialized partition: prefix-sum lookup over pp_stage_layer_counts
+// ---------------------------------------------------------------------------
+
+namespace {
+
+PPLayout makeMaterializedLayout(std::vector<int64_t> counts, int64_t pp_rank) {
+    PPLayout layout;
+    layout.pp_size = static_cast<int64_t>(counts.size());
+    layout.pp_rank = pp_rank;
+    for (const auto c : counts) {
+        layout.total_layers += c;
+    }
+    layout.layer_counts = std::move(counts);
+    return layout;
+}
+
+}  // namespace
+
+// Shape-specialized counts (e.g. a model-level partitioner): the lookup
+// follows the data, not the even-split formula. (Even-split golden values
+// are covered one level up by PPStageCacheConfigTest.stageScopedMatchesLayerPartition.)
+TEST(PPLayoutTest, MaterializedShapeSpecializedCounts) {
+    auto layout = makeMaterializedLayout({4, 12, 12}, 1);
+    EXPECT_EQ(layout.myLayerRange(), (std::pair<int64_t, int64_t>{4, 16}));
+    EXPECT_EQ(layout.layerRangeOf(2), (std::pair<int64_t, int64_t>{16, 28}));
+}
+
+// Single stage via the materialized channel.
+TEST(PPLayoutTest, MaterializedSingleStage) {
+    auto layout = makeMaterializedLayout({64}, 0);
+    EXPECT_EQ(layout.myLayerRange(), (std::pair<int64_t, int64_t>{0, 64}));
+}
+
+// Malformed materialized data fails fast.
+TEST(PPLayoutTest, MaterializedRejectsInconsistentCounts) {
+    auto layout    = makeMaterializedLayout({8, 8}, 0);
+    layout.pp_size = 3;  // size/pp_size mismatch
+    EXPECT_THROW(layout.layerRangeOf(0), std::exception);
+    // Out-of-range stage.
+    auto ok = makeMaterializedLayout({8, 8}, 0);
+    EXPECT_THROW(ok.layerRangeOf(2), std::exception);
+    EXPECT_THROW(ok.layerRangeOf(-1), std::exception);
+}
+
+// fromParallelismConfig carries every layout input over.
+TEST(PPLayoutTest, FromParallelismConfig) {
+    ParallelismConfig pc;
+    pc.pp_size               = 3;
+    pc.pp_rank               = 2;
+    pc.dp_size               = 2;
+    pc.tp_size               = 4;
+    pc.dp_rank               = 1;
+    pc.tp_rank               = 3;
+    pc.pp_stage_layer_counts = {5, 4, 4};
+    const auto layout        = PPLayout::fromParallelismConfig(pc, 13);
+    EXPECT_EQ(layout.pp_size, 3);
+    EXPECT_EQ(layout.pp_rank, 2);
+    EXPECT_EQ(layout.dp_size, 2);
+    EXPECT_EQ(layout.tp_size, 4);
+    EXPECT_EQ(layout.dp_rank, 1);
+    EXPECT_EQ(layout.tp_rank, 3);
+    EXPECT_EQ(layout.myLayerRange(), (std::pair<int64_t, int64_t>{9, 13}));
+
+    // Empty counts -> even-split fallback (golden values unchanged).
+    ParallelismConfig bare;
+    bare.pp_size           = 4;
+    bare.pp_rank           = 0;
+    const auto bare_layout = PPLayout::fromParallelismConfig(bare, 65);
+    EXPECT_EQ(bare_layout.layerRangeOf(0), (std::pair<int64_t, int64_t>{0, 17}));
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/models/BUILD
+++ b/rtp_llm/cpp/models/BUILD
@@ -173,6 +173,7 @@ cc_library(
         "//:rtp_compute_ops",
         "//rtp_llm/models_py/bindings/core:exec_ops_hdr",
         "//rtp_llm/models_py/bindings/core:tensor_holder",
+        "//rtp_llm/cpp/normal_engine:pipeline_types",
         "//rtp_llm/cpp/pybind:py_utils",
         "//rtp_llm/cpp/engine_base/stream:complete_token_ids",
         "//rtp_llm/cpp/cache:cache_types",

--- a/rtp_llm/cpp/models/PyWrappedModel.cc
+++ b/rtp_llm/cpp/models/PyWrappedModel.cc
@@ -1,5 +1,6 @@
 #include "rtp_llm/cpp/models/PyWrappedModel.h"
 #include "rtp_llm/cpp/cache/KVCacheManager.h"
+#include "rtp_llm/cpp/normal_engine/pipeline/PPTypes.h"
 #include "rtp_llm/models_py/bindings/core/ExecOps.h"
 #include "rtp_llm/cpp/utils/DebugUtils.h"
 #include "rtp_llm/cpp/utils/utils.h"
@@ -383,24 +384,30 @@ PyWrappedModel::setupKVCacheForAttentionInputs(torch_ext::PyAttentionInputs& py_
         return {};
     }
 
-    const size_t group_count = static_cast<size_t>(inputs.kv_cache_kernel_block_id.size(0));
+    const size_t col_count = static_cast<size_t>(inputs.kv_cache_kernel_block_id.size(0));
     RTP_LLM_CHECK_WITH_INFO(kv_cache_layer_layout_.has_value(),
                             "tagged attention inputs require the current model cache layout");
-    const auto& group_tags = kv_cache_layer_layout_->topology().groupTagsSnapshot();
-    RTP_LLM_CHECK_WITH_INFO(group_tags.size() == group_count,
-                            "KV block table group count=%zu does not match topology tag count=%zu",
-                            group_count,
-                            group_tags.size());
+    const auto& groups = kv_cache_layer_layout_->topology().groups();
+    RTP_LLM_CHECK_WITH_INFO(!groups.empty(), "tagged attention inputs require at least one cache group");
     RTP_LLM_CHECK_WITH_INFO(!inputs.kv_cache_block_id.defined() || inputs.kv_cache_block_id.dim() == 3,
                             "physical kv_cache_block_id must be 3-D for tagged inputs");
 
+    // Plan columns are addressed by canonical index. Under pp_size=1 the
+    // canonical index equals the local position; under pp_size>1 the leading
+    // stage emits canonical-ordered columns and each stage selects its own.
     torch_ext::AttentionInputsByTag by_tag;
-    for (size_t group_id = 0; group_id < group_count; ++group_id) {
+    for (const auto& group : groups) {
+        const size_t col = group.canonical_idx;
+        RTP_LLM_CHECK_WITH_INFO(col < col_count,
+                                "KV block table has %zu columns but group [%s] needs canonical column %zu",
+                                col_count,
+                                group.tag.c_str(),
+                                col);
         auto group_inputs                            = py_attn_inputs;
-        group_inputs.kv_cache_kernel_block_id        = inputs.kv_cache_kernel_block_id[group_id];
+        group_inputs.kv_cache_kernel_block_id        = inputs.kv_cache_kernel_block_id[col];
         group_inputs.kv_cache_kernel_block_id_device = tensorHoldHostAndToCuda(group_inputs.kv_cache_kernel_block_id);
         if (inputs.kv_cache_block_id.defined()) {
-            group_inputs.kv_cache_block_id        = inputs.kv_cache_block_id[group_id];
+            group_inputs.kv_cache_block_id        = inputs.kv_cache_block_id[col];
             group_inputs.kv_cache_block_id_device = tensorHoldHostAndToCuda(group_inputs.kv_cache_block_id);
             if (group_inputs.cache_store_inputs.has_value()) {
                 group_inputs.cache_store_inputs->host_kv_cache_offset = group_inputs.kv_cache_block_id.is_cuda() ?
@@ -408,15 +415,15 @@ PyWrappedModel::setupKVCacheForAttentionInputs(torch_ext::PyAttentionInputs& py_
                                                                             group_inputs.kv_cache_block_id;
             }
         }
-        const auto [it, inserted] = by_tag.emplace(group_tags[group_id], std::move(group_inputs));
+        const auto [it, inserted] = by_tag.emplace(group.tag, std::move(group_inputs));
         (void)it;
-        RTP_LLM_CHECK_WITH_INFO(inserted, "duplicate attention input tag=%s", group_tags[group_id].c_str());
+        RTP_LLM_CHECK_WITH_INFO(inserted, "duplicate attention input tag=%s", group.tag.c_str());
     }
 
     // A single global group keeps the direct fast path. Multiple groups are
     // exposed only through the outer tag mapping.
-    py_attn_inputs = by_tag.at(group_tags.front());
-    if (group_count == 1) {
+    py_attn_inputs = by_tag.at(groups.front().tag);
+    if (groups.size() == 1) {
         return {};
     }
     return by_tag;
@@ -732,15 +739,15 @@ void PyWrappedModel::updateKVCacheKernelBlockId(const GptModelInputs& inputs) {
     fusedCopy(d2d_copies_);
 
     if (enable_cuda_graph_) {
-        auto empty           = torch::Tensor();
-        auto py_model_inputs = PyModelInputs({empty,
-                                              empty,
-                                              empty,
-                                              torch_ext::PyEmbeddingInputs(),
-                                              torch_ext::PyMultimodalInputs(),
-                                              attention_inputs_,
-                                              attention_inputs_by_tag_,
-                                              torch_ext::BertEmbeddingInputs()});
+        auto empty                        = torch::Tensor();
+        auto py_model_inputs              = PyModelInputs({empty,
+                                                           empty,
+                                                           empty,
+                                                           torch_ext::PyEmbeddingInputs(),
+                                                           torch_ext::PyMultimodalInputs(),
+                                                           attention_inputs_,
+                                                           attention_inputs_by_tag_,
+                                                           torch_ext::BertEmbeddingInputs()});
         py_model_inputs.dspark_call_phase = inputs.dspark_call_phase;
         if (graph_runner_->canRun(py_model_inputs, graph_state_)) {
             graph_runner_->updateKVCacheKernelBlockId(py_model_inputs, graph_state_);
@@ -820,15 +827,17 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
         const bool                has_cache_store_work = !inputs.warmup && inputs.pd_separation;
         CacheStoreWriteCycleGuard cache_store_write_cycle(cache_store_async_writer_, has_cache_store_work);
 
-        auto           py_model_inputs = PyModelInputs({token_ids,
-                                                        input_hiddens,
-                                                        combo_position_ids,
-                                                        embedding_inputs,
-                                                        multimodal_inputs,
-                                                        attention_inputs_,
-                                                        attention_inputs_by_tag_,
-                                                        bert_embedding_inputs});
+        auto py_model_inputs              = PyModelInputs({token_ids,
+                                                           input_hiddens,
+                                                           combo_position_ids,
+                                                           embedding_inputs,
+                                                           multimodal_inputs,
+                                                           attention_inputs_,
+                                                           attention_inputs_by_tag_,
+                                                           bert_embedding_inputs});
         py_model_inputs.dspark_call_phase = inputs.dspark_call_phase;
+        // PP: stage-boundary tensors populated by forwardPP.
+        py_model_inputs.pp_intermediates = inputs.pp_intermediates;
         PyModelOutputs py_model_outputs;
         torch::Tensor  hidden_states;
 
@@ -865,9 +874,11 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
         RTP_LLM_LOG_DEBUG("Python object instance forward method called successfully.");
         // In-model DSpARK proposals leave the Python boundary on
         // PyModelOutputs::draft_tokens; carry them through whichever
-        // post-layers path this forward takes.
-        auto attach_draft_outputs = [&py_model_outputs](GptModelOutputs outputs) {
-            outputs.draft_tokens = py_model_outputs.draft_tokens;
+        // post-layers path this forward takes. PP stage-boundary tensors ride
+        // along the same way (forwardPP packs them for the downstream stage).
+        auto attach_model_side_outputs = [&py_model_outputs](GptModelOutputs outputs) {
+            outputs.draft_tokens     = py_model_outputs.draft_tokens;
+            outputs.pp_intermediates = py_model_outputs.pp_intermediates;
             return outputs;
         };
         if (is_dspark_draft_) {
@@ -878,17 +889,17 @@ GptModelOutputs PyWrappedModel::forward(const GptModelInputs& inputs) {
             GptModelOutputs outputs;
             outputs.hidden_states     = hidden_states;
             outputs.all_hidden_states = hidden_states;
-            return attach_draft_outputs(std::move(outputs));
+            return attach_model_side_outputs(std::move(outputs));
         }
         if (device_props_.enable_prefill_cp && has_context_request) {
             if (!inputs.need_all_logits && !inputs.need_all_hidden_states) {
                 context_parallel_processor_->handleOutputsLastHidden(hidden_states, inputs, cp_params);
-                return attach_draft_outputs(forwardPostLayersLastHidden(hidden_states, inputs));
+                return attach_model_side_outputs(forwardPostLayersLastHidden(hidden_states, inputs));
             }
             size_t num_valid_tokens = context_parallel_processor_->handleOutputs(hidden_states, inputs, cp_params);
-            return attach_draft_outputs(callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens));
+            return attach_model_side_outputs(callForwardPostLayers(hidden_states, inputs, true, num_valid_tokens));
         }
-        return attach_draft_outputs(callForwardPostLayers(hidden_states, inputs, true));
+        return attach_model_side_outputs(callForwardPostLayers(hidden_states, inputs, true));
 
     } catch (const py::error_already_set& e) {
         RTP_LLM_LOG_ERROR("Python error during forward call on Python instance: %s", e.what());
@@ -1126,6 +1137,25 @@ GptModelOutputs PyWrappedModel::forwardPostLayersLastHidden(torch::Tensor hidden
     return {logits, last_hidden, last_hidden, torch::Tensor(), torch::Tensor()};
 }
 
+// PP: thin transport adapter around the single compute path. Unpacks
+// upstream PPIntermediateTensors into inputs.pp_intermediates (read by the
+// Python model) and packs the model-emitted intermediates for the
+// downstream stage. forward() remains the only compute.
+GptModelOutputs PyWrappedModel::forwardPP(const GptModelInputs&        inputs,
+                                          const PPIntermediateTensors* input_tensors,
+                                          PPIntermediateTensors*       output_tensors) {
+    RTP_LLM_PROFILE_SCOPE("py_model.forwardPP");
+    GptModelInputs local_inputs = inputs;
+    if (pp_size_ > 1 && input_tensors != nullptr && !input_tensors->tensors.empty()) {
+        local_inputs.pp_intermediates = input_tensors->tensors;
+    }
+    GptModelOutputs outputs = forward(local_inputs);
+    if (pp_size_ > 1 && output_tensors != nullptr) {
+        output_tensors->tensors = std::move(outputs.pp_intermediates);
+    }
+    return outputs;
+}
+
 MicroBatchPlan PyWrappedModel::planMicroBatches(const GptModelInputs& inputs) {
     if (!int(device_props_.enable_layer_micro_batch)) {
         RTP_LLM_LOG_DEBUG("micro batch disable when enable_layer_micro_batch is false");
@@ -1213,11 +1243,10 @@ PyWrappedModel::splitInputsIntoMicroBatches(const GptModelInputs& inputs, const 
     size_t                      prefill_batch_idx      = 0;
     // TODO(async): micro-batch token slicing still computes CPU scalar sums.
     // Convert explicitly and keep all sliced GptModelInputs device-resident.
-    const auto input_lengths_host = inputs.input_lengths.defined() && inputs.input_lengths.is_cuda() ?
-                                        inputs.input_lengths.cpu().pin_memory() :
-                                        inputs.input_lengths;
-    const auto* input_lengths_ptr =
-        input_lengths_host.defined() ? input_lengths_host.data_ptr<int32_t>() : nullptr;
+    const auto  input_lengths_host = inputs.input_lengths.defined() && inputs.input_lengths.is_cuda() ?
+                                         inputs.input_lengths.cpu().pin_memory() :
+                                         inputs.input_lengths;
+    const auto* input_lengths_ptr  = input_lengths_host.defined() ? input_lengths_host.data_ptr<int32_t>() : nullptr;
 
     if (!micro_batch_plan.enable) {
         RTP_LLM_LOG_DEBUG("micro batch disable when enable is false, use fake");

--- a/rtp_llm/cpp/models/PyWrappedModel.h
+++ b/rtp_llm/cpp/models/PyWrappedModel.h
@@ -59,6 +59,13 @@ public:
     ~PyWrappedModel();
 
     GptModelOutputs forward(const GptModelInputs& inputs) override;
+    // PP: thin transport adapter — unpacks upstream PPIntermediateTensors
+    // into PyModelInputs.pp_intermediates, delegates to forward() (the only
+    // compute path), and packs the model-emitted intermediates for the
+    // downstream stage.
+    GptModelOutputs forwardPP(const GptModelInputs&        inputs,
+                              const PPIntermediateTensors* input_tensors,
+                              PPIntermediateTensors*       output_tensors) override;
     GptModelOutputs forwardMicroBatched(const GptModelInputs& inputs);
     void            releaseBuffers() override;
     torch::Tensor   getMtpTargetHiddenStates(int64_t num_tokens) override;
@@ -113,6 +120,7 @@ private:
     const DSparkCallPhase                           dspark_graph_phase_;
     const rtp_llm::MlaOpsType                       mla_ops_type_;
     const size_t                                    layer_num_;
+    const int64_t                                   pp_size_;
     const GptModelDescription                       description_;
     std::optional<rtp_llm::GroupedCacheLayerLayout> kv_cache_layer_layout_;
     std::shared_ptr<KVCacheManager>                 cache_manager_;  // For cache_store access
@@ -158,6 +166,7 @@ inline PyWrappedModel::PyWrappedModel(const GptModelInitParams& params,
     dspark_graph_phase_(dspark_graph_phase),
     mla_ops_type_(params.mla_ops_type),
     layer_num_(params.weights.layers.size()),
+    pp_size_(std::max<int64_t>(1, params.parallelism_config.pp_size)),
     description_(params.description),
     cache_manager_(params.cache_manager),
     // The ordinary DSpARK wrapper stays eager. Dedicated prefill-graph

--- a/rtp_llm/cpp/normal_engine/BUILD
+++ b/rtp_llm/cpp/normal_engine/BUILD
@@ -1,4 +1,18 @@
+load("//:def.bzl", "copts")
 load("@arch_config//:arch_select.bzl", "torch_deps")
+
+# Header-only PP wire types so consumers outside normal_engine (e.g. the
+# models lib building the PyWrappedModel::forwardPP adapter) can depend on
+# them without dragging in the whole executor.
+cc_library(
+    name = "pipeline_types",
+    hdrs = ["pipeline/PPTypes.h"],
+    copts = copts(),
+    deps = [
+        "//rtp_llm/models_py/bindings/core:op_data",
+    ] + torch_deps(),
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "normal_engine",
@@ -9,18 +23,21 @@ cc_library(
         "pipeline/PPExecutor.h",
         "pipeline/PPSerialization.h",
         "pipeline/PPTransport.h",
-        "pipeline/PPTypes.h",
     ],
     srcs = glob([
         "*.cc",
         "speculative/*.cc",
     ]) + [
         "pipeline/PPExecutor.cc",
+        "pipeline/PPSerialization.cc",
         "pipeline/PPTransport.cc",
     ],
     deps = [
+        ":pipeline_types",
         "//rtp_llm/cpp/cache:cache",
+        "//rtp_llm/cpp/cache:pp_topology_validator",
         "//rtp_llm/cpp/config:config_modules",
+        "//rtp_llm/cpp/config:pp_layout",
         "//rtp_llm/cpp/config:role_types",
         "//rtp_llm/cpp/cuda_graph:cuda_graph_hdrs_lib",
         "//rtp_llm/cpp/engine_base:executor",

--- a/rtp_llm/cpp/normal_engine/NormalEngine.cc
+++ b/rtp_llm/cpp/normal_engine/NormalEngine.cc
@@ -10,6 +10,7 @@
 #include "rtp_llm/cpp/engine_base/schedulers/PDFusionRatioScheduler.h"
 #include "rtp_llm/cpp/engine_base/schedulers/BatchDecodeScheduler.h"
 #include "rtp_llm/cpp/cache/CacheConfigCreator.h"
+#include "rtp_llm/cpp/cache/PPTopologyValidator.h"
 #include "rtp_llm/cpp/engine_base/system_prompt/SystemPromptConstructor.h"
 #include "rtp_llm/cpp/utils/Logger.h"
 #include "rtp_llm/cpp/utils/AssertUtils.h"
@@ -24,6 +25,7 @@
 #include <cstring>
 #include <list>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <random>
 
@@ -521,22 +523,50 @@ void NormalEngine::initCacheManager(std::optional<WarmUpResult> warm_up_result) 
     } else {
         auto result = CacheConfigCreator::createConfig(
             model_config_, parallelism_config, runtime_config, kv_cache_config, warm_up_result, sp_config);
+        // PP: fail-fast cache geometry validation at startup. Under
+        // pp_size>1 every stage exchanges its snapshot over the PP process
+        // group (registered by collective_torch at distributed init) and all
+        // stages agree on the logical (min) block count; pp_size=1 keeps the
+        // local collector. Runs after computeBlockNum (block counts are
+        // final) and before any request traffic, so it acts as a startup
+        // barrier.
+        PPValidationResult pp_validation;
+        {
+            const auto                              local_snapshot = StageCacheSnapshot::fromConfig(result);
+            std::unique_ptr<StageSnapshotCollector> pp_snapshot_collector;
+            if (parallelism_config.pp_size > 1) {
+                pp_snapshot_collector = std::make_unique<PPSnapshotCollector>(local_snapshot);
+            } else {
+                pp_snapshot_collector = std::make_unique<LocalStageSnapshotCollector>(local_snapshot);
+            }
+            pp_validation = initPPCacheGeometry(*pp_snapshot_collector);
+            RTP_LLM_CHECK_WITH_INFO(
+                pp_validation.ok, "pp cache geometry validation failed: %s", pp_validation.error.c_str());
+        }
         RTP_LLM_LOG_INFO("create cache manager with config %s", result.debugString().c_str());
         RTP_LLM_LOG_INFO("create cache manager with block nums %d, block size %ld KB",
                          result.block_num,
                          result.block_size_bytes / 1024);
         RTP_LLM_LOG_INFO("create cache manager with linear step %d", result.linear_step);
-        resource_context_.cache_manager = make_shared<KVCacheManager>(result,
-                                                                      false,
-                                                                      metrics_reporter_,
-                                                                      kv_cache_config,
-                                                                      parallelism_config,
-                                                                      runtime_config,
-                                                                      SpeculativeExecutionConfig{},
-                                                                      pd_sep_config,
-                                                                      cache_store_config,
-                                                                      use_cuda_malloc_block_pool);
-        resource_context_.role_type     = pd_sep_config.role_type;
+        // The validated cross-stage logical capacity is handed to the
+        // manager, which caps per-group block counts internally (after its
+        // finalizeBlockNums, before init() builds the pools) so admission
+        // never admits a request some stage cannot serve; a richer stage
+        // simply sizes its pools to the capped counts, leaving the surplus
+        // VRAM free.
+        resource_context_.cache_manager = make_shared<KVCacheManager>(
+            result,
+            false,
+            metrics_reporter_,
+            kv_cache_config,
+            parallelism_config,
+            runtime_config,
+            SpeculativeExecutionConfig{},
+            pd_sep_config,
+            cache_store_config,
+            use_cuda_malloc_block_pool,
+            parallelism_config.pp_size > 1 ? std::make_optional(pp_validation) : std::nullopt);
+        resource_context_.role_type = pd_sep_config.role_type;
         if (!resource_context_.cache_manager->init()) {
             RTP_LLM_FAIL("init kv cache manager failed");
         }
@@ -732,8 +762,7 @@ absl::Status NormalEngine::step() {
 absl::Status NormalEngine::pp_step() {
     RTP_LLM_PROFILE_SCOPE("engine.normal.pp_step_work");
 
-    const int64_t ranks_per_stage          = parallelism_config.dp_size * parallelism_config.tp_size;
-    const int64_t pp_rank                  = parallelism_config.world_rank / ranks_per_stage;
+    const int64_t pp_rank                  = parallelism_config.pp_rank;
     const bool    is_first_stage_scheduler = pp_rank == 0 && parallelism_config.tp_rank == 0;
 
     // Pauses only new pipeline admission so other ranks can continue draining

--- a/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
+++ b/rtp_llm/cpp/normal_engine/NormalGenerateStream.h
@@ -7,10 +7,6 @@ namespace rtp_llm {
 
 class NormalGenerateStream: public GenerateStream {
 public:
-    NormalGenerateStream(const GenerateStream& stream): GenerateStream(stream) {
-        CopyOnWrite(stream);
-    }
-
     NormalGenerateStream(const std::shared_ptr<GenerateInput>& query,
                          const ModelConfig&                    model_config,
                          const RuntimeConfig&                  runtime_config,

--- a/rtp_llm/cpp/normal_engine/pipeline/PPExecutor.cc
+++ b/rtp_llm/cpp/normal_engine/pipeline/PPExecutor.cc
@@ -43,7 +43,9 @@ PPSamplingData buildSamplingData(const StreamGroups& stream_groups) {
 
     for (const auto& stream : all_streams) {
         const auto& config = *stream->generateConfig();
-        RTP_LLM_CHECK_WITH_INFO(!stream->hasNumBeams() && stream->numReturnSequences() == 1,
+        // num_return_sequences: 0 = feature disabled (the Python-side
+        // default), 1 = single sequence; both are fine here.
+        RTP_LLM_CHECK_WITH_INFO(!stream->hasNumBeams() && stream->numReturnSequences() <= 1,
                                 "initial PP sampling does not support beam search or multiple return sequences, "
                                 "request_id=%ld",
                                 stream->streamId());
@@ -292,17 +294,17 @@ PPExecutor::PPExecutor(const EngineInitParams&                params,
     wall_tps_reporter_(WallClockMetricsLoopReporter<RtpLLMWallClockTokenPSMetrics, RtpLLMTokenPSMetricsCollector>(
         params.parallelism_config.world_rank == 0 ? metrics_reporter_ : nullptr)),
     parallelism_config_(params.parallelism_config),
-    pp_rank_(parallelism_config_.world_rank / parallelism_config_.tp_size),
+    // Stage-role truth (hasEmbedding/hasLmHead) and the materialized layer
+    // partition, shared with cache creation and the Python mirrors.
+    pp_layout_(PPLayout::fromParallelismConfig(parallelism_config_, params.model_config_.num_layers)),
     profile_step_start_(std::move(profile_step_start)),
     profile_step_finish_(std::move(profile_step_finish)),
     slots_(parallelism_config_.pp_size + 1) {
 
-    const auto previous_stage = (pp_rank_ + parallelism_config_.pp_size - 1) % parallelism_config_.pp_size;
-    const auto next_stage     = (pp_rank_ + 1) % parallelism_config_.pp_size;
-    const auto previous_rank =
-        static_cast<int>(previous_stage * parallelism_config_.tp_size + parallelism_config_.tp_rank);
-    const auto next_rank = static_cast<int>(next_stage * parallelism_config_.tp_size + parallelism_config_.tp_rank);
-    transport_           = std::make_unique<NcclPPTransport>(previous_rank, next_rank);
+    // Ring transport channels: send to the next stage, receive from the
+    // previous one (both wrap around; the protocol gates actual usage).
+    transport_ = std::make_unique<NcclPPTransport>(static_cast<int>(pp_layout_.prevRank()),
+                                                   static_cast<int>(pp_layout_.nextRank()));
 
     enable_detail_log_ = params.profiling_debug_logging_config.enable_detail_log;
     RTP_LLM_LOG_INFO("enable_detail_log_ = %d, tp_rank_ = %d", enable_detail_log_, parallelism_config_.tp_rank);

--- a/rtp_llm/cpp/normal_engine/pipeline/PPExecutor.h
+++ b/rtp_llm/cpp/normal_engine/pipeline/PPExecutor.h
@@ -12,6 +12,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/config/PPLayout.h"
 #include "rtp_llm/cpp/engine_base/Executor.h"
 #include "rtp_llm/cpp/metrics/RtpLLMMetrics.h"
 #include "rtp_llm/cpp/model_utils/MlaConfig.h"
@@ -98,11 +99,11 @@ private:
     void                            advanceSamplingStates(const PPSamplingData& sampling, PPSampleResult& result);
 
     bool isFirstStage() const {
-        return pp_rank_ == 0;
+        return pp_layout_.hasEmbedding();
     }
 
     bool isLastStage() const {
-        return pp_rank_ + 1 == parallelism_config_.pp_size;
+        return pp_layout_.hasLmHead();
     }
 
     bool isStageRoot() const {
@@ -120,9 +121,12 @@ private:
     kmonitor::MetricsReporterPtr                                             metrics_reporter_ = nullptr;
     MetricsLoopReporter<RtpLLMTokenPSMetrics, RtpLLMTokenPSMetricsCollector> tps_reporter_;
     WallClockMetricsLoopReporter<RtpLLMWallClockTokenPSMetrics, RtpLLMTokenPSMetricsCollector> wall_tps_reporter_;
-    bool                                              enable_detail_log_ = false;
-    const ParallelismConfig                           parallelism_config_;
-    const int64_t                                     pp_rank_;
+    bool                    enable_detail_log_ = false;
+    const ParallelismConfig parallelism_config_;
+    // Single source of stage-role truth (hasEmbedding/hasLmHead) and the
+    // materialized layer partition, shared with cache creation and the
+    // Python loader/model mirrors.
+    const PPLayout                                    pp_layout_;
     std::unique_ptr<PPTransport>                      transport_;
     std::function<void()>                             profile_step_start_;
     std::function<void()>                             profile_step_finish_;

--- a/rtp_llm/cpp/normal_engine/pipeline/PPSerialization.cc
+++ b/rtp_llm/cpp/normal_engine/pipeline/PPSerialization.cc
@@ -1,0 +1,429 @@
+// Placeholder implementation, provided solely to unblock integration testing:
+// PPSerialization.h shipped without a .cc, leaving undefined symbols in
+// libth_transformer.so. The PP transport owner may delete this file and
+// replace it with the official implementation, as long as the contract in
+// PPSerialization.h (consumed by PPExecutor/PPTransport) is preserved.
+
+#include "rtp_llm/cpp/normal_engine/pipeline/PPSerialization.h"
+
+#include <cstring>
+
+#include "rtp_llm/cpp/utils/AssertUtils.h"
+
+namespace rtp_llm::pp_serialization {
+
+namespace {
+
+// Self-describing byte stream. Payload layout is versioned; readers bounds-
+// check every field. Tensor bytes are staged on CPU regardless of the source
+// device; the original device is recorded and restored on read.
+constexpr uint32_t kVersion = 1;
+
+struct ByteWriter {
+    std::vector<uint8_t> buf;
+
+    void raw(const void* p, size_t n) {
+        const auto* b = static_cast<const uint8_t*>(p);
+        buf.insert(buf.end(), b, b + n);
+    }
+
+    template<typename T>
+    void val(T v) {
+        raw(&v, sizeof(T));
+    }
+
+    void flag(bool v) {
+        val<uint8_t>(v ? 1 : 0);
+    }
+
+    void str(const std::string& s) {
+        val<uint64_t>(s.size());
+        raw(s.data(), s.size());
+    }
+
+    void tensor(const torch::Tensor& t) {
+        const bool present = t.defined() && t.numel() > 0;
+        flag(present);
+        if (!present) {
+            return;
+        }
+        const auto cpu = t.contiguous().cpu();
+        val<uint8_t>(static_cast<uint8_t>(cpu.dim()));
+        for (int64_t d = 0; d < cpu.dim(); ++d) {
+            val<int64_t>(cpu.size(d));
+        }
+        val<int32_t>(static_cast<int32_t>(t.scalar_type()));
+        flag(t.is_cuda());
+        val<uint64_t>(static_cast<uint64_t>(cpu.nbytes()));
+        raw(cpu.data_ptr(), cpu.nbytes());
+    }
+
+    void optTensorList(const std::optional<std::vector<torch::Tensor>>& list) {
+        flag(list.has_value());
+        if (!list.has_value()) {
+            return;
+        }
+        val<uint64_t>(list->size());
+        for (const auto& t : *list) {
+            tensor(t);
+        }
+    }
+
+    torch::Tensor finish() const {
+        auto out = torch::empty({static_cast<int64_t>(buf.size())}, torch::TensorOptions().dtype(torch::kUInt8));
+        if (!buf.empty()) {
+            std::memcpy(out.data_ptr(), buf.data(), buf.size());
+        }
+        return out;
+    }
+};
+
+struct ByteReader {
+    const uint8_t* p   = nullptr;
+    const uint8_t* end = nullptr;
+
+    ByteReader(const torch::Tensor& buffer):
+        p(static_cast<const uint8_t*>(buffer.data_ptr())),
+        end(p + static_cast<size_t>(buffer.numel()) * buffer.element_size()) {
+        RTP_LLM_CHECK_WITH_INFO(buffer.dtype() == torch::kUInt8 && buffer.dim() == 1,
+                                "PP serialization payload must be a 1-D uint8 tensor");
+    }
+
+    void raw(void* out, size_t n) {
+        RTP_LLM_CHECK_WITH_INFO(static_cast<size_t>(end - p) >= n, "PP serialization payload truncated");
+        std::memcpy(out, p, n);
+        p += n;
+    }
+
+    template<typename T>
+    T val() {
+        T v;
+        raw(&v, sizeof(T));
+        return v;
+    }
+
+    bool flag() {
+        return val<uint8_t>() != 0;
+    }
+
+    std::string str() {
+        const auto n = val<uint64_t>();
+        RTP_LLM_CHECK_WITH_INFO(static_cast<size_t>(end - p) >= n, "PP serialization string truncated");
+        std::string s(reinterpret_cast<const char*>(p), n);
+        p += n;
+        return s;
+    }
+
+    torch::Tensor tensor() {
+        if (!flag()) {
+            return {};
+        }
+        const auto ndim = val<uint8_t>();
+        RTP_LLM_CHECK_WITH_INFO(ndim <= 8, "PP serialization tensor ndim=%u out of range", ndim);
+        std::vector<int64_t> sizes(ndim);
+        for (size_t d = 0; d < ndim; ++d) {
+            sizes[d] = val<int64_t>();
+            RTP_LLM_CHECK_WITH_INFO(sizes[d] >= 0, "PP serialization tensor has negative dim");
+        }
+        const auto dtype   = static_cast<torch::ScalarType>(val<int32_t>());
+        const bool is_cuda = flag();
+        const auto nbytes  = val<uint64_t>();
+        auto       out =
+            torch::empty(sizes, torch::TensorOptions().dtype(dtype).device(is_cuda ? torch::kCUDA : torch::kCPU));
+        RTP_LLM_CHECK_WITH_INFO(static_cast<uint64_t>(out.nbytes()) == nbytes,
+                                "PP serialization tensor byte count mismatch");
+        if (nbytes > 0) {
+            if (is_cuda) {
+                auto cpu = torch::empty(sizes, torch::TensorOptions().dtype(dtype));
+                raw(cpu.data_ptr(), nbytes);
+                out.copy_(cpu, /*non_blocking=*/false);
+            } else {
+                raw(out.data_ptr(), nbytes);
+            }
+        }
+        return out;
+    }
+
+    void optTensorList(std::optional<std::vector<torch::Tensor>>& out) {
+        if (!flag()) {
+            out = std::nullopt;
+            return;
+        }
+        const auto                 n = val<uint64_t>();
+        std::vector<torch::Tensor> list;
+        list.reserve(n);
+        for (uint64_t i = 0; i < n; ++i) {
+            list.push_back(tensor());
+        }
+        out = std::move(list);
+    }
+
+    void expectEnd() const {
+        RTP_LLM_CHECK_WITH_INFO(p == end, "PP serialization payload has %zu trailing bytes", end - p);
+    }
+};
+
+void writeModelInput(ByteWriter& w, const GptModelInputs& in) {
+    w.tensor(in.combo_tokens);
+    w.tensor(in.input_lengths);
+    w.tensor(in.sequence_lengths);
+    w.tensor(in.lm_output_indexes);
+    w.tensor(in.lm_output_lengths);
+    w.tensor(in.prefix_lengths);
+    w.tensor(in.sequence_lengths_plus_1);
+    w.tensor(in.combo_tokens_type_ids);
+    w.tensor(in.combo_position_ids);
+    w.tensor(in.last_hidden_states);
+    w.tensor(in.attention_mask);
+    w.tensor(in.kv_cache_block_id);
+    w.tensor(in.kv_cache_kernel_block_id);
+    w.tensor(in.kv_cache_group_types);
+    w.tensor(in.kv_cache_update_mapping);
+    w.tensor(in.text_tokens_mask);
+    w.tensor(in.mm_features_locs);
+    w.tensor(in.input_embeddings_locs);
+    w.tensor(in.request_id);
+    w.tensor(in.request_pd_separation);
+    w.tensor(in.cache_keys);
+    w.optTensorList(in.multimodal_features);
+    w.optTensorList(in.mm_extra_input);
+    w.optTensorList(in.input_embeddings);
+    w.val<uint64_t>(in.kv_block_stride_bytes);
+    w.val<uint64_t>(in.kv_scale_stride_bytes);
+    w.val<uint64_t>(in.seq_size_per_block);
+    w.val<uint64_t>(in.kernel_seq_size_per_block);
+    w.flag(in.pd_separation);
+    w.flag(in.decode_entrance);
+    w.flag(in.use_opaque_kv_cache_store);
+    w.flag(in.need_all_logits);
+    w.flag(in.need_all_hidden_states);
+    w.flag(in.need_moe_gating);
+    w.flag(in.warmup);
+    w.flag(in.skip_run);
+    w.flag(in.is_fake_stream);
+    w.flag(in.is_target_verify);
+    w.val<int32_t>(static_cast<int32_t>(in.dspark_call_phase));
+}
+
+void readModelInput(ByteReader& r, GptModelInputs& in) {
+    in.combo_tokens             = r.tensor();
+    in.input_lengths            = r.tensor();
+    in.sequence_lengths         = r.tensor();
+    in.lm_output_indexes        = r.tensor();
+    in.lm_output_lengths        = r.tensor();
+    in.prefix_lengths           = r.tensor();
+    in.sequence_lengths_plus_1  = r.tensor();
+    in.combo_tokens_type_ids    = r.tensor();
+    in.combo_position_ids       = r.tensor();
+    in.last_hidden_states       = r.tensor();
+    in.attention_mask           = r.tensor();
+    in.kv_cache_block_id        = r.tensor();
+    in.kv_cache_kernel_block_id = r.tensor();
+    in.kv_cache_group_types     = r.tensor();
+    in.kv_cache_update_mapping  = r.tensor();
+    in.text_tokens_mask         = r.tensor();
+    in.mm_features_locs         = r.tensor();
+    in.input_embeddings_locs    = r.tensor();
+    in.request_id               = r.tensor();
+    in.request_pd_separation    = r.tensor();
+    in.cache_keys               = r.tensor();
+    r.optTensorList(in.multimodal_features);
+    r.optTensorList(in.mm_extra_input);
+    r.optTensorList(in.input_embeddings);
+    in.kv_block_stride_bytes     = r.val<uint64_t>();
+    in.kv_scale_stride_bytes     = r.val<uint64_t>();
+    in.seq_size_per_block        = r.val<uint64_t>();
+    in.kernel_seq_size_per_block = r.val<uint64_t>();
+    in.pd_separation             = r.flag();
+    in.decode_entrance           = r.flag();
+    in.use_opaque_kv_cache_store = r.flag();
+    in.need_all_logits           = r.flag();
+    in.need_all_hidden_states    = r.flag();
+    in.need_moe_gating           = r.flag();
+    in.warmup                    = r.flag();
+    in.skip_run                  = r.flag();
+    in.is_fake_stream            = r.flag();
+    in.is_target_verify          = r.flag();
+    in.dspark_call_phase         = static_cast<DSparkCallPhase>(r.val<int32_t>());
+}
+
+void writeSamplingData(ByteWriter& w, const PPSamplingData& s) {
+    w.val<uint64_t>(s.random_seeds.size());
+    for (const auto& seed : s.random_seeds) {
+        w.flag(seed.has_value());
+        if (seed.has_value()) {
+            w.val<int64_t>(*seed);
+        }
+    }
+    w.val<uint64_t>(s.logits_processor_configs.size());
+    for (const auto& cfg : s.logits_processor_configs) {
+        w.str(cfg.grammar_type);
+        w.str(cfg.grammar_value);
+        w.val<int32_t>(cfg.combo_token_size);
+        w.val<uint64_t>(cfg.banned_combo_token_ids.size());
+        for (const auto& banned : cfg.banned_combo_token_ids) {
+            w.val<uint64_t>(banned.size());
+            for (const auto id : banned) {
+                w.val<int32_t>(id);
+            }
+        }
+        w.val<uint64_t>(cfg.end_think_token_ids.size());
+        for (const auto id : cfg.end_think_token_ids) {
+            w.val<int32_t>(id);
+        }
+    }
+    w.flag(s.need_cum_log_probs);
+    w.tensor(s.request_ids);
+    w.tensor(s.token_ids);
+    w.tensor(s.input_lengths);
+    w.tensor(s.sequence_lengths);
+    w.tensor(s.top_k);
+    w.tensor(s.top_p);
+    w.tensor(s.temperature);
+    w.tensor(s.repetition_penalty);
+    w.tensor(s.presence_penalty);
+    w.tensor(s.frequency_penalty);
+    w.tensor(s.no_repeat_ngram_size);
+    w.tensor(s.do_sample);
+    w.tensor(s.finished_mask);
+}
+
+void readSamplingData(ByteReader& r, PPSamplingData& s) {
+    const auto seed_num = r.val<uint64_t>();
+    s.random_seeds.resize(seed_num);
+    for (uint64_t i = 0; i < seed_num; ++i) {
+        if (r.flag()) {
+            s.random_seeds[i] = static_cast<int>(r.val<int64_t>());
+        }
+    }
+    const auto cfg_num = r.val<uint64_t>();
+    s.logits_processor_configs.resize(cfg_num);
+    for (uint64_t i = 0; i < cfg_num; ++i) {
+        auto& cfg             = s.logits_processor_configs[i];
+        cfg.grammar_type      = r.str();
+        cfg.grammar_value     = r.str();
+        cfg.combo_token_size  = r.val<int32_t>();
+        const auto banned_num = r.val<uint64_t>();
+        cfg.banned_combo_token_ids.resize(banned_num);
+        for (uint64_t b = 0; b < banned_num; ++b) {
+            const auto id_num = r.val<uint64_t>();
+            cfg.banned_combo_token_ids[b].resize(id_num);
+            for (uint64_t k = 0; k < id_num; ++k) {
+                cfg.banned_combo_token_ids[b][k] = r.val<int32_t>();
+            }
+        }
+        const auto end_num = r.val<uint64_t>();
+        cfg.end_think_token_ids.resize(end_num);
+        for (uint64_t k = 0; k < end_num; ++k) {
+            cfg.end_think_token_ids[k] = r.val<int32_t>();
+        }
+    }
+    s.need_cum_log_probs   = r.flag();
+    s.request_ids          = r.tensor();
+    s.token_ids            = r.tensor();
+    s.input_lengths        = r.tensor();
+    s.sequence_lengths     = r.tensor();
+    s.top_k                = r.tensor();
+    s.top_p                = r.tensor();
+    s.temperature          = r.tensor();
+    s.repetition_penalty   = r.tensor();
+    s.presence_penalty     = r.tensor();
+    s.frequency_penalty    = r.tensor();
+    s.no_repeat_ngram_size = r.tensor();
+    s.do_sample            = r.tensor();
+    s.finished_mask        = r.tensor();
+}
+
+}  // namespace
+
+torch::Tensor serializePlan(const PPExecutionPlan& plan, bool empty_plan) {
+    ByteWriter w;
+    w.val<uint32_t>(kVersion);
+    w.flag(empty_plan);
+    if (!empty_plan) {
+        writeModelInput(w, plan.model_input);
+        writeSamplingData(w, plan.sampling);
+    }
+    return w.finish();
+}
+
+PPExecutionPlan deserializePlan(const torch::Tensor& buffer) {
+    ByteReader r(buffer);
+    RTP_LLM_CHECK_WITH_INFO(r.val<uint32_t>() == kVersion, "PP plan payload version mismatch");
+    PPExecutionPlan plan;
+    if (r.flag()) {
+        return plan;  // empty plan marker
+    }
+    readModelInput(r, plan.model_input);
+    readSamplingData(r, plan.sampling);
+    r.expectEnd();
+    return plan;
+}
+
+torch::Tensor serializeSampleResult(const PPSampleResult& result) {
+    ByteWriter w;
+    w.val<uint32_t>(kVersion);
+    w.tensor(result.request_ids);
+    w.tensor(result.new_token_ids);
+    w.tensor(result.sample_success);
+    w.tensor(result.cum_log_probs);
+    w.val<uint64_t>(result.errors.size());
+    for (const auto& err : result.errors) {
+        w.val<int64_t>(err.request_id);
+        w.val<int32_t>(err.error_code);
+        w.str(err.message);
+    }
+    return w.finish();
+}
+
+torch::Tensor serializeTensorsMetadata(const PPIntermediateTensors& tensors) {
+    ByteWriter w;
+    w.val<uint32_t>(kVersion);
+    w.val<uint64_t>(tensors.tensors.size());
+    for (const auto& [name, t] : tensors.tensors) {
+        w.str(name);
+        const bool present = t.defined() && t.numel() > 0;
+        w.flag(present);
+        if (!present) {
+            continue;
+        }
+        w.val<uint8_t>(static_cast<uint8_t>(t.dim()));
+        for (int64_t d = 0; d < t.dim(); ++d) {
+            w.val<int64_t>(t.size(d));
+        }
+        w.val<int32_t>(static_cast<int32_t>(t.scalar_type()));
+        w.flag(t.is_cuda());
+    }
+    return w.finish();
+}
+
+PPIntermediateTensors deserializeTensorsMetadata(const torch::Tensor& metadata) {
+    ByteReader r(metadata);
+    RTP_LLM_CHECK_WITH_INFO(r.val<uint32_t>() == kVersion, "PP tensors-metadata payload version mismatch");
+    PPIntermediateTensors out;
+    const auto            n = r.val<uint64_t>();
+    for (uint64_t i = 0; i < n; ++i) {
+        auto name = r.str();
+        if (!r.flag()) {
+            out.tensors.emplace(std::move(name), torch::Tensor{});
+            continue;
+        }
+        const auto ndim = r.val<uint8_t>();
+        RTP_LLM_CHECK_WITH_INFO(ndim <= 8, "PP intermediate tensor ndim=%u out of range", ndim);
+        std::vector<int64_t> sizes(ndim);
+        for (size_t d = 0; d < ndim; ++d) {
+            sizes[d] = r.val<int64_t>();
+            RTP_LLM_CHECK_WITH_INFO(sizes[d] >= 0, "PP intermediate tensor has negative dim");
+        }
+        const auto dtype   = static_cast<torch::ScalarType>(r.val<int32_t>());
+        const bool is_cuda = r.flag();
+        // Pre-allocate so the transport can receive the payload in place.
+        out.tensors.emplace(
+            std::move(name),
+            torch::empty(sizes, torch::TensorOptions().dtype(dtype).device(is_cuda ? torch::kCUDA : torch::kCPU)));
+    }
+    r.expectEnd();
+    return out;
+}
+
+}  // namespace rtp_llm::pp_serialization

--- a/rtp_llm/cpp/normal_engine/test/BUILD
+++ b/rtp_llm/cpp/normal_engine/test/BUILD
@@ -94,6 +94,29 @@ cc_test(
     exec_properties = {'gpu':'H20'},
 )
 
+# pp_size=1 equivalence baseline for gatherModelInput's block-table behavior.
+cc_test(
+    name = "pp_kv_block_table_equivalence_test",
+    srcs = glob([
+        "PPKvBlockTableEquivalenceTest.cc",
+    ]),
+    data = [],
+    copts = test_copts,
+    deps = [
+        "//rtp_llm/cpp/testing:device_test_utils",
+        "//rtp_llm/cpp/normal_engine:normal_engine",
+        "//rtp_llm/cpp/models:models",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudart",
+    ] + torch_deps() + cuda13_torch_link_deps,
+    env = {
+        "TEST_USING_DEVICE": "CUDA",
+    },
+    exec_properties = {'gpu':'H20'},
+)
+
 cc_test(
     name = "async_runner_test",
     srcs = [

--- a/rtp_llm/cpp/normal_engine/test/PPKvBlockTableEquivalenceTest.cc
+++ b/rtp_llm/cpp/normal_engine/test/PPKvBlockTableEquivalenceTest.cc
@@ -1,0 +1,197 @@
+// pp_size=1 equivalence baseline for gatherModelInput's KV block table
+// assembly: any future change must keep these tests green under pp_size=1.
+//
+// What is pinned (block tables are deterministic from setBatchBlocks):
+//  - kv_cache_block_id / kv_cache_kernel_block_id contents and shapes
+//  - row order: decode streams first, then context streams
+//  - row width: max block count across the batch, zero padding
+//  - kernel expansion: kernel_id = block_id * bpk + j (bpk=2 case)
+//  - context-only full gather output (combo tokens / lengths / block tables)
+
+#include <memory>
+#include <numeric>
+#include "torch/all.h"
+#include "gtest/gtest.h"
+
+#define private public
+#define protected public
+#include "rtp_llm/cpp/normal_engine/NormalBatchStreamProcessor.h"
+#include "rtp_llm/cpp/normal_engine/NormalGenerateStream.h"
+#include "rtp_llm/cpp/models/ModelTypes.h"
+#include "rtp_llm/cpp/testing/TestBase.h"
+#include "rtp_llm/cpp/config/ConfigModules.h"
+#include "rtp_llm/cpp/cache/MHAKVCacheSpec.h"
+
+using namespace std;
+
+namespace rtp_llm {
+
+template<typename T>
+static std::vector<T> tensorToVec(const torch::Tensor& t) {
+    auto c = t.is_cuda() ? t.cpu().contiguous() : t.contiguous();
+    return std::vector<T>(c.data_ptr<T>(), c.data_ptr<T>() + c.numel());
+}
+
+static torch::Tensor intTensor(std::vector<int32_t> data) {
+    return torch::tensor(data, torch::kInt32);
+}
+
+static void initFullCacheConfig(CacheConfig& cache_config, int layer_num, uint32_t spec_seq_size = 0) {
+    auto spec = std::make_shared<MHAKVCacheSpec>();
+    spec->tag = "default";
+    if (spec_seq_size > 0) {
+        // KVCacheSpecBase defaults seq_size_per_block to 1, and setTopology prefers
+        // the spec value over the CacheConfig global — override it explicitly for
+        // kernel-expansion (bpk > 1) scenarios.
+        spec->seq_size_per_block = spec_seq_size;
+    }
+    std::vector<int> layer_ids(static_cast<size_t>(layer_num));
+    std::iota(layer_ids.begin(), layer_ids.end(), 0);
+    cache_config.layer_num     = static_cast<uint32_t>(layer_num);
+    cache_config.layer_all_num = static_cast<uint32_t>(layer_num);
+    cache_config.fromGroupedSpecs({spec}, {layer_ids}, {CacheGroupType::FULL}, {"default"});
+}
+
+class PPKvBlockTableEquivalenceTest: public DeviceTestBase {
+protected:
+    // Builds a stream with a manually assigned block list (single group).
+    GenerateStreamPtr makeStream(const ResourceContext&  resource_context,
+                                 const ModelConfig&      model_config,
+                                 const RuntimeConfig&    runtime_config,
+                                 const CacheConfig&      cache_config,
+                                 std::vector<int32_t>    input_ids,
+                                 const BlockIndicesType& blocks,
+                                 bool                    is_context) {
+        auto query             = make_shared<GenerateInput>();
+        query->input_ids       = intTensor(std::move(input_ids));
+        query->generate_config = make_shared<GenerateConfig>();
+        auto stream = make_shared<NormalGenerateStream>(query, model_config, runtime_config, resource_context, nullptr);
+
+        BatchKVCacheResource resource;
+        resource.resetBatchSize(1);
+        resource.initGroups(cache_config.topologyPtr());
+        resource.setBatchBlocks(0, 0, blocks);
+        stream->setKVCache(resource);
+        stream->setIsContextStream(is_context);
+        stream->generate_status_->status = StreamState::RUNNING;
+        return stream;
+    }
+};
+
+// Mixed decode+context batch, bpk=1: block table rows are decode-first then
+// context, width = max block count, zero padded; kernel view mirrors block ids.
+TEST_F(PPKvBlockTableEquivalenceTest, MixedBatchBlockTableBaseline) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len = 2048;
+    model_config.vocab_size  = 2048;
+    model_config.num_layers  = 2;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    initFullCacheConfig(cache_config, model_config.num_layers);
+    RuntimeConfig runtime_config;
+
+    auto decode_stream =
+        makeStream(resource_context, model_config, runtime_config, cache_config, {1, 2}, {5, 6}, false);
+    auto context_stream =
+        makeStream(resource_context, model_config, runtime_config, cache_config, {3, 4, 5}, {7, 8, 9}, true);
+
+    std::list<GenerateStreamPtr> streams{decode_stream, context_stream};
+    StreamGroups                 stream_groups(streams);
+    NormalBatchStreamProcessor   processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+    TensorHolder holder;
+    auto         status = processor.gatherModelInput(stream_groups, holder);
+    ASSERT_TRUE(status.ok());
+    auto& mi = status.value();
+
+    // [group=1, batch=2, max_blocks=3]; decode row first, zero padding.
+    ASSERT_TRUE(mi.kv_cache_block_id.defined());
+    EXPECT_EQ(mi.kv_cache_block_id.sizes().vec(), (std::vector<int64_t>{1, 2, 3}));
+    EXPECT_EQ((std::vector<int32_t>{5, 6, 0, 7, 8, 9}), tensorToVec<int32_t>(mi.kv_cache_block_id));
+
+    // bpk=1: kernel view is a mirror of the block ids.
+    ASSERT_TRUE(mi.kv_cache_kernel_block_id.defined());
+    EXPECT_EQ(mi.kv_cache_kernel_block_id.sizes().vec(), (std::vector<int64_t>{1, 2, 3}));
+    EXPECT_EQ((std::vector<int32_t>{5, 6, 0, 7, 8, 9}), tensorToVec<int32_t>(mi.kv_cache_kernel_block_id));
+}
+
+// Kernel expansion with bpk=2 (seq_size_per_block=4, kernel_seq_size_per_block=2):
+// kernel_id = block_id * 2 + j, tensor width = max_blocks * 2.
+TEST_F(PPKvBlockTableEquivalenceTest, KernelBlockExpansionBpk2) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len = 2048;
+    model_config.vocab_size  = 2048;
+    model_config.num_layers  = 2;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    cache_config.seq_size_per_block        = 4;
+    cache_config.kernel_seq_size_per_block = 2;
+    initFullCacheConfig(cache_config, model_config.num_layers, /*spec_seq_size=*/4);
+    ASSERT_EQ(cache_config.kernelBlocksPerKvBlock(), 2u);
+    RuntimeConfig runtime_config;
+
+    auto context_stream =
+        makeStream(resource_context, model_config, runtime_config, cache_config, {1, 2, 3}, {5, 7}, true);
+
+    std::list<GenerateStreamPtr> streams{context_stream};
+    StreamGroups                 stream_groups(streams);
+    NormalBatchStreamProcessor   processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+    TensorHolder holder;
+    auto         status = processor.gatherModelInput(stream_groups, holder);
+    ASSERT_TRUE(status.ok());
+    auto& mi = status.value();
+
+    // Block ids unchanged: {5, 7}.
+    ASSERT_TRUE(mi.kv_cache_block_id.defined());
+    EXPECT_EQ(mi.kv_cache_block_id.sizes().vec(), (std::vector<int64_t>{1, 1, 2}));
+    EXPECT_EQ((std::vector<int32_t>{5, 7}), tensorToVec<int32_t>(mi.kv_cache_block_id));
+
+    // Kernel view expanded: 5 -> {10, 11}, 7 -> {14, 15}; width = 2 * 2 = 4.
+    ASSERT_TRUE(mi.kv_cache_kernel_block_id.defined());
+    EXPECT_EQ(mi.kv_cache_kernel_block_id.sizes().vec(), (std::vector<int64_t>{1, 1, 4}));
+    EXPECT_EQ((std::vector<int32_t>{10, 11, 14, 15}), tensorToVec<int32_t>(mi.kv_cache_kernel_block_id));
+}
+
+// Context-only batch: pins the full gather output (combo tokens, lengths,
+// block tables) as the prefill-side baseline.
+TEST_F(PPKvBlockTableEquivalenceTest, ContextOnlyFullBaseline) {
+    ResourceContext resource_context;
+    ModelConfig     model_config;
+    model_config.max_seq_len = 2048;
+    model_config.vocab_size  = 2048;
+    model_config.num_layers  = 2;
+    PDSepConfig                 pd_sep_config;
+    ProfilingDebugLoggingConfig profiling_debug_logging_config;
+    CacheConfig                 cache_config;
+    initFullCacheConfig(cache_config, model_config.num_layers);
+    RuntimeConfig runtime_config;
+
+    auto ctx1 = makeStream(resource_context, model_config, runtime_config, cache_config, {1, 2, 3}, {5, 6}, true);
+    auto ctx2 = makeStream(resource_context, model_config, runtime_config, cache_config, {4, 5}, {7}, true);
+
+    std::list<GenerateStreamPtr> streams{ctx1, ctx2};
+    StreamGroups                 stream_groups(streams);
+    NormalBatchStreamProcessor   processor(
+        model_config, pd_sep_config, profiling_debug_logging_config, cache_config, false);
+    TensorHolder holder;
+    auto         status = processor.gatherModelInput(stream_groups, holder);
+    ASSERT_TRUE(status.ok());
+    auto& mi = status.value();
+
+    EXPECT_EQ((std::vector<int32_t>{1, 2, 3, 4, 5}), tensorToVec<int32_t>(mi.combo_tokens));
+    EXPECT_EQ((std::vector<int32_t>{3, 2}), tensorToVec<int32_t>(mi.input_lengths));
+    EXPECT_EQ((std::vector<int32_t>{0, 0}), tensorToVec<int32_t>(mi.prefix_lengths));
+    ASSERT_TRUE(mi.sequence_lengths.defined());
+    EXPECT_EQ(mi.sequence_lengths.numel(), 0);  // no decode streams
+
+    ASSERT_TRUE(mi.kv_cache_block_id.defined());
+    EXPECT_EQ(mi.kv_cache_block_id.sizes().vec(), (std::vector<int64_t>{1, 2, 2}));
+    EXPECT_EQ((std::vector<int32_t>{5, 6, 7, 0}), tensorToVec<int32_t>(mi.kv_cache_block_id));
+}
+
+}  // namespace rtp_llm

--- a/rtp_llm/cpp/pybind/ConfigInit.cc
+++ b/rtp_llm/cpp/pybind/ConfigInit.cc
@@ -1223,6 +1223,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("tp_rank", &ParallelismConfig::tp_rank)
         .def_readwrite("ep_rank", &ParallelismConfig::ep_rank)
         .def_readwrite("dp_rank", &ParallelismConfig::dp_rank)
+        .def_readwrite("pp_rank", &ParallelismConfig::pp_rank)
         .def_readwrite("ffn_tp_size", &ParallelismConfig::ffn_tp_size)
         .def_readwrite("ffn_tp_rank", &ParallelismConfig::ffn_tp_rank)
         .def_readwrite("enable_sp", &ParallelismConfig::enable_sp)
@@ -1230,6 +1231,7 @@ PYBIND11_MODULE(libth_transformer_config, m) {
         .def_readwrite("role_type", &ParallelismConfig::role_type)
         .def_readwrite("ffn_disaggregate_config", &ParallelismConfig::ffn_disaggregate_config)
         .def_readwrite("prefill_cp_config", &ParallelismConfig::prefill_cp_config)
+        .def_readwrite("pp_stage_layer_counts", &ParallelismConfig::pp_stage_layer_counts)
         .def("to_string", &ParallelismConfig::to_string)
         .def("get_attn_tp_size", &ParallelismConfig::get_attn_tp_size)
         .def("get_attn_tp_rank", &ParallelismConfig::get_attn_tp_rank)
@@ -1254,10 +1256,12 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                                       self.ffn_disaggregate_config,
                                       self.prefill_cp_config,
                                       self.use_ub_comm,
-                                      self.role_type);
+                                      self.role_type,
+                                      self.pp_rank,
+                                      self.pp_stage_layer_counts);
             },
             [](py::tuple t) {
-                if (t.size() != 17 && t.size() != 18)
+                if (t.size() != 17 && t.size() != 18 && t.size() != 19 && t.size() != 20)
                     throw std::runtime_error("Invalid state!");
                 ParallelismConfig c;
                 try {
@@ -1280,6 +1284,12 @@ PYBIND11_MODULE(libth_transformer_config, m) {
                     c.use_ub_comm             = t[16].cast<bool>();
                     if (t.size() >= 18) {
                         c.role_type = t[17].cast<RoleType>();
+                    }
+                    if (t.size() >= 19) {
+                        c.pp_rank = t[18].cast<int64_t>();
+                    }
+                    if (t.size() >= 20) {
+                        c.pp_stage_layer_counts = t[19].cast<std::vector<int64_t>>();
                     }
                 } catch (const std::exception& e) {
                     throw std::runtime_error(std::string("ParallelismConfig unpickle error: ") + e.what());

--- a/rtp_llm/model_factory.py
+++ b/rtp_llm/model_factory.py
@@ -13,6 +13,7 @@ from rtp_llm.config.engine_config import EngineConfig, finalize_scheduler_config
 from rtp_llm.config.kv_cache_config import KVCacheConfig
 from rtp_llm.config.model_args import ModelArgs
 from rtp_llm.config.model_config import ModelConfig, build_model_config
+from rtp_llm.config.pp_layout import resolve_pp_partition
 from rtp_llm.config.py_config_modules import (
     EmbeddingConfig,
     GenerateEnvConfig,
@@ -399,6 +400,29 @@ class ModelFactory:
 
         # Set model_name to engine_config.runtime_config.model_name (for backward compatibility)
         engine_config.runtime_config.model_name = model_config.model_name
+
+        # Materialize the PP layer partition once (model_config.num_layers is
+        # final here) and ship it as data on ParallelismConfig: every
+        # downstream consumer — weight loading, model construction, C++
+        # cache geometry — reads the counts instead of re-deriving the
+        # partition rule. pp_size=1 stays untouched (zero behavior change).
+        parallelism_config = engine_config.parallelism_config
+        if (
+            parallelism_config.pp_size > 1
+            and not parallelism_config.pp_stage_layer_counts
+        ):
+            counts = resolve_pp_partition(
+                model_config.num_layers,
+                parallelism_config.pp_size,
+                model_config,
+            )
+            parallelism_config.pp_stage_layer_counts = counts
+            logging.info(
+                "PP layer partition materialized: num_layers=%d pp_size=%d counts=%s",
+                model_config.num_layers,
+                parallelism_config.pp_size,
+                counts,
+            )
 
     @staticmethod
     def create_propose_model_config(

--- a/rtp_llm/model_loader/load_config.py
+++ b/rtp_llm/model_loader/load_config.py
@@ -6,6 +6,11 @@ from typing import Any, List, Optional, Union
 import torch
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
+from rtp_llm.config.pp_layout import (
+    stage_has_embedding,
+    stage_has_lm_head,
+    stage_layer_range,
+)
 from rtp_llm.ops import VitSeparation
 from rtp_llm.utils.database import BaseDatabase
 from rtp_llm.utils.util import check_with_info
@@ -49,6 +54,15 @@ class LoadConfig(BaseModel):
     bit: int = 16
     merge_lora: bool = False
 
+    # PP stage identity, fed from ParallelismConfig (see
+    # ModelWeightInfo.create_load_config). Defaults keep single-stage
+    # behavior. The layer partition rides in as materialized per-stage
+    # counts (decided once by config/pp_layout.resolve_pp_partition);
+    # capability flags are computed by config/pp_layout.py.
+    pp_size: int = 1
+    pp_rank: int = 0
+    pp_stage_layer_counts: Optional[List[int]] = None
+
     compute_dtype: Any = torch.float16
 
     quant_algo: Any = None
@@ -79,6 +93,29 @@ class LoadConfig(BaseModel):
                 f"Field '{field_name}' expects type {expected}, got {type(value)}"
             )
         return value
+
+    # ---- PP stage view (single source: config/pp_layout.py) ----
+
+    def pp_layer_range(self) -> range:
+        """Global layer ids this stage loads: lookup over the materialized
+        partition; pp_size=1 is trivially all layers (single-stage
+        deployments never materialize)."""
+        return stage_layer_range(
+            self.num_layers, self.pp_size, self.pp_rank, self.pp_stage_layer_counts
+        )
+
+    def is_layer_in_pp_range(self, layer_id: int) -> bool:
+        return layer_id in self.pp_layer_range()
+
+    @property
+    def has_pp_embedding(self) -> bool:
+        """First stage loads embedding / positional embedding."""
+        return stage_has_embedding(self.pp_rank)
+
+    @property
+    def has_pp_lm_head(self) -> bool:
+        """Last stage loads lm_head / final layernorm."""
+        return stage_has_lm_head(self.pp_rank, self.pp_size)
 
     @model_validator(mode="after")
     def _set_default_phy2log(self) -> "LoadConfig":

--- a/rtp_llm/model_loader/loader.py
+++ b/rtp_llm/model_loader/loader.py
@@ -498,7 +498,9 @@ class ModelLoader:
 
     def prepare_weights(self, device: str):
         if not self._is_attn_model:
-            for id in range(self._load_config.num_layers):
+            # PP: only enumerate layers assigned to this stage
+            # (pp_size=1 -> full range, unchanged behavior).
+            for id in self._load_config.pp_layer_range():
                 results = self._load_layer_weights(id, device)
                 for name, tensor in results.items():
                     yield (id, name, tensor)
@@ -531,7 +533,9 @@ class ModelLoader:
         tensor_to_weight_map: Dict[str, WeightInfo] = {}
         weight_info_list: List[WeightInfo] = []
         if self._model_weights_info.layer_weights != []:
-            for layer_id in range(self._load_config.num_layers):
+            # PP: only enumerate layers assigned to this stage
+            # (pp_size=1 -> full range, unchanged behavior).
+            for layer_id in self._load_config.pp_layer_range():
                 layer_weights = self._model_weights_info.layer_weights[layer_id]
                 if isinstance(layer_weights, WeightModule):
                     # For CompositeWeight (e.g. MoeWithSharedWeight), split into
@@ -579,9 +583,20 @@ class ModelLoader:
     def _maybe_skip_weight(self, weight: WeightModule):
         if weight.name in self._global_weight_aliases:
             return True
-        if self._task_type == TaskType.LANGUAGE_MODEL:
-            return False
-        return weight.name in [W.lm_head]
+        if self._task_type != TaskType.LANGUAGE_MODEL and weight.name in [W.lm_head]:
+            return True
+        # PP capability filtering (config/pp_layout.py): embedding-family
+        # weights belong to the first stage only; lm_head / final layernorm
+        # belong to the last stage only.
+        # pp_size=1: both capabilities true -> nothing skipped.
+        name = weight.name or ""
+        if name in (W.embedding, W.positional_embedding):
+            return not self._load_config.has_pp_embedding
+        if name == W.lm_head or name.startswith("final_layernorm."):
+            return not self._load_config.has_pp_lm_head
+        # TODO(PP+MTP): multi_tokens_predict_* (MTP head) weights must be
+        # restricted to the last stage once PP+MTP lands.
+        return False
 
     @staticmethod
     def force_clean_cuda_memory():
@@ -744,15 +759,18 @@ class ModelLoader:
             )
 
         if self._task_type == TaskType.LANGUAGE_MODEL:
-            lm_head_w = weight.steal_global_weight(W.lm_head)
-            if lm_head_w == None:
-                lm_head_w = weight.global_weights[W.embedding]
-            if self._weights_info.model_config.normalize_lm_head_weight:
-                lm_head_w = F.normalize(lm_head_w)
-            logit_scale = self._weights_info.model_config.logit_scale
-            if logit_scale != 1.0:
-                lm_head_w = logit_scale * lm_head_w
-            weight.set_global_weight(W.lm_head, lm_head_w)
+            # PP: only the last stage owns lm_head; other stages must NOT fall
+            # back to embedding (that tie only makes sense where both exist).
+            if self._load_config.has_pp_lm_head:
+                lm_head_w = weight.steal_global_weight(W.lm_head)
+                if lm_head_w == None:
+                    lm_head_w = weight.global_weights[W.embedding]
+                if self._weights_info.model_config.normalize_lm_head_weight:
+                    lm_head_w = F.normalize(lm_head_w)
+                logit_scale = self._weights_info.model_config.logit_scale
+                if logit_scale != 1.0:
+                    lm_head_w = logit_scale * lm_head_w
+                weight.set_global_weight(W.lm_head, lm_head_w)
         else:
             # Some LLM can be used for other tasks, e.g. classification, in which case lm_head is not needed
             weight.steal_global_weight(W.lm_head)

--- a/rtp_llm/model_loader/model_weight_info.py
+++ b/rtp_llm/model_loader/model_weight_info.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
+from rtp_llm.config.pp_layout import derive_pp_rank
 from rtp_llm.config.quant_config import (
     Fp8PerTensorQuantConfig,
     ModelOptFp4Config,
@@ -213,6 +214,24 @@ class ModelDeployWeightInfo:
         self.ep_rank = parallelism_config.ep_rank
         self.dp_size = parallelism_config.dp_size
         self.dp_rank = parallelism_config.dp_rank
+        # Canonical pp_rank lives on ParallelismConfig (derived once in
+        # collective_torch._normalize_parallelism_ranks, PP outermost layout,
+        # matching NormalEngine::pp_step); the derive_pp_rank fallback covers
+        # fake configs (test mocks) that only carry sizes.
+        self.pp_size = max(int(getattr(parallelism_config, "pp_size", 1)), 1)
+        pp_rank = getattr(parallelism_config, "pp_rank", None)
+        if pp_rank is None:
+            pp_rank = derive_pp_rank(
+                getattr(parallelism_config, "world_rank", 0),
+                getattr(parallelism_config, "dp_size", 1),
+                getattr(parallelism_config, "tp_size", 1),
+            )
+        self.pp_rank = int(pp_rank)
+        # Materialized layer partition (decided once at startup by
+        # config/pp_layout.resolve_pp_partition). Empty/absent only on
+        # pp_size=1 or fake configs; pp>1 without it is a startup error.
+        pp_counts = getattr(parallelism_config, "pp_stage_layer_counts", None)
+        self.pp_stage_layer_counts = list(pp_counts) if pp_counts else None
         self.num_nodes: int = (
             parallelism_config.world_size // parallelism_config.local_world_size
         )
@@ -786,6 +805,10 @@ class ModelDeployWeightInfo:
             ep_rank=self.ep_rank,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
+            # PP stage identity from ParallelismConfig (see __init__).
+            pp_size=getattr(self, "pp_size", 1),
+            pp_rank=getattr(self, "pp_rank", 0),
+            pp_stage_layer_counts=getattr(self, "pp_stage_layer_counts", None),
             lm_head_tp_rank=self.lm_head_tp_rank,
             lm_head_tp_size=self.lm_head_tp_size,
             num_nodes=self.num_nodes,

--- a/rtp_llm/model_loader/test/BUILD
+++ b/rtp_llm/model_loader/test/BUILD
@@ -38,6 +38,12 @@ py_test(
 )
 
 py_test(
+    name = "test_pp_layer_filter",
+    srcs = ["test_pp_layer_filter.py"],
+    deps = py_test_deps,
+)
+
+py_test(
     name = "test_model_weight_info",
     srcs = ["test_model_weight_info.py"],
     deps = py_test_deps + [

--- a/rtp_llm/model_loader/test/test_pp_layer_filter.py
+++ b/rtp_llm/model_loader/test/test_pp_layer_filter.py
@@ -1,0 +1,290 @@
+# Unit tests for the PP layer filtering in the model loader
+# (LoadConfig.pp_layer_range / capability flags / _maybe_skip_weight).
+# These pin the layout decisions from config/pp_layout.py: the materialized
+# partition (pp_stage_layer_counts) consumed by lookup, the even-split
+# fallback, embedding on first stage, lm_head/final-layernorm on last
+# stage, and pp_size=1 degenerating to today's behavior (nothing filtered).
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from rtp_llm.config.pp_layout import (
+    even_split_counts,
+    get_pp_partitioner,
+    pp_layer_range_from_counts,
+    register_pp_partitioner,
+    resolve_pp_partition,
+)
+from rtp_llm.model_loader.load_config import LoadConfig
+from rtp_llm.model_loader.loader import ModelLoader
+from rtp_llm.ops import TaskType
+from rtp_llm.utils.database import BaseDatabase
+from rtp_llm.utils.model_weight import W
+
+
+def make_load_config(
+    num_layers: int = 8,
+    pp_size: int = 1,
+    pp_rank: int = 0,
+    pp_stage_layer_counts=None,
+) -> LoadConfig:
+    # Production materializes the partition at startup; fixtures do the
+    # same for pp>1 (default even split) unless a case supplies its own.
+    if pp_size > 1 and pp_stage_layer_counts is None:
+        pp_stage_layer_counts = even_split_counts(num_layers, pp_size)
+    database = MagicMock(spec=BaseDatabase)
+    return LoadConfig(
+        database=database,
+        num_layers=num_layers,
+        hidden_size=16,
+        head_num=4,
+        head_num_kv=4,
+        size_per_head=4,
+        moe_pure_tp_mode=False,
+        align_size=1,
+        moe_align_size=1,
+        moe_layer_index=[],
+        moe_n_group=0,
+        expert_num=0,
+        enable_eplb=False,
+        phy_exp_num=0,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        dp_size=1,
+        dp_rank=0,
+        lm_head_tp_size=1,
+        lm_head_tp_rank=0,
+        ffn_tp_size=1,
+        ffn_tp_rank=0,
+        num_nodes=1,
+        compute_dtype=torch.float16,
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        pp_stage_layer_counts=pp_stage_layer_counts,
+    )
+
+
+def make_loader(
+    load_config: LoadConfig, task_type=TaskType.LANGUAGE_MODEL
+) -> ModelLoader:
+    # Bypass __init__ (needs full model config); only the fields used by
+    # _maybe_skip_weight are required here.
+    loader = object.__new__(ModelLoader)
+    loader._task_type = task_type
+    loader._load_config = load_config
+    # Normally set in __init__ (global-weight-alias feature); empty = no aliases.
+    loader._global_weight_aliases = {}
+    return loader
+
+
+class FakeWeight:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class PPLayerRangeTest(unittest.TestCase):
+    def test_pp1_degenerate_full_range(self):
+        cfg = make_load_config(num_layers=8, pp_size=1, pp_rank=0)
+        self.assertEqual(list(cfg.pp_layer_range()), list(range(8)))
+
+    def test_ranges_tile_completely(self):
+        # Fixture defaults auto-materialize the even split, so this pins the
+        # tiling property of the production lookup path.
+        for num_layers, pp_size in [(1, 1), (7, 3), (64, 4), (61, 5)]:
+            covered = []
+            for pp_rank in range(pp_size):
+                cfg = make_load_config(
+                    num_layers=num_layers, pp_size=pp_size, pp_rank=pp_rank
+                )
+                covered.extend(cfg.pp_layer_range())
+            self.assertEqual(
+                covered, list(range(num_layers)), f"layers={num_layers} pp={pp_size}"
+            )
+
+    def test_capability_flags(self):
+        # pp=1: both capabilities true (degenerate).
+        cfg = make_load_config(pp_size=1, pp_rank=0)
+        self.assertTrue(cfg.has_pp_embedding)
+        self.assertTrue(cfg.has_pp_lm_head)
+        # pp=3: first only embedding, last only lm_head, middle neither.
+        flags = []
+        for pp_rank in range(3):
+            cfg = make_load_config(pp_size=3, pp_rank=pp_rank)
+            flags.append((cfg.has_pp_embedding, cfg.has_pp_lm_head))
+        self.assertEqual(flags, [(True, False), (False, False), (False, True)])
+
+
+class PPMaterializedPartitionTest(unittest.TestCase):
+    """The materialized partition (pp_stage_layer_counts) is consumed by
+    prefix-sum lookup; consumers never re-derive the partition."""
+
+    def test_lookup_follows_materialized_data(self):
+        # counts disagree with the even split of 8/2 on purpose: the lookup
+        # must follow the data.
+        stage0 = make_load_config(
+            num_layers=8, pp_size=2, pp_rank=0, pp_stage_layer_counts=[3, 5]
+        )
+        stage1 = make_load_config(
+            num_layers=8, pp_size=2, pp_rank=1, pp_stage_layer_counts=[3, 5]
+        )
+        self.assertEqual(list(stage0.pp_layer_range()), [0, 1, 2])
+        self.assertEqual(list(stage1.pp_layer_range()), [3, 4, 5, 6, 7])
+
+    def test_counts_materialized_even_split_matches_lookup(self):
+        # Production path: counts are the even split; the lookup reproduces
+        # the golden stage ranges.
+        expected = {
+            (65, 4): [(0, 17), (17, 33), (33, 49), (49, 65)],
+            (9, 2): [(0, 5), (5, 9)],
+            (64, 4): [(0, 16), (16, 32), (32, 48), (48, 64)],
+        }
+        for (num_layers, pp_size), ranges in expected.items():
+            counts = resolve_pp_partition(num_layers, pp_size)
+            for pp_rank in range(pp_size):
+                cfg = make_load_config(
+                    num_layers=num_layers,
+                    pp_size=pp_size,
+                    pp_rank=pp_rank,
+                    pp_stage_layer_counts=counts,
+                )
+                begin, end = ranges[pp_rank]
+                self.assertEqual(
+                    list(cfg.pp_layer_range()),
+                    list(range(begin, end)),
+                    f"layers={num_layers} pp={pp_size} rank={pp_rank}",
+                )
+
+    def test_pp_gt_1_without_counts_is_an_error(self):
+        # pp>1 must carry materialized data; no silent algorithm fallback.
+        cfg = make_load_config(
+            num_layers=8, pp_size=2, pp_rank=0, pp_stage_layer_counts=None
+        )
+        # The fixture auto-materializes by default; force the empty state.
+        cfg.pp_stage_layer_counts = None
+        with self.assertRaises(ValueError):
+            cfg.pp_layer_range()
+
+    def test_range_from_counts_rejects_bad_rank(self):
+        with self.assertRaises(ValueError):
+            pp_layer_range_from_counts([4, 4], 2)
+        with self.assertRaises(ValueError):
+            pp_layer_range_from_counts([4, 4], -1)
+
+
+class PPResolvePartitionTest(unittest.TestCase):
+    """resolve_pp_partition: default even split, validation, and the
+    model-level partitioner registry."""
+
+    def test_default_even_split_golden_values(self):
+        self.assertEqual(resolve_pp_partition(65, 4), [17, 16, 16, 16])
+        self.assertEqual(resolve_pp_partition(64, 4), [16, 16, 16, 16])
+        self.assertEqual(even_split_counts(9, 2), [5, 4])
+        self.assertEqual(resolve_pp_partition(64, 1), [64])
+
+    def test_rejects_bad_partitioner_output(self):
+        register_pp_partitioner("__bad_len__", lambda n, p, mc: [n])
+        try:
+            with self.assertRaises(ValueError):
+                resolve_pp_partition(8, 2, MagicMock(model_type="__bad_len__"))
+        finally:
+            self._unregister("__bad_len__")
+
+        register_pp_partitioner("__bad_sum__", lambda n, p, mc: [4, 5])
+        try:
+            with self.assertRaises(ValueError):
+                resolve_pp_partition(8, 2, MagicMock(model_type="__bad_sum__"))
+        finally:
+            self._unregister("__bad_sum__")
+
+        register_pp_partitioner("__bad_zero__", lambda n, p, mc: [8, 0])
+        try:
+            with self.assertRaises(ValueError):
+                resolve_pp_partition(8, 2, MagicMock(model_type="__bad_zero__"))
+        finally:
+            self._unregister("__bad_zero__")
+
+    def test_registered_partitioner_wins(self):
+        register_pp_partitioner("__shaped__", lambda n, p, mc: [2, 6])
+        try:
+            counts = resolve_pp_partition(8, 2, MagicMock(model_type="__shaped__"))
+            self.assertEqual(counts, [2, 6])
+            self.assertIsNotNone(get_pp_partitioner("__shaped__"))
+        finally:
+            self._unregister("__shaped__")
+        # Unregistered model type falls back to the even split.
+        self.assertIsNone(get_pp_partitioner("__shaped__"))
+        self.assertEqual(
+            resolve_pp_partition(8, 2, MagicMock(model_type="__other__")), [4, 4]
+        )
+
+    @staticmethod
+    def _unregister(model_type: str):
+        from rtp_llm.config import pp_layout
+
+        pp_layout._PP_PARTITIONERS.pop(model_type, None)
+
+
+class PPSkipWeightTest(unittest.TestCase):
+    GLOBAL_NAMES = [
+        W.embedding,
+        W.positional_embedding,
+        W.lm_head,
+        W.final_ln_gamma,
+        W.final_ln_beta,
+        "some_other_global",
+    ]
+
+    def skipped_names(
+        self, pp_size: int, pp_rank: int, task_type=TaskType.LANGUAGE_MODEL
+    ):
+        loader = make_loader(
+            make_load_config(pp_size=pp_size, pp_rank=pp_rank), task_type
+        )
+        return {
+            name
+            for name in self.GLOBAL_NAMES
+            if loader._maybe_skip_weight(FakeWeight(name))
+        }
+
+    def test_pp1_skips_nothing(self):
+        self.assertEqual(self.skipped_names(pp_size=1, pp_rank=0), set())
+
+    def test_first_stage_skips_tail_parts(self):
+        skipped = self.skipped_names(pp_size=2, pp_rank=0)
+        self.assertEqual(skipped, {W.lm_head, W.final_ln_gamma, W.final_ln_beta})
+        self.assertNotIn(W.embedding, skipped)
+
+    def test_last_stage_skips_head_parts(self):
+        skipped = self.skipped_names(pp_size=2, pp_rank=1)
+        self.assertEqual(skipped, {W.embedding, W.positional_embedding})
+        self.assertNotIn(W.lm_head, skipped)
+        self.assertNotIn(W.final_ln_gamma, skipped)
+
+    def test_middle_stage_skips_both_ends(self):
+        skipped = self.skipped_names(pp_size=3, pp_rank=1)
+        self.assertEqual(
+            skipped,
+            {
+                W.embedding,
+                W.positional_embedding,
+                W.lm_head,
+                W.final_ln_gamma,
+                W.final_ln_beta,
+            },
+        )
+
+    def test_non_lm_task_still_skips_lm_head(self):
+        # Existing behavior preserved: non-language-model tasks skip lm_head
+        # even on the last stage.
+        skipped = self.skipped_names(
+            pp_size=1, pp_rank=0, task_type=TaskType.DENSE_EMBEDDING
+        )
+        self.assertIn(W.lm_head, skipped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models/qwen3_next/qwen3_next.py
+++ b/rtp_llm/models/qwen3_next/qwen3_next.py
@@ -41,6 +41,9 @@ class Qwen3NextBase(BaseModel):
     def support_cuda_graph(self) -> bool:
         return True
 
+    def support_pp(self) -> bool:
+        return True
+
     @classmethod
     def _create_config(cls, ckpt_path: str) -> ModelConfig:
         config_path = os.path.join(ckpt_path, "config.json")

--- a/rtp_llm/models/qwen_v3.py
+++ b/rtp_llm/models/qwen_v3.py
@@ -1,13 +1,13 @@
 import logging
 from typing import Optional
 
-from rtp_llm.ops import TaskType
 from rtp_llm.model_factory_register import register_model
 from rtp_llm.models.downstream_modules.custom_module import CustomModule
 from rtp_llm.models.downstream_modules.reranker.qwen3_reranker import (
     Qwen3RerankerModule,
 )
 from rtp_llm.models.qwen_v2 import QWenV2, QWenV2Weight
+from rtp_llm.ops import TaskType
 
 
 class QWenV3Weight(QWenV2Weight):
@@ -17,6 +17,9 @@ class QWenV3Weight(QWenV2Weight):
 
 
 class QwenV3(QWenV2):
+    def support_pp(self) -> bool:
+        return True
+
     @staticmethod
     def get_weight_cls():
         return QWenV3Weight

--- a/rtp_llm/models_py/bindings/OpDefs.cc
+++ b/rtp_llm/models_py/bindings/OpDefs.cc
@@ -54,7 +54,7 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_readwrite("kv_cache_base", &LayerKVCache::kv_cache_base, "Key/value cache tensor (per-layer view)")
         .def_readwrite("kv_scale_base", &LayerKVCache::kv_scale_base, "Key/value cache scale tensor")
         .def_readonly("seq_size_per_block", &LayerKVCache::seq_size_per_block, "Sequence size per block")
-        .def_readonly("layer_id", &LayerKVCache::layer_id, "Global layer id")
+        .def_readonly("layer_id", &LayerKVCache::layer_id, "Model-local layer id")
         .def_readonly("group_id", &LayerKVCache::group_id, "Cache group id (-1 = default)")
         .def_readonly("tag", &LayerKVCache::tag, "Cache group tag");
 
@@ -63,7 +63,7 @@ void registerPyOpDefs(pybind11::module& m) {
         .def_property_readonly("layer_count", &KVCache::layerCount, "Number of model-local cache layers")
         .def("get_layer_cache",
              static_cast<LayerKVCache (KVCache::*)(int) const>(&KVCache::getLayerCache),
-             "Return a per-layer LayerKVCache for the given global layer id")
+             "Return a per-layer LayerKVCache for the given model-local layer id")
         .def("get_layer_cache",
              static_cast<LayerKVCache (KVCache::*)(int, const std::string&) const>(&KVCache::getLayerCache),
              "Return a LayerKVCache for the given layer and tag")
@@ -273,14 +273,19 @@ void registerPyOpDefs(pybind11::module& m) {
             "A PyAttentionInputs value or a tag-to-PyAttentionInputs mapping")
         .def_readwrite(
             "bert_embedding_inputs", &PyModelInputs::bert_embedding_inputs, "BERT embedding inputs structure")
-        .def_readwrite(
-            "dspark_call_phase", &PyModelInputs::dspark_call_phase, "Explicit DSpARK proposal/commit phase");
+        .def_readwrite("dspark_call_phase", &PyModelInputs::dspark_call_phase, "Explicit DSpARK proposal/commit phase")
+        .def_readwrite("pp_intermediates",
+                       &PyModelInputs::pp_intermediates,
+                       "PP stage-boundary tensors from the upstream stage (empty under pp_size=1)");
 
     pybind11::class_<PyModelOutputs>(m, "PyModelOutputs")
         .def(pybind11::init<>(), "Default constructor")
         .def(pybind11::init<torch::Tensor>(), pybind11::arg("hidden_states"), "Initialize with hidden states tensor")
         .def_readwrite("hidden_states", &PyModelOutputs::hidden_states, "Hidden states output tensor")
-        .def_readwrite("draft_tokens", &PyModelOutputs::draft_tokens, "Optional [batch, gamma] DSpARK draft tokens");
+        .def_readwrite("draft_tokens", &PyModelOutputs::draft_tokens, "Optional [batch, gamma] DSpARK draft tokens")
+        .def_readwrite("pp_intermediates",
+                       &PyModelOutputs::pp_intermediates,
+                       "PP stage-boundary tensors to send to the downstream stage (empty on last stage)");
 }
 
 }  // namespace torch_ext

--- a/rtp_llm/models_py/bindings/OpDefs.h
+++ b/rtp_llm/models_py/bindings/OpDefs.h
@@ -51,8 +51,11 @@ struct LayerKVCache {
         tag(std::move(tag)) {}
 };
 
-// Whole-model KV cache holding tensors for all layers.
-// Call getLayerCache(global_layer_id) to obtain a per-layer LayerKVCache.
+// Whole-model KV cache holding tensors for all layers owned by this rank.
+// Layer ids are model-local (0..layerCount()-1): under pipeline parallelism
+// each rank's layout is projected to its own stage layers, so a layer's local
+// id may differ from its global id. Call getLayerCache(local_layer_id) to
+// obtain a per-layer LayerKVCache.
 class KVCache {
 public:
     explicit KVCache(rtp_llm::GroupedCacheLayerLayout grouped_layout): grouped_layout_(std::move(grouped_layout)) {}
@@ -348,6 +351,11 @@ struct PyMultimodalInputs {
 
 using AttentionInputsByTag = std::map<std::string, PyAttentionInputs>;
 
+// PP stage-boundary tensors, carried verbatim from PPIntermediateTensors.
+// Keys are model-defined; fused-residual models use "hidden_states" +
+// "residual", naive-add models use a single key.
+using PPIntermediates = std::map<std::string, torch::Tensor>;
+
 struct PyModelInputs {
     torch::Tensor      input_ids;
     torch::Tensor      input_hiddens;
@@ -360,9 +368,13 @@ struct PyModelInputs {
     AttentionInputsByTag attention_inputs_by_tag;
     BertEmbeddingInputs  bert_embedding_inputs;
     // Only interpreted by a DSpARK draft model. All other models leave NONE.
-    // Kept last so PyModelInputs stays an aggregate: existing brace-init sites
-    // that pass 8 members keep compiling and may append a 9th value.
+    // Kept second-to-last so PyModelInputs stays an aggregate: existing
+    // brace-init sites that pass 8/9 members keep compiling and may append a
+    // 10th value.
     rtp_llm::DSparkCallPhase dspark_call_phase = rtp_llm::DSparkCallPhase::NONE;
+    // PP: stage-boundary tensors received from the upstream stage; empty
+    // under pp_size=1.
+    PPIntermediates pp_intermediates;
 
     bool hasAttentionInputsByTag() const {
         return !attention_inputs_by_tag.empty();
@@ -375,6 +387,10 @@ struct PyModelOutputs {
     // sampling consumes these as an implicit point mass, so no per-vocab
     // draft probabilities cross this boundary.
     torch::Tensor draft_tokens;
+    // PP: non-last stages return their stage-boundary tensors here;
+    // PyWrappedModel::forwardPP packs them for transport. Empty under
+    // pp_size=1 and on the last stage.
+    PPIntermediates pp_intermediates;
 
     PyModelOutputs() = default;
 

--- a/rtp_llm/models_py/bindings/core/ExecOps.cc
+++ b/rtp_llm/models_py/bindings/core/ExecOps.cc
@@ -614,11 +614,12 @@ namespace {
 std::mutex g_comm_mutex;
 
 // Avoid destroying static Python objects after interpreter finalization.
-py::function* g_broadcast_fn = nullptr;
-py::function* g_allreduce_fn = nullptr;
-py::function* g_allgather_fn = nullptr;
-py::function* g_isend_fn     = nullptr;
-py::function* g_irecv_fn     = nullptr;
+py::function* g_broadcast_fn            = nullptr;
+py::function* g_allreduce_fn            = nullptr;
+py::function* g_allgather_fn            = nullptr;
+py::function* g_isend_fn                = nullptr;
+py::function* g_irecv_fn                = nullptr;
+py::function* g_pp_snapshot_exchange_fn = nullptr;
 
 void clearCommOpsUnlocked() {
     py::function broadcast_fn;
@@ -641,9 +642,12 @@ void clearCommOpsUnlocked() {
     }
 }
 
-void clearP2POpsUnlocked() {
+// PP callbacks (P2P tensor transport + startup snapshot exchange) share one
+// lifecycle: registered together via register_pp_ops, cleared via clear_pp_ops.
+void clearPPOpsUnlocked() {
     py::function isend_fn;
     py::function irecv_fn;
+    py::function pp_snapshot_exchange_fn;
     if (g_isend_fn != nullptr) {
         isend_fn = std::move(*g_isend_fn);
         delete g_isend_fn;
@@ -653,6 +657,11 @@ void clearP2POpsUnlocked() {
         irecv_fn = std::move(*g_irecv_fn);
         delete g_irecv_fn;
         g_irecv_fn = nullptr;
+    }
+    if (g_pp_snapshot_exchange_fn != nullptr) {
+        pp_snapshot_exchange_fn = std::move(*g_pp_snapshot_exchange_fn);
+        delete g_pp_snapshot_exchange_fn;
+        g_pp_snapshot_exchange_fn = nullptr;
     }
 }
 
@@ -690,7 +699,7 @@ runP2PCallback(const torch::Tensor& tensor, int global_peer, py::function** call
         }
     }
     RTP_LLM_CHECK_WITH_INFO(
-        static_cast<bool>(fn), "%s called but its callback is not registered via register_p2p_ops", callback_name);
+        static_cast<bool>(fn), "%s called but its callback is not registered via register_pp_ops", callback_name);
     py::object work = fn(tensor, global_peer);
     RTP_LLM_CHECK_WITH_INFO(!work.is_none(), "%s callback returned None", callback_name);
     RTP_LLM_CHECK_WITH_INFO(py::hasattr(work, "wait"), "%s callback returned an object without wait()", callback_name);
@@ -788,6 +797,22 @@ std::unique_ptr<P2PWork> execISend(const torch::Tensor& tensor, int global_peer)
 
 std::unique_ptr<P2PWork> execIRecv(torch::Tensor& tensor, int global_peer) {
     return runP2PCallback(tensor, global_peer, &g_irecv_fn, "execIRecv");
+}
+
+std::vector<std::string> execPPSnapshotExchange(const std::string& local_snapshot) {
+    py::function           fn;
+    py::gil_scoped_acquire gil;
+    {
+        std::lock_guard<std::mutex> lock(g_comm_mutex);
+        if (g_pp_snapshot_exchange_fn != nullptr) {
+            fn = *g_pp_snapshot_exchange_fn;
+        }
+    }
+    RTP_LLM_CHECK_WITH_INFO(static_cast<bool>(fn),
+                            "execPPSnapshotExchange called but PP snapshot callback not registered via "
+                            "register_pp_ops (collective_torch registers it when pp_size > 1)");
+    py::object result = fn(py::bytes(local_snapshot));
+    return result.cast<std::vector<std::string>>();
 }
 
 void execSyncCommunication(bool timeout) {
@@ -898,15 +923,19 @@ void registerExecCtxOps(pybind11::module& m) {
         "Register Python callbacks for C++ communication ops.");
 
     m.def(
-        "register_p2p_ops",
-        [](py::function isend_fn, py::function irecv_fn) {
+        "register_pp_ops",
+        [](py::function isend_fn, py::function irecv_fn, py::function pp_snapshot_exchange_fn) {
             std::lock_guard<std::mutex> lock(g_comm_mutex);
-            clearP2POpsUnlocked();
-            g_isend_fn = new py::function(std::move(isend_fn));
-            g_irecv_fn = new py::function(std::move(irecv_fn));
+            clearPPOpsUnlocked();
+            g_isend_fn                = new py::function(std::move(isend_fn));
+            g_irecv_fn                = new py::function(std::move(irecv_fn));
+            g_pp_snapshot_exchange_fn = new py::function(std::move(pp_snapshot_exchange_fn));
         },
         py::arg("isend_fn"),
-        py::arg("irecv_fn"));
+        py::arg("irecv_fn"),
+        py::arg("pp_snapshot_exchange_fn"),
+        "Register all PP communication callbacks: P2P tensor transport "
+        "(isend/irecv) and the startup snapshot exchange.");
 
     m.def(
         "clear_comm_ops",
@@ -916,10 +945,13 @@ void registerExecCtxOps(pybind11::module& m) {
         },
         "Clear registered Python communication callbacks.");
 
-    m.def("clear_p2p_ops", []() {
-        std::lock_guard<std::mutex> lock(g_comm_mutex);
-        clearP2POpsUnlocked();
-    });
+    m.def(
+        "clear_pp_ops",
+        []() {
+            std::lock_guard<std::mutex> lock(g_comm_mutex);
+            clearPPOpsUnlocked();
+        },
+        "Clear registered PP communication callbacks.");
 
     m.def(
         "init_cpu_tp_broadcaster",

--- a/rtp_llm/models_py/bindings/core/ExecOps.h
+++ b/rtp_llm/models_py/bindings/core/ExecOps.h
@@ -123,6 +123,12 @@ public:
 std::unique_ptr<P2PWork> execISend(const torch::Tensor& tensor, int global_peer);
 std::unique_ptr<P2PWork> execIRecv(torch::Tensor& tensor, int global_peer);
 
+// PP: exchanges the serialized stage cache snapshot with every PP stage
+// (all_gather_object over the PP process group) and returns all payloads in
+// stage (pp_rank) order. Startup-only; registered via register_pp_ops from
+// collective_torch. Requires pp_size > 1.
+std::vector<std::string> execPPSnapshotExchange(const std::string& local_snapshot);
+
 // ===================================================================
 // MOE / EPLB
 // ===================================================================

--- a/rtp_llm/models_py/bindings/core/OpData.h
+++ b/rtp_llm/models_py/bindings/core/OpData.h
@@ -8,6 +8,7 @@
 #include "rtp_llm/models_py/bindings/ParamsBase.h"
 #include "rtp_llm/models_py/bindings/core/DSparkCallPhase.h"
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <string>
 #include <memory>
@@ -19,8 +20,12 @@
 namespace rtp_llm {
 
 enum class ParallelMode {
-    TP        = 0,
-    DP        = 1,
+    TP = 0,
+    DP = 1,
+    // TODO(naming debt): legacy name from the pre-PP era; the actual
+    // semantics are WORLD (spans ALL ranks including every PP stage). Do not
+    // "narrow" it per stage; rename to ALL/WORLD when this enum is next
+    // touched (requires coordinated pybind/Python/callsite rename).
     DP_AND_TP = 2,
     FFN_TP    = 3,
     EP        = 4,
@@ -35,15 +40,15 @@ struct GptModelInputs {
     // shape [decoder_batch_size + context_batch_size], int32
     // sequence_lengths holds current sequence length for incremental decoding requests,
     // shape [decoder_batch_size], int32
-    mutable torch::Tensor combo_tokens;             // [cumulated_seq_len]
-    torch::Tensor         input_lengths;            // [batch_size]
-    torch::Tensor         sequence_lengths;         // [decoder_batch_size]
-    torch::Tensor         lm_output_indexes;        // selected output rows
+    mutable torch::Tensor combo_tokens;       // [cumulated_seq_len]
+    torch::Tensor         input_lengths;      // [batch_size]
+    torch::Tensor         sequence_lengths;   // [decoder_batch_size]
+    torch::Tensor         lm_output_indexes;  // selected output rows
     // Kept for ModelInputsLogger/legacy micro-batch consumers; the async
     // scheduling redesign no longer populates it (stays undefined).
-    torch::Tensor         lm_output_lengths;        // [total_batch_size]
-    torch::Tensor         prefix_lengths;           // [context_batch_size]
-    torch::Tensor         sequence_lengths_plus_1;  // optional CUDA mirror for target-verify linear attention
+    torch::Tensor lm_output_lengths;        // [total_batch_size]
+    torch::Tensor prefix_lengths;           // [context_batch_size]
+    torch::Tensor sequence_lengths_plus_1;  // optional CUDA mirror for target-verify linear attention
 
     torch::Tensor combo_tokens_type_ids;  // [cumulated_seq_len]
     torch::Tensor combo_position_ids;     // [cumulated_seq_len]
@@ -101,6 +106,11 @@ struct GptModelInputs {
     // Only interpreted by a DSpARK draft model. All other models leave NONE.
     DSparkCallPhase dspark_call_phase = DSparkCallPhase::NONE;
 
+    // PP: stage-boundary tensors received from the upstream stage, populated
+    // by PyWrappedModel::forwardPP. NOT part of shape hints / tpSync packing
+    // (tpSyncModelInputs enumerates fields explicitly). Empty under pp_size=1.
+    std::map<std::string, torch::Tensor> pp_intermediates;
+
     // not sync to other tp rank
     std::vector<std::string> trace_ids;
 
@@ -121,6 +131,11 @@ struct GptModelOutputs {
     torch::Tensor draft_tokens;
 
     std::vector<torch::Tensor> moe_gating;
+
+    // PP: stage-boundary tensors emitted by the model on a non-last stage;
+    // PyWrappedModel::forwardPP packs them for the downstream stage. Kept
+    // last so existing brace-init sites keep compiling.
+    std::map<std::string, torch::Tensor> pp_intermediates;
 };
 
 struct CopyParams {

--- a/rtp_llm/models_py/distributed/collective_torch.py
+++ b/rtp_llm/models_py/distributed/collective_torch.py
@@ -25,6 +25,11 @@ class Group(Enum):
 
     DP = "DP"
     TP = "TP"
+    PP = "PP"
+    # Legacy name from the pre-PP era: DP_AND_TP is bound to
+    # torch.distributed WORLD, so it spans ALL ranks including every PP
+    # stage. Do not "narrow" it per stage; rename to ALL/WORLD together with
+    # C++ ParallelMode the next time it is touched.
     DP_AND_TP = "DP_AND_TP"
 
 
@@ -77,8 +82,11 @@ def _make_cpu_tp_broadcaster_base_path(
             os.environ.get("TMPDIR", "/tmp"), f"rtp_llm_{os.getuid()}"
         )
     os.makedirs(base_dir, mode=0o700, exist_ok=True)
+    # pp_rank disambiguates the TP groups of different PP stages (they share
+    # dp_rank under the PP gate); pp_rank is 0 when pp_size == 1.
     base_path = os.path.join(
-        base_dir, f"rtp_llm_tp_{session_id}_dp{parallelism_config.dp_rank}"
+        base_dir,
+        f"rtp_llm_tp_{session_id}_pp{parallelism_config.pp_rank}_dp{parallelism_config.dp_rank}",
     )
     rank0_path = f"{base_path}_0.sock"
     if len(os.fsencode(rank0_path)) >= _UDS_SUN_PATH_LIMIT:
@@ -96,7 +104,13 @@ def _normalize_parallelism_ranks(parallelism_config: ParallelismConfig) -> None:
         old_tp_rank = parallelism_config.tp_rank
         old_dp_rank = parallelism_config.dp_rank
         tp_rank = parallelism_config.world_rank % parallelism_config.tp_size
-        dp_rank = parallelism_config.world_rank // parallelism_config.tp_size
+        # Layout is PP-outermost (world_rank = pp_rank*(dp*tp) + dp_rank*tp +
+        # tp_rank): the extra "% dp_size" strips the pp component so dp_rank
+        # stays correct when pp_size > 1. With pp_size == 1 it reduces to the
+        # historical (world_rank // tp_size), so non-PP behavior is unchanged.
+        dp_rank = (parallelism_config.world_rank // parallelism_config.tp_size) % max(
+            parallelism_config.dp_size, 1
+        )
         if (old_tp_rank, old_dp_rank) != (tp_rank, dp_rank):
             logging.warning(
                 "Normalize ParallelismConfig ranks from tp_rank=%s, dp_rank=%s "
@@ -110,6 +124,15 @@ def _normalize_parallelism_ranks(parallelism_config: ParallelismConfig) -> None:
             )
         parallelism_config.tp_rank = tp_rank
         parallelism_config.dp_rank = dp_rank
+
+    # PP stage id: PP is the outermost dim of the world-rank layout
+    # (world_rank = pp_rank * (dp_size * tp_size) + ...), matching
+    # NormalEngine::pp_step. Under the PP gate (dp_size == 1) this is
+    # equivalent to (world_rank // tp_size) % pp_size.
+    if parallelism_config.pp_size > 0:
+        parallelism_config.pp_rank = parallelism_config.world_rank // (
+            parallelism_config.dp_size * parallelism_config.tp_size
+        )
 
 
 def init_distributed_environment(
@@ -236,62 +259,125 @@ def _create_process_groups(
     world_size = parallelism_config.world_size
     tp_size = parallelism_config.tp_size
     dp_size = parallelism_config.dp_size
+    # PP is the outermost dim of the world-rank layout (world_rank =
+    # pp_rank*(dp*tp) + dp_rank*tp + tp_rank), matching
+    # _normalize_parallelism_ranks. Group membership must pin the pp
+    # component: a TP/DP collective under PP must stay inside one stage,
+    # otherwise stage-local collectives (e.g. tpSyncModelInputs broadcasts)
+    # would wait forever on ranks of other stages. With pp_size == 1 every
+    # formula and key reduces to the historical one.
+    pp_size = max(parallelism_config.pp_size, 1)
 
     if dp_size > 1 and world_size != dp_size:
         # Create all DP groups - all ranks must participate in creating all DP groups
-        # DP group: ranks with the same tp_rank (i.e., world_rank % tp_size)
-        # There are tp_size DP groups (one for each tp_rank value)
-        for tp_rank_val in range(tp_size):
-            dp_ranks = [r for r in range(world_size) if r % tp_size == tp_rank_val]
-            if len(dp_ranks) > 0:
-                logging.info(
-                    f"[rank: {world_rank}] Creating DP group for tp_rank {tp_rank_val} with ranks: {dp_ranks}"
-                )
-                dp_group = torch.distributed.new_group(
-                    ranks=dp_ranks,
-                    backend=backend,
-                    timeout=timedelta(days=36500),
-                )
-                # Only store the group if this rank is part of it
-                if world_rank in dp_ranks:
-                    group_key = Group.DP.name + str(tp_rank_val)
-                    _group_map[group_key] = dp_group
+        # DP group: ranks with the same pp_rank and tp_rank.
+        # There are pp_size*tp_size DP groups; the key suffix
+        # (pp_rank*tp_size + tp_rank) reduces to tp_rank when pp_size == 1.
+        for pp_rank_val in range(pp_size):
+            for tp_rank_val in range(tp_size):
+                dp_ranks = [
+                    r
+                    for r in range(world_size)
+                    if r % tp_size == tp_rank_val
+                    and r // (tp_size * dp_size) == pp_rank_val
+                ]
+                if len(dp_ranks) > 0:
                     logging.info(
-                        f"[rank: {world_rank}] Stored DP group with key: {group_key} {dp_group} with ranks: {dp_ranks}"
+                        f"[rank: {world_rank}] Creating DP group for pp_rank {pp_rank_val}, "
+                        f"tp_rank {tp_rank_val} with ranks: {dp_ranks}"
                     )
-                # All ranks must wait for group creation to complete
-                torch.distributed.barrier()
+                    dp_group = torch.distributed.new_group(
+                        ranks=dp_ranks,
+                        backend=backend,
+                        timeout=timedelta(days=36500),
+                    )
+                    # Only store the group if this rank is part of it
+                    if world_rank in dp_ranks:
+                        group_key = Group.DP.name + str(
+                            pp_rank_val * tp_size + tp_rank_val
+                        )
+                        _group_map[group_key] = dp_group
+                        logging.info(
+                            f"[rank: {world_rank}] Stored DP group with key: {group_key} {dp_group} with ranks: {dp_ranks}"
+                        )
+                    # All ranks must wait for group creation to complete
+                    torch.distributed.barrier()
 
     if tp_size > 1 and world_size != tp_size:
         # Create all TP groups - all ranks must participate in creating all TP groups
-        # TP group: ranks with the same dp_rank (i.e., world_rank // tp_size)
-        # There are dp_size TP groups (one for each dp_rank value)
-        for dp_rank_val in range(dp_size):
-            tp_ranks = [r for r in range(world_size) if r // tp_size == dp_rank_val]
-            if len(tp_ranks) > 0:
-                logging.info(
-                    f"[rank: {world_rank}] Creating TP group for dp_rank {dp_rank_val} with ranks: {tp_ranks}"
-                )
-                tp_group = torch.distributed.new_group(
-                    ranks=tp_ranks,
-                    backend=backend,
-                    timeout=timedelta(days=36500),
-                )
-                # Only store the group if this rank is part of it
-                if world_rank in tp_ranks:
-                    group_key = Group.TP.name + str(dp_rank_val)
-                    _group_map[group_key] = tp_group
+        # TP group: ranks with the same pp_rank and dp_rank.
+        # There are pp_size*dp_size TP groups; the key suffix
+        # (pp_rank*dp_size + dp_rank) equals world_rank // tp_size, so
+        # key-derivation callsites (_get_group / C++ registration) keep
+        # working unchanged.
+        for pp_rank_val in range(pp_size):
+            for dp_rank_val in range(dp_size):
+                tp_ranks = [
+                    r
+                    for r in range(world_size)
+                    if r // tp_size == pp_rank_val * dp_size + dp_rank_val
+                ]
+                if len(tp_ranks) > 0:
                     logging.info(
-                        f"[rank: {world_rank}] Stored TP group with key: {group_key} {tp_group} with ranks: {tp_ranks}"
+                        f"[rank: {world_rank}] Creating TP group for pp_rank {pp_rank_val}, "
+                        f"dp_rank {dp_rank_val} with ranks: {tp_ranks}"
                     )
+                    tp_group = torch.distributed.new_group(
+                        ranks=tp_ranks,
+                        backend=backend,
+                        timeout=timedelta(days=36500),
+                    )
+                    # Only store the group if this rank is part of it
+                    if world_rank in tp_ranks:
+                        group_key = Group.TP.name + str(
+                            pp_rank_val * dp_size + dp_rank_val
+                        )
+                        _group_map[group_key] = tp_group
+                        logging.info(
+                            f"[rank: {world_rank}] Stored TP group with key: {group_key} {tp_group} with ranks: {tp_ranks}"
+                        )
+                        # symm_mem fast path is per-member; only init for a
+                        # group this rank actually joins.
+                        _get_symm_mem().init_symm_mem_communicator(tp_group)
 
-                _get_symm_mem().init_symm_mem_communicator(tp_group)
-
-                # All ranks must wait for group creation to complete
-                torch.distributed.barrier()
+                    # All ranks must wait for group creation to complete
+                    torch.distributed.barrier()
     elif tp_size > 1 and world_size == tp_size:
         # Single TP group: WORLD is the TP group, init symm_mem for it
         _get_symm_mem().init_symm_mem_communicator(torch.distributed.group.WORLD)
+
+    if pp_size > 1:
+        # PP groups: ranks of the same (dp_rank, tp_rank) lane across stages.
+        # Consumed by the PP startup snapshot exchange and the PP transport
+        # P2P bootstrap; kept out of the C++ ParallelMode mapping (no mode
+        # enum change) until a C++ consumer exists.
+        for dp_rank_val in range(dp_size):
+            for tp_rank_val in range(tp_size):
+                pp_ranks = [
+                    r
+                    for r in range(world_size)
+                    if r % tp_size == tp_rank_val
+                    and (r // tp_size) % dp_size == dp_rank_val
+                ]
+                if len(pp_ranks) > 0:
+                    logging.info(
+                        f"[rank: {world_rank}] Creating PP group for dp_rank {dp_rank_val}, "
+                        f"tp_rank {tp_rank_val} with ranks: {pp_ranks}"
+                    )
+                    pp_group = torch.distributed.new_group(
+                        ranks=pp_ranks,
+                        backend=backend,
+                        timeout=timedelta(days=36500),
+                    )
+                    if world_rank in pp_ranks:
+                        group_key = Group.PP.name + str(
+                            dp_rank_val * tp_size + tp_rank_val
+                        )
+                        _group_map[group_key] = pp_group
+                        logging.info(
+                            f"[rank: {world_rank}] Stored PP group with key: {group_key} {pp_group} with ranks: {pp_ranks}"
+                        )
+                    torch.distributed.barrier()
 
 
 def _register_process_groups_to_cpp():
@@ -334,8 +420,17 @@ def _register_process_groups_to_cpp():
                         registered_modes.add(_CPP_PARALLEL_MODE_TP)
             elif group_key.startswith(Group.DP.name):
                 if _parallelism_config is not None:
-                    tp_rank = torch.distributed.get_rank() % _parallelism_config.tp_size
-                    expected_key = Group.DP.name + str(tp_rank)
+                    rank = torch.distributed.get_rank()
+                    tp_rank = rank % _parallelism_config.tp_size
+                    # PP-outermost layout: the DP key suffix is
+                    # pp_rank*tp_size + tp_rank (reduces to tp_rank at pp=1),
+                    # matching _create_process_groups.
+                    pp_rank = rank // (
+                        _parallelism_config.tp_size * _parallelism_config.dp_size
+                    )
+                    expected_key = Group.DP.name + str(
+                        pp_rank * _parallelism_config.tp_size + tp_rank
+                    )
                     if (
                         group_key == expected_key
                         and _CPP_PARALLEL_MODE_DP not in registered_modes
@@ -489,6 +584,17 @@ def _register_process_groups_to_cpp():
         f"Registered C++ comm ops callbacks (modes: {list(mode_to_group.keys())})"
     )
 
+    # PP communication callbacks: P2P tensor transport plus the startup
+    # snapshot exchange for the cross-stage cache geometry validator.
+    # Registered together as one lifecycle via the unified entry.
+    if (
+        hasattr(librtp_compute_ops, "register_pp_ops")
+        and _parallelism_config is not None
+        and _parallelism_config.pp_size > 1
+    ):
+        register_pp_process_group(_get_group(Group.PP))
+        logging.info("Registered PP communication callbacks (p2p + snapshot exchange)")
+
     # Bootstrap the UDS-backed intra-node TP broadcaster right after new_group.
     # Lazy C++ init can race if a peer reaches tpSyncModelInputs before rank 0
     # binds; cross-node TP keeps the NCCL fallback.
@@ -513,18 +619,38 @@ def _register_process_groups_to_cpp():
         )
 
 
-def register_p2p_process_group(
+def register_pp_process_group(
     process_group: torch.distributed.ProcessGroup,
 ) -> None:
+    """Register all PP communication callbacks in one call.
+
+    - isend/irecv bind the passed group (used by the PP transport). torch
+      isend/irecv take GROUP-LOCAL ranks as peer; groups are built from
+      ascending world ranks, so the global->local mapping is the member
+      array index.
+    - The snapshot exchange is always fixed to the PP lane group:
+      the all_gather must span every stage of the same lane.
+    """
     import librtp_compute_ops
 
-    if not hasattr(librtp_compute_ops, "register_p2p_ops"):
-        raise RuntimeError("register_p2p_ops is not available")
+    if not hasattr(librtp_compute_ops, "register_pp_ops"):
+        raise RuntimeError("register_pp_ops is not available")
+
+    group_ranks = torch.distributed.get_process_group_ranks(process_group)
+
+    def _to_local_peer(global_peer: int) -> int:
+        try:
+            return group_ranks.index(global_peer)
+        except ValueError:
+            raise RuntimeError(
+                f"global peer {global_peer} is not a member of the PP "
+                f"transport group {group_ranks}"
+            )
 
     def cpp_isend(tensor: torch.Tensor, global_peer: int):
         work = torch.distributed.isend(
             tensor,
-            dst=global_peer,
+            dst=_to_local_peer(global_peer),
             group=process_group,
         )
         if work is None:
@@ -534,24 +660,34 @@ def register_p2p_process_group(
     def cpp_irecv(tensor: torch.Tensor, global_peer: int):
         work = torch.distributed.irecv(
             tensor,
-            src=global_peer,
+            src=_to_local_peer(global_peer),
             group=process_group,
         )
         if work is None:
             raise RuntimeError("irecv returned no work")
         return work
 
-    librtp_compute_ops.register_p2p_ops(cpp_isend, cpp_irecv)
+    # Startup snapshot exchange for the cross-stage cache geometry validator.
+    # all_gather_object preserves group-rank order; PP group members are the
+    # ascending world ranks of one (dp, tp) lane, so the returned list is
+    # indexed by pp_rank (stage order).
+    def cpp_pp_snapshot_exchange(snapshot_bytes: bytes) -> List[bytes]:
+        pg = _get_group(Group.PP)
+        payloads: List[bytes] = [b""] * pg.size()
+        torch.distributed.all_gather_object(payloads, snapshot_bytes, group=pg)
+        return payloads
+
+    librtp_compute_ops.register_pp_ops(cpp_isend, cpp_irecv, cpp_pp_snapshot_exchange)
 
 
-def unregister_p2p_process_group() -> None:
+def unregister_pp_process_group() -> None:
     try:
         import librtp_compute_ops
     except ImportError:
         return
 
-    if hasattr(librtp_compute_ops, "clear_p2p_ops"):
-        librtp_compute_ops.clear_p2p_ops()
+    if hasattr(librtp_compute_ops, "clear_pp_ops"):
+        librtp_compute_ops.clear_pp_ops()
 
 
 def distributed_environment_initialized() -> bool:
@@ -607,7 +743,7 @@ def destroy_distributed_environment():
 
         destroy_user_buffers_communicator()
 
-    unregister_p2p_process_group()
+    unregister_pp_process_group()
 
     try:
         import librtp_compute_ops
@@ -673,13 +809,22 @@ def _get_group(group: Group) -> torch.distributed.ProcessGroup:
     group_key = group
     tp_size = _parallelism_config.tp_size
     dp_size = _parallelism_config.dp_size
+    pp_size = max(_parallelism_config.pp_size, 1)
     world_size = _parallelism_config.world_size
+    rank = torch.distributed.get_rank()
     if group == Group.DP and dp_size > 1 and world_size != dp_size:
-        tp_rank = torch.distributed.get_rank() % tp_size
-        group_key = Group.DP.name + str(tp_rank)
+        tp_rank = rank % tp_size
+        pp_rank = rank // (tp_size * dp_size)
+        group_key = Group.DP.name + str(pp_rank * tp_size + tp_rank)
     elif group == Group.TP and tp_size > 1 and world_size != tp_size:
-        dp_rank = torch.distributed.get_rank() // tp_size
+        # Key suffix == rank // tp_size == pp_rank*dp_size + dp_rank
+        # (matches _create_process_groups).
+        dp_rank = rank // tp_size
         group_key = Group.TP.name + str(dp_rank)
+    elif group == Group.PP and pp_size > 1:
+        tp_rank = rank % tp_size
+        dp_rank = (rank // tp_size) % dp_size
+        group_key = Group.PP.name + str(dp_rank * tp_size + tp_rank)
     else:
         # DP_AND_TP always uses Group.DP_AND_TP as key
         group_key = Group.DP_AND_TP
@@ -864,8 +1009,8 @@ __all__ = [
     "Group",
     "init_distributed_environment",
     "init_user_buffers_environment",
-    "register_p2p_process_group",
-    "unregister_p2p_process_group",
+    "register_pp_process_group",
+    "unregister_pp_process_group",
     "distributed_environment_initialized",
     "destroy_distributed_environment",
     "send",

--- a/rtp_llm/models_py/distributed/test/BUILD
+++ b/rtp_llm/models_py/distributed/test/BUILD
@@ -39,6 +39,17 @@ py_test(
     exec_properties = {'gpu':'H20', 'gpu_count':'4'},
 )
 
+# PP-aware process group topology: CPU-only gloo, no GPU.
+py_test(
+    name = "pp_group_topology_test",
+    srcs = ["pp_group_topology_test.py"],
+    deps = [
+        "//rtp_llm:testlib",
+        "//rtp_llm/models_py/distributed:collective_torch",
+    ],
+    timeout = 'moderate',
+)
+
 py_test(
     name = "collective_torch_hipgraph_unit_test",
     srcs = ["collective_torch_hipgraph_unit_test.py"],

--- a/rtp_llm/models_py/distributed/test/pp_group_topology_test.py
+++ b/rtp_llm/models_py/distributed/test/pp_group_topology_test.py
@@ -1,0 +1,183 @@
+# PP-aware process group topology test.
+#
+# Pins three behaviors of collective_torch._create_process_groups:
+#  1. Under pp_size > 1, TP/DP groups stay inside one PP stage (stage-local
+#     collectives like tpSyncModelInputs must never wait on other stages).
+#  2. PP groups span the stages of one (dp_rank, tp_rank) lane and are keyed
+#     deterministically for the PP snapshot exchange / transport bootstrap.
+#  3. pp_size == 1 reproduces the historical groups exactly (keys included).
+#
+# CPU-only: runs gloo under multiprocessing spawn, no GPU required.
+
+import multiprocessing as mp
+import os
+import socket
+import unittest
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _worker(rank, world_size, pp_size, dp_size, tp_size, master_port, queue):
+    import torch
+    import torch.distributed
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    torch.distributed.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        from rtp_llm.models_py.distributed import collective_torch as ct
+
+        cfg = ct.ParallelismConfig()
+        cfg.world_rank = rank
+        cfg.world_size = world_size
+        cfg.tp_size = tp_size
+        cfg.dp_size = dp_size
+        cfg.pp_size = pp_size
+        cfg.local_world_size = world_size
+        ct._normalize_parallelism_ranks(cfg)
+        ct._parallelism_config = cfg
+        # torch.distributed is already up (gloo): mark initialized so
+        # _get_group resolves keys instead of triggering the full
+        # init_distributed_environment (which requires NCCL config).
+        ct._initialized = True
+        ct._group_map.clear()
+        ct._create_process_groups(cfg, "gloo", None)
+
+        membership = {
+            str(key): torch.distributed.get_process_group_ranks(pg)
+            for key, pg in ct._group_map.items()
+        }
+        # Runtime key derivation must land on a group this rank belongs to.
+        looked_up = {}
+        if tp_size > 1 and world_size != tp_size:
+            looked_up["TP"] = torch.distributed.get_process_group_ranks(
+                ct._get_group(ct.Group.TP)
+            )
+        if dp_size > 1 and world_size != dp_size:
+            looked_up["DP"] = torch.distributed.get_process_group_ranks(
+                ct._get_group(ct.Group.DP)
+            )
+        if max(pp_size, 1) > 1:
+            looked_up["PP"] = torch.distributed.get_process_group_ranks(
+                ct._get_group(ct.Group.PP)
+            )
+        queue.put(
+            (rank, cfg.pp_rank, cfg.dp_rank, cfg.tp_rank, membership, looked_up, None)
+        )
+    except Exception as exc:  # noqa: BLE001 - propagate to parent
+        queue.put((rank, None, None, None, {}, {}, repr(exc)))
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def _run_topology(test, pp_size, dp_size, tp_size):
+    world_size = pp_size * dp_size * tp_size
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue()
+    # All workers must share one master port; pick it once before spawning.
+    master_port = _free_port()
+    procs = [
+        ctx.Process(
+            target=_worker,
+            args=(r, world_size, pp_size, dp_size, tp_size, master_port, queue),
+        )
+        for r in range(world_size)
+    ]
+    for p in procs:
+        p.start()
+    results = {}
+    try:
+        for _ in range(world_size):
+            rank, pp_rank, dp_rank, tp_rank, membership, looked_up, err = queue.get(
+                timeout=180
+            )
+            test.assertIsNone(err, f"rank {rank} failed: {err}")
+            results[rank] = (pp_rank, dp_rank, tp_rank, membership, looked_up)
+    finally:
+        for p in procs:
+            p.join(timeout=30)
+            if p.is_alive():
+                p.terminate()
+                test.fail("worker deadlocked (group creation/barrier mismatch)")
+    return results
+
+
+class PPGroupTopologyTest(unittest.TestCase):
+    @staticmethod
+    def _merge(results):
+        # _group_map only stores the groups the observing rank belongs to,
+        # so the full topology is the union over all ranks' snapshots.
+        merged = {}
+        for _, (_, _, _, membership, _) in results.items():
+            for key, ranks in membership.items():
+                if key in merged:
+                    test_ranks = merged[key]
+                    assert test_ranks == ranks, f"conflicting views of {key}"
+                merged[key] = ranks
+        return merged
+
+    def test_pp1_dp2_tp2_matches_historical_groups(self):
+        results = _run_topology(self, pp_size=1, dp_size=2, tp_size=2)
+        membership = self._merge(results)
+        self.assertEqual(membership["TP0"], [0, 1])
+        self.assertEqual(membership["TP1"], [2, 3])
+        self.assertEqual(membership["DP0"], [0, 2])
+        self.assertEqual(membership["DP1"], [1, 3])
+        self.assertFalse(any(k.startswith("PP") for k in membership))
+
+    def test_pp2_dp1_tp2_stage_local_tp_and_lane_pp(self):
+        results = _run_topology(self, pp_size=2, dp_size=1, tp_size=2)
+        membership = self._merge(results)
+        # TP groups must not cross the stage boundary at rank 2.
+        self.assertEqual(membership["TP0"], [0, 1])
+        self.assertEqual(membership["TP1"], [2, 3])
+        # PP groups span the stages of each tp lane.
+        self.assertEqual(membership["PP0"], [0, 2])
+        self.assertEqual(membership["PP1"], [1, 3])
+        self.assertFalse(any(k.startswith("DP") for k in membership))
+        # Normalized pp_rank per world rank.
+        self.assertEqual(results[0][0], 0)
+        self.assertEqual(results[3][0], 1)
+        # Runtime lookup resolves each rank's own stage/lane groups.
+        self.assertEqual(results[0][4]["TP"], [0, 1])
+        self.assertEqual(results[0][4]["PP"], [0, 2])
+        self.assertEqual(results[3][4]["TP"], [2, 3])
+        self.assertEqual(results[3][4]["PP"], [1, 3])
+
+    def test_pp2_dp2_tp2_full_combination(self):
+        results = _run_topology(self, pp_size=2, dp_size=2, tp_size=2)
+        membership = self._merge(results)
+        # 4 stage-local TP groups.
+        self.assertEqual(membership["TP0"], [0, 1])
+        self.assertEqual(membership["TP1"], [2, 3])
+        self.assertEqual(membership["TP2"], [4, 5])
+        self.assertEqual(membership["TP3"], [6, 7])
+        # 4 stage-local DP groups (same pp and tp, across dp).
+        self.assertEqual(membership["DP0"], [0, 2])
+        self.assertEqual(membership["DP1"], [1, 3])
+        self.assertEqual(membership["DP2"], [4, 6])
+        self.assertEqual(membership["DP3"], [5, 7])
+        # 4 lane PP groups (same dp and tp, across pp).
+        self.assertEqual(membership["PP0"], [0, 4])
+        self.assertEqual(membership["PP1"], [1, 5])
+        self.assertEqual(membership["PP2"], [2, 6])
+        self.assertEqual(membership["PP3"], [3, 7])
+        # rank 0 lookups: pp0/dp0/tp0 lane.
+        self.assertEqual(results[0][4]["TP"], [0, 1])
+        self.assertEqual(results[0][4]["DP"], [0, 2])
+        self.assertEqual(results[0][4]["PP"], [0, 4])
+
+    def test_pp2_dp1_tp1_pp_group_only(self):
+        results = _run_topology(self, pp_size=2, dp_size=1, tp_size=1)
+        membership = self._merge(results)
+        self.assertEqual(membership["PP0"], [0, 1])
+        self.assertFalse(any(k.startswith(("TP", "DP")) for k in membership))
+        self.assertEqual(results[0][4]["PP"], [0, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/models_py/model_desc/module_base.py
+++ b/rtp_llm/models_py/model_desc/module_base.py
@@ -5,6 +5,12 @@ from typing import Any, Optional
 from torch import nn
 
 from rtp_llm.config.model_config import ModelConfig
+from rtp_llm.config.pp_layout import (
+    derive_pp_rank,
+    stage_has_embedding,
+    stage_has_lm_head,
+    stage_layer_range,
+)
 from rtp_llm.device.device_type import DeviceType, get_device_type
 from rtp_llm.model_loader.model_weight_info import ModelWeights
 from rtp_llm.models_py.model_desc.block_map import (
@@ -53,6 +59,49 @@ class GptModelBase(nn.Module):
 
         self.kv_cache: Optional[KVCache] = None
         self.device_type: DeviceType = get_device_type()
+
+    # ------------------------------------------------------------------
+    # Pipeline-parallel stage view. pp_rank/pp_size come from
+    # ParallelismConfig; the derive_pp_rank fallback keeps fake configs
+    # (test mocks without pp fields) working. Stage layout delegates to
+    # config/pp_layout.py, shared with weight loading and cache geometry.
+    # ------------------------------------------------------------------
+    @property
+    def pp_size(self) -> int:
+        return max(int(getattr(self.parallelism_config, "pp_size", 1) or 1), 1)
+
+    @property
+    def pp_rank(self) -> int:
+        rank = getattr(self.parallelism_config, "pp_rank", None)
+        if rank is None:
+            rank = derive_pp_rank(
+                getattr(self.parallelism_config, "world_rank", 0),
+                getattr(self.parallelism_config, "dp_size", 1),
+                getattr(self.parallelism_config, "tp_size", 1),
+            )
+        return int(rank)
+
+    @property
+    def pp_has_embedding(self) -> bool:
+        """First stage owns the token/positional embedding."""
+        return stage_has_embedding(self.pp_rank)
+
+    @property
+    def pp_has_lm_head(self) -> bool:
+        """Last stage owns lm_head + final_layernorm."""
+        return stage_has_lm_head(self.pp_rank, self.pp_size)
+
+    def pp_layer_ids(self) -> list[int]:
+        """Global layer ids owned by this stage.
+
+        Lookup over the materialized partition on ParallelismConfig
+        (decided once at startup), so model construction stays in sync
+        with weight loading; pp_size=1 is trivially all layers.
+        """
+        counts = getattr(self.parallelism_config, "pp_stage_layer_counts", None)
+        return list(
+            stage_layer_range(self.layer_num, self.pp_size, self.pp_rank, counts)
+        )
 
     def initialize(self, init_resource: PyModelInitResources) -> bool:
         self.kv_cache = init_resource.kv_cache

--- a/rtp_llm/models_py/model_desc/qwen3.py
+++ b/rtp_llm/models_py/model_desc/qwen3.py
@@ -101,9 +101,17 @@ class Qwen3Model(GptModelBase):
             device_resource_config=device_resource_config,
         )
 
-        self.embed_tokens = Embedding(
-            config, parallelism_config, weights.get_global_weight(W.embedding)
+        self.embed_tokens = (
+            Embedding(
+                config, parallelism_config, weights.get_global_weight(W.embedding)
+            )
+            if self.pp_has_embedding
+            else None
         )
+        # PP : only build this stage's layers; keep global layer ids so
+        # kv-cache / fmha lookups below stay global. pp_size=1 builds every
+        # layer exactly as before.
+        self.pp_layer_ids_list = self.pp_layer_ids()
         self.layers = nn.ModuleList(
             [
                 Qwen3DecoderLayer(
@@ -114,28 +122,56 @@ class Qwen3Model(GptModelBase):
                     quant_config,
                     py_hw_kernel_config,
                 )
-                for idx in range(self.layer_num)
+                for idx in self.pp_layer_ids_list
             ]
         )
-        self.norm = RMSNorm(
-            weights.get_global_weight(W.final_ln_gamma), eps=config.layernorm_eps
+        self.norm = (
+            RMSNorm(
+                weights.get_global_weight(W.final_ln_gamma), eps=config.layernorm_eps
+            )
+            if self.pp_has_lm_head
+            else None
         )
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
-        input_ids: torch.Tensor = inputs.input_ids
-        inputs_embeds = self.embed_tokens(input_ids)
-        hidden_states = inputs_embeds
+        # First stage embeds token ids; later PP stages continue from the
+        # upstream stage's activations in pp_intermediates; input_hiddens
+        # stays as the legacy/MTP fallback channel.
+        if self.embed_tokens is not None:
+            hidden_states = self.embed_tokens(inputs.input_ids)
+        else:
+            upstream_hidden = (
+                inputs.pp_intermediates.get("hidden_states")
+                if inputs.pp_intermediates
+                else None
+            )
+            hidden_states = (
+                upstream_hidden if upstream_hidden is not None else inputs.input_hiddens
+            )
         if fmha_impl is None:
             fmha_impl = self.prepare_fmha_impl(inputs)
-        for i, decoder_layer in enumerate(self.layers[: self.layer_num]):
-            layer_fmha_impl = select_fmha_impl_for_layer(fmha_impl, self.kv_cache, i)
+        # Cache surfaces are indexed by model-local layer ids (under PP the
+        # C++ layout is projected to this stage's layers).
+        for local_idx, decoder_layer in enumerate(self.layers):
+            layer_fmha_impl = select_fmha_impl_for_layer(
+                fmha_impl, self.kv_cache, local_idx
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 layer_fmha_impl,
-                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(local_idx) if self.kv_cache else None
+                ),
             )
-        hidden_states = self.norm(hidden_states)
-        return PyModelOutputs(hidden_states)
+        if self.norm is not None:
+            hidden_states = self.norm(hidden_states)
+            return PyModelOutputs(hidden_states)
+        # Non-last PP stage: emit the combined stream. Naive add-norm models
+        # carry a single boundary tensor (fused-residual models emit both
+        # hidden_states and residual, see qwen3_next).
+        outputs = PyModelOutputs(hidden_states)
+        outputs.pp_intermediates = {"hidden_states": hidden_states}
+        return outputs
 
 
 __all__ = [

--- a/rtp_llm/models_py/model_desc/qwen3_next.py
+++ b/rtp_llm/models_py/model_desc/qwen3_next.py
@@ -1065,8 +1065,15 @@ class Qwen3NextModel(GptModelBase):
             py_hw_kernel_config=py_hw_kernel_config,
             device_resource_config=device_resource_config,
         )
-        self.embed_tokens = Embedding(
-            model_config, parallelism_config, weights.get_global_weight(W.embedding)
+        # PP : first stage owns the embedding; see Qwen3Model for the
+        # exemplar. pp_size=1 keeps today's behavior. (PP gates CP off, so the
+        # CP metadata path below never meets a non-first stage.)
+        self.embed_tokens = (
+            Embedding(
+                model_config, parallelism_config, weights.get_global_weight(W.embedding)
+            )
+            if self.pp_has_embedding
+            else None
         )
         # Get enable_cuda_graph from py_hw_kernel_config
         enable_cuda_graph = (
@@ -1074,6 +1081,7 @@ class Qwen3NextModel(GptModelBase):
             if py_hw_kernel_config is not None
             else False
         )
+        self.pp_layer_ids_list = self.pp_layer_ids()
         self.layers = nn.ModuleList(
             [
                 Qwen3NextDecoderLayer(
@@ -1086,11 +1094,16 @@ class Qwen3NextModel(GptModelBase):
                     enable_cuda_graph,
                     hw_kernel_config=py_hw_kernel_config,
                 )
-                for idx in range(self.layer_num)
+                for idx in self.pp_layer_ids_list
             ]
         )
-        self.norm = RMSResNorm(
-            weights.get_global_weight(W.final_ln_gamma), eps=model_config.layernorm_eps
+        self.norm = (
+            RMSResNorm(
+                weights.get_global_weight(W.final_ln_gamma),
+                eps=model_config.layernorm_eps,
+            )
+            if self.pp_has_lm_head
+            else None
         )
 
     def _get_fmha_group_tags(self) -> Optional[list[str]]:
@@ -1166,7 +1179,32 @@ class Qwen3NextModel(GptModelBase):
         return self.embed_tokens(input_ids)
 
     def forward(self, inputs: PyModelInputs, fmha_impl: Any = None) -> PyModelOutputs:
-        hidden_states = self.word_embedding(inputs)
+        # First stage embeds token ids (word_embedding is overridden by
+        # multimodal subclasses); later PP stages continue from the upstream
+        # stage's activations in pp_intermediates; input_hiddens stays as the
+        # legacy/MTP fallback channel.
+        if self.embed_tokens is not None:
+            hidden_states = self.word_embedding(inputs)
+        else:
+            upstream_hidden = (
+                inputs.pp_intermediates.get("hidden_states")
+                if inputs.pp_intermediates
+                else None
+            )
+            hidden_states = (
+                upstream_hidden if upstream_hidden is not None else inputs.input_hiddens
+            )
+
+        # PP: this model uses the fused add-norm pattern, so the stream at a
+        # stage boundary is split into (branch output, accumulated residual).
+        # The upstream stage's residual arrives in pp_intermediates; first
+        # stage / pp_size=1 starts from zeros.
+        residual = torch.zeros_like(hidden_states)
+        upstream_residual = (
+            inputs.pp_intermediates.get("residual") if inputs.pp_intermediates else None
+        )
+        if upstream_residual is not None:
+            residual = upstream_residual
 
         attention_inputs = get_primary_attention_inputs(inputs, self.kv_cache)
         prefill_conv1d_meta = None
@@ -1209,28 +1247,43 @@ class Qwen3NextModel(GptModelBase):
         if fmha_impl is None:
             fmha_impl = self.prepare_fmha_impl(inputs)
 
-        residual = torch.zeros_like(hidden_states)
-
-        for i, decoder_layer in enumerate(self.layers):
+        # Cache surfaces (get_layer_cache / select_*_for_layer) are indexed by
+        # model-local layer ids: under PP the C++ layout is projected to this
+        # stage's layers. Global layer ids are only needed at construction
+        # time (weight / attention-type indexing), already baked into layers.
+        for local_idx, decoder_layer in enumerate(self.layers):
             layer_attention_inputs = select_attention_inputs_for_layer(
-                inputs, self.kv_cache, i
+                inputs, self.kv_cache, local_idx
             )
             layer_fmha_impl = (
                 None
                 if decoder_layer.layer_type == HybridAttentionType.LINEAR
-                else select_fmha_impl_for_layer(fmha_impl, self.kv_cache, i)
+                else select_fmha_impl_for_layer(fmha_impl, self.kv_cache, local_idx)
             )
             hidden_states, residual = decoder_layer(
                 hidden_states,
                 residual,
                 layer_fmha_impl,
-                kv_cache=self.kv_cache.get_layer_cache(i) if self.kv_cache else None,
+                kv_cache=(
+                    self.kv_cache.get_layer_cache(local_idx) if self.kv_cache else None
+                ),
                 attention_inputs=layer_attention_inputs,
                 attn_meta=attn_meta,
             )
 
-        hidden_states, residual = self.norm(hidden_states, residual)
-        return PyModelOutputs(hidden_states)
+        if self.norm is not None:
+            hidden_states, residual = self.norm(hidden_states, residual)
+            return PyModelOutputs(hidden_states)
+        # Non-last PP stage: emit the stage-boundary tensors verbatim so the
+        # downstream stage can resume the fused (branch, residual) stream.
+        # Dropping `residual` here would make the downstream stage restart
+        # from zeros and compute garbage.
+        outputs = PyModelOutputs(hidden_states)
+        outputs.pp_intermediates = {
+            "hidden_states": hidden_states,
+            "residual": residual,
+        }
+        return outputs
 
 
 class Qwen35Model(Qwen3NextModel):

--- a/rtp_llm/models_py/model_desc/test/BUILD
+++ b/rtp_llm/models_py/model_desc/test/BUILD
@@ -48,3 +48,14 @@ py_test(
     tags = ["H20"],
     exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
 )
+
+py_test(
+    name = "pp_stage_construction_test",
+    srcs = ["pp_stage_construction_test.py"],
+    deps = [
+        "//rtp_llm/models_py/standalone:py_standalone_testlib",
+    ],
+    env = {"GPU_COUNT": "1"},
+    tags = ["H20"],
+    exec_properties = {'gpu': 'H20', 'gpu_count': '1'},
+)

--- a/rtp_llm/models_py/model_desc/test/pp_stage_construction_test.py
+++ b/rtp_llm/models_py/model_desc/test/pp_stage_construction_test.py
@@ -1,0 +1,339 @@
+# Stage-aware model construction.
+#
+# Pins two things:
+#   1. GptModelBase's PP stage view (pp_layer_ids / capability flags /
+#      pp_rank fallback) — the partition lookup must stay equivalent to
+#      LoadConfig.pp_layer_range (weight loading) and PPLayout::layerRangeOf
+#      (C++), so loader / construction / cache always agree on stage
+#      ownership. Fixtures materialize the partition like the startup
+#      decision point does.
+#   2. Qwen3Model as the exemplar refactor: each stage builds only its own
+#      layers (global ids kept) plus the global components it owns
+#      (embedding on first stage, final norm on last stage).
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from torch import nn
+
+from rtp_llm.config.pp_layout import even_split_counts
+from rtp_llm.models_py.model_desc.module_base import GptModelBase
+
+
+def make_base(
+    pp_size=1,
+    pp_rank=None,
+    world_rank=0,
+    tp_size=1,
+    dp_size=1,
+    layer_num=32,
+):
+    """GptModelBase without running __init__ (needs full model config)."""
+    model = object.__new__(GptModelBase)
+    cfg = SimpleNamespace(
+        pp_size=pp_size, tp_size=tp_size, dp_size=dp_size, world_rank=world_rank
+    )
+    if pp_rank is not None:
+        cfg.pp_rank = pp_rank
+    if pp_size > 1:
+        # Mirror the startup decision point: pp>1 carries materialized data.
+        cfg.pp_stage_layer_counts = even_split_counts(layer_num, pp_size)
+    model.parallelism_config = cfg
+    model.layer_num = layer_num
+    return model
+
+
+class PPStageViewTest(unittest.TestCase):
+    def test_pp_size_1_keeps_today_behavior(self):
+        model = make_base(pp_size=1, pp_rank=0, layer_num=36)
+        self.assertEqual(model.pp_layer_ids(), list(range(36)))
+        # pp_size=1 is both first and last stage.
+        self.assertTrue(model.pp_has_embedding)
+        self.assertTrue(model.pp_has_lm_head)
+
+    def test_even_split_two_stages(self):
+        stage0 = make_base(pp_size=2, pp_rank=0, layer_num=32)
+        stage1 = make_base(pp_size=2, pp_rank=1, layer_num=32)
+        self.assertEqual(stage0.pp_layer_ids(), list(range(0, 16)))
+        self.assertEqual(stage1.pp_layer_ids(), list(range(16, 32)))
+        self.assertTrue(stage0.pp_has_embedding)
+        self.assertFalse(stage0.pp_has_lm_head)
+        self.assertFalse(stage1.pp_has_embedding)
+        self.assertTrue(stage1.pp_has_lm_head)
+
+    def test_remainder_goes_to_earlier_stages(self):
+        # Mirrors the PPLayout::layerRangeOf example: 65 layers, pp=4 ->
+        # 17/16/16/16.
+        ranges = [
+            make_base(pp_size=4, pp_rank=r, layer_num=65).pp_layer_ids()
+            for r in range(4)
+        ]
+        self.assertEqual([len(ids) for ids in ranges], [17, 16, 16, 16])
+        self.assertEqual(ranges[0], list(range(0, 17)))
+        self.assertEqual(ranges[1], list(range(17, 33)))
+        self.assertEqual(ranges[2], list(range(33, 49)))
+        self.assertEqual(ranges[3], list(range(49, 65)))
+        # Full coverage, no overlap.
+        self.assertEqual(sorted(sum(ranges, [])), list(range(65)))
+
+    def test_pp_rank_read_from_config_field(self):
+        model = make_base(pp_size=2, pp_rank=1, world_rank=0)
+        # Field wins even when world_rank would derive a different value.
+        self.assertEqual(model.pp_rank, 1)
+
+    def test_pp_rank_fallback_derives_pp_outermost(self):
+        # Fake config without the pp_rank field: derive from world_rank
+        # (pp_rank = world_rank // (dp_size * tp_size)).
+        model = make_base(pp_size=2, pp_rank=None, world_rank=5, tp_size=2, dp_size=1)
+        self.assertEqual(model.pp_rank, 2)
+
+
+def make_qwen3(pp_size, pp_rank, num_layers=8):
+    """Construct Qwen3Model with heavy building blocks mocked out.
+
+    The mocks record their calls but return real (empty) nn.Modules, since
+    nn.ModuleList rejects non-Module children.
+    """
+    from rtp_llm.models_py.model_desc import qwen3
+
+    config = SimpleNamespace(num_layers=num_layers, vocab_size=100, layernorm_eps=1e-6)
+    parallelism_config = SimpleNamespace(
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        tp_size=1,
+        dp_size=1,
+        world_rank=pp_rank,
+    )
+    if pp_size > 1:
+        parallelism_config.pp_stage_layer_counts = even_split_counts(
+            num_layers, pp_size
+        )
+    weights = SimpleNamespace(
+        weights={idx: f"layer_{idx}" for idx in range(num_layers)},
+        get_global_weight=lambda name: f"global_{name}",
+    )
+    module_stub = lambda *args, **kwargs: nn.Module()  # noqa: E731
+    with patch.object(
+        qwen3, "Embedding", Mock(side_effect=module_stub)
+    ) as mock_emb, patch.object(
+        qwen3, "Qwen3DecoderLayer", Mock(side_effect=module_stub)
+    ) as mock_layer, patch.object(
+        qwen3, "RMSNorm", Mock(side_effect=module_stub)
+    ) as mock_norm, patch(
+        "rtp_llm.models_py.model_desc.module_base.get_device_type"
+    ):
+        model = qwen3.Qwen3Model(
+            config, parallelism_config, weights, max_generate_batch_size=1
+        )
+    return model, mock_emb, mock_layer, mock_norm
+
+
+class Qwen3StageConstructionTest(unittest.TestCase):
+    def test_pp_size_1_builds_everything(self):
+        model, mock_emb, mock_layer, mock_norm = make_qwen3(pp_size=1, pp_rank=0)
+        self.assertIsNotNone(model.embed_tokens)
+        self.assertIsNotNone(model.norm)
+        self.assertEqual(len(model.layers), 8)
+        self.assertEqual(model.pp_layer_ids_list, list(range(8)))
+        mock_emb.assert_called_once()
+        mock_norm.assert_called_once()
+        self.assertEqual(mock_layer.call_count, 8)
+
+    def test_first_stage_builds_embedding_and_front_layers(self):
+        model, mock_emb, mock_layer, mock_norm = make_qwen3(pp_size=2, pp_rank=0)
+        self.assertIsNotNone(model.embed_tokens)
+        self.assertIsNone(model.norm)  # final norm belongs to the last stage
+        self.assertEqual(model.pp_layer_ids_list, [0, 1, 2, 3])
+        self.assertEqual(len(model.layers), 4)
+        mock_emb.assert_called_once()
+        mock_norm.assert_not_called()
+        # Decoder layers are constructed with GLOBAL layer ids.
+        built_ids = [call.args[2] for call in mock_layer.call_args_list]
+        self.assertEqual(built_ids, [0, 1, 2, 3])
+
+    def test_last_stage_builds_norm_and_back_layers(self):
+        model, mock_emb, mock_layer, mock_norm = make_qwen3(pp_size=2, pp_rank=1)
+        self.assertIsNone(model.embed_tokens)  # embedding on first stage only
+        self.assertIsNotNone(model.norm)
+        self.assertEqual(model.pp_layer_ids_list, [4, 5, 6, 7])
+        self.assertEqual(len(model.layers), 4)
+        mock_emb.assert_not_called()
+        mock_norm.assert_called_once()
+        built_ids = [call.args[2] for call in mock_layer.call_args_list]
+        self.assertEqual(built_ids, [4, 5, 6, 7])
+
+    def test_middle_stage_builds_neither_global_component(self):
+        model, mock_emb, mock_layer, mock_norm = make_qwen3(pp_size=3, pp_rank=1)
+        self.assertIsNone(model.embed_tokens)
+        self.assertIsNone(model.norm)
+        # 8 layers / 3 stages -> 3/3/2; middle stage owns [3, 6).
+        self.assertEqual(model.pp_layer_ids_list, [3, 4, 5])
+        mock_emb.assert_not_called()
+        mock_norm.assert_not_called()
+
+
+class Qwen3NextPPBoundaryTest(unittest.TestCase):
+    """Stage-boundary tensors cross stages as a named map.
+
+    qwen3_next uses the fused add-norm pattern, so the stream at a stage
+    boundary is split into (branch output, accumulated residual):
+      entry: non-first stages resume `residual` from inputs.pp_intermediates
+             (first stage / pp_size=1 keeps zeros);
+      exit:  non-last stages emit {"hidden_states", "residual"} (dropping
+             the residual would corrupt the downstream stream); last stage
+             norms and returns plain hidden states.
+    """
+
+    def _make_model(self, with_norm):
+        import torch
+
+        from rtp_llm.models_py.model_desc import qwen3_next as qn
+
+        model = object.__new__(qn.Qwen3NextModel)
+        model.embed_tokens = None  # exercise the non-first-stage entry
+        model.kv_cache = None
+        model.parallelism_config = SimpleNamespace(
+            prefill_cp_config=SimpleNamespace(is_enabled=lambda: False)
+        )
+        layer = Mock()
+        layer.layer_type = qn.HybridAttentionType.LINEAR
+        # Echo layer: keeps (hidden, residual) flowing unchanged.
+        layer.side_effect = lambda h, r, *a, **k: (h, r)
+        model.layers = [layer]
+        model.norm = (
+            Mock(side_effect=lambda h, r: (h + r, h + r)) if with_norm else None
+        )
+        # Inherited from GptModelBase; needs real attention_inputs plumbing.
+        model.prepare_fmha_impl = Mock(return_value=None)
+        return model, qn
+
+    def _make_inputs(self, torch_mod, intermediates=None):
+        # Duck-typed PyModelInputs: forward() only accesses attributes, and the
+        # compiled bindings module is not in this target's runfiles.
+        # attention_inputs is read by block_map inside the layer loop; a
+        # non-empty tag mapping passes validation and with kv_cache=None the
+        # per-layer selection yields an empty list, which the echo layer
+        # ignores.
+        return SimpleNamespace(
+            input_hiddens=torch_mod.zeros(2, 4),
+            pp_intermediates=intermediates or {},
+            attention_inputs={"full": SimpleNamespace()},
+        )
+
+    def _run_forward(self, model, qn, inputs):
+        import torch
+
+        attn = SimpleNamespace(
+            is_target_verify=False, is_prefill=False, cu_seqlens_device=None
+        )
+        with patch.object(
+            qn, "get_primary_attention_inputs", return_value=attn
+        ), patch.object(qn, "prepare_causal_conv1d_metadata", return_value=None):
+            return model.forward(inputs)
+
+    def test_non_last_stage_emits_hidden_and_residual(self):
+        import torch
+
+        model, qn = self._make_model(with_norm=False)
+        outputs = self._run_forward(model, qn, self._make_inputs(torch))
+        # hidden = zeros echoed through; residual = zeros init (no upstream).
+        self.assertEqual(set(outputs.pp_intermediates), {"hidden_states", "residual"})
+        torch.testing.assert_close(
+            outputs.pp_intermediates["hidden_states"], torch.zeros(2, 4)
+        )
+        torch.testing.assert_close(
+            outputs.pp_intermediates["residual"], torch.zeros(2, 4)
+        )
+
+    def test_entry_resumes_upstream_hidden_and_residual(self):
+        import torch
+
+        model, qn = self._make_model(with_norm=False)
+        upstream_hidden = torch.full((2, 4), 2.0)
+        upstream_residual = torch.ones(2, 4)
+        inputs = self._make_inputs(
+            torch, {"hidden_states": upstream_hidden, "residual": upstream_residual}
+        )
+        outputs = self._run_forward(model, qn, inputs)
+        # Echo layer forwards both resumed boundary tensors to the stage exit;
+        # hidden must come from the map, NOT the (zeros) input_hiddens
+        # fallback channel.
+        torch.testing.assert_close(
+            outputs.pp_intermediates["hidden_states"], upstream_hidden
+        )
+        torch.testing.assert_close(
+            outputs.pp_intermediates["residual"], upstream_residual
+        )
+
+    def test_entry_falls_back_to_input_hiddens_without_map(self):
+        import torch
+
+        model, qn = self._make_model(with_norm=False)
+        # No pp_intermediates (legacy/MTP-style handoff): input_hiddens is used.
+        outputs = self._run_forward(model, qn, self._make_inputs(torch))
+        torch.testing.assert_close(
+            outputs.pp_intermediates["hidden_states"], torch.zeros(2, 4)
+        )
+
+    def test_last_stage_norms_and_emits_no_intermediates(self):
+        import torch
+
+        model, qn = self._make_model(with_norm=True)
+        outputs = self._run_forward(model, qn, self._make_inputs(torch))
+        self.assertFalse(outputs.pp_intermediates)
+        # norm mock: hidden + residual = zeros + zeros
+        torch.testing.assert_close(outputs.hidden_states, torch.zeros(2, 4))
+
+
+class Qwen3PPBoundaryTest(unittest.TestCase):
+    """Naive add-norm models carry a SINGLE boundary tensor.
+
+    qwen3.py adds the residual inside each layer, so the stream at a stage
+    boundary is already combined: the map holds only {"hidden_states"}.
+    """
+
+    def _make_model(self, with_norm):
+        import torch
+
+        from rtp_llm.models_py.model_desc import qwen3 as q3
+
+        model = object.__new__(q3.Qwen3Model)
+        model.embed_tokens = None  # non-first-stage entry
+        model.kv_cache = None
+        layer = Mock(side_effect=lambda h, *a, **k: h)  # echo layer
+        model.layers = [layer]
+        model.norm = Mock(side_effect=lambda h: h + 1.0) if with_norm else None
+        model.prepare_fmha_impl = Mock(return_value=None)
+        return model, q3
+
+    def _make_inputs(self, torch_mod, intermediates=None):
+        return SimpleNamespace(
+            input_hiddens=torch_mod.zeros(2, 4),
+            pp_intermediates=intermediates or {},
+        )
+
+    def test_non_last_stage_emits_single_hidden_key(self):
+        import torch
+
+        model, q3 = self._make_model(with_norm=False)
+        upstream_hidden = torch.full((2, 4), 3.0)
+        inputs = self._make_inputs(torch, {"hidden_states": upstream_hidden})
+        outputs = model.forward(inputs)
+        self.assertEqual(set(outputs.pp_intermediates), {"hidden_states"})
+        torch.testing.assert_close(
+            outputs.pp_intermediates["hidden_states"], upstream_hidden
+        )
+
+    def test_last_stage_norms_and_emits_no_intermediates(self):
+        import torch
+
+        model, q3 = self._make_model(with_norm=True)
+        outputs = model.forward(inputs := self._make_inputs(torch))
+        self.assertFalse(outputs.pp_intermediates)
+        # norm mock adds 1.0 to the zeros input_hiddens fallback
+        torch.testing.assert_close(outputs.hidden_states, torch.ones(2, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rtp_llm/ops/librtp_compute_ops/__init__.pyi
+++ b/rtp_llm/ops/librtp_compute_ops/__init__.pyi
@@ -33,8 +33,8 @@ __all__: list[str] = [
     "init_exec_ctx",
     "register_comm_ops",
     "clear_comm_ops",
-    "register_p2p_ops",
-    "clear_p2p_ops",
+    "register_pp_ops",
+    "clear_pp_ops",
     "init_cpu_tp_broadcaster",
     "destroy_cpu_tp_broadcaster",
     "rtp_llm_ops",
@@ -515,8 +515,8 @@ def clear_comm_ops() -> None:
     Clear registered Python communication callbacks.
     """
 
-def register_p2p_ops(isend_fn: typing.Callable, irecv_fn: typing.Callable) -> None: ...
-def clear_p2p_ops() -> None: ...
+def register_pp_ops(isend_fn: typing.Callable, irecv_fn: typing.Callable, pp_snapshot_exchange_fn: typing.Callable) -> None: ...
+def clear_pp_ops() -> None: ...
 
 def init_cpu_tp_broadcaster(tp_rank: int, tp_size: int, base_path: str) -> None: ...
 def destroy_cpu_tp_broadcaster() -> None: ...

--- a/rtp_llm/server/server_args/parallel_group_args.py
+++ b/rtp_llm/server/server_args/parallel_group_args.py
@@ -37,6 +37,16 @@ def init_parallel_group_args(
         help="设置数据并行（Data Parallelism）的副本数量或组大小。",
     )
     parallel_group.add_argument(
+        "--pp_size",
+        env_name="PP_SIZE",
+        bind_to=(parallelism_config, "pp_size"),
+        type=int,
+        default=1,
+        help="流水线并行（Pipeline Parallelism）段数。布局为 PP 最外层："
+        "world_rank = pp_rank * (dp_size * tp_size) + dp_rank * tp_size + tp_rank，"
+        "通常 WORLD_SIZE = PP_SIZE * TP_SIZE * DP_SIZE。",
+    )
+    parallel_group.add_argument(
         "--world_size",
         env_name="WORLD_SIZE",
         bind_to=(parallelism_config, "world_size"),


### PR DESCRIPTION
## Summary

Two commits (dependency-ordered) bringing pipeline parallelism support to
the KV cache layer:

1. **Data-driven layer partition** — the partition is decided once on the
   Python side and materialized as `ParallelismConfig.pp_stage_layer_counts`;
   every consumer (C++ `PPLayout` prefix-sum lookup, weight loader, model
   construction stage view) reads the data instead of re-deriving the rule.
   The previous Python/C++ algorithm mirror is eliminated.
2. **Cross-stage KV cache topology validation + stage-aware execution** —
   each stage builds its cache config from its own layer slice; at startup
   all stages exchange snapshots and agree on a canonical group table before
   any pool is allocated.

## Commit 1: partition materialization

- `ParallelismConfig`: new `pp_stage_layer_counts` field with pybind binding
  and pickle compatibility (tuple extended to 20 elements, guard 17–20)
- `PPLayout`: lookup-based `layerRangeOf` + `fromParallelismConfig` factory;
  ring neighbor ranks (`prevRank`/`nextRank`, dp-safe) for PP transport;
  even-split formula retained only as a legacy fallback
- `pp_layout.py`: decision entry (`resolve_pp_partition`), model-level
  partitioner registry skeleton, shared `derive_pp_rank` helper
- Startup wiring: materialization hook in `model_factory`, `--pp_size` /
  `PP_SIZE` argument, rank normalization
- Loader: `LoadConfig` carries the counts; per-stage weight skipping
  (embedding on the first stage, lm_head/final norm on the last stage)
- Contract: `pp_size > 1` without materialized counts is an error, not a
  silent fallback; `pp_size = 1` behavior is unchanged

## Commit 2: topology validation and stage-aware execution

- `PPTopologyValidator`: canonical group table (whole-model union in stage-0
  order), stage-0-superset gate (the leading stage physically owns every
  group since it issues all block ids), type/geometry/policy-fingerprint
  reconciliation, capacity-skew and explicit-block-num checks; snapshot wire
  format v1
- Snapshot exchange over the PP process group (`all_gather_object`, unified
  `register_pp_ops` callback registration)
- Stage-scoped cache creation: slicing for the Single and independent-pool
  paths; opaque pools rejected under PP; the hybrid positional grouping is
  retired for PP
- Write-back in the `KVCacheManager` constructor (after `finalizeBlockNums`,
  before pool allocation): `canonical_idx` backfill and per-tag cross-stage
  min capping (top-level block count follows budget-paged pools only)
- Runtime consumption: block-table column selection by `canonical_idx`
  (`PyWrappedModel`), canonical group-id translation in copy mappings
  (`KVCacheAllocator`)
- Stage-boundary tensors (`pp_intermediates`) on model input/output structs;
  `PPExecutor` consumes `PPLayout` for stage-role gating and ring neighbors
- Placeholder `PPSerialization` implementation (contract is the header;
  replaceable by the transport owner)
- Model support: `support_pp()` for qwen3 / qwen3_next; stage-aware layer
  construction and boundary protocols (single boundary tensor for plain
  add-norm models, hidden+residual pair for fused add-norm models)
- Removes the dead copy constructor in `NormalGenerateStream.h` (see notes
  below)

## Validation

- 7 test files / 93 cases, all green: layout lookup, loader filtering, stage
  construction, stage-scoped cache config, validator rules, pp=1 block-table
  equivalence baseline, and a real multi-process group-topology test (gloo)
- On-hardware integration (Qwen3-0.6B, pp=2) exercised the full startup
  chain end to end up to the sampling step: partition materialization →
  stage-filtered weight loading → cache slicing → snapshot reconciliation →
  pool allocation → server ready → request entering the pipeline

## Notes for the PP executor/transport owner

1. The `std::atomic<bool> pp_inflight_` member added to `GenerateStream`
   deletes its implicit copy constructor, which broke the build via a
   copy-style constructor in `NormalGenerateStream`. That constructor had
   zero consumers anywhere in the repo and is removed here; if copy
   semantics are needed, please define an explicit copy constructor.
2. The pre-sampling assertion in `PPExecutor` is relaxed to
   `numReturnSequences() <= 1`: the Python-side default is 0 (feature
   disabled), and the previous `== 1` crashed every ordinary request.
3. When implementing `processSampleResult`, please call
   `clearPPInflight()` after committing the sample result — otherwise a
   stream scheduled once stays inflight forever (symptom: every request
   generates exactly one token and hangs).