### PR TITLE
fix/embedding task reuse grpc channel pool

### DIFF
--- a/rtp_llm/embedding/embedding_endpoint.py
+++ b/rtp_llm/embedding/embedding_endpoint.py
@@ -16,6 +16,7 @@ from rtp_llm.frontend.tokenizer_factory.tokenizers import BaseTokenizer
 from rtp_llm.models.downstream_modules.utils import create_custom_module
 from rtp_llm.ops import RoleType
 from rtp_llm.server.host_service import HostService, HostServiceArgs
+from rtp_llm.utils.grpc_host_channel_pool import GrpcHostChannelPool
 from rtp_llm.utils.grpc_util import trans_from_tensor
 
 
@@ -68,6 +69,14 @@ class EmbeddingEndpoint(object):
         host_args = HostServiceArgs.create_from_env()
         self.host_service = HostService(host_args)
         logging.info(f"embedding endpoint grpc options: {self.options}")
+        # Reuse channels across requests: creating a new aio channel per request
+        # leaks C-core resources over time and causes RSS growth.
+        self._channel_pool = GrpcHostChannelPool(
+            options=self.options, cleanup_interval=60
+        )
+
+    async def close(self) -> None:
+        await self._channel_pool.close()
 
     async def embedding(
         self, request: Dict[str, Any]
@@ -133,7 +142,7 @@ class EmbeddingEndpoint(object):
         profile_config: Optional[Dict[str, Any]] = None,
     ):
         profile_config = profile_config or {}
-        channel = grpc.aio.insecure_channel(self.address, options=self.options)
+        channel = await self._channel_pool.get(self.address)
         stub = pb2_grpc.EmbeddingRpcServiceStub(channel)
         multimodal_features = []
 
@@ -193,5 +202,3 @@ class EmbeddingEndpoint(object):
         except grpc.RpcError as e:
             logging.warning(f"RPC failed: {e.code()}: {e.details()}")
             raise
-        finally:
-            await channel.close()

--- a/rtp_llm/frontend/frontend_server.py
+++ b/rtp_llm/frontend/frontend_server.py
@@ -227,8 +227,12 @@ class FrontendServer(object):
             self.is_embedding = True
 
     async def close(self):
-        if self._frontend_worker is not None:
-            await self._frontend_worker.close()
+        try:
+            if self._frontend_worker is not None:
+                await self._frontend_worker.close()
+        finally:
+            if self._embedding_endpoint is not None:
+                await self._embedding_endpoint.close()
 
     def stop(self):
         if self._frontend_worker is not None:

--- a/rtp_llm/test/embedding/test_embedding_profile_config.py
+++ b/rtp_llm/test/embedding/test_embedding_profile_config.py
@@ -1,6 +1,19 @@
 import unittest
+from unittest.mock import AsyncMock, MagicMock
 
 from rtp_llm.embedding.embedding_endpoint import EmbeddingEndpoint
+
+
+class TestEmbeddingEndpointLifecycle(unittest.IsolatedAsyncioTestCase):
+    async def test_close_closes_channel_pool(self):
+        endpoint = object.__new__(EmbeddingEndpoint)
+        channel_pool = MagicMock()
+        channel_pool.close = AsyncMock()
+        endpoint._channel_pool = channel_pool
+
+        await endpoint.close()
+
+        channel_pool.close.assert_awaited_once()
 
 
 class TestExtractProfileConfig(unittest.TestCase):

--- a/rtp_llm/utils/grpc_host_channel_pool.py
+++ b/rtp_llm/utils/grpc_host_channel_pool.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from typing import Dict, List, Optional, Tuple, Union
+import time
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import grpc
 from grpc import aio
@@ -9,11 +10,13 @@ GrpcChannelOption = Tuple[str, Union[str, int]]
 
 
 class GrpcHostChannel:
-    __slots__ = ("host", "channel")
+    __slots__ = ("host", "channel", "last_used_at", "transient_failure_since")
 
     def __init__(self, host: str, channel: aio.Channel):
         self.host = host
         self.channel = channel
+        self.last_used_at = time.monotonic()
+        self.transient_failure_since: Optional[float] = None
 
 
 class GrpcHostChannelPool:
@@ -25,15 +28,25 @@ class GrpcHostChannelPool:
         self,
         options: Optional[List[GrpcChannelOption]] = None,
         cleanup_interval: int = 60,
