### PR TITLE
fix(pd): discard cache after failed handoff

### DIFF
--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.cc
@@ -1486,8 +1486,8 @@ void GenerateStream::holdKVCacheForPDSep() {
     stream_cache_resource_->holdKVCacheForPDSep();
 }
 
-void GenerateStream::releaseKVCacheForPDSep() {
-    stream_cache_resource_->releaseKVCacheForPDSep();
+void GenerateStream::releaseKVCacheForPDSep(bool cache_load_succeeded) {
+    stream_cache_resource_->releaseKVCacheForPDSep(cache_load_succeeded);
 }
 
 std::pair<std::string, uint32_t> GenerateStream::prefillAddr() const {

--- a/rtp_llm/cpp/engine_base/stream/GenerateStream.h
+++ b/rtp_llm/cpp/engine_base/stream/GenerateStream.h
@@ -430,7 +430,7 @@ public:
     }
 
     void holdKVCacheForPDSep();
-    void releaseKVCacheForPDSep();
+    void releaseKVCacheForPDSep(bool cache_load_succeeded = true);
 
     std::vector<int> getLatestTokens(size_t token_num);
 

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.cc
@@ -307,17 +307,20 @@ void StreamCacheResource::releaseResource() {
     if (!need_release_resource_ && (!stream_->hasNumBeams() || !stream_->hasErrorWithoutLock())) {
         return;
     }
+    std::lock_guard<std::mutex> lock(pd_kvcache_mutex_);
     RTP_LLM_LOG_DEBUG("releaseResource: stream=%ld, curBlocksNum=%d, pd_kvcache_ref=%p",
                       stream_->streamId(),
                       curBlocksNum(),
                       pd_kvcache_ref_.get());
-    tryReleaseKVBlock(curBlocksNum());
+    const bool store_cache = pd_cache_state_ != PDSepCacheState::PENDING
+                             && pd_cache_state_ != PDSepCacheState::DISCARDED;
+    tryReleaseKVBlock(curBlocksNum(), store_cache);
     batch_kv_cache_resource_->clearBlocks();
     resource_released_ = true;
     load_cache_once_.store(false, std::memory_order_release);
 }
 
-int StreamCacheResource::tryReleaseKVBlock(size_t nums) {
+int StreamCacheResource::tryReleaseKVBlock(size_t nums, bool store_cache) {
     RTP_LLM_PROFILE_FUNCTION();
     RTP_LLM_LOG_DEBUG("stream [%s] try release [%lu] blocks", stream_->streamLogTag().c_str(), nums);
 
@@ -336,24 +339,14 @@ int StreamCacheResource::tryReleaseKVBlock(size_t nums) {
     RTP_LLM_CHECK(nums == total_blocks);
 
     if (total_blocks > 0) {
-        if (reuseCache() && !stream_->hasErrorWithoutLock() && stream_->getStatus() == StreamState::FINISHED) {
-            RTP_LLM_LOG_DEBUG(
-                "tryReleaseKVBlock: stream=%ld, storing cache, curBlocksNum=%d", stream_->streamId(), total_blocks);
-            // save cache to gpu
-            if (enableDeviceCache()) {
-                InsertInfo insert_info{batch_kv_cache_resource_, stream_->completeTokenIdsPtr(), false};
-                resource_context_.cache_manager->insertIntoCache(insert_info);
-            }
-            storeCacheAsync(batch_kv_cache_resource_,
-                            reuseCache() && enableMemoryCache() && !enableTieredMemoryCache(),
-                            reuseCache() && enableRemoteCache());
-            // only evict when succeeds
-            if (enableTieredMemoryCache()) {
-                evictDeviceCacheToMemory();
-            }
+        if (store_cache && reuseCache() && !stream_->hasErrorWithoutLock()
+            && stream_->getStatus() == StreamState::FINISHED) {
+            storeCompletedCache(batch_kv_cache_resource_);
         } else {
-            RTP_LLM_LOG_DEBUG("tryReleaseKVBlock: stream=%ld, NOT storing cache, reuseCache=%d, hasError=%d, status=%s",
+            RTP_LLM_LOG_DEBUG("tryReleaseKVBlock: stream=%ld, NOT storing cache, store_cache=%d, reuseCache=%d, "
+                              "hasError=%d, status=%s",
                               stream_->streamId(),
+                              store_cache,
                               reuseCache(),
                               stream_->hasErrorWithoutLock(),
                               StreamStateToString(stream_->getStatus()).c_str());
@@ -366,6 +359,21 @@ int StreamCacheResource::tryReleaseKVBlock(size_t nums) {
     }
 
     return total_blocks;
+}
+
+void StreamCacheResource::storeCompletedCache(const std::shared_ptr<BatchKVCacheResource>& batch_resource) {
+    RTP_LLM_LOG_DEBUG(
+        "storeCompletedCache: stream=%ld, curBlocksNum=%d", stream_->streamId(), batch_resource->curBlocksNum());
+    if (enableDeviceCache()) {
+        InsertInfo insert_info{batch_resource, stream_->completeTokenIdsPtr(), false};
+        resource_context_.cache_manager->insertIntoCache(insert_info);
+    }
+    storeCacheAsync(batch_resource,
+                    reuseCache() && enableMemoryCache() && !enableTieredMemoryCache(),
+                    reuseCache() && enableRemoteCache());
+    if (enableTieredMemoryCache()) {
+        evictDeviceCacheToMemory();
+    }
 }
 
 // TODO, 等待删除。
@@ -807,15 +815,34 @@ void StreamCacheResource::swapLinearBlocks(int32_t batch_id, size_t rhs, size_t 
 }
 
 void StreamCacheResource::holdKVCacheForPDSep() {
-    auto&       resource   = batch_kv_cache_resource_->cacheResource(0);
+    std::lock_guard<std::mutex> lock(pd_kvcache_mutex_);
+    auto&                       resource = batch_kv_cache_resource_->cacheResource(0);
     const auto& cache_keys = resource.cacheKeys();
     auto        ref = resource_context_.cache_manager->incrKVCacheRef(resource, cache_keys, /*is_connector=*/true);
     if (ref) {
-        pd_kvcache_ref_ = std::move(ref);
+        pd_kvcache_ref_            = std::move(ref);
+        pd_pending_cache_resource_ = std::make_shared<BatchKVCacheResource>(*batch_kv_cache_resource_);
+        pd_cache_state_            = PDSepCacheState::PENDING;
     }
 }
 
-void StreamCacheResource::releaseKVCacheForPDSep() {
+void StreamCacheResource::releaseKVCacheForPDSep(bool cache_load_succeeded) {
+    std::lock_guard<std::mutex> lock(pd_kvcache_mutex_);
+    if (!pd_kvcache_ref_) {
+        return;
+    }
+    if (pd_cache_state_ == PDSepCacheState::PENDING) {
+        if (cache_load_succeeded) {
+            if (resource_released_ && pd_pending_cache_resource_ && reuseCache() && !stream_->hasErrorWithoutLock()
+                && stream_->getStatus() == StreamState::FINISHED) {
+                storeCompletedCache(pd_pending_cache_resource_);
+            }
+            pd_cache_state_ = PDSepCacheState::COMMITTED;
+        } else {
+            pd_cache_state_ = PDSepCacheState::DISCARDED;
+        }
+    }
+    pd_pending_cache_resource_.reset();
     pd_kvcache_ref_.reset();
 }
 }  // namespace rtp_llm

--- a/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
+++ b/rtp_llm/cpp/engine_base/stream/StreamCacheResource.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "rtp_llm/cpp/engine_base/stream/ResourceContext.h"
@@ -33,7 +34,7 @@ public:
     // seq_len_override (-1 = unset) is forwarded to MallocInfo::incr_seq_len_override.
     absl::Status         incrKVBlock(int seq_len_override = -1);
     void                 fakeInitKVBlock(size_t reserved_blocks = 0);
-    int                  tryReleaseKVBlock(size_t nums);
+    int                  tryReleaseKVBlock(size_t nums, bool store_cache = true);
     void                 freeBatchBlocks(size_t batch_id, std::vector<int>& blocks);
     void                 releaseResource();
     bool                 asyncLoadCache();
@@ -110,7 +111,7 @@ public:
     bool enableTieredMemoryCache() const;
 
     void holdKVCacheForPDSep();
-    void releaseKVCacheForPDSep();
+    void releaseKVCacheForPDSep(bool cache_load_succeeded = true);
 
     std::string debugString() const {
         std::stringstream debug_string;
@@ -132,6 +133,7 @@ private:
                                                   bool                                         enable_remote_cache);
     void                          evictDeviceCacheToMemory();
     void                          waitStoreCacheDone(const std::shared_ptr<AsyncContext>& store_context);
+    void                          storeCompletedCache(const std::shared_ptr<BatchKVCacheResource>& batch_resource);
 
 private:
     GenerateStream*                stream_;
@@ -148,7 +150,11 @@ private:
     int                           load_cache_retry_count_ = 0;
 
     // Connector reference counting for PD separation (RAII auto-release)
+    enum class PDSepCacheState { NONE, PENDING, COMMITTED, DISCARDED };
+    std::mutex                       pd_kvcache_mutex_;
     std::shared_ptr<KVCacheResource> pd_kvcache_ref_;
+    BatchKVCacheResourcePtr          pd_pending_cache_resource_;
+    PDSepCacheState                   pd_cache_state_ = PDSepCacheState::NONE;
     /// Async connector load is gated to once per cache lifecycle: duplicate `initKVBlock` must
     /// not re-issue async read (see tests). Reset in `releaseResource()` when blocks are cleared
     /// so any future reuse of this resource can load again. Concurrent callers use `exchange`.

--- a/rtp_llm/cpp/engine_base/stream/test/PdSepKVCacheReleaseTest.cc
+++ b/rtp_llm/cpp/engine_base/stream/test/PdSepKVCacheReleaseTest.cc
@@ -546,6 +546,45 @@ TEST_F(PdSepKVCacheReleaseTest, testInsertIntoCache_CalledDuringRelease_ReuseWor
     stream2->releaseResource();
 }
 
+TEST_F(PdSepKVCacheReleaseTest, testFailedPDSepLoadDoesNotPopulateDeviceCache) {
+    const std::vector<int> tokens = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+    prepareStream(tokens);
+    allocateAndFinish();
+
+    auto& resource = stream_->streamCacheResource();
+    resource.holdKVCacheForPDSep();
+    stream_->releaseResource();
+    resource.releaseKVCacheForPDSep(false);
+
+    ResourceContext resource_context2;
+    resource_context2.cache_manager       = cache_manager_;
+    resource_context2.reuse_cache         = true;
+    resource_context2.enable_device_cache = true;
+    resource_context2.role_type           = RoleType::PREFILL;
+
+    auto generate_input2                   = std::make_shared<GenerateInput>();
+    auto generate_config2                  = std::make_shared<GenerateConfig>();
+    generate_config2->num_return_sequences = 1;
+    generate_config2->reuse_cache          = true;
+    generate_config2->enable_device_cache  = true;
+    generate_input2->input_ids       = torch::tensor(std::vector<int32_t>(tokens.begin(), tokens.end()), torch::kInt32);
+    generate_input2->generate_config = generate_config2;
+
+    ModelConfig model_config;
+    model_config.attn_config.tokens_per_block = 8;
+    model_config.max_seq_len                  = 2048;
+    RuntimeConfig runtime_config;
+
+    auto stream2 = std::make_shared<NormalGenerateStream>(
+        generate_input2, model_config, runtime_config, resource_context2, nullptr);
+    stream2->generate_status_->status = StreamState::RUNNING;
+
+    ASSERT_TRUE(stream2->streamCacheResource().initKVBlock().ok());
+    EXPECT_EQ(stream2->reuseLength(), 0)
+        << "A failed PD cache load must not leave a device-cache entry for the retry";
+    stream2->releaseResource();
+}
+
 // =============================================================================
 // Test 6: Race condition simulation
 // Engine thread calls releaseResource concurrently with

--- a/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
+++ b/rtp_llm/cpp/model_rpc/PrefillRpcServer.cc
@@ -488,17 +488,24 @@ void PrefillRpcServer::pollLocalOutput(PrefillGenerateContext& prefill_context) 
 void PrefillRpcServer::remoteLoadCacheEnd(PrefillGenerateContext& prefill_context) {
     RTP_LLM_PROFILE_FUNCTION();
     GenerateOutputsPB load_response;
-    CLIENT_GRPC_RET_IF_ERROR(
-        prefill_context, prefill_context.client_stream->Read(&load_response), ErrorCode::REMOTE_LOAD_KV_CACHE_FAILED);
+    const auto release_pd_cache = [&](bool cache_load_succeeded) {
+        if (prefill_context.generate_input->generate_config->pd_separation) {
+            prefill_context.getStream()->releaseKVCacheForPDSep(cache_load_succeeded);
+        }
+    };
+    if (!prefill_context.client_stream->Read(&load_response)) {
+        release_pd_cache(false);
+        CLIENT_GRPC_RET_IF_ERROR(prefill_context, false, ErrorCode::REMOTE_LOAD_KV_CACHE_FAILED);
+    }
     auto error_code = transRPCErrorCode(load_response.error_info().error_code());
 
     // Decode has finished loading cache, now safe to release KV cache blocks.
     // This is called after cache store transfer is complete.
-    if (prefill_context.generate_input->generate_config->pd_separation) {
-        prefill_context.getStream()->releaseKVCacheForPDSep();
+    if (error_code != ErrorCode::NONE_ERROR) {
+        release_pd_cache(false);
+        CLIENT_GRPC_RET_IF_ERROR(prefill_context, false, error_code);
     }
-
-    CLIENT_GRPC_RET_IF_ERROR(prefill_context, error_code == ErrorCode::NONE_ERROR, error_code);
+    release_pd_cache(true);
     RTP_LLM_LOG_DEBUG("request [%ld] remote load cache done", prefill_context.request_id);
 
     prefill_context.dequeueStreamFromRuntimeMeta();


### PR DESCRIPTION
On a failed P/D cache handoff, defer cache publication until Decode reports successful loading. This prevents a retry in the same service pair from reusing a partial cache block.