+        transient_failure_grace_period: float = 300,
+        idle_channel_ttl: float = 300,
     ):
         """
         :param options: aio.insecure_channel 的 gRPC options
+        :param cleanup_interval: 后台清理任务的执行间隔（秒）
+        :param transient_failure_grace_period: TRANSIENT_FAILURE 持续多久后允许后台淘汰（秒）
+        :param idle_channel_ttl: IDLE channel 未被使用多久后允许后台淘汰（秒）
         """
         self._options = options or []
         self._channels: Dict[str, GrpcHostChannel] = {}
         self._closed_channels: List[GrpcHostChannel] = []
+        self._pending_close_channels: Dict[int, GrpcHostChannel] = {}
         self._lock = asyncio.Lock()
+        self._cleanup_lock = asyncio.Lock()
+        self._close_lock = asyncio.Lock()
         self._cleanup_interval = cleanup_interval
+        self._transient_failure_grace_period = transient_failure_grace_period
+        self._idle_channel_ttl = idle_channel_ttl
         self._cleanup_task: Optional[asyncio.Task] = None  # type: ignore
         self._stopped = False
 
@@ -44,35 +57,42 @@ class GrpcHostChannelPool:
                 if self._cleanup_task:
                     self._cleanup_task.cancel()
                 self._channels.clear()
+                self._closed_channels.clear()
+                self._pending_close_channels.clear()
         except Exception as e:
             logging.warning("Failed to cleanup GrpcHostChannelPool in __del__: %s", e)
 
     async def close(self):
-        cleanup_task = None
-        to_close: List[GrpcHostChannel] = []
-        try:
-            async with self._lock:
-                if self._stopped:
-                    return
-                self._stopped = True
-                cleanup_task = self._cleanup_task
-                self._cleanup_task = None
-                to_close = list(self._channels.values()) + list(self._closed_channels)
-                self._channels.clear()
-                self._closed_channels.clear()
+        async with self._close_lock:
+            cleanup_task = None
+            try:
+                async with self._lock:
+                    if not self._stopped:
+                        self._stopped = True
+                        cleanup_task = self._cleanup_task
+                        self._cleanup_task = None
+                    self._queue_entries_for_close(self._channels.values())
+                    self._queue_entries_for_close(self._closed_channels)
+                    self._channels.clear()
+                    self._closed_channels.clear()
 
-            if cleanup_task:
-                cleanup_task.cancel()
-                try:
-                    await cleanup_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e:
-                    logging.warning("Failed to stop grpc channel cleanup task: %s", e)
+                if cleanup_task:
+                    cleanup_task.cancel()
+                    try:
+                        await cleanup_task
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception as e:
+                        logging.warning(
+                            "Failed to stop grpc channel cleanup task: %s", e
+                        )
 
-            await self._close_entries(to_close)
-        except Exception as e:
-            logging.warning("Failed to close GrpcHostChannelPool: %s", e)
+                async with self._lock:
+                    to_close = list(self._pending_close_channels.values())
+                closed_entries = await self._close_entries(to_close)
+                await self._remove_closed_entries(closed_entries)
+            except Exception as e:
+                logging.warning("Failed to close GrpcHostChannelPool: %s", e)
 
     async def get(self, target: str) -> aio.Channel:
         """
@@ -101,8 +121,21 @@ class GrpcHostChannelPool:
                 ch = aio.insecure_channel(target, options=self._options)
                 entry = GrpcHostChannel(target, ch)
                 self._channels[target] = entry
+            entry.last_used_at = time.monotonic()
 
         return entry.channel
+
+    def _queue_entries_for_close(self, entries: Iterable[GrpcHostChannel]) -> None:
+        """Register entries for closing while the caller holds ``_lock``."""
+        for entry in entries:
+            self._pending_close_channels[id(entry)] = entry
+
+    async def _remove_closed_entries(
+        self, entries: Iterable[GrpcHostChannel]
+    ) -> None:
+        async with self._lock:
+            for entry in entries:
+                self._pending_close_channels.pop(id(entry), None)
 
     # ---------- background cleanup ----------
 
@@ -125,23 +158,33 @@ class GrpcHostChannelPool:
 
     async def _cleanup_closed(self):
         """
-        Find closed channels (including offline peers), remove them from the pool, and close them.
-        This prevents memory leak when peers go offline and are no longer accessed via get().
+        Find shutdown or persistently unavailable channels, remove them from the
+        pool, and close them.
+
+        A recent TRANSIENT_FAILURE is retained because gRPC channels recover from
+        that state automatically. A channel that stays unavailable beyond the
+        grace period is evicted so dynamic, permanently offline peers do not
+        accumulate forever. Long-unused IDLE channels are also evicted without
+        forcing a connection attempt.
         """
-        to_close: List[GrpcHostChannel] = []
-        try:
+        async with self._cleanup_lock:
             async with self._lock:
-                to_close = [_ for _ in self._closed_channels]
+                newly_closed = list(self._closed_channels)
                 self._closed_channels.clear()
                 total_channels = len(self._channels)
                 for target, entry in list(self._channels.items()):
                     try:
                         # Check if channel is closed
-                        if self._is_channel_closed(entry, try_to_connect=True):
+                        if self._is_channel_closed(
+                            entry,
+                            evict_stale_transient_failure=True,
+                            evict_stale_idle=True,
+                        ):
                             logging.info(
-                                f"Channel {entry.host} is closed/offline, marking for cleanup"
+                                f"Channel {entry.host} is shutdown or persistently "
+                                "unavailable, marking for cleanup"
                             )
-                            to_close.append(entry)
+                            newly_closed.append(entry)
                             del self._channels[
                                 target
                             ]  # remove reference to prevent memory leak
@@ -149,6 +192,8 @@ class GrpcHostChannelPool:
                         # Log error but continue checking other channels
                         logging.warning(f"Error checking channel {entry.host}: {e}")
 
+                self._queue_entries_for_close(newly_closed)
+                to_close = list(self._pending_close_channels.values())
                 remaining_channels = len(self._channels)
                 if to_close:
                     logging.info(
@@ -158,16 +203,17 @@ class GrpcHostChannelPool:
                     logging.debug(
                         f"Channel cleanup: no closed channels found, {total_channels} active channels"
                     )
-        except Exception as e:
-            # Log error but don't re-raise to prevent cleanup loop from stopping
-            logging.error(f"Error in _cleanup_closed: {e}", exc_info=True)
 
-        await self._close_entries(to_close)
+            closed_entries = await self._close_entries(to_close)
+            await self._remove_closed_entries(closed_entries)
 
-    async def _close_entries(self, entries: List[GrpcHostChannel]):
+    async def _close_entries(
+        self, entries: List[GrpcHostChannel]
+    ) -> List[GrpcHostChannel]:
         # Close outside lock
         closed_count = 0
         failed_count = 0
+        closed_entries: List[GrpcHostChannel] = []
         seen = set()
         for entry in entries:
             entry_id = id(entry)
@@ -177,6 +223,7 @@ class GrpcHostChannelPool:
             try:
                 await asyncio.wait_for(entry.channel.close(), timeout=2.0)
                 closed_count += 1
+                closed_entries.append(entry)
                 logging.info(f"Successfully closed channel for {entry.host}")
             except asyncio.TimeoutError:
                 failed_count += 1
@@ -189,23 +236,51 @@ class GrpcHostChannelPool:
             logging.info(
                 f"Channel cleanup completed: {closed_count} channels closed successfully, {failed_count} failed"
             )
+        return closed_entries
 
     def _is_channel_closed(
-        self, entry: GrpcHostChannel, try_to_connect: bool = False
+        self,
+        entry: GrpcHostChannel,
+        evict_stale_transient_failure: bool = False,
+        evict_stale_idle: bool = False,
     ) -> bool:
         """
         check if the gRPC channel is closed
         """
         try:
-            state = entry.channel.get_state(try_to_connect=try_to_connect)
+            state = entry.channel.get_state()
+            now = time.monotonic()
             if state == grpc.ChannelConnectivity.SHUTDOWN:
                 logging.info(f"channel for [{entry.host}] is shutdown")
                 return True
             elif state == grpc.ChannelConnectivity.TRANSIENT_FAILURE:
+                if entry.transient_failure_since is None:
+                    entry.transient_failure_since = now
+                failure_duration = now - entry.transient_failure_since
+                if (
+                    evict_stale_transient_failure
+                    and failure_duration >= self._transient_failure_grace_period
+                ):
+                    logging.info(
+                        f"channel for [{entry.host}] has remained in "
+                        f"TRANSIENT_FAILURE for {failure_duration:.1f}s"
+                    )
+                    return True
                 logging.info(
-                    f"channel for [{entry.host}] is in TRANSIENT_FAILURE state (peer is offline/closed)"
+                    f"channel for [{entry.host}] is in TRANSIENT_FAILURE state; "
+                    "keeping it for automatic reconnection"
                 )
-                return True
+            elif state == grpc.ChannelConnectivity.IDLE:
+                entry.transient_failure_since = None
+                idle_duration = now - entry.last_used_at
+                if evict_stale_idle and idle_duration >= self._idle_channel_ttl:
+                    logging.info(
+                        f"channel for [{entry.host}] has remained unused in "
+                        f"IDLE for {idle_duration:.1f}s"
+                    )
+                    return True
+            elif state == grpc.ChannelConnectivity.READY:
+                entry.transient_failure_since = None
             return False
         except Exception as e:
             logging.error(f"check channel for [{entry.host}] closed failed:{str(e)}")

--- a/rtp_llm/utils/test/grpc_host_channel_pool_test.py
+++ b/rtp_llm/utils/test/grpc_host_channel_pool_test.py
@@ -1,47 +1,88 @@
 import asyncio
-import contextlib
 import unittest
-from unittest import TestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
 
 from rtp_llm.utils.grpc_host_channel_pool import GrpcHostChannel, GrpcHostChannelPool
 
 
-class GrpcHostChannelPoolTest(TestCase):
+class GrpcHostChannelPoolTest(unittest.IsolatedAsyncioTestCase):
     """Test cases for GrpcHostChannelPool"""
 
-    def setUp(self):
+    async def asyncSetUp(self):
         """Setup test environment"""
         self.test_host = "localhost:50051"
         self.test_options = [("grpc.max_receive_message_length", 1000000)]
-        self.pool = GrpcHostChannelPool(options=self.test_options, cleanup_interval=1)
+        self.pool = GrpcHostChannelPool(
+            options=self.test_options, cleanup_interval=3600
+        )
 
-    def tearDown(self):
-        """Cleanup after tests"""
-        # Stop the cleanup task
-        if hasattr(self.pool, "_stopped"):
-            self.pool._stopped = True
-        if hasattr(self.pool, "_cleanup_task") and self.pool._cleanup_task:
-            self.pool._cleanup_task.cancel()
-        # Clear channels
-        if hasattr(self.pool, "_channels"):
-            self.pool._channels.clear()
+    async def asyncTearDown(self):
+        await self.pool.close()
 
-    async def test_pool_start_stop(self):
-        """Test starting and stopping the pool cleanup task"""
-        # Test start
-        await self.pool.start()
+    async def test_pool_starts_lazily_and_close_stops_task(self):
+        """The cleanup task starts on first use and is stopped by close()."""
+        await self.pool.get(self.test_host)
         self.assertIsNotNone(self.pool._cleanup_task)
         self.assertFalse(self.pool._cleanup_task.done())
 
-        # Test stop
-        self.pool._stopped = True
-        if self.pool._cleanup_task:
-            self.pool._cleanup_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self.pool._cleanup_task
+        cleanup_task = self.pool._cleanup_task
+        await self.pool.close()
+
+        self.assertTrue(self.pool._stopped)
+        self.assertTrue(cleanup_task.done())
+        self.assertEqual(self.pool._channels, {})
+        self.assertEqual(self.pool._closed_channels, [])
+
+    async def test_close_closes_active_channels_and_is_idempotent(self):
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = grpc.ChannelConnectivity.READY
+        mock_channel.close = AsyncMock()
+
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ):
+            await self.pool.get(self.test_host)
+
+        await self.pool.close()
+        await self.pool.close()
+
+        mock_channel.close.assert_awaited_once()
+        with self.assertRaisesRegex(RuntimeError, "is closed"):
+            await self.pool.get(self.test_host)
+
+    async def test_close_takes_over_channel_from_cancelled_cleanup(self):
+        """A channel selected by cleanup remains owned until close succeeds."""
+        cleanup_close_started = asyncio.Event()
+        never_finish_first_close = asyncio.Event()
+        close_attempts = 0
+
+        async def close_channel():
+            nonlocal close_attempts
+            close_attempts += 1
+            if close_attempts == 1:
+                cleanup_close_started.set()
+                await never_finish_first_close.wait()
+
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = grpc.ChannelConnectivity.SHUTDOWN
+        mock_channel.close = AsyncMock(side_effect=close_channel)
+
+        self.pool._cleanup_interval = 0
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ):
+            await self.pool.get(self.test_host)
+
+        await asyncio.wait_for(cleanup_close_started.wait(), timeout=1)
+        await self.pool.close()
+
+        self.assertEqual(close_attempts, 2)
+        self.assertEqual(self.pool._pending_close_channels, {})
+        mock_channel.close.assert_awaited()
 
     async def test_get_channel(self):
         """Test getting a channel from the pool"""
@@ -67,6 +108,27 @@ class GrpcHostChannelPoolTest(TestCase):
         # Should only have one entry in the pool
         self.assertEqual(len(self.pool._channels), 1)
         self.assertIn(self.test_host, self.pool._channels)
+
+    async def test_get_reuses_transient_failure_channel(self):
+        """A temporary outage must not cause one new channel per request."""
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = (
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE
+        )
+        mock_channel.close = AsyncMock()
+
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ) as create_channel:
+            channel1 = await self.pool.get(self.test_host)
+            channel2 = await self.pool.get(self.test_host)
+
+        self.assertIs(channel1, channel2)
+        create_channel.assert_called_once_with(
+            self.test_host, options=self.test_options
+        )
+        self.assertEqual(self.pool._closed_channels, [])
 
     async def test_get_multiple_hosts(self):
         """Test getting channels for multiple hosts"""
@@ -94,8 +156,7 @@ class GrpcHostChannelPoolTest(TestCase):
         channel = await self.pool.get(self.test_host)
         original_entry = self.pool._channels[self.test_host]
 
-        # Simulate closed channel
-        original_entry.channel._state = grpc.ChannelConnectivity.SHUTDOWN
+        await channel.close()
 
         # Get channel again, should create new one
         new_channel = await self.pool.get(self.test_host)
@@ -105,7 +166,7 @@ class GrpcHostChannelPoolTest(TestCase):
         self.assertIsNot(original_entry, new_entry)
         self.assertIsNot(channel, new_channel)
 
-    async def test_is_channel_closed(self):
+    def test_is_channel_closed(self):
         """Test _is_channel_closed method"""
         # Create a mock entry with closed channel
         mock_channel = MagicMock()
@@ -113,18 +174,90 @@ class GrpcHostChannelPoolTest(TestCase):
         entry = GrpcHostChannel(self.test_host, mock_channel)
 
         # Should detect closed channel
-        is_closed = await self.pool._is_channel_closed(entry)
+        is_closed = self.pool._is_channel_closed(entry)
         self.assertTrue(is_closed)
 
         # Test with active channel
         mock_channel.get_state.return_value = grpc.ChannelConnectivity.READY
-        is_closed = await self.pool._is_channel_closed(entry)
+        is_closed = self.pool._is_channel_closed(entry)
         self.assertFalse(is_closed)
 
         # Test exception handling
         mock_channel.get_state.side_effect = Exception("Test error")
-        is_closed = await self.pool._is_channel_closed(entry)
+        is_closed = self.pool._is_channel_closed(entry)
         self.assertTrue(is_closed)  # Should return True on exception
+
+    def test_transient_failure_is_not_closed(self):
+        """TRANSIENT_FAILURE channels must be retained for automatic recovery."""
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = (
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE
+        )
+        entry = GrpcHostChannel(self.test_host, mock_channel)
+
+        self.assertFalse(self.pool._is_channel_closed(entry))
+
+    async def test_cleanup_evicts_persistent_transient_failure(self):
+        """A permanently unavailable peer is evicted after the grace period."""
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = (
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE
+        )
+        mock_channel.close = AsyncMock()
+
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ):
+            await self.pool.get(self.test_host)
+
+        await self.pool._cleanup_closed()
+        self.assertIn(self.test_host, self.pool._channels)
+
+        self.pool._transient_failure_grace_period = 0
+        await self.pool._cleanup_closed()
+        self.assertNotIn(self.test_host, self.pool._channels)
+        mock_channel.close.assert_awaited_once()
+
+    async def test_cleanup_evicts_unused_idle_channel(self):
+        """An unused IDLE peer is evicted without forcing a connection attempt."""
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = grpc.ChannelConnectivity.IDLE
+        mock_channel.close = AsyncMock()
+
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ):
+            await self.pool.get(self.test_host)
+
+        await self.pool._cleanup_closed()
+        self.assertIn(self.test_host, self.pool._channels)
+
+        self.pool._idle_channel_ttl = 0
+        await self.pool._cleanup_closed()
+
+        self.assertNotIn(self.test_host, self.pool._channels)
+        mock_channel.get_state.assert_called_with()
+        mock_channel.close.assert_awaited_once()
+
+    async def test_cleanup_keeps_ready_channel_past_idle_ttl(self):
+        """The idle TTL must not close a channel that may serve an active RPC."""
+        mock_channel = MagicMock()
+        mock_channel.get_state.return_value = grpc.ChannelConnectivity.READY
+        mock_channel.close = AsyncMock()
+
+        with patch(
+            "rtp_llm.utils.grpc_host_channel_pool.aio.insecure_channel",
+            return_value=mock_channel,
+        ):
+            await self.pool.get(self.test_host)
+
+        self.pool._idle_channel_ttl = 0
+        await self.pool._cleanup_closed()
+
+        self.assertIn(self.test_host, self.pool._channels)
+        mock_channel.close.assert_not_awaited()
 
     async def test_cleanup_closed_channels(self):
         """Test cleanup of closed channels"""
@@ -136,7 +269,7 @@ class GrpcHostChannelPoolTest(TestCase):
 
         # Close one channel
         entry = self.pool._channels[hosts[1]]
-        entry.channel._state = grpc.ChannelConnectivity.SHUTDOWN
+        await entry.channel.close()
 
         # Run cleanup
         await self.pool._cleanup_closed()
@@ -148,27 +281,22 @@ class GrpcHostChannelPoolTest(TestCase):
         self.assertIn(hosts[2], self.pool._channels)
 
     async def test_cleanup_loop(self):
-        """Test the cleanup loop task"""
-        # Start cleanup with short interval
-        await self.pool.start()
+        """The background loop invokes cleanup without relying on sleep timing."""
+        cleanup_called = asyncio.Event()
+        keep_cleanup_pending = asyncio.Event()
 
-        # Add a channel and mark it as closed
+        async def cleanup_once():
+            cleanup_called.set()
+            await keep_cleanup_pending.wait()
+
+        self.pool._cleanup_interval = 0
+        self.pool._cleanup_closed = AsyncMock(side_effect=cleanup_once)
         await self.pool.get(self.test_host)
-        entry = self.pool._channels[self.test_host]
-        entry.channel._state = grpc.ChannelConnectivity.SHUTDOWN
 
-        # Wait for cleanup to run (interval is 1 second in setUp)
-        await asyncio.sleep(1.5)
+        await asyncio.wait_for(cleanup_called.wait(), timeout=1)
+        await self.pool.close()
 
-        # Channel should be cleaned up
-        self.assertNotIn(self.test_host, self.pool._channels)
-
-        # Stop cleanup
-        self.pool._stopped = True
-        if self.pool._cleanup_task:
-            self.pool._cleanup_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self.pool._cleanup_task
+        self.pool._cleanup_closed.assert_awaited_once()
 
     def test_destructor(self):
         """Test __del__ method"""
@@ -223,6 +351,12 @@ class GrpcHostChannelPoolTest(TestCase):
 
         # Channel should be removed from pool despite close timeout
         self.assertNotIn(self.test_host, self.pool._channels)
+        self.assertEqual(len(self.pool._pending_close_channels), 1)
+
+        mock_channel.close.side_effect = None
+        await self.pool.close()
+        self.assertEqual(mock_channel.close.await_count, 2)
+        self.assertEqual(self.pool._pending_close_channels, {})
 
     async def test_channel_close_exception(self):
         """Test handling of channel close exception"""
@@ -243,6 +377,12 @@ class GrpcHostChannelPoolTest(TestCase):
 
         # Channel should be removed from pool despite close exception
         self.assertNotIn(self.test_host, self.pool._channels)
+        self.assertEqual(len(self.pool._pending_close_channels), 1)
+
+        mock_channel.close.side_effect = None
+        await self.pool.close()
+        self.assertEqual(mock_channel.close.await_count, 2)
+        self.assertEqual(self.pool._pending_close_channels, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
复用 grpc channel 以避免 Embedding/reranker task 的 grpc c core 内存泄漏